### PR TITLE
Removed ids_in_list_limit in favor of in_clause_length defined in database_limits.rb 

### DIFF
--- a/activerecord/lib/active_record/association_preload.rb
+++ b/activerecord/lib/active_record/association_preload.rb
@@ -391,9 +391,9 @@ module ActiveRecord
       # Some databases impose a limit on the number of ids in a list (in Oracle its 1000)
       # Make several smaller queries if necessary or make one query if the adapter supports it
       def associated_records(ids)
-        max_ids_in_a_list = connection.ids_in_list_limit || ids.size
+        in_clause_length = connection.in_clause_length || ids.size
         records = []
-        ids.each_slice(max_ids_in_a_list) do |some_ids|
+        ids.each_slice(in_clause_length) do |some_ids|
           records += yield(some_ids)
         end
         records

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_limits.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_limits.rb
@@ -37,9 +37,9 @@ module ActiveRecord
         16
       end
 
-      # the maximum number of elements in an IN (x,y,z) clause
+      # the maximum number of elements in an IN (x,y,z) clause. nil means no limit
       def in_clause_length
-        65535
+        nil
       end
 
       # the maximum length of an SQL query

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -91,11 +91,6 @@ module ActiveRecord
         false
       end
 
-      # Does this adapter restrict the number of ids you can use in a list. Oracle has a limit of 1000.
-      def ids_in_list_limit
-        nil
-      end
-
       # QUOTING ==================================================
 
       # Override to return the quoted table name. Defaults to column quoting.

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -80,31 +80,31 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_preloading_has_many_in_multiple_queries_with_more_ids_than_database_can_handle
-    Post.connection.expects(:ids_in_list_limit).at_least_once.returns(5)
+    Post.connection.expects(:in_clause_length).at_least_once.returns(5)
     posts = Post.find(:all, :include=>:comments)
     assert_equal 7, posts.size
   end
 
   def test_preloading_has_many_in_one_queries_when_database_has_no_limit_on_ids_it_can_handle
-    Post.connection.expects(:ids_in_list_limit).at_least_once.returns(nil)
+    Post.connection.expects(:in_clause_length).at_least_once.returns(nil)
     posts = Post.find(:all, :include=>:comments)
     assert_equal 7, posts.size
   end
 
   def test_preloading_habtm_in_multiple_queries_with_more_ids_than_database_can_handle
-    Post.connection.expects(:ids_in_list_limit).at_least_once.returns(5)
+    Post.connection.expects(:in_clause_length).at_least_once.returns(5)
     posts = Post.find(:all, :include=>:categories)
     assert_equal 7, posts.size
   end
 
   def test_preloading_habtm_in_one_queries_when_database_has_no_limit_on_ids_it_can_handle
-    Post.connection.expects(:ids_in_list_limit).at_least_once.returns(nil)
+    Post.connection.expects(:in_clause_length).at_least_once.returns(nil)
     posts = Post.find(:all, :include=>:categories)
     assert_equal 7, posts.size
   end
 
   def test_load_associated_records_in_one_query_when_adapter_has_no_limit
-    Post.connection.expects(:ids_in_list_limit).at_least_once.returns(nil)
+    Post.connection.expects(:in_clause_length).at_least_once.returns(nil)
     Post.expects(:i_was_called).with([1,2,3,4,5,6,7]).returns([1])
     associated_records = Post.send(:associated_records, [1,2,3,4,5,6,7]) do |some_ids|
       Post.i_was_called(some_ids)
@@ -113,7 +113,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_load_associated_records_in_several_queries_when_many_ids_passed
-    Post.connection.expects(:ids_in_list_limit).at_least_once.returns(5)
+    Post.connection.expects(:in_clause_length).at_least_once.returns(5)
     Post.expects(:i_was_called).with([1,2,3,4,5]).returns([1])
     Post.expects(:i_was_called).with([6,7]).returns([6])
     associated_records = Post.send(:associated_records, [1,2,3,4,5,6,7]) do |some_ids|
@@ -123,7 +123,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_load_associated_records_in_one_query_when_a_few_ids_passed
-    Post.connection.expects(:ids_in_list_limit).at_least_once.returns(5)
+    Post.connection.expects(:in_clause_length).at_least_once.returns(5)
     Post.expects(:i_was_called).with([1,2,3]).returns([1])
     associated_records = Post.send(:associated_records, [1,2,3]) do |some_ids|
       Post.i_was_called(some_ids)


### PR DESCRIPTION
As suggested by Aaron in email removed redundant database configuration "ids_in_list_limit " from abstract_adapter in favor of using "in_clause_length" from database_limits.rb
