### PR TITLE
generate HTML5 number_field tag for integer fields

### DIFF
--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -13,12 +13,13 @@ module Rails
 
       def field_type
         @field_type ||= case type
-          when :integer, :float, :decimal then :text_field
-          when :time                      then :time_select
-          when :datetime, :timestamp      then :datetime_select
-          when :date                      then :date_select
-          when :text                      then :text_area
-          when :boolean                   then :check_box
+          when :integer              then :number_field
+          when :float, :decimal      then :text_field
+          when :time                 then :time_select
+          when :datetime, :timestamp then :datetime_select
+          when :date                 then :date_select
+          when :text                 then :text_area
+          when :boolean              then :check_box
           else
             :text_field
         end

--- a/railties/test/generators/generated_attribute_test.rb
+++ b/railties/test/generators/generated_attribute_test.rb
@@ -4,8 +4,12 @@ require 'rails/generators/generated_attribute'
 class GeneratedAttributeTest < Rails::Generators::TestCase
   include GeneratorsTestHelper
 
+  def test_field_type_returns_number_field
+    assert_field_type :integer, :number_field
+  end
+
   def test_field_type_returns_text_field
-    %w(integer float decimal string).each do |attribute_type|
+    %w(float decimal string).each do |attribute_type|
       assert_field_type attribute_type, :text_field
     end
   end


### PR DESCRIPTION
I suppose this is obviously the case for suggesting people to use the HTML5 tag helper.
