### PR TITLE
Default scope breaks working of has_many :through

### DIFF
--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -5,6 +5,8 @@ class Post < ActiveRecord::Base
     end
   end
 
+  default_scope select("posts.*")
+
   scope :containing_the_letter_a, where("body LIKE '%a%'")
   scope :ranked_by_comments, order("comments_count DESC")
 


### PR DESCRIPTION
Adding a default_scope to the end of a has_many :through relationship breaks a number of things.

I've found it through a :uniq => true on the relationship, but the attached change to the tests seems to break a number of other things
