### PR TITLE
Remove unused variable causing warning in 1.9.3

### DIFF
--- a/actionpack/test/abstract/abstract_controller_test.rb
+++ b/actionpack/test/abstract/abstract_controller_test.rb
@@ -181,7 +181,7 @@ module AbstractController
     class TestLayouts < ActiveSupport::TestCase
       test "layouts are included" do
         controller = Me4.new
-        result = controller.process(:index)
+        controller.process(:index)
         assert_equal "Me4 Enter : Hello from me4/index.erb : Exit", controller.response_body
       end
     end


### PR DESCRIPTION
This fixes `warning: assigned but unused variable - result`
