### PR TITLE
AR::RecordNotFound explicit message

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -300,7 +300,7 @@ module ActiveRecord
       unless record
         conditions = arel.where_sql
         conditions = " [#{conditions}]" if conditions
-        raise RecordNotFound, "Couldn't find #{@klass.name} with ID=#{id}#{conditions}"
+        raise RecordNotFound, "Couldn't find #{@klass.name} with #{@klass.primary_key}=#{id}#{conditions}"
       end
 
       record


### PR DESCRIPTION
Replaces the message:
`ActiveRecord::RecordNotFound: Couldn't find Foo with ID=1`

by:
`ActiveRecord::RecordNotFound: Couldn't find Foo with my_primary_key=1`
