### PR TITLE
Add entry to AP changelog

### DIFF
--- a/actionpack/CHANGELOG
+++ b/actionpack/CHANGELOG
@@ -1,5 +1,7 @@
 *Rails 3.1.0 (unreleased)*
 
+* Added 'ActionView::Helpers::FormHelper.fields_for_with_index', similar to fields_for but allows to have access to the current iteration index [Jorge Bejar]
+
 * Warn if we cannot verify CSRF token authenticity [José Valim]
 
 * Allow AM/PM format in datetime selectors [Aditya Sanghi]


### PR DESCRIPTION
Adds an entry into the ActionPack CHANGELOG mentioning the following new method: https://github.com/rails/rails/pull/1189
