### PR TITLE
Specific translations for labels with values

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -947,7 +947,8 @@ module ActionView
           label_tag(name_and_id["id"], options, &block)
         else
           content = if text.blank?
-            I18n.t("helpers.label.#{object_name}.#{method_name}", :default => "").presence
+            method_and_value = tag_value.present? ? "#{method_name}.#{tag_value}" : method_name
+            I18n.t("helpers.label.#{object_name}.#{method_and_value}", :default => "").presence
           else
             text.to_s
           end

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -24,7 +24,10 @@ class FormHelperTest < ActionView::TestCase
       :helpers => {
         :label => {
           :post => {
-            :body => "Write entire text here"
+            :body => "Write entire text here",
+            :color => {
+              :red => "Rojo"
+            }
           }
         }
       }
@@ -137,6 +140,13 @@ class FormHelperTest < ActionView::TestCase
   def test_label_with_locales_and_options
     old_locale, I18n.locale = I18n.locale, :label
     assert_dom_equal('<label for="post_body" class="post_body">Write entire text here</label>', label(:post, :body, :class => 'post_body'))
+  ensure
+    I18n.locale = old_locale
+  end
+
+  def test_label_with_locales_and_value
+    old_locale, I18n.locale = I18n.locale, :label
+    assert_dom_equal('<label for="post_color_red">Rojo</label>', label(:post, :color, :value => "red"))
   ensure
     I18n.locale = old_locale
   end


### PR DESCRIPTION
Suppose I want my radio buttons' labels translated:

```
= f.radio_button(:customer_access_enabled, true)
= f.label(:customer_access_enabled, :value => true)
= f.radio_button(:customer_access_enabled, false)
= f.label(:customer_access_enabled, :value => false)
```

Both labels get the same value from `"helpers.label.#{model_name}.#{attribute_name}"` (in my case, `"helpers.label.page.customer_access_enabled"`). I would like to have specific translations for each value option of the same attribute.

Let me know if it's not clear or refactoring is needed. Thanks!

(Ported from [LightHouse Ticket #6753](https://rails.lighthouseapp.com/projects/8994/tickets/6753-specific-translations-for-labels-with-values))
