### PR TITLE
Adding i18n dependency to activesupport gemspec 

### DIFF
--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -18,4 +18,6 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.has_rdoc = true
+
+  s.add_dependency('i18n', '~> 0.5.0')
 end


### PR DESCRIPTION
activesupport has a dependency in i18n, it was missing in the gemspec.
