### PR TITLE
Fix for attr_accessor_with_default causing "singleton can't be dumped" exception on marshaling

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/attr_accessor_with_default.rb
+++ b/activesupport/lib/active_support/core_ext/module/attr_accessor_with_default.rb
@@ -19,12 +19,15 @@ class Module
   #   attr_accessor_with_default(:element_name) { name.underscore }
   #
   def attr_accessor_with_default(sym, default = Proc.new)
-    define_method(sym, block_given? ? default : Proc.new { default })
-    module_eval(<<-EVAL, __FILE__, __LINE__ + 1)
-      def #{sym}=(value)                          # def age=(value)
-        class << self; attr_accessor :#{sym} end  #   class << self; attr_accessor :age end
-        @#{sym} = value                           #   @age = value
-      end                                         # end
-    EVAL
+    attr_writer sym
+    
+    block = block_given? ? default : Proc.new { default }
+    define_method(sym) do
+      if instance_variable_defined?("@#{sym.to_s}")
+        instance_variable_get("@#{sym.to_s}")
+      else
+        instance_eval(&block)
+      end
+    end
   end
 end

--- a/activesupport/test/core_ext/module/attr_accessor_with_default_test.rb
+++ b/activesupport/test/core_ext/module/attr_accessor_with_default_test.rb
@@ -8,7 +8,12 @@ class AttrAccessorWithDefaultTest < Test::Unit::TestCase
         'helper'
       end
     end
+    self.class.const_set(:TestClass, @target)
     @instance = @target.new
+  end
+
+  def teardown
+    self.class.send(:remove_const, :TestClass)
   end
 
   def test_default_arg
@@ -27,5 +32,11 @@ class AttrAccessorWithDefaultTest < Test::Unit::TestCase
 
   def test_invalid_args
     assert_raise(ArgumentError) {@target.attr_accessor_with_default :foo}
+  end
+
+  def test_instance_with_value_set_can_be_marshaled
+    @target.attr_accessor_with_default(:foo, 'default')
+    @instance.foo = 'Hi'
+    assert_nothing_raised { Marshal.dump(@instance) }
   end
 end


### PR DESCRIPTION
Please find proposed fix for attr_accessor_with_default. It addresses the problem which can be triggered by memcached client library when it tries to marshal an object with non-default attribute value. #refactotum
