### PR TITLE
Hash.from_xml chokes on empty CDATA

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/hash/conversions.rb
@@ -108,7 +108,8 @@ class Hash
                   raise "can't typecast #{entries.inspect}"
                 end
               end
-            elsif value['type'] == 'file' || value["__content__"].present?
+            elsif value['type'] == 'file' || 
+               (value["__content__"] && (value.keys.size == 1 || value["__content__"].present?))
               content = value["__content__"]
               if parser = ActiveSupport::XmlMini::PARSING[value["type"]]
                 parser.arity == 1 ? parser.call(content) : parser.call(content, value)

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -899,9 +899,9 @@ class HashToXmlTest < Test::Unit::TestCase
   end
   
   def test_empty_cdata_from_xml
-    xml = "<content><![CDATA[]]></content>"
+    xml = "<data><![CDATA[]]></data>"
     
-    assert_equal "", Hash.from_xml(xml)["content"]
+    assert_equal "", Hash.from_xml(xml)["data"]
   end
   
   def test_xsd_like_types_from_xml

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -897,7 +897,13 @@ class HashToXmlTest < Test::Unit::TestCase
     hash = Hash.from_xml(xml)
     assert_equal "bacon is the best", hash['blog']['name']
   end
-
+  
+  def test_empty_cdata_from_xml
+    xml = "<content><![CDATA[]]></content>"
+    
+    assert_equal "", Hash.from_xml(xml)["content"]
+  end
+  
   def test_xsd_like_types_from_xml
     bacon_xml = <<-EOT
     <bacon>
@@ -940,7 +946,7 @@ class HashToXmlTest < Test::Unit::TestCase
 
     assert_equal expected_product_hash, Hash.from_xml(product_xml)["product"]
   end
-
+  
   def test_should_use_default_value_for_unknown_key
     hash_wia = HashWithIndifferentAccess.new(3)
     assert_equal 3, hash_wia[:new_key]


### PR DESCRIPTION
https://rails.lighthouseapp.com/projects/8994/tickets/6757-hashfrom_xml-chokes-on-empty-cdata

When a tag is passed to Hash.from_xml with an empty CDATA blocks as it's contents it should be return an empty string.  
