### PR TITLE
Require ActiveSupport deprecatation file before using deprecate method in database_statements

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/module/deprecation'
+
 module ActiveRecord
   module ConnectionAdapters # :nodoc:
     module DatabaseStatements


### PR DESCRIPTION
Otherwise when using external ActiveRecord adapters (e.g. Oracle) database_statements might be loaded before active_support/core_ext/module/deprecation which results in NoMethodError (commit 60cf65def805995bcca184c40b44bb01d86a48aa added "deprecate" call to database_statements.rb)
