### PR TITLE
Explicitly select * from has_and_belongs_to_many association tables, simplify exists? query

### DIFF
--- a/activerecord/lib/active_record/associations/has_and_belongs_to_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_and_belongs_to_many_association.rb
@@ -83,7 +83,8 @@ module ActiveRecord
           super.merge(
             :joins    => construct_joins,
             :readonly => ambiguous_select?(@reflection.options[:select]),
-            :select   => @reflection.options[:select] || Arel.star
+            :select   => @reflection.options[:select] ||
+              Arel.sql("#{@reflection.quoted_table_name}.*, #{@owner.connection.quote_table_name @reflection.options[:join_table]}.*")
           )
         end
 

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -171,7 +171,7 @@ module ActiveRecord
     def exists?(id = nil)
       id = id.id if ActiveRecord::Base === id
 
-      relation = select(table[primary_key]).limit(1)
+      relation = select("1").limit(1)
 
       case id
       when Array, Hash


### PR DESCRIPTION
Previous version (after commit 3103296a61709e808aa89c3d37cf22bcdbc5a675) was generating wrong SQL for Oracle when calling exists? method on HABTM association (see errors at https://gist.github.com/9ced68fffb09279af338).

"exists?" method is simplified to select just constant 1 (previously was selecting primary key value) - as just result existence is verified then there is no need to select primary key value. Previous version was also conflicting with Oracle with HABTM as then primary key value was selected twice which conflicted with subquery generated for simulating LIMIT clause.

After this patch tests on Oracle are passing as well as I tested that this patch is working on SQLite3, MySQL and PostgreSQL.
