### PR TITLE
Use PATCH instead of PUT; Fixes issue #348

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -276,7 +276,7 @@ module ActionController
       #
       # An implementation might choose not to accept a previously used nonce or a previously used digest, in order to
       # protect against a replay attack. Or, an implementation might choose to use one-time nonces or digests for
-      # POST or PUT requests and a time-stamp for GET requests. For more details on the issues involved see Section 4
+      # POST, PUT, or PATCH requests and a time-stamp for GET requests. For more details on the issues involved see Section 4
       # of this document.
       #
       # The nonce is opaque to the client. Composed of Time, and hash of Time with secret
@@ -290,7 +290,7 @@ module ActionController
       end
 
       # Might want a shorter timeout depending on whether the request
-      # is a PUT or POST, and if client is browser or web service.
+      # is a PATCH, PUT, or POST, and if client is browser or web service.
       # Can be much shorter if the Stale directive is implemented. This would
       # allow a user to use new nonce without prompting user again for their
       # username and password.

--- a/actionpack/lib/action_controller/metal/responder.rb
+++ b/actionpack/lib/action_controller/metal/responder.rb
@@ -53,7 +53,7 @@ module ActionController #:nodoc:
   #     end
   #   end
   #
-  # The same happens for PUT and DELETE requests.
+  # The same happens for PATCH and DELETE requests.
   #
   # === Nested resources
   #
@@ -118,6 +118,7 @@ module ActionController #:nodoc:
 
     ACTIONS_FOR_VERBS = {
       :post => :new,
+      :patch => :edit,
       :put => :edit
     }
 
@@ -133,7 +134,7 @@ module ActionController #:nodoc:
     end
 
     delegate :head, :render, :redirect_to,   :to => :controller
-    delegate :get?, :post?, :put?, :delete?, :to => :request
+    delegate :get?, :post?, :patch?, :put?, :delete?, :to => :request
 
     # Undefine :to_json and :to_yaml since it's defined on Object
     undef_method(:to_json) if method_defined?(:to_json)

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -224,7 +224,7 @@ module ActionController
   # == Basic example
   #
   # Functional tests are written as follows:
-  # 1. First, one uses the +get+, +post+, +put+, +delete+ or +head+ method to simulate
+  # 1. First, one uses the +get+, +post+, +patch+, +put+, +delete+ or +head+ method to simulate
   #    an HTTP request.
   # 2. Then, one asserts whether the current state is as expected. "State" can be anything:
   #    the controller's HTTP response, the database contents, etc.
@@ -367,6 +367,11 @@ module ActionController
       # Executes a request simulating POST HTTP method and set/volley the response
       def post(action, parameters = nil, session = nil, flash = nil)
         process(action, parameters, session, flash, "POST")
+      end
+
+      # Executes a request simulating PATCH HTTP method and set/volley the response
+      def patch(action, parameters = nil, session = nil, flash = nil)
+        process(action, parameters, session, flash, "PATCH")
       end
 
       # Executes a request simulating PUT HTTP method and set/volley the response

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -105,6 +105,12 @@ module ActionDispatch
       HTTP_METHOD_LOOKUP[request_method] == :post
     end
 
+    # Is this a PATCH request?
+    # Equivalent to <tt>request.request_method == :patch</tt>.
+    def patch?
+      HTTP_METHOD_LOOKUP[request_method] == :patch
+    end
+
     # Is this a PUT request?
     # Equivalent to <tt>request.request_method == :put</tt>.
     def put?

--- a/actionpack/lib/action_dispatch/routing.rb
+++ b/actionpack/lib/action_dispatch/routing.rb
@@ -182,10 +182,13 @@ module ActionDispatch
   #
   # == HTTP Methods
   #
-  # Using the <tt>:via</tt> option when specifying a route allows you to restrict it to a specific HTTP method.
-  # Possible values are <tt>:post</tt>, <tt>:get</tt>, <tt>:put</tt>, <tt>:delete</tt> and <tt>:any</tt>.
-  # If your route needs to respond to more than one method you can use an array, e.g. <tt>[ :get, :post ]</tt>.
-  # The default value is <tt>:any</tt> which means that the route will respond to any of the HTTP methods.
+  # Using the <tt>:via</tt> option when specifying a route allows you to
+  # restrict it to a specific HTTP method.  Possible values are <tt>:post</tt>,
+  # <tt>:get</tt>, <tt>:patch</tt>, <tt>:put</tt>, <tt>:delete</tt> and
+  # <tt>:any</tt>.  If your route needs to respond to more than one method you
+  # can use an array, e.g. <tt>[ :get, :post ]</tt>.  The default value is
+  # <tt>:any</tt> which means that the route will respond to any of the HTTP
+  # methods.
   #
   # Examples:
   #
@@ -198,7 +201,7 @@ module ActionDispatch
   # === HTTP helper methods
   #
   # An alternative method of specifying which HTTP method a route should respond to is to use the helper
-  # methods <tt>get</tt>, <tt>post</tt>, <tt>put</tt> and <tt>delete</tt>.
+  # methods <tt>get</tt>, <tt>post</tt>, <tt>patch</tt>, <tt>put</tt> and <tt>delete</tt>.
   #
   # Examples:
   #
@@ -284,7 +287,7 @@ module ActionDispatch
     autoload :PolymorphicRoutes, 'action_dispatch/routing/polymorphic_routes'
 
     SEPARATORS = %w( / . ? ) #:nodoc:
-    HTTP_METHODS = [:get, :head, :post, :put, :delete, :options] #:nodoc:
+    HTTP_METHODS = [:get, :head, :post, :patch, :put, :delete, :options] #:nodoc:
 
     # A helper module to hold URL related helpers.
     module Helpers #:nodoc:

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -484,6 +484,16 @@ module ActionDispatch
           map_method(:post, *args, &block)
         end
 
+        # Define a route that only recognizes HTTP PATCH.
+        # For supported arguments, see <tt>Base#match</tt>.
+        #
+        # Example:
+        #
+        # patch 'bacon', :to => 'food#bacon'
+        def patch(*args, &block)
+          map_method(:patch, *args, &block)
+        end
+
         # Define a route that only recognizes HTTP PUT.
         # For supported arguments, see <tt>Base#match</tt>.
         #
@@ -494,7 +504,7 @@ module ActionDispatch
           map_method(:put, *args, &block)
         end
 
-        # Define a route that only recognizes HTTP PUT.
+        # Define a route that only recognizes HTTP DELETE.
         # For supported arguments, see <tt>Base#match</tt>.
         #
         # Example:
@@ -532,6 +542,7 @@ module ActionDispatch
       #   POST	  /admin/posts
       #   GET	    /admin/posts/1
       #   GET	    /admin/posts/1/edit
+      #   PATCH	  /admin/posts/1
       #   PUT	    /admin/posts/1
       #   DELETE  /admin/posts/1
       #
@@ -566,6 +577,7 @@ module ActionDispatch
       #   POST	  /admin/posts
       #   GET	    /admin/posts/1
       #   GET	    /admin/posts/1/edit
+      #   PATCH	  /admin/posts/1
       #   PUT	    /admin/posts/1
       #   DELETE  /admin/posts/1
       module Scoping
@@ -661,6 +673,7 @@ module ActionDispatch
         #    new_admin_post GET    /admin/posts/new(.:format)      {:action=>"new", :controller=>"admin/posts"}
         #   edit_admin_post GET    /admin/posts/:id/edit(.:format) {:action=>"edit", :controller=>"admin/posts"}
         #        admin_post GET    /admin/posts/:id(.:format)      {:action=>"show", :controller=>"admin/posts"}
+        #        admin_post PATCH  /admin/posts/:id(.:format)      {:action=>"update", :controller=>"admin/posts"}
         #        admin_post PUT    /admin/posts/:id(.:format)      {:action=>"update", :controller=>"admin/posts"}
         #        admin_post DELETE /admin/posts/:id(.:format)      {:action=>"destroy", :controller=>"admin/posts"}
         #
@@ -974,7 +987,7 @@ module ActionDispatch
         #
         #   resource :geocoder
         #
-        # creates six different routes in your application, all mapping to
+        # creates seven different routes in your application, all mapping to
         # the GeoCoders controller (note that the controller is named after
         # the plural):
         #
@@ -982,6 +995,7 @@ module ActionDispatch
         #   POST    /geocoder
         #   GET     /geocoder
         #   GET     /geocoder/edit
+        #   PATCH   /geocoder
         #   PUT     /geocoder
         #   DELETE  /geocoder
         #
@@ -1008,6 +1022,7 @@ module ActionDispatch
             member do
               get    :edit if parent_resource.actions.include?(:edit)
               get    :show if parent_resource.actions.include?(:show)
+              patch  :update if parent_resource.actions.include?(:update)
               put    :update if parent_resource.actions.include?(:update)
               delete :destroy if parent_resource.actions.include?(:destroy)
             end
@@ -1023,13 +1038,15 @@ module ActionDispatch
         #
         #   resources :photos
         #
-        # creates seven different routes in your application, all mapping to
+        # creates eight different routes in your application, all mapping to
         # the Photos controller:
         #
+        #   GET     /photos
         #   GET     /photos/new
         #   POST    /photos
         #   GET     /photos/:id
         #   GET     /photos/:id/edit
+        #   PATCH   /photos/:id
         #   PUT     /photos/:id
         #   DELETE  /photos/:id
         #
@@ -1041,10 +1058,12 @@ module ActionDispatch
         #
         # This generates the following comments routes:
         #
+        #   GET     /photos/:id/comments
         #   GET     /photos/:id/comments/new
         #   POST    /photos/:id/comments
         #   GET     /photos/:id/comments/:id
         #   GET     /photos/:id/comments/:id/edit
+        #   PATCH   /photos/:id/comments/:id
         #   PUT     /photos/:id/comments/:id
         #   DELETE  /photos/:id/comments/:id
         #
@@ -1102,6 +1121,7 @@ module ActionDispatch
         #     new_post_comment GET    /sekret/posts/:post_id/comments/new(.:format)
         #     edit_comment     GET    /sekret/comments/:id/edit(.:format)
         #     comment          GET    /sekret/comments/:id(.:format)
+        #     comment          PATCH  /sekret/comments/:id(.:format)
         #     comment          PUT    /sekret/comments/:id(.:format)
         #     comment          DELETE /sekret/comments/:id(.:format)
         #
@@ -1134,6 +1154,7 @@ module ActionDispatch
             member do
               get    :edit if parent_resource.actions.include?(:edit)
               get    :show if parent_resource.actions.include?(:show)
+              patch  :update if parent_resource.actions.include?(:update)
               put    :update if parent_resource.actions.include?(:update)
               delete :destroy if parent_resource.actions.include?(:destroy)
             end

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -27,8 +27,8 @@ module ActionDispatch
       # object's <tt>@response</tt> instance variable will point to the same
       # response object.
       #
-      # You can also perform POST, PUT, DELETE, and HEAD requests with +#post+,
-      # +#put+, +#delete+, and +#head+.
+      # You can also perform POST, PATCH, PUT, DELETE, and HEAD requests with
+      # +#post+, +#patch+, +#put+, +#delete+, and +#head+.
       def get(path, parameters = nil, headers = nil)
         process :get, path, parameters, headers
       end
@@ -37,6 +37,12 @@ module ActionDispatch
       # details.
       def post(path, parameters = nil, headers = nil)
         process :post, path, parameters, headers
+      end
+
+      # Performs a PATCH request with the given parameters. See +#get+ for more
+      # details.
+      def patch(path, parameters = nil, headers = nil)
+        process :patch, path, parameters, headers
       end
 
       # Performs a PUT request with the given parameters. See +#get+ for more
@@ -60,10 +66,10 @@ module ActionDispatch
       # Performs an XMLHttpRequest request with the given parameters, mirroring
       # a request from the Prototype library.
       #
-      # The request_method is +:get+, +:post+, +:put+, +:delete+ or +:head+; the
-      # parameters are +nil+, a hash, or a url-encoded or multipart string;
-      # the headers are a hash.  Keys are automatically upcased and prefixed
-      # with 'HTTP_' if not already.
+      # The request_method is +:get+, +:post+, +#patch+, +:put+, +:delete+ or
+      # +:head+; the parameters are +nil+, a hash, or a url-encoded or multipart
+      # string; the headers are a hash.  Keys are automatically upcased and
+      # prefixed with 'HTTP_' if not already.
       def xml_http_request(request_method, path, parameters = nil, headers = nil)
         headers ||= {}
         headers['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest'
@@ -101,6 +107,12 @@ module ActionDispatch
       # See +request_via_redirect+ for more information.
       def post_via_redirect(path, parameters = nil, headers = nil)
         request_via_redirect(:post, path, parameters, headers)
+      end
+
+      # Performs a PATCH request, following any subsequent redirect.
+      # See +request_via_redirect+ for more information.
+      def patch_via_redirect(path, parameters = nil, headers = nil)
+        request_via_redirect(:patch, path, parameters, headers)
       end
 
       # Performs a PUT request, following any subsequent redirect.
@@ -316,7 +328,7 @@ module ActionDispatch
         @integration_session = Integration::Session.new(app)
       end
 
-      %w(get post put head delete cookies assigns
+      %w(get post patch put head delete cookies assigns
          xml_http_request xhr get_via_redirect post_via_redirect).each do |method|
         define_method(method) do |*args|
           reset! unless integration_session

--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -190,7 +190,7 @@ module ActionView
       #
       # is equivalent to something like:
       #
-      #   <%= form_for @post, :as => :post, :url => post_path(@post), :method => :put, :html => { :class => "edit_post", :id => "edit_post_45" } do |f| %>
+      #   <%= form_for @post, :as => :post, :url => post_path(@post), :method => :patch, :html => { :class => "edit_post", :id => "edit_post_45" } do |f| %>
       #     ...
       #   <% end %>
       #
@@ -245,7 +245,7 @@ module ActionView
       #
       # You can force the form to use the full array of HTTP verbs by setting 
       #
-      #    :method => (:get|:post|:put|:delete)
+      #    :method => (:get|:post|:patch|:put|:delete)
       #
       # in the options hash. If the verb is not GET or POST, which are natively supported by HTML forms, the
       # form will be set to POST and a hidden input called _method will carry the intended verb for the server
@@ -273,7 +273,7 @@ module ActionView
       #
       #   <form action='http://www.example.com' method='post' data-remote='true'>
       #     <div style='margin:0;padding:0;display:inline'>
-      #       <input name='_method' type='hidden' value='put' />
+      #       <input name='_method' type='hidden' value='patch' />
       #     </div>
       #     ...
       #   </form>
@@ -381,7 +381,7 @@ module ActionView
         object = convert_to_model(object)
 
         as = options[:as]
-        action, method = object.respond_to?(:persisted?) && object.persisted? ? [:edit, :put] : [:new, :post]
+        action, method = object.respond_to?(:persisted?) && object.persisted? ? [:edit, :patch] : [:new, :post]
         options[:html].reverse_merge!(
           :class  => as ? "#{as}_#{action}" : dom_class(object, action),
           :id     => as ? "#{as}_#{action}" : dom_id(object, action),

--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -23,7 +23,7 @@ module ActionView
       # ==== Options
       # * <tt>:multipart</tt> - If set to true, the enctype is set to "multipart/form-data".
       # * <tt>:method</tt> - The method to use when submitting the form, usually either "get" or "post".
-      #   If "put", "delete", or another verb is used, a hidden input with name <tt>_method</tt>
+      #   If "patch", "delete", or another verb is used, a hidden input with name <tt>_method</tt>
       #   is added to simulate the verb over post.
       # * <tt>:authenticity_token</tt> - Authenticity token to use in the form. Use only if you need to
       #   pass custom authenticity token string, or to not add authenticity_token field at all
@@ -36,8 +36,8 @@ module ActionView
       #   form_tag('/posts')
       #   # => <form action="/posts" method="post">
       #
-      #   form_tag('/posts/1', :method => :put)
-      #   # => <form action="/posts/1" method="put">
+      #   form_tag('/posts/1', :method => :patch)
+      #   # => <form action="/posts/1" method="patch">
       #
       #   form_tag('/upload', :multipart => true)
       #   # => <form action="/upload" method="post" enctype="multipart/form-data">

--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -146,12 +146,12 @@ module ActionView
       #   create an HTML form and immediately submit the form for processing using
       #   the HTTP verb specified. Useful for having links perform a POST operation
       #   in dangerous actions like deleting a record (which search bots can follow
-      #   while spidering your site). Supported verbs are <tt>:post</tt>, <tt>:delete</tt> and <tt>:put</tt>.
+      #   while spidering your site). Supported verbs are <tt>:post</tt>, <tt>:delete</tt>, <tt>:patch</tt>, and <tt>:put</tt>.
       #   Note that if the user has JavaScript disabled, the request will fall back
       #   to using GET. If <tt>:href => '#'</tt> is used and the user has JavaScript
       #   disabled clicking the link will have no effect. If you are relying on the
       #   POST behavior, you should check for it in your controller's action by using
-      #   the request object's methods for <tt>post?</tt>, <tt>delete?</tt> or <tt>put?</tt>.
+      #   the request object's methods for <tt>post?</tt>, <tt>delete?</tt>, <tt>:patch</tt>, or <tt>put?</tt>.
       # * <tt>:remote => true</tt> - This will allow the unobtrusive JavaScript
       #   driver to make an Ajax request to the URL in question instead of following
       #   the link. The drivers each provide mechanisms for listening for the
@@ -272,7 +272,7 @@ module ActionView
       #
       # There are a few special +html_options+:
       # * <tt>:method</tt> - Symbol of HTTP verb. Supported verbs are <tt>:post</tt>, <tt>:get</tt>,
-      #   <tt>:delete</tt> and <tt>:put</tt>. By default it will be <tt>:post</tt>.
+      #   <tt>:delete</tt>, <tt>:patch</tt>, and <tt>:put</tt>. By default it will be <tt>:post</tt>.
       # * <tt>:disabled</tt> - If set to true, it will generate a disabled button.
       # * <tt>:confirm</tt> - This will use the unobtrusive JavaScript driver to
       #   prompt with the question specified. If the user accepts, the link is
@@ -319,7 +319,7 @@ module ActionView
         convert_boolean_attributes!(html_options, %w( disabled ))
 
         method_tag = ''
-        if (method = html_options.delete('method')) && %w{put delete}.include?(method.to_s)
+        if (method = html_options.delete('method')) && %w{patch put delete}.include?(method.to_s)
           method_tag = tag('input', :type => 'hidden', :name => '_method', :value => method.to_s)
         end
 

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -140,7 +140,7 @@ class PageCachingTest < ActionController::TestCase
   end
 
   [:ok, :no_content, :found, :not_found].each do |status|
-    [:get, :post, :put, :delete].each do |method|
+    [:get, :post, :patch, :put, :delete].each do |method|
       unless method == :get and status == :ok
         define_method "test_shouldnt_cache_#{method}_with_#{status}_status" do
           send(method, status)

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -63,6 +63,12 @@ class SessionTest < Test::Unit::TestCase
     @session.post_via_redirect(path, args, headers)
   end
 
+  def test_patch_via_redirect
+    path = "/somepath"; args = {:id => '1'}; headers = {"X-Test-Header" => "testvalue" }
+    @session.expects(:request_via_redirect).with(:patch, path, args, headers)
+    @session.patch_via_redirect(path, args, headers)
+  end
+
   def test_put_via_redirect
     path = "/somepath"; args = {:id => '1'}; headers = {"X-Test-Header" => "testvalue" }
     @session.expects(:request_via_redirect).with(:put, path, args, headers)
@@ -85,6 +91,12 @@ class SessionTest < Test::Unit::TestCase
     path = "/index"; params = "blah"; headers = {:location => 'blah'}
     @session.expects(:process).with(:post,path,params,headers)
     @session.post(path,params,headers)
+  end
+
+  def test_patch
+    path = "/index"; params = "blah"; headers = {:location => 'blah'}
+    @session.expects(:process).with(:patch,path,params,headers)
+    @session.patch(path,params,headers)
   end
 
   def test_put
@@ -123,6 +135,16 @@ class SessionTest < Test::Unit::TestCase
     )
     @session.expects(:process).with(:post,path,params,headers_after_xhr)
     @session.xml_http_request(:post,path,params,headers)
+  end
+
+  def test_xml_http_request_patch
+    path = "/index"; params = "blah"; headers = {:location => 'blah'}
+    headers_after_xhr = headers.merge(
+      "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest",
+      "HTTP_ACCEPT"           => "text/javascript, text/html, application/xml, text/xml, */*"
+    )
+    @session.expects(:process).with(:patch,path,params,headers_after_xhr)
+    @session.xml_http_request(:patch,path,params,headers)
   end
 
   def test_xml_http_request_put
@@ -212,7 +234,7 @@ class IntegrationTestUsesCorrectClass < ActionDispatch::IntegrationTest
     @integration_session.stubs(:generic_url_rewriter)
     @integration_session.stubs(:process)
 
-    %w( get post head put delete ).each do |verb|
+    %w( get post head patch put delete ).each do |verb|
       assert_nothing_raised("'#{verb}' should use integration test methods") { __send__(verb, '/') }
     end
   end

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -115,6 +115,10 @@ module RequestForgeryProtectionTests
     assert_blocked { post :index, :format=>'xml' }
   end
 
+  def test_should_not_allow_patch_without_token
+    assert_blocked { patch :index }
+  end
+
   def test_should_not_allow_put_without_token
     assert_blocked { put :index }
   end
@@ -129,6 +133,10 @@ module RequestForgeryProtectionTests
 
   def test_should_allow_post_with_token
     assert_not_blocked { post :index, :authenticity_token => @token }
+  end
+
+  def test_should_allow_patch_with_token
+    assert_not_blocked { patch :index, :authenticity_token => @token }
   end
 
   def test_should_allow_put_with_token
@@ -147,6 +155,11 @@ module RequestForgeryProtectionTests
   def test_should_allow_delete_with_token_in_header
     @request.env['HTTP_X_CSRF_TOKEN'] = @token
     assert_not_blocked { delete :index }
+  end
+
+  def test_should_allow_patch_with_token_in_header
+    @request.env['HTTP_X_CSRF_TOKEN'] = @token
+    assert_not_blocked { patch :index }
   end
 
   def test_should_allow_put_with_token_in_header
@@ -210,7 +223,7 @@ class FreeCookieControllerTest < ActionController::TestCase
   end
 
   def test_should_allow_all_methods_without_token
-    [:post, :put, :delete].each do |method|
+    [:post, :patch, :put, :delete].each do |method|
       assert_nothing_raised { send(method, :index)}
     end
   end

--- a/actionpack/test/controller/resources_test.rb
+++ b/actionpack/test/controller/resources_test.rb
@@ -150,7 +150,7 @@ class ResourcesTest < ActionController::TestCase
   end
 
   def test_with_collection_actions
-    actions = { 'a' => :get, 'b' => :put, 'c' => :post, 'd' => :delete }
+    actions = { 'a' => :get, 'b' => :put, 'c' => :post, 'd' => :delete, 'e' => :patch }
 
     with_routing do |set|
       set.draw do
@@ -159,6 +159,7 @@ class ResourcesTest < ActionController::TestCase
           put    :b, :on => :collection
           post   :c, :on => :collection
           delete :d, :on => :collection
+          patch  :e, :on => :collection
         end
       end
 
@@ -177,7 +178,7 @@ class ResourcesTest < ActionController::TestCase
   end
 
   def test_with_collection_actions_and_name_prefix
-    actions = { 'a' => :get, 'b' => :put, 'c' => :post, 'd' => :delete }
+    actions = { 'a' => :get, 'b' => :put, 'c' => :post, 'd' => :delete, 'e' => :patch }
 
     with_routing do |set|
       set.draw do
@@ -187,6 +188,7 @@ class ResourcesTest < ActionController::TestCase
             put    :b, :on => :collection
             post   :c, :on => :collection
             delete :d, :on => :collection
+            patch  :e, :on => :collection
           end
         end
       end
@@ -233,7 +235,7 @@ class ResourcesTest < ActionController::TestCase
   end
 
   def test_with_collection_action_and_name_prefix_and_formatted
-    actions = { 'a' => :get, 'b' => :put, 'c' => :post, 'd' => :delete }
+    actions = { 'a' => :get, 'b' => :put, 'c' => :post, 'd' => :delete, 'e' => :patch }
 
     with_routing do |set|
       set.draw do
@@ -243,6 +245,7 @@ class ResourcesTest < ActionController::TestCase
             put    :b, :on => :collection
             post   :c, :on => :collection
             delete :d, :on => :collection
+            patch  :e, :on => :collection
           end
         end
       end
@@ -262,7 +265,7 @@ class ResourcesTest < ActionController::TestCase
   end
 
   def test_with_member_action
-    [:put, :post].each do |method|
+    [:patch, :put, :post].each do |method|
       with_restful_routing :messages, :member => { :mark => method } do
         mark_options = {:action => 'mark', :id => '1'}
         mark_path    = "/messages/1/mark"
@@ -286,7 +289,7 @@ class ResourcesTest < ActionController::TestCase
   end
 
   def test_member_when_override_paths_for_default_restful_actions_with
-    [:put, :post].each do |method|
+    [:patch, :put, :post].each do |method|
       with_restful_routing :messages, :member => { :mark => method }, :path_names => {:new => 'nuevo'} do
         mark_options = {:action => 'mark', :id => '1', :controller => "messages"}
         mark_path    = "/messages/1/mark"
@@ -303,7 +306,7 @@ class ResourcesTest < ActionController::TestCase
   end
 
   def test_with_two_member_actions_with_same_method
-    [:put, :post].each do |method|
+    [:patch, :put, :post].each do |method|
       with_routing do |set|
         set.draw do
           resources :messages do
@@ -556,7 +559,7 @@ class ResourcesTest < ActionController::TestCase
   end
 
   def test_singleton_resource_with_member_action
-    [:put, :post].each do |method|
+    [:patch, :put, :post].each do |method|
       with_routing do |set|
         set.draw do
           resource :account do
@@ -578,7 +581,7 @@ class ResourcesTest < ActionController::TestCase
   end
 
   def test_singleton_resource_with_two_member_actions_with_same_method
-    [:put, :post].each do |method|
+    [:patch, :put, :post].each do |method|
       with_routing do |set|
         set.draw do
           resource :account do
@@ -643,11 +646,15 @@ class ResourcesTest < ActionController::TestCase
     end
   end
 
-  def test_should_not_allow_delete_or_put_on_collection_path
+  def test_should_not_allow_delete_or_patch_or_put_on_collection_path
     controller_name = :messages
     with_restful_routing controller_name do
       options = { :controller => controller_name.to_s }
       collection_path = "/#{controller_name}"
+
+      assert_raise(ActionController::RoutingError) do
+        assert_recognizes(options.merge(:action => 'update'), :path => collection_path, :method => :patch)
+      end
 
       assert_raise(ActionController::RoutingError) do
         assert_recognizes(options.merge(:action => 'update'), :path => collection_path, :method => :put)
@@ -1165,6 +1172,7 @@ class ResourcesTest < ActionController::TestCase
       assert_recognizes(options[:shallow_options].merge(:action => 'show',    :id => '1'), :path => member_path,      :method => :get)
       assert_recognizes(options[:shallow_options].merge(:action => 'edit',    :id => '1'), :path => edit_member_path, :method => :get)
       assert_recognizes(options[:shallow_options].merge(:action => 'update',  :id => '1'), :path => member_path,      :method => :put)
+      assert_recognizes(options[:shallow_options].merge(:action => 'update',  :id => '1'), :path => member_path,      :method => :patch)
       assert_recognizes(options[:shallow_options].merge(:action => 'destroy', :id => '1'), :path => member_path,      :method => :delete)
 
       assert_recognizes(options[:options].merge(:action => 'index',  :format => 'xml'), :path => "#{collection_path}.xml",   :method => :get)
@@ -1173,6 +1181,7 @@ class ResourcesTest < ActionController::TestCase
       assert_recognizes(options[:shallow_options].merge(:action => 'show',    :id => '1', :format => 'xml'), :path => "#{member_path}.xml",       :method => :get)
       assert_recognizes(options[:shallow_options].merge(:action => 'edit',    :id => '1', :format => 'xml'), :path => formatted_edit_member_path, :method => :get)
       assert_recognizes(options[:shallow_options].merge(:action => 'update',  :id => '1', :format => 'xml'), :path => "#{member_path}.xml",       :method => :put)
+      assert_recognizes(options[:shallow_options].merge(:action => 'update',  :id => '1', :format => 'xml'), :path => "#{member_path}.xml",       :method => :patch)
       assert_recognizes(options[:shallow_options].merge(:action => 'destroy', :id => '1', :format => 'xml'), :path => "#{member_path}.xml",       :method => :delete)
 
       yield options[:options] if block_given?
@@ -1252,6 +1261,7 @@ class ResourcesTest < ActionController::TestCase
       assert_recognizes(options[:options].merge(:action => 'edit'),    :path => edit_path, :method => :get)
       assert_recognizes(options[:options].merge(:action => 'create'),  :path => full_path, :method => :post)
       assert_recognizes(options[:options].merge(:action => 'update'),  :path => full_path, :method => :put)
+      assert_recognizes(options[:options].merge(:action => 'update'),  :path => full_path, :method => :patch)
       assert_recognizes(options[:options].merge(:action => 'destroy'), :path => full_path, :method => :delete)
 
       assert_recognizes(options[:options].merge(:action => 'show',    :format => 'xml'), :path => "#{full_path}.xml",  :method => :get)
@@ -1259,6 +1269,7 @@ class ResourcesTest < ActionController::TestCase
       assert_recognizes(options[:options].merge(:action => 'edit',    :format => 'xml'), :path => formatted_edit_path, :method => :get)
       assert_recognizes(options[:options].merge(:action => 'create',  :format => 'xml'), :path => "#{full_path}.xml",  :method => :post)
       assert_recognizes(options[:options].merge(:action => 'update',  :format => 'xml'), :path => "#{full_path}.xml",  :method => :put)
+      assert_recognizes(options[:options].merge(:action => 'update',  :format => 'xml'), :path => "#{full_path}.xml",  :method => :patch)
       assert_recognizes(options[:options].merge(:action => 'destroy', :format => 'xml'), :path => "#{full_path}.xml",  :method => :delete)
 
       yield options[:options] if block_given?
@@ -1310,6 +1321,7 @@ class ResourcesTest < ActionController::TestCase
       assert_whether_allowed(allowed, not_allowed, shallow_options, 'show',     "#{shallow_path}#{format}",       :get)
       assert_whether_allowed(allowed, not_allowed, shallow_options, 'edit',     "#{shallow_path}/edit#{format}",  :get)
       assert_whether_allowed(allowed, not_allowed, shallow_options, 'update',   "#{shallow_path}#{format}",       :put)
+      assert_whether_allowed(allowed, not_allowed, shallow_options, 'update',   "#{shallow_path}#{format}",       :patch)
       assert_whether_allowed(allowed, not_allowed, shallow_options, 'destroy',  "#{shallow_path}#{format}",       :delete)
     end
 
@@ -1322,6 +1334,7 @@ class ResourcesTest < ActionController::TestCase
       assert_whether_allowed(allowed, not_allowed, options, 'show',     "#{path}#{format}",       :get)
       assert_whether_allowed(allowed, not_allowed, options, 'edit',     "#{path}/edit#{format}",  :get)
       assert_whether_allowed(allowed, not_allowed, options, 'update',   "#{path}#{format}",       :put)
+      assert_whether_allowed(allowed, not_allowed, options, 'update',   "#{path}#{format}",       :patch)
       assert_whether_allowed(allowed, not_allowed, options, 'destroy',  "#{path}#{format}",       :delete)
     end
 

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -531,11 +531,12 @@ class LegacyRouteSetTests < Test::Unit::TestCase
       match '/match' => 'books#get', :via => :get
       match '/match' => 'books#post', :via => :post
       match '/match' => 'books#put', :via => :put
+      match '/match' => 'books#patch', :via => :patch
       match '/match' => 'books#delete', :via => :delete
     end
   end
 
-  %w(GET POST PUT DELETE).each do |request_method|
+  %w(GET PATCH POST PUT DELETE).each do |request_method|
     define_method("test_request_method_recognized_with_#{request_method}") do
       setup_request_method_routes_for(request_method)
       params = rs.recognize_path("/match", :method => request_method)
@@ -918,6 +919,7 @@ class RouteSetTest < ActiveSupport::TestCase
       post   "/people"     => "people#create"
       get    "/people/:id" => "people#show",  :as => "person"
       put    "/people/:id" => "people#update"
+      patch  "/people/:id" => "people#update"
       delete "/people/:id" => "people#destroy"
     end
 
@@ -930,6 +932,9 @@ class RouteSetTest < ActiveSupport::TestCase
     params = set.recognize_path("/people/5", :method => :put)
     assert_equal("update", params[:action])
 
+    params = set.recognize_path("/people/5", :method => :patch)
+    assert_equal("update", params[:action])
+
     assert_raise(ActionController::UnknownHttpMethod) {
       set.recognize_path("/people", :method => :bacon)
     }
@@ -939,6 +944,10 @@ class RouteSetTest < ActiveSupport::TestCase
     assert_equal("5", params[:id])
 
     params = set.recognize_path("/people/5", :method => :put)
+    assert_equal("update", params[:action])
+    assert_equal("5", params[:id])
+
+    params = set.recognize_path("/people/5", :method => :patch)
     assert_equal("update", params[:action])
     assert_equal("5", params[:id])
 
@@ -1596,6 +1605,7 @@ class RackMountIntegrationTests < ActiveSupport::TestCase
     assert_equal({:controller => 'admin/users', :action => 'new'}, @routes.recognize_path('/admin/users/new', :method => :get))
     assert_equal({:controller => 'admin/users', :action => 'show', :id => '1'}, @routes.recognize_path('/admin/users/1', :method => :get))
     assert_equal({:controller => 'admin/users', :action => 'update', :id => '1'}, @routes.recognize_path('/admin/users/1', :method => :put))
+    assert_equal({:controller => 'admin/users', :action => 'update', :id => '1'}, @routes.recognize_path('/admin/users/1', :method => :patch))
     assert_equal({:controller => 'admin/users', :action => 'destroy', :id => '1'}, @routes.recognize_path('/admin/users/1', :method => :delete))
     assert_equal({:controller => 'admin/users', :action => 'edit', :id => '1'}, @routes.recognize_path('/admin/users/1/edit', :method => :get))
 
@@ -1619,6 +1629,7 @@ class RackMountIntegrationTests < ActiveSupport::TestCase
     assert_equal({:controller => 'people', :action => 'show', :id => '1'}, @routes.recognize_path('/people/1', :method => :get))
     assert_equal({:controller => 'people', :action => 'show', :id => '1', :format => 'xml'}, @routes.recognize_path('/people/1.xml', :method => :get))
     assert_equal({:controller => 'people', :action => 'update', :id => '1'}, @routes.recognize_path('/people/1', :method => :put))
+    assert_equal({:controller => 'people', :action => 'update', :id => '1'}, @routes.recognize_path('/people/1', :method => :patch))
     assert_equal({:controller => 'people', :action => 'destroy', :id => '1'}, @routes.recognize_path('/people/1', :method => :delete))
     assert_equal({:controller => 'people', :action => 'edit', :id => '1'}, @routes.recognize_path('/people/1/edit', :method => :get))
     assert_equal({:controller => 'people', :action => 'edit', :id => '1', :format => 'xml'}, @routes.recognize_path('/people/1/edit.xml', :method => :get))

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -308,14 +308,14 @@ class RequestTest < ActiveSupport::TestCase
   end
 
   test "String request methods" do
-    [:get, :post, :put, :delete].each do |method|
+    [:get, :post, :patch, :put, :delete].each do |method|
       request = stub_request 'REQUEST_METHOD' => method.to_s.upcase
       assert_equal method.to_s.upcase, request.method
     end
   end
 
   test "Symbol forms of request methods via method_symbol" do
-    [:get, :post, :put, :delete].each do |method|
+    [:get, :post, :patch, :put, :delete].each do |method|
       request = stub_request 'REQUEST_METHOD' => method.to_s.upcase
       assert_equal method, request.method_symbol
     end
@@ -329,7 +329,7 @@ class RequestTest < ActiveSupport::TestCase
   end
 
   test "allow method hacking on post" do
-    %w(GET OPTIONS PUT POST DELETE).each do |method|
+    %w(GET OPTIONS PATCH PUT POST DELETE).each do |method|
       request = stub_request "REQUEST_METHOD" => method.to_s.upcase
       assert_equal(method == "HEAD" ? "GET" : method, request.method)
     end
@@ -343,7 +343,7 @@ class RequestTest < ActiveSupport::TestCase
   end
 
   test "restrict method hacking" do
-    [:get, :put, :delete].each do |method|
+    [:get, :patch, :put, :delete].each do |method|
       request = stub_request 'REQUEST_METHOD' => method.to_s.upcase,
         'action_dispatch.request.request_parameters' => { :_method => 'put' }
       assert_equal method.to_s.upcase, request.method

--- a/actionpack/test/dispatch/routing_assertions_test.rb
+++ b/actionpack/test/dispatch/routing_assertions_test.rb
@@ -45,7 +45,7 @@ class RoutingAssertionsTest < ActionController::TestCase
  
   def test_assert_recognizes_with_method
     assert_recognizes({ :controller => 'articles', :action => 'create' }, { :path => '/articles', :method => :post })
-    assert_recognizes({ :controller => 'articles', :action => 'update', :id => '1' }, { :path => '/articles/1', :method => :put })
+    assert_recognizes({ :controller => 'articles', :action => 'update', :id => '1' }, { :path => '/articles/1', :method => :patch })
   end
 
   def test_assert_recognizes_with_hash_constraint

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -635,7 +635,7 @@ class FormHelperTest < ActionView::TestCase
       concat f.submit('Create post')
     end
 
-    expected = whole_form("/posts/123", "create-post" , "edit_post", :method => "put") do
+    expected = whole_form("/posts/123", "create-post" , "edit_post", :method => "patch") do
       "<label for='post_title'>The Title</label>" +
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
       "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
@@ -654,7 +654,7 @@ class FormHelperTest < ActionView::TestCase
       concat f.file_field(:file)
     end
 
-    expected = whole_form("/posts/123", "create-post" , "edit_post", :method => "put", :multipart => true) do
+    expected = whole_form("/posts/123", "create-post" , "edit_post", :method => "patch", :multipart => true) do
       "<input name='post[file]' type='file' id='post_file' />"
     end
 
@@ -670,7 +670,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form("/posts/123", "edit_post_123" , "edit_post", :method => "put", :multipart => true) do
+    expected = whole_form("/posts/123", "edit_post_123" , "edit_post", :method => "patch", :multipart => true) do
       "<input name='post[comment][file]' type='file' id='post_comment_file' />"
     end
 
@@ -683,7 +683,7 @@ class FormHelperTest < ActionView::TestCase
       concat f.label(:title)
     end
 
-    expected = whole_form("/posts/123.json", "edit_post_123" , "edit_post", :method => "put") do
+    expected = whole_form("/posts/123.json", "edit_post_123" , "edit_post", :method => "patch") do
       "<label for='post_title'>Title</label>"
     end
 
@@ -714,7 +714,7 @@ class FormHelperTest < ActionView::TestCase
       concat f.submit('Create post')
     end
 
-    expected =  whole_form("/posts/123", "create-post", "other_name_edit", :method => "put") do
+    expected =  whole_form("/posts/123", "create-post", "other_name_edit", :method => "patch") do
       "<label for='other_name_title' class='post_title'>Title</label>" +
       "<input name='other_name[title]' size='30' id='other_name_title' value='Hello World' type='text' />" +
       "<textarea name='other_name[body]' id='other_name_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
@@ -834,7 +834,7 @@ class FormHelperTest < ActionView::TestCase
       concat f.check_box(:secret)
     end
 
-    expected = whole_form('/posts/123', 'post[]_edit', 'post[]_edit', 'put') do
+    expected = whole_form('/posts/123', 'post[]_edit', 'post[]_edit', 'patch') do
       "<label for='post_123_title'>Title</label>" +
       "<input name='post[123][title]' size='30' type='text' id='post_123_title' value='Hello World' />" +
       "<textarea name='post[123][body]' id='post_123_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
@@ -852,7 +852,7 @@ class FormHelperTest < ActionView::TestCase
       concat f.check_box(:secret)
     end
 
-    expected = whole_form('/posts/123', 'post[]_edit', 'post[]_edit', 'put') do
+    expected = whole_form('/posts/123', 'post[]_edit', 'post[]_edit', 'patch') do
       "<input name='post[][title]' size='30' type='text' id='post__title' value='Hello World' />" +
       "<textarea name='post[][body]' id='post__body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
       "<input name='post[][secret]' type='hidden' value='0' />" +
@@ -886,7 +886,7 @@ class FormHelperTest < ActionView::TestCase
       concat f.submit
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       "<input name='commit' type='submit' value='Confirm Post changes' />"
     end
 
@@ -918,7 +918,7 @@ class FormHelperTest < ActionView::TestCase
       concat f.submit
     end
 
-    expected = whole_form('/posts/123', 'another_post_edit', 'another_post_edit', :method => 'put') do
+    expected = whole_form('/posts/123', 'another_post_edit', 'another_post_edit', :method => 'patch') do
       "<input name='commit' type='submit' value='Update your Post' />"
     end
 
@@ -935,7 +935,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       "<input name='post[comment][body]' size='30' type='text' id='post_comment_body' value='Hello World' />"
     end
 
@@ -950,7 +950,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form('/posts/123', 'post[]_edit', 'post[]_edit', 'put') do
+    expected = whole_form('/posts/123', 'post[]_edit', 'post[]_edit', 'patch') do
       "<input name='post[123][title]' size='30' type='text' id='post_123_title' value='Hello World' />" +
       "<input name='post[123][comment][][name]' size='30' type='text' id='post_123_comment__name' value='new comment' />"
     end
@@ -966,7 +966,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', 'patch') do
       "<input name='post[1][title]' size='30' type='text' id='post_1_title' value='Hello World' />" +
       "<input name='post[1][comment][1][name]' size='30' type='text' id='post_1_comment_1_name' value='new comment' />"
     end
@@ -981,7 +981,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', 'patch') do
       "<input name='post[1][comment][title]' size='30' type='text' id='post_1_comment_title' value='Hello World' />"
     end
 
@@ -995,7 +995,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', 'patch') do
       "<input name='post[1][comment][5][title]' size='30' type='text' id='post_1_comment_5_title' value='Hello World' />"
     end
 
@@ -1009,7 +1009,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form('/posts/123', 'post[]_edit', 'post[]_edit', 'put') do
+    expected = whole_form('/posts/123', 'post[]_edit', 'post[]_edit', 'patch') do
       "<input name='post[123][comment][title]' size='30' type='text' id='post_123_comment_title' value='Hello World' />"
     end
 
@@ -1023,7 +1023,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', 'patch') do
       "<input name='post[comment][5][title]' type='radio' id='post_comment_5_title_hello' value='hello' />"
     end
 
@@ -1037,7 +1037,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form('/posts/123', 'post[]_edit', 'post[]_edit', 'put') do
+    expected = whole_form('/posts/123', 'post[]_edit', 'post[]_edit', 'patch') do
       "<input name='post[123][comment][123][title]' size='30' type='text' id='post_123_comment_123_title' value='Hello World' />"
     end
 
@@ -1057,9 +1057,9 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form('/posts/123', 'post[]_edit', 'post[]_edit', 'put') do
+    expected = whole_form('/posts/123', 'post[]_edit', 'post[]_edit', 'patch') do
       "<input name='post[123][comment][5][title]' size='30' type='text' id='post_123_comment_5_title' value='Hello World' />"
-    end + whole_form('/posts/123', 'post_edit', 'post_edit', 'put') do
+    end + whole_form('/posts/123', 'post_edit', 'post_edit', 'patch') do
       "<input name='post[1][comment][123][title]' size='30' type='text' id='post_1_comment_123_title' value='Hello World' />"
     end
 
@@ -1076,7 +1076,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
         '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="new author" />'
     end
@@ -1103,7 +1103,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-   expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+   expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
      '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="author #321" />' +
      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" />'
@@ -1122,7 +1122,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
       '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="author #321" />' +
       '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" />'
@@ -1141,7 +1141,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
       '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="author #321" />'
     end
@@ -1159,7 +1159,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
       '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="author #321" />'
     end
@@ -1177,7 +1177,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
       '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="author #321" />' +
       '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" />'
@@ -1197,7 +1197,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
       '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" />' +
       '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="author #321" />'
@@ -1218,7 +1218,7 @@ class FormHelperTest < ActionView::TestCase
       end
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #1" />' +
       '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" />' +
@@ -1245,7 +1245,7 @@ class FormHelperTest < ActionView::TestCase
       end
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
       '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="author #321" />' +
       '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" />' +
@@ -1272,7 +1272,7 @@ class FormHelperTest < ActionView::TestCase
       end
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
       '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="author #321" />' +
       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #1" />' +
@@ -1298,7 +1298,7 @@ class FormHelperTest < ActionView::TestCase
       end
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
       '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="author #321" />' +
       '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" />' +
@@ -1321,7 +1321,7 @@ class FormHelperTest < ActionView::TestCase
       end
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #1" />' +
       '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" />' +
@@ -1345,7 +1345,7 @@ class FormHelperTest < ActionView::TestCase
       end
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
       '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" />' +
       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #1" />' +
@@ -1368,7 +1368,7 @@ class FormHelperTest < ActionView::TestCase
       end
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="new comment" />' +
       '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" size="30" type="text" value="new comment" />'
@@ -1389,7 +1389,7 @@ class FormHelperTest < ActionView::TestCase
       end
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #321" />' +
       '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="321" />' +
@@ -1407,7 +1407,7 @@ class FormHelperTest < ActionView::TestCase
       end
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />'
     end
 
@@ -1424,7 +1424,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #1" />' +
       '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" />' +
@@ -1445,7 +1445,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #1" />' +
       '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" />' +
@@ -1467,7 +1467,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #1" />' +
       '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" />' +
@@ -1490,7 +1490,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #321" />' +
       '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="321" />' +
@@ -1510,7 +1510,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       '<input id="post_comments_attributes_abc_name" name="post[comments_attributes][abc][name]" size="30" type="text" value="comment #321" />' +
       '<input id="post_comments_attributes_abc_id" name="post[comments_attributes][abc][id]" type="hidden" value="321" />'
     end
@@ -1546,7 +1546,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #321" />' +
       '<input id="post_comments_attributes_0_relevances_attributes_0_value" name="post[comments_attributes][0][relevances_attributes][0][value]" size="30" type="text" value="commentrelevance #314" />' +
       '<input id="post_comments_attributes_0_relevances_attributes_0_id" name="post[comments_attributes][0][relevances_attributes][0][id]" type="hidden" value="314" />' +
@@ -1696,7 +1696,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form('/posts/123', 'create-post', 'post_edit', :method => 'put') do
+    expected = whole_form('/posts/123', 'create-post', 'post_edit', :method => 'patch') do
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
       "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
       "<input name='parent_post[secret]' type='hidden' value='0' />" +
@@ -1716,7 +1716,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form('/posts/123', 'create-post', 'post_edit', :method => 'put') do
+    expected = whole_form('/posts/123', 'create-post', 'post_edit', :method => 'patch') do
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
       "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
       "<input name='post[comment][name]' type='text' id='post_comment_name' value='new comment' size='30' />"
@@ -1742,7 +1742,7 @@ class FormHelperTest < ActionView::TestCase
       concat f.check_box(:secret)
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       "<label for='title'>Title:</label> <input name='post[title]' size='30' type='text' id='post_title' value='Hello World' /><br/>" +
       "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea><br/>" +
       "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' /><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' /><br/>"
@@ -1792,7 +1792,7 @@ class FormHelperTest < ActionView::TestCase
       concat f.check_box(:secret)
     end
 
-    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
       "<label for='title'>Title:</label> <input name='post[title]' size='30' type='text' id='post_title' value='Hello World' /><br/>" +
       "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea><br/>" +
       "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' /><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' /><br/>"
@@ -1861,7 +1861,7 @@ class FormHelperTest < ActionView::TestCase
 
   def test_form_for_with_html_options_adds_options_to_form_tag
     form_for(@post, :html => {:id => 'some_form', :class => 'some_class'}) do |f| end
-    expected = whole_form("/posts/123", "some_form", "some_class", 'put')
+    expected = whole_form("/posts/123", "some_form", "some_class", 'patch')
 
     assert_dom_equal expected, output_buffer
   end
@@ -1869,7 +1869,7 @@ class FormHelperTest < ActionView::TestCase
   def test_form_for_with_string_url_option
     form_for(@post, :url => 'http://www.otherdomain.com') do |f| end
 
-    assert_equal whole_form("http://www.otherdomain.com", 'edit_post_123', 'edit_post', 'put'), output_buffer
+    assert_equal whole_form("http://www.otherdomain.com", 'edit_post_123', 'edit_post', 'patch'), output_buffer
   end
 
   def test_form_for_with_hash_url_option
@@ -1882,14 +1882,14 @@ class FormHelperTest < ActionView::TestCase
   def test_form_for_with_record_url_option
     form_for(@post, :url => @post) do |f| end
 
-    expected = whole_form("/posts/123", 'edit_post_123', 'edit_post', 'put')
+    expected = whole_form("/posts/123", 'edit_post_123', 'edit_post', 'patch')
     assert_equal expected, output_buffer
   end
 
   def test_form_for_with_existing_object
     form_for(@post) do |f| end
 
-    expected = whole_form("/posts/123", "edit_post_123", "edit_post", "put")
+    expected = whole_form("/posts/123", "edit_post_123", "edit_post", "patch")
     assert_equal expected, output_buffer
   end
 
@@ -1908,7 +1908,7 @@ class FormHelperTest < ActionView::TestCase
     @comment.save
     form_for([@post, @comment]) {}
 
-    expected = whole_form(post_comment_path(@post, @comment), "edit_comment_1", "edit_comment", "put")
+    expected = whole_form(post_comment_path(@post, @comment), "edit_comment_1", "edit_comment", "patch")
     assert_dom_equal expected, output_buffer
   end
 
@@ -1923,7 +1923,7 @@ class FormHelperTest < ActionView::TestCase
     @comment.save
     form_for([:admin, @post, @comment]) {}
 
-    expected = whole_form(admin_post_comment_path(@post, @comment), "edit_comment_1", "edit_comment", "put")
+    expected = whole_form(admin_post_comment_path(@post, @comment), "edit_comment_1", "edit_comment", "patch")
     assert_dom_equal expected, output_buffer
   end
 
@@ -1937,7 +1937,7 @@ class FormHelperTest < ActionView::TestCase
   def test_form_for_with_existing_object_and_custom_url
     form_for(@post, :url => "/super_posts") do |f| end
 
-    expected = whole_form("/super_posts", "edit_post_123", "edit_post", "put")
+    expected = whole_form("/super_posts", "edit_post_123", "edit_post", "patch")
     assert_equal expected, output_buffer
   end
 

--- a/actionpack/test/template/form_tag_helper_test.rb
+++ b/actionpack/test/template/form_tag_helper_test.rb
@@ -76,6 +76,12 @@ class FormTagHelperTest < ActionView::TestCase
     assert_dom_equal expected, actual
   end
 
+  def test_form_tag_with_method_patch
+    actual = form_tag({}, { :method => :patch })
+    expected = whole_form("http://www.example.com", :method => :patch)
+    assert_dom_equal expected, actual
+  end
+
   def test_form_tag_with_method_put
     actual = form_tag({}, { :method => :put })
     expected = whole_form("http://www.example.com", :method => :put)

--- a/activemodel/lib/active_model/lint.rb
+++ b/activemodel/lib/active_model/lint.rb
@@ -57,7 +57,7 @@ module ActiveModel
       # Returns a boolean that specifies whether the object has been persisted yet.
       # This is used when calculating the URL for an object. If the object is
       # not persisted, a form for that object, for instance, will be POSTed to the
-      # collection. If it is persisted, a form for the object will be PUT to the
+      # collection. If it is persisted, a form for the object will PATCH to the
       # URL for the object.
       def test_persisted?
         assert model.respond_to?(:persisted?), "The model should respond to persisted?"

--- a/activeresource/lib/active_resource/connection.rb
+++ b/activeresource/lib/active_resource/connection.rb
@@ -15,6 +15,7 @@ module ActiveResource
     HTTP_FORMAT_HEADER_NAMES = {  :get => 'Accept',
       :put => 'Content-Type',
       :post => 'Content-Type',
+      :patch => 'Content-Type',
       :delete => 'Accept',
       :head => 'Accept'
     }
@@ -84,6 +85,12 @@ module ActiveResource
     # Used to delete resources.
     def delete(path, headers = {})
       with_auth { request(:delete, path, build_request_headers(headers, :delete, self.site.merge(path))) }
+    end
+
+    # Executes a PATCH request (see HTTP protocol documentation if unfamiliar).
+    # Used to update resources.
+    def patch(path, body = '', headers = {})
+      with_auth { request(:patch, path, body.to_s, build_request_headers(headers, :patch, self.site.merge(path))) }
     end
 
     # Executes a PUT request (see HTTP protocol documentation if unfamiliar).

--- a/activeresource/lib/active_resource/custom_methods.rb
+++ b/activeresource/lib/active_resource/custom_methods.rb
@@ -13,6 +13,7 @@ module ActiveResource
   #
   #    POST    /people/new/register.xml # PeopleController.register
   #    PUT     /people/1/promote.xml    # PeopleController.promote with :id => 1
+  #    PATCH   /people/1/promote.xml    # PeopleController.promote with :id => 1
   #    DELETE  /people/1/deactivate.xml # PeopleController.deactivate with :id => 1
   #    GET     /people/active.xml       # PeopleController.active
   #
@@ -27,6 +28,7 @@ module ActiveResource
   #   # => { :id => 1, :name => 'Ryan' }
   #
   #   Person.find(1).put(:promote, :position => 'Manager') # PUT /people/1/promote.xml
+  #   Person.find(1).patch(:promote, :position => 'Manager') # PATCH /people/1/promote.xml
   #   Person.find(1).delete(:deactivate) # DELETE /people/1/deactivate.xml
   #
   #   Person.get(:active)  # GET /people/active.xml
@@ -59,6 +61,10 @@ module ActiveResource
 
         def post(custom_method_name, options = {}, body = '')
           connection.post(custom_method_collection_url(custom_method_name, options), body, headers)
+        end
+
+        def patch(custom_method_name, options = {}, body = '')
+          connection.patch(custom_method_collection_url(custom_method_name, options), body, headers)
         end
 
         def put(custom_method_name, options = {}, body = '')
@@ -95,6 +101,10 @@ module ActiveResource
         else
           connection.post(custom_method_element_url(method_name, options), request_body, self.class.headers)
         end
+      end
+
+      def patch(method_name, options = {}, body = '')
+        connection.patch(custom_method_element_url(method_name, options), body, self.class.headers)
       end
 
       def put(method_name, options = {}, body = '')

--- a/activeresource/lib/active_resource/http_mock.rb
+++ b/activeresource/lib/active_resource/http_mock.rb
@@ -15,7 +15,7 @@ module ActiveResource
   #
   #   mock.http_method(path, request_headers = {}, body = nil, status = 200, response_headers = {})
   #
-  # * <tt>http_method</tt> - The HTTP method to listen for.  This can be +get+, +post+, +put+, +delete+ or
+  # * <tt>http_method</tt> - The HTTP method to listen for.  This can be +get+, +post+, +patch+, +put+, +delete+ or
   #   +head+.
   # * <tt>path</tt> - A string, starting with a "/", defining the URI that is expected to be
   #   called.
@@ -39,6 +39,7 @@ module ActiveResource
   #     ActiveResource::HttpMock.respond_to do |mock|
   #       mock.post   "/people.xml",   {}, @matz, 201, "Location" => "/people/1.xml"
   #       mock.get    "/people/1.xml", {}, @matz
+  #       mock.patch  "/people/1.xml", {}, nil, 204
   #       mock.put    "/people/1.xml", {}, nil, 204
   #       mock.delete "/people/1.xml", {}, nil, 200
   #     end
@@ -55,7 +56,7 @@ module ActiveResource
         @responses = responses
       end
 
-      for method in [ :post, :put, :get, :delete, :head ]
+      for method in [ :post, :patch, :put, :get, :delete, :head ]
         # def post(path, request_headers = {}, body = nil, status = 200, response_headers = {})
         #   @responses[Request.new(:post, path, nil, request_headers)] = Response.new(body || "", status, response_headers)
         # end
@@ -121,6 +122,7 @@ module ActiveResource
       #   ActiveResource::HttpMock.respond_to do |mock|
       #     mock.post   "/people.xml",   {}, @matz, 201, "Location" => "/people/1.xml"
       #     mock.get    "/people/1.xml", {}, @matz
+      #     mock.patch  "/people/1.xml", {}, nil, 204
       #     mock.put    "/people/1.xml", {}, nil, 204
       #     mock.delete "/people/1.xml", {}, nil, 200
       #   end
@@ -217,7 +219,7 @@ module ActiveResource
     end
 
     # body?       methods
-    { true  => %w(post put),
+    { true  => %w(post patch put),
       false => %w(get delete head) }.each do |has_body, methods|
       methods.each do |method|
         # def post(path, body, headers)

--- a/activeresource/test/cases/format_test.rb
+++ b/activeresource/test/cases/format_test.rb
@@ -11,11 +11,15 @@ class FormatTest < Test::Unit::TestCase
   end
 
   def test_http_format_header_name
-    header_name = ActiveResource::Connection::HTTP_FORMAT_HEADER_NAMES[:get]
-    assert_equal 'Accept', header_name
+    [:get, :head].each do |verb|
+      header_name = ActiveResource::Connection::HTTP_FORMAT_HEADER_NAMES[verb]
+      assert_equal 'Accept', header_name
+    end
 
-    headers_names = [ActiveResource::Connection::HTTP_FORMAT_HEADER_NAMES[:put], ActiveResource::Connection::HTTP_FORMAT_HEADER_NAMES[:post]]
-    headers_names.each{ |name| assert_equal 'Content-Type', name }
+    [:patch, :put, :post].each do |verb|
+      header_name = ActiveResource::Connection::HTTP_FORMAT_HEADER_NAMES[verb]
+      assert_equal 'Content-Type', header_name
+    end
   end
 
   def test_formats_on_single_element

--- a/activeresource/test/cases/http_mock_test.rb
+++ b/activeresource/test/cases/http_mock_test.rb
@@ -8,7 +8,7 @@ class HttpMockTest < ActiveSupport::TestCase
 
   FORMAT_HEADER = ActiveResource::Connection::HTTP_FORMAT_HEADER_NAMES
 
-  [:post, :put, :get, :delete, :head].each do |method|
+  [:post, :patch, :put, :get, :delete, :head].each do |method|
     test "responds to simple #{method} request" do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.send(method, "/people/1", {FORMAT_HEADER[method] => "application/xml"}, "Response")
@@ -193,7 +193,7 @@ class HttpMockTest < ActiveSupport::TestCase
   end
 
   def request(method, path, headers = {}, body = nil)
-    if method.in?([:put, :post])
+    if method.in?([:patch, :put, :post])
       @http.send(method, path, body, headers)
     else
       @http.send(method, path, headers)

--- a/railties/guides/source/action_controller_overview.textile
+++ b/railties/guides/source/action_controller_overview.textile
@@ -535,7 +535,7 @@ The request object contains a lot of useful information about the request coming
 |domain(n=2)|The hostname's first +n+ segments, starting from the right (the TLD).|
 |format|The content type requested by the client.|
 |method|The HTTP method used for the request.|
-|get?, post?, put?, delete?, head?|Returns true if the HTTP method is GET/POST/PUT/DELETE/HEAD.|
+|get?, post?, patch?, put?, delete?, head?|Returns true if the HTTP method is GET/POST/PATCH/PUT/DELETE/HEAD.|
 |headers|Returns a hash containing the headers associated with the request.|
 |port|The port number (integer) used for the request.|
 |protocol|Returns a string containing the protocol used plus "://", for example "http://".|

--- a/railties/guides/source/ajax_on_rails.textile
+++ b/railties/guides/source/ajax_on_rails.textile
@@ -87,7 +87,8 @@ link_to_remote "Add new item",
   :position => :bottom
 </ruby>
 
-** *:method* Most typically you want to use a POST request when adding a remote link to your view so this is the default behavior. However, sometimes you'll want to update (PUT) or delete/destroy (DELETE) something and you can specify this with the +:method+ option. Let's see an example for a typical AJAX link for deleting an item from a list:
+** *:method* Most typically you want to use a POST request when adding a remote
+link to your view so this is the default behavior. However, sometimes you'll want to update (PATCH) or delete/destroy (DELETE) something and you can specify this with the +:method+ option. Let's see an example for a typical AJAX link for deleting an item from a list:
 
 <ruby>
 link_to_remote "Delete the item",
@@ -108,7 +109,7 @@ Note that if we wouldn't override the default behavior (POST), the above snippet
 <ruby>
 link_to_remote "Update record",
   :url => record_url(record),
-  :method => :put,
+  :method => :patch,
   :with => "'status=' + 'encodeURIComponent($('status').value) + '&completed=' + $('completed')"
 </ruby>
 

--- a/railties/guides/source/configuring.textile
+++ b/railties/guides/source/configuring.textile
@@ -165,7 +165,7 @@ Every Rails application comes with a standard set of middleware which it uses in
 * +ActionDispatch::Session::CookieStore+ is responsible for storing the session in cookies. An alternate middleware can be used for this by changing the +config.action_controller.session_store+ to an alternate value. Additionally, options passed to this can be configured by using +config.action_controller.session_options+.
 * +ActionDispatch::Flash+ sets up the +flash+ keys. Only available if +config.action_controller.session_store+ is set to a value.
 * +ActionDispatch::ParamsParser+ parses out parameters from the request into +params+
-* +Rack::MethodOverride+ allows the method to be overridden if +params[:_method]+ is set. This is the middleware which supports the PUT and DELETE HTTP method types.
+* +Rack::MethodOverride+ allows the method to be overridden if * +params[:_method]+ is set. This is the middleware which supports the PATCH, * PUT, and DELETE HTTP method types.
 * +ActionDispatch::Head+ converts HEAD requests to GET requests and serves them as so.
 * +ActionDispatch::BestStandardsSupport+ enables "best standards support" so that IE8 renders some elements correctly.
 

--- a/railties/guides/source/form_helpers.textile
+++ b/railties/guides/source/form_helpers.textile
@@ -301,7 +301,7 @@ form_for(@article)
 
 ## Editing an existing article
 # long-style:
-form_for(@article, :url => article_path(@article), :html => { :method => "put" })
+form_for(@article, :url => article_path(@article), :html => { :method => "patch" })
 # short-style:
 form_for(@article)
 </ruby>
@@ -329,14 +329,14 @@ form_for [:admin, :management, @article]
 For more information on Rails' routing system and the associated conventions, please see the "routing guide":routing.html.
 
 
-h4. How do forms with PUT or DELETE methods work?
+h4. How do forms with PATCH or DELETE methods work?
 
-The Rails framework encourages RESTful design of your applications, which means you'll be making a lot of "PUT" and "DELETE" requests (besides "GET" and "POST"). However, most browsers _don't support_ methods other than "GET" and "POST" when it comes to submitting forms.
+The Rails framework encourages RESTful design of your applications, which means you'll be making a lot of "PATCH" and "DELETE" requests (besides "GET" and "POST"). However, most browsers _don't support_ methods other than "GET" and "POST" when it comes to submitting forms.
 
 Rails works around this issue by emulating other methods over POST with a hidden input named +"_method"+, which is set to reflect the desired method:
 
 <ruby>
-form_tag(search_path, :method => "put")
+form_tag(search_path, :method => "patch")
 </ruby>
 
 output:
@@ -344,14 +344,14 @@ output:
 <html>
 <form accept-charset="UTF-8" action="/search" method="post">
   <div style="margin:0;padding:0">
-    <input name="_method" type="hidden" value="put" />
+    <input name="_method" type="hidden" value="patch" />
     <input name="utf8" type="hidden" value="&#x2713;" />
     <input name="authenticity_token" type="hidden" value="f755bb0ed134b76c432144748a6d4b7a7ddf2b71" />
   </div>
   ...
 </html>
 
-When parsing POSTed data, Rails will take into account the special +_method+ parameter and acts as if the HTTP method was the one specified inside it ("PUT" in this example).
+When parsing POSTed data, Rails will take into account the special +_method+ parameter and acts as if the HTTP method was the one specified inside it ("PATCH" in this example).
 
 
 h3. Making Select Boxes with Ease

--- a/railties/guides/source/getting_started.textile
+++ b/railties/guides/source/getting_started.textile
@@ -729,7 +729,7 @@ After finding the requested post, Rails uses the +edit.html.erb+ view to display
 <%= link_to 'Back', posts_path %>
 </erb>
 
-Again, as with the +new+ action, the +edit+ action is using the +form+ partial, this time however, the form will do a PUT action to the PostsController and the submit button will display "Update Post"
+Again, as with the +new+ action, the +edit+ action is using the +form+ partial, this time however, the form will do a PATCH action to the PostsController and the submit button will display "Update Post"
 
 Submitting the form created by this view will invoke the +update+ action within the controller:
 

--- a/railties/guides/source/routing.textile
+++ b/railties/guides/source/routing.textile
@@ -50,7 +50,7 @@ Resource routing allows you to quickly declare all of the common routes for a gi
 
 h4. Resources on the Web
 
-Browsers request pages from Rails by making a request for a URL using a specific HTTP method, such as +GET+, +POST+, +PUT+ and +DELETE+. Each method is a request to perform an operation on the resource. A resource route maps a number of related requests to actions in a single controller.
+Browsers request pages from Rails by making a request for a URL using a specific HTTP method, such as +GET+, +POST+, +PATCH+, +PUT+ and +DELETE+. Each method is a request to perform an operation on the resource. A resource route maps a number of related requests to actions in a single controller.
 
 When your Rails application receives an incoming request for
 
@@ -74,7 +74,7 @@ In Rails, a resourceful route provides a mapping between HTTP verbs and URLs and
 resources :photos
 </ruby>
 
-creates seven different routes in your application, all mapping to the +Photos+ controller:
+creates eight different routes in your application, all mapping to the +Photos+ controller:
 
 |_. HTTP Verb |_.Path            |_.action |_.used for                                   |
 |GET          |/photos           |index    |display a list of all photos                 |
@@ -82,11 +82,12 @@ creates seven different routes in your application, all mapping to the +Photos+ 
 |POST         |/photos           |create   |create a new photo                           |
 |GET          |/photos/:id       |show     |display a specific photo                     |
 |GET          |/photos/:id/edit  |edit     |return an HTML form for editing a photo      |
+|PATCH        |/photos/:id       |update   |update a specific photo                      |
 |PUT          |/photos/:id       |update   |update a specific photo                      |
 |DELETE       |/photos/:id       |destroy  |delete a specific photo                      |
 
 
-NOTE: Rails routes are matched in the order they are specified, so if you have a +resources :photos+ above a +get 'photos/poll'+ the +show+ action's route for the +resources+ line will be matched before the +get+ line. To fix this, move the +get+ line *above* the +resources+ line so that it is matched first.
+NOTE: The default HTTP Verb for the +update+ action is PATCH; PUT is supported for backwards compatibility. Rails routes are matched in the order they are specified, so if you have a +resources :photos+ above a +get 'photos/poll'+ the +show+ action's route for the +resources+ line will be matched before the +get+ line. To fix this, move the +get+ line *above* the +resources+ line so that it is matched first.
 
 h4. Paths and URLs
 
@@ -131,17 +132,18 @@ This resourceful route
 resource :geocoder
 </ruby>
 
-creates six different routes in your application, all mapping to the +Geocoders+ controller:
+creates seven different routes in your application, all mapping to the +Geocoders+ controller:
 
 |_.HTTP Verb |_.Path         |_.action |_.used for                                    |
 |GET         |/geocoder/new  |new      |return an HTML form for creating the geocoder |
 |POST        |/geocoder      |create   |create the new geocoder                       |
 |GET         |/geocoder      |show     |display the one and only geocoder resource    |
 |GET         |/geocoder/edit |edit     |return an HTML form for editing the geocoder  |
+|PATCH       |/geocoder      |update   |update the one and only geocoder resource     |
 |PUT         |/geocoder      |update   |update the one and only geocoder resource     |
 |DELETE      |/geocoder      |destroy  |delete the geocoder resource                  |
 
-NOTE: Because you might want to use the same controller for a singular route (+/account+) and a plural route (+/accounts/45+), singular resources map to plural controllers.
+NOTE: The default HTTP Verb for the +update+ action is PATCH; PUT is supported for backwards compatibility. Because you might want to use the same controller for a singular route (+/account+) and a plural route (+/accounts/45+), singular resources map to plural controllers.
 
 A singular resourceful route generates these helpers:
 
@@ -169,6 +171,7 @@ This will create a number of routes for each of the +posts+ and +comments+ contr
 |POST        |/admin/posts        |create   | admin_posts_path         |
 |GET         |/admin/posts/1      |show     | admin_post_path(id)      |
 |GET         |/admin/posts/1/edit |edit     | edit_admin_post_path(id) |
+|PATCH       |/admin/posts/1      |update   | admin_post_path(id)      |
 |PUT         |/admin/posts/1      |update   | admin_post_path(id)      |
 |DELETE      |/admin/posts/1      |destroy  | admin_post_path(id)      |
 
@@ -208,6 +211,7 @@ In each of these cases, the named routes remain the same as if you did not use +
 |POST        |/admin/posts         |create   | posts_path         |
 |GET         |/admin/posts/1       |show     | post_path(id)      |
 |GET         |/admin/posts/1/edit  |edit     | edit_post_path(id) |
+|PATCH       |/admin/posts/1       |update   | post_path(id)      |
 |PUT         |/admin/posts/1       |update   | post_path(id)      |
 |DELETE      |/admin/posts/1       |destroy  | post_path(id)      |
 
@@ -241,6 +245,7 @@ In addition to the routes for magazines, this declaration will also route ads to
 |POST        |/magazines/1/ads        |create   |create a new ad belonging to a specific magazine                           |
 |GET         |/magazines/1/ads/1      |show     |display a specific ad belonging to a specific magazine                     |
 |GET         |/magazines/1/ads/1/edit |edit     |return an HTML form for editing an ad belonging to a specific magazine     |
+|PATCH       |/magazines/1/ads/1      |update   |update a specific ad belonging to a specific magazine                      |
 |PUT         |/magazines/1/ads/1      |update   |update a specific ad belonging to a specific magazine                      |
 |DELETE      |/magazines/1/ads/1      |destroy  |delete a specific ad belonging to a specific magazine                      |
 
@@ -323,7 +328,7 @@ end
 
 This will recognize +/photos/1/preview+ with GET, and route to the +preview+ action of +PhotosController+. It will also create the +preview_photo_url+ and +preview_photo_path+ helpers.
 
-Within the block of member routes, each route name specifies the HTTP verb that it will recognize. You can use +get+, +put+, +post+, or +delete+ here. If you don't have multiple +member+ routes, you can also pass +:on+ to a route, eliminating the block:
+Within the block of member routes, each route name specifies the HTTP verb that it will recognize. You can use +get+, +patch+, +put+, +post+, or +delete+ here. If you don't have multiple +member+ routes, you can also pass +:on+ to a route, eliminating the block:
 
 <ruby>
 resources :photos do
@@ -634,6 +639,7 @@ will recognize incoming paths beginning with +/photos+ but route to the +Images+
 |POST        |/photos        |create   | photos_path         |
 |GET         |/photos/1      |show     | photo_path(id)      |
 |GET         |/photos/1/edit |edit     | edit_photo_path(id) |
+|PATCH       |/photos/1      |update   | photo_path(id)      |
 |PUT         |/photos/1      |update   | photo_path(id)      |
 |DELETE      |/photos/1      |destroy  | photo_path(id)      |
 
@@ -678,6 +684,7 @@ will recognize incoming paths beginning with +/photos+ and route the requests to
 |POST       |/photos         |create   | images_path         |
 |GET        |/photos/1       |show     | image_path(id)      |
 |GET        |/photos/1/edit  |edit     | edit_image_path(id) |
+|PATCH      |/photos/1       |update   | image_path(id)      |
 |PUT        |/photos/1       |update   | image_path(id)      |
 |DELETE     |/photos/1       |destroy  | image_path(id)      |
 
@@ -782,6 +789,7 @@ Rails now creates routes to the +CategoriesController+.
 |POST       |/kategorien              |create   | categories_path        |
 |GET        |/kategorien/1            |show     | category_path(id)      |
 |GET        |/kategorien/1/bearbeiten |edit     | edit_category_path(id) |
+|PATCH      |/kategorien/1            |update   | category_path(id)      |
 |PUT        |/kategorien/1            |update   | category_path(id)      |
 |DELETE     |/kategorien/1            |destroy  | category_path(id)      |
 

--- a/railties/guides/source/security.textile
+++ b/railties/guides/source/security.textile
@@ -209,7 +209,7 @@ The HTTP protocol basically provides two main types of requests - GET and POST (
 * The interaction _(highlight)changes the state_ of the resource in a way that the user would perceive (e.g., a subscription to a service), or
 * The user is _(highlight)held accountable for the results_ of the interaction.
 
-If your web application is RESTful, you might be used to additional HTTP verbs, such as PUT or DELETE. Most of today‘s web browsers, however do not support them - only GET and POST. Rails uses a hidden +_method+ field to handle this barrier.
+If your web application is RESTful, you might be used to additional HTTP verbs, such as PATCH or DELETE. Most of today‘s web browsers, however do not support them - only GET and POST. Rails uses a hidden +_method+ field to handle this barrier.
 
 _(highlight)POST requests can be sent automatically, too_. Here is an example for a link which displays www.harmless.com as destination in the browser's status bar. In fact it dynamically creates a new form that sends a POST request.
 

--- a/railties/guides/source/testing.textile
+++ b/railties/guides/source/testing.textile
@@ -490,10 +490,11 @@ Now you can try running all the tests and they should pass.
 
 h4. Available Request Types for Functional Tests
 
-If you're familiar with the HTTP protocol, you'll know that +get+ is a type of request. There are 5 request types supported in Rails functional tests:
+If you're familiar with the HTTP protocol, you'll know that +get+ is a type of request. There are 6 request types supported in Rails functional tests:
 
 * +get+
 * +post+
+* +patch+
 * +put+
 * +head+
 * +delete+
@@ -645,6 +646,7 @@ In addition to the standard testing helpers, there are some additional helpers a
 |+request_via_redirect(http_method, path, [parameters], [headers])+                 |Allows you to make an HTTP request and follow any subsequent redirects.|
 |+post_via_redirect(path, [parameters], [headers])+                                 |Allows you to make an HTTP POST request and follow any subsequent redirects.|
 |+get_via_redirect(path, [parameters], [headers])+                                  |Allows you to make an HTTP GET request and follow any subsequent redirects.|
+|+patch_via_redirect(path, [parameters], [headers])+                                |Allows you to make an HTTP PATCH request and follow any subsequent redirects.|
 |+put_via_redirect(path, [parameters], [headers])+                                  |Allows you to make an HTTP PUT request and follow any subsequent redirects.|
 |+delete_via_redirect(path, [parameters], [headers])+                               |Allows you to make an HTTP DELETE request and follow any subsequent redirects.|
 |+open_session+                                                                     |Opens a new session instance.|
@@ -818,7 +820,7 @@ class PostsControllerTest < ActionController::TestCase
   end
 
   test "should update post" do
-    put :update, :id => @post.id, :post => { }
+    patch :update, :id => @post.id, :post => { }
     assert_redirected_to post_path(assigns(:post))
   end
 

--- a/railties/lib/rails/generators/active_model.rb
+++ b/railties/lib/rails/generators/active_model.rb
@@ -37,7 +37,7 @@ module Rails
 
       # GET show
       # GET edit
-      # PUT update
+      # PATCH update
       # DELETE destroy
       def self.find(klass, params=nil)
         "#{klass}.find(#{params})"
@@ -58,13 +58,13 @@ module Rails
         "#{name}.save"
       end
 
-      # PUT update
+      # PATCH update
       def update_attributes(params=nil)
         "#{name}.update_attributes(#{params})"
       end
 
       # POST create
-      # PUT update
+      # PATCH update
       def errors
         "#{name}.errors"
       end

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
@@ -54,8 +54,8 @@ class <%= controller_class_name %>Controller < ApplicationController
     end
   end
 
-  # PUT <%= route_url %>/1
-  # PUT <%= route_url %>/1.json
+  # PATCH <%= route_url %>/1
+  # PATCH <%= route_url %>/1.json
   def update
     @<%= singular_table_name %> = <%= orm_class.find(class_name, "params[:id]") %>
 


### PR DESCRIPTION
PATCH is the correct HTML verb to map to the #update action. The semantics for
PATCH allows for partial updates, whereas PUT requires a complete replacement.

Changes:
- adds the #patch verb to routes to detect PATCH requests
- adds #patch? to Request
- adds the PATCH -> update mapping in the #resource(s) routes.
- changes default form helpers to prefer :patch instead of :put for updates
- changes documentation and comments to indicate the preference for PATCH

This change tries to maintain complete backwards compatibility by keeping the
original PUT -> update mapping. Users using the #resource(s) routes should not
notice a change in behavior since both PUT and PATCH requests get mapped to
update.
