### PR TITLE
This doesn't yet exist in 3-1-stable leading to uninitialized constant Sprockets::Helpers

### DIFF
--- a/railties/lib/rails/tasks/assets.rake
+++ b/railties/lib/rails/tasks/assets.rake
@@ -2,7 +2,7 @@ namespace :assets do
   desc "Compile all the assets named in config.assets.precompile"
   task :precompile => :environment do
     # Give assets access to asset_path
-    Sprockets::Helpers::RailsHelper
+    ActionView::Helpers::SprocketsHelper
 
     assets = Rails.application.config.assets.precompile
     Rails.application.assets.precompile(*assets)


### PR DESCRIPTION
Revert "Renaming helper in the Rake task, but why is this needed in the first place? (paging JP)"

This reverts commit 9701014b960e8679af8652c5cd0b413a0ad04f58.
