### PR TITLE
Adding rdoc dependency to fix issue #1598

### DIFF
--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('rake',          '>= 0.8.7')
   s.add_dependency('thor',          '~> 0.14.4')
+  s.add_dependency('rdoc',          '~> 3.4')
   s.add_dependency('activesupport', version)
   s.add_dependency('actionpack',    version)
 end


### PR DESCRIPTION
As suggested by @tenderlove and @amatsuda here: https://github.com/rails/rails/issues/1598

I used the same rdoc version as in the Gemfile for Rails. 
