### PR TITLE
attr_accessor_with_default

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/attr_accessor_with_default.rb
+++ b/activesupport/lib/active_support/core_ext/module/attr_accessor_with_default.rb
@@ -21,10 +21,10 @@ class Module
   def attr_accessor_with_default(sym, default = Proc.new)
     define_method(sym, block_given? ? default : Proc.new { default })
     module_eval(<<-EVAL, __FILE__, __LINE__ + 1)
-      def #{sym}=(value)                        # def age=(value)
-        class << self; attr_reader :#{sym} end  #   class << self; attr_reader :age end
-        @#{sym} = value                         #   @age = value
-      end                                       # end
+      def #{sym}=(value)                          # def age=(value)
+        class << self; attr_accessor :#{sym} end  #   class << self; attr_accessor :age end
+        @#{sym} = value                           #   @age = value
+      end                                         # end
     EVAL
   end
 end


### PR DESCRIPTION
https://rails.lighthouseapp.com/projects/8994/tickets/5551-patch-fix-warning-method-redefined-in-attr_accessor_with_default-for-ruby-192
