### PR TITLE
This fixes rake for me in RefineryCMS. 

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -211,12 +211,11 @@ module Rails
     end
 
     def initialize_tasks
-      self.class.rake_tasks do
-        require "rails/tasks"
-        task :environment do
-          $rails_rake_task = true
-          require_environment!
-        end
+      extend Rake::DSL if defined? Rake::DSL
+      require "rails/tasks"
+      task :environment do
+        $rails_rake_task = true
+        require_environment!
       end
     end
 

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -181,7 +181,6 @@ module Rails
     end
 
     def load_tasks
-      extend Rake::DSL if defined? Rake::DSL
       self.class.rake_tasks.each(&:call)
     end
 


### PR DESCRIPTION
This fixes rake for me in RefineryCMS. Otherwise, I get: undefined method 'prerequisites' for nil:NilClass (from rspec)
