### PR TITLE
Fix for startup problems due to deprecation warning on nested models

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -99,18 +99,25 @@ module ActiveRecord
 
     config.after_initialize do
       container  = :"activerecord.attributes"
-      I18n.t(container, :default => {}).each do |key, value|
-        if value.is_a?(Hash) && value.any? { |k,v| v.is_a?(Hash) }
-          $stderr.puts "[DEPRECATION WARNING] Nested I18n namespace lookup under \"#{container}.#{key}\" is no longer supported"
+      lookup = I18n.t(container, :default => {})
+      if lookup.is_a?(Hash)
+        lookup.each do |key, value| 
+          if value.is_a?(Hash) && value.any? { |k,v| v.is_a?(Hash) }
+            $stderr.puts "[DEPRECATION WARNING] Nested I18n namespace lookup under \"#{container}.#{key}\" is no longer supported"
+          end
         end
       end
 
       container  = :"activerecord.models"
-      I18n.t(container, :default => {}).each do |key, value|
-        if value.is_a?(Hash)
-          $stderr.puts "[DEPRECATION WARNING] Nested I18n namespace lookup under \"#{container}.#{key}\" is no longer supported"
+      lookup = I18n.t(container, :default => {})
+      if lookup.is_a?(Hash)
+        lookup.each do |key, value|
+          if value.is_a?(Hash)
+            $stderr.puts "[DEPRECATION WARNING] Nested I18n namespace lookup under \"#{container}.#{key}\" is no longer supported"
+          end
         end
       end
     end
+
   end
 end


### PR DESCRIPTION
Only emit deprecation warning if there´s a Hash object under the keys "activerecord.models" and "activerecord.attributes". See issue #1662
