### PR TITLE
Reloading an association works incorrectly when there is overloading or composed_of

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -407,7 +407,7 @@ module ActiveRecord
                 # FIXME: this call to attributes causes many NoMethodErrors
                 attributes = f.attributes
                 (attributes.keys - keys).each do |k|
-                  t.send("#{k}=", attributes[k])
+                  t.send('write_attribute', k, attributes[k])
                 end
               end
             else

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1445,4 +1445,18 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_not_equal target.object_id, ary.object_id
   end
+  
+    
+  def test_load_target_respects_overridden_assignment
+    post = Post.last
+    post.comments << AwesomeComment.new(:body => "Test Comment")
+    assert_equal post.comments[-1].body, Awesomeness.awesomeify("Test Comment")
+  end
+
+  def test_load_target_respects_composed_of
+    post = Post.last
+    post.comments << SuperAwesomeComment.new(:body => Awesomeness.new("Test Comment"))
+    assert_equal post.comments[-1].body.to_s, Awesomeness.awesomeify("Test Comment")
+  end
+  
 end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1456,7 +1456,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_load_target_respects_composed_of
     post = Post.last
     post.comments << SuperAwesomeComment.new(:body => Awesomeness.new("Test Comment"))
-    assert_equal post.comments[-1].body.to_s, Awesomeness.awesomeify("Test Comment")
+    assert post.comments[-1].body.is_a?(Awesomeness), "a class should not lose it's composed of relationship when added in a has_many relationship"
   end
   
 end

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -43,10 +43,6 @@ class AwesomeComment < Comment
   def body=(the_body)
     self.send('write_attribute', 'body', Awesomeness.awesomeify(the_body))
   end
-  
-  def self.awesomeify(str)
-    "Awesome " + str
-  end
 end
 
 class SuperAwesomeComment < Comment
@@ -65,6 +61,6 @@ class Awesomeness
   end
   
   def to_s
-    self.class.awesomeify text
+    self.class.awesomeify @text
   end
 end

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -38,3 +38,33 @@ class VerySpecialComment < Comment
     'a very special comment...'
   end
 end
+
+class AwesomeComment < Comment
+  def body=(the_body)
+    self.send('write_attribute', 'body', Awesomeness.awesomeify(the_body))
+  end
+  
+  def self.awesomeify(str)
+    "Awesome " + str
+  end
+end
+
+class SuperAwesomeComment < Comment
+  composed_of :body, :class_name => 'Awesomeness', :mapping => [%w(body text)]
+end
+
+class Awesomeness
+  def self.awesomeify(str)
+    "Awesome " + str
+  end
+  
+  attr_reader :text
+  
+  def initialize(awesome_text)
+    @text = awesome_text
+  end
+  
+  def to_s
+    self.class.awesomeify text
+  end
+end


### PR DESCRIPTION
reloading an association will properly set attributes of instantiated objects respecting overloading and composed_of
