### PR TITLE
removed deprecated methods, and related tests, from ActiveRecord

### DIFF
--- a/activerecord/lib/active_record/associations/builder/singular_association.rb
+++ b/activerecord/lib/active_record/associations/builder/singular_association.rb
@@ -13,19 +13,6 @@ module ActiveRecord::Associations::Builder
 
     private
 
-      def define_readers
-        super
-        name = self.name
-
-        model.redefine_method("#{name}_loaded?") do
-          ActiveSupport::Deprecation.warn(
-            "Calling obj.#{name}_loaded? is deprecated. Please use " \
-            "obj.association(:#{name}).loaded? instead."
-          )
-          association(name).loaded?
-        end
-      end
-
       def define_constructors
         name = self.name
 

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -123,30 +123,6 @@ module ActiveRecord
           method_missing(:new, *args, &block)
         end
       end
-
-      def proxy_owner
-        ActiveSupport::Deprecation.warn(
-          "Calling record.#{@association.reflection.name}.proxy_owner is deprecated. Please use " \
-          "record.association(:#{@association.reflection.name}).owner instead."
-        )
-        @association.owner
-      end
-
-      def proxy_target
-        ActiveSupport::Deprecation.warn(
-          "Calling record.#{@association.reflection.name}.proxy_target is deprecated. Please use " \
-          "record.association(:#{@association.reflection.name}).target instead."
-        )
-        @association.target
-      end
-
-      def proxy_reflection
-        ActiveSupport::Deprecation.warn(
-          "Calling record.#{@association.reflection.name}.proxy_reflection is deprecated. Please use " \
-          "record.association(:#{@association.reflection.name}).reflection instead."
-        )
-        @association.reflection
-      end
     end
   end
 end

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1662,9 +1662,6 @@ MSG
       # If any attributes are protected by either +attr_protected+ or
       # +attr_accessible+ then only settable attributes will be assigned.
       #
-      # The +guard_protected_attributes+ argument is now deprecated, use
-      # the +assign_attributes+ method if you want to bypass mass-assignment security.
-      #
       #   class User < ActiveRecord::Base
       #     attr_protected :is_admin
       #   end
@@ -1673,20 +1670,10 @@ MSG
       #   user.attributes = { :username => 'Phusion', :is_admin => true }
       #   user.username   # => "Phusion"
       #   user.is_admin?  # => false
-      def attributes=(new_attributes, guard_protected_attributes = nil)
-        unless guard_protected_attributes.nil?
-          message = "the use of 'guard_protected_attributes' will be removed from the next major release of rails, " +
-                    "if you want to bypass mass-assignment security then look into using assign_attributes"
-          ActiveSupport::Deprecation.warn(message)
-        end
-
+      def attributes=(new_attributes)
         return unless new_attributes.is_a?(Hash)
 
-        if guard_protected_attributes == false
-          assign_attributes(new_attributes, :without_protection => true)
-        else
-          assign_attributes(new_attributes)
-        end
+        assign_attributes(new_attributes)
       end
 
       # Allows you to set all the attributes for a particular mass-assignment

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -1,5 +1,3 @@
-require 'active_support/core_ext/module/deprecation'
-
 module ActiveRecord
   module ConnectionAdapters # :nodoc:
     module DatabaseStatements
@@ -245,31 +243,6 @@ module ActiveRecord
       # done if the transaction block raises an exception or returns false.
       def rollback_db_transaction() end
 
-      # Appends +LIMIT+ and +OFFSET+ options to an SQL statement, or some SQL
-      # fragment that has the same semantics as LIMIT and OFFSET.
-      #
-      # +options+ must be a Hash which contains a +:limit+ option
-      # and an +:offset+ option.
-      #
-      # This method *modifies* the +sql+ parameter.
-      #
-      # This method is deprecated!! Stop using it!
-      #
-      # ===== Examples
-      #  add_limit_offset!('SELECT * FROM suppliers', {:limit => 10, :offset => 50})
-      # generates
-      #  SELECT * FROM suppliers LIMIT 10 OFFSET 50
-      def add_limit_offset!(sql, options)
-        if limit = options[:limit]
-          sql << " LIMIT #{sanitize_limit(limit)}"
-        end
-        if offset = options[:offset]
-          sql << " OFFSET #{offset.to_i}"
-        end
-        sql
-      end
-      deprecate :add_limit_offset!
-
       def default_sequence_name(table, column)
         nil
       end
@@ -308,10 +281,10 @@ module ActiveRecord
       # Sanitizes the given LIMIT parameter in order to prevent SQL injection.
       #
       # The +limit+ may be anything that can evaluate to a string via #to_s. It
-      # should look like an integer, or a comma-delimited list of integers, or 
+      # should look like an integer, or a comma-delimited list of integers, or
       # an Arel SQL literal.
       #
-      # Returns Integer and Arel::Nodes::SqlLiteral limits as is. 
+      # Returns Integer and Arel::Nodes::SqlLiteral limits as is.
       # Returns the sanitized limit parameter, either as an integer, or as a
       # string which contains a comma-delimited list of integers.
       def sanitize_limit(limit)

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -347,19 +347,6 @@ module ActiveRecord
         execute("RELEASE SAVEPOINT #{current_savepoint_name}")
       end
 
-      def add_limit_offset!(sql, options)
-        limit, offset = options[:limit], options[:offset]
-        if limit && offset
-          sql << " LIMIT #{offset.to_i}, #{sanitize_limit(limit)}"
-        elsif limit
-          sql << " LIMIT #{sanitize_limit(limit)}"
-        elsif offset
-          sql << " OFFSET #{offset.to_i}"
-        end
-        sql
-      end
-      deprecate :add_limit_offset!
-
       # SCHEMA STATEMENTS ========================================
 
       def structure_dump
@@ -581,11 +568,6 @@ module ActiveRecord
         pk_and_sequence = pk_and_sequence_for(table)
         pk_and_sequence && pk_and_sequence.first
       end
-
-      def case_sensitive_equality_operator
-        "= BINARY"
-      end
-      deprecate :case_sensitive_equality_operator
 
       def case_sensitive_modifier(node)
         Arel::Nodes::Bin.new(node)

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -487,19 +487,6 @@ module ActiveRecord
         execute("RELEASE SAVEPOINT #{current_savepoint_name}")
       end
 
-      def add_limit_offset!(sql, options) #:nodoc:
-        limit, offset = options[:limit], options[:offset]
-        if limit && offset
-          sql << " LIMIT #{offset.to_i}, #{sanitize_limit(limit)}"
-        elsif limit
-          sql << " LIMIT #{sanitize_limit(limit)}"
-        elsif offset
-          sql << " OFFSET #{offset.to_i}"
-        end
-        sql
-      end
-      deprecate :add_limit_offset!
-
       # SCHEMA STATEMENTS ========================================
 
       def structure_dump #:nodoc:
@@ -711,11 +698,6 @@ module ActiveRecord
         pk_and_sequence = pk_and_sequence_for(table)
         pk_and_sequence && pk_and_sequence.first
       end
-
-      def case_sensitive_equality_operator
-        "= BINARY"
-      end
-      deprecate :case_sensitive_equality_operator
 
       def case_sensitive_modifier(node)
         Arel::Nodes::Bin.new(node)

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -12,7 +12,6 @@ require 'active_support/core_ext/array/wrap'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/logger'
 require 'active_support/ordered_hash'
-require 'active_support/core_ext/module/deprecation'
 require 'active_record/fixtures/file'
 
 if defined? ActiveRecord
@@ -392,9 +391,6 @@ class FixturesFileNotFound < StandardError; end
 #     *DEFAULTS
 #
 # Any fixture labeled "DEFAULTS" is safely ignored.
-
-Fixture = ActiveSupport::Deprecation::DeprecatedConstantProxy.new('Fixture', 'ActiveRecord::Fixture')
-Fixtures = ActiveSupport::Deprecation::DeprecatedConstantProxy.new('Fixtures', 'ActiveRecord::Fixtures')
 
 module ActiveRecord
   class Fixtures

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -1,5 +1,4 @@
 require 'active_support/core_ext/class/attribute'
-require 'active_support/core_ext/module/deprecation'
 require 'active_support/core_ext/object/inclusion'
 
 module ActiveRecord
@@ -201,11 +200,6 @@ module ActiveRecord
       def foreign_key
         @foreign_key ||= options[:foreign_key] || derive_foreign_key
       end
-
-      def primary_key_name
-        foreign_key
-      end
-      deprecate :primary_key_name => :foreign_key
 
       def foreign_type
         @foreign_type ||= options[:foreign_type] || "#{name}_type"

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -370,15 +370,6 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert_nil new_ship.pirate_id
   end
 
-  def test_deprecated_association_loaded
-    firm   = companies(:first_firm)
-    firm.association(:account).stubs(:loaded?).returns(stub)
-
-    assert_deprecated do
-      assert_equal firm.association(:account).loaded?, firm.account_loaded?
-    end
-  end
-
   def test_association_keys_bypass_attribute_protection
     car = Car.create(:name => 'honda')
 

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -203,18 +203,6 @@ class AssociationProxyTest < ActiveRecord::TestCase
       assert_equal david.projects, david.projects.reload.reload
     end
   end
-
-  # Tests that proxy_owner, proxy_target and proxy_reflection are implement as deprecated methods
-  def test_proxy_deprecations
-    david = developers(:david)
-    david.projects.load_target
-
-    [:owner, :target, :reflection].each do |name|
-      assert_deprecated do
-        assert_equal david.association(:projects).send(name), david.projects.send("proxy_#{name}")
-      end
-    end
-  end
 end
 
 class OverridingAssociationsTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -502,13 +502,6 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal 'value2', weird.send('a$b')
   end
 
-  def test_attributes_guard_protected_attributes_is_deprecated
-    attributes = { "title" => "An amazing title" }
-    post = ProtectedTitlePost.new
-    assert_deprecated { post.send(:attributes=, attributes, false) }
-    assert_equal "An amazing title", post.title
-  end
-
   def test_multiparameter_attributes_on_date
     attributes = { "last_read(1i)" => "2004", "last_read(2i)" => "6", "last_read(3i)" => "24" }
     topic = Topic.find(1)

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -304,13 +304,6 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal "category_id", Post.reflect_on_association(:categorizations).foreign_key.to_s
   end
 
-  def test_primary_key_name
-    assert_deprecated do
-      assert_equal "author_id", Author.reflect_on_association(:posts).primary_key_name.to_s
-      assert_equal "category_id", Post.reflect_on_association(:categorizations).primary_key_name.to_s
-    end
-  end
-
   private
     def assert_reflection(klass, association, options)
       assert reflection = klass.reflect_on_association(association)


### PR DESCRIPTION
Hey @jonleighton and @tenderlove

The commit removes arguments and methods, and relating tests, from ActiveRecord which were deprecated in 3.1.

Let me know if I have missed anything.

Thanks,

Josh
