### PR TITLE
fixed test_finding_with_complex_order and test_finding_with_complex_order_and_limit for Oracle

### DIFF
--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -148,6 +148,8 @@ class RelationTest < ActiveRecord::TestCase
   def test_finding_with_complex_order_and_limit
     if current_adapter?(:SQLite3Adapter)
       tags = Tag.includes(:taggings).order("MIN(1,2)").limit(1).to_a
+    elsif current_adapter?(:OracleAdapter)
+      tags = Tag.includes(:taggings).order("LEAST(1,COS(1)*COS(-1)*COS(taggings.super_tag_id * 3.14159265359/180))").limit(1).to_a
     else
       tags = Tag.includes(:taggings).order("LEAST(1,COS(1)*COS(-1)*COS(RADIANS(taggings.super_tag_id)))").limit(1).to_a
     end
@@ -158,6 +160,8 @@ class RelationTest < ActiveRecord::TestCase
   def test_finding_with_complex_order
     if current_adapter?(:SQLite3Adapter)
       tags = Tag.includes(:taggings).order("MIN(1,2)").to_a
+    elsif current_adapter?(:OracleAdapter)
+      tags = Tag.includes(:taggings).order("LEAST(1,COS(1)*COS(-1)*COS(taggings.super_tag_id * 3.14159265359/180))").to_a
     else
       tags = Tag.includes(:taggings).order("LEAST(1,COS(1)*COS(-1)*COS(RADIANS(taggings.super_tag_id)))").to_a
     end


### PR DESCRIPTION
Commit
3146aa68fd03ea4392b45f1c8771675a9c850471 Fixes queries using limits and punctuation in order, removes order("col1, col2") usage in favor of order(["col1", "col2"})
added tests test_finding_with_complex_order and test_finding_with_complex_order_and_limit with complex functions and one particular function RADIANS is not available in Oracle. I modified these tests to pass on Oracle.

And it would be good not to include such database specific functions in general test as it might fail also on many other less popular databases as well.
