### PR TITLE
Singularize individual table name

### DIFF
--- a/activerecord/lib/active_record/associations/alias_tracker.rb
+++ b/activerecord/lib/active_record/associations/alias_tracker.rb
@@ -49,8 +49,8 @@ module ActiveRecord
         end
       end
 
-      def pluralize(table_name)
-        ActiveRecord::Base.pluralize_table_names ? table_name.to_s.pluralize : table_name.to_s
+      def pluralize(table_name, base)
+        base.pluralize_table_names ? table_name.to_s.pluralize : table_name.to_s
       end
 
       private

--- a/activerecord/lib/active_record/associations/join_helper.rb
+++ b/activerecord/lib/active_record/associations/join_helper.rb
@@ -32,7 +32,7 @@ module ActiveRecord
       end
 
       def table_alias_for(reflection, join = false)
-        name = alias_tracker.pluralize(reflection.name)
+        name = alias_tracker.pluralize(reflection.name, reflection.active_record)
         name << "_#{alias_suffix}"
         name << "_join" if join
         name

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -393,8 +393,8 @@ module ActiveRecord #:nodoc:
     # Indicates whether table names should be the pluralized versions of the corresponding class names.
     # If true, the default table name for a Product class will be +products+. If false, it would just be +product+.
     # See table_name for the full rules on table/class naming. This is true, by default.
-    cattr_accessor :pluralize_table_names, :instance_writer => false
-    @@pluralize_table_names = true
+    class_attribute :pluralize_table_names, :instance_writer => false
+    self.pluralize_table_names = true
 
     ##
     # :singleton-method:

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -708,12 +708,9 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
   end
 
   def test_has_many_with_pluralize_table_names_false
-    engine = Engine.create(:car_id => 1)
-    Aircraft.pluralize_table_names = false
+    engine = Engine.create!(:car_id => 1)
     aircraft = Aircraft.create!(:name => "Airbus 380", :id => 1)
     assert_equal aircraft.engines, [engine]
-  ensure
-    ActiveRecord::Base.pluralize_table_names = true
   end
 
   private

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -367,6 +367,15 @@ class BasicsTest < ActiveRecord::TestCase
     GUESSED_CLASSES.each(&:reset_table_name)
   end
 
+  def test_singular_table_name_guesses_for_individual_table
+    CreditCard.pluralize_table_names = false
+    CreditCard.reset_table_name
+    assert_equal "credit_card", CreditCard.table_name
+    assert_equal "categories", Category.table_name
+  ensure
+    CreditCard.pluralize_table_names = true
+    CreditCard.reset_table_name
+  end
 
   if current_adapter?(:MysqlAdapter) or current_adapter?(:Mysql2Adapter)
     def test_update_all_with_order_and_limit

--- a/activerecord/test/models/aircraft.rb
+++ b/activerecord/test/models/aircraft.rb
@@ -1,3 +1,4 @@
 class Aircraft < ActiveRecord::Base
+  self.pluralize_table_names = false
   has_many :engines, :foreign_key => "car_id"
 end


### PR DESCRIPTION
This allow set pluralize_table_names for an individual class.

```
class Post < ActiveRecord::Base
  self.pluralize_table_names = false
end
```

Previously when you set it for a class it was used globally (We discuss a little about it here: https://github.com/rails/rails/pull/560#issuecomment-1165420)

cc @jonleighton
