### PR TITLE
Error when using trust_ident with pg and the :sql schema dumper

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -371,7 +371,8 @@ db_namespace = namespace :db do
         unless search_path.blank?
           search_path = search_path.split(",").map{|search_path| "--schema=#{search_path.strip}" }.join(" ")
         end
-        `pg_dump -i -U "#{abcs[Rails.env]['username']}" -s -x -O -f db/#{Rails.env}_structure.sql #{search_path} #{abcs[Rails.env]['database']}`
+        username = abcs[Rails.env]['username'] ? %Q{-U "#{abcs[Rails.env]['username']}"} : ""
+        `pg_dump -i #{username} -s -x -O -f db/#{Rails.env}_structure.sql #{search_path} #{abcs[Rails.env]['database']}`
         raise 'Error dumping database' if $?.exitstatus == 1
       when /sqlite/
         dbfile = abcs[Rails.env]['database'] || abcs[Rails.env]['dbfile']
@@ -418,7 +419,8 @@ db_namespace = namespace :db do
         ENV['PGHOST']     = abcs['test']['host'] if abcs['test']['host']
         ENV['PGPORT']     = abcs['test']['port'].to_s if abcs['test']['port']
         ENV['PGPASSWORD'] = abcs['test']['password'].to_s if abcs['test']['password']
-        `psql -U "#{abcs['test']['username']}" -f #{Rails.root}/db/#{Rails.env}_structure.sql #{abcs['test']['database']} #{abcs['test']['template']}`
+        username = abcs['test']['username'] ? %Q{-U "#{abcs['test']['username']}"} : ""
+        `psql #{username} -f #{Rails.root}/db/#{Rails.env}_structure.sql #{abcs['test']['database']} #{abcs['test']['template']}`
       when /sqlite/
         dbfile = abcs['test']['database'] || abcs['test']['dbfile']
         `sqlite3 #{dbfile} < #{Rails.root}/db/#{Rails.env}_structure.sql`


### PR DESCRIPTION
The rake tasks used when dumping the database structure (db:structure:dump and db:test:clone_structure) both make an assumption that a username will be provided with the database config for postgres, which isn't automatically the case if you have set up trust_ident for postgres.

This fix simply checks if a username has been provided and if it hasn't then it doesn't provide a -U string (and the commands will default to being attempted with the user running the rake task).

Couldn't see a clean way to test the rake tasks, especially not with these one's relying on command line tools. I verified by hand that the error had been solved.
