### PR TITLE
Fixes an issue when creating a date select with too many options.

### DIFF
--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -810,6 +810,12 @@ module ActionView
           step          = options.delete(:step) || 1
           options.reverse_merge!({:leading_zeros => true})
           leading_zeros = options.delete(:leading_zeros)
+          limit         = (stop - start).abs
+          max_options   = 1000
+
+          if limit / step.abs > max_options
+            raise ArgumentError, "Cannot build too many options for select."
+          end
 
           select_options = []
           start.step(stop, step) do |i|

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -668,6 +668,11 @@ class DateHelperTest < ActionView::TestCase
     assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), :start_year => 2003, :end_year => 2005, :prefix => "date[first]", :order => [:month, :day, :year])
   end
 
+  def test_select_date_with_too_big_range_between_start_year_and_end_year
+    assert_raise(ArgumentError) { select_date(Time.mktime(2003, 8, 16), :start_year => 2000, :end_year => 20000.years, :prefix => "date[first]", :order => [:month, :day, :year]) }
+    assert_raise(ArgumentError) { select_date(Time.mktime(2003, 8, 16), :start_year => Date.today.year - 100.years, :end_year => 2000, :prefix => "date[first]", :order => [:month, :day, :year]) }
+  end
+
   def test_select_date_with_incomplete_order
     # Since the order is incomplete nothing will be shown
     expected = %(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" />\n)


### PR DESCRIPTION
This commit fixes issue #6627 (https://rails.lighthouseapp.com/projects/8994/tickets/6627-server-hanging-when-using-extreme-values-for-date_select-start_year). The issue occurs because the build_options method loops forever when the range between start_date and end_date is too big.

This commit adds a verification to #build_options and raises an error when the range is greater than 1000.
