### PR TITLE
Fields for fixes for non nested attributes and without object

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -584,8 +584,8 @@ module ActionView
       #     <% end %>
       #     ...
       #   <% end %>
-      def fields_for(record, record_object = nil, options = {}, &block)
-        builder = instantiate_builder(record, record_object, options, &block)
+      def fields_for(record_name, record_object = nil, options = {}, &block)
+        builder = instantiate_builder(record_name, record_object, options, &block)
         output = capture(builder, &block)
         output.concat builder.hidden_field(:id) if output && options[:hidden_field_id] && !builder.emitted_hidden_id?
         output
@@ -898,13 +898,13 @@ module ActionView
 
       private
 
-        def instantiate_builder(record, record_object, options, &block)
-          case record
+        def instantiate_builder(record_name, record_object, options, &block)
+          case record_name
           when String, Symbol
             object = record_object
-            object_name = record
+            object_name = record_name
           else
-            object = record
+            object = record_name
             object_name = ActiveModel::Naming.param_key(object)
           end
 

--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -243,7 +243,7 @@ module ActionView
       #
       # === Setting the method
       #
-      # You can force the form to use the full array of HTTP verbs by setting 
+      # You can force the form to use the full array of HTTP verbs by setting
       #
       #    :method => (:get|:post|:put|:delete)
       #
@@ -898,10 +898,7 @@ module ActionView
 
       private
 
-        def instantiate_builder(record, *args, &block)
-          options = args.extract_options!
-          record_object = args.shift
-
+        def instantiate_builder(record, record_object, options, &block)
           case record
           when String, Symbol
             object = record_object

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -1725,6 +1725,20 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_form_for_and_fields_for_with_non_nested_association_and_without_object
+    form_for(@post) do |f|
+      concat f.fields_for(:category) { |c|
+        concat c.text_field(:name)
+      }
+    end
+
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', 'put') do
+      "<input name='post[category][name]' type='text' size='30' id='post_category_name' />"
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   class LabelledFormBuilder < ActionView::Helpers::FormBuilder
     (field_helpers - %w(hidden_field)).each do |selector|
       class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1


### PR DESCRIPTION
This makes the `fields_for` and `instantiate_builder` methods more clear and consistent, and fixes an issue with non nested attributes and no object given. We had this issue while working on SimpleForm compatibility for Rails 3.1.
