### PR TITLE
Use set data structure to speed up circular reference checks on large/deeply nested objects

### DIFF
--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -14,6 +14,7 @@ require 'time'
 require 'active_support/core_ext/time/conversions'
 require 'active_support/core_ext/date_time/conversions'
 require 'active_support/core_ext/date/conversions'
+require 'set'
 
 module ActiveSupport
   class << self
@@ -39,7 +40,7 @@ module ActiveSupport
 
         def initialize(options = nil)
           @options = options
-          @seen = []
+          @seen = Set.new
         end
 
         def encode(value, use_options = true)
@@ -71,13 +72,12 @@ module ActiveSupport
 
         private
           def check_for_circular_references(value)
-            if @seen.any? { |object| object.equal?(value) }
+            unless @seen.add?(value.__id__)
               raise CircularReferenceError, 'object references itself'
             end
-            @seen.unshift value
             yield
           ensure
-            @seen.shift
+            @seen.delete(value.__id__)
           end
       end
 


### PR DESCRIPTION
This is a refactor, so no updates to tests.

This also could be cherry picked cleanly into 3-1-stable.
