### PR TITLE
Use rubys own Float#round method in versions 1.9 and above

### DIFF
--- a/activesupport/lib/active_support/core_ext/float.rb
+++ b/activesupport/lib/active_support/core_ext/float.rb
@@ -1,1 +1,1 @@
-require 'active_support/core_ext/float/rounding'
+require 'active_support/core_ext/float/rounding' if RUBY_VERSION < '1.9'

--- a/railties/guides/source/active_support_core_extensions.textile
+++ b/railties/guides/source/active_support_core_extensions.textile
@@ -1818,7 +1818,7 @@ h3. Extensions to +Float+
 
 h4. +round+
 
-The built-in method +Float#round+ rounds a float to the nearest integer. Active Support adds an optional parameter to let you specify a precision:
+The built-in method +Float#round+ rounds a float to the nearest integer. In Ruby 1.9 this method have optional parameter to let you specify a precision. Active Support adds that functionality to +round+ in previous versions of Ruby:
 
 <ruby>
 Math::E.round(4) # => 2.7183


### PR DESCRIPTION
Rubys own `Float#round` method in versions 1.9 and above accept optional precision and at least two times faster then ActiveSupport's `Float#round`.
