### PR TITLE
Corrected dbconsole usage message

### DIFF
--- a/railties/lib/rails/commands/dbconsole.rb
+++ b/railties/lib/rails/commands/dbconsole.rb
@@ -23,7 +23,7 @@ module Rails
       include_password = false
       options = {}
       OptionParser.new do |opt|
-        opt.banner = "Usage: dbconsole [options] [environment]"
+        opt.banner = "Usage: dbconsole [environment] [options]"
         opt.on("-p", "--include-password", "Automatically provide the password from database.yml") do |v|
           include_password = true
         end


### PR DESCRIPTION
Actual arguments order is the same as in rails console. Fixes #5930.
