### PR TITLE
distance_of_time_in_words calculates wrong no of years 

### DIFF
--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -94,9 +94,20 @@ module ActionView
             when 43200..86399    then locale.t :about_x_months, :count => 1
             when 86400..525599   then locale.t :x_months,       :count => (distance_in_minutes.to_f / 43200.0).round
             else
-              distance_in_years           = distance_in_minutes / 525600
-              minute_offset_for_leap_year = (distance_in_years / 4) * 1440
-              remainder                   = ((distance_in_minutes - minute_offset_for_leap_year) % 525600)
+              fyear = from_time.year
+              fyear += 1 if from_time.month >= 3
+              tyear = to_time.year
+              tyear -= 1 if to_time.month < 3
+              leap_years = (fyear > tyear) ? 0 : (fyear..tyear).count{|x| Date.leap?(x)}
+              minute_offset_for_leap_year = leap_years * 1440
+              # Discount the leap year days when calculating year distance.
+              # e.g. if there are 20 leap year days between 2 dates having the same day 
+              # and month then the based on 365 days calculation
+              # the distance in years will come out to over 80 years when in written 
+              # english it would read better as about 80 years.
+              minutes_with_offset         = distance_in_minutes - minute_offset_for_leap_year
+              remainder                   = (minutes_with_offset % 525600)
+              distance_in_years           = (minutes_with_offset / 525600)
               if remainder < 131400
                 locale.t(:about_x_years,  :count => distance_in_years)
               elsif remainder < 394200

--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -101,9 +101,9 @@ module ActionView
               leap_years = (fyear > tyear) ? 0 : (fyear..tyear).count{|x| Date.leap?(x)}
               minute_offset_for_leap_year = leap_years * 1440
               # Discount the leap year days when calculating year distance.
-              # e.g. if there are 20 leap year days between 2 dates having the same day 
+              # e.g. if there are 20 leap year days between 2 dates having the same day
               # and month then the based on 365 days calculation
-              # the distance in years will come out to over 80 years when in written 
+              # the distance in years will come out to over 80 years when in written
               # english it would read better as about 80 years.
               minutes_with_offset         = distance_in_minutes - minute_offset_for_leap_year
               remainder                   = (minutes_with_offset % 525600)

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -121,6 +121,10 @@ class DateHelperTest < ActionView::TestCase
     start_date = Date.new 1975, 1, 31
     end_date = Date.new 1977, 1, 31
     assert_equal("about 2 years", distance_of_time_in_words(start_date, end_date))
+
+    start_date = Date.new 1982, 12, 3
+    end_date = Date.new 2010, 11, 30
+    assert_equal("almost 28 years", distance_of_time_in_words(start_date, end_date))
   end
 
   def test_distance_in_words_with_integers


### PR DESCRIPTION
`distance_of_time_in_words` does not take leap years into account accurately. The bug was raised on [Lighthouse 6074](https://rails.lighthouseapp.com/projects/8994/tickets/6074-distance_of_time_in_words-calculates-wrong-no-of-years). 

Patch with test provided. Feel free to comment/review/suggest changes.
