### PR TITLE
Removed double assignment of same local variable

### DIFF
--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -576,9 +576,9 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_polymorphic_counter_cache
-    tagging     = taggings(:welcome_general)
-    post = post = posts(:welcome)
-    comment     = comments(:greetings)
+    tagging = taggings(:welcome_general)
+    post    = posts(:welcome)
+    comment = comments(:greetings)
 
     assert_difference 'post.reload.taggings_count', -1 do
       assert_difference 'comment.reload.taggings_count', +1 do


### PR DESCRIPTION
I saw this was part of a warning clean up for Ruby 1.9.3 that @tenderlove did. If this is necessary I'd love to be enlightened as to why it is causing warnings :)
