### PR TITLE
Bugfix for serialized_attributes to be class specific

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -553,7 +553,9 @@ module ActiveRecord #:nodoc:
                   Coders::YAMLColumn.new(class_name)
                 end
 
-        serialized_attributes[attr_name.to_s] = coder
+        # merge new serialized attribute and create new hash to ensure that each class in inheritance hierarchy
+        # has its own hash of own serialized attributes
+        self.serialized_attributes = serialized_attributes.merge(attr_name.to_s => coder)
       end
 
       # Guesses the table name (in forced lower-case) based on the name of the class in the

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -8,6 +8,7 @@ require 'models/topic'
 require 'models/company'
 require 'models/category'
 require 'models/reply'
+require 'models/contact'
 
 class AttributeMethodsTest < ActiveRecord::TestCase
   fixtures :topics, :developers, :companies, :computers
@@ -609,6 +610,10 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     Object.send(:undef_method, :title) # remove test method from object
   end
 
+  def test_list_of_serialized_attributes
+    assert_equal %w(content), Topic.serialized_attributes.keys
+    assert_equal %w(preferences), Contact.serialized_attributes.keys
+  end
 
   private
   def cached_columns


### PR DESCRIPTION
Previously serialized_attributes were kept as class attribute of ActiveRecord::Base - if some attribute was defined as serialized in one subclass then it was serialized in all other subclasses as well (if it had the same name).
