### PR TITLE
Disable IdentityMap by default for ActiveRecord testing on 3-1-stable

### DIFF
--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -26,8 +26,8 @@ ActiveSupport::Deprecation.debug = true
 # Quote "type" if it's a reserved word for the current connection.
 QUOTED_TYPE = ActiveRecord::Base.connection.quote_column_name('type')
 
-# Enable Identity Map for testing
-ActiveRecord::IdentityMap.enabled = (ENV['IM'] == "false" ? false : true)
+# Enable Identity Map only when ENV['IM'] is set to "true"
+ActiveRecord::IdentityMap.enabled = (ENV['IM'] == "true")
 
 def current_adapter?(*types)
   types.any? do |type|


### PR DESCRIPTION
Cherry-picked #1368 to 3-1-stable branch. This also unveils 7 failure cases.
