### PR TITLE
Add ArgumentError to Object#in? if supplied param doesn't respond to :include?

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/inclusion.rb
+++ b/activesupport/lib/active_support/core_ext/object/inclusion.rb
@@ -6,6 +6,7 @@ class Object
   #   "Konata".in?(characters) # => true
   #
   def in?(another_object)
+    raise ArgumentError.new("You must supply another object that responds to include?") unless another_object.respond_to?(:include?)
     another_object.include?(self)
   end
 end

--- a/activesupport/lib/active_support/core_ext/object/inclusion.rb
+++ b/activesupport/lib/active_support/core_ext/object/inclusion.rb
@@ -5,8 +5,11 @@ class Object
   #   characters = ["Konata", "Kagami", "Tsukasa"]
   #   "Konata".in?(characters) # => true
   #
+  # This will throw an ArgumentError if the supplied argument doesnt not respond
+  # to +#include?+.
   def in?(another_object)
-    raise ArgumentError.new("You must supply another object that responds to include?") unless another_object.respond_to?(:include?)
     another_object.include?(self)
+  rescue NoMethodError
+    raise ArgumentError.new("The parameter passed to #in? must respond to #include?")
   end
 end

--- a/activesupport/test/core_ext/object/inclusion_test.rb
+++ b/activesupport/test/core_ext/object/inclusion_test.rb
@@ -43,4 +43,8 @@ class InTest < Test::Unit::TestCase
     assert A.in?(C)
     assert !A.in?(A)
   end
+  
+  def test_no_method_catching
+    assert_raise(ArgumentError) { 1.in?(1) }
+  end
 end


### PR DESCRIPTION
The comment above the method specifically states the supplied param must respond to include?, but allows a method that doesn't fall through to a NoMethodError.  Instead it should raise a more descriptive error.
