### PR TITLE
Using the correct CSS compressor for the yui-compressor gem.

### DIFF
--- a/actionpack/lib/sprockets/railtie.rb
+++ b/actionpack/lib/sprockets/railtie.rb
@@ -99,7 +99,7 @@ module Sprockets
         compressor
       when :yui
         require 'yui/compressor'
-        YUI::JavaScriptCompressor.new(:munge => true)
+        YUI::CssCompressor.new
       else
         sym
       end


### PR DESCRIPTION
Using the `CssCompressor` instead of `JavaScriptCompressor` just like Jammit does. 

[]'s
Lucas.
