### PR TITLE
Fixes #6073, #6383 - Postgres added tsvector type, and fixed money_precision= NoMethodError

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -939,7 +939,7 @@ module ActiveRecord
           # Money type has a fixed precision of 10 in PostgreSQL 8.2 and below, and as of
           # PostgreSQL 8.3 it has a fixed precision of 19. PostgreSQLColumn.extract_precision
           # should know about this but can't detect it there, so deal with it here.
-          PostgreSQLColumn.money_precision = (postgresql_version >= 80300) ? 19 : 10
+          ActiveRecord::ConnectionAdapters::PostgreSQLColumn.money_precision = (postgresql_version >= 80300) ? 19 : 10
 
           configure_connection
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -111,6 +111,9 @@ module ActiveRecord
             # UUID type
             when 'uuid'
               :string
+            # TSVector type
+            when 'tsvector'
+              :tsvector
             # Small and big integer types
             when /^(?:small|big)int$/
               :integer
@@ -207,7 +210,8 @@ module ActiveRecord
         :date        => { :name => "date" },
         :binary      => { :name => "bytea" },
         :boolean     => { :name => "boolean" },
-        :xml         => { :name => "xml" }
+        :xml         => { :name => "xml" },
+        :tsvector    => { :name => "tsvector" }
       }
 
       # Returns 'PostgreSQL' as adapter name for identification purposes.


### PR DESCRIPTION
This fixes a couple of issues that I have encountered while using postgres tesearch functionality:

  #6073 - Patch by Robert Sosinski (www.robertsosinski.com) adding the tsvector data type

  #6382 - Patch to fix money_precision= setting the variable in the wrong class
