### PR TITLE
File should be open in read/write mode. When doing lock on a file.

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -121,7 +121,7 @@ module ActiveSupport
         # Lock a file for a block so only one process can modify it at a time.
         def lock_file(file_name, &block) # :nodoc:
           if File.exist?(file_name)
-            File.open(file_name, 'r') do |f|
+            File.open(file_name, 'r+') do |f|
               begin
                 f.flock File::LOCK_EX
                 yield


### PR DESCRIPTION
File should be open in 'r+' mode to pass with jruby-1.6.1.

Tested with other ruby version as well.

Solved LightHouse Ticket [#6662]

https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/6662-fileflock-cant-lock-read-only-file-for-exclusive-access

Jruby Change-log :-

http://jira.codehaus.org/browse/JRUBY-5627
