### PR TITLE
Missing i18n dependency on ActiveSupport ?

### DIFF
--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_dependency('multi_json', '~> 1.0')
+  s.add_dependency('i18n')
 end


### PR DESCRIPTION
i18n is used for even basic parts like core_ext/string, so really, it's a dependency
