### PR TITLE
Dup reset timestamps

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1625,6 +1625,7 @@ MSG
 
         ensure_proper_type
         populate_with_current_scope_attributes
+        clear_timestamp_attributes
       end
 
       # Returns +true+ if the record is read only. Records loaded through joins with piggy-back
@@ -1829,6 +1830,16 @@ MSG
         if scope = self.class.send(:current_scoped_methods)
           create_with = scope.scope_for_create
           create_with.each { |att,value| self.respond_to?(:"#{att}=") && self.send("#{att}=", value) } if create_with
+        end
+      end
+
+      # Clear attributes and changged_attributes
+      def clear_timestamp_attributes
+        %w(created_at created_on updated_at updated_on).each do |attribute_name|
+          if self.has_attribute?(attribute_name)
+            self[attribute_name] = nil
+            self.changed_attributes.delete(attribute_name)
+          end
         end
       end
   end

--- a/activerecord/test/cases/dup_test.rb
+++ b/activerecord/test/cases/dup_test.rb
@@ -51,7 +51,12 @@ module ActiveRecord
 
       topic.attributes = dbtopic.attributes
 
+      #duped has no timestamp values
       duped = dbtopic.dup
+
+      #clear topic timestamp values
+      topic.send(:clear_timestamp_attributes)
+
       assert_equal topic.changes, duped.changes
     end
 
@@ -75,5 +80,24 @@ module ActiveRecord
       assert_equal 'Aaron', topic.author_name
       assert_equal 'meow', duped.author_name
     end
+
+    def test_dup_timestamps_are_cleared
+      topic = Topic.first
+      assert_not_nil topic.updated_at
+      assert_not_nil topic.created_at
+
+      # temporary change to the topic object
+      topic.updated_at -= 3.days
+
+      #dup should not preserve the timestamps if present
+      new_topic = topic.dup
+      assert_nil new_topic.updated_at
+      assert_nil new_topic.created_at
+
+      new_topic.save
+      assert_not_nil new_topic.updated_at
+      assert_not_nil new_topic.created_at
+    end
+
   end
 end


### PR DESCRIPTION
The [last changes in the CHANGELOG](https://github.com/rails/rails/blob/0456feab1198456069d4b5a9da221e6fd818e3da/activerecord/CHANGELOG#L3-L12) makes it clear that AR::Base.dup returns an object where new_record? is true. The attached patch clears the timestamps (if they exist) when calling `dup`. If we don't want that behavior though, we should document that `dup` preserves these AR-managed attributes.

In any case we should also close/mark as invalid that ticket [AR::Clone does not clear out timestamps](https://rails.lighthouseapp.com/projects/8994/tickets/4538-activerecordclone-does-not-clear-out-timestamps)
