### PR TITLE
changed AR::Base#attributes to return a hash with indifferent access for the sake of API consistency

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1713,7 +1713,7 @@ MSG
 
       # Returns a hash of all the attributes with their names as keys and the values of the attributes as values.
       def attributes
-        Hash[@attributes.map { |name, _| [name, read_attribute(name)] }]
+        Hash[@attributes.map { |name, _| [name, read_attribute(name)] }].with_indifferent_access
       end
 
       # Returns an <tt>#inspect</tt>-like string for the value of the

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -26,6 +26,12 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     ActiveRecord::Base.send(:attribute_method_matchers).concat(@old_matchers)
   end
 
+  def test_attributes_hash
+    attributes = Category.new({:name => "Test categoty"}).attributes
+    assert_equal "Test categoty", attributes['name']
+    assert_equal "Test categoty", attributes[:name]
+  end
+
   def test_attribute_present
     t = Topic.new
     t.title = "hello there!"

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -124,9 +124,9 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   end
 
   def test_read_attributes_before_type_cast
-    category = Category.new({:name=>"Test categoty", :type => nil})
-    category_attrs = {"name"=>"Test categoty", "id" => nil, "type" => nil, "categorizations_count" => nil}
-    assert_equal category_attrs , category.attributes_before_type_cast
+    category = Category.new({:name => "Test categoty", :type => nil})
+    category_attrs = {"name" => "Test categoty", "id" => nil, "type" => nil, "categorizations_count" => nil}
+    assert_equal category_attrs, category.attributes_before_type_cast
   end
 
   if current_adapter?(:MysqlAdapter)
@@ -214,7 +214,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     topic = Topic.new(new_topic)
     assert_equal new_topic[:title], topic.title
 
-    topic.attributes= new_topic_values
+    topic.attributes = new_topic_values
     assert_equal new_topic_values[:title], topic.title
   end
 


### PR DESCRIPTION
returning hwia is more consistent with other APIs, for example:
- attributes= and update_attributes= accept both symbolized and stringified hash
- [] accessor method accepts both Symbol and String for the attribute name
