### PR TITLE
ActiveRecord::Persistence#touch should not use default_scope

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -279,7 +279,7 @@ module ActiveRecord
 
         @changed_attributes.except!(*changes.keys)
         primary_key = self.class.primary_key
-        self.class.update_all(changes, { primary_key => self[primary_key] }) == 1
+        self.class.unscoped.update_all(changes, { primary_key => self[primary_key] }) == 1
       end
     end
 

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -40,6 +40,15 @@ class TimestampTest < ActiveRecord::TestCase
     assert_equal previous_salary, @developer.salary
   end
 
+  def test_touching_a_record_with_default_scope_that_exludes_it_updates_its_timestamp
+    developer = @developer.becomes(DeveloperCalledJamis)
+
+    developer.touch
+    assert_not_equal @previously_updated_at, developer.updated_at
+    developer.reload
+    assert_not_equal @previously_updated_at, developer.updated_at
+  end
+
   def test_saving_when_record_timestamps_is_false_doesnt_update_its_timestamp
     Developer.record_timestamps = false
     @developer.name = "John Smith"

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -11,6 +11,7 @@ class TimestampTest < ActiveRecord::TestCase
 
   def setup
     @developer = Developer.first
+    @developer.update_attribute(:updated_at, Time.now.prev_month)
     @previously_updated_at = @developer.updated_at
   end
 


### PR DESCRIPTION
Hi.

Using `update_all` in `touch` looks smart enough, but there is a hidden issue in this: `update_all` uses `default_scope`.

Imagine a situation: you have the following `User` class:

``` ruby
class User < ActiveRecord::Base
  default_scope :active => true
end

user = User.unscoped.where(:active => false).first

user.touch
# This fires sql "UPDATE `users` SET `updated_at` = ? WHERE `users`.`active` = 0"
# and so our user instance remains changed (and the database remains unchanged)
user.changed? #=> true
user.reload # brings old updated_at value back to life
```

I've provided a test proving that and a fix for the issue.
