### PR TITLE
Namespacesd Models and model_name.human/human_attribute_for

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -31,7 +31,7 @@ module ActiveModel
                            @klass.respond_to?(:i18n_scope)
 
       defaults = @klass.lookup_ancestors.map do |klass|
-        klass.model_name.underscore.to_sym
+        klass.model_name.underscore.gsub('/','.').to_sym
       end
 
       defaults << options.delete(:default) if options[:default]

--- a/activemodel/lib/active_model/translation.rb
+++ b/activemodel/lib/active_model/translation.rb
@@ -43,8 +43,13 @@ module ActiveModel
     #
     # Specify +options+ with additional translating options.
     def human_attribute_name(attribute, options = {})
-      defaults = lookup_ancestors.map do |klass|
-        :"#{self.i18n_scope}.attributes.#{klass.model_name.underscore}.#{attribute}"
+      defaults = []
+      lookup_ancestors.each do |klass|
+        name = klass.model_name.underscore.split('/')
+        while name.size > 0
+          defaults << :"#{self.i18n_scope}.attributes.#{name * '.'}.#{attribute}"
+          name.pop
+        end
       end
 
       defaults << :"attributes.#{attribute}"


### PR DESCRIPTION
I'm just localizing Humpyard and as it has namespaced models like Humpyard::Elements::TextElement it would be in the I18n yml:

```
activerecord:
  models:
    humpyard/elements/text_element: 'Text Element'
  attributes:
    humpyard/elements/text_element:
      content: 'Content'
      display_from: 'Display from'
```

This ist not very nice to read and I would have to redefine common fields like "display_from", which exists for all Humpyard::Elements:: models.
So I wrote a patch where the namespaced model translation could be in a namespaced yml/format:

```
activerecord:
  models:
    humpyard:
      elements:
        text_element: 'Text element'
  attributes:
    humpyard:
      elements:
        display_from: 'Display from'
        text_element:
          content: 'Content'
```

Note the fallback to 'activerecord.attributes.humpyard.elements.display_from for the common field. This is of course a simple example - when you have many Humpyard::Pages::\* and Humpyard::Elements::\* this syntax makes much more sense than it may look like. ;-)

CU
StarPeak
