### PR TITLE
Remove autoload for non-existing constants

### DIFF
--- a/actionpack/lib/action_view.rb
+++ b/actionpack/lib/action_view.rb
@@ -71,11 +71,6 @@ module ActionView
       autoload :TemplateError
       autoload :WrongEncodingError
     end
-
-    autoload_at "action_view/template" do
-      autoload :TemplateHandler
-      autoload :TemplateHandlers
-    end
   end
 
   ENCODING_FLAG = '#.*coding[:=]\s*(\S+)[ \t]*'


### PR DESCRIPTION
Previously ActionView contained TemplateHandler, TemplateHandlers (@d182b6ee9c99901553e6 removed them), but declarations of autoload for these constants are still there. I've removed them in this patch since they don't exist anymore. 

Backstory: 
I've found out about this when was figuring out why haml stopped working with latest head of rails. Turned out haml was checking for ActionView.const_defined?("TemplateHandlers") which returned true because of autoload for this constant, but was failing afterwords since this constant doesn't exist.
