### PR TITLE
The URL http://dev.mysql.com/doc/refman/5.0/en/savepoints.html is no long

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -165,7 +165,7 @@ module ActiveRecord
     # writing, the only database that we're aware of that supports true nested
     # transactions, is MS-SQL. Because of this, Active Record emulates nested
     # transactions by using savepoints on MySQL and PostgreSQL. See
-    # http://dev.mysql.com/doc/refman/5.0/en/savepoints.html
+    # http://www.postgresql.org/docs/current/static/sql-savepoint.html
     # for more information about savepoints.
     #
     # === Callbacks


### PR DESCRIPTION
The URL http://dev.mysql.com/doc/refman/5.0/en/savepoints.html is no longer available
