### PR TITLE
Return and instance of Arel::Attributes when calling `[]` on the model.

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -867,6 +867,11 @@ module ActiveRecord #:nodoc:
         end
       end
 
+      # Returns an instance of Arel::Attributes which you can call ARel's method on it.
+      def [](column_name)
+        @arel_table[column_name]
+      end
+
       # Returns a scope for this class without taking into account the default_scope.
       #
       #   class Post < ActiveRecord::Base

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -148,6 +148,10 @@ class BasicsTest < ActiveRecord::TestCase
     relation.table.engine = engine
   end
 
+  def test_returning_arel_attribute_instance_using_bracket
+    assert_equal Topic.arel_table[:id], Topic[:id]
+  end
+
   def test_preserving_time_objects
     assert_kind_of(
       Time, Topic.find(1).bonus_time,


### PR DESCRIPTION
Hi,

I've discussed with Aaron a while ago about the way that I can use ARel's comparison methods (`#gt`, `#lt`, and so on) in AR. Turned out that I have to access it via `#arel_table` method of the model:

```
users = User.arel_table
famous_users = User.where(users[:fame].gt(80))
```

This become a bit tedious as I have to have another variable to store an instance of `Arel::Table` to be able to call those methods on it. Also, I don't think the code look clean if I merge those two lines together and make it as

```
famous_users = User.where(User.arel_table[:fame].gt(80))
```

So, after some discussion, I think it's better to make AR `.[]` method to return the instance of `Arel::Attributes::*`. This will give more readability to the code example above, and I think it fits in great with the context.

After applying my patch, you would then can do

```
famous_users = User.where(User[:fame].gt(80))
```

I think that looks really nice. I really wish I could get some feedback from you guys.
