### PR TITLE
Make sure that we're able to run Action Pack test standalone.

### DIFF
--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../../../load_paths', __FILE__)
+require File.expand_path('../../../version', __FILE__)
 
 lib = File.expand_path("#{File.dirname(__FILE__)}/../lib")
 $:.unshift(lib) unless $:.include?('lib') || $:.include?(lib)

--- a/actionpack/test/template/sprockets_helper_test.rb
+++ b/actionpack/test/template/sprockets_helper_test.rb
@@ -1,8 +1,13 @@
 require 'abstract_unit'
+
+module Rails
+  class Engine
+    def self.initializer(*args); end
+  end
+end
+
 require 'sprockets'
 require 'mocha'
-
-module Rails; end
 
 class SprocketsHelperTest < ActionView::TestCase
   tests ActionView::Helpers::SprocketsHelper


### PR DESCRIPTION
There was a problem that I can't `cd actionpack` and `bundle exec rake` in there. Sprocket was trying to look for these two things:
- `Rails::VERSION::STRING`
- `.initializer(str)` in `Rails::Engine`

This commit added require to version.rb into Abstract Unit, and mocking the `Rails::Engine.initializer` in `sprockets_helper_test.rb`
