### PR TITLE
Fix inflection for olive

### DIFF
--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -30,6 +30,7 @@ module ActiveSupport
     inflect.singular(/([^f])ves$/i, '\1fe')
     inflect.singular(/(hive)s$/i, '\1')
     inflect.singular(/(tive)s$/i, '\1')
+    inflect.singular(/(olive)s$/i, '\1')
     inflect.singular(/([lr])ves$/i, '\1f')
     inflect.singular(/([^aeiouy]|qu)ies$/i, '\1y')
     inflect.singular(/(s)eries$/i, '\1eries')

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -103,7 +103,9 @@ module InflectorTestCases
     "edge"        => "edges",
 
     "cow"         => "kine",
-    "database"    => "databases"
+    "database"    => "databases",
+    
+    "olive"       => "olives"
   }
 
   CamelToUnderscore = {


### PR DESCRIPTION
Previously 'olive' inflected to 'olife'. It now correctly inflects to 'olives'.
