### PR TITLE
column_names sometimes doesn't fetch all columns

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -701,7 +701,8 @@ module ActiveRecord #:nodoc:
 
       # Returns an array of column names as strings.
       def column_names
-        @column_names ||= columns.map { |column| column.name }
+        @column_names = columns.map { |column| column.name }
+        # @column_names ||= columns.map { |column| column.name }
       end
 
       # Returns an array of column objects where the primary id, all columns ending in "_id" or "_count",


### PR DESCRIPTION
changed AR base#column_names, now instance variable @column_names ever assigned

see: 
https://rails.lighthouseapp.com/projects/8994/tickets/6774-arcolumn_names-doesnt-get-all-columns
