### PR TITLE
Overridden ActiveRecord attributes should appear as the value in text fie

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -973,7 +973,7 @@ module ActionView
           options.delete("size")
         end
         options["type"]  ||= field_type
-        options["value"] = options.fetch("value"){ value_before_type_cast(object) } unless field_type == "file"
+        options["value"] = options.fetch("value"){ value(object) } unless field_type == "file"
         options["value"] &&= ERB::Util.html_escape(options["value"])
         add_default_name_and_id(options)
         tag("input", options)

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -198,6 +198,18 @@ class FormHelperTest < ActionView::TestCase
       '<input id="person_name" name="person[name]" size="30" type="password" />', password_field("person", "name")
     )
   end
+  
+  def test_text_field_with_overridden_active_record_attribute
+    @post.class_eval do
+      define_method :title_before_type_cast do
+        nil
+      end
+    end
+    @post.title = 'my-title'
+    assert_dom_equal(
+      '<input id="post_title" name="post[title]" size="30" type="text" value="my-title" />', text_field("post", "title")
+    )
+  end
 
   def test_text_field_with_escapes
     @post.title = "<b>Hello World</b>"


### PR DESCRIPTION
This commit (3021297e89dc3720d1bce50dabf1177f8935172e) removed the ability to override an ActiveRecord attribute, to have it return a default value for example, and have the overridden value appear in a text field.

I'm guessing there might be a good reason to want to call `#<method>_before_type_cast` but it's not tested so I've added a test and fix to produce the behaviour I want.

I'm doing this more to discuss why it might be useful to call `#<method>_before_type_cast` and work out what tests are missing should that be the case.
