### PR TITLE
syntax error for null column.type_cast_code

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -61,7 +61,9 @@ module ActiveRecord
           # Define an attribute reader method.  Cope with nil column.
           def define_read_method(symbol, attr_name, column)
             cast_code = column.type_cast_code('v')
-            access_code = "(v=@attributes['#{attr_name}']) && #{cast_code}"
+            access_code = "(v=@attributes['#{attr_name}'])"
+
+	    access_code += " && #{cast_code}" unless cast_code.nil?
 
             unless attr_name.to_s == self.primary_key.to_s
               access_code.insert(0, "missing_attribute('#{attr_name}', caller) unless @attributes.has_key?('#{attr_name}'); ")


### PR DESCRIPTION
In activerecord/lib/active_record/attribute_methods/read.rb define_read_method() if column.type_cast_code('v') returns nil then you get a syntax error when the code is evaluated because the resulting access_code ends with "&& ;"
