### PR TITLE
Relation insert fix (was causing test failures on Oracle)

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -31,7 +31,7 @@ module ActiveRecord
       im = arel.compile_insert values
       im.into @table
       primary_key_name = @klass.primary_key
-      primary_key_value = Hash === values ? values[primary_key_name] : nil
+      primary_key_value = primary_key_name && Hash === values ? values[primary_key] : nil
 
       @klass.connection.insert(
         im.to_sql,


### PR DESCRIPTION
Fixed retrieval of primary key value in Ralation#insert method.

Previously primary key value was always assigned nil which caused Oracle enhanced adapter failing tests.
