### PR TITLE
Fixed bug #6105 - Rails 3 cannot be installed from scratch due to failed dependency on i18n 0.5.0

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activemodel',      version)
   s.add_dependency('rack-cache',       '~> 0.5.3')
   s.add_dependency('builder',          '~> 3.0.0')
-  s.add_dependency('i18n',             '~> 0.4.2')
+  s.add_dependency('i18n',             '~> 0.5.0')
   s.add_dependency('rack',             '~> 1.2.1')
   s.add_dependency('rack-test',        '~> 0.5.6')
   s.add_dependency('rack-mount',       '~> 0.6.13')

--- a/activemodel/activemodel.gemspec
+++ b/activemodel/activemodel.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency('activesupport', version)
   s.add_dependency('builder',       '~> 3.0.0')
-  s.add_dependency('i18n',          '~> 0.4.2')
+  s.add_dependency('i18n',          '~> 0.5.0')
 end


### PR DESCRIPTION
If you used actionmailer, master-branch would not install with bundler due to dependency-issues, which have been sorted out in this commit. The only thing it does is bring the i18n-dependency of actionpack and activemodel up to ~>0.5.0 (same as actionmailer).

https://rails.lighthouseapp.com/projects/8994/tickets/6105-rails-3-cannot-be-installed-from-scratch-due-to-failed-dependency-on-i18n-050
