### PR TITLE
3.0.9rc1 fix escape_javascript

### DIFF
--- a/actionpack/lib/action_view/helpers/javascript_helper.rb
+++ b/actionpack/lib/action_view/helpers/javascript_helper.rb
@@ -49,7 +49,7 @@ module ActionView
       # Escape carrier returns and single and double quotes for JavaScript segments.
       def escape_javascript(javascript)
         if javascript
-          javascript.gsub(/(\\|<\/|\r\n|[\n\r"'])/) {|match| JS_ESCAPE_MAP[match] }
+          (javascript.gsub(/(\\|<\/|\r\n|[\n\r"'])/) {|match| JS_ESCAPE_MAP[match] }).to_s.html_safe
         else
           ''
         end


### PR DESCRIPTION
Fixes Issue #1596 and Issue #1576 with escape_javascript only working if raw(escape_javascript(js)) used. Actionpack tests re-run and all passed.
