### PR TITLE
Really fix #1322 (Rake::DSL issue)

### DIFF
--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -181,7 +181,7 @@ module Rails
     end
 
     def load_tasks
-      extend Rake::DSL if defined? Rake::DSL
+      self.class.extend Rake::DSL if defined? Rake::DSL
       self.class.rake_tasks.each(&:call)
     end
 


### PR DESCRIPTION
`extend` must be called on `this.class`, resolves #1322 (Rake 0.9 related).
