### PR TITLE
Failing fragment_for test with Builder

### DIFF
--- a/actionpack/lib/action_view/helpers/cache_helper.rb
+++ b/actionpack/lib/action_view/helpers/cache_helper.rb
@@ -51,9 +51,16 @@ module ActionView
           # This dance is needed because Builder can't use capture
           pos = output_buffer.length
           yield
-          safe_output_buffer = output_buffer.to_str
-          fragment = safe_output_buffer.slice!(pos..-1)
-          self.output_buffer = ActionView::OutputBuffer.new(safe_output_buffer)
+
+          if output_buffer.instance_of?(String)
+            fragment = output_buffer.slice!(pos..-1)
+          else
+            klass = output_buffer.class
+            safe_output_buffer = output_buffer.to_str
+            fragment = safe_output_buffer.slice!(pos..-1)
+            self.output_buffer = klass.new(safe_output_buffer)
+          end
+
           controller.write_fragment(name, fragment, options)
         end
       end


### PR DESCRIPTION
Builder's output buffer is a String, not a OutputBuffer.  Make fragment_for smart enough to handle either.  

@tenderlove is there a better way we should be handling this?

Addresses failing test:

```
Loaded suite test/controller/caching_test
Started
......................................F.........................
Finished in 1.059313 seconds.

  1) Failure:
test_xml_formatted_fragment_caching(FunctionalFragmentCachingTest)
    [test/controller/caching_test.rb:784:in `test_xml_formatted_fragment_caching'
     /home/cmeiklejohn/Repositories/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:67:in `__send__'
     /home/cmeiklejohn/Repositories/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:67:in `run'
     /home/cmeiklejohn/Repositories/rails/activesupport/lib/active_support/callbacks.rb:426:in `_run_setup_callbacks'
     /home/cmeiklejohn/Repositories/rails/activesupport/lib/active_support/callbacks.rb:81:in `send'
     /home/cmeiklejohn/Repositories/rails/activesupport/lib/active_support/callbacks.rb:81:in `run_callbacks'
     /home/cmeiklejohn/Repositories/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:65:in `run']:
<"<body>\n  <p>Builder</p>\n</body>\n"> expected but was
<"<body>\n</body>\n">.
```
