### PR TITLE
Fix for Issue #1205

### DIFF
--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -79,8 +79,12 @@ module ActiveRecord
       end
 
       def invert_add_index(args)
-        table, columns, _ = *args
-        [:remove_index, [table, {:column => columns}]]
+        table, columns, options = *args
+        if options && options[:name]
+          [:remove_index, [table, {:name => options[:name]}]]
+        else
+          [:remove_index, [table, {:column => columns}]]
+        end
       end
 
       def invert_remove_timestamps(args)

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -80,11 +80,8 @@ module ActiveRecord
 
       def invert_add_index(args)
         table, columns, options = *args
-        if options && options[:name]
-          options_hash = {:name => options[:name]}
-        else
-          options_hash = {:column => columns}
-        end
+        index_name = options.try(:[], :name)
+        options_hash =  index_name ? {:name => index_name} : {:column => columns}
         [:remove_index, [table, options_hash]]
       end
 

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -81,10 +81,11 @@ module ActiveRecord
       def invert_add_index(args)
         table, columns, options = *args
         if options && options[:name]
-          [:remove_index, [table, {:name => options[:name]}]]
+          options_hash = {:name => options[:name]}
         else
-          [:remove_index, [table, {:column => columns}]]
+          options_hash = {:column => columns}
         end
+        [:remove_index, [table, options_hash]]
       end
 
       def invert_remove_timestamps(args)

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -92,6 +92,12 @@ module ActiveRecord
           assert_equal [:remove_index, [:table, {:name => "new_index"}]], remove
       end
 
+      def test_invert_add_index_with_no_options
+        @recorder.record :add_index, [:table, [:one, :two]]
+        remove = @recorder.inverse.first
+        assert_equal [:remove_index, [:table, {:column => [:one, :two]}]], remove
+      end
+
       def test_invert_rename_index
         @recorder.record :rename_index, [:old, :new]
         rename = @recorder.inverse.first

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -86,6 +86,12 @@ module ActiveRecord
         assert_equal [:remove_index, [:table, {:column => [:one, :two]}]], remove
       end
 
+      def test_invert_add_index_with_name
+          @recorder.record :add_index, [:table, [:one, :two], {:name => "new_index"}]
+          remove = @recorder.inverse.first
+          assert_equal [:remove_index, [:table, {:name => "new_index"}]], remove
+      end
+
       def test_invert_rename_index
         @recorder.record :rename_index, [:old, :new]
         rename = @recorder.inverse.first


### PR DESCRIPTION
Simple fix for correctly inverting an add_index migration when a name has been provided

This is for Issue #1205 on the github tracker.
