### PR TITLE
Extra requires for AR::Migration

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1,5 +1,7 @@
 require 'active_support/core_ext/kernel/singleton_class'
 require 'active_support/core_ext/module/aliasing'
+require 'active_support/core_ext/module/delegation'
+require 'active_support/core_ext/class/attribute_accessors'
 
 module ActiveRecord
   # Exception that can be raised to stop migrations from going backwards.


### PR DESCRIPTION
Add a couple of missing activesupport requires so AR::Migration can be used independently.
