### PR TITLE
fix merging the targer lists in 1.8.

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -402,9 +402,8 @@ module ActiveRecord
           return memory    if persisted.empty?
 
           persisted.map! do |record|
-            mem_record = memory.delete(record)
-
-            if mem_record
+            if mem_id = memory.index(record)
+              mem_record = memory.delete_at(mem_id)
               (record.attribute_names - mem_record.changes.keys).each do |name|
                 mem_record[name] = record[name]
               end


### PR DESCRIPTION
For some reason, #delete(record) didn't return the record in memory, but the persisted one.
This could be considered as a bug in ruby, which is fixed in 1.9.
