### PR TITLE
renamed the wrap_parameters :only and :except options to :include and :ex

### DIFF
--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -4,7 +4,7 @@ require "action_controller/log_subscriber"
 
 module Another
   class LogSubscribersController < ActionController::Base
-    wrap_parameters :person, :only => :name, :format => :json
+    wrap_parameters :person, :include => :name, :format => :json
 
     def show
       render :nothing => true
@@ -34,11 +34,11 @@ module Another
       cache_page("Super soaker", "/index.html")
       render :nothing => true
     end
-    
+
     def with_exception
       raise Exception
     end
-    
+
   end
 end
 

--- a/actionpack/test/controller/params_wrapper_test.rb
+++ b/actionpack/test/controller/params_wrapper_test.rb
@@ -65,9 +65,9 @@ class ParamsWrapperTest < ActionController::TestCase
     end
   end
 
-  def test_specify_only_option
+  def test_specify_include_option
     with_default_wrapper_options do
-      UsersController.wrap_parameters :only => :username
+      UsersController.wrap_parameters :include => :username
 
       @request.env['CONTENT_TYPE'] = 'application/json'
       post :parse, { 'username' => 'sikachu', 'title' => 'Developer' }
@@ -75,9 +75,9 @@ class ParamsWrapperTest < ActionController::TestCase
     end
   end
 
-  def test_specify_except_option
+  def test_specify_exclude_option
     with_default_wrapper_options do
-      UsersController.wrap_parameters :except => :title
+      UsersController.wrap_parameters :exclude => :title
 
       @request.env['CONTENT_TYPE'] = 'application/json'
       post :parse, { 'username' => 'sikachu', 'title' => 'Developer' }
@@ -85,9 +85,9 @@ class ParamsWrapperTest < ActionController::TestCase
     end
   end
 
-  def test_specify_both_wrapper_name_and_only_option
+  def test_specify_both_wrapper_name_and_include_option
     with_default_wrapper_options do
-      UsersController.wrap_parameters :person, :only => :username
+      UsersController.wrap_parameters :person, :include => :username
 
       @request.env['CONTENT_TYPE'] = 'application/json'
       post :parse, { 'username' => 'sikachu', 'title' => 'Developer' }


### PR DESCRIPTION
Hey Guys,

I renamed the wrap_parameters :only and :except options to :include and :exclude to make it consistent with controller filters options.

Enjoy,

Josh
