### PR TITLE
Lambda default scope

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1146,12 +1146,17 @@ MSG
 
           if previous.respond_to?(:call) or options.respond_to?(:call)
             new_default_scope = lambda do
-              sane_options = options.respond_to?(:call) ? options.call : options
-              sane_previous = previous.respond_to?(:call) ? previous.call : previous
-              construct_finder_arel sane_options, sane_previous
+              sane_options = options.respond_to?(:call) ? relation.scoping{ options.call } : options
+              sane_options = sane_options.without_default if sane_options.respond_to? :without_default
+              sane_previous = previous.respond_to?(:call) ? relation.scoping{ previous.call } : previous
+
+              new_scope = construct_finder_arel sane_options, sane_previous
+              new_scope.without_default = relation
+              new_scope
             end
           else
             new_default_scope = construct_finder_arel options, previous
+            new_default_scope.without_default = relation
           end
 
           self.default_scoping = default_scoping << new_default_scope

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -852,11 +852,6 @@ module ActiveRecord #:nodoc:
       #     limit(10) # Fires "SELECT * FROM posts LIMIT 10"
       #   }
       #
-      # It is recommended to use block form of unscoped because chaining unscoped with <tt>scope</tt>
-      # does not work. Assuming that <tt>published</tt> is a <tt>scope</tt> following two statements are same.
-      #
-      # Post.unscoped.published
-      # Post.published
       def unscoped #:nodoc:
         block_given? ? relation.scoping { yield } : relation
       end

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1144,10 +1144,10 @@ MSG
           default_scoping = self.default_scoping.dup
           previous = default_scoping.pop
 
-          if previous.kind_of?(Proc) or options.kind_of?(Proc)
+          if previous.respond_to?(:call) or options.respond_to?(:call)
             new_default_scope = lambda do
-              sane_options = options.kind_of?(Proc) ? options.call : options
-              sane_previous = previous.kind_of?(Proc) ? previous.call : previous
+              sane_options = options.respond_to?(:call) ? options.call : options
+              sane_previous = previous.respond_to?(:call) ? previous.call : previous
               construct_finder_arel sane_options, sane_previous
             end
           else

--- a/activerecord/lib/active_record/named_scope.rb
+++ b/activerecord/lib/active_record/named_scope.rb
@@ -111,7 +111,11 @@ module ActiveRecord
           relation = if options.is_a?(Hash)
             scoped.apply_finder_options(options)
           elsif options
-            scoped.merge(options)
+            if options.respond_to? :without_default
+              scoped.merge(options.without_default)
+            else
+              scoped.merge(options)
+            end
           else
             scoped
           end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -370,13 +370,26 @@ module ActiveRecord
       to_a.inspect
     end
 
+    def without_default?
+      defined?(@without_default) and !!@without_default
+    end
+
+    def without_default= clean
+      @without_default = clean
+    end
+
+    def without_default
+      return @without_default if defined? @without_default
+      self
+    end
+
     protected
 
     def method_missing(method, *args, &block)
       if Array.method_defined?(method)
         to_a.send(method, *args, &block)
       elsif @klass.scopes[method]
-        merge(@klass.send(method, *args, &block))
+        scoping { merge(@klass.send(method, *args, &block)) }
       elsif @klass.respond_to?(method)
         scoping { @klass.send(method, *args, &block) }
       elsif arel.respond_to?(method)

--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -116,7 +116,6 @@ module ActiveRecord
       relation = relation.includes(finders[:include]) if options.has_key?(:include)
       relation = relation.extending(finders[:extend]) if options.has_key?(:extend)
 
-      relation.without_default = without_default.apply_finder_options(options) if without_default?
       relation
     end
 

--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -58,6 +58,10 @@ module ActiveRecord
       # Apply scope extension modules
       merged_relation.send :apply_modules, r.extensions
 
+      if without_default? or r.without_default?
+        merged_relation.without_default = without_default.merge r.without_default
+      end
+
       merged_relation
     end
 
@@ -74,6 +78,7 @@ module ActiveRecord
         result.send(:"#{method}_value=", send(:"#{method}_value"))
       end
 
+      result.without_default = without_default.except(*skips) if without_default?
       result
     end
 
@@ -88,6 +93,7 @@ module ActiveRecord
         result.send(:"#{method}_value=", send(:"#{method}_value"))
       end
 
+      result.without_default = without_default.only(*onlies) if without_default?
       result
     end
 
@@ -110,6 +116,7 @@ module ActiveRecord
       relation = relation.includes(finders[:include]) if options.has_key?(:include)
       relation = relation.extending(finders[:extend]) if options.has_key?(:extend)
 
+      relation.without_default = without_default.apply_finder_options(options) if without_default?
       relation
     end
 

--- a/activerecord/test/cases/named_scope_test.rb
+++ b/activerecord/test/cases/named_scope_test.rb
@@ -6,9 +6,10 @@ require 'models/comment'
 require 'models/reply'
 require 'models/author'
 require 'models/developer'
+require 'models/note'
 
 class NamedScopeTest < ActiveRecord::TestCase
-  fixtures :posts, :authors, :topics, :comments, :author_addresses
+  fixtures :posts, :authors, :topics, :comments, :author_addresses, :notes
 
   def test_implements_enumerable
     assert !Topic.find(:all).empty?
@@ -457,6 +458,11 @@ class NamedScopeTest < ActiveRecord::TestCase
     assert_nothing_raised do
       require "models/without_table"
     end
+  end
+
+  def test_named_scopes_dont_force_default_scopes
+    assert_equal 3, Note.english.count
+    assert_equal 4, Note.unscoped.english.count
   end
 end
 

--- a/activerecord/test/fixtures/notes.yml
+++ b/activerecord/test/fixtures/notes.yml
@@ -1,0 +1,23 @@
+first:
+  deleted: 0
+  content: First note
+  language: en
+second:
+  deleted: 0
+  content: Second note
+  language: pl
+  due_date: "2009-10-10"
+deleted_note:
+  deleted: 1
+  content: deleted_note
+  language: en
+a_todo:
+  deleted: 0
+  content: a_todo
+  language: en
+  due_date: "2011-11-10"
+an_old_todo:
+  deleted: 0
+  content: an_old_todo
+  language: en
+  due_date: "2010-10-10"

--- a/activerecord/test/models/note.rb
+++ b/activerecord/test/models/note.rb
@@ -1,0 +1,4 @@
+class Note < ActiveRecord::Base
+  default_scope where(:deleted => 0)
+  scope :english, where(:language => 'en')
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -366,6 +366,13 @@ ActiveRecord::Schema.define do
     end
   end
 
+  create_table :notes, :force => true do |t|
+    t.boolean :deleted, :default => 0
+    t.string  :content
+    t.string  :language
+    t.datetime :due_date, :default => nil
+  end
+
   create_table :orders, :force => true do |t|
     t.string  :name
     t.integer :billing_customer_id


### PR DESCRIPTION
Previous implementation was throwing exceptions when default_scope was called multiple times for the same model. This fix uses the old finder merging (using construct_finder_arel method) for non-lambda arguments and recursive lambdas when necessary.

More info in ticket #1812 on lighthouse.
