### PR TITLE
Improved "treat  0000-00-00 00:00:00 as nil Date"

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -189,7 +189,7 @@ module ActiveRecord
 
           def new_time(year, mon, mday, hour, min, sec, microsec)
             # Treat 0000-00-00 00:00:00 as nil.
-            return nil if year.nil? || year == 0
+            return nil if year.nil? || (year == 0 && mon == 0 && mday == 0)
 
             Time.time_with_datetime_fallback(Base.default_timezone, year, mon, mday, hour, min, sec, microsec) rescue nil
           end


### PR DESCRIPTION
It is not right to assume that if year is 0 then date is nil.
In our example we store dates in BC and 0000-01-01 is a valid date

So I've added check that for date to be nil year month and mday have to be 0.

I couldnt find a test for this case and wasnt sure where is a good place to add it.

Cheers,
Kirill R
