### PR TITLE
Puts ActiveRecord::SessionStore attributes in white list, fixes #483

### DIFF
--- a/activerecord/lib/active_record/session_store.rb
+++ b/activerecord/lib/active_record/session_store.rb
@@ -83,6 +83,8 @@ module ActiveRecord
       cattr_accessor :data_column_name
       self.data_column_name = 'data'
 
+      attr_accessible :session_id, :data, :marshaled_data
+
       before_save :marshal_data!
       before_save :raise_on_session_data_overflow!
 

--- a/activerecord/test/cases/session_store/session_test.rb
+++ b/activerecord/test/cases/session_store/session_test.rb
@@ -21,6 +21,12 @@ module ActiveRecord
         assert_equal 'sessions', Session.table_name
       end
 
+      def test_accessible_attributes
+        assert Session.accessible_attributes.include?(:session_id)
+        assert Session.accessible_attributes.include?(:data)
+        assert Session.accessible_attributes.include?(:marshaled_data)
+      end
+
       def test_create_table!
         assert !Session.table_exists?
         Session.create_table!


### PR DESCRIPTION
When using global whitelisting, AR::SS does not work at all (depending of your RDBMS you may get an ActiveRecord::StatementInvalid exception because of NULL constraint on session_id).

This problem exists in Rails 2, Rails 3 and Rails 3.1.

But as Rails 3.1 got a new feature to easily enable global whitelisting (config.active_record.whitelist_attributes = true), I think we should fix AR::SS to work by default when using this feature.
