### PR TITLE
Don't reuse a closed flash when using now

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/flash.rb
+++ b/actionpack/lib/action_dispatch/middleware/flash.rb
@@ -70,6 +70,10 @@ module ActionDispatch
       def close!(new_flash)
         @flash = new_flash
       end
+      
+      def closed?
+        @flash.closed?
+      end
     end
 
     class FlashHash
@@ -146,7 +150,7 @@ module ActionDispatch
       #
       # Entries set via <tt>now</tt> are accessed the same way as standard entries: <tt>flash['my-key']</tt>.
       def now
-        @now ||= FlashNow.new(self)
+        @now = (!@now || @now.closed?) ? FlashNow.new(self) : @now
       end
 
       attr_reader :closed

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -272,6 +272,14 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_setting_flash_now_does_not_raise_in_following_requests
+    with_test_route_set do
+      env = { 'action_dispatch.request.flash_hash' => ActionDispatch::Flash::FlashHash.new }
+      get '/set_flash_now', nil, env
+      get '/set_flash_now', nil, env
+    end
+  end
+
   def test_setting_flash_raises_after_stream_back_to_client_even_with_an_empty_flash
     with_test_route_set do
       env = { 'action_dispatch.request.flash_hash' => ActionDispatch::Flash::FlashHash.new }


### PR DESCRIPTION
After rails/rails@6380f1a9f45e68f38480c0805cac62eb6708f72e from @josevalim, I had some problems when using flash.now in 2 requests in a row.
Here is a test and an attempt for patching this issue.
