### PR TITLE
Fragment caching needs to operate on the pure output, not the safebuffer.

### DIFF
--- a/actionpack/lib/action_view/helpers/cache_helper.rb
+++ b/actionpack/lib/action_view/helpers/cache_helper.rb
@@ -51,7 +51,9 @@ module ActionView
           # This dance is needed because Builder can't use capture
           pos = output_buffer.length
           yield
-          fragment = output_buffer.slice!(pos..-1)
+          safe_output_buffer = output_buffer.to_str
+          fragment = safe_output_buffer.slice!(pos..-1)
+          self.output_buffer = ActionView::OutputBuffer.new(safe_output_buffer)
           controller.write_fragment(name, fragment, options)
         end
       end


### PR DESCRIPTION
Fix for #1537.

Ensure that we can operate directly on the output buffer, and not the safe buffer as it prevents certain operations.

Let me know if there's a more elegant way to approach this, or if there's something you'd like to see changed.  This addresses test failures on 3.0.8 and master in actionpack/test/controller/caching_test.rb.
