### PR TITLE
Fixes for Rake::GemPackageTask deprecation warnings from Rake 0.9.0

### DIFF
--- a/actionmailer/Rakefile
+++ b/actionmailer/Rakefile
@@ -1,7 +1,7 @@
 #!/usr/bin/env rake
 require 'rake/testtask'
 require 'rake/packagetask'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 
 desc "Default Task"
 task :default => [ :test ]
@@ -24,7 +24,7 @@ end
 
 spec = eval(File.read('actionmailer.gemspec'))
 
-Rake::GemPackageTask.new(spec) do |p|
+Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
 end
 

--- a/actionpack/Rakefile
+++ b/actionpack/Rakefile
@@ -1,7 +1,7 @@
 #!/usr/bin/env rake
 require 'rake/testtask'
 require 'rake/packagetask'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 
 desc "Default Task"
 task :default => :test
@@ -36,7 +36,7 @@ end
 
 spec = eval(File.read('actionpack.gemspec'))
 
-Rake::GemPackageTask.new(spec) do |p|
+Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
 end
 

--- a/activemodel/Rakefile
+++ b/activemodel/Rakefile
@@ -20,11 +20,11 @@ namespace :test do
 end
 
 require 'rake/packagetask'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 
 spec = eval(File.read("#{dir}/activemodel.gemspec"))
 
-Rake::GemPackageTask.new(spec) do |p|
+Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
 end
 

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -1,7 +1,7 @@
 #!/usr/bin/env rake
 require 'rake/testtask'
 require 'rake/packagetask'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 
 require File.expand_path(File.dirname(__FILE__)) + "/test/config"
 
@@ -171,7 +171,7 @@ task :rebuild_frontbase_databases => 'frontbase:rebuild_databases'
 
 spec = eval(File.read('activerecord.gemspec'))
 
-Rake::GemPackageTask.new(spec) do |p|
+Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
 end
 

--- a/activeresource/Rakefile
+++ b/activeresource/Rakefile
@@ -1,7 +1,7 @@
 #!/usr/bin/env rake
 require 'rake/testtask'
 require 'rake/packagetask'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 
 desc "Default Task"
 task :default => [ :test ]
@@ -26,7 +26,7 @@ end
 
 spec = eval(File.read('activeresource.gemspec'))
 
-Rake::GemPackageTask.new(spec) do |p|
+Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
 end
 

--- a/activesupport/Rakefile
+++ b/activesupport/Rakefile
@@ -1,5 +1,5 @@
 require 'rake/testtask'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 
 task :default => :test
 Rake::TestTask.new do |t|
@@ -20,7 +20,7 @@ dist_dirs = [ "lib", "test"]
 
 spec = eval(File.read('activesupport.gemspec'))
 
-Rake::GemPackageTask.new(spec) do |p|
+Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
 end
 

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -1,6 +1,6 @@
 #!/usr/bin/env rake
 require 'rake/testtask'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 
 require 'date'
 require 'rbconfig'
@@ -55,7 +55,7 @@ end
 
 spec = eval(File.read('railties.gemspec'))
 
-Rake::GemPackageTask.new(spec) do |pkg|
+Gem::PackageTask.new(spec) do |pkg|
   pkg.gem_spec = spec
 end
 


### PR DESCRIPTION
Fixing the deprecation of Rake::GemPackageTask in Rake 0.9.0.
