### PR TITLE
Simplify boolean logic into ternary

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -113,7 +113,7 @@ class Module
       raise ArgumentError, "Can only automatically set the delegation prefix when delegating to a method."
     end
 
-    prefix = options[:prefix] && "#{options[:prefix] == true ? to : options[:prefix]}_" || ''
+    prefix = options[:prefix] ? "#{options[:prefix] == true ? to : options[:prefix]}_" : ''
 
     file, line = caller.first.split(':', 2)
     line = line.to_i


### PR DESCRIPTION
A line with foo && bar || baz is equivalent to foo ? bar : baz, but the latter is almost definitely easier to follow. I think it's a clear readability win to switch.

Comments welcome!
