### PR TITLE
Fix test on 3-0-stable regarding SafeBuffer

### DIFF
--- a/actionpack/lib/action_view/helpers/cache_helper.rb
+++ b/actionpack/lib/action_view/helpers/cache_helper.rb
@@ -53,7 +53,13 @@ module ActionView
           # This dance is needed because Builder can't use capture
           pos = output_buffer.length
           yield
-          fragment = output_buffer.to_str.slice!(pos..-1)
+          if output_buffer.is_a?(ActionView::OutputBuffer)
+            safe_output_buffer = output_buffer.to_str
+            fragment = safe_output_buffer.slice!(pos..-1)
+            self.output_buffer = ActionView::OutputBuffer.new(safe_output_buffer)
+          else
+            fragment = output_buffer.slice!(pos..-1)
+          end
           controller.write_fragment(name, fragment, options)
         end
       end


### PR DESCRIPTION
Adapt [059692a74692917cf1d6bbe4fafe19211f363fe2] to make sure we perform correct cloning before manipulation on `OutputBuffer`.

This has been adapted from [823aa223efbac6ad4d31ea33402892267bb77cb4]. However, after the fragment rendering, `Builder` returns the `String` object instead of `ActionView::OutputBuffer`. Somehow the same procedure which was in [823aa223efbac6ad4d31ea33402892267bb77cb4] does not play nice with the String, and result in the fragment got lost.
