### PR TITLE
root route should be the very first route in routes.rb for efficiency reason

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/routes.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/routes.rb
@@ -1,4 +1,9 @@
 <%= app_const %>.routes.draw do
+
+  # You can have the root of your site routed with "root"
+  # just remember to delete public/index.html.
+  # root :to => 'welcome#index'
+
   # The priority is based upon order of creation:
   # first created -> highest priority.
 
@@ -45,10 +50,6 @@
   #     # (app/controllers/admin/products_controller.rb)
   #     resources :products
   #   end
-
-  # You can have the root of your site routed with "root"
-  # just remember to delete public/index.html.
-  # root :to => 'welcome#index'
 
   # See how all your routes lay out with "rake routes"
 


### PR DESCRIPTION
As per comment mentioned for 'def root' at

https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/routing/mapper.rb#L259

root route should be at the very top because that will help it match
first. Since root is most popular route it is beneficial.

I agree with that and this patch moves the root route to the top
to encourage that behavior .
