### PR TITLE
Fixed typos in documentation for the date_select helper in actionpack/act

### DIFF
--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -197,7 +197,7 @@ module ActionView
       #   # lacking a year field.
       #   date_select("user", "birthday", :order => [:month, :day])
       #
-      #   # Generates a date select that when POSTed is stored in the user variable, in the birthday attribute
+      #   # Generates a date select that when POSTed is stored in the post variable, in the written_on attribute
       #   # which is initially set to the date 3 days from the current date
       #   date_select("post", "written_on", :default => 3.days.from_now)
       #


### PR DESCRIPTION
Fixed typos in documentation for the date_select helper in actionpack/action_view.

The description for an example of the date_select method did not match the actual code example.

This patch changes no code, only documentation comments.
