### PR TITLE
Fix FinderMethods#exists? sql generation to make picky sql servers happy - 3 0 stable

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -173,7 +173,7 @@ module ActiveRecord
 
       join_dependency = construct_join_dependency_for_association_find
       relation = construct_relation_for_association_find(join_dependency)
-      relation = relation.except(:select).select("1").limit(1)
+      relation = relation.except(:select).select("1 AS _one").limit(1)
 
       case id
       when Array, Hash


### PR DESCRIPTION
Minimal change to query generation of FinderMethods#exists? that makes SQLServer and others happy that do not like columns without an alias.

Without this patch MS-SQLServer doesn't like the generated SQL and barks for FinderMethods#exists?, ie:

ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: No column was specified for column 2 of 't'.: SELECT t.\* FROM (SELECT ROW_NUMBER() OVER(ORDER BY huhu.id) AS _row_num, 1 FROM huhu WHERE huhu.[id] = 83287) AS t WHERE t._row_num BETWEEN 1 AND 1
