### PR TITLE
Attributes with :string type should not be given the type passed in model. Closes #1058.

### DIFF
--- a/activemodel/lib/active_model/serializers/xml.rb
+++ b/activemodel/lib/active_model/serializers/xml.rb
@@ -25,7 +25,7 @@ module ActiveModel
           def decorations
             decorations = {}
             decorations[:encoding] = 'base64' if type == :binary
-            decorations[:type] = type unless type == :string
+            decorations[:type] = (type == :string) ? nil : type
             decorations[:nil] = true if value.nil?
             decorations
           end

--- a/activemodel/test/cases/serializers/xml_serialization_test.rb
+++ b/activemodel/test/cases/serializers/xml_serialization_test.rb
@@ -92,7 +92,7 @@ class XmlSerializationTest < ActiveModel::TestCase
   test "should serialize string" do
     assert_match %r{<name>aaron stack</name>}, @contact.to_xml
   end
-  
+
   test "should serialize nil" do
     assert_match %r{<pseudonyms nil=\"true\"></pseudonyms>}, @contact.to_xml(:methods => :pseudonyms)
   end
@@ -131,5 +131,11 @@ class XmlSerializationTest < ActiveModel::TestCase
     proc = Proc.new { |options, record| options[:builder].tag!('name-reverse', record.name.reverse) }
     xml = @contact.to_xml(:procs => [ proc ])
     assert_match %r{<name-reverse>kcats noraa</name-reverse>}, xml
+  end
+
+  test "should serialize string correctly when type passed" do
+    xml = @contact.to_xml :type => 'Contact'
+    assert_match %r{<contact type="Contact">}, xml
+    assert_match %r{<name>aaron stack</name>}, xml
   end
 end


### PR DESCRIPTION
Hey Guys,

This is a fixed patch for #1058.

Enjoy,

Josh
