### PR TITLE
Don't quote ID's as Arel will quote them -- follow same conventions as the delete method. 

### DIFF
--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -94,7 +94,7 @@ module ActiveRecord
             relation = self.class.unscoped
 
             stmt = relation.where(
-              relation.table[self.class.primary_key].eq(quoted_id).and(
+              relation.table[self.class.primary_key].eq(id).and(
                 relation.table[lock_col].eq(quote_value(previous_lock_value))
               )
             ).arel.compile_update(arel_attributes_values(false, false, attribute_names))

--- a/activerecord/test/fixtures/string_key_objects.yml
+++ b/activerecord/test/fixtures/string_key_objects.yml
@@ -1,0 +1,7 @@
+first:
+  id: record1
+  name: first record
+
+second:
+  id: record2
+  name: second record

--- a/activerecord/test/models/string_key_object.rb
+++ b/activerecord/test/models/string_key_object.rb
@@ -1,0 +1,3 @@
+class StringKeyObject < ActiveRecord::Base
+  set_primary_key :id
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -528,6 +528,12 @@ ActiveRecord::Schema.define do
     t.string :sponsorable_type
   end
 
+  create_table :string_key_objects, :id => false, :primary_key => :id, :force => true do |t|
+    t.string     :id
+    t.string     :name
+    t.integer    :lock_version, :null => false, :default => 0
+  end
+
   create_table :students, :force => true do |t|
     t.string :name
   end


### PR DESCRIPTION
Don't quote IDs as Arel will quote them -- follow same conventions as the delete method, which is already in place.  This causes problems when working with strings as primary keys which are then quoted twice.

Included is a patch to resolve this issue. The delete method uses ID, not quoted ID, as ARel will quote it.

See both:

https://rails.lighthouseapp.com/projects/8994/tickets/6230-optimistic-locking-quoting-id-applied-twice-for-update-statement
https://rails.lighthouseapp.com/projects/8994/tickets/6578-optimistic-locking-and-double-quoting-of-strings
