### PR TITLE
Fix i18n load path setup when eager loading

### DIFF
--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -24,9 +24,8 @@ module I18n
       end
     end
 
-    # Set the i18n configuration only after initialization since a lot of
-    # configuration is still usually done in application initializers.
-    config.after_initialize do |app|
+    # Proc to set up i18n configuration
+    init_load_path = Proc.new do |app|
       fallbacks = app.config.i18n.delete(:fallbacks)
 
       app.config.i18n.each do |setting, value|
@@ -45,6 +44,14 @@ module I18n
       reloader.paths.concat I18n.load_path
       reloader.execute_if_updated
     end
+
+    # Set the i18n configuration only after initialization since a lot of
+    # configuration is still usually done in application initializers.
+    config.after_initialize(&init_load_path)
+
+    # Trigger i18n config before any eager loading has happened
+    # so it's ready if any classes require it when eager loaded
+    config.before_eager_load(&init_load_path)
 
   protected
 

--- a/railties/test/application/initializers/i18n_test.rb
+++ b/railties/test/application/initializers/i18n_test.rb
@@ -63,6 +63,36 @@ module ApplicationTests
       assert I18n.load_path.include?("#{app_path}/config/another_locale.yml")
     end
 
+    test "load_path is populated before eager loaded models" do
+      add_to_config <<-RUBY
+        config.cache_classes = true
+      RUBY
+
+      app_file "config/locales/en.yml", <<-YAML
+en:
+  foo: "1"
+      YAML
+
+      app_file 'app/models/foo.rb', <<-RUBY
+        class Foo < ActiveRecord::Base
+          @foo = I18n.t(:foo)
+        end
+      RUBY
+
+      app_file 'config/routes.rb', <<-RUBY
+        AppTemplate::Application.routes.draw do
+          match '/i18n',   :to => lambda { |env| [200, {}, [Foo.instance_variable_get('@foo')]] }
+        end
+      RUBY
+
+      require 'rack/test'
+      extend Rack::Test::Methods
+      load_app
+
+      get "/i18n"
+      assert_equal "1", last_response.body
+    end
+
     test "locales are reloaded if they change between requests" do
       add_to_config <<-RUBY
         config.cache_classes = false


### PR DESCRIPTION
While running some cucumber features I came across a failing cuke that at first glance seemed to be a simple case of a missing translation. In fact, the translation was not missing at all and was rendered properly when viewing the same page in development.

I traced the issue to the fact that in certain cases, when config.cache_classes is true (e.g. in cucumber environments), eager loading of various initializers triggers loading of app models (e.g. via observers). The I18n load path is setup (e.g. config/locales/*.{rb,yml} added to it) via an after_initialize hook but in this particular case, active record models that have been loaded via eagerly loaded initializers (e.g.) and use I18n (.e.g validation messages) don't see the fully loaded load path and thus we get the missing translation issue.

In my opinion, the I18n load path setup should happen before any eager loading is done so that it's completely setup if any AR models are eagerly loaded.

This pull request contains both a fix and a test that fails without the fix but passes with it.

See also: https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/6353-i18n-load-path-needs-to-be-setup-before-eager-loading
