### PR TITLE
Default scope tests fix

### DIFF
--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -466,7 +466,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_with_default_scope_on_join_model
-    assert_equal posts(:welcome).comments, authors(:david).comments_on_first_posts
+    assert_equal posts(:welcome).comments.order('id').all, authors(:david).comments_on_first_posts
   end
 
   def test_create_has_many_through_with_default_scope_on_join_model

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -235,6 +235,6 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_one_through_with_default_scope_on_join_model
-    assert_equal posts(:welcome).comments.first, authors(:david).comment_on_first_posts
+    assert_equal posts(:welcome).comments.order('id').first, authors(:david).comment_on_first_posts
   end
 end


### PR DESCRIPTION
This is additional fix for commit

ebc47465a5865ab91dc7d058d2d8a0cc961510d7 Respect the default_scope on a join model when reading a through association

which otherwise was failing on Oracle (as it returned fixture comments in different order).
