### PR TITLE
Fix creating an empty route on 1.8. Closes #1210

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1423,7 +1423,9 @@ module ActionDispatch
           end
 
           def action_path(name, path = nil) #:nodoc:
-            path || @scope[:path_names][name.to_sym] || name.to_s
+            # Ruby 1.8 can't transform empty strings to symbols
+            name = name.to_sym if name.is_a?(String) && !name.empty?
+            path || @scope[:path_names][name] || name.to_s
           end
 
           def prefix_name_for_action(as, action) #:nodoc:

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -492,6 +492,8 @@ class ApplicationIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   routes.draw do
+    match '',    :to => 'application_integration_test/test#index', :as => :empty_string
+    
     match 'foo', :to => 'application_integration_test/test#index', :as => :foo
     match 'bar', :to => 'application_integration_test/test#index', :as => :bar
   end
@@ -501,11 +503,15 @@ class ApplicationIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "includes route helpers" do
+    assert_equal '/', empty_string_path
     assert_equal '/foo', foo_path
     assert_equal '/bar', bar_path
   end
 
   test "route helpers after controller access" do
+    get '/'
+    assert_equal '/', empty_string_path
+    
     get '/foo'
     assert_equal '/foo', foo_path
 


### PR DESCRIPTION
Ruby 1.8 doesn't accepts empty strings to be converted to symbols.
An empty route would therefore generate an error.

See, as a use case of this, the issue #1210.
