### PR TITLE
#364 composed_of: Access record information from converter

### DIFF
--- a/activerecord/CHANGELOG
+++ b/activerecord/CHANGELOG
@@ -1,5 +1,11 @@
 *Rails 3.1.0 (unreleased)*
 
+* AR#composed_of can now access the associated record
+
+    class User < ActiveRecord::Base
+      composed_of :some_aggregation, ...,  :converter => Proc.new { |record, values| ... }
+    end
+
 * AR#pluralize_table_names can be used to singularize/pluralize table name of an individual model:
 
     class User < ActiveRecord::Base

--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -185,9 +185,11 @@ module ActiveRecord
       #   to instantiate a <tt>:class_name</tt> object.
       #   The default is <tt>:new</tt>.
       # * <tt>:converter</tt> - A symbol specifying the name of a class method of <tt>:class_name</tt>
-      #   or a Proc that is called when a new value is assigned to the value object. The converter is
-      #   passed the single value that is used in the assignment and is only called if the new value is
-      #   not an instance of <tt>:class_name</tt>.
+      #   or a Proc that is called when a new value is assigned to the value object. Depending on its arity,
+      #   the converter is passed either:
+      #   * the single value that is used in the assignment
+      #   * or the current object and this single value
+      #   The converter is only called if the new value is not an instance of <tt>:class_name</tt>.
       #
       # Option examples:
       #   composed_of :temperature, :mapping => %w(reading celsius)

--- a/activerecord/test/cases/aggregations_test.rb
+++ b/activerecord/test/cases/aggregations_test.rb
@@ -119,6 +119,12 @@ class AggregationsTest < ActiveRecord::TestCase
     assert_equal 'Barnoit GUMBLEAU', customers(:barney).fullname.to_s
     assert_kind_of Fullname, customers(:barney).fullname
   end
+
+  def test_custom_converter_with_arity_of_2
+    customers(:barney).fullname = 'Franck Verrot'
+    customers(:barney).location = %w(Lyon France)
+    assert_equal 'Franck VERROT from Lyon, France', customers(:barney).location.to_s
+  end
 end
 
 class OverridingAggregationsTest < ActiveRecord::TestCase

--- a/activerecord/test/models/customer.rb
+++ b/activerecord/test/models/customer.rb
@@ -3,6 +3,7 @@ class Customer < ActiveRecord::Base
   composed_of :balance, :class_name => "Money", :mapping => %w(balance amount), :converter => Proc.new { |balance| balance.to_money }
   composed_of :gps_location, :allow_nil => true
   composed_of :fullname, :mapping => %w(name to_s), :constructor => Proc.new { |name| Fullname.parse(name) }, :converter => :parse
+  composed_of :location, :class_name => "Location", :mapping => [ %w(address_city city), %w(address_country country) ], :converter => :convert_location
 end
 
 class Address
@@ -32,6 +33,21 @@ class Money
 
   def exchange_to(other_currency)
     Money.new((amount * EXCHANGE_RATES["#{currency}_TO_#{other_currency}"]).floor, other_currency)
+  end
+end
+
+class Location
+  attr_reader :city, :country, :who
+  def initialize(city, country, who = "")
+    @city, @country, @who = city, country, who
+  end
+
+  def self.convert_location(customer, values)
+    new(values.first, values.last, customer.fullname)
+  end
+
+  def to_s
+    "#{who} from #{city}, #{country}"
   end
 end
 


### PR DESCRIPTION
AR#composed_of can now access the associated record

``` ruby
    class User < ActiveRecord::Base
      composed_of :some_aggregation, ...,  :converter => Proc.new { |record, values| ... }
    end
```

Tested against REE and 1.9.2-p180.
