### PR TITLE
Make ParamsWrapper use a well-defined API and not rely on AR methods

### DIFF
--- a/actionpack/CHANGELOG
+++ b/actionpack/CHANGELOG
@@ -17,7 +17,7 @@
     class PostsController < ActionController::Base
       stream :only => :index
     end
-  
+
   Please read the docs at `ActionController::Streaming` for more information.
 
 * Added `ActionDispatch::Request.ignore_accept_header` to ignore accept headers and only consider the format given as parameter [José Valim]

--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -145,7 +145,7 @@ module ActionController
         begin
           model_klass = model_name.constantize
         rescue NameError, ArgumentError => e
-          if e.message =~ /is not missing constant|uninitialized constant #{model_name}/ 
+          if e.message =~ /is not missing constant|uninitialized constant #{model_name}/
             namespaces = model_name.split("::")
             namespaces.delete_at(-2)
             break if namespaces.last == model_name
@@ -163,8 +163,8 @@ module ActionController
 
         unless options[:only] || options[:except]
           model ||= _default_wrap_model
-          if !(model.respond_to?(:abstract_class?) && model.abstract_class?) && model.respond_to?(:column_names)
-            options[:only] = model.column_names
+          if model.respond_to?(:attribute_names) && model.attribute_names.present?
+            options[:only] = model.attribute_names
           end
         end
 

--- a/actionpack/test/controller/params_wrapper_test.rb
+++ b/actionpack/test/controller/params_wrapper_test.rb
@@ -133,9 +133,8 @@ class ParamsWrapperTest < ActionController::TestCase
   end
 
   def test_derived_wrapped_keys_from_matching_model
-    User.expects(:respond_to?).with(:abstract_class?).returns(false)
-    User.expects(:respond_to?).with(:column_names).returns(true)
-    User.expects(:column_names).returns(["username"])
+    User.expects(:respond_to?).with(:attribute_names).returns(true)
+    User.expects(:attribute_names).twice.returns(["username"])
 
     with_default_wrapper_options do
       @request.env['CONTENT_TYPE'] = 'application/json'
@@ -146,9 +145,8 @@ class ParamsWrapperTest < ActionController::TestCase
 
   def test_derived_wrapped_keys_from_specified_model
     with_default_wrapper_options do
-      Person.expects(:respond_to?).with(:abstract_class?).returns(false)
-      Person.expects(:respond_to?).with(:column_names).returns(true)
-      Person.expects(:column_names).returns(["username"])
+      Person.expects(:respond_to?).with(:attribute_names).returns(true)
+      Person.expects(:attribute_names).twice.returns(["username"])
 
       UsersController.wrap_parameters Person
 
@@ -159,8 +157,8 @@ class ParamsWrapperTest < ActionController::TestCase
   end
 
   def test_not_wrapping_abstract_model
-    User.expects(:respond_to?).with(:abstract_class?).returns(true)
-    User.expects(:abstract_class?).returns(true)
+    User.expects(:respond_to?).with(:attribute_names).returns(true)
+    User.expects(:attribute_names).returns([])
 
     with_default_wrapper_options do
       @request.env['CONTENT_TYPE'] = 'application/json'
@@ -198,13 +196,13 @@ class NamespacedParamsWrapperTest < ActionController::TestCase
   end
 
   class SampleOne
-    def self.column_names
+    def self.attribute_names
       ["username"]
     end
   end
 
   class SampleTwo
-    def self.column_names
+    def self.attribute_names
       ["title"]
     end
   end

--- a/activerecord/CHANGELOG
+++ b/activerecord/CHANGELOG
@@ -1,5 +1,7 @@
 *Rails 3.1.0 (unreleased)*
 
+* Add ActiveRecord::Base.attribute_names to return a list of attribute names. This will return an empty array if the model is abstract or table does not exists. [Prem Sichanugrist]
+
 * CSV Fixtures are deprecated and support will be removed in Rails 3.2.0
 
 * AR#new, AR#create, AR#create!, AR#update_attributes and AR#update_attributes! all accept a second hash as option that allows you

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -767,6 +767,14 @@ module ActiveRecord #:nodoc:
         super || (table_exists? && column_names.include?(attribute.to_s.sub(/=$/, '')))
       end
 
+      def attribute_names
+        @attribute_names ||= if !abstract_class? && table_exists?
+            column_names
+          else
+            []
+          end
+      end
+
       # Set the lookup ancestors for ActiveModel.
       def lookup_ancestors #:nodoc:
         klass = self

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1790,4 +1790,17 @@ class BasicsTest < ActiveRecord::TestCase
 
     assert_equal expected.attributes, actual.attributes
   end
+
+  def test_attribute_names
+    assert_equal ["id", "type", "ruby_type", "firm_id", "firm_name", "name", "client_of", "rating", "account_id"],
+                 Company.attribute_names
+  end
+
+  def test_attribute_names_on_table_not_exists
+    assert_equal [], NonExistentTable.attribute_names
+  end
+
+  def test_attribtue_names_on_abstract_class
+    assert_equal [], AbstractCompany.attribute_names
+  end
 end


### PR DESCRIPTION
From the concern in #567, I've added a class method name `.attribute_names` to both `ActiveModel` and `ActiveRecord`. This method should return an array of attribute names, usually the column names if it's a database-backed storage. However, it's less fragile and will return empty array if the table is not exists or the model is an abstract model.

I've added appropriate test case for each of it. Please review and merge it if you see appropriate.

Thank you.
