### PR TITLE
Disable keys for postgres 9.0.1is broken

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -404,10 +404,7 @@ module ActiveRecord
       # REFERENTIAL INTEGRITY ====================================
 
       def supports_disable_referential_integrity?() #:nodoc:
-        version = query("SHOW server_version")[0][0].split('.')
-        version[0].to_i >= 8 && version[1].to_i >= 1
-      rescue
-        return false
+        postgresql_version >= 80100
       end
 
       def disable_referential_integrity #:nodoc:

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -953,8 +953,12 @@ module ActiveRecord
             else
               # Mimic PGconn.server_version behavior
               begin
-                query('SELECT version()')[0][0] =~ /PostgreSQL (\d+)\.(\d+)\.(\d+)/
-                ($1.to_i * 10000) + ($2.to_i * 100) + $3.to_i
+                if query('SELECT version()')[0][0] =~ /PostgreSQL ([0-9.]+)/
+                  major, minor, tiny = $1.split(".")
+                  (major.to_i * 10000) + (minor.to_i * 100) + tiny.to_i
+                else
+                  0
+                end
               rescue
                 0
               end


### PR DESCRIPTION
here is the lighthouse ticket

https://rails.lighthouseapp.com/projects/8994/tickets/5635-postgresql_adapter-doesnt-disable-referential-integrity-for-pg-90

the gist is;

rails tests are broken on postgres 9.0.1, if using foreign keys
