### PR TITLE
A fix for mark_for_destruction failing test in AssociationsTest (small patch: only 2 lines)

### DIFF
--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -56,8 +56,8 @@ class AssociationsTest < ActiveRecord::TestCase
 
   def test_loading_the_association_target_should_keep_child_records_marked_for_destruction
     ship = Ship.create!(:name => "The good ship Dollypop")
-    part = ship.parts.create!(:name => "Mast")
-    part.mark_for_destruction
+    ship.parts.create!(:name => "Mast")
+    ship.parts[0].mark_for_destruction
     ship.parts.send(:load_target)
     assert ship.parts[0].marked_for_destruction?
   end

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -591,6 +591,7 @@ module NestedAttributesOnACollectionAssociationTests
 
   def test_should_not_remove_scheduled_destroys_when_loading_association
     @pirate.reload
+    @pirate.send(@association_name).send(:load_target)
     @pirate.send(association_setter, [{ :id => @child_1.id, :_destroy => '1' }])
     assert @pirate.send(@association_name).send(:load_target).find { |r| r.id == @child_1.id }.marked_for_destruction?
   end


### PR DESCRIPTION
This is one of the failures that I'm seeing on master.

This is testing mark_for_destruction against a has_many association. The problem is, once the 'part' object becomes divorced from it's association, it cannot share it's instance variables with the original association it belonged to. At first I was curious to know if there was some other functionality that allowed this to happen. Maybe objects are added to associations during creation? I didn't see anything to this effect, especially since #create! doesn't trigger a full load of the association.

There are a number of tests for mark_for_destruction in autosave_association_test.rb that don't divorce the object from the association, so I feel that this is the appropriate semantics.

Sorry for such a long discussion on what is essentially a 2-line commit. But I'd rather head off any misunderstandings well before making this submission.
