### PR TITLE
Example now uses find_each instead of find(:all).each

### DIFF
--- a/railties/lib/rails/commands/runner.rb
+++ b/railties/lib/rails/commands/runner.rb
@@ -25,7 +25,7 @@ ARGV.clone.options do |opts|
     opts.separator "-------------------------------------------------------------"
     opts.separator "#!/usr/bin/env #{File.expand_path($0)} runner"
     opts.separator ""
-    opts.separator "Product.find(:all).each { |p| p.price *= 2 ; p.save! }"
+    opts.separator "Product.find_each { |p| p.price *= 2 ; p.save! }"
     opts.separator "-------------------------------------------------------------"
   end
 


### PR DESCRIPTION
Changed the example code output by the runner command to use find_each instead of find(:all).each.
