### PR TITLE
Fix engine's generators

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -45,9 +45,9 @@ module Rails
 
     def lib
       template "lib/%name%.rb"
+      template "lib/%name%/application.rb"
       template "lib/tasks/%name%_tasks.rake"
       if full?
-        template "lib/%name%/application.rb"
         template "lib/%name%/engine.rb"
       end
     end

--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -47,6 +47,7 @@ module Rails
       template "lib/%name%.rb"
       template "lib/tasks/%name%_tasks.rake"
       if full?
+        template "lib/%name%/application.rb"
         template "lib/%name%/engine.rb"
       end
     end

--- a/railties/lib/rails/generators/rails/plugin_new/templates/lib/%name%/application.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/lib/%name%/application.rb
@@ -1,0 +1,6 @@
+require "rails/all"
+
+module <%= camelized %>
+  class Application < ::Rails::Application
+  end
+end

--- a/railties/lib/rails/generators/rails/plugin_new/templates/script/rails.tt
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/script/rails.tt
@@ -1,4 +1,4 @@
 # This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
 
-ENGINE_PATH = File.expand_path('../..',  __FILE__)
-load File.expand_path('../../<%= dummy_path %>/script/rails',  __FILE__)
+APP_PATH = File.expand_path('../../lib/<%= name %>/application',  __FILE__)
+require 'rails/commands'

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -148,7 +148,7 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
     assert_file "app/views"
     assert_file "app/helpers"
     assert_file "config/routes.rb", /Rails.application.routes.draw do/
-    assert_file "lib/bukkits/application.rb", /module Bukkits\n  class Application < Rails::Application\n  end\nend/
+    assert_file "lib/bukkits/application.rb", /module Bukkits\n  class Application < ::Rails::Application\n  end\nend/
     assert_file "lib/bukkits/engine.rb", /module Bukkits\n  class Engine < Rails::Engine\n  end\nend/
     assert_file "lib/bukkits.rb", /require "bukkits\/engine"/
   end
@@ -176,6 +176,18 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
     assert_file "bukkits.gemspec", /s.files = Dir\["\{app,config,lib\}\/\*\*\/\*"\]/
     assert_file "bukkits.gemspec", /s.test_files = Dir\["test\/\*\*\/\*"\]/
     assert_file "bukkits.gemspec", /s.version = "0.0.1"/
+  end
+
+  def test_application_class
+    run_generator
+    assert_file "lib/bukkits/application.rb", /require "rails\/all"/
+    assert_file "lib/bukkits/application.rb", /class Application < ::Rails::Application/
+  end
+
+  def test_requiring_generators
+    run_generator
+    assert_file "script/rails", /APP_PATH = File.expand_path\('..\/..\/lib\/bukkits\/application',  __FILE__\)/
+    assert_file "script/rails", /require 'rails\/commands'/
   end
 
   def test_shebang
@@ -233,7 +245,6 @@ class CustomPluginGeneratorTest < Rails::Generators::TestCase
     assert_file 'spec/dummy'
     assert_file 'Rakefile', /task :default => :spec/
     assert_file 'Rakefile', /# spec tasks in rakefile/
-    assert_file 'script/rails', %r{spec/dummy}
   end
 
 protected

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -148,6 +148,7 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
     assert_file "app/views"
     assert_file "app/helpers"
     assert_file "config/routes.rb", /Rails.application.routes.draw do/
+    assert_file "lib/bukkits/application.rb", /module Bukkits\n  class Application < Rails::Application\n  end\nend/
     assert_file "lib/bukkits/engine.rb", /module Bukkits\n  class Engine < Rails::Engine\n  end\nend/
     assert_file "lib/bukkits.rb", /require "bukkits\/engine"/
   end


### PR DESCRIPTION
Hi all,

this is a fix for Rails generators inside an engine. They currently depend on the dummy app that breaks them if no dummy app exists (e.g. if test unit files are skipped).

I've extracted the generators and added a new class _Application_ inside the _lib_ folder, that provides a _Rails::Application_ but doesn't get loaded by Rails applications that use the engine.

This fixes issue #1259.

Regards
