### PR TITLE
Adding back Sass compressor

### DIFF
--- a/actionpack/lib/sprockets/railtie.rb
+++ b/actionpack/lib/sprockets/railtie.rb
@@ -30,7 +30,7 @@ module Sprockets
 
       ActiveSupport.on_load(:action_view) do
         include ::Sprockets::Helpers::RailsHelper
-        
+
         app.assets.context_class.instance_eval do
           include ::Sprockets::Helpers::RailsHelper
         end
@@ -82,6 +82,9 @@ module Sprockets
 
       def expand_css_compressor(sym)
         case sym
+        when :scss
+          require 'sass/rails/compressor'
+          Sass::Rails::CssCompressor.new
         when :yui
           require 'yui/compressor'
           YUI::CssCompressor.new


### PR DESCRIPTION
Adding back support for sass-rails CSS compressor with config.assets.css_compressor = :scss

Fix #1578 and #1619

cc @chriseppstein: please, can you review this? :)
