### PR TITLE
Don't raise "Task not supported by..." exception for mysql2 adapter in 2-3-stable

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/misc.rb
+++ b/activesupport/lib/active_support/core_ext/object/misc.rb
@@ -38,7 +38,7 @@ class Object
   #  
   #  foo # => ['bar', 'baz']
   def returning(value)
-    ActiveSupport::Deprecation.warn('Object#returning has been deprecated in favor of Object#tap.', caller)
+    ActiveSupport::Deprecation.warn('Kernel#returning has been deprecated in favor of Object#tap.', caller)
     yield(value)
     value
   end

--- a/railties/lib/tasks/databases.rake
+++ b/railties/lib/tasks/databases.rake
@@ -46,14 +46,14 @@ namespace :db do
             $stderr.puts "Couldn't create database for #{config.inspect}"
           end
         end
-        return # Skip the else clause of begin/rescue    
+        return # Skip the else clause of begin/rescue
       else
         ActiveRecord::Base.establish_connection(config)
         ActiveRecord::Base.connection
       end
     rescue
       case config['adapter']
-      when 'mysql'
+      when /^mysql/
         @charset   = ENV['CHARSET']   || 'utf8'
         @collation = ENV['COLLATION'] || 'utf8_unicode_ci'
         begin
@@ -159,7 +159,7 @@ namespace :db do
   task :charset => :environment do
     config = ActiveRecord::Base.configurations[RAILS_ENV || 'development']
     case config['adapter']
-    when 'mysql'
+    when /^mysql/
       ActiveRecord::Base.establish_connection(config)
       puts ActiveRecord::Base.connection.charset
     when 'postgresql'
@@ -174,7 +174,7 @@ namespace :db do
   task :collation => :environment do
     config = ActiveRecord::Base.configurations[RAILS_ENV || 'development']
     case config['adapter']
-    when 'mysql'
+    when /^mysql/
       ActiveRecord::Base.establish_connection(config)
       puts ActiveRecord::Base.connection.collation
     else
@@ -274,7 +274,7 @@ namespace :db do
     task :dump => :environment do
       abcs = ActiveRecord::Base.configurations
       case abcs[RAILS_ENV]["adapter"]
-      when "mysql", "oci", "oracle"
+      when /^mysql/, "oci", "oracle"
         ActiveRecord::Base.establish_connection(abcs[RAILS_ENV])
         File.open("#{RAILS_ROOT}/db/#{RAILS_ENV}_structure.sql", "w+") { |f| f << ActiveRecord::Base.connection.structure_dump }
       when "postgresql"
@@ -320,7 +320,7 @@ namespace :db do
     task :clone_structure => [ "db:structure:dump", "db:test:purge" ] do
       abcs = ActiveRecord::Base.configurations
       case abcs["test"]["adapter"]
-      when "mysql"
+      when /^mysql/
         ActiveRecord::Base.establish_connection(:test)
         ActiveRecord::Base.connection.execute('SET foreign_key_checks = 0')
         IO.readlines("#{RAILS_ROOT}/db/#{RAILS_ENV}_structure.sql").join.split("\n\n").each do |table|
@@ -354,14 +354,14 @@ namespace :db do
     task :purge => :environment do
       abcs = ActiveRecord::Base.configurations
       case abcs["test"]["adapter"]
-      when "mysql"
+      when /^mysql/
         ActiveRecord::Base.establish_connection(:test)
         ActiveRecord::Base.connection.recreate_database(abcs["test"]["database"], abcs["test"])
       when "postgresql"
         ActiveRecord::Base.clear_active_connections!
         drop_database(abcs['test'])
         create_database(abcs['test'])
-      when "sqlite","sqlite3"
+      when "sqlite", "sqlite3"
         dbfile = abcs["test"]["database"] || abcs["test"]["dbfile"]
         File.delete(dbfile) if File.exist?(dbfile)
       when "sqlserver"
@@ -408,7 +408,7 @@ end
 def drop_database(config)
   begin
     case config['adapter']
-    when 'mysql'
+    when /^mysql/
       ActiveRecord::Base.establish_connection(config)
       ActiveRecord::Base.connection.drop_database config['database']
     when /^sqlite/


### PR DESCRIPTION
I was working with Rob Olson at Pivotal Labs debugging an issue running `rake spec` after switching from the default mysql adapter to the mysql2 adapter. Changing the matcher from "mysql" to /mysql/ in databases.rake solved the problem.
