### PR TITLE
Change Array#from to return consistent results

### DIFF
--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency('actionpack',  version)
-  s.add_dependency('mail',        '~> 2.2.16')
+  s.add_dependency('mail',        '~> 2.3.0')
 end

--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -23,17 +23,17 @@ if "ruby".encoding_aware?
   end
 end
 
-silence_warnings do
-  # These external dependencies have warnings :/
-  require 'mail'
-end
-
 lib = File.expand_path("#{File.dirname(__FILE__)}/../lib")
 $:.unshift(lib) unless $:.include?('lib') || $:.include?(lib)
 
 require 'test/unit'
 require 'action_mailer'
 require 'action_mailer/test_case'
+
+silence_warnings do
+  # These external dependencies have warnings :/
+  require 'mail'
+end
 
 # Show backtraces for deprecated behavior for quicker cleanup.
 ActiveSupport::Deprecation.debug = true

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activemodel',      version)
   s.add_dependency('rack-cache',       '~> 1.0.0')
   s.add_dependency('builder',          '~> 3.0.0')
-  s.add_dependency('i18n',             '~> 0.5.0')
+  s.add_dependency('i18n',             '~> 0.6.0beta1')
   s.add_dependency('rack',             '~> 1.2.1')
   s.add_dependency('rack-test',        '~> 0.5.7')
   s.add_dependency('rack-mount',       '~> 0.7.1')

--- a/actionpack/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helper.rb
@@ -57,7 +57,7 @@ module ActionView
     # +asset_host+ to a proc like this:
     #
     #   ActionController::Base.asset_host = Proc.new { |source|
-    #     "http://assets#{source.hash % 2 + 1}.example.com"
+    #     "http://assets#{Digest::MD5.hexdigest(source).to_i(16) % 2 + 1}.example.com"
     #   }
     #   image_tag("rails.png")
     #   # => <img alt="Rails" src="http://assets1.example.com/images/rails.png?1230601161" />

--- a/actionpack/lib/action_view/helpers/translation_helper.rb
+++ b/actionpack/lib/action_view/helpers/translation_helper.rb
@@ -5,7 +5,7 @@ module I18n
   class ExceptionHandler
     include Module.new {
       def call(exception, locale, key, options)
-        exception.is_a?(MissingTranslationData) ? super.html_safe : super
+        exception.is_a?(MissingTranslation) ? super.html_safe : super
       end
     }
   end
@@ -17,8 +17,8 @@ module ActionView
     module TranslationHelper
       # Delegates to I18n#translate but also performs three additional functions.
       #
-      # First, it'll pass the :rescue_format => :html option to I18n so that any caught
-      # MissingTranslationData exceptions will be turned into inline spans that
+      # First, it'll pass the :rescue_format => :html option to I18n so that any
+      # thrown MissingTranslation messages will be turned into inline spans that
       #
       #   * have a "translation-missing" class set,
       #   * contain the missing key as a title attribute and

--- a/activemodel/activemodel.gemspec
+++ b/activemodel/activemodel.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency('activesupport', version)
   s.add_dependency('builder',       '~> 3.0.0')
-  s.add_dependency('i18n',          '~> 0.5.0')
+  s.add_dependency('i18n',          '~> 0.6.0beta1')
   s.add_dependency('bcrypt-ruby',   '~> 2.1.4')
 end

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1621,11 +1621,11 @@ end
       # Allows you to set all the attributes at once by passing in a hash with keys
       # matching the attribute names (which again matches the column names).
       #
-      # If +guard_protected_attributes+ is true (the default), then sensitive
-      # attributes can be protected from this form of mass-assignment by using
-      # the +attr_protected+ macro. Or you can alternatively specify which
-      # attributes *can* be accessed with the +attr_accessible+ macro. Then all the
-      # attributes not included in that won't be allowed to be mass-assigned.
+      # If any attributes are protected by either +attr_protected+ or
+      # +attr_accessible+ then only settable attributes will be assigned.
+      #
+      # The +guard_protected_attributes+ argument is now deprecated, use
+      # the +assign_attributes+ method if you want to bypass mass-assignment security.
       #
       #   class User < ActiveRecord::Base
       #     attr_protected :is_admin
@@ -1635,11 +1635,16 @@ end
       #   user.attributes = { :username => 'Phusion', :is_admin => true }
       #   user.username   # => "Phusion"
       #   user.is_admin?  # => false
-      #
-      #   user.send(:attributes=, { :username => 'Phusion', :is_admin => true }, false)
-      #   user.is_admin?  # => true
-      def attributes=(new_attributes, guard_protected_attributes = true)
+      def attributes=(new_attributes, guard_protected_attributes = nil)
+        unless guard_protected_attributes.nil?
+          message = "the use of 'guard_protected_attributes' will be removed from the next major release of rails, " +
+                    "if you want to bypass mass-assignment security then look into using assign_attributes"
+          ActiveSupport::Deprecation.warn(message)
+        end
+
         return unless new_attributes.is_a?(Hash)
+
+        guard_protected_attributes ||= true
         if guard_protected_attributes
           assign_attributes(new_attributes)
         else

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -95,6 +95,9 @@ module ActiveRecord
             # XML type
             when 'xml'
               :xml
+            # tsvector type
+            when 'tsvector'
+              :tsvector
             # Arrays
             when /^\D+\[\]$/
               :string
@@ -186,6 +189,11 @@ module ActiveRecord
           options = args.extract_options!
           column(args[0], 'xml', options)
         end
+
+        def tsvector(*args)
+          options = args.extract_options!
+          column(args[0], 'tsvector', options)
+        end
       end
 
       ADAPTER_NAME = 'PostgreSQL'
@@ -203,7 +211,8 @@ module ActiveRecord
         :date        => { :name => "date" },
         :binary      => { :name => "bytea" },
         :boolean     => { :name => "boolean" },
-        :xml         => { :name => "xml" }
+        :xml         => { :name => "xml" },
+        :tsvector    => { :name => "tsvector" }
       }
 
       # Returns 'PostgreSQL' as adapter name for identification purposes.

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -136,22 +136,27 @@ module ActiveRecord
     # Updates the attributes of the model from the passed-in hash and saves the
     # record, all wrapped in a transaction. If the object is invalid, the saving
     # will fail and false will be returned.
-    def update_attributes(attributes)
+    #
+    # When updating model attributes, mass-assignment security protection is respected.
+    # If no +:as+ option is supplied then the :default scope will be used.
+    # If you want to bypass the protection given by +attr_protected+ and
+    # +attr_accessible+ then you can do so using the +:without_protection+ option.
+    def update_attributes(attributes, options = {})
       # The following transaction covers any possible database side-effects of the
       # attributes assignment. For example, setting the IDs of a child collection.
       with_transaction_returning_status do
-        self.attributes = attributes
+        self.assign_attributes(attributes, options)
         save
       end
     end
 
     # Updates its receiver just like +update_attributes+ but calls <tt>save!</tt> instead
     # of +save+, so an exception is raised if the record is invalid.
-    def update_attributes!(attributes)
+    def update_attributes!(attributes, options = {})
       # The following transaction covers any possible database side-effects of the
       # attributes assignment. For example, setting the IDs of a child collection.
       with_transaction_returning_status do
-        self.attributes = attributes
+        self.assign_attributes(attributes, options)
         save!
       end
     end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -138,7 +138,7 @@ module ActiveRecord
     # will fail and false will be returned.
     #
     # When updating model attributes, mass-assignment security protection is respected.
-    # If no +:as+ option is supplied then the :default scope will be used.
+    # If no +:as+ option is supplied then the +:default+ scope will be used.
     # If you want to bypass the protection given by +attr_protected+ and
     # +attr_accessible+ then you can do so using the +:without_protection+ option.
     def update_attributes(attributes, options = {})

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -100,7 +100,7 @@ db_namespace = namespace :db do
             $stderr.puts "(if you set the charset manually, make sure you have a matching collation)" if config['charset']
           end
         end
-      when 'postgresql'
+      when /postgresql/
         @encoding = config['encoding'] || ENV['CHARSET'] || 'utf8'
         begin
           ActiveRecord::Base.establish_connection(config.merge('database' => 'postgres', 'schema_search_path' => 'public'))

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -279,8 +279,8 @@ module ActiveRecord
 
       unless record
         record = @klass.new do |r|
-          r.send(:attributes=, protected_attributes_for_create, true) unless protected_attributes_for_create.empty?
-          r.send(:attributes=, unprotected_attributes_for_create, false) unless unprotected_attributes_for_create.empty?
+          r.assign_attributes(protected_attributes_for_create)
+          r.assign_attributes(unprotected_attributes_for_create, :without_protection => true)
         end
         yield(record) if block_given?
         record.save if match.instantiator == :create

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -489,6 +489,12 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal 'value2', weird.send('a$b')
   end
 
+  def test_attributes_guard_protected_attributes_is_deprecated
+    attributes = { "title" => "An amazing title" }
+    topic = Topic.new
+    assert_deprecated { topic.send(:attributes=, attributes, false) }
+  end
+
   def test_multiparameter_attributes_on_date
     attributes = { "last_read(1i)" => "2004", "last_read(2i)" => "6", "last_read(3i)" => "24" }
     topic = Topic.find(1)

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -491,6 +491,26 @@ class PersistencesTest < ActiveRecord::TestCase
     assert_equal "The First Topic", topic.title
   end
 
+  def test_update_attributes_as_admin
+    person = TightPerson.create
+    person.update_attributes({ "first_name" => 'Josh', "gender" => 'male', "comments" => 'from NZ' }, :as => :admin)
+    person.reload
+
+    assert_equal 'Josh', person.first_name
+    assert_equal 'male', person.gender
+    assert_equal 'from NZ', person.comments
+  end
+
+  def test_update_attributes_as_without_protection
+    person = TightPerson.create
+    person.update_attributes({ "first_name" => 'Josh', "gender" => 'male', "comments" => 'from NZ' }, :without_protection => true)
+    person.reload
+
+    assert_equal 'Josh', person.first_name
+    assert_equal 'male', person.gender
+    assert_equal 'from NZ', person.comments
+  end
+
   def test_update_attributes!
     Reply.validates_presence_of(:title)
     reply = Reply.find(2)
@@ -510,6 +530,26 @@ class PersistencesTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::RecordInvalid) { reply.update_attributes!(:title => nil, :content => "Have a nice evening") }
   ensure
     Reply.reset_callbacks(:validate)
+  end
+
+  def test_update_attributes_as_admin
+    person = TightPerson.create
+    person.update_attributes!({ "first_name" => 'Josh', "gender" => 'male', "comments" => 'from NZ' }, :as => :admin)
+    person.reload
+
+    assert_equal 'Josh', person.first_name
+    assert_equal 'male', person.gender
+    assert_equal 'from NZ', person.comments
+  end
+
+  def test_update_attributes_as_without_protection
+    person = TightPerson.create
+    person.update_attributes!({ "first_name" => 'Josh', "gender" => 'male', "comments" => 'from NZ' }, :without_protection => true)
+    person.reload
+
+    assert_equal 'Josh', person.first_name
+    assert_equal 'male', person.gender
+    assert_equal 'from NZ', person.comments
   end
 
   def test_destroyed_returns_boolean

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -203,6 +203,13 @@ class SchemaDumperTest < ActiveRecord::TestCase
         assert_match %r{t.xml "data"}, output
       end
     end
+
+    def test_schema_dump_includes_tsvector_shorthand_definition
+      output = standard_dump
+      if %r{create_table "postgresql_tsvectors"} =~ output
+        assert_match %r{t.tsvector "text_vector"}, output
+      end
+    end
   end
 
   def test_schema_dump_keeps_large_precision_integer_columns_as_decimal

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -1,6 +1,6 @@
 ActiveRecord::Schema.define do
 
-  %w(postgresql_arrays postgresql_moneys postgresql_numbers postgresql_times postgresql_network_addresses postgresql_bit_strings
+  %w(postgresql_tsvectors postgresql_arrays postgresql_moneys postgresql_numbers postgresql_times postgresql_network_addresses postgresql_bit_strings
       postgresql_oids postgresql_xml_data_type defaults geometrics postgresql_timestamp_with_zones).each do |table_name|
     execute "DROP TABLE  IF EXISTS #{quote_table_name table_name}"
   end
@@ -55,6 +55,14 @@ _SQL
     nicknames TEXT[]
   );
 _SQL
+
+  execute <<_SQL
+  CREATE TABLE postgresql_tsvectors (
+    id SERIAL PRIMARY KEY,
+    text_vector tsvector
+  );
+_SQL
+
   execute <<_SQL
   CREATE TABLE postgresql_moneys (
     id SERIAL PRIMARY KEY,

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.files        = Dir['CHANGELOG', 'README.rdoc', 'lib/**/*']
   s.require_path = 'lib'
 
-  s.add_dependency('multi_json', '~> 1.0.0.rc3')
+  s.add_dependency('multi_json', '~> 1.0.0')
 end

--- a/activesupport/lib/active_support/buffered_logger.rb
+++ b/activesupport/lib/active_support/buffered_logger.rb
@@ -41,7 +41,7 @@ module ActiveSupport
 
     def initialize(log, level = DEBUG)
       @level         = level
-      @buffer        = {}
+      @buffer        = Hash.new { |h,k| h[k] = [] }
       @auto_flushing = 1
       @guard = Mutex.new
 
@@ -100,13 +100,8 @@ module ActiveSupport
 
     def flush
       @guard.synchronize do
-        unless buffer.empty?
-          old_buffer = buffer
-          all_content = StringIO.new
-          old_buffer.each do |content|
-            all_content << content
-          end
-          @log.write(all_content.string)
+        buffer.each do |content|
+          @log.write(content)
         end
 
         # Important to do this even if buffer was empty or else @buffer will
@@ -127,7 +122,7 @@ module ActiveSupport
       end
 
       def buffer
-        @buffer[Thread.current] ||= []
+        @buffer[Thread.current]
       end
 
       def clear_buffer

--- a/activesupport/lib/active_support/core_ext/array/access.rb
+++ b/activesupport/lib/active_support/core_ext/array/access.rb
@@ -3,10 +3,10 @@ class Array
   #
   #   %w( a b c d ).from(0)  # => %w( a b c d )
   #   %w( a b c d ).from(2)  # => %w( c d )
-  #   %w( a b c d ).from(10) # => nil
+  #   %w( a b c d ).from(10) # => %w()
   #   %w().from(0)           # => %w()
   def from(position)
-    self[position..-1]
+    position > length ? [] : self[position..-1]
   end
 
   # Returns the beginning of the array up to +position+.

--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -81,7 +81,7 @@ module ActiveSupport
 
       # Flush all log_subscribers' logger.
       def flush_all!
-        flushable_loggers.each(&:flush)
+        flushable_loggers.each { |log| log.flush }
       end
     end
 

--- a/activesupport/test/core_ext/array_ext_test.rb
+++ b/activesupport/test/core_ext/array_ext_test.rb
@@ -10,7 +10,7 @@ class ArrayExtAccessTests < Test::Unit::TestCase
   def test_from
     assert_equal %w( a b c d ), %w( a b c d ).from(0)
     assert_equal %w( c d ), %w( a b c d ).from(2)
-    assert_nil %w( a b c d ).from(10)
+    assert_equal %w(), %w( a b c d ).from(10)
   end
 
   def test_to

--- a/railties/lib/rails/commands/console.rb
+++ b/railties/lib/rails/commands/console.rb
@@ -51,6 +51,6 @@ module Rails
 end
 
 # Has to set the RAILS_ENV before config/application is required
-if ARGV.first && !ARGV.first.index("-") && env = ARGV.pop # has to pop the env ARGV so IRB doesn't freak
+if ARGV.first && !ARGV.first.index("-") && env = ARGV.shift # has to shift the env ARGV so IRB doesn't freak
   ENV['RAILS_ENV'] = %w(production development test).detect {|e| e =~ /^#{env}/} || env
 end

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -10,7 +10,7 @@ module Rails
   module Generators
     class AppBase < Base
       DATABASES = %w( mysql oracle postgresql sqlite3 frontbase ibm_db )
-      JDBC_DATABASES = %w( jdbcmysql jdbcsqlite3 )
+      JDBC_DATABASES = %w( jdbcmysql jdbcsqlite3 jdbcpostgresql )
       DATABASES.concat(JDBC_DATABASES)
       JAVASCRIPTS = %w( jquery prototype )
 
@@ -158,7 +158,7 @@ module Rails
       end
 
       def gem_for_database
-        # %w( mysql oracle postgresql sqlite3 frontbase ibm_db jdbcmysql jdbcsqlite3)
+        # %w( mysql oracle postgresql sqlite3 frontbase ibm_db jdbcmysql jdbcsqlite3 jdbcpostgresql )
         case options[:database]
         when "oracle"     then "ruby-oci8"
         when "postgresql" then "pg"
@@ -166,6 +166,7 @@ module Rails
         when "mysql"      then "mysql2"
         when "jdbcmysql"  then "activerecord-jdbcmysql-adapter"
         when "jdbcsqlite3"  then "activerecord-jdbcsqlite3-adapter"
+        when "jdbcpostgresql"  then "activerecord-jdbcpostgresql-adapter"
         else options[:database]
         end
       end

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
@@ -1,0 +1,48 @@
+# PostgreSQL. Versions 7.4 and 8.x are supported.
+#
+# Install the pg driver:
+#   gem install pg
+# On Mac OS X with macports:
+#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
+# On Windows:
+#   gem install pg
+#       Choose the win32 build.
+#       Install PostgreSQL and put its /bin directory on your path.
+development:
+  adapter: jdbcpostgresql
+  encoding: unicode
+  database: <%= app_name %>_development
+  username: <%= app_name %>
+  password:
+
+  # Connect on a TCP socket. Omitted by default since the client uses a
+  # domain socket that doesn't need configuration. Windows does not have
+  # domain sockets, so uncomment these lines.
+  #host: localhost
+  #port: 5432
+
+  # Schema search path. The server defaults to $user,public
+  #schema_search_path: myapp,sharedapp,public
+
+  # Minimum log levels, in increasing order:
+  #   debug5, debug4, debug3, debug2, debug1,
+  #   log, notice, warning, error, fatal, and panic
+  # The server defaults to notice.
+  #min_messages: warning
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  adapter: jdbcpostgresql
+  encoding: unicode
+  database: <%= app_name %>_test
+  username: <%= app_name %>
+  password:
+
+production:
+  adapter: jdbcpostgresql
+  encoding: unicode
+  database: <%= app_name %>_production
+  username: <%= app_name %>
+  password:

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -143,6 +143,12 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "Gemfile", /^gem\s+["']activerecord-jdbcsqlite3-adapter["']$/
   end
 
+  def test_config_jdbcpostgresql_database
+    run_generator([destination_root, "-d", "jdbcpostgresql"])
+    assert_file "config/database.yml", /jdbcpostgresql/
+    assert_file "Gemfile", /^gem\s+["']activerecord-jdbcpostgresql-adapter["']$/
+  end
+
   def test_generator_if_skip_active_record_is_given
     run_generator [destination_root, "--skip-active-record"]
     assert_no_file "config/database.yml"

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -624,7 +624,7 @@ module RailtiesTest
       boot_rails
       require "#{rails_root}/config/environment"
 
-      methods = Bukkits::Engine.helpers.public_instance_methods.sort
+      methods = Bukkits::Engine.helpers.public_instance_methods.collect(&:to_s).sort
       expected = ["bar", "baz"]
       assert_equal expected, methods
     end


### PR DESCRIPTION
Right now `Array#from` will return `nil` if the index passed in is outside the bounds of the array, which is inconsistent with all other returns (including `%().from(0)`, which is technically outside the bounds of the array), and so using `Array#from`  we'll have to do things like

```
unless %(a, b, c, d).from(5).nil?
   # ... do something here
end
```

This commit will change it so that all return values of `Array#from` are an array.

Tests and documentation update included.

I ran benchmarks using the following:

```
require 'benchmark'

class Array

  def from(position)
    self[position..-1]
  end

  def new_from(position)
    position > length ? [] : self[position..-1]
  end

end

array = (1..10).to_a
n = 200_000

Benchmark.bm(3) do |x|
  x.report("1:") { n.times { array.from(1) } }
  x.report("2:") { n.times { array.new_from(1) } }
  x.report("3:") { n.times { array.from(100001) } }
  x.report("4:") { n.times { array.new_from(100001) } }
end
```

And got

```
         user     system      total        real
1:   0.360000   0.000000   0.360000 (  0.362778)
2:   0.400000   0.000000   0.400000 (  0.396071)
3:   0.320000   0.010000   0.330000 (  0.337338)
4:   0.170000   0.000000   0.170000 (  0.161635)
```

Which is a 8% increase on calls that go through and a 50% decrease when a call is outside the arrays range.

If I increased the array size to 100,000 items, it became a 10% increase in time.
