### PR TITLE
Enumerable should pass encoding options to children in #as_json/#to_json

### DIFF
--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -205,7 +205,9 @@ class Regexp
 end
 
 module Enumerable
-  def as_json(options = nil) to_a end #:nodoc:
+  def as_json(options = nil) #:nodoc:
+    to_a.as_json(options)
+  end
 end
 
 class Array

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -215,6 +215,30 @@ class TestJSONEncoding < Test::Unit::TestCase
     assert_equal(%([{"address":{"city":"London"}},{"address":{"city":"Paris"}}]), json)
   end
 
+  def test_enumerable_should_pass_encoding_options_to_children_in_as_json
+    people = [
+      { :name => 'John', :address => { :city => 'London', :country => 'UK' }},
+      { :name => 'Jean', :address => { :city => 'Paris' , :country => 'France' }}
+    ]
+    json = people.each.as_json :only => [:address, :city]
+    expected = [
+      { 'address' => { 'city' => 'London' }},
+      { 'address' => { 'city' => 'Paris' }}
+    ]
+
+    assert_equal(expected, json)
+  end
+
+  def test_enumerable_should_pass_encoding_options_to_children_in_to_json
+    people = [
+      { :name => 'John', :address => { :city => 'London', :country => 'UK' }},
+      { :name => 'Jean', :address => { :city => 'Paris' , :country => 'France' }}
+    ]
+    json = people.each.to_json :only => [:address, :city]
+
+    assert_equal(%([{"address":{"city":"London"}},{"address":{"city":"Paris"}}]), json)
+  end
+
   def test_struct_encoding
     Struct.new('UserNameAndEmail', :name, :email)
     Struct.new('UserNameAndDate', :name, :date)
@@ -258,13 +282,4 @@ class TestJSONEncoding < Test::Unit::TestCase
     ensure
       old_tz ? ENV['TZ'] = old_tz : ENV.delete('TZ')
     end
-end
-
-class JsonOptionsTests < Test::Unit::TestCase
-  def test_enumerable_should_passthrough_options_to_elements
-    value, options = Object.new, Object.new
-    def value.as_json(options) options end
-    def options.encode_json(encoder) self end
-    assert_equal options, ActiveSupport::JSON.encode(value, options)
-  end
 end


### PR DESCRIPTION
The test that's being removed is an old test that was (I think) trying to test something similar but became a false positive, see https://github.com/rails/rails/commit/d780d1f508c880c59d6d932bd052cb0b1c1c76b0
