### PR TITLE
Make csrf_meta_tags use the tag helper

### DIFF
--- a/actionpack/lib/action_view/helpers/csrf_helper.rb
+++ b/actionpack/lib/action_view/helpers/csrf_helper.rb
@@ -17,10 +17,12 @@ module ActionView
       # Note that regular forms generate hidden fields, and that Ajax calls are whitelisted,
       # so they do not use these tags.
       def csrf_meta_tags
-        <<-METAS.strip_heredoc.chomp.html_safe if protect_against_forgery?
-          <meta name="csrf-param" content="#{Rack::Utils.escape_html(request_forgery_protection_token)}"/>
-          <meta name="csrf-token" content="#{Rack::Utils.escape_html(form_authenticity_token)}"/>
-        METAS
+        if protect_against_forgery?
+          [
+            tag('meta', :name => 'csrf-param', :content => request_forgery_protection_token),
+            tag('meta', :name => 'csrf-token', :content => form_authenticity_token)
+          ].join("\n").html_safe
+        end
       end
 
       # For backwards compatibility.

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -172,13 +172,11 @@ end
 class RequestForgeryProtectionControllerTest < ActionController::TestCase
   include RequestForgeryProtectionTests
 
-  test 'should emit a csrf-token meta tag' do
+  test 'should emit a csrf-param meta tag and a csrf-token meta tag' do
     ActiveSupport::SecureRandom.stubs(:base64).returns(@token + '<=?')
     get :meta
-    assert_equal <<-METAS.strip_heredoc.chomp, @response.body
-      <meta name="csrf-param" content="authenticity_token"/>
-      <meta name="csrf-token" content="cf50faa3fe97702ca1ae&lt;=?"/>
-    METAS
+    assert_select 'meta[name=?][content=?]', 'csrf-param', 'authenticity_token'
+    assert_select 'meta[name=?][content=?]', 'csrf-token', 'cf50faa3fe97702ca1ae&lt;=?'
   end
 end
 


### PR DESCRIPTION
The csrf_meta_tags helper should use the tag helper, both for consistency and in order to support cases where TagHelper::tag is overridden.
