### PR TITLE
Mutex

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1,3 +1,4 @@
+require 'thread'
 require 'monitor'
 require 'set'
 require 'active_support/core_ext/module/synchronization'

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -1,3 +1,4 @@
+require 'thread'
 require "cases/helper"
 require 'models/person'
 require 'models/reader'

--- a/activesupport/lib/active_support/core_ext/module/synchronization.rb
+++ b/activesupport/lib/active_support/core_ext/module/synchronization.rb
@@ -1,3 +1,4 @@
+require 'thread'
 require 'active_support/core_ext/module/aliasing'
 require 'active_support/core_ext/array/extract_options'
 

--- a/activesupport/test/core_ext/module/synchronization_test.rb
+++ b/activesupport/test/core_ext/module/synchronization_test.rb
@@ -1,3 +1,4 @@
+require 'thread'
 require 'abstract_unit'
 
 require 'active_support/core_ext/class/attribute_accessors'


### PR DESCRIPTION
RubyGems < 1.4 loaded the thread library that provides mutex.

RubyGems 1.4 will not do this, and this will cause even rake tasks to explode with:

```
uninitialized constant ActiveSupport::Dependencies::Mutex
```

This needs backporting to other releases, and i'd strongly recommend getting some point release fixes out soon so that when RubyGems 1.4 is released, all our users don't suffer for updating.

Thanks.
