### PR TITLE
rake foo:install:assets instead of create_symlinks for engines

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -494,7 +494,7 @@ namespace :railties do
       end
 
       on_skip = Proc.new do |name, migration|
-        $stderr.puts "WARNING: Migration #{migration.basename} from #{name} has been skipped. Migration with the same name already exists."
+        puts "NOTE: Migration #{migration.basename} from #{name} has been skipped. Migration with the same name already exists."
       end
 
       on_copy = Proc.new do |name, migration, old_path|

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -538,6 +538,12 @@ module Rails
       next if self.is_a?(Rails::Application)
 
       namespace railtie_name do
+        desc "Shortcut for running both rake #{railtie_name}:install:migrations and #{railtie_name}:install:assets"
+        task :install do
+          Rake::Task["#{railtie_name}:install:migrations"].invoke
+          Rake::Task["#{railtie_name}:install:assets"].invoke
+        end
+
         namespace :install do
           # TODO Add assets copying to this list
           # TODO Skip this if there is no paths["db/migrate"] for the engine

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -510,7 +510,7 @@ module Rails
     end
 
     initializer :append_asset_paths do
-      config.asset_path ||= "/#{engine_name}%s"
+      config.asset_path ||= "/#{railtie_name}%s"
 
       public_path = paths["public"].first
       if config.compiled_asset_path && File.exist?(public_path)

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -546,12 +546,12 @@ module Rails
             ENV["FROM"] = railtie_name
             Rake::Task["railties:install:migrations"].invoke
           end
-        end
 
-        desc "Copy assets from #{railtie_name} to application"
-        task :assets do
-          ENV["FROM"] = railtie_name
-          Rake::Task["railties:install:assets"].invoke
+          desc "Copy assets from #{railtie_name} to application"
+          task :assets do
+            ENV["FROM"] = railtie_name
+            Rake::Task["railties:install:assets"].invoke
+          end
         end
       end
     end

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -547,6 +547,12 @@ module Rails
             Rake::Task["railties:install:migrations"].invoke
           end
         end
+
+        desc "Copy assets from #{railtie_name} to application"
+        task :assets do
+          ENV["FROM"] = railtie_name
+          Rake::Task["railties:install:assets"].invoke
+        end
       end
     end
 

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -189,17 +189,14 @@ module Rails
   # served by default. You should choose one of the two following strategies:
   #
   # * enable serving static files by setting config.serve_static_assets to true
-  # * symlink engines' public directories in application's public directory by running
-  #   `rake ENGINE_NAME:install:assets`, where ENGINE_NAME is usually my_engine for the
-  #   examples above
+  # * copy engine's public files to application's public folder with rake ENGINE_NAME:install:assets, for example
+  #   rake my_engine:install:assets
   #
   # == Engine name
   #
-  # There are some places where engine's name is used.
-  #
+  # There are some places where engine's name is used:
   # * routes: when you mount engine with mount(MyEngine::Engine => '/my_engine'), it's used as default :as option
-  #
-  # * rake tasks: engines have a few rake tasks. They are usually under my_engine namespace.
+  # * some of the rake tasks are based on engine name, e.g. my_engine:install:migrations, my_engine:install:assets
   #
   # Engine name is set by default based on class name. For MyEngine::Engine it will be my_engine_engine.
   # You can change it manually it manually using engine_name method:
@@ -316,6 +313,10 @@ module Rails
   # application's dir:
   #
   #   rake ENGINE_NAME:install:migrations
+  #
+  # Note that some of the migrations may be skipped if migration with the same name already exists
+  # in application. In such situation you must decide whether to leave that migration or rename the
+  # migration in application and rerun copying migrations.
   #
   # If your engine has migrations, you may also want to prepare data for the database in
   # seeds.rb file. You can load that data using load_seed method, e.g.

--- a/railties/lib/rails/tasks/railties.rake
+++ b/railties/lib/rails/tasks/railties.rake
@@ -17,4 +17,32 @@ namespace :railties do
       puts "Created symlink #{symlink_path} -> #{path}"
     end
   end
+
+  namespace :install do
+    desc "Copies missing assets from Railties (e.g. plugins, engines). You can specify Railties to use with FROM=railtie1,railtie2"
+    task :assets => :rails_env do
+      require 'rails/generators/base'
+      Rails.application.initialize!
+
+      to_load = ENV["FROM"].blank? ? :all : ENV["FROM"].split(",").map {|n| n.strip }
+      app_public_path = Rails.application.paths["public"].first
+
+      Rails.application.railties.all do |railtie|
+        next unless to_load == :all || to_load.include?(railtie.railtie_name)
+
+        if railtie.respond_to?(:paths) && (path = railtie.paths["public"].first) &&
+           (assets_dir = railtie.config.compiled_asset_path) && File.exist?(path)
+
+          Rails::Generators::Base.source_root(path)
+          copier = Rails::Generators::Base.new
+          Dir[File.join(path, "**/*")].each do |file|
+            relative = file.gsub(/^#{path}\//, '')
+            if File.file?(file)
+              copier.copy_file relative, File.join(app_public_path, assets_dir, relative)
+            end
+          end
+        end
+      end
+    end
+  end
 end

--- a/railties/lib/rails/tasks/railties.rake
+++ b/railties/lib/rails/tasks/railties.rake
@@ -1,23 +1,4 @@
 namespace :railties do
-  # desc "Create symlinks to railties public directories in application's public directory."
-  task :create_symlinks => :environment do
-    paths = Rails.application.config.static_asset_paths.dup
-    app_public_path = Rails.application.paths["public"].first
-
-    paths.each do |mount_path, path|
-      symlink_path = File.join(app_public_path, mount_path)
-      if File.exist?(symlink_path)
-        File.symlink?(symlink_path) ? FileUtils.rm(symlink_path) : next
-      end
-
-      next unless File.exist?(path)
-
-      File.symlink(path, symlink_path)
-
-      puts "Created symlink #{symlink_path} -> #{path}"
-    end
-  end
-
   namespace :install do
     desc "Copies missing assets from Railties (e.g. plugins, engines). You can specify Railties to use with FROM=railtie1,railtie2"
     task :assets => :rails_env do

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -568,63 +568,6 @@ module RailtiesTest
       assert rack_body(response[2]) =~ /name="post\[title\]"/
     end
 
-    test "creating symlinks" do
-      @plugin.write "lib/bukkits.rb", <<-RUBY
-        module Bukkits
-          class Engine < ::Rails::Engine
-            isolate_namespace(Bukkits)
-          end
-        end
-      RUBY
-
-      @plugin.write "public/hello.txt", "foo"
-      @plugin.write "alternate_public/hello.txt", "bar"
-
-      Dir.chdir(app_path) do
-        output = `rake railties:create_symlinks`
-
-        assert_match /Created symlink/, output
-        assert_match /#{app_path}\/public\/bukkits/, output
-        assert_match /#{@plugin.path}\/public/, output
-
-        assert File.symlink?(File.join(app_path, 'public/bukkits'))
-        assert_equal "foo\n", File.read(File.join(app_path, 'public/bukkits/hello.txt'))
-
-        @plugin.write "lib/bukkits.rb", <<-RUBY
-          module Bukkits
-            class Engine < ::Rails::Engine
-              isolate_namespace(Bukkits)
-              paths["public"] = "#{File.join(@plugin.path, "alternate_public")}"
-            end
-          end
-        RUBY
-
-        output = `rake railties:create_symlinks`
-
-        assert_match /Created symlink/, output
-        assert_match /#{app_path}\/public\/bukkits/, output
-        assert_match /#{@plugin.path}\/alternate_public/, output
-
-        assert File.symlink?(File.join(app_path, 'public/bukkits'))
-        assert_equal "bar\n", File.read(File.join(app_path, 'public/bukkits/hello.txt'))
-
-        @plugin.write "lib/bukkits.rb", <<-RUBY
-          module Bukkits
-            class Engine < ::Rails::Engine
-              isolate_namespace(Bukkits)
-              paths["public"] = "#{File.join(@plugin.path, "not_existing")}"
-            end
-          end
-        RUBY
-
-        FileUtils.rm File.join(app_path, 'public/bukkits')
-
-        output = `rake railties:create_symlinks`
-        assert_no_match /Created symlink/, output
-        assert !File.exist?(File.join(app_path, 'public/bukkits'))
-      end
-    end
-
     test "loading seed data" do
       @plugin.write "db/seeds.rb", <<-RUBY
         Bukkits::Engine.config.bukkits_seeds_loaded = true

--- a/railties/test/railties/shared_tests.rb
+++ b/railties/test/railties/shared_tests.rb
@@ -10,6 +10,28 @@ module RailtiesTest
       @app ||= Rails.application
     end
 
+    def test_install_migrations_and_assets
+      @plugin.write "public/javascripts/foo.js", "doSomething()"
+
+      @plugin.write "db/migrate/1_create_users.rb", <<-RUBY
+        class CreateUsers < ActiveRecord::Migration
+        end
+      RUBY
+
+      app_file "db/migrate/1_create_sessions.rb", <<-RUBY
+        class CreateSessions < ActiveRecord::Migration
+        end
+      RUBY
+
+      add_to_config "ActiveRecord::Base.timestamped_migrations = false"
+
+      Dir.chdir(app_path) do
+        `rake bukkits:install`
+        assert File.exists?("#{app_path}/db/migrate/2_create_users.rb")
+        assert File.exists?(app_path("public/bukkits/javascripts/foo.js"))
+      end
+    end
+
     def test_copying_assets
       @plugin.write "public/javascripts/foo.js", "doSomething()"
       @plugin.write "public/stylesheets/foo.css", "h1 { font-size: 10000px }"
@@ -19,7 +41,9 @@ module RailtiesTest
         `rake bukkits:install:assets --trace`
 
         assert File.exists?(app_path("public/bukkits/javascripts/foo.js"))
+        assert_equal "doSomething()\n", File.read(app_path("public/bukkits/javascripts/foo.js"))
         assert File.exists?(app_path("public/bukkits/stylesheets/foo.css"))
+        assert_equal "h1 { font-size: 10000px }\n", File.read(app_path("public/bukkits/stylesheets/foo.css"))
         assert File.exists?(app_path("public/bukkits/images/img.png"))
       end
     end

--- a/railties/test/railties/shared_tests.rb
+++ b/railties/test/railties/shared_tests.rb
@@ -43,24 +43,24 @@ module RailtiesTest
       add_to_config "ActiveRecord::Base.timestamped_migrations = false"
 
       Dir.chdir(app_path) do
-        output = `rake bukkits:install:migrations 2>&1`
+        output = `rake bukkits:install:migrations`
 
         assert File.exists?("#{app_path}/db/migrate/2_create_users.rb")
         assert File.exists?("#{app_path}/db/migrate/3_add_last_name_to_users.rb")
         assert_match /Copied migration 2_create_users.rb from bukkits/, output
         assert_match /Copied migration 3_add_last_name_to_users.rb from bukkits/, output
-        assert_match /WARNING: Migration 3_create_sessions.rb from bukkits has been skipped/, output
+        assert_match /NOTE: Migration 3_create_sessions.rb from bukkits has been skipped/, output
         assert_equal 3, Dir["#{app_path}/db/migrate/*.rb"].length
 
-        output = `rake railties:install:migrations 2>&1`
+        output = `rake railties:install:migrations`
 
         assert File.exists?("#{app_path}/db/migrate/4_create_yaffles.rb")
-        assert_match /WARNING: Migration 3_create_sessions.rb from bukkits has been skipped/, output
+        assert_match /NOTE: Migration 3_create_sessions.rb from bukkits has been skipped/, output
         assert_match /Copied migration 4_create_yaffles.rb from acts_as_yaffle/, output
         assert_no_match /2_create_users/, output
 
         migrations_count = Dir["#{app_path}/db/migrate/*.rb"].length
-        output = `rake railties:install:migrations 2>&1`
+        output = `rake railties:install:migrations`
 
         assert_equal migrations_count, Dir["#{app_path}/db/migrate/*.rb"].length
       end

--- a/railties/test/railties/shared_tests.rb
+++ b/railties/test/railties/shared_tests.rb
@@ -10,6 +10,20 @@ module RailtiesTest
       @app ||= Rails.application
     end
 
+    def test_copying_assets
+      @plugin.write "public/javascripts/foo.js", "doSomething()"
+      @plugin.write "public/stylesheets/foo.css", "h1 { font-size: 10000px }"
+      @plugin.write "public/images/img.png", ""
+
+      Dir.chdir(app_path) do
+        `rake bukkits:install:assets --trace`
+
+        assert File.exists?(app_path("public/bukkits/javascripts/foo.js"))
+        assert File.exists?(app_path("public/bukkits/stylesheets/foo.css"))
+        assert File.exists?(app_path("public/bukkits/images/img.png"))
+      end
+    end
+
     def test_copying_migrations
       @plugin.write "db/migrate/1_create_users.rb", <<-RUBY
         class CreateUsers < ActiveRecord::Migration


### PR DESCRIPTION
Copying static assets to application's public directory is saner way of handling engines' assets. This commits remove railties:create_symlinks rake task in favor of foo:install:assets (where foo is engine's name).

The implementation is really straightforward and simple, all the files from engine's public directory are copied to application. It is done with Generators::Base#copy_file, so if files differ user will be asked if the file should be replaced.

I don't see a need for anything more sophisticated, as in 3.1 preferred way of handling assets will be to keep them in app/assets and API behind that will be probably used to properly handle engines' assets.
