### PR TITLE
Fix gemspec of full or mountable engines

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
@@ -4,6 +4,6 @@ Gem::Specification.new do |s|
   s.name = "<%= name %>"
   s.summary = "Insert <%= camelized %> summary."
   s.description = "Insert <%= camelized %> description."
-  s.files = Dir["lib/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
+  s.files = Dir["{app,config,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.version = "0.0.1"
 end

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -169,6 +169,12 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
     assert_file "app/views/layouts/bukkits/application.html.erb", /<title>Bukkits<\/title>/
   end
 
+  def test_creating_gemspec
+    assert_file "bukkits.gemspec", /s.name = "bukkits"/
+    assert_file "bukkits.gemspec", /s.files = Dir["{app,config,lib}\/**\/*"]/
+    assert_file "bukkits.gemspec", /s.version = "0.0.1"/
+  end
+
   def test_passing_dummy_path_as_a_parameter
     run_generator [destination_root, "--dummy_path", "spec/dummy"]
     assert_file "spec/dummy"


### PR DESCRIPTION
At the moment, the files of an engine, as specified in its gemspec, only include the lib folder, Rakefile, MIT-LICENSE and README.rdoc.

Nevertheless, if you're using the options _--full_ or _--mountable_ when generating an engine, the project will also include the folders app and config. But they're never part of the gemspec.

This patch fixes this issue by adding the concerning folders if they're available.
