### PR TITLE
Fix marshal round-tripping of fractional seconds (Time#subsec).

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/marshal.rb
+++ b/activesupport/lib/active_support/core_ext/time/marshal.rb
@@ -37,6 +37,7 @@ if Time.local(2010).zone != Marshal.load(Marshal.dump(Time.local(2010))).zone
         time.instance_eval do
           if zone = defined?(@_zone) && remove_instance_variable('@_zone')
             ary = to_a
+            ary[0] += subsec if ary[0] == sec
             ary[-1] = zone
             utc? ? Time.utc(*ary) : Time.local(*ary)
           else

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -808,4 +808,11 @@ class TimeExtMarshalingTest < Test::Unit::TestCase
     assert_equal t.zone, unmarshaled.zone
     assert_equal t, unmarshaled
   end
+
+  def test_marshalling_preserves_fractional_seconds
+    t = Time.parse('00:00:00.500')
+    unmarshaled = Marshal.load(Marshal.dump(t))
+    assert_equal t.to_f, unmarshaled.to_f
+    assert_equal t, unmarshaled
+  end
 end


### PR DESCRIPTION
"Ruby 1.9.2: marshaling round-trips Time#zone" 41e7c68d87903d0596228b6c1ae2c5d87b209280 broke round-tripping of fractional seconds when marshalling Time on Ruby 1.9.2.
