### PR TITLE
Mass assignment

### DIFF
--- a/activemodel/lib/active_model/mass_assignment_security.rb
+++ b/activemodel/lib/active_model/mass_assignment_security.rb
@@ -1,4 +1,4 @@
-require 'active_support/core_ext/class/attribute.rb'
+require 'active_support/core_ext/class/attribute'
 require 'active_support/core_ext/string/inflections'
 require 'active_model/mass_assignment_security/permission_set'
 require 'active_model/mass_assignment_security/sanitizer'

--- a/activemodel/lib/active_model/mass_assignment_security.rb
+++ b/activemodel/lib/active_model/mass_assignment_security.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/class/attribute.rb'
+require 'active_support/core_ext/string/inflections'
 require 'active_model/mass_assignment_security/permission_set'
 require 'active_model/mass_assignment_security/sanitizer'
 


### PR DESCRIPTION
This requires string's inflections in mass_assignment security, therefore fixing activemodel's isolation tests.
I've also removed a useless .rb in a require.
