### PR TITLE
It should be possible to use ActiveSupport::DescendantTracker without ActiveSupport::Dependencies

### DIFF
--- a/activesupport/lib/active_support/descendants_tracker.rb
+++ b/activesupport/lib/active_support/descendants_tracker.rb
@@ -1,5 +1,3 @@
-require 'active_support/dependencies'
-
 module ActiveSupport
   # This module provides an internal implementation to track descendants
   # which is faster than iterating through ObjectSpace.
@@ -18,12 +16,16 @@ module ActiveSupport
     end
 
     def self.clear
-      @@direct_descendants.each do |klass, descendants|
-        if ActiveSupport::Dependencies.autoloaded?(klass)
-          @@direct_descendants.delete(klass)
-        else
-          descendants.reject! { |v| ActiveSupport::Dependencies.autoloaded?(v) }
+      if defined? ActiveSupport::Dependencies
+        @@direct_descendants.each do |klass, descendants|
+          if ActiveSupport::Dependencies.autoloaded?(klass)
+            @@direct_descendants.delete(klass)
+          else
+            descendants.reject! { |v| ActiveSupport::Dependencies.autoloaded?(v) }
+          end
         end
+      else
+        @@direct_descendants.clear
       end
     end
 


### PR DESCRIPTION
Currently, ActiveSupport::DescendantTracker depends on ActiveSupport::Dependencies. That does not really make sense, since it is only used in the `clear` method.

AS::Callbacks depends on AS::DescendantTracker, but never calls the clear method. It should be possible to use AS::Callbacks without getting AS::Dependencies for free. Especially since AS::Dependencies overrides a few Ruby core methods.

This patch checks for the presence of AS::Dependencies when clearing the DescendantTracker and removes the explicit dependency.
