### PR TITLE
Use existing #empty_insert_statement_value for an insert with no columns.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -287,10 +287,6 @@ module ActiveRecord
         execute "INSERT INTO #{quote_table_name(table_name)} (#{key_list.join(', ')}) VALUES (#{value_list.join(', ')})", 'Fixture Insert'
       end
 
-      def null_insert_value
-        Arel.sql 'DEFAULT'
-      end
-
       def empty_insert_statement_value
         "VALUES(DEFAULT)"
       end

--- a/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
@@ -346,10 +346,6 @@ module ActiveRecord
         alter_table(table_name, :rename => {column_name.to_s => new_column_name.to_s})
       end
 
-      def null_insert_value
-        Arel.sql 'NULL'
-      end
-
       def empty_insert_statement_value
         "VALUES(NULL)"
       end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -60,7 +60,7 @@ module ActiveRecord
       end
 
       if values.empty? # empty insert
-        im.values = im.create_values [connection.null_insert_value], []
+        im.values = Arel.sql(connection.empty_insert_statement_value)
       else
         im.insert substitutes
       end


### PR DESCRIPTION
Aaron, following up from our email exchange.
Arel has logic that does not include columns for an insert statement if they are empty. 

    def visit_Arel_Nodes_InsertStatement o
      [ "INSERT INTO #{visit o.relation}",
        ( "(#{o.columns.map { |x|
        quote_column_name x.name
      }.join ', '})" unless o.columns.empty?),
        (visit o.values if o.values),
      ].compact.join ' '
    end

The SQL Server adapter defines the older #empty_insert_statement_value method as such. This is because there is no such thing as "VALUES(DEFAULT)" that would work.

    def empty_insert_statement_value
      "DEFAULT VALUES"
    end

In the latest version of rails we are no longer using this but #null_insert_value instead and AR is hooking into it from ActiveRecord::Relation#insert like so.

    if values.empty? # empty insert
      im.values = im.create_values [connection.null_insert_value], []
    else
      im.insert substitutes
    end

This gives no one a chance to construct something like #empty_insert_statement_value for the SQLServerAdapter. We should utilize the existing #empty_insert_statement_value instead which seems more inline with Arel's InsertManager too.
