### PR TITLE
Add http method to RoutingError message 

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -50,7 +50,7 @@ module ActionDispatch
         # Only this middleware cares about RoutingError. So, let's just raise
         # it here.
         if headers['X-Cascade'] == 'pass'
-           raise ActionController::RoutingError, "No route matches #{env['PATH_INFO'].inspect}"
+           raise ActionController::RoutingError, "No route matches [#{env['REQUEST_METHOD']}] #{env['PATH_INFO'].inspect}"
         end
       rescue Exception => exception
         raise exception if env['action_dispatch.show_exceptions'] == false


### PR DESCRIPTION
Currently ActionController::RoutingError message will alert the user of a bad path but not the method.

```
No route matches "/join"
```

This patch adds the method used to call the url for debugging. 

```
No route matches [POST] "/join"
```

By showing the method used, certain routing problems are easier to find, especially for a new rails user who is not as familliar with restful routing. 
