### PR TITLE
Length validation fix

### DIFF
--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -40,10 +40,10 @@ module ActiveModel
 
         CHECKS.each do |key, validity_check|
           next unless check_value = options[key]
-
+          
           value ||= [] if key == :maximum
-
-          next if value && value.to_s.size.send(validity_check, check_value)
+          
+          next if value && value.size.send(validity_check, check_value)
 
           errors_options = options.except(*RESERVED_OPTIONS)
           errors_options[:count] = check_value

--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -43,7 +43,7 @@ module ActiveModel
 
           value ||= [] if key == :maximum
 
-          next if value && value.size.send(validity_check, check_value)
+          next if value && value.to_s.size.send(validity_check, check_value)
 
           errors_options = options.except(*RESERVED_OPTIONS)
           errors_options[:count] = check_value

--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -40,9 +40,10 @@ module ActiveModel
 
         CHECKS.each do |key, validity_check|
           next unless check_value = options[key]
-          
+
           value ||= [] if key == :maximum
           
+          next if value.kind_of?(Fixnum) && value.to_s.size.send(validity_check, check_value)
           next if value && value.size.send(validity_check, check_value)
 
           errors_options = options.except(*RESERVED_OPTIONS)

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -341,6 +341,17 @@ class LengthValidationTest < ActiveModel::TestCase
     assert t.errors[:content].any?
     assert_equal ["Your essay must be at least 5 words."], t.errors[:content]
   end
+  
+  def test_validates_length_of_for_fixnum
+    Topic.validates_length_of(:approved, :is => 4)
+    
+    t = Topic.new("title" => "uhohuhoh", "content" => "whatever", :approved => 1)
+    assert t.invalid?
+    assert t.errors[:approved].any?
+    
+    t = Topic.new("title" => "uhohuhoh", "content" => "whatever", :approved => 1234)
+    assert t.valid?
+  end
 
   def test_validates_length_of_for_ruby_class
     Person.validates_length_of :karma, :minimum => 5


### PR DESCRIPTION
https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/6556-length-validation-for-integer-fixnum-fields
