### PR TITLE
Fix for ruby 1.8 bug with ActiveSupport::OrderedHash

### DIFF
--- a/activesupport/lib/active_support/ordered_hash.rb
+++ b/activesupport/lib/active_support/ordered_hash.rb
@@ -158,7 +158,11 @@ module ActiveSupport
         self
       end
 
-      alias_method :each_pair, :each
+      def each_pair
+        return to_enum(:each_pair) unless block_given?
+        @keys.each {|key| yield key, self[key]}
+        self
+      end
 
       alias_method :select, :find_all
 

--- a/activesupport/test/ordered_hash_test.rb
+++ b/activesupport/test/ordered_hash_test.rb
@@ -114,6 +114,9 @@ class OrderedHashTest < Test::Unit::TestCase
     end
     assert_equal @values, values
     assert_equal @keys, keys
+
+    expected_class = RUBY_VERSION < '1.9' ? Enumerable::Enumerator : Enumerator
+    assert_kind_of expected_class, @ordered_hash.each_pair
   end
 
   def test_find_all
@@ -255,6 +258,26 @@ class OrderedHashTest < Test::Unit::TestCase
 
     @deserialized_ordered_hash.each {|key, value| values << value}
     assert_equal @values, values
+  end
+
+  def test_each_when_yielding_to_block_with_splat
+    hash_values         = []
+    ordered_hash_values = []
+
+    @hash.each         { |*v| hash_values         << v }
+    @ordered_hash.each { |*v| ordered_hash_values << v }
+
+    assert_equal hash_values.sort, ordered_hash_values.sort
+  end
+
+  def test_each_pair_when_yielding_to_block_with_splat
+    hash_values         = []
+    ordered_hash_values = []
+
+    @hash.each_pair         { |*v| hash_values         << v }
+    @ordered_hash.each_pair { |*v| ordered_hash_values << v }
+
+    assert_equal hash_values.sort, ordered_hash_values.sort
   end
 
   def test_order_after_yaml_serialization


### PR DESCRIPTION
An example of the problem can be seen in this gist: https://gist.github.com/994919.

Basically, `ActiveSupport::OrderedHash` behaves differently than the built-in `Hash` when yielding to a block that accepts its parameters with a splat. This is only an issue on ruby 1.8 because 1.9 uses the built-in `Hash` at all times. It's a very minor inconsistency, but it causes some problems with `pp`, for example.

Tested with rvm-installed ruby 1.8.7-p330, on Mac OS X 10.6.7. At least on this machine, tests are all running green.
