### PR TITLE
Do not hardcode :id as it was ignored by mass assignment filter

### DIFF
--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -722,8 +722,8 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
   end
 
   def test_has_many_with_pluralize_table_names_false
-    engine = Engine.create!(:car_id => 1)
-    aircraft = Aircraft.create!(:name => "Airbus 380", :id => 1)
+    aircraft = Aircraft.create!(:name => "Airbus 380")
+    engine = Engine.create!(:car_id => aircraft.id)
     assert_equal aircraft.engines, [engine]
   end
 


### PR DESCRIPTION
As a result test was failing on Oracle where ids are assigned by default from 1000
