### PR TITLE
Class.__subclasses__ was removed from Rubinius

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/subclasses.rb
+++ b/activesupport/lib/active_support/core_ext/class/subclasses.rb
@@ -2,49 +2,35 @@ require 'active_support/core_ext/module/anonymous'
 require 'active_support/core_ext/module/reachable'
 
 class Class #:nodoc:
-  # Rubinius
-  if defined?(Class.__subclasses__)
-    alias :subclasses :__subclasses__
+  begin
+    ObjectSpace.each_object(Class.new) {}
 
     def descendants
       descendants = []
-      __subclasses__.each do |k|
-        descendants << k
-        descendants.concat k.descendants
+      ObjectSpace.each_object(class << self; self; end) do |k|
+        descendants.unshift k unless k == self
       end
       descendants
     end
-  else # MRI
-    begin
-      ObjectSpace.each_object(Class.new) {}
-
-      def descendants
-        descendants = []
-        ObjectSpace.each_object(class << self; self; end) do |k|
-          descendants.unshift k unless k == self
-        end
-        descendants
+  rescue StandardError # JRuby
+    def descendants
+      descendants = []
+      ObjectSpace.each_object(Class) do |k|
+        descendants.unshift k if k < self
       end
-    rescue StandardError # JRuby
-      def descendants
-        descendants = []
-        ObjectSpace.each_object(Class) do |k|
-          descendants.unshift k if k < self
-        end
-        descendants.uniq!
-        descendants
-      end
+      descendants.uniq!
+      descendants
     end
+  end
 
-    # Returns an array with the direct children of +self+.
-    #
-    #   Integer.subclasses # => [Bignum, Fixnum]
-    def subclasses
-      subclasses, chain = [], descendants
-      chain.each do |k|
-        subclasses << k unless chain.any? { |c| c > k }
-      end
-      subclasses
+  # Returns an array with the direct children of +self+.
+  #
+  #   Integer.subclasses # => [Bignum, Fixnum]
+  def subclasses
+    subclasses, chain = [], descendants
+    chain.each do |k|
+      subclasses << k unless chain.any? { |c| c > k }
     end
+    subclasses
   end
 end


### PR DESCRIPTION
https://github.com/evanphx/rubinius/issues/issue/11
https://github.com/evanphx/rubinius/commit/2fccbb5dad5cb3f5414d635547290538cfc0a2d4

This commit removes its use in Rails. Besides removing code which is now dead on all existing interpreters, it's probably not good practice to rely on the behavior of a non-standard extension.
