### PR TITLE
app generator not including script.aculo.us with Prototype

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -104,18 +104,18 @@ module Rails
 
     def javascripts
       empty_directory "public/javascripts"
-          
+
       unless options[:skip_javascript]
         copy_file "public/javascripts/#{@options[:javascript]}.js"
         copy_file "public/javascripts/#{@options[:javascript]}_ujs.js", "public/javascripts/rails.js"
-        
-        if options[:prototype]
+
+        if options[:javascript] == "prototype"
           copy_file "public/javascripts/controls.js"
           copy_file "public/javascripts/dragdrop.js"
           copy_file "public/javascripts/effects.js"
         end
       end
-      
+
       copy_file "public/javascripts/application.js"
     end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -134,6 +134,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "config/application.rb", /#\s+config\.action_view\.javascript_expansions\[:defaults\]\s+=\s+%w\(jquery rails\)/
     assert_file "public/javascripts/application.js"
     assert_file "public/javascripts/prototype.js"
+    assert_file "public/javascripts/controls.js"
+    assert_file "public/javascripts/dragdrop.js"
+    assert_file "public/javascripts/effects.js"
     assert_file "public/javascripts/rails.js"
     assert_file "test"
   end
@@ -151,6 +154,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "config/application.rb", /#\s+config\.action_view\.javascript_expansions\[:defaults\]\s+=\s+%w\(jquery rails\)/
     assert_file "public/javascripts/application.js"
     assert_file "public/javascripts/prototype.js"
+    assert_file "public/javascripts/controls.js"
+    assert_file "public/javascripts/dragdrop.js"
+    assert_file "public/javascripts/effects.js"
     assert_file "public/javascripts/rails.js", /prototype/
   end
 


### PR DESCRIPTION
The recently added support for --javascript and --skip_javascript options checks for the wrong option when determining whether or not to copy the script.aculo.us JS files. Simple one-line patch plus tests resolves it. Lighthouse ticket coming in a jiffy :-)
