### PR TITLE
Ensure RDoc::Task exists even if 'rdoc/task' was not required

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,6 @@
 #!/usr/bin/env rake
 
-
-begin
-  require 'rdoc/task'
-rescue LoadError
-  require 'rake/rdoctask'
-end
+require 'rdoc/task'
 require 'net/http'
 
 $:.unshift File.expand_path('..', __FILE__)

--- a/railties/lib/rails/generators/rails/plugin_new/templates/Rakefile
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/Rakefile
@@ -7,7 +7,9 @@ end
 begin
   require 'rdoc/task'
 rescue LoadError
+  require 'rdoc/rdoc'
   require 'rake/rdoctask'
+  RDoc::Task = Rake::RDocTask
 end
 
 RDoc::Task.new(:rdoc) do |rdoc|

--- a/railties/lib/rails/tasks/documentation.rake
+++ b/railties/lib/rails/tasks/documentation.rake
@@ -1,7 +1,9 @@
 begin
   require 'rdoc/task'
 rescue LoadError
+  require 'rdoc/rdoc'
   require 'rake/rdoctask'
+  RDoc::Task = Rake::RDocTask
 end
 
 # Monkey-patch to remove redoc'ing and clobber descriptions to cut down on rake -T noise

--- a/railties/test/railties/railtie_test.rb
+++ b/railties/test/railties/railtie_test.rb
@@ -97,12 +97,7 @@ module RailtiesTest
       assert !$ran_block
       require 'rake'
       require 'rake/testtask'
-      begin
-        require 'rdoc/task'
-      rescue LoadError
-        require 'rake/rdoctask'
-      end
-
+      require 'rdoc/task'
 
       AppTemplate::Application.load_tasks
       assert $ran_block

--- a/railties/test/railties/shared_tests.rb
+++ b/railties/test/railties/shared_tests.rb
@@ -237,11 +237,7 @@ module RailtiesTest
 
       boot_rails
       require 'rake'
-      begin
-        require 'rdoc/task'
-      rescue LoadError
-        require 'rake/rdoctask'
-      end
+      require 'rdoc/task'
       require 'rake/testtask'
       Rails.application.load_tasks
       Rake::Task[:foo].invoke


### PR DESCRIPTION
I'm sorry my previous commit 24b28a2a0c6a58e177b07ce3ccf56dc975541780 was still not perfect.
This time, I made sure the rdoc task runs.
