### PR TITLE
ActiveModel::MassAssignmentSecurity.mass_assignment_sanitizer method

### DIFF
--- a/activemodel/lib/active_model/mass_assignment_security/sanitizer.rb
+++ b/activemodel/lib/active_model/mass_assignment_security/sanitizer.rb
@@ -20,7 +20,7 @@ module ActiveModel
       end
 
     end
-    class DefaultSanitizer < Sanitizer
+    class LoggerSanitizer < Sanitizer
 
       attr_accessor :logger
 
@@ -33,5 +33,15 @@ module ActiveModel
         self.logger.debug "WARNING: Can't mass-assign protected attributes: #{attrs.join(', ')}" if self.logger
       end
     end
+
+    class StrictSanitizer < Sanitizer
+      def process_removed_attributes(attrs)
+        raise ActiveModel::MassAssignmentSecurity::Error, "Can't mass-assign protected attributes: #{attrs.join(', ')}"
+      end
+    end
+
+    class Error < StandardError
+    end
+
   end
 end


### PR DESCRIPTION
In order to specify your own sanitize method
Implemented .mass_assignment_sanitizer configuration option

As we discussed here:
https://github.com/rails/rails/pull/1334#issuecomment-1247794
