### PR TITLE
fix table_exists? in postgresql adapter to always use current search_path

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -636,7 +636,7 @@ module ActiveRecord
             SELECT COUNT(*)
             FROM pg_tables
             WHERE tablename = '#{table.gsub(/(^"|"$)/,'')}'
-            #{schema ? "AND schemaname = '#{schema}'" : ''}
+            AND schemaname = #{schema ? "'#{schema}'" : "ANY (current_schemas(false))"}
         SQL
       end
 


### PR DESCRIPTION
modified table_exists? in the postgresql adapter to always use the current search_path unless a explicit schema is specified.

Currently one cannot load schema.rb into a new (empty) postgresql schema. create_table forces a table drop which checks table_exists? first. This returns true even though the table doesn't actually exist in the current schema. Thus a PG error is thrown when it tries to drop the nonexistent table.
