### PR TITLE
Cache DRYup

### DIFF
--- a/actionpack/lib/action_controller/caching/pages.rb
+++ b/actionpack/lib/action_controller/caching/pages.rb
@@ -134,7 +134,7 @@ module ActionController #:nodoc:
       # If no options are provided, the requested url is used. Example:
       #   cache_page "I'm the cached content", :controller => "lists", :action => "show"
       def cache_page(content = nil, options = nil)
-        return unless self.class.perform_caching && caching_allowed
+        return unless self.class.perform_caching && caching_allowed?
 
         path = case options
           when Hash
@@ -148,10 +148,6 @@ module ActionController #:nodoc:
         self.class.cache_page(content || response.body, path)
       end
 
-      private
-        def caching_allowed
-          request.get? && response.status.to_i == 200
-        end
     end
   end
 end


### PR DESCRIPTION
No need to define `#caching_allowed` here. It's already defined in http://github.com/rails/rails/blob/master/actionpack/lib/action_controller/caching.rb#L70-72
