### PR TITLE
Ensure original exception message is present in both Template::Error#message and Template::Error#inspect.

### DIFF
--- a/actionpack/lib/action_view/template/error.rb
+++ b/actionpack/lib/action_view/template/error.rb
@@ -52,6 +52,7 @@ module ActionView
       attr_reader :original_exception, :backtrace
 
       def initialize(template, assigns, original_exception)
+        super(original_exception.message)
         @template, @assigns, @original_exception = template, assigns.dup, original_exception
         @sub_templates = nil
         @backtrace = original_exception.backtrace
@@ -59,10 +60,6 @@ module ActionView
 
       def file_name
         @template.identifier
-      end
-
-      def message
-        original_exception.message
       end
 
       def sub_template_message

--- a/actionpack/lib/action_view/template/error.rb
+++ b/actionpack/lib/action_view/template/error.rb
@@ -62,7 +62,7 @@ module ActionView
       end
 
       def message
-        ActiveSupport::Deprecation.silence { original_exception.message }
+        original_exception.message
       end
 
       def sub_template_message

--- a/actionpack/test/template/template_error_test.rb
+++ b/actionpack/test/template/template_error_test.rb
@@ -1,0 +1,13 @@
+require "abstract_unit"
+
+class TemplateErrorTest < ActiveSupport::TestCase
+  def test_provides_original_message
+    error = ActionView::Template::Error.new("test", {}, Exception.new("original"))
+    assert_equal "original", error.message
+  end
+
+  def test_provides_useful_inspect
+    error = ActionView::Template::Error.new("test", {}, Exception.new("original"))
+    assert_equal "#<ActionView::Template::Error: original>", error.inspect
+  end
+end


### PR DESCRIPTION
Previously, #inspect would produce #<ActionView::Template::Error: ActionView::Template::Error>, which is not very useful.
