### PR TITLE
accepts_nested_attributes_for reject_if => {blank id} raises ActiveRecord::RecordNotFound when id is an empty string 

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -323,7 +323,7 @@ module ActiveRecord
           (options[:update_only] || record.id.to_s == attributes['id'].to_s)
         assign_to_or_mark_for_destruction(record, attributes, options[:allow_destroy])
 
-      elsif attributes['id']
+      elsif not attributes['id'].blank?
         existing_record = self.class.reflect_on_association(association_name).klass.find(attributes['id'])
         assign_to_or_mark_for_destruction(existing_record, attributes, options[:allow_destroy])
         self.send(association_name.to_s+'=', existing_record)

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -114,6 +114,15 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
     pirate.ship_attributes = { :name => 'Hello Pearl' }
     assert_difference('Ship.count') { pirate.save! }
   end
+  
+  def test_reject_if_with_blank_nested_attributes_id
+    # When using a select list to choose an existing 'ship' id, with :include_blank => true
+    Pirate.accepts_nested_attributes_for :ship, :reject_if => proc {|attributes| attributes[:id].blank? }
+
+    pirate = Pirate.new(:catchphrase => "Stop wastin' me time")
+    pirate.ship_attributes = { :id => "" }
+    assert_nothing_raised(ActiveRecord::RecordNotFound) { pirate.save! }
+  end
 end
 
 class TestNestedAttributesOnAHasOneAssociation < ActiveRecord::TestCase


### PR DESCRIPTION
Please see https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/5638-patch-rails3-accepts_nested_attributes_for-reject_if-blank-id-raises-activerecordrecordnotfound-when-id-is-an-empty-string
