### PR TITLE
ActiveResource should work for non-generated ids

### DIFF
--- a/activeresource/lib/active_resource/base.rb
+++ b/activeresource/lib/active_resource/base.rb
@@ -886,7 +886,7 @@ module ActiveResource
         end
 
         def instantiate_record(record, prefix_options = {})
-          new(record).tap do |resource|
+          new(record, true).tap do |resource|
             resource.prefix_options = prefix_options
           end
         end
@@ -959,9 +959,10 @@ module ActiveResource
     #
     #   my_other_course = Course.new(:name => "Philosophy: Reason and Being", :lecturer => "Ralph Cling")
     #   my_other_course.save
-    def initialize(attributes = {})
+    def initialize(attributes = {}, persisted = false)
       @attributes     = {}.with_indifferent_access
       @prefix_options = {}
+      @persisted = persisted
       load(attributes)
     end
 
@@ -1011,7 +1012,7 @@ module ActiveResource
     #   is_new.new? # => false
     #
     def new?
-      id.nil?
+      !persisted?
     end
     alias :new_record? :new?
 
@@ -1028,7 +1029,7 @@ module ActiveResource
     #   not_persisted.persisted? # => true
     #
     def persisted?
-      !new?
+      @persisted
     end
 
     # Gets the <tt>\id</tt> attribute of the resource.
@@ -1317,6 +1318,7 @@ module ActiveResource
       def load_attributes_from_response(response)
         if !response['Content-Length'].blank? && response['Content-Length'] != "0" && !response.body.nil? && response.body.strip.size > 0
           load(self.class.format.decode(response.body))
+          @persisted = true
         end
       end
 

--- a/activeresource/test/cases/base/custom_methods_test.rb
+++ b/activeresource/test/cases/base/custom_methods_test.rb
@@ -91,7 +91,7 @@ class CustomMethodsTest < Test::Unit::TestCase
                    201, {'Location' => '/people/1/addresses/2.xml'}),
                  addy.post(:link)
 
-    matz = Person.new(:id => 1, :name => 'Matz')
+    matz = Person.find(1)
     assert_equal ActiveResource::Response.new(@matz, 201), matz.post(:register)
   end
 

--- a/activeresource/test/fixtures/address.rb
+++ b/activeresource/test/fixtures/address.rb
@@ -1,0 +1,19 @@
+# turns everyting into the same object
+class AddressXMLFormatter
+  include ActiveResource::Formats::XmlFormat
+
+  def decode(xml)
+    data = ActiveResource::Formats::XmlFormat.decode(xml)
+    # process address fields
+    data.each do |address|
+      address['city_state'] = "#{address['city']}, #{address['state']}"
+    end
+    data
+  end
+
+end
+
+class AddressResource < ActiveResource::Base
+  self.element_name = "address"
+  self.format = AddressXMLFormatter.new
+end

--- a/activeresource/test/fixtures/subscription_plan.rb
+++ b/activeresource/test/fixtures/subscription_plan.rb
@@ -1,0 +1,5 @@
+class SubscriptionPlan < ActiveResource::Base
+  self.site = "http://37s.sunrise.i:3000"
+  self.element_name = 'plan'
+  self.primary_key = :code
+end


### PR DESCRIPTION
associated ticket here:
https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/5660-activeresource-should-work-for-non-generated-ids

This ActiveResource patch allows you to override your resource to work with custom primary keys not generated by the server
