### PR TITLE
cleanups on AMo validator initializers

### DIFF
--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -16,7 +16,7 @@ module ActiveModel
           options[:maximum] -= 1 if range.exclude_end?
         end
 
-        super(options.reverse_merge(:tokenizer => DEFAULT_TOKENIZER))
+        super
       end
 
       def check_validity!
@@ -36,7 +36,7 @@ module ActiveModel
       end
 
       def validate_each(record, attribute, value)
-        value = options[:tokenizer].call(value) if value.kind_of?(String)
+        value = (options[:tokenizer] || DEFAULT_TOKENIZER).call(value) if value.kind_of?(String)
 
         CHECKS.each do |key, validity_check|
           next unless check_value = options[key]

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -9,10 +9,6 @@ module ActiveModel
 
       RESERVED_OPTIONS = CHECKS.keys + [:only_integer]
 
-      def initialize(options)
-        super(options.reverse_merge(:only_integer => false, :allow_nil => false))
-      end
-
       def check_validity!
         keys = CHECKS.keys - [:odd, :even]
         options.slice(*keys).each do |option, value|


### PR DESCRIPTION
I'm working on HTML5 client side validator plugin and found these unneeded options are making my plugin difficult to implement.
I believe these default values should not be merged on initializer so that we can know what kind of options were passed to the validator.

These commits were actually extracted from this patch. https://github.com/rails/rails/issues/702
