### PR TITLE
Needless to_s in attribute methods test

### DIFF
--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -131,7 +131,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_equal developer.created_at, nil
 
     developer.created_at = "2010-03-21 21:23:32"
-    assert_equal developer.created_at_before_type_cast.to_s, "2010-03-21 21:23:32"
+    assert_equal developer.created_at_before_type_cast, "2010-03-21 21:23:32"
     assert_equal developer.created_at, Time.parse("2010-03-21 21:23:32")
   end
 


### PR DESCRIPTION
This is a fix for this comment. https://github.com/rails/rails/commit/c8b7606734cc556ae17a9dd5bb12994a3cff6b7e#L1R130
Removed a to_s call and made the test a bit more meaningful.
