### PR TITLE
Fix undefined method sprockets_javascript_include_tag

### DIFF
--- a/actionpack/lib/action_view/helpers/asset_tag_helpers/javascript_tag_helpers.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helpers/javascript_tag_helpers.rb
@@ -83,11 +83,7 @@ module ActionView
         #   javascript_path "http://www.example.com/js/xmlhr"    # => http://www.example.com/js/xmlhr
         #   javascript_path "http://www.example.com/js/xmlhr.js" # => http://www.example.com/js/xmlhr.js
         def javascript_path(source)
-          if config.use_sprockets
-            asset_path(source, 'js')
-          else
-            asset_paths.compute_public_path(source, 'javascripts', 'js')
-          end
+          asset_paths.compute_public_path(source, 'javascripts', 'js')
         end
         alias_method :path_to_javascript, :javascript_path # aliased to avoid conflicts with a javascript_path named route
 
@@ -187,12 +183,8 @@ module ActionView
         #
         #   javascript_include_tag :all, :cache => true, :recursive => true
         def javascript_include_tag(*sources)
-          if config.use_sprockets
-            sprockets_javascript_include_tag(*sources)
-          else
-            @javascript_include ||= JavascriptIncludeTag.new(config, asset_paths)
-            @javascript_include.include_tag(*sources)
-          end
+          @javascript_include ||= JavascriptIncludeTag.new(config, asset_paths)
+          @javascript_include.include_tag(*sources)
         end
       end
     end


### PR DESCRIPTION
This got refactored out and is now overridden by sprockets/helpers/rails_helper.rb but was never applied to 3-1-stable.
