### PR TITLE
config.action_controller.include_all_helpers

### DIFF
--- a/actionpack/CHANGELOG
+++ b/actionpack/CHANGELOG
@@ -1,5 +1,7 @@
 *Rails 3.1.0 (unreleased)*
 
+* Added config.action_controller.include_all_helpers. By default 'helper :all' is done in ActionController::Base, which includes all the helpers by default. Setting include_all_helpers to false will result in including only application_helper and helper corresponding to controller (like foo_helper for foo_controller). [Piotr Sarnacki]
+
 * Added a convenience idiom to generate HTML5 data-* attributes in tag helpers from a :data hash of options:
 
     tag("div", :data => {:name => 'Stephen', :city_state => %w(Chicago IL)})

--- a/actionpack/lib/action_controller/metal/helpers.rb
+++ b/actionpack/lib/action_controller/metal/helpers.rb
@@ -53,8 +53,9 @@ module ActionController
     include AbstractController::Helpers
 
     included do
-      config_accessor :helpers_path
+      config_accessor :helpers_path, :include_all_helpers
       self.helpers_path ||= []
+      self.include_all_helpers = true
     end
 
     module ClassMethods

--- a/actionpack/lib/action_controller/railties/paths.rb
+++ b/actionpack/lib/action_controller/railties/paths.rb
@@ -13,7 +13,9 @@ module ActionController
             end
 
             klass.helpers_path = paths
-            klass.helper :all if klass.superclass == ActionController::Base
+            if klass.superclass == ActionController::Base && ActionController::Base.include_all_helpers
+              klass.helper :all
+            end
           end
         end
       end


### PR DESCRIPTION
From commit message:
    In older rails versions there was a way to use only helpers from
    helper file corresponding to current controller and you could also
    include all helpers by saying 'helper :all' in controller. This config
    allows to return to older behavior by setting it to false.
