### PR TITLE
Adding missing require to join_model_test

### DIFF
--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -15,6 +15,7 @@ require 'models/book'
 require 'models/citation'
 require 'models/aircraft'
 require 'models/engine'
+require 'models/car'
 
 class AssociationsJoinModelTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false unless supports_savepoints?


### PR DESCRIPTION
This fix the "NameError: uninitialized constant Engine::Car" raised when try to run test individually (rake test_sqlite3 TEST=test/cases/associations/join_model_test.rb)
