### PR TITLE
MassAssignmentSecurity: add ability to specify your own sanitizer

### DIFF
--- a/activemodel/lib/active_model/mass_assignment_security/permission_set.rb
+++ b/activemodel/lib/active_model/mass_assignment_security/permission_set.rb
@@ -1,10 +1,8 @@
 require 'set'
-require 'active_model/mass_assignment_security/sanitizer'
 
 module ActiveModel
   module MassAssignmentSecurity
     class PermissionSet < Set
-      attr_accessor :logger
 
       def +(values)
         super(values.map(&:to_s))
@@ -12,6 +10,10 @@ module ActiveModel
 
       def include?(key)
         super(remove_multiparameter_id(key))
+      end
+
+      def deny?(key)
+        raise NotImplementedError, "#deny?(key) suppose to be overwritten"
       end
 
     protected
@@ -22,7 +24,6 @@ module ActiveModel
     end
 
     class WhiteList < PermissionSet
-      include Sanitizer
 
       def deny?(key)
         !include?(key)
@@ -30,7 +31,6 @@ module ActiveModel
     end
 
     class BlackList < PermissionSet
-      include Sanitizer
 
       def deny?(key)
         include?(key)

--- a/activemodel/test/cases/mass_assignment_security/black_list_test.rb
+++ b/activemodel/test/cases/mass_assignment_security/black_list_test.rb
@@ -16,13 +16,5 @@ class BlackListTest < ActiveModel::TestCase
     assert_equal false, @black_list.deny?('first_name')
   end
 
-  test "sanitize attributes" do
-    original_attributes = { 'first_name' => 'allowed', 'admin' => 'denied', 'admin(1)' => 'denied' }
-    attributes = @black_list.sanitize(original_attributes)
-
-    assert attributes.key?('first_name'), "Allowed key shouldn't be rejected"
-    assert !attributes.key?('admin'),     "Denied key should be rejected"
-    assert !attributes.key?('admin(1)'),  "Multi-parameter key should be detected"
-  end
 
 end

--- a/activemodel/test/cases/mass_assignment_security/sanitizer_test.rb
+++ b/activemodel/test/cases/mass_assignment_security/sanitizer_test.rb
@@ -4,24 +4,21 @@ require 'active_support/core_ext/object/inclusion'
 
 class SanitizerTest < ActiveModel::TestCase
 
-  class SanitizingAuthorizer
-    include ActiveModel::MassAssignmentSecurity::Sanitizer
 
-    attr_accessor :logger
-
+  class Authorizer < ActiveModel::MassAssignmentSecurity::PermissionSet
     def deny?(key)
       key.in?(['admin'])
     end
-
   end
 
   def setup
-    @sanitizer = SanitizingAuthorizer.new
+    @sanitizer = ActiveModel::MassAssignmentSecurity::DefaultSanitizer.new
+    @authorizer = Authorizer.new
   end
 
   test "sanitize attributes" do
     original_attributes = { 'first_name' => 'allowed', 'admin' => 'denied' }
-    attributes = @sanitizer.sanitize(original_attributes)
+    attributes = @sanitizer.sanitize(original_attributes, @authorizer)
 
     assert attributes.key?('first_name'), "Allowed key shouldn't be rejected"
     assert !attributes.key?('admin'),     "Denied key should be rejected"
@@ -31,7 +28,7 @@ class SanitizerTest < ActiveModel::TestCase
     original_attributes = { 'first_name' => 'allowed', 'admin' => 'denied' }
     log = StringIO.new
     @sanitizer.logger = Logger.new(log)
-    @sanitizer.sanitize(original_attributes)
+    @sanitizer.sanitize(original_attributes, @authorizer)
     assert_match(/admin/, log.string, "Should log removed attributes: #{log.string}")
   end
 

--- a/activemodel/test/cases/mass_assignment_security/white_list_test.rb
+++ b/activemodel/test/cases/mass_assignment_security/white_list_test.rb
@@ -16,13 +16,4 @@ class WhiteListTest < ActiveModel::TestCase
     assert_equal true, @white_list.deny?('admin')
   end
 
-  test "sanitize attributes" do
-    original_attributes = { 'first_name' => 'allowed', 'admin' => 'denied', 'admin(1)' => 'denied' }
-    attributes = @white_list.sanitize(original_attributes)
-
-    assert attributes.key?('first_name'), "Allowed key shouldn't be rejected"
-    assert !attributes.key?('admin'),     "Denied key should be rejected"
-    assert !attributes.key?('admin(1)'),  "Multi-parameter key should be detected"
-  end
-
 end

--- a/activemodel/test/cases/mass_assignment_security_test.rb
+++ b/activemodel/test/cases/mass_assignment_security_test.rb
@@ -1,6 +1,15 @@
 require "cases/helper"
 require 'models/mass_assignment_specific'
 
+
+class CustomSanitizer < ActiveModel::MassAssignmentSecurity::Sanitizer
+
+  def process_removed_attributes(attrs)
+    raise StandardError
+  end
+
+end
+
 class MassAssignmentSecurityTest < ActiveModel::TestCase
 
   def test_attribute_protection
@@ -74,6 +83,17 @@ class MassAssignmentSecurityTest < ActiveModel::TestCase
     attributes = { "starting(1i)" => "2004", "starting(2i)" => "6", "starting(3i)" => "24" }
     sanitized = task.sanitize_for_mass_assignment(attributes)
     assert_equal sanitized, { }
+  end
+
+  def test_custom_sanitizer
+    user = User.new
+    User.mass_assignment_sanitizer = CustomSanitizer.new
+    assert_raise StandardError do
+      user.sanitize_for_mass_assignment("admin" => true)
+    end
+  ensure
+    User.mass_assignment_sanitizer = nil
+
   end
 
 end


### PR DESCRIPTION
With respect to discussion:
https://github.com/rails/rails/pull/1320

Added an ability to specify your own behavior on mass assingment
protection, controlled by option:

```
ActiveModel::MassAssignmentSecurity.mass_assignment_sanitizer
```

I hope this is right way to do it. Because I don't understand how the customizations can be done without monkey patch or configuration option.

BTW code seems more clean now even without customization benefits.

If there is still something I need to fix please let me know.
