### PR TITLE
Fix nested attribute for memory record.

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -402,7 +402,11 @@ module ActiveRecord
           return memory    if persisted.empty?
 
           persisted.map! do |record|
-            mem_record = memory.delete(record)
+            mem_record_index = memory.index(record)
+            if mem_record_index
+              mem_record = memory.at(mem_record_index)
+              memory.delete_at(mem_record_index)
+            end
 
             if mem_record
               (record.attribute_names - mem_record.changes.keys).each do |name|

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -402,6 +402,9 @@ module ActiveRecord
           return memory    if persisted.empty?
 
           persisted.map! do |record|
+
+            # To work with ruby 1.8.7
+            # > 1.9 #=> mem_record = memory.delete(record)
             mem_record_index = memory.index(record)
             if mem_record_index
               mem_record = memory.at(mem_record_index)

--- a/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
+++ b/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
@@ -8,10 +8,12 @@ require 'models/company'
 require 'models/topic'
 require 'models/reply'
 require 'models/person'
+require 'models/vertex'
+require 'models/edge'
 
 class CascadedEagerLoadingTest < ActiveRecord::TestCase
   fixtures :authors, :mixins, :companies, :posts, :topics, :accounts, :comments,
-           :categorizations, :people, :categories
+           :categorizations, :people, :categories, :edges, :vertices
 
   def test_eager_association_loading_with_cascaded_two_levels
     authors = Author.find(:all, :include=>{:posts=>:comments}, :order=>"authors.id")
@@ -164,12 +166,6 @@ class CascadedEagerLoadingTest < ActiveRecord::TestCase
       authors[2].post_about_thinking.comments.first
     end
   end
-end
-
-require 'models/vertex'
-require 'models/edge'
-class CascadedEagerLoadingTest < ActiveRecord::TestCase
-  fixtures :edges, :vertices
 
   def test_eager_association_loading_with_recursive_cascading_four_levels_has_many_through
     source = Vertex.find(:first, :include=>{:sinks=>{:sinks=>{:sinks=>:sinks}}}, :order => 'vertices.id')


### PR DESCRIPTION
Fixed nested_attributes tests

I found that 

mem_record = memory.delete(record) is returning record itself. with ruby-1.8.7

/cc @jonleighton

/cc @tenderlove
