### PR TITLE
Accept options to ActiveRecord::Base#arel_table 

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -877,8 +877,9 @@ module ActiveRecord #:nodoc:
         store_full_sti_class ? name : name.demodulize
       end
 
-      def arel_table
-        Arel::Table.new(table_name, arel_engine)
+      def arel_table(opts = {})
+        opts[:engine] ||= arel_engine
+        Arel::Table.new(table_name, opts)
       end
 
       def arel_engine

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -133,6 +133,12 @@ class BasicsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_arel_table_with_options
+    table = Topic.arel_table :as => "an_alias"
+    assert_equal "an_alias", table.table_alias
+    assert_equal ActiveRecord::Base, table.engine
+  end
+
   def test_use_table_engine_for_quoting_where
     relation = Topic.where(Topic.arel_table[:id].eq(1))
     engine = relation.table.engine


### PR DESCRIPTION
When joining a single table in to a query multiple times, it's convenient to be able to access an Arel::Table with a specific alias, without manually creating it. Example:

```
org1 = Organization.arel_table
org2 = Organization.arel_table as: "organizations_user_organizations"
```
