### PR TITLE
Change Array#from to return consistent results

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/access.rb
+++ b/activesupport/lib/active_support/core_ext/array/access.rb
@@ -3,10 +3,10 @@ class Array
   #
   #   %w( a b c d ).from(0)  # => %w( a b c d )
   #   %w( a b c d ).from(2)  # => %w( c d )
-  #   %w( a b c d ).from(10) # => nil
+  #   %w( a b c d ).from(10) # => %w()
   #   %w().from(0)           # => %w()
   def from(position)
-    self[position..-1]
+    position > length ? [] : self[position..-1]
   end
 
   # Returns the beginning of the array up to +position+.

--- a/activesupport/lib/active_support/core_ext/array/access.rb
+++ b/activesupport/lib/active_support/core_ext/array/access.rb
@@ -6,7 +6,7 @@ class Array
   #   %w( a b c d ).from(10) # => %w()
   #   %w().from(0)           # => %w()
   def from(position)
-    position > length ? [] : self[position..-1]
+    [position, length] || []
   end
 
   # Returns the beginning of the array up to +position+.

--- a/activesupport/test/core_ext/array_ext_test.rb
+++ b/activesupport/test/core_ext/array_ext_test.rb
@@ -10,7 +10,7 @@ class ArrayExtAccessTests < Test::Unit::TestCase
   def test_from
     assert_equal %w( a b c d ), %w( a b c d ).from(0)
     assert_equal %w( c d ), %w( a b c d ).from(2)
-    assert_nil %w( a b c d ).from(10)
+    assert_equal %w(), %w( a b c d ).from(10)
   end
 
   def test_to


### PR DESCRIPTION
Copied from https://github.com/rails/rails/pull/282, re-created the pull-request just to clean up the commit range.

Right now `Array#from` will return `nil` if the index passed in is outside the bounds of the array, which is inconsistent with all other returns (including `%().from(0)`, which is technically outside the bounds of the array), and so using `Array#from`  we'll have to do things like

```
unless %(a, b, c, d).from(5).nil?
   # ... do something here
end
```

This commit will change it so that all return values of `Array#from` are an array.

Tests and documentation update included.

I ran benchmarks using the following:

```
require 'benchmark'

class Array

  def from(position)
    self[position..-1]
  end

  def new_from(position)
    position > length ? [] : self[position..-1]
  end

end

array = (1..10).to_a
n = 200_000

Benchmark.bm(3) do |x|
  x.report("1:") { n.times { array.from(1) } }
  x.report("2:") { n.times { array.new_from(1) } }
  x.report("3:") { n.times { array.from(100001) } }
  x.report("4:") { n.times { array.new_from(100001) } }
end
```

And got

```
         user     system      total        real
1:   0.360000   0.000000   0.360000 (  0.362778)
2:   0.400000   0.000000   0.400000 (  0.396071)
3:   0.320000   0.010000   0.330000 (  0.337338)
4:   0.170000   0.000000   0.170000 (  0.161635)
```

Which is a 8% increase on calls that go through and a 50% decrease when a call is outside the arrays range.

If I increased the array size to 100,000 items, it became a 10% increase in time.
