### PR TITLE
Support for custom Relation classes

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -657,11 +657,8 @@ module ActiveRecord #:nodoc:
       #     set_table_name "project"
       #   end
       def set_table_name(value = nil, &block)
-        @quoted_table_name = nil
+        @quoted_table_name = @arel_table = @relation = nil
         define_attr_method :table_name, value, &block
-        @arel_table = nil
-
-        @relation = create_relation
       end
       alias :table_name= :set_table_name
 

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -661,7 +661,7 @@ module ActiveRecord #:nodoc:
         define_attr_method :table_name, value, &block
         @arel_table = nil
 
-        @relation = Relation.new(self, arel_table)
+        @relation = create_relation
       end
       alias :table_name= :set_table_name
 
@@ -974,13 +974,17 @@ module ActiveRecord #:nodoc:
       private
 
         def relation #:nodoc:
-          @relation ||= Relation.new(self, arel_table)
+          @relation ||= create_relation
 
           if finder_needs_type_condition?
             @relation.where(type_condition).create_with(inheritance_column.to_sym => sti_name)
           else
             @relation
           end
+        end
+
+        def create_relation
+          Relation.new(self, arel_table)
         end
 
         def find_sti_class(type_name)

--- a/activerecord/test/cases/custom_relation_test.rb
+++ b/activerecord/test/cases/custom_relation_test.rb
@@ -1,0 +1,76 @@
+require "cases/helper"
+require "models/secure_person"
+
+class CustomRelationTest < ActiveRecord::TestCase
+  def test_scope_returns_the_custom_relation
+    assert_equal SecurePerson.scoped.class, EncryptedRelation
+  end
+
+  def test_spawns_the_custom_relation_on_where
+    assert_equal SecurePerson.where(:name => "test").class, EncryptedRelation
+  end
+
+  def test_spawns_the_custom_relation_on_select
+    assert_equal SecurePerson.select(:name).class, EncryptedRelation
+  end
+
+  def test_spawns_the_custom_relation_on_group
+    assert_equal SecurePerson.group(:parent).class, EncryptedRelation
+  end
+
+  def test_spawns_the_custom_relation_on_order
+    assert_equal SecurePerson.order(:name).class, EncryptedRelation
+  end
+
+  def test_spawns_the_custom_relation_on_except
+    assert_equal SecurePerson.except(:name).class, EncryptedRelation
+  end
+
+  def test_spawns_the_custom_relation_on_reorder
+    assert_equal SecurePerson.reorder(:name).class, EncryptedRelation
+  end
+
+  def test_spawns_the_custom_relation_on_limit
+    assert_equal SecurePerson.limit(5).class, EncryptedRelation
+  end
+
+  def test_spawns_the_custom_relation_on_offset
+    assert_equal SecurePerson.offset(5).class, EncryptedRelation
+  end
+
+  def test_spawns_the_custom_relation_on_joins
+    assert_equal SecurePerson.joins(:parent).class, EncryptedRelation
+  end
+
+  def test_spawns_the_custom_relation_on_where
+    assert_equal SecurePerson.where(:name => "test").class, EncryptedRelation
+  end
+
+  def test_spawns_the_custom_relation_on_preload
+    assert_equal SecurePerson.preload(:parent).class, EncryptedRelation
+  end
+
+  def test_spawns_the_custom_relation_on_eager_load
+    assert_equal SecurePerson.eager_load(:parent).class, EncryptedRelation
+  end
+
+  def test_spawns_the_custom_relation_on_includes
+    assert_equal SecurePerson.includes(:parent).class, EncryptedRelation
+  end
+
+  def test_spawns_the_custom_relation_on_from
+    assert_equal SecurePerson.from(:secure_people).class, EncryptedRelation
+  end
+
+  def test_spawns_the_custom_relation_on_lock
+    assert_equal SecurePerson.lock(:name).class, EncryptedRelation
+  end
+
+  def test_spawns_the_custom_relation_on_readonly
+    assert_equal SecurePerson.readonly.class, EncryptedRelation
+  end
+
+  def test_spawns_the_custom_relation_on_having
+    assert_equal SecurePerson.having(:name => "test").class, EncryptedRelation
+  end
+end

--- a/activerecord/test/models/secure_person.rb
+++ b/activerecord/test/models/secure_person.rb
@@ -1,0 +1,22 @@
+class SecurePerson < ActiveRecord::Base
+  belongs_to :parent, :class_name => "SecurePerson"
+
+  before_save :encrypt_name
+
+  private
+
+  def encrypt_name
+    self.name = name.reverse
+  end
+
+  def self.create_relation
+    EncryptedRelation.new(self, arel_table)
+  end
+end
+
+class EncryptedRelation < ActiveRecord::Relation
+  def build_where(opts, *args)
+    opts[:name] = opts[:name].reverse if opts[:name]
+    super
+  end
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -709,6 +709,11 @@ ActiveRecord::Schema.define do
     t.string 'a$b'
   end
 
+  create_table :secure_people, :force => true do |t|
+    t.integer :parent_id
+    t.string :name
+  end
+
   except 'SQLite' do
     # fk_test_has_fk should be before fk_test_has_pk
     create_table :fk_test_has_fk, :force => true do |t|


### PR DESCRIPTION
Just extracted the creation of the Relation object to a separated method, so we can easily use a subclassed relation.
