### PR TITLE
Implemented support for usage of alternative conventions for namespaced models in error messages. 

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -294,8 +294,12 @@ module ActiveModel
       type = options.delete(:message) if options[:message].is_a?(Symbol)
 
       defaults = @base.class.lookup_ancestors.map do |klass|
-        [ :"#{@base.class.i18n_scope}.errors.models.#{klass.model_name.i18n_key}.attributes.#{attribute}.#{type}",
-          :"#{@base.class.i18n_scope}.errors.models.#{klass.model_name.i18n_key}.#{type}" ]
+        [
+          :"#{@base.class.i18n_scope}.errors.models.#{klass.model_name.i18n_key}.attributes.#{attribute}.#{type}",
+          :"#{@base.class.i18n_scope}.errors.models.#{klass.model_name.i18n_key}.#{type}",
+          :"#{@base.class.i18n_scope}.errors.models.#{klass.model_name.i18n_key.to_s.tr(".", "/").to_sym}.attributes.#{attribute}.#{type}",
+          :"#{@base.class.i18n_scope}.errors.models.#{klass.model_name.i18n_key.to_s.tr(".", "/").to_sym}.#{type}"
+        ]
       end
 
       defaults << options.delete(:message)

--- a/activemodel/test/cases/translation_test.rb
+++ b/activemodel/test/cases/translation_test.rb
@@ -86,5 +86,25 @@ class ActiveModelI18nTests < ActiveModel::TestCase
     I18n.backend.store_translations 'en', :activemodel => {:models => {:person => {:gender => 'person gender model'}}}
     assert_equal 'person gender model', Person::Gender.model_name.human
   end
+
+  def test_alternate_namespaced_model_error_translation
+    with_test_translations_loaded do
+      post = Blog::Post.new
+      post.valid?
+      assert_equal "can't be blank - dot notation", post.errors.get(:title).first    # both notations exist 
+      assert_equal "can't be blank - dot notation", post.errors.get(:header).first   # only dot notation exists
+      assert_equal "can't be blank - slash notation", post.errors.get(:editor).first # only slash notation exists
+    end
+  end
+
+
+  private
+
+  def with_test_translations_loaded
+    yaml_file = File.dirname(__FILE__) + '/translation_test.yml'
+    I18n.load_path << yaml_file
+    yield if block_given?
+    I18n.load_path.delete(yaml_file)
+  end
 end
 

--- a/activemodel/test/cases/translation_test.yml
+++ b/activemodel/test/cases/translation_test.yml
@@ -1,0 +1,30 @@
+# Sample localization file for English. Add more files in this directory for other locales.
+# See http://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
+
+en:
+  activemodel:
+    models:
+      invoice:
+        item: "Invoice::Item dot notation"
+      invoice/item: "Invoice::Item slash notation"
+    attributes:
+      invoice/item:
+        name: "Invoice::Item.name slash notation"
+      invoice:
+        item:
+          name: "Invoice::Item.name dot notation"
+    errors:
+      models:
+        blog:
+          post:
+            attributes:
+              title:
+                blank: "can't be blank - dot notation"
+              header:
+                blank: "can't be blank - dot notation"
+        blog/post:
+          attributes:
+            title:
+              blank: "can't be blank - slash notation"
+            editor:
+              blank: "can't be blank - slash notation"

--- a/activemodel/test/models/blog_post.rb
+++ b/activemodel/test/models/blog_post.rb
@@ -9,5 +9,12 @@ module Blog
 
   class Post
     extend ActiveModel::Naming
+    include ActiveModel::Validations
+
+    attr_accessor :title, :header, :editor
+    validates :title, :presence => true
+    validates :header, :presence => true
+    validates :editor, :presence => true
+
   end
 end


### PR DESCRIPTION
Implemented support for usage of alternative conventions for namespaced models in error messages. This solves issue #1402 completely. 

This means you can write your model errors like this:

en:
  activemodel:
    errors:
      models:
        blog:
          post:
            attributes:
              title:
                blank: "can't be blank - dot notation"
              header:
                blank: "can't be blank - dot notation"
        blog/post:
          attributes:
            title:
              blank: "can't be blank - slash notation"
            editor:
              blank: "can't be blank - slash notation"
