### PR TITLE
AS::Dependencies.load_missing_constant should return the constant if it is already loaded

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -473,7 +473,7 @@ module ActiveSupport #:nodoc:
         raise ArgumentError, "A copy of #{from_mod} has been removed from the module tree but is still active!"
       end
 
-      raise ArgumentError, "#{from_mod} is not missing constant #{const_name}!" if local_const_defined?(from_mod, const_name)
+      return from_mod.const_get(const_name) if local_const_defined?(from_mod, const_name)
 
       qualified_name = qualified_name_for from_mod, const_name
       path_suffix = qualified_name.underscore

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -143,6 +143,9 @@ class DependenciesTest < Test::Unit::TestCase
       assert_kind_of Class, A::B
       assert_kind_of Class, A::C::D
       assert_kind_of Class, A::C::E::F
+      
+      assert_equal A::B, A::C::B
+      assert_equal A::B, A::C::E::B
     end
   end
 
@@ -441,7 +444,7 @@ class DependenciesTest < Test::Unit::TestCase
     with_autoloading_fixtures do
       require_dependency '././counting_loader'
       assert_equal 1, $counting_loaded_times
-      assert_raise(ArgumentError) { ActiveSupport::Dependencies.load_missing_constant Object, :CountingLoader }
+      ActiveSupport::Dependencies.load_missing_constant Object, :CountingLoader
       assert_equal 1, $counting_loaded_times
     end
   end


### PR DESCRIPTION
https://github.com/spohlenz/AS-autoload contains a demonstration of the problem that this commit fixes.

This issue was uncovered because of the way the inherited_resources gem autodetects constants based on the controller name, but I don't believe that inherited_resources is doing anything wrong here.

This commit also rids ActiveSupport of the confusing "X is not missing constant Y" error.
