### PR TITLE
MemcacheStore: deserialize the entry reading from local_cache when using 

### DIFF
--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -183,6 +183,14 @@ module ActiveSupport
       # Provide support for raw values in the local cache strategy.
       module LocalCacheWithRaw # :nodoc:
         protected
+          def read_entry(key, options)
+            entry = super
+            if options[:raw] && local_cache && entry
+               entry = deserialize_entry(entry.value)
+            end
+            entry
+          end
+
           def write_entry(key, entry, options) # :nodoc:
             retval = super
             if options[:raw] && local_cache && retval

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -630,13 +630,29 @@ uses_memcached 'memcached backed store' do
       cache.write("foo", 2)
       assert_equal "2", cache.read("foo")
     end
-
+    
+    def test_raw_values_with_marshal
+      cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, :raw => true)
+      cache.clear
+      cache.write("foo", Marshal.dump([]))
+      assert_equal [], cache.read("foo")      
+    end
+    
     def test_local_cache_raw_values
       cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, :raw => true)
       cache.clear
       cache.with_local_cache do
         cache.write("foo", 2)
         assert_equal "2", cache.read("foo")
+      end
+    end
+
+    def test_local_cache_raw_values_with_marshal
+      cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, :raw => true)
+      cache.clear
+      cache.with_local_cache do
+        cache.write("foo", Marshal.dump([]))
+        assert_equal [], cache.read("foo")
       end
     end
   end


### PR DESCRIPTION
MemcacheStore: deserialize the entry reading from local_cache when using raw.

When with :raw => true and storing the Marshal.dump(obj) into the memcached, Rails.cache.read(key) will return the the serialization data. MemCacheStore should try to deserialize the entry before returning the result.
