### PR TITLE
Missing require on ActionDispatch

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -2,6 +2,7 @@ require 'tempfile'
 require 'stringio'
 require 'strscan'
 
+require 'active_support/core_ext/module/deprecation'
 require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/core_ext/string/access'
 require 'active_support/inflector'


### PR DESCRIPTION
Hey there, while running SimpleForm tests on 3.0.4, I got this missing require and I had to add it manually before requiring `action_view/test_case`. Here is the line that calls the `deprecate` method:
https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/http/request.rb#L138

I believe this can be safely applied on both master and 3-0-stable branch.
Thanks.
