### PR TITLE
Fix timezone handling in String.to_time

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/string/conversions.rb
@@ -34,9 +34,9 @@ class String
   # Form can be either :utc (default) or :local.
   def to_time(form = :utc)
     return nil if self.blank?
-    d = ::Date._parse(self, false).values_at(:year, :mon, :mday, :hour, :min, :sec, :sec_fraction).map { |arg| arg || 0 }
+    d = ::Date._parse(self, false).values_at(:year, :mon, :mday, :hour, :min, :sec, :sec_fraction, :offset).map { |arg| arg || 0 }
     d[6] *= 1000000
-    ::Time.send("#{form}_time", *d)
+    ::Time.send("#{form}_time", *d[0..6]) - d[7]
   end
 
   def to_date

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -158,6 +158,7 @@ class StringInflectionsTest < Test::Unit::TestCase
     assert_equal Time.local(2005, 2, 27, 23, 50, 19, 275038), "2005-02-27T23:50:19.275038".to_time(:local)
     assert_equal DateTime.civil(2039, 2, 27, 23, 50), "2039-02-27 23:50".to_time
     assert_equal Time.local_time(2039, 2, 27, 23, 50), "2039-02-27 23:50".to_time(:local)
+    assert_equal Time.utc(2039, 2, 27, 23, 50), "2039-02-27 22:50 -0100".to_time
     assert_nil "".to_time
   end
 


### PR DESCRIPTION
Currently, if your string includes a timezone (like "2011-05-27 10:13:49 -0700") the to_time method will ignore it and do the conversion assuming a timezone of utc or local, depending on how it was called.  With this patch you'll get a time object with the correct time, represented in utc or local.
