### PR TITLE
#drop_table accepts no options now.

### DIFF
--- a/activerecord/test/cases/adapters/firebird/migration_test.rb
+++ b/activerecord/test/cases/adapters/firebird/migration_test.rb
@@ -24,7 +24,7 @@ class FirebirdMigrationTest < ActiveRecord::TestCase
     assert !sequence_exists?('foo_seq')
     assert sequence_exists?('foo_custom_seq')
 
-    assert_nothing_raised { @connection.drop_table(:foo, :sequence => 'foo_custom_seq') }
+    assert_nothing_raised { @connection.drop_table(:foo) }
     assert !sequence_exists?('foo_custom_seq')
   ensure
     FireRuby::Generator.new('foo_custom_seq', @fireruby_connection).drop rescue nil


### PR DESCRIPTION
This commit removes the options hash from #drop_column: https://github.com/rails/rails/commit/bcb466c543451dce69403aaae047295758589d8e

This test was making use of it, so I removed it.
