### PR TITLE
Delegate method that accepts keywords.

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -131,15 +131,15 @@ class Module
           remove_possible_method("#{prefix}#{method}")
         end
 
-        def #{prefix}#{method}(*args, &block)               # def customer_name(*args, &block)
-          #{to}.__send__(#{method.inspect}, *args, &block)  #   client.__send__(:name, *args, &block)
-        rescue NoMethodError                                # rescue NoMethodError
-          if #{to}.nil?                                     #   if client.nil?
-            #{on_nil}                                       #     return # depends on :allow_nil
-          else                                              #   else
-            raise                                           #     raise
-          end                                               #   end
-        end                                                 # end
+        def #{prefix}#{method}(*args, &block)                   # def customer_name(*args, &block)
+          self.#{to}.__send__(#{method.inspect}, *args, &block) #   self.client.__send__(:name, *args, &block)
+        rescue NoMethodError                                    # rescue NoMethodError
+          if self.#{to}.nil?                                    #   if self.client.nil?
+            #{on_nil}                                           #     return # depends on :allow_nil
+          else                                                  #   else
+            raise                                               #     raise
+          end                                                   #   end
+        end                                                     # end
       EOS
     end
   end


### PR DESCRIPTION
The delegate method currently cannot be used with keywords (such as `module`).

This won't work:

```
class DelegateExample
  attr_accessor :module
  delegate :title, :to => :module
end
```

The method being created by delegate currently looks like this:

```
def title(*args, &block)
  module.__send__(:title, *args, &block)
rescue NoMethodError
  if module.nil?
    return # depends on :allow_nil
  else
    raise
  end
end
```

I've add `self.` to prevent errors when using keywords:

```
def title(*args, &block)
  self.module.__send__(:title, *args, &block)
rescue NoMethodError
  if self.module.nil?
    return # depends on :allow_nil
  else
    raise
  end
end
```
