### PR TITLE
Fix repeated column lookups in 3.0.5+ (eager loaded has_one association with conditions)

### DIFF
--- a/activerecord/lib/active_record/associations/association_proxy.rb
+++ b/activerecord/lib/active_record/associations/association_proxy.rb
@@ -102,7 +102,7 @@ module ActiveRecord
       # Returns the SQL string that corresponds to the <tt>:conditions</tt>
       # option of the macro, if given, or +nil+ otherwise.
       def conditions
-        @conditions ||= @reflection.options[:conditions] && interpolate_and_sanitize_sql(@reflection.options[:conditions])
+        @conditions ||= interpolate_sanitized_sql(@reflection.sanitized_conditions) if @reflection.sanitized_conditions
       end
       alias :sql_conditions :conditions
 
@@ -159,6 +159,10 @@ module ActiveRecord
         # Does the association have a <tt>:dependent</tt> option?
         def dependent?
           @reflection.options[:dependent]
+        end
+
+        def interpolate_sanitized_sql(sql, record = nil, sanitize_klass = @reflection.klass)
+          @owner.send(:interpolate_sanitized_sql, sql, record, sanitize_klass)
         end
 
         def interpolate_and_sanitize_sql(sql, record = nil, sanitize_klass = @reflection.klass)

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1733,7 +1733,10 @@ MSG
 
       def interpolate_and_sanitize_sql(sql, record = nil, sanitize_klass = self.class)
         sanitized = sanitize_klass.send(:sanitize_sql, sql)
+        interpolate_sanitized_sql(sanitized, record, sanitize_klass)
+      end
 
+      def interpolate_sanitized_sql(sanitized, record = nil, sanitize_klass = self.class)
         if sanitized =~ /\#\{.*\}/
           ActiveSupport::Deprecation.warn(
             'String-based interpolation of association conditions is deprecated. Please use a ' \
@@ -1741,8 +1744,8 @@ MSG
             'should be changed to has_many :older_friends, :conditions => proc { "age > #{age}" }.'
           )
           instance_eval("%@#{sanitized.gsub('@', '\@')}@", __FILE__, __LINE__)
-        elsif sql.respond_to?(:to_proc)
-          sanitize_klass.send(:sanitize_sql, instance_exec(record, &sql))
+        elsif sanitized.respond_to?(:to_proc)
+          sanitize_klass.send(:sanitize_sql, instance_exec(record, &sanitized))
         else
           sanitized
         end

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -39,11 +39,14 @@ ActiveRecord::Base.connection.class.class_eval do
 end
 
 ActiveRecord::Base.connection.class.class_eval {
-  attr_accessor :column_calls
+  attr_accessor :column_calls, :column_calls_by_table
 
   def columns_with_calls(*args)
     @column_calls ||= 0
+    @column_calls_by_table ||= Hash.new {|h,table| h[table] = 0}
+
     @column_calls += 1
+    @column_calls_by_table[args.first.to_s] += 1
     columns_without_calls(*args)
   end
 

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -44,6 +44,7 @@ class Post < ActiveRecord::Base
       :conditions => proc { ["#{"#{aliased_table_name}." rescue ""}body = ?", 'Thank you for the welcome'] }
   has_many :comments_with_deprecated_interpolated_conditions, :class_name => 'Comment',
       :conditions => ['#{"#{aliased_table_name}." rescue ""}body = ?', 'Thank you for the welcome']
+  has_one :first_post_comment, :class_name => 'Comment', :conditions => {:body => 'First Post!'}
 
   has_one  :very_special_comment
   has_one  :very_special_comment_with_post, :class_name => "VerySpecialComment", :include => :post


### PR DESCRIPTION
The following issue affects the 3-0-stable branch:

https://rails.lighthouseapp.com/projects/8994/tickets/6599-305-introduced-repeated-column-lookups-for-eager-loaded-has_one-with-conditions

The AssociationProxy code appears to have been completely rewritten on master so I am not sure if this is a problem there or not (I am also not able to run my app against master right now to test it). But in the meantime I am asking that this patch get pulled into 3.0 stable to improve the situation for the 3.0.x line.

Even with this patch applied I am still seeing slower performance with (patched) 3.0.5+ vs 3.0.4, but it is much improved (3 - 4 times faster for a page loading many rows).
