### PR TITLE
Debug mass assignment protection bugs made easy

### DIFF
--- a/activemodel/lib/active_model/mass_assignment_security.rb
+++ b/activemodel/lib/active_model/mass_assignment_security.rb
@@ -10,6 +10,7 @@ module ActiveModel
       class_attribute :_accessible_attributes
       class_attribute :_protected_attributes
       class_attribute :_active_authorizer
+      class_attribute :strict_mass_assignment
     end
 
     # Mass assignment security provides an interface for protecting attributes
@@ -40,6 +41,16 @@ module ActiveModel
     #     end
     #
     #   end
+    #
+    # The option <tt>strict_mass_assignment</tt> controls whether mass assignment proctection
+    # is exceptional or not.
+    # If false (the default) +sanitize_for_mass_assignment+ will warn about protected attributes.
+    # If true +sanitize_for_mass_assignment+ will raise an <tt>ActiveModel::MassAssignmentSecurity::Error</tt> exception.
+    # Example:
+    #
+    #   Customer.strict_mass_assignment = true
+    #   customer = Customer.new
+    #   customer.assign_attributes({"protected_attribute_name" => "value" }) # => raises exception
     #
     module ClassMethods
       # Attributes named in this macro are protected from mass-assignment
@@ -160,6 +171,7 @@ module ActiveModel
         self._active_authorizer = self._accessible_attributes
       end
 
+
       def protected_attributes(role = :default)
         protected_attributes_configs[role]
       end
@@ -198,8 +210,8 @@ module ActiveModel
 
   protected
 
-    def sanitize_for_mass_assignment(attributes, role = :default)
-      mass_assignment_authorizer(role).sanitize(attributes)
+    def sanitize_for_mass_assignment(attributes, role = :default, strict = nil)
+      mass_assignment_authorizer(role).sanitize(attributes, strict.nil? ? self.strict_mass_assignment : strict)
     end
 
     def mass_assignment_authorizer(role = :default)

--- a/activemodel/lib/active_model/mass_assignment_security/sanitizer.rb
+++ b/activemodel/lib/active_model/mass_assignment_security/sanitizer.rb
@@ -1,23 +1,45 @@
 module ActiveModel
   module MassAssignmentSecurity
     module Sanitizer
+
+      extend ActiveSupport::Concern
+      included do
+        class_attribute :strict_mass_assignment
+      end
+
       # Returns all attributes not denied by the authorizer.
-      def sanitize(attributes)
+      def sanitize(attributes, strict = false)
         sanitized_attributes = attributes.reject { |key, value| deny?(key) }
-        debug_protected_attribute_removal(attributes, sanitized_attributes)
+        debug_protected_attribute_removal(attributes, sanitized_attributes, strict)
         sanitized_attributes
       end
 
-    protected
+      protected
 
-      def debug_protected_attribute_removal(attributes, sanitized_attributes)
+      def debug_protected_attribute_removal(attributes, sanitized_attributes, strict)
         removed_keys = attributes.keys - sanitized_attributes.keys
-        warn!(removed_keys) if removed_keys.any?
+        process_error(removed_keys, strict) if removed_keys.any?
       end
 
-      def warn!(attrs)
-        self.logger.debug "WARNING: Can't mass-assign protected attributes: #{attrs.join(', ')}" if self.logger
+      def process_error(attrs, strict)
+        message = "Can't mass-assign protected attributes: #{attrs.join(', ')}"
+        if strict
+          raise ActiveModel::MassAssignmentSecurity::Error.new(message, attrs)
+        else
+          self.logger.debug "WARNING: #{message}" if self.logger
+        end
       end
+    end
+
+    class Error < StandardError
+      
+      attr_accessor :attrs
+      
+      def initialize(message, attrs)
+        super(message)
+        self.attrs = attrs
+      end
+
     end
   end
 end

--- a/activemodel/lib/active_model/mass_assignment_security/sanitizer.rb
+++ b/activemodel/lib/active_model/mass_assignment_security/sanitizer.rb
@@ -2,11 +2,6 @@ module ActiveModel
   module MassAssignmentSecurity
     module Sanitizer
 
-      extend ActiveSupport::Concern
-      included do
-        class_attribute :strict_mass_assignment
-      end
-
       # Returns all attributes not denied by the authorizer.
       def sanitize(attributes, strict = false)
         sanitized_attributes = attributes.reject { |key, value| deny?(key) }
@@ -18,10 +13,10 @@ module ActiveModel
 
       def debug_protected_attribute_removal(attributes, sanitized_attributes, strict)
         removed_keys = attributes.keys - sanitized_attributes.keys
-        process_error(removed_keys, strict) if removed_keys.any?
+        process_removed_keys(removed_keys, strict) if removed_keys.any?
       end
 
-      def process_error(attrs, strict)
+      def process_removed_keys(attrs, strict)
         message = "Can't mass-assign protected attributes: #{attrs.join(', ')}"
         if strict
           raise ActiveModel::MassAssignmentSecurity::Error.new(message, attrs)

--- a/activemodel/test/cases/mass_assignment_security_test.rb
+++ b/activemodel/test/cases/mass_assignment_security_test.rb
@@ -76,4 +76,19 @@ class MassAssignmentSecurityTest < ActiveModel::TestCase
     assert_equal sanitized, { }
   end
 
+
+  def test_strict_mass_assignment_protection
+    user = User.new
+    expected = { "name" => "John Smith", "email" => "john@smith.com" }
+    assert_raise ActiveModel::MassAssignmentSecurity::Error do
+      user.sanitize_for_mass_assignment(expected.merge("admin" => true), :default, true)
+    end
+    User.strict_mass_assignment = true
+    assert_raise ActiveModel::MassAssignmentSecurity::Error do
+      user.sanitize_for_mass_assignment(expected.merge("admin" => true))
+    end
+  ensure
+    User.strict_mass_assignment = false
+  end
+
 end


### PR DESCRIPTION
One thing I don't understand about mass assignment protection is - Why is it a warning but not exception?

Mass assignment sanitizer works in the following use cases:
- Attempt to hack something 
- Bug in the source code that made protected things that should not be protected

I think both cases should throw an exception at least in development and test environment at most always.

Otherwise bugs can stay uncovered by test suite or manual QA for a long time.
