### PR TITLE
Body attributes and some new Tag Helpers

### DIFF
--- a/actionpack/lib/action_view/helpers.rb
+++ b/actionpack/lib/action_view/helpers.rb
@@ -7,6 +7,7 @@ module ActionView #:nodoc:
     autoload :ActiveModelHelper
     autoload :AssetTagHelper
     autoload :AtomFeedHelper
+    autoload :BodyHelper
     autoload :CacheHelper
     autoload :CaptureHelper
     autoload :CsrfHelper
@@ -37,6 +38,7 @@ module ActionView #:nodoc:
     include ActiveModelHelper
     include AssetTagHelper
     include AtomFeedHelper
+    include BodyHelper
     include CacheHelper
     include CaptureHelper
     include CsrfHelper

--- a/actionpack/lib/action_view/helpers/body_helper.rb
+++ b/actionpack/lib/action_view/helpers/body_helper.rb
@@ -1,0 +1,62 @@
+require 'action_view/helpers/tag_helper'
+require 'active_support/core_ext/string/inflections'
+require 'active_support/core_ext/object/blank'
+
+module ActionView
+  module Helpers #:nodoc:
+    # The TextHelper module provides a set of methods for filtering, formatting
+    # and transforming strings, which can reduce the amount of inline Ruby code in
+    # your views. These helper methods extend ActionView making them callable
+    # within your template files.
+    #
+    # XXX: Should the @body_attributes hash have indifferent access?
+    module BodyHelper
+      # Returns a hash of attributes for the body tag
+      # with the default body id and class.
+      #
+      # You can override the defaults by calling set_body_id and set_body_class
+      #
+      # You can also pass in an attribute hash directly to provide other attributes:
+      #
+      #   body_attributes(:style => "padding: 1em;")
+      #
+      # When using haml, this can be passed directly to the body tag:
+      #   %body{body_attributes}
+      #
+      # When using ERB:
+      #   <% content_tag(:body, body_attributes) do - %>
+      #      Hello, World!
+      #   <% end %>
+      def body_attributes(additional_attributes = {})
+        attrs = merge_tag_attributes(@body_attributes, additional_attributes)
+        attrs[:class] ||= controller_class_names
+        attrs
+      end
+
+      # This method makes creating a default body tag even easier:
+      #   <%= body_tag do -%>
+      #     Hello world!
+      #   <% end -%>
+      def body_tag(additional_attributes = {}, &block)
+        content_tag("body", body_attributes(additional_attributes), &block)
+      end
+
+      # Returns classes for the current controller and action.
+      # For instance, in the PostsController index:
+      # => "posts index"
+      # And in the Scoped::WizzBangController show action:
+      # => "scoped wizz-bang show"
+      def controller_class_names
+        controller.controller_path.tr("/"," ").dasherize + " " + controller.action_name
+      end
+
+      # Uses the TagHelper#merge_tag_attributes! method to add
+      # additional attributes to the body tag in the layout.
+      def add_body_attributes(attributes)
+        @body_attributes ||= {}
+        merge_tag_attributes!(@body_attributes, attributes)
+      end
+
+    end
+  end
+end

--- a/actionpack/test/template/body_helper_test.rb
+++ b/actionpack/test/template/body_helper_test.rb
@@ -1,0 +1,58 @@
+require 'abstract_unit'
+
+class BodyHelperTest < ActionView::TestCase
+  tests ActionView::Helpers::BodyHelper
+
+  MockController = Struct.new(:controller_path, :action_name)
+
+  attr_accessor :controller
+
+  def setup
+    @controller = MockController.new("foo", "bar")
+  end
+
+  def teardown
+    @controller = nil
+    @body_attributes = nil
+  end
+
+  def test_controller_class_names
+    assert_equal("foo bar", controller_class_names)
+  end
+
+  def test_controller_class_names_for_complex_controllers
+    @controller.controller_path = "scoped/camel_cased"
+    assert_equal("scoped camel-cased bar", controller_class_names)
+  end
+
+  def test_unspecified_body_attributes_just_class_names
+    assert_equal({:class => controller_class_names}, body_attributes)
+  end
+
+  def test_body_attributes_can_be_overridden
+    # The default attributes are there unless specified
+    add_body_attributes(:style=>"color:#333;")
+    assert_equal({:class=>"foo bar", :style=>"color:#333;"}, body_attributes)
+
+    # can specify only some of the default attributes
+    add_body_attributes(:id=>"special-id")
+    assert_equal({:class=>"foo bar", :id=>"special-id", :style=>"color:#333;"}, body_attributes)
+    add_body_attributes(:class=>"special-class")
+    assert_equal({:class=>"special-class", :id=>"special-id", :style=>"color:#333;"}, body_attributes)
+
+    # tag attributes are merged when they can be
+    add_body_attributes(:class=>"another-special-class")
+    assert_equal({:class=>"another-special-class special-class", :id=>"special-id", :style=>"color:#333;"}, body_attributes)
+  end
+
+  def test_body_tag
+    buffer = body_tag { concat "Hello world!" }
+    assert_dom_equal %Q{<body class="foo bar">Hello world!</body>}, buffer
+
+    buffer = body_tag(:style => "color:red;") { concat "Hello world!" }
+    assert_dom_equal %Q{<body class="foo bar" style="color:red;">Hello world!</body>}, buffer
+
+    buffer = body_tag(:class=>"hi", :id=>"world") { concat "Hello world, again!" }
+    assert_dom_equal %Q{<body id="world" class="hi">Hello world, again!</body>}, buffer
+  end
+end

--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -6,9 +6,9 @@
   <%%= javascript_include_tag :defaults %>
   <%%= csrf_meta_tags %>
 </head>
-<body>
+<%%= body_tag do -%>
 
 <%%= yield %>
 
-</body>
+<%% end %>
 </html>


### PR DESCRIPTION
Having a consistent convention for body classes makes styling easier :) This approach also let's the body live in the layout but still be modified by the template if necessary.
