### PR TITLE
Serialized methods that return nil should not be considered YAML

### DIFF
--- a/activemodel/lib/active_model/serializers/xml.rb
+++ b/activemodel/lib/active_model/serializers/xml.rb
@@ -33,6 +33,7 @@ module ActiveModel
         protected
 
           def compute_type
+            return if value.nil?
             type = ActiveSupport::XmlMini::TYPE_NAMES[value.class.name]
             type ||= :string if value.respond_to?(:to_str)
             type ||= :yaml

--- a/activemodel/test/cases/serializers/xml_serialization_test.rb
+++ b/activemodel/test/cases/serializers/xml_serialization_test.rb
@@ -92,6 +92,10 @@ class XmlSerializationTest < ActiveModel::TestCase
   test "should serialize string" do
     assert_match %r{<name>aaron stack</name>}, @contact.to_xml
   end
+  
+  test "should serialize nil" do
+    assert_match %r{<pseudonyms nil=\"true\"></pseudonyms>}, @contact.to_xml(:methods => :pseudonyms)
+  end
 
   test "should serialize integer" do
     assert_match %r{<age type="integer">25</age>}, @contact.to_xml

--- a/activemodel/test/models/contact.rb
+++ b/activemodel/test/models/contact.rb
@@ -16,6 +16,10 @@ class Contact
     options.each { |name, value| send("#{name}=", value) }
   end
 
+  def pseudonyms
+    nil
+  end
+
   def persisted?
     id
   end

--- a/activerecord/test/cases/xml_serialization_test.rb
+++ b/activerecord/test/cases/xml_serialization_test.rb
@@ -143,10 +143,7 @@ class NilXmlSerializationTest < ActiveRecord::TestCase
   end
 
   def test_should_serialize_yaml
-    assert %r{<preferences(.*)></preferences>}.match(@xml)
-    attributes = $1
-    assert_match %r{type="yaml"}, attributes
-    assert_match %r{nil="true"}, attributes
+    assert_match %r{<preferences nil=\"true\"></preferences>}, @xml
   end
 end
 


### PR DESCRIPTION
(Rebased version of https://github.com/rails/rails/pull/200#commits-pushed-7448ec0)

The way ActiveModel computes the type of serializable methods and attributes, any that return nil will be described as being YAML. 

This produces XML like:

```
<person>
  <name>John Doe</name>
  <preferences type="yaml" nil="true"></preferences>
</person>
```

However, in many cases, the 'type="yaml"' part is unnecessary, and potentially misleading.

With this patch, the equivalent to the above XML would be:

```
<person>
  <name>John Doe</name>
  <preferences nil="true"></preferences>
</person>
```
