### PR TITLE
Stringify param values in controller tests.

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -395,7 +395,26 @@ module ActionController
       end
       alias xhr :xml_http_request
 
+      def stringify_values(hash_or_array_or_value)
+        case hash_or_array_or_value
+        when Hash
+          hash_or_array_or_value.each do |key, value|
+            hash_or_array_or_value[key] = stringify_values(value)
+          end
+        when Array
+          hash_or_array_or_value.map {|i| stringify_values(i)}
+        when Numeric, Symbol
+          hash_or_array_or_value.to_s
+        else
+          hash_or_array_or_value
+        end
+      end
+
       def process(action, parameters = nil, session = nil, flash = nil, http_method = 'GET')
+        # Ensure that numbers and symbols passed as params are converted to
+        # strings, as is the case when engaging rack.
+        stringify_values(parameters)
+
         # Sanity check for required instance variables so we can give an
         # understandable error message.
         %w(@routes @controller @request @response).each do |iv_name|

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -395,25 +395,25 @@ module ActionController
       end
       alias xhr :xml_http_request
 
-      def stringify_values(hash_or_array_or_value)
+      def paramify_values(hash_or_array_or_value)
         case hash_or_array_or_value
         when Hash
           hash_or_array_or_value.each do |key, value|
-            hash_or_array_or_value[key] = stringify_values(value)
+            hash_or_array_or_value[key] = paramify_values(value)
           end
         when Array
-          hash_or_array_or_value.map {|i| stringify_values(i)}
-        when Numeric, Symbol
-          hash_or_array_or_value.to_s
-        else
+          hash_or_array_or_value.map {|i| paramify_values(i)}
+        when Rack::Test::UploadedFile
           hash_or_array_or_value
+        else
+          hash_or_array_or_value.to_param
         end
       end
 
       def process(action, parameters = nil, session = nil, flash = nil, http_method = 'GET')
         # Ensure that numbers and symbols passed as params are converted to
-        # strings, as is the case when engaging rack.
-        stringify_values(parameters)
+        # proper params, as is the case when engaging rack.
+        paramify_values(parameters)
 
         # Sanity check for required instance variables so we can give an
         # understandable error message.

--- a/actionpack/test/controller/test_test.rb
+++ b/actionpack/test/controller/test_test.rb
@@ -493,6 +493,16 @@ XML
     )
   end
 
+  def test_params_passing_with_fixnums
+    get :test_params, :page => {:name => "Page name", :month => 4, :year => 2004, :day => 6}
+    parsed_params = eval(@response.body)
+    assert_equal(
+      {'controller' => 'test_test/test', 'action' => 'test_params',
+       'page' => {'name' => "Page name", 'month' => '4', 'year' => '2004', 'day' => '6'}},
+      parsed_params
+    )
+  end
+
   def test_params_passing_with_frozen_values
     assert_nothing_raised do
       get :test_params, :frozen => 'icy'.freeze, :frozens => ['icy'.freeze].freeze


### PR DESCRIPTION
This reduces false positives that come from using ints in params in
tests, which do not get converted to strings in the tests. In
implementations going through rack, they do get converted to strings.
- David Chelimsky and Sam Umbach
