### PR TITLE
Using linecache 0.43 for 1.8 build. 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem "memcache-client", ">= 1.8.5"
 platforms :mri_18 do
   gem "system_timer"
   gem "ruby-debug", ">= 0.10.3"
+  gem "linecache", " 0.43"
   gem "json"
 end
 
@@ -59,6 +60,7 @@ end
 
 platforms :jruby do
   gem "ruby-debug", ">= 0.10.3"
+  gem "linecache", " 0.43"
   gem "json"
   gem "activerecord-jdbcsqlite3-adapter"
 


### PR DESCRIPTION
As linecache updated to 0.45. It breaks the build for 1.8.7. 

They have added 

<pre>
require 'require_relative'
require_relative 'tracelines'
require_relative 'version'
</pre>


So the build gets failed with this version. May be we can create a issue with them to fix it in new version. But right now to run the Build with 1.8.7 we need to load linecache 0.43
