### PR TITLE
Don't raise an exception if the format isn't recognized

### DIFF
--- a/actionpack/lib/action_controller/metal/instrumentation.rb
+++ b/actionpack/lib/action_controller/metal/instrumentation.rb
@@ -19,7 +19,7 @@ module ActionController
         :controller => self.class.name,
         :action     => self.action_name,
         :params     => request.filtered_parameters,
-        :format     => request.format.ref,
+        :format     => request.format.try(:ref),
         :method     => request.method,
         :path       => (request.fullpath rescue "unknown")
       }

--- a/actionpack/test/controller/mime_responds_test.rb
+++ b/actionpack/test/controller/mime_responds_test.rb
@@ -498,6 +498,12 @@ class RespondToControllerTest < ActionController::TestCase
     assert_equal '<html><div id="iphone">Hello iPhone future from iPhone!</div></html>', @response.body
     assert_equal "text/html", @response.content_type
   end
+  
+  def test_invalid_format
+    get :using_defaults, :format => "invalidformat"
+    assert_equal " ", @response.body
+    assert_equal "text/html", @response.content_type
+  end
 end
 
 class RespondWithController < ActionController::Base


### PR DESCRIPTION
Master has a regression whenever the :format parameter isn't a recognized MIME type.
This pull requests fixes it, so that there's no exception raised, without being trigger by respond_to either.
