### PR TITLE
[Feature] ActiveResource - Associations through reflections

### DIFF
--- a/activeresource/lib/active_resource/associations.rb
+++ b/activeresource/lib/active_resource/associations.rb
@@ -3,6 +3,7 @@ module ActiveResource::Associations
   module Builder
     autoload :Association, 'active_resource/associations/builder/association'
     autoload :HasMany,     'active_resource/associations/builder/has_many'
+    autoload :HasOne,      'active_resource/associations/builder/has_one'
   end
 
 

--- a/activeresource/lib/active_resource/associations.rb
+++ b/activeresource/lib/active_resource/associations.rb
@@ -4,6 +4,7 @@ module ActiveResource::Associations
     autoload :Association, 'active_resource/associations/builder/association'
     autoload :HasMany,     'active_resource/associations/builder/has_many'
     autoload :HasOne,      'active_resource/associations/builder/has_one'
+    autoload :BelongsTo,   'active_resource/associations/builder/belongs_to'
   end
 
 
@@ -28,10 +29,10 @@ module ActiveResource::Associations
   # ====
   #
   # <tt>has_many :comments, :class_name => 'myblog/comment'</tt>
-  # Would resolve this comments into the <tt>Myblog::Comment</tt> class.
+  # Would resolve those comments into the <tt>Myblog::Comment</tt> class.
   def has_many(name, options = {})
     Builder::HasMany.build(self, name, options)
-  end 
+  end
 
   # Specifies a one-to-one association.
   #
@@ -49,12 +50,63 @@ module ActiveResource::Associations
   #       <name>caffeinatedBoys</name>
   #     </author>
   #   </post>
-  # ==== 
+  # ====
   #
   # <tt>has_one :author, :class_name => 'myblog/author'</tt>
   # Would resolve this author into the <tt>Myblog::Author</tt> class.
   def has_one(name, options = {})
     Builder::HasOne.build(self, name, options)
-  end 
+  end
+
+  # Specifies a one-to-one association with another class. This class should only be used
+  # if this class contains the foreign key. 
+  #
+  # Methods will be added for retrieval and query for a single associated object, for which
+  # this object holds an id:
+  #
+  # [association(force_reload = false)]
+  #   Returns the associated object. +nil+ is returned if the foreign key is +nil+.
+  #   Throws a ActiveResource::ResourceNotFound exception if the foreign key is not +nil+
+  #   and the resource is not found.
+  # 
+  # (+association+ is replaced with the symbol passed as the first argument, so
+  # <tt>belongs_to :post</tt> would add among others <tt>post.nil?</tt>.
+  #
+  # === Example
+  #
+  # A Comment class declaress <tt>belongs_to :post</tt>, which will add:
+  # * <tt>Comment#post</tt> (similar to <tt>Post.find(post_id)</tt>)
+  # The declaration can also include an options hash to specialize the behavior of the association.
+  #
+  # === Options
+  # [:class_name]
+  #   Specify the class name for the association. Use it only if that name canÄt be inferred from association name.
+  #   So <tt>belongs_to :post</tt> will by default be linked to the Post class, but if the real class name is Article,
+  #   you'll have to specify it with whis option.
+  # [:foreign_key]
+  #   Specify the foreign key used for the association. By default this is guessed to be the name
+  #   of the association with an "_id" suffix. So a class that defines a <tt>belongs_to :post</tt>
+  #   association will use "post_id" as the default <tt>:foreign_key</tt>. Similarly,
+  #   <tt>belongs_to :article, :class_name => "Post"</tt> will use a foreign key
+  #   of "article_id".
+  #
+  # Option examples:
+  # <tt>belongs_to :customer, :class_name => 'User'</tt>
+  # Creates a belongs_to association called customer which is represented through the <tt>User</tt> class.
+  #
+  # <tt>belongs_to :customer, :foreign_key => 'user_id'</tt>
+  # Creates a belongs_to association called customer which would be resolved by the foreign_key <tt>user_id</tt> instead of <tt>customer_id</tt>
+  #
+  def belongs_to(name, options={})
+    Builder::BelongsTo.build(self, name, options)
+  end
+
+  # Defines the belongs_to association finder method
+  def defines_belongs_to_finder_method(method_name, association_model, finder_key)
+    define_method(method_name) do
+      ivar_name = :"@#{method_name}"
+      instance_variable_defined?(ivar_name) ? instance_variable_get(ivar_name) : instance_variable_set(ivar_name, association_model.find(send(finder_key)))
+    end
+  end
 
 end

--- a/activeresource/lib/active_resource/associations.rb
+++ b/activeresource/lib/active_resource/associations.rb
@@ -1,0 +1,17 @@
+module ActiveResource::Associations
+
+  module Builder
+    autoload :Association, 'active_resource/associations/builder/association'
+    autoload :HasMany,     'active_resource/associations/builder/has_many'
+  end
+
+
+
+  # 
+  #
+  #
+  #
+  def has_many(name, options = {})
+    Builder::HasMany.build(self, name, options)
+  end 
+end

--- a/activeresource/lib/active_resource/associations.rb
+++ b/activeresource/lib/active_resource/associations.rb
@@ -7,11 +7,53 @@ module ActiveResource::Associations
 
 
 
-  # 
+  # Specifies a one-to-many association.
   #
+  # === Options
+  # [:class_name]
+  #   Specify the class name of the association. This class name would
+  #   be used for resolving the association class. 
   #
+  # ==== Example for [:class_name] - option
+  # GET /posts/123.xml delivers following response body:
+  #   <post>
+  #     <title>ActiveResource now have associations</title>
+  #     <content> ... </content>
+  #     <comments>
+  #       <comment> ... </comment>
+  #       <comment> ... </comment>
+  #     </comments>
+  #   </post>
+  # ====
   #
+  # <tt>has_many :comments, :class_name => 'myblog/comment'</tt>
+  # Would resolve this comments into the <tt>Myblog::Comment</tt> class.
   def has_many(name, options = {})
     Builder::HasMany.build(self, name, options)
   end 
+
+  # Specifies a one-to-one association.
+  #
+  # === Options
+  # [:class_name]
+  #   Specify the class name of the association. This class name would
+  #   be used for resolving the association class. 
+  #
+  # ==== Example for [:class_name] - option
+  # GET /posts/123.xml delivers following response body:
+  #   <post>
+  #     <title>ActiveResource now have associations</title>
+  #     <content> ... </content>
+  #     <author>
+  #       <name>caffeinatedBoys</name>
+  #     </author>
+  #   </post>
+  # ==== 
+  #
+  # <tt>has_one :author, :class_name => 'myblog/author'</tt>
+  # Would resolve this author into the <tt>Myblog::Author</tt> class.
+  def has_one(name, options = {})
+    Builder::HasOne.build(self, name, options)
+  end 
+
 end

--- a/activeresource/lib/active_resource/associations/builder/association.rb
+++ b/activeresource/lib/active_resource/associations/builder/association.rb
@@ -1,7 +1,7 @@
 module ActiveResource::Associations::Builder
   class Association #:nodoc:
 
-    # providing a Class-Variable, which will have a differend store of subclasses
+    # providing a Class-Variable, which will have a different store of subclasses
     class_attribute :valid_options
     self.valid_options = [:class_name]
 

--- a/activeresource/lib/active_resource/associations/builder/association.rb
+++ b/activeresource/lib/active_resource/associations/builder/association.rb
@@ -1,0 +1,32 @@
+module ActiveResource::Associations::Builder
+  class Association #:nodoc:
+
+    # providing a Class-Variable, which will have a differend store of subclasses
+    class_attribute :valid_options
+    self.valid_options = [:class_name]
+
+    # would identify subclasses of association
+    class_attribute :macro
+
+    attr_reader :model, :name, :options, :klass
+
+    def self.build(model, name, options)
+      new(model, name, options).build
+    end
+
+    def initialize(model, name, options)
+      @model, @name, @options = model, name, options
+    end
+
+    def build
+      validate_options
+      reflection = model.create_reflection(self.class.macro, name, options)
+    end
+
+    private
+
+    def validate_options
+      options.assert_valid_keys(self.class.valid_options)
+    end
+  end
+end

--- a/activeresource/lib/active_resource/associations/builder/belongs_to.rb
+++ b/activeresource/lib/active_resource/associations/builder/belongs_to.rb
@@ -1,0 +1,14 @@
+module ActiveResource::Associations::Builder 
+  class BelongsTo < Association
+    self.valid_options += [:foreign_key]
+
+    self.macro = :belongs_to
+
+    def build
+      validate_options
+      reflection = model.create_reflection(self.class.macro, name, options)
+      model.defines_belongs_to_finder_method(reflection.name, reflection.klass, reflection.foreign_key)
+      return reflection
+    end
+  end
+end

--- a/activeresource/lib/active_resource/associations/builder/has_many.rb
+++ b/activeresource/lib/active_resource/associations/builder/has_many.rb
@@ -1,0 +1,5 @@
+module ActiveResource::Associations::Builder 
+  class HasMany < Associations
+    self.macro = :has_many 
+  end
+end

--- a/activeresource/lib/active_resource/associations/builder/has_many.rb
+++ b/activeresource/lib/active_resource/associations/builder/has_many.rb
@@ -1,5 +1,5 @@
 module ActiveResource::Associations::Builder 
-  class HasMany < Associations
+  class HasMany < Association
     self.macro = :has_many 
   end
 end

--- a/activeresource/lib/active_resource/associations/builder/has_one.rb
+++ b/activeresource/lib/active_resource/associations/builder/has_one.rb
@@ -1,5 +1,5 @@
 module ActiveResource::Associations::Builder 
-  class HasOne < Associations
+  class HasOne < Association
     self.macro = :has_one
   end
 end

--- a/activeresource/lib/active_resource/associations/builder/has_one.rb
+++ b/activeresource/lib/active_resource/associations/builder/has_one.rb
@@ -1,0 +1,5 @@
+module ActiveResource::Associations::Builder 
+  class HasOne < Associations
+    self.macro = :has_one
+  end
+end

--- a/activeresource/lib/active_resource/base.rb
+++ b/activeresource/lib/active_resource/base.rb
@@ -17,6 +17,8 @@ require 'active_resource/connection'
 require 'active_resource/formats'
 require 'active_resource/schema'
 require 'active_resource/log_subscriber'
+require 'active_resource/associations'
+require 'active_resource/reflection'
 
 module ActiveResource
   # ActiveResource::Base is the main class for mapping RESTful resources as models in a Rails application.
@@ -1479,5 +1481,6 @@ module ActiveResource
     include ActiveModel::Conversion
     include ActiveModel::Serializers::JSON
     include ActiveModel::Serializers::Xml
+    include ActiveResource::Reflection
   end
 end

--- a/activeresource/lib/active_resource/base.rb
+++ b/activeresource/lib/active_resource/base.rb
@@ -1405,6 +1405,7 @@ module ActiveResource
 
       # Tries to find a resource for a given collection name; if it fails, then the resource is created
       def find_or_create_resource_for_collection(name)
+        return reflections[name.to_sym].klass if reflections.key?(name.to_sym)
         find_or_create_resource_for(ActiveSupport::Inflector.singularize(name.to_s))
       end
 
@@ -1425,6 +1426,8 @@ module ActiveResource
 
       # Tries to find a resource for a given name; if it fails, then the resource is created
       def find_or_create_resource_for(name)
+        return reflections[name.to_sym].klass if reflections.key?(name.to_sym)
+
         resource_name = name.to_s.camelize
 
         const_args = RUBY_VERSION < "1.9" ? [resource_name] : [resource_name, false]
@@ -1477,6 +1480,8 @@ module ActiveResource
 
   class Base
     extend ActiveModel::Naming
+    extend ActiveResource::Associations
+
     include CustomMethods, Observing, Validations
     include ActiveModel::Conversion
     include ActiveModel::Serializers::JSON

--- a/activeresource/lib/active_resource/reflection.rb
+++ b/activeresource/lib/active_resource/reflection.rb
@@ -59,10 +59,19 @@ module ActiveResource
         @class_name ||= derive_class_name
       end
 
+      # Returns the foreign_key for the macro.
+      def foreign_key
+        @foreign_key ||= self.options[:foreign_key] || "#{self.name.to_s.downcase}_id"
+      end
+
       private
-        def derive_class_name
-          return (options[:class_name] ? options[:class_name].to_s : name.to_s).classify
-        end
+      def derive_class_name
+        return (options[:class_name] ? options[:class_name].to_s : name.to_s).classify
+      end
+
+      def derive_foreign_key
+        return options[:foreign_key] ? options[:foreign_key].to_s : "#{name.to_s.downcase}_id"
+      end
     end
   end
 end

--- a/activeresource/lib/active_resource/reflection.rb
+++ b/activeresource/lib/active_resource/reflection.rb
@@ -3,10 +3,10 @@ require 'active_support/core_ext/module/deprecation'
 
 module ActiveResource
   # = Active Resource reflection
-  # 
+  #
   # Associations in ActiveResource would be used to resolve nested attributes
   # in a response with correct classes.
-  # Now they could be specify over Associations with the options :class_name 
+  # Now they could be specified over Associations with the options :class_name
   module Reflection # :nodoc:
     extend ActiveSupport::Concern
 

--- a/activeresource/lib/active_resource/reflection.rb
+++ b/activeresource/lib/active_resource/reflection.rb
@@ -1,0 +1,68 @@
+require 'active_support/core_ext/class/attribute'
+require 'active_support/core_ext/module/deprecation'
+
+module ActiveResource
+  # = Active Resource reflection
+  # 
+  # Associations in ActiveResource would be used to resolve nested attributes
+  # in a response with correct classes.
+  # Now they could be specify over Associations with the options :class_name 
+  module Reflection # :nodoc:
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :reflections
+      self.reflections = {}
+    end
+
+    module ClassMethods
+      def create_reflection(macro, name, options)
+        reflection = AssociationReflection.new(macro, name, options)
+        self.reflections = self.reflections.merge(name => reflection)
+        reflection
+      end
+    end
+
+
+    class AssociationReflection
+
+      def initialize(macro, name, options)
+        @macro, @name, @options = macro, name, options
+      end
+
+      # Returns the name of the macro.
+      #
+      # <tt>has_many :clients</tt> returns <tt>:clients</tt>
+      attr_reader :name
+
+      # Returns the macro type.
+      #
+      # <tt>has_many :clients</tt> returns <tt>:has_many</tt>
+      attr_reader :macro
+
+      # Returns the hash of options used for the macro.
+      #
+      # <tt>has_many :clients</tt> returns +{}+
+      attr_reader :options
+
+      # Returns the class for the macro.
+      #
+      # <tt>has_many :clients</tt> returns the Client class
+      def klass
+        @klass ||= class_name.constantize
+      end
+
+      # Returns the class name for the macro.
+      #
+      # <tt>has_many :clients</tt> returns <tt>'Client'</tt>
+      def class_name
+        @class_name ||= derive_class_name
+      end
+
+      private
+        def derive_class_name
+          return (options[:class_name] ? options[:class_name].to_s : name.to_s).classify
+        end
+    end
+  end
+end

--- a/activeresource/test/abstract_unit.rb
+++ b/activeresource/test/abstract_unit.rb
@@ -74,7 +74,9 @@ def setup_response
             :children => []
           }
         ]
-      }]
+      }],
+      :enemies => [{:name => 'Joker'}],
+      :mother => {:name => 'Ingeborg'}
     }
   }.to_json
   # - resource with yaml array of strings; for ARs using serialize :bar, Array

--- a/activeresource/test/cases/association_test.rb
+++ b/activeresource/test/cases/association_test.rb
@@ -22,7 +22,9 @@ class AssociationTest < Test::Unit::TestCase
   end
 
   def test_valid_options
-    assert_raise ArgumentError do 
+    assert @klass.build(Person, :customers, {:class_name => 'Client'})
+
+    assert_raise ArgumentError do
       @klass.build(Person, :customers, {:soo_invalid => true})
     end
   end
@@ -32,12 +34,12 @@ class AssociationTest < Test::Unit::TestCase
   end
 
   def test_has_many
-    External::Person.send(:has_many, :people)
+    External::Person.has_many(:people)
     assert_equal 1, External::Person.reflections.select{|name, reflection| reflection.macro.eql?(:has_many)}.count
   end
 
   def test_has_one
-    External::Person.send(:has_one, :customer)
+    External::Person.has_one(:customer)
     assert_equal 1, External::Person.reflections.select{|name, reflection| reflection.macro.eql?(:has_one)}.count
   end
 
@@ -45,9 +47,25 @@ class AssociationTest < Test::Unit::TestCase
     External::Person.send(:has_many, :people)
     assert_equal 1, External::Person.reflections.select{|name, reflection| reflection.macro.eql?(:has_many)}.count
   end
-  
+
   def test_has_one
     External::Person.send(:has_one, :customer)
     assert_equal 1, External::Person.reflections.select{|name, reflection| reflection.macro.eql?(:has_one)}.count
+  end
+
+  def test_belongs_to
+    External::Person.belongs_to(:Customer)
+    assert_equal 1, External::Person.reflections.select{|name, reflection| reflection.macro.eql?(:belongs_to)}.count
+  end
+
+  def test_defines_belongs_to_finder_method_with_instance_variable_cache
+    Person.defines_belongs_to_finder_method(:customer, Customer, 'customer_id')
+
+    person = Person.new
+    assert !person.instance_variable_defined?(:@customer)
+    person.stubs(:customer_id).returns(2)
+    Customer.expects(:find).with(2).once()
+    2.times{person.customer}
+    assert person.instance_variable_defined?(:@customer)
   end
 end

--- a/activeresource/test/cases/association_test.rb
+++ b/activeresource/test/cases/association_test.rb
@@ -1,0 +1,43 @@
+require 'abstract_unit'
+
+require 'fixtures/person'
+require 'fixtures/beast'
+require 'fixtures/customer'
+
+
+class AssociationTest < Test::Unit::TestCase
+  def setup
+    @klass = ActiveResource::Associations::Builder::Association
+  end
+
+
+  def test_validations_for_instance
+    object = @klass.new(Person, :customers, {})
+    assert_equal({}, object.send(:validate_options))
+  end
+
+  def test_instance_build
+    object = @klass.new(Person, :customers, {})
+    assert_kind_of ActiveResource::Reflection::AssociationReflection, object.build
+  end
+
+  def test_valid_options
+    assert_raise ArgumentError do 
+      @klass.build(Person, :customers, {:soo_invalid => true})
+    end
+  end
+
+  def test_association_class_build
+    assert_kind_of ActiveResource::Reflection::AssociationReflection, @klass.build(Person, :customers, {})
+  end
+
+  def test_has_many
+    External::Person.send(:has_many, :people)
+    assert_equal 1, External::Person.reflections.select{|name, reflection| reflection.macro.eql?(:has_many)}.count
+  end
+
+  def test_has_one
+    External::Person.send(:has_one, :customer)
+    assert_equal 1, External::Person.reflections.select{|name, reflection| reflection.macro.eql?(:has_one)}.count
+  end
+end

--- a/activeresource/test/cases/association_test.rb
+++ b/activeresource/test/cases/association_test.rb
@@ -40,4 +40,14 @@ class AssociationTest < Test::Unit::TestCase
     External::Person.send(:has_one, :customer)
     assert_equal 1, External::Person.reflections.select{|name, reflection| reflection.macro.eql?(:has_one)}.count
   end
+
+  def test_has_many
+    External::Person.send(:has_many, :people)
+    assert_equal 1, External::Person.reflections.select{|name, reflection| reflection.macro.eql?(:has_many)}.count
+  end
+  
+  def test_has_one
+    External::Person.send(:has_one, :customer)
+    assert_equal 1, External::Person.reflections.select{|name, reflection| reflection.macro.eql?(:has_one)}.count
+  end
 end

--- a/activeresource/test/cases/associations/builder/belongs_to_test.rb
+++ b/activeresource/test/cases/associations/builder/belongs_to_test.rb
@@ -1,0 +1,35 @@
+
+require 'abstract_unit'
+
+require 'fixtures/person'
+require 'fixtures/beast'
+require 'fixtures/customer'
+
+
+class ActiveResource::Associations::Builder::BelongsToTest < Test::Unit::TestCase
+  def setup
+    @klass = ActiveResource::Associations::Builder::BelongsTo
+  end
+
+
+  def test_validations_for_instance
+    object = @klass.new(Person, :customer, {})
+    assert_equal({}, object.send(:validate_options))
+  end
+
+  def test_instance_build
+    object = @klass.new(Person, :customer, {})
+    Person.expects(:defines_belongs_to_finder_method).with(:customer, Customer, 'customer_id')
+    assert_kind_of ActiveResource::Reflection::AssociationReflection, object.build
+  end
+
+
+  def test_valid_options
+    assert @klass.build(Person, :customer, {:class_name => 'Person'})
+    assert @klass.build(Person, :customer, {:foreign_key => 'person_id'})
+
+    assert_raise ArgumentError do
+      @klass.build(Person, :customer, {:soo_invalid => true})
+    end
+  end
+end

--- a/activeresource/test/cases/base_test.rb
+++ b/activeresource/test/cases/base_test.rb
@@ -1077,6 +1077,20 @@ class BaseTest < Test::Unit::TestCase
     end
   end
 
+  def test_parse_resource_with_given_has_one_resources
+    Customer.send(:has_one, :mother, :class_name => "external/person")
+    luis = Customer.find(1)
+    assert_kind_of External::Person, luis.mother
+  end
+
+  def test_parse_resources_with_given_has_many_resources
+    Customer.send(:has_many, :enemies, :class_name => "external/person")
+    luis = Customer.find(1)
+    luis.enemies.each do |enemy|
+      assert_kind_of External::Person, enemy
+    end
+  end
+
   def test_load_yaml_array
     assert_nothing_raised do
       Person.format = :xml

--- a/activeresource/test/cases/reflection_test.rb
+++ b/activeresource/test/cases/reflection_test.rb
@@ -6,46 +6,44 @@ require 'fixtures/customer'
 
 
 class ReflectionTest < Test::Unit::TestCase
-  def setup
-  end
 
   def test_correct_class_attributes
     object = ActiveResource::Reflection::AssociationReflection.new(:test, :people, {})
-    assert_equal object.name, :people
-    assert_equal object.macro, :test
-    assert_equal object.options, {} 
+    assert_equal :people, object.name
+    assert_equal :test, object.macro
+    assert_equal({}, object.options)
   end
 
   def test_correct_class_name_matching_without_class_name
     object = ActiveResource::Reflection::AssociationReflection.new(:test, :people, {})
-    assert_equal object.klass, Person
+    assert_equal Person, object.klass
   end
 
   def test_correct_class_name_matching_as_string
     object = ActiveResource::Reflection::AssociationReflection.new(:test, :people, {:class_name => 'Person'})
-    assert_equal object.klass, Person
+    assert_equal Person, object.klass
   end
 
   def test_correct_class_name_matching_as_symbol
     object = ActiveResource::Reflection::AssociationReflection.new(:test, :people, {:class_name => :person})
-    assert_equal object.klass, Person
+    assert_equal Person, object.klass
   end
 
   def test_correct_class_name_matching_as_class
     object = ActiveResource::Reflection::AssociationReflection.new(:test, :people, {:class_name => Person})
-    assert_equal object.klass, Person
+    assert_equal Person, object.klass
   end
 
   def test_correct_class_name_matching_as_string_with_namespace
     object = ActiveResource::Reflection::AssociationReflection.new(:test, :people, {:class_name => 'external/person'})
-    assert_equal object.klass, External::Person
+    assert_equal External::Person, object.klass
   end
 
   def test_creation_of_reflection
     object = Person.create_reflection(:test, :people, {})
-    assert_equal object.class, ActiveResource::Reflection::AssociationReflection
-    assert_equal Person.reflections.count, 1
-    assert_equal Person.reflections[:people].klass, Person
+    assert_equal ActiveResource::Reflection::AssociationReflection, object.class
+    assert Person.reflections[:people].present?
+    assert_equal Person, Person.reflections[:people].klass
   end
 
 end

--- a/activeresource/test/cases/reflection_test.rb
+++ b/activeresource/test/cases/reflection_test.rb
@@ -1,0 +1,51 @@
+require 'abstract_unit'
+
+require 'fixtures/person'
+require 'fixtures/customer'
+
+
+
+class ReflectionTest < Test::Unit::TestCase
+  def setup
+  end
+
+  def test_correct_class_attributes
+    object = ActiveResource::Reflection::AssociationReflection.new(:test, :people, {})
+    assert_equal object.name, :people
+    assert_equal object.macro, :test
+    assert_equal object.options, {} 
+  end
+
+  def test_correct_class_name_matching_without_class_name
+    object = ActiveResource::Reflection::AssociationReflection.new(:test, :people, {})
+    assert_equal object.klass, Person
+  end
+
+  def test_correct_class_name_matching_as_string
+    object = ActiveResource::Reflection::AssociationReflection.new(:test, :people, {:class_name => 'Person'})
+    assert_equal object.klass, Person
+  end
+
+  def test_correct_class_name_matching_as_symbol
+    object = ActiveResource::Reflection::AssociationReflection.new(:test, :people, {:class_name => :person})
+    assert_equal object.klass, Person
+  end
+
+  def test_correct_class_name_matching_as_class
+    object = ActiveResource::Reflection::AssociationReflection.new(:test, :people, {:class_name => Person})
+    assert_equal object.klass, Person
+  end
+
+  def test_correct_class_name_matching_as_string_with_namespace
+    object = ActiveResource::Reflection::AssociationReflection.new(:test, :people, {:class_name => 'external/person'})
+    assert_equal object.klass, External::Person
+  end
+
+  def test_creation_of_reflection
+    object = Person.create_reflection(:test, :people, {})
+    assert_equal object.class, ActiveResource::Reflection::AssociationReflection
+    assert_equal Person.reflections.count, 1
+    assert_equal Person.reflections[:people].klass, Person
+  end
+
+end

--- a/activeresource/test/cases/reflection_test.rb
+++ b/activeresource/test/cases/reflection_test.rb
@@ -39,6 +39,16 @@ class ReflectionTest < Test::Unit::TestCase
     assert_equal External::Person, object.klass
   end
 
+  def test_foreign_key_method_with_no_foreign_key_option
+    object = ActiveResource::Reflection::AssociationReflection.new(:test, :person, {})
+    assert_equal 'person_id', object.foreign_key
+  end
+
+  def test_foreign_key_method_with_with_foreign_key_option
+    object = ActiveResource::Reflection::AssociationReflection.new(:test, :people, {:foreign_key => 'client_id'})
+    assert_equal 'client_id', object.foreign_key
+  end
+
   def test_creation_of_reflection
     object = Person.create_reflection(:test, :people, {})
     assert_equal ActiveResource::Reflection::AssociationReflection, object.class

--- a/activeresource/test/fixtures/person.rb
+++ b/activeresource/test/fixtures/person.rb
@@ -7,3 +7,8 @@ module External
     self.site = "http://atq.caffeine.intoxication.it"
   end
 end
+
+class SalesMan < ActiveResource::Base
+  self.site = "http://atq.is.hungry.it"
+  has_many :people
+end

--- a/activeresource/test/fixtures/person.rb
+++ b/activeresource/test/fixtures/person.rb
@@ -1,3 +1,9 @@
 class Person < ActiveResource::Base
   self.site = "http://37s.sunrise.i:3000"
 end
+
+module External
+  class Person < ActiveResource::Base
+    self.site = "http://atq.caffeine.intoxication.it"
+  end
+end

--- a/activeresource/test/fixtures/person.rb
+++ b/activeresource/test/fixtures/person.rb
@@ -8,7 +8,3 @@ module External
   end
 end
 
-class SalesMan < ActiveResource::Base
-  self.site = "http://atq.is.hungry.it"
-  has_many :people
-end


### PR DESCRIPTION
Matthias Folz and I've added associations (has_many and has_one) via reflection classes to ActiveResources.

Here is the link to the googlegroups discussion:
http://groups.google.com/group/rubyonrails-core/browse_thread/thread/dd8d83955a7cf9e8/1f95a896887cd9a9#1f95a896887cd9a9 

And the lighthouse ticket:
https://rails.lighthouseapp.com/projects/8994/tickets/6473-activeresource-adding-associations-through-reflections#ticket-6473-1

I hope, it's not impolite to open a pull request without an answer on the lighthouse ticket form a core member.
If it's so: I'm sorry... ;)

Greetz
Markus Schwed
