### PR TITLE
Modified CollectionAssociation documentation to refer to the new class name

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module Associations
     # = Active Record Association Collection
     #
-    # AssociationCollection is an abstract class that provides common stuff to
+    # CollectionAssociation is an abstract class that provides common stuff to
     # ease the implementation of association proxies that represent
     # collections. See the class hierarchy in AssociationProxy.
     #

--- a/activerecord/test/cases/named_scope_test.rb
+++ b/activerecord/test/cases/named_scope_test.rb
@@ -462,7 +462,7 @@ class NamedScopeTest < ActiveRecord::TestCase
     [:destroy_all, :reset, :delete_all].each do |method|
       before = post.comments.containing_the_letter_e
       post.association(:comments).send(method)
-      assert before.object_id != post.comments.containing_the_letter_e.object_id, "AssociationCollection##{method} should reset the named scopes cache"
+      assert before.object_id != post.comments.containing_the_letter_e.object_id, "CollectionAssociation##{method} should reset the named scopes cache"
     end
   end
 


### PR DESCRIPTION
Been looking for an opportunity to help out for a little while, and I just noticed that there was one reference in CollectionAssociation's class docs to AssocationCollection. I also noticed that it was referenced (in a string) in the NamedScopeTest.

Also, should the header `# = Active Record Association Collection` be changed to `# = Active Record Collection Association`?
