### PR TITLE
Small fix to the default rails .gitignore

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/gitignore
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore
@@ -1,4 +1,4 @@
 .bundle
 db/*.sqlite3
 log/*.log
-tmp/**/*
+tmp/


### PR DESCRIPTION
`rails new` produces a `.gitignore` file that uses Ruby-style globbing that git doesn't recognize (`tmp/**/*`). As a result, something like `tmp/foo.rb` would not be ignored.

A simple `tmp/` should ignore the `tmp` directory - whatever it contains in terms of files or sub-directories..
