### PR TITLE
Fix profile script

### DIFF
--- a/activerecord/examples/performance.rb
+++ b/activerecord/examples/performance.rb
@@ -88,7 +88,7 @@ else
     )
   end
 
-  mysqldump_bin = %w[mysqldump mysqldump5].select { |bin| `which #{bin}`.length > 0 }
+  mysqldump_bin = %w[mysqldump mysqldump5].detect { |bin| `which #{bin}`.length > 0 }
   `#{mysqldump_bin} -u #{conn[:username]} #{"-p#{conn[:password]}" unless conn[:password].blank?} #{conn[:database]} exhibits users > #{sqlfile}`
 end
 


### PR DESCRIPTION
Use detect instead find to prevent this error:

Generating data...
Inserting 10,000 users and exhibits...
sh: [mysqldump]: command not found
