### PR TITLE
Defer reloading until #close is called on request body

### DIFF
--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -53,6 +53,7 @@ module ActionDispatch
     autoload :Flash
     autoload :Head
     autoload :ParamsParser
+    autoload :Reloader
     autoload :RemoteIp
     autoload :Rescue
     autoload :ShowExceptions

--- a/actionpack/lib/action_dispatch/middleware/callbacks.rb
+++ b/actionpack/lib/action_dispatch/middleware/callbacks.rb
@@ -1,32 +1,14 @@
 module ActionDispatch
   # Provide callbacks to be executed before and after the request dispatch.
-  #
-  # It also provides a to_prepare callback, which is performed in all requests
-  # in development by only once in production and notification callback for async
-  # operations.
-  #
   class Callbacks
     include ActiveSupport::Callbacks
 
     define_callbacks :call, :rescuable => true
-    define_callbacks :prepare, :scope => :name
 
-    # Add a preparation callback. Preparation callbacks are run before every
-    # request in development mode, and before the first request in production mode.
-    #
-    # If a symbol with a block is given, the symbol is used as an identifier.
-    # That allows to_prepare to be called again with the same identifier to
-    # replace the existing callback. Passing an identifier is a suggested
-    # practice if the code adding a preparation block may be reloaded.
     def self.to_prepare(*args, &block)
-      first_arg = args.first
-      if first_arg.is_a?(Symbol) && block_given?
-        remove_method :"__#{first_arg}" if method_defined?(:"__#{first_arg}")
-        define_method :"__#{first_arg}", &block
-        set_callback(:prepare, :"__#{first_arg}")
-      else
-        set_callback(:prepare, *args, &block)
-      end
+      ActiveSupport::Deprecation.warn "ActionDispatch::Callbacks.to_prepare is deprecated. " <<
+        "Please use ActionDispatch::Reloader.to_prepare instead."
+      ActionDispatch::Reloader.to_prepare(*args, &block)
     end
 
     def self.before(*args, &block)
@@ -37,14 +19,13 @@ module ActionDispatch
       set_callback(:call, :after, *args, &block)
     end
 
-    def initialize(app, prepare_each_request = false)
-      @app, @prepare_each_request = app, prepare_each_request
-      _run_prepare_callbacks
+    def initialize(app, unused = nil)
+      ActiveSupport::Deprecation.warn "Passing a second argument to ActionDispatch::Callbacks.new is deprecated." unless unused.nil?
+      @app = app
     end
 
     def call(env)
       _run_call_callbacks do
-        _run_prepare_callbacks if @prepare_each_request
         @app.call(env)
       end
     end

--- a/actionpack/lib/action_dispatch/middleware/reloader.rb
+++ b/actionpack/lib/action_dispatch/middleware/reloader.rb
@@ -1,0 +1,82 @@
+module ActionDispatch
+  # ActionDispatch::Reloader provides to_prepare and to_cleanup callbacks.
+  # These are analogs of ActionDispatch::Callback's before and after
+  # callbacks, with the difference that to_cleanup is not called until the
+  # request is fully complete -- that is, after #close has been called on
+  # the request body. This is important for streaming responses such as the
+  # following:
+  #
+  #     self.response_body = lambda { |response, output|
+  #       # code here which refers to application models
+  #     }
+  #
+  # Cleanup callbacks will not be called until after the response_body lambda
+  # is evaluated, ensuring that it can refer to application models and other
+  # classes before they are unloaded.
+  #
+  # By default, ActionDispatch::Reloader is included in the middleware stack
+  # only in the development environment.
+  #
+  class Reloader
+    include ActiveSupport::Callbacks
+
+    define_callbacks :prepare, :scope => :name
+    define_callbacks :cleanup, :scope => :name
+
+    # Add a preparation callback. Preparation callbacks are run before each
+    # request.
+    #
+    # If a symbol with a block is given, the symbol is used as an identifier.
+    # That allows to_prepare to be called again with the same identifier to
+    # replace the existing callback. Passing an identifier is a suggested
+    # practice if the code adding a preparation block may be reloaded.
+    def self.to_prepare(*args, &block)
+      first_arg = args.first
+      if first_arg.is_a?(Symbol) && block_given?
+        remove_method :"__#{first_arg}" if method_defined?(:"__#{first_arg}")
+        define_method :"__#{first_arg}", &block
+        set_callback(:prepare, :"__#{first_arg}")
+      else
+        set_callback(:prepare, *args, &block)
+      end
+    end
+
+    # Add a cleanup callback. Cleanup callbacks are run after each request is
+    # complete (after #close is called on the response body).
+    def self.to_cleanup(&block)
+      set_callback(:cleanup, &block)
+    end
+
+    def self.prepare!
+      new(nil).send(:_run_prepare_callbacks)
+    end
+
+    def self.cleanup!
+      new(nil).send(:_run_cleanup_callbacks)
+    end
+
+    def self.reload!
+      prepare!
+      cleanup!
+    end
+
+    def initialize(app)
+      @app = app
+    end
+
+    module CleanupOnClose
+      def close
+        super if defined?(super)
+      ensure
+        ActionDispatch::Reloader.cleanup!
+      end
+    end
+
+    def call(env)
+      _run_prepare_callbacks
+      response = @app.call(env)
+      response[2].extend(CleanupOnClose)
+      response
+    end
+  end
+end

--- a/actionpack/test/dispatch/callbacks_test.rb
+++ b/actionpack/test/dispatch/callbacks_test.rb
@@ -1,6 +1,6 @@
 require 'abstract_unit'
 
-class DispatcherTest < Test::Unit::TestCase
+class DispatcherTest < ActiveSupport::TestCase
   class Foo
     cattr_accessor :a, :b
   end
@@ -13,63 +13,7 @@ class DispatcherTest < Test::Unit::TestCase
 
   def setup
     Foo.a, Foo.b = 0, 0
-    ActionDispatch::Callbacks.reset_callbacks(:prepare)
     ActionDispatch::Callbacks.reset_callbacks(:call)
-  end
-
-  def test_prepare_callbacks_with_cache_classes
-    a = b = c = nil
-    ActionDispatch::Callbacks.to_prepare { |*args| a = b = c = 1 }
-    ActionDispatch::Callbacks.to_prepare { |*args| b = c = 2 }
-    ActionDispatch::Callbacks.to_prepare { |*args| c = 3 }
-
-    # Ensure to_prepare callbacks are not run when defined
-    assert_nil a || b || c
-
-    # Run callbacks
-    dispatch
-
-    assert_equal 1, a
-    assert_equal 2, b
-    assert_equal 3, c
-
-    # Make sure they are only run once
-    a = b = c = nil
-    dispatch
-    assert_nil a || b || c
-  end
-
-  def test_prepare_callbacks_without_cache_classes
-    a = b = c = nil
-    ActionDispatch::Callbacks.to_prepare { |*args| a = b = c = 1 }
-    ActionDispatch::Callbacks.to_prepare { |*args| b = c = 2 }
-    ActionDispatch::Callbacks.to_prepare { |*args| c = 3 }
-
-    # Ensure to_prepare callbacks are not run when defined
-    assert_nil a || b || c
-
-    # Run callbacks
-    dispatch(false)
-
-    assert_equal 1, a
-    assert_equal 2, b
-    assert_equal 3, c
-
-    # Make sure they are run again
-    a = b = c = nil
-    dispatch(false)
-    assert_equal 1, a
-    assert_equal 2, b
-    assert_equal 3, c
-  end
-
-  def test_to_prepare_with_identifier_replaces
-    ActionDispatch::Callbacks.to_prepare(:unique_id) { |*args| Foo.a, Foo.b = 1, 1 }
-    ActionDispatch::Callbacks.to_prepare(:unique_id) { |*args| Foo.a = 2 }
-
-    dispatch
-    assert_equal 2, Foo.a
-    assert_equal 0, Foo.b
   end
 
   def test_before_and_after_callbacks
@@ -85,10 +29,20 @@ class DispatcherTest < Test::Unit::TestCase
     assert_equal 4, Foo.b
   end
 
+  def test_to_prepare_deprecation
+    prepared = false
+    assert_deprecated do
+      ActionDispatch::Callbacks.to_prepare { prepared = true }
+    end
+
+    ActionDispatch::Reloader.prepare!
+    assert prepared
+  end
+
   private
 
-    def dispatch(cache_classes = true, &block)
-      @dispatcher ||= ActionDispatch::Callbacks.new(block || DummyApp.new, !cache_classes)
+    def dispatch(&block)
+      @dispatcher ||= ActionDispatch::Callbacks.new(block || DummyApp.new)
       @dispatcher.call({'rack.input' => StringIO.new('')})
     end
 

--- a/actionpack/test/dispatch/reloader_test.rb
+++ b/actionpack/test/dispatch/reloader_test.rb
@@ -1,0 +1,139 @@
+require 'abstract_unit'
+
+class ReloaderTest < Test::Unit::TestCase
+  Reloader = ActionDispatch::Reloader
+
+  def test_prepare_callbacks
+    a = b = c = nil
+    Reloader.to_prepare { |*args| a = b = c = 1 }
+    Reloader.to_prepare { |*args| b = c = 2 }
+    Reloader.to_prepare { |*args| c = 3 }
+
+    # Ensure to_prepare callbacks are not run when defined
+    assert_nil a || b || c
+
+    # Run callbacks
+    call_and_return_body
+
+    assert_equal 1, a
+    assert_equal 2, b
+    assert_equal 3, c
+  end
+
+  def test_to_prepare_with_identifier_replaces
+    a = b = 0
+    Reloader.to_prepare(:unique_id) { |*args| a = b = 1 }
+    Reloader.to_prepare(:unique_id) { |*args| a = 2 }
+
+    call_and_return_body
+    assert_equal 2, a
+    assert_equal 0, b
+  end
+
+  class MyBody < Array
+    def initialize(&block)
+      @on_close = block
+    end
+
+    def foo
+      "foo"
+    end
+
+    def bar
+      "bar"
+    end
+
+    def close
+      @on_close.call if @on_close
+    end
+  end
+
+  def test_returned_body_object_always_responds_to_close
+    body = call_and_return_body
+    assert body.respond_to?(:close)
+  end
+
+  def test_returned_body_object_behaves_like_underlying_object
+    body = call_and_return_body do
+      b = MyBody.new
+      b << "hello"
+      b << "world"
+      [200, { "Content-Type" => "text/html" }, b]
+    end
+    assert_equal 2, body.size
+    assert_equal "hello", body[0]
+    assert_equal "world", body[1]
+    assert_equal "foo", body.foo
+    assert_equal "bar", body.bar
+  end
+
+  def test_it_calls_close_on_underlying_object_when_close_is_called_on_body
+    close_called = false
+    body = call_and_return_body do
+      b = MyBody.new do
+        close_called = true
+      end
+      [200, { "Content-Type" => "text/html" }, b]
+    end
+    body.close
+    assert close_called
+  end
+
+  def test_returned_body_object_responds_to_all_methods_supported_by_underlying_object
+    body = call_and_return_body do
+      [200, { "Content-Type" => "text/html" }, MyBody.new]
+    end
+    assert body.respond_to?(:size)
+    assert body.respond_to?(:each)
+    assert body.respond_to?(:foo)
+    assert body.respond_to?(:bar)
+  end
+
+  def test_cleanup_callbacks_are_called_when_body_is_closed
+    cleaned = false
+    Reloader.to_cleanup { cleaned = true }
+
+    body = call_and_return_body
+    assert !cleaned
+
+    body.close
+    assert cleaned
+  end
+
+  def test_prepare_callbacks_arent_called_when_body_is_closed
+    prepared = false
+    Reloader.to_prepare { prepared = true }
+
+    body = call_and_return_body
+    prepared = false
+
+    body.close
+    assert !prepared
+  end
+
+  def test_manual_reloading
+    prepared = cleaned = false
+    Reloader.to_prepare { prepared = true }
+    Reloader.to_cleanup { cleaned  = true }
+
+    Reloader.prepare!
+    assert prepared
+    assert !cleaned
+
+    prepared = cleaned = false
+    Reloader.cleanup!
+    assert !prepared
+    assert cleaned
+
+    prepared = cleaned = false
+    Reloader.reload!
+    assert prepared
+    assert cleaned
+  end
+
+  private
+    def call_and_return_body(&block)
+      @reloader ||= Reloader.new(block || proc {[200, {}, 'response']})
+      @reloader.call({'rack.input' => StringIO.new('')})[2]
+    end
+end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -69,11 +69,9 @@ module ActiveRecord
     end
 
     initializer "active_record.set_dispatch_hooks", :before => :set_clear_dependencies_hook do |app|
-      unless app.config.cache_classes
-        ActiveSupport.on_load(:active_record) do
-          ActionDispatch::Callbacks.after do
-            ActiveRecord::Base.clear_reloadable_connections!
-          end
+      ActiveSupport.on_load(:active_record) do
+        ActionDispatch::Reloader.to_cleanup do
+          ActiveRecord::Base.clear_reloadable_connections!
         end
       end
     end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -82,7 +82,7 @@ module ActiveRecord
       ActiveSupport.on_load(:active_record) do
         instantiate_observers
 
-        ActionDispatch::Callbacks.to_prepare(:activerecord_instantiate_observers) do
+        ActionDispatch::Reloader.to_prepare(:activerecord_instantiate_observers) do
           ActiveRecord::Base.instantiate_observers
         end
       end

--- a/activesupport/lib/active_support/file_update_checker.rb
+++ b/activesupport/lib/active_support/file_update_checker.rb
@@ -8,7 +8,7 @@ module ActiveSupport
   #     I18n.reload!
   #   end
   #
-  #   ActionDispatch::Callbacks.to_prepare do
+  #   ActionDispatch::Reloader.to_prepare do
   #     i18n_reloader.execute_if_updated
   #   end
   #

--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -19,7 +19,7 @@ module I18n
     # on to_prepare callbacks. This will only happen on the config.after_initialize
     # callback below.
     initializer "i18n.callbacks" do
-      ActionDispatch::Callbacks.to_prepare do
+      ActionDispatch::Reloader.to_prepare do
         I18n::Railtie.reloader.execute_if_updated
       end
     end

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -157,7 +157,7 @@ module Rails
         middleware.use ::ActionDispatch::RemoteIp, config.action_dispatch.ip_spoofing_check, config.action_dispatch.trusted_proxies
         middleware.use ::Rack::Sendfile, config.action_dispatch.x_sendfile_header
         middleware.use ::ActionDispatch::Reloader unless config.cache_classes
-        middleware.use ::ActionDispatch::Callbacks, !config.cache_classes
+        middleware.use ::ActionDispatch::Callbacks
         middleware.use ::ActionDispatch::Cookies
 
         if config.session_store

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -156,6 +156,7 @@ module Rails
         middleware.use ::ActionDispatch::ShowExceptions, config.consider_all_requests_local if config.action_dispatch.show_exceptions
         middleware.use ::ActionDispatch::RemoteIp, config.action_dispatch.ip_spoofing_check, config.action_dispatch.trusted_proxies
         middleware.use ::Rack::Sendfile, config.action_dispatch.x_sendfile_header
+        middleware.use ::ActionDispatch::Reloader unless config.cache_classes
         middleware.use ::ActionDispatch::Callbacks, !config.cache_classes
         middleware.use ::ActionDispatch::Cookies
 

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -51,11 +51,9 @@ module Rails
       end
 
       initializer :set_clear_dependencies_hook do
-        unless config.cache_classes
-          ActionDispatch::Callbacks.after do
-            ActiveSupport::DescendantsTracker.clear
-            ActiveSupport::Dependencies.clear
-          end
+        ActionDispatch::Reloader.to_cleanup do
+          ActiveSupport::DescendantsTracker.clear
+          ActiveSupport::Dependencies.clear
         end
       end
 

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -21,7 +21,7 @@ module Rails
 
       initializer :add_to_prepare_blocks do
         config.to_prepare_blocks.each do |block|
-          ActionDispatch::Callbacks.to_prepare(&block)
+          ActionDispatch::Reloader.to_prepare(&block)
         end
       end
 
@@ -35,6 +35,10 @@ module Rails
 
       initializer :build_middleware_stack do
         build_middleware_stack
+      end
+
+      initializer :run_prepare_callbacks do
+        ActionDispatch::Reloader.prepare!
       end
 
       initializer :eager_load! do
@@ -52,7 +56,7 @@ module Rails
       initializer :set_routes_reloader do |app|
         reloader = lambda { app.routes_reloader.execute_if_updated }
         reloader.call
-        ActionDispatch::Callbacks.to_prepare(&reloader)
+        ActionDispatch::Reloader.to_prepare(&reloader)
       end
 
       # Disable dependency loading during request cycle

--- a/railties/lib/rails/console/app.rb
+++ b/railties/lib/rails/console/app.rb
@@ -26,7 +26,6 @@ end
 # reloads the environment
 def reload!(print=true)
   puts "Reloading..." if print
-  # This triggers the to_prepare callbacks
-  ActionDispatch::Callbacks.new(Proc.new {}, false).call({})
+  ActionDispatch::Reloader.reload!
   true
 end

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -26,14 +26,14 @@ class ConsoleTest < Test::Unit::TestCase
     assert_instance_of ActionDispatch::Integration::Session, session
   end
 
-  def test_reload_should_fire_preparation_callbacks
+  def test_reload_should_fire_preparation_and_cleanup_callbacks
     load_environment
     a = b = c = nil
 
     # TODO: These should be defined on the initializer
-    ActionDispatch::Callbacks.to_prepare { a = b = c = 1 }
-    ActionDispatch::Callbacks.to_prepare { b = c = 2 }
-    ActionDispatch::Callbacks.to_prepare { c = 3 }
+    ActionDispatch::Reloader.to_prepare { a = b = c = 1 }
+    ActionDispatch::Reloader.to_prepare { b = c = 2 }
+    ActionDispatch::Reloader.to_cleanup { c = 3 }
 
     # Hide Reloading... output
     silence_stream(STDOUT) { reload! }

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -27,6 +27,7 @@ module ApplicationTests
         "ActionDispatch::ShowExceptions",
         "ActionDispatch::RemoteIp",
         "Rack::Sendfile",
+        "ActionDispatch::Reloader",
         "ActionDispatch::Callbacks",
         "ActiveRecord::ConnectionAdapters::ConnectionManagement",
         "ActiveRecord::QueryCache",
@@ -79,6 +80,12 @@ module ApplicationTests
       add_to_config "config.action_dispatch.show_exceptions = false"
       boot!
       assert !middleware.include?("ActionDispatch::ShowExceptions")
+    end
+
+    test "removes ActionDispatch::Reloader if cache_classes is true" do
+      add_to_config "config.cache_classes = true"
+      boot!
+      assert !middleware.include?("ActionDispatch::Reloader")
     end
 
     test "use middleware" do


### PR DESCRIPTION
https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/2873

Defer reloading until #close is called on request body [#2873 state:resolved]

Reloading in the ActionDispatch::Callback middleware's after hook
was problematic with streaming responses such as the following:

```
self.response_body = lambda do |response, output|
  # code here which refers to application models
end
```

A new middleware, ActionDispatch::Reloader, provides an appropriate
callback hook and is responsible for lock management. It is included
in the stack only in the !config.cache_classes case.

Based on the implementation on the 2-3-stable branch and patches
by Hongli Lai hongli@phusion.nl. His patches included locking
around the request cycle; this is now handled by Rack::Lock
(https://github.com/rack/rack/issues/issue/87/).
