### PR TITLE
Plugin gen typos

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -8,7 +8,7 @@ module Rails
 
       def show_deprecation
         return unless behavior == :invoke
-        message = "Plugin generator is depreacted, please use 'rails plugin new' command to generate plugin structure."
+        message = "Plugin generator is deprecated, please use 'rails plugin new' command to generate plugin structure."
         ActiveSupport::Deprecation.warn message
       end
 

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -66,6 +66,6 @@ class PluginGeneratorTest < Rails::Generators::TestCase
 
   def test_deprecation
     output = capture(:stderr) { run_generator }
-    assert_match /Plugin generator is depreacted, please use 'rails plugin new' command to generate plugin structure./, output
+    assert_match /Plugin generator is deprecated, please use 'rails plugin new' command to generate plugin structure./, output
   end
 end


### PR DESCRIPTION
Fix misspelling of 'deprecation' in plugin_generator.
