### PR TITLE
ActiveRecord::Relation#first convenience method

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -138,6 +138,10 @@ module ActiveRecord
       relation
     end
 
+    def first
+      limit(1).to_a.first
+    end
+
     def extending(*modules)
       modules << Module.new(&Proc.new) if block_given?
 

--- a/activerecord/test/cases/relation_scoping_test.rb
+++ b/activerecord/test/cases/relation_scoping_test.rb
@@ -24,6 +24,12 @@ class RelationScopingTest < ActiveRecord::TestCase
     end
   end
 
+  def test_scoped_find_first_only_queries_one_record
+    scoped = Developer.scoped
+    scoped.expects(:limit).with(1).returns(['record'])
+    assert_equal 'record', scoped.first
+  end
+
   def test_scoped_find_last
     highest_salary = Developer.order("salary DESC").first
 


### PR DESCRIPTION
Will force a limit(1) on the scope.

Currently when calling #first on a scope it does the full query through the method_missing fallback. (calls #to_a) If we're calling #first there is no reason to query for the rest of that data.
