### PR TITLE
Fix test warnings

### DIFF
--- a/activesupport/test/whiny_nil_test.rb
+++ b/activesupport/test/whiny_nil_test.rb
@@ -33,11 +33,10 @@ class WhinyNilTest < Test::Unit::TestCase
   end
 
   def test_id
-    nil.stubs(:object_id).returns(999)
     nil.id
   rescue RuntimeError => nme
     assert_no_match(/nil:NilClass/, nme.message)
-    assert_match(/999/, nme.message)
+    assert_match(Regexp.new(nil.object_id.to_s), nme.message)
   end
 
   def test_no_to_ary_coercion


### PR DESCRIPTION
This commit fixes a few warnings when running the tests.
- In Active Record for @cesario's fix in #inspect last week, when `@attributes` is not defined.
- In whiny_nil, where it's not useful to stub object_id of nil.
