### PR TITLE
Google Chrome sometimes incorrectly identifies the rescues template charset

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -116,7 +116,7 @@ module ActionDispatch
       end
 
       def render(status, body)
-        [status, {'Content-Type' => 'text/html', 'Content-Length' => body.bytesize.to_s}, [body]]
+        [status, {'Content-Type' => "text/html; charset=#{Response.default_charset}", 'Content-Length' => body.bytesize.to_s}, [body]]
       end
 
       def public_path

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -1,11 +1,13 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+  <meta charset="utf-8" />
   <title>Action Controller: Exception caught</title>
   <style>
     body { background-color: #fff; color: #333; }
 
     body, p, ol, ul, td {
-      font-family: verdana, arial, helvetica, sans-serif;
+      font-family: helvetica, verdana, arial, sans-serif;
       font-size:   13px;
       line-height: 18px;
     }

--- a/actionpack/test/dispatch/show_exceptions_test.rb
+++ b/actionpack/test/dispatch/show_exceptions_test.rb
@@ -137,4 +137,11 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
     assert_response 500
     assert_match(/RuntimeError\n    in FeaturedTilesController/, body)
   end
+
+  test "sets the HTTP charset parameter" do
+    @app = DevelopmentApp
+
+    get "/", {}, {'action_dispatch.show_exceptions' => true}
+    assert_equal "text/html; charset=utf-8", response.headers["Content-Type"]
+  end
 end


### PR DESCRIPTION
Due to the missing charset metatag, Google Chrome sometimes misidentifies the rescue page charset, resulting in incorrect characters being displayed.

For example:
![Action Controller: Exception caught](https://img.skitch.com/20110503-bdkxy73g3qunhd9jyp8ms4arfi.png)

This commit also adds the correct HTML5 doctype and switches the font-family ordering for the benefit of Mac users (and other users who have Helvetica installed).

Please also apply to 3-0-stable.
