### PR TITLE
Lighthouse/5277: Empty HTTP_ACCEPT means the clients accept all media types

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -43,7 +43,7 @@ module ActionDispatch
       end
 
       def formats
-        accept = @env['HTTP_ACCEPT']
+        accept = (@env['HTTP_ACCEPT'] ||= '*/*')
 
         @env["action_dispatch.request.formats"] ||=
           if parameters[:format]

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -65,7 +65,7 @@ class ACLogSubscriberTest < ActionController::TestCase
     get :show
     wait
     assert_equal 2, logs.size
-    assert_equal "Processing by Another::LogSubscribersController#show as HTML", logs.first
+    assert_equal "Processing by Another::LogSubscribersController#show as */*", logs.first
   end
 
   def test_process_action

--- a/actionpack/test/controller/new_base/content_negotiation_test.rb
+++ b/actionpack/test/controller/new_base/content_negotiation_test.rb
@@ -14,5 +14,10 @@ module ContentNegotiation
       get "/content_negotiation/basic/hello", {}, "HTTP_ACCEPT" => "*/*"
       assert_body "Hello world */*!"
     end
+
+    test "An empty accept header will return HTML" do
+      get "/content_negotiation/basic/hello", {}, "HTTP_ACCEPT" => nil
+      assert_body "Hello world */*!"
+    end
   end
 end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -403,7 +403,8 @@ class RequestTest < ActiveSupport::TestCase
     assert_equal [ Mime::HTML ], request.formats
 
     request = stub_request 'CONTENT_TYPE' => 'application/xml; charset=UTF-8',
-                           'HTTP_X_REQUESTED_WITH' => "XMLHttpRequest"
+                           'HTTP_X_REQUESTED_WITH' => "XMLHttpRequest",
+                           'HTTP_ACCEPT' => 'application/xml'
     request.expects(:parameters).at_least_once.returns({})
     assert_equal with_set(Mime::XML), request.formats
 


### PR DESCRIPTION
Link to LH : https://rails.lighthouseapp.com/projects/8994/tickets/5277-rails-300rc-responds-strangely-to-empty-accept-header
