### PR TITLE
Fix subtle bug with difference between behavior of empty? and blank? for ActiveModel::Error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ railties/test/initializer/root/log
 railties/doc
 railties/guides/output
 railties/tmp
+.idea

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -147,7 +147,7 @@ module ActiveModel
     def empty?
       all? { |k, v| v && v.empty? }
     end
-
+    alias_method :blank?, :empty?
     # Returns an xml formatted representation of the Errors hash.
     #
     #   p.errors.add(:name, "can't be blank")

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -25,7 +25,13 @@ class ErrorsTest < ActiveModel::TestCase
     def self.lookup_ancestors
       [self]
     end
+  end
 
+  test "should return true if no errors" do
+    person = Person.new
+    person.errors[:foo]
+    assert person.errors.empty?
+    assert person.errors.blank?
   end
 
   test "method validate! should work" do


### PR DESCRIPTION
As the subject says. 
