### PR TITLE
auto_link to return sanitized strings

### DIFF
--- a/actionpack/lib/action_view/helpers/text_helper.rb
+++ b/actionpack/lib/action_view/helpers/text_helper.rb
@@ -269,7 +269,9 @@ module ActionView
       # will limit what should be linked. You can add HTML attributes to the links using
       # <tt>:html</tt>. Possible values for <tt>:link</tt> are <tt>:all</tt> (default),
       # <tt>:email_addresses</tt>, and <tt>:urls</tt>. If a block is given, each URL and
-      # e-mail address is yielded and the result is used as the link text.
+      # e-mail address is yielded and the result is used as the link text. By default the 
+      # text given is sanitized, you can override this behaviour setting the
+      # <tt>:sanitize</tt> option to false.
       #
       # ==== Examples
       #   auto_link("Go to http://www.rubyonrails.org and say hello to david@loudthinking.com")
@@ -303,7 +305,7 @@ module ActionView
       #   # => "Welcome to my new blog at <a href=\"http://www.myblog.com/\" target=\"_blank\">http://www.myblog.com</a>.
       #         Please e-mail me at <a href=\"mailto:me@email.com\">me@email.com</a>."
       def auto_link(text, *args, &block)#link = :all, html = {}, &block)
-        return '' if text.blank?
+        return ''.html_safe if text.blank?
 
         options = args.size == 2 ? {} : args.extract_options! # this is necessary because the old auto_link API has a Hash as its last parameter
         unless args.empty?
@@ -311,6 +313,8 @@ module ActionView
           options[:html] = args[1] || {}
         end
         options.reverse_merge!(:link => :all, :html => {})
+        
+        text = sanitize(text) unless options[:sanitize] == false
 
         case options[:link].to_sym
           when :all                         then auto_link_email_addresses(auto_link_urls(text, options[:html], options, &block), options[:html], &block)

--- a/actionpack/test/template/text_helper_test.rb
+++ b/actionpack/test/template/text_helper_test.rb
@@ -326,6 +326,15 @@ class TextHelperTest < ActionView::TestCase
     assert auto_link("hello #{email_raw}").html_safe?, 'should be html safe'
     assert auto_link("hello #{email_raw} #{malicious_script}").html_safe?, 'should be html safe'
   end
+  
+  def test_auto_link_should_not_be_html_safe_when_sanitize_option_false
+    email_raw         = 'santiago@wyeworks.com'
+    link_raw          = 'http://www.rubyonrails.org'
+
+    assert !auto_link("hello", :sanitize => false).html_safe?, 'should not be html safe'
+    assert !auto_link("#{link_raw} #{link_raw} #{link_raw}", :sanitize => false).html_safe?, 'should not be html safe'
+    assert !auto_link("hello #{email_raw}", :sanitize => false).html_safe?, 'should not be html safe'
+  end
 
   def test_auto_link_email_address
     email_raw    = 'aaron@tenderlovemaking.com'

--- a/actionpack/test/template/text_helper_test.rb
+++ b/actionpack/test/template/text_helper_test.rb
@@ -315,14 +315,16 @@ class TextHelperTest < ActionView::TestCase
     end
   end
 
-  def test_auto_link_should_not_be_html_safe
-    email_raw    = 'santiago@wyeworks.com'
-    link_raw     = 'http://www.rubyonrails.org'
+  def test_auto_link_should_be_html_safe
+    email_raw         = 'santiago@wyeworks.com'
+    link_raw          = 'http://www.rubyonrails.org'
+    malicious_script  = '<script>alert("malicious!")</script>'
 
-    assert !auto_link(nil).html_safe?, 'should not be html safe'
-    assert !auto_link('').html_safe?, 'should not be html safe'
-    assert !auto_link("#{link_raw} #{link_raw} #{link_raw}").html_safe?, 'should not be html safe'
-    assert !auto_link("hello #{email_raw}").html_safe?, 'should not be html safe'
+    assert auto_link(nil).html_safe?, 'should be html safe'
+    assert auto_link('').html_safe?, 'should be html safe'
+    assert auto_link("#{link_raw} #{link_raw} #{link_raw}").html_safe?, 'should be html safe'
+    assert auto_link("hello #{email_raw}").html_safe?, 'should be html safe'
+    assert auto_link("hello #{email_raw} #{malicious_script}").html_safe?, 'should be html safe'
   end
 
   def test_auto_link_email_address
@@ -431,12 +433,14 @@ class TextHelperTest < ActionView::TestCase
 
   def test_auto_link_should_sanitize_input_when_sanitize_option_is_not_false
     link_raw     = %{http://www.rubyonrails.com?id=1&num=2}
-    assert_equal %{<a href="http://www.rubyonrails.com?id=1&num=2">http://www.rubyonrails.com?id=1&num=2</a>}, auto_link(link_raw)
+    malicious_script  = '<script>alert("malicious!")</script>'
+    assert_equal %{<a href="http://www.rubyonrails.com?id=1&num=2">http://www.rubyonrails.com?id=1&num=2</a>}, auto_link("#{link_raw}#{malicious_script}")
   end
 
   def test_auto_link_should_not_sanitize_input_when_sanitize_option_is_false
     link_raw     = %{http://www.rubyonrails.com?id=1&num=2}
-    assert_equal %{<a href="http://www.rubyonrails.com?id=1&num=2">http://www.rubyonrails.com?id=1&num=2</a>}, auto_link(link_raw, :sanitize => false)
+    malicious_script  = '<script>alert("malicious!")</script>'
+    assert_equal %{<a href="http://www.rubyonrails.com?id=1&num=2">http://www.rubyonrails.com?id=1&num=2</a><script>alert("malicious!")</script>}, auto_link("#{link_raw}#{malicious_script}", :sanitize => false)
   end
 
   def test_auto_link_other_protocols
@@ -461,7 +465,7 @@ class TextHelperTest < ActionView::TestCase
     linked5 = %('<a href="#close">close</a> <a href="http://www.example.com"><b>www.example.com</b></a>')
     assert_equal linked1, auto_link(linked1)
     assert_equal linked2, auto_link(linked2)
-    assert_equal linked3, auto_link(linked3)
+    assert_equal linked3, auto_link(linked3, :sanitize => false)
     assert_equal linked4, auto_link(linked4)
     assert_equal linked5, auto_link(linked5)
 


### PR DESCRIPTION
This code returns insecure content, and I think that's very counter-intuitive:
auto_link("&lt;script>alert('malicious')&lt;/script> www.rubyonrails.org", :sanitize => true)

I propose to avoid the vulnerability this commit from @tenderlove fixed: https://github.com/rails/rails/commit/61ee3449674c591747db95f9b3472c5c3bd9e84d and at the same time give a better use to the existent (but not documented) :sanitize option. 
