### PR TITLE
make dbconsole honor environment when options specified

### DIFF
--- a/railties/lib/rails/commands/dbconsole.rb
+++ b/railties/lib/rails/commands/dbconsole.rb
@@ -11,6 +11,8 @@ require 'rbconfig'
 
 module Rails
   class DBConsole
+    MODES = ['html', 'list', 'line', 'column']
+
     def self.start(app)
       new(app).start
     end
@@ -28,8 +30,8 @@ module Rails
           include_password = true
         end
 
-        opt.on("--mode [MODE]", ['html', 'list', 'line', 'column'],
-          "Automatically put the sqlite3 database in the specified mode (html, list, line, column).") do |mode|
+        opt.on("--mode [MODE]", MODES,
+          "Automatically put the sqlite3 database in the specified mode (#{MODES.join(', ')}).") do |mode|
             options['mode'] = mode
         end
 
@@ -118,6 +120,6 @@ module Rails
 end
 
 # Has to set the RAILS_ENV before config/application is required
-if ARGV.first && !ARGV.first.index("-") && env = ARGV.first
+if (arg = ARGV.last) && !arg.index("-") && !Rails::DBConsole::MODES.include?(arg) && env = arg
   ENV['RAILS_ENV'] = %w(production development test).detect {|e| e =~ /^#{env}/} || env
 end


### PR DESCRIPTION
Is it just reasonable to change dbconsole usage message?
From:
    Usage: dbconsole [options] [environment]
to
    Usage: dbconsole [environment] [options]
