### PR TITLE
Object#avoids? for checking against several objects/patterns at once

### DIFF
--- a/activesupport/lib/active_support/core_ext/object.rb
+++ b/activesupport/lib/active_support/core_ext/object.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/object/acts_like'
+require 'active_support/core_ext/object/avoids'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/object/duplicable'
 require 'active_support/core_ext/object/try'

--- a/activesupport/lib/active_support/core_ext/object/avoids.rb
+++ b/activesupport/lib/active_support/core_ext/object/avoids.rb
@@ -1,0 +1,37 @@
+class Object
+  # Returns +false+ is this object matches any of the arguments passed in. Object
+  # comparisons are made the same way as in +case+ statementes. Otherwise it 
+  # returns +true+.
+  #
+  # +avoids?+ always expects several arguments. If an array is passed in as an
+  # argument, it is treated as an array; it is *not* flattened to test this
+  # object against the individual members of the array. This is the case even
+  # if only a single array provided.
+  #
+  # Use a splat to pass in an array when you are trying to test a single 
+  # list of conditions to avoid.
+  #
+  # ==== Examples
+  #
+  # weak_passwords = ['qwerty', /passwo?r?d/, /^123\d{0,3}/, /.{0,4}/]
+  #
+  # user.password = '$tr0ng_Pas$word?'
+  # user.password.avoids?(*weak_passwords)              # => true
+  # user.password = '1234'
+  # user.password.avoids?(*weak_passwords)              # => false
+  #
+  # some_array = [1,2,3,4]
+  #
+  # some_array.avoids?([1,2,3,4])                       # => false
+  # some_array.avoids?(1,2,3,4)                         # => true
+  # some_array.avoids?(*[1,2,3,4])                      # => true
+  def avoids?(*args)
+    for a in args do
+      case self
+        when a then return false
+      end
+    end
+ 
+    return true
+  end
+end


### PR DESCRIPTION
Pretty self explanatory, tests an obj against a number of other objects to make sure it does NOT match any of them. Leverages case comparison, so arbitrary argument types resulting in nonsense tests are ignored (eg a regex against a hash)

Good, for example, for checking a password against a variety of restrictions:
    weak_passwords = ['qwerty', '123456', /passwo?r?d/]
    user.password.avoids?(*weak_passwords)

Was more topical yesterday when SecurePassword still had some passwd strength code floating around, but as a reverse #include? it's a better option than weak_passwords.include?(password) and has value in other situations as well.
