### PR TITLE
Stripping tags from a frozen string

### DIFF
--- a/actionpack/lib/action_controller/vendor/html-scanner/html/sanitizer.rb
+++ b/actionpack/lib/action_controller/vendor/html-scanner/html/sanitizer.rb
@@ -33,7 +33,7 @@ module HTML
       result = super
       # strip any comments, and if they have a newline at the end (ie. line with
       # only a comment) strip that too
-      result.gsub!(/<!--(.*?)-->[\n]?/m, "") if result
+      result = result.gsub(/<!--(.*?)-->[\n]?/m, "") if (result && result =~ /<!--(.*?)-->[\n]?/m)
       # Recurse - handle all dirty nested tags
       result == text ? result : sanitize(result, options)
     end

--- a/actionpack/test/template/html-scanner/sanitizer_test.rb
+++ b/actionpack/test/template/html-scanner/sanitizer_test.rb
@@ -20,6 +20,7 @@ class SanitizerTest < ActionController::TestCase
     assert_equal "This has a  here.", sanitizer.sanitize("This has a <![CDATA[<section>]]> here.")
     assert_equal "This has an unclosed ", sanitizer.sanitize("This has an unclosed <![CDATA[<section>]] here...")
     [nil, '', '   '].each { |blank| assert_equal blank, sanitizer.sanitize(blank) }
+    assert_nothing_raised { sanitizer.sanitize("This is a frozen string with no tags".freeze) }
   end
 
   def test_strip_links


### PR DESCRIPTION
Using HTML::FullSanitizer to strip tags from a frozen string works under Ruby 1.8, but fails under Ruby 1.9 due to the change in behavior of String#gsub! on frozen strings.
