### PR TITLE
3.1: params_wrapper raises error on anynomous controllers

### DIFF
--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -140,6 +140,9 @@ module ActionController
       # This method also does namespace lookup. Foo::Bar::UsersController will
       # try to find Foo::Bar::User, Foo::User and finally User.
       def _default_wrap_model #:nodoc:
+        # Return nil if the class is unnamed (i.e., anonymous)
+        return nil if self.name.nil?
+
         model_name = self.name.sub(/Controller$/, '').singularize
 
         begin
@@ -168,7 +171,7 @@ module ActionController
           end
         end
 
-        unless options[:name]
+        unless options[:name] || self.name.nil?
           model ||= _default_wrap_model
           options[:name] = model ? model.to_s.demodulize.underscore :
             controller_name.singularize

--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -140,7 +140,6 @@ module ActionController
       # This method also does namespace lookup. Foo::Bar::UsersController will
       # try to find Foo::Bar::User, Foo::User and finally User.
       def _default_wrap_model #:nodoc:
-        # Return nil if the class is unnamed (i.e., anonymous)
         return nil if self.name.nil?
 
         model_name = self.name.sub(/Controller$/, '').singularize
@@ -229,7 +228,7 @@ module ActionController
       # Checks if we should perform parameters wrapping.
       def _wrapper_enabled?
         ref = request.content_mime_type.try(:ref)
-        _wrapper_formats.include?(ref) && !request.request_parameters[_wrapper_key]
+        _wrapper_formats.include?(ref) && _wrapper_key && !request.request_parameters[_wrapper_key]
       end
   end
 end

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -413,7 +413,11 @@ module ActionController
         @request.env['REQUEST_METHOD'] = http_method
 
         parameters ||= {}
-        @request.assign_parameters(@routes, @controller.class.name.underscore.sub(/_controller$/, ''), action.to_s, parameters)
+        controller_class_name = @controller.class.name ?
+          @controller.class.name.underscore.sub(/_controller$/, '') :
+          "anonymous_controller"
+
+        @request.assign_parameters(@routes, controller_class_name, action.to_s, parameters)
 
         @request.session = ActionController::TestSession.new(session) if session
         @request.session["flash"] = @request.flash.update(flash || {})

--- a/actionpack/test/controller/params_wrapper_test.rb
+++ b/actionpack/test/controller/params_wrapper_test.rb
@@ -31,7 +31,7 @@ class ParamsWrapperTest < ActionController::TestCase
     end
   end
 
-  def test_derived_name_from_controller_given_an_anonymous_controller
+  def test_allow_anonymous_controller
     with_default_wrapper_options do
       # This should not raise an error.
       Class.new(UsersController)

--- a/actionpack/test/controller/params_wrapper_test.rb
+++ b/actionpack/test/controller/params_wrapper_test.rb
@@ -31,6 +31,13 @@ class ParamsWrapperTest < ActionController::TestCase
     end
   end
 
+  def test_derived_name_from_controller_given_an_anonymous_controller
+    with_default_wrapper_options do
+      # This should not raise an error.
+      Class.new(UsersController)
+    end
+  end
+
   def test_specify_wrapper_name
     with_default_wrapper_options do
       UsersController.wrap_parameters :person

--- a/actionpack/test/controller/params_wrapper_test.rb
+++ b/actionpack/test/controller/params_wrapper_test.rb
@@ -2,7 +2,21 @@ require 'abstract_unit'
 
 module Admin; class User; end; end
 
+module ParamsWrapperTestHelp
+  def with_default_wrapper_options(&block)
+    @controller.class._wrapper_options = {:format => [:json]}
+    @controller.class.inherited(@controller.class)
+    yield
+  end
+
+  def assert_parameters(expected)
+    assert_equal expected, self.class.controller_class.last_parameters
+  end
+end
+
 class ParamsWrapperTest < ActionController::TestCase
+  include ParamsWrapperTestHelp
+
   class UsersController < ActionController::Base
     class << self
       attr_accessor :last_parameters
@@ -28,13 +42,6 @@ class ParamsWrapperTest < ActionController::TestCase
       @request.env['CONTENT_TYPE'] = 'application/json'
       post :parse, { 'username' => 'sikachu' }
       assert_parameters({ 'username' => 'sikachu', 'user' => { 'username' => 'sikachu' }})
-    end
-  end
-
-  def test_allow_anonymous_controller
-    with_default_wrapper_options do
-      # This should not raise an error.
-      Class.new(UsersController)
     end
   end
 
@@ -173,20 +180,11 @@ class ParamsWrapperTest < ActionController::TestCase
       assert_parameters({ 'username' => 'sikachu', 'title' => 'Developer', 'user' => { 'username' => 'sikachu', 'title' => 'Developer' }})
     end
   end
-
-  private
-    def with_default_wrapper_options(&block)
-      @controller.class._wrapper_options = {:format => [:json]}
-      @controller.class.inherited(@controller.class)
-      yield
-    end
-
-    def assert_parameters(expected)
-      assert_equal expected, UsersController.last_parameters
-    end
 end
 
 class NamespacedParamsWrapperTest < ActionController::TestCase
+  include ParamsWrapperTestHelp
+
   module Admin
     module Users
       class UsersController < ActionController::Base;
@@ -254,14 +252,36 @@ class NamespacedParamsWrapperTest < ActionController::TestCase
     end
   end
 
-  private
-    def with_default_wrapper_options(&block)
-      @controller.class._wrapper_options = {:format => [:json]}
-      @controller.class.inherited(@controller.class)
-      yield
+end
+
+class AnonymousControllerParamsWrapperTest < ActionController::TestCase
+  include ParamsWrapperTestHelp
+
+  tests(Class.new(ActionController::Base) do
+    class << self
+      attr_accessor :last_parameters
     end
 
-    def assert_parameters(expected)
-      assert_equal expected, Admin::Users::UsersController.last_parameters
+    def parse
+      self.class.last_parameters = request.params.except(:controller, :action)
+      head :ok
     end
+  end)
+
+  def test_does_not_implicitly_wrap_params
+    with_default_wrapper_options do
+      @request.env['CONTENT_TYPE'] = 'application/json'
+      post :parse, { 'username' => 'sikachu' }
+      assert_parameters({ 'username' => 'sikachu' })
+    end
+  end
+
+  def test_does_wrap_params_if_name_provided
+    with_default_wrapper_options do
+      @controller.class.wrap_parameters(:name => "guest")
+      @request.env['CONTENT_TYPE'] = 'application/json'
+      post :parse, { 'username' => 'sikachu' }
+      assert_parameters({ 'username' => 'sikachu', 'guest' => { 'username' => 'sikachu' }})
+    end
+  end
 end


### PR DESCRIPTION
Given this code:

``` ruby
Class.new(ApplicationController)
```

I get the following error:

```
+/Users/david/.rvm/gems/ruby-1.9.2-p180@rspec-dev/gems/activesupport-3.1.0.beta1/lib/active_support/whiny_nil.rb:48:in `method_missing': undefined method `sub' for nil:NilClass (NoMethodError)
+   from /Users/david/.rvm/gems/ruby-1.9.2-p180@rspec-dev/gems/actionpack-3.1.0.beta1/lib/action_controller/metal/params_wrapper.rb:140:in `_default_wrap_model'
```

This is caused by `model_name = self.name.sub(/Controller$/, '').singularize` on https://github.com/rails/rails/blob/8b0262f9535cb9ad2215e5ed672150e2c52cb4b4/actionpack/lib/action_controller/metal/params_wrapper.rb#L143

I've added a failing test case, and will offer up a solution in the next day or so.
