### PR TITLE
Fix several of the rubygem issues in rails 2-3-stable. 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 require 'rake'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 env = %(PKG_BUILD="#{ENV['PKG_BUILD']}") if ENV['PKG_BUILD']
 
@@ -23,7 +23,7 @@ end
 
 
 desc "Generate documentation for the Rails framework"
-Rake::RDocTask.new do |rdoc|
+RDoc::Task.new do |rdoc|
   rdoc.rdoc_dir = 'doc/rdoc'
   rdoc.title    = "Ruby on Rails Documentation"
   rdoc.main     = "railties/README"

--- a/actionmailer/Rakefile
+++ b/actionmailer/Rakefile
@@ -1,9 +1,9 @@
 require 'rubygems'
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 require 'rake/packagetask'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 require File.join(File.dirname(__FILE__), 'lib', 'action_mailer', 'version')
 
 PKG_BUILD     = ENV['PKG_BUILD'] ? '.' + ENV['PKG_BUILD'] : ''
@@ -29,7 +29,7 @@ Rake::TestTask.new { |t|
 
 
 # Generate the RDoc documentation
-Rake::RDocTask.new { |rdoc|
+RDoc::Task.new { |rdoc|
   rdoc.rdoc_dir = 'doc'
   rdoc.title    = "Action Mailer -- Easy email delivery and testing"
   rdoc.options << '--line-numbers' << '--inline-source' << '-A cattr_accessor=object'
@@ -54,19 +54,17 @@ spec = Gem::Specification.new do |s|
   s.rubyforge_project = "actionmailer"
   s.homepage = "http://www.rubyonrails.org"
 
-  s.add_dependency('actionpack', '= 2.3.11' + PKG_BUILD)
+  s.add_dependency('actionpack', '= 2.3.12' + PKG_BUILD)
 
-  s.has_rdoc = true
   s.requirements << 'none'
   s.require_path = 'lib'
-  s.autorequire = 'action_mailer'
 
   s.files = [ "Rakefile", "install.rb", "README", "CHANGELOG", "MIT-LICENSE" ]
   s.files = s.files + Dir.glob( "lib/**/*" ).delete_if { |item| item.include?( "\.svn" ) }
   s.files = s.files + Dir.glob( "test/**/*" ).delete_if { |item| item.include?( "\.svn" ) }
 end
   
-Rake::GemPackageTask.new(spec) do |p|
+Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
   p.need_tar = true
   p.need_zip = true

--- a/actionmailer/lib/action_mailer/version.rb
+++ b/actionmailer/lib/action_mailer/version.rb
@@ -2,7 +2,7 @@ module ActionMailer
   module VERSION #:nodoc:
     MAJOR = 2
     MINOR = 3
-    TINY  = 11
+    TINY  = 12
 
     STRING = [MAJOR, MINOR, TINY].join('.')
   end

--- a/actionpack/Rakefile
+++ b/actionpack/Rakefile
@@ -1,9 +1,9 @@
 require 'rubygems'
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 require 'rake/packagetask'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 require File.join(File.dirname(__FILE__), 'lib', 'action_pack', 'version')
 
 PKG_BUILD     = ENV['PKG_BUILD'] ? '.' + ENV['PKG_BUILD'] : ''
@@ -45,7 +45,7 @@ end
 
 # Genereate the RDoc documentation
 
-Rake::RDocTask.new { |rdoc|
+RDoc::Task.new { |rdoc|
   rdoc.rdoc_dir = 'doc'
   rdoc.title    = "Action Pack -- On rails from request to response"
   rdoc.options << '--line-numbers' << '--inline-source'
@@ -76,14 +76,12 @@ spec = Gem::Specification.new do |s|
   s.rubyforge_project = "actionpack"
   s.homepage = "http://www.rubyonrails.org"
 
-  s.has_rdoc = true
   s.requirements << 'none'
 
-  s.add_dependency('activesupport', '= 2.3.11' + PKG_BUILD)
+  s.add_dependency('activesupport', '= 2.3.12' + PKG_BUILD)
   s.add_dependency('rack', '~> 1.1.0')
 
   s.require_path = 'lib'
-  s.autorequire = 'action_controller'
 
   s.files = [ "Rakefile", "install.rb", "README", "RUNNING_UNIT_TESTS", "CHANGELOG", "MIT-LICENSE" ]
   dist_dirs.each do |dir|
@@ -91,7 +89,7 @@ spec = Gem::Specification.new do |s|
   end
 end
   
-Rake::GemPackageTask.new(spec) do |p|
+Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
   p.need_tar = true
   p.need_zip = true

--- a/actionpack/lib/action_pack/version.rb
+++ b/actionpack/lib/action_pack/version.rb
@@ -2,7 +2,7 @@ module ActionPack #:nodoc:
   module VERSION #:nodoc:
     MAJOR = 2
     MINOR = 3
-    TINY  = 11
+    TINY  = 12
 
     STRING = [MAJOR, MINOR, TINY].join('.')
   end

--- a/activemodel/Rakefile
+++ b/activemodel/Rakefile
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 task :default => :test
 
@@ -13,7 +13,7 @@ Rake::TestTask.new do |t|
 end
 
 # Generate the RDoc documentation
-Rake::RDocTask.new do |rdoc|
+RDoc::Task.new do |rdoc|
   rdoc.rdoc_dir = 'doc'
   rdoc.title    = "Active Model"
   rdoc.options << '--line-numbers' << '--inline-source' << '-A cattr_accessor=object'

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -1,9 +1,9 @@
 require 'rubygems'
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 require 'rake/packagetask'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 
 require File.join(File.dirname(__FILE__), 'lib', 'active_record', 'version')
 require File.expand_path(File.dirname(__FILE__)) + "/test/config"
@@ -157,7 +157,7 @@ task :rebuild_frontbase_databases => 'frontbase:rebuild_databases'
 
 # Generate the RDoc documentation
 
-Rake::RDocTask.new { |rdoc|
+RDoc::Task.new { |rdoc|
   rdoc.rdoc_dir = 'doc'
   rdoc.title    = "Active Record -- Object-relation mapping put on rails"
   rdoc.options << '--line-numbers' << '--inline-source' << '-A cattr_accessor=object'
@@ -192,16 +192,14 @@ spec = Gem::Specification.new do |s|
     s.files = s.files + Dir.glob( "#{dir}/**/*" ).delete_if { |item| item.include?( "\.svn" ) }
   end
 
-  s.add_dependency('activesupport', '= 2.3.11' + PKG_BUILD)
+  s.add_dependency('activesupport', '= 2.3.12' + PKG_BUILD)
 
   s.files.delete FIXTURES_ROOT + "/fixture_database.sqlite"
   s.files.delete FIXTURES_ROOT + "/fixture_database_2.sqlite"
   s.files.delete FIXTURES_ROOT + "/fixture_database.sqlite3"
   s.files.delete FIXTURES_ROOT + "/fixture_database_2.sqlite3"
   s.require_path = 'lib'
-  s.autorequire = 'active_record'
 
-  s.has_rdoc = true
   s.extra_rdoc_files = %w( README )
   s.rdoc_options.concat ['--main',  'README']
 
@@ -211,7 +209,7 @@ spec = Gem::Specification.new do |s|
   s.rubyforge_project = "activerecord"
 end
 
-Rake::GemPackageTask.new(spec) do |p|
+Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
   p.need_tar = true
   p.need_zip = true

--- a/activerecord/lib/active_record/version.rb
+++ b/activerecord/lib/active_record/version.rb
@@ -2,7 +2,7 @@ module ActiveRecord
   module VERSION #:nodoc:
     MAJOR = 2
     MINOR = 3
-    TINY  = 11
+    TINY  = 12
 
     STRING = [MAJOR, MINOR, TINY].join('.')
   end

--- a/activeresource/Rakefile
+++ b/activeresource/Rakefile
@@ -1,9 +1,9 @@
 require 'rubygems'
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 require 'rake/packagetask'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 
 require File.join(File.dirname(__FILE__), 'lib', 'active_resource', 'version')
 
@@ -38,7 +38,7 @@ Rake::TestTask.new { |t|
 
 # Generate the RDoc documentation
 
-Rake::RDocTask.new { |rdoc|
+RDoc::Task.new { |rdoc|
   rdoc.rdoc_dir = 'doc'
   rdoc.title    = "Active Resource -- Object-oriented REST services"
   rdoc.options << '--line-numbers' << '--inline-source' << '-A cattr_accessor=object'
@@ -66,12 +66,10 @@ spec = Gem::Specification.new do |s|
     s.files = s.files + Dir.glob( "#{dir}/**/*" ).delete_if { |item| item.include?( "\.svn" ) }
   end
   
-  s.add_dependency('activesupport', '= 2.3.11' + PKG_BUILD)
+  s.add_dependency('activesupport', '= 2.3.12' + PKG_BUILD)
 
   s.require_path = 'lib'
-  s.autorequire = 'active_resource'
 
-  s.has_rdoc = true
   s.extra_rdoc_files = %w( README )
   s.rdoc_options.concat ['--main',  'README']
   
@@ -81,7 +79,7 @@ spec = Gem::Specification.new do |s|
   s.rubyforge_project = "activeresource"
 end
   
-Rake::GemPackageTask.new(spec) do |p|
+Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
   p.need_tar = true
   p.need_zip = true

--- a/activeresource/lib/active_resource/version.rb
+++ b/activeresource/lib/active_resource/version.rb
@@ -2,7 +2,7 @@ module ActiveResource
   module VERSION #:nodoc:
     MAJOR = 2
     MINOR = 3
-    TINY  = 11
+    TINY  = 12
 
     STRING = [MAJOR, MINOR, TINY].join('.')
   end

--- a/activesupport/Rakefile
+++ b/activesupport/Rakefile
@@ -1,6 +1,6 @@
 require 'rake/testtask'
-require 'rake/rdoctask'
-require 'rake/gempackagetask'
+require 'rdoc/task'
+require 'rubygems/package_task'
 
 require File.join(File.dirname(__FILE__), 'lib', 'active_support', 'version')
 
@@ -27,7 +27,7 @@ dist_dirs = [ "lib", "test"]
 
 # Genereate the RDoc documentation
 
-Rake::RDocTask.new { |rdoc|
+RDoc::Task.new { |rdoc|
   rdoc.rdoc_dir = 'doc'
   rdoc.title    = "Active Support -- Utility classes and standard library extensions from Rails"
   rdoc.options << '--line-numbers' << '--inline-source'
@@ -48,7 +48,6 @@ spec = Gem::Specification.new do |s|
 
   s.files = [ "CHANGELOG", "README" ] + Dir.glob( "lib/**/*" ).delete_if { |item| item.include?( "\.svn" ) }
   s.require_path = 'lib'
-  s.has_rdoc = true
 
   s.author = "David Heinemeier Hansson"
   s.email = "david@loudthinking.com"
@@ -56,7 +55,7 @@ spec = Gem::Specification.new do |s|
   s.rubyforge_project = "activesupport"
 end
 
-Rake::GemPackageTask.new(spec) do |p|
+Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
   p.need_tar = true
   p.need_zip = true

--- a/activesupport/lib/active_support/version.rb
+++ b/activesupport/lib/active_support/version.rb
@@ -2,7 +2,7 @@ module ActiveSupport
   module VERSION #:nodoc:
     MAJOR = 2
     MINOR = 3
-    TINY  = 11
+    TINY  = 12
 
     STRING = [MAJOR, MINOR, TINY].join('.')
   end

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -1,7 +1,7 @@
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
-require 'rake/gempackagetask'
+require 'rdoc/task'
+require 'rubygems/package_task'
 
 require 'date'
 require 'rbconfig'
@@ -267,7 +267,7 @@ task :generate_app_doc do
   system %{cd #{PKG_DESTINATION}; rake doc:app}
 end
 
-Rake::RDocTask.new { |rdoc|
+RDoc::Task.new { |rdoc|
   rdoc.rdoc_dir = 'doc'
   rdoc.title    = "Railties -- Gluing the Engine to the Rails"
   rdoc.options << '--line-numbers' << '--inline-source' << '--accessor' << 'cattr_accessor=object'
@@ -313,20 +313,18 @@ spec = Gem::Specification.new do |s|
   EOF
 
   s.add_dependency('rake', '>= 0.8.3')
-  s.add_dependency('activesupport',    '= 2.3.11' + PKG_BUILD)
-  s.add_dependency('activerecord',     '= 2.3.11' + PKG_BUILD)
-  s.add_dependency('actionpack',       '= 2.3.11' + PKG_BUILD)
-  s.add_dependency('actionmailer',     '= 2.3.11' + PKG_BUILD)
-  s.add_dependency('activeresource',   '= 2.3.11' + PKG_BUILD)
+  s.add_dependency('activesupport',    '= 2.3.12' + PKG_BUILD)
+  s.add_dependency('activerecord',     '= 2.3.12' + PKG_BUILD)
+  s.add_dependency('actionpack',       '= 2.3.12' + PKG_BUILD)
+  s.add_dependency('actionmailer',     '= 2.3.12' + PKG_BUILD)
+  s.add_dependency('activeresource',   '= 2.3.12' + PKG_BUILD)
 
   s.rdoc_options << '--exclude' << '.'
-  s.has_rdoc = false
 
   s.files = PKG_FILES
   s.require_path = 'lib'
   s.bindir = "bin"                               # Use these for applications.
   s.executables = ["rails"]
-  s.default_executable = "rails"
 
   s.author = "David Heinemeier Hansson"
   s.email = "david@loudthinking.com"
@@ -334,7 +332,7 @@ spec = Gem::Specification.new do |s|
   s.rubyforge_project = "rails"
 end
 
-Rake::GemPackageTask.new(spec) do |pkg|
+Gem::PackageTask.new(spec) do |pkg|
   pkg.gem_spec = spec
 end
 

--- a/railties/lib/rails/gem_dependency.rb
+++ b/railties/lib/rails/gem_dependency.rb
@@ -274,7 +274,8 @@ module Rails
     end
 
     def ==(other)
-      self.name == other.name && self.requirement == other.requirement
+      Gem::Dependency === other.class &&
+        self.name == other.name && self.requirement == other.requirement
     end
     alias_method :eql?, :"=="
 

--- a/railties/lib/rails/gem_dependency.rb
+++ b/railties/lib/rails/gem_dependency.rb
@@ -72,7 +72,13 @@ module Rails
         @load_paths_added = @loaded = @frozen = true
         return
       end
-      gem self
+
+      begin
+        self.to_spec.activate           # >= 1.8 happy way
+      rescue
+        gem self.name, self.requirement # <  1.8 unhappy way
+      end
+
       @spec = Gem.loaded_specs[name]
       @frozen = @spec.loaded_from.include?(self.class.unpacked_path) if @spec
       @load_paths_added = true

--- a/railties/lib/rails/gem_dependency.rb
+++ b/railties/lib/rails/gem_dependency.rb
@@ -117,18 +117,6 @@ module Rails
       @spec = s
     end
 
-    if method_defined?(:requirement)
-      def requirement
-        req = super
-        req unless req == Gem::Requirement.default
-      end
-    else
-      def requirement
-        req = version_requirements
-        req unless req == Gem::Requirement.default
-      end
-    end
-
     def built?
       return false unless frozen?
 

--- a/railties/lib/rails/gem_dependency.rb
+++ b/railties/lib/rails/gem_dependency.rb
@@ -38,7 +38,7 @@ module Rails
       result = self.new(name, :version => version)
       spec_filename = File.join(directory_name, '.specification')
       if load_spec
-        raise "Missing specification file in #{File.dirname(spec_filename)}. Perhaps you need to do a 'rake gems:refresh_specs'?" unless File.exists?(spec_filename)
+        raise "Missing specification file in #{File.dirname(spec_filename)}. Perhaps you need to do a 'rake gems:refresh_specs'\?" unless File.exists?(spec_filename)
         spec = YAML::load_file(spec_filename)
         result.specification = spec
       end
@@ -276,7 +276,7 @@ module Rails
     def ==(other)
       self.name == other.name && self.requirement == other.requirement
     end
-    alias_method :"eql?", :"=="
+    alias_method :eql?, :"=="
 
     private
 

--- a/railties/lib/rails/vendor_gem_source_index.rb
+++ b/railties/lib/rails/vendor_gem_source_index.rb
@@ -31,7 +31,7 @@ module Rails
 
     def refresh!
       # reload the installed gems
-      @installed_source_index.refresh!
+      # HACK: I don't think this is needed: @installed_source_index.refresh!
       vendor_gems = {}
 
       # handle vendor Rails gems - they are identified by having loaded_from set to ""

--- a/railties/lib/rails/version.rb
+++ b/railties/lib/rails/version.rb
@@ -2,7 +2,7 @@ module Rails
   module VERSION #:nodoc:
     MAJOR = 2
     MINOR = 3
-    TINY  = 11
+    TINY  = 12
 
     STRING = [MAJOR, MINOR, TINY].join('.')
   end

--- a/railties/lib/rails_generator/generators/components/plugin/templates/Rakefile
+++ b/railties/lib/rails_generator/generators/components/plugin/templates/Rakefile
@@ -1,6 +1,6 @@
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 desc 'Default: run unit tests.'
 task :default => :test
@@ -14,7 +14,7 @@ Rake::TestTask.new(:test) do |t|
 end
 
 desc 'Generate documentation for the <%= file_name %> plugin.'
-Rake::RDocTask.new(:rdoc) do |rdoc|
+RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
   rdoc.title    = '<%= class_name %>'
   rdoc.options << '--line-numbers' << '--inline-source'

--- a/railties/lib/tasks/documentation.rake
+++ b/railties/lib/tasks/documentation.rake
@@ -1,6 +1,6 @@
 namespace :doc do
   desc "Generate documentation for the application. Set custom template with TEMPLATE=/path/to/rdoc/template.rb or title with TITLE=\"Custom Title\""
-  Rake::RDocTask.new("app") { |rdoc|
+  RDoc::Task.new("app") { |rdoc|
     rdoc.rdoc_dir = 'doc/app'
     rdoc.template = ENV['template'] if ENV['template']
     rdoc.title    = ENV['title'] || "Rails Application Documentation"
@@ -12,7 +12,7 @@ namespace :doc do
   }
 
   desc "Generate documentation for the Rails framework"
-  Rake::RDocTask.new("rails") { |rdoc|
+  RDoc::Task.new("rails") { |rdoc|
     rdoc.rdoc_dir = 'doc/api'
     rdoc.template = "#{ENV['template']}.rb" if ENV['template']
     rdoc.title    = "Rails Framework Documentation"


### PR DESCRIPTION
There were a lot of simple errors with railties' gem code causing exceptions to be raised when starting a rails 2.3 app with rubygems 1.8.x installed. This fixes those errors. This should also address nearly all deprecations.

I still need to work the use of SourceIndex out of it, but that can come later.
