### PR TITLE
Update Mailer generator to use 1.9 styled hash when run on Ruby 1.9

### DIFF
--- a/actionmailer/lib/rails/generators/mailer/templates/mailer.rb
+++ b/actionmailer/lib/rails/generators/mailer/templates/mailer.rb
@@ -1,6 +1,6 @@
 <% module_namespacing do -%>
 class <%= class_name %> < ActionMailer::Base
-  default :from => "from@example.com"
+  default <%= key_value :from, '"from@example.com"' %>
 <% for action in actions -%>
 
   # Subject can be set in your I18n file at config/locales/en.yml
@@ -11,7 +11,7 @@ class <%= class_name %> < ActionMailer::Base
   def <%= action %>
     @greeting = "Hi"
 
-    mail :to => "to@example.org"
+    mail <%= key_value :to, '"to@example.org"' %>
   end
 <% end -%>
 end

--- a/railties/CHANGELOG
+++ b/railties/CHANGELOG
@@ -30,7 +30,7 @@ by the prototype-rails gem. [fxn]
 
 * jQuery is the new default JavaScript library. [fxn]
 
-* Changed scaffold and app generator to create Ruby 1.9 style hash when running on Ruby 1.9 [Prem Sichanugrist]
+* Changed scaffold, application, and mailer generator to create Ruby 1.9 style hash when running on Ruby 1.9 [Prem Sichanugrist]
 
   So instead of creating something like:
 


### PR DESCRIPTION
This is per @dhh request as to complete the 1.9 generator series
