### PR TITLE
Remove redundant line

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -181,7 +181,6 @@ module ActiveSupport #:nodoc:
         nesting.each do |namespace|
           begin
             return Dependencies.load_missing_constant Inflector.constantize(namespace), const_name
-          rescue NoMethodError then raise
           rescue NameError => e
             error ||= e
           end


### PR DESCRIPTION
Following line is redundant and I've removed it from dependencies.rb:

```
rescue NoMethodError then raise 
```
