### PR TITLE
Add association join conditions to JOIN clause, not WHERE

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -91,11 +91,11 @@ module ActiveRecord
 
             constraint = build_constraint(reflection, table, key, foreign_table, foreign_key)
 
-            relation.from(join(table, constraint))
-
             unless conditions[i].empty?
-              relation.where(sanitize(conditions[i], table))
+              constraint = constraint.and(sanitize(conditions[i], table))
             end
+
+            relation.from(join(table, constraint))
 
             # The current table in this iteration becomes the foreign table in the next
             foreign_table = table

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -40,6 +40,11 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
     assert_no_match(/WHERE/i, sql)
   end
 
+  def test_join_conditions_allow_nil_associations
+    authors = Author.includes(:essays).where(:essays => {:id => nil})
+    assert_equal 2, authors.count
+  end
+
   def test_find_with_implicit_inner_joins_honors_readonly_without_select
     authors = Author.joins(:posts).to_a
     assert !authors.empty?, "expected authors to be non-empty"

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -34,6 +34,12 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
     assert_no_match(/JOIN/i, sql)
   end
 
+  def test_join_conditions_added_to_join_clause
+    sql = Author.joins(:essays).to_sql
+    assert_match(/writer_type.*?=.*?Author/i, sql)
+    assert_no_match(/WHERE/i, sql)
+  end
+
   def test_find_with_implicit_inner_joins_honors_readonly_without_select
     authors = Author.joins(:posts).to_a
     assert !authors.empty?, "expected authors to be non-empty"


### PR DESCRIPTION
Encountered this this morning -- looks like we're adding conditions from a join to the where clause, not the join clause.

Apart from having joins_values affect the where clause being a bit counterintuitive, placing join conditions here prevents us from using an Arel::OuterJoin to select all records without a corresponding record on the joined table.
