### PR TITLE
Relation subqueries

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -18,7 +18,10 @@ module ActiveRecord
           attribute = table[column.to_sym]
 
           case value
-          when Array, ActiveRecord::Associations::AssociationCollection, ActiveRecord::Relation
+          when ActiveRecord::Relation
+            value.select_values = Array.wrap("#{value.klass.quoted_table_name}.id") if value.select_values.empty?
+            attribute.in(value.arel.ast)
+          when Array, ActiveRecord::Associations::AssociationCollection
             values = value.to_a.map { |x|
               x.is_a?(ActiveRecord::Base) ? x.id : x
             }

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -467,7 +467,7 @@ class RelationTest < ActiveRecord::TestCase
     authors = Author.find_by_id([author])
     assert_equal author, authors
   end
-
+  
   def test_find_all_using_where_twice_should_or_the_relation
     david = authors(:david)
     relation = Author.unscoped
@@ -487,6 +487,33 @@ class RelationTest < ActiveRecord::TestCase
       memo.where(param)
     end
     assert_equal [david], relation.all
+  end
+  
+  def test_find_all_using_where_with_relation
+    david = authors(:david)
+    # switching the lines below would succeed in current rails
+    # assert_queries(2) {
+    assert_queries(1) {
+      relation = Author.where(:id => Author.where(:id => david.id))
+      assert_equal [david], relation.all
+    }
+  end
+
+  def test_find_all_using_where_with_relation_with_joins
+    david = authors(:david)
+    assert_queries(1) {
+      relation = Author.where(:id => Author.joins(:posts).where(:id => david.id))
+      assert_equal [david], relation.all
+    }
+  end
+
+  
+  def test_find_all_using_where_with_relation_with_select_to_build_subquery
+    david = authors(:david)
+    assert_queries(1) {
+      relation = Author.where(:name => Author.where(:id => david.id).select(:name))
+      assert_equal [david], relation.all
+    }
   end
 
   def test_exists


### PR DESCRIPTION
ActiveRecord::Relation where clauses hash syntax accepts an ActiveRecord::Relation as a value, but it maps the relation to ids when it could just use a subquery.  By converting the Relation to an ast we can now accept any subquery.

Model.where(:id => AnotherModel.some_scope.select(:some_id))

will only run one query and it supports references to tables from the outer query.

Have corresponded with @tenderlove on this.
