### PR TITLE
Use instance_of? in #fields_for to check specifically for a Hash (excluding subclasses)

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -1237,7 +1237,7 @@ module ActionView
       end
 
       def fields_for(record_name, record_object = nil, fields_options = {}, &block)
-        fields_options, record_object = record_object, nil if record_object.is_a?(Hash)
+        fields_options, record_object = record_object, nil if record_object.instance_of?(Hash)
         fields_options[:builder] ||= options[:builder]
         fields_options[:parent_builder] = self
 


### PR DESCRIPTION
`ActionView::Helpers::FormBuilder#fields_for` was refactored recently (f0479cbbd52961c75906022003d4f03aa39556e0). It now checks whether the second parameter `is_a? Hash`, and if so, it assumes that it's an options hash (not a record object).

Unfortunately, if your record object is a subclass of Hash, `#fields_for` now mistakenly tries to interpret your record as an options hash. This is a real-world problem for the [admittedly fringe] case of [Casted Models in CouchRest Model](http://www.couchrest.info/model/casted_models.html), which are subclassed from Hash with a mix-in.

I don't think anybody who really intends to pass in an options hash is doing so with anything but a real Hash, so this can be fixed easily by using `instance_of?` (which will be false for casted models) instead of `is_a?`.
