### PR TITLE
Add MailBag to Action Mailer to handling bulk mailing and chaining method

### DIFF
--- a/actionmailer/CHANGELOG
+++ b/actionmailer/CHANGELOG
@@ -1,6 +1,18 @@
 *Rails 3.1.0 (unreleased)*
 
-* No changes
+* Add MailBag to Action Mailer to handling bulk mailing and chaining method [Prem Sichnaugrist]
+
+  MailBag gives you the ability to bulk mailing to multiple users. Instead of having to call the mailer multiple time, you can now pass the list of emails to it like this:
+
+      Notification.plan_expire.to_bulk(@users.map(&:email)).deliver
+
+  You could also modify the headers of your E-Mail at runtime by do a chaining, just like Active Record's scope.
+
+      Notification.plan_expire.subject("Your plan is expired!").deliver
+
+  Please note that calling your mailer's method will now always returning a MailBag object. This is only for method chaining, and you can always call another methods such as #deliver on it as normal. The only gotcha would be the resulting object after you call #deliver will now always be an array.
+
+  You can also get the normal Mail::Message objects before delivery by calling #mails method on the MailBag instance. This will be helpful when you're performing a test.
 
 
 *Rails 3.0.7 (April 18, 2011)*

--- a/actionmailer/lib/action_mailer.rb
+++ b/actionmailer/lib/action_mailer.rb
@@ -43,6 +43,7 @@ module ActionMailer
   autoload :Collector
   autoload :Base
   autoload :DeliveryMethods
+  autoload :MailBagHelper, "action_mailer/mail_bag"
   autoload :MailHelper
   autoload :TestCase
   autoload :TestHelper

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -331,6 +331,7 @@ module ActionMailer #:nodoc:
     include AbstractController::Helpers
     include AbstractController::Translation
     include AbstractController::AssetPaths
+    include ActionMailer::MailBagHelper
 
     self.protected_instance_variables = %w(@_action_has_layout)
 
@@ -434,7 +435,7 @@ module ActionMailer #:nodoc:
 
       def method_missing(method, *args) #:nodoc:
         return super unless respond_to?(method)
-        new(method, *args).message
+        MailBag.new(self).public_send(method, *args)
       end
     end
 

--- a/actionmailer/lib/action_mailer/mail_bag.rb
+++ b/actionmailer/lib/action_mailer/mail_bag.rb
@@ -1,0 +1,229 @@
+require 'active_support/concern'
+
+module ActionMailer
+  # = Action Mailer Mail Bag Helper
+  module MailBagHelper
+    extend ActiveSupport::Concern
+
+    # <tt>MailBag</tt> is acting as a wrapper for <tt>Mail::Message</tt>,
+    # allowing you to do various things with the mailer such as chaining the
+    # headers and perform a bulk mailing without having to create multiple
+    # emails yourself.
+    #
+    # The API of this <tt>MailBag</tt> is the same as Action Mailer API. You
+    # can call your mailer method on it as you normally do in Action Mailer.
+    # Any method call will override your configuration in your mailer method.
+    #
+    # == Available Methods
+    #
+    # These methods can be called before or after you call your normal mailer
+    # method, and are available to be called from the your <tt>Mailer</tt> class:
+    #
+    # * <tt>subject</tt> - Specifies a subject on an E-Mail.
+    # * <tt>to</tt> - Specifies a list of recipients. Note that if you pass a list
+    #   of E-Mail addresses, it will send a single E-Mail with multiple recipients.
+    # * <tt>to_bulk</tt> - Specifies a list of recipients. However, separate E-Mail
+    #   will be created for each of the recipient.
+    # * <tt>from</tt> - Specifies sender's E-Mail address.
+    # * <tt>cc</tt> - Specifies CC recipients.
+    # * <tt>bcc</tt> - Specifies BCC recipients.
+    # * <tt>reply_to</tt> - Specifies a reply to E-Mail address.
+    # * <tt>date</tt> - Specifies a timestamp of the E-Mail.
+    # * <tt>headers</tt> - Specifies the custom headers of the E-Mail.
+    #
+    # These methods are available only after you've called your mailer method:
+    #
+    # * <tt>mails</tt> - Retrieve a list of finished <tt>Mail::Message</tt> objects.
+    # * <tt>merge!</tt> - Merge a list of headers into this <tt>MailBag</tt> object.
+    # * <tt>deliver</tt> - Delivers emails by calling <tt>#deliver</tt> on each of the
+    #   <tt>Mail::Message</tt> object.
+    #
+    # == Examples
+    #
+    # Sending an E-Mail to user:
+    #
+    #    Notification.welcome.to(@user.email).deliver
+    #
+    # Sending bulk E-Mail to multiple users:
+    #
+    #    Notification.package_expire.to_bulk(@users.map(&:emails)).deliver
+    module ClassMethods
+      [:subject, :to, :to_bulk, :from, :cc, :bcc, :reply_to, :date, :headers].each do |method|
+        class_eval <<-ACCESSORS, __FILE__, __LINE__ + 1
+          def #{method}(#{method})
+            MailBag.new(self).#{method}(#{method})
+          end
+        ACCESSORS
+      end
+    end
+  end
+
+  # A wrapper class for <tt>ActionMailer::Base</tt> which allow methods to be
+  # chainable and bulk-mailingable. You can see the list of methods you can call
+  # and usage example of this by consulting <tt>ActionMailer::MailBagHelper::ClassMethods</tt>
+  # documentation.
+  class MailBag
+    class UnspecifiedMailerMethod < ArgumentError; end
+
+    # Store the class instance of the mailer
+    attr_reader :mailer
+
+    # The list of headers, used for generate getter/setter methods
+    HEADERS = [:subject, :cc, :bcc, :reply_to, :date]
+
+    delegate :each, :to => :mails
+
+    # Create a <tt>MailBag</tt> object which will handle the chaining and
+    # bulk mailing
+    def initialize(mailer, headers = {})
+      @message_template = nil
+      @mailer = mailer
+      @headers = headers
+    end
+
+    # Create the getter/setter methods
+    HEADERS.each do |method|
+      class_eval <<-ACCESSORS, __FILE__, __LINE__ + 1
+        def #{method}(#{method} = nil)
+          if #{method}
+            @mails = nil
+            @headers[:#{method}] = #{method}
+            self
+          else
+            @headers[:#{method}] || @message_template.#{method}
+          end
+        end
+      ACCESSORS
+    end
+
+    # Get and set the sender E-Mail address. If this method is called with an
+    # argument, it will set the E-Mail address and returns the <tt>MailBag</tt>
+    # object. If no argument, it will returns the array of sender E-Mail address.
+    #
+    # Note: This method returns an array to be compatible with <tt>Mail::Message</tt>.
+    def from(emails = nil)
+      if emails
+        @mails = nil
+        @headers[:from] = Array.wrap(emails)
+        self
+      else
+        @headers[:from] || @message_template.from
+      end
+    end
+
+
+    # Get and set the recipient E-Mail address. If this method is called with an
+    # argument, it will set the E-Mail address in a single E-Mail and returns the
+    # <tt>MailBag</tt> object. If no argument, it will returns the array of sender
+    # E-Mail address.
+    #
+    # Note: This method returns an array to be compatible with <tt>Mail::Message</tt>.
+    # This method may also returning an nested array of recipients if the bulk mailing
+    # recipients was specified by using <tt>#to_bulk</tt> method:
+    #
+    #    mail = Notification.welcome.to("konata@luckystar.net")
+    #    mail.to    # => ["konata@luckystar.net"]
+    #
+    #    mail = Notification.welcome.to(["konata@luckystar.net", "kagami@luckystar.net"])
+    #    mail.to    # => ["konata@luckystar.net", "kagami@luckystar.net"]
+    #
+    #    mail = Notification.welcome.to_bulk(["konata@luckystar.net", "kagami@luckystar.net"])
+    #    mail.to    # => [["konata@luckystar.net"], ["kagami@luckystar.net"]]
+    def to(emails = nil)
+      if emails
+        @mails = nil
+
+        # Store this as a nested array instead of normal array because this
+        # array is shared with the <tt>#to_bulk</tt> to. The outer array represents
+        # the number of messages, and the inner array represents the number of recipients
+        # of that message.
+        @headers[:to] = [ Array.wrap(emails) ]
+        self
+      else
+        # This condition is needed to not return a nested array if there's only
+        # going to be a single E-Mail generated.
+        if @headers[:to].present?
+          if @headers[:to].length == 1
+            @headers[:to].first
+          else
+            @headers[:to]
+          end
+        else
+          @message_template.to
+        end
+      end
+    end
+
+    # Sets the E-Mail addresses to perform bulk mailing. The difference between
+    # using this method and <tt>#to</tt> method is that this method will create
+    # multiple <tt>Mail::Message</tt> objects when you're trying to deliver the
+    # E-Mail, resulting multiple E-Mails to multiple recipients, not single
+    # E-Mail to multiple recipents.
+    def to_bulk(recipients)
+      @mails = nil
+      @headers[:to] = recipients.map{ |recipient| Array.wrap(recipient) }
+      self
+    end
+
+    # Get and set the custom headers of the E-Mail. If this method is called with
+    # an argument, it will merge your argument hash to your <tt>Mail::Message</tt>
+    # header and return <tt>self</tt>. If no argument, it will returns the hash
+    # of headers.
+    def headers(headers = nil)
+      if headers
+        merge!(headers)
+      else
+        @headers.merge(@message_template.try(:headers) || {})
+      end
+    end
+
+    # Merge your custom headers into this <tt>MailBag</tt> instance.
+    def merge!(headers = {})
+      @mails = nil
+      @headers.merge!(headers)
+      self
+    end
+
+    # Returns a list of <tt>Mail::Message</tt> objects which represent the real
+    # E-Mail which will be sent. This method will always return an array.
+    #
+    # Calling this method before calling your mailer's method will raise an
+    # UnspecifiedMailerMethod error.
+    def mails
+      raise UnspecifiedMailerMethod, "You have to call mailer's method first before getting mails collection or delivers it." if @message_template.nil?
+
+      @mails ||= if @headers[:to].present?
+                   # Clone mail message to preserve the original message
+                   @headers[:to].map do |recipient|
+                     @message_template.clone.tap do |message|
+                       message.headers(@headers.merge(:to => recipient))
+                     end
+                   end
+                 else
+                   [@message_template.clone.tap{ |message| message.headers(@headers) }]
+                 end
+    end
+
+    # Calls the <tt>#deliver</tt> method on each of the <tt>Mail::Message</tt>
+    # object to perform the delivery of E-Mail.
+    def deliver
+      mails.each(&:deliver)
+    end
+
+    protected
+
+      # Handles the call to the mailer's method, which isn't defined in this
+      # <tt>MailBag</tt> class.
+      def method_missing(name, *args)
+        if @message_template
+          @message_template.send(name, *args)
+        elsif @mailer.respond_to?(name)
+          # It's a bad hack, but this is the only way to prevent circular call
+          @message_template = @mailer.send(:new, name, *args).message
+          self
+        else
+          super
+        end
+      end
+  end
+end

--- a/actionmailer/test/delivery_methods_test.rb
+++ b/actionmailer/test/delivery_methods_test.rb
@@ -101,18 +101,18 @@ class MailDeliveryTest < ActiveSupport::TestCase
   end
 
   test "delivery method can be customized per instance" do
-    email = DeliveryMailer.welcome.deliver
-    assert_instance_of Mail::SMTP, email.delivery_method
-    email = DeliveryMailer.welcome(:delivery_method => :test).deliver
-    assert_instance_of Mail::TestMailer, email.delivery_method
+    emails = DeliveryMailer.welcome.deliver
+    assert_instance_of Mail::SMTP, emails[0].delivery_method
+    emails = DeliveryMailer.welcome(:delivery_method => :test).deliver
+    assert_instance_of Mail::TestMailer, emails[0].delivery_method
   end
 
   test "delivery method can be customized in subclasses not changing the parent" do
     DeliveryMailer.delivery_method = :test
     assert_equal :smtp, ActionMailer::Base.delivery_method
     $BREAK = true
-    email = DeliveryMailer.welcome.deliver
-    assert_instance_of Mail::TestMailer, email.delivery_method
+    emails = DeliveryMailer.welcome.deliver
+    assert_instance_of Mail::TestMailer, emails[0].delivery_method
   end
 
   test "non registered delivery methods raises errors" do

--- a/actionmailer/test/mail_bag_test.rb
+++ b/actionmailer/test/mail_bag_test.rb
@@ -1,0 +1,126 @@
+require 'abstract_unit'
+require 'mailers/base_mailer'
+
+class MailBagTest < ActiveSupport::TestCase
+  test "sets mail subject" do
+    mail_bag = BaseMailer.subject("Welcome!").welcome
+    assert_equal "Welcome!", mail_bag.subject
+
+    mail_bag = BaseMailer.welcome.subject("Welcome!")
+    assert_equal "Welcome!", mail_bag.subject
+  end
+
+  test "sets mail to" do
+    mail_bag = BaseMailer.to("konata@luckystar.net").welcome
+    assert_equal ["konata@luckystar.net"], mail_bag.to
+
+    mail_bag = BaseMailer.welcome.to("konata@luckystar.net")
+    assert_equal ["konata@luckystar.net"], mail_bag.to
+  end
+
+  test "sets mail from" do
+    mail_bag = BaseMailer.from("kagami@luckystar.net").welcome
+    assert_equal ["kagami@luckystar.net"], mail_bag.from
+
+    mail_bag = BaseMailer.welcome.from("kagami@luckystar.net")
+    assert_equal ["kagami@luckystar.net"], mail_bag.from
+  end
+
+  test "sets mail cc" do
+    mail_bag = BaseMailer.cc("tsukasa@luckystar.net").welcome
+    assert_equal "tsukasa@luckystar.net", mail_bag.cc
+
+    mail_bag = BaseMailer.welcome.cc("tsukasa@luckystar.net")
+    assert_equal "tsukasa@luckystar.net", mail_bag.cc
+  end
+
+  test "sets mail bcc" do
+    mail_bag = BaseMailer.bcc("iluvgirlsinglasses@luckystar.net").welcome
+    assert_equal "iluvgirlsinglasses@luckystar.net", mail_bag.bcc
+
+    mail_bag = BaseMailer.welcome.bcc("iluvgirlsinglasses@luckystar.net")
+    assert_equal "iluvgirlsinglasses@luckystar.net", mail_bag.bcc
+  end
+
+  test "sets mail reply_to" do
+    mail_bag = BaseMailer.reply_to("kagami@luckystar.net").welcome
+    assert_equal "kagami@luckystar.net", mail_bag.reply_to
+
+    mail_bag = BaseMailer.welcome.reply_to("kagami@luckystar.net")
+    assert_equal "kagami@luckystar.net", mail_bag.reply_to
+  end
+
+  test "sets mail date" do
+    date = Time.now
+
+    mail_bag = BaseMailer.date(date).welcome
+    assert_equal date, mail_bag.date
+
+    mail_bag = BaseMailer.welcome.date(date)
+    assert_equal date, mail_bag.date
+  end
+
+  test "sets mail header" do
+    mail_bag = BaseMailer.headers("X-SPAM" => "Not SPAM").welcome
+    assert_equal "Not SPAM", mail_bag.headers["X-SPAM"]
+
+    mail_bag = BaseMailer.welcome.headers("X-SPAM" => "Not SPAM")
+    assert_equal "Not SPAM", mail_bag.headers["X-SPAM"]
+  end
+
+  test "return list of mail objects" do
+    mail_bag = BaseMailer.welcome.subject("Hello World!")
+    assert_equal 1, mail_bag.mails.size
+    assert_equal "Hello World!",  mail_bag.mails.first.subject
+  end
+
+  test "create multiple mails using to_bulk" do
+    mail_bag = BaseMailer.welcome.to_bulk(["konata@luckystar.net", "miyuki@luckystar.net"])
+    assert_equal 2, mail_bag.mails.size
+
+    mail_bag = BaseMailer.welcome.to_bulk([["konata@luckystar.net","iluvgirlsinglasses@luckystar.net"], "miyuki@luckystar.net"])
+    assert_equal 2, mail_bag.mails.size
+  end
+
+  test "retrives bulk recipients using to" do
+    mail_bag = BaseMailer.welcome.to(["konata@luckystar.net", "kagami@luckystar.net"])
+    assert_equal ["konata@luckystar.net", "kagami@luckystar.net"], mail_bag.to
+
+    mail_bag = BaseMailer.welcome.to_bulk(["konata@luckystar.net", "kagami@luckystar.net"])
+    assert_equal [["konata@luckystar.net"], ["kagami@luckystar.net"]], mail_bag.to
+  end
+
+  test "chainable mail bag call" do
+    mail_bag = BaseMailer.welcome.to("konata@luckystar.net").from("kagami@luckystar.net").subject("Let's meet at the train station!")
+
+    assert_equal ["konata@luckystar.net"], mail_bag.to
+    assert_equal ["kagami@luckystar.net"], mail_bag.from
+    assert_equal "Let's meet at the train station!", mail_bag.subject
+  end
+
+  test "iterates between each mail" do
+    BaseMailer.welcome.each do |mail|
+      assert mail
+    end
+  end
+
+  test "deliver delegates to the mail object" do
+    mail_bag = BaseMailer.welcome.to("konata@luckystar.net")
+    mail = mail_bag.mails.first
+    mail.expects(:deliver).returns(true)
+
+    mail_bag.deliver
+  end
+
+  test "calls mails before calling mailer's method" do
+    assert_raise(ActionMailer::MailBag::UnspecifiedMailerMethod) do
+      BaseMailer.to("konata@luckystar.net").mails
+    end
+  end
+
+  test "calls deliver before calling mailer's method" do
+    assert_raise(ActionMailer::MailBag::UnspecifiedMailerMethod) do
+      BaseMailer.to("konata@luckystar.net").deliver
+    end
+  end
+end


### PR DESCRIPTION
Add MailBag to Action Mailer to handling bulk mailing and chaining method

MailBag gives you the ability to bulk mailing to multiple users. Instead of having to call the mailer multiple time, you can now pass the list of emails to it like this:

```
Notification.plan_expire.to_bulk(@users.map(&:email)).deliver
```

You could also modify the headers of your E-Mail at runtime by do a chaining, just like Active Record's scope.

```
Notification.plan_expire.subject("Your plan is expired!").deliver
```

---

@mikel and @dhh, do you mind giving feedbacks on this? Is this too overkill?
