### PR TITLE
Follow code conventions on ActiveRecord tests

### DIFF
--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -96,25 +96,25 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_preloading_has_many_in_multiple_queries_with_more_ids_than_database_can_handle
     Post.connection.expects(:in_clause_length).at_least_once.returns(5)
-    posts = Post.find(:all, :include=>:comments)
+    posts = Post.find(:all, :include => :comments)
     assert_equal 11, posts.size
   end
 
   def test_preloading_has_many_in_one_queries_when_database_has_no_limit_on_ids_it_can_handle
     Post.connection.expects(:in_clause_length).at_least_once.returns(nil)
-    posts = Post.find(:all, :include=>:comments)
+    posts = Post.find(:all, :include => :comments)
     assert_equal 11, posts.size
   end
 
   def test_preloading_habtm_in_multiple_queries_with_more_ids_than_database_can_handle
     Post.connection.expects(:in_clause_length).at_least_once.returns(5)
-    posts = Post.find(:all, :include=>:categories)
+    posts = Post.find(:all, :include => :categories)
     assert_equal 11, posts.size
   end
 
   def test_preloading_habtm_in_one_queries_when_database_has_no_limit_on_ids_it_can_handle
     Post.connection.expects(:in_clause_length).at_least_once.returns(nil)
-    posts = Post.find(:all, :include=>:categories)
+    posts = Post.find(:all, :include => :categories)
     assert_equal 11, posts.size
   end
 
@@ -662,21 +662,21 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_eager_with_invalid_association_reference
     assert_raise(ActiveRecord::ConfigurationError, "Association was not found; perhaps you misspelled it?  You specified :include => :monkeys") {
-      Post.find(6, :include=> :monkeys )
+      Post.find(6, :include => :monkeys )
     }
     assert_raise(ActiveRecord::ConfigurationError, "Association was not found; perhaps you misspelled it?  You specified :include => :monkeys") {
-      Post.find(6, :include=>[ :monkeys ])
+      Post.find(6, :include => [ :monkeys ])
     }
     assert_raise(ActiveRecord::ConfigurationError, "Association was not found; perhaps you misspelled it?  You specified :include => :monkeys") {
-      Post.find(6, :include=>[ 'monkeys' ])
+      Post.find(6, :include => [ 'monkeys' ])
     }
     assert_raise(ActiveRecord::ConfigurationError, "Association was not found; perhaps you misspelled it?  You specified :include => :monkeys, :elephants") {
-      Post.find(6, :include=>[ :monkeys, :elephants ])
+      Post.find(6, :include => [ :monkeys, :elephants ])
     }
   end
 
   def find_all_ordered(className, include=nil)
-    className.find(:all, :order=>"#{className.table_name}.#{className.primary_key}", :include=>include)
+    className.find(:all, :order => "#{className.table_name}.#{className.primary_key}", :include => include)
   end
 
   def test_limited_eager_with_order

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -498,14 +498,14 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_create_with_bang_on_has_many_when_parent_is_new_raises
     assert_raise(ActiveRecord::RecordNotSaved) do
       firm = Firm.new
-      firm.plain_clients.create! :name=>"Whoever"
+      firm.plain_clients.create! :name => "Whoever"
     end
   end
 
   def test_regular_create_on_has_many_when_parent_is_new_raises
     assert_raise(ActiveRecord::RecordNotSaved) do
       firm = Firm.new
-      firm.plain_clients.create :name=>"Whoever"
+      firm.plain_clients.create :name => "Whoever"
     end
   end
 

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -351,7 +351,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     # 1 query for the new record, 1 for the join table record
     # No need to update the actual collection yet!
     assert_queries(2) do
-      posts(:thinking).people.create(:first_name=>"Jeb")
+      posts(:thinking).people.create(:first_name => "Jeb")
     end
 
     # *Now* we actually need the collection so it's loaded

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -118,8 +118,8 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   end
 
   def test_read_attributes_before_type_cast
-    category = Category.new({:name=>"Test categoty", :type => nil})
-    category_attrs = {"name"=>"Test categoty", "id" => nil, "type" => nil, "categorizations_count" => nil}
+    category = Category.new({:name => "Test categoty", :type => nil})
+    category_attrs = {"name" => "Test categoty", "id" => nil, "type" => nil, "categorizations_count" => nil}
     assert_equal category_attrs , category.attributes_before_type_cast
   end
 

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -181,7 +181,7 @@ class TestDefaultAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCas
     eye = Eye.create(:iris_attributes => {:color => 'honey'})
     eye.update_attributes(:iris_attributes => {:color => 'green'})
     assert_equal [true, false], eye.after_update_callbacks_stack
-  end
+ end
 
   def test_callbacks_firing_order_on_save
     eye = Eye.create(:iris_attributes => {:color => 'honey'})
@@ -219,7 +219,7 @@ class TestDefaultAutosaveAssociationOnABelongsToAssociation < ActiveRecord::Test
 
   def test_save_succeeds_for_invalid_belongs_to_with_validate_false
     # Oracle saves empty string as NULL therefore :message changed to one space
-    assert log = AuditLog.create(:developer_id => 0, :message=> " ")
+    assert log = AuditLog.create(:developer_id => 0, :message => " ")
 
     log.unvalidated_developer = Developer.new
     assert !log.unvalidated_developer.valid?

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -730,7 +730,7 @@ module NestedAttributesOnACollectionAssociationTests
       assert_difference 'Man.count' do
         assert_difference 'Interest.count', 2 do
           man = Man.create!(:name => 'John',
-                            :interests_attributes => [{:topic=>'Cars'}, {:topic=>'Sports'}])
+                            :interests_attributes => [{:topic => 'Cars'}, {:topic => 'Sports'}])
           assert_equal 2, man.interests.count
         end
       end
@@ -746,7 +746,7 @@ module NestedAttributesOnACollectionAssociationTests
       Interest.validates_presence_of(:man)
       assert_no_difference ['Man.count', 'Interest.count'] do
         man = Man.create(:name => 'John',
-                         :interests_attributes => [{:topic=>'Cars'}, {:topic=>'Sports'}])
+                         :interests_attributes => [{:topic => 'Cars'}, {:topic => 'Sports'}])
         assert !man.errors[:"interests.man"].empty?
       end
     end
@@ -868,7 +868,7 @@ class TestNestedAttributesWithNonStandardPrimaryKeys < ActiveRecord::TestCase
     attributes = {:pets_attributes => { "1"=> { :id => @pet1.id,
                                                 :name => "Foo2",
                                                 :current_user => "John",
-                                                :_destroy=>true }}}
+                                                :_destroy => true }}}
     @owner.update_attributes(attributes)
     assert_equal 'John', Pet.after_destroy_output
   end

--- a/activerecord/test/cases/validations/association_validation_test.rb
+++ b/activerecord/test/cases/validations/association_validation_test.rb
@@ -62,7 +62,7 @@ class AssociationValidationTest < ActiveRecord::TestCase
   end
 
   def test_validates_associated_with_custom_message_using_quotes
-    Reply.validates_associated :topic, :message=> "This string contains 'single' and \"double\" quotes"
+    Reply.validates_associated :topic, :message => "This string contains 'single' and \"double\" quotes"
     Topic.validates_presence_of :content
     r = Reply.create("title" => "A reply", "content" => "with content!")
     r.topic = Topic.create("title" => "uhohuhoh")

--- a/activerecord/test/cases/xml_serialization_test.rb
+++ b/activerecord/test/cases/xml_serialization_test.rb
@@ -14,7 +14,7 @@ class XmlSerializationTest < ActiveRecord::TestCase
   end
 
   def test_should_serialize_default_root_with_namespace
-    @xml = Contact.new.to_xml :namespace=>"http://xml.rubyonrails.org/contact"
+    @xml = Contact.new.to_xml :namespace => "http://xml.rubyonrails.org/contact"
     assert_match %r{^<contact xmlns="http://xml.rubyonrails.org/contact">},  @xml
     assert_match %r{</contact>$}, @xml
   end
@@ -163,7 +163,7 @@ class DatabaseConnectedXmlSerializationTest < ActiveRecord::TestCase
   end
 
   def test_passing_hash_shouldnt_reuse_builder
-    options = {:include=>:posts}
+    options = {:include => :posts}
     david = authors(:david)
     first_xml_size = david.to_xml(options).size
     second_xml_size = david.to_xml(options).size
@@ -171,14 +171,14 @@ class DatabaseConnectedXmlSerializationTest < ActiveRecord::TestCase
   end
 
   def test_include_uses_association_name
-    xml = authors(:david).to_xml :include=>:hello_posts, :indent => 0
+    xml = authors(:david).to_xml :include => :hello_posts, :indent => 0
     assert_match %r{<hello-posts type="array">}, xml
     assert_match %r{<hello-post type="Post">}, xml
     assert_match %r{<hello-post type="StiPost">}, xml
   end
 
   def test_included_associations_should_skip_types
-    xml = authors(:david).to_xml :include=>:hello_posts, :indent => 0, :skip_types => true
+    xml = authors(:david).to_xml :include => :hello_posts, :indent => 0, :skip_types => true
     assert_match %r{<hello-posts>}, xml
     assert_match %r{<hello-post>}, xml
     assert_match %r{<hello-post>}, xml
@@ -190,7 +190,7 @@ class DatabaseConnectedXmlSerializationTest < ActiveRecord::TestCase
   end
 
   def test_should_not_call_methods_on_associations_that_dont_respond
-    xml = authors(:david).to_xml :include=>:hello_posts, :methods => :label, :indent => 2
+    xml = authors(:david).to_xml :include => :hello_posts, :methods => :label, :indent => 2
     assert !authors(:david).hello_posts.first.respond_to?(:label)
     assert_match %r{^  <label>.*</label>}, xml
     assert_no_match %r{^      <label>}, xml
@@ -231,14 +231,14 @@ class DatabaseConnectedXmlSerializationTest < ActiveRecord::TestCase
 
   def test_should_include_empty_has_many_as_empty_array
     authors(:david).posts.delete_all
-    xml = authors(:david).to_xml :include=>:posts, :indent => 2
+    xml = authors(:david).to_xml :include => :posts, :indent => 2
 
     assert_equal [], Hash.from_xml(xml)['author']['posts']
     assert_match %r{^  <posts type="array"/>}, xml
   end
 
   def test_should_has_many_array_elements_should_include_type_when_different_from_guessed_value
-    xml = authors(:david).to_xml :include=>:posts_with_comments, :indent => 2
+    xml = authors(:david).to_xml :include => :posts_with_comments, :indent => 2
 
     assert Hash.from_xml(xml)
     assert_match %r{^  <posts-with-comments type="array">}, xml

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -73,7 +73,7 @@ class Firm < Company
 
   has_one :account, :foreign_key => "firm_id", :dependent => :destroy, :validate => true
   has_one :unvalidated_account, :foreign_key => "firm_id", :class_name => 'Account', :validate => false
-  has_one :account_with_select, :foreign_key => "firm_id", :select => "id, firm_id", :class_name=>'Account'
+  has_one :account_with_select, :foreign_key => "firm_id", :select => "id, firm_id", :class_name => 'Account'
   has_one :readonly_account, :foreign_key => "firm_id", :class_name => "Account", :readonly => true
   # added order by id as in fixtures there are two accounts for Rails Core
   # Oracle tests were failing because of that as the second fixture was selected

--- a/activerecord/test/models/computer.rb
+++ b/activerecord/test/models/computer.rb
@@ -1,3 +1,3 @@
 class Computer < ActiveRecord::Base
-  belongs_to :developer, :foreign_key=>'developer'
+  belongs_to :developer, :foreign_key => 'developer'
 end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -106,7 +106,7 @@ class Post < ActiveRecord::Base
   has_many :readers_with_person, :include => :person, :class_name => "Reader"
   has_many :people, :through => :readers
   has_many :single_people, :through => :readers
-  has_many :people_with_callbacks, :source=>:person, :through => :readers,
+  has_many :people_with_callbacks, :source => :person, :through => :readers,
               :before_add    => lambda {|owner, reader| log(:added,   :before, reader.first_name) },
               :after_add     => lambda {|owner, reader| log(:added,   :after,  reader.first_name) },
               :before_remove => lambda {|owner, reader| log(:removed, :before, reader.first_name) },

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -41,8 +41,8 @@ ActiveRecord::Schema.define do
   end
 
   create_table :audit_logs, :force => true do |t|
-    t.column :message, :string, :null=>false
-    t.column :developer_id, :integer, :null=>false
+    t.column :message, :string, :null => false
+    t.column :developer_id, :integer, :null => false
   end
 
   create_table :authors, :force => true do |t|


### PR DESCRIPTION
Following with #503 (by @smartinez87), I changed "something=>other"  to "something => other" on ActiveRecord tests
