### PR TITLE
Fix empty jsdirectory

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -99,7 +99,7 @@ task :default => :test
     def javascripts
       return unless options[:mountable]
 
-      empty_directory "#{app_templates_dir}/public/javascripts"
+      empty_directory "public/javascripts"
 
       unless options[:skip_javascript]
         copy_file "#{app_templates_dir}/public/javascripts/#{options[:javascript]}.js", "public/javascripts/#{options[:javascript]}.js"


### PR DESCRIPTION
Small change that fixes this bug:

https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/6539-plugin_new-generator-creates-empty-apptemplatespublicjavascripts-directory-instead-of-publicjavascripts

Any reason this shouldn't be applied Piotr?
