### PR TITLE
Update copyright year in Active Resource & Active Support

### DIFF
--- a/activeresource/lib/active_resource.rb
+++ b/activeresource/lib/active_resource.rb
@@ -1,5 +1,5 @@
 #--
-# Copyright (c) 2006 David Heinemeier Hansson
+# Copyright (c) 2006-2011 David Heinemeier Hansson
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/activeresource/lib/active_resource.rb
+++ b/activeresource/lib/active_resource.rb
@@ -1,5 +1,5 @@
 #--
-# Copyright (c) 2006 David Heinemeier Hansson
+# Copyright (c) 2011 David Heinemeier Hansson
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/activeresource/lib/active_resource.rb
+++ b/activeresource/lib/active_resource.rb
@@ -1,5 +1,5 @@
 #--
-# Copyright (c) 2011 David Heinemeier Hansson
+# Copyright (c) 2006-2011 David Heinemeier Hansson
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -1,5 +1,5 @@
 #--
-# Copyright (c) 2005 David Heinemeier Hansson
+# Copyright (c) 2005-2011 David Heinemeier Hansson
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the


### PR DESCRIPTION
Update copyright year to include up to 2011 in Active Resource & Active Support.
