### PR TITLE
"use" in ActionController doesn't take block arguments (but MiddlewareStack does) test and fix included

### DIFF
--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -12,7 +12,7 @@ module ActionController
   #
   class MiddlewareStack < ActionDispatch::MiddlewareStack #:nodoc:
     class Middleware < ActionDispatch::MiddlewareStack::Middleware #:nodoc:
-      def initialize(klass, *args)
+      def initialize(klass, *args, &block)
         options = args.extract_options!
         @only   = Array(options.delete(:only)).map(&:to_s)
         @except = Array(options.delete(:except)).map(&:to_s)
@@ -149,8 +149,8 @@ module ActionController
       super
     end
 
-    def self.use(*args)
-      middleware_stack.use(*args)
+    def self.use(*args, &block)
+      middleware_stack.use(*args, &block)
     end
 
     def self.middleware


### PR DESCRIPTION
```
added block arguments to ActionController::Metal#use

Useful for cases such as warden, where a block configuration is taken.

    class SomeController < ApplicationController
      use RailsWarden::Manager do |manager|
        manager.default_strategies :facebook_oauth
        manager.failure_app = SomeController.action(:authorize)
      end
    end
```
