### PR TITLE
Fix for Lighthouse ticket # 6334 : to_xml should render valid xml or raise an error all the time

### DIFF
--- a/activesupport/test/xml_mini_test.rb
+++ b/activesupport/test/xml_mini_test.rb
@@ -87,6 +87,16 @@ module XmlMiniTest
       @xml.to_tag(:b, "Howdy", @options)
       assert_xml "<b>Howdy</b>"
     end
+    
+    test "#to_tag should dasherize the space when passed a string with spaces as a key" do
+      @xml.to_tag("New   York", 33, @options)
+      assert_xml "<New---York type=\"integer\">33</New---York>"
+    end
+    
+    test "#to_tag should dasherize the space when passed a symbol with spaces as a key" do
+      @xml.to_tag(:"New   York", 33, @options)
+      assert_xml "<New---York type=\"integer\">33</New---York>"
+    end
     # TODO: test the remaining functions hidden in #to_tag.
   end
 end


### PR DESCRIPTION
Raise a RuntimeException with custom message when hash key contains space. Old behavior was { "New York"=>33, :Versailles => 3231 }.to_xml created an xml which was invalid. 
