### PR TITLE
Fix Date.today error in MIT-LICENSE

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/hash/slice'
 require "rails/generators/rails/app/app_generator"
+require 'date'
 
 module Rails
   class PluginBuilder


### PR DESCRIPTION
Currently blowing up as discussed here:

https://rails.lighthouseapp.com/projects/8994/tickets/6519-plugin_new_generator-fails-in-template-undefined-method-today-for-dateclass-nomethoderror

Creating this in case it's easier to pull in than a diff, and if require 'date' makes more sense than pulling in AS/time
