### PR TITLE
The cookie jar does not to_s cookie names (keys)

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -167,8 +167,8 @@ module ActionDispatch
 
         handle_options(options)
 
-        @set_cookies[key] = options
-        @delete_cookies.delete(key)
+        @set_cookies[key.to_s] = options
+        @delete_cookies.delete(key.to_s)
         value
       end
 
@@ -181,7 +181,7 @@ module ActionDispatch
         handle_options(options)
 
         value = @cookies.delete(key.to_s)
-        @delete_cookies[key] = options
+        @delete_cookies[key.to_s] = options
         value
       end
 

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -121,7 +121,7 @@ class CookiesTest < ActionController::TestCase
     end
 
     def string_key
-      cookies['user_name'] = "david"
+      cookies['user_name'] = "dhh"
       head :ok
     end
 
@@ -417,13 +417,17 @@ class CookiesTest < ActionController::TestCase
     assert_cookie_header "user_name=; path=/; expires=Thu, 01-Jan-1970 00:00:00 GMT"
   end
 
+  
   def test_cookies_hash_is_indifferent_access
-    [:symbol_key, :string_key].each do |cookie_key|
-      get cookie_key
+      get :symbol_key
       assert_equal "david", cookies[:user_name]
       assert_equal "david", cookies['user_name']
-    end
+      get :string_key
+      assert_equal "dhh", cookies[:user_name]
+      assert_equal "dhh", cookies['user_name']
   end
+
+
 
   def test_setting_request_cookies_is_indifferent_access
     @request.cookies.clear


### PR DESCRIPTION
Because of this it is probable to have two cookies (even session cookies) in the jar, one keyed as a symbol, one as a string. These two cookies are sent to the browser and the browser "chooses" which cookie to use. If it is a session cookie (as was my case) things like csrf get reset on every request which makes submitting forms hard.
