### PR TITLE
implement AS::Duration#send and #try to avoid unexpected behavior

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -50,6 +50,14 @@ module ActiveSupport
       end
     end
 
+    def send(method, *args, &block)
+      __send__(method, *args, &block)
+    end
+
+    def try(method, *args, &block)
+      send(method, *args, &block)
+    end
+
     def self.===(other) #:nodoc:
       other.is_a?(Duration)
     rescue ::NoMethodError

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -40,6 +40,16 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal '14 days',                         1.fortnight.inspect
   end
 
+  def test_try
+    assert 1.day.try(:is_a?, ActiveSupport::Duration),
+      "Duration#try should invoke Duration's instance methods"
+  end
+
+  def test_send
+    assert 1.day.send(:is_a?, ActiveSupport::Duration),
+      "Duration#send should invoke Duration's instance methods"
+  end
+
   def test_minus_with_duration_does_not_break_subtraction_of_date_from_date
     assert_nothing_raised { Date.today - Date.today }
   end


### PR DESCRIPTION
since Duration inherits from ::BasicObject when using Ruby 1.9, send and try aren't implemented so they're delegated to the Integer value by method_missing.  This causes unexpected behavior:

```
d = 1.day
d.inspect                #=> "1 day"
d.try(:inspect) || "N/A" #=> "86400"
# ^^^ standard null checking goes pear-shaped
```
