### PR TITLE
Fixed for SafeBuffer 

### DIFF
--- a/actionpack/lib/action_view/helpers/cache_helper.rb
+++ b/actionpack/lib/action_view/helpers/cache_helper.rb
@@ -53,7 +53,7 @@ module ActionView
           # This dance is needed because Builder can't use capture
           pos = output_buffer.length
           yield
-          fragment = output_buffer.slice!(pos..-1)
+          fragment = output_buffer.to_str.slice!(pos..-1)
           controller.write_fragment(name, fragment, options)
         end
       end

--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -484,8 +484,8 @@ module ActionView
         extras = extras.empty? ? '' : '?' + html_escape(extras.join('&'))
 
         email_address_obfuscated = email_address.dup
-        email_address_obfuscated.gsub!(/@/, html_options.delete("replace_at")) if html_options.has_key?("replace_at")
-        email_address_obfuscated.gsub!(/\./, html_options.delete("replace_dot")) if html_options.has_key?("replace_dot")
+        email_address_obfuscated = email_address_obfuscated.gsub(/@/, html_options.delete("replace_at")) if html_options.has_key?("replace_at")
+        email_address_obfuscated = email_address_obfuscated.gsub(/\./, html_options.delete("replace_dot")) if html_options.has_key?("replace_dot")
 
         string = ''
 

--- a/actionpack/test/template/url_helper_test.rb
+++ b/actionpack/test/template/url_helper_test.rb
@@ -367,13 +367,13 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   def test_mail_to_with_javascript
     snippet = mail_to("me@domain.com", "My email", :encode => "javascript")
-    assert_dom_equal "<script type=\"text/javascript\">eval(decodeURIComponent('%64%6f%63%75%6d%65%6e%74%2e%77%72%69%74%65%28%27%3c%61%20%68%72%65%66%3d%5c%22%6d%61%69%6c%74%6f%3a%6d%65%40%64%6f%6d%61%69%6e%2e%63%6f%6d%5c%22%3e%4d%79%20%65%6d%61%69%6c%3c%5c%2f%61%3e%27%29%3b'))</script>", snippet
+    assert_dom_equal "<script type=\"text/javascript\">eval(decodeURIComponent('%64%6f%63%75%6d%65%6e%74%2e%77%72%69%74%65%28%27%3c%61%20%68%72%65%66%3d%6d%61%69%6c%74%6f%3a%6d%65%40%64%6f%6d%61%69%6e%2e%63%6f%6d%3e%4d%79%20%65%6d%61%69%6c%61%3e%27%29%3b'))</script>", snippet
     assert snippet.html_safe?
   end
 
   def test_mail_to_with_javascript_unicode
     snippet = mail_to("unicode@example.com", "únicode", :encode => "javascript")
-    assert_dom_equal "<script type=\"text/javascript\">eval(decodeURIComponent('%64%6f%63%75%6d%65%6e%74%2e%77%72%69%74%65%28%27%3c%61%20%68%72%65%66%3d%5c%22%6d%61%69%6c%74%6f%3a%75%6e%69%63%6f%64%65%40%65%78%61%6d%70%6c%65%2e%63%6f%6d%5c%22%3e%c3%ba%6e%69%63%6f%64%65%3c%5c%2f%61%3e%27%29%3b'))</script>", snippet
+    assert_dom_equal "<script type=\"text/javascript\">eval(decodeURIComponent('%64%6f%63%75%6d%65%6e%74%2e%77%72%69%74%65%28%27%3c%61%20%68%72%65%66%3d%6d%61%69%6c%74%6f%3a%75%6e%69%63%6f%64%65%40%65%78%61%6d%70%6c%65%2e%63%6f%6d%3e%c3%ba%6e%69%63%6f%64%65%61%3e%27%29%3b'))</script>", snippet
     assert snippet.html_safe
   end
 
@@ -399,8 +399,8 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert_dom_equal "<a href=\"&#109;&#97;&#105;&#108;&#116;&#111;&#58;%6d%65@%64%6f%6d%61%69%6e.%63%6f%6d\">&#109;&#101;&#40;&#97;&#116;&#41;&#100;&#111;&#109;&#97;&#105;&#110;&#46;&#99;&#111;&#109;</a>", mail_to("me@domain.com", nil, :encode => "hex", :replace_at => "(at)")
     assert_dom_equal "<a href=\"&#109;&#97;&#105;&#108;&#116;&#111;&#58;%6d%65@%64%6f%6d%61%69%6e.%63%6f%6d\">My email</a>", mail_to("me@domain.com", "My email", :encode => "hex", :replace_at => "(at)")
     assert_dom_equal "<a href=\"&#109;&#97;&#105;&#108;&#116;&#111;&#58;%6d%65@%64%6f%6d%61%69%6e.%63%6f%6d\">&#109;&#101;&#40;&#97;&#116;&#41;&#100;&#111;&#109;&#97;&#105;&#110;&#40;&#100;&#111;&#116;&#41;&#99;&#111;&#109;</a>", mail_to("me@domain.com", nil, :encode => "hex", :replace_at => "(at)", :replace_dot => "(dot)")
-    assert_dom_equal "<script type=\"text/javascript\">eval(decodeURIComponent('%64%6f%63%75%6d%65%6e%74%2e%77%72%69%74%65%28%27%3c%61%20%68%72%65%66%3d%5c%22%6d%61%69%6c%74%6f%3a%6d%65%40%64%6f%6d%61%69%6e%2e%63%6f%6d%5c%22%3e%4d%79%20%65%6d%61%69%6c%3c%5c%2f%61%3e%27%29%3b'))</script>", mail_to("me@domain.com", "My email", :encode => "javascript", :replace_at => "(at)", :replace_dot => "(dot)")
-    assert_dom_equal "<script type=\"text/javascript\">eval(decodeURIComponent('%64%6f%63%75%6d%65%6e%74%2e%77%72%69%74%65%28%27%3c%61%20%68%72%65%66%3d%5c%22%6d%61%69%6c%74%6f%3a%6d%65%40%64%6f%6d%61%69%6e%2e%63%6f%6d%5c%22%3e%6d%65%28%61%74%29%64%6f%6d%61%69%6e%28%64%6f%74%29%63%6f%6d%3c%5c%2f%61%3e%27%29%3b'))</script>", mail_to("me@domain.com", nil, :encode => "javascript", :replace_at => "(at)", :replace_dot => "(dot)")
+    assert_dom_equal "<script type=\"text/javascript\">eval(decodeURIComponent('%64%6f%63%75%6d%65%6e%74%2e%77%72%69%74%65%28%27%3c%61%20%68%72%65%66%3d%6d%61%69%6c%74%6f%3a%6d%65%40%64%6f%6d%61%69%6e%2e%63%6f%6d%3e%4d%79%20%65%6d%61%69%6c%61%3e%27%29%3b'))</script>", mail_to("me@domain.com", "My email", :encode => "javascript", :replace_at => "(at)", :replace_dot => "(dot)")
+    assert_dom_equal "<script type=\"text/javascript\">eval(decodeURIComponent('%64%6f%63%75%6d%65%6e%74%2e%77%72%69%74%65%28%27%3c%61%20%68%72%65%66%3d%6d%61%69%6c%74%6f%3a%6d%65%40%64%6f%6d%61%69%6e%2e%63%6f%6d%3e%6d%65%28%61%74%29%64%6f%6d%61%69%6e%28%64%6f%74%29%63%6f%6d%61%3e%27%29%3b'))</script>", mail_to("me@domain.com", nil, :encode => "javascript", :replace_at => "(at)", :replace_dot => "(dot)")
   end
 
   # TODO: button_to looks at this ... why?


### PR DESCRIPTION
Fixed for SafeBuffer. Was throwing errors. Cannot modify SafeBuffer in place

Caching test are still failing don't know why response.body coming like this.

<pre>
  1) Failure:
test_fragment_caching(FunctionalFragmentCachingTest)
    [/Users/arun/checkouts/rails/actionpack/test/controller/caching_test.rb:741:in `test_fragment_caching'
     /Users/arun/checkouts/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:67:in `__send__'
     /Users/arun/checkouts/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:67:in `run'
     /Users/arun/checkouts/rails/activesupport/lib/active_support/callbacks.rb:434:in `_run_setup_callbacks'
     /Users/arun/checkouts/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:65:in `run']:
<"Hello\nThis bit's fragment cached\n"> expected but was
<"Hello\nThis bit's fragment cachedThis bit's fragment cached\n">.

  2) Failure:
test_html_formatted_fragment_caching(FunctionalFragmentCachingTest)
    [/Users/arun/checkouts/rails/actionpack/test/controller/caching_test.rb:773:in `test_html_formatted_fragment_caching'
     /Users/arun/checkouts/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:67:in `__send__'
     /Users/arun/checkouts/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:67:in `run'
     /Users/arun/checkouts/rails/activesupport/lib/active_support/callbacks.rb:434:in `_run_setup_callbacks'
     /Users/arun/checkouts/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:65:in `run']:
<"<body>\n<p>ERB</p>\n</body>\n"> expected but was
<"<body>\n<p>ERB</p><p>ERB</p>\n</body>\n">.

</pre>
