### PR TITLE
Allow the connection pool's #table_exists? method to give the connections

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -119,6 +119,7 @@ module ActiveRecord
 
         with_connection do |conn|
           conn.tables.each { |table| @tables[table] = true }
+          @tables[name] = true if !@tables.key?(name) && conn.table_exists?(name)
         end
 
         @tables.key? name


### PR DESCRIPTION
The use case for the default abstract adapter's #table_exists? method is to give adapters a chance to return true in special cases where the core #tables does not include a name. Common use cases are for views and tables in other schemas. The connection pool should give a connection to respond true to with this matching name. If this was not done, I get errors in the SQL Server Adapter where column objects are not cached and respond properly for either the entire table or specific attribute of columns for said table, like @primary. This fixes that.

I did not include a test because this looked to be too low level white-box testing and I could not see any parallel in the connection_pool_test.rb file All tests for MySQL, PostgreSQL, and SQLite3 still pass with this change.
