### PR TITLE
fix bug in usage example of #unscoped

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -895,7 +895,7 @@ module ActiveRecord #:nodoc:
       # not use the default_scope:
       #
       #   Post.unscoped {
-      #     limit(10) # Fires "SELECT * FROM posts LIMIT 10"
+      #     Post.limit(10) # Fires "SELECT * FROM posts LIMIT 10"
       #   }
       #
       # It is recommended to use block form of unscoped because chaining unscoped with <tt>scope</tt>


### PR DESCRIPTION
I'm not 100% sure if this is a documentation bug or a bug in AR itself. However the old example in the docs

```
Post.unscoped {
  limit(10) # Fires "SELECT * FROM posts LIMIT 10"
}
```

does not work, it has to be

```
Post.unscoped {
  Post.limit(10) # Fires "SELECT * FROM posts LIMIT 10"
}
```
