### PR TITLE
Fix for SafeBuffer#gsub and magic match globs

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -116,6 +116,22 @@ module ActiveSupport #:nodoc:
         end
       EOT
     end
+
+    # Provides a special-case override for String#gsub
+    # to preserve some of the standard behaviour with respect
+    # to magic matching global variables
+    #
+    # Unlike standard gsub, magic matching globs are _not_
+    # available in code following a SafeBuffer#gsub call,
+    # but they are available within a block passed to gsub, eg:
+    #   SafeBuffer.new('m').gsub(/(m)/){ $1 }
+    # In this case $1 == 'm' within the block, but not afterwards
+    #
+    # If you really need the magic matching variables after the gsub call
+    # you will need to covert SafeBuffer to a String first
+    def gsub(*args)
+      String.new(self).gsub(*args)
+    end
   end
 end
 

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -129,8 +129,8 @@ module ActiveSupport #:nodoc:
     #
     # If you really need the magic matching variables after the gsub call
     # you will need to convert SafeBuffer to a String first
-    def gsub(*args)
-      to_str.gsub(*args)
+    def gsub(*args, &block)
+      to_str.gsub(*args, &block)
     end
   end
 end

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -128,7 +128,7 @@ module ActiveSupport #:nodoc:
     # In this case $1 == 'm' within the block, but not afterwards
     #
     # If you really need the magic matching variables after the gsub call
-    # you will need to covert SafeBuffer to a String first
+    # you will need to convert SafeBuffer to a String first
     def gsub(*args)
       to_str.gsub(*args)
     end

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -130,7 +130,7 @@ module ActiveSupport #:nodoc:
     # If you really need the magic matching variables after the gsub call
     # you will need to covert SafeBuffer to a String first
     def gsub(*args)
-      String.new(self).gsub(*args)
+      to_str.gsub(*args)
     end
   end
 end

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -63,8 +63,8 @@ class SafeBufferTest < ActiveSupport::TestCase
     @buffer.gsub(/(vesta)/, '')
     assert !$1, %(
       if you can make this test fail it is a _good_ thing: somehow you have
-      restored the standard behaviour of SafeBuffer#gsub to make magic matching variables
-      available after the call, and you can probably deprecate this test
+      restored the standard behaviour of SafeBuffer#gsub to make magic matching
+      variables available after the call, and you could invert this test
     )
   end
 

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -52,13 +52,13 @@ class SafeBufferTest < ActiveSupport::TestCase
   end
 
   test "Should set magic match variables within block passed to gsub" do
-    'clear'[/(matches)/]
+    'burn'[/(matches)/]
     @buffer << 'swan'
     @buffer.gsub(/(swan)/) { assert_equal 'swan', $1 }
   end
 
   test "Should not expect magic match variables after gsub call" do
-    'clear'[/(matches)/]
+    'burn'[/(matches)/]
     @buffer << 'vesta'
     @buffer.gsub(/(vesta)/, '')
     assert !$1, %(

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -54,7 +54,9 @@ class SafeBufferTest < ActiveSupport::TestCase
   test "Should set magic match variables within block passed to gsub" do
     'burn'[/(matches)/]
     @buffer << 'swan'
-    @buffer.gsub(/(swan)/) { assert_equal 'swan', $1 }
+    result = nil
+    @buffer.gsub(/(swan)/) { result = $1 }
+    assert_equal 'swan', result, "dang it, still not working"
   end
 
   test "Should not expect magic match variables after gsub call" do

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -50,4 +50,22 @@ class SafeBufferTest < ActiveSupport::TestCase
       @buffer.gsub!('', 'asdf')
     end
   end
+
+  test "Should set magic match variables within block passed to gsub" do
+    'clear'[/(matches)/]
+    @buffer << 'swan'
+    @buffer.gsub(/(swan)/) { assert_equal 'swan', $1 }
+  end
+
+  test "Should not expect magic match variables after gsub call" do
+    'clear'[/(matches)/]
+    @buffer << 'vesta'
+    @buffer.gsub(/(vesta)/, '')
+    assert !$1, %(
+      if you can make this test fail it is a _good_ thing: somehow you have
+      restored the standard behaviour of SafeBuffer#gsub to make magic matching variables
+      available after the call, and you can probably deprecate this test
+    )
+  end
+
 end


### PR DESCRIPTION
(NB: so far not a viable fix .. still looking for solutions). 
Was only going to be partial anyway:
- $1, $2, $`, $&, and $’ now available within a block passed to SafeBuffer#gsub
- documented limitation that they are not available after the SafeBuffer#gsub call
  See GH#1555 for the original issue report
