### PR TITLE
Added missing AS require to active_model/naming.rb

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -1,5 +1,6 @@
 require 'active_support/inflector'
 require 'active_support/core_ext/hash/except'
+require 'active_support/core_ext/module/introspection'
 
 module ActiveModel
   class Name < String


### PR DESCRIPTION
Added missing AS require to active_model/naming.rb

We saw a failing spec when running the DataMapper
ActiveModel compliance specs for dm-active_model.

  ActiveModel::Naming#model_name

relies on the Module#parents method defined in

  active_support/core_ext/module/introspection.rb

Adding the appropriate require statement of course
fixed our specs.
