### PR TITLE
Remove deprecation warning in ActiveRecord::Errors#generate_message

### DIFF
--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -333,7 +333,6 @@ module ActiveRecord
     end
 
     def generate_message(attribute, message = :invalid, options = {})
-      ActiveSupport::Deprecation.warn("ActiveRecord::Errors#generate_message has been deprecated. Please use ActiveRecord::Error.new().to_s.")
       Error.new(@base, attribute, message, options).to_s
     end
   end


### PR DESCRIPTION
Remove deprecation warning for ActiveRecord::Errors#generate_message. This is the same API that ActiveModel ended up using and that won't be changing.
