### PR TITLE
Stop ambiguous first arg warnings

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -145,6 +145,7 @@ task :default => :test
       def initialize(*args)
         raise Error, "Options should be given after the plugin name. For details run: rails plugin --help" if args[0].blank?
 
+        @dummy_path = nil
         super
       end
 

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -55,7 +55,7 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
 
   def test_ensure_that_plugin_options_are_not_passed_to_app_generator
     FileUtils.cd(Rails.root)
-    assert_no_match /It works from file!.*It works_from_file/, run_generator([destination_root, "-m", "lib/template.rb"])
+    assert_no_match(/It works from file!.*It works_from_file/, run_generator([destination_root, "-m", "lib/template.rb"]))
   end
 
   def test_ensure_that_test_dummy_can_be_generated_from_a_template
@@ -85,7 +85,7 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
   def test_ensure_that_skip_active_record_option_is_passed_to_app_generator
     run_generator [destination_root, "--skip_active_record"]
     assert_no_file "test/dummy/config/database.yml"
-    assert_no_match /ActiveRecord/, File.read(File.join(destination_root, "test/test_helper.rb"))
+    assert_no_match(/ActiveRecord/, File.read(File.join(destination_root, "test/test_helper.rb")))
   end
 
   def test_ensure_that_database_option_is_passed_to_app_generator
@@ -134,21 +134,21 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
 
   def test_template_from_dir_pwd
     FileUtils.cd(Rails.root)
-    assert_match /It works from file!/, run_generator([destination_root, "-m", "lib/template.rb"])
+    assert_match(/It works from file!/, run_generator([destination_root, "-m", "lib/template.rb"]))
   end
 
   def test_ensure_that_tests_works
     run_generator
     FileUtils.cd destination_root
     `bundle install`
-    assert_match /1 tests, 1 assertions, 0 failures, 0 errors/, `bundle exec rake test`
+    assert_match(/1 tests, 1 assertions, 0 failures, 0 errors/, `bundle exec rake test`)
   end
 
   def test_ensure_that_tests_works_in_full_mode
     run_generator [destination_root, "--full", "--skip_active_record"]
     FileUtils.cd destination_root
     `bundle install`
-    assert_match /2 tests, 2 assertions, 0 failures, 0 errors/, `bundle exec rake test`
+    assert_match(/2 tests, 2 assertions, 0 failures, 0 errors/, `bundle exec rake test`)
   end
 
   def test_creating_engine_in_full_mode
@@ -159,7 +159,7 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_being_quiet_while_creating_dummy_application
-    assert_no_match /create\s+config\/application.rb/, run_generator
+    assert_no_match(/create\s+config\/application.rb/, run_generator)
   end
 
   def test_create_mountable_application_with_mountable_option

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -32,7 +32,7 @@ module SharedGeneratorTests
 
   def test_invalid_database_option_raises_an_error
     content = capture(:stderr){ run_generator([destination_root, "-d", "unknown"]) }
-    assert_match /Invalid value for \-\-database option/, content
+    assert_match(/Invalid value for \-\-database option/, content)
   end
 
   def test_test_unit_is_skipped_if_required
@@ -42,21 +42,21 @@ module SharedGeneratorTests
 
   def test_options_before_application_name_raises_an_error
     content = capture(:stderr){ run_generator(["--pretend", destination_root]) }
-    assert_match /Options should be given after the \w+ name. For details run: rails( plugin)? --help\n/, content
+    assert_match(/Options should be given after the \w+ name. For details run: rails( plugin)? --help\n/, content)
   end
 
   def test_name_collision_raises_an_error
     reserved_words = %w[application destroy plugin runner test]
     reserved_words.each do |reserved|
       content = capture(:stderr){ run_generator [File.join(destination_root, reserved)] }
-      assert_match /Invalid \w+ name #{reserved}. Please give a name which does not match one of the reserved rails words.\n/, content
+      assert_match(/Invalid \w+ name #{reserved}. Please give a name which does not match one of the reserved rails words.\n/, content)
     end
   end
 
   def test_name_raises_an_error_if_name_already_used_constant
     %w{ String Hash Class Module Set Symbol }.each do |ruby_class|
       content = capture(:stderr){ run_generator [File.join(destination_root, ruby_class)] }
-      assert_match /Invalid \w+ name #{ruby_class}, constant #{ruby_class} is already in use. Please choose another \w+ name.\n/, content
+      assert_match(/Invalid \w+ name #{ruby_class}, constant #{ruby_class} is already in use. Please choose another \w+ name.\n/, content)
     end
   end
 
@@ -72,8 +72,8 @@ module SharedGeneratorTests
 
   def test_template_raises_an_error_with_invalid_path
     content = capture(:stderr){ run_generator([destination_root, "-m", "non/existant/path"]) }
-    assert_match /The template \[.*\] could not be loaded/, content
-    assert_match /non\/existant\/path/, content
+    assert_match(/The template \[.*\] could not be loaded/, content)
+    assert_match(/non\/existant\/path/, content)
   end
 
   def test_template_is_executed_when_supplied
@@ -82,7 +82,7 @@ module SharedGeneratorTests
     template.instance_eval "def read; self; end" # Make the string respond to read
 
     generator([destination_root], :template => path).expects(:open).with(path, 'Accept' => 'application/x-thor-template').returns(template)
-    assert_match /It works!/, silence(:stdout){ generator.invoke_all }
+    assert_match(/It works!/, silence(:stdout){ generator.invoke_all })
   end
 
   def test_dev_option
@@ -100,8 +100,8 @@ module SharedGeneratorTests
 
   def test_template_raises_an_error_with_invalid_path
     content = capture(:stderr){ run_generator([destination_root, "-m", "non/existant/path"]) }
-    assert_match /The template \[.*\] could not be loaded/, content
-    assert_match /non\/existant\/path/, content
+    assert_match(/The template \[.*\] could not be loaded/, content)
+    assert_match(/non\/existant\/path/, content)
   end
 
   def test_template_is_executed_when_supplied
@@ -110,7 +110,7 @@ module SharedGeneratorTests
     template.instance_eval "def read; self; end" # Make the string respond to read
 
     generator([destination_root], :template => path).expects(:open).with(path, 'Accept' => 'application/x-thor-template').returns(template)
-    assert_match /It works!/, silence(:stdout){ generator.invoke_all }
+    assert_match(/It works!/, silence(:stdout){ generator.invoke_all })
   end
 
   def test_template_is_executed_when_supplied_an_https_path
@@ -119,7 +119,7 @@ module SharedGeneratorTests
     template.instance_eval "def read; self; end" # Make the string respond to read
 
     generator([destination_root], :template => path).expects(:open).with(path, 'Accept' => 'application/x-thor-template').returns(template)
-    assert_match /It works!/, silence(:stdout){ generator.invoke_all }
+    assert_match(/It works!/, silence(:stdout){ generator.invoke_all })
   end
 
   def test_dev_option
@@ -191,6 +191,6 @@ module SharedCustomGeneratorTests
     generator([destination_root], :builder => path).expects(:open).with(path, 'Accept' => 'application/x-thor-template').returns(template)
     capture(:stdout) { generator.invoke_all }
 
-    default_files.each{ |path| assert_no_file path }
+    default_files.each{ |path| assert_no_file(path) }
   end
 end


### PR DESCRIPTION
Cleaned up loads of warnings with a couple parens and instance var initialization.
