### PR TITLE
Make Rake::DSL methods available within Railtie rake_tasks block

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -185,10 +185,12 @@ module Rails
     end
 
     def initialize_tasks
-      require "rails/tasks"
-      task :environment do
-        $rails_rake_task = true
-        require_environment!
+      self.class.rake_tasks do
+        require "rails/tasks"
+        task :environment do
+          $rails_rake_task = true
+          require_environment!
+        end
       end
     end
 

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -178,6 +178,7 @@ module Rails
     end
 
     def load_tasks
+      extend Rake::DSL if defined? Rake::DSL
       self.class.rake_tasks.each(&:call)
 
       # load also tasks from all superclasses


### PR DESCRIPTION
Fixes incompatibility introduced by Rake 0.9.0

As of Rake 0.9.0, methods such as 'task' are no longer available globally.  They're placed in Rake::DSL instead.  This breaks Rails::Application's initialize_tasks method.  It also breaks subclasses of Railties which call Rake's methods in a rake_tasks block.

I've updated Rails::Railtie to extend Rake::DSL (if available) before loading tasks, so that formerly-global rake methods can still be called within rake_tasks blocks.  I also updated Rails::Application to add its tasks within a rake_task block so it can use the rake DSL methods without issues.

This fixes [issue 1171](https://github.com/rails/rails/issues/1171).  The code is compatible with Rake 0.9.0 and Rake 0.8.7.  

The change needs to be back-ported to the 3-0-stable branch as well.
