### PR TITLE
Removing railties/tmp folder on every CI build

### DIFF
--- a/ci/ci_build.rb
+++ b/ci/ci_build.rb
@@ -38,6 +38,7 @@ cd "#{root_dir}/activesupport" do
   # build_results[:activesupport_isolated] = rake 'test:isolated'
 end
 
+system "sudo rm -R #{root_dir}/railties/tmp"
 cd "#{root_dir}/railties" do
   puts
   puts "[CruiseControl] Building RailTies"


### PR DESCRIPTION
(The last two pull request came with bad commit, sorry about that)

There was an error on CI regarding unable to require arel gem from source when testing application build for a while ago. It seems to me like there's a permission problem on the process of cloning the application and removing Gemfile. This would make sure that the temporary application got removed every time the build is run.

This one is for master. I've also add change for 3-0-stable but would like to test if this one is working first.

Thank you
