### PR TITLE
Fix #update_attributes api format error

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -138,7 +138,7 @@ module ActiveRecord
     # will fail and false will be returned.
     #
     # When updating model attributes, mass-assignment security protection is respected.
-    # If no +:as+ option is supplied then the :default scope will be used.
+    # If no +:as+ option is supplied then the +:default+ scope will be used.
     # If you want to bypass the protection given by +attr_protected+ and
     # +attr_accessible+ then you can do so using the +:without_protection+ option.
     def update_attributes(attributes, options = {})


### PR DESCRIPTION
This fixes formatting on #update_attributes docs, introduced in this commit: https://github.com/rails/rails/commit/8111facdb4d98ad9fce0892a68f790e32aa27002
