### PR TITLE
1.9.2 warnings

### DIFF
--- a/actionpack/lib/action_controller/caching/actions.rb
+++ b/actionpack/lib/action_controller/caching/actions.rb
@@ -161,7 +161,11 @@ module ActionController #:nodoc:
         def normalize!(path)
           path << 'index' if path[-1] == ?/
           path << ".#{extension}" if extension and !path.ends_with?(extension)
-          URI.unescape(path)
+          uri_parser.unescape(path)
+        end
+
+        def uri_parser
+          @uri_parser ||= URI.const_defined?(:Parser) ? URI::Parser.new : URI
         end
       end
     end

--- a/actionpack/lib/action_controller/caching/pages.rb
+++ b/actionpack/lib/action_controller/caching/pages.rb
@@ -99,7 +99,7 @@ module ActionController #:nodoc:
 
         private
           def page_cache_file(path)
-            name = (path.empty? || path == "/") ? "/index" : URI.unescape(path.chomp('/'))
+            name = (path.empty? || path == "/") ? "/index" : uri_parser.unescape(path.chomp('/'))
             name << page_cache_extension unless (name.split('/').last || name).include? '.'
             return name
           end
@@ -110,6 +110,10 @@ module ActionController #:nodoc:
 
           def instrument_page_cache(name, path)
             ActiveSupport::Notifications.instrument("#{name}.action_controller", :path => path){ yield }
+          end
+
+          def uri_parser
+            @uri_parser ||= URI.const_defined?(:Parser) ? URI::Parser.new : URI
           end
       end
 

--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -85,6 +85,8 @@ module ActionController
     def initialize(*)
       @_headers = {"Content-Type" => "text/html"}
       @_status = 200
+      @_request = nil
+      @_response = nil
       super
     end
 
@@ -99,7 +101,7 @@ module ActionController
     # Basic implementations for content_type=, location=, and headers are
     # provided to reduce the dependency on the RackDelegation module
     # in Renderer and Redirector.
-    
+
     def content_type=(type)
       headers["Content-Type"] = type.to_s
     end

--- a/actionpack/lib/action_controller/metal/helpers.rb
+++ b/actionpack/lib/action_controller/metal/helpers.rb
@@ -96,9 +96,9 @@ module ActionController
 
         def all_helpers_from_path(path)
           helpers = []
-          Array.wrap(path).each do |path|
-            extract  = /^#{Regexp.quote(path.to_s)}\/?(.*)_helper.rb$/
-            helpers += Dir["#{path}/**/*_helper.rb"].map { |file| file.sub(extract, '\1') }
+          Array.wrap(path).each do |p|
+            extract  = /^#{Regexp.quote(p.to_s)}\/?(.*)_helper.rb$/
+            helpers += Dir["#{p}/**/*_helper.rb"].map { |file| file.sub(extract, '\1') }
           end
           helpers.sort!
           helpers.uniq!

--- a/actionpack/lib/action_controller/metal/url_for.rb
+++ b/actionpack/lib/action_controller/metal/url_for.rb
@@ -6,6 +6,7 @@ module ActionController
 
     def url_options
       options = {}
+      @_routes ||= nil
       if _routes.equal?(env["action_dispatch.routes"])
         options[:script_name] = request.script_name.dup
       end

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -421,7 +421,7 @@ module ActionController
 
         @request.env.delete('PATH_INFO')
 
-        if @controller
+        if defined?(@controller) && @controller
           @controller.request = @request
           @controller.params = {}
         end

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -127,7 +127,11 @@ module ActionController
     class Result < ::Array #:nodoc:
       def to_s() join '/' end
       def self.new_escaped(strings)
-        new strings.collect {|str| URI.unescape str}
+        new strings.collect {|str| uri_parser.unescape str}
+      end
+
+      def uri_parser
+        @uri_parser ||= URI.const_defined?(:Parser) ? URI::Parser.new : URI
       end
     end
 

--- a/actionpack/lib/action_controller/vendor/html-scanner/html/node.rb
+++ b/actionpack/lib/action_controller/vendor/html-scanner/html/node.rb
@@ -18,12 +18,12 @@ module HTML #:nodoc:
             hash[k] = Conditions.new(v)
           when :children
             hash[k] = v = keys_to_symbols(v)
-            v.each do |k,v2|
-              case k
+            v.each do |key,v2|
+              case key
                 when :count, :greater_than, :less_than
                   # keys are valid, and require no further processing
                 when :only
-                  v[k] = Conditions.new(v2)
+                  v[key] = Conditions.new(v2)
                 else
                   raise "illegal key #{k.inspect} => #{v2.inspect}"
               end

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -43,6 +43,7 @@ module ActionDispatch # :nodoc:
         @writer = lambda { |x| @body << x }
         @block = nil
         @length = 0
+        @_etag = nil
 
         @status, @header = status, header
         self.body = body

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -676,6 +676,7 @@ module ActionDispatch
           DEFAULT_ACTIONS = [:show, :create, :update, :destroy, :new, :edit]
 
           def initialize(entities, options)
+            @as         = nil
             @name       = entities.to_s
             @path       = (options.delete(:path) || @name).to_s
             @controller = (options.delete(:controller) || plural).to_s

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -395,10 +395,10 @@ module ActionDispatch
       #   namespace "admin" do
       #     resources :posts, :comments
       #   end
-      # 
+      #
       # This will create a number of routes for each of the posts and comments
       # controller. For Admin::PostsController, Rails will create:
-      # 
+      #
       #   GET	    /admin/photos
       #   GET	    /admin/photos/new
       #   POST	  /admin/photos
@@ -406,33 +406,33 @@ module ActionDispatch
       #   GET	    /admin/photos/1/edit
       #   PUT	    /admin/photos/1
       #   DELETE  /admin/photos/1
-      # 
+      #
       # If you want to route /photos (without the prefix /admin) to
       # Admin::PostsController, you could use
-      # 
+      #
       #   scope :module => "admin" do
       #     resources :posts, :comments
       #   end
       #
       # or, for a single case
-      # 
+      #
       #   resources :posts, :module => "admin"
-      # 
+      #
       # If you want to route /admin/photos to PostsController
       # (without the Admin:: module prefix), you could use
-      # 
+      #
       #   scope "/admin" do
       #     resources :posts, :comments
       #   end
       #
       # or, for a single case
-      # 
+      #
       #   resources :posts, :path => "/admin"
       #
       # In each of these cases, the named routes remain the same as if you did
       # not use scope. In the last case, the following paths map to
       # PostsController:
-      # 
+      #
       #   GET	    /admin/photos
       #   GET	    /admin/photos/new
       #   POST	  /admin/photos

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -350,7 +350,7 @@ module ActionDispatch
           options = args.last.is_a?(Hash) ? args.pop : {}
 
           path      = args.shift || block
-          path_proc = path.is_a?(Proc) ? path : proc { |params| path % params }
+          path_proc = path.is_a?(Proc) ? path : proc { |params| params.empty? ? path : (path % params) }
           status    = options[:status] || 301
 
           lambda do |env|

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -161,6 +161,7 @@ module ActionDispatch
 
             # We use module_eval to avoid leaks
             @module.module_eval <<-END_EVAL, __FILE__, __LINE__ + 1
+              remove_method :#{selector} if method_defined?(:#{selector})
               def #{selector}(*args)
                 options = args.extract_options!
 
@@ -194,6 +195,7 @@ module ActionDispatch
             hash_access_method = hash_access_name(name, kind)
 
             @module.module_eval <<-END_EVAL, __FILE__, __LINE__ + 1
+              remove_method :#{selector} if method_defined?(:#{selector})
               def #{selector}(*args)
                 url_for(#{hash_access_method}(*args))
               end

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -66,7 +66,11 @@ module ActionDispatch
         end
 
         def split_glob_param!(params)
-          params[@glob_param] = params[@glob_param].split('/').map { |v| URI.unescape(v) }
+          params[@glob_param] = params[@glob_param].split('/').map { |v| uri_parser.unescape(v) }
+        end
+
+        def uri_parser
+          @uri_parser ||= URI.const_defined?(:Parser) ? URI::Parser.new : URI
         end
       end
 
@@ -543,7 +547,7 @@ module ActionDispatch
           params.each do |key, value|
             if value.is_a?(String)
               value = value.dup.force_encoding(Encoding::BINARY) if value.encoding_aware?
-              params[key] = URI.unescape(value)
+              params[key] = uri_parser.unescape(value)
             end
           end
 
@@ -560,6 +564,10 @@ module ActionDispatch
       end
 
       private
+        def uri_parser
+          @uri_parser ||= URI.const_defined?(:Parser) ? URI::Parser.new : URI
+        end
+
         def handle_positional_args(options)
           return unless args = options.delete(:_positional_args)
 

--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -128,6 +128,7 @@ module ActionDispatch
         when String
           options
         when nil, Hash
+          @_routes ||= nil
           _routes.url_for((options || {}).reverse_merge!(url_options).symbolize_keys)
         else
           polymorphic_url(options)

--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -146,25 +146,25 @@ module ActionDispatch
       #
       def with_routing
         old_routes, @routes = @routes, ActionDispatch::Routing::RouteSet.new
-        old_controller, @controller = @controller, @controller.clone if @controller
-        _routes = @routes
+        if defined?(@controller) && @controller
+          old_controller, @controller = @controller, @controller.clone
 
-        # Unfortunately, there is currently an abstraction leak between AC::Base
-        # and AV::Base which requires having the URL helpers in both AC and AV.
-        # To do this safely at runtime for tests, we need to bump up the helper serial
-        # to that the old AV subclass isn't cached.
-        #
-        # TODO: Make this unnecessary
-        if @controller
+          # Unfortunately, there is currently an abstraction leak between AC::Base
+          # and AV::Base which requires having the URL helpers in both AC and AV.
+          # To do this safely at runtime for tests, we need to bump up the helper serial
+          # to that the old AV subclass isn't cached.
+          #
+          # TODO: Make this unnecessary
           @controller.singleton_class.send(:include, _routes.url_helpers)
           @controller.view_context_class = Class.new(@controller.view_context_class) do
             include _routes.url_helpers
           end
         end
+        _routes = @routes
         yield @routes
       ensure
         @routes = old_routes
-        if @controller
+        if defined?(@controller) && @controller
           @controller = old_controller
         end
       end

--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -171,7 +171,7 @@ module ActionDispatch
 
       # ROUTES TODO: These assertions should really work in an integration context
       def method_missing(selector, *args, &block)
-        if @controller && @routes && @routes.named_routes.helpers.include?(selector)
+        if defined?(@controller) && @controller && @routes && @routes.named_routes.helpers.include?(selector)
           @controller.send(selector, *args, &block)
         else
           super

--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -148,6 +148,7 @@ module ActionDispatch
         old_routes, @routes = @routes, ActionDispatch::Routing::RouteSet.new
         if defined?(@controller) && @controller
           old_controller, @controller = @controller, @controller.clone
+          _routes = @routes
 
           # Unfortunately, there is currently an abstraction leak between AC::Base
           # and AV::Base which requires having the URL helpers in both AC and AV.
@@ -160,7 +161,6 @@ module ActionDispatch
             include _routes.url_helpers
           end
         end
-        _routes = @routes
         yield @routes
       ensure
         @routes = old_routes

--- a/actionpack/lib/action_dispatch/testing/assertions/selector.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/selector.rb
@@ -513,8 +513,8 @@ module ActionDispatch
           node.content.gsub(/<!\[CDATA\[(.*)(\]\]>)?/m) { Rack::Utils.escapeHTML($1) }
         end
 
-        selected = elements.map do |element|
-          text = element.children.select{ |c| not c.tag? }.map{ |c| fix_content[c] }.join
+        selected = elements.map do |ele|
+          text = ele.children.select{ |c| not c.tag? }.map{ |c| fix_content[c] }.join
           root = HTML::Document.new(CGI.unescapeHTML("<encoded>#{text}</encoded>")).root
           css_select(root, "encoded:root", &block)[0]
         end

--- a/actionpack/lib/action_dispatch/testing/test_request.rb
+++ b/actionpack/lib/action_dispatch/testing/test_request.rb
@@ -66,7 +66,7 @@ module ActionDispatch
 
     def accept=(mime_types)
       @env.delete('action_dispatch.request.accepts')
-      @env['HTTP_ACCEPT'] = Array(mime_types).collect { |mime_types| mime_types.to_s }.join(",")
+      @env['HTTP_ACCEPT'] = Array(mime_types).collect { |mime_type| mime_type.to_s }.join(",")
     end
 
     def cookies

--- a/actionpack/lib/action_dispatch/testing/test_request.rb
+++ b/actionpack/lib/action_dispatch/testing/test_request.rb
@@ -13,6 +13,7 @@ module ActionDispatch
       env = Rails.application.env_config.merge(env) if defined?(Rails.application)
       super(DEFAULT_ENV.merge(env))
 
+      @cookies = nil
       self.host        = 'test.host'
       self.remote_addr = '0.0.0.0'
       self.user_agent  = 'Rails Testing'

--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -923,6 +923,7 @@ module ActionView
       private
         def datetime_selector(options, html_options)
           datetime = value(object) || default_datetime(options)
+          @auto_index ||= nil
 
           options = options.dup
           options[:field_name]           = @method_name

--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -1237,7 +1237,7 @@ module ActionView
       end
 
       def emitted_hidden_id?
-        @emitted_hidden_id
+        @emitted_hidden_id ||= nil
       end
 
       private

--- a/actionpack/lib/action_view/test_case.rb
+++ b/actionpack/lib/action_view/test_case.rb
@@ -127,6 +127,7 @@ module ActionView
 
       def say_no_to_protect_against_forgery!
         _helpers.module_eval do
+          remove_method :protect_against_forgery? if method_defined?(:protect_against_forgery?)
           def protect_against_forgery?
             false
           end

--- a/actionpack/lib/action_view/testing/resolvers.rb
+++ b/actionpack/lib/action_view/testing/resolvers.rb
@@ -22,10 +22,10 @@ module ActionView #:nodoc:
       end
 
       templates = []
-      @hash.select { |k,v| k =~ /^#{query}$/ }.each do |path, source|
-        handler, format = extract_handler_and_format(path, formats)
-        templates << Template.new(source, path, handler,
-          :virtual_path => path, :format => format)
+      @hash.select { |k,v| k =~ /^#{query}$/ }.each do |_path, source|
+        handler, format = extract_handler_and_format(_path, formats)
+        templates << Template.new(source, _path, handler,
+          :virtual_path => _path, :format => format)
       end
 
       templates.sort_by {|t| -t.identifier.match(/^#{query}$/).captures.reject(&:blank?).size }

--- a/actionpack/test/activerecord/controller_runtime_test.rb
+++ b/actionpack/test/activerecord/controller_runtime_test.rb
@@ -37,6 +37,6 @@ class ControllerRuntimeLogSubscriberTest < ActionController::TestCase
     wait
 
     assert_equal 2, @logger.logged(:info).size
-    assert_match /\(Views: [\d\.]+ms | ActiveRecord: [\d\.]+ms\)/, @logger.logged(:info)[1]
+    assert_match(/\(Views: [\d\.]+ms | ActiveRecord: [\d\.]+ms\)/, @logger.logged(:info)[1])
   end
 end

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -314,7 +314,7 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
   def test_redirect_url_match
     process :redirect_external
     assert @response.redirect?
-    assert_match /rubyonrails/, @response.redirect_url
+    assert_match(/rubyonrails/, @response.redirect_url)
     assert !/perloffrails/.match(@response.redirect_url)
   end
 

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -728,7 +728,7 @@ CACHED
     get :html_fragment_cached_with_partial
     assert_response :success
     assert_match(/Old fragment caching in a partial/, @response.body)
-    assert_match "Old fragment caching in a partial", @store.read('views/test.host/functional_caching/html_fragment_cached_with_partial')
+    assert_match("Old fragment caching in a partial", @store.read('views/test.host/functional_caching/html_fragment_cached_with_partial'))
   end
 
   def test_render_inline_before_fragment_caching
@@ -736,14 +736,14 @@ CACHED
     assert_response :success
     assert_match(/Some inline content/, @response.body)
     assert_match(/Some cached content/, @response.body)
-    assert_match "Some cached content", @store.read('views/test.host/functional_caching/inline_fragment_cached')
+    assert_match("Some cached content", @store.read('views/test.host/functional_caching/inline_fragment_cached'))
   end
 
   def test_fragment_caching_in_rjs_partials
     xhr :get, :js_fragment_cached_with_partial
     assert_response :success
     assert_match(/Old fragment caching in a partial/, @response.body)
-    assert_match "Old fragment caching in a partial", @store.read('views/test.host/functional_caching/js_fragment_cached_with_partial')
+    assert_match("Old fragment caching in a partial", @store.read('views/test.host/functional_caching/js_fragment_cached_with_partial'))
   end
 
   def test_html_formatted_fragment_caching

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -72,8 +72,8 @@ class ACLogSubscriberTest < ActionController::TestCase
     get :show
     wait
     assert_equal 2, logs.size
-    assert_match /Completed/, logs.last
-    assert_match /200 OK/, logs.last
+    assert_match(/Completed/, logs.last)
+    assert_match(/200 OK/, logs.last)
   end
 
   def test_process_action_without_parameters
@@ -93,7 +93,7 @@ class ACLogSubscriberTest < ActionController::TestCase
   def test_process_action_with_view_runtime
     get :show
     wait
-    assert_match /\(Views: [\d\.]+ms\)/, logs[1]
+    assert_match(/\(Views: [\d\.]+ms\)/, logs[1])
   end
 
   def test_process_action_with_filter_parameters
@@ -103,9 +103,9 @@ class ACLogSubscriberTest < ActionController::TestCase
     wait
 
     params = logs[1]
-    assert_match /"amount"=>"\[FILTERED\]"/, params
-    assert_match /"lifo"=>"\[FILTERED\]"/, params
-    assert_match /"step"=>"1"/, params
+    assert_match(/"amount"=>"\[FILTERED\]"/, params)
+    assert_match(/"lifo"=>"\[FILTERED\]"/, params)
+    assert_match(/"step"=>"1"/, params)
   end
 
   def test_redirect_to
@@ -121,7 +121,7 @@ class ACLogSubscriberTest < ActionController::TestCase
     wait
 
     assert_equal 3, logs.size
-    assert_match /Sent data file\.txt/, logs[1]
+    assert_match(/Sent data file\.txt/, logs[1])
   end
 
   def test_send_file
@@ -129,8 +129,8 @@ class ACLogSubscriberTest < ActionController::TestCase
     wait
 
     assert_equal 3, logs.size
-    assert_match /Sent file/, logs[1]
-    assert_match /test\/fixtures\/company\.rb/, logs[1]
+    assert_match(/Sent file/, logs[1])
+    assert_match(/test\/fixtures\/company\.rb/, logs[1])
   end
 
   def test_with_fragment_cache
@@ -139,8 +139,8 @@ class ACLogSubscriberTest < ActionController::TestCase
     wait
 
     assert_equal 4, logs.size
-    assert_match /Exist fragment\? views\/foo/, logs[1]
-    assert_match /Write fragment views\/foo/, logs[2]
+    assert_match(/Exist fragment\? views\/foo/, logs[1])
+    assert_match(/Write fragment views\/foo/, logs[2])
   ensure
     @controller.config.perform_caching = true
   end
@@ -163,8 +163,8 @@ class ACLogSubscriberTest < ActionController::TestCase
     wait
 
     assert_equal 3, logs.size
-    assert_match /Write page/, logs[1]
-    assert_match /\/index\.html/, logs[1]
+    assert_match(/Write page/, logs[1])
+    assert_match(/\/index\.html/, logs[1])
   ensure
     @controller.config.perform_caching = true
   end

--- a/actionpack/test/controller/mime_responds_test.rb
+++ b/actionpack/test/controller/mime_responds_test.rb
@@ -784,8 +784,8 @@ class RespondWithControllerTest < ActionController::TestCase
     get :using_resource_with_collection
     assert_equal "application/xml", @response.content_type
     assert_equal 200, @response.status
-    assert_match /<name>david<\/name>/, @response.body
-    assert_match /<name>jamis<\/name>/, @response.body
+    assert_match(/<name>david<\/name>/, @response.body)
+    assert_match(/<name>jamis<\/name>/, @response.body)
   end
 
   def test_using_resource_with_action

--- a/actionpack/test/controller/render_other_test.rb
+++ b/actionpack/test/controller/render_other_test.rb
@@ -224,15 +224,15 @@ class RenderOtherTest < ActionController::TestCase
     get :update_page_with_instance_variables
     assert_template nil
     assert_equal 'text/javascript; charset=utf-8', @response.headers["Content-Type"]
-    assert_match /balance/, @response.body
-    assert_match /\$37/, @response.body
+    assert_match(/balance/, @response.body)
+    assert_match(/\$37/, @response.body)
   end
 
   def test_update_page_with_view_method
     get :update_page_with_view_method
     assert_template nil
     assert_equal 'text/javascript; charset=utf-8', @response.headers["Content-Type"]
-    assert_match /2 people/, @response.body
+    assert_match(/2 people/, @response.body)
   end
 
   def test_should_render_html_formatted_partial_with_rjs

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -55,26 +55,25 @@ module RequestForgeryProtectionTests
     ActionController::Base.request_forgery_protection_token = nil
   end
 
-
   def test_should_render_form_with_token_tag
-     get :index
-     assert_select 'form>div>input[name=?][value=?]', 'authenticity_token', @token
-   end
+    get :index
+    assert_select 'form>div>input[name=?][value=?]', 'authenticity_token', @token
+  end
 
-   def test_should_render_button_to_with_token_tag
-     get :show_button
-     assert_select 'form>div>input[name=?][value=?]', 'authenticity_token', @token
-   end
+  def test_should_render_button_to_with_token_tag
+    get :show_button
+    assert_select 'form>div>input[name=?][value=?]', 'authenticity_token', @token
+  end
 
-   def test_should_allow_get
-     get :index
-     assert_response :success
-   end
+  def test_should_allow_get
+    get :index
+    assert_response :success
+  end
 
-   def test_should_allow_post_without_token_on_unsafe_action
-     post :unsafe
-     assert_response :success
-   end
+  def test_should_allow_post_without_token_on_unsafe_action
+    post :unsafe
+    assert_response :success
+  end
 
   def test_should_not_allow_html_post_without_token
     @request.env['CONTENT_TYPE'] = Mime::URL_ENCODED_FORM.to_s

--- a/actionpack/test/controller/selector_test.rb
+++ b/actionpack/test/controller/selector_test.rb
@@ -471,7 +471,7 @@ class SelectorTest < Test::Unit::TestCase
   end
 
 
-  def test_first_and_last
+  def test_only_child_and_only_type_first_and_last
     # Only child.
     parse(%Q{<table><tr></tr></table>})
     select("table:only-child")

--- a/actionpack/test/controller/test_test.rb
+++ b/actionpack/test/controller/test_test.rb
@@ -591,7 +591,7 @@ XML
           assert false, "expected RuntimeError, got nothing"
         rescue RuntimeError => error
           assert true
-          assert_match %r{@#{variable} is nil}, error.message
+          assert_match(%r{@#{variable} is nil}, error.message)
         rescue => error
           assert false, "expected RuntimeError, got #{error.class}"
         end

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -219,7 +219,7 @@ module AbstractController
 
       def test_hash_recursive_and_array_parameters
         url = W.new.url_for(:only_path => true, :controller => 'c', :action => 'a', :id => 101, :query => {:person => {:name => 'Bob', :position => ['prof', 'art director']}, :hobby => 'piercing'})
-        assert_match %r(^/c/a/101), url
+        assert_match(%r(^/c/a/101), url)
         params = extract_params(url)
         assert_equal params[0], { 'query[hobby]'              => 'piercing'     }.to_query
         assert_equal params[1], { 'query[person][name]'       => 'Bob'          }.to_query

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -47,7 +47,7 @@ class CookiesTest < ActionController::TestCase
       cookies["user_name"] = { :value => "david", :httponly => true }
       head :ok
     end
-    
+
     def authenticate_with_secure
       cookies["user_name"] = { :value => "david", :secure => true }
       head :ok
@@ -133,7 +133,7 @@ class CookiesTest < ActionController::TestCase
     assert_cookie_header "user_name=david; path=/; HttpOnly"
     assert_equal({"user_name" => "david"}, @response.cookies)
   end
-  
+
   def test_setting_cookie_with_secure
     get :authenticate_with_secure
     assert_cookie_header "user_name=david; path=/; secure"
@@ -169,8 +169,8 @@ class CookiesTest < ActionController::TestCase
 
   def test_permanent_cookie
     get :set_permanent_cookie
-    assert_match /Jamie/, @response.headers["Set-Cookie"]
-    assert_match %r(#{20.years.from_now.utc.year}), @response.headers["Set-Cookie"]
+    assert_match(/Jamie/, @response.headers["Set-Cookie"])
+    assert_match(%r(#{20.years.from_now.utc.year}), @response.headers["Set-Cookie"])
   end
 
   def test_signed_cookie
@@ -185,7 +185,7 @@ class CookiesTest < ActionController::TestCase
 
   def test_permanent_signed_cookie
     get :set_permanent_signed_cookie
-    assert_match %r(#{20.years.from_now.utc.year}), @response.headers["Set-Cookie"]
+    assert_match(%r(#{20.years.from_now.utc.year}), @response.headers["Set-Cookie"])
     assert_equal 100, @controller.send(:cookies).signed[:remember_me]
   end
 

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -45,9 +45,9 @@ class RequestTest < ActiveSupport::TestCase
     e = assert_raise(ActionDispatch::RemoteIp::IpSpoofAttackError) {
       request.remote_ip
     }
-    assert_match /IP spoofing attack/, e.message
-    assert_match /HTTP_X_FORWARDED_FOR="1.1.1.1"/, e.message
-    assert_match /HTTP_CLIENT_IP="2.2.2.2"/, e.message
+    assert_match(/IP spoofing attack/, e.message)
+    assert_match(/HTTP_X_FORWARDED_FOR="1.1.1.1"/, e.message)
+    assert_match(/HTTP_CLIENT_IP="2.2.2.2"/, e.message)
 
     # turn IP Spoofing detection off.
     # This is useful for sites that are aimed at non-IP clients.  The typical

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -120,10 +120,10 @@ class ResponseTest < ActiveSupport::TestCase
   end
 
   test "read cache control" do
-    resp = ActionDispatch::Response.new.tap { |resp|
-      resp.cache_control[:public] = true
-      resp.etag = '123'
-      resp.body = 'Hello'
+    resp = ActionDispatch::Response.new.tap { |_resp|
+      _resp.cache_control[:public] = true
+      _resp.etag = '123'
+      _resp.body = 'Hello'
     }
     resp.to_a
 
@@ -135,10 +135,10 @@ class ResponseTest < ActiveSupport::TestCase
   end
 
   test "read charset and content type" do
-    resp = ActionDispatch::Response.new.tap { |resp|
-      resp.charset = 'utf-16'
-      resp.content_type = Mime::XML
-      resp.body = 'Hello'
+    resp = ActionDispatch::Response.new.tap { |_resp|
+      _resp.charset = 'utf-16'
+      _resp.content_type = Mime::XML
+      _resp.body = 'Hello'
     }
     resp.to_a
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1216,14 +1216,6 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     end
   end
 
-  def test_index
-    with_test_routes do
-      assert_equal '/info', info_path
-      get '/info'
-      assert_equal 'projects#info', @response.body
-    end
-  end
-
   def test_match_shorthand_with_no_scope
     with_test_routes do
       assert_equal '/account/overview', account_overview_path

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -279,7 +279,7 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
   def test_session_store_with_explicit_domain
     with_test_route_set(:domain => "example.es") do
       get '/set_session_value'
-      assert_match /domain=example\.es/, headers['Set-Cookie']
+      assert_match(/domain=example\.es/, headers['Set-Cookie'])
       headers['Set-Cookie']
     end
   end

--- a/actionpack/test/dispatch/show_exceptions_test.rb
+++ b/actionpack/test/dispatch/show_exceptions_test.rb
@@ -58,15 +58,15 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
 
       get "/", {}, {'action_dispatch.show_exceptions' => true}
       assert_response 500
-      assert_match /puke/, body
+      assert_match(/puke/, body)
 
       get "/not_found", {}, {'action_dispatch.show_exceptions' => true}
       assert_response 404
-      assert_match /#{ActionController::UnknownAction.name}/, body
+      assert_match(/#{ActionController::UnknownAction.name}/, body)
 
       get "/method_not_allowed", {}, {'action_dispatch.show_exceptions' => true}
       assert_response 405
-      assert_match /ActionController::MethodNotAllowed/, body
+      assert_match(/ActionController::MethodNotAllowed/, body)
     end
   end
 
@@ -96,15 +96,15 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
 
     get "/", {}, {'action_dispatch.show_exceptions' => true}
     assert_response 500
-    assert_match /puke/, body
+    assert_match(/puke/, body)
 
     get "/not_found", {}, {'action_dispatch.show_exceptions' => true}
     assert_response 404
-    assert_match /#{ActionController::UnknownAction.name}/, body
+    assert_match(/#{ActionController::UnknownAction.name}/, body)
 
     get "/method_not_allowed", {}, {'action_dispatch.show_exceptions' => true}
     assert_response 405
-    assert_match /ActionController::MethodNotAllowed/, body
+    assert_match(/ActionController::MethodNotAllowed/, body)
   end
 
   test "does not show filtered parameters" do
@@ -113,6 +113,6 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
     get "/", {"foo"=>"bar"}, {'action_dispatch.show_exceptions' => true,
       'action_dispatch.parameter_filter' => [:foo]}
     assert_response 500
-    assert_match "&quot;foo&quot;=&gt;&quot;[FILTERED]&quot;", body
+    assert_match("&quot;foo&quot;=&gt;&quot;[FILTERED]&quot;", body)
   end
 end

--- a/actionpack/test/template/asset_tag_helper_test.rb
+++ b/actionpack/test/template/asset_tag_helper_test.rb
@@ -975,7 +975,7 @@ class AssetTagHelperNonVhostTest < ActionView::TestCase
 
   def test_should_wildcard_asset_host_between_zero_and_four
     @controller.config.asset_host = 'http://a%d.example.com'
-    assert_match %r(http://a[0123].example.com/collaboration/hieraki/images/xml.png), image_path('xml.png')
+    assert_match(%r(http://a[0123].example.com/collaboration/hieraki/images/xml.png), image_path('xml.png'))
   end
 
   def test_asset_host_without_protocol_should_use_request_protocol

--- a/actionpack/test/template/atom_feed_helper_test.rb
+++ b/actionpack/test/template/atom_feed_helper_test.rb
@@ -203,7 +203,7 @@ class AtomFeedTest < ActionController::TestCase
   def test_feed_should_use_default_language_if_none_is_given
     with_restful_routing(:scrolls) do
       get :index, :id => "defaults"
-      assert_match %r{xml:lang="en-US"}, @response.body
+      assert_match(%r{xml:lang="en-US"}, @response.body)
     end
   end
 

--- a/actionpack/test/template/log_subscriber_test.rb
+++ b/actionpack/test/template/log_subscriber_test.rb
@@ -29,7 +29,7 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
     wait
 
     assert_equal 1, @logger.logged(:info).size
-    assert_match /Rendered test\/hello_world\.erb/, @logger.logged(:info).last
+    assert_match(/Rendered test\/hello_world\.erb/, @logger.logged(:info).last)
   end
 
   def test_render_text_template
@@ -37,7 +37,7 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
     wait
 
     assert_equal 1, @logger.logged(:info).size
-    assert_match /Rendered text template/, @logger.logged(:info).last
+    assert_match(/Rendered text template/, @logger.logged(:info).last)
   end
 
   def test_render_inline_template
@@ -45,7 +45,7 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
     wait
 
     assert_equal 1, @logger.logged(:info).size
-    assert_match /Rendered inline template/, @logger.logged(:info).last
+    assert_match(/Rendered inline template/, @logger.logged(:info).last)
   end
 
   def test_render_partial_template
@@ -53,7 +53,7 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
     wait
 
     assert_equal 1, @logger.logged(:info).size
-    assert_match /Rendered test\/_customer.erb/, @logger.logged(:info).last
+    assert_match(/Rendered test\/_customer.erb/, @logger.logged(:info).last)
   end
 
   def test_render_partial_with_implicit_path
@@ -62,7 +62,7 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
     wait
 
     assert_equal 1, @logger.logged(:info).size
-    assert_match /Rendered customers\/_customer\.html\.erb/, @logger.logged(:info).last
+    assert_match(/Rendered customers\/_customer\.html\.erb/, @logger.logged(:info).last)
   end
 
   def test_render_collection_template
@@ -70,7 +70,7 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
     wait
 
     assert_equal 1, @logger.logged(:info).size
-    assert_match /Rendered test\/_customer.erb/, @logger.logged(:info).last
+    assert_match(/Rendered test\/_customer.erb/, @logger.logged(:info).last)
   end
 
   def test_render_collection_with_implicit_path
@@ -79,7 +79,7 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
     wait
 
     assert_equal 1, @logger.logged(:info).size
-    assert_match /Rendered customers\/_customer\.html\.erb/, @logger.logged(:info).last
+    assert_match(/Rendered customers\/_customer\.html\.erb/, @logger.logged(:info).last)
   end
 
   def test_render_collection_template_without_path
@@ -88,6 +88,6 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
     wait
 
     assert_equal 1, @logger.logged(:info).size
-    assert_match /Rendered collection/, @logger.logged(:info).last
+    assert_match(/Rendered collection/, @logger.logged(:info).last)
   end
 end

--- a/actionpack/test/template/tag_helper_test.rb
+++ b/actionpack/test/template/tag_helper_test.rb
@@ -11,8 +11,8 @@ class TagHelperTest < ActionView::TestCase
 
   def test_tag_options
     str = tag("p", "class" => "show", :class => "elsewhere")
-    assert_match /class="show"/, str
-    assert_match /class="elsewhere"/, str
+    assert_match(/class="show"/, str)
+    assert_match(/class="elsewhere"/, str)
   end
 
   def test_tag_options_rejects_nil_option

--- a/actionpack/test/template/test_case_test.rb
+++ b/actionpack/test/template/test_case_test.rb
@@ -112,7 +112,7 @@ module ActionView
       @controller.controller_path = 'test'
 
       @customers = [stub(:name => 'Eloy'), stub(:name => 'Manfred')]
-      assert_match /Hello: EloyHello: Manfred/, render(:partial => 'test/from_helper')
+      assert_match(/Hello: EloyHello: Manfred/, render(:partial => 'test/from_helper'))
     end
   end
 
@@ -201,7 +201,7 @@ module ActionView
       @controller.controller_path = "test"
 
       @customers = [stub(:name => 'Eloy'), stub(:name => 'Manfred')]
-      assert_match /Hello: EloyHello: Manfred/, render(:file => 'test/list')
+      assert_match(/Hello: EloyHello: Manfred/, render(:file => 'test/list'))
     end
 
     test "is able to render partials from templates and also use instance variables after view has been referenced" do
@@ -210,7 +210,7 @@ module ActionView
       view
 
       @customers = [stub(:name => 'Eloy'), stub(:name => 'Manfred')]
-      assert_match /Hello: EloyHello: Manfred/, render(:file => 'test/list')
+      assert_match(/Hello: EloyHello: Manfred/, render(:file => 'test/list'))
     end
 
   end

--- a/actionpack/test/template/text_helper_test.rb
+++ b/actionpack/test/template/text_helper_test.rb
@@ -491,7 +491,7 @@ class TextHelperTest < ActionView::TestCase
     url = "http://api.rubyonrails.com/Foo.html"
     email = "fantabulous@shiznadel.ic"
 
-    assert_equal %(<p><a href="#{url}">#{url[0...7]}...</a><br /><a href="mailto:#{email}">#{email[0...7]}...</a><br /></p>), auto_link("<p>#{url}<br />#{email}<br /></p>") { |url| truncate(url, :length => 10) }
+    assert_equal %(<p><a href="#{url}">#{url[0...7]}...</a><br /><a href="mailto:#{email}">#{email[0...7]}...</a><br /></p>), auto_link("<p>#{url}<br />#{email}<br /></p>") { |u| truncate(u, :length => 10) }
   end
 
   def test_auto_link_with_block_with_html

--- a/activemodel/lib/active_model/validations/confirmation.rb
+++ b/activemodel/lib/active_model/validations/confirmation.rb
@@ -10,7 +10,9 @@ module ActiveModel
       end
 
       def setup(klass)
-        klass.send(:attr_accessor, *attributes.map { |attribute| :"#{attribute}_confirmation" })
+        klass.send(:attr_accessor, *attributes.map do |attribute|
+          :"#{attribute}_confirmation" unless klass.method_defined?(:"#{attribute}_confirmation")
+        end.compact)
       end
     end
 

--- a/activerecord/lib/active_record/association_preload.rb
+++ b/activerecord/lib/active_record/association_preload.rb
@@ -321,14 +321,14 @@ module ActiveRecord
           klasses_and_ids[reflection.klass.name] = id_map unless id_map.empty?
         end
 
-        klasses_and_ids.each do |klass_name, id_map|
+        klasses_and_ids.each do |klass_name, _id_map|
           klass = klass_name.constantize
 
           table_name = klass.quoted_table_name
           primary_key = reflection.options[:primary_key] || klass.primary_key
           column_type = klass.columns.detect{|c| c.name == primary_key}.type
 
-          ids = id_map.keys.map do |id|
+          ids = _id_map.keys.map do |id|
             if column_type == :integer
               id.to_i
             elsif column_type == :float
@@ -343,7 +343,7 @@ module ActiveRecord
 
           associated_records = klass.unscoped.where([conditions, ids]).apply_finder_options(options.slice(:include, :select, :joins, :order)).to_a
 
-          set_association_single_records(id_map, reflection.name, associated_records, primary_key)
+          set_association_single_records(_id_map, reflection.name, associated_records, primary_key)
         end
       end
 

--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -75,6 +75,7 @@ class Class
           val
         end
 
+        remove_method :#{name} if method_defined?(:#{name})
         def #{name}
           defined?(@#{name}) ? @#{name} : singleton_class.#{name}
         end


### PR DESCRIPTION
I've been working on removing 1.9.2 warnings. There are a lot more on actionpack but i will continue working on this, is the only module that has disabled warnings in its Rakefile and i suppose it's because there are so many of them.
