### PR TITLE
Lighthouse 3353

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -363,7 +363,7 @@ module ActiveRecord
         if autosave && association.marked_for_destruction?
           association.destroy
         elsif autosave != false
-          saved = association.save(:validate => !autosave) if association.new_record? || autosave
+          saved = association.save(:validate => !autosave) if association.new_record? || (autosave && association.changed_for_autosave?)
 
           if association.updated?
             association_id = association.send(reflection.options[:primary_key] || :id)

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -673,6 +673,19 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
     assert_not_nil @ship.reload.pirate
   end
 
+  def test_shoud_not_save_associated_record_if_not_changed
+    # Stub the save method of the @ship.pirate instance to make sure save is not called
+    class << @ship.pirate
+      def save(*args)
+        super
+        raise "Oh noes!"
+      end
+    end
+
+    assert_nothing_raised(RuntimeError) { assert @ship.save }
+    assert_not_nil @ship.reload.pirate
+  end
+
   def test_should_save_changed_child_objects_if_parent_is_saved
     @pirate = @ship.create_pirate(:catchphrase => "Don' botharrr talkin' like one, savvy?")
     @parrot = @pirate.parrots.create!(:name => 'Posideons Killer')

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -667,8 +667,19 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
       end
     end
 
+    @ship.pirate.catchphrase = "Changed Catchphrase"
+
     assert_raise(RuntimeError) { assert !@ship.save }
     assert_not_nil @ship.reload.pirate
+  end
+
+  def test_should_save_changed_child_objects_if_parent_is_saved
+    @pirate = @ship.create_pirate(:catchphrase => "Don' botharrr talkin' like one, savvy?")
+    @parrot = @pirate.parrots.create!(:name => 'Posideons Killer')
+    @parrot.name = "NewName"
+    @ship.save
+
+    assert_equal 'NewName', @parrot.reload.name
   end
 
   # has_many & has_and_belongs_to


### PR DESCRIPTION
There was an issue that belongs_to associations with autosave enabled calls save and all callbacks every time the parent record was saved. This results in unexpected behaviour. I've changed this to only call save if the associated record is changed.
