### PR TITLE
Optionally change the cost of ActiveModel::SecurePassword encryption

### DIFF
--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -44,6 +44,17 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert @user.authenticate("secret")
   end
 
+  test "ensure default cost" do
+    @user.password = "secret"
+    assert_equal BCrypt::Engine::DEFAULT_COST, @user.password_digest.cost
+  end
+
+  test "increase cost" do
+    @visitor = Visitor.new
+    @visitor.password = "secure"
+    assert_equal 9, @visitor.password_digest.cost
+  end
+
   test "visitor#password_digest should be protected against mass assignment" do
     assert Visitor.active_authorizer.kind_of?(ActiveModel::MassAssignmentSecurity::BlackList)
     assert Visitor.active_authorizer.include?(:password_digest)

--- a/activemodel/test/models/visitor.rb
+++ b/activemodel/test/models/visitor.rb
@@ -3,7 +3,7 @@ class Visitor
   include ActiveModel::SecurePassword
   include ActiveModel::MassAssignmentSecurity
 
-  has_secure_password
+  has_secure_password :cost => 9
 
   attr_accessor :password_digest
 end


### PR DESCRIPTION
Currently ActiveModel::SecurePassword defaults to BCrypt::Engine::DEFAULT_COST which is 10. It would be nice if we could override this. By overriding the instance method #password_digest_cost this can be done
