### PR TITLE
Dynamic find_or_create_by_x_and_y always creates new records in Rails 2.3.11 

### DIFF
--- a/activerecord/lib/active_record/associations/association_collection.rb
+++ b/activerecord/lib/active_record/associations/association_collection.rb
@@ -381,7 +381,7 @@ module ActiveRecord
           when /^find_or_create_by_(.*)$/
             rest = $1
             find_args = pull_finder_args_from(DynamicFinderMatch.match(method).attribute_names, *args)
-            return  send("find_by_#{rest}", find_args) ||
+            return  send("find_by_#{rest}", *find_args) ||
                     method_missing("create_by_#{rest}", *args, &block)
           when /^create_by_(.*)$/
             return create($1.split('_and_').zip(args).inject({}) { |h,kv| k,v=kv ; h[k] = v ; h }, &block)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -82,6 +82,15 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 4, post.comments.length
   end
 
+  def test_find_or_create_by_with_same_parameters_creates_a_single_record
+    author = Author.first
+    assert_difference "Post.count", +1 do
+      2.times do
+        author.posts.find_or_create_by_body_and_title('one', 'two')
+      end
+    end
+  end
+
   def test_find_or_create_by_with_block
     post = Post.create! :title => 'test_find_or_create_by_with_additional_parameters', :body => 'this is the body'
     comment = post.comments.find_or_create_by_body('other test comment body') { |comment| comment.type = 'test' }


### PR DESCRIPTION
This is a regression that was introduced in fdfc8e3b9c4905057677fd009f463a377be60b93.

Any create_or_find_by_x_and_y call on an association will _aways_ create a new record.

To recreate:

Say you have two models, one has_many of another:

```
class Author < ActiveRecord::Base
  has_many :posts
end

class Post < ActiveRecord::Base
  belongs_to :author
end
```

Jump into the console and enable AR logging.  Then run the dynamic find_or_create_by twice:

```
Author.first.posts.find_or_create_by_title_and_published('Post Title', true)
Author.first.posts.find_or_create_by_title_and_published('Post Title', true)
```

You'll see that the query looks generates something like

```
select * from posts where title IN ('Post Title', 1) and published = '' and author_id = 7
```

i.e. the title is getting passed an array of the input.

Failing test and patch included below in the merge request (9f7ff621bd62ade37b4ae4e608bdf24b7f7b1456).
