### PR TITLE
AC LogSubscriber fix

### DIFF
--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -42,7 +42,7 @@ module ActionController
         def #{method}(event)
           key_or_path = event.payload[:key] || event.payload[:path]
           human_name  = #{method.to_s.humanize.inspect}
-          info("\#{human_name} \#{key_or_path} (%.1fms)" % event.duration)
+          info("\#{human_name} \#{key_or_path} \#{"(%.1fms)" % event.duration}")
         end
       METHOD
     end

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -23,6 +23,10 @@ module Another
     def with_fragment_cache
       render :inline => "<%= cache('foo'){ 'bar' } %>"
     end
+    
+    def with_fragment_cache_and_percent_in_key
+      render :inline => "<%= cache('foo%bar'){ 'Contains % sign in key' } %>"
+    end
 
     def with_page_cache
       cache_page("Super soaker", "/index.html")
@@ -137,6 +141,18 @@ class ACLogSubscriberTest < ActionController::TestCase
     assert_equal 4, logs.size
     assert_match /Exist fragment\? views\/foo/, logs[1]
     assert_match /Write fragment views\/foo/, logs[2]
+  ensure
+    @controller.config.perform_caching = true
+  end
+  
+  def test_with_fragment_cache_and_percent_in_key
+    @controller.config.perform_caching = true
+    get :with_fragment_cache_and_percent_in_key
+    wait
+
+    assert_equal 4, logs.size
+    assert_match /Exist fragment\? views\/foo%bar/, logs[1]
+    assert_match /Write fragment views\/foo%bar/, logs[2]
   ensure
     @controller.config.perform_caching = true
   end


### PR DESCRIPTION
https://rails.lighthouseapp.com/projects/8994/tickets/5570-fragment-cache-logging-fails-in-30-when-fragment-path-contains-printf-chars-eg-a
