### PR TITLE
Instance variable not used.

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -660,7 +660,6 @@ module ActiveRecord #:nodoc:
         @quoted_table_name = nil
         define_attr_method :table_name, value, &block
 
-        @arel_table = Arel::Table.new(table_name, arel_engine)
         @relation = Relation.new(self, arel_table)
       end
       alias :table_name= :set_table_name


### PR DESCRIPTION
The arel_table method already returns a new correct arel_table using the new table_name.
