### PR TITLE
Try block

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/try.rb
+++ b/activesupport/lib/active_support/core_ext/object/try.rb
@@ -8,6 +8,8 @@ class Object
   # *Unlike* that method however, a +NoMethodError+ exception will *not* be raised
   # and +nil+ will be returned instead, if the receiving object is a +nil+ object or NilClass.
   #
+  # If try is called without a method to call, it will yield any given block with the object.
+  #
   # ==== Examples
   #
   # Without try
@@ -21,10 +23,20 @@ class Object
   # +try+ also accepts arguments and/or a block, for the method it is trying
   #   Person.try(:find, 1)
   #   @people.try(:collect) {|p| p.name}
+  #
+  # Without a method argument try will yield to the block unless the reciever is nil.
+  #   @person.try { |p| "#{p.first_name} #{p.last_name}" }
   #--
   # +try+ behaves like +Object#send+, unless called on +NilClass+.
 
-  alias_method :try, :__send__
+  def try(*a, &b)
+    if a.empty? && block_given?
+      yield self
+    else
+      __send__(*a, &b)
+    end
+  end
+
 end
 
 class NilClass #:nodoc:

--- a/activesupport/test/core_ext/object_and_class_ext_test.rb
+++ b/activesupport/test/core_ext/object_and_class_ext_test.rb
@@ -165,4 +165,14 @@ class ObjectTryTest < Test::Unit::TestCase
   def test_false_try
     assert_equal 'false', false.try(:to_s)
   end
+
+  def test_try_only_block
+    assert_equal @string.reverse, @string.try { |s| s.reverse }
+  end
+
+  def test_try_only_block_nil
+    ran = false
+    nil.try { ran = true }
+    assert_equal false, ran
+  end
 end


### PR DESCRIPTION
Add support for Object#try to just invoke a block if no method to be called has been given. This replaces the need for other hacks like unless_blank? { code } and if_present? { code } off of an existing method and paradigm.

Example:

```
@person = Struct.new(:first_name, :last_name).new("David", "Heinemeier Hansson")
@person.try { |p| "#{p.first_name} #{p.last_name}" } # => "David Heinemeier Hansson"
```
