### PR TITLE
removed unused result variable from ActiveRecord::Base initializer

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1440,9 +1440,8 @@ MSG
         populate_with_current_scope_attributes
         self.attributes = attributes unless attributes.nil?
 
-        result = yield self if block_given?
+        yield self if block_given?
         run_callbacks :initialize
-        result
       end
 
       # Populate +coder+ with attributes about this record that should be


### PR DESCRIPTION
result variable is never used within the initializer
