### PR TITLE
Add alias `r` for rails runner

### DIFF
--- a/railties/lib/rails/commands.rb
+++ b/railties/lib/rails/commands.rb
@@ -6,7 +6,8 @@ aliases = {
   "g"  => "generate",
   "c"  => "console",
   "s"  => "server",
-  "db" => "dbconsole"
+  "db" => "dbconsole",
+  "r"  => "runner"
 }
 
 command = ARGV.shift


### PR DESCRIPTION
For coherence.

I've seen lots of noobs assume `rails r` would become `rails runner` the same way `rails c` becomes `rails console`.
