### PR TITLE
model_name at the instance level

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -305,7 +305,7 @@ module ActionView
           object      = nil
         else
           object      = record.is_a?(Array) ? record.last : record
-          object_name = options[:as] || ActiveModel::Naming.param_key(object)
+          object_name = options[:as] || ActiveModel::Naming.param_key(convert_to_model(object))
           apply_form_for_options!(record, options)
         end
 

--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -305,7 +305,7 @@ module ActionView
           object      = nil
         else
           object      = record.is_a?(Array) ? record.last : record
-          object_name = options[:as] || ActiveModel::Naming.param_key(convert_to_model(object))
+          object_name = options[:as] || ActiveModel::Naming.param_key(object)
           apply_form_for_options!(record, options)
         end
 

--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -1123,6 +1123,10 @@ module ActionView
         parent_builder.multipart = multipart if parent_builder
       end
 
+      def model_name
+        self.class.model_name
+      end
+
       def self.model_name
         @model_name ||= Struct.new(:partial_path).new(name.demodulize.underscore.sub!(/_builder$/, ''))
       end
@@ -1256,8 +1260,8 @@ module ActionView
           object = convert_to_model(@object)
           key    = object ? (object.persisted? ? :update : :create) : :submit
 
-          model = if object.class.respond_to?(:model_name)
-            object.class.model_name.human
+          model = if object.respond_to?(:model_name)
+            object.model_name.human
           else
             @object_name.to_s.humanize
           end

--- a/actionpack/lib/action_view/render/partials.rb
+++ b/actionpack/lib/action_view/render/partials.rb
@@ -44,9 +44,9 @@ module ActionView
   #
   # The <tt>:object</tt> option can be used to directly specify which object is rendered into the partial;
   # useful when the template's object is elsewhere, in a different ivar or in a local variable for instance.
-  # 
+  #
   # Revisiting a previous example we could have written this code:
-  # 
+  #
   #   <%= render :partial => "account", :object => @buyer %>
   #
   #   <% for ad in @advertisements %>
@@ -69,7 +69,7 @@ module ActionView
   # +partial_name_counter+. In the case of the example above, the template would be fed +ad_counter+.
   #
   # The <tt>:as</tt> option may be used when rendering partials.
-  # 
+  #
   # You can specify a partial to be rendered between elements via the <tt>:spacer_template</tt> option.
   # The following example will render <tt>advertiser/_ad_divider.html.erb</tt> between each ad partial:
   #
@@ -352,7 +352,7 @@ module ActionView
         @partial_names[object.class.name] ||= begin
           object = object.to_model if object.respond_to?(:to_model)
 
-          object.class.model_name.partial_path.dup.tap do |partial|
+          object.model_name.partial_path.dup.tap do |partial|
             path = @view.controller_path
             partial.insert(0, "#{File.dirname(path)}/") if partial.include?(?/) && path.include?(?/)
           end

--- a/activemodel/lib/active_model/lint.rb
+++ b/activemodel/lib/active_model/lint.rb
@@ -69,9 +69,21 @@ module ActiveModel
       # Model.model_name must return a string with some convenience methods as
       # :human and :partial_path. Check ActiveModel::Naming for more information.
       #
+      # An instance method, Model#model_name must also exist. It's perfectly acceptable
+      # for this method to call self.class.model_name, but it may be that certain
+      # instances would like to override values of the class-level model_name, such as
+      # with a search model that wraps another model, for instance.
       def test_model_naming
-        assert model.class.respond_to?(:model_name), "The model should respond to model_name"
+        assert model.class.respond_to?(:model_name), "The model class should respond to model_name"
         model_name = model.class.model_name
+        assert_kind_of String, model_name
+        assert_kind_of String, model_name.human
+        assert_kind_of String, model_name.partial_path
+        assert_kind_of String, model_name.singular
+        assert_kind_of String, model_name.plural
+
+        assert model.respond_to?(:model_name), "The model instance should respond to model_name"
+        model_name = model.model_name
         assert_kind_of String, model_name
         assert_kind_of String, model_name.human
         assert_kind_of String, model_name.partial_path

--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -92,7 +92,7 @@ module ActiveModel
     #   ActiveModel::Naming.plural(post)             # => "posts"
     #   ActiveModel::Naming.plural(Highrise::Person) # => "highrise_people"
     def self.plural(record_or_class)
-      record_or_class.model_name.plural
+      model_name_from_record_or_class(record_or_class).plural
     end
 
     # Returns the singular class name of a record or class. Examples:
@@ -100,7 +100,7 @@ module ActiveModel
     #   ActiveModel::Naming.singular(post)             # => "post"
     #   ActiveModel::Naming.singular(Highrise::Person) # => "highrise_person"
     def self.singular(record_or_class)
-      record_or_class.model_name.singular
+      model_name_from_record_or_class(record_or_class).singular
     end
 
     # Identifies whether the class name of a record or class is uncountable. Examples:
@@ -120,7 +120,7 @@ module ActiveModel
     # For shared engine:
     # ActiveModel::Naming.route_key(Blog::Post) #=> blog_posts
     def self.route_key(record_or_class)
-      record_or_class.model_name.route_key
+      model_name_from_record_or_class(record_or_class).route_key
     end
 
     # Returns string to use for params names. It differs for
@@ -132,8 +132,19 @@ module ActiveModel
     # For shared engine:
     # ActiveModel::Naming.param_key(Blog::Post) #=> blog_post
     def self.param_key(record_or_class)
-      record_or_class.model_name.param_key
+      model_name_from_record_or_class(record_or_class).param_key
     end
+
+    private
+      def self.model_name_from_record_or_class(record_or_class)
+        if record_or_class.is_a?(Class) || record_or_class.respond_to?(:model_name)
+          record_or_class
+        elsif record_or_class.respond_to?(:to_model)
+          record_or_class.to_model
+        else
+          record_or_class.class
+        end.model_name
+      end
   end
 
 end

--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -70,6 +70,14 @@ module ActiveModel
   # is required to pass the Active Model Lint test.  So either extending the provided
   # method below, or rolling your own is required..
   module Naming
+    def self.extended(base)
+      base.class_eval do
+        def model_name
+          self.class.model_name
+        end
+      end
+    end
+
     # Returns an ActiveModel::Name object for module. It can be
     # used to retrieve all kinds of naming-related information.
     def model_name
@@ -84,7 +92,7 @@ module ActiveModel
     #   ActiveModel::Naming.plural(post)             # => "posts"
     #   ActiveModel::Naming.plural(Highrise::Person) # => "highrise_people"
     def self.plural(record_or_class)
-      model_name_from_record_or_class(record_or_class).plural
+      record_or_class.model_name.plural
     end
 
     # Returns the singular class name of a record or class. Examples:
@@ -92,7 +100,7 @@ module ActiveModel
     #   ActiveModel::Naming.singular(post)             # => "post"
     #   ActiveModel::Naming.singular(Highrise::Person) # => "highrise_person"
     def self.singular(record_or_class)
-      model_name_from_record_or_class(record_or_class).singular
+      record_or_class.model_name.singular
     end
 
     # Identifies whether the class name of a record or class is uncountable. Examples:
@@ -112,7 +120,7 @@ module ActiveModel
     # For shared engine:
     # ActiveModel::Naming.route_key(Blog::Post) #=> blog_posts
     def self.route_key(record_or_class)
-      model_name_from_record_or_class(record_or_class).route_key
+      record_or_class.model_name.route_key
     end
 
     # Returns string to use for params names. It differs for
@@ -124,13 +132,8 @@ module ActiveModel
     # For shared engine:
     # ActiveModel::Naming.param_key(Blog::Post) #=> blog_post
     def self.param_key(record_or_class)
-      model_name_from_record_or_class(record_or_class).param_key
+      record_or_class.model_name.param_key
     end
-
-    private
-      def self.model_name_from_record_or_class(record_or_class)
-        (record_or_class.is_a?(Class) ? record_or_class : record_or_class.class).model_name
-      end
   end
 
 end

--- a/activemodel/lib/active_model/serializers/json.rb
+++ b/activemodel/lib/active_model/serializers/json.rb
@@ -85,7 +85,7 @@ module ActiveModel
 
         if include_root_in_json
           custom_root = options && options[:root]
-          hash = { custom_root || self.class.model_name.element => hash }
+          hash = { custom_root || self.model_name.element => hash }
         end
 
         hash

--- a/activemodel/lib/active_model/serializers/xml.rb
+++ b/activemodel/lib/active_model/serializers/xml.rb
@@ -90,7 +90,7 @@ module ActiveModel
           @builder = options[:builder]
           @builder.instruct! unless options[:skip_instruct]
 
-          root = (options[:root] || @serializable.class.model_name.element).to_s
+          root = (options[:root] || @serializable.model_name.element).to_s
           root = ActiveSupport::XmlMini.rename_key(root, options)
 
           args = [root]

--- a/activemodel/test/cases/naming_test.rb
+++ b/activemodel/test/cases/naming_test.rb
@@ -74,6 +74,14 @@ class NamingWithNamespacedModelInIsolatedNamespaceTest < ActiveModel::TestCase
   def test_recognizing_namespace
     assert_equal 'Post', Blog::Post.model_name.instance_variable_get("@unnamespaced")
   end
+
+  def test_instance_model_name
+    auto = Automobile.new
+    auto.make = 'MINI'
+    auto.model = 'Cooper'
+    assert_equal 'automobiles', Automobile.model_name.plural
+    assert_equal 'mini_coopers', auto.model_name.plural
+  end
 end
 
 class NamingWithNamespacedModelInSharedNamespaceTest < ActiveModel::TestCase

--- a/activemodel/test/models/automobile.rb
+++ b/activemodel/test/models/automobile.rb
@@ -1,9 +1,16 @@
 class Automobile
+  extend ActiveModel::Naming
   include ActiveModel::Validations
 
   validate :validations
 
   attr_accessor :make, :model
+
+  def model_name
+      name = self.class.model_name
+      name.instance_variable_set :@plural, "#{make}_#{model}s".downcase
+      name
+  end
 
   def validations
     validates_presence_of :make


### PR DESCRIPTION
As discussed on http://github.com/rails/rails/commit/6807b080996ee4bd6b80abb4f5e9964632c421c8#commitcomment-159080 and via Twitter with Jose and Yehuda, this patch add model_name at the instance level as well. Lint is updated,  a couple of tests have been added and all ActiveModel and ActionPack tests are still passing.

I think I caught all of the places that we'd want to/it'd make sense to call model_name on the instance, first -- but if I missed any, please let me know.

Thanks!
