### PR TITLE
*.js.erb should not be rendered using layout

### DIFF
--- a/actionpack/lib/abstract_controller/layouts.rb
+++ b/actionpack/lib/abstract_controller/layouts.rb
@@ -356,6 +356,7 @@ module AbstractController
     end
 
     def _include_layout?(options)
+      return false if self.request.formats.include?("text/javascript")
       (options.keys & [:text, :inline, :partial]).empty? || options.key?(:layout)
     end
   end


### PR DESCRIPTION
As mentioned in a chat with Jose Valim in rc.1 it is necessary to do

  ....
   format.js  { render :layout => false }
  ....

because with just
  ...
    format.js #no params
  ...
the default layout will be rendered.

have fun
- Andi Altendorfer
