### PR TITLE
Select_tag should have the same API of select from form_builder

### DIFF
--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -74,6 +74,8 @@ module ActionView
       # ==== Options
       # * <tt>:multiple</tt> - If set to true the selection will allow multiple choices.
       # * <tt>:disabled</tt> - If set to true, the user will not be able to use this input.
+      # * <tt>:include_blank</tt> - If set to true, an empty option will be create
+      # * <tt>:prompt</tt> - Create a prompt option with blank value and the text asking user to select something
       # * Any other key creates standard HTML attributes for the tag.
       #
       # ==== Examples
@@ -99,18 +101,26 @@ module ActionView
       #   # => <select class="form_input" id="access" multiple="multiple" name="access[]"><option>Read</option>
       #   #    <option>Write</option></select>
       #
+      #   select_tag "people", options_from_collection_for_select(@people, "id", "name"), :include_blank => true
+      #   # => <select id="people" name="people"><option value=""></option><option value="1">David</option></select>
+      #
+      #   select_tag "people", options_from_collection_for_select(@people, "id", "name"), :prompt => "Select something"
+      #   # => <select id="people" name="people"><option value="">Select something</option><option value="1">David</option></select>
+      #
       #   select_tag "destination", "<option>NYC</option><option>Paris</option><option>Rome</option>", :disabled => true
       #   # => <select disabled="disabled" id="destination" name="destination"><option>NYC</option>
       #   #    <option>Paris</option><option>Rome</option></select>
       def select_tag(name, option_tags = nil, options = {})
         html_name = (options[:multiple] == true && !name.to_s.ends_with?("[]")) ? "#{name}[]" : name
-        if blank = options.delete(:include_blank)
-          if blank.kind_of?(String)
-            option_tags = "<option value=\"\">#{blank}</option>".html_safe + option_tags
-          else
-            option_tags = "<option value=\"\"></option>".html_safe + option_tags
-          end
+
+        if options.delete(:include_blank)
+          option_tags = "<option value=\"\"></option>".html_safe + option_tags
         end
+
+        if prompt = options.delete(:prompt)
+          option_tags = "<option value=\"\">#{prompt}</option>".html_safe + option_tags
+        end
+
         content_tag :select, option_tags, { "name" => html_name, "id" => sanitize_to_id(name) }.update(options.stringify_keys)
       end
 

--- a/actionpack/test/template/form_tag_helper_test.rb
+++ b/actionpack/test/template/form_tag_helper_test.rb
@@ -200,9 +200,15 @@ class FormTagHelperTest < ActionView::TestCase
     assert_dom_equal expected, actual
   end
 
-  def test_select_tag_with_include_blank_with_string
-    actual = select_tag "places", "<option>Home</option><option>Work</option><option>Pub</option>".html_safe, :include_blank => "string"
+  def test_select_tag_with_prompt
+    actual = select_tag "places", "<option>Home</option><option>Work</option><option>Pub</option>".html_safe, :prompt => "string"
     expected = %(<select id="places" name="places"><option value="">string</option><option>Home</option><option>Work</option><option>Pub</option></select>)
+    assert_dom_equal expected, actual
+  end
+
+  def test_select_tag_with_prompt_and_include_blank
+    actual = select_tag "places", "<option>Home</option><option>Work</option><option>Pub</option>".html_safe, :prompt => "string", :include_blank => true
+    expected = %(<select name="places" id="places"><option value="">string</option><option value=""></option><option>Home</option><option>Work</option><option>Pub</option></select>)
     assert_dom_equal expected, actual
   end
 


### PR DESCRIPTION
Hello, Today when we want a select_tag with a prompt we need to pass :include_bank => "My Prompt". I think this is incoherent with the select method from form builders. Also, the documentation don't cover this behavior, which means, to know about include_blank with string people should read the source code.

My small pull request make select_tag behave like select and add docs from prompt and include blank. 

Thanks.
