### PR TITLE
Make sure `escape_javascript` return `SafeBuffer` if the incoming argumen

### DIFF
--- a/actionpack/CHANGELOG
+++ b/actionpack/CHANGELOG
@@ -1,5 +1,7 @@
 *Rails 3.1.0 (unreleased)*
 
+* Make sure escape_js returns SafeBuffer string if it receives SafeBuffer string [Prem Sichanugrist]
+
 * Fix escape_js to work correctly with the new SafeBuffer restriction [Paul Gallagher]
 
 * Brought back alternative convention for namespaced models in i18n [thoefer]

--- a/actionpack/lib/action_view/helpers/javascript_helper.rb
+++ b/actionpack/lib/action_view/helpers/javascript_helper.rb
@@ -18,7 +18,8 @@ module ActionView
       #   $('some_element').replaceWith('<%=j render 'some/element_template' %>');
       def escape_javascript(javascript)
         if javascript
-          javascript.gsub(/(\\|<\/|\r\n|[\n\r"'])/) {|match| JS_ESCAPE_MAP[match] }
+          result = javascript.gsub(/(\\|<\/|\r\n|[\n\r"'])/) {|match| JS_ESCAPE_MAP[match] }
+          javascript.html_safe? ? result.html_safe : result
         else
           ''
         end

--- a/actionpack/test/template/javascript_helper_test.rb
+++ b/actionpack/test/template/javascript_helper_test.rb
@@ -35,6 +35,8 @@ class JavaScriptHelperTest < ActionView::TestCase
     expect = %(\\'quoted\\' \\"double-quoted\\" new-line:\\n <\\/closed>)
     assert_equal expect, escape_javascript(given)
     assert_equal expect, escape_javascript(ActiveSupport::SafeBuffer.new(given))
+    assert_instance_of String, escape_javascript(given)
+    assert_instance_of ActiveSupport::SafeBuffer, escape_javascript(ActiveSupport::SafeBuffer.new(given))
   end
 
   def test_button_to_function


### PR DESCRIPTION
Make sure `escape_javascript` return `SafeBuffer` if the incoming argument is already html_safe
