### PR TITLE
Fixed starting Rails::Server when using a Rack::URLMap in 3.1.0.rc1

### DIFF
--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -43,7 +43,7 @@ module Rails
     end
 
     def app
-      @app ||= super.instance
+      @app ||= super
     end
 
     def opt_parser

--- a/railties/test/application/server_test.rb
+++ b/railties/test/application/server_test.rb
@@ -1,0 +1,43 @@
+require 'isolation/abstract_unit'
+require 'open-uri'
+
+class ServerTest < Test::Unit::TestCase
+  include ActiveSupport::Testing::Isolation  
+
+  def setup
+    build_app
+  end
+
+  def test_app_should_run
+    start_server
+  end
+
+  def test_app_should_run_in_a_rack_urlmap
+    urlmap_config_ru = <<-EOF
+    require ::File.expand_path('../config/environment',  __FILE__)
+    run Rack::URLMap.new "/" => AppTemplate::Application
+    EOF
+
+    File.open("#{app_path}/config.ru", 'w') {|f| f.write(urlmap_config_ru) }
+
+    start_server
+  end
+  
+  def start_server
+    Dir.chdir(app_path)
+
+    require "#{rails_root}/config/environment"
+
+    require 'rails/commands/server'
+
+    server = Rails::Server.new
+
+    t = Thread.new { server.start }
+    until t.status == 'sleep'; t.join(0.5) end
+    body = open("http://0.0.0.0:3000/") { |f| f.read }
+    assert body.match(/Welcome aboard/)
+
+    Process.kill(:INT, $$)
+    t.join
+  end
+end


### PR DESCRIPTION
https://github.com/rails/rails/tree/19c763f7831e08606e6b4fa516f5ad3b00c6428f broke using a Rack::URLMap in your config.ru, rails would simply not start.

The use case is something like this in config.ru:

```
run Rack::URLMap.new "/"       => Deploytracking::Application,
                     "/resque" => Resque::Server.new
```

I've fixed it to get it starting again and added some tests to a piece which previously had no tests, which are similar to how rack tests Rack::Server: https://github.com/rack/rack/blob/master/test/spec_server.rb#L52

The only thing that I couldn't do was silence the server output in the tests.
