### PR TITLE
Allow page cache location to be set to a Pathname

### DIFF
--- a/actionpack/lib/action_controller/caching/pages.rb
+++ b/actionpack/lib/action_controller/caching/pages.rb
@@ -106,7 +106,7 @@ module ActionController #:nodoc:
           end
 
           def page_cache_path(path, extension = nil)
-            page_cache_directory + page_cache_file(path, extension)
+            page_cache_directory.to_s + page_cache_file(path, extension)
           end
 
           def instrument_page_cache(name, path)

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -156,6 +156,17 @@ class PageCachingTest < ActionController::TestCase
     assert_page_not_cached :ok
   end
 
+  def test_page_caching_directory_set_as_pathname
+    begin
+      ActionController::Base.page_cache_directory = Pathname.new(FILE_STORE_PATH)
+      get :ok
+      assert_response :ok
+      assert_page_cached :ok
+    ensure
+      ActionController::Base.page_cache_directory = FILE_STORE_PATH
+    end
+  end
+
   private
     def assert_page_cached(action, message = "#{action} should have been cached")
       assert page_cached?(action), message


### PR DESCRIPTION
Now that Rails.root is a Pathname, it seems like you should be able to do this:

```
config.action_controller.page_cache_directory = Rails.root.join("public/cache")
```

This patch (and test) allow you to do that. Without it, you get inexplicable and impenetrable 500 errors with logs that (super helpfully) look like this:

```
Started GET "/" for 127.0.0.1 at Sat Feb 05 15:19:06 -0800 2011
  Processing by MediaController#index as XML
Rendered media/index.xml.builder (0.2ms)
Write page /index.html (0.4ms)
Completed   in 6ms

Errno::ENOENT (No such file or directory - ):
```
