### PR TITLE
Fix AS::Duration#duplicable? on 1.8

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -10,6 +10,7 @@ module ActiveSupport
   #   1.month.ago       # equivalent to Time.now.advance(:months => -1)
   class Duration < BasicObject
     attr_accessor :value, :parts
+    delegate :duplicable?, :to => :value # required when using ActiveSupport's BasicObject on 1.8
 
     def initialize(value, parts) #:nodoc:
       @value, @parts = value, parts

--- a/activesupport/test/core_ext/duplicable_test.rb
+++ b/activesupport/test/core_ext/duplicable_test.rb
@@ -1,9 +1,10 @@
 require 'abstract_unit'
 require 'bigdecimal'
 require 'active_support/core_ext/object/duplicable'
+require 'active_support/core_ext/numeric/time'
 
 class DuplicableTest < Test::Unit::TestCase
-  NO  = [nil, false, true, :symbol, 1, 2.3, BigDecimal.new('4.56'), Class.new, Module.new]
+  NO  = [nil, false, true, :symbol, 1, 2.3, BigDecimal.new('4.56'), Class.new, Module.new, 5.seconds]
   YES = ['1', Object.new, /foo/, [], {}, Time.now]
 
   def test_duplicable


### PR DESCRIPTION
On 1.8 when using `ActiveSupport`'s implementation of the `BasicObject` if some `Object` extensions are loaded after the `active_support/basic_object` the do sneak their methods into `BasicObject` as well. In this case `BasicObject` ends up using `Object#duplicable?` instead of `Fixnum#duplicable?`.

This should got both into `master` and `3-0-stable`.
