### PR TITLE
Multiple aggregates

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -31,8 +31,7 @@ module ActiveRecord
       # Returns an array containing the field values.
       # Order is the same as that returned by +columns+.
       def select_row(sql, name = nil)
-        result = select_rows(sql, name)
-        result[0]
+        select_rows(sql, name).first
       end
 
       # Returns an array of arrays containing the field values.

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -28,6 +28,13 @@ module ActiveRecord
         result.map { |v| v[0] }
       end
 
+      # Returns an array containing the field values.
+      # Order is the same as that returned by +columns+.
+      def select_row(sql, name = nil)
+        result = select_rows(sql, name)
+        result[0]
+      end
+
       # Returns an array of arrays containing the field values.
       # Order is the same as that returned by +columns+.
       def select_rows(sql, name = nil)

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -170,15 +170,13 @@ module ActiveRecord
 
     def normalize_column_names_and_options(operations, column_names)
       operations, column_names = [*operations], [*column_names]
-      li = [operations.length, column_names.length].max - 1
-
-      if li > 0
-        for i in 0..li do
+      params_last_index = [operations.length, column_names.length].max - 1
+      if params_last_index > 0
+        (0..params_last_index).each do |i|
           operations << operations.last  if operations[i].nil?
           column_names << column_names.last if column_names[i].nil?
         end
       end
-
       operations.map! { |o| o.to_s.downcase }
       [operations, column_names]
     end

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -173,7 +173,7 @@ module ActiveRecord
       params_last_index = [operations.length, column_names.length].max - 1
       if params_last_index > 0
         (0..params_last_index).each do |i|
-          operations << operations.last  if operations[i].nil?
+          operations << operations.last if operations[i].nil?
           column_names << column_names.last if column_names[i].nil?
         end
       end
@@ -233,7 +233,7 @@ module ActiveRecord
                          "maximum" => nil}
 
           operations.each_with_index do |op, i| 
-            values << type_cast_calculated_value(null_values[operations[i]], column_for(column_names[i]), operations[i])
+            values << type_cast_calculated_value(null_values[op], column_for(column_names[i]), op)
           end
           return values.length == 1 ? values.first : values
         else

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -169,8 +169,7 @@ module ActiveRecord
     private
 
     def normalize_column_names_and_options(operations, column_names)
-      operations = [operations] if !operations.kind_of?(Array)
-      column_names = [column_names] if !column_names.kind_of?(Array)
+      operations, column_names = [*operations], [*column_names]
       li = [operations.length, column_names.length].max - 1
 
       if li > 0

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -58,42 +58,46 @@ module ActiveRecord
       calculate(:count, column_name, options)
     end
 
-    # Calculates the average value on a given column. Returns +nil+ if there's
+    # Calculates the average value on one or more given columns. Returns +nil+ if there's
     # no row. See +calculate+ for examples with options.
     #
     #   Person.average('age') # => 35.8
+    #   Person.average(['age', 'weight']) # => [35.8, 170]
     def average(column_names, options = {})
       calculate(:average, column_names, options)
     end
 
-    # Calculates the minimum value on a given column. The value is returned
+    # Calculates the minimum value on one or more given columns. The value is returned
     # with the same data type of the column, or +nil+ if there's no row. See
     # +calculate+ for examples with options.
     #
     #   Person.minimum('age') # => 7
+    #   Person.minimum(['age', 'weight']) # => [7, 100]
     def minimum(column_names, options = {})
       calculate(:minimum, column_names, options)
     end
 
-    # Calculates the maximum value on a given column. The value is returned
+    # Calculates the maximum value on one or more given columns. The value is returned
     # with the same data type of the column, or +nil+ if there's no row. See
     # +calculate+ for examples with options.
     #
     #   Person.maximum('age') # => 93
+    #   Person.maximum(['age', 'weight']) # => [93, 210]
     def maximum(column_names, options = {})
       calculate(:maximum, column_names, options)
     end
 
-    # Calculates the sum of values on a given column. The value is returned
+    # Calculates the sum of values on one or more given columns. The value is returned
     # with the same data type of the column, 0 if there's no row. See
     # +calculate+ for examples with options.
     #
     #   Person.sum('age') # => 4562
+    #   Person.sum(['age', 'weight']) # => [4562, 16721]
     def sum(column_names, options = {})
       calculate(:sum, column_names, options)
     end
 
-    # This calculates aggregate values in the given column. Methods for count, sum, average,
+    # This calculates aggregate values in one or more given columns. Methods for count, sum, average,
     # minimum, and maximum have been added as shortcuts. Options such as <tt>:conditions</tt>,
     # <tt>:order</tt>, <tt>:group</tt>, <tt>:having</tt>, and <tt>:joins</tt> can be passed to customize the query.
     #
@@ -142,6 +146,11 @@ module ActiveRecord
     #   Person.minimum(:age, :having => 'min(age) > 17', :group => :last_name)
     #
     #   Person.sum("2 * age")
+    #
+    #   # Using multiple columns or aggregate functions
+    #   Person.calculate(:average, [:age, :weight]) # SELECT AVG(age), AVG(weight) FROM people
+    #   Person.calculate([:average, :sum], :age) # SELECT AVG(age), SUM(age) FROM people
+    #   Person.calculate([:average, :sum], [:age, :weight]) # SELECT AVG(age), SUM(weight) FROM people
     def calculate(operations, column_names, options = {})
       operations, column_names = normalize_column_names_and_options(operations, column_names)
       if options.except(:distinct).present?

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -232,8 +232,10 @@ module ActiveRecord
                          "minimum" => nil,
                          "maximum" => nil}
 
-          operations.each_with_index { |op, i| values << type_cast_calculated_value(null_values[operations[i]], column_for(column_names[i]), operations[i]) }
-          return values.length == 1 ? values[0] : values
+          operations.each_with_index do |op, i| 
+            values << type_cast_calculated_value(null_values[operations[i]], column_for(column_names[i]), operations[i])
+          end
+          return values.length == 1 ? values.first : values
         else
           query_builder = build_aggregate_subquery(relation, operations, column_names, distinct)
         end
@@ -248,9 +250,10 @@ module ActiveRecord
 
           query_builder = relation.arel
       end
+
       row = @klass.connection.select_row(query_builder.to_sql)
       row.each_with_index { |value, i| values << type_cast_calculated_value(value, column_for(column_names[i]), operations[i]) }
-      values.length == 1 ? values[0] : values
+      values.length == 1 ? values.first : values
     end
 
     def execute_grouped_calculation(operations, column_names, distinct) #:nodoc:
@@ -299,8 +302,12 @@ module ActiveRecord
         }
         key = key.first if key.size == 1
         key = key_records[key] if associated
+
         values = []
-        aggregate_aliases.each_with_index { |aa, i| values << type_cast_calculated_value(row[aa], column_for(column_names[i]), operations[i]) }
+        aggregate_aliases.each_with_index do |aa, i| 
+          values << type_cast_calculated_value(row[aa], column_for(column_names[i]), operations[i])
+        end
+
         [key, values.length == 1 ? values.first : values]
       end]
     end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -83,54 +83,69 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal [318, 3.5], Account.calculate([:sum, :average], [:credit_limit, :id])
   end
 
-#  def test_should_group_by_field
-#    c = Account.sum(:credit_limit, :group => :firm_id)
-#    [1,6,2].each { |firm_id| assert c.keys.include?(firm_id) }
-#  end
-#
-#  def test_should_group_by_multiple_fields
-#    c = Account.count(:all, :group => ['firm_id', :credit_limit])
-#    [ [nil, 50], [1, 50], [6, 50], [6, 55], [9, 53], [2, 60] ].each { |firm_and_limit| assert c.keys.include?(firm_and_limit) }
-#  end
-#
-#  def test_should_group_by_multiple_fields_having_functions
-#    c = Topic.group(:author_name, 'COALESCE(type, title)').count(:all)
-#    assert_equal 1, c[["Carl", "The Third Topic of the day"]]
-#    assert_equal 1, c[["Mary", "Reply"]]
-#    assert_equal 1, c[["David", "The First Topic"]]
-#    assert_equal 1, c[["Carl", "Reply"]]
-#  end
-#
-#  def test_should_group_by_summed_field
-#    c = Account.sum(:credit_limit, :group => :firm_id)
-#    assert_equal 50,   c[1]
-#    assert_equal 105,  c[6]
-#    assert_equal 60,   c[2]
-#  end
-#
-#  def test_should_order_by_grouped_field
-#    c = Account.sum(:credit_limit, :group => :firm_id, :order => "firm_id")
-#    assert_equal [1, 2, 6, 9], c.keys.compact
-#  end
-#
-#  def test_should_order_by_calculation
-#    c = Account.sum(:credit_limit, :group => :firm_id, :order => "sum_credit_limit desc, firm_id")
-#    assert_equal [105, 60, 53, 50, 50], c.keys.collect { |k| c[k] }
-#    assert_equal [6, 2, 9, 1], c.keys.compact
-#  end
-#
-#  def test_should_limit_calculation
-#    c = Account.sum(:credit_limit, :conditions => "firm_id IS NOT NULL",
-#                    :group => :firm_id, :order => "firm_id", :limit => 2)
-#    assert_equal [1, 2], c.keys.compact
-#  end
-#
-#  def test_should_limit_calculation_with_offset
-#    c = Account.sum(:credit_limit, :conditions => "firm_id IS NOT NULL",
-#                    :group => :firm_id, :order => "firm_id", :limit => 2, :offset => 1)
-#    assert_equal [2, 6], c.keys.compact
-#  end
-#
+  def test_should_group_by_field
+    c = Account.sum(:credit_limit, :group => :firm_id)
+    [1,6,2].each { |firm_id| assert c.keys.include?(firm_id) }
+  end
+
+  def test_should_group_by_multiple_fields
+    c = Account.count(:all, :group => ['firm_id', :credit_limit])
+    [ [nil, 50], [1, 50], [6, 50], [6, 55], [9, 53], [2, 60] ].each { |firm_and_limit| assert c.keys.include?(firm_and_limit) }
+  end
+
+  def test_should_group_by_multiple_fields_having_functions
+    c = Topic.group(:author_name, 'COALESCE(type, title)').count(:all)
+    assert_equal 1, c[["Carl", "The Third Topic of the day"]]
+    assert_equal 1, c[["Mary", "Reply"]]
+    assert_equal 1, c[["David", "The First Topic"]]
+    assert_equal 1, c[["Carl", "Reply"]]
+  end
+
+  def test_should_group_by_summed_field
+    c = Account.sum(:credit_limit, :group => :firm_id)
+    assert_equal 50,   c[1]
+    assert_equal 105,  c[6]
+    assert_equal 60,   c[2]
+  end
+
+  def test_should_group_by_multiple_aggregate_fields
+    ops = [:count, :sum, :average, :minimum, :maximum]
+    c = Account.calculate(ops, :credit_limit, :group => :firm_id)
+    assert_equal [1, 50, 50, 50, 50],     c[1]
+    assert_equal [2, 105, 52.5, 50, 55],  c[6]
+    assert_equal [1, 60, 60, 60, 60],     c[2]
+  end
+
+  def test_should_order_by_grouped_field
+    c = Account.sum(:credit_limit, :group => :firm_id, :order => "firm_id")
+    assert_equal [1, 2, 6, 9], c.keys.compact
+  end
+
+  def test_should_order_by_calculation
+    c = Account.sum(:credit_limit, :group => :firm_id, :order => "sum_credit_limit desc, firm_id")
+    assert_equal [105, 60, 53, 50, 50], c.keys.collect { |k| c[k] }
+    assert_equal [6, 2, 9, 1], c.keys.compact
+  end
+
+  def test_should_order_by_multiple_calculation
+    ops = [:sum, :minimum]
+    c = Account.calculate(ops, :credit_limit, :group => :firm_id, :order => "minimum_credit_limit asc, sum_credit_limit desc, firm_id")
+    assert_equal [[105, 50], [50, 50], [50, 50], [53, 53], [60, 60]], c.keys.collect { |k| c[k] }
+    assert_equal [6, 1, 9, 2], c.keys.compact
+  end
+
+  def test_should_limit_calculation
+    c = Account.sum(:credit_limit, :conditions => "firm_id IS NOT NULL",
+                    :group => :firm_id, :order => "firm_id", :limit => 2)
+    assert_equal [1, 2], c.keys.compact
+  end
+
+  def test_should_limit_calculation_with_offset
+    c = Account.sum(:credit_limit, :conditions => "firm_id IS NOT NULL",
+                    :group => :firm_id, :order => "firm_id", :limit => 2, :offset => 1)
+    assert_equal [2, 6], c.keys.compact
+  end
+
   def test_limit_should_apply_before_count
     accounts = Account.limit(3).where('firm_id IS NOT NULL')
 
@@ -257,29 +272,29 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_no_match(/OFFSET/, queries.first)
   end
 
-#  def test_should_group_by_summed_field_having_condition
-#    c = Account.sum(:credit_limit, :group => :firm_id,
-#                                   :having => 'sum(credit_limit) > 50')
-#    assert_nil        c[1]
-#    assert_equal 105, c[6]
-#    assert_equal 60,  c[2]
-#  end
-#
-#  def test_should_group_by_summed_field_having_sanitized_condition
-#    c = Account.sum(:credit_limit, :group => :firm_id,
-#                                   :having => ['sum(credit_limit) > ?', 50])
-#    assert_nil        c[1]
-#    assert_equal 105, c[6]
-#    assert_equal 60,  c[2]
-#  end
-#
-#  def test_should_group_by_summed_association
-#    c = Account.sum(:credit_limit, :group => :firm)
-#    assert_equal 50,   c[companies(:first_firm)]
-#    assert_equal 105,  c[companies(:rails_core)]
-#    assert_equal 60,   c[companies(:first_client)]
-#  end
-#
+  def test_should_group_by_summed_field_having_condition
+    c = Account.sum(:credit_limit, :group => :firm_id,
+                                   :having => 'sum(credit_limit) > 50')
+    assert_nil        c[1]
+    assert_equal 105, c[6]
+    assert_equal 60,  c[2]
+  end
+
+  def test_should_group_by_summed_field_having_sanitized_condition
+    c = Account.sum(:credit_limit, :group => :firm_id,
+                                   :having => ['sum(credit_limit) > ?', 50])
+    assert_nil        c[1]
+    assert_equal 105, c[6]
+    assert_equal 60,  c[2]
+  end
+
+  def test_should_group_by_summed_association
+    c = Account.sum(:credit_limit, :group => :firm)
+    assert_equal 50,   c[companies(:first_firm)]
+    assert_equal 105,  c[companies(:rails_core)]
+    assert_equal 60,   c[companies(:first_client)]
+  end
+
   def test_should_sum_field_with_conditions
     assert_equal 105, Account.sum(:credit_limit, :conditions => 'firm_id = 6')
   end
@@ -293,77 +308,77 @@ class CalculationsTest < ActiveRecord::TestCase
     NumericData.create(:bank_balance => 19.83)
     assert_equal 19.83, NumericData.sum(:bank_balance)
   end
-#
-#  def test_should_group_by_summed_field_with_conditions
-#    c = Account.sum(:credit_limit, :conditions => 'firm_id > 1',
-#                                   :group => :firm_id)
-#    assert_nil        c[1]
-#    assert_equal 105, c[6]
-#    assert_equal 60,  c[2]
-#  end
-#
-#  def test_should_group_by_summed_field_with_conditions_and_having
-#    c = Account.sum(:credit_limit, :conditions => 'firm_id > 1',
-#                                   :group => :firm_id,
-#                                   :having => 'sum(credit_limit) > 60')
-#    assert_nil        c[1]
-#    assert_equal 105, c[6]
-#    assert_nil        c[2]
-#  end
-#
-#  def test_should_group_by_fields_with_table_alias
-#    c = Account.sum(:credit_limit, :group => 'accounts.firm_id')
-#    assert_equal 50,  c[1]
-#    assert_equal 105, c[6]
-#    assert_equal 60,  c[2]
-#  end
-#
+
+  def test_should_group_by_summed_field_with_conditions
+    c = Account.sum(:credit_limit, :conditions => 'firm_id > 1',
+                                   :group => :firm_id)
+    assert_nil        c[1]
+    assert_equal 105, c[6]
+    assert_equal 60,  c[2]
+  end
+
+  def test_should_group_by_summed_field_with_conditions_and_having
+    c = Account.sum(:credit_limit, :conditions => 'firm_id > 1',
+                                   :group => :firm_id,
+                                   :having => 'sum(credit_limit) > 60')
+    assert_nil        c[1]
+    assert_equal 105, c[6]
+    assert_nil        c[2]
+  end
+
+  def test_should_group_by_fields_with_table_alias
+    c = Account.sum(:credit_limit, :group => 'accounts.firm_id')
+    assert_equal 50,  c[1]
+    assert_equal 105, c[6]
+    assert_equal 60,  c[2]
+  end
+
   def test_should_calculate_with_invalid_field
     assert_equal 6, Account.calculate(:count, '*')
     assert_equal 6, Account.calculate(:count, :all)
   end
-#
-#  def test_should_calculate_grouped_with_invalid_field
-#    c = Account.count(:all, :group => 'accounts.firm_id')
-#    assert_equal 1, c[1]
-#    assert_equal 2, c[6]
-#    assert_equal 1, c[2]
-#  end
-#
-#  def test_should_calculate_grouped_association_with_invalid_field
-#    c = Account.count(:all, :group => :firm)
-#    assert_equal 1, c[companies(:first_firm)]
-#    assert_equal 2, c[companies(:rails_core)]
-#    assert_equal 1, c[companies(:first_client)]
-#  end
-#
-#  def test_should_group_by_association_with_non_numeric_foreign_key
-#    ActiveRecord::Base.connection.expects(:select_all).returns([{"count_all" => 1, "firm_id" => "ABC"}])
-#
-#    firm = mock()
-#    firm.expects(:id).returns("ABC")
-#    firm.expects(:class).returns(Firm)
-#    Company.expects(:find).with(["ABC"]).returns([firm])
-#
-#    column = mock()
-#    column.expects(:name).at_least_once.returns(:firm_id)
-#    column.expects(:type_cast).with("ABC").returns("ABC")
-#    Account.expects(:columns).at_least_once.returns([column])
-#
-#    c = Account.count(:all, :group => :firm)
-#    first_key = c.keys.first
-#    assert_equal Firm, first_key.class
-#    assert_equal 1, c[first_key]
-#  end
-#
-#  def test_should_calculate_grouped_association_with_foreign_key_option
-#    Account.belongs_to :another_firm, :class_name => 'Firm', :foreign_key => 'firm_id'
-#    c = Account.count(:all, :group => :another_firm)
-#    assert_equal 1, c[companies(:first_firm)]
-#    assert_equal 2, c[companies(:rails_core)]
-#    assert_equal 1, c[companies(:first_client)]
-#  end
-#
+
+  def test_should_calculate_grouped_with_invalid_field
+    c = Account.count(:all, :group => 'accounts.firm_id')
+    assert_equal 1, c[1]
+    assert_equal 2, c[6]
+    assert_equal 1, c[2]
+  end
+
+  def test_should_calculate_grouped_association_with_invalid_field
+    c = Account.count(:all, :group => :firm)
+    assert_equal 1, c[companies(:first_firm)]
+    assert_equal 2, c[companies(:rails_core)]
+    assert_equal 1, c[companies(:first_client)]
+  end
+
+  def test_should_group_by_association_with_non_numeric_foreign_key
+    ActiveRecord::Base.connection.expects(:select_all).returns([{"count_all" => 1, "firm_id" => "ABC"}])
+
+    firm = mock()
+    firm.expects(:id).returns("ABC")
+    firm.expects(:class).returns(Firm)
+    Company.expects(:find).with(["ABC"]).returns([firm])
+
+    column = mock()
+    column.expects(:name).at_least_once.returns(:firm_id)
+    column.expects(:type_cast).with("ABC").returns("ABC")
+    Account.expects(:columns).at_least_once.returns([column])
+
+    c = Account.count(:all, :group => :firm)
+    first_key = c.keys.first
+    assert_equal Firm, first_key.class
+    assert_equal 1, c[first_key]
+  end
+
+  def test_should_calculate_grouped_association_with_foreign_key_option
+    Account.belongs_to :another_firm, :class_name => 'Firm', :foreign_key => 'firm_id'
+    c = Account.count(:all, :group => :another_firm)
+    assert_equal 1, c[companies(:first_firm)]
+    assert_equal 2, c[companies(:rails_core)]
+    assert_equal 1, c[companies(:first_client)]
+  end
+
   def test_should_not_modify_options_when_using_includes
     options = {:conditions => 'companies.id > 1', :include => :firm}
     options_copy = options.dup
@@ -371,23 +386,23 @@ class CalculationsTest < ActiveRecord::TestCase
     Account.count(:all, options)
     assert_equal options_copy, options
   end
-#
-#  def test_should_calculate_grouped_by_function
-#    c = Company.count(:all, :group => "UPPER(#{QUOTED_TYPE})")
-#    assert_equal 2, c[nil]
-#    assert_equal 1, c['DEPENDENTFIRM']
-#    assert_equal 4, c['CLIENT']
-#    assert_equal 2, c['FIRM']
-#  end
-#
-#  def test_should_calculate_grouped_by_function_with_table_alias
-#    c = Company.count(:all, :group => "UPPER(companies.#{QUOTED_TYPE})")
-#    assert_equal 2, c[nil]
-#    assert_equal 1, c['DEPENDENTFIRM']
-#    assert_equal 4, c['CLIENT']
-#    assert_equal 2, c['FIRM']
-#  end
-#
+
+  def test_should_calculate_grouped_by_function
+    c = Company.count(:all, :group => "UPPER(#{QUOTED_TYPE})")
+    assert_equal 2, c[nil]
+    assert_equal 1, c['DEPENDENTFIRM']
+    assert_equal 4, c['CLIENT']
+    assert_equal 2, c['FIRM']
+  end
+
+  def test_should_calculate_grouped_by_function_with_table_alias
+    c = Company.count(:all, :group => "UPPER(companies.#{QUOTED_TYPE})")
+    assert_equal 2, c[nil]
+    assert_equal 1, c['DEPENDENTFIRM']
+    assert_equal 4, c['CLIENT']
+    assert_equal 2, c['FIRM']
+  end
+
   def test_should_not_overshadow_enumerable_sum
     assert_equal 6, [1, 2, 3].sum(&:abs)
   end
@@ -403,20 +418,20 @@ class CalculationsTest < ActiveRecord::TestCase
   def test_should_sum_scoped_field_with_conditions
     assert_equal 8,  companies(:rails_core).companies.sum(:id, :conditions => 'id > 7')
   end
-#
-#  def test_should_group_by_scoped_field
-#    c = companies(:rails_core).companies.sum(:id, :group => :name)
-#    assert_equal 7, c['Leetsoft']
-#    assert_equal 8, c['Jadedpixel']
-#  end
-#
-#  def test_should_group_by_summed_field_through_association_and_having
-#    c = companies(:rails_core).companies.sum(:id, :group => :name,
-#                                                  :having => 'sum(id) > 7')
-#    assert_nil      c['Leetsoft']
-#    assert_equal 8, c['Jadedpixel']
-#  end
-#
+
+  def test_should_group_by_scoped_field
+    c = companies(:rails_core).companies.sum(:id, :group => :name)
+    assert_equal 7, c['Leetsoft']
+    assert_equal 8, c['Jadedpixel']
+  end
+
+  def test_should_group_by_summed_field_through_association_and_having
+    c = companies(:rails_core).companies.sum(:id, :group => :name,
+                                                  :having => 'sum(id) > 7')
+    assert_nil      c['Leetsoft']
+    assert_equal 8, c['Jadedpixel']
+  end
+
   def test_should_count_selected_field_with_include
     assert_equal 6, Account.count(:distinct => true, :include => :firm)
     assert_equal 4, Account.count(:distinct => true, :include => :firm, :select => :credit_limit)
@@ -463,12 +478,12 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 4, Account.count('companies.id', :joins => :firm, :distinct => true)
   end
 
-#  def test_should_count_field_in_joined_table_with_group_by
-#    c = Account.count('companies.id', :group => 'accounts.firm_id', :joins => :firm)
-#
-#    [1,6,2,9].each { |firm_id| assert c.keys.include?(firm_id) }
-#  end
-#
+  def test_should_count_field_in_joined_table_with_group_by
+    c = Account.count('companies.id', :group => 'accounts.firm_id', :joins => :firm)
+
+    [1,6,2,9].each { |firm_id| assert c.keys.include?(firm_id) }
+  end
+
   def test_count_with_no_parameters_isnt_deprecated
     assert_not_deprecated { Account.count }
   end
@@ -537,12 +552,12 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal Account.count(:all), Company.count(:all, :from => 'accounts')
   end
 
-#  def test_distinct_is_honored_when_used_with_count_operation_after_group
-#    # Count the number of authors for approved topics
-#    approved_topics_count = Topic.group(:approved).count(:author_name)[true]
-#    assert_equal approved_topics_count, 3
-#    # Count the number of distinct authors for approved Topics
-#    distinct_authors_for_approved_count = Topic.group(:approved).count(:author_name, :distinct => true)[true]
-#    assert_equal distinct_authors_for_approved_count, 2
-#  end
+  def test_distinct_is_honored_when_used_with_count_operation_after_group
+    # Count the number of authors for approved topics
+    approved_topics_count = Topic.group(:approved).count(:author_name)[true]
+    assert_equal approved_topics_count, 3
+    # Count the number of distinct authors for approved Topics
+    distinct_authors_for_approved_count = Topic.group(:approved).count(:author_name, :distinct => true)[true]
+    assert_equal distinct_authors_for_approved_count, 2
+  end
 end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1059,6 +1059,14 @@ class FinderTest < ActiveRecord::TestCase
       Company.connection.select_rows("SELECT id, name FROM companies WHERE id IN (1,2,3) ORDER BY id").map! {|i| i.map! {|j| j.to_s unless j.nil?}}
   end
 
+  def test_select_row
+    assert_equal(
+      ["1", "1", nil, "37signals"],
+      Company.connection.select_row("SELECT id, firm_id, client_of, name FROM companies WHERE id = (1)").map! {|j| j.to_s unless j.nil?})
+    assert_equal(nil,
+      Company.connection.select_row("SELECT id, name FROM companies WHERE id = 11"))
+  end
+
   def test_find_with_order_on_included_associations_with_construct_finder_sql_for_association_limiting_and_is_distinct
     assert_equal 2, Post.find(:all, :include => { :authors => :author_address }, :order => ' author_addresses.id DESC ', :limit => 2).size
 


### PR DESCRIPTION
This patch allows to mix multiple columns and multiple aggregate functions in the same query

Examples:

<pre>
# SELECT SUM(age) FROM people
Person.sum('age') => 4562

# SELECT SUM(age), SUM(weight) FROM people
Person.sum(['age', 'weight']) => [4562, 16721]

# SELECT AVG(age), AVG(weight) FROM people
Person.calculate(:average, [:age, :weight]) => [35, 170]

# SELECT AVG(age), SUM(age) FROM people
Person.calculate([:average, :sum], :age) => [35, 4562]

# SELECT AVG(age), SUM(weight) FROM people
Person.calculate([:average, :sum], [:age, :weight]) => [35, 16721]
</pre>


This is my first contribution to rails, hope it helps.
