### PR TITLE
Fix failing test because of Timezone difference.

### DIFF
--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -589,8 +589,8 @@ class FoxyFixturesTest < ActiveRecord::TestCase
   end
 
   def test_preserves_existing_fixture_data
-    assert_equal(2.weeks.ago.to_date, pirates(:redbeard).created_on.to_date)
-    assert_equal(2.weeks.ago.to_date, pirates(:redbeard).updated_on.to_date)
+    assert_equal(2.weeks.ago.utc.to_date, pirates(:redbeard).created_on.utc.to_date)
+    assert_equal(2.weeks.ago.utc.to_date, pirates(:redbeard).updated_on.utc.to_date)
   end
 
   def test_generates_unique_ids


### PR DESCRIPTION
So following is the result of 'rake test_mysql' on 'activerecord'

<pre>
Finished in 187.706285 seconds.

  1) Failure:
test_preserves_existing_fixture_data(FoxyFixturesTest) [/Users/anil.wadghule/Code/rails/rails/activerecord/test/cases/fixtures_test.rb:592]:
<Sun, 22 May 2011> expected but was
<Mon, 23 May 2011>.

2982 tests, 9217 assertions, 1 failures, 0 errors, 0 skips
</pre>


Commit fixes this failing test.
