### PR TITLE
Double assignment of attributes on a collection association occurs fixed #1467

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -436,7 +436,6 @@ module ActiveRecord
         def build_record(attributes, options)
           record = reflection.build_association(attributes, options)
           record.assign_attributes(create_scope.except(*record.changed), :without_protection => true)
-          record.assign_attributes(attributes, options)
           record
         end
 


### PR DESCRIPTION
Double assignment of attributes on a collection association occurs fixed for the issue issue #1467
