### PR TITLE
Unnecessary redundancy in Time/Date calculations

### DIFF
--- a/activesupport/lib/active_support/core_ext/date/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date/calculations.rb
@@ -206,7 +206,7 @@ class Date
 
   # Returns a new ; DateTime objects will have time set to 0:00DateTime representing the start of the month (1st of the month; DateTime objects will have time set to 0:00)
   def beginning_of_month
-    self.acts_like?(:time) ? change(:day => 1,:hour => 0, :min => 0, :sec => 0) : change(:day => 1)
+    self.acts_like?(:time) ? change(:day => 1, :hour => 0) : change(:day => 1)
   end
   alias :at_beginning_of_month :beginning_of_month
 
@@ -231,13 +231,13 @@ class Date
 
   # Returns a new Date/DateTime representing the start of the year (1st of january; DateTime objects will have time set to 0:00)
   def beginning_of_year
-    self.acts_like?(:time) ? change(:month => 1, :day => 1, :hour => 0, :min => 0, :sec => 0) : change(:month => 1, :day => 1)
+    self.acts_like?(:time) ? change(:month => 1, :day => 1, :hour => 0) : change(:month => 1, :day => 1)
   end
   alias :at_beginning_of_year :beginning_of_year
 
   # Returns a new Time representing the end of the year (31st of december; DateTime objects will have time set to 23:59:59)
   def end_of_year
-    self.acts_like?(:time) ? change(:month => 12,:day => 31,:hour => 23, :min => 59, :sec => 59) : change(:month => 12, :day => 31)
+    self.acts_like?(:time) ? change(:month => 12, :day => 31, :hour => 23, :min => 59, :sec => 59) : change(:month => 12, :day => 31)
   end
   alias :at_end_of_year :end_of_year
 

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -187,7 +187,7 @@ class Time
   # Returns a new Time representing the start of the day (0:00)
   def beginning_of_day
     #(self - seconds_since_midnight).change(:usec => 0)
-    change(:hour => 0, :min => 0, :sec => 0, :usec => 0)
+    change(:hour => 0)
   end
   alias :midnight :beginning_of_day
   alias :at_midnight :beginning_of_day
@@ -201,7 +201,7 @@ class Time
   # Returns a new Time representing the start of the month (1st of the month, 0:00)
   def beginning_of_month
     #self - ((self.mday-1).days + self.seconds_since_midnight)
-    change(:day => 1,:hour => 0, :min => 0, :sec => 0, :usec => 0)
+    change(:day => 1, :hour => 0)
   end
   alias :at_beginning_of_month :beginning_of_month
 
@@ -227,7 +227,7 @@ class Time
 
   # Returns  a new Time representing the start of the year (1st of january, 0:00)
   def beginning_of_year
-    change(:month => 1, :day => 1, :hour => 0, :min => 0, :sec => 0, :usec => 0)
+    change(:month => 1, :day => 1, :hour => 0)
   end
   alias :at_beginning_of_year :beginning_of_year
 


### PR DESCRIPTION
I haven't run into any edge cases where cascading doesn't work as advertised and the extra options need to be explicit. If there are cases like that the tests should be changed to reflect it.

There were also a few white space inconsistencies that I fixed.
