### PR TITLE
Numericality :within validator

### DIFF
--- a/activemodel/lib/active_model/locale/en.yml
+++ b/activemodel/lib/active_model/locale/en.yml
@@ -23,5 +23,6 @@ en:
       equal_to: "must be equal to %{count}"
       less_than: "must be less than %{count}"
       less_than_or_equal_to: "must be less than or equal to %{count}"
+      within: "must be between %{count.min} and %{count.max}"
       odd: "must be odd"
       even: "must be even"

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -50,6 +50,13 @@ class NumericalityValidationTest < ActiveModel::TestCase
     valid!(NIL + INTEGERS)
   end
 
+  def test_validates_numericality_with_within
+    Topic.validates_numericality_of :approved, :within => 10..20
+
+    invalid!([-10, 9, 21], 'must be within 10 and 20')
+    valid!([11])
+  end
+
   def test_validates_numericality_with_greater_than
     Topic.validates_numericality_of :approved, :greater_than => 10
 


### PR DESCRIPTION
I am trying to simplify the **numericality** validator a little by allowing something like

<pre>validates :price_range, :numericality => {:within => 10..20}</pre>


instead of 

<pre>validates :price_range, :numericality => {:greater_than_or_equal_to => 10, :less_than_or_equal_to => 20}</pre>


It looks to me like the _:within_ option currently only works for the length of an attribute?

I tried to add a test case and an update to the translation file, but I don't know enough about the Rails internals for validations and how it works behind the scenes. 
