### PR TITLE
Allow to_json to override the value of include_root_in_json

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -235,9 +235,7 @@ module ActionDispatch
       # Set the host name to use in the next request.
       #
       #   session.host! "www.example.com"
-      def host!(name)
-        @host = name
-      end
+      alias :host! :host=
 
       private
         def _mock_session

--- a/actionpack/lib/action_view/renderer/template_renderer.rb
+++ b/actionpack/lib/action_view/renderer/template_renderer.rb
@@ -45,7 +45,7 @@ module ActionView
       elsif options.key?(:file)
         with_fallbacks { find_template(options[:file], options[:prefix], false, keys) }
       elsif options.key?(:inline)
-        handler = Template.handler_class_for_extension(options[:type] || "erb")
+        handler = Template.handler_for_extension(options[:type] || "erb")
         Template.new(options[:inline], "inline template", handler, :locals => keys)
       elsif options.key?(:template)
         options[:template].respond_to?(:render) ?

--- a/actionpack/lib/action_view/template/handlers.rb
+++ b/actionpack/lib/action_view/template/handlers.rb
@@ -44,7 +44,13 @@ module ActionView #:nodoc:
       end
 
       def handler_class_for_extension(extension)
-        (extension && registered_template_handler(extension.to_sym)) || @@default_template_handlers
+        ActiveSupport::Deprecation.warn "handler_class_for_extension is deprecated. " <<
+          "Please use handler_for_extension instead", caller
+        handler_for_extension(extension)
+      end
+
+      def handler_for_extension(extension)
+        registered_template_handler(extension) || @@default_template_handlers
       end
     end
   end

--- a/actionpack/lib/action_view/template/resolver.rb
+++ b/actionpack/lib/action_view/template/resolver.rb
@@ -129,7 +129,7 @@ module ActionView
     def extract_handler_and_format(path, default_formats)
       pieces = File.basename(path).split(".")
       pieces.shift
-      handler = Template.handler_class_for_extension(pieces.pop)
+      handler = Template.handler_for_extension(pieces.pop)
       format  = pieces.last && Mime[pieces.last]
       [handler, format]
     end

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -165,7 +165,13 @@ module ActiveModel
 
     # Returns an ActiveSupport::OrderedHash that can be used as the JSON representation for this object.
     def as_json(options=nil)
-      self
+      to_hash
+    end
+
+    def to_hash
+      hash = ActiveSupport::OrderedHash.new
+      each { |k, v| (hash[k] ||= []) << v }
+      hash
     end
 
     # Adds +message+ to the error messages on +attribute+, which will be returned on a call to

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -167,16 +167,6 @@ module ActiveModel
     def as_json(options=nil)
       self
     end
-    
-    def encode_json(encoder)
-      errors = []
-      each_pair do |key, value|
-        value = value.first if value.size == 1
-        errors << "#{encoder.encode(key.to_s)}:#{encoder.encode(value, false)}"
-      end
-
-      "{#{errors * ','}}"
-    end
 
     # Adds +message+ to the error messages on +attribute+, which will be returned on a call to
     # <tt>on(attribute)</tt> for the same attribute. More than one error can be added to the same

--- a/activemodel/lib/active_model/serializers/json.rb
+++ b/activemodel/lib/active_model/serializers/json.rb
@@ -83,8 +83,8 @@ module ActiveModel
       def as_json(options = nil)
         hash = serializable_hash(options)
 
-        if include_root_in_json
-          custom_root = options && options[:root]
+        if !(options && options[:root] == false) && ((options && options[:root]) || include_root_in_json)
+          custom_root = options && options[:root] != true && options[:root]
           hash = { custom_root || self.class.model_name.element => hash }
         end
 

--- a/activemodel/lib/active_model/serializers/json.rb
+++ b/activemodel/lib/active_model/serializers/json.rb
@@ -32,6 +32,22 @@ module ActiveModel
       #   # => {"id": 1, "name": "Konata Izumi", "age": 16,
       #         "created_at": "2006/08/01", "awesome": true}
       #
+      # The <tt>include_root_in_json</tt> option can be overriden when calling
+      # +to_json+ to include or omit the default root as well as changing the root.
+      #
+      #   konata.as_json(:root => false)
+      #   # => {"id": 1, "name": "Konata Izumi", "age": 16,
+      #         "created_at": "2006/08/01", "awesome": true}
+      #
+      #   ActiveRecord::Base.include_root_in_json = false
+      #   konata.as_json(:root => true)
+      #   # => { "user": {"id": 1, "name": "Konata Izumi", "age": 16,
+      #                   "created_at": "2006/08/01", "awesome": true} }
+      #
+      #   konata.as_json(:root => 'person')
+      #   # => { "person": {"id": 1, "name": "Konata Izumi", "age": 16,
+      #                   "created_at": "2006/08/01", "awesome": true} }
+      #
       # The remainder of the examples in this section assume +include_root_in_json+
       # is false.
       #

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -62,4 +62,9 @@ class ErrorsTest < ActiveModel::TestCase
 
   end
 
+  test 'to_hash should return an ordered hash' do
+    person = Person.new
+    person.errors.add(:name, "can not be blank")
+    assert_instance_of ActiveSupport::OrderedHash, person.errors.to_hash
+  end
 end

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -61,15 +61,5 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal ["name can not be blank", "name can not be nil"], person.errors.to_a
 
   end
-  
-  test 'to_json should return valid json string' do
-    person = Person.new
-    person.errors.add(:name, "can not be blank")
-    person.errors.add(:name, "can not be nil")
-    
-    hash = ActiveSupport::OrderedHash[:name, ["can not be blank", "can not be nil"]]
-    
-    assert_equal person.errors.to_json, hash.to_json
-  end
 
 end

--- a/activemodel/test/cases/serializeration/json_serialization_test.rb
+++ b/activemodel/test/cases/serializeration/json_serialization_test.rb
@@ -6,6 +6,7 @@ require 'active_support/core_ext/object/instance_variables'
 class Contact
   extend ActiveModel::Naming
   include ActiveModel::Serializers::JSON
+  include ActiveModel::Validations
 
   def attributes
     instance_values
@@ -134,15 +135,15 @@ class JsonSerializationTest < ActiveModel::TestCase
   end
 
   test "should return OrderedHash for errors" do
-    car = Automobile.new
-
-    # run the validation
-    car.valid?
+    contact = Contact.new
+    contact.errors.add :name, "can't be blank"
+    contact.errors.add :name, "is too short (minimum is 2 characters)"
+    contact.errors.add :age, "must be 16 or over"
 
     hash = ActiveSupport::OrderedHash.new
-    hash[:make]  = "can't be blank"
-    hash[:model] = "is too short (minimum is 2 characters)"
-    assert_equal hash.to_json, car.errors.to_json
+    hash[:name] = ["can't be blank", "is too short (minimum is 2 characters)"]
+    hash[:age]  = ["must be 16 or over"]
+    assert_equal hash.to_json, contact.errors.to_json
   end
 
   test "serializable_hash should not modify options passed in argument" do

--- a/activemodel/test/cases/serializeration/json_serialization_test.rb
+++ b/activemodel/test/cases/serializeration/json_serialization_test.rb
@@ -60,6 +60,35 @@ class JsonSerializationTest < ActiveModel::TestCase
     assert_match %r{"preferences":\{"shows":"anime"\}}, json
   end
 
+  test "should include root in json when root is true" do
+    begin
+      Contact.include_root_in_json = false
+      json = @contact.to_json(:root => true)
+
+      assert_match %r{^\{"contact":\{}, json
+      assert_match %r{"name":"Konata Izumi"}, json
+      assert_match %r{"age":16}, json
+      assert json.include?(%("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))}))
+      assert_match %r{"awesome":true}, json
+      assert_match %r{"preferences":\{"shows":"anime"\}}, json
+    ensure
+      Contact.include_root_in_json = true
+    end
+  end
+
+  test "should not include root in json when root is false" do
+    begin
+      json = @contact.to_json(:root => false)
+
+      assert_no_match %r{^\{"contact":\{}, json
+      assert_match %r{"name":"Konata Izumi"}, json
+      assert_match %r{"age":16}, json
+      assert json.include?(%("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))}))
+      assert_match %r{"awesome":true}, json
+      assert_match %r{"preferences":\{"shows":"anime"\}}, json
+    end
+  end
+
   test "should encode all encodable attributes" do
     json = @contact.to_json
 

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -174,8 +174,8 @@ class ValidationsTest < ActiveModel::TestCase
     assert_match %r{<error>Content can't be blank</error>}, xml
 
     hash = ActiveSupport::OrderedHash.new
-    hash[:title] = "can't be blank"
-    hash[:content] = "can't be blank"
+    hash[:title] = ["can't be blank"]
+    hash[:content] = ["can't be blank"]
     assert_equal t.errors.to_json, hash.to_json
   end
 

--- a/activerecord/lib/active_record/associations/class_methods/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/class_methods/join_dependency.rb
@@ -9,7 +9,8 @@ module ActiveRecord
         attr_reader :join_parts, :reflections, :table_aliases
 
         def initialize(base, associations, joins)
-          @join_parts            = [JoinBase.new(base, joins)]
+          @table_joins           = joins || ''
+          @join_parts            = [JoinBase.new(base)]
           @associations          = {}
           @reflections           = []
           @table_aliases         = Hash.new(0)
@@ -45,7 +46,7 @@ module ActiveRecord
         def count_aliases_from_table_joins(name)
           # quoted_name should be downcased as some database adapters (Oracle) return quoted name in uppercase
           quoted_name = join_base.active_record.connection.quote_table_name(name.downcase).downcase
-          join_sql = join_base.table_joins.to_s.downcase
+          join_sql = @table_joins.downcase
           join_sql.blank? ? 0 :
             # Table names
             join_sql.scan(/join(?:\s+\w+)?\s+#{quoted_name}\son/).size +

--- a/activerecord/lib/active_record/associations/class_methods/join_dependency/join_base.rb
+++ b/activerecord/lib/active_record/associations/class_methods/join_dependency/join_base.rb
@@ -3,14 +3,6 @@ module ActiveRecord
     module ClassMethods
       class JoinDependency # :nodoc:
         class JoinBase < JoinPart # :nodoc:
-          # Extra joins provided when the JoinDependency was created
-          attr_reader :table_joins
-
-          def initialize(active_record, joins = nil)
-            super(active_record)
-            @table_joins = joins
-          end
-
           def ==(other)
             other.class == self.class &&
               other.active_record == active_record

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1830,7 +1830,9 @@ MSG
       def populate_with_current_scope_attributes
         if scope = self.class.send(:current_scoped_methods)
           create_with = scope.scope_for_create
-          create_with.each { |att,value| self.respond_to?(:"#{att}=") && self.send("#{att}=", value) } if create_with
+          create_with.each { |att,value|
+            respond_to?(:"#{att}=") && send("#{att}=", value)
+          }
         end
       end
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -329,7 +329,7 @@ module ActiveRecord
     def scope_for_create
       @scope_for_create ||= begin
         if @create_with_value
-          @create_with_value.reverse_merge(where_values_hash)
+          where_values_hash.merge @create_with_value
         else
           where_values_hash
         end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -319,13 +319,13 @@ module ActiveRecord
     end
 
     def where_values_hash
-      Hash[@where_values.find_all { |w|
-        w.respond_to?(:operator) && w.operator == :== && w.left.relation.name == table_name
-      }.map { |where|
-        [
-          where.left.name,
-          where.right.respond_to?(:value) ? where.right.value : where.right
-        ]
+      equalities = @where_values.grep(Arel::Nodes::Equality).find_all { |node|
+        node.left.relation.name == table_name
+      }
+
+      Hash[equalities.map { |where|
+        left, right = where.left, where.right
+        [ left.name, right.respond_to?(:value) ? right.value : right ]
       }]
     end
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -339,7 +339,7 @@ module ActiveRecord
       when Relation
         other.to_sql == to_sql
       when Array
-        to_a == other.to_a
+        to_a == other
       end
     end
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -371,7 +371,7 @@ module ActiveRecord
 
     def references_eager_loaded_tables?
       # always convert table names to downcase as in Oracle quoted table names are in uppercase
-      joined_tables = (tables_in_string(arel.joins(arel)) + [table.name, table.table_alias]).compact.map{ |t| t.downcase }.uniq
+      joined_tables = (tables_in_string(arel.join_sql) + [table.name, table.table_alias]).compact.map{ |t| t.downcase }.uniq
       (tables_in_string(to_sql) - joined_tables).any?
     end
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -327,13 +327,7 @@ module ActiveRecord
     end
 
     def scope_for_create
-      @scope_for_create ||= begin
-        if @create_with_value
-          where_values_hash.merge @create_with_value
-        else
-          where_values_hash
-        end
-      end
+      @scope_for_create ||= where_values_hash.merge(@create_with_value || {})
     end
 
     def eager_loading?

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -356,6 +356,10 @@ module ActiveRecord
       to_a.inspect
     end
 
+    def table_name
+      @klass.table_name
+    end
+
     protected
 
     def method_missing(method, *args, &block)

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -323,10 +323,7 @@ module ActiveRecord
         node.left.relation.name == table_name
       }
 
-      Hash[equalities.map { |where|
-        left, right = where.left, where.right
-        [ left.name, right.respond_to?(:value) ? right.value : right ]
-      }]
+      Hash[equalities.map { |where| [where.left.name, where.right] }]
     end
 
     def scope_for_create

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -166,7 +166,7 @@ module ActiveRecord
       if operation == "count"
         column_name ||= (select_for_count || :all)
 
-        if arel.joins(arel) =~ /LEFT OUTER/i
+        if arel.join_sql =~ /LEFT OUTER/i
           distinct = true
           column_name = @klass.primary_key if column_name == :all
         end

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -166,7 +166,7 @@ module ActiveRecord
       if operation == "count"
         column_name ||= (select_for_count || :all)
 
-        if arel.join_sql =~ /LEFT OUTER/i
+        unless arel.ast.grep(Arel::Nodes::OuterJoin).empty?
           distinct = true
           column_name = @klass.primary_key if column_name == :all
         end

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -196,7 +196,7 @@ module ActiveRecord
 
     def construct_relation_for_association_calculations
       including = (@eager_load_values + @includes_values).uniq
-      join_dependency = ActiveRecord::Associations::ClassMethods::JoinDependency.new(@klass, including, arel.joins(arel))
+      join_dependency = ActiveRecord::Associations::ClassMethods::JoinDependency.new(@klass, including, arel.join_sql)
       relation = except(:includes, :eager_load, :preload)
       apply_join_dependency(relation, join_dependency)
     end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -162,7 +162,7 @@ module ActiveRecord
       @arel ||= build_arel
     end
 
-    def custom_join_sql(*joins)
+    def custom_join_sql(joins)
       arel = table.select_manager
 
       joins.each do |join|
@@ -254,7 +254,7 @@ module ActiveRecord
       stashed_association_joins = joins.grep(ActiveRecord::Associations::ClassMethods::JoinDependency::JoinAssociation)
 
       non_association_joins = (joins - association_joins - stashed_association_joins)
-      custom_joins = custom_join_sql(*non_association_joins)
+      custom_joins = custom_join_sql(non_association_joins)
 
       join_dependency = ActiveRecord::Associations::ClassMethods::JoinDependency.new(@klass, association_joins, custom_joins)
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -180,7 +180,7 @@ module ActiveRecord
         arel.join(join)
       end
 
-      arel.joins(arel)
+      arel.join_sql
     end
 
     def build_arel

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -243,12 +243,10 @@ module ActiveRecord
     end
 
     def build_joins(relation, joins)
-      association_joins = []
-
       joins = joins.map {|j| j.respond_to?(:strip) ? j.strip : j}.uniq
 
-      joins.each do |join|
-        association_joins << join if [Hash, Array, Symbol].include?(join.class) && !array_of_strings?(join)
+      association_joins = joins.find_all do |join|
+        [Hash, Array, Symbol].include?(join.class) && !array_of_strings?(join)
       end
 
       stashed_association_joins = joins.grep(ActiveRecord::Associations::ClassMethods::JoinDependency::JoinAssociation)

--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -3,9 +3,10 @@ require 'active_support/core_ext/object/blank'
 module ActiveRecord
   module SpawnMethods
     def merge(r)
-      merged_relation = clone
-      return merged_relation unless r
+      return self unless r
       return to_a & r if r.is_a?(Array)
+
+      merged_relation = clone
 
       Relation::ASSOCIATION_METHODS.each do |method|
         value = r.send(:"#{method}_values")
@@ -24,7 +25,7 @@ module ActiveRecord
         merged_relation.send(:"#{method}_values=", merged_relation.send(:"#{method}_values") + value) if value.present?
       end
 
-      merged_relation = merged_relation.joins(r.joins_values)
+      merged_relation.joins_values += r.joins_values
 
       merged_wheres = @where_values + r.where_values
 

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -38,9 +38,9 @@ module ActiveRecord
             assert_not_nil connection
           end
         end
-        
+
         threads.each {|t| t.join}
-        
+
         Thread.new do
           threads.each do |t|
             thread_ids = pool.instance_variable_get(:@reserved_connections).keys

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -848,13 +848,12 @@ class TestNestedAttributesWithNonStandardPrimaryKeys < ActiveRecord::TestCase
   def test_attr_accessor_of_child_should_be_value_provided_during_update_attributes
     @owner = owners(:ashley)
     @pet1 = pets(:chew)
-    assert_equal nil, $current_user
     attributes = {:pets_attributes => { "1"=> { :id => @pet1.id,
                                                 :name => "Foo2",
                                                 :current_user => "John",
                                                 :_destroy=>true }}}
     @owner.update_attributes(attributes)
-    assert_equal 'John', $after_destroy_callback_output
+    assert_equal 'John', Pet.after_destroy_output
   end
 
 end

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -98,5 +98,19 @@ module ActiveRecord
       relation = Relation.new :a, :b
       assert_equal({}, relation.scope_for_create)
     end
+
+    def test_create_with_value
+      relation = Relation.new Post, Post.arel_table
+      hash = { :hello => 'world' }
+      relation.create_with_value = hash
+      assert_equal hash, relation.scope_for_create
+    end
+
+    def test_create_with_value_with_wheres
+      relation = Relation.new Post, Post.arel_table
+      relation.where_values << relation.table[:id].eq(10)
+      relation.create_with_value = {:hello => 'world'}
+      assert_equal({:hello => 'world', :id => 10}, relation.scope_for_create)
+    end
   end
 end

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -2,6 +2,9 @@ require "cases/helper"
 
 module ActiveRecord
   class RelationTest < ActiveRecord::TestCase
+    class FakeTable < Struct.new(:table_name)
+    end
+
     def test_construction
       relation = nil
       assert_nothing_raised do
@@ -51,6 +54,24 @@ module ActiveRecord
     def test_extensions
       relation = Relation.new :a, :b
       assert_equal [], relation.extensions
+    end
+
+    def test_where_values_hash
+      relation = Relation.new :a, :b
+      assert_equal({}, relation.where_values_hash)
+
+      relation.where_values << :hello
+      assert_equal({}, relation.where_values_hash)
+    end
+
+    def test_table_name_delegates_to_klass
+      relation = Relation.new FakeTable.new('foo'), :b
+      assert_equal 'foo', relation.table_name
+    end
+
+    def test_scope_for_create
+      relation = Relation.new :a, :b
+      assert_equal({}, relation.scope_for_create)
     end
   end
 end

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -80,6 +80,15 @@ module ActiveRecord
       assert_equal({}, relation.where_values_hash)
     end
 
+    def test_tree_is_not_traversed
+      relation = Relation.new Post, Post.arel_table
+      left     = relation.table[:id].eq(10)
+      right    = relation.table[:id].eq(10)
+      combine  = left.and right
+      relation.where_values << combine
+      assert_equal({}, relation.where_values_hash)
+    end
+
     def test_table_name_delegates_to_klass
       relation = Relation.new FakeKlass.new('foo'), :b
       assert_equal 'foo', relation.table_name

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -124,5 +124,16 @@ module ActiveRecord
       relation.create_with_value = {:hello => 'world'}
       assert_equal({}, relation.scope_for_create)
     end
+
+    def test_empty_eager_loading?
+      relation = Relation.new :a, :b
+      assert !relation.eager_loading?
+    end
+
+    def test_eager_load_values
+      relation = Relation.new :a, :b
+      relation.eager_load_values << :b
+      assert relation.eager_loading?
+    end
   end
 end

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -1,0 +1,56 @@
+require "cases/helper"
+
+module ActiveRecord
+  class RelationTest < ActiveRecord::TestCase
+    def test_construction
+      relation = nil
+      assert_nothing_raised do
+        relation = Relation.new :a, :b
+      end
+      assert_equal :a, relation.klass
+      assert_equal :b, relation.table
+      assert !relation.loaded, 'relation is not loaded'
+    end
+
+    def test_single_values
+      assert_equal [:limit, :offset, :lock, :readonly, :create_with, :from].sort,
+        Relation::SINGLE_VALUE_METHODS.sort
+    end
+
+    def test_initialize_single_values
+      relation = Relation.new :a, :b
+      Relation::SINGLE_VALUE_METHODS.each do |method|
+        assert_nil relation.send("#{method}_value"), method.to_s
+      end
+    end
+
+    def test_association_methods
+      assert_equal [:includes, :eager_load, :preload].sort,
+        Relation::ASSOCIATION_METHODS.sort
+    end
+
+    def test_initialize_association_methods
+      relation = Relation.new :a, :b
+      Relation::ASSOCIATION_METHODS.each do |method|
+        assert_equal [], relation.send("#{method}_values"), method.to_s
+      end
+    end
+
+    def test_multi_value_methods
+      assert_equal [:select, :group, :order, :joins, :where, :having, :bind].sort,
+        Relation::MULTI_VALUE_METHODS.sort
+    end
+
+    def test_multi_value_initialize
+      relation = Relation.new :a, :b
+      Relation::MULTI_VALUE_METHODS.each do |method|
+        assert_equal [], relation.send("#{method}_values"), method.to_s
+      end
+    end
+
+    def test_extensions
+      relation = Relation.new :a, :b
+      assert_equal [], relation.extensions
+    end
+  end
+end

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -20,8 +20,8 @@ module ActiveRecord
     end
 
     def test_single_values
-      assert_equal [:limit, :offset, :lock, :readonly, :create_with, :from].sort,
-        Relation::SINGLE_VALUE_METHODS.sort
+      assert_equal [:limit, :offset, :lock, :readonly, :create_with, :from].map(&:to_s).sort,
+        Relation::SINGLE_VALUE_METHODS.map(&:to_s).sort
     end
 
     def test_initialize_single_values
@@ -32,8 +32,8 @@ module ActiveRecord
     end
 
     def test_association_methods
-      assert_equal [:includes, :eager_load, :preload].sort,
-        Relation::ASSOCIATION_METHODS.sort
+      assert_equal [:includes, :eager_load, :preload].map(&:to_s).sort,
+        Relation::ASSOCIATION_METHODS.map(&:to_s).sort
     end
 
     def test_initialize_association_methods
@@ -44,8 +44,8 @@ module ActiveRecord
     end
 
     def test_multi_value_methods
-      assert_equal [:select, :group, :order, :joins, :where, :having, :bind].sort,
-        Relation::MULTI_VALUE_METHODS.sort
+      assert_equal [:select, :group, :order, :joins, :where, :having, :bind].map(&:to_s).sort,
+        Relation::MULTI_VALUE_METHODS.map(&:to_s).sort
     end
 
     def test_multi_value_initialize

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -1,8 +1,12 @@
 require "cases/helper"
+require 'models/post'
+require 'models/comment'
 
 module ActiveRecord
   class RelationTest < ActiveRecord::TestCase
-    class FakeTable < Struct.new(:table_name)
+    fixtures :posts, :comments
+
+    class FakeKlass < Struct.new(:table_name)
     end
 
     def test_construction
@@ -56,7 +60,7 @@ module ActiveRecord
       assert_equal [], relation.extensions
     end
 
-    def test_where_values_hash
+    def test_empty_where_values_hash
       relation = Relation.new :a, :b
       assert_equal({}, relation.where_values_hash)
 
@@ -64,8 +68,20 @@ module ActiveRecord
       assert_equal({}, relation.where_values_hash)
     end
 
+    def test_has_values
+      relation = Relation.new Post, Post.arel_table
+      relation.where_values << relation.table[:id].eq(10)
+      assert_equal({:id => 10}, relation.where_values_hash)
+    end
+
+    def test_values_wrong_table
+      relation = Relation.new Post, Post.arel_table
+      relation.where_values << Comment.arel_table[:id].eq(10)
+      assert_equal({}, relation.where_values_hash)
+    end
+
     def test_table_name_delegates_to_klass
-      relation = Relation.new FakeTable.new('foo'), :b
+      relation = Relation.new FakeKlass.new('foo'), :b
       assert_equal 'foo', relation.table_name
     end
 

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -112,5 +112,17 @@ module ActiveRecord
       relation.create_with_value = {:hello => 'world'}
       assert_equal({:hello => 'world', :id => 10}, relation.scope_for_create)
     end
+
+    # FIXME: is this really wanted or expected behavior?
+    def test_scope_for_create_is_cached
+      relation = Relation.new Post, Post.arel_table
+      assert_equal({}, relation.scope_for_create)
+
+      relation.where_values << relation.table[:id].eq(10)
+      assert_equal({}, relation.scope_for_create)
+
+      relation.create_with_value = {:hello => 'world'}
+      assert_equal({}, relation.scope_for_create)
+    end
   end
 end

--- a/activerecord/test/models/pet.rb
+++ b/activerecord/test/models/pet.rb
@@ -6,8 +6,12 @@ class Pet < ActiveRecord::Base
   belongs_to :owner, :touch => true
   has_many :toys
 
+  class << self
+    attr_accessor :after_destroy_output
+  end
+
   after_destroy do |record|
-    $after_destroy_callback_output = record.current_user
+    Pet.after_destroy_output = record.current_user
   end
 
 end


### PR DESCRIPTION
If you want to override the value of include_root_in_json for a specific controller and action there is currently no thread-safe way of doing that.

Now you can call @contact.to_json(:root => true) to always have a root, :root => false to always omit the root and :root => 'whatever' now always includes the root 'whatever' (previously it wouldn't include the custom root if specified when include_root_in_json was false).
