### PR TITLE
Handle polymorphic_type NOT NULL columns

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -19,7 +19,7 @@ module ActiveRecord
 
         def klass
           type = owner[reflection.foreign_type]
-          type && type.constantize
+          type.presence && type.constantize
         end
 
         def raise_on_type_mismatch(record)

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -158,6 +158,17 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_not_nil Company.find(3).firm_with_condition, "Microsoft should have a firm"
   end
 
+  def test_polymorphic_association_class
+    sponsor = Sponsor.new
+    assert_nil sponsor.association(:sponsorable).send(:klass)
+
+    sponsor.sponsorable_type = '' # the column doesn't have to be declared NOT NULL
+    assert_nil sponsor.association(:sponsorable).send(:klass)
+
+    sponsor.sponsorable = Member.new :name => "Bert"
+    assert_equal Member, sponsor.association(:sponsorable).send(:klass)
+  end
+
   def test_with_polymorphic_and_condition
     sponsor = Sponsor.create
     member = Member.create :name => "Bert"


### PR DESCRIPTION
`ActiveRecord::Associations::BelongsToPolymorphicAssociation#klass` returns a wrong value if the `polymorphic_type` attribute contains an empty string (`''.constantize` returns an `Object` instead of `nil`).
