### PR TITLE
Fixes Rake::RDocTask deprecation warnings from Rake 0.9.0

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/Rakefile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Rakefile.tt
@@ -1,6 +1,6 @@
 #!/usr/bin/env rake
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 desc 'Default: run unit tests.'
 task :default => :test
@@ -14,7 +14,7 @@ Rake::TestTask.new(:test) do |t|
 end
 
 desc 'Generate documentation for the <%= file_name %> plugin.'
-Rake::RDocTask.new(:rdoc) do |rdoc|
+RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
   rdoc.title    = '<%= class_name %>'
   rdoc.options << '--line-numbers' << '--inline-source'

--- a/railties/lib/rails/generators/rails/plugin_new/templates/Rakefile
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/Rakefile
@@ -5,9 +5,9 @@ rescue LoadError
   puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
 end
 
-require 'rake/rdoctask'
+require 'rdoc/task'
 
-Rake::RDocTask.new(:rdoc) do |rdoc|
+RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
   rdoc.title    = '<%= camelized %>'
   rdoc.options << '--line-numbers' << '--inline-source'

--- a/railties/lib/rails/tasks/documentation.rake
+++ b/railties/lib/rails/tasks/documentation.rake
@@ -1,7 +1,7 @@
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 # Monkey-patch to remove redoc'ing and clobber descriptions to cut down on rake -T noise
-class RDocTaskWithoutDescriptions < Rake::RDocTask
+class RDocTaskWithoutDescriptions < RDoc::Task
   def define
     task rdoc_task_name
 

--- a/railties/test/railties/railtie_test.rb
+++ b/railties/test/railties/railtie_test.rb
@@ -97,7 +97,7 @@ module RailtiesTest
       assert !$ran_block
       require 'rake'
       require 'rake/testtask'
-      require 'rake/rdoctask'
+      require 'rdoc/task'
 
       AppTemplate::Application.load_tasks
       assert $ran_block
@@ -121,7 +121,7 @@ module RailtiesTest
       assert_equal [], $ran_block
       require 'rake'
       require 'rake/testtask'
-      require 'rake/rdoctask'
+      require 'rdoc/task'
 
       AppTemplate::Application.load_tasks
       assert $ran_block.include?("my_tie")

--- a/railties/test/railties/shared_tests.rb
+++ b/railties/test/railties/shared_tests.rb
@@ -237,7 +237,7 @@ module RailtiesTest
 
       boot_rails
       require 'rake'
-      require 'rake/rdoctask'
+      require 'rdoc/task'
       require 'rake/testtask'
       Rails.application.load_tasks
       Rake::Task[:foo].invoke


### PR DESCRIPTION
Fixing the deprecation of Rake::RDocTask in Rake 0.9.0. Using RDoc::Task instead, as mentioned here: http://drake.rubyforge.org/classes/Rake/RDocTask.html
