### PR TITLE
Ensure engine migrations are copied in correct sequence

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -498,7 +498,7 @@ namespace :railties do
     # desc "Copies missing migrations from Railties (e.g. plugins, engines). You can specify Railties to use with FROM=railtie1,railtie2"
     task :migrations => :'db:load_config' do
       to_load = ENV['FROM'].blank? ? :all : ENV['FROM'].split(",").map {|n| n.strip }
-      railties = {}
+      railties = ActiveSupport::OrderedHash.new
       Rails.application.railties.all do |railtie|
         next unless to_load == :all || to_load.include?(railtie.railtie_name)
 

--- a/railties/test/railties/shared_tests.rb
+++ b/railties/test/railties/shared_tests.rb
@@ -53,6 +53,9 @@ module RailtiesTest
 
       add_to_config "ActiveRecord::Base.timestamped_migrations = false"
 
+      boot_rails
+      railties = Rails.application.railties.all.map(&:railtie_name)
+
       Dir.chdir(app_path) do
         output = `bundle exec rake bukkits:install:migrations`
 
@@ -63,12 +66,16 @@ module RailtiesTest
         assert_match /NOTE: Migration 3_create_sessions.rb from bukkits has been skipped/, output
         assert_equal 3, Dir["#{app_path}/db/migrate/*.rb"].length
 
-        output = `bundle exec rake railties:install:migrations`
+        output = `bundle exec rake railties:install:migrations`.split("\n")
 
         assert File.exists?("#{app_path}/db/migrate/4_create_yaffles.rb")
-        assert_match /NOTE: Migration 3_create_sessions.rb from bukkits has been skipped/, output
-        assert_match /Copied migration 4_create_yaffles.rb from acts_as_yaffle/, output
-        assert_no_match /2_create_users/, output
+        assert_no_match /2_create_users/, output.join("\n")
+
+        yaffle_migration_order = output.index(output.detect{|o| /Copied migration 4_create_yaffles.rb from acts_as_yaffle/ =~ o })
+        bukkits_migration_order = output.index(output.detect{|o| /NOTE: Migration 3_create_sessions.rb from bukkits has been skipped/ =~ o })
+        assert_not_nil yaffle_migration_order, "Expected migration to be copied"
+        assert_not_nil bukkits_migration_order, "Expected migration to be skipped"
+        assert_equal (railties.index('acts_as_yaffle') > railties.index('bukkits')) , (yaffle_migration_order > bukkits_migration_order)
 
         migrations_count = Dir["#{app_path}/db/migrate/*.rb"].length
         output = `bundle exec rake railties:install:migrations`


### PR DESCRIPTION
Currently rake railties:install:migrations copies & re-numbers migrations from engines in a random order. This commit ensures that they are copied in the same sequence that they are required.
