### PR TITLE
Fixes deprecation message for ActiveRecord::Base#class_name

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1286,7 +1286,7 @@ module ActiveRecord #:nodoc:
 
       # Turns the +table_name+ back into a class name following the reverse rules of +table_name+.
       def class_name(table_name = table_name) # :nodoc:
-        ActiveSupport::Deprecation.warn("ActiveRecord::Base#class_name is deprecated and will be removed in Rails 2.3.9.", caller)
+        ActiveSupport::Deprecation.warn("ActiveRecord::Base#class_name is deprecated and will be removed in Rails 3.", caller)
 
         # remove any prefix and/or suffix from the table name
         class_name = table_name[table_name_prefix.length..-(table_name_suffix.length + 1)].camelize


### PR DESCRIPTION
The message wrongly says that ActiveRecord::Base#class_name will be removed in Rails 2.3.9, but it is still available in 2.3.10 and now 2.3.11.
