### PR TITLE
Make test meaningful

### DIFF
--- a/actionpack/test/abstract/callbacks_test.rb
+++ b/actionpack/test/abstract/callbacks_test.rb
@@ -131,7 +131,7 @@ module AbstractController
       end
 
       def authenticate
-        @list = []
+        @list ||= []
         @authenticated = "true"
       end
     end


### PR DESCRIPTION
If before_filter list was being called mistakenly then
the test should fail. However test will not fail because
second filter is assigning new values to @list. To truly
test that first before_filter is not called when it should
not be called then @list should not assigned value unconditionally.

This patch will make the test fail if first filter is called.
