### PR TITLE
Support JDBC PostgreSQL adapter under JRuby

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -430,7 +430,7 @@ namespace :db do
       when /mysql/
         ActiveRecord::Base.establish_connection(:test)
         ActiveRecord::Base.connection.recreate_database(abcs["test"]["database"], abcs["test"])
-      when "postgresql"
+      when /postgresql/
         ActiveRecord::Base.clear_active_connections!
         drop_database(abcs['test'])
         create_database(abcs['test'])


### PR DESCRIPTION
When trying to run rake test under jruby, Rake fails with "unknown task jdbcpostgresql" during db:test:purge. This simple fix works for me, and is similar to how the mysql task is implemented.
