### PR TITLE
Fix plugin generator license

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/hash/slice'
 require "rails/generators/rails/app/app_generator"
+require 'date'
 
 module Rails
   class PluginBuilder


### PR DESCRIPTION
`railties/lib/rails/generators/rails/plugin_new/templates/MIT-LICENSE` uses `Date.today` without its generator `require 'date'` which is needed for that method.
