### PR TITLE
Fix inherited table_name from abstract class

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -658,10 +658,11 @@ module ActiveRecord #:nodoc:
       #   end
       def set_table_name(value = nil, &block)
         @quoted_table_name = nil
-        define_attr_method :table_name, value, &block
-
-        @arel_table = Arel::Table.new(table_name, arel_engine)
-        @relation = Relation.new(self, arel_table)
+        value = block.call if block_given?
+        define_attr_method :table_name, value unless abstract_class?
+      
+        @arel_table = Arel::Table.new(value, arel_engine)
+        @relation = Relation.new(self, @arel_table)
       end
       alias :table_name= :set_table_name
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -21,6 +21,7 @@ require 'models/parrot'
 require 'models/person'
 require 'models/edge'
 require 'models/joke'
+require 'models/ad'
 require 'rexml/document'
 require 'active_support/core_ext/exception'
 
@@ -276,6 +277,8 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal "credit_card_pin_numbers", CreditCard::SubPinNumber.table_name
     assert_equal "categories", CreditCard::Brand.table_name
     assert_equal "master_credit_cards", MasterCreditCard.table_name
+    assert_equal "abstract_ads", AbstractAd.table_name
+    assert_equal "ads", Ad.table_name
   ensure
     GUESSED_CLASSES.each(&:reset_table_name)
   end

--- a/activerecord/test/models/ad.rb
+++ b/activerecord/test/models/ad.rb
@@ -1,0 +1,7 @@
+class AbstractAd < ActiveRecord::Base
+  self.abstract_class = true
+  table_name
+end
+
+class Ad < AbstractAd
+end


### PR DESCRIPTION
Hi guys, I found this when I worked on my project. Let me explain situation.
When 
class Parent < ActiveRecord::Base
  self.abstract_class = true
  # in the end it call table_name method
  default_scope where(...) # for example
end

class Child < Parent
end
Then Child has an incorrect table_name method, because Parent is loaded first and already has overrided table_name method like this:

def table_name; “parents”; end;

which inherits Child.
