### PR TITLE
Removed the hard-coded timestamp values in AR::Base#clear_timestamp_attributes

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1875,11 +1875,9 @@ MSG
 
       # Clear attributes and changed_attributes
       def clear_timestamp_attributes
-        %w(created_at created_on updated_at updated_on).each do |attribute_name|
-          if has_attribute?(attribute_name)
-            self[attribute_name] = nil
-            changed_attributes.delete(attribute_name)
-          end
+        all_timestamp_attributes_in_model.each do |attribute_name|
+          self[attribute_name] = nil
+          changed_attributes.delete(attribute_name)
         end
       end
   end

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -74,6 +74,10 @@ module ActiveRecord
       timestamp_attributes_for_update.select { |c| self.class.column_names.include?(c.to_s) }
     end
 
+    def all_timestamp_attributes_in_model
+      timestamp_attributes_for_create_in_model + timestamp_attributes_for_update_in_model
+    end
+
     def timestamp_attributes_for_update #:nodoc:
       [:updated_at, :updated_on]
     end

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -66,6 +66,10 @@ module ActiveRecord
       self.record_timestamps && (!partial_updates? || changed? || (attributes.keys & self.class.serialized_attributes.keys).present?)
     end
 
+    def timestamp_attributes_for_create_in_model
+      timestamp_attributes_for_create.select { |c| self.class.column_names.include?(c.to_s) }
+    end
+
     def timestamp_attributes_for_update_in_model
       timestamp_attributes_for_update.select { |c| self.class.column_names.include?(c.to_s) }
     end

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -165,4 +165,9 @@ class TimestampTest < ActiveRecord::TestCase
     toy = Toy.first
     assert_equal toy.send(:timestamp_attributes_for_update_in_model), [:updated_at]
   end
+
+  def test_all_timestamp_attributes_in_model
+    toy = Toy.first
+    assert_equal toy.send(:all_timestamp_attributes_in_model), [:created_at, :updated_at]
+  end
 end

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -140,4 +140,9 @@ class TimestampTest < ActiveRecord::TestCase
   ensure
     Toy.belongs_to :pet
   end
+
+  def test_timestamp_attributes_for_create
+    toy = Toy.first
+    assert_equal toy.send(:timestamp_attributes_for_create), [:created_at, :created_on]
+  end
 end

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -160,4 +160,9 @@ class TimestampTest < ActiveRecord::TestCase
     toy = Toy.first
     assert_equal toy.send(:timestamp_attributes_for_create_in_model), [:created_at]
   end
+
+  def test_timestamp_attributes_for_update_in_model
+    toy = Toy.first
+    assert_equal toy.send(:timestamp_attributes_for_update_in_model), [:updated_at]
+  end
 end

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -145,4 +145,9 @@ class TimestampTest < ActiveRecord::TestCase
     toy = Toy.first
     assert_equal toy.send(:timestamp_attributes_for_create), [:created_at, :created_on]
   end
+
+  def test_timestamp_attributes_for_update
+    toy = Toy.first
+    assert_equal toy.send(:timestamp_attributes_for_update), [:updated_at, :updated_on]
+  end
 end

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -155,4 +155,9 @@ class TimestampTest < ActiveRecord::TestCase
     toy = Toy.first
     assert_equal toy.send(:all_timestamp_attributes), [:created_at, :created_on, :updated_at, :updated_on]
   end
+
+  def test_timestamp_attributes_for_create_in_model
+    toy = Toy.first
+    assert_equal toy.send(:timestamp_attributes_for_create_in_model), [:created_at]
+  end
 end

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -150,4 +150,9 @@ class TimestampTest < ActiveRecord::TestCase
     toy = Toy.first
     assert_equal toy.send(:timestamp_attributes_for_update), [:updated_at, :updated_on]
   end
+
+  def test_all_timestamp_attributes
+    toy = Toy.first
+    assert_equal toy.send(:all_timestamp_attributes), [:created_at, :created_on, :updated_at, :updated_on]
+  end
 end


### PR DESCRIPTION
Removed the hard-coded timestamp values in `AR::Base#clear_timestamp_attributes`
