### PR TITLE
Namespace engine assets

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -11,15 +11,15 @@ module Rails
     def app
       if mountable?
         directory "app"
-        template "#{app_templates_dir}/app/views/layouts/application.html.erb.tt",
+        template "app/views/layouts/application.html.erb.tt",
                  "app/views/layouts/#{name}/application.html.erb"
-        empty_directory_with_gitkeep "app/assets/images"
+        empty_directory_with_gitkeep "app/assets/images/#{name}"
       elsif full?
         empty_directory_with_gitkeep "app/models"
         empty_directory_with_gitkeep "app/controllers"
         empty_directory_with_gitkeep "app/views"
         empty_directory_with_gitkeep "app/helpers"
-        empty_directory_with_gitkeep "app/assets/images"
+        empty_directory_with_gitkeep "app/assets/images/#{name}"
       end
     end
 
@@ -108,9 +108,9 @@ task :default => :test
     def stylesheets
       if mountable?
         copy_file "#{app_templates_dir}/app/assets/stylesheets/application.css",
-                  "app/assets/stylesheets/application.css"
+                  "app/assets/stylesheets/#{name}/application.css"
       elsif full?
-        empty_directory_with_gitkeep "app/assets/stylesheets"
+        empty_directory_with_gitkeep "app/assets/stylesheets/#{name}"
       end
     end
 
@@ -119,9 +119,9 @@ task :default => :test
 
       if mountable?
         template "#{app_templates_dir}/app/assets/javascripts/application.js.tt",
-                  "app/assets/javascripts/application.js"
+                  "app/assets/javascripts/#{name}/application.js"
       elsif full?
-        empty_directory_with_gitkeep "app/assets/javascripts"
+        empty_directory_with_gitkeep "app/assets/javascripts/#{name}"
       end
     end
 

--- a/railties/lib/rails/generators/rails/plugin_new/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/app/views/layouts/application.html.erb.tt
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title><%= camelized %></title>
+  <%%= stylesheet_link_tag    "<%= name %>/application" %>
+  <%%= javascript_include_tag "<%= name %>/application" %>
+  <%%= csrf_meta_tags %>
+</head>
+<body>
+
+<%%= yield %>
+
+</body>
+</html>

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -101,19 +101,19 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
 
   def test_skipping_javascripts_without_mountable_option
     run_generator
-    assert_no_file "app/assets/javascripts/application.js"
+    assert_no_file "app/assets/javascripts/bukkits/application.js"
     assert_no_file "vendor/assets/javascripts/jquery.js"
     assert_no_file "vendor/assets/javascripts/jquery_ujs.js"
   end
 
   def test_javascripts_generation
     run_generator [destination_root, "--mountable"]
-    assert_file "app/assets/javascripts/application.js"
+    assert_file "app/assets/javascripts/bukkits/application.js"
   end
 
   def test_jquery_is_the_default_javascript_library
     run_generator [destination_root, "--mountable"]
-    assert_file "app/assets/javascripts/application.js" do |contents|
+    assert_file "app/assets/javascripts/bukkits/application.js" do |contents|
       assert_match %r{^//= require jquery}, contents
       assert_match %r{^//= require jquery_ujs}, contents
     end
@@ -124,7 +124,7 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
 
   def test_other_javascript_libraries
     run_generator [destination_root, "--mountable", '-j', 'prototype']
-    assert_file "app/assets/javascripts/application.js" do |contents|
+    assert_file "app/assets/javascripts/bukkits/application.js" do |contents|
       assert_match %r{^//= require prototype}, contents
       assert_match %r{^//= require prototype_ujs}, contents
     end
@@ -135,7 +135,7 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
 
   def test_skip_javascripts
     run_generator [destination_root, "--skip-javascript", "--mountable"]
-    assert_no_file "app/assets/javascripts/application.js"
+    assert_no_file "app/assets/javascripts/bukkits/application.js"
     assert_no_file "vendor/assets/javascripts/jquery.js"
     assert_no_file "vendor/assets/javascripts/jquery_ujs.js"
   end
@@ -161,9 +161,9 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
 
   def test_creating_engine_in_full_mode
     run_generator [destination_root, "--full"]
-    assert_file "app/assets/javascripts"
-    assert_file "app/assets/stylesheets"
-    assert_file "app/assets/images"
+    assert_file "app/assets/javascripts/bukkits"
+    assert_file "app/assets/stylesheets/bukkits"
+    assert_file "app/assets/images/bukkits"
     assert_file "app/models"
     assert_file "app/controllers"
     assert_file "app/views"
@@ -180,15 +180,19 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
 
   def test_create_mountable_application_with_mountable_option
     run_generator [destination_root, "--mountable"]
-    assert_file "app/assets/javascripts"
-    assert_file "app/assets/stylesheets"
-    assert_file "app/assets/images"
+    assert_file "app/assets/javascripts/bukkits"
+    assert_file "app/assets/stylesheets/bukkits"
+    assert_file "app/assets/images/bukkits"
     assert_file "config/routes.rb", /Bukkits::Engine.routes.draw do/
     assert_file "lib/bukkits/engine.rb", /isolate_namespace Bukkits/
     assert_file "test/dummy/config/routes.rb", /mount Bukkits::Engine => "\/bukkits"/
     assert_file "app/controllers/bukkits/application_controller.rb", /module Bukkits\n  class ApplicationController < ActionController::Base/
     assert_file "app/helpers/bukkits/application_helper.rb", /module Bukkits\n  module ApplicationHelper/
-    assert_file "app/views/layouts/bukkits/application.html.erb", /<title>Bukkits<\/title>/
+    assert_file "app/views/layouts/bukkits/application.html.erb" do |contents|
+      assert_match "<title>Bukkits</title>", contents
+      assert_match /stylesheet_link_tag\s+['"]bukkits\/application['"]/, contents
+      assert_match /javascript_include_tag\s+['"]bukkits\/application['"]/, contents
+    end
   end
 
   def test_creating_gemspec


### PR DESCRIPTION
This changes the `plugin new --mountable` generator so it places javascript/stylesheet/image engine assets in their own namespaced directory so they don't conflict with those in the main app. Instead of `app/assets/javascripts/application.js` it places it in `app/assets/javascripts/ENGINE_NAME/application.js`. It also changes the `application.html.erb` layout file to use the new path.
