### PR TITLE
Tidying up the language in wrap_parameters.rb

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/wrap_parameters.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/wrap_parameters.rb.tt
@@ -3,7 +3,7 @@
 # This file contains the settings for ActionController::ParametersWrapper
 # which will be enabled by default in the upcoming version of Ruby on Rails.
 
-# Enable parameter wrapping for JSON. You can disable this by set :format to empty array.
+# Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
 ActionController::Base.wrap_parameters :format => [:json]
 
 # Disable root element in JSON by default.


### PR DESCRIPTION
Just cleaning up the comments in the generated wrap_parameters.rb file
