### PR TITLE
require 'rake/rdoctask' if failed to require 'rdoc/task'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,11 @@
 #!/usr/bin/env rake
 
-require 'rdoc/task'
+
+begin
+  require 'rdoc/task'
+rescue LoadError
+  require 'rake/rdoctask'
+end
 require 'net/http'
 
 $:.unshift File.expand_path('..', __FILE__)

--- a/railties/lib/rails/generators/rails/plugin_new/templates/Rakefile
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/Rakefile
@@ -4,8 +4,11 @@ begin
 rescue LoadError
   puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
 end
-
-require 'rdoc/task'
+begin
+  require 'rdoc/task'
+rescue LoadError
+  require 'rake/rdoctask'
+end
 
 RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_dir = 'rdoc'

--- a/railties/lib/rails/tasks/documentation.rake
+++ b/railties/lib/rails/tasks/documentation.rake
@@ -1,4 +1,8 @@
-require 'rdoc/task'
+begin
+  require 'rdoc/task'
+rescue LoadError
+  require 'rake/rdoctask'
+end
 
 # Monkey-patch to remove redoc'ing and clobber descriptions to cut down on rake -T noise
 class RDocTaskWithoutDescriptions < RDoc::Task

--- a/railties/test/railties/railtie_test.rb
+++ b/railties/test/railties/railtie_test.rb
@@ -97,7 +97,12 @@ module RailtiesTest
       assert !$ran_block
       require 'rake'
       require 'rake/testtask'
-      require 'rdoc/task'
+      begin
+        require 'rdoc/task'
+      rescue LoadError
+        require 'rake/rdoctask'
+      end
+
 
       AppTemplate::Application.load_tasks
       assert $ran_block

--- a/railties/test/railties/shared_tests.rb
+++ b/railties/test/railties/shared_tests.rb
@@ -237,7 +237,11 @@ module RailtiesTest
 
       boot_rails
       require 'rake'
-      require 'rdoc/task'
+      begin
+        require 'rdoc/task'
+      rescue LoadError
+        require 'rake/rdoctask'
+      end
       require 'rake/testtask'
       Rails.application.load_tasks
       Rake::Task[:foo].invoke


### PR DESCRIPTION
fixes a regression introduced by b921679d0dd3d5ca16f0362c2b34e7703cfe15e5
require 'rdoc/task' fails if the system RDoc version is below 2.4.2 (e.g. CRuby 1.8.7)
