### PR TITLE
`guard_protected_attributes` has invalid assignment to be always true in attributes=

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1652,11 +1652,10 @@ MSG
 
         return unless new_attributes.is_a?(Hash)
 
-        guard_protected_attributes ||= true
-        if guard_protected_attributes
-          assign_attributes(new_attributes)
-        else
+        if guard_protected_attributes == false
           assign_attributes(new_attributes, :without_protection => true)
+        else
+          assign_attributes(new_attributes)
         end
       end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -45,6 +45,10 @@ class ReadonlyTitlePost < Post
   attr_readonly :title
 end
 
+class ProtectedTitlePost < Post
+  attr_protected :title
+end
+
 class Weird < ActiveRecord::Base; end
 
 class Boolean < ActiveRecord::Base; end
@@ -491,8 +495,9 @@ class BasicsTest < ActiveRecord::TestCase
 
   def test_attributes_guard_protected_attributes_is_deprecated
     attributes = { "title" => "An amazing title" }
-    topic = Topic.new
-    assert_deprecated { topic.send(:attributes=, attributes, false) }
+    post = ProtectedTitlePost.new
+    assert_deprecated { post.send(:attributes=, attributes, false) }
+    assert_equal "An amazing title", post.title
   end
 
   def test_multiparameter_attributes_on_date


### PR DESCRIPTION
As I commented in https://github.com/rails/rails/commit/f9d5a7bb8c5d224f689dafb4ff641e2ced244f03#L0R1647 `guard_protected_attributes` has invalid assignment to be always true. In consequence, when you had `guard_protected_attributes` set to `false` in `attributes=`, it stopped working.
