### PR TITLE
Remove line causing uninitialized constant Sprockets::Helpers

### DIFF
--- a/railties/lib/rails/tasks/assets.rake
+++ b/railties/lib/rails/tasks/assets.rake
@@ -1,8 +1,6 @@
 namespace :assets do
   desc "Compile all the assets named in config.assets.precompile"
   task :precompile => :environment do
-    # Give assets access to asset_path
-    Sprockets::Helpers::RailsHelper
 
     assets = Rails.application.config.assets.precompile
     Rails.application.assets.precompile(*assets)


### PR DESCRIPTION
As far as I can tell this is not needed. Running the task with the original
line, ActionView::Helpers::SprocketsHelper, does nothing different to the final output.
Whatever the case, I could find nowhere that Sprockets::Helpers is defined.

Other option is to revert 9701014b960e8679af86

@josh can you shed some light on this?
