### PR TITLE
enabling uglifier gem 

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -8,7 +8,7 @@ source 'http://rubygems.org'
 <%= "gem 'json'\n" if RUBY_VERSION < "1.9.2" -%>
 gem 'sass'
 gem 'coffee-script'
-# gem 'uglifier'
+gem 'uglifier'
 
 # Use unicorn as the web server
 # gem 'unicorn'

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -16,7 +16,7 @@
   config.action_dispatch.x_sendfile_header = "X-Sendfile" # Use 'X-Accel-Redirect' for nginx
 
   # Compress both stylesheets and JavaScripts
-  # config.assets.js_compressor  = :uglifier
+  config.assets.js_compressor  = :uglifier
   config.assets.css_compressor = :scss
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.


### PR DESCRIPTION
Since new version of execjs(0.3.0) is released. we can enable uglifier gem  
