### PR TITLE
Customizable form class

### DIFF
--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -253,8 +253,9 @@ module ActionView
       # using the +link_to+ method with the <tt>:method</tt> modifier as described in
       # the +link_to+ documentation.
       #
-      # The generated form element has a class name of <tt>button_to</tt>
-      # to allow styling of the form itself and its children. You can control
+      # By default, the generated form element has a class name of <tt>button_to</tt>
+      # to allow styling of the form itself and its children. This can be changed
+      # using the <tt>:form_class</tt> modifier within +html_options+. You can control
       # the form submission and input element behavior using +html_options+.
       # This method accepts the <tt>:method</tt> and <tt>:confirm</tt> modifiers
       # described in the +link_to+ documentation. If no <tt>:method</tt> modifier
@@ -275,10 +276,18 @@ module ActionView
       #   processed normally, otherwise no action is taken.
       # * <tt>:remote</tt> -  If set to true, will allow the Unobtrusive JavaScript drivers to control the
       #   submit behaviour. By default this behaviour is an ajax submit.
+      # * <tt>:form_class</tt> - This controls the class of the form within which the submit button will
+      #   be placed
       #
       # ==== Examples
       #   <%= button_to "New", :action => "new" %>
       #   # => "<form method="post" action="/controller/new" class="button_to">
+      #   #      <div><input value="New" type="submit" /></div>
+      #   #    </form>"
+      #
+      #
+      #   <%= button_to "New", :action => "new", :form_class => "new-thing" %>
+      #   # => "<form method="post" action="/controller/new" class="new-thing">
       #   #      <div><input value="New" type="submit" /></div>
       #   #    </form>"
       #
@@ -312,6 +321,7 @@ module ActionView
         end
 
         form_method = method.to_s == 'get' ? 'get' : 'post'
+        form_class = html_options.delete('form_class') || 'button_to'
 
         remote = html_options.delete('remote')
 
@@ -327,7 +337,7 @@ module ActionView
 
         html_options.merge!("type" => "submit", "value" => name)
 
-        ("<form method=\"#{form_method}\" action=\"#{ERB::Util.html_escape(url)}\" #{"data-remote=\"true\"" if remote} class=\"button_to\"><div>" +
+        ("<form method=\"#{form_method}\" action=\"#{ERB::Util.html_escape(url)}\" #{"data-remote=\"true\"" if remote} class=\"#{ERB::Util.html_escape(form_class)}\"><div>" +
           method_tag + tag("input", html_options) + request_token_tag + "</div></form>").html_safe
       end
 

--- a/actionpack/test/template/url_helper_test.rb
+++ b/actionpack/test/template/url_helper_test.rb
@@ -50,6 +50,10 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert_dom_equal "<form method=\"post\" action=\"http://www.example.com\" class=\"button_to\"><div><input type=\"submit\" value=\"Hello\" /></div></form>", button_to("Hello", "http://www.example.com")
   end
 
+  def test_button_to_with_form_class
+    assert_dom_equal "<form method=\"post\" action=\"http://www.example.com\" class=\"custom-class\"><div><input type=\"submit\" value=\"Hello\" /></div></form>", button_to("Hello", "http://www.example.com", :form_class => 'custom-class')
+  end
+
   def test_button_to_with_query
     assert_dom_equal "<form method=\"post\" action=\"http://www.example.com/q1=v1&amp;q2=v2\" class=\"button_to\"><div><input type=\"submit\" value=\"Hello\" /></div></form>", button_to("Hello", "http://www.example.com/q1=v1&q2=v2")
   end


### PR DESCRIPTION
Currently, button_to's generated form element is hard coded to having the class "button_to".

This is somewhat inconvenient when trying to hook forms for ajax trickery, as the only class you control is the class of the submit element.

If, for instance, you've got several actions rendered as button_to, the only way to properly hook the submits would be to use 'form:has(.some-action-class)' selectors, which is quite convoluted.

This patch adds the :form_class modifier to button_to's html_options.
