### PR TITLE
Fix problem with tests declared with nonalphanumeric characters in their name

### DIFF
--- a/activesupport/lib/active_support/testing/declarative.rb
+++ b/activesupport/lib/active_support/testing/declarative.rb
@@ -23,7 +23,8 @@ module ActiveSupport
         #   ...
         # end
         def test(name, &block)
-          test_name = "test_#{name.gsub(/\s+/,'_')}".to_sym
+          methodified_name = name.gsub(/\s+/,'_').gsub(/(\W)/) { |s| s.unpack('M') }
+          test_name = "test_#{methodified_name}".to_sym
           defined = instance_method(test_name) rescue false
           raise "#{test_name} is already defined in #{self}" if defined
           if block_given?


### PR DESCRIPTION
If I define my unit tests declaratively and use characters that are not alphanumeric, the Declarative module tries to generate a test method with an invalid name.  For example:

test "method's return value" do
   # something
end

Generates a test method called "s_return_value". This sucks when the tests run (especially in an IDE) because the test name displayed doesn't make any sense.  It also leads to some tricky bugs.  If I have another test method in the same suite like this:

test "other method's return value" do
   # something
end

The Declarative module has now blown away the first test method without telling me.  Gross.

This change MIME-encodes any nonprintable characters in the test method name, avoiding this issue.
