### PR TITLE
Only use LOWER for mysql uniqueness check when column is case sensitive

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -238,6 +238,10 @@ module ActiveRecord
         node
       end
 
+      def case_insensitive_comparison(table, attribute, column, value)
+        table[attribute].lower.eq(table.lower(value))
+      end
+
       def current_savepoint_name
         "active_record_#{open_transactions}"
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -4,6 +4,14 @@ module ActiveRecord
   module ConnectionAdapters
     class AbstractMysqlAdapter < AbstractAdapter
       class Column < ConnectionAdapters::Column # :nodoc:
+
+        attr_reader :collation
+
+        def initialize(name, default, sql_type = nil, null = true, collation = nil)
+          super(name, default, sql_type, null)
+          @collation = collation
+        end
+
         def extract_default(default)
           if sql_type =~ /blob/i || type == :text
             if default.blank?
@@ -26,6 +34,10 @@ module ActiveRecord
         # Must return the relevant concrete adapter
         def adapter
           raise NotImplementedError
+        end
+
+        def case_sensitive?
+          collation && !collation.match(/_ci$/)
         end
 
         private
@@ -157,8 +169,8 @@ module ActiveRecord
       end
 
       # Overridden by the adapters to instantiate their specific Column type.
-      def new_column(field, default, type, null) # :nodoc:
-        Column.new(field, default, type, null)
+      def new_column(field, default, type, null, collation) # :nodoc:
+        Column.new(field, default, type, null, collation)
       end
 
       # Must return the Mysql error number from the exception, if the exception has an
@@ -393,10 +405,10 @@ module ActiveRecord
 
       # Returns an array of +Column+ objects for the table specified by +table_name+.
       def columns(table_name, name = nil)#:nodoc:
-        sql = "SHOW FIELDS FROM #{quote_table_name(table_name)}"
+        sql = "SHOW FULL FIELDS FROM #{quote_table_name(table_name)}"
         execute_and_free(sql, 'SCHEMA') do |result|
           each_hash(result).map do |field|
-            new_column(field[:Field], field[:Default], field[:Type], field[:Null] == "YES")
+            new_column(field[:Field], field[:Default], field[:Type], field[:Null] == "YES", field[:Collation])
           end
         end
       end
@@ -499,6 +511,14 @@ module ActiveRecord
 
       def case_sensitive_modifier(node)
         Arel::Nodes::Bin.new(node)
+      end
+
+      def case_insensitive_comparison(table, attribute, column, value)
+        if column.case_sensitive?
+          super
+        else
+          table[attribute].eq(value)
+        end
       end
 
       def limited_update_conditions(where_sql, quoted_table_name, quoted_primary_key)

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -47,8 +47,8 @@ module ActiveRecord
         end
       end
 
-      def new_column(field, default, type, null) # :nodoc:
-        Column.new(field, default, type, null)
+      def new_column(field, default, type, null, collation) # :nodoc:
+        Column.new(field, default, type, null, collation)
       end
 
       def error_number(exception)

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -150,8 +150,8 @@ module ActiveRecord
         end
       end
 
-      def new_column(field, default, type, null) # :nodoc:
-        Column.new(field, default, type, null)
+      def new_column(field, default, type, null, collation) # :nodoc:
+        Column.new(field, default, type, null, collation)
       end
 
       def error_number(exception) # :nodoc:

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -57,8 +57,8 @@ module ActiveRecord
         value = column.limit ? value.to_s.mb_chars[0, column.limit] : value.to_s if column.text?
 
         if !options[:case_sensitive] && value && column.text?
-          # will use SQL LOWER function before comparison
-          relation = table[attribute].lower.eq(table.lower(value))
+          # will use SQL LOWER function before comparison, unless it detects a case insensitive collation
+          relation = klass.connection.case_insensitive_comparison(table, attribute, column, value)
         else
           value    = klass.connection.case_sensitive_modifier(value)
           relation = table[attribute].eq(value)

--- a/activerecord/test/cases/adapters/mysql/case_sensitivity_test.rb
+++ b/activerecord/test/cases/adapters/mysql/case_sensitivity_test.rb
@@ -1,0 +1,38 @@
+require "cases/helper"
+require 'models/person'
+
+class MysqlCaseSensitivityTest < ActiveRecord::TestCase
+
+  class CollationTest < ActiveRecord::Base
+    validates_uniqueness_of :string_cs_column, :case_sensitive => false
+    validates_uniqueness_of :string_ci_column, :case_sensitive => false
+  end
+
+  def test_columns_include_collation_different_from_table
+    assert_equal 'utf8_bin', CollationTest.columns_hash['string_cs_column'].collation
+    assert_equal 'utf8_general_ci', CollationTest.columns_hash['string_ci_column'].collation
+  end
+
+  def test_case_sensitive
+    assert !CollationTest.columns_hash['string_ci_column'].case_sensitive?
+    assert CollationTest.columns_hash['string_cs_column'].case_sensitive?
+  end
+
+  def test_case_insensitive_comparison_for_ci_column
+    CollationTest.create!(:string_ci_column => 'A')
+    invalid = CollationTest.new(:string_ci_column => 'a')
+    queries = assert_sql { invalid.save }
+    ci_uniqueness_query = queries.detect { |q| q.match /string_ci_column/ }
+    assert_no_match(/lower/i, ci_uniqueness_query)
+  end
+
+  def test_case_insensitive_comparison_for_cs_column
+    CollationTest.create!(:string_cs_column => 'A')
+    invalid = CollationTest.new(:string_cs_column => 'a')
+    queries = assert_sql { invalid.save }
+    cs_uniqueness_query = queries.detect { |q| q.match /string_cs_column/ }
+    assert_match(/lower/i, cs_uniqueness_query)
+  end
+
+
+end

--- a/activerecord/test/cases/adapters/mysql2/case_sensitivity_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/case_sensitivity_test.rb
@@ -1,0 +1,38 @@
+require "cases/helper"
+require 'models/person'
+
+class Mysql2CaseSensitivityTest < ActiveRecord::TestCase
+
+  class CollationTest < ActiveRecord::Base
+    validates_uniqueness_of :string_cs_column, :case_sensitive => false
+    validates_uniqueness_of :string_ci_column, :case_sensitive => false
+  end
+
+  def test_columns_include_collation_different_from_table
+    assert_equal 'utf8_bin', CollationTest.columns_hash['string_cs_column'].collation
+    assert_equal 'utf8_general_ci', CollationTest.columns_hash['string_ci_column'].collation
+  end
+
+  def test_case_sensitive
+    assert !CollationTest.columns_hash['string_ci_column'].case_sensitive?
+    assert CollationTest.columns_hash['string_cs_column'].case_sensitive?
+  end
+
+  def test_case_insensitive_comparison_for_ci_column
+    CollationTest.create!(:string_ci_column => 'A')
+    invalid = CollationTest.new(:string_ci_column => 'a')
+    queries = assert_sql { invalid.save }
+    ci_uniqueness_query = queries.detect { |q| q.match /string_ci_column/ }
+    assert_no_match(/lower/i, ci_uniqueness_query)
+  end
+
+  def test_case_insensitive_comparison_for_cs_column
+    CollationTest.create!(:string_cs_column => 'A')
+    invalid = CollationTest.new(:string_cs_column => 'a')
+    queries = assert_sql { invalid.save }
+    cs_uniqueness_query = queries.detect { |q| q.match /string_cs_column/ }
+    assert_match(/lower/i, cs_uniqueness_query)
+  end
+
+
+end

--- a/activerecord/test/schema/mysql2_specific_schema.rb
+++ b/activerecord/test/schema/mysql2_specific_schema.rb
@@ -21,4 +21,15 @@ BEGIN
 END
 SQL
 
+  ActiveRecord::Base.connection.execute <<-SQL
+DROP TABLE IF EXISTS collation_tests;
+SQL
+
+  ActiveRecord::Base.connection.execute <<-SQL
+CREATE TABLE collation_tests (
+  string_cs_column VARCHAR(1) COLLATE utf8_bin,
+  string_ci_column VARCHAR(1) COLLATE utf8_general_ci
+) CHARACTER SET utf8 COLLATE utf8_general_ci
+SQL
+
 end

--- a/activerecord/test/schema/mysql_specific_schema.rb
+++ b/activerecord/test/schema/mysql_specific_schema.rb
@@ -32,4 +32,15 @@ BEGIN
 END
 SQL
 
+  ActiveRecord::Base.connection.execute <<-SQL
+DROP TABLE IF EXISTS collation_tests;
+SQL
+
+  ActiveRecord::Base.connection.execute <<-SQL
+CREATE TABLE collation_tests (
+  string_cs_column VARCHAR(1) COLLATE utf8_bin,
+  string_ci_column VARCHAR(1) COLLATE utf8_general_ci
+) CHARACTER SET utf8 COLLATE utf8_general_ci
+SQL
+
 end


### PR DESCRIPTION
This addresses this two year old ticket:
https://rails.lighthouseapp.com/projects/8994/tickets/2503

I have one comment in the code looking for suggestions on how to reduce the number of arguments to the new method:
https://github.com/jpalermo/rails/commit/47e6809a4d437a8913bb167db476206a5f8e69d9#commitcomment-383890
