### PR TITLE
Rails::Server#app should be nice with Rack::URLMap

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -138,6 +138,10 @@ module Rails
       @config ||= Application::Configuration.new(find_root_with_flag("config.ru", Dir.pwd))
     end
 
+    def to_app
+      self
+    end
+
   protected
 
     alias :build_middleware_stack :app

--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -43,7 +43,7 @@ module Rails
     end
 
     def app
-      @app ||= super.instance
+      @app ||= super.respond_to?(:to_app) ? super.to_app : super
     end
 
     def opt_parser


### PR DESCRIPTION
This a follow-up of #1331 (Actually I'm looking to solve this because I need it urgently).

I'm checking if super.instance exists before call it and call to super if it doesn't exists (for Rack::URLMap), I don't want remove entire method since according to 19c763f7831e08606e6b4fa516f5ad3b00c6428f using it here reduces 2 methods call per request.

Also I do some changes to @andrew test to use a free port instead of port 3000 for server_tests. (Some people runs another Rails apps while run the tests ;)).

cc. @andrew @josevalim
