### PR TITLE
Add test files to engine's gemspec

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
@@ -5,5 +5,8 @@ Gem::Specification.new do |s|
   s.summary = "Insert <%= camelized %> summary."
   s.description = "Insert <%= camelized %> description."
   s.files = Dir["{app,config,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
+<% unless options.skip_test_unit? -%>
+  s.test_files = Dir["test/**/*"]
+<% end -%>
   s.version = "0.0.1"
 end

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -188,7 +188,7 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
     assert_file "spec/dummy/config/application.rb"
     assert_no_file "test/dummy"
   end
-  
+
   def test_creating_dummy_without_tests_but_with_dummy_path
     run_generator [destination_root, "--dummy_path", "spec/dummy", "--skip-test-unit"]
     assert_file "spec/dummy"

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -173,6 +173,7 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_file "bukkits.gemspec", /s.name = "bukkits"/
     assert_file "bukkits.gemspec", /s.files = Dir\["\{app,config,lib\}\/\*\*\/\*"\]/
+    assert_file "bukkits.gemspec", /s.test_files = Dir\["test\/\*\*\/\*"\]/
     assert_file "bukkits.gemspec", /s.version = "0.0.1"/
   end
 
@@ -193,6 +194,12 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
     assert_file "spec/dummy"
     assert_file "spec/dummy/config/application.rb"
     assert_no_file "test"
+  end
+
+  def test_skipping_test_unit
+    run_generator [destination_root, "--skip-test-unit"]
+    assert_no_file "test"
+    assert_no_match(/s.test_files = Dir\["test\/\*\*\/\*"\]/, File.read(File.join(destination_root, "bukkits.gemspec")))
   end
 
   def test_skipping_gemspec

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -199,7 +199,9 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
   def test_skipping_test_unit
     run_generator [destination_root, "--skip-test-unit"]
     assert_no_file "test"
-    assert_no_match(/s.test_files = Dir\["test\/\*\*\/\*"\]/, File.read(File.join(destination_root, "bukkits.gemspec")))
+    assert_file "bukkits.gemspec" do |contents|
+      assert_no_match /s.test_files = Dir\["test\/\*\*\/\*"\]/, contents
+    end
   end
 
   def test_skipping_gemspec


### PR DESCRIPTION
Hi guys,

I've added the test files to the engine's gemspec unless the option _--skip-test-unit_ is used.
Furthermore, I've cleaned up the test file a little bit by removing whitespaces from an empty line, I don't want to open a separate pull request for this minor issue.

Regards
