### PR TITLE
Refactor ActionController::TestCase cookies

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -185,6 +185,11 @@ module ActionDispatch
         value
       end
 
+      # Removes all cookies on the client machine by calling <tt>delete</tt> for each cookie
+      def clear(options = {})
+        @cookies.keys.each{ |k| delete(k, options) }
+      end
+
       # Returns a jar that'll automatically set the assigned cookies to have an expiration date 20 years from now. Example:
       #
       #   cookies.permanent[:prefers_open_id] = true
@@ -220,6 +225,11 @@ module ActionDispatch
       def write(headers)
         @set_cookies.each { |k, v| ::Rack::Utils.set_cookie_header!(headers, k, v) if write_cookie?(v) }
         @delete_cookies.each { |k, v| ::Rack::Utils.delete_cookie_header!(headers, k, v) }
+      end
+
+      def reset! #:nodoc:
+        @set_cookies.clear
+        @delete_cookies.clear
       end
 
       private

--- a/actionpack/lib/action_dispatch/testing/test_process.rb
+++ b/actionpack/lib/action_dispatch/testing/test_process.rb
@@ -22,7 +22,7 @@ module ActionDispatch
     end
 
     def cookies
-      @request.cookies.merge(@response.cookies).with_indifferent_access
+      @request.cookie_jar
     end
 
     def redirect_to_url

--- a/actionpack/lib/action_dispatch/testing/test_request.rb
+++ b/actionpack/lib/action_dispatch/testing/test_request.rb
@@ -20,12 +20,6 @@ module ActionDispatch
       self.user_agent  = 'Rails Testing'
     end
 
-    def env
-      write_cookies!
-      delete_nil_values!
-      super
-    end
-
     def request_method=(method)
       @env['REQUEST_METHOD'] = method.to_s.upcase
     end
@@ -70,24 +64,5 @@ module ActionDispatch
       @env.delete('action_dispatch.request.accepts')
       @env['HTTP_ACCEPT'] = Array(mime_types).collect { |mime_type| mime_type.to_s }.join(",")
     end
-
-    def cookies
-      @cookies ||= super
-    end
-
-    private
-      def write_cookies!
-        unless @cookies.blank?
-          @env['HTTP_COOKIE'] = @cookies.map { |name, value| escape_cookie(name, value) }.join('; ')
-        end
-      end
-
-      def escape_cookie(name, value)
-        "#{Rack::Utils.escape(name)}=#{Rack::Utils.escape(value)}"
-      end
-
-      def delete_nil_values!
-        @env.delete_if { |k, v| v.nil? }
-      end
   end
 end

--- a/actionpack/test/controller/test_test.rb
+++ b/actionpack/test/controller/test_test.rb
@@ -593,13 +593,13 @@ XML
   end
 
   def test_should_have_knowledge_of_client_side_cookie_state_even_if_they_are_not_set
-    @request.cookies['foo'] = 'bar'
+    cookies['foo'] = 'bar'
     get :no_op
     assert_equal 'bar', cookies['foo']
   end
 
   def test_should_detect_if_cookie_is_deleted
-    @request.cookies['foo'] = 'bar'
+    cookies['foo'] = 'bar'
     get :delete_cookie
     assert_nil cookies['foo']
   end

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -430,54 +430,48 @@ class CookiesTest < ActionController::TestCase
 
 
   def test_setting_request_cookies_is_indifferent_access
-    @request.cookies.clear
-    @request.cookies[:user_name] = "andrew"
+    cookies.clear
+    cookies[:user_name] = "andrew"
     get :string_key_mock
-    assert_equal "david", cookies[:user_name]
-
-    @request.cookies.clear
-    @request.cookies['user_name'] = "andrew"
-    get :symbol_key_mock
     assert_equal "david", cookies['user_name']
+
+    cookies.clear
+    cookies['user_name'] = "andrew"
+    get :symbol_key_mock
+    assert_equal "david", cookies[:user_name]
   end
 
   def test_cookies_retained_across_requests
     get :symbol_key
-    assert_equal "user_name=david; path=/", @response.headers["Set-Cookie"]
+    assert_cookie_header "user_name=david; path=/"
     assert_equal "david", cookies[:user_name]
 
     get :noop
     assert_nil @response.headers["Set-Cookie"]
-    assert_equal "user_name=david", @request.env['HTTP_COOKIE']
     assert_equal "david", cookies[:user_name]
 
     get :noop
     assert_nil @response.headers["Set-Cookie"]
-    assert_equal "user_name=david", @request.env['HTTP_COOKIE']
     assert_equal "david", cookies[:user_name]
   end
 
   def test_cookies_can_be_cleared
     get :symbol_key
-    assert_equal "user_name=david; path=/", @response.headers["Set-Cookie"]
     assert_equal "david", cookies[:user_name]
 
-    @request.cookies.clear
+    cookies.clear
     get :noop
-    assert_nil @response.headers["Set-Cookie"]
-    assert_nil @request.env['HTTP_COOKIE']
     assert_nil cookies[:user_name]
 
     get :symbol_key
-    assert_equal "user_name=david; path=/", @response.headers["Set-Cookie"]
     assert_equal "david", cookies[:user_name]
   end
 
-  def test_cookies_are_escaped
-    @request.cookies[:user_ids] = '1;2'
+  def test_can_set_http_cookie_header
+    @request.env['HTTP_COOKIE'] = "user_name=david"
     get :noop
-    assert_equal "user_ids=1%3B2", @request.env['HTTP_COOKIE']
-    assert_equal "1;2", cookies[:user_ids]
+    assert_equal 'david', cookies['user_name']
+    assert_equal 'david', cookies[:user_name]
   end
 
   private

--- a/actionpack/test/dispatch/test_request_test.rb
+++ b/actionpack/test/dispatch/test_request_test.rb
@@ -34,12 +34,15 @@ class TestRequestTest < ActiveSupport::TestCase
     assert_equal({}, req.cookies)
     assert_equal nil, req.env["HTTP_COOKIE"]
 
-    req.cookies["user_name"] = "david"
-    assert_equal({"user_name" => "david"}, req.cookies)
-    assert_equal "user_name=david", req.env["HTTP_COOKIE"]
+    req.cookie_jar["user_name"] = "david"
+    assert_cookies({"user_name" => "david"}, req.cookie_jar)
 
-    req.cookies["login"] = "XJ-122"
-    assert_equal({"user_name" => "david", "login" => "XJ-122"}, req.cookies)
-    assert_equal %w(login=XJ-122 user_name=david), req.env["HTTP_COOKIE"].split(/; /).sort
+    req.cookie_jar["login"] = "XJ-122"
+    assert_cookies({"user_name" => "david", "login" => "XJ-122"}, req.cookie_jar)
   end
+
+  private
+    def assert_cookies(expected, cookie_jar)
+      assert_equal(expected, cookie_jar.instance_variable_get("@cookies"))
+    end
 end


### PR DESCRIPTION
Assigning cookies for test cases should now use cookies[], e.g:

```
cookies[:email] = 'user@example.com'
get :index
assert_equal 'user@example.com', cookies[:email]
```

To clear the cookies, use clear, e.g:

```
cookies.clear
get :index
assert_nil cookies[:email]
```

We now no longer write out HTTP_COOKIE and the cookie jar is
persistent between requests so if you need to manipulate the environment
for your test you need to do it before the cookie jar is created.

This commit fixes #1464.
