### PR TITLE
No need in autoloading TemplateHandlers since it's removed.

### DIFF
--- a/actionpack/lib/action_view.rb
+++ b/actionpack/lib/action_view.rb
@@ -74,7 +74,6 @@ module ActionView
 
     autoload_at "action_view/template" do
       autoload :TemplateHandler
-      autoload :TemplateHandlers
     end
   end
 


### PR DESCRIPTION
Without removing it it breaks some gems which checks if TemplateHandlers const defined in ActionView
