### PR TITLE
load_generators_from_railties was removed, remove test with error about it

### DIFF
--- a/railties/test/generators_test.rb
+++ b/railties/test/generators_test.rb
@@ -185,13 +185,6 @@ class GeneratorsTest < Rails::Generators::TestCase
     Rails::Generators.subclasses.delete(WithOptionsGenerator)
   end
 
-  def test_load_generators_from_railties
-    Rails::Generators::ModelGenerator.expects(:start).with(["Account"], {})
-    Rails::Generators.send(:remove_instance_variable, :@generators_from_railties)
-    Rails.application.expects(:load_generators)
-    Rails::Generators.invoke("model", ["Account"])
-  end
-
   def test_rails_root_templates
     template = File.join(Rails.root, "lib", "templates", "active_record", "model", "model.rb")
 


### PR DESCRIPTION
load_generators_from_railties was removed by @josevalim in https://github.com/rails/rails/commit/594b749f3c81102a1f89480d0f8f10b464b895a7#L5L327
