### PR TITLE
Fix broken asset pipeline paths

### DIFF
--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -4,6 +4,9 @@ require "action_view/helpers/asset_tag_helper"
 module Sprockets
   module Helpers
     module RailsHelper
+      extend ActiveSupport::Concern
+      include ActionView::Helpers::AssetTagHelper
+      
       def asset_paths
         @asset_paths ||= begin
           config     = self.config if respond_to?(:config)

--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -12,12 +12,6 @@ module Sprockets
         end
       end
 
-      def asset_path(source, default_ext = nil, body = false)
-        source = source.logical_path if source.respond_to?(:logical_path)
-        path = asset_paths.compute_public_path(source, 'assets', default_ext, true)
-        body ? "#{path}?body=1" : path
-      end
-
       def javascript_include_tag(source, options = {})
         debug = options.key?(:debug) ? options.delete(:debug) : debug_assets?
         body  = options.key?(:body)  ? options.delete(:body)  : false

--- a/actionpack/lib/sprockets/railtie.rb
+++ b/actionpack/lib/sprockets/railtie.rb
@@ -29,6 +29,8 @@ module Sprockets
       app.assets = asset_environment(app)
 
       ActiveSupport.on_load(:action_view) do
+        include ::Sprockets::Helpers::RailsHelper
+        
         app.assets.context_class.instance_eval do
           include ::Sprockets::Helpers::RailsHelper
         end


### PR DESCRIPTION
This needs to be there to generate urls with assets/ in paths vs stylesheets/, javascripts/. Brings 3-1 inline with master.
