### PR TITLE
Fix ConnectionPool thread-safe issue

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -216,6 +216,18 @@ module ActiveRecord
         end
       end
 
+      # Return any checked-out connections back to the pool by threads that
+      # are no longer alive.
+      def clear_stale_cached_connections!
+        keys = @reserved_connections.keys - Thread.list.find_all { |t|
+          t.alive?
+        }.map { |thread| thread.object_id }
+        keys.each do |key|
+          checkin @reserved_connections[key]
+          @reserved_connections.delete(key)
+        end
+      end
+
       # Check-out a database connection from the pool, indicating that you want
       # to use it. You should call #checkin when you no longer need this.
       #
@@ -276,17 +288,6 @@ module ActiveRecord
         :connection, :release_connection, :connected?, :disconnect!, :with => :@connection_mutex
 
       private
-      # Return any checked-out connections back to the pool by threads that
-      # are no longer alive.
-      def clear_stale_cached_connections!
-        keys = @reserved_connections.keys - Thread.list.find_all { |t|
-          t.alive?
-        }.map { |thread| thread.object_id }
-        keys.each do |key|
-          checkin @reserved_connections[key]
-          @reserved_connections.delete(key)
-        end
-      end
 
       def new_connection
         ActiveRecord::Base.send(spec.adapter_method, spec.config)

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -81,7 +81,7 @@ module ActiveRecord
         }
         pool.checkins = []
 
-        cleared_threads = pool.clear_stale_cached_connections!
+        cleared_threads = pool.send(:clear_stale_cached_connections!)
         assert((cleared_threads - threads.map { |x| x.object_id }).empty?,
                "threads should have been removed")
         assert_equal pool.checkins.length, threads.length

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -81,7 +81,7 @@ module ActiveRecord
         }
         pool.checkins = []
 
-        cleared_threads = pool.send(:clear_stale_cached_connections!)
+        cleared_threads = pool.clear_stale_cached_connections!
         assert((cleared_threads - threads.map { |x| x.object_id }).empty?,
                "threads should have been removed")
         assert_equal pool.checkins.length, threads.length


### PR DESCRIPTION
This is a new fix NZKoz suggested, details: https://github.com/rails/rails/pull/563

Changes made: covered ConnectionPool#connection and #release_connection methods by mutex to fix thread-safe issue; changed ConnectionPool#clear_stale_cached_connections! to private to avoid outside call, which would not be thread-safe,

The old patch with the test provided to prove the thread-safe issue on jruby can be found at: https://github.com/xli/rails/commit/23828c0a9eca44c697765e06f39e0bc33ec74bb6
