### PR TITLE
Updated ActiveRecord::Base.find_or_create_by for 2 attributes when 1 is n

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -273,8 +273,13 @@ module ActiveRecord
           unprotected_attributes_for_create[attributes[i]] = args[i]
         end
       end
+      attributes_for_create = protected_attributes_for_create.merge(unprotected_attributes_for_create)
 
-      conditions = (protected_attributes_for_create.merge(unprotected_attributes_for_create)).slice(*attributes).symbolize_keys
+      if attributes_for_create.length < attributes.length
+        attributes.each { |attrib| attributes_for_create[attrib] ||= nil }
+      end
+
+      conditions = (attributes_for_create).slice(*attributes).symbolize_keys
 
       record = where(conditions).first
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -815,6 +815,18 @@ class FinderTest < ActiveRecord::TestCase
     assert created_customer.persisted?
   end
 
+  def test_find_or_create_from_two_attributes_with_one_not_included
+    assert Author.find_by_name('David')
+    assert_no_difference 'Author.count' do
+      Author.find_or_create_by_name('David')
+    end
+
+    assert_nil Author.find_by_name_and_author_address_id('David')
+    assert_difference 'Author.count' do
+      Author.find_or_create_by_name_and_author_address_id('David')
+    end
+  end
+
   def test_find_or_create_from_one_attribute_and_hash
     number_of_companies = Company.count
     sig38 = Company.find_or_create_by_name({:name => "38signals", :firm_id => 17, :client_of => 23})


### PR DESCRIPTION
Updated ActiveRecord::Base.find_or_create_by for 2 attributes when 1 is nil

Updated the find_or_create_by_foo_and_bar('hello') to process the find portion
similar to find_by_foo_and_bar('hello').  In the original
find_by_foo_and_bar('hello'), the resulting query was something like
"foo = 'hello' AND bar IS NULL".  In the original
find_or_create_by_foo_and_bar('hello'), the resulting query was something like
"foo = 'hello'"

This patch aligns those two methods expected behaviors on the "find" portion
of the method call.
