### PR TITLE
Remove useless argument

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ platforms :ruby do
   group :db do
     gem "pg", ">= 0.11.0"
     gem "mysql", ">= 2.8.1"
-    gem "mysql2", :git => "git://github.com/brianmario/mysql2.git"
+    gem "mysql2", ">= 0.3.0"
   end
 end
 

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -147,7 +147,9 @@ module ActionController
         if value.is_a? Fixnum
           value = value.to_s
         elsif value.is_a? Array
-          value = Result.new(value)
+          value = Result.new(value.map { |v| v.is_a?(String) ? v.dup : v })
+        elsif value.is_a? String
+          value = value.dup
         end
 
         if extra_keys.include?(key.to_sym)

--- a/actionpack/lib/action_view/helpers/asset_paths.rb
+++ b/actionpack/lib/action_view/helpers/asset_paths.rb
@@ -12,13 +12,13 @@ module ActionView
         @controller = controller
       end
 
-      # Add the extension +ext+ if not present. Return full URLs otherwise untouched.
+      # Add the extension +ext+ if not present. Return full or scheme-relative URLs otherwise untouched.
       # Prefix with <tt>/dir/</tt> if lacking a leading +/+. Account for relative URL
       # roots. Rewrite the asset path for cache-busting asset ids. Include
       # asset host, if configured, with the correct request protocol.
       def compute_public_path(source, dir, ext = nil, include_host = true)
         source = source.to_s
-        return source if is_uri?(source)
+        return source if is_uri?(source) || is_scheme_relative_uri?(source)
 
         source = rewrite_extension(source, dir, ext) if ext
         source = "/#{dir}/#{source}" unless source[0] == ?/
@@ -34,6 +34,13 @@ module ActionView
 
       def is_uri?(path)
         path =~ %r{^[-a-z]+://|^cid:}
+      end
+
+      # A URI relative to a base URI's scheme?
+      # See http://labs.apache.org/webarch/uri/rfc/rfc3986.html#relative-normal
+      # "//g" => "http://g"
+      def is_scheme_relative_uri?(path)
+        path =~ %r{^//}
       end
 
     private

--- a/actionpack/lib/action_view/helpers/asset_paths.rb
+++ b/actionpack/lib/action_view/helpers/asset_paths.rb
@@ -18,7 +18,7 @@ module ActionView
       # asset host, if configured, with the correct request protocol.
       def compute_public_path(source, dir, ext = nil, include_host = true)
         source = source.to_s
-        return source if is_uri?(source) || is_scheme_relative_uri?(source)
+        return source if is_uri?(source)
 
         source = rewrite_extension(source, dir, ext) if ext
         source = "/#{dir}/#{source}" unless source[0] == ?/
@@ -33,14 +33,7 @@ module ActionView
       end
 
       def is_uri?(path)
-        path =~ %r{^[-a-z]+://|^cid:}
-      end
-
-      # A URI relative to a base URI's scheme?
-      # See http://labs.apache.org/webarch/uri/rfc/rfc3986.html#relative-normal
-      # "//g" => "http://g"
-      def is_scheme_relative_uri?(path)
-        path =~ %r{^//}
+        path =~ %r{^[-a-z]+://|^cid:|^//}
       end
 
     private

--- a/actionpack/lib/action_view/helpers/asset_paths.rb
+++ b/actionpack/lib/action_view/helpers/asset_paths.rb
@@ -12,13 +12,13 @@ module ActionView
         @controller = controller
       end
 
-      # Add the extension +ext+ if not present. Return full or scheme-relative URLs otherwise untouched.
+      # Add the extension +ext+ if not present. Return full URLs otherwise untouched.
       # Prefix with <tt>/dir/</tt> if lacking a leading +/+. Account for relative URL
       # roots. Rewrite the asset path for cache-busting asset ids. Include
       # asset host, if configured, with the correct request protocol.
       def compute_public_path(source, dir, ext = nil, include_host = true)
         source = source.to_s
-        return source if is_uri?(source) || is_scheme_relative_uri?(source)
+        return source if is_uri?(source)
 
         source = rewrite_extension(source, dir, ext) if ext
         source = "/#{dir}/#{source}" unless source[0] == ?/
@@ -34,13 +34,6 @@ module ActionView
 
       def is_uri?(path)
         path =~ %r{^[-a-z]+://|^cid:}
-      end
-
-      # A URI relative to a base URI's scheme?
-      # See http://labs.apache.org/webarch/uri/rfc/rfc3986.html#relative-normal
-      # "//g" => "http://g"
-      def is_scheme_relative_uri?(path)
-        path =~ %r{^//}
       end
 
     private

--- a/actionpack/test/controller/test_test.rb
+++ b/actionpack/test/controller/test_test.rb
@@ -493,6 +493,18 @@ XML
     )
   end
 
+  def test_params_passing_with_frozen_values
+    assert_nothing_raised do
+      get :test_params, :frozen => 'icy'.freeze, :frozens => ['icy'.freeze].freeze
+    end
+    parsed_params = eval(@response.body)
+    assert_equal(
+      {'controller' => 'test_test/test', 'action' => 'test_params',
+       'frozen' => 'icy', 'frozens' => ['icy']},
+      parsed_params
+    )
+  end
+
   def test_id_converted_to_string
     get :test_params, :id => 20, :foo => Object.new
     assert_kind_of String, @request.path_parameters['id']

--- a/actionpack/test/template/asset_tag_helper_test.rb
+++ b/actionpack/test/template/asset_tag_helper_test.rb
@@ -66,6 +66,7 @@ class AssetTagHelperTest < ActionView::TestCase
     %(auto_discovery_link_tag(:xml)) => %(<link href="http://www.example.com" rel="alternate" title="XML" type="application/xml" />),
     %(auto_discovery_link_tag(:rss, :action => "feed")) => %(<link href="http://www.example.com" rel="alternate" title="RSS" type="application/rss+xml" />),
     %(auto_discovery_link_tag(:rss, "http://localhost/feed")) => %(<link href="http://localhost/feed" rel="alternate" title="RSS" type="application/rss+xml" />),
+    %(auto_discovery_link_tag(:rss, "//localhost/feed")) => %(<link href="//localhost/feed" rel="alternate" title="RSS" type="application/rss+xml" />),
     %(auto_discovery_link_tag(:rss, {:action => "feed"}, {:title => "My RSS"})) => %(<link href="http://www.example.com" rel="alternate" title="My RSS" type="application/rss+xml" />),
     %(auto_discovery_link_tag(:rss, {}, {:title => "My RSS"})) => %(<link href="http://www.example.com" rel="alternate" title="My RSS" type="application/rss+xml" />),
     %(auto_discovery_link_tag(nil, {}, {:type => "text/html"})) => %(<link href="http://www.example.com" rel="alternate" title="" type="text/html" />),
@@ -100,6 +101,7 @@ class AssetTagHelperTest < ActionView::TestCase
 
     %(javascript_include_tag("http://example.com/all")) => %(<script src="http://example.com/all" type="text/javascript"></script>),
     %(javascript_include_tag("http://example.com/all.js")) => %(<script src="http://example.com/all.js" type="text/javascript"></script>),
+    %(javascript_include_tag("//example.com/all.js")) => %(<script src="//example.com/all.js" type="text/javascript"></script>),
   }
 
   StylePathToTag = {
@@ -129,6 +131,7 @@ class AssetTagHelperTest < ActionView::TestCase
 
     %(stylesheet_link_tag("http://www.example.com/styles/style")) => %(<link href="http://www.example.com/styles/style" media="screen" rel="stylesheet" type="text/css" />),
     %(stylesheet_link_tag("http://www.example.com/styles/style.css")) => %(<link href="http://www.example.com/styles/style.css" media="screen" rel="stylesheet" type="text/css" />),
+    %(stylesheet_link_tag("//www.example.com/styles/style.css")) => %(<link href="//www.example.com/styles/style.css" media="screen" rel="stylesheet" type="text/css" />),
   }
 
   ImagePathToTag = {
@@ -157,6 +160,7 @@ class AssetTagHelperTest < ActionView::TestCase
     %(image_tag("slash..png")) => %(<img alt="Slash." src="/images/slash..png" />),
     %(image_tag(".pdf.png")) => %(<img alt=".pdf" src="/images/.pdf.png" />),
     %(image_tag("http://www.rubyonrails.com/images/rails.png")) => %(<img alt="Rails" src="http://www.rubyonrails.com/images/rails.png" />),
+    %(image_tag("//www.rubyonrails.com/images/rails.png")) => %(<img alt="Rails" src="//www.rubyonrails.com/images/rails.png" />),
     %(image_tag("mouse.png", :mouseover => "/images/mouse_over.png")) => %(<img alt="Mouse" onmouseover="this.src='/images/mouse_over.png'" onmouseout="this.src='/images/mouse.png'" src="/images/mouse.png" />),
     %(image_tag("mouse.png", :mouseover => image_path("mouse_over.png"))) => %(<img alt="Mouse" onmouseover="this.src='/images/mouse_over.png'" onmouseout="this.src='/images/mouse.png'" src="/images/mouse.png" />),
     %(image_tag("mouse.png", :alt => nil)) => %(<img src="/images/mouse.png" />)
@@ -195,6 +199,7 @@ class AssetTagHelperTest < ActionView::TestCase
     %(video_tag("error.avi", "size" => "100 x 100")) => %(<video src="/videos/error.avi" />),
     %(video_tag("error.avi", "size" => "x")) => %(<video src="/videos/error.avi" />),
     %(video_tag("http://media.rubyonrails.org/video/rails_blog_2.mov")) => %(<video src="http://media.rubyonrails.org/video/rails_blog_2.mov" />),
+    %(video_tag("//media.rubyonrails.org/video/rails_blog_2.mov")) => %(<video src="//media.rubyonrails.org/video/rails_blog_2.mov" />),
     %(video_tag(["multiple.ogg", "multiple.avi"])) => %(<video><source src="multiple.ogg" /><source src="multiple.avi" /></video>),
     %(video_tag(["multiple.ogg", "multiple.avi"], :size => "160x120", :controls => true)) => %(<video controls="controls" height="120" width="160"><source src="multiple.ogg" /><source src="multiple.avi" /></video>)
   }
@@ -217,6 +222,7 @@ class AssetTagHelperTest < ActionView::TestCase
     %(audio_tag("xml.wav")) => %(<audio src="/audios/xml.wav" />),
     %(audio_tag("rss.wav", :autoplay => true, :controls => true)) => %(<audio autoplay="autoplay" controls="controls" src="/audios/rss.wav" />),
     %(audio_tag("http://media.rubyonrails.org/audio/rails_blog_2.mov")) => %(<audio src="http://media.rubyonrails.org/audio/rails_blog_2.mov" />),
+    %(audio_tag("//media.rubyonrails.org/audio/rails_blog_2.mov")) => %(<audio src="//media.rubyonrails.org/audio/rails_blog_2.mov" />),
   }
 
   def test_auto_discovery_link_tag
@@ -503,6 +509,10 @@ class AssetTagHelperTest < ActionView::TestCase
 
   def test_should_skip_asset_id_on_complete_url
     assert_equal %(<img alt="Rails" src="http://www.example.com/rails.png" />), image_tag("http://www.example.com/rails.png")
+  end
+
+  def test_should_skip_asset_id_on_scheme_relative_url
+    assert_equal %(<img alt="Rails" src="//www.example.com/rails.png" />), image_tag("//www.example.com/rails.png")
   end
 
   def test_should_use_preset_asset_id
@@ -1093,6 +1103,11 @@ class AssetTagHelperNonVhostTest < ActionView::TestCase
   def test_should_ignore_asset_host_on_complete_url
     @controller.config.asset_host = "http://assets.example.com"
     assert_dom_equal(%(<link href="http://bar.example.com/stylesheets/style.css" media="screen" rel="stylesheet" type="text/css" />), stylesheet_link_tag("http://bar.example.com/stylesheets/style.css"))
+  end
+
+  def test_should_ignore_asset_host_on_scheme_relative_url
+    @controller.config.asset_host = "http://assets.example.com"
+    assert_dom_equal(%(<link href="//bar.example.com/stylesheets/style.css" media="screen" rel="stylesheet" type="text/css" />), stylesheet_link_tag("//bar.example.com/stylesheets/style.css"))
   end
 
   def test_should_wildcard_asset_host_between_zero_and_four

--- a/actionpack/test/template/asset_tag_helper_test.rb
+++ b/actionpack/test/template/asset_tag_helper_test.rb
@@ -66,7 +66,6 @@ class AssetTagHelperTest < ActionView::TestCase
     %(auto_discovery_link_tag(:xml)) => %(<link href="http://www.example.com" rel="alternate" title="XML" type="application/xml" />),
     %(auto_discovery_link_tag(:rss, :action => "feed")) => %(<link href="http://www.example.com" rel="alternate" title="RSS" type="application/rss+xml" />),
     %(auto_discovery_link_tag(:rss, "http://localhost/feed")) => %(<link href="http://localhost/feed" rel="alternate" title="RSS" type="application/rss+xml" />),
-    %(auto_discovery_link_tag(:rss, "//localhost/feed")) => %(<link href="//localhost/feed" rel="alternate" title="RSS" type="application/rss+xml" />),
     %(auto_discovery_link_tag(:rss, {:action => "feed"}, {:title => "My RSS"})) => %(<link href="http://www.example.com" rel="alternate" title="My RSS" type="application/rss+xml" />),
     %(auto_discovery_link_tag(:rss, {}, {:title => "My RSS"})) => %(<link href="http://www.example.com" rel="alternate" title="My RSS" type="application/rss+xml" />),
     %(auto_discovery_link_tag(nil, {}, {:type => "text/html"})) => %(<link href="http://www.example.com" rel="alternate" title="" type="text/html" />),
@@ -101,7 +100,6 @@ class AssetTagHelperTest < ActionView::TestCase
 
     %(javascript_include_tag("http://example.com/all")) => %(<script src="http://example.com/all" type="text/javascript"></script>),
     %(javascript_include_tag("http://example.com/all.js")) => %(<script src="http://example.com/all.js" type="text/javascript"></script>),
-    %(javascript_include_tag("//example.com/all.js")) => %(<script src="//example.com/all.js" type="text/javascript"></script>),
   }
 
   StylePathToTag = {
@@ -131,7 +129,6 @@ class AssetTagHelperTest < ActionView::TestCase
 
     %(stylesheet_link_tag("http://www.example.com/styles/style")) => %(<link href="http://www.example.com/styles/style" media="screen" rel="stylesheet" type="text/css" />),
     %(stylesheet_link_tag("http://www.example.com/styles/style.css")) => %(<link href="http://www.example.com/styles/style.css" media="screen" rel="stylesheet" type="text/css" />),
-    %(stylesheet_link_tag("//www.example.com/styles/style.css")) => %(<link href="//www.example.com/styles/style.css" media="screen" rel="stylesheet" type="text/css" />),
   }
 
   ImagePathToTag = {
@@ -160,7 +157,6 @@ class AssetTagHelperTest < ActionView::TestCase
     %(image_tag("slash..png")) => %(<img alt="Slash." src="/images/slash..png" />),
     %(image_tag(".pdf.png")) => %(<img alt=".pdf" src="/images/.pdf.png" />),
     %(image_tag("http://www.rubyonrails.com/images/rails.png")) => %(<img alt="Rails" src="http://www.rubyonrails.com/images/rails.png" />),
-    %(image_tag("//www.rubyonrails.com/images/rails.png")) => %(<img alt="Rails" src="//www.rubyonrails.com/images/rails.png" />),
     %(image_tag("mouse.png", :mouseover => "/images/mouse_over.png")) => %(<img alt="Mouse" onmouseover="this.src='/images/mouse_over.png'" onmouseout="this.src='/images/mouse.png'" src="/images/mouse.png" />),
     %(image_tag("mouse.png", :mouseover => image_path("mouse_over.png"))) => %(<img alt="Mouse" onmouseover="this.src='/images/mouse_over.png'" onmouseout="this.src='/images/mouse.png'" src="/images/mouse.png" />),
     %(image_tag("mouse.png", :alt => nil)) => %(<img src="/images/mouse.png" />)
@@ -199,7 +195,6 @@ class AssetTagHelperTest < ActionView::TestCase
     %(video_tag("error.avi", "size" => "100 x 100")) => %(<video src="/videos/error.avi" />),
     %(video_tag("error.avi", "size" => "x")) => %(<video src="/videos/error.avi" />),
     %(video_tag("http://media.rubyonrails.org/video/rails_blog_2.mov")) => %(<video src="http://media.rubyonrails.org/video/rails_blog_2.mov" />),
-    %(video_tag("//media.rubyonrails.org/video/rails_blog_2.mov")) => %(<video src="//media.rubyonrails.org/video/rails_blog_2.mov" />),
     %(video_tag(["multiple.ogg", "multiple.avi"])) => %(<video><source src="multiple.ogg" /><source src="multiple.avi" /></video>),
     %(video_tag(["multiple.ogg", "multiple.avi"], :size => "160x120", :controls => true)) => %(<video controls="controls" height="120" width="160"><source src="multiple.ogg" /><source src="multiple.avi" /></video>)
   }
@@ -222,7 +217,6 @@ class AssetTagHelperTest < ActionView::TestCase
     %(audio_tag("xml.wav")) => %(<audio src="/audios/xml.wav" />),
     %(audio_tag("rss.wav", :autoplay => true, :controls => true)) => %(<audio autoplay="autoplay" controls="controls" src="/audios/rss.wav" />),
     %(audio_tag("http://media.rubyonrails.org/audio/rails_blog_2.mov")) => %(<audio src="http://media.rubyonrails.org/audio/rails_blog_2.mov" />),
-    %(audio_tag("//media.rubyonrails.org/audio/rails_blog_2.mov")) => %(<audio src="//media.rubyonrails.org/audio/rails_blog_2.mov" />),
   }
 
   def test_auto_discovery_link_tag
@@ -509,10 +503,6 @@ class AssetTagHelperTest < ActionView::TestCase
 
   def test_should_skip_asset_id_on_complete_url
     assert_equal %(<img alt="Rails" src="http://www.example.com/rails.png" />), image_tag("http://www.example.com/rails.png")
-  end
-
-  def test_should_skip_asset_id_on_scheme_relative_url
-    assert_equal %(<img alt="Rails" src="//www.example.com/rails.png" />), image_tag("//www.example.com/rails.png")
   end
 
   def test_should_use_preset_asset_id
@@ -1103,11 +1093,6 @@ class AssetTagHelperNonVhostTest < ActionView::TestCase
   def test_should_ignore_asset_host_on_complete_url
     @controller.config.asset_host = "http://assets.example.com"
     assert_dom_equal(%(<link href="http://bar.example.com/stylesheets/style.css" media="screen" rel="stylesheet" type="text/css" />), stylesheet_link_tag("http://bar.example.com/stylesheets/style.css"))
-  end
-
-  def test_should_ignore_asset_host_on_scheme_relative_url
-    @controller.config.asset_host = "http://assets.example.com"
-    assert_dom_equal(%(<link href="//bar.example.com/stylesheets/style.css" media="screen" rel="stylesheet" type="text/css" />), stylesheet_link_tag("//bar.example.com/stylesheets/style.css"))
   end
 
   def test_should_wildcard_asset_host_between_zero_and_four

--- a/activemodel/lib/active_model/observer_array.rb
+++ b/activemodel/lib/active_model/observer_array.rb
@@ -1,0 +1,98 @@
+require 'set'
+
+module ActiveModel
+  # Stores the enabled/disabled state of individual observers for
+  # a particular model classes.
+  class ObserverArray < Array
+    INSTANCES = Hash.new do |hash, model_class|
+      hash[model_class] = new(model_class)
+    end
+
+    def self.for(model_class)
+      return nil unless model_class < ActiveModel::Observing
+      INSTANCES[model_class]
+    end
+
+    # returns false if:
+    #   - the ObserverArray for the given model's class has the given observer
+    #     in its disabled_observers set.
+    #   - or that is the case at any level of the model's superclass chain.
+    def self.observer_enabled?(observer, model)
+      klass = model.class
+      observer_class = observer.class
+
+      loop do
+        break unless array = self.for(klass)
+        return false if array.disabled_observers.include?(observer_class)
+        klass = klass.superclass
+      end
+
+      true # observers are enabled by default
+    end
+
+    def disabled_observers
+      @disabled_observers ||= Set.new
+    end
+
+    attr_reader :model_class
+    def initialize(model_class, *args)
+      @model_class = model_class
+      super(*args)
+    end
+
+    def disable(*observers, &block)
+      set_enablement(false, observers, &block)
+    end
+
+    def enable(*observers, &block)
+      set_enablement(true, observers, &block)
+    end
+
+    private
+
+      def observer_class_for(observer)
+        return observer if observer.is_a?(Class)
+
+        if observer.respond_to?(:to_sym) # string/symbol
+          observer.to_s.camelize.constantize
+        else
+          raise ArgumentError, "#{observer} was not a class or a " +
+            "lowercase, underscored class name as expected."
+        end
+      end
+
+      def transaction
+        orig_disabled_observers = disabled_observers.dup
+
+        begin
+          yield
+        ensure
+          @disabled_observers = orig_disabled_observers
+        end
+      end
+
+      def set_enablement(enabled, observers)
+        if block_given?
+          transaction do
+            set_enablement(enabled, observers)
+            yield
+          end
+        else
+          observers = ActiveModel::Observer.all_observers if observers == [:all]
+          observers.each do |obs|
+            klass = observer_class_for(obs)
+
+            unless klass < ActiveModel::Observer
+              raise ArgumentError.new("#{obs} does not refer to a valid observer")
+            end
+
+            if enabled
+              disabled_observers.delete(klass)
+            else
+              disabled_observers << klass
+            end
+          end
+        end
+      end
+  end
+end

--- a/activemodel/lib/active_model/observer_array.rb
+++ b/activemodel/lib/active_model/observer_array.rb
@@ -13,10 +13,12 @@ module ActiveModel
       INSTANCES[model_class]
     end
 
-    # returns false if:
+    # Returns false if:
     #   - the ObserverArray for the given model's class has the given observer
     #     in its disabled_observers set.
     #   - or that is the case at any level of the model's superclass chain.
+    #
+    # In other cases it returns true, since observers are enabled by default.
     def self.observer_enabled?(observer, model)
       klass = model.class
       observer_class = observer.class
@@ -40,10 +42,12 @@ module ActiveModel
       super(*args)
     end
 
+    # Disable the given observers.
     def disable(*observers, &block)
       set_enablement(false, observers, &block)
     end
 
+    # Enable the given observers.
     def enable(*observers, &block)
       set_enablement(true, observers, &block)
     end

--- a/activemodel/lib/active_model/observing.rb
+++ b/activemodel/lib/active_model/observing.rb
@@ -70,6 +70,10 @@ module ActiveModel
         observer_instances.size
       end
 
+      def subclasses
+        @subclasses ||= []
+      end
+
       protected
         def instantiate_observer(observer) #:nodoc:
           # string/symbol
@@ -89,6 +93,7 @@ module ActiveModel
         # Notify observers when the observed class is subclassed.
         def inherited(subclass)
           super
+          subclasses << subclass
           notify_observers :observed_class_inherited, subclass
         end
     end

--- a/activemodel/lib/active_model/observing.rb
+++ b/activemodel/lib/active_model/observing.rb
@@ -76,7 +76,11 @@ module ActiveModel
           elsif observer.respond_to?(:instance)
             observer.instance
           else
-            raise ArgumentError, "#{observer} must be a lowercase, underscored class name (or an instance of the class itself) responding to the instance method. Example: Person.observers = :big_brother # calls BigBrother.instance"
+            raise ArgumentError,
+              "#{observer} must be a lowercase, underscored class name (or an " +
+              "instance of the class itself) responding to the instance " +
+              "method. Example: Person.observers = :big_brother # calls " +
+              "BigBrother.instance"
           end
         end
 

--- a/activemodel/test/cases/observer_array_test.rb
+++ b/activemodel/test/cases/observer_array_test.rb
@@ -1,0 +1,122 @@
+require 'cases/helper'
+require 'models/observers'
+
+class ObserverArrayTest < ActiveModel::TestCase
+  def teardown
+    ORM.observers.enable :all
+    Budget.observers.enable :all
+    Widget.observers.enable :all
+  end
+
+  def assert_observer_notified(model_class, observer_class)
+    observer_class.instance.before_save_invocations.clear
+    model_instance = model_class.new
+    model_instance.save
+    assert_equal [model_instance], observer_class.instance.before_save_invocations
+  end
+
+  def assert_observer_not_notified(model_class, observer_class)
+    observer_class.instance.before_save_invocations.clear
+    model_instance = model_class.new
+    model_instance.save
+    assert_equal [], observer_class.instance.before_save_invocations
+  end
+
+  test "all observers are enabled by default" do
+    assert_observer_notified Widget, WidgetObserver
+    assert_observer_notified Budget, BudgetObserver
+    assert_observer_notified Widget, AuditTrail
+    assert_observer_notified Budget, AuditTrail
+  end
+
+  test "can disable individual observers using a class constant" do
+    ORM.observers.disable WidgetObserver
+
+    assert_observer_not_notified Widget, WidgetObserver
+    assert_observer_notified     Budget, BudgetObserver
+    assert_observer_notified     Widget, AuditTrail
+    assert_observer_notified     Budget, AuditTrail
+  end
+
+  test "can disable individual observers using a symbol" do
+    ORM.observers.disable :budget_observer
+
+    assert_observer_notified     Widget, WidgetObserver
+    assert_observer_not_notified Budget, BudgetObserver
+    assert_observer_notified     Widget, AuditTrail
+    assert_observer_notified     Budget, AuditTrail
+  end
+
+  test "can disable all observers using :all" do
+    ORM.observers.disable :all
+
+    assert_observer_not_notified Widget, WidgetObserver
+    assert_observer_not_notified Budget, BudgetObserver
+    assert_observer_not_notified Widget, AuditTrail
+    assert_observer_not_notified Budget, AuditTrail
+  end
+
+  test "can disable observers on individual models without affecting observers on other models" do
+    Widget.observers.disable :all
+
+    assert_observer_not_notified Widget, WidgetObserver
+    assert_observer_notified     Budget, BudgetObserver
+    assert_observer_not_notified Widget, AuditTrail
+    assert_observer_notified     Budget, AuditTrail
+  end
+
+  test "can disable observers for the duration of a block" do
+    yielded = false
+    ORM.observers.disable :budget_observer do
+      yielded = true
+      assert_observer_notified     Widget, WidgetObserver
+      assert_observer_not_notified Budget, BudgetObserver
+      assert_observer_notified     Widget, AuditTrail
+      assert_observer_notified     Budget, AuditTrail
+    end
+
+    assert yielded
+    assert_observer_notified Widget, WidgetObserver
+    assert_observer_notified Budget, BudgetObserver
+    assert_observer_notified Widget, AuditTrail
+    assert_observer_notified Budget, AuditTrail
+  end
+
+  test "can enable observers for the duration of a block" do
+    yielded = false
+    Widget.observers.disable :all
+
+    Widget.observers.enable :all do
+      yielded = true
+      assert_observer_notified Widget, WidgetObserver
+      assert_observer_notified Budget, BudgetObserver
+      assert_observer_notified Widget, AuditTrail
+      assert_observer_notified Budget, AuditTrail
+    end
+
+    assert yielded
+    assert_observer_not_notified Widget, WidgetObserver
+    assert_observer_notified     Budget, BudgetObserver
+    assert_observer_not_notified Widget, AuditTrail
+    assert_observer_notified     Budget, AuditTrail
+  end
+
+  test "raises an appropriate error when a developer accidentally enables or disables the wrong class (i.e. Widget instead of WidgetObserver)" do
+    assert_raise ArgumentError do
+      ORM.observers.enable :widget
+    end
+
+    assert_raise ArgumentError do
+      ORM.observers.enable Widget
+    end
+
+    assert_raise ArgumentError do
+      ORM.observers.disable :widget
+    end
+
+    assert_raise ArgumentError do
+      ORM.observers.disable Widget
+    end
+  end
+end
+

--- a/activemodel/test/cases/observer_array_test.rb
+++ b/activemodel/test/cases/observer_array_test.rb
@@ -118,5 +118,44 @@ class ObserverArrayTest < ActiveModel::TestCase
       ORM.observers.disable Widget
     end
   end
+
+  test "allows #enable at the superclass level to override #disable at the subclass level when called last" do
+    Widget.observers.disable :all
+    ORM.observers.enable :all
+
+    assert_observer_notified Widget, WidgetObserver
+    assert_observer_notified Budget, BudgetObserver
+    assert_observer_notified Widget, AuditTrail
+    assert_observer_notified Budget, AuditTrail
+  end
+
+  test "allows #disable at the superclass level to override #enable at the subclass level when called last" do
+    Budget.observers.enable :audit_trail
+    ORM.observers.disable :audit_trail
+
+    assert_observer_notified     Widget, WidgetObserver
+    assert_observer_notified     Budget, BudgetObserver
+    assert_observer_not_notified Widget, AuditTrail
+    assert_observer_not_notified Budget, AuditTrail
+  end
+
+  test "can use the block form at different levels of the hierarchy" do
+    yielded = false
+    Widget.observers.disable :all
+
+    ORM.observers.enable :all do
+      yielded = true
+      assert_observer_notified Widget, WidgetObserver
+      assert_observer_notified Budget, BudgetObserver
+      assert_observer_notified Widget, AuditTrail
+      assert_observer_notified Budget, AuditTrail
+    end
+
+    assert yielded
+    assert_observer_not_notified Widget, WidgetObserver
+    assert_observer_notified     Budget, BudgetObserver
+    assert_observer_not_notified Widget, AuditTrail
+    assert_observer_notified     Budget, AuditTrail
+  end
 end
 

--- a/activemodel/test/cases/observing_test.rb
+++ b/activemodel/test/cases/observing_test.rb
@@ -43,6 +43,11 @@ class ObservingTest < ActiveModel::TestCase
     assert ObservedModel.observers.include?(:bar), ":bar not in #{ObservedModel.observers.inspect}"
   end
 
+  test "uses an ObserverArray so observers can be disabled" do
+    ObservedModel.observers = [:foo, :bar]
+    assert ObservedModel.observers.is_a?(ActiveModel::ObserverArray)
+  end
+
   test "instantiates observer names passed as strings" do
     ObservedModel.observers << 'foo_observer'
     FooObserver.expects(:instance)

--- a/activemodel/test/models/observers.rb
+++ b/activemodel/test/models/observers.rb
@@ -1,0 +1,27 @@
+class ORM
+  include ActiveModel::Observing
+
+  def save
+    notify_observers :before_save
+  end
+
+  class Observer < ActiveModel::Observer
+    def before_save_invocations
+      @before_save_invocations ||= []
+    end
+
+    def before_save(record)
+      before_save_invocations << record
+    end
+  end
+end
+
+class Widget < ORM; end
+class Budget < ORM; end
+class WidgetObserver < ORM::Observer; end
+class BudgetObserver < ORM::Observer; end
+class AuditTrail < ORM::Observer
+  observe :widget, :budget
+end
+
+ORM.instantiate_observers

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -90,7 +90,7 @@ module ActiveRecord
           h[table_name] = with_connection do |conn|
 
             # Fetch a list of columns
-            conn.columns(table_name, "#{table_name} Columns").tap do |columns|
+            conn.columns(table_name).tap do |columns|
 
               # set primary key information
               columns.each do |column|

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -50,7 +50,7 @@ module ActiveRecord
 
       # Returns an array of Column objects for the table specified by +table_name+.
       # See the concrete implementation for details on the expected parameter values.
-      def columns(table_name, name = nil) end
+      def columns(table_name) end
 
       # Checks to see if a column exists in a given table.
       #

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+gem 'mysql2', '~> 0.3.0'
 require 'mysql2'
 
 module ActiveRecord

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -423,7 +423,7 @@ module ActiveRecord
         indexes
       end
 
-      def columns(table_name, name = nil)
+      def columns(table_name)
         sql = "SHOW FIELDS FROM #{quote_table_name(table_name)}"
         columns = []
         result = execute(sql)

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -625,7 +625,7 @@ module ActiveRecord
         indexes
       end
 
-      def columns(table_name, name = nil)#:nodoc:
+      def columns(table_name)#:nodoc:
         sql = "SHOW FIELDS FROM #{quote_table_name(table_name)}"
         columns = []
         result = execute(sql, 'SCHEMA')

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -734,7 +734,7 @@ module ActiveRecord
       end
 
       # Returns the list of all column definitions for a table.
-      def columns(table_name, name = nil)
+      def columns(table_name)
         # Limit, precision, and scale are all handled by the superclass.
         column_definitions(table_name).collect do |column_name, type, default, notnull|
           PostgreSQLColumn.new(column_name, default, type, notnull == 'f')

--- a/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
@@ -244,7 +244,7 @@ module ActiveRecord
         end
       end
 
-      def columns(table_name, name = nil) #:nodoc:
+      def columns(table_name) #:nodoc:
         table_structure(table_name).map do |field|
           case field["dflt_value"]
           when /^null$/i

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -242,8 +242,8 @@ module ActiveRecord
         end
       end
 
-      def columns(tbl_name, log_msg)
-        @columns ||= klass.connection.columns(tbl_name, log_msg)
+      def columns(tbl_name)
+        @columns ||= klass.connection.columns(tbl_name)
       end
 
       def reset_column_information

--- a/activerecord/test/active_record/connection_adapters/fake_adapter.rb
+++ b/activerecord/test/active_record/connection_adapters/fake_adapter.rb
@@ -28,7 +28,7 @@ module ActiveRecord
           options[:null])
       end
 
-      def columns(table_name, message)
+      def columns(table_name)
         @columns[table_name]
       end
     end

--- a/activerecord/test/cases/mass_assignment_security_test.rb
+++ b/activerecord/test/cases/mass_assignment_security_test.rb
@@ -35,10 +35,10 @@ class MassAssignmentSecurityTest < ActiveRecord::TestCase
     p = LoosePerson.new
     p.assign_attributes(attributes_hash)
 
-    assert_equal nil, p.id
+    assert_equal nil,    p.id
     assert_equal 'Josh', p.first_name
-    assert_equal 'male', p.gender
-    assert_equal nil, p.comments
+    assert_equal 'm',    p.gender
+    assert_equal nil,    p.comments
   end
 
   def test_assign_attributes_skips_mass_assignment_security_protection_when_without_protection_is_used
@@ -47,7 +47,7 @@ class MassAssignmentSecurityTest < ActiveRecord::TestCase
 
     assert_equal 5, p.id
     assert_equal 'Josh', p.first_name
-    assert_equal 'male', p.gender
+    assert_equal 'm', p.gender
     assert_equal 'rides a sweet bike', p.comments
   end
 
@@ -57,7 +57,7 @@ class MassAssignmentSecurityTest < ActiveRecord::TestCase
 
     assert_equal nil, p.id
     assert_equal 'Josh', p.first_name
-    assert_equal 'male', p.gender
+    assert_equal 'm', p.gender
     assert_equal nil, p.comments
   end
 
@@ -67,7 +67,7 @@ class MassAssignmentSecurityTest < ActiveRecord::TestCase
 
     assert_equal nil, p.id
     assert_equal 'Josh', p.first_name
-    assert_equal 'male', p.gender
+    assert_equal 'm', p.gender
     assert_equal 'rides a sweet bike', p.comments
   end
 
@@ -77,7 +77,7 @@ class MassAssignmentSecurityTest < ActiveRecord::TestCase
 
     assert_equal nil, p.id
     assert_equal 'Josh', p.first_name
-    assert_equal 'male', p.gender
+    assert_equal 'm', p.gender
     assert_equal nil, p.comments
   end
 
@@ -87,7 +87,7 @@ class MassAssignmentSecurityTest < ActiveRecord::TestCase
 
     assert_equal nil, p.id
     assert_equal 'Josh', p.first_name
-    assert_equal 'male', p.gender
+    assert_equal 'm', p.gender
     assert_equal 'rides a sweet bike', p.comments
   end
 
@@ -107,7 +107,7 @@ class MassAssignmentSecurityTest < ActiveRecord::TestCase
     {
       :id => 5,
       :first_name => 'Josh',
-      :gender => 'male',
+      :gender   => 'm',
       :comments => 'rides a sweet bike'
     }
   end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -905,20 +905,19 @@ if ActiveRecord::Base.connection.supports_migrations?
 
     def test_change_column
       Person.connection.add_column 'people', 'age', :integer
-      label = "test_change_column Columns"
-      old_columns = Person.connection.columns(Person.table_name, label)
+      old_columns = Person.connection.columns(Person.table_name)
       assert old_columns.find { |c| c.name == 'age' and c.type == :integer }
 
       assert_nothing_raised { Person.connection.change_column "people", "age", :string }
 
-      new_columns = Person.connection.columns(Person.table_name, label)
+      new_columns = Person.connection.columns(Person.table_name)
       assert_nil new_columns.find { |c| c.name == 'age' and c.type == :integer }
       assert new_columns.find { |c| c.name == 'age' and c.type == :string }
 
-      old_columns = Topic.connection.columns(Topic.table_name, label)
+      old_columns = Topic.connection.columns(Topic.table_name)
       assert old_columns.find { |c| c.name == 'approved' and c.type == :boolean and c.default == true }
       assert_nothing_raised { Topic.connection.change_column :topics, :approved, :boolean, :default => false }
-      new_columns = Topic.connection.columns(Topic.table_name, label)
+      new_columns = Topic.connection.columns(Topic.table_name)
       assert_nil new_columns.find { |c| c.name == 'approved' and c.type == :boolean and c.default == true }
       assert new_columns.find { |c| c.name == 'approved' and c.type == :boolean and c.default == false }
       assert_nothing_raised { Topic.connection.change_column :topics, :approved, :boolean, :default => true }

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -492,7 +492,7 @@ class PersistencesTest < ActiveRecord::TestCase
   end
 
   def test_update_attributes_as_admin
-    person = TightPerson.create
+    person = TightPerson.create({ "first_name" => 'Joshua' })
     person.update_attributes({ "first_name" => 'Josh', "gender" => 'm', "comments" => 'from NZ' }, :as => :admin)
     person.reload
 
@@ -501,8 +501,8 @@ class PersistencesTest < ActiveRecord::TestCase
     assert_equal 'from NZ', person.comments
   end
 
-  def test_update_attributes_as_without_protection
-    person = TightPerson.create
+  def test_update_attributes_without_protection
+    person = TightPerson.create({ "first_name" => 'Joshua' })
     person.update_attributes({ "first_name" => 'Josh', "gender" => 'm', "comments" => 'from NZ' }, :without_protection => true)
     person.reload
 
@@ -532,8 +532,8 @@ class PersistencesTest < ActiveRecord::TestCase
     Reply.reset_callbacks(:validate)
   end
 
-  def test_update_attributes_as_admin
-    person = TightPerson.create
+  def test_update_attributes_with_bang_as_admin
+    person = TightPerson.create({ "first_name" => 'Joshua' })
     person.update_attributes!({ "first_name" => 'Josh', "gender" => 'm', "comments" => 'from NZ' }, :as => :admin)
     person.reload
 
@@ -542,8 +542,8 @@ class PersistencesTest < ActiveRecord::TestCase
     assert_equal 'from NZ', person.comments
   end
 
-  def test_update_attributes_as_without_protection
-    person = TightPerson.create
+  def test_update_attributestes_with_bang_without_protection
+    person = TightPerson.create({ "first_name" => 'Joshua' })
     person.update_attributes!({ "first_name" => 'Josh', "gender" => 'm', "comments" => 'from NZ' }, :without_protection => true)
     person.reload
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -493,21 +493,21 @@ class PersistencesTest < ActiveRecord::TestCase
 
   def test_update_attributes_as_admin
     person = TightPerson.create
-    person.update_attributes({ "first_name" => 'Josh', "gender" => 'male', "comments" => 'from NZ' }, :as => :admin)
+    person.update_attributes({ "first_name" => 'Josh', "gender" => 'm', "comments" => 'from NZ' }, :as => :admin)
     person.reload
 
-    assert_equal 'Josh', person.first_name
-    assert_equal 'male', person.gender
+    assert_equal 'Josh',    person.first_name
+    assert_equal 'm',       person.gender
     assert_equal 'from NZ', person.comments
   end
 
   def test_update_attributes_as_without_protection
     person = TightPerson.create
-    person.update_attributes({ "first_name" => 'Josh', "gender" => 'male', "comments" => 'from NZ' }, :without_protection => true)
+    person.update_attributes({ "first_name" => 'Josh', "gender" => 'm', "comments" => 'from NZ' }, :without_protection => true)
     person.reload
 
-    assert_equal 'Josh', person.first_name
-    assert_equal 'male', person.gender
+    assert_equal 'Josh',    person.first_name
+    assert_equal 'm',       person.gender
     assert_equal 'from NZ', person.comments
   end
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -534,21 +534,21 @@ class PersistencesTest < ActiveRecord::TestCase
 
   def test_update_attributes_as_admin
     person = TightPerson.create
-    person.update_attributes!({ "first_name" => 'Josh', "gender" => 'male', "comments" => 'from NZ' }, :as => :admin)
+    person.update_attributes!({ "first_name" => 'Josh', "gender" => 'm', "comments" => 'from NZ' }, :as => :admin)
     person.reload
 
     assert_equal 'Josh', person.first_name
-    assert_equal 'male', person.gender
+    assert_equal 'm',    person.gender
     assert_equal 'from NZ', person.comments
   end
 
   def test_update_attributes_as_without_protection
     person = TightPerson.create
-    person.update_attributes!({ "first_name" => 'Josh', "gender" => 'male', "comments" => 'from NZ' }, :without_protection => true)
+    person.update_attributes!({ "first_name" => 'Josh', "gender" => 'm', "comments" => 'from NZ' }, :without_protection => true)
     person.reload
 
     assert_equal 'Josh', person.first_name
-    assert_equal 'male', person.gender
+    assert_equal 'm',    person.gender
     assert_equal 'from NZ', person.comments
   end
 

--- a/activeresource/test/connection_test.rb
+++ b/activeresource/test/connection_test.rb
@@ -50,7 +50,7 @@ class ConnectionTest < Test::Unit::TestCase
     # 404 is a missing resource.
     assert_response_raises ActiveResource::ResourceNotFound, 404
 
-    # 405 is a missing not allowed error
+    # 405 is a method not allowed error
     assert_response_raises ActiveResource::MethodNotAllowed, 405
 
     # 409 is an optimistic locking error

--- a/activesupport/lib/active_support/core_ext/array/access.rb
+++ b/activesupport/lib/active_support/core_ext/array/access.rb
@@ -3,10 +3,10 @@ class Array
   #
   #   %w( a b c d ).from(0)  # => %w( a b c d )
   #   %w( a b c d ).from(2)  # => %w( c d )
-  #   %w( a b c d ).from(10) # => nil
+  #   %w( a b c d ).from(10) # => %w()
   #   %w().from(0)           # => %w()
   def from(position)
-    self[position..-1]
+    position > length ? [] : self[position..-1]
   end
 
   # Returns the beginning of the array up to +position+.

--- a/activesupport/lib/active_support/core_ext/array/access.rb
+++ b/activesupport/lib/active_support/core_ext/array/access.rb
@@ -6,7 +6,7 @@ class Array
   #   %w( a b c d ).from(10) # => %w()
   #   %w().from(0)           # => %w()
   def from(position)
-    [position, length] || []
+    self[position, length] || []
   end
 
   # Returns the beginning of the array up to +position+.

--- a/activesupport/lib/active_support/core_ext/array/access.rb
+++ b/activesupport/lib/active_support/core_ext/array/access.rb
@@ -6,7 +6,7 @@ class Array
   #   %w( a b c d ).from(10) # => %w()
   #   %w().from(0)           # => %w()
   def from(position)
-    position > length ? [] : self[position..-1]
+    [position, length] || []
   end
 
   # Returns the beginning of the array up to +position+.

--- a/activesupport/test/core_ext/array_ext_test.rb
+++ b/activesupport/test/core_ext/array_ext_test.rb
@@ -10,7 +10,7 @@ class ArrayExtAccessTests < Test::Unit::TestCase
   def test_from
     assert_equal %w( a b c d ), %w( a b c d ).from(0)
     assert_equal %w( c d ), %w( a b c d ).from(2)
-    assert_nil %w( a b c d ).from(10)
+    assert_equal %w(), %w( a b c d ).from(10)
   end
 
   def test_to

--- a/railties/lib/rails/commands/console.rb
+++ b/railties/lib/rails/commands/console.rb
@@ -51,6 +51,6 @@ module Rails
 end
 
 # Has to set the RAILS_ENV before config/application is required
-if ARGV.first && !ARGV.first.index("-") && env = ARGV.pop # has to pop the env ARGV so IRB doesn't freak
+if ARGV.first && !ARGV.first.index("-") && env = ARGV.shift # has to shift the env ARGV so IRB doesn't freak
   ENV['RAILS_ENV'] = %w(production development test).detect {|e| e =~ /^#{env}/} || env
 end

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -135,14 +135,14 @@ module Rails
             gem 'rails',     :path => '#{Rails::Generators::RAILS_DEV_PATH}'
             gem 'arel',      :git => 'git://github.com/rails/arel.git'
             gem 'rack',      :git => 'git://github.com/rack/rack.git'
-            gem 'sprockets', :git => "git://github.com/sstephenson/sprockets.git"
+            gem 'sprockets', :git => 'git://github.com/sstephenson/sprockets.git'
           GEMFILE
         elsif options.edge?
           <<-GEMFILE.strip_heredoc
             gem 'rails',     :git => 'git://github.com/rails/rails.git'
             gem 'arel',      :git => 'git://github.com/rails/arel.git'
             gem 'rack',      :git => 'git://github.com/rack/rack.git'
-            gem 'sprockets', :git => "git://github.com/sstephenson/sprockets.git"
+            gem 'sprockets', :git => 'git://github.com/sstephenson/sprockets.git'
           GEMFILE
         else
           <<-GEMFILE.strip_heredoc
@@ -152,7 +152,7 @@ module Rails
             # gem 'rails',     :git => 'git://github.com/rails/rails.git'
             # gem 'arel',      :git => 'git://github.com/rails/arel.git'
             # gem 'rack',      :git => 'git://github.com/rack/rack.git'
-            # gem 'sprockets', :git => "git://github.com/sstephenson/sprockets.git"
+            # gem 'sprockets', :git => 'git://github.com/sstephenson/sprockets.git'
           GEMFILE
         end
       end

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -8,7 +8,7 @@ source 'http://rubygems.org'
 <%= "gem 'json'\n" if RUBY_VERSION < "1.9.2" -%>
 gem 'sass'
 gem 'coffee-script'
-# gem 'uglifier'
+gem 'uglifier'
 
 # Use unicorn as the web server
 # gem 'unicorn'

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -16,7 +16,7 @@
   config.action_dispatch.x_sendfile_header = "X-Sendfile" # Use 'X-Accel-Redirect' for nginx
 
   # Compress both stylesheets and JavaScripts
-  # config.assets.js_compressor  = :uglifier
+  config.assets.js_compressor  = :uglifier
   config.assets.css_compressor = :scss
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -11,13 +11,13 @@
   # Disable Rails's static asset server (Apache or nginx will already do this)
   config.serve_static_assets = false
 
-  # Specifies the header that your server uses for sending files
-  # (comment out if your front-end server doesn't support this)
-  config.action_dispatch.x_sendfile_header = "X-Sendfile" # Use 'X-Accel-Redirect' for nginx
-
   # Compress both stylesheets and JavaScripts
   config.assets.js_compressor  = :uglifier
   config.assets.css_compressor = :scss
+
+  # Specifies the header that your server uses for sending files
+  # (comment out if your front-end server doesn't support this)
+  config.action_dispatch.x_sendfile_header = "X-Sendfile" # Use 'X-Accel-Redirect' for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -624,7 +624,7 @@ module RailtiesTest
       boot_rails
       require "#{rails_root}/config/environment"
 
-      methods = Bukkits::Engine.helpers.public_instance_methods.sort
+      methods = Bukkits::Engine.helpers.public_instance_methods.collect(&:to_s).sort
       expected = ["bar", "baz"]
       assert_equal expected, methods
     end


### PR DESCRIPTION
The +name+ argument on the #columns method is useless, no implementation of this method makes use of it.
I removed the argument since it only creates confusion.
