### PR TITLE
LH#5956 Hash with indifferent access should not change array subclass

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -144,7 +144,7 @@ module ActiveSupport
         when Hash
           self.class.new_from_hash_copying_default(value)
         when Array
-          value.collect { |e| e.is_a?(Hash) ? self.class.new_from_hash_copying_default(e) : e }
+          value.dup.replace(value.collect { |e| e.is_a?(Hash) ? self.class.new_from_hash_copying_default(e) : e })
         else
           value
         end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -8,6 +8,9 @@ require 'active_support/core_ext/object/conversions'
 class HashExtTest < Test::Unit::TestCase
   class IndifferentHash < HashWithIndifferentAccess
   end
+  
+  class SubclassingArray < Array
+  end
 
   def setup
     @strings = { 'a' => 1, 'b' => 2 }
@@ -250,6 +253,20 @@ class HashExtTest < Test::Unit::TestCase
   def test_indifferent_hash_with_array_of_hashes
     hash = { "urls" => { "url" => [ { "address" => "1" }, { "address" => "2" } ] }}.with_indifferent_access
     assert_equal "1", hash[:urls][:url].first[:address]
+  end
+  
+  def test_should_preserve_array_subclass_when_value_is_array
+    array = SubclassingArray.new
+    array << { "address" => "1" }
+    hash = { "urls" => { "url" => array }}.with_indifferent_access
+    assert_equal SubclassingArray, hash[:urls][:url].class
+  end
+  
+  def test_should_preserve_array_class_when_hash_value_is_frozen_array
+    array = SubclassingArray.new
+    array << { "address" => "1" }
+    hash = { "urls" => { "url" => array.freeze }}.with_indifferent_access
+    assert_equal SubclassingArray, hash[:urls][:url].class
   end
 
   def test_stringify_and_symbolize_keys_on_indifferent_preserves_hash


### PR DESCRIPTION
Link to lighthouse issue:
https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/5956-hashwithindifferentaccess-should-not-change-the-class-of-an-array#ticket-5956-5
