### PR TITLE
Prefix option for number_to_human_size

### DIFF
--- a/actionpack/lib/action_view/helpers/number_helper.rb
+++ b/actionpack/lib/action_view/helpers/number_helper.rb
@@ -304,6 +304,7 @@ module ActionView
       # * <tt>:separator</tt>  - Sets the separator between the fractional and integer digits (defaults to ".").
       # * <tt>:delimiter</tt>  - Sets the thousands delimiter (defaults to "").
       # * <tt>:strip_insignificant_zeros</tt>  - If +true+ removes insignificant zeros after the decimal separator (defaults to +true+)
+      # * <tt>:prefix</tt>  - If +:si+ formats the number using the SI prefix (defaults to :binary)
       # ==== Examples
       #  number_to_human_size(123)                                          # => 123 Bytes
       #  number_to_human_size(1234)                                         # => 1.21 KB
@@ -341,15 +342,17 @@ module ActionView
         options[:strip_insignificant_zeros] = true if not options.key?(:strip_insignificant_zeros)
 
         storage_units_format = I18n.translate(:'number.human.storage_units.format', :locale => options[:locale], :raise => true)
+        
+        base = options[:prefix] == :si ? 1000 : 1024
 
-        if number.to_i < 1024
+        if number.to_i < base
           unit = I18n.translate(:'number.human.storage_units.units.byte', :locale => options[:locale], :count => number.to_i, :raise => true)
           storage_units_format.gsub(/%n/, number.to_i.to_s).gsub(/%u/, unit).html_safe
         else
           max_exp  = STORAGE_UNITS.size - 1
-          exponent = (Math.log(number) / Math.log(1024)).to_i # Convert to base 1024
+          exponent = (Math.log(number) / Math.log(base)).to_i # Convert to base
           exponent = max_exp if exponent > max_exp # we need this to avoid overflow for the highest unit
-          number  /= 1024 ** exponent
+          number  /= base ** exponent
 
           unit_key = STORAGE_UNITS[exponent]
           unit = I18n.translate(:"number.human.storage_units.units.#{unit_key}", :locale => options[:locale], :count => number, :raise => true)

--- a/actionpack/test/template/number_helper_test.rb
+++ b/actionpack/test/template/number_helper_test.rb
@@ -172,6 +172,17 @@ class NumberHelperTest < ActionView::TestCase
     assert_equal '10 Bytes', number_to_human_size(10)
   end
 
+  def test_number_to_human_size_with_si_prefix
+    assert_equal '3 Bytes',    number_to_human_size(3.14159265, :prefix => :si)
+    assert_equal '123 Bytes',  number_to_human_size(123.0, :prefix => :si)
+    assert_equal '123 Bytes',  number_to_human_size(123, :prefix => :si)
+    assert_equal '1.23 KB',    number_to_human_size(1234, :prefix => :si)
+    assert_equal '12.3 KB',    number_to_human_size(12345, :prefix => :si)
+    assert_equal '1.23 MB',    number_to_human_size(1234567, :prefix => :si)
+    assert_equal '1.23 GB',    number_to_human_size(1234567890, :prefix => :si)
+    assert_equal '1.23 TB',    number_to_human_size(1234567890123, :prefix => :si)
+  end
+
   def test_number_to_human_size_with_options_hash
     assert_equal '1.2 MB',   number_to_human_size(1234567, :precision => 2)
     assert_equal '3 Bytes',   number_to_human_size(3.14159265, :precision => 4)


### PR DESCRIPTION
As @trejkaz mentioned, in some cases it's useful to use the SI prefix when formatting bytes. I understand why this is not the default, but the related patch added a :prefix option to number_to_human_size so the developer can choose what to display in each scenario.
