### PR TITLE
Updates documentation for save method in ActiveRecord::Validations.

### DIFF
--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -37,7 +37,7 @@ module ActiveRecord
       end
     end
 
-    # The validation process on save can be skipped by passing false. The regular Base#save method is
+    # The validation process on save can be skipped by passing :validate => false. The regular Base#save method is
     # replaced with this when the validations module is mixed in, which it is by default.
     def save(options={})
       perform_validations(options) ? super : false


### PR DESCRIPTION
The current documentation says: 'The validation process on save can be skipped by passing false.'.
But it was deprecated, so it should say: The validation process on save can be skipped by passing :validate => false".
