### PR TITLE
ActiveRecord::Relation#except and #only loses scope extensions

### DIFF
--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -79,6 +79,9 @@ module ActiveRecord
         result.send(:"#{method}_value=", send(:"#{method}_value"))
       end
 
+      # Apply scope extension modules
+      result.send(:apply_modules, extensions)
+
       result
     end
 
@@ -99,6 +102,9 @@ module ActiveRecord
       (Relation::SINGLE_VALUE_METHODS & onlies).each do |method|
         result.send(:"#{method}_value=", send(:"#{method}_value"))
       end
+
+      # Apply scope extension modules
+      result.send(:apply_modules, extensions)
 
       result
     end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -797,6 +797,10 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal Post.all, all_posts.all
   end
 
+  def test_extensions_with_except
+    assert_equal 2, Topic.named_extension.order(:author_name).except(:order).two
+  end
+
   def test_only
     relation = Post.where(:author_id => 1).order('id ASC').limit(1)
     assert_equal [posts(:welcome)], relation.all
@@ -806,6 +810,10 @@ class RelationTest < ActiveRecord::TestCase
 
     all_posts = relation.only(:limit)
     assert_equal Post.limit(1).all.first, all_posts.first
+  end
+
+  def test_extensions_with_only
+    assert_equal 2, Topic.named_extension.order(:author_name).only(:order).two
   end
 
   def test_anonymous_extension


### PR DESCRIPTION
Repeating what I've said in [Lighthouse ticket 6598](https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/6598-activerecordrelationexcept-and-only-loses-scope-extensions)

Given a scope with extensions
When I use the except to remove a part from the relation
Then the extensions are gone, because except returns a brand new relation object.

This means the following doesn't work (when using Kaminari, which uses extensions):

```
Post.page(2).except(:order).current_page
```

Because the current_page method was added by the page scope.

This issue is present in at least 3.0.5 and master.

The supplied patch will apply the extensions again after using except and only.

There is some duplication going on in both methods. A private method could certainly be extracted (although I'm clueless on a name).
