### PR TITLE
Bump the ruby version check to 1.9.2+

### DIFF
--- a/railties/lib/rails/ruby_version_check.rb
+++ b/railties/lib/rails/ruby_version_check.rb
@@ -1,23 +1,13 @@
-if RUBY_VERSION < '1.8.7'
+if RUBY_VERSION < '1.9.2'
   desc = defined?(RUBY_DESCRIPTION) ? RUBY_DESCRIPTION : "ruby #{RUBY_VERSION} (#{RUBY_RELEASE_DATE})"
   abort <<-end_message
 
-    Rails 3 requires Ruby 1.8.7 or 1.9.2.
+    Rails 3.1 requires Ruby 1.9.2 or higher.
 
     You're running
       #{desc}
 
     Please upgrade to continue.
-
-  end_message
-elsif RUBY_VERSION > '1.9' and RUBY_VERSION < '1.9.2'
-  $stderr.puts <<-end_message
-
-    Rails 3 doesn't officially support Ruby 1.9.1 since recent stable
-    releases have segfaulted the test suite. Please upgrade to Ruby 1.9.2.
-
-    You're running
-      #{RUBY_DESCRIPTION}
 
   end_message
 end


### PR DESCRIPTION
It is my understanding that versions of Ruby prior to 1.9.2 are not supported in Rails 3.1+. This enforces that.
