### PR TITLE
Add method FormHelper#fields_for_with_index

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -555,6 +555,19 @@ module ActionView
       #     ...
       #   <% end %>
       #
+      # In addition, you may want to have access to the current iteration index.
+      # In that case, you can use a similar method called fields_for_with_index
+      # which receives a block with an extra parameter:
+      #
+      #   <%= form_for @person do |person_form| %>
+      #     ...
+      #     <%= person_form.fields_for_with_index :projects do |project_fields, index| %>
+      #       Position: <%= index %>
+      #       Name: <%= project_fields.text_field :name %>
+      #     <% end %>
+      #     ...
+      #   <% end %>
+      #
       # When projects is already an association on Person you can use
       # +accepts_nested_attributes_for+ to define the writer method for you:
       #
@@ -1214,6 +1227,12 @@ module ActionView
               objectify_options(options))        #     objectify_options(options))
           end                                    # end
         RUBY_EVAL
+      end
+
+      def fields_for_with_index(record_name, record_object = nil, fields_options = {}, &block)
+        index = fields_options[:index] || options[:child_index] || nested_child_index(@object_name)
+        block_with_index = Proc.new{ |obj| block.call(obj, index) }
+        fields_for(record_name, record_object, fields_options, &block_with_index)
       end
 
       def fields_for(record_name, record_object = nil, fields_options = {}, &block)

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -974,6 +974,22 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_nested_fields_for_with_index_with_index_and_parent_fields
+    form_for(@post, :index => 1) do |c|
+      concat c.text_field(:title)
+      concat c.fields_for_with_index('comment', @comment, :index => 1) { |r, comment_index|
+        concat r.text_field(:name, "data-index" => comment_index)
+      }
+    end
+
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', 'put') do
+      "<input name='post[1][title]' size='30' type='text' id='post_1_title' value='Hello World' />" +
+      "<input name='post[1][comment][1][name]' size='30' type='text' id='post_1_comment_1_name' value='new comment' data-index='1' />"
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_form_for_with_index_and_nested_fields_for
     output_buffer = form_for(@post, :index => 1) do |f|
       concat f.fields_for(:comment, @post) { |c|
@@ -1025,6 +1041,20 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', 'put') do
       "<input name='post[comment][5][title]' type='radio' id='post_comment_5_title_hello' value='hello' />"
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_nested_fields_for_with_index_with_index_radio_button
+    form_for(@post) do |f|
+      concat f.fields_for_with_index(:comment, @post, :index => 5) { |c, index|
+        concat c.radio_button(:title, "hello", "data-index" => index)
+      }
+    end
+
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', 'put') do
+      "<input name='post[comment][5][title]' type='radio' id='post_comment_5_title_hello' value='hello' data-index='5' />"
     end
 
     assert_dom_equal expected, output_buffer
@@ -1229,6 +1259,29 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_nested_fields_for_with_index_with_existing_records_on_a_nested_attributes_collection_association
+    @post.comments = Array.new(2) { |id| Comment.new(id + 1) }
+
+    form_for(@post) do |f|
+      concat f.text_field(:title)
+      @post.comments.each do |comment|
+        concat f.fields_for_with_index(:comments, comment) { |cf, index|
+          concat cf.text_field(:name, "data-index" => index)
+        }
+      end
+    end
+
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #1" data-index="0" />' +
+      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" />' +
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" size="30" type="text" value="comment #2" data-index="1" />' +
+      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" />'
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_nested_fields_for_with_existing_records_on_a_nested_attributes_collection_association_with_disabled_hidden_id
     @post.comments = Array.new(2) { |id| Comment.new(id + 1) }
     @post.author = Author.new(321)
@@ -1251,6 +1304,33 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" />' +
       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #1" />' +
       '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" size="30" type="text" value="comment #2" />'
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_nested_fields_for_with_index_with_existing_records_on_a_nested_attributes_collection_association_with_disabled_hidden_id
+    @post.comments = Array.new(2) { |id| Comment.new(id + 1) }
+    @post.author = Author.new(321)
+
+    form_for(@post) do |f|
+      concat f.text_field(:title)
+      concat f.fields_for(:author) { |af|
+        concat af.text_field(:name)
+      }
+      @post.comments.each do |comment|
+        concat f.fields_for_with_index(:comments, comment, :include_id => false) { |cf, index|
+          concat cf.text_field(:name, 'data-index' => index)
+        }
+      end
+    end
+
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="author #321" />' +
+      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" />' +
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #1" data-index="0" />' +
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" size="30" type="text" value="comment #2" data-index="1" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1377,6 +1457,28 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_nested_fields_for_with_index_with_new_records_on_a_nested_attributes_collection_association
+    @post.comments = [Comment.new, Comment.new]
+
+    form_for(@post) do |f|
+      concat f.text_field(:title)
+      @post.comments.each do |comment|
+        concat f.fields_for_with_index(:comments, comment) { |cf, index|
+          concat cf.text_field(:name, "data-index" => index)
+        }
+      end
+    end
+
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="new comment" data-index="0" />' +
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" size="30" type="text" value="new comment" data-index="1" />'
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
+
   def test_nested_fields_for_with_existing_and_new_records_on_a_nested_attributes_collection_association
     @post.comments = [Comment.new(321), Comment.new]
 
@@ -1398,6 +1500,29 @@ class FormHelperTest < ActionView::TestCase
 
     assert_dom_equal expected, output_buffer
   end
+
+  def test_nested_fields_for_with_index_with_existing_and_new_records_on_a_nested_attributes_collection_association
+    @post.comments = [Comment.new(321), Comment.new]
+
+    form_for(@post) do |f|
+      concat f.text_field(:title)
+      @post.comments.each do |comment|
+        concat f.fields_for_with_index(:comments, comment) { |cf, index|
+          concat cf.text_field(:name, "data-index" => index)
+        }
+      end
+    end
+
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #321" data-index="0" />' +
+      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="321" />' +
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" size="30" type="text" value="new comment" data-index="1" />'
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
 
   def test_nested_fields_for_with_an_empty_supplied_attributes_collection
     form_for(@post) do |f|


### PR DESCRIPTION
Hi guys!

This patch adds the method FormHelper#fields_for_with_index which may be useful in situations where you need to access to the current child index while invoking field_for on a collection.

This feature is inspired on the discussion under the following open issue: https://github.com/rails/rails/issues/642.

Although I guess it's not a very common situation, I had to figure out how to access to the child index a few times. In the meanwhile, the best solution that I found it's the following:

http://stackoverflow.com/questions/4853373/rails-fields-for-with-index

However, the proposed method would allow us to write the same code more concisely, leaving to Rails the responsibility of iterating over collection members.

Hope it helps!

Cheers,
Regards
