### PR TITLE
Do not try to call `column_names` on the abstract class.

### DIFF
--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -163,7 +163,7 @@ module ActionController
 
         unless options[:only] || options[:except]
           model ||= _default_wrap_model
-          if model.respond_to?(:column_names)
+          if !(model.respond_to?(:abstract_class?) && model.abstract_class?) && model.respond_to?(:column_names)
             options[:only] = model.column_names
           end
         end

--- a/actionpack/test/controller/params_wrapper_test.rb
+++ b/actionpack/test/controller/params_wrapper_test.rb
@@ -133,6 +133,7 @@ class ParamsWrapperTest < ActionController::TestCase
   end
 
   def test_derived_wrapped_keys_from_matching_model
+    User.expects(:respond_to?).with(:abstract_class?).returns(false)
     User.expects(:respond_to?).with(:column_names).returns(true)
     User.expects(:column_names).returns(["username"])
 
@@ -145,6 +146,7 @@ class ParamsWrapperTest < ActionController::TestCase
 
   def test_derived_wrapped_keys_from_specified_model
     with_default_wrapper_options do
+      Person.expects(:respond_to?).with(:abstract_class?).returns(false)
       Person.expects(:respond_to?).with(:column_names).returns(true)
       Person.expects(:column_names).returns(["username"])
 
@@ -153,6 +155,17 @@ class ParamsWrapperTest < ActionController::TestCase
       @request.env['CONTENT_TYPE'] = 'application/json'
       post :parse, { 'username' => 'sikachu', 'title' => 'Developer' }
       assert_parameters({ 'username' => 'sikachu', 'title' => 'Developer', 'person' => { 'username' => 'sikachu' }})
+    end
+  end
+
+  def test_not_wrapping_abstract_model
+    User.expects(:respond_to?).with(:abstract_class?).returns(true)
+    User.expects(:abstract_class?).returns(true)
+
+    with_default_wrapper_options do
+      @request.env['CONTENT_TYPE'] = 'application/json'
+      post :parse, { 'username' => 'sikachu', 'title' => 'Developer' }
+      assert_parameters({ 'username' => 'sikachu', 'title' => 'Developer', 'user' => { 'username' => 'sikachu', 'title' => 'Developer' }})
     end
   end
 


### PR DESCRIPTION
Normally the table for abstract class won't be existed, so we should not trying to call `#column_names` on it.
