### PR TITLE
Fix destroy arity

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1431,7 +1431,7 @@ module ActiveRecord
         # callbacks will be executed after the association is wiped out.
         include Module.new {
           class_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def destroy                     # def destroy
+            def destroy(*params, &block)    # def destroy(*params, &block)
               #{reflection.name}.clear      #   posts.clear
               super                         #   super
             end                             # end


### PR DESCRIPTION
Don't assume that the arity of active record method was not changed. Someone could extend the method so it takes some options and provides defaults.

For example: I extended destroy to work with validations and have a definition
like def destroy(options = {}).
