### PR TITLE
Make +collection_size+ available as a local variable when rendering collections

### DIFF
--- a/actionpack/lib/action_view/renderer/partial_renderer.rb
+++ b/actionpack/lib/action_view/renderer/partial_renderer.rb
@@ -64,9 +64,10 @@ module ActionView
   #
   #   <%= render :partial => "ad", :collection => @advertisements %>
   #
-  # This will render "advertiser/_ad.html.erb" and pass the local variable +ad+ to the template for display. An
-  # iteration counter will automatically be made available to the template with a name of the form
-  # +partial_name_counter+. In the case of the example above, the template would be fed +ad_counter+.
+  # This will render "advertiser/_ad.html.erb" and pass the local variable +ad+ to the template for display.
+  # Two locals variables will automatically be made available to the template: +collection_size+ and an
+  # iteration counter in the form +partial_name_counter+. In the case of the example above, the template would
+  # be fed +ad_counter+.
   #
   # The <tt>:as</tt> option may be used when rendering partials.
   #

--- a/actionpack/lib/action_view/renderer/partial_renderer.rb
+++ b/actionpack/lib/action_view/renderer/partial_renderer.rb
@@ -321,7 +321,10 @@ module ActionView
       if path = @path
         locals = @locals.keys
         locals << @variable
-        locals << @variable_counter if @collection
+        if @collection
+          locals << @variable_counter
+          locals << :collection_size
+        end
         find_template(path, locals)
       end
     end
@@ -340,6 +343,7 @@ module ActionView
       @collection.each do |object|
         locals[counter] += 1
         locals[as] = object
+        locals[:collection_size] = @collection.size
         segments << template.render(@view, locals)
       end
 

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -563,6 +563,10 @@ class TestController < ActionController::Base
     render :partial => "customer", :spacer_template => "partial_only", :collection => [ Customer.new("david"), Customer.new("mary") ]
   end
 
+  def partial_collection_with_collection_size
+    render :partial => "customer_collection_size", :collection => [ Customer.new("david"), Customer.new("mary") ]
+  end
+
   def partial_collection_shorthand_with_locals
     render :partial => [ Customer.new("david"), Customer.new("mary") ], :locals => { :greeting => "Bonjour" }
   end
@@ -1254,6 +1258,11 @@ class RenderTest < ActionController::TestCase
   def test_partial_collection
     get :partial_collection
     assert_equal "Hello: davidHello: mary", @response.body
+  end
+
+  def test_partial_collection_size
+    get :partial_collection_with_collection_size
+    assert_equal "1 of 22 of 2", @response.body
   end
 
   def test_partial_collection_with_as

--- a/actionpack/test/fixtures/test/_customer_collection_size.html.erb
+++ b/actionpack/test/fixtures/test/_customer_collection_size.html.erb
@@ -1,0 +1,1 @@
+<%= customer_collection_size_counter+1 %> of <%= collection_size %>

--- a/actionpack/test/template/render_test.rb
+++ b/actionpack/test/template/render_test.rb
@@ -153,7 +153,7 @@ module RenderTestCases
   end
 
   def test_render_partial_collection_without_as
-    assert_equal "local_inspector,local_inspector_counter",
+    assert_equal "collection_size,local_inspector,local_inspector_counter",
       @view.render(:partial => "test/local_inspector", :collection => [ Customer.new("mary") ])
   end
 


### PR DESCRIPTION
A nice convenience to go with the +partial_name_counter+ local when rendering collections.
