### PR TITLE
Add a newline after a textarea's opening tag. Closes #393

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -1056,7 +1056,7 @@ module ActionView
           options["cols"], options["rows"] = size.split("x") if size.respond_to?(:split)
         end
 
-        content_tag("textarea", ERB::Util.html_escape(options.delete('value') || value_before_type_cast(object)), options)
+        content_tag("textarea", ERB::Util.html_escape(options.delete('value') || value_before_type_cast(object)), options, true, true)
       end
 
       def to_check_box_tag(options = {}, checked_value = "1", unchecked_value = "0")

--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -85,12 +85,12 @@ module ActionView
       #     Hello world!
       #   <% end -%>
       #    # => <div class="strong">Hello world!</div>
-      def content_tag(name, content_or_options_with_block = nil, options = nil, escape = true, &block)
+      def content_tag(name, content_or_options_with_block = nil, options = nil, escape = true, newline_after_opening_tag = false, &block)
         if block_given?
           options = content_or_options_with_block if content_or_options_with_block.is_a?(Hash)
-          content_tag_string(name, capture(&block), options, escape)
+          content_tag_string(name, capture(&block), options, escape, newline_after_opening_tag)
         else
-          content_tag_string(name, content_or_options_with_block, options, escape)
+          content_tag_string(name, content_or_options_with_block, options, escape, newline_after_opening_tag)
         end
       end
 
@@ -123,9 +123,9 @@ module ActionView
 
       private
 
-        def content_tag_string(name, content, options, escape = true)
+        def content_tag_string(name, content, options, escape = true, newline_after_opening_tag = false)
           tag_options = tag_options(options, escape) if options
-          "<#{name}#{tag_options}>#{escape ? ERB::Util.h(content) : content}</#{name}>".html_safe
+          "<#{name}#{tag_options}>#{newline_after_opening_tag ? "\n" : ""}#{escape ? ERB::Util.h(content) : content}</#{name}>".html_safe
         end
 
         def tag_options(options, escape = true)

--- a/actionpack/test/template/active_model_helper_test.rb
+++ b/actionpack/test/template/active_model_helper_test.rb
@@ -27,7 +27,7 @@ class ActiveModelHelperTest < ActionView::TestCase
 
   def test_text_area_with_errors
     assert_dom_equal(
-      %(<div class="field_with_errors"><textarea cols="40" id="post_body" name="post[body]" rows="20">Back to the hill and over it again!</textarea></div>),
+      %(<div class="field_with_errors"><textarea cols="40" id="post_body" name="post[body]" rows="20">\nBack to the hill and over it again!</textarea></div>),
       text_area("post", "body")
     )
   end

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -382,7 +382,7 @@ class FormHelperTest < ActionView::TestCase
 
   def test_text_area
     assert_dom_equal(
-      '<textarea cols="40" id="post_body" name="post[body]" rows="20">Back to the hill and over it again!</textarea>',
+      "<textarea cols='40' id='post_body' name='post[body]' rows='20'>\nBack to the hill and over it again!</textarea>",
       text_area("post", "body")
     )
   end
@@ -390,14 +390,14 @@ class FormHelperTest < ActionView::TestCase
   def test_text_area_with_escapes
     @post.body        = "Back to <i>the</i> hill and over it again!"
     assert_dom_equal(
-      '<textarea cols="40" id="post_body" name="post[body]" rows="20">Back to &lt;i&gt;the&lt;/i&gt; hill and over it again!</textarea>',
+      "<textarea cols='40' id='post_body' name='post[body]' rows='20'>\nBack to &lt;i&gt;the&lt;/i&gt; hill and over it again!</textarea>",
       text_area("post", "body")
     )
   end
 
   def test_text_area_with_alternate_value
     assert_dom_equal(
-      '<textarea cols="40" id="post_body" name="post[body]" rows="20">Testing alternate values.</textarea>',
+      "<textarea cols='40' id='post_body' name='post[body]' rows='20'>\nTesting alternate values.</textarea>",
       text_area("post", "body", :value => 'Testing alternate values.')
     )
   end
@@ -405,14 +405,14 @@ class FormHelperTest < ActionView::TestCase
   def test_text_area_with_html_entities
     @post.body        = "The HTML Entity for & is &amp;"
     assert_dom_equal(
-      '<textarea cols="40" id="post_body" name="post[body]" rows="20">The HTML Entity for &amp; is &amp;amp;</textarea>',
+      "<textarea cols='40' id='post_body' name='post[body]' rows='20'>\nThe HTML Entity for &amp; is &amp;amp;</textarea>",
       text_area("post", "body")
     )
   end
 
   def test_text_area_with_size_option
     assert_dom_equal(
-      '<textarea cols="183" id="post_body" name="post[body]" rows="820">Back to the hill and over it again!</textarea>',
+      "<textarea cols='183' id='post_body' name='post[body]' rows='820'>\nBack to the hill and over it again!</textarea>",
       text_area("post", "body", :size => "183x820")
     )
   end
@@ -452,7 +452,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_title" name="dont guess" size="30" type="text" value="Hello World" />', text_field("post", "title", "name" => "dont guess")
     )
     assert_dom_equal(
-      '<textarea cols="40" id="post_body" name="really!" rows="20">Back to the hill and over it again!</textarea>',
+      "<textarea cols='40' id='post_body' name='really!' rows='20'>\nBack to the hill and over it again!</textarea>",
       text_area("post", "body", "name" => "really!")
     )
     assert_dom_equal(
@@ -472,7 +472,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="dont guess" name="post[title]" size="30" type="text" value="Hello World" />', text_field("post", "title", "id" => "dont guess")
     )
     assert_dom_equal(
-      '<textarea cols="40" id="really!" name="post[body]" rows="20">Back to the hill and over it again!</textarea>',
+      "<textarea cols='40' id='really!' name='post[body]' rows='20'>\nBack to the hill and over it again!</textarea>",
       text_area("post", "body", "id" => "really!")
     )
     assert_dom_equal(
@@ -492,7 +492,7 @@ class FormHelperTest < ActionView::TestCase
       '<input name="post[title]" size="30" type="text" value="Hello World" />', text_field("post", "title", "id" => nil)
     )
     assert_dom_equal(
-      '<textarea cols="40" name="post[body]" rows="20">Back to the hill and over it again!</textarea>',
+      "<textarea cols='40' name='post[body]' rows='20'>\nBack to the hill and over it again!</textarea>",
       text_area("post", "body", "id" => nil)
     )
     assert_dom_equal(
@@ -523,7 +523,7 @@ class FormHelperTest < ActionView::TestCase
       text_field("post", "title", "index" => 5)
     )
     assert_dom_equal(
-      '<textarea cols="40" name="post[5][body]" id="post_5_body" rows="20">Back to the hill and over it again!</textarea>',
+      "<textarea cols='40' name='post[5][body]' id='post_5_body' rows='20'>\nBack to the hill and over it again!</textarea>",
       text_area("post", "body", "index" => 5)
     )
     assert_dom_equal(
@@ -550,7 +550,7 @@ class FormHelperTest < ActionView::TestCase
       text_field("post", "title", "index" => 5, 'id' => nil)
     )
     assert_dom_equal(
-      '<textarea cols="40" name="post[5][body]" rows="20">Back to the hill and over it again!</textarea>',
+      "<textarea cols='40' name='post[5][body]' rows='20'>\nBack to the hill and over it again!</textarea>",
       text_area("post", "body", "index" => 5, 'id' => nil)
     )
     assert_dom_equal(
@@ -574,25 +574,25 @@ class FormHelperTest < ActionView::TestCase
   def test_auto_index
     pid = @post.id
     assert_dom_equal(
-      "<label for=\"post_#{pid}_title\">Title</label>",
+      "<label for='post_#{pid}_title'>Title</label>",
       label("post[]", "title")
     )
     assert_dom_equal(
-      "<input id=\"post_#{pid}_title\" name=\"post[#{pid}][title]\" size=\"30\" type=\"text\" value=\"Hello World\" />", text_field("post[]","title")
+      "<input id='post_#{pid}_title' name='post[#{pid}][title]' size='30' type='text' value='Hello World' />", text_field("post[]","title")
     )
     assert_dom_equal(
-      "<textarea cols=\"40\" id=\"post_#{pid}_body\" name=\"post[#{pid}][body]\" rows=\"20\">Back to the hill and over it again!</textarea>",
+      "<textarea cols='40' id='post_#{pid}_body' name='post[#{pid}][body]' rows='20'>\nBack to the hill and over it again!</textarea>",
       text_area("post[]", "body")
     )
     assert_dom_equal(
-      "<input name=\"post[#{pid}][secret]\" type=\"hidden\" value=\"0\" /><input checked=\"checked\" id=\"post_#{pid}_secret\" name=\"post[#{pid}][secret]\" type=\"checkbox\" value=\"1\" />",
+      "<input name='post[#{pid}][secret]' type='hidden' value='0' /><input checked='checked' id='post_#{pid}_secret' name='post[#{pid}][secret]' type='checkbox' value='1' />",
       check_box("post[]", "secret")
     )
    assert_dom_equal(
-"<input checked=\"checked\" id=\"post_#{pid}_title_hello_world\" name=\"post[#{pid}][title]\" type=\"radio\" value=\"Hello World\" />",
+"<input checked='checked' id='post_#{pid}_title_hello_world' name='post[#{pid}][title]' type='radio' value='Hello World' />",
       radio_button("post[]", "title", "Hello World")
     )
-    assert_dom_equal("<input id=\"post_#{pid}_title_goodbye_world\" name=\"post[#{pid}][title]\" type=\"radio\" value=\"Goodbye World\" />",
+    assert_dom_equal("<input id='post_#{pid}_title_goodbye_world' name='post[#{pid}][title]' type='radio' value='Goodbye World' />",
       radio_button("post[]", "title", "Goodbye World")
     )
   end
@@ -600,22 +600,22 @@ class FormHelperTest < ActionView::TestCase
   def test_auto_index_with_nil_id
     pid = @post.id
     assert_dom_equal(
-      "<input name=\"post[#{pid}][title]\" size=\"30\" type=\"text\" value=\"Hello World\" />",
+      "<input name='post[#{pid}][title]' size='30' type='text' value='Hello World' />",
       text_field("post[]","title", :id => nil)
     )
     assert_dom_equal(
-      "<textarea cols=\"40\" name=\"post[#{pid}][body]\" rows=\"20\">Back to the hill and over it again!</textarea>",
+      "<textarea cols='40' name='post[#{pid}][body]' rows='20'>\nBack to the hill and over it again!</textarea>",
       text_area("post[]", "body", :id => nil)
     )
     assert_dom_equal(
-      "<input name=\"post[#{pid}][secret]\" type=\"hidden\" value=\"0\" /><input checked=\"checked\" name=\"post[#{pid}][secret]\" type=\"checkbox\" value=\"1\" />",
+      "<input name='post[#{pid}][secret]' type='hidden' value='0' /><input checked='checked' name='post[#{pid}][secret]' type='checkbox' value='1' />",
       check_box("post[]", "secret", :id => nil)
     )
    assert_dom_equal(
-"<input checked=\"checked\" name=\"post[#{pid}][title]\" type=\"radio\" value=\"Hello World\" />",
+"<input checked='checked' name='post[#{pid}][title]' type='radio' value='Hello World' />",
       radio_button("post[]", "title", "Hello World", :id => nil)
     )
-    assert_dom_equal("<input name=\"post[#{pid}][title]\" type=\"radio\" value=\"Goodbye World\" />",
+    assert_dom_equal("<input name='post[#{pid}][title]' type='radio' value='Goodbye World' />",
       radio_button("post[]", "title", "Goodbye World", :id => nil)
     )
   end
@@ -638,7 +638,7 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/posts/123", "create-post" , "edit_post", :method => "put") do
       "<label for='post_title'>The Title</label>" +
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />" +
       "<input name='commit' type='submit' value='Create post' />"
@@ -717,7 +717,7 @@ class FormHelperTest < ActionView::TestCase
     expected =  whole_form("/posts/123", "create-post", "other_name_edit", :method => "put") do
       "<label for='other_name_title' class='post_title'>Title</label>" +
       "<input name='other_name[title]' size='30' id='other_name_title' value='Hello World' type='text' />" +
-      "<textarea name='other_name[body]' id='other_name_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='other_name[body]' id='other_name_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='other_name[secret]' value='0' type='hidden' />" +
       "<input name='other_name[secret]' checked='checked' id='other_name_secret' value='1' type='checkbox' />" +
       "<input name='commit' value='Create post' type='submit' />"
@@ -735,7 +735,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected =  whole_form("/", "create-post", "edit_post", "delete") do
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
@@ -752,7 +752,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected =  whole_form("/", "create-post", "edit_post", "delete") do
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
@@ -783,7 +783,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected =  whole_form("/", "create-post", "edit_post", :method => "put", :remote => true) do
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
@@ -818,7 +818,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected =  whole_form("/posts", 'new_post', 'new_post', :remote => true) do
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
@@ -835,7 +835,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form("/", "create-post") do
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
@@ -854,7 +854,7 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form('/posts/123', 'post[]_edit', 'post[]_edit', 'put') do
       "<label for='post_123_title'>Title</label>" +
       "<input name='post[123][title]' size='30' type='text' id='post_123_title' value='Hello World' />" +
-      "<textarea name='post[123][body]' id='post_123_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[123][body]' id='post_123_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[123][secret]' type='hidden' value='0' />" +
       "<input name='post[123][secret]' checked='checked' type='checkbox' id='post_123_secret' value='1' />"
     end
@@ -871,7 +871,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form('/posts/123', 'post[]_edit', 'post[]_edit', 'put') do
       "<input name='post[][title]' size='30' type='text' id='post__title' value='Hello World' />" +
-      "<textarea name='post[][body]' id='post__body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[][body]' id='post__body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[][secret]' type='hidden' value='0' />" +
       "<input name='post[][secret]' checked='checked' type='checkbox' id='post__secret' value='1' />"
     end
@@ -1606,7 +1606,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected =
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
 
@@ -1622,7 +1622,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected =
       "<input name='post[123][title]' size='30' type='text' id='post_123_title' value='Hello World' />" +
-      "<textarea name='post[123][body]' id='post_123_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[123][body]' id='post_123_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[123][secret]' type='hidden' value='0' />" +
       "<input name='post[123][secret]' checked='checked' type='checkbox' id='post_123_secret' value='1' />"
 
@@ -1638,7 +1638,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected =
       "<input name='post[][title]' size='30' type='text' id='post__title' value='Hello World' />" +
-      "<textarea name='post[][body]' id='post__body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[][body]' id='post__body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[][secret]' type='hidden' value='0' />" +
       "<input name='post[][secret]' checked='checked' type='checkbox' id='post__secret' value='1' />"
 
@@ -1654,7 +1654,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected =
       "<input name='post[abc][title]' size='30' type='text' id='post_abc_title' value='Hello World' />" +
-      "<textarea name='post[abc][body]' id='post_abc_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[abc][body]' id='post_abc_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[abc][secret]' type='hidden' value='0' />" +
       "<input name='post[abc][secret]' checked='checked' type='checkbox' id='post_abc_secret' value='1' />"
 
@@ -1670,7 +1670,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected =
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
 
@@ -1686,7 +1686,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected =
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
 
@@ -1699,7 +1699,7 @@ class FormHelperTest < ActionView::TestCase
       concat f.text_field(:title)
     end
 
-    assert_dom_equal "<label for=\"author_post_title\">Title</label>" +
+    assert_dom_equal "<label for='author_post_title'>Title</label>" +
     "<input name='author[post][title]' size='30' type='text' id='author_post_title' value='Hello World' />",
       output_buffer
   end
@@ -1710,7 +1710,7 @@ class FormHelperTest < ActionView::TestCase
       concat f.text_field(:title)
     end
 
-    assert_dom_equal "<label for=\"author_post_1_title\">Title</label>" +
+    assert_dom_equal "<label for='author_post_1_title'>Title</label>" +
       "<input name='author[post][1][title]' size='30' type='text' id='author_post_1_title' value='Hello World' />",
       output_buffer
   end
@@ -1731,7 +1731,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form('/posts/123', 'create-post', 'post_edit', :method => 'put') do
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='parent_post[secret]' type='hidden' value='0' />" +
       "<input name='parent_post[secret]' checked='checked' type='checkbox' id='parent_post_secret' value='1' />"
     end
@@ -1751,7 +1751,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form('/posts/123', 'create-post', 'post_edit', :method => 'put') do
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[comment][name]' type='text' id='post_comment_name' value='new comment' size='30' />"
     end
 
@@ -1791,7 +1791,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
       "<label for='title'>Title:</label> <input name='post[title]' size='30' type='text' id='post_title' value='Hello World' /><br/>" +
-      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea><br/>" +
+      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea><br/>" +
       "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' /><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' /><br/>"
     end
 
@@ -1841,7 +1841,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
       "<label for='title'>Title:</label> <input name='post[title]' size='30' type='text' id='post_title' value='Hello World' /><br/>" +
-      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea><br/>" +
+      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea><br/>" +
       "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' /><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' /><br/>"
     end
 
@@ -1859,7 +1859,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected =
       "<label for='title'>Title:</label> <input name='post[title]' size='30' type='text' id='post_title' value='Hello World' /><br/>" +
-      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea><br/>" +
+      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea><br/>" +
       "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' /><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' /><br/>"
 
     assert_dom_equal expected, output_buffer

--- a/actionpack/test/template/tag_helper_test.rb
+++ b/actionpack/test/template/tag_helper_test.rb
@@ -86,6 +86,11 @@ class TagHelperTest < ActionView::TestCase
     str = content_tag('p', "limelight", {:class => ["song", "play>"]}, false)
     assert_equal "<p class=\"song play>\">limelight</p>", str
   end
+  
+  def test_content_tag_with_newline
+    str = content_tag('p', "limelight", {}, true, true)
+    assert_dom_equal "<p>\nlimelight</p>", str
+  end
 
   def test_cdata_section
     assert_equal "<![CDATA[<hello world>]]>", cdata_section("<hello world>")


### PR DESCRIPTION
As per the [HTML 4.01 specification appendice](http://www.w3.org/TR/html401/appendix/notes.html#notes-line-breaks)

> SGML (see [ISO8879], section 7.6.1) specifies that a line break immediately following a start tag must be ignored, as must a line break immediately before an end tag. This applies to all HTML elements without exception.

I've added it only on the textarea because it's the only place where this has an impact (see more detailed description of the problem in #393 ).
