### PR TITLE
Specify the name to be used for ActiveModel::Name fixes #1168

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -7,8 +7,9 @@ module ActiveModel
     attr_reader :singular, :plural, :element, :collection, :partial_path, :route_key, :param_key, :i18n_key
     alias_method :cache_key, :collection
 
-    def initialize(klass, namespace = nil)
-      super(klass.name)
+    def initialize(klass, namespace = nil, name = nil)
+      name ||= klass.name
+      super(name)
       @unnamespaced = self.sub(/^#{namespace.name}::/, '') if namespace
 
       @klass = klass

--- a/activemodel/test/cases/naming_test.rb
+++ b/activemodel/test/cases/naming_test.rb
@@ -114,6 +114,44 @@ class NamingWithNamespacedModelInSharedNamespaceTest < ActiveModel::TestCase
   end
 end
 
+class NamingWithSuppliedModelNameTest < ActiveModel::TestCase
+  def setup
+    @model_name = ActiveModel::Name.new(Blog::Post, nil, 'Article')
+  end
+
+  def test_singular
+    assert_equal 'article', @model_name.singular
+  end
+
+  def test_plural
+    assert_equal 'articles', @model_name.plural
+  end
+
+  def test_element
+    assert_equal 'article', @model_name.element
+  end
+
+  def test_collection
+    assert_equal 'articles', @model_name.collection
+  end
+
+  def test_partial_path
+    assert_equal 'articles/article', @model_name.partial_path
+  end
+
+  def test_human
+    'Article'
+  end
+
+  def test_route_key
+    assert_equal 'articles', @model_name.route_key
+  end
+
+  def test_param_key
+    assert_equal 'article', @model_name.param_key
+  end
+end
+
 class NamingHelpersTest < Test::Unit::TestCase
   def setup
     @klass  = Contact
@@ -171,4 +209,3 @@ class NamingHelpersTest < Test::Unit::TestCase
       ActiveModel::Naming.send(method, *args)
     end
 end
-


### PR DESCRIPTION
This patch allows to specify the name of your models independent of the class name.

I added a third Argument to the #initialize method to maintain backward compatibility. It would probably be cleaner to add an options hash after the class, which contains the namespace and the name options.

This request solves the issue #1168
