### PR TITLE
Don't hide _method param in logs; Issue #426

### DIFF
--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -2,7 +2,7 @@ require 'active_support/core_ext/object/blank'
 
 module ActionController
   class LogSubscriber < ActiveSupport::LogSubscriber
-    INTERNAL_PARAMS = %w(controller action format _method only_path)
+    INTERNAL_PARAMS = %w(controller action format only_path)
 
     def start_processing(event)
       payload = event.payload

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -10,6 +10,10 @@ module Another
       render :nothing => true
     end
 
+    def update
+      render :nothing => true
+    end
+
     def redirector
       redirect_to "http://foo.bar/"
     end
@@ -96,6 +100,14 @@ class ACLogSubscriberTest < ActionController::TestCase
     assert_equal 3, logs.size
     assert_equal 'Parameters: {"id"=>"10"}', logs[1]
   end
+
+  def test_process_action_with_methodoverride_parameter
+    post :update, :id => '10', :_method => "put"
+    wait
+
+    assert_match('"_method"=>"put"', logs[1])
+  end
+
 
   def test_process_action_with_wrapped_parameters
     @request.env['CONTENT_TYPE'] = 'application/json'


### PR DESCRIPTION
Hiding the _method param leaves no indication in the Rails log that a request
would be interpreted by the Rails app according to the method override.
