### PR TITLE
Polish pull request 113: typo + documentation

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1833,7 +1833,7 @@ MSG
         end
       end
 
-      # Clear attributes and changged_attributes
+      # Clear attributes and changed_attributes
       def clear_timestamp_attributes
         %w(created_at created_on updated_at updated_on).each do |attribute_name|
           if self.has_attribute?(attribute_name)

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1605,6 +1605,7 @@ MSG
       # only, not its associations. The extent of a "deep" copy is application
       # specific and is therefore left to the application to implement according
       # to its need.
+      # The dup method does not preserve the timestamps (created|updated)_(at|on).
       def initialize_dup(other)
         cloned_attributes = other.clone_attributes(:read_attribute_before_type_cast)
         cloned_attributes.delete(self.class.primary_key)


### PR DESCRIPTION
Here are two changes, fixing the small typo and document that the shallow copy issues by dup does not preserve timestamps. 
