### PR TITLE
Fixed failing isolated test

### DIFF
--- a/activesupport/test/core_ext/kernel_test.rb
+++ b/activesupport/test/core_ext/kernel_test.rb
@@ -60,7 +60,7 @@ class KernelTest < ActiveSupport::TestCase
 
   def test_require_library_or_gem_deprecated
     assert_deprecated do
-      require_library_or_gem 'i18n'
+      require_library_or_gem 'multi_json'
     end
   end
 end


### PR DESCRIPTION
Don't know why it's giving error with i18n gem. 

It was loading i18n/version actually. Need to figure out why not working with i18n.

Changing gem here in test doesn't matter. As checking same. 

Error coming was 

<pre>
  1) Error:
test_require_library_or_gem_deprecated(KernelTest):
NameError: uninitialized constant I18n
    /Users/arunagw/checkouts/rails/activesupport/lib/active_support/i18n.rb:9
    /Users/arunagw/checkouts/rails/bundle/ruby/1.8/gems/i18n-0.6.0/lib/i18n/version.rb:1
    /Users/arunagw/checkouts/rails/bundle/ruby/1.8/gems/i18n-0.6.0/lib/i18n.rb:1:in `require'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.8/gems/i18n-0.6.0/lib/i18n.rb:1

</pre>


This is only for 3-1-stable as it's deprecated in 3-1-stable branch only.
This can give 3-1-stable as green build.
