### PR TITLE
Always flush logger at exit

### DIFF
--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -37,6 +37,7 @@ module Rails
           )
           logger
         end
+        at_exit { Rails.logger.flush if Rails.logger.respond_to?(:flush) }
       end
 
       # Initialize cache early in the stack so railties can make use of it.

--- a/railties/lib/rails/commands/runner.rb
+++ b/railties/lib/rails/commands/runner.rb
@@ -39,18 +39,12 @@ ENV["RAILS_ENV"] = options[:environment]
 require APP_PATH
 Rails.application.require_environment!
 
-begin
-  if code_or_file.nil?
-    $stderr.puts "Run '#{$0} -h' for help."
-    exit 1
-  elsif File.exist?(code_or_file)
-    $0 = code_or_file
-    eval(File.read(code_or_file), nil, code_or_file)
-  else
-    eval(code_or_file)
-  end
-ensure
-  if defined? Rails
-    Rails.logger.flush if Rails.logger.respond_to?(:flush)
-  end
+if code_or_file.nil?
+  $stderr.puts "Run '#{$0} -h' for help."
+  exit 1
+elsif File.exist?(code_or_file)
+  $0 = code_or_file
+  eval(File.read(code_or_file), nil, code_or_file)
+else
+  eval(code_or_file)
 end

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -73,6 +73,19 @@ module ApplicationTests
       assert_match 'custom_assets GET /custom/assets(.:format)', Dir.chdir(app_path){ `rake routes` }
     end
 
+    def test_logger_is_flushed_when_exiting_production_rake_tasks
+      add_to_config <<-RUBY
+        rake_tasks do
+          task :log_something => :environment do
+            Rails.logger.error("Sample log message")
+          end
+        end
+      RUBY
+
+      output = Dir.chdir(app_path){ `rake log_something RAILS_ENV=production && cat log/production.log` }
+      assert_match "Sample log message", output
+    end
+
     def test_model_and_migration_generator_with_change_syntax
       Dir.chdir(app_path) do
         `rails generate model user username:string password:string`


### PR DESCRIPTION
Remove special-case code in the "runner" command, and replace it with a general solution to ensure that the logger gets flushed at exit. This solution works for "runner", "console", "server", rake tasks, and any other process that loads the Rails environment.

Here's a detailed description of the issue that this commit resolves:
### Rake tasks fail to log when running in production mode

In production mode, when you write a single line to the Rails logger via script/runner, it writes the line to production.log.  (This is, of course, the expected behavior.)

In production mode, when you write a single line to the Rails logger via rake, it writes nothing to production.log.  

It's odd to have this difference in behavior between running via script/runner and running via rake.  It seems to violate the principle of least surprise.  This [gist demonstrates the issue](https://gist.github.com/956295#file_script_with_output).
