### PR TITLE
Allow per Resource format settings (will allow pagination with ActiveResource)

### DIFF
--- a/activeresource/lib/active_resource/base.rb
+++ b/activeresource/lib/active_resource/base.rb
@@ -678,7 +678,7 @@ module ActiveResource
       # Returns the new resource instance.
       #
       def build(attributes = {})
-        attrs = connection.get("#{new_element_path}").merge(attributes)
+        attrs = self.format.decode(connection.get("#{new_element_path}").body).merge(attributes)
         self.new(attrs)
       end
 
@@ -850,11 +850,11 @@ module ActiveResource
               instantiate_collection(get(from, options[:params]))
             when String
               path = "#{from}#{query_string(options[:params])}"
-              instantiate_collection(connection.get(path, headers) || [])
+              instantiate_collection(format.decode(connection.get(path, headers).body) || [])
             else
               prefix_options, query_options = split_options(options[:params])
               path = collection_path(prefix_options, query_options)
-              instantiate_collection( (connection.get(path, headers) || []), prefix_options )
+              instantiate_collection( (format.decode(connection.get(path, headers).body) || []), prefix_options )
             end
           rescue ActiveResource::ResourceNotFound
             # Swallowing ResourceNotFound exceptions and return nil - as per
@@ -870,7 +870,7 @@ module ActiveResource
             instantiate_record(get(from, options[:params]))
           when String
             path = "#{from}#{query_string(options[:params])}"
-            instantiate_record(connection.get(path, headers))
+            instantiate_record(format.decode(connection.get(path, headers).body))
           end
         end
 
@@ -878,7 +878,7 @@ module ActiveResource
         def find_single(scope, options)
           prefix_options, query_options = split_options(options[:params])
           path = element_path(scope, prefix_options, query_options)
-          instantiate_record(connection.get(path, headers), prefix_options)
+          instantiate_record(format.decode(connection.get(path, headers).body), prefix_options)
         end
 
         def instantiate_collection(collection, prefix_options = {})

--- a/activeresource/lib/active_resource/base.rb
+++ b/activeresource/lib/active_resource/base.rb
@@ -886,7 +886,7 @@ module ActiveResource
         end
 
         def instantiate_record(record, prefix_options = {})
-          new(record).tap do |resource|
+          new(record, true).tap do |resource|
             resource.prefix_options = prefix_options
           end
         end
@@ -959,9 +959,10 @@ module ActiveResource
     #
     #   my_other_course = Course.new(:name => "Philosophy: Reason and Being", :lecturer => "Ralph Cling")
     #   my_other_course.save
-    def initialize(attributes = {})
+    def initialize(attributes = {}, persisted = false)
       @attributes     = {}.with_indifferent_access
       @prefix_options = {}
+      @persisted = persisted
       load(attributes)
     end
 
@@ -1014,7 +1015,7 @@ module ActiveResource
     #   is_new.new? # => false
     #
     def new?
-      id.nil?
+      !persisted?
     end
     alias :new_record? :new?
 
@@ -1031,7 +1032,7 @@ module ActiveResource
     #   not_persisted.persisted? # => true
     #
     def persisted?
-      !new?
+      @persisted
     end
 
     # Gets the <tt>\id</tt> attribute of the resource.
@@ -1320,6 +1321,7 @@ module ActiveResource
       def load_attributes_from_response(response)
         if response['Content-Length'] != "0" && response.body.strip.size > 0
           load(self.class.format.decode(response.body))
+          @persisted = true
         end
       end
 

--- a/activeresource/lib/active_resource/connection.rb
+++ b/activeresource/lib/active_resource/connection.rb
@@ -76,7 +76,7 @@ module ActiveResource
     # Executes a GET request.
     # Used to get (find) resources.
     def get(path, headers = {})
-      with_auth { format.decode(request(:get, path, build_request_headers(headers, :get, self.site.merge(path))).body) }
+      with_auth { request(:get, path, build_request_headers(headers, :get, self.site.merge(path))) }
     end
 
     # Executes a DELETE request (see HTTP protocol documentation if unfamiliar).

--- a/activeresource/lib/active_resource/custom_methods.rb
+++ b/activeresource/lib/active_resource/custom_methods.rb
@@ -54,7 +54,7 @@ module ActiveResource
         #
         #   Person.find(:all, :from => :active)
         def get(custom_method_name, options = {})
-          connection.get(custom_method_collection_url(custom_method_name, options), headers)
+          format.decode(connection.get(custom_method_collection_url(custom_method_name, options), headers).body)
         end
 
         def post(custom_method_name, options = {}, body = '')
@@ -85,7 +85,7 @@ module ActiveResource
 
     module InstanceMethods
       def get(method_name, options = {})
-        connection.get(custom_method_element_url(method_name, options), self.class.headers)
+        self.class.format.decode(connection.get(custom_method_element_url(method_name, options), self.class.headers).body)
       end
 
       def post(method_name, options = {}, body = nil)

--- a/activeresource/test/cases/authorization_test.rb
+++ b/activeresource/test/cases/authorization_test.rb
@@ -132,7 +132,7 @@ class AuthorizationTest < Test::Unit::TestCase
   end
 
   def test_get
-    david = @authenticated_conn.get("/people/2.xml")
+    david = decode(@authenticated_conn.get("/people/2.xml"))
     assert_equal "David", david["name"]
   end
 
@@ -159,7 +159,7 @@ class AuthorizationTest < Test::Unit::TestCase
   def test_get_with_digest_auth_handles_initial_401_response_and_retries
     @authenticated_conn.auth_type = :digest
     response = @authenticated_conn.get("/people/2.xml")
-    assert_equal "David", response["name"]
+    assert_equal "David", decode(response)["name"]
   end
 
   def test_post_with_digest_auth_handles_initial_401_response_and_retries
@@ -190,11 +190,11 @@ class AuthorizationTest < Test::Unit::TestCase
   def test_get_with_digest_auth_caches_nonce
     @authenticated_conn.auth_type = :digest
     response = @authenticated_conn.get("/people/2.xml")
-    assert_equal "David", response["name"]
+    assert_equal "David", decode(response)["name"]
 
     # There is no mock for this request with a non-cached nonce.
     response = @authenticated_conn.get("/people/1.xml")
-    assert_equal "Matz", response["name"]
+    assert_equal "Matz", decode(response)["name"]
   end
 
   def test_retry_on_401_only_happens_with_digest_auth
@@ -240,5 +240,9 @@ class AuthorizationTest < Test::Unit::TestCase
 
     def response_digest_auth_header
       %Q(Digest realm="RailsTestApp", qop="auth", algorithm=MD5, nonce="#{@nonce}", opaque="ef6dfb078ba22298d366f99567814ffb")
+    end
+
+    def decode(response)
+      @authenticated_conn.format.decode(response.body)
     end
 end

--- a/activeresource/test/cases/base/custom_methods_test.rb
+++ b/activeresource/test/cases/base/custom_methods_test.rb
@@ -91,7 +91,7 @@ class CustomMethodsTest < Test::Unit::TestCase
                    201, {'Location' => '/people/1/addresses/2.xml'}),
                  addy.post(:link)
 
-    matz = Person.new(:id => 1, :name => 'Matz')
+    matz = Person.find(1)
     assert_equal ActiveResource::Response.new(@matz, 201), matz.post(:register)
   end
 

--- a/activeresource/test/cases/base_test.rb
+++ b/activeresource/test/cases/base_test.rb
@@ -5,6 +5,7 @@ require "fixtures/street_address"
 require "fixtures/sound"
 require "fixtures/beast"
 require "fixtures/proxy"
+require "fixtures/address"
 require 'active_support/json'
 require 'active_support/ordered_hash'
 require 'active_support/core_ext/hash/conversions'
@@ -1025,5 +1026,19 @@ class BaseTest < Test::Unit::TestCase
         assert_kind_of String, color
       end
     end
+  end
+
+  def test_with_custom_formatter
+    @addresses = [{:id => "1", :street => "1 Infinite Loop", :city => "Cupertino", :state => "CA"}].to_xml(:root => 'addresses')
+
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/addresses.xml", {}, @addresses, 200
+    end
+
+    # late bind the site
+    AddressResource.site = "http://localhost"
+    addresses = AddressResource.find(:all)
+
+    assert_equal "Cupertino, CA", addresses.first.city_state
   end
 end

--- a/activeresource/test/connection_test.rb
+++ b/activeresource/test/connection_test.rb
@@ -120,7 +120,7 @@ class ConnectionTest < Test::Unit::TestCase
   end
 
   def test_get
-    matz = @conn.get("/people/1.xml")
+    matz = decode(@conn.get("/people/1.xml"))
     assert_equal "Matz", matz["name"]
   end
 
@@ -131,23 +131,23 @@ class ConnectionTest < Test::Unit::TestCase
   end
 
   def test_get_with_header
-    david = @conn.get("/people/2.xml", @header)
+    david = decode(@conn.get("/people/2.xml", @header))
     assert_equal "David", david["name"]
   end
 
   def test_get_collection
-    people = @conn.get("/people.xml")
+    people = decode(@conn.get("/people.xml"))
     assert_equal "Matz", people[0]["name"]
     assert_equal "David", people[1]["name"]
   end
 
   def test_get_collection_single
-    people = @conn.get("/people_single_elements.xml")
+    people = decode(@conn.get("/people_single_elements.xml"))
     assert_equal "Matz", people[0]["name"]
   end
 
   def test_get_collection_empty
-    people = @conn.get("/people_empty_elements.xml")
+    people = decode(@conn.get("/people_empty_elements.xml"))
     assert_equal [], people
   end
 
@@ -249,5 +249,9 @@ class ConnectionTest < Test::Unit::TestCase
 
     def handle_response(response)
       @conn.__send__(:handle_response, response)
+    end
+
+    def decode(response)
+      @conn.format.decode(response.body)
     end
 end

--- a/activeresource/test/fixtures/address.rb
+++ b/activeresource/test/fixtures/address.rb
@@ -1,0 +1,19 @@
+# turns everyting into the same object
+class AddressXMLFormatter
+  include ActiveResource::Formats::XmlFormat
+
+  def decode(xml)
+    data = ActiveResource::Formats::XmlFormat.decode(xml)
+    # process address fields
+    data.each do |address|
+      address['city_state'] = "#{address['city']}, #{address['state']}"
+    end
+    data
+  end
+
+end
+
+class AddressResource < ActiveResource::Base
+  self.element_name = "address"
+  self.format = AddressXMLFormatter.new
+end

--- a/activeresource/test/fixtures/subscription_plan.rb
+++ b/activeresource/test/fixtures/subscription_plan.rb
@@ -1,0 +1,5 @@
+class SubscriptionPlan < ActiveResource::Base
+  self.site = "http://37s.sunrise.i:3000"
+  self.element_name = 'plan'
+  self.primary_key = :code
+end


### PR DESCRIPTION
ActiveResource currently uses connection level formatter for get requests. This makes it impossible to use custom formatters per resource.

This commit makes the Connection request methods more consistent. It always returns a Response object (instead of sometimes decoding, and sometimes not decoding). The base Resource should decode it using its own configured formatter.

Merging this commit will allow users to add custom formatters on a per Resource basis. The main use case for this is allowing per model handling of _pagination_. This is sorely needed in ActiveResource, and right now its impossible without monkeypatching XmlFormat (PoxPaginate is the best example at the moment).
