### PR TITLE
Jruby 3 0 stable

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -57,7 +57,7 @@ namespace :db do
       end
     rescue
       case config['adapter']
-      when /mysql/
+      when /^(jdbc)?mysql/
         @charset   = ENV['CHARSET']   || 'utf8'
         @collation = ENV['COLLATION'] || 'utf8_unicode_ci'
         creation_options = {:charset => (config['charset'] || @charset), :collation => (config['collation'] || @collation)}
@@ -232,7 +232,7 @@ namespace :db do
   task :charset => :environment do
     config = ActiveRecord::Base.configurations[Rails.env || 'development']
     case config['adapter']
-    when /mysql/
+    when /^(jdbc)?mysql/
       ActiveRecord::Base.establish_connection(config)
       puts ActiveRecord::Base.connection.charset
     when /^(jdbc)?postgresql$/
@@ -250,7 +250,7 @@ namespace :db do
   task :collation => :environment do
     config = ActiveRecord::Base.configurations[Rails.env || 'development']
     case config['adapter']
-    when /mysql/
+    when /^(jdbc)?mysql/
       ActiveRecord::Base.establish_connection(config)
       puts ActiveRecord::Base.connection.collation
     else
@@ -351,7 +351,7 @@ namespace :db do
     task :dump => :environment do
       abcs = ActiveRecord::Base.configurations
       case abcs[Rails.env]["adapter"]
-      when /mysql/, "oci", "oracle"
+      when /^(jdbc)?mysql/, "oci", "oracle"
         ActiveRecord::Base.establish_connection(abcs[Rails.env])
         File.open("#{Rails.root}/db/#{Rails.env}_structure.sql", "w+") { |f| f << ActiveRecord::Base.connection.structure_dump }
       when /^(jdbc)?postgresql$/
@@ -399,7 +399,7 @@ namespace :db do
     task :clone_structure => [ "db:structure:dump", "db:test:purge" ] do
       abcs = ActiveRecord::Base.configurations
       case abcs["test"]["adapter"]
-      when /mysql/
+      when /^(jdbc)?mysql/
         ActiveRecord::Base.establish_connection(:test)
         ActiveRecord::Base.connection.execute('SET foreign_key_checks = 0')
         IO.readlines("#{Rails.root}/db/#{Rails.env}_structure.sql").join.split("\n\n").each do |table|
@@ -433,7 +433,7 @@ namespace :db do
     task :purge => :environment do
       abcs = ActiveRecord::Base.configurations
       case abcs["test"]["adapter"]
-      when /mysql/
+      when /^(jdbc)?mysql/
         ActiveRecord::Base.establish_connection(:test)
         ActiveRecord::Base.connection.recreate_database(abcs["test"]["database"], abcs["test"])
       when /^(jdbc)?postgresql$/
@@ -489,7 +489,7 @@ task 'test:prepare' => 'db:test:prepare'
 
 def drop_database(config)
   case config['adapter']
-  when /mysql/
+  when /^(jdbc)?mysql/
     ActiveRecord::Base.establish_connection(config)
     ActiveRecord::Base.connection.drop_database config['database']
   when /^(jdbc)?sqlite/

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -238,7 +238,7 @@ namespace :db do
     when /^(jdbc)?postgresql$/
       ActiveRecord::Base.establish_connection(config)
       puts ActiveRecord::Base.connection.encoding
-    when /sqlite3/
+    when /^(jdbc)?sqlite/
       ActiveRecord::Base.establish_connection(config)
       puts ActiveRecord::Base.connection.encoding
     else

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -61,7 +61,13 @@ namespace :db do
         @charset   = ENV['CHARSET']   || 'utf8'
         @collation = ENV['COLLATION'] || 'utf8_unicode_ci'
         creation_options = {:charset => (config['charset'] || @charset), :collation => (config['collation'] || @collation)}
-        error_class = config['adapter'] =~ /mysql2/ ? Mysql2::Error : Mysql::Error
+        if config['adapter'] =~ /jdbc/
+          #FIXME After Jdbcmysql gives this class
+          require 'active_record/railties/jdbcmysql_error'
+          error_class = ArJdbcMySQL::Error
+        else
+          error_class = config['adapter'] =~ /mysql2/ ? Mysql2::Error : Mysql::Error
+        end
         access_denied_error = 1045
         begin
           ActiveRecord::Base.establish_connection(config.merge('database' => nil))

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -238,7 +238,7 @@ namespace :db do
     when /postgresql/
       ActiveRecord::Base.establish_connection(config)
       puts ActiveRecord::Base.connection.encoding
-    when 'sqlite3'
+    when /sqlite3/
       ActiveRecord::Base.establish_connection(config)
       puts ActiveRecord::Base.connection.encoding
     else
@@ -364,9 +364,9 @@ namespace :db do
         end
         `pg_dump -i -U "#{abcs[Rails.env]["username"]}" -s -x -O -f db/#{Rails.env}_structure.sql #{search_path} #{abcs[Rails.env]["database"]}`
         raise "Error dumping database" if $?.exitstatus == 1
-      when "sqlite", "sqlite3"
+      when /sqlite/
         dbfile = abcs[Rails.env]["database"] || abcs[Rails.env]["dbfile"]
-        `#{abcs[Rails.env]["adapter"]} #{dbfile} .schema > db/#{Rails.env}_structure.sql`
+        `sqlite3 #{dbfile} .schema > db/#{Rails.env}_structure.sql`
       when "sqlserver"
         `scptxfr /s #{abcs[Rails.env]["host"]} /d #{abcs[Rails.env]["database"]} /I /f db\\#{Rails.env}_structure.sql /q /A /r`
         `scptxfr /s #{abcs[Rails.env]["host"]} /d #{abcs[Rails.env]["database"]} /I /F db\ /q /A /r`
@@ -410,9 +410,9 @@ namespace :db do
         ENV['PGPORT']     = abcs["test"]["port"].to_s if abcs["test"]["port"]
         ENV['PGPASSWORD'] = abcs["test"]["password"].to_s if abcs["test"]["password"]
         `psql -U "#{abcs["test"]["username"]}" -f #{Rails.root}/db/#{Rails.env}_structure.sql #{abcs["test"]["database"]}`
-      when "sqlite", "sqlite3"
+      when /sqlite/
         dbfile = abcs["test"]["database"] || abcs["test"]["dbfile"]
-        `#{abcs["test"]["adapter"]} #{dbfile} < #{Rails.root}/db/#{Rails.env}_structure.sql`
+        `sqlite3 #{dbfile} < #{Rails.root}/db/#{Rails.env}_structure.sql`
       when "sqlserver"
         `osql -E -S #{abcs["test"]["host"]} -d #{abcs["test"]["database"]} -i db\\#{Rails.env}_structure.sql`
       when "oci", "oracle"
@@ -440,7 +440,7 @@ namespace :db do
         ActiveRecord::Base.clear_active_connections!
         drop_database(abcs['test'])
         create_database(abcs['test'])
-      when "sqlite","sqlite3"
+      when /sqlite/
         dbfile = abcs["test"]["database"] || abcs["test"]["dbfile"]
         File.delete(dbfile) if File.exist?(dbfile)
       when "sqlserver"
@@ -492,7 +492,7 @@ def drop_database(config)
   when /mysql/
     ActiveRecord::Base.establish_connection(config)
     ActiveRecord::Base.connection.drop_database config['database']
-  when /^sqlite/
+  when /sqlite/
     require 'pathname'
     path = Pathname.new(config['database'])
     file = path.absolute? ? path.to_s : File.join(Rails.root, path)

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -364,7 +364,7 @@ namespace :db do
         end
         `pg_dump -i -U "#{abcs[Rails.env]["username"]}" -s -x -O -f db/#{Rails.env}_structure.sql #{search_path} #{abcs[Rails.env]["database"]}`
         raise "Error dumping database" if $?.exitstatus == 1
-      when /sqlite/
+      when /^(jdbc)?sqlite/
         dbfile = abcs[Rails.env]["database"] || abcs[Rails.env]["dbfile"]
         `sqlite3 #{dbfile} .schema > db/#{Rails.env}_structure.sql`
       when "sqlserver"
@@ -410,7 +410,7 @@ namespace :db do
         ENV['PGPORT']     = abcs["test"]["port"].to_s if abcs["test"]["port"]
         ENV['PGPASSWORD'] = abcs["test"]["password"].to_s if abcs["test"]["password"]
         `psql -U "#{abcs["test"]["username"]}" -f #{Rails.root}/db/#{Rails.env}_structure.sql #{abcs["test"]["database"]}`
-      when /sqlite/
+      when /^(jdbc)?sqlite/
         dbfile = abcs["test"]["database"] || abcs["test"]["dbfile"]
         `sqlite3 #{dbfile} < #{Rails.root}/db/#{Rails.env}_structure.sql`
       when "sqlserver"
@@ -440,7 +440,7 @@ namespace :db do
         ActiveRecord::Base.clear_active_connections!
         drop_database(abcs['test'])
         create_database(abcs['test'])
-      when /sqlite/
+      when /^(jdbc)?sqlite/
         dbfile = abcs["test"]["database"] || abcs["test"]["dbfile"]
         File.delete(dbfile) if File.exist?(dbfile)
       when "sqlserver"
@@ -492,7 +492,7 @@ def drop_database(config)
   when /mysql/
     ActiveRecord::Base.establish_connection(config)
     ActiveRecord::Base.connection.drop_database config['database']
-  when /sqlite/
+  when /^(jdbc)?sqlite/
     require 'pathname'
     path = Pathname.new(config['database'])
     file = path.absolute? ? path.to_s : File.join(Rails.root, path)

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -91,7 +91,7 @@ namespace :db do
             $stderr.puts "(if you set the charset manually, make sure you have a matching collation)" if config['charset']
           end
         end
-      when 'postgresql'
+      when /postgresql/
         @encoding = config['encoding'] || ENV['CHARSET'] || 'utf8'
         begin
           ActiveRecord::Base.establish_connection(config.merge('database' => 'postgres', 'schema_search_path' => 'public'))
@@ -235,7 +235,7 @@ namespace :db do
     when /mysql/
       ActiveRecord::Base.establish_connection(config)
       puts ActiveRecord::Base.connection.charset
-    when 'postgresql'
+    when /postgresql/
       ActiveRecord::Base.establish_connection(config)
       puts ActiveRecord::Base.connection.encoding
     when 'sqlite3'
@@ -354,7 +354,7 @@ namespace :db do
       when /mysql/, "oci", "oracle"
         ActiveRecord::Base.establish_connection(abcs[Rails.env])
         File.open("#{Rails.root}/db/#{Rails.env}_structure.sql", "w+") { |f| f << ActiveRecord::Base.connection.structure_dump }
-      when "postgresql"
+      when /postgresql/
         ENV['PGHOST']     = abcs[Rails.env]["host"] if abcs[Rails.env]["host"]
         ENV['PGPORT']     = abcs[Rails.env]["port"].to_s if abcs[Rails.env]["port"]
         ENV['PGPASSWORD'] = abcs[Rails.env]["password"].to_s if abcs[Rails.env]["password"]
@@ -405,7 +405,7 @@ namespace :db do
         IO.readlines("#{Rails.root}/db/#{Rails.env}_structure.sql").join.split("\n\n").each do |table|
           ActiveRecord::Base.connection.execute(table)
         end
-      when "postgresql"
+      when /postgresql/
         ENV['PGHOST']     = abcs["test"]["host"] if abcs["test"]["host"]
         ENV['PGPORT']     = abcs["test"]["port"].to_s if abcs["test"]["port"]
         ENV['PGPASSWORD'] = abcs["test"]["password"].to_s if abcs["test"]["password"]
@@ -436,7 +436,7 @@ namespace :db do
       when /mysql/
         ActiveRecord::Base.establish_connection(:test)
         ActiveRecord::Base.connection.recreate_database(abcs["test"]["database"], abcs["test"])
-      when "postgresql"
+      when /postgresql/
         ActiveRecord::Base.clear_active_connections!
         drop_database(abcs['test'])
         create_database(abcs['test'])
@@ -498,7 +498,7 @@ def drop_database(config)
     file = path.absolute? ? path.to_s : File.join(Rails.root, path)
 
     FileUtils.rm(file)
-  when 'postgresql'
+  when /postgresql/
     ActiveRecord::Base.establish_connection(config.merge('database' => 'postgres', 'schema_search_path' => 'public'))
     ActiveRecord::Base.connection.drop_database config['database']
   end

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -91,7 +91,7 @@ namespace :db do
             $stderr.puts "(if you set the charset manually, make sure you have a matching collation)" if config['charset']
           end
         end
-      when /postgresql/
+      when /^(jdbc)?postgresql$/
         @encoding = config['encoding'] || ENV['CHARSET'] || 'utf8'
         begin
           ActiveRecord::Base.establish_connection(config.merge('database' => 'postgres', 'schema_search_path' => 'public'))
@@ -235,7 +235,7 @@ namespace :db do
     when /mysql/
       ActiveRecord::Base.establish_connection(config)
       puts ActiveRecord::Base.connection.charset
-    when /postgresql/
+    when /^(jdbc)?postgresql$/
       ActiveRecord::Base.establish_connection(config)
       puts ActiveRecord::Base.connection.encoding
     when /sqlite3/
@@ -354,7 +354,7 @@ namespace :db do
       when /mysql/, "oci", "oracle"
         ActiveRecord::Base.establish_connection(abcs[Rails.env])
         File.open("#{Rails.root}/db/#{Rails.env}_structure.sql", "w+") { |f| f << ActiveRecord::Base.connection.structure_dump }
-      when /postgresql/
+      when /^(jdbc)?postgresql$/
         ENV['PGHOST']     = abcs[Rails.env]["host"] if abcs[Rails.env]["host"]
         ENV['PGPORT']     = abcs[Rails.env]["port"].to_s if abcs[Rails.env]["port"]
         ENV['PGPASSWORD'] = abcs[Rails.env]["password"].to_s if abcs[Rails.env]["password"]
@@ -405,7 +405,7 @@ namespace :db do
         IO.readlines("#{Rails.root}/db/#{Rails.env}_structure.sql").join.split("\n\n").each do |table|
           ActiveRecord::Base.connection.execute(table)
         end
-      when /postgresql/
+      when /^(jdbc)?postgresql$/
         ENV['PGHOST']     = abcs["test"]["host"] if abcs["test"]["host"]
         ENV['PGPORT']     = abcs["test"]["port"].to_s if abcs["test"]["port"]
         ENV['PGPASSWORD'] = abcs["test"]["password"].to_s if abcs["test"]["password"]
@@ -436,7 +436,7 @@ namespace :db do
       when /mysql/
         ActiveRecord::Base.establish_connection(:test)
         ActiveRecord::Base.connection.recreate_database(abcs["test"]["database"], abcs["test"])
-      when /postgresql/
+      when /^(jdbc)?postgresql$/
         ActiveRecord::Base.clear_active_connections!
         drop_database(abcs['test'])
         create_database(abcs['test'])
@@ -498,7 +498,7 @@ def drop_database(config)
     file = path.absolute? ? path.to_s : File.join(Rails.root, path)
 
     FileUtils.rm(file)
-  when /postgresql/
+  when /^(jdbc)?postgresql$/
     ActiveRecord::Base.establish_connection(config.merge('database' => 'postgres', 'schema_search_path' => 'public'))
     ActiveRecord::Base.connection.drop_database config['database']
   end

--- a/activerecord/lib/active_record/railties/jdbcmysql_error.rb
+++ b/activerecord/lib/active_record/railties/jdbcmysql_error.rb
@@ -1,0 +1,16 @@
+#FIXME Remove if ArJdbcMysql will give.
+module ArJdbcMySQL
+  class Error < StandardError
+    attr_accessor :error_number, :sql_state
+
+    def initialize msg
+      super
+      @error_number = nil
+      @sql_state    = nil
+    end
+
+    # Mysql gem compatibility
+    alias_method :errno, :error_number
+    alias_method :error, :message
+  end
+end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -154,7 +154,7 @@ module Rails
                         plugin runner test]
 
     class AppGenerator < Base
-      DATABASES = %w( mysql oracle postgresql sqlite3 frontbase ibm_db jdbcmysql)
+      DATABASES = %w( mysql oracle postgresql sqlite3 frontbase ibm_db jdbcmysql jdbcsqlite3)
 
       attr_accessor :rails_template
       add_shebang_option!
@@ -402,6 +402,7 @@ module Rails
         when "frontbase"  then "ruby-frontbase"
         when "mysql"      then "mysql2"
         when "jdbcmysql"  then "activerecord-jdbcmysql-adapter"
+        when "jdbcsqlite3"  then "activerecord-jdbcsqlite3-adapter"
         else options[:database]
         end
       end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -154,8 +154,8 @@ module Rails
                         plugin runner test]
 
     class AppGenerator < Base
-      JDBC_DATABASES = %w( jdbcmysql jdbcsqlite3 jdbcpostgresql )
       DATABASES = %w( mysql oracle postgresql sqlite3 frontbase ibm_db )
+      JDBC_DATABASES = %w( jdbcmysql jdbcsqlite3 jdbcpostgresql jdbc )
       DATABASES.concat(JDBC_DATABASES)
 
       attr_accessor :rails_template
@@ -406,6 +406,7 @@ module Rails
         when "jdbcmysql"  then "activerecord-jdbcmysql-adapter"
         when "jdbcsqlite3"  then "activerecord-jdbcsqlite3-adapter"
         when "jdbcpostgresql"  then "activerecord-jdbcpostgresql-adapter"
+        when "jdbc"           then "activerecord-jdbc-adapter"
         else options[:database]
         end
       end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -154,7 +154,7 @@ module Rails
                         plugin runner test]
 
     class AppGenerator < Base
-      DATABASES = %w( mysql oracle postgresql sqlite3 frontbase ibm_db jdbcmysql jdbcsqlite3)
+      DATABASES = %w( mysql oracle postgresql sqlite3 frontbase ibm_db jdbcmysql jdbcsqlite3 )
 
       attr_accessor :rails_template
       add_shebang_option!
@@ -394,7 +394,7 @@ module Rails
       end
 
       def gem_for_database
-        # %w( mysql oracle postgresql sqlite3 frontbase ibm_db jdbcmysql)
+        # %w( mysql oracle postgresql sqlite3 frontbase ibm_db jdbcmysql jdbcsqlite3)
         case options[:database]
         when "oracle"     then "ruby-oci8"
         when "postgresql" then "pg"

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -154,7 +154,9 @@ module Rails
                         plugin runner test]
 
     class AppGenerator < Base
-      DATABASES = %w( mysql oracle postgresql sqlite3 frontbase ibm_db jdbcmysql jdbcsqlite3 jdbcpostgresql )
+      JDBC_DATABASES = %w( jdbcmysql jdbcsqlite3 jdbcpostgresql )
+      DATABASES = %w( mysql oracle postgresql sqlite3 frontbase ibm_db )
+      DATABASES.concat(JDBC_DATABASES)
 
       attr_accessor :rails_template
       add_shebang_option!

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -154,7 +154,7 @@ module Rails
                         plugin runner test]
 
     class AppGenerator < Base
-      DATABASES = %w( mysql oracle postgresql sqlite3 frontbase ibm_db jdbcmysql jdbcsqlite3 )
+      DATABASES = %w( mysql oracle postgresql sqlite3 frontbase ibm_db jdbcmysql jdbcsqlite3 jdbcpostgresql )
 
       attr_accessor :rails_template
       add_shebang_option!
@@ -394,7 +394,7 @@ module Rails
       end
 
       def gem_for_database
-        # %w( mysql oracle postgresql sqlite3 frontbase ibm_db jdbcmysql jdbcsqlite3)
+        # %w( mysql oracle postgresql sqlite3 frontbase ibm_db jdbcmysql jdbcsqlite3 jdbcpostgresql)
         case options[:database]
         when "oracle"     then "ruby-oci8"
         when "postgresql" then "pg"
@@ -403,6 +403,7 @@ module Rails
         when "mysql"      then "mysql2"
         when "jdbcmysql"  then "activerecord-jdbcmysql-adapter"
         when "jdbcsqlite3"  then "activerecord-jdbcsqlite3-adapter"
+        when "jdbcpostgresql"  then "activerecord-jdbcpostgresql-adapter"
         else options[:database]
         end
       end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -206,6 +206,7 @@ module Rails
         @original_wd = Dir.pwd
 
         super
+        convert_database_option_for_jruby
 
         if !options[:skip_active_record] && !DATABASES.include?(options[:database])
           raise Error, "Invalid value for --database option. Supported for preconfiguration are: #{DATABASES.join(", ")}."
@@ -408,6 +409,17 @@ module Rails
         when "jdbcpostgresql"  then "activerecord-jdbcpostgresql-adapter"
         when "jdbc"           then "activerecord-jdbc-adapter"
         else options[:database]
+        end
+      end
+
+      def convert_database_option_for_jruby
+        if defined?(JRUBY_VERSION)
+          case options[:database]
+          when "oracle"     then options[:database].replace "jdbc"
+          when "postgresql" then options[:database].replace "jdbcpostgresql"
+          when "mysql"      then options[:database].replace "jdbcmysql"
+          when "sqlite3"    then options[:database].replace "jdbcsqlite3"
+          end
         end
       end
 

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -154,7 +154,7 @@ module Rails
                         plugin runner test]
 
     class AppGenerator < Base
-      DATABASES = %w( mysql oracle postgresql sqlite3 frontbase ibm_db )
+      DATABASES = %w( mysql oracle postgresql sqlite3 frontbase ibm_db jdbcmysql)
 
       attr_accessor :rails_template
       add_shebang_option!
@@ -394,13 +394,14 @@ module Rails
       end
 
       def gem_for_database
-        # %w( mysql oracle postgresql sqlite3 frontbase ibm_db )
+        # %w( mysql oracle postgresql sqlite3 frontbase ibm_db jdbcmysql)
         case options[:database]
         when "oracle"     then "ruby-oci8"
         when "postgresql" then "pg"
         when "sqlite3"    then "sqlite3"
         when "frontbase"  then "ruby-frontbase"
         when "mysql"      then "mysql2"
+        when "jdbcmysql"  then "activerecord-jdbcmysql-adapter"
         else options[:database]
         end
       end

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -7,6 +7,7 @@ gem 'rails', :git => 'git://github.com/rails/rails.git'
 <%- else -%>
 gem 'rails', '<%= Rails::VERSION::STRING %>'
 
+<%= "gem 'jruby-openssl'\n" if defined?(JRUBY_VERSION) -%>
 # Bundle edge Rails instead:
 # gem 'rails', :git => 'git://github.com/rails/rails.git'
 <%- end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml
@@ -1,0 +1,62 @@
+# If you are using mssql, derby, hsqldb, or h2 with one of the
+# ActiveRecord JDBC adapters, install the appropriate driver, e.g.,:
+#   gem install activerecord-jdbcmssql-adapter
+#
+# Configure using Gemfile:
+#   gem 'activerecord-jdbcmssql-adapter'
+#
+#development:
+#  adapter: mssql
+#  username: <%= app_name %>
+#  password:
+#  host: localhost
+#  database: <%= app_name %>_development
+#
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+#
+#test:
+#  adapter: mssql
+#  username: <%= app_name %>
+#  password:
+#  host: localhost
+#  database: <%= app_name %>_test
+#
+#production:
+#  adapter: mssql
+#  username: <%= app_name %>
+#  password:
+#  host: localhost
+#  database: <%= app_name %>_production
+
+# If you are using oracle, db2, sybase, informix or prefer to use the plain
+# JDBC adapter, configure your database setting as the example below (requires
+# you to download and manually install the database vendor's JDBC driver .jar
+# file). See your driver documentation for the apropriate driver class and
+# connection string:
+
+development:
+  adapter: jdbc
+  username: <%= app_name %>
+  password:
+  driver:
+  url: jdbc:db://localhost/<%= app_name %>_development
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+
+test:
+  adapter: jdbc
+  username: <%= app_name %>
+  password:
+  driver:
+  url: jdbc:db://localhost/<%= app_name %>_test
+
+production:
+  adapter: jdbc
+  username: <%= app_name %>
+  password:
+  driver:
+  url: jdbc:db://localhost/<%= app_name %>_production

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml
@@ -1,0 +1,30 @@
+# MySQL.  Versions 4.1 and 5.0 are recommended.
+#
+# Install the MySQL driver:
+#   gem install activerecord-jdbcmysql-adapter
+#
+# And be sure to use new-style password hashing:
+#   http://dev.mysql.com/doc/refman/5.0/en/old-client.html
+development:
+  adapter: jdbcmysql
+  database: <%= app_name %>_development
+  username: root
+  password:
+  host: localhost
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  adapter: jdbcmysql
+  database: <%= app_name %>_test
+  username: root
+  password:
+  host: localhost
+
+production:
+  adapter: jdbcmysql
+  database: <%= app_name %>_production
+  username: root
+  password:
+  host: localhost

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml
@@ -6,7 +6,7 @@
 # And be sure to use new-style password hashing:
 #   http://dev.mysql.com/doc/refman/5.0/en/old-client.html
 development:
-  adapter: jdbcmysql
+  adapter: mysql
   database: <%= app_name %>_development
   username: root
   password:
@@ -16,14 +16,14 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: jdbcmysql
+  adapter: mysql
   database: <%= app_name %>_test
   username: root
   password:
   host: localhost
 
 production:
-  adapter: jdbcmysql
+  adapter: mysql
   database: <%= app_name %>_production
   username: root
   password:

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
@@ -1,0 +1,48 @@
+# PostgreSQL. Versions 7.4 and 8.x are supported.
+#
+# Install the pg driver:
+#   gem install pg
+# On Mac OS X with macports:
+#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
+# On Windows:
+#   gem install pg
+#       Choose the win32 build.
+#       Install PostgreSQL and put its /bin directory on your path.
+development:
+  adapter: jdbcpostgresql
+  encoding: unicode
+  database: <%= app_name %>_development
+  username: <%= app_name %>
+  password:
+
+  # Connect on a TCP socket. Omitted by default since the client uses a
+  # domain socket that doesn't need configuration. Windows does not have
+  # domain sockets, so uncomment these lines.
+  #host: localhost
+  #port: 5432
+
+  # Schema search path. The server defaults to $user,public
+  #schema_search_path: myapp,sharedapp,public
+
+  # Minimum log levels, in increasing order:
+  #   debug5, debug4, debug3, debug2, debug1,
+  #   log, notice, warning, error, fatal, and panic
+  # The server defaults to notice.
+  #min_messages: warning
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  adapter: jdbcpostgresql
+  encoding: unicode
+  database: <%= app_name %>_test
+  username: <%= app_name %>
+  password:
+
+production:
+  adapter: jdbcpostgresql
+  encoding: unicode
+  database: <%= app_name %>_production
+  username: <%= app_name %>
+  password:

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
@@ -1,13 +1,8 @@
 # PostgreSQL. Versions 7.4 and 8.x are supported.
 #
-# Install the pg driver:
-#   gem install pg
-# On Mac OS X with macports:
-#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
-# On Windows:
-#   gem install pg
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
+ # Configure Using Gemfile
+ # gem 'activerecord-jdbcpostgresql-adapter'development:
+
 development:
   adapter: jdbcpostgresql
   encoding: unicode

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
@@ -4,7 +4,7 @@
  # gem 'activerecord-jdbcpostgresql-adapter'development:
 
 development:
-  adapter: jdbcpostgresql
+  adapter: postgresql
   encoding: unicode
   database: <%= app_name %>_development
   username: <%= app_name %>
@@ -29,14 +29,14 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: jdbcpostgresql
+  adapter: postgresql
   encoding: unicode
   database: <%= app_name %>_test
   username: <%= app_name %>
   password:
 
 production:
-  adapter: jdbcpostgresql
+  adapter: postgresql
   encoding: unicode
   database: <%= app_name %>_production
   username: <%= app_name %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml
@@ -1,0 +1,17 @@
+# SQLite version 3.x
+#   gem 'activerecord-jdbcsqlite3-adapter'
+
+development:
+  adapter: jdbcsqlite3
+  database: db/development.sqlite3
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  adapter: jdbcsqlite3
+  database: db/test.sqlite3
+
+production:
+  adapter: jdbcsqlite3
+  database: db/production.sqlite3

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml
@@ -2,16 +2,16 @@
 #   gem 'activerecord-jdbcsqlite3-adapter'
 
 development:
-  adapter: jdbcsqlite3
+  adapter: sqlite3
   database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: jdbcsqlite3
+  adapter: sqlite3
   database: db/test.sqlite3
 
 production:
-  adapter: jdbcsqlite3
+  adapter: sqlite3
   database: db/production.sqlite3

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -165,6 +165,12 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "Gemfile", /^gem\s+["']mysql2["'],\s*'~> 0.2.6'$/
   end
 
+  def test_config_jdbcmysql_database
+    run_generator([destination_root, "-d", "jdbcmysql"])
+    assert_file "config/database.yml", /jdbcmysql/
+    assert_file "Gemfile", /^gem\s+["']activerecord-jdbcmysql-adapter["']$/
+  end
+
   def test_config_database_is_not_added_if_skip_active_record_is_given
     run_generator [destination_root, "--skip-active-record"]
     assert_no_file "config/database.yml"

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -171,6 +171,12 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "Gemfile", /^gem\s+["']activerecord-jdbcmysql-adapter["']$/
   end
 
+  def test_config_jdbcsqlite3_database
+    run_generator([destination_root, "-d", "jdbcsqlite3"])
+    assert_file "config/database.yml", /jdbcsqlite3/
+    assert_file "Gemfile", /^gem\s+["']activerecord-jdbcsqlite3-adapter["']$/
+  end
+
   def test_config_database_is_not_added_if_skip_active_record_is_given
     run_generator [destination_root, "--skip-active-record"]
     assert_no_file "config/database.yml"

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -167,7 +167,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_config_jdbcmysql_database
     run_generator([destination_root, "-d", "jdbcmysql"])
-    assert_file "config/database.yml", /jdbcmysql/
+    assert_file "config/database.yml", /mysql/
     assert_file "Gemfile", /^gem\s+["']activerecord-jdbcmysql-adapter["']$/
     # TODO: When the JRuby guys merge jruby-openssl in
     # jruby this will be removed
@@ -176,13 +176,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_config_jdbcsqlite3_database
     run_generator([destination_root, "-d", "jdbcsqlite3"])
-    assert_file "config/database.yml", /jdbcsqlite3/
+    assert_file "config/database.yml", /sqlite3/
     assert_file "Gemfile", /^gem\s+["']activerecord-jdbcsqlite3-adapter["']$/
   end
 
   def test_config_jdbcpostgresql_database
     run_generator([destination_root, "-d", "jdbcpostgresql"])
-    assert_file "config/database.yml", /jdbcpostgresql/
+    assert_file "config/database.yml", /postgresql/
     assert_file "Gemfile", /^gem\s+["']activerecord-jdbcpostgresql-adapter["']$/
   end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -177,6 +177,12 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "Gemfile", /^gem\s+["']activerecord-jdbcsqlite3-adapter["']$/
   end
 
+  def test_config_jdbcpostgresql_database
+    run_generator([destination_root, "-d", "jdbcpostgresql"])
+    assert_file "config/database.yml", /jdbcpostgresql/
+    assert_file "Gemfile", /^gem\s+["']activerecord-jdbcpostgresql-adapter["']$/
+  end
+
   def test_config_database_is_not_added_if_skip_active_record_is_given
     run_generator [destination_root, "--skip-active-record"]
     assert_no_file "config/database.yml"

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -186,6 +186,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "Gemfile", /^gem\s+["']activerecord-jdbcpostgresql-adapter["']$/
   end
 
+  def test_config_jdbc_database
+    run_generator([destination_root, "-d", "jdbc"])
+    assert_file "config/database.yml", /jdbc/
+    assert_file "config/database.yml", /mssql/
+    assert_file "Gemfile", /^gem\s+["']activerecord-jdbc-adapter["']$/
+  end
+
   def test_config_database_is_not_added_if_skip_active_record_is_given
     run_generator [destination_root, "--skip-active-record"]
     assert_no_file "config/database.yml"

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -169,6 +169,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator([destination_root, "-d", "jdbcmysql"])
     assert_file "config/database.yml", /jdbcmysql/
     assert_file "Gemfile", /^gem\s+["']activerecord-jdbcmysql-adapter["']$/
+    # TODO: When the JRuby guys merge jruby-openssl in
+    # jruby this will be removed
+    assert_file "Gemfile", /^gem\s+["']jruby-openssl["']$/ if defined?(JRUBY_VERSION)
   end
 
   def test_config_jdbcsqlite3_database

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -193,6 +193,14 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "Gemfile", /^gem\s+["']activerecord-jdbc-adapter["']$/
   end
 
+  def test_config_jdbc_database_when_no_option_given
+    if defined?(JRUBY_VERSION)
+      run_generator([destination_root])
+      assert_file "config/database.yml", /sqlite3/
+      assert_file "Gemfile", /^gem\s+["']activerecord-jdbcsqlite3-adapter["']$/
+    end
+  end
+
   def test_config_database_is_not_added_if_skip_active_record_is_given
     run_generator [destination_root, "--skip-active-record"]
     assert_no_file "config/database.yml"


### PR DESCRIPTION
These are template changes. As i forgot that time to add in 3-0-stable branch. By these changes user will be able to generate application for jdbc\* stuff. 

As Activerecord-jdbc-adapter is not is good shape with 3.1.rc\* so these will help who using jruby + rails. They can use 3-0-*. 

And also included database..rake file changes to allow database operation for jdbc-*

Not be able to cherry-pick from master as file changed in master.

Cheers, 
Arun
