### PR TITLE
Replace LH with GitHub url for filing issues

### DIFF
--- a/activesupport/README.rdoc
+++ b/activesupport/README.rdoc
@@ -30,4 +30,4 @@ API documentation is at
 
 Bug reports and feature requests can be filed with the rest for the Ruby on Rails project here:
 
-* https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets
+* https://github.com/rails/rails/issues


### PR DESCRIPTION
Replace the LH ticket url with GitHub url for filing issues
