### PR TITLE
always enable `pp` on the Rails console

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -195,6 +195,7 @@ module Rails
     end
 
     def initialize_console(sandbox=false)
+      require "pp"
       require "rails/console/app"
       require "rails/console/helpers"
     end


### PR DESCRIPTION
I believe this is as useful as `ActiveRecord::Base.logger = Logger.new(STDERR)` thing (yes, I really love that too!)
