### PR TITLE
Custom attribute name in has_secure_password

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -1,4 +1,5 @@
 require 'bcrypt'
+require 'active_support/core_ext/class/attribute_accessors'
 
 module ActiveModel
   module SecurePassword
@@ -6,7 +7,8 @@ module ActiveModel
 
     module ClassMethods
       # Adds methods to set and authenticate against a BCrypt password.
-      # This mechanism requires you to have a password_digest attribute.
+      # This mechanism requires you to have a password_digest (default) attribute
+      # or a custom defined attribute like encrypted_password.
       #
       # Validations for presence of password, confirmation of password (using
       # a "password_confirmation" attribute) are automatically added.
@@ -19,6 +21,12 @@ module ActiveModel
       #     has_secure_password
       #   end
       #
+      #   # Custom Schema Definition : User(name:string, encrypted_password:string)
+      #   # Schema: User(name:string, password_digest:string)
+      #   class User < ActiveRecord::Base
+      #     has_secure_password :encrypted_password
+      #   end
+      #
       #   user = User.new(:name => "david", :password => "", :password_confirmation => "nomatch")
       #   user.save                                                      # => false, password required
       #   user.password = "mUc3m00RsqyRe"
@@ -29,26 +37,45 @@ module ActiveModel
       #   user.authenticate("mUc3m00RsqyRe")                             # => user
       #   User.find_by_name("david").try(:authenticate, "notright")      # => nil
       #   User.find_by_name("david").try(:authenticate, "mUc3m00RsqyRe") # => user
-      def has_secure_password
+      def has_secure_password(custom_password_attribute=:password_digest)
         attr_reader :password
 
-        validates_confirmation_of :password
-        validates_presence_of     :password_digest
+        cattr_accessor :custom_password_attribute
+        self.custom_password_attribute = custom_password_attribute
 
+        include Validations
         include InstanceMethodsOnActivation
+        include UpdateAttributesProtectedByDefault
+      end
+    end
 
+    module UpdateAttributesProtectedByDefault
+      extend ActiveSupport::Concern
+      included do
         if respond_to?(:attributes_protected_by_default)
           def self.attributes_protected_by_default
-            super + ['password_digest']
+            super + ["#{custom_password_attribute}"]
           end
         end
       end
     end
 
+    module Validations
+      extend ActiveSupport::Concern
+      included do
+        validates_confirmation_of :password
+        validates_presence_of     custom_password_attribute
+      end
+    end
+
     module InstanceMethodsOnActivation
+      def custom_password_attribute
+        self.class.custom_password_attribute
+      end
+
       # Returns self if the password is correct, otherwise false.
       def authenticate(unencrypted_password)
-        if BCrypt::Password.new(password_digest) == unencrypted_password
+        if BCrypt::Password.new(send(:"#{custom_password_attribute}")) == unencrypted_password
           self
         else
           false
@@ -59,7 +86,7 @@ module ActiveModel
       def password=(unencrypted_password)
         @password = unencrypted_password
         unless unencrypted_password.blank?
-          self.password_digest = BCrypt::Password.create(unencrypted_password)
+          self.send(:"#{custom_password_attribute}=", BCrypt::Password.create(unencrypted_password))
         end
       end
     end

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -75,7 +75,7 @@ module ActiveModel
 
       # Returns self if the password is correct, otherwise false.
       def authenticate(unencrypted_password)
-        if BCrypt::Password.new(send(:"#{custom_password_attribute}")) == unencrypted_password
+        if BCrypt::Password.new(send(custom_password_attribute)) == unencrypted_password
           self
         else
           false

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -22,7 +22,6 @@ module ActiveModel
       #   end
       #
       #   # Custom Schema Definition : User(name:string, encrypted_password:string)
-      #   # Schema: User(name:string, password_digest:string)
       #   class User < ActiveRecord::Base
       #     has_secure_password :encrypted_password
       #   end

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -2,6 +2,7 @@ require 'cases/helper'
 require 'models/user'
 require 'models/visitor'
 require 'models/administrator'
+require 'models/user_with_custom_password_attribute'
 
 class SecurePasswordTest < ActiveModel::TestCase
 
@@ -42,6 +43,14 @@ class SecurePasswordTest < ActiveModel::TestCase
 
     assert !@user.authenticate("wrong")
     assert @user.authenticate("secret")
+  end
+
+  test "authenticate user with custom password attribute" do
+    user = UserWithCustomPasswordAttribute.new
+    user.password = "secret"
+
+    assert !user.authenticate("wrong")
+    assert user.authenticate("secret")
   end
 
   test "visitor#password_digest should be protected against mass assignment" do

--- a/activemodel/test/models/user_with_custom_password_attribute.rb
+++ b/activemodel/test/models/user_with_custom_password_attribute.rb
@@ -1,0 +1,8 @@
+class UserWithCustomPasswordAttribute
+  include ActiveModel::Validations
+  include ActiveModel::SecurePassword
+
+  has_secure_password :encrypted_password
+
+  attr_accessor :encrypted_password
+end


### PR DESCRIPTION
Added code to allow users to pass a custom attribute name to has_secure_password.

Example:

<pre>
class User
   has_secure_password :encrypted_password
end
</pre>
