### PR TITLE
Added a helper to make OPTIONS calls in controller tests

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -412,6 +412,11 @@ module ActionController
         process(action, "HEAD", parameters, session, flash)
       end
 
+      # Executes a request simulating OPTIONS HTTP method and set/volley the response
+      def options(action, parameters = nil, session = nil, flash = nil)
+        process(action, parameters, session, flash, "OPTIONS")
+      end
+
       def xml_http_request(request_method, action, parameters = nil, session = nil, flash = nil)
         @request.env['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest'
         @request.env['HTTP_ACCEPT'] ||=  [Mime::JS, Mime::HTML, Mime::XML, 'text/xml', Mime::ALL].join(', ')

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -56,6 +56,12 @@ module ActionDispatch
         process :delete, path, parameters, headers
       end
 
+      # Performs a OPTIONS request with the given parameters. See +#get+ for
+      # more details.
+      def options(path, parameters = nil, headers = nil)
+        process :options, path, parameters, headers
+      end
+
       # Performs a HEAD request with the given parameters. See +#get+ for more
       # details.
       def head(path, parameters = nil, headers = nil)
@@ -130,6 +136,12 @@ module ActionDispatch
       # See +request_via_redirect+ for more information.
       def delete_via_redirect(path, parameters = nil, headers = nil)
         request_via_redirect(:delete, path, parameters, headers)
+      end
+
+      # Performs a OPTIONS request, following any subsequent redirect.
+      # See +request_via_redirect+ for more information.
+      def options_via_redirect(path, parameters = nil, headers = nil)
+        request_via_redirect(:options, path, parameters, headers)
       end
     end
 

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -81,6 +81,12 @@ class SessionTest < ActiveSupport::TestCase
     @session.delete_via_redirect(path, args, headers)
   end
 
+  def test_options_via_redirect
+    path = "/somepath"; args = {:id => '1'}; headers = {"X-Test-Header" => "testvalue" }
+    @session.expects(:request_via_redirect).with(:options, path, args, headers)
+    @session.options_via_redirect(path, args, headers)
+  end
+
   def test_get
     path = "/index"; params = "blah"; headers = {:location => 'blah'}
     @session.expects(:process).with(:get,path,params,headers)
@@ -109,6 +115,12 @@ class SessionTest < ActiveSupport::TestCase
     path = "/index"; params = "blah"; headers = {:location => 'blah'}
     @session.expects(:process).with(:delete,path,params,headers)
     @session.delete(path,params,headers)
+  end
+
+  def test_options
+    path = "/index"; params = "blah"; headers = {:location => 'blah'}
+    @session.expects(:process).with(:options, path, params, headers)
+    @session.options(path, params, headers)
   end
 
   def test_head
@@ -171,6 +183,16 @@ class SessionTest < ActiveSupport::TestCase
     )
     @session.expects(:process).with(:delete,path,params,headers_after_xhr)
     @session.xml_http_request(:delete,path,params,headers)
+  end
+
+  def test_xml_http_request_options
+    path = "/index"; params = "blah"; headers = {:location => 'blah'}
+    headers_after_xhr = headers.merge(
+      "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest",
+      "HTTP_ACCEPT"           => "text/javascript, text/html, application/xml, text/xml, */*"
+    )
+    @session.expects(:process).with(:options, path, params, headers_after_xhr)
+    @session.xml_http_request(:options, path, params, headers)
   end
 
   def test_xml_http_request_head


### PR DESCRIPTION
I just saw a request by someone on the rspec-users mailing list for support for the OPTIONS http verb in controller specs. See http://rubyforge.org/pipermail/rspec-users/2011-May/020082.html

It makes sense to me that this exist in Rails (as opposed to rspec-rails) since OPTIONS is one of the better ways to figure out what resources do when building RESTful APIs.

I couldn't find where I should write the tests - if you could point me at the file where they're written, I'd be happy to add them.
