### PR TITLE
Configurable tld length for subdomains in ActionDispatch::Http::URL

### DIFF
--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -1,7 +1,9 @@
 module ActionDispatch
   module Http
     module URL
-      # Returns the complete \URL used for this request.
+      mattr_accessor :tld_length
+
+      # Returns the complete URL used for this request.
       def url
         protocol + host_with_port + fullpath
       end
@@ -85,13 +87,13 @@ module ActionDispatch
       # returned for "dev.www.rubyonrails.org". You can specify a different <tt>tld_length</tt>,
       # such as 2 to catch <tt>["www"]</tt> instead of <tt>["www", "rubyonrails"]</tt>
       # in "www.rubyonrails.co.uk".
-      def subdomains(tld_length = 1)
+      def subdomains(tld_length = @@tld_length)
         return [] unless named_host?(host)
         parts = host.split('.')
         parts[0..-(tld_length+2)]
       end
 
-      def subdomain(tld_length = 1)
+      def subdomain(tld_length = @@tld_length)
         subdomains(tld_length).join('.')
       end
 

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -8,5 +8,15 @@ module ActionDispatch
     config.action_dispatch.ip_spoofing_check = true
     config.action_dispatch.show_exceptions = true
     config.action_dispatch.best_standards_support = true
+    config.action_dispatch.tld_length = 1
+
+    # Prepare dispatcher callbacks and run 'prepare' callbacks
+    initializer "action_dispatch.prepare_dispatcher" do |app|
+      ActionDispatch::Callbacks.to_prepare { app.routes_reloader.execute_if_updated }
+    end
+
+    initializer "action_dispatch.configure" do |app|
+      ActionDispatch::Http::URL.tld_length = app.config.action_dispatch.tld_length
+    end
   end
 end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -116,6 +116,9 @@ class RequestTest < ActiveSupport::TestCase
     request = stub_request 'HTTP_HOST' => "dev.www.rubyonrails.co.uk"
     assert_equal %w( dev www ), request.subdomains(2)
 
+    request = stub_request 'HTTP_HOST' => "dev.www.rubyonrails.co.uk", :tld_length => 2
+    assert_equal %w( dev www ), request.subdomains
+
     request = stub_request 'HTTP_HOST' => "foobar.foobar.com"
     assert_equal %w( foobar ), request.subdomains
 
@@ -472,7 +475,9 @@ protected
   def stub_request(env = {})
     ip_spoofing_check = env.key?(:ip_spoofing_check) ? env.delete(:ip_spoofing_check) : true
     ip_app = ActionDispatch::RemoteIp.new(Proc.new { }, ip_spoofing_check, @trusted_proxies)
+    tld_length = env.key?(:tld_length) ? env.delete(:tld_length) : 1
     ip_app.call(env)
+    ActionDispatch::Http::URL.tld_length = tld_length
     ActionDispatch::Request.new(env)
   end
 

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -65,6 +65,13 @@ module ApplicationTests
       assert_equal ["notify"], Foo.action_methods
     end
 
+    # AD
+    test "action_dispatch extensions are applied to ActionDispatch" do
+      add_to_config "config.action_dispatch.tld_length = 2"
+      require "#{app_path}/config/environment"
+      assert_equal 2, ActionDispatch::Http::URL.tld_length
+    end
+
     # AS
     test "if there's no config.active_support.bare, all of ActiveSupport is required" do
       use_frameworks []


### PR DESCRIPTION
This is a rebased version of the patch for [this lighthouse ticket](https://rails.lighthouseapp.com/projects/8994/tickets/5215-configurable-tld_length-for-subdomains). After seeing wycats tweet re: pull requests I thought I'd try my luck this way...
