### PR TITLE
Assert queries oracle fix for 3 0

### DIFF
--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -41,6 +41,19 @@ ActiveRecord::Base.connection.class.class_eval do
   alias_method_chain :execute, :query_record
 end
 
+# Oracle specific ignored SQLs
+ActiveRecord::Base.connection.class.class_eval do
+  IGNORED_SELECT_SQL = [/^select .*nextval/i, /^SAVEPOINT/, /^ROLLBACK TO/, /^\s*select .* from ((all|user)_tab_columns|(all|user)_triggers|(all|user)_constraints)/im]
+
+  def select_with_query_record(sql, name = nil)
+    $queries_executed ||= []
+    $queries_executed << sql unless IGNORED_SELECT_SQL.any? { |r| sql =~ r }
+    select_without_query_record(sql, name)
+  end
+
+  alias_method_chain :select, :query_record
+end if ENV['ARCONN'] == 'oracle'
+
 ActiveRecord::Base.connection.class.class_eval {
   attr_accessor :column_calls, :column_calls_by_table
 


### PR DESCRIPTION
Fix for Oracle adapter to count SELECT queries for assert_queries assertion

Needed just in 3-0-stable branch, query counting is refactored in 3-1-stable and master branches and do not need this patch anymore.
