### PR TITLE
Follow code conventions on some tests

### DIFF
--- a/activemodel/test/cases/validations/conditional_validation_test.rb
+++ b/activemodel/test/cases/validations/conditional_validation_test.rb
@@ -11,7 +11,7 @@ class ConditionalValidationTest < ActiveModel::TestCase
 
   def test_if_validation_using_method_true
     # When the method returns true
-    Topic.validates_length_of( :title, :maximum=>5, :too_long=>"hoo %{count}", :if => :condition_is_true )
+    Topic.validates_length_of( :title, :maximum => 5, :too_long => "hoo %{count}", :if => :condition_is_true )
     t = Topic.new("title" => "uhohuhoh", "content" => "whatever")
     assert t.invalid?
     assert t.errors[:title].any?
@@ -20,7 +20,7 @@ class ConditionalValidationTest < ActiveModel::TestCase
 
   def test_unless_validation_using_method_true
     # When the method returns true
-    Topic.validates_length_of( :title, :maximum=>5, :too_long=>"hoo %{count}", :unless => :condition_is_true )
+    Topic.validates_length_of( :title, :maximum => 5, :too_long => "hoo %{count}", :unless => :condition_is_true )
     t = Topic.new("title" => "uhohuhoh", "content" => "whatever")
     assert t.valid?
     assert t.errors[:title].empty?
@@ -28,7 +28,7 @@ class ConditionalValidationTest < ActiveModel::TestCase
 
   def test_if_validation_using_method_false
     # When the method returns false
-    Topic.validates_length_of( :title, :maximum=>5, :too_long=>"hoo %{count}", :if => :condition_is_true_but_its_not )
+    Topic.validates_length_of( :title, :maximum => 5, :too_long => "hoo %{count}", :if => :condition_is_true_but_its_not )
     t = Topic.new("title" => "uhohuhoh", "content" => "whatever")
     assert t.valid?
     assert t.errors[:title].empty?
@@ -36,7 +36,7 @@ class ConditionalValidationTest < ActiveModel::TestCase
 
   def test_unless_validation_using_method_false
     # When the method returns false
-    Topic.validates_length_of( :title, :maximum=>5, :too_long=>"hoo %{count}", :unless => :condition_is_true_but_its_not )
+    Topic.validates_length_of( :title, :maximum => 5, :too_long => "hoo %{count}", :unless => :condition_is_true_but_its_not )
     t = Topic.new("title" => "uhohuhoh", "content" => "whatever")
     assert t.invalid?
     assert t.errors[:title].any?
@@ -45,7 +45,7 @@ class ConditionalValidationTest < ActiveModel::TestCase
 
   def test_if_validation_using_string_true
     # When the evaluated string returns true
-    Topic.validates_length_of( :title, :maximum=>5, :too_long=>"hoo %{count}", :if => "a = 1; a == 1" )
+    Topic.validates_length_of( :title, :maximum => 5, :too_long => "hoo %{count}", :if => "a = 1; a == 1" )
     t = Topic.new("title" => "uhohuhoh", "content" => "whatever")
     assert t.invalid?
     assert t.errors[:title].any?
@@ -54,7 +54,7 @@ class ConditionalValidationTest < ActiveModel::TestCase
 
   def test_unless_validation_using_string_true
     # When the evaluated string returns true
-    Topic.validates_length_of( :title, :maximum=>5, :too_long=>"hoo %{count}", :unless => "a = 1; a == 1" )
+    Topic.validates_length_of( :title, :maximum => 5, :too_long => "hoo %{count}", :unless => "a = 1; a == 1" )
     t = Topic.new("title" => "uhohuhoh", "content" => "whatever")
     assert t.valid?
     assert t.errors[:title].empty?
@@ -62,7 +62,7 @@ class ConditionalValidationTest < ActiveModel::TestCase
 
   def test_if_validation_using_string_false
     # When the evaluated string returns false
-    Topic.validates_length_of( :title, :maximum=>5, :too_long=>"hoo %{count}", :if => "false")
+    Topic.validates_length_of( :title, :maximum => 5, :too_long => "hoo %{count}", :if => "false")
     t = Topic.new("title" => "uhohuhoh", "content" => "whatever")
     assert t.valid?
     assert t.errors[:title].empty?
@@ -70,7 +70,7 @@ class ConditionalValidationTest < ActiveModel::TestCase
 
   def test_unless_validation_using_string_false
     # When the evaluated string returns false
-    Topic.validates_length_of( :title, :maximum=>5, :too_long=>"hoo %{count}", :unless => "false")
+    Topic.validates_length_of( :title, :maximum => 5, :too_long => "hoo %{count}", :unless => "false")
     t = Topic.new("title" => "uhohuhoh", "content" => "whatever")
     assert t.invalid?
     assert t.errors[:title].any?
@@ -79,7 +79,7 @@ class ConditionalValidationTest < ActiveModel::TestCase
 
   def test_if_validation_using_block_true
     # When the block returns true
-    Topic.validates_length_of( :title, :maximum=>5, :too_long=>"hoo %{count}",
+    Topic.validates_length_of( :title, :maximum => 5, :too_long => "hoo %{count}",
       :if => Proc.new { |r| r.content.size > 4 } )
     t = Topic.new("title" => "uhohuhoh", "content" => "whatever")
     assert t.invalid?
@@ -89,7 +89,7 @@ class ConditionalValidationTest < ActiveModel::TestCase
 
   def test_unless_validation_using_block_true
     # When the block returns true
-    Topic.validates_length_of( :title, :maximum=>5, :too_long=>"hoo %{count}",
+    Topic.validates_length_of( :title, :maximum => 5, :too_long => "hoo %{count}",
       :unless => Proc.new { |r| r.content.size > 4 } )
     t = Topic.new("title" => "uhohuhoh", "content" => "whatever")
     assert t.valid?
@@ -98,7 +98,7 @@ class ConditionalValidationTest < ActiveModel::TestCase
 
   def test_if_validation_using_block_false
     # When the block returns false
-    Topic.validates_length_of( :title, :maximum=>5, :too_long=>"hoo %{count}",
+    Topic.validates_length_of( :title, :maximum => 5, :too_long => "hoo %{count}",
       :if => Proc.new { |r| r.title != "uhohuhoh"} )
     t = Topic.new("title" => "uhohuhoh", "content" => "whatever")
     assert t.valid?
@@ -107,7 +107,7 @@ class ConditionalValidationTest < ActiveModel::TestCase
 
   def test_unless_validation_using_block_false
     # When the block returns false
-    Topic.validates_length_of( :title, :maximum=>5, :too_long=>"hoo %{count}",
+    Topic.validates_length_of( :title, :maximum => 5, :too_long => "hoo %{count}",
       :unless => Proc.new { |r| r.title != "uhohuhoh"} )
     t = Topic.new("title" => "uhohuhoh", "content" => "whatever")
     assert t.invalid?

--- a/activemodel/test/cases/validations/format_validation_test.rb
+++ b/activemodel/test/cases/validations/format_validation_test.rb
@@ -27,7 +27,7 @@ class PresenceValidationTest < ActiveModel::TestCase
   end
 
   def test_validate_format_with_allow_blank
-    Topic.validates_format_of(:title, :with => /^Validation\smacros \w+!$/, :allow_blank=>true)
+    Topic.validates_format_of(:title, :with => /^Validation\smacros \w+!$/, :allow_blank => true)
     assert Topic.new("title" => "Shouldn't be valid").invalid?
     assert Topic.new("title" => "").valid?
     assert Topic.new("title" => nil).valid?

--- a/activemodel/test/cases/validations/inclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/inclusion_validation_test.rb
@@ -42,7 +42,7 @@ class InclusionValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_inclusion_of_with_allow_nil
-    Topic.validates_inclusion_of( :title, :in => %w( a b c d e f g ), :allow_nil=>true )
+    Topic.validates_inclusion_of( :title, :in => %w( a b c d e f g ), :allow_nil => true )
 
     assert Topic.new("title" => "a!", "content" => "abc").invalid?
     assert Topic.new("title" => "",   "content" => "abc").invalid?

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -11,7 +11,7 @@ class LengthValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_length_of_with_allow_nil
-    Topic.validates_length_of( :title, :is => 5, :allow_nil=>true )
+    Topic.validates_length_of( :title, :is => 5, :allow_nil => true )
 
     assert Topic.new("title" => "ab").invalid?
     assert Topic.new("title" => "").invalid?
@@ -20,7 +20,7 @@ class LengthValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_length_of_with_allow_blank
-    Topic.validates_length_of( :title, :is => 5, :allow_blank=>true )
+    Topic.validates_length_of( :title, :is => 5, :allow_blank => true )
 
     assert Topic.new("title" => "ab").invalid?
     assert Topic.new("title" => "").valid?
@@ -176,16 +176,16 @@ class LengthValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_length_of_nasty_params
-    assert_raise(ArgumentError) { Topic.validates_length_of(:title, :is=>-6) }
-    assert_raise(ArgumentError) { Topic.validates_length_of(:title, :within=>6) }
-    assert_raise(ArgumentError) { Topic.validates_length_of(:title, :minimum=>"a") }
-    assert_raise(ArgumentError) { Topic.validates_length_of(:title, :maximum=>"a") }
-    assert_raise(ArgumentError) { Topic.validates_length_of(:title, :within=>"a") }
-    assert_raise(ArgumentError) { Topic.validates_length_of(:title, :is=>"a") }
+    assert_raise(ArgumentError) { Topic.validates_length_of(:title, :is => -6) }
+    assert_raise(ArgumentError) { Topic.validates_length_of(:title, :within => 6) }
+    assert_raise(ArgumentError) { Topic.validates_length_of(:title, :minimum => "a") }
+    assert_raise(ArgumentError) { Topic.validates_length_of(:title, :maximum => "a") }
+    assert_raise(ArgumentError) { Topic.validates_length_of(:title, :within => "a") }
+    assert_raise(ArgumentError) { Topic.validates_length_of(:title, :is => "a") }
   end
 
   def test_validates_length_of_custom_errors_for_minimum_with_message
-    Topic.validates_length_of( :title, :minimum=>5, :message=>"boo %{count}" )
+    Topic.validates_length_of( :title, :minimum => 5, :message => "boo %{count}" )
     t = Topic.new("title" => "uhoh", "content" => "whatever")
     assert t.invalid?
     assert t.errors[:title].any?
@@ -193,7 +193,7 @@ class LengthValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_length_of_custom_errors_for_minimum_with_too_short
-    Topic.validates_length_of( :title, :minimum=>5, :too_short=>"hoo %{count}" )
+    Topic.validates_length_of( :title, :minimum => 5, :too_short => "hoo %{count}" )
     t = Topic.new("title" => "uhoh", "content" => "whatever")
     assert t.invalid?
     assert t.errors[:title].any?
@@ -201,7 +201,7 @@ class LengthValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_length_of_custom_errors_for_maximum_with_message
-    Topic.validates_length_of( :title, :maximum=>5, :message=>"boo %{count}" )
+    Topic.validates_length_of( :title, :maximum => 5, :message => "boo %{count}" )
     t = Topic.new("title" => "uhohuhoh", "content" => "whatever")
     assert t.invalid?
     assert t.errors[:title].any?
@@ -222,7 +222,7 @@ class LengthValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_length_of_custom_errors_for_maximum_with_too_long
-    Topic.validates_length_of( :title, :maximum=>5, :too_long=>"hoo %{count}" )
+    Topic.validates_length_of( :title, :maximum => 5, :too_long => "hoo %{count}" )
     t = Topic.new("title" => "uhohuhoh", "content" => "whatever")
     assert t.invalid?
     assert t.errors[:title].any?
@@ -244,7 +244,7 @@ class LengthValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_length_of_custom_errors_for_is_with_message
-    Topic.validates_length_of( :title, :is=>5, :message=>"boo %{count}" )
+    Topic.validates_length_of( :title, :is => 5, :message => "boo %{count}" )
     t = Topic.new("title" => "uhohuhoh", "content" => "whatever")
     assert t.invalid?
     assert t.errors[:title].any?
@@ -252,7 +252,7 @@ class LengthValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_length_of_custom_errors_for_is_with_wrong_length
-    Topic.validates_length_of( :title, :is=>5, :wrong_length=>"hoo %{count}" )
+    Topic.validates_length_of( :title, :is => 5, :wrong_length => "hoo %{count}" )
     t = Topic.new("title" => "uhohuhoh", "content" => "whatever")
     assert t.invalid?
     assert t.errors[:title].any?
@@ -331,7 +331,7 @@ class LengthValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_length_of_with_block
-    Topic.validates_length_of :content, :minimum => 5, :too_short=>"Your essay must be at least %{count} words.",
+    Topic.validates_length_of :content, :minimum => 5, :too_short => "Your essay must be at least %{count} words.",
                                         :tokenizer => lambda {|str| str.scan(/\w+/) }
     t = Topic.new(:content => "this content should be long enough")
     assert t.valid?

--- a/activeresource/test/cases/format_test.rb
+++ b/activeresource/test/cases/format_test.rb
@@ -86,7 +86,7 @@ class FormatTest < Test::Unit::TestCase
 
   def test_serialization_of_nested_resource
     address  = { :street => '12345 Street' }
-    person  = { :name=> 'Rus', :address => address}
+    person  = { :name => 'Rus', :address => address}
 
     [:json, :xml].each do |format|
       encoded_person = ActiveResource::Formats[format].encode(person)


### PR DESCRIPTION
changed all the places when we had <pre><code>something=>other</code></pre> to <pre><code>something => other</code></pre>
