### PR TITLE
Show exceptions fix

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -53,8 +53,8 @@ module ActionDispatch
            exception = ActionController::RoutingError.new("No route matches #{env['PATH_INFO'].inspect}")
         end
       rescue Exception => exception
+        raise exception if env['action_dispatch.show_exceptions'] == false
       end
-      raise exception if env['action_dispatch.show_exceptions'] == false
 
       exception ? render_exception(env, exception) : [status, headers, body]
     end


### PR DESCRIPTION
Seems that a little mistake happened in last commit in this file. raise should be in rescue section like it was before. This broke [cucumber-rails](https://github.com/aslakhellesoy/cucumber-rails/issues#issue/95)
