### PR TITLE
Also reset put_via_redirect and delete_via_redirect.

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -317,7 +317,8 @@ module ActionDispatch
       end
 
       %w(get post put head delete cookies assigns
-         xml_http_request xhr get_via_redirect post_via_redirect).each do |method|
+         xml_http_request xhr get_via_redirect post_via_redirect
+         put_via_redirect delete_via_redirect).each do |method|
         define_method(method) do |*args|
           reset! unless integration_session
           # reset the html_document variable, but only for new get/post calls


### PR DESCRIPTION
We ran in to an issue upgrading a Rails 2.3.10 project to Rails 3.0 due to put_via_redirect not being included in the list of methods that Runner wraps with a reset for @html_document. I also added delete_via_redirect for completeness.
