### PR TITLE
Fixed typo in deprecation Rails 2.3.9 deprecation warning

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/misc.rb
+++ b/activesupport/lib/active_support/core_ext/object/misc.rb
@@ -38,7 +38,7 @@ class Object
   #  
   #  foo # => ['bar', 'baz']
   def returning(value)
-    ActiveSupport::Deprecation.warn('Object#returning has been deprecated in favor of Object#tap.', caller)
+    ActiveSupport::Deprecation.warn('Kernel#returning has been deprecated in favor of Object#tap.', caller)
     yield(value)
     value
   end


### PR DESCRIPTION
Following this conversation with Jeremy:
http://twitter.com/sferik/status/23933365677
http://twitter.com/bitsweat/status/23936636728
