### PR TITLE
class WithSymbolReturningString is not used anywhere in the test.

### DIFF
--- a/actionpack/test/abstract/layouts_test.rb
+++ b/actionpack/test/abstract/layouts_test.rb
@@ -87,18 +87,6 @@ module AbstractControllerTests
       end
     end
 
-    class WithSymbolReturningString < Base
-      layout :no_hello
-
-      def index
-        render :template => ActionView::Template::Text.new("Hello missing symbol!")
-      end
-    private
-      def no_hello
-        nil
-      end
-    end
-
     class WithSymbolReturningNil < Base
       layout :nilz
 


### PR DESCRIPTION
Secondly it seemed from the method that the intent was to test a case
where layout was declared in a symbol and the method named mention in
layout returns nil.

That case is already covered with class     class WithSymbolReturningNil .

Also the case of SymbolReturningString is covered with the class
WithSymbol.
