### PR TITLE
Add support for fetch methods or return the default value informed

### DIFF
--- a/activesupport/lib/active_support/core_ext/object.rb
+++ b/activesupport/lib/active_support/core_ext/object.rb
@@ -2,6 +2,7 @@ require 'active_support/core_ext/object/acts_like'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/object/duplicable'
 require 'active_support/core_ext/object/try'
+require 'active_support/core_ext/object/fetch'
 require 'active_support/core_ext/object/inclusion'
 
 require 'active_support/core_ext/object/conversions'

--- a/activesupport/lib/active_support/core_ext/object/fetch.rb
+++ b/activesupport/lib/active_support/core_ext/object/fetch.rb
@@ -1,0 +1,19 @@
+class Object
+  # Invokes the method and pass the arguments if object respond to it, if not returns
+  # the last argument if present, otherwise return nil
+  #
+  # ==== Examples
+  #
+  # Without +fetch+
+  #   @person.respond_to?(:to_model) ? @person.to_model : @person
+  #
+  # With +fetch+
+  #   @person.fetch(:to_model, @person)
+  #
+  # +fetch+ also accepts arguments for the method
+  #   Person.fetch(:find, 1, 'not find')
+  def fetch(method, *args)
+    default = args.pop || nil
+    respond_to?(method) ? __send__(method, *args) : default
+  end
+end

--- a/activesupport/test/core_ext/object_and_class_ext_test.rb
+++ b/activesupport/test/core_ext/object_and_class_ext_test.rb
@@ -133,3 +133,36 @@ class ObjectTryTest < Test::Unit::TestCase
     assert_equal false, ran
   end
 end
+
+class ObjectFetchTest < Test::Unit::TestCase
+  def setup
+    @string = "Hello"
+  end
+
+  def test_nonexisting_method
+    method = :undefined_method
+    assert !@string.respond_to?(method)
+    assert_equal 'default return', @string.fetch(method, 'default return')
+  end
+
+  def test_valid_method
+    assert_equal 5, @string.fetch(:size, 'default return')
+  end
+
+  def test_argument_forwarding
+    assert_equal 'Hey', @string.fetch(:sub, 'llo', 'y', 'default return')
+  end
+
+  def test_default_value
+    assert_equal 5, @string.fetch(:size)
+  end
+  
+  def test_nil_return
+    assert !@string.respond_to?(:to_float)
+    assert_nil @string.fetch(:to_float)
+  end
+
+  def test_default_return
+    assert_equal 'default return', @string.fetch(:to_float, 'default return')
+  end
+end


### PR DESCRIPTION
Hey guys,

This patch allows use object.fetch(:method, 'default return') instead: object.respond_to?(:method) ? object.method : 'default return'

It's is a shortcut that i've been using

Hope this helps someone else
