### PR TITLE
Accept single prefix in ActionView::MissingTemplate#initialize

### DIFF
--- a/actionpack/lib/action_view/path_set.rb
+++ b/actionpack/lib/action_view/path_set.rb
@@ -15,7 +15,7 @@ module ActionView #:nodoc:
     end
 
     def find_all(path, prefixes = [], *args)
-      prefixes = [prefixes] if String === prefixes
+      prefixes = Array.wrap(prefixes) if String === prefixes
       prefixes.each do |prefix|
         each do |resolver|
           templates = resolver.find_all(path, prefix, *args)

--- a/actionpack/lib/action_view/path_set.rb
+++ b/actionpack/lib/action_view/path_set.rb
@@ -15,7 +15,7 @@ module ActionView #:nodoc:
     end
 
     def find_all(path, prefixes = [], *args)
-      prefixes = Array.wrap(prefixes) if String === prefixes
+      prefixes = Array.wrap(prefixes)
       prefixes.each do |prefix|
         each do |resolver|
           templates = resolver.find_all(path, prefix, *args)

--- a/actionpack/lib/action_view/path_set.rb
+++ b/actionpack/lib/action_view/path_set.rb
@@ -1,3 +1,5 @@
+require "active_support/core_ext/array/wrap"
+
 module ActionView #:nodoc:
   # = Action View PathSet
   class PathSet < Array #:nodoc:

--- a/actionpack/lib/action_view/template/error.rb
+++ b/actionpack/lib/action_view/template/error.rb
@@ -1,3 +1,4 @@
+require "active_support/core_ext/array/wrap"
 require "active_support/core_ext/enumerable"
 
 module ActionView

--- a/actionpack/lib/action_view/template/error.rb
+++ b/actionpack/lib/action_view/template/error.rb
@@ -29,7 +29,7 @@ module ActionView
 
     def initialize(paths, path, prefixes, partial, details, *)
       @path = path
-      prefixes = [prefixes] if String === prefixes
+      prefixes = Array.wrap(prefixes) if String === prefixes
       display_paths = paths.compact.map{ |p| p.to_s.inspect }.join(", ")
       template_type = if partial
         "partial"

--- a/actionpack/lib/action_view/template/error.rb
+++ b/actionpack/lib/action_view/template/error.rb
@@ -29,6 +29,7 @@ module ActionView
 
     def initialize(paths, path, prefixes, partial, details, *)
       @path = path
+      prefixes = [prefixes] if String === prefixes
       display_paths = paths.compact.map{ |p| p.to_s.inspect }.join(", ")
       template_type = if partial
         "partial"

--- a/actionpack/lib/action_view/template/error.rb
+++ b/actionpack/lib/action_view/template/error.rb
@@ -29,7 +29,7 @@ module ActionView
 
     def initialize(paths, path, prefixes, partial, details, *)
       @path = path
-      prefixes = Array.wrap(prefixes) if String === prefixes
+      prefixes = Array.wrap(prefixes)
       display_paths = paths.compact.map{ |p| p.to_s.inspect }.join(", ")
       template_type = if partial
         "partial"

--- a/actionpack/test/template/lookup_context_test.rb
+++ b/actionpack/test/template/lookup_context_test.rb
@@ -251,4 +251,13 @@ class TestMissingTemplate < ActiveSupport::TestCase
     end
     assert_match %r{Missing partial parent/foo, child/foo with .* Searched in:\n  \* "/Path/to/views"\n}, e.message
   end
+
+  test "if a single prefix is passed as a string and the lookup fails, MissingTemplate accepts it" do
+    e = assert_raise ActionView::MissingTemplate do
+      details = {:handlers=>[], :formats=>[], :locale=>[]}
+      @lookup_context.view_paths.find("foo", "parent", true, details)
+    end
+    assert_match %r{Missing partial parent/foo with .* Searched in:\n  \* "/Path/to/views"\n}, e.message
+  end 
+  
 end


### PR DESCRIPTION
Made ActionView::MissingTemplate#initialize optionally accept a single string
prefix to be converted to an array [as in ActionView::PathSet#find_all.](https://github.com/rails/rails/blob/master/actionpack/lib/action_view/path_set.rb#L18)

This is minor, but it solved an issue I was having with a completely unrelated gem, and feels like a gain in consistency to me, given how these two methods are called on [line 14](https://github.com/rails/rails/blob/master/actionpack/lib/action_view/path_set.rb#L14).
