### PR TITLE
We don't need to load version any more as Sprockets.beta8 is included. 

### DIFF
--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -1,5 +1,4 @@
 require File.expand_path('../../../load_paths', __FILE__)
-require File.expand_path('../../../version', __FILE__)
 
 lib = File.expand_path("#{File.dirname(__FILE__)}/../lib")
 $:.unshift(lib) unless $:.include?('lib') || $:.include?(lib)

--- a/actionpack/test/template/sprockets_helper_test.rb
+++ b/actionpack/test/template/sprockets_helper_test.rb
@@ -1,11 +1,4 @@
 require 'abstract_unit'
-
-module Rails
-  class Engine
-    def self.initializer(*args); end
-  end
-end
-
 require 'sprockets'
 require 'mocha'
 


### PR DESCRIPTION
Kind of Revert 

https://github.com/rails/rails/commit/90f028a4dc48152baded4cba9ec66474c2e98f48
