### PR TITLE
Fix for relative_url_root when used with sprockets

### DIFF
--- a/actionpack/lib/action_view/helpers/asset_paths.rb
+++ b/actionpack/lib/action_view/helpers/asset_paths.rb
@@ -44,7 +44,12 @@ module ActionView
         raise NotImplementedError
       end
 
+      def rewrite_relative_url_root(source, relative_url_root)
+        relative_url_root && !source.starts_with?("#{relative_url_root}/") ? "#{relative_url_root}#{source}" : source
+      end
+
       def rewrite_host_and_protocol(source, has_request)
+        source = rewrite_relative_url_root(source, controller.config.relative_url_root) if has_request
         host = compute_asset_host(source)
         if has_request && host && !is_uri?(host)
           host = "#{controller.request.protocol}#{host}"

--- a/actionpack/lib/action_view/helpers/asset_tag_helpers/asset_paths.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helpers/asset_paths.rb
@@ -85,15 +85,6 @@ module ActionView
             end
           end
         end
-
-        def rewrite_relative_url_root(source, relative_url_root)
-          relative_url_root && !source.starts_with?("#{relative_url_root}/") ? "#{relative_url_root}#{source}" : source
-        end
-
-        def rewrite_host_and_protocol(source, has_request)
-          source = rewrite_relative_url_root(source, controller.config.relative_url_root) if has_request
-          super(source, has_request)
-        end
       end
 
     end

--- a/actionpack/test/template/sprockets_helper_test.rb
+++ b/actionpack/test/template/sprockets_helper_test.rb
@@ -57,6 +57,12 @@ class SprocketsHelperTest < ActionView::TestCase
       asset_path("http://www.example.com/video/play.mp4")
   end
 
+  test "asset path with relavtive url root" do
+    @controller.config.relative_url_root = "/collaboration/hieraki"
+    assert_equal "/collaboration/hieraki/images/logo.gif",
+     asset_path("/images/logo.gif")
+  end
+
   test "javascript path" do
     assert_equal "/assets/application-d41d8cd98f00b204e9800998ecf8427e.js",
       asset_path(:application, "js")


### PR DESCRIPTION
Sprockets does not use the ActionView::Helpers::AssetTagHelper::AssetPaths sub-class of ActionView::Helpers::AssetPaths which is where the relative_url_root logic has been moved to.

This fix moves the relative_url_root logic into ActionView::Helpers::AssetPaths so that it works with sprockets.
