### PR TITLE
Isolated engines with nested modules should set correct module route prefix

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -360,11 +360,11 @@ module Rails
       def isolate_namespace(mod)
         engine_name(generate_railtie_name(mod))
 
-        name = engine_name
-        self.routes.default_scope = {:module => name}
+        self.routes.default_scope = { :module => ActiveSupport::Inflector.underscore(mod.name) }
         self.isolated = true
 
         unless mod.respond_to?(:_railtie)
+          name = engine_name
           _railtie = self
           mod.singleton_class.instance_eval do
             define_method(:_railtie) do


### PR DESCRIPTION
Currently, engines that use `isolate_namespace` with nested modules (e.g. `Foo::Bar`) do not correctly set the `module` prefix of the engine's routes. It is set to `foo_bar`, while it should be set to `foo/bar`. This means that none of the routes for that engine will work. This patch provides a test plus fix.
