### PR TITLE
LH#6061 rake db:fixtures:load with FIXTURES=tables is broken

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -296,8 +296,8 @@ db_namespace = namespace :db do
       base_dir = ENV['FIXTURES_PATH'] ? File.join(Rails.root, ENV['FIXTURES_PATH']) : File.join(Rails.root, 'test', 'fixtures')
       fixtures_dir = ENV['FIXTURES_DIR'] ? File.join(base_dir, ENV['FIXTURES_DIR']) : base_dir
 
-      (ENV['FIXTURES'] ? ENV['FIXTURES'].split(/,/).map {|f| File.join(fixtures_dir, f) } : Dir["#{fixtures_dir}/**/*.{yml,csv}"]).each do |fixture_file|
-        Fixtures.create_fixtures(fixtures_dir, fixture_file[(fixtures_dir.size + 1)..-5])
+      (ENV['FIXTURES'] ? ENV['FIXTURES'].split(/,/) : Dir["#{fixtures_dir}/**/*.{yml,csv}"].map {|f| f[(fixtures_dir.size + 1)..-5] }).each do |fixture_file|
+        Fixtures.create_fixtures(fixtures_dir, fixture_file)
       end
     end
 

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -82,5 +82,22 @@ module ApplicationTests
       assert_match /remove_column\("users", :email\)/, output
       assert_match /AddEmailToUsers: reverted/, output
     end
+
+    def test_loading_specific_fixtures
+      Dir.chdir(app_path) do
+        `rails generate model user username:string password:string`
+        `rails generate model product name:string`
+        `rake db:migrate`
+      end
+
+      require "#{rails_root}/config/environment"
+      
+      # loading a specific fixture
+      errormsg = Dir.chdir(app_path) { `rake db:fixtures:load FIXTURES=products` }
+      assert $?.success?, errormsg
+
+      assert_equal 2, ::AppTemplate::Application::Product.count
+      assert_equal 0, ::AppTemplate::Application::User.count
+    end
   end
 end


### PR DESCRIPTION
The db:fixtures:load rake task allows specifying a comma list of which fixtures to load as FIXTURES. However, it incorrectly strips the last 4 characters off each table name since 8ec085bf1804770a547894967fcdee24087fda87.

$ rake db:fixtures:load FIXTURES=products
rake aborted!
Could not find /home/jhawthorn/example/test/fixtures/prod.yml or /home/jhawthorn/example/test/fixtures/prod.csv
