### PR TITLE
removed :nodoc: from ActionController::MimeResponds

### DIFF
--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -2,7 +2,7 @@ require 'abstract_controller/collector'
 require 'active_support/core_ext/class/attribute'
 
 module ActionController #:nodoc:
-  module MimeResponds #:nodoc:
+  module MimeResponds
     extend ActiveSupport::Concern
 
     included do
@@ -260,7 +260,7 @@ module ActionController #:nodoc:
     # Collects mimes and return the response for the negotiated format. Returns
     # nil if :not_acceptable was sent to the client.
     #
-    def retrieve_response_from_mimes(mimes=nil, &block)
+    def retrieve_response_from_mimes(mimes=nil, &block) #:nodoc:
       mimes ||= collect_mimes_from_class_level
       collector = Collector.new(mimes) { |options| default_render(options || {}) }
       block.call(collector) if block_given?


### PR DESCRIPTION
So we don't miss out on the nice documentation of the respond_to and
respond_with instance methods.  Also added :nodoc: to protected method.

Closes [#6261](https://rails.lighthouseapp.com/projects/8994/tickets/6261-why-does-actioncontrollermimeresponds-have-nodoc).
