### PR TITLE
Adds a migration helper for has_secure_password

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -257,6 +257,10 @@ module ActiveRecord
         column(:updated_at, :datetime, options)
       end
 
+      def password
+        column(:password_digest, :string)
+      end
+
       def references(*args)
         options = args.extract_options!
         polymorphic = options.delete(:polymorphic)
@@ -356,6 +360,20 @@ module ActiveRecord
       #  t.timestamps
       def timestamps
         @base.add_timestamps(@table_name)
+      end
+
+      # Adds password (+password_digest+) column to the table. See SchemaStatements#add_password
+      # ===== Example
+      #  t.password
+      def password
+        @base.add_password(@table_name)
+      end
+
+      # Removes password (+password_digest+) column from table. See SchemaStatements#remove_password
+      # ===== Example
+      #  t.remove_password
+      def remove_password
+        @base.remove_password(@table_name)
       end
 
       # Changes the column's definition according to the new options.
@@ -479,4 +497,3 @@ module ActiveRecord
 
   end
 end
-

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -519,6 +519,20 @@ module ActiveRecord
         remove_column table_name, :created_at
       end
 
+      # Adds password digest column, suitable for using with ActiveModel's has_secure_password
+      # ===== Examples
+      #  add_password(:users)
+      def add_password(table_name)
+        add_column table_name, :password_digest, :string
+      end
+
+      # Removes password digest column
+      # ===== Examples
+      #  remove_password(:users)
+      def remove_password(table_name)
+        remove_column table_name, :password_digest
+      end
+
       protected
         # Overridden by the mysql adapter for supporting index lengths
         def quoted_columns_for_index(column_names, options = {})

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -91,6 +91,14 @@ module ActiveRecord
         [:remove_timestamps, args]
       end
 
+      def invert_remove_password(args)
+        [:add_password, args]
+      end
+
+      def invert_add_password(args)
+        [:remove_password, args]
+      end
+
       # Forwards any missing method call to the \target.
       def method_missing(method, *args, &block)
         @delegate.send(method, *args, &block)

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -103,6 +103,18 @@ module ActiveRecord
         add = @recorder.inverse.first
         assert_equal [:add_timestamps, [:table]], add
       end
+
+      def test_invert_add_password
+        @recorder.record :add_password, [:table]
+        remove = @recorder.inverse.first
+        assert_equal [:remove_password, [:table]], remove
+      end
+
+      def test_invert_remove_password
+        @recorder.record :remove_password, [:table]
+        remove = @recorder.inverse.first
+        assert_equal [:add_password, [:table]], remove
+      end
     end
   end
 end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -412,6 +412,21 @@ if ActiveRecord::Base.connection.supports_migrations?
       Person.connection.drop_table table_name rescue nil
     end
 
+    def test_create_table_with_password_should_create_password_digest_column
+      table_name = :testings
+
+      Person.connection.create_table table_name do |t|
+        t.password
+      end
+      created_columns = Person.connection.columns(table_name)
+
+      password_digest_column = created_columns.detect {|c| c.name == 'password_digest' }
+
+      assert password_digest_column.null
+    ensure
+      Person.connection.drop_table table_name rescue nil
+    end
+
     def test_create_table_without_a_block
       table_name = :testings
       Person.connection.create_table table_name
@@ -1607,6 +1622,13 @@ if ActiveRecord::Base.connection.supports_migrations?
       end
     end
 
+    def test_password_creates_encrypted_password
+      with_new_table do |t|
+        t.expects(:column).with(:password_digest, :string)
+        t.password
+      end
+    end
+
     def test_integer_creates_integer_column
       with_new_table do |t|
         t.expects(:column).with(:foo, 'integer', {})
@@ -1785,6 +1807,20 @@ if ActiveRecord::Base.connection.supports_migrations?
       with_change_table do |t|
         @connection.expects(:remove_timestamps).with(:delete_me)
         t.remove_timestamps
+      end
+    end
+
+    def test_password_creates_password_digest
+      with_change_table do |t|
+        @connection.expects(:add_password).with(:delete_me)
+        t.password
+      end
+    end
+
+    def test_remove_password_removes_password_digest
+      with_change_table do |t|
+        @connection.expects(:remove_password).with(:delete_me)
+        t.remove_password
       end
     end
 


### PR DESCRIPTION
So you can just say `t.password` instead of `t.add_column :password_digest`

I think it's a nice complement to the ActiveModel `has_secure_password`, where the programmer does't need to worry about the underlying implementation that uses `password_digest`.
