### PR TITLE
Fixes for incorrect INNER JOIN through two polymorphic resources (NoMethodError: undefined method `to_sym' for nil:NilClass)

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -2174,7 +2174,7 @@ module ActiveRecord
                   end
 
                   case source_reflection.macro
-                  when :has_many
+                  when :has_many, :has_one
                     if source_reflection.options[:as]
                       first_key   = "#{source_reflection.options[:as]}_id"
                       second_key  = options[:foreign_key] || primary_key

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -2199,7 +2199,7 @@ module ActiveRecord
 
                   [
                     [parent_table[jt_primary_key].eq(join_table[jt_foreign_key]), jt_as_extra, jt_source_extra, jt_sti_extra].reject{|x| x.blank? },
-                    aliased_table[first_key].eq(join_table[second_key])
+                    [aliased_table[first_key].eq(join_table[second_key]), as_extra].reject{ |x| x.blank? }
                   ]
                 elsif reflection.options[:as]
                   id_rel = aliased_table["#{reflection.options[:as]}_id"].eq(parent_table[parent.primary_key])

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -4,6 +4,7 @@ require 'models/comment'
 require 'models/author'
 require 'models/category'
 require 'models/categorization'
+require 'models/tagging'
 
 class InnerJoinAssociationTest < ActiveRecord::TestCase
   fixtures :authors, :posts, :comments, :categories, :categories_posts, :categorizations
@@ -21,6 +22,14 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
   def test_construct_finder_sql_ignores_empty_joins_array
     sql = Author.joins([]).to_sql
     assert_no_match(/JOIN/i, sql)
+  end
+
+  def test_construct_finder_sql_on_polymorphic_through_includes_type
+    # Posts has one tagging (polymorphic)
+    # Author has one tagging through post.
+    # Should be something like:
+    # INNER JOIN taggings.taggable_id = posts.id AND taggings.taggable_type = 'Post'
+    assert_match(/taggable_type/i, Author.joins(:taggings).to_sql.to_s)
   end
 
   def test_find_with_implicit_inner_joins_honors_readonly_without_select

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -7,7 +7,7 @@ require 'models/categorization'
 require 'models/tagging'
 
 class InnerJoinAssociationTest < ActiveRecord::TestCase
-  fixtures :authors, :posts, :comments, :categories, :categories_posts, :categorizations
+  fixtures :authors, :posts, :comments, :categories, :categories_posts, :categorizations, :taggings, :tags
 
   def test_construct_finder_sql_applies_aliases_tables_on_association_conditions
     result = Author.joins(:thinking_posts, :welcome_posts).to_a
@@ -70,5 +70,11 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
     real_count = Author.scoped.to_a.select {|a| a.posts.any? {|p| p.title =~ /^Welcome/} }.length
     authors_with_welcoming_post_titles = Author.calculate(:count, 'authors.id', :joins => :posts, :distinct => true, :conditions => "posts.title like 'Welcome%'")
     assert_equal real_count, authors_with_welcoming_post_titles, "inner join and conditions should have only returned authors posting titles starting with 'Welcome'"
+  end
+
+  def test_find_on_polymorphic_has_one_association
+    # Author => has_one :tagging, :through => :posts
+    # Post => has_one :tagging, :as => :taggable
+    assert_equal Author.joins(:posts => :tagging).all, Author.joins(:tagging).all
   end
 end

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -379,7 +379,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_polymorphic_has_one
-    assert_equal Tagging.find(1,2).sort_by { |t| t.id }, authors(:david).tagging
+    assert_equal Tagging.find(1,2).sort_by { |t| t.id }, authors(:david).taggings
   end
 
   def test_has_many_through_polymorphic_has_many

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -83,7 +83,7 @@ class Author < ActiveRecord::Base
   has_many :author_favorites
   has_many :favorite_authors, :through => :author_favorites, :order => 'name'
 
-  has_many :tagging,  :through => :posts # through polymorphic has_one
+  has_one  :tagging,  :through => :posts # through polymorphic has_one
   has_many :taggings, :through => :posts, :source => :taggings # through polymorphic has_many
   has_many :tags,     :through => :posts # through has_many :through
   has_many :post_categories, :through => :posts, :source => :categories


### PR DESCRIPTION
This merge requests contains two patches that address the following situation of polymorphic has_one associations:

``` ruby
class Address < ActiveRecord::Base
  belongs_to :addressable, :polymorphic => true
  has_one :location, :as => :locatable
end

class GeoLocation < ActiveRecord::Base
  belongs_to :geo_locatable, :polymorphic => true
end

class Business < ActiveRecord::Base
  has_one :address, :as => :addressable
  has_one :geo_location, :through => :geo_locatable
end
```

Say you want to query Business records and you want to join in the location records as well.

If you execute the following line:

``` ruby
Business.joins(:geo_location).all
```

you will see the following exception:

```
NoMethodError: undefined method `to_sym' for nil:NilClass
from ~/.rvm/gems/ruby-1.9.2-p180@shoploaf/gems/activesupport-3.0.7/lib/active_support/whiny_nil.rb:48:in `method_missing'
from ~/.rvm/gems/ruby-1.9.2-p180@shoploaf/gems/arel-2.0.9/lib/arel/table.rb:103:in `[]'
from ~/.rvm/gems/ruby-1.9.2-p180@shoploaf/gems/activerecord-3.0.7/lib/active_record/associations.rb:2202:in `association_join'
from ~/.rvm/gems/ruby-1.9.2-p180@shoploaf/gems/activerecord-3.0.7/lib/active_record/relation/query_methods.rb:256:in `block in build_joins'
from ~/.rvm/gems/ruby-1.9.2-p180@shoploaf/gems/activerecord-3.0.7/lib/active_record/relation/query_methods.rb:254:in `each'
from ~/.rvm/gems/ruby-1.9.2-p180@shoploaf/gems/activerecord-3.0.7/lib/active_record/relation/query_methods.rb:254:in `build_joins'
from ~/.rvm/gems/ruby-1.9.2-p180@shoploaf/gems/activerecord-3.0.7/lib/active_record/relation/query_methods.rb:176:in `build_arel'
from ~/.rvm/gems/ruby-1.9.2-p180@shoploaf/gems/activerecord-3.0.7/lib/active_record/relation/query_methods.rb:149:in `arel'
from ~/.rvm/gems/ruby-1.9.2-p180@shoploaf/gems/activerecord-3.0.7/lib/active_record/relation.rb:64:in `to_a'
from ~/.rvm/gems/ruby-1.9.2-p180@shoploaf/gems/activerecord-3.0.7/lib/active_record/relation/finder_methods.rb:143:in `all'
```

Once I got in there to fix this bug, I noticed that joining through to a polymorphic has_one, like above, or a polymorphic has_many neglects to filter on the polymorphic_type column as well.

The SQL statement for a correct query should contain the following:

```
INNER JOIN businesses.id ON addresses.addressable_id AND addresses.addressable_type = 'Business'
INNER JOIN addresses.id = geo_locations.geo_locatable_id AND geo_locations.geo_locatable_type = 'Address'
```

i.e. both inner join statements should reference the type.

Instead, the following SQL is generated:

```
INNER JOIN businesses.id ON addresses.addressable_id AND addresses.addressable_type = 'Business'
INNER JOIN addresses.id = geo_locations.geo_locatable_id
```

The merge requests includes a fix for this as well.

Also, there are tests for both of these issues.
