### PR TITLE
QueryCache/ConnectionPool thread fix

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -314,7 +314,7 @@ module ActiveRecord
       end
 
       def current_connection_id #:nodoc:
-        Thread.current.object_id
+        ActiveRecord::Base.connection_id ||= Thread.current.object_id
       end
 
       def checkout_new_connection

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -293,7 +293,7 @@ module ActiveRecord
       end
 
       def current_connection_id #:nodoc:
-        Thread.current.object_id
+        ActiveRecord::Base.connection_id ||= Thread.current.object_id
       end
 
       def checkout_new_connection

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_specification.rb
@@ -89,6 +89,14 @@ module ActiveRecord
         retrieve_connection
       end
 
+      def connection_id
+        Thread.current['ActiveRecord::Base.connection_id']
+      end
+
+      def connection_id=(connection_id)
+        Thread.current['ActiveRecord::Base.connection_id'] = connection_id
+      end
+
       # Returns the configuration of the associated connection as a hash:
       #
       #  ActiveRecord::Base.connection_config

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -28,9 +28,10 @@ module ActiveRecord
     end
 
     class BodyProxy # :nodoc:
-      def initialize(original_cache_value, target)
+      def initialize(original_cache_value, target, connection_id)
         @original_cache_value = original_cache_value
         @target               = target
+        @connection_id        = connection_id
       end
 
       def method_missing(method_sym, *arguments, &block)
@@ -48,6 +49,7 @@ module ActiveRecord
       def close
         @target.close if @target.respond_to?(:close)
       ensure
+        ActiveRecord::Base.connection_id = @connection_id
         ActiveRecord::Base.connection.clear_query_cache
         unless @original_cache_value
           ActiveRecord::Base.connection.disable_query_cache!
@@ -60,7 +62,7 @@ module ActiveRecord
       ActiveRecord::Base.connection.enable_query_cache!
 
       status, headers, body = @app.call(env)
-      [status, headers, BodyProxy.new(old, body)]
+      [status, headers, BodyProxy.new(old, body, ActiveRecord::Base.connection_id)]
     rescue Exception => e
       ActiveRecord::Base.connection.clear_query_cache
       unless old

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -28,9 +28,10 @@ module ActiveRecord
     end
 
     class BodyProxy # :nodoc:
-      def initialize(original_cache_value, target)
+      def initialize(original_cache_value, target, connection_id)
         @original_cache_value = original_cache_value
         @target               = target
+        @connection_id        = connection_id
       end
 
       def each(&block)
@@ -40,6 +41,7 @@ module ActiveRecord
       def close
         @target.close if @target.respond_to?(:close)
       ensure
+        ActiveRecord::Base.connection_id = @connection_id
         ActiveRecord::Base.connection.clear_query_cache
         unless @original_cache_value
           ActiveRecord::Base.connection.disable_query_cache!
@@ -52,7 +54,7 @@ module ActiveRecord
       ActiveRecord::Base.connection.enable_query_cache!
 
       status, headers, body = @app.call(env)
-      [status, headers, BodyProxy.new(old, body)]
+      [status, headers, BodyProxy.new(old, body, ActiveRecord::Base.connection_id)]
     end
   end
 end

--- a/railties/guides/source/asset_pipeline.textile
+++ b/railties/guides/source/asset_pipeline.textile
@@ -398,7 +398,7 @@ This can be changed with the +config.assets.manifest+ option. A fully specified 
 config.assets.manifest = '/path/to/some/other/location'
 </erb>
 
-NOTE: If there are missing precompiled files in production you will get an <tt>AssetNoPrecompiledError</tt> exception indicating the name of the missing file(s).
+NOTE: If there are missing precompiled files in production you will get an <tt>Sprockets::Helpers::RailsHelper:: AssetPaths::AssetNotPrecompiledError</tt> exception indicating the name of the missing file(s).
 
 h5. Server Configuration
 
@@ -436,9 +436,9 @@ location ~ ^/assets/ {
 }
 </plain>
 
-When files are precompiled, Sprockets also creates a "Gzip":http://en.wikipedia.org/wiki/Gzip (.gz) version of your assets. This avoids the server having to do this for any requests; it can simply read the compressed files from disk. You must configure your server to use gzip compression and serve the compressed assets that will be stored in the +public/assets+ folder. The following configuration options can be used:
+When files are precompiled, Sprockets also creates a "gzipped":http://en.wikipedia.org/wiki/Gzip (.gz) version of your assets. Web servers are typically configured to use a moderate compression ratio as a compromise, but since precompilation happens once Sprockets uses the maximum compression ratio, thus reducing the size of the data transfer to the minimum. One the other hand, web servers can be configured to serve compressed content directly from disk, rather than deflating non-compressed files themselves.
 
-For Apache:
+A possible configuration for Apache could be:
 
 <plain>
 <LocationMatch "^/assets/.*$">

--- a/railties/guides/source/asset_pipeline.textile
+++ b/railties/guides/source/asset_pipeline.textile
@@ -398,7 +398,7 @@ This can be changed with the +config.assets.manifest+ option. A fully specified 
 config.assets.manifest = '/path/to/some/other/location'
 </erb>
 
-NOTE: If there are missing precompiled files in production you will get an <tt>Sprockets::Helpers::RailsHelper:: AssetPaths::AssetNotPrecompiledError</tt> exception indicating the name of the missing file(s).
+NOTE: If there are missing precompiled files in production you will get an <tt>Sprockets::Helpers::RailsHelper::AssetPaths::AssetNotPrecompiledError</tt> exception indicating the name of the missing file(s).
 
 h5. Server Configuration
 


### PR DESCRIPTION
Under thin, QueryCache is leaking connections.

This is caused by the fact that the thread that runs the `QueryCache::BodyProxy#close` method is not the same as the thread that executes `QueryCache#call`.  A connection is checked out within `QueryCache#call`; this connection becomes orphaned, while a new connection is checked out within `#close` when the`clear_query_cache` call is made.

This patch prevents the connection checked out within `QueryCache#call` from being orphaned by creating an identifier that is stored within a thread local and used within `ConnectionPool` to uniquely identify the connection.  This identifier is passed to `BodyProxy` at construction time and pushed into the thread that ultimately becomes responsible for the `clear_query_cache` call.

The connection is subsequently checked back in as expected at the end of the request lifecycle, plugging the leak.
