### PR TITLE
Don't raise NoMethodError the tried method doesn't exists

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/try.rb
+++ b/activesupport/lib/active_support/core_ext/object/try.rb
@@ -28,6 +28,8 @@ class Object
   def try(*a, &b)
     if a.empty? && block_given?
       yield self
+    elsif !a.empty? && !respond_to?(a.first)
+      nil
     else
       __send__(*a, &b)
     end

--- a/activesupport/test/core_ext/object_and_class_ext_test.rb
+++ b/activesupport/test/core_ext/object_and_class_ext_test.rb
@@ -101,6 +101,12 @@ class ObjectTryTest < Test::Unit::TestCase
     assert !@string.respond_to?(method)
     assert_nil @string.try(method)
   end
+  
+  def test_nonexisting_method_with_arguments
+    method = :undefined_method
+    assert !@string.respond_to?(method)
+    assert_nil @string.try(method, 'llo', 'y')
+  end
 
   def test_valid_method
     assert_equal 5, @string.try(:size)

--- a/activesupport/test/core_ext/object_and_class_ext_test.rb
+++ b/activesupport/test/core_ext/object_and_class_ext_test.rb
@@ -99,7 +99,7 @@ class ObjectTryTest < Test::Unit::TestCase
   def test_nonexisting_method
     method = :undefined_method
     assert !@string.respond_to?(method)
-    assert_raise(NoMethodError) { @string.try(method) }
+    assert_nil @string.try(method)
   end
 
   def test_valid_method


### PR DESCRIPTION
As said at the time by @rwdaigle in the [edge rails blog](http://ryandaigle.com/articles/2008/11/20/what-s-new-in-edge-rails-object-try),

> If the method doesn’t exist, or if the target object nil, then nil will be returned without exceptions

That's not the case however.
Only nil returns nil for try. If the method does not exists, a NoMethoderror will be raised.

This pull request changes it.
