### PR TITLE
performance trumps syntactical sugar

### DIFF
--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -299,12 +299,12 @@ module ActionView
 
         container = container.to_a if Hash === container
         selected, disabled = extract_selected_and_disabled(selected).map do | r |
-           Array.wrap(r).map(&:to_s)
+           Array.wrap(r).map { |item| item.to_s }
         end
 
         container.map do |element|
           html_attributes = option_html_attributes(element)
-          text, value = option_text_and_value(element).map(&:to_s)
+          text, value = option_text_and_value(element).map { |item| item.to_s }
           selected_attribute = ' selected="selected"' if option_value_selected?(value, selected)
           disabled_attribute = ' disabled="disabled"' if disabled && option_value_selected?(value, disabled)
           %(<option value="#{html_escape(value)}"#{selected_attribute}#{disabled_attribute}#{html_attributes}>#{html_escape(text)}</option>)


### PR DESCRIPTION
The options_for_select is invoking map(&:to_s) in loops. When options_for_select is invoked with many options, the memory impact of map(&:to_s) is more than necessary.

While map(&:to_s) stuff has been optimized, it is not free in ruby 1.8.7 and should yield way to performance.

Note, I made this request initially into rails:master (https://github.com/rails/rails/pull/346). This is the same change but into rails:3-0-stable instead, which is perhaps a better fit for this type of performance change.
