### PR TITLE
Remove unused options from drop_table

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -161,7 +161,7 @@ module ActiveRecord
         yield td if block_given?
 
         if options[:force] && table_exists?(table_name)
-          drop_table(table_name, options)
+          drop_table(table_name)
         end
 
         create_sql = "CREATE#{' TEMPORARY' if options[:temporary]} TABLE "
@@ -253,7 +253,7 @@ module ActiveRecord
       end
 
       # Drops a table from the database.
-      def drop_table(table_name, options = {})
+      def drop_table(table_name)
         execute "DROP TABLE #{quote_table_name(table_name)}"
       end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -427,10 +427,6 @@ module ActiveRecord
         tables(nil, schema).include? table
       end
 
-      def drop_table(table_name, options = {})
-        super(table_name, options)
-      end
-
       # Returns an array of indexes for the given table.
       def indexes(table_name, name = nil)
         indexes = []

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -568,10 +568,6 @@ module ActiveRecord
         tables(nil, schema).include? table
       end
 
-      def drop_table(table_name, options = {})
-        super(table_name, options)
-      end
-
       # Returns an array of indexes for the given table.
       def indexes(table_name, name = nil)#:nodoc:
         indexes = []


### PR DESCRIPTION
Removed unused `options` parameter from `SchemaStatements#drop_table`.
This matches to the documentations, and all existing tests passed.
