### PR TITLE
properly require javascript libraries when generating mountable engine

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -118,7 +118,7 @@ task :default => :test
       return if options.skip_javascript?
 
       if mountable?
-        copy_file "#{app_templates_dir}/app/assets/javascripts/application.js.tt",
+        template "#{app_templates_dir}/app/assets/javascripts/application.js.tt",
                   "app/assets/javascripts/application.js"
       elsif full?
         empty_directory_with_gitkeep "app/assets/javascripts"

--- a/railties/lib/rails/generators/rails/plugin_new/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/Gemfile
@@ -6,6 +6,10 @@ source "http://rubygems.org"
 <%= database_gemfile_entry -%>
 <% end -%>
 
+<% if mountable? -%>
+<%= gem_for_javascript -%>
+<% end -%>
+
 if RUBY_VERSION < '1.9'
   gem "ruby-debug", ">= 0.10.3"
 end

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -112,6 +112,28 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
     assert_file "app/assets/javascripts/application.js"
   end
 
+  def test_jquery_is_the_default_javascript_library
+    run_generator [destination_root, "--mountable"]
+    assert_file "app/assets/javascripts/application.js" do |contents|
+      assert_match %r{^//= require jquery}, contents
+      assert_match %r{^//= require jquery_ujs}, contents
+    end
+    assert_file 'Gemfile' do |contents|
+      assert_match(/^gem 'jquery-rails'/, contents)
+    end
+  end
+
+  def test_other_javascript_libraries
+    run_generator [destination_root, "--mountable", '-j', 'prototype']
+    assert_file "app/assets/javascripts/application.js" do |contents|
+      assert_match %r{^//= require prototype}, contents
+      assert_match %r{^//= require prototype_ujs}, contents
+    end
+    assert_file 'Gemfile' do |contents|
+      assert_match(/^gem 'prototype-rails'/, contents)
+    end
+  end
+
   def test_skip_javascripts
     run_generator [destination_root, "--skip-javascript", "--mountable"]
     assert_no_file "app/assets/javascripts/application.js"


### PR DESCRIPTION
I noticed that creating a mountable engine with:

```
rails plugin new foo --mountable
```

gives me the following in 'app/assets/javascripts/application.js':

```
<% unless options[:skip_javascript] -%>
//= require <%= options[:javascript] %>
//= require <%= options[:javascript] %>_ujs
<% end -%>
//= require_tree .
```

This commit properly renders the ERB and adds the appropriate javascript gem to the plugin's Gemfile.
