### PR TITLE
add test case for turn gem for testunit.

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -165,7 +165,7 @@ module Rails
       end
 
       def gem_for_ruby_debugger
-        if RUBY_VERSION < "1.9.2"
+        if RUBY_VERSION < "1.9"
           "gem 'ruby-debug'"
         else
           "gem 'ruby-debug19', :require => 'ruby-debug'"

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -173,7 +173,7 @@ module Rails
       end
 
       def gem_for_turn
-        unless RUBY_VERSION < "1.9.2"
+        unless RUBY_VERSION < "1.9.2" || options[:skip_test_unit]
           <<-GEMFILE.strip_heredoc
             group :test do
               # Pretty printed test output

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -210,6 +210,20 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_inclusion_of_ruby_debug
+    run_generator
+    assert_file "Gemfile" do |contents|
+      assert_match /gem 'ruby-debug'/, contents if RUBY_VERSION < '1.9'
+    end
+  end
+
+  def test_inclusion_of_ruby_debug19_if_ruby19
+    run_generator
+    assert_file "Gemfile" do |contents|
+      assert_match /gem 'ruby-debug19', :require => 'ruby-debug'/, contents unless RUBY_VERSION < '1.9'
+    end
+  end
+
   def test_template_from_dir_pwd
     FileUtils.cd(Rails.root)
     assert_match /It works from file!/, run_generator([destination_root, "-m", "lib/template.rb"])

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -210,6 +210,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_turn_gem_is_not_included_in_gemfile_if_skipping_test_unit
+    run_generator [destination_root, "--skip-test-unit"]
+    assert_file "Gemfile" do |contents|
+      assert_no_match /gem 'tuarn'/, contents unless RUBY_VERSION < '1.9.2'
+    end
+  end
+
   def test_inclusion_of_ruby_debug
     run_generator
     assert_file "Gemfile" do |contents|

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -202,6 +202,14 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_inclusion_of_turn_gem_in_gemfile
+    run_generator
+    assert_file "Gemfile" do |contents|
+      assert_match /gem 'turn'/, contents unless RUBY_VERSION < '1.9.2'
+      assert_no_match /gem 'turn'/, contents if RUBY_VERSION < '1.9.2'
+    end
+  end
+
   def test_template_from_dir_pwd
     FileUtils.cd(Rails.root)
     assert_match /It works from file!/, run_generator([destination_root, "-m", "lib/template.rb"])


### PR DESCRIPTION
Add test case for inclusion of 'turn' gem in Gemfile unless RUBY_VERSION < 1.9.2.

I have a question for this, why only inclusion of 'turn' gem unless RUBY_VERSION < 1.9.2?
