### PR TITLE
Add support for proc or lambda as an option for InclusionValidator, ExclusionValidator, and FormatValidator

### DIFF
--- a/activemodel/CHANGELOG
+++ b/activemodel/CHANGELOG
@@ -1,5 +1,14 @@
 *Rails 3.1.0 (unreleased)*
 
+* Add support for proc or lambda as an option for InclusionValidator,
+  ExclusionValidator, and FormatValidator [Prem Sichanugrist]
+
+  You can now supply Proc, lambda, or anything that respond to #call in those
+  validations, and it will be called with current record as an argument.
+  That given proc or lambda must returns an object which respond to #include? for
+  InclusionValidator and ExclusionValidator, and returns a regular expression
+  object for FormatValidator.
+
 * Added ActiveModel::SecurePassword to encapsulate dead-simple password usage with BCrypt encryption and salting [DHH]
 
 * ActiveModel::AttributeMethods allows attributes to be defined on demand [Alexander Uvarov]

--- a/activemodel/lib/active_model/validations/format.rb
+++ b/activemodel/lib/active_model/validations/format.rb
@@ -4,11 +4,23 @@ module ActiveModel
   module Validations
     class FormatValidator < EachValidator
       def validate_each(record, attribute, value)
-        if options[:with] && value.to_s !~ options[:with]
-          record.errors.add(attribute, :invalid, options.except(:with).merge!(:value => value))
-        elsif options[:without] && value.to_s =~ options[:without]
-          record.errors.add(attribute, :invalid, options.except(:without).merge!(:value => value))
+        if options[:with]
+          regexp = options[:with].respond_to?(:call) ? options[:with].call(record) : options[:with]
+          if regexp.is_a?(Regexp)
+            record.errors.add(attribute, :invalid, options.except(:with).merge!(:value => value)) if value.to_s !~ regexp
+          else
+            raise ArgumentError, "A proc or lambda given to :with option must returns a regular expression"
+          end
+        elsif options[:without]
+          regexp = options[:without].respond_to?(:call) ? options[:without].call(record) : options[:without]
+          if regexp.is_a?(Regexp)
+            record.errors.add(attribute, :invalid, options.except(:without).merge!(:value => value)) if value.to_s =~ regexp
+          else
+            raise ArgumentError, "A proc or lambda given to :without option must returns a regular expression"
+          end
         end
+      rescue TypeError
+        raise ArgumentError, "A proc or lambda given to :with or :without option must returns a regular expression"
       end
 
       def check_validity!
@@ -16,12 +28,12 @@ module ActiveModel
           raise ArgumentError, "Either :with or :without must be supplied (but not both)"
         end
 
-        if options[:with] && !options[:with].is_a?(Regexp)
-          raise ArgumentError, "A regular expression must be supplied as the :with option of the configuration hash"
+        if options[:with] && !options[:with].is_a?(Regexp) && !options[:with].respond_to?(:call)
+          raise ArgumentError, "A regular expression or a proc or lambda must be supplied as the :with option of the configuration hash"
         end
 
-        if options[:without] && !options[:without].is_a?(Regexp)
-          raise ArgumentError, "A regular expression must be supplied as the :without option of the configuration hash"
+        if options[:without] && !options[:without].is_a?(Regexp) && !options[:without].respond_to?(:call)
+          raise ArgumentError, "A regular expression or a proc or lambda must be supplied as the :without option of the configuration hash"
         end
       end
     end
@@ -40,17 +52,26 @@ module ActiveModel
       #     validates_format_of :email, :without => /NOSPAM/
       #   end
       #
+      # You can also provide a proc or lambda which will determine the regular expression that will be used to validate the attribute
+      #
+      #   class Person < ActiveRecord::Base
+      #     # Admin can have number as a first letter in their screen name
+      #     validates_format_of :screen_name, :with => lambda{ |person| person.admin? ? /\A[a-z0-9][a-z0-9_\-]*\Z/i : /\A[a-z][a-z0-9_\-]*\Z/i }
+      #   end
+      #
       # Note: use <tt>\A</tt> and <tt>\Z</tt> to match the start and end of the string, <tt>^</tt> and <tt>$</tt> match the start/end of a line.
       #
-      # You must pass either <tt>:with</tt> or <tt>:without</tt> as an option. In addition, both must be a regular expression,
-      # or else an exception will be raised.
+      # You must pass either <tt>:with</tt> or <tt>:without</tt> as an option. In addition, both must be a regular expression
+      # or a proc or lambda, or else an exception will be raised.
       #
       # Configuration options:
       # * <tt>:message</tt> - A custom error message (default is: "is invalid").
       # * <tt>:allow_nil</tt> - If set to true, skips this validation if the attribute is +nil+ (default is +false+).
       # * <tt>:allow_blank</tt> - If set to true, skips this validation if the attribute is blank (default is +false+).
       # * <tt>:with</tt> - Regular expression that if the attribute matches will result in a successful validation.
+      #   This can be provided as a proc or lambda returning regular expression which will be called at runtime.
       # * <tt>:without</tt> - Regular expression that if the attribute does not match will result in a successful validation.
+      #   This can be provided as a proc or lambda returning regular expression which will be called at runtime.
       # * <tt>:on</tt> - Specifies when this validation is active. Runs in all
       #   validation contexts by default (+nil+), other options are <tt>:create</tt>
       #   and <tt>:update</tt>.

--- a/activemodel/lib/active_model/validations/inclusion.rb
+++ b/activemodel/lib/active_model/validations/inclusion.rb
@@ -16,8 +16,8 @@ module ActiveModel
 
       def validate_each(record, attribute, value)
         exclusions = options[:in].respond_to?(:call) ? options[:in].call(record) : options[:in]
-        unless exclusions.send(inclusion_method(exclusions), value)
-          record.errors.add(attribute, :inclusion, options.except(:in).merge!(:value => value))
+        unless exclusions.send(inclusion_method(exclusions, options[:use_include]), value)
+          record.errors.add(attribute, :inclusion, options.except(:in, :use_include).merge!(:value => value))
         end
       rescue NoMethodError
         raise ArgumentError, "Exclusion validation for :#{attribute} in #{record.class.name}: #{ERROR_MESSAGE}"
@@ -28,8 +28,8 @@ module ActiveModel
       # In Ruby 1.9 <tt>Range#include?</tt> on non-numeric ranges checks all possible values in the
       # range for equality, so it may be slow for large ranges. The new <tt>Range#cover?</tt>
       # uses the previous logic of comparing a value with the range endpoints.
-      def inclusion_method(enumerable)
-        enumerable.is_a?(Range) ? :cover? : :include?
+      def inclusion_method(enumerable, use_include = nil)
+        !use_include && enumerable.is_a?(Range) ? :cover? : :include?
       end
     end
 
@@ -45,9 +45,11 @@ module ActiveModel
       #
       # Configuration options:
       # * <tt>:in</tt> - An enumerable object of available items. This can be
-      #   supplied as a proc or lambda which returns an enumerable. If the enumerable
-      #   is a range the test is performed with <tt>Range#cover?</tt>
-      #   (backported in Active Support for 1.8), otherwise with <tt>include?</tt>.
+      #   supplied as a proc or lambda which returns an enumerable.
+      # * <tt>:use_include</tt> - If set to true and the enumerable in <tt>:in</tt> option is a range,
+      #   it will explicitly use <tt>Range#include?</tt> to perform the test. Otherwise <tt>Range#cover?</tt>
+      #   will be used to perform the test for performance reason.
+      #   (Range#cover? was backported in Active Support for 1.8.x)
       # * <tt>:message</tt> - Specifies a custom error message (default is: "is not included in the list").
       # * <tt>:allow_nil</tt> - If set to true, skips this validation if the attribute is +nil+ (default is +false+).
       # * <tt>:allow_blank</tt> - If set to true, skips this validation if the attribute is blank (default is +false+).

--- a/activemodel/lib/active_model/validations/inclusion.rb
+++ b/activemodel/lib/active_model/validations/inclusion.rb
@@ -5,20 +5,31 @@ module ActiveModel
   # == Active Model Inclusion Validator
   module Validations
     class InclusionValidator < EachValidator
+      ERROR_MESSAGE = "An object with the method #include? or a proc or lambda is required, " <<
+                      "and must be supplied as the :in option of the configuration hash"
+
       def check_validity!
-         raise ArgumentError, "An object with the method include? is required must be supplied as the " <<
-                              ":in option of the configuration hash" unless options[:in].respond_to?(:include?)
+        unless [:include?, :call].any?{ |method| options[:in].respond_to?(method) }
+          raise ArgumentError, ERROR_MESSAGE
+        end
       end
 
       def validate_each(record, attribute, value)
-        record.errors.add(attribute, :inclusion, options.except(:in).merge!(:value => value)) unless options[:in].send(include?, value)
+        exclusions = options[:in].respond_to?(:call) ? options[:in].call(record) : options[:in]
+        unless exclusions.send(inclusion_method(exclusions), value)
+          record.errors.add(attribute, :inclusion, options.except(:in).merge!(:value => value))
+        end
+      rescue NoMethodError
+        raise ArgumentError, "Exclusion validation for :#{attribute} in #{record.class.name}: #{ERROR_MESSAGE}"
       end
+
+    private
 
       # In Ruby 1.9 <tt>Range#include?</tt> on non-numeric ranges checks all possible values in the
       # range for equality, so it may be slow for large ranges. The new <tt>Range#cover?</tt>
       # uses the previous logic of comparing a value with the range endpoints.
-      def include?
-        options[:in].is_a?(Range) ? :cover? : :include?
+      def inclusion_method(enumerable)
+        enumerable.is_a?(Range) ? :cover? : :include?
       end
     end
 
@@ -29,11 +40,13 @@ module ActiveModel
       #     validates_inclusion_of :gender, :in => %w( m f )
       #     validates_inclusion_of :age, :in => 0..99
       #     validates_inclusion_of :format, :in => %w( jpg gif png ), :message => "extension %{value} is not included in the list"
+      #     validates_inclusion_of :states, :in => lambda{ |person| STATES[person.country] }
       #   end
       #
       # Configuration options:
-      # * <tt>:in</tt> - An enumerable object of available items.
-      #   If the enumerable is a range the test is performed with <tt>Range#cover?</tt>
+      # * <tt>:in</tt> - An enumerable object of available items. This can be
+      #   supplied as a proc or lambda which returns an enumerable. If the enumerable
+      #   is a range the test is performed with <tt>Range#cover?</tt>
       #   (backported in Active Support for 1.8), otherwise with <tt>include?</tt>.
       # * <tt>:message</tt> - Specifies a custom error message (default is: "is not included in the list").
       # * <tt>:allow_nil</tt> - If set to true, skips this validation if the attribute is +nil+ (default is +false+).

--- a/activemodel/test/cases/validations/exclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/exclusion_validation_test.rb
@@ -42,4 +42,25 @@ class ExclusionValidationTest < ActiveModel::TestCase
   ensure
     Person.reset_callbacks(:validate)
   end
+
+  def test_validates_exclusion_of_with_lambda
+    Topic.validates_exclusion_of :title, :in => lambda{ |topic| topic.author_name == "sikachu" ? %w( monkey elephant ) : %w( abe wasabi ) }
+
+    p = Topic.new
+    p.title = "elephant"
+    p.author_name = "sikachu"
+    assert p.invalid?
+
+    p.title = "wasabi"
+    assert p.valid?
+  end
+
+  def test_validates_exclustion_with_invalid_lambda_return
+    Topic.validates_exclusion_of :title, :in => lambda{ |topic| false }
+
+    p = Topic.new
+    p.title = "wasabi"
+    p.author_name = "sikachu"
+    assert_raise(ArgumentError){ p.valid? }
+  end
 end

--- a/activemodel/test/cases/validations/exclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/exclusion_validation_test.rb
@@ -63,4 +63,14 @@ class ExclusionValidationTest < ActiveModel::TestCase
     p.author_name = "sikachu"
     assert_raise(ArgumentError){ p.valid? }
   end
+
+  def test_validates_inclusion_with_explicit_include
+    range = (1..100)
+    Topic.validates_exclusion_of :title, :in => range, :use_include => true
+    range.expects(:include?).returns(false)
+
+    t = Topic.new
+    t.title = 102
+    assert t.valid?
+  end
 end

--- a/activemodel/test/cases/validations/format_validation_test.rb
+++ b/activemodel/test/cases/validations/format_validation_test.rb
@@ -98,6 +98,46 @@ class PresenceValidationTest < ActiveModel::TestCase
     assert_raise(ArgumentError) { Topic.validates_format_of(:title, :without => "clearly not a regexp") }
   end
 
+  def test_validates_format_of_with_lambda
+    Topic.validates_format_of :content, :with => lambda{ |topic| topic.title == "digit" ? /\A\d+\Z/ : /\A\S+\Z/ }
+
+    p = Topic.new
+    p.title = "digit"
+    p.content = "Pixies"
+    assert p.invalid?
+
+    p.content = "1234"
+    assert p.valid?
+  end
+
+  def test_validates_format_of_without_lambda
+    Topic.validates_format_of :content, :without => lambda{ |topic| topic.title == "characters" ? /\A\d+\Z/ : /\A\S+\Z/ }
+
+    p = Topic.new
+    p.title = "characters"
+    p.content = "1234"
+    assert p.invalid?
+
+    p.content = "Pixies"
+    assert p.valid?
+  end
+
+  def test_validates_format_of_with_lambda_not_returns_regexp
+    Topic.validates_format_of :content, :with => lambda{ |topic| false }
+
+    p = Topic.new
+    p.content = "Pixies"
+    assert_raise(ArgumentError){ p.valid? }
+  end
+
+  def test_validates_format_of_without_lambda_not_returns_regexp
+    Topic.validates_format_of :content, :without => lambda{ |topic| false }
+
+    p = Topic.new
+    p.content = "Pixies"
+    assert_raise(ArgumentError){ p.valid? }
+  end
+
   def test_validates_format_of_for_ruby_class
     Person.validates_format_of :karma, :with => /\A\d+\Z/
 

--- a/activemodel/test/cases/validations/inclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/inclusion_validation_test.rb
@@ -95,4 +95,13 @@ class InclusionValidationTest < ActiveModel::TestCase
     p.author_name = "sikachu"
     assert_raise(ArgumentError){ p.valid? }
   end
+
+  def test_validates_inclusion_with_explicit_include
+    range = (1..100)
+    Topic.validates_inclusion_of :title, :in => range, :use_include => true
+
+    t = Topic.new
+    t.title = 42
+    assert t.valid?
+  end
 end

--- a/activemodel/test/cases/validations/inclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/inclusion_validation_test.rb
@@ -74,4 +74,25 @@ class InclusionValidationTest < ActiveModel::TestCase
   ensure
     Person.reset_callbacks(:validate)
   end
+
+  def test_validates_inclusion_of_with_lambda
+    Topic.validates_inclusion_of :title, :in => lambda{ |topic| topic.author_name == "sikachu" ? %w( monkey elephant ) : %w( abe wasabi ) }
+
+    p = Topic.new
+    p.title = "wasabi"
+    p.author_name = "sikachu"
+    assert p.invalid?
+
+    p.title = "elephant"
+    assert p.valid?
+  end
+
+  def test_validates_inclustion_with_invalid_lambda_return
+    Topic.validates_inclusion_of :title, :in => lambda{ |topic| false }
+
+    p = Topic.new
+    p.title = "monkey"
+    p.author_name = "sikachu"
+    assert_raise(ArgumentError){ p.valid? }
+  end
 end


### PR DESCRIPTION
I found that in some case there's a need for you to change the validator's rule by record's condition. This patch will provide you the option to add proc or lambda as the :in option for InclusionValidator and ExclusionValidator, and :with, :without option for FormatValidator

Please review my patch and see if it's any good. Thank you.
