### PR TITLE
Return a non-zero exit code when commands fail

### DIFF
--- a/railties/lib/rails/cli.rb
+++ b/railties/lib/rails/cli.rb
@@ -6,7 +6,7 @@ require 'rails/script_rails_loader'
 Rails::ScriptRailsLoader.exec_script_rails!
 
 require 'rails/ruby_version_check'
-Signal.trap("INT") { puts; exit }
+Signal.trap("INT") { puts; exit(1) }
 
 if ARGV.first == 'plugin'
   ARGV.shift

--- a/railties/lib/rails/commands.rb
+++ b/railties/lib/rails/commands.rb
@@ -62,6 +62,7 @@ when 'application', 'runner'
 when 'new'
   puts "Can't initialize a new Rails application within the directory of another, please change to a non-Rails directory first.\n"
   puts "Type 'rails' for help."
+  exit(false)
 
 when '--version', '-v'
   ARGV.unshift '--version'
@@ -91,4 +92,5 @@ In addition to those, there are:
 
 All commands can be run with -h for more information.
   EOT
+  exit(false)
 end

--- a/railties/lib/rails/commands.rb
+++ b/railties/lib/rails/commands.rb
@@ -62,7 +62,7 @@ when 'application', 'runner'
 when 'new'
   puts "Can't initialize a new Rails application within the directory of another, please change to a non-Rails directory first.\n"
   puts "Type 'rails' for help."
-  exit(false)
+  exit(1)
 
 when '--version', '-v'
   ARGV.unshift '--version'
@@ -92,5 +92,5 @@ In addition to those, there are:
 
 All commands can be run with -h for more information.
   EOT
-  exit(false)
+  exit(1)
 end

--- a/railties/lib/rails/commands/application.rb
+++ b/railties/lib/rails/commands/application.rb
@@ -15,4 +15,16 @@ require 'rubygems' if ARGV.include?("--dev")
 require 'rails/generators'
 require 'rails/generators/rails/app/app_generator'
 
+module Rails
+  module Generators
+    class AppGenerator
+      # We want to exit on failure to be kind to other libraries
+      # This is only when accessing via CLI
+      def self.exit_on_failure?
+        true
+      end
+    end
+  end
+end
+
 Rails::Generators::AppGenerator.start

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -70,6 +70,17 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_equal false, $?.success?
   end
 
+  def test_application_new_exits_with_message_and_non_zero_code_when_generating_inside_existing_rails_directory
+    app_root = File.join(destination_root, 'myfirstapp')
+    run_generator [app_root]
+    output = nil
+    Dir.chdir(app_root) do
+      output = `rails new mysecondapp`
+    end
+    assert_equal "Can't initialize a new Rails application within the directory of another, please change to a non-Rails directory first.\nType 'rails' for help.\n", output
+    assert_equal false, $?.success?
+  end
+
   def test_application_name_is_detected_if_it_exists_and_app_folder_renamed
     app_root       = File.join(destination_root, "myapp")
     app_moved_root = File.join(destination_root, "myapp_moved")

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -64,10 +64,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "things-43/config/application.rb", /^module Things43$/
   end
 
-  def test_application_new_exits_with_non_zero_code_on_failure
-    Dir.chdir(destination_root) do
-      `rails new test`
-    end
+  def test_application_new_exits_with_non_zero_code_on_invalid_application_name
+    # TODO: Suppress the output of this (it's because of a Thor::Error)
+    `rails new test`
     assert_equal false, $?.success?
   end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -64,6 +64,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "things-43/config/application.rb", /^module Things43$/
   end
 
+  def test_application_new_exits_with_non_zero_code_on_failure
+    Dir.chdir(destination_root) do
+      `rails new test`
+    end
+    assert_equal false, $?.success?
+  end
+
   def test_application_name_is_detected_if_it_exists_and_app_folder_renamed
     app_root       = File.join(destination_root, "myapp")
     app_moved_root = File.join(destination_root, "myapp_moved")


### PR DESCRIPTION
This is as per "exit" documentation here: http://www.ruby-doc.org/core/classes/Kernel.html#M001444

Use case: In my library I want to run system("rails new inside_existing_rails_dir") but that fails because you can't initialize an application while inside the directory of another.  However, I as a library author may assume it worked because $? == 0 as below (in irb):

```
> `rails new inside_existing_rails_dir`
   => "Can't initialize a new Rails application within the directory of another, please change to a non-Rails directory first.\nType 'rails' for help.\n" 
> $? == 0
   => true
```

Thanks!
