### PR TITLE
Make button_tag more helpful

### DIFF
--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -431,16 +431,16 @@ module ActionView
       #
       # ==== Examples
       #   button_tag
-      #   # => <button name="button" type="button">Button</button>
+      #   # => <button name="button" type="submit">Button</button>
       #
-      #   button_tag "<strong>Ask me!</strong>"
+      #   button_tag "<strong>Ask me!</strong>", :type => 'button'
       #   # => <button name="button" type="button">
       #          <strong>Ask me!</strong>
       #        </button>
       #
       #   button_tag "Checkout", :disable_with => "Please wait..."
       #   # => <button data-disable-with="Please wait..." name="button"
-      #                type="button">Checkout</button>
+      #                type="submit">Checkout</button>
       #
       def button_tag(label = "Button", options = {})
         options.stringify_keys!
@@ -453,9 +453,7 @@ module ActionView
           options["data-confirm"] = confirm
         end
 
-        ["type", "name"].each do |option|
-          options[option] = "button" unless options[option]
-        end
+        options.reverse_merge! 'name' => 'button', 'type' => 'submit'
 
         content_tag :button, label, { "type" => options.delete("type") }.update(options)
       end

--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -414,7 +414,8 @@ module ActionView
       # <tt>reset</tt>button or a generic button which can be used in
       # JavaScript, for example. You can use the button tag as a regular
       # submit tag but it isn't supported in legacy browsers. However,
-      # button tag allows richer labels such as images and emphasis.
+      # the button tag allows richer labels such as images and emphasis,
+      # so this helper will also accept a block.
       #
       # ==== Options
       # * <tt>:confirm => 'question?'</tt> - If present, the
@@ -433,7 +434,9 @@ module ActionView
       #   button_tag
       #   # => <button name="button" type="submit">Button</button>
       #
-      #   button_tag "<strong>Ask me!</strong>", :type => 'button'
+      #   button_tag(:type => 'button') do
+      #     content_tag(:strong, 'Ask me!')
+      #   end
       #   # => <button name="button" type="button">
       #          <strong>Ask me!</strong>
       #        </button>
@@ -442,7 +445,9 @@ module ActionView
       #   # => <button data-disable-with="Please wait..." name="button"
       #                type="submit">Checkout</button>
       #
-      def button_tag(label = "Button", options = {})
+      def button_tag(content_or_options = nil, options = nil, &block)
+        options = content_or_options if block_given? && content_or_options.is_a?(Hash)
+        options ||= {}
         options.stringify_keys!
 
         if disable_with = options.delete("disable_with")
@@ -455,7 +460,7 @@ module ActionView
 
         options.reverse_merge! 'name' => 'button', 'type' => 'submit'
 
-        content_tag :button, label, { "type" => options.delete("type") }.update(options)
+        content_tag :button, content_or_options || 'Button', options, &block
       end
 
       # Displays an image which when clicked will submit the form.

--- a/actionpack/test/template/form_tag_helper_test.rb
+++ b/actionpack/test/template/form_tag_helper_test.rb
@@ -387,7 +387,7 @@ class FormTagHelperTest < ActionView::TestCase
 
   def test_button_tag
     assert_dom_equal(
-      %(<button name="button" type="button">Button</button>),
+      %(<button name="button" type="submit">Button</button>),
       button_tag
     )
   end
@@ -396,6 +396,13 @@ class FormTagHelperTest < ActionView::TestCase
     assert_dom_equal(
       %(<button name="button" type="submit">Save</button>),
       button_tag("Save", :type => "submit")
+    )
+  end
+
+  def test_button_tag_with_button_type
+    assert_dom_equal(
+      %(<button name="button" type="button">Button</button>),
+      button_tag("Button", :type => "button")
     )
   end
 

--- a/actionpack/test/template/form_tag_helper_test.rb
+++ b/actionpack/test/template/form_tag_helper_test.rb
@@ -427,6 +427,15 @@ class FormTagHelperTest < ActionView::TestCase
     )
   end
 
+  def test_button_tag_with_block
+    assert_dom_equal('<button name="button" type="submit">Content</button>', button_tag { 'Content' })
+  end
+
+  def test_button_tag_with_block_and_options
+    output = button_tag(:name => 'temptation', :type => 'button') { content_tag(:strong, 'Do not press me') }
+    assert_dom_equal('<button name="temptation" type="button"><strong>Do not press me</strong></button>', output)
+  end
+
   def test_image_submit_tag_with_confirmation
     assert_dom_equal(
       %(<input type="image" src="/images/save.gif" data-confirm="Are you sure?" />),


### PR DESCRIPTION
The `button_tag` helper isn't very helpful at the moment for two reasons:
- it defaults the `type` attribute to `"button"`, which is unexpected since `type="submit"` is HTML's default for the `<button>` element; and
- it doesn't take a block, but the main reason to use `<button>` (instead of `<input type="submit">` et al) is that you want to include styled text or other elements like images.

These two commits fix the implementation, tests and docs for these two issues respectively.
