### PR TITLE
fixed Subject model for Oracle specific test_oracle_synonym

### DIFF
--- a/activerecord/test/models/subject.rb
+++ b/activerecord/test/models/subject.rb
@@ -1,12 +1,16 @@
 # used for OracleSynonymTest, see test/synonym_test_oracle.rb
 #
 class Subject < ActiveRecord::Base
+
+  # added initialization of author_email_address in the same way as in Topic class
+  # as otherwise synonym test was failing
+  after_initialize :set_email_address
+
   protected
-    # added initialization of author_email_address in the same way as in Topic class
-    # as otherwise synonym test was failing
-    def after_initialize
+    def set_email_address
       if self.new_record?
         self.author_email_address = 'test@test.com'
       end
     end
+
 end


### PR DESCRIPTION
It seams that after_initialize instance method can't be used anymore and therefore test_oracle_synonym was failing on Oracle.

Please apply to 3-0-stable branch as well.
