### PR TITLE
raise an error if the old router draw method is used

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -240,6 +240,11 @@ module ActionDispatch
       end
 
       def eval_block(block)
+        if block.arity == 1
+          raise "You are using the old router DSL which has been removed in Rails 3.1. " <<
+            "Please check how to update your routes file at: http://www.engineyard.com/blog/2010/the-lowdown-on-routes-in-rails-3/ " <<
+            "or add the rails_legacy_mapper gem to your Gemfile"
+        end
         mapper = Mapper.new(self)
         if default_scope
           mapper.with_default_scope(default_scope, &block)

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -92,6 +92,12 @@ class LegacyRouteSetTests < Test::Unit::TestCase
     @rs.clear!
   end
 
+  def test_draw_with_block_arity_one_raises
+    assert_raise(RuntimeError) do
+      @rs.draw { |map| map.match '/:controller(/:action(/:id))' }
+    end
+  end
+
   def test_default_setup
     @rs.draw { match '/:controller(/:action(/:id))' }
     assert_equal({:controller => "content", :action => 'index'}, rs.recognize_path("/content"))


### PR DESCRIPTION
Hey Guys,

This commit raises an error if the old router draw method is used, along with a message advising them to either upgrade their routes or add rails_legacy_mapper to their Gemfile.

Let me know if the error type needs changing.

Thanks,

Josh
