### PR TITLE
ActionController::TestCase#process barfs if it gets any frozen values as params

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -147,7 +147,9 @@ module ActionController
         if value.is_a? Fixnum
           value = value.to_s
         elsif value.is_a? Array
-          value = Result.new(value)
+          value = Result.new(value.map { |v| v.is_a?(String) ? v.dup : v })
+        elsif value.is_a? String
+          value = value.dup
         end
 
         if extra_keys.include?(key.to_sym)

--- a/actionpack/test/controller/test_test.rb
+++ b/actionpack/test/controller/test_test.rb
@@ -493,6 +493,18 @@ XML
     )
   end
 
+  def test_params_passing_with_frozen_values
+    assert_nothing_raised do
+      get :test_params, :frozen => 'icy'.freeze, :frozens => ['icy'.freeze].freeze
+    end
+    parsed_params = eval(@response.body)
+    assert_equal(
+      {'controller' => 'test_test/test', 'action' => 'test_params',
+       'frozen' => 'icy', 'frozens' => ['icy']},
+      parsed_params
+    )
+  end
+
   def test_id_converted_to_string
     get :test_params, :id => 20, :foo => Object.new
     assert_kind_of String, @request.path_parameters['id']


### PR DESCRIPTION
If you do this on Ruby 1.9 (or any encoding aware Ruby) it will get pissed:

```
TPS_REPORT_TOPICS = { 'synergy' => "Synergy", 'rev_stream' => "Revenue Streams" }

class ActionController::TestCase
  #...
  test "can create a TPS report with a topic" do
    post :create, :tps_report => { :topic => TPS_REPORT_TOPICS.keys.first }
  end
end
```

Since rails tries to force encoding in-place (in ActionDispatch::Http::Parameters#encode_params) on all strings that are passed in, it will raise an error if it gets a frozen string.

I included a patch that dups all strings that are passed as parameters so that rails doesn't do in-place encoding on the strings that are passed in
