### PR TITLE
Add rvmrc to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ railties/test/initializer/root/log
 railties/doc
 railties/guides/output
 railties/tmp
+.rvmrc


### PR DESCRIPTION
I think a fairly large portion of the people hacking on rails might be using rvm. It might be time to add the .rvmrc to .gitignore so that peoples personal ruby version/gemset don't accidentally get pushed up to rails/rails. 
