### PR TITLE
Add the documentation for :spacer_template in partial rendering

### DIFF
--- a/actionpack/lib/action_view/render/partials.rb
+++ b/actionpack/lib/action_view/render/partials.rb
@@ -71,6 +71,11 @@ module ActionView
   #
   # The :as option may be used when rendering partials.
   # 
+  # Also, you can specify a partial which will be render as a spacer between each element by passing partial name to
+  # +:spacer_template+. The following example will render "advertiser/_ad_divider.erb" between each ad partial.
+  #
+  #   <%= render :partial => "ad", :collection => @advertisements, :spacer_template => "ad_divider" %>
+  #
   # NOTE: Due to backwards compatibility concerns, the collection can't be one of hashes. Normally you'd also
   # just keep domain objects, like Active Records, in there.
   #


### PR DESCRIPTION
I just found out that in action_view/render/partials.rb there was an option called :spacer_template which you can specify in render :template => 'template_name', :collection => @collection call. It will render the spacer template and put it between each object partial.

I think the documentation for this option has been left out from Rails 2 -> Rails 3 migration, as I found test case exists in the test directory for this feature. Also, I found the documentation of this option in Rails 2.

So I've added an example to demonstrate how to use this particular feature.
