### PR TITLE
Add :required parameter to AS::SecurePassword

### DIFF
--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -1,5 +1,6 @@
 require 'cases/helper'
 require 'models/user'
+require 'models/user_with_optional_password'
 require 'models/visitor'
 require 'models/administrator'
 
@@ -7,18 +8,26 @@ class SecurePasswordTest < ActiveModel::TestCase
 
   setup do
     @user = User.new
+		@user_no_password = UserWithOptionalPassword.new
   end
 
   test "blank password" do
     user = User.new
     user.password = ''
     assert !user.valid?, 'user should be invalid'
+		user = UserWithOptionalPassword.new
+		user.password = ''
+		assert user.valid?, 'user should be valid'
   end
 
   test "nil password" do
     user = User.new
     user.password = nil
     assert !user.valid?, 'user should be invalid'
+		user = UserWithOptionalPassword.new
+		user.password = nil
+		assert user.valid?, 'user should be valid'
+		assert user.password_digest.nil?, 'password_digest should be nil'
   end
 
   test "password must be present" do
@@ -42,6 +51,10 @@ class SecurePasswordTest < ActiveModel::TestCase
 
     assert !@user.authenticate("wrong")
     assert @user.authenticate("secret")
+
+		@user_no_password.password = ""
+
+		assert !@user_no_password.authenticate("")
   end
 
   test "visitor#password_digest should be protected against mass assignment" do

--- a/activemodel/test/models/user_with_optional_password.rb
+++ b/activemodel/test/models/user_with_optional_password.rb
@@ -1,8 +1,8 @@
-class User
+class UserWithOptionalPassword
   include ActiveModel::Validations
   include ActiveModel::SecurePassword
 
-  has_secure_password
+  has_secure_password :required => false
 
   attr_accessor :password_digest
 end


### PR DESCRIPTION
The ActiveModel::SecurePassword module is outstanding but I think allowing the password to be optional would allow many more use cases for this feature. E.g. an application using Omniauth in tandem with local authentication probably doesn't require a password for each User.  This commit adds a :required configuration parameter (defaults to true) and ensures that the authenticate method returns false for a blank password.

This patch original submitted to LH #6742.  Tests included.

This is my first patch submission so please forgive any faux pas I may have made. :)
