### PR TITLE
[patch] Asset helpers should understand scheme-relative URLs

### DIFF
--- a/actionpack/lib/action_view/helpers/asset_paths.rb
+++ b/actionpack/lib/action_view/helpers/asset_paths.rb
@@ -12,13 +12,13 @@ module ActionView
         @controller = controller
       end
 
-      # Add the extension +ext+ if not present. Return full URLs otherwise untouched.
+      # Add the extension +ext+ if not present. Return full or scheme-relative URLs otherwise untouched.
       # Prefix with <tt>/dir/</tt> if lacking a leading +/+. Account for relative URL
       # roots. Rewrite the asset path for cache-busting asset ids. Include
       # asset host, if configured, with the correct request protocol.
       def compute_public_path(source, dir, ext = nil, include_host = true)
         source = source.to_s
-        return source if is_uri?(source)
+        return source if is_uri?(source) || is_scheme_relative_uri?(source)
 
         source = rewrite_extension(source, dir, ext) if ext
         source = "/#{dir}/#{source}" unless source[0] == ?/
@@ -34,6 +34,13 @@ module ActionView
 
       def is_uri?(path)
         path =~ %r{^[-a-z]+://|^cid:}
+      end
+
+      # A URI relative to a base URI's scheme?
+      # See http://labs.apache.org/webarch/uri/rfc/rfc3986.html#relative-normal
+      # "//g" => "http://g"
+      def is_scheme_relative_uri?(path)
+        path =~ %r{^//}
       end
 
     private

--- a/actionpack/lib/action_view/helpers/asset_paths.rb
+++ b/actionpack/lib/action_view/helpers/asset_paths.rb
@@ -18,7 +18,7 @@ module ActionView
       # asset host, if configured, with the correct request protocol.
       def compute_public_path(source, dir, ext = nil, include_host = true)
         source = source.to_s
-        return source if is_uri?(source) || is_scheme_relative_uri?(source)
+        return source if is_uri?(source)
 
         source = rewrite_extension(source, dir, ext) if ext
         source = "/#{dir}/#{source}" unless source[0] == ?/
@@ -33,14 +33,7 @@ module ActionView
       end
 
       def is_uri?(path)
-        path =~ %r{^[-a-z]+://|^cid:}
-      end
-
-      # A URI relative to a base URI's scheme?
-      # See http://labs.apache.org/webarch/uri/rfc/rfc3986.html#relative-normal
-      # "//g" => "http://g"
-      def is_scheme_relative_uri?(path)
-        path =~ %r{^//}
+        path =~ %r{^[-a-z]+://|^cid:|^//}
       end
 
     private

--- a/actionpack/lib/action_view/helpers/asset_paths.rb
+++ b/actionpack/lib/action_view/helpers/asset_paths.rb
@@ -12,13 +12,13 @@ module ActionView
         @controller = controller
       end
 
-      # Add the extension +ext+ if not present. Return full or scheme-relative URLs otherwise untouched.
+      # Add the extension +ext+ if not present. Return full URLs otherwise untouched.
       # Prefix with <tt>/dir/</tt> if lacking a leading +/+. Account for relative URL
       # roots. Rewrite the asset path for cache-busting asset ids. Include
       # asset host, if configured, with the correct request protocol.
       def compute_public_path(source, dir, ext = nil, include_host = true)
         source = source.to_s
-        return source if is_uri?(source) || is_scheme_relative_uri?(source)
+        return source if is_uri?(source)
 
         source = rewrite_extension(source, dir, ext) if ext
         source = "/#{dir}/#{source}" unless source[0] == ?/
@@ -34,13 +34,6 @@ module ActionView
 
       def is_uri?(path)
         path =~ %r{^[-a-z]+://|^cid:}
-      end
-
-      # A URI relative to a base URI's scheme?
-      # See http://labs.apache.org/webarch/uri/rfc/rfc3986.html#relative-normal
-      # "//g" => "http://g"
-      def is_scheme_relative_uri?(path)
-        path =~ %r{^//}
       end
 
     private

--- a/actionpack/test/template/asset_tag_helper_test.rb
+++ b/actionpack/test/template/asset_tag_helper_test.rb
@@ -66,6 +66,7 @@ class AssetTagHelperTest < ActionView::TestCase
     %(auto_discovery_link_tag(:xml)) => %(<link href="http://www.example.com" rel="alternate" title="XML" type="application/xml" />),
     %(auto_discovery_link_tag(:rss, :action => "feed")) => %(<link href="http://www.example.com" rel="alternate" title="RSS" type="application/rss+xml" />),
     %(auto_discovery_link_tag(:rss, "http://localhost/feed")) => %(<link href="http://localhost/feed" rel="alternate" title="RSS" type="application/rss+xml" />),
+    %(auto_discovery_link_tag(:rss, "//localhost/feed")) => %(<link href="//localhost/feed" rel="alternate" title="RSS" type="application/rss+xml" />),
     %(auto_discovery_link_tag(:rss, {:action => "feed"}, {:title => "My RSS"})) => %(<link href="http://www.example.com" rel="alternate" title="My RSS" type="application/rss+xml" />),
     %(auto_discovery_link_tag(:rss, {}, {:title => "My RSS"})) => %(<link href="http://www.example.com" rel="alternate" title="My RSS" type="application/rss+xml" />),
     %(auto_discovery_link_tag(nil, {}, {:type => "text/html"})) => %(<link href="http://www.example.com" rel="alternate" title="" type="text/html" />),
@@ -100,6 +101,7 @@ class AssetTagHelperTest < ActionView::TestCase
 
     %(javascript_include_tag("http://example.com/all")) => %(<script src="http://example.com/all" type="text/javascript"></script>),
     %(javascript_include_tag("http://example.com/all.js")) => %(<script src="http://example.com/all.js" type="text/javascript"></script>),
+    %(javascript_include_tag("//example.com/all.js")) => %(<script src="//example.com/all.js" type="text/javascript"></script>),
   }
 
   StylePathToTag = {
@@ -129,6 +131,7 @@ class AssetTagHelperTest < ActionView::TestCase
 
     %(stylesheet_link_tag("http://www.example.com/styles/style")) => %(<link href="http://www.example.com/styles/style" media="screen" rel="stylesheet" type="text/css" />),
     %(stylesheet_link_tag("http://www.example.com/styles/style.css")) => %(<link href="http://www.example.com/styles/style.css" media="screen" rel="stylesheet" type="text/css" />),
+    %(stylesheet_link_tag("//www.example.com/styles/style.css")) => %(<link href="//www.example.com/styles/style.css" media="screen" rel="stylesheet" type="text/css" />),
   }
 
   ImagePathToTag = {
@@ -157,6 +160,7 @@ class AssetTagHelperTest < ActionView::TestCase
     %(image_tag("slash..png")) => %(<img alt="Slash." src="/images/slash..png" />),
     %(image_tag(".pdf.png")) => %(<img alt=".pdf" src="/images/.pdf.png" />),
     %(image_tag("http://www.rubyonrails.com/images/rails.png")) => %(<img alt="Rails" src="http://www.rubyonrails.com/images/rails.png" />),
+    %(image_tag("//www.rubyonrails.com/images/rails.png")) => %(<img alt="Rails" src="//www.rubyonrails.com/images/rails.png" />),
     %(image_tag("mouse.png", :mouseover => "/images/mouse_over.png")) => %(<img alt="Mouse" onmouseover="this.src='/images/mouse_over.png'" onmouseout="this.src='/images/mouse.png'" src="/images/mouse.png" />),
     %(image_tag("mouse.png", :mouseover => image_path("mouse_over.png"))) => %(<img alt="Mouse" onmouseover="this.src='/images/mouse_over.png'" onmouseout="this.src='/images/mouse.png'" src="/images/mouse.png" />),
     %(image_tag("mouse.png", :alt => nil)) => %(<img src="/images/mouse.png" />)
@@ -195,6 +199,7 @@ class AssetTagHelperTest < ActionView::TestCase
     %(video_tag("error.avi", "size" => "100 x 100")) => %(<video src="/videos/error.avi" />),
     %(video_tag("error.avi", "size" => "x")) => %(<video src="/videos/error.avi" />),
     %(video_tag("http://media.rubyonrails.org/video/rails_blog_2.mov")) => %(<video src="http://media.rubyonrails.org/video/rails_blog_2.mov" />),
+    %(video_tag("//media.rubyonrails.org/video/rails_blog_2.mov")) => %(<video src="//media.rubyonrails.org/video/rails_blog_2.mov" />),
     %(video_tag(["multiple.ogg", "multiple.avi"])) => %(<video><source src="multiple.ogg" /><source src="multiple.avi" /></video>),
     %(video_tag(["multiple.ogg", "multiple.avi"], :size => "160x120", :controls => true)) => %(<video controls="controls" height="120" width="160"><source src="multiple.ogg" /><source src="multiple.avi" /></video>)
   }
@@ -217,6 +222,7 @@ class AssetTagHelperTest < ActionView::TestCase
     %(audio_tag("xml.wav")) => %(<audio src="/audios/xml.wav" />),
     %(audio_tag("rss.wav", :autoplay => true, :controls => true)) => %(<audio autoplay="autoplay" controls="controls" src="/audios/rss.wav" />),
     %(audio_tag("http://media.rubyonrails.org/audio/rails_blog_2.mov")) => %(<audio src="http://media.rubyonrails.org/audio/rails_blog_2.mov" />),
+    %(audio_tag("//media.rubyonrails.org/audio/rails_blog_2.mov")) => %(<audio src="//media.rubyonrails.org/audio/rails_blog_2.mov" />),
   }
 
   def test_auto_discovery_link_tag
@@ -503,6 +509,10 @@ class AssetTagHelperTest < ActionView::TestCase
 
   def test_should_skip_asset_id_on_complete_url
     assert_equal %(<img alt="Rails" src="http://www.example.com/rails.png" />), image_tag("http://www.example.com/rails.png")
+  end
+
+  def test_should_skip_asset_id_on_scheme_relative_url
+    assert_equal %(<img alt="Rails" src="//www.example.com/rails.png" />), image_tag("//www.example.com/rails.png")
   end
 
   def test_should_use_preset_asset_id
@@ -1093,6 +1103,11 @@ class AssetTagHelperNonVhostTest < ActionView::TestCase
   def test_should_ignore_asset_host_on_complete_url
     @controller.config.asset_host = "http://assets.example.com"
     assert_dom_equal(%(<link href="http://bar.example.com/stylesheets/style.css" media="screen" rel="stylesheet" type="text/css" />), stylesheet_link_tag("http://bar.example.com/stylesheets/style.css"))
+  end
+
+  def test_should_ignore_asset_host_on_scheme_relative_url
+    @controller.config.asset_host = "http://assets.example.com"
+    assert_dom_equal(%(<link href="//bar.example.com/stylesheets/style.css" media="screen" rel="stylesheet" type="text/css" />), stylesheet_link_tag("//bar.example.com/stylesheets/style.css"))
   end
 
   def test_should_wildcard_asset_host_between_zero_and_four

--- a/actionpack/test/template/asset_tag_helper_test.rb
+++ b/actionpack/test/template/asset_tag_helper_test.rb
@@ -66,7 +66,6 @@ class AssetTagHelperTest < ActionView::TestCase
     %(auto_discovery_link_tag(:xml)) => %(<link href="http://www.example.com" rel="alternate" title="XML" type="application/xml" />),
     %(auto_discovery_link_tag(:rss, :action => "feed")) => %(<link href="http://www.example.com" rel="alternate" title="RSS" type="application/rss+xml" />),
     %(auto_discovery_link_tag(:rss, "http://localhost/feed")) => %(<link href="http://localhost/feed" rel="alternate" title="RSS" type="application/rss+xml" />),
-    %(auto_discovery_link_tag(:rss, "//localhost/feed")) => %(<link href="//localhost/feed" rel="alternate" title="RSS" type="application/rss+xml" />),
     %(auto_discovery_link_tag(:rss, {:action => "feed"}, {:title => "My RSS"})) => %(<link href="http://www.example.com" rel="alternate" title="My RSS" type="application/rss+xml" />),
     %(auto_discovery_link_tag(:rss, {}, {:title => "My RSS"})) => %(<link href="http://www.example.com" rel="alternate" title="My RSS" type="application/rss+xml" />),
     %(auto_discovery_link_tag(nil, {}, {:type => "text/html"})) => %(<link href="http://www.example.com" rel="alternate" title="" type="text/html" />),
@@ -101,7 +100,6 @@ class AssetTagHelperTest < ActionView::TestCase
 
     %(javascript_include_tag("http://example.com/all")) => %(<script src="http://example.com/all" type="text/javascript"></script>),
     %(javascript_include_tag("http://example.com/all.js")) => %(<script src="http://example.com/all.js" type="text/javascript"></script>),
-    %(javascript_include_tag("//example.com/all.js")) => %(<script src="//example.com/all.js" type="text/javascript"></script>),
   }
 
   StylePathToTag = {
@@ -131,7 +129,6 @@ class AssetTagHelperTest < ActionView::TestCase
 
     %(stylesheet_link_tag("http://www.example.com/styles/style")) => %(<link href="http://www.example.com/styles/style" media="screen" rel="stylesheet" type="text/css" />),
     %(stylesheet_link_tag("http://www.example.com/styles/style.css")) => %(<link href="http://www.example.com/styles/style.css" media="screen" rel="stylesheet" type="text/css" />),
-    %(stylesheet_link_tag("//www.example.com/styles/style.css")) => %(<link href="//www.example.com/styles/style.css" media="screen" rel="stylesheet" type="text/css" />),
   }
 
   ImagePathToTag = {
@@ -160,7 +157,6 @@ class AssetTagHelperTest < ActionView::TestCase
     %(image_tag("slash..png")) => %(<img alt="Slash." src="/images/slash..png" />),
     %(image_tag(".pdf.png")) => %(<img alt=".pdf" src="/images/.pdf.png" />),
     %(image_tag("http://www.rubyonrails.com/images/rails.png")) => %(<img alt="Rails" src="http://www.rubyonrails.com/images/rails.png" />),
-    %(image_tag("//www.rubyonrails.com/images/rails.png")) => %(<img alt="Rails" src="//www.rubyonrails.com/images/rails.png" />),
     %(image_tag("mouse.png", :mouseover => "/images/mouse_over.png")) => %(<img alt="Mouse" onmouseover="this.src='/images/mouse_over.png'" onmouseout="this.src='/images/mouse.png'" src="/images/mouse.png" />),
     %(image_tag("mouse.png", :mouseover => image_path("mouse_over.png"))) => %(<img alt="Mouse" onmouseover="this.src='/images/mouse_over.png'" onmouseout="this.src='/images/mouse.png'" src="/images/mouse.png" />),
     %(image_tag("mouse.png", :alt => nil)) => %(<img src="/images/mouse.png" />)
@@ -199,7 +195,6 @@ class AssetTagHelperTest < ActionView::TestCase
     %(video_tag("error.avi", "size" => "100 x 100")) => %(<video src="/videos/error.avi" />),
     %(video_tag("error.avi", "size" => "x")) => %(<video src="/videos/error.avi" />),
     %(video_tag("http://media.rubyonrails.org/video/rails_blog_2.mov")) => %(<video src="http://media.rubyonrails.org/video/rails_blog_2.mov" />),
-    %(video_tag("//media.rubyonrails.org/video/rails_blog_2.mov")) => %(<video src="//media.rubyonrails.org/video/rails_blog_2.mov" />),
     %(video_tag(["multiple.ogg", "multiple.avi"])) => %(<video><source src="multiple.ogg" /><source src="multiple.avi" /></video>),
     %(video_tag(["multiple.ogg", "multiple.avi"], :size => "160x120", :controls => true)) => %(<video controls="controls" height="120" width="160"><source src="multiple.ogg" /><source src="multiple.avi" /></video>)
   }
@@ -222,7 +217,6 @@ class AssetTagHelperTest < ActionView::TestCase
     %(audio_tag("xml.wav")) => %(<audio src="/audios/xml.wav" />),
     %(audio_tag("rss.wav", :autoplay => true, :controls => true)) => %(<audio autoplay="autoplay" controls="controls" src="/audios/rss.wav" />),
     %(audio_tag("http://media.rubyonrails.org/audio/rails_blog_2.mov")) => %(<audio src="http://media.rubyonrails.org/audio/rails_blog_2.mov" />),
-    %(audio_tag("//media.rubyonrails.org/audio/rails_blog_2.mov")) => %(<audio src="//media.rubyonrails.org/audio/rails_blog_2.mov" />),
   }
 
   def test_auto_discovery_link_tag
@@ -509,10 +503,6 @@ class AssetTagHelperTest < ActionView::TestCase
 
   def test_should_skip_asset_id_on_complete_url
     assert_equal %(<img alt="Rails" src="http://www.example.com/rails.png" />), image_tag("http://www.example.com/rails.png")
-  end
-
-  def test_should_skip_asset_id_on_scheme_relative_url
-    assert_equal %(<img alt="Rails" src="//www.example.com/rails.png" />), image_tag("//www.example.com/rails.png")
   end
 
   def test_should_use_preset_asset_id
@@ -1103,11 +1093,6 @@ class AssetTagHelperNonVhostTest < ActionView::TestCase
   def test_should_ignore_asset_host_on_complete_url
     @controller.config.asset_host = "http://assets.example.com"
     assert_dom_equal(%(<link href="http://bar.example.com/stylesheets/style.css" media="screen" rel="stylesheet" type="text/css" />), stylesheet_link_tag("http://bar.example.com/stylesheets/style.css"))
-  end
-
-  def test_should_ignore_asset_host_on_scheme_relative_url
-    @controller.config.asset_host = "http://assets.example.com"
-    assert_dom_equal(%(<link href="//bar.example.com/stylesheets/style.css" media="screen" rel="stylesheet" type="text/css" />), stylesheet_link_tag("//bar.example.com/stylesheets/style.css"))
   end
 
   def test_should_wildcard_asset_host_between_zero_and_four


### PR DESCRIPTION
Hello,

Please see the lighthouse ticket I submitted for details on this patch request:

https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/6748

A Rails contributer, @sferik, suggested I also submit a pull request.

Does this change look OK?  Your time and feedback are appreciated.

Thanks,
Chad
