### PR TITLE
form_for extra tags formatting fix in form_tag_helper.rb

### DIFF
--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -620,7 +620,7 @@ module ActionView
           end
 
           tags = snowman_tag << method_tag
-          content_tag(:div, tags, :style => 'margin:0;padding:0;display:inline')
+          content_tag(:div, tags, :style => 'margin:0;padding:0;display:none')
         end
 
         def form_tag_html(html_options)


### PR DESCRIPTION
Stop extra tags in form_for constructed forms from potentially affecting the layout of the form in browsers (can cause a space due to the display:inline box).
