### PR TITLE
rails runner without any options should show usage information

### DIFF
--- a/railties/lib/rails/commands/runner.rb
+++ b/railties/lib/rails/commands/runner.rb
@@ -4,6 +4,10 @@ require 'rbconfig'
 options = { :environment => (ENV['RAILS_ENV'] || "development").dup }
 code_or_file = nil
 
+if ARGV.first.nil?
+  ARGV.push "-h"
+end
+
 ARGV.clone.options do |opts|
   script_name = File.basename($0)
   opts.banner = "Usage: runner [options] ('Some.ruby(code)' or a filename)"

--- a/railties/test/application/runner_test.rb
+++ b/railties/test/application/runner_test.rb
@@ -22,6 +22,10 @@ module ApplicationTests
       teardown_app
     end
 
+    def test_should_include_runner_in_shebang_line_in_help_without_option
+      assert_match "/rails runner", Dir.chdir(app_path) { `bundle exec rails runner` }
+    end
+
     def test_should_include_runner_in_shebang_line_in_help
       assert_match "/rails runner", Dir.chdir(app_path) { `bundle exec rails runner --help` }
     end


### PR DESCRIPTION
Currently, `rails runner` when run without any options shows `Run 'script/rails -h' for help.` which is not in line with other commands which display the usage help information when run without any options. 

Fixed it to make it consistent and display the usage information when run without options.
