### PR TITLE
Remove shebang from the template

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/templates/script/rails.tt
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/script/rails.tt
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
 
 ENGINE_PATH = File.expand_path('../..',  __FILE__)

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -176,6 +176,11 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
     assert_file "bukkits.gemspec", /s.version = "0.0.1"/
   end
 
+  def test_shebang
+    run_generator
+    assert_file "script/rails", /#!\/usr\/bin\/env ruby/
+  end
+
   def test_passing_dummy_path_as_a_parameter
     run_generator [destination_root, "--dummy_path", "spec/dummy"]
     assert_file "spec/dummy"


### PR DESCRIPTION
I've removed the shebang from the template since it's already added by the engine generator.
Otherwise it would be generated twice.
