### PR TITLE
Fixed error when running db:create with jdbcmysql

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -70,7 +70,13 @@ db_namespace = namespace :db do
         @charset   = ENV['CHARSET']   || 'utf8'
         @collation = ENV['COLLATION'] || 'utf8_unicode_ci'
         creation_options = {:charset => (config['charset'] || @charset), :collation => (config['collation'] || @collation)}
-        error_class = config['adapter'] =~ /mysql2/ ? Mysql2::Error : Mysql::Error
+        if config['adapter'] =~ /jdbc/
+          #FIXME After Jdbcmysql gives this class
+          require 'active_record/railties/jdbcmysql_error'
+          error_class = ArJdbcMySQL::Error
+        else
+          error_class = config['adapter'] =~ /mysql2/ ? Mysql2::Error : Mysql::Error
+        end
         access_denied_error = 1045
         begin
           ActiveRecord::Base.establish_connection(config.merge('database' => nil))

--- a/activerecord/lib/active_record/railties/jdbcmysql_error.rb
+++ b/activerecord/lib/active_record/railties/jdbcmysql_error.rb
@@ -1,0 +1,16 @@
+#FIXME Remove if ArJdbcMysql will give.
+module ArJdbcMySQL
+  class Error < StandardError
+    attr_accessor :error_number, :sql_state
+
+    def initialize msg
+      super
+      @error_number = nil
+      @sql_state    = nil
+    end
+
+    # Mysql gem compatibility
+    alias_method :errno, :error_number
+    alias_method :error, :message
+  end
+end


### PR DESCRIPTION
When using jdbcmysql running db:create gives error "uninitialized constant Mysql::Error"

Fix is to add a error class for JdbcMsql right now. We will remove ArJdbcMySQL::Error when it will come with activerecord-jdbc-adapter

LightHouse issue report before by me : https://rails.lighthouseapp.com/projects/8994/tickets/6628-uninitialized-constant-mysqlerror

resolved [#6628] 
