### PR TITLE
Fix #6036

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -20,7 +20,7 @@ module ActiveRecord
           case value
           when Array, ActiveRecord::Associations::AssociationCollection, ActiveRecord::Relation
             values = value.to_a.map { |x|
-              x.respond_to?(:quoted_id) ? x.quoted_id : x
+              x.is_a?(ActiveRecord::Base) ? x.id : x
             }
             attribute.in(values)
           when Range, Arel::Relation

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -27,6 +27,12 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal van.id, Minivan.where(:minivan_id => van).to_a.first.minivan_id
   end
 
+  def test_do_not_double_quote_string_id_with_array
+    van = Minivan.last
+    assert van
+    assert_equal van, Minivan.where(:minivan_id => [van]).to_a.first
+  end
+
   def test_bind_values
     relation = Post.scoped
     assert_equal [], relation.bind_values


### PR DESCRIPTION
https://rails.lighthouseapp.com/projects/8994/tickets/6036-id-is-inproperly-escaped-on-postgresql-statements-when-primary-key-is-a-string

This bug has already been fixed. However it tourned out that not completely.
