### PR TITLE
Always return decimal average of integer fields

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -273,15 +273,11 @@ module ActiveRecord
     end
 
     def type_cast_calculated_value(value, column, operation = nil)
-      if value.is_a?(String) || value.nil?
-        case operation
-          when 'count'   then value.to_i
-          when 'sum'     then type_cast_using_column(value || '0', column)
-          when 'average' then value.try(:to_d)
-          else type_cast_using_column(value, column)
-        end
-      else
-        type_cast_using_column(value, column)
+      case operation
+        when 'count'   then value.to_i
+        when 'sum'     then type_cast_using_column(value || '0', column)
+        when 'average' then value.try(:to_d)
+        else type_cast_using_column(value, column)
       end
     end
 

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -23,6 +23,11 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 53.0, value
   end
 
+  def test_should_return_decimal_average_of_integer_field
+    value = Account.average(:id)
+    assert_equal 3.5, value
+  end
+
   def test_should_return_nil_as_average
     assert_nil NumericData.average(:bank_balance)
   end


### PR DESCRIPTION
In previous version if database adapter (e.g. SQLite and Oracle) returned non-String calculated values then type_cast_using_column converted decimal average value of intefer field to integer value. Now operation parameter is always checked to decide which conversion of calculated value should be done.

This is fix for Lighthouse issue #6103
https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/6103-average-returns-integer-values-instead-of-decimals
and is fixing bug that was introduced by commit 0a8eaff3d16fbf48259319ff17e2fe8f6cb3d450

This should be applied to master branch as well.
