### PR TITLE
Support fractional seconds in DateTime#to_time

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/conversions.rb
@@ -66,7 +66,7 @@ class DateTime
   # Attempts to convert self to a Ruby Time object; returns self if out of range of Ruby Time class
   # If self has an offset other than 0, self will just be returned unaltered, since there's no clean way to map it to a Time
   def to_time
-    self.offset == 0 ? ::Time.utc_time(year, month, day, hour, min, sec) : self
+    self.offset == 0 ? ::Time.utc_time(year, month, day, hour, min, sec, sec_fraction * (RUBY_VERSION < '1.9' ? 86400000000 : 1000000)) : self
   end
 
   # To be able to keep Times, Dates and DateTimes interchangeable on conversions

--- a/activesupport/lib/active_support/core_ext/time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/time/conversions.rb
@@ -55,31 +55,9 @@ class Time
     utc? && alternate_utc_string || ActiveSupport::TimeZone.seconds_to_utc_offset(utc_offset, colon)
   end
 
-  # Converts a Time object to a Date, dropping hour, minute, and second precision.
-  #
-  #   my_time = Time.now  # => Mon Nov 12 22:59:51 -0500 2007
-  #   my_time.to_date     # => Mon, 12 Nov 2007
-  #
-  #   your_time = Time.parse("1/13/2009 1:13:03 P.M.")  # => Tue Jan 13 13:13:03 -0500 2009
-  #   your_time.to_date                                 # => Tue, 13 Jan 2009
-  def to_date
-    ::Date.new(year, month, day)
-  end unless method_defined?(:to_date)
-
   # A method to keep Time, Date and DateTime instances interchangeable on conversions.
   # In this case, it simply returns +self+.
   def to_time
     self
   end unless method_defined?(:to_time)
-
-  # Converts a Time instance to a Ruby DateTime instance, preserving UTC offset.
-  #
-  #   my_time = Time.now    # => Mon Nov 12 23:04:21 -0500 2007
-  #   my_time.to_datetime   # => Mon, 12 Nov 2007 23:04:21 -0500
-  #
-  #   your_time = Time.parse("1/13/2009 1:13:03 P.M.")  # => Tue Jan 13 13:13:03 -0500 2009
-  #   your_time.to_datetime                             # => Tue, 13 Jan 2009 13:13:03 -0500
-  def to_datetime
-    ::DateTime.civil(year, month, day, hour, min, sec, Rational(utc_offset, 86400))
-  end unless method_defined?(:to_datetime)
 end

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -38,6 +38,8 @@ class DateTimeExtCalculationsTest < Test::Unit::TestCase
     assert_equal Time.utc_time(2039, 2, 21, 10, 11, 12), DateTime.new(2039, 2, 21, 10, 11, 12, 0, 0).to_time
     # DateTimes with offsets other than 0 are returned unaltered
     assert_equal DateTime.new(2005, 2, 21, 10, 11, 12, Rational(-5, 24)), DateTime.new(2005, 2, 21, 10, 11, 12, Rational(-5, 24)).to_time
+    # Fractional seconds are preserved
+    assert_equal Time.utc(2005, 2, 21, 10, 11, 12, 256), DateTime.new(2005, 2, 21, 10, 11, 12 + Rational(256, 1000000), 0).to_time
   end
 
   def test_civil_from_format

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -533,19 +533,9 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     Time::DATE_FORMATS.delete(:custom)
   end
 
-  def test_to_date
-    assert_equal Date.new(2005, 2, 21), Time.local(2005, 2, 21, 17, 44, 30).to_date
-  end
-
-  def test_to_datetime
-    assert_equal Time.utc(2005, 2, 21, 17, 44, 30).to_datetime, DateTime.civil(2005, 2, 21, 17, 44, 30, 0, 0)
-    with_env_tz 'US/Eastern' do
-      assert_equal Time.local(2005, 2, 21, 17, 44, 30).to_datetime, DateTime.civil(2005, 2, 21, 17, 44, 30, Rational(Time.local(2005, 2, 21, 17, 44, 30).utc_offset, 86400), 0)
-    end
-    with_env_tz 'NZ' do
-      assert_equal Time.local(2005, 2, 21, 17, 44, 30).to_datetime, DateTime.civil(2005, 2, 21, 17, 44, 30, Rational(Time.local(2005, 2, 21, 17, 44, 30).utc_offset, 86400), 0)
-    end
-    assert_equal ::Date::ITALY, Time.utc(2005, 2, 21, 17, 44, 30).to_datetime.start # use Ruby's default start value
+  def test_conversion_methods_are_publicized
+    assert Time.public_instance_methods.include?(:to_date)     || Time.public_instance_methods.include?('to_date')
+    assert Time.public_instance_methods.include?(:to_datetime) || Time.public_instance_methods.include?('to_datetime')
   end
 
   def test_to_time


### PR DESCRIPTION
While working on the equivalent patch for `Time#to_datetime`, I learned that Ruby 1.8.7+ already provides a definition which correctly handles fractional seconds. Since 1.8.6 is not supported by Rails 3, I simply removed the unused AS definition.

Tested on 1.8.7, 1.9.2, and JRuby 1.5.6.
