### PR TITLE
Disable IdentityMap by default for ActiveRecord testing

### DIFF
--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -26,8 +26,8 @@ ActiveSupport::Deprecation.debug = true
 # Quote "type" if it's a reserved word for the current connection.
 QUOTED_TYPE = ActiveRecord::Base.connection.quote_column_name('type')
 
-# Enable Identity Map for testing
-ActiveRecord::IdentityMap.enabled = (ENV['IM'] == "false" ? false : true)
+# Enable Identity Map only when ENV['IM'] is set to "true"
+ActiveRecord::IdentityMap.enabled = (ENV['IM'] == "true")
 
 def current_adapter?(*types)
   types.any? do |type|


### PR DESCRIPTION
I propose that IM should be turned off for AR testing by default. It is strange that the default test doesn't run on the library's default behavior.

In fact, this patch reveals 7 failing cases for each adapters on current master. This means, people are not testing with `ENV['IM']=false` option, and AR 3.1 is shipped untested for its default option.
