### PR TITLE
The #substitute_at gets an ActiveRecord::ConnectionAdapters::Column in #i

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -56,7 +56,7 @@ module ActiveRecord
       end
 
       substitutes.each_with_index do |tuple, i|
-        tuple[1] = conn.substitute_at(tuple.first, i)
+        tuple[1] = conn.substitute_at(binds[i][0], i)
       end
 
       if values.empty? # empty insert


### PR DESCRIPTION
The #substitute_at gets an ActiveRecord::ConnectionAdapters::Column in #insert to match replacement in #exec_query.

Aaron, I did not write a test for this because I am not sure if/how this behavior should be fleshed out. The idea is that when building the query in #exec_query and/or #exec_insert I need to know the active record column which I do get in those methods. However, I also need to know when I am asked to #substitue_at when the bind params are inserted. 

This is critical for the SQL Server adapter since there are some columns (binary timestamp) that I really have to account for. I do realize that passing a string down is OK for this and I am OK with adhoc usage of not passing an AR column down. I just need to hand what rails is doing. BTW, I could not use the Arel attribute here because code like <code>column.relation.columns[...]</code> is deprecated in Arel and it seemed appropriate for rails to standardize on passing AR columns vs hacking Arel.
