### PR TITLE
Switch from XML to JSON in scaffold generator, and use Ruby 1.9 hash style

### DIFF
--- a/railties/CHANGELOG
+++ b/railties/CHANGELOG
@@ -1,6 +1,6 @@
 *Rails 3.1.0 (unreleased)*
 
-* Changed scaffold generator to create Ruby 1.9 style hash when running on Ruby 1.9 [Prem Sichanugrist]
+* Changed scaffold and app generator to create Ruby 1.9 style hash when running on Ruby 1.9 [Prem Sichanugrist]
 
   So instead of creating something like:
 

--- a/railties/CHANGELOG
+++ b/railties/CHANGELOG
@@ -1,5 +1,7 @@
 *Rails 3.1.0 (unreleased)*
 
+* Changed scaffold_controller generator to create format block for JSON instead of XML [Prem Sichanugrist]
+
 * Add using Turn with natural language test case names for test_help.rb when running with minitest (Ruby 1.9.2+) [DHH]
 
 * Direct logging of Active Record to STDOUT so it's shown inline with the results in the console [DHH]

--- a/railties/CHANGELOG
+++ b/railties/CHANGELOG
@@ -10,6 +10,8 @@
 
     redirect_to users_path, notice: "User has been created"
 
+  You can also passing `--old-style-hash` to make Rails generate old style hash even you're on Ruby 1.9
+
 * Changed scaffold_controller generator to create format block for JSON instead of XML [Prem Sichanugrist]
 
 * Add using Turn with natural language test case names for test_help.rb when running with minitest (Ruby 1.9.2+) [DHH]

--- a/railties/CHANGELOG
+++ b/railties/CHANGELOG
@@ -1,5 +1,15 @@
 *Rails 3.1.0 (unreleased)*
 
+* Changed scaffold generator to create Ruby 1.9 style hash when running on Ruby 1.9 [Prem Sichanugrist]
+
+  So instead of creating something like:
+
+    redirect_to users_path, :notice => "User has been created"
+
+  it will now be like this:
+
+    redirect_to users_path, notice: "User has been created"
+
 * Changed scaffold_controller generator to create format block for JSON instead of XML [Prem Sichanugrist]
 
 * Add using Turn with natural language test case names for test_help.rb when running with minitest (Ruby 1.9.2+) [DHH]

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -53,6 +53,9 @@ module Rails
 
         class_option :help,               :type => :boolean, :aliases => "-h", :group => :rails,
                                           :desc => "Show this help message and quit"
+
+        class_option :old_style_hash,     :type => :boolean, :default => false,
+                                          :desc => "Force using old style hash (:foo => 'bar') on Ruby >= 1.9"
       end
 
       def initialize(*args)
@@ -177,7 +180,7 @@ module Rails
       # Returns Ruby 1.9 style key-value pair if current code is running on
       # Ruby 1.9.x. Returns the old-style (with hash rocket) otherwise.
       def key_value(key, value)
-        if RUBY_VERSION < '1.9'
+        if options[:old_style_hash] || RUBY_VERSION < '1.9'
           ":#{key} => #{value}"
         else
           "#{key}: #{value}"

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -174,6 +174,15 @@ module Rails
         create_file("#{destination}/.gitkeep") unless options[:skip_git]
       end
 
+      # Returns Ruby 1.9 style key-value pair if current code is running on
+      # Ruby 1.9.x. Returns the old-style (with hash rocket) otherwise.
+      def key_value(key, value)
+        if RUBY_VERSION < '1.9'
+          ":#{key} => #{value}"
+        else
+          "#{key}: #{value}"
+        end
+      end
     end
   end
 end

--- a/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb
@@ -17,7 +17,7 @@
 <% end -%>
     <td><%%= link_to 'Show', <%= singular_table_name %> %></td>
     <td><%%= link_to 'Edit', edit_<%= singular_table_name %>_path(<%= singular_table_name %>) %></td>
-    <td><%%= link_to 'Destroy', <%= singular_table_name %>, :confirm => 'Are you sure?', :method => :delete %></td>
+    <td><%%= link_to 'Destroy', <%= singular_table_name %>, <%= key_value :confirm, "'Are you sure?'" %>, <%= key_value :method, ":delete" %> %></td>
   </tr>
 <%% end %>
 </table>

--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -181,6 +181,16 @@ module Rails
             class_collisions "#{options[:prefix]}#{name}#{options[:suffix]}"
           end
         end
+
+        # Returns Ruby 1.9 style key-value pair if current code is running on
+        # Ruby 1.9.x. Returns the old-style (with hash rocket) otherwise.
+        def key_value(key, value)
+          if RUBY_VERSION < '1.9'
+            ":#{key} => #{value}"
+          else
+            "#{key}: #{value}"
+          end
+        end
     end
   end
 end

--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -8,6 +8,9 @@ module Rails
       class_option :skip_namespace, :type => :boolean, :default => false,
                                     :desc => "Skip namespace (affects only isolated applications)"
 
+      class_option :old_style_hash, :type => :boolean, :default => false,
+                                    :desc => "Force using old style hash (:foo => 'bar') on Ruby >= 1.9"
+
       def initialize(args, *options) #:nodoc:
         # Unfreeze name in case it's given as a frozen string
         args[0] = args[0].dup if args[0].is_a?(String) && args[0].frozen?
@@ -185,7 +188,7 @@ module Rails
         # Returns Ruby 1.9 style key-value pair if current code is running on
         # Ruby 1.9.x. Returns the old-style (with hash rocket) otherwise.
         def key_value(key, value)
-          if RUBY_VERSION < '1.9'
+          if options[:old_style_hash] || RUBY_VERSION < '1.9'
             ":#{key} => #{value}"
           else
             "#{key}: #{value}"

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/session_store.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/session_store.rb.tt
@@ -1,6 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-<%= app_const %>.config.session_store :cookie_store, :key => '_<%= app_name %>_session'
+<%= app_const %>.config.session_store :cookie_store, <%= key_value :key, "'_#{app_name}_session'" %>
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information

--- a/railties/lib/rails/generators/rails/app/templates/db/seeds.rb
+++ b/railties/lib/rails/generators/rails/app/templates/db/seeds.rb
@@ -3,5 +3,5 @@
 #
 # Examples:
 #
-#   cities = City.create([{ :name => 'Chicago' }, { :name => 'Copenhagen' }])
-#   Mayor.create(:name => 'Daley', :city => cities.first)
+#   cities = City.create([{ <%= key_value :name, "'Chicago'" %> }, { <%= key_value :name, "'Copenhagen'" %> }])
+#   Mayor.create(<%= key_value :name, "'Daley'" %>, <%= key_value :city, "cities.first" %>)

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
@@ -7,7 +7,7 @@ class <%= controller_class_name %>Controller < ApplicationController
 
     respond_to do |format|
       format.html # index.html.erb
-      format.json { render :json => @<%= plural_table_name %> }
+      format.json { render <%= key_value :json, "@#{plural_table_name}" %> }
     end
   end
 
@@ -18,7 +18,7 @@ class <%= controller_class_name %>Controller < ApplicationController
 
     respond_to do |format|
       format.html # show.html.erb
-      format.json { render :json => @<%= singular_table_name %> }
+      format.json { render <%= key_value :json, "@#{singular_table_name}" %> }
     end
   end
 
@@ -29,7 +29,7 @@ class <%= controller_class_name %>Controller < ApplicationController
 
     respond_to do |format|
       format.html # new.html.erb
-      format.json { render :json => @<%= singular_table_name %> }
+      format.json { render <%= key_value :json, "@#{singular_table_name}" %> }
     end
   end
 
@@ -45,11 +45,11 @@ class <%= controller_class_name %>Controller < ApplicationController
 
     respond_to do |format|
       if @<%= orm_instance.save %>
-        format.html { redirect_to(@<%= singular_table_name %>, :notice => '<%= human_name %> was successfully created.') }
-        format.json { render :json => @<%= singular_table_name %>, :status => :created, :location => @<%= singular_table_name %> }
+        format.html { redirect_to @<%= singular_table_name %>, <%= key_value :notice, "'#{human_name} was successfully created.'" %> }
+        format.json { render <%= key_value :json, "@#{singular_table_name}" %>, <%= key_value :status, ':created' %>, <%= key_value :location, "@#{singular_table_name}" %> }
       else
-        format.html { render :action => "new" }
-        format.json { render :json => @<%= orm_instance.errors %>, :status => :unprocessable_entity }
+        format.html { render <%= key_value :action, '"new"' %> }
+        format.json { render <%= key_value :json, "@#{orm_instance.errors}" %>, <%= key_value :status, ':unprocessable_entity' %> }
       end
     end
   end
@@ -61,11 +61,11 @@ class <%= controller_class_name %>Controller < ApplicationController
 
     respond_to do |format|
       if @<%= orm_instance.update_attributes("params[:#{singular_table_name}]") %>
-        format.html { redirect_to(@<%= singular_table_name %>, :notice => '<%= human_name %> was successfully updated.') }
-        format.json { render :json => {}, :status => :ok }
+        format.html { redirect_to @<%= singular_table_name %>, <%= key_value :notice, "'#{human_name} was successfully updated.'" %> }
+        format.json { render <%= key_value :json, '{}' %>, <%= key_value :status, ':ok' %> }
       else
-        format.html { render :action => "edit" }
-        format.json { render :json => @<%= orm_instance.errors %>, :status => :unprocessable_entity }
+        format.html { render <%= key_value :action, '"edit"' %> }
+        format.json { render <%= key_value :json, "@#{orm_instance.errors}" %>, <%= key_value :status, ':unprocessable_entity' %> }
       end
     end
   end
@@ -77,8 +77,8 @@ class <%= controller_class_name %>Controller < ApplicationController
     @<%= orm_instance.destroy %>
 
     respond_to do |format|
-      format.html { redirect_to(<%= index_helper %>_url) }
-      format.json { render :json => {}, :status => :ok }
+      format.html { redirect_to <%= index_helper %>_url }
+      format.json { render <%= key_value :json, '{}' %>, <%= key_value :status, ':ok' %> }
     end
   end
 end

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
@@ -1,35 +1,35 @@
 <% module_namespacing do -%>
 class <%= controller_class_name %>Controller < ApplicationController
   # GET <%= route_url %>
-  # GET <%= route_url %>.xml
+  # GET <%= route_url %>.json
   def index
     @<%= plural_table_name %> = <%= orm_class.all(class_name) %>
 
     respond_to do |format|
       format.html # index.html.erb
-      format.xml  { render :xml => @<%= plural_table_name %> }
+      format.json { render :json => @<%= plural_table_name %> }
     end
   end
 
   # GET <%= route_url %>/1
-  # GET <%= route_url %>/1.xml
+  # GET <%= route_url %>/1.json
   def show
     @<%= singular_table_name %> = <%= orm_class.find(class_name, "params[:id]") %>
 
     respond_to do |format|
       format.html # show.html.erb
-      format.xml  { render :xml => @<%= singular_table_name %> }
+      format.json { render :json => @<%= singular_table_name %> }
     end
   end
 
   # GET <%= route_url %>/new
-  # GET <%= route_url %>/new.xml
+  # GET <%= route_url %>/new.json
   def new
     @<%= singular_table_name %> = <%= orm_class.build(class_name) %>
 
     respond_to do |format|
       format.html # new.html.erb
-      format.xml  { render :xml => @<%= singular_table_name %> }
+      format.json { render :json => @<%= singular_table_name %> }
     end
   end
 
@@ -39,46 +39,46 @@ class <%= controller_class_name %>Controller < ApplicationController
   end
 
   # POST <%= route_url %>
-  # POST <%= route_url %>.xml
+  # POST <%= route_url %>.json
   def create
     @<%= singular_table_name %> = <%= orm_class.build(class_name, "params[:#{singular_table_name}]") %>
 
     respond_to do |format|
       if @<%= orm_instance.save %>
         format.html { redirect_to(@<%= singular_table_name %>, :notice => '<%= human_name %> was successfully created.') }
-        format.xml  { render :xml => @<%= singular_table_name %>, :status => :created, :location => @<%= singular_table_name %> }
+        format.json { render :json => @<%= singular_table_name %>, :status => :created, :location => @<%= singular_table_name %> }
       else
         format.html { render :action => "new" }
-        format.xml  { render :xml => @<%= orm_instance.errors %>, :status => :unprocessable_entity }
+        format.json { render :json => @<%= orm_instance.errors %>, :status => :unprocessable_entity }
       end
     end
   end
 
   # PUT <%= route_url %>/1
-  # PUT <%= route_url %>/1.xml
+  # PUT <%= route_url %>/1.json
   def update
     @<%= singular_table_name %> = <%= orm_class.find(class_name, "params[:id]") %>
 
     respond_to do |format|
       if @<%= orm_instance.update_attributes("params[:#{singular_table_name}]") %>
         format.html { redirect_to(@<%= singular_table_name %>, :notice => '<%= human_name %> was successfully updated.') }
-        format.xml  { head :ok }
+        format.json { render :json => {}, :status => :ok }
       else
         format.html { render :action => "edit" }
-        format.xml  { render :xml => @<%= orm_instance.errors %>, :status => :unprocessable_entity }
+        format.json { render :json => @<%= orm_instance.errors %>, :status => :unprocessable_entity }
       end
     end
   end
 
   # DELETE <%= route_url %>/1
-  # DELETE <%= route_url %>/1.xml
+  # DELETE <%= route_url %>/1.json
   def destroy
     @<%= singular_table_name %> = <%= orm_class.find(class_name, "params[:id]") %>
     @<%= orm_instance.destroy %>
 
     respond_to do |format|
       format.html { redirect_to(<%= index_helper %>_url) }
-      format.xml  { head :ok }
+      format.json { render :json => {}, :status => :ok }
     end
   end
 end

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
@@ -19,30 +19,30 @@ class <%= controller_class_name %>ControllerTest < ActionController::TestCase
 
   test "should create <%= singular_table_name %>" do
     assert_difference('<%= class_name %>.count') do
-      post :create, :<%= singular_table_name %> => @<%= singular_table_name %>.attributes
+      post :create, <%= key_value singular_table_name, "@#{singular_table_name}.attributes" %>
     end
 
     assert_redirected_to <%= singular_table_name %>_path(assigns(:<%= singular_table_name %>))
   end
 
   test "should show <%= singular_table_name %>" do
-    get :show, :id => @<%= singular_table_name %>.to_param
+    get :show, <%= key_value :id, "@#{singular_table_name}.to_param" %>
     assert_response :success
   end
 
   test "should get edit" do
-    get :edit, :id => @<%= singular_table_name %>.to_param
+    get :edit, <%= key_value :id, "@#{singular_table_name}.to_param" %>
     assert_response :success
   end
 
   test "should update <%= singular_table_name %>" do
-    put :update, :id => @<%= singular_table_name %>.to_param, :<%= singular_table_name %> => @<%= singular_table_name %>.attributes
+    put :update, <%= key_value :id, "@#{singular_table_name}.to_param" %>, <%= key_value singular_table_name, "@#{singular_table_name}.attributes" %>
     assert_redirected_to <%= singular_table_name %>_path(assigns(:<%= singular_table_name %>))
   end
 
   test "should destroy <%= singular_table_name %>" do
     assert_difference('<%= class_name %>.count', -1) do
-      delete :destroy, :id => @<%= singular_table_name %>.to_param
+      delete :destroy, <%= key_value :id, "@#{singular_table_name}.to_param" %>
     end
 
     assert_redirected_to <%= index_helper %>_path

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -216,6 +216,16 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_new_hash_style
+    run_generator [destination_root]
+    assert_file "config/initializers/session_store.rb" do |file|
+      if RUBY_VERSION < "1.9"
+        assert_match /config.session_store :cookie_store, :key => '_.+_session'/, file
+      else
+        assert_match /config.session_store :cookie_store, key: '_.+_session'/, file
+      end
+    end
+  end
 protected
 
   def action(*args, &block)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -226,6 +226,14 @@ class AppGeneratorTest < Rails::Generators::TestCase
       end
     end
   end
+
+  def test_force_old_style_hash
+    run_generator [destination_root, "--old-style-hash"]
+    assert_file "config/initializers/session_store.rb" do |file|
+      assert_match /config.session_store :cookie_store, :key => '_.+_session'/, file
+    end
+  end
+
 protected
 
   def action(*args, &block)

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -122,4 +122,15 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
   ensure
     Unknown::Generators.send :remove_const, :ActiveModel
   end
+
+  def test_new_hash_style
+    run_generator
+    assert_file "app/controllers/users_controller.rb" do |content|
+      if RUBY_VERSION < "1.9"
+        assert_match /\{ render :action => "new" \}/, content
+      else
+        assert_match /\{ render action: "new" \}/, content
+      end
+    end
+  end
 end

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -133,4 +133,11 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       end
     end
   end
+
+  def test_force_old_style_hash
+    run_generator ["User", "--old-style-hash"]
+    assert_file "app/controllers/users_controller.rb" do |content|
+      assert_match /\{ render :action => "new" \}/, content
+    end
+  end
 end


### PR DESCRIPTION
Hi guys,

As per @dhh's request, I've finished the following patches:
## Switch from XML to JSON in scaffold generator

This is really straightforward. Note that in `update` and `destroy` we have to return empty hash so that jQuery will understand that the response is correct. That has been patched in https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/metal/responder.rb#L262-278 as well.
## Use Ruby 1.9 hash style

I've updated scaffold generator and app generator to use Ruby 1.9 hash. I've accomplished it by adding `key_value` method which will detect Ruby version and returns the right key-value hash according to the version.

I also take it further by adding `--old-style-hash` in case someone might want to make their code compatible with 1.8.x, or just sanely hate 1.9 style hash.

Please review the patch and see if they're appropriate. Thank you.
