### PR TITLE
Fixes a documentation issue in ActionDispatch::Routing:Mapper::Resources::resource

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -985,11 +985,11 @@ module ActionDispatch
         #
         # [:path]
         #
-        #  Set a path prefix for this resource.
+        #  Set a path for this resource.
         #
-        #     resources :posts, :path => "admin"
+        #     resources :posts, :path => "entries"
         #
-        #  All actions for this resource will now be at +/admin/posts+.
+        #  All actions for this resource will now be at +/entries+.
         def resources(*resources, &block)
           options = resources.extract_options!
 


### PR DESCRIPTION
The documentation siad that path would add a prefix, however that's not what it does. For isntance, `resource :posts, :path => 'notas'` would display on `rake routes`:

```
GET    /notas(.:format)            {:action=>"index", :controller=>"posts"}
POST   /notas(.:format)            {:action=>"create", :controller=>"posts"}
GET    /notas/crear(.:format)      {:action=>"new", :controller=>"posts"}
GET    /notas/:id/editar(.:format) {:action=>"edit", :controller=>"posts"}
GET    /notas/:id(.:format)        {:action=>"show", :controller=>"posts"}
PUT    /notas/:id(.:format)        {:action=>"update", :controller=>"posts"}
DELETE /notas/:id(.:format)        {:action=>"destroy", :controller=>"posts"}
```
