### PR TITLE
Patch for issue #6564

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -110,11 +110,10 @@ module ActiveRecord
 
     # Returns true if there are no records.
     def empty?
-      if loaded?
-        @records.empty?
-      else
-        count.is_a?(Numeric) ? count.zero? : count.empty?
-      end
+      return @records.empty? if loaded?
+
+      c = count
+      c.respond_to?(:zero?) ? c.zero? : c.empty?
     end
 
     def any?

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -110,7 +110,11 @@ module ActiveRecord
 
     # Returns true if there are no records.
     def empty?
-      loaded? ? @records.empty? : count.zero?
+      if loaded?
+        @records.empty?
+      else
+        count.is_a?(Numeric) ? count.zero? : count.empty?
+      end
     end
 
     def any?

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -673,6 +673,36 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal expected, posts.count
   end
 
+  def test_empty
+    posts = Post.scoped
+    
+    assert_queries(1) { assert_equal false, posts.empty? }
+    assert ! posts.loaded?
+
+    no_posts = posts.where(:title => "")
+    assert_queries(1) { assert_equal true, no_posts.empty? }
+    assert ! no_posts.loaded?
+
+    best_posts = posts.where(:comments_count => 0)
+    best_posts.to_a # force load
+    assert_no_queries { assert_equal false, best_posts.empty? }
+  end
+
+  def test_empty_complex_chained_relations
+    posts = Post.select("comments_count").where("id is not null").group("author_id").where("comments_count > 0")
+    assert_queries(1) { assert_equal false, posts.empty? }
+    assert ! posts.loaded?
+
+    no_posts = posts.where(:title => "")
+    assert_queries(1) { assert_equal true, no_posts.empty? }
+    assert ! no_posts.loaded?
+
+    best_posts = posts.where(:comments_count => 0)
+    best_posts.to_a # force load
+    assert_no_queries { assert_equal true, best_posts.empty? }
+    assert best_posts.loaded?
+  end
+
   def test_any
     posts = Post.scoped
 


### PR DESCRIPTION
https://rails.lighthouseapp.com/projects/8994/tickets/6564-undefined-method-zero-for-orderedhash#ticket-6564-4

After a group query, a Relation that hasn't been loaded will throw an error calling empty? as the count variable is an OrderedHash instead of a Numeric. This tests for the Numeric case and uses the appropriate call.
