### PR TITLE
Deprecate kernel requires

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency('rack-cache',       '~> 1.0.1')
   s.add_dependency('builder',          '~> 3.0.0')
   s.add_dependency('i18n',             '~> 0.6')
-  s.add_dependency('rack',             '~> 1.3.0.beta2')
+  s.add_dependency('rack',             '~> 1.3.0')
   s.add_dependency('rack-test',        '~> 0.6.0')
   s.add_dependency('rack-mount',       '~> 0.8.1')
   s.add_dependency('sprockets',        '~> 2.0.0.beta.8')

--- a/activesupport/lib/active_support/core_ext/kernel/requires.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/requires.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/kernel/reporting'
+require 'active_support/core_ext/module/deprecation'
 
 module Kernel
   # Require a library with fallback to RubyGems.  Warnings during library
@@ -23,4 +24,5 @@ module Kernel
       end
     end
   end
+  deprecate :require_library_or_gem
 end

--- a/activesupport/test/core_ext/kernel_test.rb
+++ b/activesupport/test/core_ext/kernel_test.rb
@@ -1,7 +1,7 @@
 require 'abstract_unit'
 require 'active_support/core_ext/kernel'
 
-class KernelTest < Test::Unit::TestCase
+class KernelTest < ActiveSupport::TestCase
   def test_silence_warnings
     silence_warnings { assert_nil $VERBOSE }
     assert_equal 1234, silence_warnings { 1234 }
@@ -52,10 +52,16 @@ class KernelTest < Test::Unit::TestCase
     class << o; @x = 1; end
     assert_equal 1, o.class_eval { @x }
   end
-  
+
   def test_capture
     assert_equal 'STDERR', capture(:stderr) {$stderr.print 'STDERR'}
     assert_equal 'STDOUT', capture(:stdout) {print 'STDOUT'}
+  end
+
+  def test_require_library_or_gem_deprecated
+    assert_deprecated do
+      require_library_or_gem 'i18n'
+    end
   end
 end
 

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -141,8 +141,6 @@ module Rails
 
     def default_middleware_stack
       ActionDispatch::MiddlewareStack.new.tap do |middleware|
-        middleware.use ::Rails::Rack::ContentLength, config.action_dispatch.x_sendfile_header
-
         if rack_cache = config.action_controller.perform_caching && config.action_dispatch.rack_cache
           require "action_dispatch/http/rack_cache"
           middleware.use ::Rack::Cache, rack_cache

--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -78,6 +78,7 @@ module Rails
       middlewares = []
       middlewares << [Rails::Rack::LogTailer, log_path] unless options[:daemonize]
       middlewares << [Rails::Rack::Debugger]  if options[:debugger]
+      middlewares << [Rails::Rack::ContentLength]
       Hash.new(middlewares)
     end
 

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -19,7 +19,6 @@ module ApplicationTests
       boot!
 
       assert_equal [
-        "Rails::Rack::ContentLength",
         "ActionDispatch::Static",
         "Rack::Lock",
         "ActiveSupport::Cache::Strategy::LocalCache",
@@ -49,7 +48,7 @@ module ApplicationTests
 
       boot!
 
-      assert_equal "Rack::Cache", middleware.second
+      assert_equal "Rack::Cache", middleware.first
     end
 
     test "Rack::SSL is present when force_ssl is set" do
@@ -104,7 +103,7 @@ module ApplicationTests
     end
 
     test "insert middleware after" do
-      add_to_config "config.middleware.insert_after Rails::Rack::ContentLength, Rack::Config"
+      add_to_config "config.middleware.insert_after ActionDispatch::Static, Rack::Config"
       boot!
       assert_equal "Rack::Config", middleware.second
     end
@@ -112,12 +111,12 @@ module ApplicationTests
     test "RAILS_CACHE does not respond to middleware" do
       add_to_config "config.cache_store = :memory_store"
       boot!
-      assert_equal "Rack::Runtime", middleware.fourth
+      assert_equal "Rack::Runtime", middleware.third
     end
 
     test "RAILS_CACHE does respond to middleware" do
       boot!
-      assert_equal "Rack::Runtime", middleware.fifth
+      assert_equal "Rack::Runtime", middleware.fourth
     end
 
     test "identity map is inserted" do
@@ -127,7 +126,7 @@ module ApplicationTests
     end
 
     test "insert middleware before" do
-      add_to_config "config.middleware.insert_before Rails::Rack::ContentLength, Rack::Config"
+      add_to_config "config.middleware.insert_before ActionDispatch::Static, Rack::Config"
       boot!
       assert_equal "Rack::Config", middleware.first
     end


### PR DESCRIPTION
Hey Guys,

This patch is for 3-1-stable and deprecates `require_library_or_gem` as its been removed in 3.2.

Enjoy,

Josh
