### PR TITLE
Plural of hardware

### DIFF
--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -51,6 +51,6 @@ module ActiveSupport
     inflect.irregular('move', 'moves')
     inflect.irregular('cow', 'kine')
 
-    inflect.uncountable(%w(equipment information rice money species series fish sheep jeans))
+    inflect.uncountable(%w(equipment hardware information rice money species series fish sheep jeans))
   end
 end

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -74,6 +74,7 @@ module InflectorTestCases
     "elf"         => "elves",
     "information" => "information",
     "equipment"   => "equipment",
+    "hardware"    => "hardware",
     "bus"         => "buses",
     "status"      => "statuses",
     "status_code" => "status_codes",


### PR DESCRIPTION
'Hardware" current pluralizes into "Hardwares", should still be "Hardware"
