### PR TITLE
Patch for issue 6440 - Session Reset undefined method `destroy' for {}:Hash 

### DIFF
--- a/actionpack/lib/action_controller/request.rb
+++ b/actionpack/lib/action_controller/request.rb
@@ -446,7 +446,9 @@ EOM
     end
 
     def reset_session
-      session.destroy if session
+      # session may be a hash, if so, we do not want to call destroy
+      # fixes issue 6440
+      session.destroy if session and session.respond_to?(:destroy)
       self.session = {}
     end
 

--- a/actionpack/test/controller/session/cookie_store_test.rb
+++ b/actionpack/test/controller/session/cookie_store_test.rb
@@ -42,6 +42,12 @@ class CookieStoreTest < ActionController::IntegrationTest
       head :ok
     end
 
+    def call_reset_session_twice
+      reset_session
+      reset_session
+      head :ok
+    end
+
     def call_reset_session
       reset_session
       head :ok
@@ -187,6 +193,44 @@ class CookieStoreTest < ActionController::IntegrationTest
       get '/no_session_access'
       assert_response :success
       assert_equal nil, headers['Set-Cookie']
+    end
+  end
+
+  def test_calling_session_reset_twice
+    with_test_route_set do
+      get '/set_session_value'
+      assert_response :success
+      session_payload = response.body
+      assert_equal "_myapp_session=#{response.body}; path=/; HttpOnly",
+        headers['Set-Cookie']
+
+      get '/call_reset_session_twice'
+      assert_response :success
+      assert_not_equal "", headers['Set-Cookie']
+      assert_not_equal session_payload, cookies[SessionKey]
+
+      get '/get_session_value'
+      assert_response :success
+      assert_equal 'foo: nil', response.body
+    end
+  end
+
+  def test_setting_session_value_after_session_reset
+    with_test_route_set do
+      get '/set_session_value'
+      assert_response :success
+      session_payload = response.body
+      assert_equal "_myapp_session=#{response.body}; path=/; HttpOnly",
+        headers['Set-Cookie']
+
+      get '/call_reset_session'
+      assert_response :success
+      assert_not_equal "", headers['Set-Cookie']
+      assert_not_equal session_payload, cookies[SessionKey]
+
+      get '/get_session_value'
+      assert_response :success
+      assert_equal 'foo: nil', response.body
     end
   end
 


### PR DESCRIPTION
As described in Rails issue 6440](https://rails.lighthouseapp.com/projects/8994/tickets/6440-session-reset-undefined-method-destroy-for-hash), when reset_session is called on the request twice, an error is thrown.  The error is thrown because the first reset_session sets the session to a hash, which no longer has a destroy method.  Thus, the second call throws a "undefined method `destroy' for {}:Hash" error.

The pull request has two commits.  The first is a unit test that executes the bug and the second is a patch that checks that session can respond to destroy before calling it.
