### PR TITLE
fix respond_with when responding with a simple hash

### DIFF
--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -227,7 +227,7 @@ module ActionController #:nodoc:
             "controller responds to in the class level" if self.class.mimes_for_respond_to.empty?
 
       if response = retrieve_response_from_mimes(&block)
-        options = resources.extract_options!
+        options = resources.size == 1 ? {} : resources.extract_options!
         options.merge!(:default_response => response)
         (options.delete(:responder) || self.class.responder).call(self, resources, options)
       end

--- a/actionpack/test/controller/mime_responds_test.rb
+++ b/actionpack/test/controller/mime_responds_test.rb
@@ -487,6 +487,10 @@ class RespondWithController < ActionController::Base
     respond_with(resource)
   end
 
+  def using_hash_resource
+    respond_with({:result => resource})
+  end
+
   def using_resource_with_block
     respond_with(resource) do |format|
       format.csv { render :text => "CSV" }
@@ -585,6 +589,18 @@ class RespondWithControllerTest < ActionController::TestCase
     assert_raise ActionView::MissingTemplate do
       get :using_resource
     end
+  end
+
+  def test_using_hash_resource
+    @request.accept = "application/xml"
+    get :using_hash_resource
+    assert_equal "application/xml", @response.content_type
+    assert_equal "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<hash>\n  <name>david</name>\n</hash>\n", @response.body
+
+    @request.accept = "application/json"
+    get :using_hash_resource
+    assert_equal "application/json", @response.content_type
+    assert_equal %Q[{"result":["david",13]}], @response.body
   end
 
   def test_using_resource_with_block


### PR DESCRIPTION
Currently if you pass a single hash to respond_with, it assumes it is the options hash, but if there's a single argument, I think the more correct assumption is that it is the resource. This commit adds a special case for a single argument to avoid calling `extract_options!`
