### PR TITLE
Fixes for errors in railties

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -306,11 +306,11 @@ module ActionView
           object = record_object
         when Array
           object = record.last
-          object_name = options[:as] || ActiveModel::Naming.singular(object)
+          object_name = options[:as] || ActiveModel::Naming.param_key(object)
           apply_form_for_options!(record, options)
         else
           object = record
-          object_name = options[:as] || ActiveModel::Naming.singular(object)
+          object_name = options[:as] || ActiveModel::Naming.param_key(object)
           apply_form_for_options!([object], options)
         end
 

--- a/railties/test/application/routing_test.rb
+++ b/railties/test/application/routing_test.rb
@@ -218,11 +218,9 @@ module ApplicationTests
     test 'routes are loaded just after initialization' do
       require "#{app_path}/config/application"
 
-      ActiveSupport.on_load(:after_initialize) do
-        ::InitializeRackApp = lambda { |env| [200, {}, ["InitializeRackApp"]] }
-      end
-
       app_file 'config/routes.rb', <<-RUBY
+        InitializeRackApp = lambda { |env| [200, {}, ["InitializeRackApp"]] }
+
         AppTemplate::Application.routes.draw do
           match 'foo', :to => ::InitializeRackApp
         end


### PR DESCRIPTION
Fixes:
test_routes_are_loaded_just_after_initialization(ApplicationTests::RoutingTest)
test_isolated_engine_should_avoid_namespace_in_names_if_that's_possible(RailtiesTest::EngineTest)
