### PR TITLE
For now using older rake version. 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "coffee-script"
 gem "sass"
 gem "uglifier", :git => "git://github.com/lautis/uglifier.git"
 
-gem "rake",  ">= 0.8.7"
+gem "rake",  "= 0.8.7"
 gem "mocha", ">= 0.9.8"
 
 group :doc do


### PR DESCRIPTION
Reasons :
1.  rake_test_loader.rb in rake-0.9.0 loading twice cause test failing 
   <pre>
   1) Failure:
   test_uniq_load_paths(LoadPathsTest)
   [/home/ubuntu/clones/rails/activesupport/test/load_paths_test.rb:14:in `test_uniq_load_paths'
    /home/ubuntu/clones/rails/tmp/bundle/ruby/1.8/gems/mocha-0.9.12/lib/mocha/integration/test_unit/ruby_version_186_and_above.rb:22:in`**send**'
    /home/ubuntu/clones/rails/tmp/bundle/ruby/1.8/gems/mocha-0.9.12/lib/mocha/integration/test_unit/ruby_version_186_and_above.rb:22:in `run']:

</pre>
1. https://github.com/rails/rails/pull/1174 

I think we need to wait for newer version.
