### PR TITLE
properly escape "'" to "&apos;" for XML

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -3,7 +3,7 @@ require 'active_support/core_ext/kernel/singleton_class'
 
 class ERB
   module Util
-    HTML_ESCAPE = { '&' => '&amp;',  '>' => '&gt;',   '<' => '&lt;', '"' => '&quot;', "'" => '&apos;' }
+    XML_ESCAPE = { '&' => '&amp;', '>' => '&gt;', '<' => '&lt;', '"' => '&quot;', "'" => '&apos;' }
     JSON_ESCAPE = { '&' => '\u0026', '>' => '\u003E', '<' => '\u003C' }
 
     # A utility method for escaping HTML tag characters.
@@ -20,7 +20,7 @@ class ERB
       if s.html_safe?
         s
       else
-        s.gsub(/[&"'><]/) { |special| HTML_ESCAPE[special] }.html_safe
+        s.gsub(/[&"'><]/) { |special| XML_ESCAPE[special] }.html_safe
       end
     end
 

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -3,7 +3,7 @@ require 'active_support/core_ext/kernel/singleton_class'
 
 class ERB
   module Util
-    HTML_ESCAPE = { '&' => '&amp;',  '>' => '&gt;',   '<' => '&lt;', '"' => '&quot;' }
+    HTML_ESCAPE = { '&' => '&amp;',  '>' => '&gt;',   '<' => '&lt;', '"' => '&quot;', "'" => '&apos;' }
     JSON_ESCAPE = { '&' => '\u0026', '>' => '\u003E', '<' => '\u003C' }
 
     # A utility method for escaping HTML tag characters.
@@ -20,7 +20,7 @@ class ERB
       if s.html_safe?
         s
       else
-        s.gsub(/[&"><]/) { |special| HTML_ESCAPE[special] }.html_safe
+        s.gsub(/[&"'><]/) { |special| HTML_ESCAPE[special] }.html_safe
       end
     end
 

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -381,6 +381,18 @@ class OutputSafetyTest < ActiveSupport::TestCase
     assert !@other_combination.html_safe?
   end
 
+  test "Escapes special HTML/XML characters" do
+    @other_string = "other".html_safe
+    @combination = @other_string + "<foo>&\"'"
+    @other_combination = @string + "<foo>&\"'"
+
+    assert_equal "other&lt;foo&gt;&amp;&quot;&apos;", @combination
+    assert_equal "hello<foo>&\"'", @other_combination
+
+    assert @combination.html_safe?
+    assert !@other_combination.html_safe?
+  end
+
   test "Concatting safe onto unsafe yields unsafe" do
     @other_string = "other"
 


### PR DESCRIPTION
An apostrophe has to be escaped as &apos; in attribute values.
