### PR TITLE
This should fix the 7 tests failing on master for ActiveRecord

### DIFF
--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -56,8 +56,8 @@ class AssociationsTest < ActiveRecord::TestCase
 
   def test_loading_the_association_target_should_keep_child_records_marked_for_destruction
     ship = Ship.create!(:name => "The good ship Dollypop")
-    part = ship.parts.create!(:name => "Mast")
-    part.mark_for_destruction
+    ship.parts.create!(:name => "Mast")
+    ship.parts[0].mark_for_destruction
     ship.parts.send(:load_target)
     assert ship.parts[0].marked_for_destruction?
   end


### PR DESCRIPTION
This should fix the 7 tests failing on master for ActiveRecord
# test_loading_the_association_target_should_keep_child_records_marked_for_destruction

The part object was divorced from the association, so the instance variable for mark_for_destruction could never be reached.
# test_should_not_overwrite_unsaved_updates_when_loading_association and #test_should_not_remove_scheduled_destroys_when_loading_association

As far as I can tell, nested attributes are not enough to force a load of an association. 

TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations

Avoid accessing the association directly in setup, in light of the two test cases below it. Both of those cases had been loading the association directly, by mistake.
