### PR TITLE
Order by complex function

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -937,7 +937,7 @@ module ActiveRecord
 
         # Construct a clean list of column names from the ORDER BY clause, removing
         # any ASC/DESC modifiers
-        order_columns = orders.collect { |s| s.split.first }
+        order_columns = orders.collect { |s| s =~ /^(.+)\s+(ASC|DESC)\s*$/i ? $1 : s }
         order_columns.delete_if { |c| c.blank? }
         order_columns = order_columns.zip((0...order_columns.size).to_a).map { |s,i| "#{s} AS alias_#{i}" }
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -146,22 +146,12 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_finding_with_complex_order_and_limit
-    if current_adapter?(:SQLite3Adapter)
-      tags = Tag.includes(:taggings).order("MIN(1,2)").limit(1).to_a
-    else
-      tags = Tag.includes(:taggings).order("LEAST(1,COS(1)*COS(-1)*COS(RADIANS(taggings.super_tag_id)))").limit(1).to_a
-    end
-
+    tags = Tag.includes(:taggings).order("REPLACE('abc','a','b')").limit(1).to_a
     assert_equal 1, tags.length
   end
 
   def test_finding_with_complex_order
-    if current_adapter?(:SQLite3Adapter)
-      tags = Tag.includes(:taggings).order("MIN(1,2)").to_a
-    else
-      tags = Tag.includes(:taggings).order("LEAST(1,COS(1)*COS(-1)*COS(RADIANS(taggings.super_tag_id)))").to_a
-    end
-
+    tags = Tag.includes(:taggings).order("REPLACE('abc','a','b')").to_a
     assert_equal 2, tags.length
   end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -146,12 +146,12 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_finding_with_complex_order_and_limit
-    tags = Tag.includes(:taggings).order("REPLACE('abc','a','b')").limit(1).to_a
+    tags = Tag.includes(:taggings).order("REPLACE('abc', taggings.taggable_type, taggings.taggable_type)").limit(1).to_a
     assert_equal 1, tags.length
   end
 
   def test_finding_with_complex_order
-    tags = Tag.includes(:taggings).order("REPLACE('abc','a','b')").to_a
+    tags = Tag.includes(:taggings).order("REPLACE('abc', taggings.taggable_type, taggings.taggable_type)").to_a
     assert_equal 2, tags.length
   end
 


### PR DESCRIPTION
This replaces previous pull request https://github.com/rails/rails/pull/92

Redefined test_finding_with_complex_order_and_limit and test_finding_with_complex_order to use REPLACE functions which seems to be one of the rare functions which has the same name and syntax in all main databases (see http://troels.arvin.dk/db/rdbms/#functions-REPLACE).
