### PR TITLE
ActiveRecord::LogSubscriber.runtime should be reset at the start of each request

### DIFF
--- a/actionpack/test/activerecord/controller_runtime_test.rb
+++ b/actionpack/test/activerecord/controller_runtime_test.rb
@@ -11,6 +11,10 @@ class ControllerRuntimeLogSubscriberTest < ActionController::TestCase
     def show
       render :inline => "<%= Project.all %>"
     end
+
+    def zero
+      render :inline => "Zero DB runtime"
+    end
   end
 
   include ActiveSupport::LogSubscriber::TestHelper
@@ -38,5 +42,14 @@ class ControllerRuntimeLogSubscriberTest < ActionController::TestCase
 
     assert_equal 2, @logger.logged(:info).size
     assert_match(/\(Views: [\d.]+ms \| ActiveRecord: [\d.]+ms\)/, @logger.logged(:info)[1])
+  end
+
+  def test_runtime_reset_before_requests
+    ActiveRecord::LogSubscriber.runtime += 12345
+    get :zero
+    wait
+
+    assert_equal 2, @logger.logged(:info).size
+    assert_match(/\(Views: [\d.]+ms \| ActiveRecord: 0.0ms\)/, @logger.logged(:info)[1])
   end
 end

--- a/actionpack/test/activerecord/controller_runtime_test.rb
+++ b/actionpack/test/activerecord/controller_runtime_test.rb
@@ -37,6 +37,6 @@ class ControllerRuntimeLogSubscriberTest < ActionController::TestCase
     wait
 
     assert_equal 2, @logger.logged(:info).size
-    assert_match(/\(Views: [\d.]+ms | ActiveRecord: [\d.]+ms\)/, @logger.logged(:info)[1])
+    assert_match(/\(Views: [\d.]+ms \| ActiveRecord: [\d.]+ms\)/, @logger.logged(:info)[1])
   end
 end

--- a/activerecord/lib/active_record/railties/controller_runtime.rb
+++ b/activerecord/lib/active_record/railties/controller_runtime.rb
@@ -9,6 +9,11 @@ module ActiveRecord
 
       attr_internal :db_runtime
 
+      def process_action(action, *args)
+        ActiveRecord::LogSubscriber.reset_runtime
+        super
+      end
+
       def cleanup_view_runtime
         if ActiveRecord::Base.connected?
           db_rt_before_render = ActiveRecord::LogSubscriber.reset_runtime


### PR DESCRIPTION
Currently, the runtime isn't reset following a redirect or a send_file, so any time taken to process those actions is added to the time for the subsequent request.
