### PR TITLE
use association_primary_key in AssociationScope#add_constraints

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -60,7 +60,7 @@ module ActiveRecord
 
             scope = scope.joins(join(
               join_table,
-              table[reflection.active_record_primary_key].
+              table[reflection.association_primary_key].
                 eq(join_table[reflection.association_foreign_key])
             ))
 

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -100,6 +100,13 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 'c1', record[0]
     assert_equal 't1', record[1]
   end
+  
+  def test_proper_usage_of_primary_keys_and_join_table
+    setup_data_for_habtm_case
+
+    country = Country.first
+    assert_equal 1, country.treaties.count
+  end
 
   def test_has_and_belongs_to_many
     david = Developer.find(1)

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -104,6 +104,9 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
   def test_proper_usage_of_primary_keys_and_join_table
     setup_data_for_habtm_case
 
+    assert_equal 'country_id', Country.primary_key
+    assert_equal 'treaty_id', Treaty.primary_key
+
     country = Country.first
     assert_equal 1, country.treaties.count
   end


### PR DESCRIPTION
AssociationScope#add_constraints was incorrectly using Reflection#active_record_primary_key instead of Reflection#association_primary_key (Line 63)
