### PR TITLE
Prevent callbacks in child classes from being executed more than once

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -416,7 +416,7 @@ module ActiveSupport
         options = filters.last.is_a?(Hash) ? filters.pop : {}
         filters.unshift(block) if block
 
-        ([self] + ActiveSupport::DescendantsTracker.descendants(self)).each do |target|
+        ([self] + ActiveSupport::DescendantsTracker.descendants(self)).reverse.each do |target|
           chain = target.send("_#{name}_callbacks")
           yield target, chain.dup, type, filters, options
           target.__define_runner(name)

--- a/activesupport/test/callback_inheritance_test.rb
+++ b/activesupport/test/callback_inheritance_test.rb
@@ -82,6 +82,30 @@ class EmptyChild < EmptyParent
   end
 end
 
+class CountingParent
+  include ActiveSupport::Callbacks
+
+  attr_reader :count
+
+  define_callbacks :dispatch
+
+  def initialize
+    @count = 0
+  end
+
+  def count!
+    @count += 1
+  end
+
+  def dispatch
+    run_callbacks(:dispatch)
+    self
+  end
+end
+
+class CountingChild < CountingParent
+end
+
 class BasicCallbacksTest < Test::Unit::TestCase
   def setup
     @index    = GrandParent.new("index").dispatch
@@ -146,5 +170,11 @@ class DynamicInheritedCallbacks < Test::Unit::TestCase
     EmptyParent.set_callback :dispatch, :before, :perform!
     child = EmptyChild.new.dispatch
     assert child.performed?
+  end
+
+  def test_callbacks_should_be_performed_once_in_child_class
+    CountingParent.set_callback(:dispatch, :before) { count! }
+    child = CountingChild.new.dispatch
+    assert_equal 1, child.count
   end
 end


### PR DESCRIPTION
Currently, when a callback is set in a parent class after it has been inherited from, the callback will be run multiple times in child classes. Observe:

```
require "active_support/callbacks"

class Parent
  include ActiveSupport::Callbacks
  define_callbacks :run

  def run
    run_callbacks :run
  end
end

class Child < Parent
end

class Parent
  set_callback :run, :before do
    puts "callback called"
  end
end

Child.new.run
# "callback called"
# "callback called"
```

This commit provides a fix, by updating the callback chain in reverse order (child classes first). The callback is now correctly run only once in child classes.

```
Child.new.run
# "callback called"
```
