### PR TITLE
Fix SQLite adapter so that it correctly fetches the names of temporary tables.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
@@ -248,8 +248,10 @@ module ActiveRecord
 
       def tables(name = 'SCHEMA') #:nodoc:
         sql = <<-SQL
-          SELECT name
-          FROM sqlite_master
+          SELECT name FROM sqlite_master
+          WHERE type = 'table' AND NOT name = 'sqlite_sequence'
+          UNION
+          SELECT name FROM sqlite_temp_master
           WHERE type = 'table' AND NOT name = 'sqlite_sequence'
         SQL
 

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -6,11 +6,17 @@ class AdapterTest < ActiveRecord::TestCase
   end
 
   def test_tables
+    @connection.create_table :temporary_things, :temporary => true do |t|
+      t.string :name
+    end
+
     tables = @connection.tables
     assert tables.include?("accounts")
     assert tables.include?("authors")
     assert tables.include?("tasks")
     assert tables.include?("topics")
+
+    assert tables.include?("temporary_things")
   end
 
   def test_table_exists?


### PR DESCRIPTION
The SQLite adapter currently doesn't query the sqlite_temp_master table, so any temporary tables created are never found. This patch fixes it by performing a UNION on the sqlite_master and sqlite_temp_master tables.
