### PR TITLE
I added ".DS_Store" to gitignore files

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/gitignore
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore
@@ -3,3 +3,4 @@ db/*.sqlite3
 log/*.log
 tmp/
 .sass-cache/
+.DS_Store

--- a/railties/lib/rails/generators/rails/plugin_new/templates/gitignore
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/gitignore
@@ -4,3 +4,4 @@ pkg/
 test/dummy/db/*.sqlite3
 test/dummy/log/*.log
 test/dummy/tmp/
+.DS_Store


### PR DESCRIPTION
A lot of Rails devs use Macs and end up with .DS_Store files in their Rails apps. Everyone **should** put ".DS_Store" in their global .gitignore, but most don't. This will keep .DS_Store files out of repos.
