### PR TITLE
fix AS::Duration#try and #send

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -8,7 +8,7 @@ module ActiveSupport
   # Example:
   #
   #   1.month.ago       # equivalent to Time.now.advance(:months => -1)
-  class Duration < BasicObject
+  class Duration
     attr_accessor :value, :parts
 
     def initialize(value, parts) #:nodoc:

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -20,7 +20,6 @@ class DurationTest < ActiveSupport::TestCase
     assert ActiveSupport::Duration === 1.day
     assert !(ActiveSupport::Duration === 1.day.to_i)
     assert !(ActiveSupport::Duration === 'foo')
-    assert !(ActiveSupport::Duration === ActiveSupport::BasicObject.new)
   end
 
   def test_equals
@@ -38,6 +37,16 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal '10 years, 2 months, and 1 day',   (10.years + 2.months + 1.day).inspect
     assert_equal '7 days',                          1.week.inspect
     assert_equal '14 days',                         1.fortnight.inspect
+  end
+
+  def test_try
+    assert 1.day.try(:is_a?, ActiveSupport::Duration),
+      "Duration#try should invoke Duration's instance methods"
+  end
+
+  def test_send
+    assert 1.day.send(:is_a?, ActiveSupport::Duration),
+      "Duration#send should invoke Duration's instance methods"
   end
 
   def test_minus_with_duration_does_not_break_subtraction_of_date_from_date


### PR DESCRIPTION
when Duration inherits from BasicObject, send and try aren't implemented so they're delegated to the Integer value by method_missing.  This causes unexpected behavior:

```
d = 1.day
d.inspect                #=> "1 day"
d.try(:inspect) || "N/A" #=> "86400"
# ^^^ standard null checking goes pear-shaped
```

I had a different pull request for this that I closed because this commit is a better solution.  Here's the other one for context:
https://github.com/rails/rails/pull/320
