### PR TITLE
Fix for issue 1553 - escape_javascript to support SafeBuffer strings

### DIFF
--- a/actionpack/lib/action_view/helpers/javascript_helper.rb
+++ b/actionpack/lib/action_view/helpers/javascript_helper.rb
@@ -49,7 +49,7 @@ module ActionView
       # Escape carrier returns and single and double quotes for JavaScript segments.
       def escape_javascript(javascript)
         if javascript
-          javascript.gsub(/(\\|<\/|\r\n|[\n\r"'])/) { JS_ESCAPE_MAP[$1] }
+          javascript.gsub(/(\\|<\/|\r\n|[\n\r"'])/) {|match| JS_ESCAPE_MAP[match] }
         else
           ''
         end

--- a/actionpack/test/template/javascript_helper_test.rb
+++ b/actionpack/test/template/javascript_helper_test.rb
@@ -31,6 +31,13 @@ class JavaScriptHelperTest < ActionView::TestCase
     assert_equal %(dont <\\/close> tags), escape_javascript(%(dont </close> tags))
   end
 
+  def test_escape_javascript_with_safebuffer
+    given = %('quoted' "double-quoted" new-line:\n </closed>)
+    expect = %(\\'quoted\\' \\"double-quoted\\" new-line:\\n <\\/closed>)
+    assert_equal expect, escape_javascript(given)
+    assert_equal expect, escape_javascript(ActiveSupport::SafeBuffer.new(given))
+  end
+
   def test_button_to_function
     assert_dom_equal %(<input type="button" onclick="alert('Hello world!');" value="Greeting" />),
       button_to_function("Greeting", "alert('Hello world!')")


### PR DESCRIPTION
Seems like no-one has pushed the fix yet, so here's my shot.

This fixes escape_javascript to allow for the fact that gsub on SafeBuffer does not pass match variables $1, $2 etc to a block. See issue GH#1553

It doesn't fix the fact that gsub on a SafeBuffer still behaves differently from ruby core gsub when given a block (issue GH#1555)
