### PR TITLE
Move #exec_insert to abstract adapter's database statements.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -55,6 +55,13 @@ module ActiveRecord
       def exec_query(sql, name = 'SQL', binds = [])
       end
 
+      # Executes insert +sql+ statement in the context of this connection using 
+      # +binds+ as the bind substitutes. +name+ is the logged along with
+      # the executed +sql+ statement.
+      def exec_insert(sql, name, binds)
+        exec_query(sql, name, binds)
+      end
+
       # Returns the last auto-generated ID from the affected table.
       #
       # +id_value+ will be returned unless the value is nil, in

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -427,10 +427,6 @@ module ActiveRecord
         end
       end
 
-      def exec_insert(sql, name, binds)
-        exec_query(sql, name, binds)
-      end
-
       def last_inserted_id(result)
         @connection.insert_id
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -552,10 +552,6 @@ module ActiveRecord
         end
       end
 
-      def exec_insert(sql, name, binds)
-        exec_query(sql, name, binds)
-      end
-
       def sql_for_insert(sql, pk, id_value, sequence_name, binds)
         unless pk
           _, table = extract_schema_and_table(sql.split(" ", 4)[2])

--- a/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
@@ -173,10 +173,6 @@ module ActiveRecord
         end
       end
 
-      def exec_insert(sql, name, binds)
-        exec_query(sql, name, binds)
-      end
-
       def last_inserted_id(result)
         @connection.last_insert_row_id
       end


### PR DESCRIPTION
Aaron, just following up on moving #exec_insert to the proper place in abstract adapter's database statements.
