### PR TITLE
Addresses an inconsistency in the ActiveRecord::Base.method_missing handl

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1052,7 +1052,7 @@ module ActiveRecord #:nodoc:
             if match.finder?
               options = arguments.extract_options!
               relation = options.any? ? scoped(options) : scoped
-              relation.send :find_by_attributes, match, attribute_names, *arguments
+              relation.send :find_by_attributes, match, attribute_names, *arguments, &block
             elsif match.instantiator?
               scoped.send :find_or_instantiator_by_attributes, match, attribute_names, *arguments, &block
             end

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -259,6 +259,7 @@ module ActiveRecord
       if match.bang? && result.blank?
         raise RecordNotFound, "Couldn't find #{@klass.name} with #{conditions.to_a.collect {|p| p.join(' = ')}.join(', ')}"
       else
+        yield(result) if block_given?
         result
       end
     end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -372,6 +372,15 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal Post.find(1).last_comment, post.last_comment
   end
 
+  def test_dynamic_find_by_attributes_should_yield_found_object
+    david = authors(:david)
+    yielded_value = nil
+    Author.find_by_name(david.name) do |author|
+      yielded_value = author
+    end
+    assert_equal david, yielded_value
+  end
+
   def test_dynamic_find_by_attributes
     david = authors(:david)
     author = Author.preload(:taggings).find_by_id(david.id)


### PR DESCRIPTION
Addresses an inconsistency in the ActiveRecord::Base.method_missing handling of dynamic finder methods and the passing of the &block parameter for :find_by_attributes.
