### PR TITLE
Warning on uncopied migrations from railties

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -384,8 +384,8 @@ module ActiveRecord
         end
       end
 
-      def copy(destination, sources)
-        copied = []
+      def uncopied_migrations(destination, sources)
+        migrations = []
 
         sources.each do |scope, path|
           destination_migrations = ActiveRecord::Migrator.migrations(destination)
@@ -399,9 +399,19 @@ module ActiveRecord
             last = migration
 
             new_path = File.join(destination, "#{migration.version}_#{migration.name.underscore}.#{scope}.rb")
-            FileUtils.cp(migration.filename, new_path)
-            copied << new_path
+            migrations << [scope, migration.filename, new_path]
           end
+        end
+
+        migrations
+      end
+
+      def copy(destination, sources)
+        copied = []
+
+        uncopied_migrations(destination, sources).each do |scope, path, new_path|
+          FileUtils.cp(path, new_path)
+          copied << new_path
         end
 
         copied

--- a/railties/test/railties/shared_tests.rb
+++ b/railties/test/railties/shared_tests.rb
@@ -38,6 +38,13 @@ module RailtiesTest
       add_to_config "ActiveRecord::Base.timestamped_migrations = false"
 
       Dir.chdir(app_path) do
+        output = `rake db:migrate`
+
+        assert_match /not copied migrations exist/, output
+        assert_match /bukkits: .*db\/migrate\/1_create_users.rb/, output
+        assert_match /bukkits: .*db\/migrate\/2_add_last_name_to_users.rb/, output
+        assert_match /acts_as_yaffle: .*db\/migrate\/1_create_yaffles.rb/, output
+
         output = `rake railties:copy_migrations FROM=bukkits`
 
         assert File.exists?("#{app_path}/db/migrate/2_create_users.bukkits.rb")


### PR DESCRIPTION
Currently, there is a rake task to copy migrations from railties: rake railties:copy_migrations

It would be nice to give user a warning when doing db:migrate with not copied migrations and say how to copy them.
