### PR TITLE
Predefined formats on format validator

### DIFF
--- a/activemodel/lib/active_model/validations/format.rb
+++ b/activemodel/lib/active_model/validations/format.rb
@@ -77,6 +77,17 @@ module ActiveModel
       #     validates_format_of :screen_name, :with => lambda{ |person| person.admin? ? /\A[a-z0-9][a-z0-9_\-]*\Z/i : /\A[a-z][a-z0-9_\-]*\Z/i }
       #   end
       #
+      # And finally, you can register formats for easy use for later, for example, to register an integer format and them use the alias
+      # you can do by
+      #
+      #   # Register the alias
+      #   ActiveModel::Validations::FormatValidator.register_format_alias(:number, /\d+/)
+      #
+      #   class Person < ActiveRecord::Base
+      #     # Now using the registered alias
+      #     validates_format_of :screen_name, :with => :number
+      #   end
+      #
       # Note: use <tt>\A</tt> and <tt>\Z</tt> to match the start and end of the string, <tt>^</tt> and <tt>$</tt> match the start/end of a line.
       #
       # You must pass either <tt>:with</tt> or <tt>:without</tt> as an option. In addition, both must be a regular expression

--- a/activemodel/test/cases/validations/format_validation_test.rb
+++ b/activemodel/test/cases/validations/format_validation_test.rb
@@ -138,6 +138,44 @@ class PresenceValidationTest < ActiveModel::TestCase
     assert_raise(ArgumentError){ p.valid? }
   end
 
+  def test_find_format_alias_that_is_valid
+    ActiveModel::Validations::FormatValidator.register_format_alias(:valid_alias, /\d+/)
+
+    regexp = ActiveModel::Validations::FormatValidator.find_format_alias(:valid_alias)
+
+    assert_equal regexp, /\d+/
+  end
+
+  def test_find_format_alias_that_is_not_valid
+    assert_raise(ArgumentError) { ActiveModel::Validations::FormatValidator.find_format_alias(:invalid_alias) }
+  end
+
+  def test_validates_format_with_using_pre_defined_alias
+    ActiveModel::Validations::FormatValidator.register_format_alias(:test_number, /\d+/)
+
+    Topic.validates_format_of :content, :with => :test_number
+
+    p = Topic.new
+    p.content = "hello"
+    assert p.invalid?
+
+    p.content = "1234"
+    assert p.valid?
+  end
+
+  def test_validates_format_without_using_pre_defined_alias
+    ActiveModel::Validations::FormatValidator.register_format_alias(:test_number, /\d+/)
+
+    Topic.validates_format_of :content, :without => :test_number
+
+    p = Topic.new
+    p.content = "1234"
+    assert p.invalid?
+
+    p.content = "hello"
+    assert p.valid?
+  end
+
   def test_validates_format_of_for_ruby_class
     Person.validates_format_of :karma, :with => /\A\d+\Z/
 

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/formats.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/formats.rb
@@ -1,0 +1,4 @@
+# Be sure to restart your server when you modify this file.
+
+# Add new format alias for use in validates_format_of:
+# ActiveModel::Validations::FormatValidator.register_format_alias(:email, /\b[A-Z0-9._%-]+@[A-Z0-9.-]+\.[A-Z]{2,4}\b/)


### PR DESCRIPTION
I always wanted on format validator do something like:

```
validates_format_of :email, :with => :email
```

the idea is to have pre-defined formats for common used expressions. in this pull request I'm sending my implementation for that idea. this is a simple engine to register and use format aliases, also included a sample file for initialization to make user able to define these aliases.

to define a new alias you just need to:

```
ActiveModel::Validations::FormatValidator.register_format_alias(:my_alias, /my_expression/)
```

this way, we can have some default most common ones (like :email one) and other libraries can define some for convenience.
