### PR TITLE
Passing nil in array for conditions appears to be broken

### DIFF
--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -997,6 +997,28 @@ class FinderTest < ActiveRecord::TestCase
                               :order => ' author_addresses_authors.id DESC ', :limit => 3).size
   end
 
+  def test_find_with_nil_inside_set_passed_for_attribute
+    client_of = Company.find(
+      :all,
+      :conditions => {
+        :client_of => [2, 1, nil],
+        :name => ['37signals', 'Summit', 'Microsoft'] },
+      :order => 'client_of DESC'
+    ).map { |x| x.client_of }
+
+    assert_equal [2, 1, nil], client_of
+  end
+
+  def test_find_with_nil_inside_set_passed_for_attribute
+    client_of = Company.find(
+      :all,
+      :conditions => { :client_of => [nil] },
+      :order => 'client_of DESC'
+    ).map { |x| x.client_of }
+
+    assert_equal [nil], client_of
+  end
+
   def test_with_limiting_with_custom_select
     posts = Post.find(:all, :include => :author, :select => ' posts.*, authors.id as "author_id"', :limit => 3, :order => 'posts.id')
     assert_equal 3, posts.size


### PR DESCRIPTION
I've noticed that passing `nil` inside an array in conditions generates wrong SQL. It appears that Arel is to blame. I'll pushing a patch for Arel also, if you confirm this.

Here are some failing tests.
