### PR TITLE
Create the dummy app if there's no test_unit but there's a dummy_path

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -202,7 +202,7 @@ task :default => :test
       end
 
       def create_test_dummy_files
-        return if options[:skip_test_unit]
+        return if options[:skip_test_unit] && options[:dummy_path] == 'test/dummy'
         create_dummy_app
       end
 

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -182,6 +182,13 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
     assert_file "spec/dummy/config/application.rb"
     assert_no_file "test/dummy"
   end
+  
+  def test_creating_dummy_without_tests_but_with_dummy_path
+    run_generator [destination_root, "--dummy_path", "spec/dummy", "--skip-test-unit"]
+    assert_file "spec/dummy"
+    assert_file "spec/dummy/config/application.rb"
+    assert_no_file "test"
+  end
 
   def test_skipping_gemspec
     run_generator [destination_root, "--skip-gemspec"]


### PR DESCRIPTION
This pull request follows #1259

When creating a new plugin with the `skip-test-unit` option, the dummy app isn't generated, which is the expected behavior.
However, if we provide the `dummy-path` option, it should generate the dummy app where we specified it to.
