### PR TITLE
Adding .sass-cache to gitignore template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/gitignore
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore
@@ -2,3 +2,4 @@
 db/*.sqlite3
 log/*.log
 tmp/
+.sass-cache/


### PR DESCRIPTION
Now that Sass is used by default in new apps is a good idea add .sass-cache/ to .gitignore by default
