### PR TITLE
Resolve issue #534

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -76,12 +76,6 @@ module ActiveRecord
     end
   end
 
-  class HasAndBelongsToManyAssociationWithPrimaryKeyError < ActiveRecordError #:nodoc:
-    def initialize(reflection)
-      super("Primary key is not allowed in a has_and_belongs_to_many join table (#{reflection.options[:join_table]}).")
-    end
-  end
-
   class HasAndBelongsToManyAssociationForeignKeyNeeded < ActiveRecordError #:nodoc:
     def initialize(reflection)
       super("Cannot create self referential has_and_belongs_to_many association on '#{reflection.class_name rescue nil}##{reflection.name rescue nil}'. :association_foreign_key cannot be the same as the :foreign_key.")

--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -39,10 +39,6 @@ module ActiveRecord::Associations::Builder
           model.send(:undecorated_table_name, model.to_s),
           model.send(:undecorated_table_name, reflection.class_name)
         )
-
-        if model.connection.supports_primary_key? && (model.connection.primary_key(reflection.options[:join_table]) rescue false)
-          raise ActiveRecord::HasAndBelongsToManyAssociationWithPrimaryKeyError.new(reflection)
-        end
       end
 
       # Generates a join table name from two provided table names.

--- a/activerecord/test/cases/associations/habtm_join_table_test.rb
+++ b/activerecord/test/cases/associations/habtm_join_table_test.rb
@@ -32,12 +32,4 @@ class HabtmJoinTableTest < ActiveRecord::TestCase
     ActiveRecord::Base.connection.drop_table :my_readers
     ActiveRecord::Base.connection.drop_table :my_books_my_readers
   end
-
-  uses_transaction :test_should_not_raise_exception_when_join_table_has_a_primary_key
-  def test_should_not_raise_exception_when_join_table_has_a_primary_key
-    if ActiveRecord::Base.connection.supports_primary_key?
-      # This test is to confirm that this feature is now gone 
-      assert MyReader.has_and_belongs_to_many(:my_books).is_a?(ActiveRecord::Reflection::AssociationReflection)
-    end
-  end
 end

--- a/activerecord/test/cases/associations/habtm_join_table_test.rb
+++ b/activerecord/test/cases/associations/habtm_join_table_test.rb
@@ -33,12 +33,11 @@ class HabtmJoinTableTest < ActiveRecord::TestCase
     ActiveRecord::Base.connection.drop_table :my_books_my_readers
   end
 
-  uses_transaction :test_should_raise_exception_when_join_table_has_a_primary_key
-  def test_should_raise_exception_when_join_table_has_a_primary_key
+  uses_transaction :test_should_not_raise_exception_when_join_table_has_a_primary_key
+  def test_should_not_raise_exception_when_join_table_has_a_primary_key
     if ActiveRecord::Base.connection.supports_primary_key?
-      assert_raise ActiveRecord::HasAndBelongsToManyAssociationWithPrimaryKeyError do
-        MyReader.has_and_belongs_to_many :my_books
-      end
+      # This test is to confirm that this feature is now gone 
+      assert MyReader.has_and_belongs_to_many(:my_books).is_a?(ActiveRecord::Reflection::AssociationReflection)
     end
   end
 end


### PR DESCRIPTION
## Removes the restriction on primary key when joining in a habtm && test that it was properly removed

So I saw issue #534 and thought that it looked simple and gave it a try. Added a test to prove that it works fine without it. First commit pretty nervous that I just screwed everything up or something :P so anyway, hope I understood the ticket correctly and the code is satisfactory. 
