### PR TITLE
Failing Test Case for Issue #1692 Routes not found in TestRequest#assign_parameters

### DIFF
--- a/actionpack/test/controller/test_test.rb
+++ b/actionpack/test/controller/test_test.rb
@@ -439,6 +439,15 @@ XML
       assert_routing({ :method => 'post', :path => 'content' }, { :controller => 'content', :action => 'create' })
     end
   end
+  
+  def test_routing_with_method
+    with_routing do |set|
+      set.draw { |map| map.route 'testmethod', :controller => 'test_test/test', :action => 'create', :method => :post }
+      assert_nothing_raised {
+        post :create
+      }
+    end
+  end
 
   def test_assert_routing_in_module
     assert_routing 'admin/user', :controller => 'admin/user', :action => 'index'


### PR DESCRIPTION
I have encountered (probably) the following problem in a 2.3.12 app:

We have a route with `:method => :post`

In our controller test, calling `post action, …` fails unless I explicity set a `:format => :post` parameter although that should have been inferred by the `assign_parameters` method.

The reason for this is, as far as I figured out:
`assign_parameters` calls `Route#extra_keys`
_`extra_keys` calls `RouteSet#generate_extras`
__which in turn calls `route_generate_raw`
__which doesn't return a path
_which causes `RouteSet#generate` to raise a RoutingError

I'm not sure where exactly to fix this problem.
I'd simply add a line or two to `assign_parameters` that adds the `:format` to the options but I'm happy to implement other suggestions.

See issue #1692
