### PR TITLE
Active model observer disabling

### DIFF
--- a/activemodel/lib/active_model/observer_array.rb
+++ b/activemodel/lib/active_model/observer_array.rb
@@ -1,0 +1,98 @@
+require 'set'
+
+module ActiveModel
+  # Stores the enabled/disabled state of individual observers for
+  # a particular model classes.
+  class ObserverArray < Array
+    INSTANCES = Hash.new do |hash, model_class|
+      hash[model_class] = new(model_class)
+    end
+
+    def self.for(model_class)
+      return nil unless model_class < ActiveModel::Observing
+      INSTANCES[model_class]
+    end
+
+    # returns false if:
+    #   - the ObserverArray for the given model's class has the given observer
+    #     in its disabled_observers set.
+    #   - or that is the case at any level of the model's superclass chain.
+    def self.observer_enabled?(observer, model)
+      klass = model.class
+      observer_class = observer.class
+
+      loop do
+        break unless array = self.for(klass)
+        return false if array.disabled_observers.include?(observer_class)
+        klass = klass.superclass
+      end
+
+      true # observers are enabled by default
+    end
+
+    def disabled_observers
+      @disabled_observers ||= Set.new
+    end
+
+    attr_reader :model_class
+    def initialize(model_class, *args)
+      @model_class = model_class
+      super(*args)
+    end
+
+    def disable(*observers, &block)
+      set_enablement(false, observers, &block)
+    end
+
+    def enable(*observers, &block)
+      set_enablement(true, observers, &block)
+    end
+
+    private
+
+      def observer_class_for(observer)
+        return observer if observer.is_a?(Class)
+
+        if observer.respond_to?(:to_sym) # string/symbol
+          observer.to_s.camelize.constantize
+        else
+          raise ArgumentError, "#{observer} was not a class or a " +
+            "lowercase, underscored class name as expected."
+        end
+      end
+
+      def transaction
+        orig_disabled_observers = disabled_observers.dup
+
+        begin
+          yield
+        ensure
+          @disabled_observers = orig_disabled_observers
+        end
+      end
+
+      def set_enablement(enabled, observers)
+        if block_given?
+          transaction do
+            set_enablement(enabled, observers)
+            yield
+          end
+        else
+          observers = ActiveModel::Observer.all_observers if observers == [:all]
+          observers.each do |obs|
+            klass = observer_class_for(obs)
+
+            unless klass < ActiveModel::Observer
+              raise ArgumentError.new("#{obs} does not refer to a valid observer")
+            end
+
+            if enabled
+              disabled_observers.delete(klass)
+            else
+              disabled_observers << klass
+            end
+          end
+        end
+      end
+  end
+end

--- a/activemodel/lib/active_model/observing.rb
+++ b/activemodel/lib/active_model/observing.rb
@@ -70,6 +70,10 @@ module ActiveModel
         observer_instances.size
       end
 
+      def subclasses
+        @subclasses ||= []
+      end
+
       protected
         def instantiate_observer(observer) #:nodoc:
           # string/symbol
@@ -89,6 +93,7 @@ module ActiveModel
         # Notify observers when the observed class is subclassed.
         def inherited(subclass)
           super
+          subclasses << subclass
           notify_observers :observed_class_inherited, subclass
         end
     end

--- a/activemodel/lib/active_model/observing.rb
+++ b/activemodel/lib/active_model/observing.rb
@@ -76,7 +76,11 @@ module ActiveModel
           elsif observer.respond_to?(:instance)
             observer.instance
           else
-            raise ArgumentError, "#{observer} must be a lowercase, underscored class name (or an instance of the class itself) responding to the instance method. Example: Person.observers = :big_brother # calls BigBrother.instance"
+            raise ArgumentError,
+              "#{observer} must be a lowercase, underscored class name (or an " +
+              "instance of the class itself) responding to the instance " +
+              "method. Example: Person.observers = :big_brother # calls " +
+              "BigBrother.instance"
           end
         end
 

--- a/activemodel/test/cases/observer_array_test.rb
+++ b/activemodel/test/cases/observer_array_test.rb
@@ -1,0 +1,122 @@
+require 'cases/helper'
+require 'models/observers'
+
+class ObserverArrayTest < ActiveModel::TestCase
+  def teardown
+    ORM.observers.enable :all
+    Budget.observers.enable :all
+    Widget.observers.enable :all
+  end
+
+  def assert_observer_notified(model_class, observer_class)
+    observer_class.instance.before_save_invocations.clear
+    model_instance = model_class.new
+    model_instance.save
+    assert_equal [model_instance], observer_class.instance.before_save_invocations
+  end
+
+  def assert_observer_not_notified(model_class, observer_class)
+    observer_class.instance.before_save_invocations.clear
+    model_instance = model_class.new
+    model_instance.save
+    assert_equal [], observer_class.instance.before_save_invocations
+  end
+
+  test "all observers are enabled by default" do
+    assert_observer_notified Widget, WidgetObserver
+    assert_observer_notified Budget, BudgetObserver
+    assert_observer_notified Widget, AuditTrail
+    assert_observer_notified Budget, AuditTrail
+  end
+
+  test "can disable individual observers using a class constant" do
+    ORM.observers.disable WidgetObserver
+
+    assert_observer_not_notified Widget, WidgetObserver
+    assert_observer_notified     Budget, BudgetObserver
+    assert_observer_notified     Widget, AuditTrail
+    assert_observer_notified     Budget, AuditTrail
+  end
+
+  test "can disable individual observers using a symbol" do
+    ORM.observers.disable :budget_observer
+
+    assert_observer_notified     Widget, WidgetObserver
+    assert_observer_not_notified Budget, BudgetObserver
+    assert_observer_notified     Widget, AuditTrail
+    assert_observer_notified     Budget, AuditTrail
+  end
+
+  test "can disable all observers using :all" do
+    ORM.observers.disable :all
+
+    assert_observer_not_notified Widget, WidgetObserver
+    assert_observer_not_notified Budget, BudgetObserver
+    assert_observer_not_notified Widget, AuditTrail
+    assert_observer_not_notified Budget, AuditTrail
+  end
+
+  test "can disable observers on individual models without affecting observers on other models" do
+    Widget.observers.disable :all
+
+    assert_observer_not_notified Widget, WidgetObserver
+    assert_observer_notified     Budget, BudgetObserver
+    assert_observer_not_notified Widget, AuditTrail
+    assert_observer_notified     Budget, AuditTrail
+  end
+
+  test "can disable observers for the duration of a block" do
+    yielded = false
+    ORM.observers.disable :budget_observer do
+      yielded = true
+      assert_observer_notified     Widget, WidgetObserver
+      assert_observer_not_notified Budget, BudgetObserver
+      assert_observer_notified     Widget, AuditTrail
+      assert_observer_notified     Budget, AuditTrail
+    end
+
+    assert yielded
+    assert_observer_notified Widget, WidgetObserver
+    assert_observer_notified Budget, BudgetObserver
+    assert_observer_notified Widget, AuditTrail
+    assert_observer_notified Budget, AuditTrail
+  end
+
+  test "can enable observers for the duration of a block" do
+    yielded = false
+    Widget.observers.disable :all
+
+    Widget.observers.enable :all do
+      yielded = true
+      assert_observer_notified Widget, WidgetObserver
+      assert_observer_notified Budget, BudgetObserver
+      assert_observer_notified Widget, AuditTrail
+      assert_observer_notified Budget, AuditTrail
+    end
+
+    assert yielded
+    assert_observer_not_notified Widget, WidgetObserver
+    assert_observer_notified     Budget, BudgetObserver
+    assert_observer_not_notified Widget, AuditTrail
+    assert_observer_notified     Budget, AuditTrail
+  end
+
+  test "raises an appropriate error when a developer accidentally enables or disables the wrong class (i.e. Widget instead of WidgetObserver)" do
+    assert_raise ArgumentError do
+      ORM.observers.enable :widget
+    end
+
+    assert_raise ArgumentError do
+      ORM.observers.enable Widget
+    end
+
+    assert_raise ArgumentError do
+      ORM.observers.disable :widget
+    end
+
+    assert_raise ArgumentError do
+      ORM.observers.disable Widget
+    end
+  end
+end
+

--- a/activemodel/test/cases/observer_array_test.rb
+++ b/activemodel/test/cases/observer_array_test.rb
@@ -118,5 +118,44 @@ class ObserverArrayTest < ActiveModel::TestCase
       ORM.observers.disable Widget
     end
   end
+
+  test "allows #enable at the superclass level to override #disable at the subclass level when called last" do
+    Widget.observers.disable :all
+    ORM.observers.enable :all
+
+    assert_observer_notified Widget, WidgetObserver
+    assert_observer_notified Budget, BudgetObserver
+    assert_observer_notified Widget, AuditTrail
+    assert_observer_notified Budget, AuditTrail
+  end
+
+  test "allows #disable at the superclass level to override #enable at the subclass level when called last" do
+    Budget.observers.enable :audit_trail
+    ORM.observers.disable :audit_trail
+
+    assert_observer_notified     Widget, WidgetObserver
+    assert_observer_notified     Budget, BudgetObserver
+    assert_observer_not_notified Widget, AuditTrail
+    assert_observer_not_notified Budget, AuditTrail
+  end
+
+  test "can use the block form at different levels of the hierarchy" do
+    yielded = false
+    Widget.observers.disable :all
+
+    ORM.observers.enable :all do
+      yielded = true
+      assert_observer_notified Widget, WidgetObserver
+      assert_observer_notified Budget, BudgetObserver
+      assert_observer_notified Widget, AuditTrail
+      assert_observer_notified Budget, AuditTrail
+    end
+
+    assert yielded
+    assert_observer_not_notified Widget, WidgetObserver
+    assert_observer_notified     Budget, BudgetObserver
+    assert_observer_not_notified Widget, AuditTrail
+    assert_observer_notified     Budget, AuditTrail
+  end
 end
 

--- a/activemodel/test/cases/observing_test.rb
+++ b/activemodel/test/cases/observing_test.rb
@@ -43,6 +43,11 @@ class ObservingTest < ActiveModel::TestCase
     assert ObservedModel.observers.include?(:bar), ":bar not in #{ObservedModel.observers.inspect}"
   end
 
+  test "uses an ObserverArray so observers can be disabled" do
+    ObservedModel.observers = [:foo, :bar]
+    assert ObservedModel.observers.is_a?(ActiveModel::ObserverArray)
+  end
+
   test "instantiates observer names passed as strings" do
     ObservedModel.observers << 'foo_observer'
     FooObserver.expects(:instance)

--- a/activemodel/test/models/observers.rb
+++ b/activemodel/test/models/observers.rb
@@ -1,0 +1,27 @@
+class ORM
+  include ActiveModel::Observing
+
+  def save
+    notify_observers :before_save
+  end
+
+  class Observer < ActiveModel::Observer
+    def before_save_invocations
+      @before_save_invocations ||= []
+    end
+
+    def before_save(record)
+      before_save_invocations << record
+    end
+  end
+end
+
+class Widget < ORM; end
+class Budget < ORM; end
+class WidgetObserver < ORM::Observer; end
+class BudgetObserver < ORM::Observer; end
+class AuditTrail < ORM::Observer
+  observe :widget, :budget
+end
+
+ORM.instantiate_observers


### PR DESCRIPTION
These changes allow you to selectively disable and enable observers.  By default, all observers are enabled (as they are now).  You can enable or disable them using APIs like these:
- `ActiveRecord::Base.disable_observers :audit_trail, :logger` (symbols)
- `ActiveRecord::Base.enable_observers AuditTrail, Logger` (classes)
- `ActiveRecord::Base.enable_observer :user_observer` (singular)
- `ActiveRecord::Base.with_observers_disabled(:audit_trail, :logger) { ... }` (disables the observers only for the duration of the block.)

I find this to be very useful for model unit tests, but I'm sure it could be useful in other situations, such as a rake task where you are backfilling data and don't want to trigger email notification to a user via an observer.

Let me know if you want me to submit another pull request with this rebased against 3-0-stable (i.e. if you plan to do another 3.0.x release).
