### PR TITLE
Namespaced validators

### DIFF
--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -55,6 +55,10 @@ module ActiveModel
       #     validates :name, :title => true
       #   end
       #
+      # Additionally validator classes may be in another namespace and still used within any class.
+      #
+      #   validates :name, :'file/title' => true
+      #
       # The validators hash can also handle regular expressions, ranges, 
       # arrays and strings in shortcut form, e.g.
       #
@@ -86,8 +90,10 @@ module ActiveModel
         defaults.merge!(:attributes => attributes)
 
         validations.each do |key, options|
+          key = "#{key.to_s.camelize}Validator"
+
           begin
-            validator = const_get("#{key.to_s.camelize}Validator")
+            validator = key.include?('::') ? key.constantize : const_get(key)
           rescue NameError
             raise ArgumentError, "Unknown validator: '#{key}'"
           end

--- a/activemodel/test/cases/validations/validates_test.rb
+++ b/activemodel/test/cases/validations/validates_test.rb
@@ -3,6 +3,7 @@ require 'cases/helper'
 require 'models/person'
 require 'models/person_with_validator'
 require 'validators/email_validator'
+require 'validators/namespace/email_validator'
 
 class ValidatesTest < ActiveModel::TestCase
   setup :reset_callbacks
@@ -29,6 +30,13 @@ class ValidatesTest < ActiveModel::TestCase
 
   def test_validates_with_validator_class
     Person.validates :karma, :email => true
+    person = Person.new
+    person.valid?
+    assert_equal ['is not an email'], person.errors[:karma]
+  end
+
+  def test_validates_with_namespaced_validator_class
+    Person.validates :karma, :'namespace/email' => true
     person = Person.new
     person.valid?
     assert_equal ['is not an email'], person.errors[:karma]

--- a/activemodel/test/validators/namespace/email_validator.rb
+++ b/activemodel/test/validators/namespace/email_validator.rb
@@ -1,0 +1,6 @@
+require 'validators/email_validator'
+
+module Namespace
+  class EmailValidator < ::EmailValidator
+  end
+end


### PR DESCRIPTION
Adds support to have namespace validators that aren't inside the model itself.

`validates :attr, :'namespace/some' => true` looks for `Namespace::SomeValidator`
