### PR TITLE
Rename duplicate tests

### DIFF
--- a/activesupport/test/class_cache_test.rb
+++ b/activesupport/test/class_cache_test.rb
@@ -58,7 +58,7 @@ module ActiveSupport
         assert @cache.key?(ClassCacheTest.name)
       end
 
-      def test_new_rejects_strings
+      def test_new_rejects_strings_when_called_on_a_new_string
         assert_deprecated do
           @cache.new ClassCacheTest.name
         end

--- a/activesupport/test/xml_mini_test.rb
+++ b/activesupport/test/xml_mini_test.rb
@@ -48,7 +48,7 @@ module XmlMiniTest
       assert_equal "__id", ActiveSupport::XmlMini.rename_key("__id")
     end
 
-    def test_rename_key_does_not_dasherize_multiple_leading_underscores
+    def test_rename_key_does_not_dasherize_multiple_trailing_underscores
       assert_equal "id__", ActiveSupport::XmlMini.rename_key("id__")
     end  
   end


### PR DESCRIPTION
Silence duplicate test warnings that appeared after Jose got the xml_mini_test.rb running again (https://github.com/rails/rails/commit/803548c46b32d1be760b21da80477f43b801b8e9) because of duplicate test names.  

There is now one failing test in xml_mini_test.rb that was failing before the rename but was never getting run before.  It looks like the _dasherize() method isn't working properly but the regex that it is using to satisfy the tests is above my head.

I will open a new issue about the failing test and take a look at it when I have more time.
