### PR TITLE
[3.1.0rc1] Undefined method 'collect!' bug in ActiveResource instantiate_collection

### DIFF
--- a/activeresource/lib/active_resource/base.rb
+++ b/activeresource/lib/active_resource/base.rb
@@ -919,6 +919,7 @@ module ActiveResource
         end
 
         def instantiate_collection(collection, prefix_options = {})
+          collection = collection['records'] if collection.instance_of?(Hash)
           collection.collect! { |record| instantiate_record(record, prefix_options) }
         end
 


### PR DESCRIPTION
Fix undefined method collect bug in ActiveResource instantiate_collection. When trying to interact with the Basecamp API I ran into this bug and am able to consistently reproduce it with the following steps:

```
>> require 'active_resource'
=> true
>> class Project < ActiveResource::Base
>>   self.site = "https://BASECAMPURL.basecamphq.com"
>>   self.user = "BASECAMPAPIKEY"
>>   self.password = "X" # Leave as X as mentioned in the documentation
>> end
=> "X"
>> Project.all
NoMethodError: undefined method `collect!' for #<Hash:0x101b45788>
    from /Library/Ruby/Gems/1.8/gems/activeresource-3.1.0.rc1/lib/active_resource/base.rb:926:in `instantiate_collection'
    from /Library/Ruby/Gems/1.8/gems/activeresource-3.1.0.rc1/lib/active_resource/base.rb:894:in `find_every'
    from /Library/Ruby/Gems/1.8/gems/activeresource-3.1.0.rc1/lib/active_resource/base.rb:806:in `find'
    from /Library/Ruby/Gems/1.8/gems/activeresource-3.1.0.rc1/lib/active_resource/base.rb:832:in `all'
    from (irb):7
```

instantiate_collection is expecting an Array to be returned but after the XML decode it's receiving a Hash like this:
`{"count"=>1, "records"=>[{"name"=>"Project1", ... }], "nextOffset"=>nil, "limit"=>25, "offset"=>0}`

I wasn't sure what the best way would be to reproduce this in a test case, but if you have any suggestions, please let me know.
