### PR TITLE
Use all in place of find(:all)

### DIFF
--- a/railties/lib/rails/commands/runner.rb
+++ b/railties/lib/rails/commands/runner.rb
@@ -25,7 +25,7 @@ ARGV.clone.options do |opts|
     opts.separator "-------------------------------------------------------------"
     opts.separator "#!/usr/bin/env #{File.expand_path($0)} runner"
     opts.separator ""
-    opts.separator "Product.find(:all).each { |p| p.price *= 2 ; p.save! }"
+    opts.separator "Product.all.each { |p| p.price *= 2 ; p.save! }"
     opts.separator "-------------------------------------------------------------"
   end
 


### PR DESCRIPTION
Use all in place of find(:all) in the rails runner help message
