### PR TITLE
Ignore :includes on through associations

### DIFF
--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -16,7 +16,7 @@ module ActiveRecord
           chain[1..-1].each do |reflection|
             scope = scope.merge(
               reflection.klass.scoped.with_default_scope.
-                except(:select, :create_with)
+                except(:select, :create_with, :includes)
             )
           end
           scope

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -448,6 +448,12 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal post_tags, eager_post_tags
   end
 
+  def test_eager_with_has_many_through_join_model_ignores_default_includes
+    assert_nothing_raised do
+      authors(:david).comments_on_posts_with_default_include.to_a
+    end
+  end
+
   def test_eager_with_has_many_and_limit
     posts = Post.find(:all, :order => 'posts.id asc', :include => [ :author, :comments ], :limit => 2)
     assert_equal 2, posts.size

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -138,6 +138,9 @@ class Author < ActiveRecord::Base
   has_many :misc_post_first_blue_tags_2, :through => :posts, :source => :first_blue_tags_2,
            :conditions => { :posts => { :title => ['misc post by bob', 'misc post by mary'] } }
 
+  has_many :posts_with_default_include, :class_name => 'PostWithDefaultInclude'
+  has_many :comments_on_posts_with_default_include, :through => :posts_with_default_include, :source => :comments
+
   scope :relation_include_posts, includes(:posts)
   scope :relation_include_tags, includes(:tags)
 

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -162,3 +162,9 @@ class FirstPost < ActiveRecord::Base
   has_many :comments, :foreign_key => :post_id
   has_one  :comment,  :foreign_key => :post_id
 end
+
+class PostWithDefaultInclude < ActiveRecord::Base
+  self.table_name = 'posts'
+  default_scope includes(:comments)
+  has_many :comments, :foreign_key => :post_id
+end


### PR DESCRIPTION
@jonleighton this is the other :includes problem that I mentioned in #1233. Again this is a regression from 3.0.x.
