### PR TITLE
Fix ActiveResource::HttpMock.respond_to method do not replace the response 

### DIFF
--- a/activeresource/lib/active_resource/http_mock.rb
+++ b/activeresource/lib/active_resource/http_mock.rb
@@ -168,6 +168,15 @@ module ActiveResource
       #
       #   ActiveResource::HttpMock.respond_to(pairs, false)
       #   ActiveResource::HttpMock.responses.length #=> 2
+      #
+      #   # If you add a response with an existing request, it will be replaced
+      #
+      #   fail_response      = ActiveResource::Response.new("", 404, {})
+      #   pairs = {get_matz => fail_response}
+      #
+      #   ActiveResource::HttpMock.respond_to(pairs, false)
+      #   ActiveResource::HttpMock.responses.length #=> 2
+      #
       def respond_to(*args) #:yields: mock
         pairs = args.first || {}
         reset! if args.last.class != FalseClass

--- a/activeresource/test/cases/http_mock_test.rb
+++ b/activeresource/test/cases/http_mock_test.rb
@@ -140,7 +140,7 @@ class HttpMockTest < ActiveSupport::TestCase
     assert_equal 2, ActiveResource::HttpMock.responses.length
   end
 
-  test "allows you to add replace the existing reponese with the same path" do
+  test "allows you to replace the existing reponse with the same request" do
     ActiveResource::HttpMock.respond_to do |mock|
       mock.send(:get, "/people/1", {}, "XML1")
     end
@@ -153,6 +153,19 @@ class HttpMockTest < ActiveSupport::TestCase
     ActiveResource::HttpMock.respond_to({get_matz => ok_response}, false)
 
     assert_equal 1, ActiveResource::HttpMock.responses.length
+  end
+
+  test "do not replace the response with the same path but different method" do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.send(:get, "/people/1", {}, "XML1")
+    end
+    assert_equal 1, ActiveResource::HttpMock.responses.length
+
+    put_matz = ActiveResource::Request.new(:put, '/people/1', nil)
+    ok_response = ActiveResource::Response.new("", 200, {})
+
+    ActiveResource::HttpMock.respond_to({put_matz => ok_response}, false)
+    assert_equal 2, ActiveResource::HttpMock.responses.length
   end
 
   def request(method, path, headers = {}, body = nil)


### PR DESCRIPTION
HttpMock do not replace the response if it exists and it should replace it:

require 'active_resource'
ActiveResource::HttpMock.respond_to do |mock|
   mock.send(:get, "/people/1", {}, "XML1")
end

ActiveResource::HttpMock.responses.length 
# => 1

get_matz = ActiveResource::Request.new(:get, '/people/1', nil)
ok_response = ActiveResource::Response.new("", 200, {})

ActiveResource::HttpMock.respond_to({get_matz => ok_response}, false)
ActiveResource::HttpMock.responses.length
# => 2

My patch solve this problem.
Thanks.
