### PR TITLE
peformance trumps syntactical sugar

### DIFF
--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -298,12 +298,12 @@ module ActionView
         return container if String === container
 
         selected, disabled = extract_selected_and_disabled(selected).map do | r |
-           Array.wrap(r).map(&:to_s)
+           Array.wrap(r).map { |item| item.to_s }
         end
 
         container.map do |element|
           html_attributes = option_html_attributes(element)
-          text, value = option_text_and_value(element).map(&:to_s)
+          text, value = option_text_and_value(element).map { |item| item.to_s }
           selected_attribute = ' selected="selected"' if option_value_selected?(value, selected)
           disabled_attribute = ' disabled="disabled"' if disabled && option_value_selected?(value, disabled)
           %(<option value="#{ERB::Util.html_escape(value)}"#{selected_attribute}#{disabled_attribute}#{html_attributes}>#{ERB::Util.html_escape(text)}</option>)


### PR DESCRIPTION
The options_for_select is invoking map(&:to_s) in loops. When options_for_select is invoked with many options, the memory impact of map(&:to_s) is more than necessary.

While map(&:to_s) stuff has been optimized, it is not free and should yield way to performance. 
