### PR TITLE
`button_tag` helper

### DIFF
--- a/actionpack/CHANGELOG
+++ b/actionpack/CHANGELOG
@@ -1,5 +1,8 @@
 *Rails 3.1.0 (unreleased)*
 
+* button_tag added. This is in similarity with submit_tag but allows more
+visual flexibility. [Rizwan Reza]
+
 * brought back config.action_view.cache_template_loading, which allows to decide whether templates should be cached or not [Piotr Sarnacki]
 
 * url_for and named url helpers now accept :subdomain and :domain as options [Josh Kalderimis]

--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -401,6 +401,56 @@ module ActionView
         tag :input, { "type" => "submit", "name" => "commit", "value" => value }.update(options.stringify_keys)
       end
 
+      # Creates a button element that defines a <tt>submit</tt> button,
+      # <tt>reset</tt>button or a generic button which can be used in
+      # JavaScript, for example. You can use the button tag as a regular
+      # submit tag but it isn't supported in legacy browsers. However,
+      # button tag allows richer labels such as images and emphasis.
+      #
+      # ==== Options
+      # * <tt>:confirm => 'question?'</tt> - If present, the
+      #   unobtrusive JavaScript drivers will provide a prompt with
+      #   the question specified. If the user accepts, the form is
+      #   processed normally, otherwise no action is taken.
+      # * <tt>:disabled</tt> - If true, the user will not be able to
+      #   use this input.
+      # * <tt>:disable_with</tt> - Value of this parameter will be
+      #   used as the value for a disabled version of the submit
+      #   button when the form is submitted. This feature is provided
+      #   by the unobtrusive JavaScript driver.
+      # * Any other key creates standard HTML options for the tag.
+      #
+      # ==== Examples
+      #   button_tag
+      #   # => <button name="button" type="button">Button</button>
+      #
+      #   button_tag "<strong>Ask me!</strong>"
+      #   # => <button name="button" type="button">
+      #          <strong>Ask me!</strong>
+      #        </button>
+      #
+      #   button_tag "Checkout", :disable_with => "Please wait..."
+      #   # => <button data-disable-with="Please wait..." name="button"
+      #                type="button">Checkout</button>
+      #
+      def button_tag(label = "Button", options = {})
+        options.stringify_keys!
+
+        if disable_with = options.delete("disable_with")
+          options["data-disable-with"] = disable_with
+        end
+
+        if confirm = options.delete("confirm")
+          options["data-confirm"] = confirm
+        end
+
+        ["type", "name"].each do |option|
+          options[option] = "button" unless options[option]
+        end
+
+        content_tag :button, label.to_s.html_safe, { "type" => options.delete("type") }.update(options)
+      end
+
       # Displays an image which when clicked will submit the form.
       #
       # <tt>source</tt> is passed to AssetTagHelper#path_to_image

--- a/actionpack/test/template/form_tag_helper_test.rb
+++ b/actionpack/test/template/form_tag_helper_test.rb
@@ -385,6 +385,34 @@ class FormTagHelperTest < ActionView::TestCase
     )
   end
 
+  def test_button_tag
+    assert_dom_equal(
+      %(<button name="button" type="button">Button</button>),
+      button_tag
+    )
+  end
+
+  def test_button_tag_with_submit_type
+    assert_dom_equal(
+      %(<button name="button" type="submit">Save</button>),
+      button_tag("Save", :type => "submit")
+    )
+  end
+
+  def test_button_tag_with_reset_type
+    assert_dom_equal(
+      %(<button name="button" type="reset">Reset</button>),
+      button_tag("Reset", :type => "reset")
+    )
+  end
+
+  def test_button_tag_with_disabled_option
+    assert_dom_equal(
+      %(<button name="button" type="reset" disabled="disabled">Reset</button>),
+      button_tag("Reset", :type => "reset", :disabled => true)
+    )
+  end
+
   def test_image_submit_tag_with_confirmation
     assert_dom_equal(
       %(<input type="image" src="/images/save.gif" data-confirm="Are you sure?" />),


### PR DESCRIPTION
I've added button_tag helper and tests that allow the creation of button element in Rails views. This clearly has several advantages over the normal input tag with submit type, as it has support for much richer content due to the change in the HTML structure:

```
<button type="submit|reset|button">
  <strong><em>Save changes</em></strong>
</button>
```

Please have a look. Thanks!
