### PR TITLE
Fix #1571 ActiveRecord::Relation#order no longer works with arel ordering nodes

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -307,8 +307,7 @@ module ActiveRecord
 
       order_query.map do |o|
         case o
-        when Arel::Nodes::Ascending
-        when Arel::Nodes::Descending
+        when Arel::Nodes::Ascending, Arel::Nodes::Descending
           o.reverse
         when String, Symbol
           o.to_s.split(',').collect do |s|

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -307,7 +307,8 @@ module ActiveRecord
 
       order_query.map do |o|
         case o
-        when Arel::Nodes::Ordering
+        when Arel::Nodes::Ascending
+        when Arel::Nodes::Descending
           o.reverse
         when String, Symbol
           o.to_s.split(',').collect do |s|

--- a/activerecord/test/cases/relation_scoping_test.rb
+++ b/activerecord/test/cases/relation_scoping_test.rb
@@ -15,6 +15,10 @@ class RelationScopingTest < ActiveRecord::TestCase
     assert_equal Developer.order("id DESC").to_a.reverse, Developer.order("id DESC").reverse_order
   end
 
+  def test_reverse_order_with_arel_node
+    assert_equal Developer.order("id DESC").to_a.reverse, Developer.order(Developer.arel_table[:id].desc).reverse_order
+  end
+
   def test_double_reverse_order_produces_original_order
     assert_equal Developer.order("name DESC"), Developer.order("name DESC").reverse_order.reverse_order
   end

--- a/activerecord/test/cases/relation_scoping_test.rb
+++ b/activerecord/test/cases/relation_scoping_test.rb
@@ -19,6 +19,14 @@ class RelationScopingTest < ActiveRecord::TestCase
     assert_equal Developer.order("id DESC").to_a.reverse, Developer.order(Developer.arel_table[:id].desc).reverse_order
   end
 
+  def test_reverse_order_with_multiple_arel_nodes
+    assert_equal Developer.order("id DESC").order("name DESC").to_a.reverse, Developer.order(Developer.arel_table[:id].desc).order(Developer.arel_table[:name].desc).reverse_order
+  end
+
+  def test_reverse_order_with_arel_nodes_and_strings
+    assert_equal Developer.order("id DESC").order("name DESC").to_a.reverse, Developer.order("id DESC").order(Developer.arel_table[:name].desc).reverse_order
+  end
+
   def test_double_reverse_order_produces_original_order
     assert_equal Developer.order("name DESC"), Developer.order("name DESC").reverse_order.reverse_order
   end


### PR DESCRIPTION
Added different test cases for the issue. Not sure if the implementation of the fix is the best
