### PR TITLE
Allow STI building on has_many associations

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -161,6 +161,15 @@ module ActiveRecord
         @klass ||= active_record.send(:compute_type, class_name)
       end
 
+      def klass_with_sti(*opts)
+        sti_col = klass.inheritance_column
+        if (h = opts.first).is_a? Hash and (passed_type = ( h[sti_col] || h[sti_col.to_sym] ))
+          active_record.send(:compute_type, passed_type)
+        else
+          klass
+        end
+      end
+
       def initialize(macro, name, options, active_record)
         super
         @collection = macro.in?([:has_many, :has_and_belongs_to_many])
@@ -169,14 +178,14 @@ module ActiveRecord
       # Returns a new, unsaved instance of the associated class. +options+ will
       # be passed to the class's constructor.
       def build_association(*options)
-        klass.new(*options)
+        klass_with_sti(*options).new(*options)
       end
 
       # Creates a new instance of the associated class, and immediately saves it
       # with ActiveRecord::Base#save. +options+ will be passed to the class's
       # creation method. Returns the newly created object.
       def create_association(*options)
-        klass.create(*options)
+        klass_with_sti.create(*options)
       end
 
       # Creates a new instance of the associated class, and immediately saves it

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -161,6 +161,15 @@ module ActiveRecord
         @klass ||= active_record.send(:compute_type, class_name)
       end
 
+      # Returns the target association's class, taking into account opts.first[klass.inheritance_column] (usually opts.first[:type]).
+      #
+      #   class Author < ActiveRecord::Base
+      #     has_many :books
+      #   end
+      #
+      #   Author.reflect_on_association(:books).klass(:type => "ComicBook")
+      #   # => ComicBook
+      #
       def klass_with_sti(*opts)
         sti_col = klass.inheritance_column
         if (h = opts.first).is_a? Hash and (passed_type = ( h[sti_col] || h[sti_col.to_sym] ))

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1,4 +1,5 @@
 require "cases/helper"
+require 'models/bird'
 require 'models/developer'
 require 'models/project'
 require 'models/company'
@@ -6,6 +7,7 @@ require 'models/contract'
 require 'models/topic'
 require 'models/reply'
 require 'models/category'
+require 'models/pirate'
 require 'models/post'
 require 'models/author'
 require 'models/comment'
@@ -66,6 +68,25 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     bulb = car.bulbs.create(:name => 'exotic')
     assert_equal 'exotic', bulb.name
+  end
+
+  def test_create_from_association_with_type_should_respect_sti
+    pirate = Pirate.create!(:catchphrase => "SCAAAAAARRRRRRRRVES")
+    opts = {:name => "Grover"}
+
+    bird = pirate.birds.build opts.dup
+    assert_equal Bird, bird.class
+
+    bird = pirate.birds.create opts.dup
+    assert_equal Bird, bird.class
+
+    opts = opts.merge(Bird.inheritance_column => "Robin")
+
+    bird = pirate.birds.build opts.dup
+    assert_equal Robin, bird.class
+
+    bird = pirate.birds.create opts.dup
+    assert_equal Robin, bird.class
   end
 
   def test_create_from_association_with_nil_values_should_work

--- a/activerecord/test/models/bird.rb
+++ b/activerecord/test/models/bird.rb
@@ -7,3 +7,6 @@ class Bird < ActiveRecord::Base
     false
   end
 end
+
+class Robin < Bird
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define do
   create_table :birds, :force => true do |t|
     t.string :name
     t.string :color
+    t.string :type
     t.integer :pirate_id
   end
 


### PR DESCRIPTION
This is a patch for https://github.com/rails/rails/issues/815

Given:
class Tree < ActiveRecord::Base
has_many :birds
end

class Bird < ActiveRecord::Base; end
class Robin < Bird; end

Tree.birds.create(:type => "Robin") will create a robin.
