### PR TITLE
to_xml doesn't work in such case: Event.select('title as t').to_xml [#4840 state:resolved] 

### DIFF
--- a/activerecord/lib/active_record/serializers/xml_serializer.rb
+++ b/activerecord/lib/active_record/serializers/xml_serializer.rb
@@ -227,7 +227,7 @@ module ActiveRecord #:nodoc:
     class Attribute < ActiveModel::Serializers::Xml::Serializer::Attribute #:nodoc:
       def compute_type
         type = @serializable.class.serialized_attributes.has_key?(name) ?
-          super : @serializable.class.columns_hash[name].type
+          super : @serializable.class.columns_hash[name].class
 
         case type
         when :text


### PR DESCRIPTION
NilClass.type is no longer defined in Ruby 1.9 and causes ActiveRecord::Base.to_xml to fail with message: undefined method `type' for nil:NilClass
