### PR TITLE
Propagate association extensions to scopes called on the association.

### DIFF
--- a/activerecord/lib/active_record/associations/association_proxy.rb
+++ b/activerecord/lib/active_record/associations/association_proxy.rb
@@ -188,6 +188,9 @@ module ActiveRecord
           if select = select_value
             scope = scope.select(select)
           end
+          if Relation === scope
+            scope = scope.extending(*Array.wrap(@reflection.options[:extend]))
+          end
           scope.where(construct_owner_conditions)
         end
 

--- a/activerecord/test/cases/associations/extension_test.rb
+++ b/activerecord/test/cases/associations/extension_test.rb
@@ -29,6 +29,11 @@ class AssociationsExtensionsTest < ActiveRecord::TestCase
     assert_equal projects(:action_controller), developers(:david).projects_extended_by_name_and_block.find_most_recent
     assert_equal projects(:active_record), developers(:david).projects_extended_by_name_and_block.find_least_recent
   end
+  
+  def test_extension_with_scopes
+    assert_equal comments(:greetings), posts(:welcome).comments.offset(1).find_most_recent
+    assert_equal comments(:greetings), posts(:welcome).comments.not_again.find_most_recent
+  end
 
   def test_marshalling_extensions
     david = developers(:david)

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -1,6 +1,7 @@
 class Comment < ActiveRecord::Base
   scope :limit_by, lambda {|l| limit(l) }
   scope :containing_the_letter_e, :conditions => "comments.body LIKE '%e%'"
+  scope :not_again, where("comments.body NOT LIKE '%again%'")
   scope :for_first_post, :conditions => { :post_id => 1 }
   scope :for_first_author,
               :joins => :post,


### PR DESCRIPTION
Extension modules defined on associations are added to the association proxy itself, but are not propagated to scopes created from that association proxy.  This commit fixes that.

(The two assertions in the test case cover both built-in scope methods such as `where`, `limit`, etc., as well as scopes defined on the target class of the association.  During initial development, I tried a solution that addressed built-in scopes but failed for named scopes on the target class.)
