### PR TITLE
Character encoding issues with MemCacheStore in 1.9.2

### DIFF
--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -158,7 +158,10 @@ module ActiveSupport
 
       private
         def escape_key(key)
-          key = key.to_s.gsub(ESCAPE_KEY_CHARS){|match| "%#{match.getbyte(0).to_s(16).upcase}"}
+          # Fix for EncodedKeyCacheBehavior failing tests in caching_test.rb.
+          key = key.to_s.dup
+          key = key.force_encoding(ESCAPE_KEY_CHARS.encoding) if key.respond_to?(:encoding) && key.encoding != ESCAPE_KEY_CHARS.encoding
+          key = key.gsub(ESCAPE_KEY_CHARS){|match| "%#{match.getbyte(0).to_s(16).upcase}"}
           key = "#{key[0, 213]}:md5:#{Digest::MD5.hexdigest(key)}" if key.size > 250
           key
         end

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -352,6 +352,43 @@ module CacheStoreBehavior
   end
 end
 
+# https://rails.lighthouseapp.com/projects/8994/tickets/6225-memcachestore-cant-deal-with-umlauts-and-special-characters
+# The error is caused by charcter encodings that can't be compared with ASCII-8BIT regular expressions and by special
+# characters like the umlaut in UTF-8.
+module EncodedKeyCacheBehavior
+  if defined?(Encoding)
+    Encoding.list.each do |encoding|
+      define_method "test_#{encoding.name.underscore}_encoded_values" do
+        key = "foo".force_encoding(encoding)
+        assert_equal true, @cache.write(key, "1", :raw => true)
+        assert_equal "1", @cache.read(key)
+        assert_equal "1", @cache.fetch(key)
+        assert_equal true, @cache.delete(key)
+        assert_equal "2", @cache.fetch(key, :raw => true) { "2" }
+        assert_equal 3, @cache.increment(key)
+        assert_equal 2, @cache.decrement(key)
+      end
+    end
+
+    def test_common_utf8_values
+      key = "\xC3\xBCmlaut".force_encoding(Encoding::UTF_8)
+      assert_equal true, @cache.write(key, "1", :raw => true)
+      assert_equal "1", @cache.read(key)
+      assert_equal "1", @cache.fetch(key)
+      assert_equal true, @cache.delete(key)
+      assert_equal "2", @cache.fetch(key, :raw => true) { "2" }
+      assert_equal 3, @cache.increment(key)
+      assert_equal 2, @cache.decrement(key)
+    end
+
+    def test_retains_encoding
+      key = "\xC3\xBCmlaut".force_encoding(Encoding::UTF_8)
+      assert_equal true, @cache.write(key, "1", :raw => true)
+      assert_equal Encoding::UTF_8, key.encoding
+    end
+  end
+end
+
 module CacheDeleteMatchedBehavior
   def test_delete_matched
     @cache.write("foo", "bar")
@@ -617,6 +654,7 @@ uses_memcached 'memcached backed store' do
     include CacheStoreBehavior
     include LocalCacheBehavior
     include CacheIncrementDecrementBehavior
+    include EncodedKeyCacheBehavior
 
     def test_raw_values
       cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, :raw => true)


### PR DESCRIPTION
The original bug is reported in this lighthouse ticket:

https://rails.lighthouseapp.com/projects/8994/tickets/6225-memcachestore-cant-deal-with-umlauts-and-special-characters

The ticket has more details about my implementation. I've included tests and comments in my commit.
