### PR TITLE
Sexier migrations

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -154,11 +154,11 @@ module ActiveRecord
       #  )
       #
       # See also TableDefinition#column for details on how to create columns.
-      def create_table(table_name, options = {})
+      def create_table(table_name, options = {}, &blk)
         td = table_definition
         td.primary_key(options[:primary_key] || Base.get_primary_key(table_name.to_s.singularize)) unless options[:id] == false
 
-        yield td if block_given?
+        td.instance_eval(&blk) if blk
 
         if options[:force] && table_exists?(table_name)
           drop_table(table_name, options)

--- a/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
@@ -394,27 +394,29 @@ module ActiveRecord
           drop_table(from)
         end
 
-        def copy_table(from, to, options = {}) #:nodoc:
-          options = options.merge(:id => (!columns(from).detect{|c| c.name == 'id'}.nil? && 'id' == primary_key(from).to_s))
+        def copy_table(from, to, options = {}, &block) #:nodoc:
+          from_columns, from_primary_key = columns(from), primary_key(from)
+          options = options.merge(:id => (!from_columns.detect {|c| c.name == 'id'}.nil? && 'id' == primary_key(from).to_s))
+          table_definition = nil
           create_table(to, options) do |definition|
-            @definition = definition
-            columns(from).each do |column|
+            table_definition = definition
+            from_columns.each do |column|
               column_name = options[:rename] ?
                 (options[:rename][column.name] ||
                  options[:rename][column.name.to_sym] ||
                  column.name) : column.name
 
-              @definition.column(column_name, column.type,
+              table_definition.column(column_name, column.type,
                 :limit => column.limit, :default => column.default,
                 :null => column.null)
             end
-            @definition.primary_key(primary_key(from)) if primary_key(from)
-            yield @definition if block_given?
+            table_definition.primary_key from_primary_key if from_primary_key
+            table_definition.instance_eval(&block) if block
           end
 
           copy_table_indexes(from, to, options[:rename] || {})
           copy_table_contents(from, to,
-            @definition.columns.map {|column| column.name},
+            table_definition.columns.map {|column| column.name},
             options[:rename] || {})
         end
 

--- a/activerecord/lib/active_record/session_store.rb
+++ b/activerecord/lib/active_record/session_store.rb
@@ -64,12 +64,13 @@ module ActiveRecord
       end
 
       def create_table!
+        id_col_name, data_col_name = session_id_column, data_column_name
         connection_pool.clear_table_cache!(table_name)
         connection.create_table(table_name) do |t|
-          t.string session_id_column, :limit => 255
-          t.text data_column_name
+          t.string id_col_name, :limit => 255
+          t.text data_col_name
         end
-        connection.add_index table_name, session_id_column, :unique => true
+        connection.add_index table_name, id_col_name, :unique => true
       end
     end
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1653,6 +1653,26 @@ if ActiveRecord::Base.connection.supports_migrations?
 
   end # SexyMigrationsTest
 
+  class SexierMigrationsTest < ActiveRecord::TestCase
+    def test_create_table_with_column_without_block_parameter
+      Person.connection.create_table :testings, :force => true do
+        column :foo, :string
+      end
+      assert Person.connection.column_exists?(:testings, :foo, :string)
+    ensure
+      Person.connection.drop_table :testings rescue nil
+    end
+
+    def test_create_table_with_sexy_column_without_block_parameter
+      Person.connection.create_table :testings, :force => true do
+        integer :bar
+      end
+      assert Person.connection.column_exists?(:testings, :bar, :integer)
+    ensure
+      Person.connection.drop_table :testings rescue nil
+    end
+  end # SexierMigrationsTest
+
   class MigrationLoggerTest < ActiveRecord::TestCase
     def test_migration_should_be_run_without_logger
       previous_logger = ActiveRecord::Base.logger


### PR DESCRIPTION
Let me propose a new Rails-3-ish cooler syntax for the database migrations.
This pull request enables you to remove the block parameter and t. t. t. t. t. t. t. ... from your migration code.

This is actually the same thing with what I posted here in January, so please refer to this ticket for details.
https://rails.lighthouseapp.com/projects/8994/tickets/6339

The reasons why I made another pull request today are:
- The attached patch on the ticket does not apply anymore to the current master
- The proposal got many +1s from people
- The ticket is in "wontfix" state (by mistake?), and maybe because of that, was not copied to GH issues
- I think 3.1 is the best timing for including another change on the migration syntax
- I guess @tenderlove have not looked at it yet

So, @tenderlove, can you please take a look at [the former ticket](https://rails.lighthouseapp.com/projects/8994/tickets/6339) and this pull request, then give me your thoughts?
Thanks in advance!
