### PR TITLE
Patch for performance test: make it run with ruby19/minitest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,10 @@ group :doc do
   gem "RedCloth", "~> 4.2" if RUBY_VERSION < "1.9.3"
 end
 
+group :test do
+  gem "ruby-prof"
+end
+
 # AS
 gem "memcache-client", ">= 1.8.5"
 

--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -65,6 +65,31 @@ module ApplicationTests
       run_test 'integration/posts_test.rb'
     end
 
+    test "performance test" do
+      controller 'posts', <<-RUBY
+        class PostsController < ActionController::Base
+        end
+      RUBY
+
+      app_file 'app/views/posts/index.html.erb', <<-HTML
+        Posts#index
+      HTML
+
+      app_file 'test/performance/posts_test.rb', <<-RUBY
+        require 'test_helper'
+        require 'rails/performance_test_help'
+
+        class PostsTest < ActionDispatch::PerformanceTest
+          def test_index
+            get '/posts'
+            assert_response :success
+          end
+        end
+      RUBY
+
+      run_test 'performance/posts_test.rb'
+    end
+
     private
       def run_test(name)
         result = ruby '-Itest', "#{app_path}/test/#{name}"


### PR DESCRIPTION
I'm using ruby 1.9.2, I got this error when running a fresh generated performance test:

```
Started
/home/jan/.rvm/gems/ruby-1.9.2-p180/gems/aws-s3-0.6.2/lib/aws/s3/extensions.rb:206:in `const_missing_from_s3_library': uninitialized constant CategoryPagesTest::STARTED (NameError)
    from /home/jan/.rvm/gems/ruby-1.9.2-p180/bundler/gems/rails-e99c1e3a3bd2/activesupport/lib/active_support/testing/performance.rb:39:in `run'
    from /home/jan/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/minitest/unit.rb:656:in `block (2 levels) in run_test_suites'
    from /home/jan/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/minitest/unit.rb:650:in `each'
    from /home/jan/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/minitest/unit.rb:650:in `block in run_test_suites'
    from /home/jan/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/minitest/unit.rb:649:in `each'
    from /home/jan/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/minitest/unit.rb:649:in `run_test_suites'
    from /home/jan/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/minitest/unit.rb:609:in `run'
    from /home/jan/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/minitest/unit.rb:508:in `block in autorun'
```

Some investigation shows performance tests only works with old classic test:unit. The patch added support for minitest.
