### PR TITLE
Relation fails to act like an Array on intersection

### DIFF
--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -5,6 +5,7 @@ module ActiveRecord
     def merge(r)
       merged_relation = clone
       return merged_relation unless r
+      return to_a & r if r.is_a?(Array)
 
       Relation::ASSOCIATION_METHODS.each do |method|
         value = r.send(:"#{method}_values")

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -699,5 +699,11 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal 'zyke', car.name
   end
 
+  def test_intersection_with_array
+    relation = Author.where(:name => "David")
+    rails_author = relation.first
 
+    assert_equal [rails_author], [rails_author] & relation
+    assert_equal [rails_author], relation & [rails_author]
+  end
 end


### PR DESCRIPTION
Hi,

Rizwan Reza just suggest me to make a pull request for this ticket (https://rails.lighthouseapp.com/projects/8994/tickets/5552-relation-fails-to-act-like-an-array-on-intersection), as it is already verified.

Thanks!
