### PR TITLE
config.generators.orm = false when skipping active record. LightHouse #5796

### DIFF
--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -52,13 +52,13 @@ module Rails
         :integration_tool => nil,
         :javascripts => true,
         :javascript_engine => nil,
-        :orm => nil,
+        :orm => false,
         :performance_tool => nil,
         :resource_controller => :controller,
         :scaffold_controller => :scaffold_controller,
         :stylesheets => true,
         :stylesheet_engine => nil,
-        :test_framework => nil,
+        :test_framework => false,
         :template_engine => :erb
       },
 

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -120,6 +120,14 @@ module Rails
         options[:skip_active_record] ? "" : "gem '#{gem_for_database}'\n"
       end
 
+      def include_all_railties?
+        !options[:skip_active_record] && !options[:skip_test_unit]
+      end
+
+      def comment_if(value)
+        options[value] ? '#' : ''
+      end
+
       def rails_gemfile_entry
         if options.dev?
           <<-GEMFILE.strip_heredoc

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -1,14 +1,14 @@
 require File.expand_path('../boot', __FILE__)
 
-<% if !options[:skip_active_record] && !options[:skip_test_unit] -%>
+<% if include_all_railties? -%>
 require 'rails/all'
 <% else -%>
 # Pick the frameworks you want:
-<%= options[:skip_active_record] ? "#" : "" %> require "active_record/railtie"
+<%= comment_if :skip_active_record %> require "active_record/railtie"
 require "action_controller/railtie"
 require "action_mailer/railtie"
 require "active_resource/railtie"
-<%= options[:skip_test_unit] ? "#" : "" %> require "rails/test_unit/railtie"
+<%= comment_if :skip_test_unit %> require "rails/test_unit/railtie"
 <% end -%>
 
 # If you have a Gemfile, require the gems listed there, including any gems
@@ -59,8 +59,6 @@ module <%= app_const_base %>
 <% unless options[:skip_active_record] -%>
     # Enable IdentityMap for Active Record, to disable set to false or remove the line below.
     config.active_record.identity_map = true
-<% else -%>
-    config.generators.orm = false
 <% end -%>
 
     # Enable the asset pipeline

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -63,6 +63,8 @@ module <%= app_const_base %>
 <% unless options[:skip_active_record] -%>
     # Enable IdentityMap for Active Record, to disable set to false or remove the line below.
     config.active_record.identity_map = true
+<% else -%>
+    config.generators.orm = false
 <% end -%>
 
     # Enable the asset pipeline

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -1,14 +1,14 @@
 require File.expand_path('../boot', __FILE__)
 
-<% unless options[:skip_active_record] -%>
+<% if !options[:skip_active_record] && !options[:skip_test_unit] -%>
 require 'rails/all'
 <% else -%>
 # Pick the frameworks you want:
-# require "active_record/railtie"
+<%= options[:skip_active_record] ? "#" : "" %> require "active_record/railtie"
 require "action_controller/railtie"
 require "action_mailer/railtie"
 require "active_resource/railtie"
-require "rails/test_unit/railtie"
+<%= options[:skip_test_unit] ? "#" : "" %> require "rails/test_unit/railtie"
 <% end -%>
 
 # If you have a Gemfile, require the gems listed there, including any gems
@@ -48,10 +48,6 @@ module <%= app_const_base %>
     # config.action_view.javascript_expansions[:defaults] = %w()
 <% else -%>
     # config.action_view.javascript_expansions[:defaults] = %w(prototype prototype_ujs)
-<% end -%>
-
-<% if options[:skip_test_unit] -%>
-    config.generators.test_framework = false
 <% end -%>
 
     # Configure the default encoding used in templates for Ruby 1.9.

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -161,7 +161,10 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_active_record_is_removed_from_frameworks_if_skip_active_record_is_given
     run_generator [destination_root, "--skip-active-record"]
-    assert_file "config/application.rb", /#\s+require\s+["']active_record\/railtie["']/
+    assert_file "config/application.rb" do |file|
+      assert_match /#\s+require\s+["']active_record\/railtie["']/, file
+      assert_match /config.generators.orm = false/, file
+    end
   end
 
   def test_creation_of_a_test_directory

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -230,9 +230,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_test_unit_is_removed_from_frameworks_if_skip_test_unit_is_given
     run_generator [destination_root, "--skip-test-unit"]
-    assert_file "config/application.rb" do |file|
-      assert_match /config.generators.test_framework = false/, file
-    end
+    assert_file "config/application.rb", /#\s+require\s+["']rails\/test_unit\/railtie["']/
+  end
+
+  def test_no_active_record_or_test_unit_if_skips_given
+    run_generator [destination_root, "--skip-test-unit", "--skip-active-record"]
+    assert_file "config/application.rb", /#\s+require\s+["']rails\/test_unit\/railtie["']/
+    assert_file "config/application.rb", /#\s+require\s+["']active_record\/railtie["']/
   end
 
   def test_new_hash_style

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -161,9 +161,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_active_record_is_removed_from_frameworks_if_skip_active_record_is_given
     run_generator [destination_root, "--skip-active-record"]
-    assert_file "config/application.rb" do |file|
-      assert_match /#\s+require\s+["']active_record\/railtie["']/, file
-    end
+    assert_file "config/application.rb", /#\s+require\s+["']active_record\/railtie["']/
   end
 
   def test_creation_of_a_test_directory

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -163,7 +163,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator [destination_root, "--skip-active-record"]
     assert_file "config/application.rb" do |file|
       assert_match /#\s+require\s+["']active_record\/railtie["']/, file
-      assert_match /config.generators.orm = false/, file
     end
   end
 


### PR DESCRIPTION
/cc @josevalim

Please [see](https://rails.lighthouseapp.com/projects/8994/tickets/5796-rails-30-generator-inconsistency). As per your comment another patch was provided which i think you missed (you also reopened the ticket back in Nov 2010).

Providing a rebased patch. Pull if still relevant.
