### PR TITLE
Move uri_parser to AS

### DIFF
--- a/actionpack/lib/action_controller.rb
+++ b/actionpack/lib/action_controller.rb
@@ -8,7 +8,6 @@ module ActionController
   autoload :Caching
   autoload :Metal
   autoload :Middleware
-  autoload :UriParser
 
   autoload_under "metal" do
     autoload :Compatibility
@@ -73,4 +72,5 @@ require 'active_support/core_ext/load_error'
 require 'active_support/core_ext/module/attr_internal'
 require 'active_support/core_ext/module/delegation'
 require 'active_support/core_ext/name_error'
+require 'active_support/core_ext/uri'
 require 'active_support/inflector'

--- a/actionpack/lib/action_controller/caching/actions.rb
+++ b/actionpack/lib/action_controller/caching/actions.rb
@@ -141,8 +141,6 @@ module ActionController #:nodoc:
       end
 
       class ActionCachePath
-        include UriParser
-
         attr_reader :path, :extension
 
         # If +infer_extension+ is true, the cache path extension is looked up from the request's
@@ -163,7 +161,7 @@ module ActionController #:nodoc:
         def normalize!(path)
           path << 'index' if path[-1] == ?/
           path << ".#{extension}" if extension and !path.ends_with?(extension)
-          uri_parser.unescape(path)
+          URI.parser.unescape(path)
         end
       end
     end

--- a/actionpack/lib/action_controller/caching/pages.rb
+++ b/actionpack/lib/action_controller/caching/pages.rb
@@ -57,8 +57,6 @@ module ActionController #:nodoc:
       end
 
       module ClassMethods
-        include UriParser
-
         # Expires the page that was cached with the +path+ as a key. Example:
         #   expire_page "/lists/show"
         def expire_page(path)
@@ -100,7 +98,7 @@ module ActionController #:nodoc:
 
         private
           def page_cache_file(path)
-            name = (path.empty? || path == "/") ? "/index" : uri_parser.unescape(path.chomp('/'))
+            name = (path.empty? || path == "/") ? "/index" : URI.parser.unescape(path.chomp('/'))
             name << page_cache_extension unless (name.split('/').last || name).include? '.'
             return name
           end
@@ -111,10 +109,6 @@ module ActionController #:nodoc:
 
           def instrument_page_cache(name, path)
             ActiveSupport::Notifications.instrument("#{name}.action_controller", :path => path){ yield }
-          end
-
-          def uri_parser
-            @uri_parser ||= URI.const_defined?(:Parser) ? URI::Parser.new : URI
           end
       end
 

--- a/actionpack/lib/action_controller/uri_parser.rb
+++ b/actionpack/lib/action_controller/uri_parser.rb
@@ -1,9 +1,0 @@
-require 'uri'
-
-module ActionController #:nodoc:
-  module UriParser
-    def uri_parser
-      @uri_parser ||= URI.const_defined?(:Parser) ? URI::Parser.new : URI
-    end
-  end
-end

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -5,8 +5,6 @@ require 'active_support/core_ext/object/to_query'
 module ActionDispatch
   module Routing
     class RouteSet #:nodoc:
-      include ActionController::UriParser
-
       PARAMETERS_KEY = 'action_dispatch.request.path_parameters'
 
       class Dispatcher #:nodoc:
@@ -68,7 +66,7 @@ module ActionDispatch
         end
 
         def split_glob_param!(params)
-          params[@glob_param] = params[@glob_param].split('/').map { |v| uri_parser.unescape(v) }
+          params[@glob_param] = params[@glob_param].split('/').map { |v| URI.parser.unescape(v) }
         end
       end
 
@@ -546,7 +544,7 @@ module ActionDispatch
           params.each do |key, value|
             if value.is_a?(String)
               value = value.dup.force_encoding(Encoding::BINARY) if value.encoding_aware?
-              params[key] = uri_parser.unescape(value)
+              params[key] = URI.parser.unescape(value)
             end
           end
 
@@ -563,10 +561,6 @@ module ActionDispatch
       end
 
       private
-        def uri_parser
-          @uri_parser ||= URI.const_defined?(:Parser) ? URI::Parser.new : URI
-        end
-
         def handle_positional_args(options)
           return unless args = options.delete(:_positional_args)
 

--- a/activeresource/lib/active_resource/base.rb
+++ b/activeresource/lib/active_resource/base.rb
@@ -12,6 +12,7 @@ require 'active_support/core_ext/object/duplicable'
 require 'set'
 require 'uri'
 
+require 'active_support/core_ext/uri'
 require 'active_resource/exceptions'
 require 'active_resource/connection'
 require 'active_resource/formats'
@@ -414,8 +415,8 @@ module ActiveResource
           @site = nil
         else
           @site = create_site_uri_from(site)
-          @user = uri_parser.unescape(@site.user) if @site.user
-          @password = uri_parser.unescape(@site.password) if @site.password
+          @user = URI.parser.unescape(@site.user) if @site.user
+          @password = URI.parser.unescape(@site.password) if @site.password
         end
       end
 
@@ -588,7 +589,7 @@ module ActiveResource
       # Default value is <tt>site.path</tt>.
       def prefix=(value = '/')
         # Replace :placeholders with '#{embedded options[:lookups]}'
-        prefix_call = value.gsub(/:\w+/) { |key| "\#{URI.escape options[#{key}].to_s}" }
+        prefix_call = value.gsub(/:\w+/) { |key| "\#{URI.parser.escape options[#{key}].to_s}" }
 
         # Clear prefix parameters in case they have been cached
         @prefix_parameters = nil
@@ -635,7 +636,7 @@ module ActiveResource
         check_prefix_options(prefix_options)
 
         prefix_options, query_options = split_options(prefix_options) if query_options.nil?
-        "#{prefix(prefix_options)}#{collection_name}/#{URI.escape id.to_s}.#{format.extension}#{query_string(query_options)}"
+        "#{prefix(prefix_options)}#{collection_name}/#{URI.parser.escape id.to_s}.#{format.extension}#{query_string(query_options)}"
       end
 
       # Gets the new element path for REST resources.
@@ -916,12 +917,12 @@ module ActiveResource
 
         # Accepts a URI and creates the site URI from that.
         def create_site_uri_from(site)
-          site.is_a?(URI) ? site.dup : uri_parser.parse(site)
+          site.is_a?(URI) ? site.dup : URI.parser.parse(site)
         end
 
         # Accepts a URI and creates the proxy URI from that.
         def create_proxy_uri_from(proxy)
-          proxy.is_a?(URI) ? proxy.dup : uri_parser.parse(proxy)
+          proxy.is_a?(URI) ? proxy.dup : URI.parser.parse(proxy)
         end
 
         # contains a set of the current prefix parameters.
@@ -945,10 +946,6 @@ module ActiveResource
           end
 
           [ prefix_options, query_options ]
-        end
-
-        def uri_parser
-          @uri_parser ||= URI.const_defined?(:Parser) ? URI::Parser.new : URI
         end
     end
 

--- a/activeresource/lib/active_resource/connection.rb
+++ b/activeresource/lib/active_resource/connection.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/benchmark'
+require 'active_support/core_ext/uri'
 require 'net/https'
 require 'date'
 require 'time'
@@ -31,21 +32,20 @@ module ActiveResource
     def initialize(site, format = ActiveResource::Formats::XmlFormat)
       raise ArgumentError, 'Missing site URI' unless site
       @user = @password = nil
-      @uri_parser = URI.const_defined?(:Parser) ? URI::Parser.new : URI
       self.site = site
       self.format = format
     end
 
     # Set URI for remote service.
     def site=(site)
-      @site = site.is_a?(URI) ? site : @uri_parser.parse(site)
-      @user = @uri_parser.unescape(@site.user) if @site.user
-      @password = @uri_parser.unescape(@site.password) if @site.password
+      @site = site.is_a?(URI) ? site : URI.parser.parse(site)
+      @user = URI.parser.unescape(@site.user) if @site.user
+      @password = URI.parser.unescape(@site.password) if @site.password
     end
 
     # Set the proxy for remote service.
     def proxy=(proxy)
-      @proxy = proxy.is_a?(URI) ? proxy : @uri_parser.parse(proxy)
+      @proxy = proxy.is_a?(URI) ? proxy : URI.parser.parse(proxy)
     end
 
     # Sets the user for remote service.

--- a/activesupport/lib/active_support/core_ext/uri.rb
+++ b/activesupport/lib/active_support/core_ext/uri.rb
@@ -20,3 +20,11 @@ if RUBY_VERSION >= '1.9'
     end
   end
 end
+
+module URI
+  class << self
+    def parser
+      @parser ||= URI.const_defined?(:Parser) ? URI::Parser.new : URI
+    end
+  end
+end


### PR DESCRIPTION
As suggested on:

http://github.com/rails/rails/commit/2f326b7f27349b933fe617d83b3f80c6573ce5d8#commitcomment-156519

I moved uri parser to AS, and reused it in ARes/AP.
