### PR TITLE
Fixing failing test case on 1.8.7 & bump Rack version

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency('rack-cache',       '~> 1.0.0')
   s.add_dependency('builder',          '~> 3.0.0')
   s.add_dependency('i18n',             '~> 0.6.0beta1')
-  s.add_dependency('rack',             '~> 1.2.1')
+  s.add_dependency('rack',             '~> 1.3.0')
   s.add_dependency('rack-test',        '~> 0.5.7')
   s.add_dependency('rack-mount',       '~> 0.7.2')
   s.add_dependency('sprockets',        '~> 2.0.0.beta.2')


### PR DESCRIPTION
Hi guys,

So I've misably break the test on 1.8.7 due to hash order, so I've update the test case to fix it. Also, current Rails `master` is broken because you can't run `bundle update` due to `Rack`'s `HEAD` is at 1.3.0 already, so I've updated the dependency as well.

Will be careful next time >_<
