### PR TITLE
#LH4840 to_xml doesn't work in such case: Event.select('title as t').to_xml

### DIFF
--- a/activerecord/lib/active_record/serializers/xml_serializer.rb
+++ b/activerecord/lib/active_record/serializers/xml_serializer.rb
@@ -226,8 +226,14 @@ module ActiveRecord #:nodoc:
 
     class Attribute < ActiveModel::Serializers::Xml::Serializer::Attribute #:nodoc:
       def compute_type
-        type = @serializable.class.serialized_attributes.has_key?(name) ?
-          super : @serializable.class.columns_hash[name].type
+        case
+          when @serializable.class.serialized_attributes.has_key?(name)
+            type = super
+          when @serializable.class.columns_hash.has_key?(name)
+            type = @serializable.class.columns_hash[name].type
+          else
+            type = NilClass
+        end
 
         case type
         when :text

--- a/activerecord/test/cases/xml_serialization_test.rb
+++ b/activerecord/test/cases/xml_serialization_test.rb
@@ -241,4 +241,10 @@ class DatabaseConnectedXmlSerializationTest < ActiveRecord::TestCase
     assert array.include? 'github'
   end
 
+  def test_should_support_aliased_attributes
+    xml = Author.select("name as firstname").to_xml
+    array = Hash.from_xml(xml)['authors']
+    assert_equal array.size, array.select { |author| author.has_key? 'firstname' }.size
+  end
+
 end


### PR DESCRIPTION
These commits fix https://rails.lighthouseapp.com/projects/8994/tickets/4840-to_xml-doesnt-work-in-such-case-eventselecttitle-as-tto_xml
