### PR TITLE
Small fix for previous Hash.from_xml fix

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/hash/conversions.rb
@@ -96,7 +96,7 @@ class Hash
                   raise "can't typecast #{entries.inspect}"
                 end
               end
-            elsif value.has_key?("__content__") && value["__content__"].gsub(/\s/, '').present?
+            elsif value.has_key?("__content__") && value["__content__"].present?
               content = value["__content__"]
               if parser = ActiveSupport::XmlMini::PARSING[value["type"]]
                 parser.arity == 1 ? parser.call(content) : parser.call(content, value)

--- a/activesupport/lib/active_support/core_ext/hash/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/hash/conversions.rb
@@ -96,7 +96,7 @@ class Hash
                   raise "can't typecast #{entries.inspect}"
                 end
               end
-            elsif value.has_key?("__content__")
+            elsif value.has_key?("__content__") && value["__content__"].gsub(/\s/, '').present?
               content = value["__content__"]
               if parser = ActiveSupport::XmlMini::PARSING[value["type"]]
                 parser.arity == 1 ? parser.call(content) : parser.call(content, value)

--- a/activesupport/lib/active_support/core_ext/hash/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/hash/conversions.rb
@@ -96,7 +96,7 @@ class Hash
                   raise "can't typecast #{entries.inspect}"
                 end
               end
-            elsif value.has_key?("__content__") && value["__content__"].present?
+            elsif value['type'] == 'file' || value["__content__"].present?
               content = value["__content__"]
               if parser = ActiveSupport::XmlMini::PARSING[value["type"]]
                 parser.arity == 1 ? parser.call(content) : parser.call(content, value)

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -857,6 +857,15 @@ class HashToXmlTest < Test::Unit::TestCase
     assert_equal 'application/octet-stream', file.content_type
   end
 
+  def test_tag_with_attrs_and_whitespace
+    xml = <<-XML
+      <blog name="bacon is the best">
+      </blog>
+    XML
+    hash = Hash.from_xml(xml)
+    assert_equal "bacon is the best", hash['blog']['name']
+  end
+
   def test_xsd_like_types_from_xml
     bacon_xml = <<-EOT
     <bacon>


### PR DESCRIPTION
@fxn pointed out to me that the gsub was unneeded, so I removed it. Hopefully this can go into 3-0-stable as well as master, so I can use the fix in the next point release. :)
