### PR TITLE
respect :expire_after

### DIFF
--- a/actionpack/lib/action_controller/session/abstract_store.rb
+++ b/actionpack/lib/action_controller/session/abstract_store.rb
@@ -196,6 +196,7 @@ module ActionController
 
           if (request_cookies.nil? || request_cookies[@key] != sid) || options[:expire_after]
             cookie = {:value => sid}
+            cookie[:expires] = Time.now + options[:expire_after] if options[:expire_after]
             Rack::Utils.set_cookie_header!(response[1], @key, cookie.merge(options))
           end
         end

--- a/actionpack/test/controller/session/abstract_store_test.rb
+++ b/actionpack/test/controller/session/abstract_store_test.rb
@@ -1,0 +1,64 @@
+require 'abstract_unit'
+
+# You need to start a memcached server inorder to run these tests
+class AbstractStoreTest < ActionController::IntegrationTest
+  SessionKey = '_myapp_session'
+  DispatcherApp = ActionController::Dispatcher.new
+
+  class TestController < ActionController::Base
+    def get_session
+      session[:test] = 'test'
+      head :ok
+    end
+  end
+
+  def test_expiry_after
+    with_test_route_set(:expire_after => 5 * 60) do
+      get 'get_session'
+      assert_response :success
+      assert_match /expires=\S+/, headers['Set-Cookie']
+    end
+  end
+
+protected
+
+  def with_test_route_set(options = {})
+    with_routing do |set|
+      set.draw do |map|
+        map.with_options :controller => "abstract_store_test/test" do |c|
+          c.connect "/:action"
+        end
+      end
+
+      options = { :key => SessionKey, :secret => 'SessionSecret' }.merge!(options)
+      @integration_session = open_session(TestStore.new(DispatcherApp, options))
+
+      yield
+    end
+  end
+
+  class TestStore < ActionController::Session::AbstractStore
+    def initialize(app, options = {})
+      super
+      @_store = Hash.new({})
+    end
+
+  private
+
+    def get_session(env, sid)
+      sid ||= generate_sid
+      session = @_store[sid]
+      [sid, session]
+    end
+
+    def set_session(env, sid, session_data)
+      @_store[sid] = session_data
+    end
+
+    def destroy(env)
+      @_store.delete(sid)
+    end
+  end
+
+end
+


### PR DESCRIPTION
- it was broken after
  [commit](https://github.com/rails/rails/commit/e0eb8e9c65ededce64169948d4dd51b0079cdd10)
- there's also
  [issue](https://rails.lighthouseapp.com/projects/8994/tickets/6634-railsrack-inconsistency-about-expires_afterexpires-cookie-option)
- also: maybe it worth making Rack understand :expire_after as we
  duplicate same logic in [cookie_store](https://github.com/gmarik/rails/blob/v2.3.11/actionpack/lib/action_controller/session/cookie_store.rb#L114)
