### PR TITLE
Remove useless argument

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -90,7 +90,7 @@ module ActiveRecord
           h[table_name] = with_connection do |conn|
 
             # Fetch a list of columns
-            conn.columns(table_name, "#{table_name} Columns").tap do |columns|
+            conn.columns(table_name).tap do |columns|
 
               # set primary key information
               columns.each do |column|

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -50,7 +50,7 @@ module ActiveRecord
 
       # Returns an array of Column objects for the table specified by +table_name+.
       # See the concrete implementation for details on the expected parameter values.
-      def columns(table_name, name = nil) end
+      def columns(table_name) end
 
       # Checks to see if a column exists in a given table.
       #

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -424,7 +424,7 @@ module ActiveRecord
         indexes
       end
 
-      def columns(table_name, name = nil)
+      def columns(table_name)
         sql = "SHOW FIELDS FROM #{quote_table_name(table_name)}"
         columns = []
         result = execute(sql)

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -625,7 +625,7 @@ module ActiveRecord
         indexes
       end
 
-      def columns(table_name, name = nil)#:nodoc:
+      def columns(table_name)#:nodoc:
         sql = "SHOW FIELDS FROM #{quote_table_name(table_name)}"
         columns = []
         result = execute(sql, 'SCHEMA')

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -734,7 +734,7 @@ module ActiveRecord
       end
 
       # Returns the list of all column definitions for a table.
-      def columns(table_name, name = nil)
+      def columns(table_name)
         # Limit, precision, and scale are all handled by the superclass.
         column_definitions(table_name).collect do |column_name, type, default, notnull|
           PostgreSQLColumn.new(column_name, default, type, notnull == 'f')

--- a/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
@@ -244,7 +244,7 @@ module ActiveRecord
         end
       end
 
-      def columns(table_name, name = nil) #:nodoc:
+      def columns(table_name) #:nodoc:
         table_structure(table_name).map do |field|
           case field["dflt_value"]
           when /^null$/i

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -242,8 +242,8 @@ module ActiveRecord
         end
       end
 
-      def columns(tbl_name, log_msg)
-        @columns ||= klass.connection.columns(tbl_name, log_msg)
+      def columns(tbl_name)
+        @columns ||= klass.connection.columns(tbl_name)
       end
 
       def reset_column_information

--- a/activerecord/test/active_record/connection_adapters/fake_adapter.rb
+++ b/activerecord/test/active_record/connection_adapters/fake_adapter.rb
@@ -28,7 +28,7 @@ module ActiveRecord
           options[:null])
       end
 
-      def columns(table_name, message)
+      def columns(table_name)
         @columns[table_name]
       end
     end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -905,20 +905,19 @@ if ActiveRecord::Base.connection.supports_migrations?
 
     def test_change_column
       Person.connection.add_column 'people', 'age', :integer
-      label = "test_change_column Columns"
-      old_columns = Person.connection.columns(Person.table_name, label)
+      old_columns = Person.connection.columns(Person.table_name)
       assert old_columns.find { |c| c.name == 'age' and c.type == :integer }
 
       assert_nothing_raised { Person.connection.change_column "people", "age", :string }
 
-      new_columns = Person.connection.columns(Person.table_name, label)
+      new_columns = Person.connection.columns(Person.table_name)
       assert_nil new_columns.find { |c| c.name == 'age' and c.type == :integer }
       assert new_columns.find { |c| c.name == 'age' and c.type == :string }
 
-      old_columns = Topic.connection.columns(Topic.table_name, label)
+      old_columns = Topic.connection.columns(Topic.table_name)
       assert old_columns.find { |c| c.name == 'approved' and c.type == :boolean and c.default == true }
       assert_nothing_raised { Topic.connection.change_column :topics, :approved, :boolean, :default => false }
-      new_columns = Topic.connection.columns(Topic.table_name, label)
+      new_columns = Topic.connection.columns(Topic.table_name)
       assert_nil new_columns.find { |c| c.name == 'approved' and c.type == :boolean and c.default == true }
       assert new_columns.find { |c| c.name == 'approved' and c.type == :boolean and c.default == false }
       assert_nothing_raised { Topic.connection.change_column :topics, :approved, :boolean, :default => true }


### PR DESCRIPTION
The +name+ argument on the #columns method is useless, no implementation of this method makes use of it.
I removed the argument since it only creates confusion.
