### PR TITLE
Update rack mount

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency('i18n',             '~> 0.6.0beta1')
   s.add_dependency('rack',             '~> 1.3.0.beta')
   s.add_dependency('rack-test',        '~> 0.6.0')
-  s.add_dependency('rack-mount',       '~> 0.7.2')
+  s.add_dependency('rack-mount',       '~> 0.7.3')
   s.add_dependency('sprockets',        '~> 2.0.0.beta.2')
   s.add_dependency('tzinfo',           '~> 0.3.27')
   s.add_dependency('erubis',           '~> 2.7.0')

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -93,6 +93,34 @@ module RailtiesTest
       assert_equal "HELLO WORLD", last_response.body
     end
 
+    test "pass the value of the segment" do
+      controller "foo", <<-RUBY
+        class FooController < ActionController::Base
+          def index
+            render :text => params[:username]
+          end
+        end
+      RUBY
+
+      @plugin.write "config/routes.rb", <<-RUBY
+        Bukkits::Engine.routes.draw do
+          root :to => "foo#index"
+        end
+      RUBY
+
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          mount(Bukkits::Engine => "/:username")
+        end
+      RUBY
+
+      boot_rails
+
+      get("/arunagw")
+      assert_equal "arunagw", last_response.body
+
+    end
+
     test "it provides routes as default endpoint" do
       @plugin.write "lib/bukkits.rb", <<-RUBY
         class Bukkits


### PR DESCRIPTION
Commit 1 : rack-mount gem updated to 0.7.3 (contains fix for (route segment values) #529

Commit2 : Added tests for #529 (Not sure if we needed here. If not please discard this.)
