### PR TITLE
Add support for Object#in? in Active Support

### DIFF
--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -1,5 +1,6 @@
 require 'abstract_controller/collector'
 require 'active_support/core_ext/class/attribute'
+require 'active_support/core_ext/object/inclusion'
 
 module ActionController #:nodoc:
   module MimeResponds #:nodoc:
@@ -248,9 +249,9 @@ module ActionController #:nodoc:
         config = self.class.mimes_for_respond_to[mime]
 
         if config[:except]
-          !config[:except].include?(action)
+          !action.in?(config[:except])
         elsif config[:only]
-          config[:only].include?(action)
+          action.in?(config[:only])
         else
           true
         end

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1,6 +1,7 @@
 require 'erb'
 require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/object/blank'
+require 'active_support/core_ext/object/inclusion'
 require 'active_support/inflector'
 require 'action_dispatch/routing/redirection'
 
@@ -1345,11 +1346,11 @@ module ActionDispatch
           end
 
           def resource_scope? #:nodoc:
-            [:resource, :resources].include?(@scope[:scope_level])
+            @scope[:scope_level].either?(:resource, :resources)
           end
 
           def resource_method_scope? #:nodoc:
-            [:collection, :member, :new].include?(@scope[:scope_level])
+            @scope[:scope_level].either?(:collection, :member, :new)
           end
 
           def with_exclusive_scope

--- a/actionpack/lib/action_dispatch/testing/assertions/response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/response.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/object/inclusion'
+
 module ActionDispatch
   module Assertions
     # A small suite of assertions that test responses from \Rails applications.
@@ -33,7 +35,7 @@ module ActionDispatch
       def assert_response(type, message = nil)
         validate_request!
 
-        if [ :success, :missing, :redirect, :error ].include?(type) && @response.send("#{type}?")
+        if type.either?(:success, :missing, :redirect, :error) && @response.send("#{type}?")
           assert_block("") { true } # to count the assertion
         elsif type.is_a?(Fixnum) && @response.response_code == type
           assert_block("") { true } # to count the assertion

--- a/actionpack/lib/action_dispatch/testing/assertions/selector.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/selector.rb
@@ -1,4 +1,5 @@
 require 'action_controller/vendor/html-scanner'
+require 'active_support/core_ext/object/inclusion'
 
 #--
 # Copyright (c) 2006 Assaf Arkin (http://labnotes.org)
@@ -441,7 +442,7 @@ module ActionDispatch
 
         if matches
           assert_block("") { true } # to count the assertion
-          if block_given? && !([:remove, :show, :hide, :toggle].include? rjs_type)
+          if block_given? && !rjs_type.either?(:remove, :show, :hide, :toggle)
             begin
               @selected ||= nil
               in_scope, @selected = @selected, matches

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -1,6 +1,7 @@
 require 'stringio'
 require 'uri'
 require 'active_support/core_ext/kernel/singleton_class'
+require 'active_support/core_ext/object/inclusion'
 require 'active_support/core_ext/object/try'
 require 'rack/test'
 require 'test/unit/assertions'
@@ -320,7 +321,7 @@ module ActionDispatch
         define_method(method) do |*args|
           reset! unless integration_session
           # reset the html_document variable, but only for new get/post calls
-          @html_document = nil unless %w(cookies assigns).include?(method)
+          @html_document = nil unless method.either?("cookies", "assigns")
           integration_session.__send__(method, *args).tap do
             copy_session_variables!
           end

--- a/actionpack/test/controller/mime_responds_test.rb
+++ b/actionpack/test/controller/mime_responds_test.rb
@@ -1,6 +1,7 @@
 require 'abstract_unit'
 require 'controller/fake_models'
 require 'active_support/core_ext/hash/conversions'
+require 'active_support/core_ext/object/inclusion'
 
 class StarStarMimeController < ActionController::Base
   layout nil
@@ -158,7 +159,7 @@ class RespondToController < ActionController::Base
 
   protected
     def set_layout
-      if ["all_types_with_layout", "iphone_with_html_response_type"].include?(action_name)
+      if action_name.either?("all_types_with_layout", "iphone_with_html_response_type")
         "respond_to/layouts/standard"
       elsif action_name == "iphone_with_html_response_type_without_layout"
         "respond_to/layouts/missing"

--- a/actionpack/test/controller/resources_test.rb
+++ b/actionpack/test/controller/resources_test.rb
@@ -1,6 +1,7 @@
 require 'abstract_unit'
 require 'active_support/core_ext/object/try'
 require 'active_support/core_ext/object/with_options'
+require 'active_support/core_ext/object/inclusion'
 
 class ResourcesController < ActionController::Base
   def index() render :nothing => true end
@@ -1292,7 +1293,7 @@ class ResourcesTest < ActionController::TestCase
     def assert_resource_methods(expected, resource, action_method, method)
       assert_equal expected.length, resource.send("#{action_method}_methods")[method].size, "#{resource.send("#{action_method}_methods")[method].inspect}"
       expected.each do |action|
-        assert resource.send("#{action_method}_methods")[method].include?(action),
+        assert action.in?(resource.send("#{action_method}_methods")[method])
           "#{method} not in #{action_method} methods: #{resource.send("#{action_method}_methods")[method].inspect}"
       end
     end
@@ -1329,9 +1330,9 @@ class ResourcesTest < ActionController::TestCase
       options = options.merge(:action => action.to_s)
       path_options = { :path => path, :method => method }
 
-      if Array(allowed).include?(action)
+      if action.in?(Array(allowed))
         assert_recognizes options, path_options
-      elsif Array(not_allowed).include?(action)
+      elsif action.in?(Array(not_allowed))
         assert_not_recognizes options, path_options
       end
     end

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1,6 +1,7 @@
 require 'erb'
 require 'abstract_unit'
 require 'controller/fake_controllers'
+require 'active_support/core_ext/object/inclusion'
 
 class TestRoutingMapper < ActionDispatch::IntegrationTest
   SprocketsApp = lambda { |env|
@@ -495,7 +496,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
         resources :todos, :id => /\d+/
       end
 
-      scope '/countries/:country', :constraints => lambda { |params, req| %[all France].include?(params[:country]) } do
+      scope '/countries/:country', :constraints => lambda { |params, req| params[:country].either?("all", "france") } do
         match '/',       :to => 'countries#index'
         match '/cities', :to => 'countries#cities'
       end

--- a/actionpack/test/template/erb_util_test.rb
+++ b/actionpack/test/template/erb_util_test.rb
@@ -1,4 +1,5 @@
 require 'abstract_unit'
+require 'active_support/core_ext/object/inclusion'
 
 class ErbUtilTest < Test::Unit::TestCase
   include ERB::Util
@@ -29,7 +30,7 @@ class ErbUtilTest < Test::Unit::TestCase
 
   def test_rest_in_ascii
     (0..127).to_a.map {|int| int.chr }.each do |chr|
-      next if %w(& " < >).include?(chr)
+      next if chr.in?('&"<>')
       assert_equal chr, html_escape(chr)
     end
   end

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -1,5 +1,6 @@
 require 'abstract_unit'
 require 'controller/fake_models'
+require 'active_support/core_ext/object/inclusion'
 
 class FormHelperTest < ActionView::TestCase
   tests ActionView::Helpers::FormHelper
@@ -1743,7 +1744,7 @@ class FormHelperTest < ActionView::TestCase
   def snowman(method = nil)
     txt =  %{<div style="margin:0;padding:0;display:inline">}
     txt << %{<input name="utf8" type="hidden" value="&#x2713;" />}
-    if (method && !['get','post'].include?(method.to_s))
+    if method && !method.to_s.either?('get', 'post')
       txt << %{<input name="_method" type="hidden" value="#{method}" />}
     end
     txt << %{</div>}

--- a/actionpack/test/template/form_options_helper_test.rb
+++ b/actionpack/test/template/form_options_helper_test.rb
@@ -1,5 +1,6 @@
 require 'abstract_unit'
 require 'tzinfo'
+require 'active_support/core_ext/object/inclusion'
 
 class Map < Hash
   def category
@@ -82,7 +83,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   def test_collection_options_with_proc_for_disabled
     assert_dom_equal(
       "<option value=\"&lt;Abe&gt;\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\" disabled=\"disabled\">Babe went home</option>\n<option value=\"Cabe\" disabled=\"disabled\">Cabe went home</option>",
-      options_from_collection_for_select(dummy_posts, "author_name", "title", :disabled => lambda{|p| %w(Babe Cabe).include? p.author_name })
+      options_from_collection_for_select(dummy_posts, "author_name", "title", :disabled => lambda{|p| p.author_name.either?("Babe", "Cabe") })
     )
   end
 

--- a/actionpack/test/template/form_tag_helper_test.rb
+++ b/actionpack/test/template/form_tag_helper_test.rb
@@ -1,4 +1,5 @@
 require 'abstract_unit'
+require 'active_support/core_ext/object/inclusion'
 
 class FormTagHelperTest < ActionView::TestCase
   tests ActionView::Helpers::FormTagHelper
@@ -13,7 +14,7 @@ class FormTagHelperTest < ActionView::TestCase
 
     txt =  %{<div style="margin:0;padding:0;display:inline">}
     txt << %{<input name="utf8" type="hidden" value="&#x2713;" />}
-    if (method && !['get','post'].include?(method.to_s))
+    if method && !method.to_s.either?('get','post')
       txt << %{<input name="_method" type="hidden" value="#{method}" />}
     end
     txt << %{</div>}

--- a/activemodel/lib/active_model/validator.rb
+++ b/activemodel/lib/active_model/validator.rb
@@ -1,6 +1,7 @@
 require 'active_support/core_ext/array/wrap'
 require "active_support/core_ext/module/anonymous"
 require 'active_support/core_ext/object/blank'
+require 'active_support/core_ext/object/inclusion'
 
 module ActiveModel #:nodoc:
 
@@ -67,7 +68,7 @@ module ActiveModel #:nodoc:
   #
   #   class TitleValidator < ActiveModel::EachValidator
   #     def validate_each(record, attribute, value)
-  #       record.errors[attribute] << 'must be Mr. Mrs. or Dr.' unless ['Mr.', 'Mrs.', 'Dr.'].include?(value)
+  #       record.errors[attribute] << 'must be Mr. Mrs. or Dr.' unless value.either?('Mr.', 'Mrs.', 'Dr.')
   #     end
   #   end
   #

--- a/activemodel/test/cases/mass_assignment_security/sanitizer_test.rb
+++ b/activemodel/test/cases/mass_assignment_security/sanitizer_test.rb
@@ -1,5 +1,6 @@
 require "cases/helper"
 require 'logger'
+require 'active_support/core_ext/object/inclusion'
 
 class SanitizerTest < ActiveModel::TestCase
 
@@ -9,7 +10,7 @@ class SanitizerTest < ActiveModel::TestCase
     attr_accessor :logger
 
     def deny?(key)
-       [ 'admin' ].include?(key)
+      key.in?(['admin'])
     end
 
   end

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/array/wrap'
+require 'active_support/core_ext/object/inclusion'
 
 module ActiveRecord
   module Associations
@@ -163,7 +164,7 @@ module ActiveRecord
         def creation_attributes
           attributes = {}
 
-          if [:has_one, :has_many].include?(reflection.macro) && !options[:through]
+          if reflection.macro.either?(:has_one, :has_many) && !options[:through]
             attributes[reflection.foreign_key] = owner[reflection.active_record_primary_key]
 
             if reflection.options[:as]

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/object/inclusion'
+
 module ActiveRecord::Associations::Builder
   class BelongsTo < SingularAssociation #:nodoc:
     self.macro = :belongs_to
@@ -65,7 +67,7 @@ module ActiveRecord::Associations::Builder
 
       def configure_dependency
         if options[:dependent]
-          unless [:destroy, :delete].include?(options[:dependent])
+          unless options[:dependent].either?(:destroy, :delete)
             raise ArgumentError, "The :dependent option expects either :destroy or :delete (#{options[:dependent].inspect})"
           end
 

--- a/activerecord/lib/active_record/associations/builder/has_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_many.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/object/inclusion'
+
 module ActiveRecord::Associations::Builder
   class HasMany < CollectionAssociation #:nodoc:
     self.macro = :has_many
@@ -14,7 +16,7 @@ module ActiveRecord::Associations::Builder
 
       def configure_dependency
         if options[:dependent]
-          unless [:destroy, :delete_all, :nullify, :restrict].include?(options[:dependent])
+          unless options[:dependent].either?(:destroy, :delete_all, :nullify, :restrict)
             raise ArgumentError, "The :dependent option expects either :destroy, :delete_all, " \
                                  ":nullify or :restrict (#{options[:dependent].inspect})"
           end

--- a/activerecord/lib/active_record/associations/builder/has_one.rb
+++ b/activerecord/lib/active_record/associations/builder/has_one.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/object/inclusion'
+
 module ActiveRecord::Associations::Builder
   class HasOne < SingularAssociation #:nodoc:
     self.macro = :has_one
@@ -27,7 +29,7 @@ module ActiveRecord::Associations::Builder
 
       def configure_dependency
         if options[:dependent]
-          unless [:destroy, :delete, :nullify, :restrict].include?(options[:dependent])
+          unless options[:dependent].either?(:destroy, :delete, :nullify, :restrict)
             raise ArgumentError, "The :dependent option expects either :destroy, :delete, " \
                                  ":nullify or :restrict (#{options[:dependent].inspect})"
           end

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/object/inclusion'
+
 module ActiveRecord
   # = Active Record Belongs To Has One Association
   module Associations
@@ -50,7 +52,7 @@ module ActiveRecord
         end
 
         def remove_target!(method)
-          if [:delete, :destroy].include?(method)
+          if method.either?(:delete, :destroy)
             target.send(method)
           else
             nullify_owner_attributes(target)

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/class/attribute'
+require 'active_support/core_ext/object/inclusion'
 
 module ActiveRecord
   module AttributeMethods
@@ -58,7 +59,7 @@ module ActiveRecord
 
         private
           def create_time_zone_conversion_attribute?(name, column)
-            time_zone_aware_attributes && !self.skip_time_zone_conversion_for_attributes.include?(name.to_sym) && [:datetime, :timestamp].include?(column.type)
+            time_zone_aware_attributes && !self.skip_time_zone_conversion_for_attributes.include?(name.to_sym) && column.type.either?(:datetime, :timestamp)
           end
       end
     end

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/object/inclusion'
+
 db_namespace = namespace :db do
   task :load_config => :rails_env do
     require 'active_record'
@@ -135,7 +137,7 @@ db_namespace = namespace :db do
   end
 
   def local_database?(config, &block)
-    if %w( 127.0.0.1 localhost ).include?(config['host']) || config['host'].blank?
+    if config['host'].either?("127.0.0.1", "localhost") || config['host'].blank?
       yield
     else
       $stderr.puts "This task only modifies local databases. #{config['database']} is on a remote host."

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/class/attribute'
 require 'active_support/core_ext/module/deprecation'
+require 'active_support/core_ext/object/inclusion'
 
 module ActiveRecord
   # = Active Record Reflection
@@ -163,7 +164,7 @@ module ActiveRecord
 
       def initialize(macro, name, options, active_record)
         super
-        @collection = [:has_many, :has_and_belongs_to_many].include?(macro)
+        @collection = macro.either?(:has_many, :has_and_belongs_to_many)
       end
 
       # Returns a new, unsaved instance of the associated class. +options+ will

--- a/activerecord/lib/rails/generators/active_record/session_migration/session_migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/session_migration/session_migration_generator.rb
@@ -1,4 +1,5 @@
 require 'rails/generators/active_record'
+require 'active_support/core_ext/object/inclusion'
 
 module ActiveRecord
   module Generators
@@ -13,7 +14,7 @@ module ActiveRecord
 
         def session_table_name
           current_table_name = ActiveRecord::SessionStore::Session.table_name
-          if ["sessions", "session"].include?(current_table_name)
+          if current_table_name.either?("sessions", "session")
             current_table_name = (ActiveRecord::Base.pluralize_table_names ? 'session'.pluralize : 'session')
           end
           current_table_name

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -1,4 +1,5 @@
 require "cases/helper"
+require 'active_support/core_ext/object/inclusion'
 require 'models/tag'
 require 'models/tagging'
 require 'models/post'
@@ -453,7 +454,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     assert saved_post.tags.include?(new_tag)
 
     assert new_tag.persisted?
-    assert saved_post.reload.tags(true).include?(new_tag)
+    assert new_tag.in?(saved_post.reload.tags(true))
 
 
     new_post = Post.new(:title => "Association replacmenet works!", :body => "You best believe it.")
@@ -466,7 +467,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
 
     new_post.save!
     assert new_post.persisted?
-    assert new_post.reload.tags(true).include?(saved_tag)
+    assert saved_tag.in?(new_post.reload.tags(true))
 
     assert !posts(:thinking).tags.build.persisted?
     assert !posts(:thinking).tags.new.persisted?

--- a/activerecord/test/cases/attribute_methods/read_test.rb
+++ b/activerecord/test/cases/attribute_methods/read_test.rb
@@ -1,4 +1,5 @@
 require "cases/helper"
+require 'active_support/core_ext/object/inclusion'
 
 module ActiveRecord
   module AttributeMethods
@@ -41,13 +42,13 @@ module ActiveRecord
         instance = @klass.new
 
         @klass.column_names.each do |name|
-          assert ! instance.methods.map(&:to_s).include?(name)
+          assert !name.in?(instance.methods.map(&:to_s))
         end
 
         @klass.define_attribute_methods
 
         @klass.column_names.each do |name|
-          assert(instance.methods.map(&:to_s).include?(name), "#{name} is not defined")
+          assert name.in?(instance.methods.map(&:to_s)), "#{name} is not defined"
         end
       end
 

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1,4 +1,5 @@
 require "cases/helper"
+require 'active_support/core_ext/object/inclusion'
 require 'models/minimalistic'
 require 'models/developer'
 require 'models/auto_id'
@@ -638,7 +639,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   end
 
   def time_related_columns_on_topic
-    Topic.columns.select { |c| [:time, :date, :datetime, :timestamp].include?(c.type) }
+    Topic.columns.select { |c| c.type.either?(:time, :date, :datetime, :timestamp) }
   end
 
   def serialized_columns_on_topic

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -1,4 +1,5 @@
 require "cases/helper"
+require 'active_support/core_ext/object/inclusion'
 require 'models/default'
 require 'models/entrant'
 
@@ -94,7 +95,7 @@ if current_adapter?(:MysqlAdapter) or current_adapter?(:Mysql2Adapter)
       assert_equal 0, klass.columns_hash['zero'].default
       assert !klass.columns_hash['zero'].null
       # 0 in MySQL 4, nil in 5.
-      assert [0, nil].include?(klass.columns_hash['omit'].default)
+      assert klass.columns_hash['omit'].default.either?(0, nil)
       assert !klass.columns_hash['omit'].null
 
       assert_raise(ActiveRecord::StatementInvalid) { klass.create! }

--- a/activeresource/lib/active_resource/connection.rb
+++ b/activeresource/lib/active_resource/connection.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/benchmark'
 require 'active_support/core_ext/uri'
+require 'active_support/core_ext/object/inclusion'
 require 'net/https'
 require 'date'
 require 'time'
@@ -277,7 +278,7 @@ module ActiveResource
       def legitimize_auth_type(auth_type)
         return :basic if auth_type.nil?
         auth_type = auth_type.to_sym
-        [:basic, :digest].include?(auth_type) ? auth_type : :basic
+        auth_type.either?(:basic, :digest) ? auth_type : :basic
       end
   end
 end

--- a/activeresource/lib/active_resource/http_mock.rb
+++ b/activeresource/lib/active_resource/http_mock.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/kernel/reporting'
+require 'active_support/core_ext/object/inclusion'
 
 module ActiveResource
   class InvalidRequestError < StandardError; end #:nodoc:
@@ -299,7 +300,7 @@ module ActiveResource
     end
 
     def success?
-      (200..299).include?(code)
+      code.in?(200..299)
     end
 
     def [](key)

--- a/activeresource/test/cases/http_mock_test.rb
+++ b/activeresource/test/cases/http_mock_test.rb
@@ -1,4 +1,5 @@
 require 'abstract_unit'
+require 'active_support/core_ext/object/inclusion'
 
 class HttpMockTest < ActiveSupport::TestCase
   setup do
@@ -192,7 +193,7 @@ class HttpMockTest < ActiveSupport::TestCase
   end
 
   def request(method, path, headers = {}, body = nil)
-    if [:put, :post].include? method
+    if method.either?(:put, :post)
       @http.send(method, path, body, headers)
     else
       @http.send(method, path, headers)

--- a/activesupport/CHANGELOG
+++ b/activesupport/CHANGELOG
@@ -1,5 +1,7 @@
 *Rails 3.1.0 (unreleased)*
 
+* Add Object#in? to test if an object is included in another object, and Object#either? to test if an object is included in a list of objects which will be passed as arguments. [Prem Sichanugrist, Brian Morearty, John Reitano]
+
 * LocalCache strategy is now a real middleware class, not an anonymous class
 posing for pictures.
 

--- a/activesupport/bin/generate_tables
+++ b/activesupport/bin/generate_tables
@@ -105,7 +105,7 @@ module ActiveSupport
 
         def normalize_boundary_map
           @ucd.boundary.each do |k,v|
-            if [:lf, :cr].include? k
+            if k.in(:lf, :cr)
               @ucd.boundary[k] = v[0]
             end
           end

--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/file/atomic'
 require 'active_support/core_ext/string/conversions'
+require 'active_support/core_ext/object/inclusion'
 require 'rack/utils'
 
 module ActiveSupport
@@ -20,7 +21,7 @@ module ActiveSupport
       end
 
       def clear(options = nil)
-        root_dirs = Dir.entries(cache_path).reject{|f| ['.', '..'].include?(f)}
+        root_dirs = Dir.entries(cache_path).reject{|f| f.either?('.', '..')}
         FileUtils.rm_r(root_dirs.collect{|f| File.join(cache_path, f)})
       end
 
@@ -161,7 +162,7 @@ module ActiveSupport
         # Delete empty directories in the cache.
         def delete_empty_directories(dir)
           return if dir == cache_path
-          if Dir.entries(dir).reject{|f| ['.', '..'].include?(f)}.empty?
+          if Dir.entries(dir).reject{|f| f.either?('.', '..')}.empty?
             File.delete(dir) rescue nil
             delete_empty_directories(File.dirname(dir))
           end

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -4,6 +4,7 @@ require 'active_support/core_ext/array/wrap'
 require 'active_support/core_ext/class/attribute'
 require 'active_support/core_ext/kernel/reporting'
 require 'active_support/core_ext/kernel/singleton_class'
+require 'active_support/core_ext/object/inclusion'
 
 module ActiveSupport
   # \Callbacks are code hooks that are run at key points in an object's lifecycle.
@@ -412,7 +413,7 @@ module ActiveSupport
       # CallbackChain.
       #
       def __update_callbacks(name, filters = [], block = nil) #:nodoc:
-        type = [:before, :after, :around].include?(filters.first) ? filters.shift : :before
+        type = filters.first.either?(:before, :after, :around) ? filters.shift : :before
         options = filters.last.is_a?(Hash) ? filters.pop : {}
         filters.unshift(block) if block
 

--- a/activesupport/lib/active_support/core_ext/object/inclusion.rb
+++ b/activesupport/lib/active_support/core_ext/object/inclusion.rb
@@ -1,0 +1,20 @@
+class Object
+  # Returns true if this object is included in the argument. Argument must be
+  # any object which respond to +#include?+. Usage:
+  #
+  #   characters = ["Konata", "Kagami", "Tsukasa"]
+  #   "Konata".in?(characters) # => true
+  #
+  def in?(another_object)
+    another_object.include?(self)
+  end
+
+  # Returns true if this object is included in the argument list. Usage:
+  #
+  #   username = "sikachu"
+  #   username.either?("josevalim", "dhh", "wycats") # => false
+  #
+  def either?(*objects)
+    objects.include?(self)
+  end
+end

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -1,5 +1,6 @@
 require "active_support/values/time_zone"
 require 'active_support/core_ext/object/acts_like'
+require 'active_support/core_ext/object/inclusion'
 
 module ActiveSupport
   # A Time-like class that can represent a time in any time zone. Necessary because standard Ruby Time instances are
@@ -344,7 +345,7 @@ module ActiveSupport
       end
 
       def duration_of_variable_length?(obj)
-        ActiveSupport::Duration === obj && obj.parts.any? {|p| [:years, :months, :days].include? p[0] }
+        ActiveSupport::Duration === obj && obj.parts.any? {|p| p[0].either?(:years, :months, :days) }
       end
   end
 end

--- a/activesupport/test/core_ext/object/inclusion_test.rb
+++ b/activesupport/test/core_ext/object/inclusion_test.rb
@@ -1,0 +1,52 @@
+require 'abstract_unit'
+require 'active_support/core_ext/object/inclusion'
+
+class InTest < Test::Unit::TestCase
+  def test_in_array
+    assert 1.in?([1,2])
+    assert !3.in?([1,2])
+  end
+
+  def test_in_hash
+    h = { "a" => 100, "b" => 200 }
+    assert "a".in?(h)
+    assert !"z".in?(h)
+  end
+
+  def test_in_string
+    assert "lo".in?("hello")
+    assert !"ol".in?("hello")
+    assert ?h.in?("hello")
+  end
+
+  def test_in_range
+    assert 25.in?(1..50)
+    assert !75.in?(1..50)
+  end
+
+  def test_in_set
+    s = Set.new([1,2])
+    assert 1.in?(s)
+    assert !3.in?(s)
+  end
+
+  def test_either
+    assert 1.either?(1,2,3)
+    assert !5.either?(1,2,3)
+    assert [1,2,3].either?([1,2,3], 2, [3,4,5])
+  end
+
+  module A
+  end
+  class B
+    include A
+  end
+  class C < B
+  end
+
+  def test_in_module
+    assert A.in?(B)
+    assert A.in?(C)
+    assert !A.in?(A)
+  end
+end

--- a/activesupport/test/transliterate_test.rb
+++ b/activesupport/test/transliterate_test.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require 'abstract_unit'
 require 'active_support/inflector/transliterate'
+require 'active_support/core_ext/object/inclusion'
 
 class TransliterateTest < Test::Unit::TestCase
 
@@ -15,7 +16,7 @@ class TransliterateTest < Test::Unit::TestCase
     # create string with range of Unicode"s western characters with
     # diacritics, excluding the division and multiplication signs which for
     # some reason or other are floating in the middle of all the letters.
-    string = (0xC0..0x17E).to_a.reject {|c| [0xD7, 0xF7].include? c}.pack("U*")
+    string = (0xC0..0x17E).to_a.reject {|c| c.either?(0xD7, 0xF7)}.pack("U*")
     string.each_char do |char|
       assert_match %r{^[a-zA-Z']*$}, ActiveSupport::Inflector.transliterate(string)
     end

--- a/railties/guides/rails_guides/textile_extensions.rb
+++ b/railties/guides/rails_guides/textile_extensions.rb
@@ -1,9 +1,11 @@
+require 'active_support/core_ext/object/inclusion'
+
 module RailsGuides
   module TextileExtensions
     def notestuff(body)
       body.gsub!(/^(IMPORTANT|CAUTION|WARNING|NOTE|INFO)[.:](.*)$/) do |m|
         css_class = $1.downcase
-        css_class = 'warning' if ['caution', 'important'].include?(css_class)
+        css_class = 'warning' if css_class.either?('caution', 'important')
 
         result = "<div class='#{css_class}'><p>"
         result << $2.strip
@@ -33,7 +35,7 @@ module RailsGuides
     def code(body)
       body.gsub!(%r{<(yaml|shell|ruby|erb|html|sql|plain)>(.*?)</\1>}m) do |m|
         es = ERB::Util.h($2)
-        css_class = ['erb', 'shell'].include?($1) ? 'html' : $1
+        css_class = $1.either?('erb', 'shell') ? 'html' : $1
         %{<notextile><div class="code_container"><code class="#{css_class}">#{es}</code></div></notextile>}
       end
     end

--- a/railties/lib/rails/commands.rb
+++ b/railties/lib/rails/commands.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/object/inclusion'
+
 ARGV << '--help' if ARGV.empty?
 
 aliases = {
@@ -69,7 +71,7 @@ when '--version', '-v'
   require 'rails/commands/application'
 
 else
-  puts "Error: Command not recognized" unless %w(-h --help).include?(command)
+  puts "Error: Command not recognized" unless command.either?('-h', '--help')
   puts <<-EOT
 Usage: rails COMMAND [ARGS]
 

--- a/railties/lib/rails/commands/application.rb
+++ b/railties/lib/rails/commands/application.rb
@@ -1,5 +1,7 @@
 require 'rails/version'
-if %w(--version -v).include? ARGV.first
+require 'active_support/core_ext/object/inclusion'
+
+if ARGV.first.either?('--version', '-v')
   puts "Rails #{Rails::VERSION::STRING}"
   exit(0)
 end

--- a/railties/lib/rails/commands/benchmarker.rb
+++ b/railties/lib/rails/commands/benchmarker.rb
@@ -1,4 +1,6 @@
-if [nil, "-h", "--help"].include?(ARGV.first)
+require 'active_support/core_ext/object/inclusion'
+
+if ARGV.first.either?(nil, "-h", "--help")
   puts "Usage: rails benchmarker [times] 'Person.expensive_way' 'Person.another_expensive_way' ..."
   exit 1
 end

--- a/railties/lib/rails/commands/destroy.rb
+++ b/railties/lib/rails/commands/destroy.rb
@@ -1,7 +1,9 @@
 require 'rails/generators'
+require 'active_support/core_ext/object/inclusion'
+
 Rails::Generators.configure!
 
-if [nil, "-h", "--help"].include?(ARGV.first)
+if ARGV.first.either?(nil, "-h", "--help")
   Rails::Generators.help 'destroy'
   exit
 end

--- a/railties/lib/rails/commands/generate.rb
+++ b/railties/lib/rails/commands/generate.rb
@@ -1,7 +1,9 @@
 require 'rails/generators'
+require 'active_support/core_ext/object/inclusion'
+
 Rails::Generators.configure!
 
-if [nil, "-h", "--help"].include?(ARGV.first)
+if ARGV.first.either?(nil, "-h", "--help")
   Rails::Generators.help 'generate'
   exit
 end

--- a/railties/lib/rails/commands/profiler.rb
+++ b/railties/lib/rails/commands/profiler.rb
@@ -1,4 +1,6 @@
-if [nil, "-h", "--help"].include?(ARGV.first)
+require 'active_support/core_ext/object/inclusion'
+
+if ARGV.first.either?(nil, "-h", "--help")
   $stderr.puts "Usage: rails profiler 'Person.expensive_method(10)' [times] [flat|graph|graph_html]"
   exit(1)
 end

--- a/railties/lib/rails/generators/base.rb
+++ b/railties/lib/rails/generators/base.rb
@@ -8,6 +8,7 @@ rescue LoadError
 end
 
 require 'rails/generators/actions'
+require 'active_support/core_ext/object/inclusion'
 
 module Rails
   module Generators
@@ -164,7 +165,7 @@ module Rails
         names.each do |name|
           defaults = if options[:type] == :boolean
             { }
-          elsif [true, false].include?(default_value_for_option(name, options))
+          elsif default_value_for_option(name, options).either?(true, false)
             { :banner => "" }
           else
             { :desc => "#{name.to_s.humanize} to be invoked", :banner => "NAME" }

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -1,4 +1,5 @@
 require 'active_support/time'
+require 'active_support/core_ext/object/inclusion'
 
 module Rails
   module Generators
@@ -44,7 +45,7 @@ module Rails
       end
 
       def reference?
-        [ :references, :belongs_to ].include?(self.type)
+        self.type.either?(:references, :belongs_to)
       end
     end
   end


### PR DESCRIPTION
This will allow you to check if an object is included in another object or the list of objects or not.

This patch is derived from patch by Brian Morearty and John Reitano on Lighthouse ticket. I've rewrite it and make sure that we support both 'another object' and 'list of objects' version, as it surely be useful to support both.

Original ticket: https://rails.lighthouseapp.com/projects/8994/tickets/6321

Original discussion: http://groups.google.com/group/rubyonrails-core/browse_thread/thread/218a36184fe1176c

Please review it for me and see if it's appropriate. I really want to see this one got merged into Rails core, as I personally like `Object#in?` myself.
