### PR TITLE
Simple format

### DIFF
--- a/actionmailer/lib/action_mailer/mail_helper.rb
+++ b/actionmailer/lib/action_mailer/mail_helper.rb
@@ -4,7 +4,7 @@ module ActionMailer
     # each line, and wrapped at 72 columns.
     def block_format(text)
       formatted = text.split(/\n\r\n/).collect { |paragraph|
-        simple_format(paragraph)
+        format_paragraph(paragraph)
       }.join("\n")
 
       # Make list points stand on their own line
@@ -30,7 +30,7 @@ module ActionMailer
     end
 
     private
-    def simple_format(text, len = 72, indent = 2)
+    def format_paragraph(text, len = 72, indent = 2)
       sentences = [[]]
 
       text.split.each do |word|


### PR DESCRIPTION
The private `simple_format` method introduced in `ActionMailer::MailHelper` breaks the method of the same name in `ActionView::Helpers::TextHelper`. This patch renames the former.

Commit with the regression: https://github.com/rails/rails/commit/4083e0ea2ae6f87929a32935122f2427845098e0

Lighthouse ticket: https://rails.lighthouseapp.com/projects/8994/tickets/6513-simple_format-behaviour-changed-when-used-in-mailer-view
