### PR TITLE
New test: setting response_body to a Proc should be supported.

### DIFF
--- a/actionpack/test/dispatch/response_body_is_proc_test.rb
+++ b/actionpack/test/dispatch/response_body_is_proc_test.rb
@@ -1,0 +1,38 @@
+require 'abstract_unit'
+
+class ResponseBodyIsProcTest < ActionDispatch::IntegrationTest
+  class TestController < ActionController::Base
+    def test
+      request.session_options[:renew] = true
+      self.response_body = proc { |response, output|
+        puts caller
+        output.write 'Hello'
+      }
+    end
+
+    def rescue_action(e) raise end
+  end
+
+  def test_simple_get
+    with_test_route_set do
+      get '/test'
+      assert_response :success
+      assert_equal 'Hello', response.body
+    end
+  end
+
+  private
+    def with_test_route_set(options = {})
+      with_routing do |set|
+        set.draw do
+          match ':action', :to => ::ResponseBodyIsProcTest::TestController
+        end
+
+        @app = self.class.build_app(set) do |middleware|
+          middleware.delete "ActionDispatch::ShowExceptions"
+        end
+
+        yield
+      end
+    end
+end


### PR DESCRIPTION
It looks like commit a66c91723565d37969de4cb46baa50fb8865b02a "Do not inherit from Rack::Response, remove a shit-ton of unused code." removed the possibility for the user to set response_body to a Proc.  Here is a test that demonstrates this behavior working in 3.0.7 and breaking in edge.
@ecoffey
