### PR TITLE
Require attr_internal before using in ActionView::Helpers

### DIFF
--- a/actionpack/lib/action_view/helpers/controller_helper.rb
+++ b/actionpack/lib/action_view/helpers/controller_helper.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/module/attr_internal'
+
 module ActionView
   module Helpers
     # This module keeps all methods and behavior in ActionView


### PR DESCRIPTION
Per discussion at https://github.com/rails/rails/commit/1632a3a49fb318be25d832b7efb17093bd7ef8ae#commitcomment-409761
