### PR TITLE
fix for test_read_attributes_before_type_cast_on_datetime - Oracle adapter also returns Time value

### DIFF
--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -118,8 +118,8 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   def test_read_attributes_before_type_cast_on_datetime
     developer = Developer.find(:first)
-    if current_adapter?(:Mysql2Adapter)
-      # Mysql2 keeps the value in Time instance
+    if current_adapter?(:Mysql2Adapter, :OracleAdapter)
+      # Mysql2 and Oracle adapters keep the value in Time instance
       assert_equal developer.created_at.to_s(:db), developer.attributes_before_type_cast["created_at"].to_s(:db)
     else
       assert_equal developer.created_at.to_s(:db), developer.attributes_before_type_cast["created_at"].to_s


### PR DESCRIPTION
test_read_attributes_before_type_cast_on_datetime previously had already condition for Oracle adapter but it was deleted by commit 817e37013610c8e8866197594d5e408b4d5daec5. Now I added back this condition as Oracle adapter returns Time value before type cast on datetime attributes.

This patch should be applied to 3-0-stable branch as well where this mentioned commit was applied as well.
