### PR TITLE
improvements on PostgreSQL schema queries

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -823,7 +823,6 @@ module ActiveRecord
           FROM pg_class      seq,
                pg_attribute  attr,
                pg_depend     dep,
-               pg_namespace  name,
                pg_constraint cons
           WHERE seq.oid           = dep.objid
             AND seq.relkind       = 'S'
@@ -847,7 +846,6 @@ module ActiveRecord
           SELECT DISTINCT(attr.attname)
           FROM pg_attribute  attr,
                pg_depend     dep,
-               pg_namespace  name,
                pg_constraint cons
           WHERE attr.attrelid     = dep.refobjid
             AND attr.attnum       = dep.refobjsubid

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -820,18 +820,13 @@ module ActiveRecord
         # given table's primary key.
         result = exec_query(<<-end_sql, 'SCHEMA').rows.first
           SELECT attr.attname, seq.relname
-          FROM pg_class      seq,
-               pg_attribute  attr,
-               pg_depend     dep,
-               pg_constraint cons
-          WHERE seq.oid           = dep.objid
-            AND seq.relkind       = 'S'
-            AND attr.attrelid     = dep.refobjid
-            AND attr.attnum       = dep.refobjsubid
-            AND attr.attrelid     = cons.conrelid
-            AND attr.attnum       = cons.conkey[1]
-            AND cons.contype      = 'p'
-            AND dep.refobjid      = '#{quote_table_name(table)}'::regclass
+          FROM pg_class seq
+          INNER JOIN pg_depend dep on seq.oid = dep.objid
+          INNER JOIN pg_attribute attr ON attr.attrelid = dep.refobjid AND attr.attnum = dep.refobjsubid
+          INNER JOIN pg_constraint cons ON attr.attrelid = cons.conrelid AND attr.attnum = cons.conkey[1]
+          WHERE seq.relkind  = 'S'
+            AND cons.contype = 'p'
+            AND dep.refobjid = '#{quote_table_name(table)}'::regclass
         end_sql
 
         # [primary_key, sequence]
@@ -844,15 +839,11 @@ module ActiveRecord
       def primary_key(table)
         row = exec_query(<<-end_sql, 'SCHEMA', [[nil, table]]).rows.first
           SELECT DISTINCT(attr.attname)
-          FROM pg_attribute  attr,
-               pg_depend     dep,
-               pg_constraint cons
-          WHERE attr.attrelid     = dep.refobjid
-            AND attr.attnum       = dep.refobjsubid
-            AND attr.attrelid     = cons.conrelid
-            AND attr.attnum       = cons.conkey[1]
-            AND cons.contype      = 'p'
-            AND dep.refobjid      = $1::regclass
+          FROM pg_attribute attr
+          INNER JOIN pg_depend dep ON attr.attrelid = dep.refobjid AND attr.attnum = dep.refobjsubid
+          INNER JOIN pg_constraint cons ON attr.attrelid = cons.conrelid AND attr.attnum = cons.conkey[1]
+          WHERE cons.contype = 'p'
+            AND dep.refobjid = $1::regclass
         end_sql
 
         row && row.first

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -701,11 +701,11 @@ module ActiveRecord
          schemas = schema_search_path.split(/,/).map { |p| quote(p) }.join(',')
          result = query(<<-SQL, name)
            SELECT distinct i.relname, d.indisunique, d.indkey, t.oid
-             FROM pg_class t, pg_class i, pg_index d
+           FROM pg_class t
+           INNER JOIN pg_index d ON t.oid = d.indrelid
+           INNER JOIN pg_class i ON d.indexrelid = i.oid
            WHERE i.relkind = 'i'
-             AND d.indexrelid = i.oid
              AND d.indisprimary = 'f'
-             AND t.oid = d.indrelid
              AND t.relname = '#{table_name}'
              AND i.relnamespace IN (SELECT oid FROM pg_namespace WHERE nspname IN (#{schemas}) )
           ORDER BY i.relname


### PR DESCRIPTION
Generally, we should use JOIN clause for joining tables unless the DBMS is a legacy DB like Oracle 8.

Also, I found there were some unused tables in the FROM clause in Postgres schema_queries that probably made the query slow. df13f55d757dc8af30391b8d15af2c2d04f26aa4
