### PR TITLE
Optimize parts of HashWithIndifferentAccess

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -10,6 +10,10 @@ module ActiveSupport
       true
     end
 
+    def with_indifferent_access
+      self
+    end
+
     def initialize(constructor = {})
       if constructor.is_a?(Hash)
         super()
@@ -58,8 +62,12 @@ module ActiveSupport
     #   hash_1.update(hash_2) # => {"key"=>"New Value!"}
     #
     def update(other_hash)
-      other_hash.each_pair { |key, value| regular_writer(convert_key(key), convert_value(value)) }
-      self
+      if other_hash.is_a? HashWithIndifferentAccess
+        super(other_hash)
+      else
+        other_hash.each_pair { |key, value| regular_writer(convert_key(key), convert_value(value)) }
+        self
+      end
     end
 
     alias_method :merge!, :update

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -971,6 +971,11 @@ class HashToXmlTest < Test::Unit::TestCase
     assert_nil hash_wia.default
   end
 
+  def test_should_return_self_for_with_indifferent_access
+    hash_wia = HashWithIndifferentAccess.new
+    assert_equal hash_wia, hash_wia.with_indifferent_access
+  end
+
   def test_should_copy_the_default_value_when_converting_to_hash_with_indifferent_access
     hash = Hash.new(3)
     hash_wia = hash.with_indifferent_access


### PR DESCRIPTION
Specifically, skip redundant work when calling <tt>with_indifferent_access()</tt>, and skip key/value conversions when calling <tt>update()</tt> with another HashWithIndifferentAccess.
