### PR TITLE
Date#freeze fails when called more than once in 1.8

### DIFF
--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -454,4 +454,10 @@ class DateExtBehaviorTest < Test::Unit::TestCase
       Date.today.freeze.inspect
     end
   end
+
+  def test_can_freeze_twice
+    assert_nothing_raised do
+      Date.today.freeze.freeze
+    end
+  end
 end


### PR DESCRIPTION
The ActiveSupport Date#freeze monkey-patch tries to call Date's metaprogrammed memoization logic every time you call Date#freeze. As a result, you can't do this:

`> Date.today.freeze.freeze
TypeError: can't modify frozen object
        from rails/activesupport/lib/active_support/core_ext/date/freeze.rb:22:in `instance_variable_set'
        from rails/activesupport/lib/active_support/core_ext/date/freeze.rb:22:in `freeze'
        from rails/activesupport/lib/active_support/core_ext/date/freeze.rb:20:in `each'
        from rails/activesupport/lib/active_support/core_ext/date/freeze.rb:20:in `freeze'
        from (irb):2`

The fix is simple; check to see if we've already frozen the object and don't run the memoization logic twice. Patch and unit test are attached.
