### PR TITLE
Sass 3.1.0 is out, removing Sass alpha version from default Gemfile

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -6,7 +6,7 @@ source 'http://rubygems.org'
 
 # Asset template engines
 <%= "gem 'json'\n" if RUBY_VERSION < "1.9.2" -%>
-gem 'sass', '~> 3.1.0.alpha'
+gem 'sass'
 gem 'coffee-script'
 gem 'uglifier'
 


### PR DESCRIPTION
http://nex-3.com/posts/104-haml-and-sass-3-1-are-released
