### PR TITLE
Fix "warning: assigned but unused variable" on AR tests

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -707,7 +707,7 @@ module ActiveRecord
         def quoted_columns_for_index(column_names, options = {})
           length = options[:length] if options.is_a?(Hash)
 
-          quoted_column_names = case length
+          case length
           when Hash
             column_names.map {|name| length[name] ? "#{quote_column_name(name)}(#{length[name]})" : quote_column_name(name) }
           when Fixnum

--- a/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
@@ -87,8 +87,8 @@ class MysqlReservedWordTest < ActiveRecord::TestCase
     assert_nothing_raised { x.save }
     x.order = 'y'
     assert_nothing_raised { x.save }
-    assert_nothing_raised { y = Group.find_by_order('y') }
-    assert_nothing_raised { y = Group.find(1) }
+    assert_nothing_raised { Group.find_by_order('y') }
+    assert_nothing_raised { Group.find(1) }
     x = Group.find(1)
   end
 


### PR DESCRIPTION
This removes a couple of variables being assigned but never used.
