### PR TITLE
Fix 'warning: ambiguous first argument; put parentheses or even spaces'.

### DIFF
--- a/railties/test/application/initializers/notifications_test.rb
+++ b/railties/test/application/initializers/notifications_test.rb
@@ -33,7 +33,7 @@ module ApplicationTests
       wait
 
       assert_equal 1, logger.logged(:debug).size
-      assert_match /SHOW tables/, logger.logged(:debug).last
+      assert_match(/SHOW tables/, logger.logged(:debug).last)
     end
   end
 end

--- a/railties/test/application/rack/logger_test.rb
+++ b/railties/test/application/rack/logger_test.rb
@@ -21,19 +21,19 @@ module ApplicationTests
       test "logger logs proper HTTP verb and path" do
         get "/blah"
         wait
-        assert_match /^Started GET "\/blah"/, logs[0]
+        assert_match(/^Started GET "\/blah"/, logs[0])
       end
 
       test "logger logs HTTP verb override" do
         post "/", {:_method => 'put'}
         wait
-        assert_match /^Started PUT "\/"/, logs[0]
+        assert_match(/^Started PUT "\/"/, logs[0])
       end
 
       test "logger logs HEAD requests" do
         post "/", {:_method => 'head'}
         wait
-        assert_match /^Started HEAD "\/"/, logs[0]
+        assert_match(/^Started HEAD "\/"/, logs[0])
       end
     end
   end

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -31,7 +31,7 @@ module ApplicationTests
         AppTemplate::Application.initialize!
       RUBY
 
-      assert_match "SuperMiddleware", Dir.chdir(app_path){ `rake middleware` }
+      assert_match("SuperMiddleware", Dir.chdir(app_path){ `rake middleware` })
     end
 
     def test_initializers_are_executed_in_rake_tasks
@@ -93,16 +93,16 @@ module ApplicationTests
       end
 
       output = Dir.chdir(app_path){ `rake db:migrate` }
-      assert_match /create_table\(:users\)/, output
-      assert_match /CreateUsers: migrated/, output
-      assert_match /add_column\(:users, :email, :string\)/, output
-      assert_match /AddEmailToUsers: migrated/, output
+      assert_match(/create_table\(:users\)/, output)
+      assert_match(/CreateUsers: migrated/, output)
+      assert_match(/add_column\(:users, :email, :string\)/, output)
+      assert_match(/AddEmailToUsers: migrated/, output)
 
       output = Dir.chdir(app_path){ `rake db:rollback STEP=2` }
-      assert_match /drop_table\("users"\)/, output
-      assert_match /CreateUsers: reverted/, output
-      assert_match /remove_column\("users", :email\)/, output
-      assert_match /AddEmailToUsers: reverted/, output
+      assert_match(/drop_table\("users"\)/, output)
+      assert_match(/CreateUsers: reverted/, output)
+      assert_match(/remove_column\("users", :email\)/, output)
+      assert_match(/AddEmailToUsers: reverted/, output)
     end
 
     def test_loading_specific_fixtures


### PR DESCRIPTION
Parenthesize arguments when the first one is a Regexp literal.
