### PR TITLE
Brought back alternative convention for namespaced models in i18n

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -21,7 +21,7 @@ module ActiveModel
       @partial_path = "#{@collection}/#{@element}".freeze
       @param_key = (namespace ? _singularize(@unnamespaced) : @singular).freeze
       @route_key = (namespace ? ActiveSupport::Inflector.pluralize(@param_key) : @plural).freeze
-      @i18n_key = self.underscore.to_sym
+      @i18n_key = self.underscore.tr('/', '.').to_sym
     end
 
     # Transform the model name into a more humane format, using I18n. By default,
@@ -35,8 +35,9 @@ module ActiveModel
                            @klass.respond_to?(:i18n_scope)
 
       defaults = @klass.lookup_ancestors.map do |klass|
-        klass.model_name.i18n_key
-      end
+        [klass.model_name.i18n_key,
+         klass.model_name.i18n_key.to_s.tr('.', '/').to_sym]
+      end.flatten
 
       defaults << options[:default] if options[:default]
       defaults << @human

--- a/activemodel/lib/active_model/translation.rb
+++ b/activemodel/lib/active_model/translation.rb
@@ -44,8 +44,9 @@ module ActiveModel
     # Specify +options+ with additional translating options.
     def human_attribute_name(attribute, options = {})
       defaults = lookup_ancestors.map do |klass|
-        :"#{self.i18n_scope}.attributes.#{klass.model_name.i18n_key}.#{attribute}"
-      end
+        [:"#{self.i18n_scope}.attributes.#{klass.model_name.i18n_key}.#{attribute}",
+         :"#{self.i18n_scope}.attributes.#{klass.model_name.i18n_key.to_s.tr('.', '/')}.#{attribute}"]
+      end.flatten
 
       defaults << :"attributes.#{attribute}"
       defaults << options.delete(:default) if options[:default]

--- a/activemodel/test/cases/translation_test.rb
+++ b/activemodel/test/cases/translation_test.rb
@@ -76,5 +76,15 @@ class ActiveModelI18nTests < ActiveModel::TestCase
     Person.model_name.human(options)
     assert_equal({:default => 'person model'}, options)
   end
+  
+  def test_alternate_namespaced_model_attribute_translation
+    I18n.backend.store_translations 'en', :activemodel => {:attributes => {:person => {:gender => {:attribute => 'person gender attribute'}}}}
+    assert_equal 'person gender attribute', Person::Gender.human_attribute_name('attribute')
+  end
+
+  def test_alternate_namespaced_model_translation
+    I18n.backend.store_translations 'en', :activemodel => {:models => {:person => {:gender => 'person gender model'}}}
+    assert_equal 'person gender model', Person::Gender.model_name.human
+  end
 end
 


### PR DESCRIPTION
See issue #1402

I did NOT implement the usage for "Namespaced::Model.new.errors.add(...)" as I am a bit short in time currently. I basically brought back the changes from "jfirebaugh" in commit "https://github.com/rails/rails/commit/5b8dbb0eee0a3277ef51e4bf31555ef27410272f". 

This means you can write your yaml file like this:

...
  activerecord:
    models: 
      invoice:
        item: "Invoice::Item dot notation"
      invoice/item: "Invoice::Item slash notation"
    attributes:
      invoice/item:
        name: "Invoice::Item.name slash notation"
      invoice:
        item:
          name: "Invoice::Item.name dot notation"
