### PR TITLE
Fix for bug #6036

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -25,13 +25,13 @@ module ActiveRecord
           case value
           when Array, ActiveRecord::Associations::AssociationCollection, ActiveRecord::Relation
             values = value.to_a.map { |x|
-              x.respond_to?(:quoted_id) ? x.quoted_id : x
+              x.is_a?(ActiveRecord::Base) ? x.id : x
             }
             attribute.in(values)
           when Range, Arel::Relation
             attribute.in(value)
           when ActiveRecord::Base
-            attribute.eq(Arel.sql(value.quoted_id))
+            attribute.eq(value.id)
           when Class
             # FIXME: I think we need to deprecate this behavior
             attribute.eq(value.name)

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -26,6 +26,12 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal van.id, Minivan.where(:minivan_id => van).to_a.first.minivan_id
   end
 
+  def test_do_not_double_quote_string_id_with_array
+    van = Minivan.last
+    assert van
+    assert_equal van, Minivan.where(:minivan_id => [van]).to_a.first
+  end
+
   def test_two_named_scopes_with_includes_should_not_drop_any_include
     car = Car.incl_engines.incl_tyres.first
     assert_no_queries { car.tyres.length }


### PR DESCRIPTION
https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/6036-id-is-inproperly-escaped-on-postgresql-statements-when-primary-key-is-a-string

This bug has already been fixed, however one more failing test case was found.

This is the test case and fix for 3.0-stable.
