### PR TITLE
1.9 style Hash format in generated files breaks when deployed to 1.8.7

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/session_store.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/session_store.rb.tt
@@ -1,6 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-<%= app_const %>.config.session_store :cookie_store, <%= key_value :key, "'_#{app_name}_session'" %>
+<%= app_const %>.config.session_store :cookie_store, :key => '_<%= app_name %>_session'
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/wrap_parameters.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/wrap_parameters.rb.tt
@@ -4,7 +4,7 @@
 # which will be enabled by default in the upcoming version of Ruby on Rails.
 
 # Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
-ActionController::Base.wrap_parameters <%= key_value :format, "[:json]" %>
+ActionController::Base.wrap_parameters :format => [:json]
 
 # Disable root element in JSON by default.
 if defined?(ActiveRecord)


### PR DESCRIPTION
This change to Hash key format (from `:key => val`, to `key: val`) breaks if you:
1. generate `rails new foo` on a machine w/ 1.9.2
2. then deploy to a machine running 1.8.7 (like REE)

example:

```
/config/initializers/session_store.rb:3: syntax error, unexpected ':', expecting $end (SyntaxError)
```
