### PR TITLE
Rake rdoc fixes cherry picks for 3-0-stable

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,11 @@ gem 'rdoc', '>= 2.5.10'
 require 'rdoc'
 
 require 'rake'
-require 'rdoc/task'
+begin
+  require 'rdoc/task'
+rescue LoadError
+  require 'rake/rdoctask'
+end
 
 $:.unshift File.expand_path('..', __FILE__)
 require "tasks/release"

--- a/Rakefile
+++ b/Rakefile
@@ -2,11 +2,7 @@ gem 'rdoc', '>= 2.5.10'
 require 'rdoc'
 
 require 'rake'
-begin
-  require 'rdoc/task'
-rescue LoadError
-  require 'rake/rdoctask'
-end
+require 'rdoc/task'
 
 $:.unshift File.expand_path('..', __FILE__)
 require "tasks/release"

--- a/actionmailer/Rakefile
+++ b/actionmailer/Rakefile
@@ -1,7 +1,7 @@
 require 'rake'
 require 'rake/testtask'
 require 'rake/packagetask'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 
 desc "Default Task"
 task :default => [ :test ]
@@ -24,7 +24,7 @@ end
 
 spec = eval(File.read('actionmailer.gemspec'))
 
-Rake::GemPackageTask.new(spec) do |p|
+Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
 end
 

--- a/actionpack/Rakefile
+++ b/actionpack/Rakefile
@@ -1,7 +1,7 @@
 require 'rake'
 require 'rake/testtask'
 require 'rake/packagetask'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 
 desc "Default Task"
 task :default => :test
@@ -35,7 +35,7 @@ end
 
 spec = eval(File.read('actionpack.gemspec'))
 
-Rake::GemPackageTask.new(spec) do |p|
+Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
 end
 

--- a/activemodel/Rakefile
+++ b/activemodel/Rakefile
@@ -20,11 +20,11 @@ namespace :test do
 end
 
 require 'rake/packagetask'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 
 spec = eval(File.read("#{dir}/activemodel.gemspec"))
 
-Rake::GemPackageTask.new(spec) do |p|
+Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
 end
 

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -1,7 +1,7 @@
 require 'rake'
 require 'rake/testtask'
 require 'rake/packagetask'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 
 require File.expand_path(File.dirname(__FILE__)) + "/test/config"
 
@@ -160,7 +160,7 @@ task :rebuild_frontbase_databases => 'frontbase:rebuild_databases'
 
 spec = eval(File.read('activerecord.gemspec'))
 
-Rake::GemPackageTask.new(spec) do |p|
+Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
 end
 

--- a/activeresource/Rakefile
+++ b/activeresource/Rakefile
@@ -1,7 +1,7 @@
 require 'rake'
 require 'rake/testtask'
 require 'rake/packagetask'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 
 desc "Default Task"
 task :default => [ :test ]
@@ -26,7 +26,7 @@ end
 
 spec = eval(File.read('activeresource.gemspec'))
 
-Rake::GemPackageTask.new(spec) do |p|
+Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
 end
 

--- a/activesupport/Rakefile
+++ b/activesupport/Rakefile
@@ -1,5 +1,5 @@
 require 'rake/testtask'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 
 task :default => :test
 Rake::TestTask.new do |t|
@@ -20,7 +20,7 @@ dist_dirs = [ "lib", "test"]
 
 spec = eval(File.read('activesupport.gemspec'))
 
-Rake::GemPackageTask.new(spec) do |p|
+Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
 end
 

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -1,6 +1,6 @@
 require 'rake'
 require 'rake/testtask'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 
 require 'date'
 require 'rbconfig'
@@ -59,7 +59,7 @@ end
 
 spec = eval(File.read('railties.gemspec'))
 
-Rake::GemPackageTask.new(spec) do |pkg|
+Gem::PackageTask.new(spec) do |pkg|
   pkg.gem_spec = spec
 end
 

--- a/railties/lib/rails/generators/rails/plugin/templates/Rakefile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Rakefile.tt
@@ -1,6 +1,6 @@
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 desc 'Default: run unit tests.'
 task :default => :test
@@ -14,7 +14,7 @@ Rake::TestTask.new(:test) do |t|
 end
 
 desc 'Generate documentation for the <%= file_name %> plugin.'
-Rake::RDocTask.new(:rdoc) do |rdoc|
+RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
   rdoc.title    = '<%= class_name %>'
   rdoc.options << '--line-numbers' << '--inline-source'

--- a/railties/lib/rails/tasks/documentation.rake
+++ b/railties/lib/rails/tasks/documentation.rake
@@ -1,7 +1,7 @@
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 # Monkey-patch to remove redoc'ing and clobber descriptions to cut down on rake -T noise
-class RDocTaskWithoutDescriptions < Rake::RDocTask
+class RDocTaskWithoutDescriptions < RDoc::Task
   def define
     task rdoc_task_name
 

--- a/railties/lib/rails/tasks/documentation.rake
+++ b/railties/lib/rails/tasks/documentation.rake
@@ -1,7 +1,9 @@
 begin
   require 'rdoc/task'
 rescue LoadError
+  require 'rdoc/rdoc'
   require 'rake/rdoctask'
+  RDoc::Task = Rake::RDocTask
 end
 
 # Monkey-patch to remove redoc'ing and clobber descriptions to cut down on rake -T noise

--- a/railties/lib/rails/tasks/documentation.rake
+++ b/railties/lib/rails/tasks/documentation.rake
@@ -1,4 +1,8 @@
-require 'rdoc/task'
+begin
+  require 'rdoc/task'
+rescue LoadError
+  require 'rake/rdoctask'
+end
 
 # Monkey-patch to remove redoc'ing and clobber descriptions to cut down on rake -T noise
 class RDocTaskWithoutDescriptions < RDoc::Task

--- a/railties/test/railties/railtie_test.rb
+++ b/railties/test/railties/railtie_test.rb
@@ -85,7 +85,7 @@ module RailtiesTest
       assert !$ran_block
       require 'rake'
       require 'rake/testtask'
-      require 'rake/rdoctask'
+      require 'rdoc/task'
 
       AppTemplate::Application.load_tasks
       assert $ran_block

--- a/railties/test/railties/railtie_test.rb
+++ b/railties/test/railties/railtie_test.rb
@@ -85,12 +85,7 @@ module RailtiesTest
       assert !$ran_block
       require 'rake'
       require 'rake/testtask'
-      begin
-        require 'rdoc/task'
-      rescue LoadError
-        require 'rake/rdoctask'
-      end
-
+      require 'rdoc/task'
 
       AppTemplate::Application.load_tasks
       assert $ran_block

--- a/railties/test/railties/railtie_test.rb
+++ b/railties/test/railties/railtie_test.rb
@@ -85,7 +85,12 @@ module RailtiesTest
       assert !$ran_block
       require 'rake'
       require 'rake/testtask'
-      require 'rdoc/task'
+      begin
+        require 'rdoc/task'
+      rescue LoadError
+        require 'rake/rdoctask'
+      end
+
 
       AppTemplate::Application.load_tasks
       assert $ran_block

--- a/railties/test/railties/shared_tests.rb
+++ b/railties/test/railties/shared_tests.rb
@@ -170,7 +170,7 @@ module RailtiesTest
 
       boot_rails
       require 'rake'
-      require 'rake/rdoctask'
+      require 'rdoc/task'
       require 'rake/testtask'
       Rails.application.load_tasks
       Rake::Task[:foo].invoke

--- a/railties/test/railties/shared_tests.rb
+++ b/railties/test/railties/shared_tests.rb
@@ -170,11 +170,7 @@ module RailtiesTest
 
       boot_rails
       require 'rake'
-      begin
-        require 'rdoc/task'
-      rescue LoadError
-        require 'rake/rdoctask'
-      end
+      require 'rdoc/task'
       require 'rake/testtask'
       Rails.application.load_tasks
       Rake::Task[:foo].invoke

--- a/railties/test/railties/shared_tests.rb
+++ b/railties/test/railties/shared_tests.rb
@@ -170,7 +170,11 @@ module RailtiesTest
 
       boot_rails
       require 'rake'
-      require 'rdoc/task'
+      begin
+        require 'rdoc/task'
+      rescue LoadError
+        require 'rake/rdoctask'
+      end
       require 'rake/testtask'
       Rails.application.load_tasks
       Rake::Task[:foo].invoke


### PR DESCRIPTION
@josevalim: As requested in https://github.com/rails/rails/pull/1508.

Please note that I've to cherry pick and edit the commits because 'plugin_new' doesn't exist in 3-0-stable.

And Rakefile in the top of the tree already had <code>require rdoc/task</code> and hence is not included in the diff.
