### PR TITLE
Correct documentation for asset host strategy for 1.9.2

### DIFF
--- a/actionpack/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helper.rb
@@ -57,7 +57,7 @@ module ActionView
     # +asset_host+ to a proc like this:
     #
     #   ActionController::Base.asset_host = Proc.new { |source|
-    #     "http://assets#{source.hash % 2 + 1}.example.com"
+    #     "http://assets#{Digest::MD5.hexdigest(source).to_i(16) % 2 + 1}.example.com"
     #   }
     #   image_tag("rails.png")
     #   # => <img alt="Rails" src="http://assets1.example.com/images/rails.png?1230601161" />


### PR DESCRIPTION
ruby 1.9.2 and other ruby implementations may not return the same hash value for the same string each time. This can result in your static assets being served from different asset hosts, which makes browser caching less effective. Use md5 or some other digest method instead.
