### PR TITLE
Revert "Use Rack::ContentLength."

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -141,8 +141,6 @@ module Rails
 
     def default_middleware_stack
       ActionDispatch::MiddlewareStack.new.tap do |middleware|
-        middleware.use ::Rack::ContentLength, config.action_dispatch.x_sendfile_header
-
         if rack_cache = config.action_controller.perform_caching && config.action_dispatch.rack_cache
           require "action_dispatch/http/rack_cache"
           middleware.use ::Rack::Cache, rack_cache

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -19,7 +19,6 @@ module ApplicationTests
       boot!
 
       assert_equal [
-        "Rack::ContentLength",
         "ActionDispatch::Static",
         "Rack::Lock",
         "ActiveSupport::Cache::Strategy::LocalCache",
@@ -49,7 +48,7 @@ module ApplicationTests
 
       boot!
 
-      assert_equal "Rack::Cache", middleware.second
+      assert_equal "Rack::Cache", middleware.first
     end
 
     test "Rack::SSL is present when force_ssl is set" do
@@ -104,7 +103,7 @@ module ApplicationTests
     end
 
     test "insert middleware after" do
-      add_to_config "config.middleware.insert_after Rack::ContentLength, Rack::Config"
+      add_to_config "config.middleware.insert_after ActionDispatch::Static, Rack::Config"
       boot!
       assert_equal "Rack::Config", middleware.second
     end
@@ -112,12 +111,12 @@ module ApplicationTests
     test "RAILS_CACHE does not respond to middleware" do
       add_to_config "config.cache_store = :memory_store"
       boot!
-      assert_equal "Rack::Runtime", middleware.fourth
+      assert_equal "Rack::Runtime", middleware.third
     end
 
     test "RAILS_CACHE does respond to middleware" do
       boot!
-      assert_equal "Rack::Runtime", middleware.fifth
+      assert_equal "Rack::Runtime", middleware.fourth
     end
 
     test "identity map is inserted" do
@@ -127,7 +126,7 @@ module ApplicationTests
     end
 
     test "insert middleware before" do
-      add_to_config "config.middleware.insert_before Rack::ContentLength, Rack::Config"
+      add_to_config "config.middleware.insert_before ActionDispatch::Static, Rack::Config"
       boot!
       assert_equal "Rack::Config", middleware.first
     end


### PR DESCRIPTION
This reverts commit e4ebded5bcd4f54fee0c4f643c9df76aeb22436e.

@josh 

As this got reverted https://github.com/rack/rack/commit/bc30108180e2472423497657b55f7ccb8749a7a0
