### PR TITLE
Specify a character encoding on application layout page

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8"/>
   <title><%= camelized %></title>
   <%%= stylesheet_link_tag :all %>
   <%%= javascript_include_tag :defaults %>


### PR DESCRIPTION
Using the words from diveintohtml5.org[1]:

"You should always specify a character encoding on every HTML page you serve. Not specifying an encoding can lead to security vulnerabilities[2]."

[1] http://diveintohtml5.org/semantics.html#encoding
[2] http://code.google.com/p/doctype/wiki/ArticleUtf7
