### PR TITLE
A failing test case for 3.1.rc1

### DIFF
--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -139,6 +139,17 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
     assert man.reload.interests.empty?
   end
 
+  def test_has_many_association_setting_attributes_for_an_unloaded_single_record
+    ActiveRecord::IdentityMap.without do
+      Man.accepts_nested_attributes_for(:interests)
+      man = Man.create(:name => 'Ken')
+      interest = man.interests.create(:topic => 'photography')
+      man.reload
+      man.attributes = {:interests_attributes => {:topic => 'mahjong', :id => interest.id}}
+      assert_equal 'mahjong', man.interests.first.topic
+    end
+  end
+
   def test_has_many_association_updating_a_single_record
     Man.accepts_nested_attributes_for(:interests)
     man = Man.create(:name => 'John')


### PR DESCRIPTION
I found a regression on 3.1.rc1.

Updating nested_attributes fails when (IdentityMap is disabled) && (target is not loaded).
Attached is a test case which passes on 3.1.beta1 and fails on 3.1.rc1.

There were no changes on active_record/nested_attributes.rb in v3.1.0.beta1..v3.1.0.rc1, thus maybe some changes on active_record/associations are the cause.
