### PR TITLE
Fix for polymorphic belongs to associationproxy raising errors when loading target

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -23,6 +23,10 @@ module ActiveRecord
         @updated
       end
 
+      def conditions
+        @conditions ||= interpolate_sql(association_class.send(:sanitize_sql, @reflection.options[:conditions])) if @reflection.options[:conditions]
+      end
+
       private
 
         # NOTE - for now, we're only supporting inverse setting from belongs_to back onto

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -159,6 +159,15 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_not_nil Company.find(3).firm_with_condition, "Microsoft should have a firm"
   end
 
+  def test_with_polymorphic_and_condition
+    sponsor = Sponsor.create
+    member = Member.create :name => "Bert"
+    sponsor.sponsorable = member
+
+    assert_equal member, sponsor.sponsorable
+    assert_nil sponsor.sponsorable_with_conditions
+  end
+
   def test_with_select
     assert_equal Company.find(2).firm_with_select.attributes.size, 1
     assert_equal Company.find(2, :include => :firm_with_select ).firm_with_select.attributes.size, 1

--- a/activerecord/test/models/sponsor.rb
+++ b/activerecord/test/models/sponsor.rb
@@ -1,4 +1,7 @@
 class Sponsor < ActiveRecord::Base
   belongs_to :sponsor_club, :class_name => "Club", :foreign_key => "club_id"
   belongs_to :sponsorable, :polymorphic => true
+
+  belongs_to :sponsorable_with_conditions, :polymorphic => true,
+             :foreign_type => 'sponsorable_type', :foreign_key => 'sponsorable_id', :conditions => {:name => 'Ernie'}
 end


### PR DESCRIPTION
Hey all, just a small fix for polymorphic belongs_to associations here. The associationproxy should be generating conditions for the association_class instead of using reflection.sanitized_conditions, since that will just give a NameError on something like Note::Notable.
