### PR TITLE
accept variadic arguments for AR destroy, destroy_all and find_by_sql

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -462,9 +462,14 @@ module ActiveRecord #:nodoc:
       #   > [#<Post:0x36bff9c @attributes={"title"=>"Ruby Meetup", "first_name"=>"Quentin"}>, ...]
       #
       #   # You can use the same string replacement techniques as you can with ActiveRecord#find
+      #   Post.find_by_sql "SELECT title FROM posts WHERE author = ? AND created > ?", author_id, start_date
+      #   > [#<Post:0x36bff9c @attributes={"title"=>"The Cheap Man Buys Twice"}>, ...]
       #   Post.find_by_sql ["SELECT title FROM posts WHERE author = ? AND created > ?", author_id, start_date]
       #   > [#<Post:0x36bff9c @attributes={"title"=>"The Cheap Man Buys Twice"}>, ...]
-      def find_by_sql(sql, binds = [])
+      def find_by_sql(*sql_and_binds)
+        binds = (sql_and_binds.many? && sql_and_binds.last.is_a?(Array)) ? sql_and_binds.pop : []
+        sql = (sql_and_binds.one? && sql_and_binds.first.is_a?(Array)) ? sql_and_binds.first : sql_and_binds
+        sql = sql.first if sql.one?
         connection.select_all(sanitize_sql(sql), "#{name} Load", binds).collect! { |record| instantiate(record) }
       end
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -243,19 +243,20 @@ module ActiveRecord
     #
     # ==== Parameters
     #
-    # * +conditions+ - A string, array, or hash that specifies which records
-    #   to destroy. If omitted, all records are destroyed. See the
+    # * +conditions+ - A string, array, variable arguments, or hash that specifies
+    #   which records to destroy. If omitted, all records are destroyed. See the
     #   Conditions section in the introduction to ActiveRecord::Base for
     #   more information.
     #
     # ==== Examples
     #
-    #   Person.destroy_all("last_login < '2004-04-04'")
+    #   Person.destroy_all("first_name like '%dummy%'")
     #   Person.destroy_all(:status => "inactive")
+    #   Person.destroy_all("last_login < ?", 1.year.ago)
     #   Person.where(:age => 0..18).destroy_all
-    def destroy_all(conditions = nil)
-      if conditions
-        where(conditions).destroy_all
+    def destroy_all(*conditions)
+      if conditions.present?
+        where(*conditions).destroy_all
       else
         to_a.each {|object| object.destroy }.tap { reset }
       end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -270,21 +270,26 @@ module ActiveRecord
     #
     # ==== Parameters
     #
-    # * +id+ - Can be either an Integer or an Array of Integers.
+    # * +ids+ - Can be an Integer or multiple integers or an Array of Integers.
     #
     # ==== Examples
     #
     #   # Destroy a single object
     #   Todo.destroy(1)
     #
-    #   # Destroy multiple objects
-    #   todos = [1,2,3]
+    #   # Destroy multiple objects with variable arguments
+    #   Todo.destroy(2, 5, 8)
+    #
+    #   # Destroy multiple objects with an Array
+    #   todos = [1, 2, 3]
     #   Todo.destroy(todos)
-    def destroy(id)
-      if id.is_a?(Array)
-        id.map { |one_id| destroy(one_id) }
+    def destroy(*ids)
+      if ids.many?
+        ids.map { |id| destroy(id) }
+      elsif ids.first.is_a?(Array)
+        ids.first.map { |id| destroy(id) }
       else
-        find(id).destroy
+        find(*ids).destroy
       end
     end
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -159,7 +159,14 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal(topics(:second).title, topics.first.title)
   end
 
-  def test_find_with_prepared_select_statement
+  def test_find_with_prepared_select_statement_with_varargs
+    topics = Topic.find_by_sql "SELECT * FROM topics WHERE author_name = ?", "Mary"
+
+    assert_equal(1, topics.size)
+    assert_equal(topics(:second).title, topics.first.title)
+  end
+
+  def test_find_with_prepared_select_statement_with_array
     topics = Topic.find_by_sql ["SELECT * FROM topics WHERE author_name = ?", "Mary"]
 
     assert_equal(1, topics.size)

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -98,7 +98,17 @@ class PersistencesTest < ActiveRecord::TestCase
     end
   end
 
-  def test_destroy_many
+  def test_destroy_many_with_varargs
+    clients = Client.find([2, 3], :order => 'id')
+
+    assert_difference('Client.count', -2) do
+      destroyed = Client.destroy(2, 3).sort_by(&:id)
+      assert_equal clients, destroyed
+      assert destroyed.all? { |client| client.frozen? }, "destroyed clients should be frozen"
+    end
+  end
+
+  def test_destroy_many_with_array
     clients = Client.find([2, 3], :order => 'id')
 
     assert_difference('Client.count', -2) do

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -98,6 +98,28 @@ class PersistencesTest < ActiveRecord::TestCase
     end
   end
 
+  def test_destroy_all_with_varargs
+    topics_by_mary = Topic.where('author_name = ?', 'Mary').order(:id).all
+    assert ! topics_by_mary.empty?
+
+    assert_difference('Topic.count', -topics_by_mary.size) do
+      destroyed = Topic.destroy_all('author_name = ?', 'Mary').sort_by(&:id)
+      assert_equal topics_by_mary, destroyed
+      assert destroyed.all? { |topic| topic.frozen? }, "destroyed topics should be frozen"
+    end
+  end
+
+  def test_destroy_all_with_array
+    topics_by_mary = Topic.where(['author_name = ?', 'Mary']).order(:id).all
+    assert ! topics_by_mary.empty?
+
+    assert_difference('Topic.count', -topics_by_mary.size) do
+      destroyed = Topic.destroy_all(['author_name = ?', 'Mary']).sort_by(&:id)
+      assert_equal topics_by_mary, destroyed
+      assert destroyed.all? { |topic| topic.frozen? }, "destroyed topics should be frozen"
+    end
+  end
+
   def test_destroy_many_with_varargs
     clients = Client.find([2, 3], :order => 'id')
 


### PR DESCRIPTION
I found `destroy`, `destroy_all` and `find_by_sql` only accepts arguments in Array form whereas methods like `find` and `where` accepts variadic arguments.

```
User.find([1, 2, 3])
#=> SELECT "users".* FROM "users" WHERE "users"."id" IN (1, 2, 3)
User.find(1, 2, 3)
#=> SELECT "users".* FROM "users" WHERE "users"."id" IN (1, 2, 3)
User.destroy([1, 2, 3])
#=> DELETE 3 users
User.destroy(1, 2, 3)
#=> ArgumentError: wrong number of arguments (3 for 1)

User.where(['name = ?', 'user001'])
#=> SELECT "users".* FROM "users" WHERE (name = 'user001')
User.where('name = ?', 'user001')
#=> SELECT "users".* FROM "users" WHERE (name = 'user001')
User.destroy_all(['name = ?', 'user001'])
#=> DELETE user001
User.destroy_all('name = ?', 'user001')
#=> ArgumentError: wrong number of arguments (2 for 1)
```

This pull request enables accepting varargs for those 3 methods in order to get rid of the API inconsistency, and makes the whole API more Rails-3-ish.

I think the implementations could be more cleaner (especially, find_by_sql looks ugly and dirty), but anyway it works and passes all tests on both 1.8.7 and 1.9.2.
