### PR TITLE
ActiveRecord::Base.default_timezone

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -35,7 +35,7 @@ module ActiveRecord
     initializer "active_record.initialize_timezone" do
       ActiveSupport.on_load(:active_record) do
         self.time_zone_aware_attributes = true
-        self.default_timezone = :utc
+        self.default_timezone = :local
       end
     end
 


### PR DESCRIPTION
Valim,

I have a problem with ActiveRecord default_timezone because the railtie.rb change it to :utc

I created a ticket on lighthouse: https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/5679-activerecordbasedefault_timezone

Please consider this pull request

tk's
