### PR TITLE
Fix engine's generator

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -105,14 +105,6 @@ module Rails
       self
     end
 
-    def load_generators(app=self)
-      initialize_generators
-      railties.all { |r| r.load_generators(app) }
-      Rails::Generators.configure!(app.config.generators)
-      super
-      self
-    end
-
     def load_console(app=self)
       initialize_console
       railties.all { |r| r.load_console(app) }
@@ -193,10 +185,6 @@ module Rails
           require_environment!
         end
       end
-    end
-
-    def initialize_generators
-      require "rails/generators"
     end
 
     def initialize_console

--- a/railties/lib/rails/commands.rb
+++ b/railties/lib/rails/commands.rb
@@ -23,11 +23,7 @@ when 'generate', 'destroy', 'plugin'
     require APP_PATH
     Rails.application.require_environment!
 
-    if defined?(ENGINE_PATH) && engine = Rails::Engine.find(ENGINE_PATH)
-      Rails.application.load_generators(engine)
-    else
-      Rails.application.load_generators
-    end
+    Rails.application.load_generators
 
     require "rails/commands/#{command}"
   end

--- a/railties/lib/rails/commands/generate.rb
+++ b/railties/lib/rails/commands/generate.rb
@@ -7,4 +7,9 @@ if ARGV.first.in?([nil, "-h", "--help"])
 end
 
 name = ARGV.shift
-Rails::Generators.invoke name, ARGV, :behavior => :invoke, :destination_root => Rails.root
+
+if defined?(ENGINE_ROOT)
+  Rails::Generators.invoke name, ARGV, :behavior => :invoke, :destination_root => ENGINE_ROOT
+else
+  Rails::Generators.invoke name, ARGV, :behavior => :invoke, :destination_root => Rails.root
+end

--- a/railties/lib/rails/commands/generate.rb
+++ b/railties/lib/rails/commands/generate.rb
@@ -8,8 +8,5 @@ end
 
 name = ARGV.shift
 
-if defined?(ENGINE_ROOT)
-  Rails::Generators.invoke name, ARGV, :behavior => :invoke, :destination_root => ENGINE_ROOT
-else
-  Rails::Generators.invoke name, ARGV, :behavior => :invoke, :destination_root => Rails.root
-end
+root = defined?(ENGINE_ROOT) ? ENGINE_ROOT : Rails.root
+Rails::Generators.invoke name, ARGV, :behavior => :invoke, :destination_root => root

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -330,6 +330,14 @@ module Rails
     autoload :Configuration, "rails/engine/configuration"
     autoload :Railties,      "rails/engine/railties"
 
+    def load_generators(app=self)
+      initialize_generators
+      railties.all { |r| r.load_generators(app) }
+      Rails::Generators.configure!(app.config.generators)
+      super
+      self
+    end
+
     class << self
       attr_accessor :called_from, :isolated
       alias :isolated? :isolated
@@ -566,6 +574,10 @@ module Rails
     end
 
   protected
+
+    def initialize_generators
+      require "rails/generators"
+    end
 
     def routes?
       defined?(@routes)

--- a/railties/lib/rails/engine/commands.rb
+++ b/railties/lib/rails/engine/commands.rb
@@ -13,10 +13,10 @@ require ENGINE_PATH
 engine = ::Rails::Engine.find(ENGINE_ROOT)
 
 case command
-when 'generate'
+when 'generate', 'destroy'
   require 'rails/generators'
   engine.load_generators
-  require 'rails/commands/generate'
+  require "rails/commands/#{command}"
 
 when '--version', '-v'
   ARGV.unshift '--version'
@@ -29,6 +29,7 @@ Usage: rails COMMAND [ARGS]
 
 The common rails commands available for engines are:
  generate    Generate new code (short-cut alias: "g")
+ destroy     Undo code generated with "generate"
 
 All commands can be run with -h for more information.
   EOT

--- a/railties/lib/rails/engine/commands.rb
+++ b/railties/lib/rails/engine/commands.rb
@@ -1,0 +1,37 @@
+require 'active_support/core_ext/object/inclusion'
+
+ARGV << '--help' if ARGV.empty?
+
+aliases = {
+  "g" => "generate"
+}
+
+command = ARGV.shift
+command = aliases[command] || command
+
+case command
+when 'generate'
+  require 'rails/generators'
+
+  require ENGINE_PATH
+  engine = ::Rails::Engine.find(ENGINE_ROOT)
+  engine.load_generators
+
+  require 'rails/commands/generate'
+
+when '--version', '-v'
+  ARGV.unshift '--version'
+  require 'rails/commands/application'
+
+else
+  puts "Error: Command not recognized" unless command.in?(['-h', '--help'])
+  puts <<-EOT
+Usage: rails COMMAND [ARGS]
+
+The common rails commands available for engines are:
+ generate    Generate new code (short-cut alias: "g")
+
+All commands can be run with -h for more information.
+  EOT
+  exit(1)
+end

--- a/railties/lib/rails/engine/commands.rb
+++ b/railties/lib/rails/engine/commands.rb
@@ -9,14 +9,13 @@ aliases = {
 command = ARGV.shift
 command = aliases[command] || command
 
+require ENGINE_PATH
+engine = ::Rails::Engine.find(ENGINE_ROOT)
+
 case command
 when 'generate'
   require 'rails/generators'
-
-  require ENGINE_PATH
-  engine = ::Rails::Engine.find(ENGINE_ROOT)
   engine.load_generators
-
   require 'rails/commands/generate'
 
 when '--version', '-v'

--- a/railties/lib/rails/engine/commands.rb
+++ b/railties/lib/rails/engine/commands.rb
@@ -15,6 +15,7 @@ engine = ::Rails::Engine.find(ENGINE_ROOT)
 case command
 when 'generate', 'destroy'
   require 'rails/generators'
+  Rails::Generators.namespace = engine.railtie_namespace
   engine.load_generators
   require "rails/commands/#{command}"
 

--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -20,6 +20,8 @@ module Rails
     autoload :ResourceHelpers, 'rails/generators/resource_helpers'
     autoload :TestCase,        'rails/generators/test_case'
 
+    mattr_accessor :namespace
+
     DEFAULT_ALIASES = {
       :rails => {
         :actions => '-a',
@@ -88,16 +90,6 @@ module Rails
 
     def self.options #:nodoc:
       @options ||= DEFAULT_OPTIONS.dup
-    end
-
-    def self.namespace
-      @namespace ||= if defined?(Rails) && Rails.application
-         Rails.application.class.parents.detect { |n| n.respond_to?(:_railtie) }
-      end
-    end
-
-    def self.namespace=(namespace)
-      @namespace ||= namespace
     end
 
     # Hold configured generators fallbacks. If a plugin developer wants a

--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -90,6 +90,16 @@ module Rails
       @options ||= DEFAULT_OPTIONS.dup
     end
 
+    def self.namespace
+      @namespace ||= if defined?(Rails) && Rails.application
+         Rails.application.class.parents.detect { |n| n.respond_to?(:_railtie) }
+      end
+    end
+
+    def self.namespace=(namespace)
+      @namespace ||= namespace
+    end
+
     # Hold configured generators fallbacks. If a plugin developer wants a
     # generator group to fallback to another group in case of missing generators,
     # they can add a fallback.

--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -63,9 +63,7 @@ module Rails
         end
 
         def namespace
-          @namespace ||= if defined?(Rails) && Rails.application
-            Rails.application.class.parents.detect { |n| n.respond_to?(:_railtie) }
-          end
+          Rails::Generators.namespace
         end
 
         def namespaced?

--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -126,6 +126,8 @@ task :default => :test
     end
 
     def script(force = false)
+      return unless full?
+
       directory "script", :force => force do |content|
         "#{shebang}\n" + content
       end

--- a/railties/lib/rails/generators/rails/plugin_new/templates/script/rails.tt
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/script/rails.tt
@@ -1,7 +1,7 @@
 # This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
 
-ENGINE_ROOT = File.expand_path('../..',  __FILE__)
-ENGINE_PATH = File.expand_path('../../lib/<%= name -%>/engine',  __FILE__)
+ENGINE_ROOT = File.expand_path('../..', __FILE__)
+ENGINE_PATH = File.expand_path('../../lib/<%= name -%>/engine', __FILE__)
 
 require 'rails/all'
 require 'rails/engine/commands'

--- a/railties/lib/rails/generators/rails/plugin_new/templates/script/rails.tt
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/script/rails.tt
@@ -1,4 +1,7 @@
 # This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
 
-ENGINE_PATH = File.expand_path('../..',  __FILE__)
-load File.expand_path('../../<%= dummy_path %>/script/rails',  __FILE__)
+ENGINE_ROOT = File.expand_path('../..',  __FILE__)
+ENGINE_PATH = File.expand_path('../../lib/<%= name -%>/engine',  __FILE__)
+
+require 'rails/all'
+require 'rails/engine/commands'

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -1,6 +1,7 @@
 require 'rails/initializable'
 require 'rails/configuration'
 require 'active_support/inflector'
+require 'active_support/core_ext/module/introspection'
 
 module Rails
   # Railtie is the core of the Rails framework and provides several hooks to extend
@@ -191,6 +192,10 @@ module Rails
 
     def load_generators(app)
       self.class.generators.each { |block| block.call(app) }
+    end
+
+    def railtie_namespace
+      @railtie_namespace ||= self.class.parents.detect { |n| n.respond_to?(:_railtie) }
     end
   end
 end

--- a/railties/test/abstract_unit.rb
+++ b/railties/test/abstract_unit.rb
@@ -10,7 +10,6 @@ require 'active_support/core_ext/logger'
 require 'action_controller'
 require 'rails/all'
 
-# TODO: Remove these hacks
 module TestApp
   class Application < Rails::Application
     config.root = File.dirname(__FILE__)

--- a/railties/test/engine/generators_test.rb
+++ b/railties/test/engine/generators_test.rb
@@ -1,0 +1,54 @@
+# require 'isolation/abstract_unit'
+
+require 'fileutils'
+
+require 'test/unit'
+require 'rubygems'
+
+# TODO: Remove setting this magic constant
+RAILS_FRAMEWORK_ROOT = File.expand_path("#{File.dirname(__FILE__)}/../../..")
+
+# These files do not require any others and are needed
+# to run the tests
+require "#{RAILS_FRAMEWORK_ROOT}/activesupport/lib/active_support/testing/isolation"
+require "#{RAILS_FRAMEWORK_ROOT}/activesupport/lib/active_support/testing/declarative"
+require "#{RAILS_FRAMEWORK_ROOT}/activesupport/lib/active_support/core_ext/kernel/reporting"
+require "#{RAILS_FRAMEWORK_ROOT}/railties/lib/rails/generators/test_case"
+
+module EngineTests
+  class ControllerGenerator < Rails::Generators::TestCase
+    include ActiveSupport::Testing::Isolation
+    
+    TMP_PATH = File.expand_path(File.join(File.dirname(__FILE__), *%w[.. .. tmp]))
+    self.destination_root = File.join(TMP_PATH, "foo_bar")
+
+    def tmp_path(*args)
+      File.join(TMP_PATH, *args)
+    end
+    
+    def engine_path
+      tmp_path('foo_bar')
+    end
+    
+    def build_engine
+      FileUtils.mkdir_p(engine_path)
+      FileUtils.rm_r(engine_path)
+      environment = File.expand_path('../../../../load_paths', __FILE__)
+      if File.exist?("#{environment}.rb")
+        require_environment = "-r #{environment}"
+      end
+      `#{Gem.ruby} #{require_environment} #{RAILS_FRAMEWORK_ROOT}/bin/rails plugin new #{engine_path} --full --mountable`
+    end
+
+    def setup
+      build_engine
+    end
+    
+    def test_omg
+      Dir.chdir(engine_path) do
+        `rails g controller topics`
+        assert_file "app/controllers/foo_bar/topics_controller.rb"
+      end
+    end
+  end
+end

--- a/railties/test/engine/generators_test.rb
+++ b/railties/test/engine/generators_test.rb
@@ -28,7 +28,7 @@ module EngineTests
       tmp_path('foo_bar')
     end
 
-    def bundle_exec(cmd)
+    def bundled_rails(cmd)
       `bundle exec rails #{cmd}`
     end
 
@@ -68,15 +68,22 @@ module EngineTests
 
     def test_controllers_are_correctly_namespaced
       Dir.chdir(engine_path) do
-        bundle_exec("g controller topics")
+        bundled_rails("g controller topics")
         assert_file "app/controllers/foo_bar/topics_controller.rb", /FooBar::TopicsController/
       end
     end
 
     def test_models_are_correctly_namespaced
       Dir.chdir(engine_path) do
-        bundle_exec("g model topic")
+        bundled_rails("g model topic")
         assert_file "app/models/foo_bar/topic.rb", /FooBar::Topic/
+      end
+    end
+
+    def test_helpers_are_correctly_namespaced
+      Dir.chdir(engine_path) do
+        bundled_rails("g helper topics")
+        assert_file "app/helpers/foo_bar/topics_helper.rb", /FooBar::TopicsHelper/
       end
     end
   end

--- a/railties/test/engine/generators_test.rb
+++ b/railties/test/engine/generators_test.rb
@@ -29,25 +29,37 @@ module EngineTests
     def engine_path
       tmp_path('foo_bar')
     end
-    
-    def build_engine
-      FileUtils.mkdir_p(engine_path)
-      FileUtils.rm_r(engine_path)
+
+    def rails(cmd)
       environment = File.expand_path('../../../../load_paths', __FILE__)
       if File.exist?("#{environment}.rb")
         require_environment = "-r #{environment}"
       end
-      `#{Gem.ruby} #{require_environment} #{RAILS_FRAMEWORK_ROOT}/bin/rails plugin new #{engine_path} --full --mountable`
+      `#{Gem.ruby} #{require_environment} #{RAILS_FRAMEWORK_ROOT}/bin/rails #{cmd}`
+    end
+    
+    def build_engine
+      FileUtils.mkdir_p(engine_path)
+      FileUtils.rm_r(engine_path)
+      
+      rails("plugin new #{engine_path} --full --mountable")
     end
 
     def setup
       build_engine
     end
     
-    def test_omg
+    def test_controllers_are_correctly_namespaced
       Dir.chdir(engine_path) do
-        `rails g controller topics`
+        rails("g controller topics")
         assert_file "app/controllers/foo_bar/topics_controller.rb"
+      end
+    end
+    
+    def test_models_are_correctly_namespaced
+      Dir.chdir(engine_path) do
+        rails("g model topic")
+        assert_file "app/models/foo_bar/topic.rb"
       end
     end
   end

--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -7,15 +7,7 @@ require 'rails/generators/rails/scaffold/scaffold_generator'
 
 class NamespacedGeneratorTestCase < Rails::Generators::TestCase
   def setup
-    TestApp::Application.isolate_namespace(TestApp)
-  end
-
-  def teardown
-    if TestApp.respond_to?(:_railtie)
-      TestApp.singleton_class.send(:undef_method, :_railtie)
-      TestApp.singleton_class.send(:undef_method, :table_name_prefix)
-      TestApp::Application.isolated = false
-    end
+    Rails::Generators.namespace = TestApp
   end
 end
 

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -232,7 +232,6 @@ class CustomPluginGeneratorTest < Rails::Generators::TestCase
     assert_file 'spec/dummy'
     assert_file 'Rakefile', /task :default => :spec/
     assert_file 'Rakefile', /# spec tasks in rakefile/
-    assert_file 'script/rails', %r{spec/dummy}
   end
 
 protected

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -177,6 +177,14 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
     assert_file "bukkits.gemspec", /s.version = "0.0.1"/
   end
 
+  def test_usage_of_engine_commands
+    run_generator
+    assert_file "script/rails", /ENGINE_PATH = File.expand_path\('..\/..\/lib\/bukkits\/engine', __FILE__\)/
+    assert_file "script/rails", /ENGINE_ROOT = File.expand_path\('..\/..', __FILE__\)/
+    assert_file "script/rails", /require 'rails\/all'/
+    assert_file "script/rails", /require 'rails\/engine\/commands/
+  end
+
   def test_shebang
     run_generator
     assert_file "script/rails", /#!\/usr\/bin\/env ruby/

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -182,7 +182,7 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
     assert_file "script/rails", /ENGINE_PATH = File.expand_path\('..\/..\/lib\/bukkits\/engine', __FILE__\)/
     assert_file "script/rails", /ENGINE_ROOT = File.expand_path\('..\/..', __FILE__\)/
     assert_file "script/rails", /require 'rails\/all'/
-    assert_file "script/rails", /require 'rails\/engine\/commands/
+    assert_file "script/rails", /require 'rails\/engine\/commands'/
   end
 
   def test_shebang

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -12,7 +12,6 @@ DEFAULT_PLUGIN_FILES = %w(
   lib
   lib/bukkits.rb
   lib/tasks/bukkits_tasks.rake
-  script/rails
   test/bukkits_test.rb
   test/test_helper.rb
   test/dummy
@@ -150,6 +149,7 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
     assert_file "config/routes.rb", /Rails.application.routes.draw do/
     assert_file "lib/bukkits/engine.rb", /module Bukkits\n  class Engine < ::Rails::Engine\n  end\nend/
     assert_file "lib/bukkits.rb", /require "bukkits\/engine"/
+    assert_file "script/rails"
   end
 
   def test_being_quiet_while_creating_dummy_application
@@ -178,7 +178,7 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_usage_of_engine_commands
-    run_generator
+    run_generator [destination_root, "--full"]
     assert_file "script/rails", /ENGINE_PATH = File.expand_path\('..\/..\/lib\/bukkits\/engine', __FILE__\)/
     assert_file "script/rails", /ENGINE_ROOT = File.expand_path\('..\/..', __FILE__\)/
     assert_file "script/rails", /require 'rails\/all'/
@@ -186,7 +186,7 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_shebang
-    run_generator
+    run_generator [destination_root, "--full"]
     assert_file "script/rails", /#!\/usr\/bin\/env ruby/
   end
 

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -67,12 +67,12 @@ module SharedGeneratorTests
   end
 
   def test_shebang_is_added_to_rails_file
-    run_generator [destination_root, "--ruby", "foo/bar/baz"]
+    run_generator [destination_root, "--ruby", "foo/bar/baz", "--full"]
     assert_file "script/rails", /#!foo\/bar\/baz/
   end
 
   def test_shebang_when_is_the_same_as_default_use_env
-    run_generator [destination_root, "--ruby", Thor::Util.ruby_command]
+    run_generator [destination_root, "--ruby", Thor::Util.ruby_command, "--full"]
     assert_file "script/rails", /#!\/usr\/bin\/env/
   end
 

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -280,4 +280,4 @@ Module.new do
     end
     f.puts "require 'rails/all'"
   end
-end
+end unless RAILS_ISOLATION_COMMAND=="engine"

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -280,4 +280,4 @@ Module.new do
     end
     f.puts "require 'rails/all'"
   end
-end unless RAILS_ISOLATION_COMMAND=="engine"
+end unless defined?(RAILS_ISOLATED_ENGINE)

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -15,7 +15,7 @@ module RailtiesTest
 
       @plugin = engine "bukkits" do |plugin|
         plugin.write "lib/bukkits.rb", <<-RUBY
-          class Bukkits
+          module Bukkits
             class Engine < ::Rails::Engine
               railtie_name "bukkits"
             end
@@ -32,7 +32,7 @@ module RailtiesTest
 
     test "initializers are executed after application configuration initializers" do
       @plugin.write "lib/bukkits.rb", <<-RUBY
-        class Bukkits
+        module Bukkits
           class Engine < ::Rails::Engine
             initializer "dummy_initializer" do
             end
@@ -73,7 +73,7 @@ module RailtiesTest
       add_to_config("config.action_dispatch.show_exceptions = false")
 
       @plugin.write "lib/bukkits.rb", <<-RUBY
-        class Bukkits
+        module Bukkits
           class Engine < ::Rails::Engine
             endpoint lambda { |env| [200, {'Content-Type' => 'text/html'}, ['Hello World']] }
             config.middleware.use ::RailtiesTest::EngineTest::Upcaser
@@ -123,7 +123,7 @@ module RailtiesTest
 
     test "it provides routes as default endpoint" do
       @plugin.write "lib/bukkits.rb", <<-RUBY
-        class Bukkits
+        module Bukkits
           class Engine < ::Rails::Engine
           end
         end
@@ -149,7 +149,7 @@ module RailtiesTest
 
     test "engine can load its own plugins" do
       @plugin.write "lib/bukkits.rb", <<-RUBY
-        class Bukkits
+        module Bukkits
           class Engine < ::Rails::Engine
           end
         end
@@ -166,7 +166,7 @@ module RailtiesTest
 
     test "engine does not load plugins that already exists in application" do
       @plugin.write "lib/bukkits.rb", <<-RUBY
-        class Bukkits
+        module Bukkits
           class Engine < ::Rails::Engine
           end
         end
@@ -189,7 +189,7 @@ module RailtiesTest
 
     test "it loads its environment file" do
       @plugin.write "lib/bukkits.rb", <<-RUBY
-        class Bukkits
+        module Bukkits
           class Engine < ::Rails::Engine
           end
         end
@@ -208,7 +208,7 @@ module RailtiesTest
 
     test "it passes router in env" do
       @plugin.write "lib/bukkits.rb", <<-RUBY
-        class Bukkits
+        module Bukkits
           class Engine < ::Rails::Engine
             endpoint lambda { |env| [200, {'Content-Type' => 'text/html'}, 'hello'] }
           end

--- a/railties/test/railties/generators_test.rb
+++ b/railties/test/railties/generators_test.rb
@@ -1,4 +1,4 @@
-RAILS_ISOLATION_COMMAND = "engine"
+RAILS_ISOLATED_ENGINE = true
 require "isolation/abstract_unit"
 
 require "#{RAILS_FRAMEWORK_ROOT}/railties/lib/rails/generators/test_case"

--- a/railties/test/railties/generators_test.rb
+++ b/railties/test/railties/generators_test.rb
@@ -1,16 +1,6 @@
-require 'fileutils'
+RAILS_ISOLATION_COMMAND = "engine"
+require "isolation/abstract_unit"
 
-require 'test/unit'
-require 'rubygems'
-
-# TODO: Remove setting this magic constant
-RAILS_FRAMEWORK_ROOT = File.expand_path("#{File.dirname(__FILE__)}/../../..")
-
-# These files do not require any others and are needed
-# to run the tests
-require "#{RAILS_FRAMEWORK_ROOT}/activesupport/lib/active_support/testing/isolation"
-require "#{RAILS_FRAMEWORK_ROOT}/activesupport/lib/active_support/testing/declarative"
-require "#{RAILS_FRAMEWORK_ROOT}/activesupport/lib/active_support/core_ext/kernel/reporting"
 require "#{RAILS_FRAMEWORK_ROOT}/railties/lib/rails/generators/test_case"
 
 module RailtiesTests
@@ -70,6 +60,7 @@ module RailtiesTests
       Dir.chdir(engine_path) do
         bundled_rails("g controller topics")
         assert_file "app/controllers/foo_bar/topics_controller.rb", /FooBar::TopicsController/
+        assert_no_file "app/controllers/topics_controller.rb"
       end
     end
 
@@ -77,6 +68,7 @@ module RailtiesTests
       Dir.chdir(engine_path) do
         bundled_rails("g model topic")
         assert_file "app/models/foo_bar/topic.rb", /FooBar::Topic/
+        assert_no_file "app/models/topic.rb"
       end
     end
 
@@ -84,6 +76,7 @@ module RailtiesTests
       Dir.chdir(engine_path) do
         bundled_rails("g helper topics")
         assert_file "app/helpers/foo_bar/topics_helper.rb", /FooBar::TopicsHelper/
+        assert_no_file "app/helpers/topics_helper.rb"
       end
     end
   end

--- a/railties/test/railties/generators_test.rb
+++ b/railties/test/railties/generators_test.rb
@@ -30,11 +30,13 @@ module RailtiesTests
       `#{Gem.ruby} #{require_environment} #{RAILS_FRAMEWORK_ROOT}/bin/rails #{cmd}`
     end
 
-    def build_engine
+    def build_engine(is_mountable=false)
       FileUtils.mkdir_p(engine_path)
       FileUtils.rm_r(engine_path)
 
-      rails("plugin new #{engine_path} --full --mountable")
+      mountable = is_mountable ? "--mountable" : ""
+
+      rails("plugin new #{engine_path} --full #{mountable}")
 
       Dir.chdir(engine_path) do
         File.open("Gemfile", "w") do |f|
@@ -52,31 +54,64 @@ module RailtiesTests
       end
     end
 
-    def setup
-      build_engine
+    def build_mountable_engine
+      build_engine(true)
     end
 
-    def test_controllers_are_correctly_namespaced
+    def setup
+    end
+
+    def test_controllers_are_correctly_namespaced_when_engine_is_mountable
+      build_mountable_engine
       Dir.chdir(engine_path) do
         bundled_rails("g controller topics")
-        assert_file "app/controllers/foo_bar/topics_controller.rb", /FooBar::TopicsController/
+        assert_file "app/controllers/foo_bar/topics_controller.rb", /module FooBar\n  class TopicsController/
         assert_no_file "app/controllers/topics_controller.rb"
       end
     end
 
-    def test_models_are_correctly_namespaced
+    def test_models_are_correctly_namespaced_when_engine_is_mountable
+      build_mountable_engine
       Dir.chdir(engine_path) do
         bundled_rails("g model topic")
-        assert_file "app/models/foo_bar/topic.rb", /FooBar::Topic/
+        assert_file "app/models/foo_bar/topic.rb", /module FooBar\n  class Topic/
         assert_no_file "app/models/topic.rb"
       end
     end
 
-    def test_helpers_are_correctly_namespaced
+    def test_helpers_are_correctly_namespaced_when_engine_is_mountable
+      build_mountable_engine
       Dir.chdir(engine_path) do
         bundled_rails("g helper topics")
-        assert_file "app/helpers/foo_bar/topics_helper.rb", /FooBar::TopicsHelper/
+        assert_file "app/helpers/foo_bar/topics_helper.rb", /module FooBar\n  module TopicsHelper/
         assert_no_file "app/helpers/topics_helper.rb"
+      end
+    end
+
+    def test_controllers_are_not_namespaced_when_engine_is_not_mountable
+      build_engine
+      Dir.chdir(engine_path) do
+        bundled_rails("g controller topics")
+        assert_file "app/controllers/topics_controller.rb", /class TopicsController/
+        assert_no_file "app/controllers/foo_bar/topics_controller.rb"
+      end
+    end
+
+    def test_models_are_not_namespaced_when_engine_is_not_mountable
+      build_engine
+      Dir.chdir(engine_path) do
+        bundled_rails("g model topic")
+        assert_file "app/models/topic.rb", /class Topic/
+        assert_no_file "app/models/foo_bar/topic.rb"
+      end
+    end
+
+    def test_helpers_are_not_namespaced_when_engine_is_not_mountable
+      build_engine
+      Dir.chdir(engine_path) do
+        bundled_rails("g helper topics")
+        assert_file "app/helpers/topics_helper.rb", /module TopicsHelper/
+        assert_no_file "app/helpers/foo_bar/topics_helper.rb"
       end
     end
   end

--- a/railties/test/railties/generators_test.rb
+++ b/railties/test/railties/generators_test.rb
@@ -13,7 +13,7 @@ require "#{RAILS_FRAMEWORK_ROOT}/activesupport/lib/active_support/testing/declar
 require "#{RAILS_FRAMEWORK_ROOT}/activesupport/lib/active_support/core_ext/kernel/reporting"
 require "#{RAILS_FRAMEWORK_ROOT}/railties/lib/rails/generators/test_case"
 
-module EngineTests
+module RailtiesTests
   class GeneratorTest < Rails::Generators::TestCase
     include ActiveSupport::Testing::Isolation
 

--- a/railties/test/railties/generators_test.rb
+++ b/railties/test/railties/generators_test.rb
@@ -58,9 +58,6 @@ module RailtiesTests
       build_engine(true)
     end
 
-    def setup
-    end
-
     def test_controllers_are_correctly_namespaced_when_engine_is_mountable
       build_mountable_engine
       Dir.chdir(engine_path) do

--- a/railties/test/railties/shared_tests.rb
+++ b/railties/test/railties/shared_tests.rb
@@ -54,7 +54,7 @@ module RailtiesTest
       add_to_config "ActiveRecord::Base.timestamped_migrations = false"
 
       Dir.chdir(app_path) do
-        output = `rake bukkits:install:migrations`
+        output = `bundle exec rake bukkits:install:migrations`
 
         assert File.exists?("#{app_path}/db/migrate/2_create_users.rb")
         assert File.exists?("#{app_path}/db/migrate/3_add_last_name_to_users.rb")
@@ -63,7 +63,7 @@ module RailtiesTest
         assert_match /NOTE: Migration 3_create_sessions.rb from bukkits has been skipped/, output
         assert_equal 3, Dir["#{app_path}/db/migrate/*.rb"].length
 
-        output = `rake railties:install:migrations`
+        output = `bundle exec rake railties:install:migrations`
 
         assert File.exists?("#{app_path}/db/migrate/4_create_yaffles.rb")
         assert_match /NOTE: Migration 3_create_sessions.rb from bukkits has been skipped/, output
@@ -71,7 +71,7 @@ module RailtiesTest
         assert_no_match /2_create_users/, output
 
         migrations_count = Dir["#{app_path}/db/migrate/*.rb"].length
-        output = `rake railties:install:migrations`
+        output = `bundle exec rake railties:install:migrations`
 
         assert_equal migrations_count, Dir["#{app_path}/db/migrate/*.rb"].length
       end


### PR DESCRIPTION
I've moved _load_generator_ from _Rails::Application_ to _Rails::Engine_ in order to provide generators for Rails engines (fixes #1259).

I've introduced _rails/engine/commands_ that provides engine specific commands.
Furthermore, I've done some small cleanups and improvements.

Regards
