### PR TITLE
Serializable ActiveRecord columns with JSON

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -84,6 +84,7 @@ module ActiveRecord
 
   module Coders
     autoload :YAMLColumn, 'active_record/coders/yaml_column'
+    autoload :JSONColumn, 'active_record/coders/json_column'
   end
 
   module AttributeMethods

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -537,15 +537,19 @@ module ActiveRecord #:nodoc:
       #
       # * +attr_name+ - The field name that should be serialized.
       # * +class_name+ - Optional, class name that the object type should be equal to.
+      # * +options+ - Optional, hash allowing the :format option. Available formats are :json and :yaml, the latter
+      #   being default.
       #
       # ==== Example
       #   # Serialize a preferences attribute
       #   class User
       #     serialize :preferences
       #   end
-      def serialize(attr_name, class_name = Object)
+      def serialize(attr_name, class_name = Object, options = {})
         coder = if [:load, :dump].all? { |x| class_name.respond_to?(x) }
                   class_name
+                elsif options[:format] == :json
+                  Coders::JSONColumn.new(class_name)
                 else
                   Coders::YAMLColumn.new(class_name)
                 end

--- a/activerecord/lib/active_record/coders/json_column.rb
+++ b/activerecord/lib/active_record/coders/json_column.rb
@@ -1,0 +1,39 @@
+
+module ActiveRecord
+  # :stopdoc:
+  module Coders
+    class JSONColumn
+      RESCUE_ERRORS = [ ActiveSupport::JSON.backend::ParseError ]
+
+      attr_accessor :object_class
+
+      def initialize(object_class = Object)
+        @object_class = object_class
+      end
+
+      def dump(obj)
+        ActiveSupport::JSON.encode obj
+      end
+
+      def load(json)
+        return object_class.new if object_class != Object && json.nil?
+        return json unless json.is_a?(String)
+
+        begin
+          obj = ActiveSupport::JSON.decode(json)
+
+          unless obj.is_a?(object_class) || obj.nil?
+            raise SerializationTypeMismatch,
+              "Attribute was supposed to be a #{object_class}, but was a #{obj.class}"
+          end
+          obj ||= object_class.new if object_class != Object
+
+          obj
+        rescue *RESCUE_ERRORS
+          json
+        end
+      end
+    end
+  end
+  # :startdoc
+end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1108,6 +1108,28 @@ class BasicsTest < ActiveRecord::TestCase
     Topic.serialize(:content)
   end
 
+  def test_serialize_with_json_hash
+    Topic.serialize(:content, Object, :format => :json)
+    s = { 'hello' => 'world' }
+    topic = Topic.new(:content => s)
+    assert topic.save
+    topic = topic.reload
+    assert_equal({ 'hello' => 'world' }, topic.content)
+  ensure
+    Topic.serialize(:content)
+  end
+
+  def test_serialize_with_json_array
+    Topic.serialize(:content, Array, :format => :json)
+    s = [1, 2, 3, "foo", "bar", "baz"]
+    topic = Topic.new(:content => s)
+    assert topic.save
+    topic = topic.reload
+    assert_equal([1, 2, 3, "foo", "bar", "baz"], topic.content)
+  ensure
+    Topic.serialize(:content)
+  end
+
   def test_serialize_with_bcrypt_coder
     crypt_coder = Class.new {
       def load(thing)

--- a/activerecord/test/cases/coders/json_column_test.rb
+++ b/activerecord/test/cases/coders/json_column_test.rb
@@ -1,0 +1,45 @@
+require "cases/helper"
+
+module ActiveRecord
+  module Coders
+    class JSONColumnTest < ActiveRecord::TestCase
+      def test_initialize_takes_class
+        coder = JSONColumn.new(Object)
+        assert_equal Object, coder.object_class
+      end
+
+      def test_type_mismatch_on_different_classes
+        coder = JSONColumn.new(Array)
+        assert_raises(SerializationTypeMismatch) do
+          coder.load "{ \"foo\": \"bar\" }"
+        end
+      end
+
+      def test_nil_is_ok
+        coder = JSONColumn.new
+        assert_nil coder.load ""
+      end
+
+      def test_returns_new_with_different_class
+        coder = JSONColumn.new SerializationTypeMismatch
+        assert_equal SerializationTypeMismatch, coder.load("").class
+      end
+
+      def test_returns_value_unless_is_a_string
+        coder = JSONColumn.new
+        assert_equal 235, coder.load(235)
+      end
+
+      def test_load_handles_other_classes
+        coder = JSONColumn.new
+        assert_equal [], coder.load([])
+      end
+
+      def test_load_swallows_json_exceptions
+        coder = JSONColumn.new
+        bad_json = '{ ]'
+        assert_equal bad_json, coder.load(bad_json)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi! I'd like to include a JSON Column encoder to use with ActiveRecord::Base `serialize`. Now it only supports YAML.

What I don't quite like is that, since `serialize` already has a last argument with a default, the `options` hash isn't so comfortable to use. In my pull request to serialize a column with JSON you must do this:

```
class Post < ActiveRecord::Base
  serialize :data, Hash, :format => :json
end
```

You can't omit the `Hash` part if you want to specify a `:format`, and I don't like that. How would you improve this?
