### PR TITLE
Allow access to a callback event's return result from around callbacks

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -225,7 +225,10 @@ module ActiveSupport
           # end
           [@compiled_options[0], @filter, @compiled_options[1]].compact.join("\n")
         when :around
-          "end"
+          <<-RUBY_EVAL
+            value
+          end
+          RUBY_EVAL
         end
       end
 
@@ -423,7 +426,7 @@ module ActiveSupport
       #
       #   set_callback :save, :before, :before_meth
       #   set_callback :save, :after,  :after_meth, :if => :condition
-      #   set_callback :save, :around, lambda { |r| stuff; yield; stuff }
+      #   set_callback :save, :around, lambda { |r| stuff; result = yield; stuff }
       #
       # The second arguments indicates whether the callback is to be run +:before+,
       # +:after+, or +:around+ the event. If omitted, +:before+ is assumed. This
@@ -442,6 +445,9 @@ module ActiveSupport
       #
       # Before and around callbacks are called in the order that they are set; after
       # callbacks are called in the reverse order.
+      # 
+      # Around callbacks can access the return value from the event, if it
+      # wasn't halted, from the +yield+ call.
       #
       # ===== Options
       #

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -299,6 +299,22 @@ module CallbacksTest
       end
     end
   end
+  
+  class AroundPersonResult < MySuper
+    attr_reader :result
+
+    set_callback :save, :around, :tweedle_dum
+
+    def tweedle_dum
+      @result = yield
+    end
+
+    def save
+      run_callbacks :save do
+        :running
+      end
+    end
+  end
 
   class HyphenatedCallbacks
     include ActiveSupport::Callbacks
@@ -336,6 +352,14 @@ module CallbacksTest
         "tweedle dum post",
         "tweedle"
       ], around.history
+    end
+  end
+  
+  class AroundCallbackResultTest < Test::Unit::TestCase
+    def test_save_around
+      around = AroundPersonResult.new
+      around.save
+      assert_equal :running, around.result
     end
   end
 

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -303,12 +303,22 @@ module CallbacksTest
   class AroundPersonResult < MySuper
     attr_reader :result
 
+    set_callback :save, :after, :tweedle_1
     set_callback :save, :around, :tweedle_dum
+    set_callback :save, :after, :tweedle_2
 
     def tweedle_dum
       @result = yield
     end
+    
+    def tweedle_1
+      :tweedle_1
+    end
 
+    def tweedle_2
+      :tweedle_2
+    end
+    
     def save
       run_callbacks :save do
         :running


### PR DESCRIPTION
I'd like to define behavior within an around callback based on the value from the return result of the event.  Currently, this is possible (seemingly be chance) based on the order and types of callbacks you're using.  For example, the following example will allow access to the result:

```
class MySuper
  include ActiveSupport::Callbacks

  define_callbacks :save
end

class AroundCallback < MySuper
  attr_reader :result

  set_callback :save, :around, :around_save

  def around_save
    @result = yield
  end

  def save
    run_callbacks :save do
      :saved
    end
  end
end

o = AroundCallback.new
o.save    # => :saved
o.result  # => :saved
```

However, once you start incorporating after callbacks, the results are inconsistent due to the order in which callbacks are invoked.  Adding to the example above:

```
class MultipleCallbacks < AroundCallback
  attr_reader :result

  set_callback :save, :after, :after_save

  def after_save
    :after_save
  end
end

o = MultipleCallbacks.new
o.save    # => :saved
o.result  # => :after_save
```

This change makes the behavior consistent by always returning the event's (:save in the example) result to the around callback.
