### PR TITLE
Jruby dir pwd

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -122,10 +122,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     Rails.application.class.stubs(:name).returns("Myapp")
     Rails.application.stubs(:is_a?).returns(Rails::Application)
 
-    FileUtils.mv(app_root, app_moved_root)
-
     generator = Rails::Generators::AppGenerator.new ["rails"], { :with_dispatchers => true },
                                                                :destination_root => app_moved_root, :shell => @shell
+    FileUtils.mv(app_root, app_moved_root)
     generator.send(:app_const)
     silence(:stdout){ generator.send(:create_config_files) }
     assert_file "myapp_moved/config/environment.rb", /Myapp::Application\.initialize!/


### PR DESCRIPTION
For ruby-1.9.2

<pre>
rails/railties git:(3-0-stable)* ruby -I test test/generators/app_generator_test.rb --name="/test_application_name_is_detected_if_it_exists_and_app_folder_renamed/"
Loaded suite test/generators/app_generator_test
Started
"/Users/arun/checkouts/rails/railties/test/fixtures/tmp/myapp" # Before FileUtils.mv (Dir.pwd)
"/Users/arun/checkouts/rails/railties/test/fixtures/tmp/myapp_moved" # After FileUtils.mv (Dir.pwd)
.
Finished in 0.094365 seconds.

1 tests, 4 assertions, 0 failures, 0 errors, 0 skips
</pre>


For Jruby-1.6.2

<pre>
rails/railties git:(3-0-stable)* ruby -I test test/generators/app_generator_test.rb --name="/test_application_name_is_detected_if_it_exists_and_app_folder_renamed/"
Loaded suite test/generators/app_generator_test
Started
"/Users/arun/checkouts/rails/railties/test/fixtures/tmp/myapp" # Before FileUtils.mv (Dir.pwd)
"/Users/arun/checkouts/rails/railties/test/fixtures/tmp/myapp" # After FileUtils.mv (Dir.pwd)
E
Finished in 0.53 seconds.

</pre>


It's changing the @original_wd for AppGenerator. That cause error in Tests.
