### PR TITLE
Unquoted query generated by through-association scope

### DIFF
--- a/activerecord/lib/active_record/associations/through_association_scope.rb
+++ b/activerecord/lib/active_record/associations/through_association_scope.rb
@@ -30,7 +30,9 @@ module ActiveRecord
       # Associate attributes pointing to owner, quoted.
       def construct_quoted_owner_attributes(reflection)
         if as = reflection.options[:as]
-          { "#{as}_id"   => @owner.class.quote_value(@owner[reflection.active_record_primary_key]),
+          { "#{as}_id"   => @owner.class.quote_value(
+              @owner[reflection.active_record_primary_key],
+              reflection.klass.columns_hash["#{as}_id"]),
             "#{as}_type" => reflection.klass.quote_value(
               @owner.class.base_class.name.to_s,
               reflection.klass.columns_hash["#{as}_type"]) }

--- a/activerecord/lib/active_record/associations/through_association_scope.rb
+++ b/activerecord/lib/active_record/associations/through_association_scope.rb
@@ -30,7 +30,7 @@ module ActiveRecord
       # Associate attributes pointing to owner, quoted.
       def construct_quoted_owner_attributes(reflection)
         if as = reflection.options[:as]
-          { "#{as}_id"   => @owner[reflection.active_record_primary_key],
+          { "#{as}_id"   => @owner.class.quote_value(@owner[reflection.active_record_primary_key]),
             "#{as}_type" => reflection.klass.quote_value(
               @owner.class.base_class.name.to_s,
               reflection.klass.columns_hash["#{as}_type"]) }

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -471,6 +471,10 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal 1, authors(:mary).categories.general.count
   end
 
+  def test_has_many_through_on_new_record
+    assert_equal [], Post.new.tags.all
+  end
+
   def test_joining_has_many_through_belongs_to
     posts = Post.joins(:author_categorizations).
                  where('categorizations.id' => categorizations(:mary_thinking_sti).id)


### PR DESCRIPTION
Through-association owner's primary key wasn't quoted. This generates invalid SQL if the record wasn't saved yet (i.e. the primary key's value is nil) and you try to access the relation (should return an empty result).

Real-world example of generated sql:

```
SELECT `tags`.*
  FROM `tags`
  INNER JOIN `taggings` ON `tags`.id = `taggings`.tag_id
  WHERE
    ((`taggings`.taggable_id = ) AND (`taggings`.taggable_type = 'Ticket'))
    AND (taggings.context = 'tags' AND taggings.tagger_id IS NULL)
```
