### PR TITLE
ActiveSupport::StringInquirer does a regexp check instead of direct match

### DIFF
--- a/activesupport/lib/active_support/string_inquirer.rb
+++ b/activesupport/lib/active_support/string_inquirer.rb
@@ -12,7 +12,7 @@ module ActiveSupport
   class StringInquirer < String
     def method_missing(method_name, *arguments)
       if method_name.to_s[-1,1] == "?"
-        self == method_name.to_s[0..-2]
+        self =~ /#{method_name.to_s[0..-2]}/
       else
         super
       end

--- a/activesupport/test/string_inquirer_test.rb
+++ b/activesupport/test/string_inquirer_test.rb
@@ -12,4 +12,8 @@ class StringInquirerTest < Test::Unit::TestCase
   def test_missing_question_mark
     assert_raise(NoMethodError) { ActiveSupport::StringInquirer.new("production").production }
   end
+
+  def test_regexp_match
+    assert ActiveSupport::StringInquirer.new("test1").test?
+  end
 end


### PR DESCRIPTION
This adds the convenience of allowing developers to continue to use the simple boolean check on multiple environments. We use parallel_spec which creates test[1..4], breaking our .test? assumptions. This fixes that issue by doing a regexp check on the string.

``` ruby
RAILS_ENV=test
Rails.env.test? #=> true
```

``` ruby
RAILS_ENV=test1
Rails.env.test? #=> true
```
