### PR TITLE
fix mass-assignment security tests

### DIFF
--- a/activerecord/test/cases/mass_assignment_security_test.rb
+++ b/activerecord/test/cases/mass_assignment_security_test.rb
@@ -35,10 +35,10 @@ class MassAssignmentSecurityTest < ActiveRecord::TestCase
     p = LoosePerson.new
     p.assign_attributes(attributes_hash)
 
-    assert_equal nil, p.id
+    assert_equal nil,    p.id
     assert_equal 'Josh', p.first_name
-    assert_equal 'male', p.gender
-    assert_equal nil, p.comments
+    assert_equal 'm',    p.gender
+    assert_equal nil,    p.comments
   end
 
   def test_assign_attributes_skips_mass_assignment_security_protection_when_without_protection_is_used
@@ -47,7 +47,7 @@ class MassAssignmentSecurityTest < ActiveRecord::TestCase
 
     assert_equal 5, p.id
     assert_equal 'Josh', p.first_name
-    assert_equal 'male', p.gender
+    assert_equal 'm', p.gender
     assert_equal 'rides a sweet bike', p.comments
   end
 
@@ -57,7 +57,7 @@ class MassAssignmentSecurityTest < ActiveRecord::TestCase
 
     assert_equal nil, p.id
     assert_equal 'Josh', p.first_name
-    assert_equal 'male', p.gender
+    assert_equal 'm', p.gender
     assert_equal nil, p.comments
   end
 
@@ -67,7 +67,7 @@ class MassAssignmentSecurityTest < ActiveRecord::TestCase
 
     assert_equal nil, p.id
     assert_equal 'Josh', p.first_name
-    assert_equal 'male', p.gender
+    assert_equal 'm', p.gender
     assert_equal 'rides a sweet bike', p.comments
   end
 
@@ -77,7 +77,7 @@ class MassAssignmentSecurityTest < ActiveRecord::TestCase
 
     assert_equal nil, p.id
     assert_equal 'Josh', p.first_name
-    assert_equal 'male', p.gender
+    assert_equal 'm', p.gender
     assert_equal nil, p.comments
   end
 
@@ -87,7 +87,7 @@ class MassAssignmentSecurityTest < ActiveRecord::TestCase
 
     assert_equal nil, p.id
     assert_equal 'Josh', p.first_name
-    assert_equal 'male', p.gender
+    assert_equal 'm', p.gender
     assert_equal 'rides a sweet bike', p.comments
   end
 
@@ -107,7 +107,7 @@ class MassAssignmentSecurityTest < ActiveRecord::TestCase
     {
       :id => 5,
       :first_name => 'Josh',
-      :gender => 'male',
+      :gender   => 'm',
       :comments => 'rides a sweet bike'
     }
   end

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -493,21 +493,21 @@ class PersistencesTest < ActiveRecord::TestCase
 
   def test_update_attributes_as_admin
     person = TightPerson.create
-    person.update_attributes({ "first_name" => 'Josh', "gender" => 'male', "comments" => 'from NZ' }, :as => :admin)
+    person.update_attributes({ "first_name" => 'Josh', "gender" => 'm', "comments" => 'from NZ' }, :as => :admin)
     person.reload
 
-    assert_equal 'Josh', person.first_name
-    assert_equal 'male', person.gender
+    assert_equal 'Josh',    person.first_name
+    assert_equal 'm',       person.gender
     assert_equal 'from NZ', person.comments
   end
 
   def test_update_attributes_as_without_protection
     person = TightPerson.create
-    person.update_attributes({ "first_name" => 'Josh', "gender" => 'male', "comments" => 'from NZ' }, :without_protection => true)
+    person.update_attributes({ "first_name" => 'Josh', "gender" => 'm', "comments" => 'from NZ' }, :without_protection => true)
     person.reload
 
-    assert_equal 'Josh', person.first_name
-    assert_equal 'male', person.gender
+    assert_equal 'Josh',    person.first_name
+    assert_equal 'm',       person.gender
     assert_equal 'from NZ', person.comments
   end
 


### PR DESCRIPTION
Hey Guys,

This was due to a string column limit which doesn't cause issues on sqlite, sorry.

Josh
