### PR TITLE
password_digest should be protected by active authorizer

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -33,12 +33,16 @@ module ActiveModel
         attr_reader   :password
         attr_accessor :password_confirmation
 
-        attr_protected(:password_digest) if respond_to?(:attr_protected)
-
         validates_confirmation_of :password
         validates_presence_of     :password_digest
         
         include InstanceMethodsOnActivation
+
+        if respond_to?(:attributes_protected_by_default)
+          def self.attributes_protected_by_default
+            super + ['password_digest']
+          end
+        end
       end
     end
 

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -1,5 +1,7 @@
 require 'cases/helper'
 require 'models/user'
+require 'models/visitor'
+require 'models/administrator'
 
 class SecurePasswordTest < ActiveModel::TestCase
 
@@ -28,5 +30,16 @@ class SecurePasswordTest < ActiveModel::TestCase
 
     assert !@user.authenticate("wrong")
     assert @user.authenticate("secret")
+  end
+
+  test "visitor#password_digest should be protected against mass assignment" do
+    assert Visitor.active_authorizer.kind_of?(ActiveModel::MassAssignmentSecurity::BlackList)
+    assert Visitor.active_authorizer.include?(:password_digest)
+  end
+
+  test "Administrator's mass_assignment_authorizer should be WhiteList" do
+    assert Administrator.active_authorizer.kind_of?(ActiveModel::MassAssignmentSecurity::WhiteList)
+    assert !Administrator.active_authorizer.include?(:password_digest)
+    assert Administrator.active_authorizer.include?(:name)
   end
 end

--- a/activemodel/test/models/administrator.rb
+++ b/activemodel/test/models/administrator.rb
@@ -1,0 +1,10 @@
+class Administrator
+  include ActiveModel::Validations
+  include ActiveModel::SecurePassword
+  include ActiveModel::MassAssignmentSecurity
+
+  attr_accessor :name, :password_digest
+  attr_accessible :name
+
+  has_secure_password
+end

--- a/activemodel/test/models/visitor.rb
+++ b/activemodel/test/models/visitor.rb
@@ -1,0 +1,9 @@
+class Visitor
+  include ActiveModel::Validations
+  include ActiveModel::SecurePassword
+  include ActiveModel::MassAssignmentSecurity
+
+  has_secure_password
+
+  attr_accessor :password_digest
+end


### PR DESCRIPTION
This is a small fix on ActiveModel::SecurePassword module.

Currently, `attr_protected(:password_digest)` is called always if the model class responds to `:attr_protected`.

When the model class has called `attr_accssible`, `attr_protected` should not be called.

It changes the active mass assignment authorizer from WhiteList to BlackList. That nullifies the existing protection.
