### PR TITLE
Take into account time spent in AR even if a redirect occurs or if it is 

### DIFF
--- a/activerecord/lib/active_record/railties/controller_runtime.rb
+++ b/activerecord/lib/active_record/railties/controller_runtime.rb
@@ -23,8 +23,8 @@ module ActiveRecord
           db_rt_before_render = ActiveRecord::LogSubscriber.reset_runtime
           runtime = super
           db_rt_after_render = ActiveRecord::LogSubscriber.reset_runtime
-          self.db_runtime = db_rt_before_render + db_rt_after_render
-          runtime - db_rt_after_render
+          self.db_runtime = db_rt_before_render + db_during_render          
+          runtime - db_during_render
         else
           super
         end
@@ -32,7 +32,9 @@ module ActiveRecord
 
       def append_info_to_payload(payload)
         super
-        payload[:db_runtime] = db_runtime
+        if ActiveRecord::Base.connected?
+          payload[:db_runtime] = (db_runtime || 0) + ActiveRecord::LogSubscriber.reset_runtime
+        end
       end
 
       module ClassMethods


### PR DESCRIPTION
The performance breakdown at the end of an action doesn't include all time spent in activerecord - it only includes time spent until the point where the view finishes rendering. If more time is spent afterwards (or if no view is rendered at all, ie the response is a redirect) then it is not included in the total
