### PR TITLE
AR update_attributes api is updated to reflect the addition of assign_att

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -136,22 +136,27 @@ module ActiveRecord
     # Updates the attributes of the model from the passed-in hash and saves the
     # record, all wrapped in a transaction. If the object is invalid, the saving
     # will fail and false will be returned.
-    def update_attributes(attributes)
+    #
+    # When updating model attributes, mass-assignment security protection is respected.
+    # If no +:as+ option is supplied then the :default scope will be used.
+    # If you want to bypass the protection given by +attr_protected+ and
+    # +attr_accessible+ then you can do so using the +:without_protection+ option.
+    def update_attributes(attributes, options = {})
       # The following transaction covers any possible database side-effects of the
       # attributes assignment. For example, setting the IDs of a child collection.
       with_transaction_returning_status do
-        self.attributes = attributes
+        self.assign_attributes(attributes, options)
         save
       end
     end
 
     # Updates its receiver just like +update_attributes+ but calls <tt>save!</tt> instead
     # of +save+, so an exception is raised if the record is invalid.
-    def update_attributes!(attributes)
+    def update_attributes!(attributes, options = {})
       # The following transaction covers any possible database side-effects of the
       # attributes assignment. For example, setting the IDs of a child collection.
       with_transaction_returning_status do
-        self.attributes = attributes
+        self.assign_attributes(attributes, options)
         save!
       end
     end

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -491,6 +491,26 @@ class PersistencesTest < ActiveRecord::TestCase
     assert_equal "The First Topic", topic.title
   end
 
+  def test_update_attributes_as_admin
+    person = TightPerson.create
+    person.update_attributes({ "first_name" => 'Josh', "gender" => 'male', "comments" => 'from NZ' }, :as => :admin)
+    person.reload
+
+    assert_equal 'Josh', person.first_name
+    assert_equal 'male', person.gender
+    assert_equal 'from NZ', person.comments
+  end
+
+  def test_update_attributes_as_without_protection
+    person = TightPerson.create
+    person.update_attributes({ "first_name" => 'Josh', "gender" => 'male', "comments" => 'from NZ' }, :without_protection => true)
+    person.reload
+
+    assert_equal 'Josh', person.first_name
+    assert_equal 'male', person.gender
+    assert_equal 'from NZ', person.comments
+  end
+
   def test_update_attributes!
     Reply.validates_presence_of(:title)
     reply = Reply.find(2)
@@ -510,6 +530,26 @@ class PersistencesTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::RecordInvalid) { reply.update_attributes!(:title => nil, :content => "Have a nice evening") }
   ensure
     Reply.reset_callbacks(:validate)
+  end
+
+  def test_update_attributes_as_admin
+    person = TightPerson.create
+    person.update_attributes!({ "first_name" => 'Josh', "gender" => 'male', "comments" => 'from NZ' }, :as => :admin)
+    person.reload
+
+    assert_equal 'Josh', person.first_name
+    assert_equal 'male', person.gender
+    assert_equal 'from NZ', person.comments
+  end
+
+  def test_update_attributes_as_without_protection
+    person = TightPerson.create
+    person.update_attributes!({ "first_name" => 'Josh', "gender" => 'male', "comments" => 'from NZ' }, :without_protection => true)
+    person.reload
+
+    assert_equal 'Josh', person.first_name
+    assert_equal 'male', person.gender
+    assert_equal 'from NZ', person.comments
   end
 
   def test_destroyed_returns_boolean


### PR DESCRIPTION
Hey Guys,

This brings AR update_attributes in line with assign_attributes in accepting a scope using :as or bypass mass-assignment security using :without_protection => true

Thanks,

J
