### PR TITLE
Fix requires for inflection related files

### DIFF
--- a/activesupport/lib/active_support/i18n.rb
+++ b/activesupport/lib/active_support/i18n.rb
@@ -1,5 +1,6 @@
 begin
   require 'i18n'
+  require 'lazy_load_hooks'
 rescue LoadError => e
   $stderr.puts "You don't have i18n installed in your application. Please add it to your Gemfile and run bundle install"
   raise e

--- a/activesupport/lib/active_support/inflector/transliterate.rb
+++ b/activesupport/lib/active_support/inflector/transliterate.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require 'active_support/core_ext/string/multibyte'
+require 'active_support/i18n'
 
 module ActiveSupport
   module Inflector


### PR DESCRIPTION
Documented an issue here in lighthouse: https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/5630-active_supportinflectortransliterate-using-i18n-without-requiring-it

Should be simple enough to fix. The lazy_load_hooks require in active_support/i18n feels weird, but not sure there's a better way.
