### PR TITLE
Do not show optional (.:format) block for wildcard route

### DIFF
--- a/actionpack/CHANGELOG
+++ b/actionpack/CHANGELOG
@@ -1,5 +1,7 @@
 *Rails 3.0.6 (unreleased)*
 
+* Fixes the output of `rake routes` to be correctly match to the behavior of the application, as the regular expression used to match the path is greedy and won't capture the format part by default [Prem Sichanugrist]
+
 * Fixes an issue with number_to_human when converting values which are less than 1 but greater than -1 [Josh Kalderimis]
 
 * Sensitive query string parameters (specified in config.filter_parameters) will now be filtered out from the request paths in the log file. [Prem Sichanugrist, fxn]

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency('i18n',          '~> 0.5.0')
   s.add_dependency('rack',          '~> 1.2.1')
   s.add_dependency('rack-test',     '~> 0.5.7')
-  s.add_dependency('rack-mount',    '~> 0.6.13')
+  s.add_dependency('rack-mount',    '~> 0.6.14')
   s.add_dependency('tzinfo',        '~> 0.3.23')
   s.add_dependency('erubis',        '~> 2.6.6')
 end

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -106,7 +106,7 @@ module ActionDispatch
             if @options[:format] == false
               @options.delete(:format)
               path
-            elsif path.include?(":format")
+            elsif path.include?(":format") || path.match(/\*[^\/]+$/)
               path
             else
               "#{path}(.:format)"

--- a/actionpack/test/dispatch/mapper_test.rb
+++ b/actionpack/test/dispatch/mapper_test.rb
@@ -1,0 +1,56 @@
+require 'abstract_unit'
+
+module ActionDispatch
+  module Routing
+    class MapperTest < ActiveSupport::TestCase
+      class FakeSet
+        attr_reader :routes
+
+        def initialize
+          @routes = []
+        end
+
+        def resources_path_names
+          {}
+        end
+
+        def request_class
+          ActionDispatch::Request
+        end
+
+        def add_route(*args)
+          routes << args
+        end
+
+        def conditions
+          routes.map { |x| x[1] }
+        end
+      end
+
+      def test_initialize
+        Mapper.new FakeSet.new
+      end
+
+      def test_map_wildcard
+        fakeset = FakeSet.new
+        mapper = Mapper.new fakeset
+        mapper.match '/*path', :to => 'pages#show', :as => :page
+        assert_equal '/*path', fakeset.conditions.first[:path_info]
+      end
+
+      def test_map_wildcard_with_other_element
+        fakeset = FakeSet.new
+        mapper = Mapper.new fakeset
+        mapper.match '/*path/foo/:bar', :to => 'pages#show', :as => :page
+        assert_equal '/*path/foo/:bar(.:format)', fakeset.conditions.first[:path_info]
+      end
+
+      def test_map_wildcard_with_multiple_wildcard
+        fakeset = FakeSet.new
+        mapper = Mapper.new fakeset
+        mapper.match '/*foo/*bar', :to => 'pages#show', :as => :page
+        assert_equal '/*foo/*bar', fakeset.conditions.first[:path_info]
+      end
+    end
+  end
+end

--- a/railties/guides/source/routing.textile
+++ b/railties/guides/source/routing.textile
@@ -554,6 +554,12 @@ match '*a/foo/*b' => 'test#index'
 
 would match +zoo/woo/foo/bar/baz+ with +params[:a]+ equals +"zoo/woo"+, and +params[:b]+ equals +"bar/baz"+.
 
+NOTE: If the wildcard segment is the last segment of the route, the format segment will not be added to the path unless you explicitly specify it as a constraint.
+
+<ruby>
+match '/:path(.:format)', :to => 'pages#show', :constraints => { :path => /.+?/ }
+</ruby>
+
 h4. Redirection
 
 You can redirect any path to another path using the +redirect+ helper in your router:


### PR DESCRIPTION
Do not show optional (.:format) block for wildcard route [#6605 state:resolved]

This will make the output of `rake routes` to be correctly match to the behavior of the application, as the regular expression used to match the path is greedy and won't capture the format part by default

This commit is the second attempt on fixing the issue, as the regular expression on another commit on `master` was invalid.
