### PR TITLE
Add support to custom field on has_secure_password

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -5,13 +5,14 @@ module ActiveModel
     extend ActiveSupport::Concern
 
     module ClassMethods
-      # Adds methods to set and authenticate against a BCrypt password.
-      # This mechanism requires you to have a password_digest attribute.
+      # Adds methods to set and authenticate against a BCrypt password. 
+      # As default, this mechanism requires you to have a password_digest,
+      # attribute.
       #
       # Validations for presence of password, confirmation of password (using
       # a "password_confirmation" attribute) are automatically added.
       # You can add more validations by hand if need be.
-      #
+			# 
       # Example using Active Record (which automatically includes ActiveModel::SecurePassword):
       #
       #   # Schema: User(name:string, password_digest:string)
@@ -29,39 +30,67 @@ module ActiveModel
       #   user.authenticate("mUc3m00RsqyRe")                             # => user
       #   User.find_by_name("david").try(:authenticate, "notright")      # => nil
       #   User.find_by_name("david").try(:authenticate, "mUc3m00RsqyRe") # => user
-      def has_secure_password
-        attr_reader :password
+			#
+      # Example using custom fields:
+      #
+      #   # Schema: Account(name:string, phrase:string)
+      #   class Account < ActiveRecord::Base
+      #     has_secure_password :password, :phrase
+      #   end
+			#
+			#   account = Account.create
+			#   account.errors[:phrase]  # => ["can't be blank"]
+			#	
+      #   account = Account.new(:name => "david", :password => "", :password_confirmation => "nomatch")
+      #   account.save                                                      # => false, password required
+      #   account.password = "mUc3m00RsqyRe"
+      #   account.save                                                      # => false, confirmation doesn't match
+      #   account.password_confirmation = "mUc3m00RsqyRe"
+      #   account.save                                                      # => true
+      #   account.authenticate("notright")                                  # => false
+      #   account.authenticate("mUc3m00RsqyRe")                             # => account
+      #   Account.find_by_name("david").try(:authenticate, "notright")      # => nil
+      #   Account.find_by_name("david").try(:authenticate, "mUc3m00RsqyRe") # => account
+			#
+      # Configuration options:
+      # * <tt>password_attribute</tt> - Specifies the virtual password attribute. (default is: :password)
+      # * <tt>password_digest_attribute<tt> - Speficies the real password attribute. (default is: Considering the <tt>password_attribute</tt> as :password, :password_digest
+      def has_secure_password(password_attribute = :password, password_digest_attribute = "#{password_attribute}_digest")
+	      password_attribute = password_attribute.to_sym
+	      password_digest_attribute = password_digest_attribute.to_sym
+	      
+        attr_reader password_attribute
 
-        validates_confirmation_of :password
-        validates_presence_of     :password_digest
+        validates_confirmation_of password_attribute
+        validates_presence_of     password_digest_attribute
+        
+        # Returns self if the password is correct, otherwise false.
+        define_method(:authenticate) do |unencrypted_password|
+		      if BCrypt::Password.new(instance_variable_get("@#{password_digest_attribute}")) == unencrypted_password
+		        self
+		      else
+		        false
+		      end
+		    end
+		    
+		    # Encrypts the password into the password_digest attribute.
+		    define_method("#{password_attribute}=") do |unencrypted_password|
+		      instance_variable_set "@#{password_attribute}", unencrypted_password
+		      
+		      unless unencrypted_password.blank?
+		      	instance_variable_set "@#{password_digest_attribute}", BCrypt::Password.create(unencrypted_password)
+		      end
+		    end
 
-        include InstanceMethodsOnActivation
-
-        if respond_to?(:attributes_protected_by_default)
+        if self.respond_to?(:attributes_protected_by_default)
+        	# FIXME: Work around to get the password_digest_attribute name
+          @@has_secure_password_digest_attribute = password_digest_attribute.to_s
           def self.attributes_protected_by_default
-            super + ['password_digest']
+            super + [@@has_secure_password_digest_attribute]
           end
         end
       end
     end
 
-    module InstanceMethodsOnActivation
-      # Returns self if the password is correct, otherwise false.
-      def authenticate(unencrypted_password)
-        if BCrypt::Password.new(password_digest) == unencrypted_password
-          self
-        else
-          false
-        end
-      end
-
-      # Encrypts the password into the password_digest attribute.
-      def password=(unencrypted_password)
-        @password = unencrypted_password
-        unless unencrypted_password.blank?
-          self.password_digest = BCrypt::Password.create(unencrypted_password)
-        end
-      end
-    end
   end
 end

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -21,9 +21,9 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert !user.valid?, 'user should be invalid'
   end
 
-  test "password must be present" do
+  test "password digest must be present" do
     assert !@user.valid?
-    assert_equal 1, @user.errors.size
+    assert_equal ["can't be blank"], @user.errors[:password_digest]
   end
 
   test "password must match confirmation" do
@@ -54,5 +54,5 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert active_authorizer.kind_of?(ActiveModel::MassAssignmentSecurity::WhiteList)
     assert !active_authorizer.include?(:password_digest)
     assert active_authorizer.include?(:name)
-  end
+  end  
 end


### PR DESCRIPTION
 # Schema: Account(name:string, phrase:string)
 class Account < ActiveRecord::Base
  has_secure_password :password, :phrase
 end

 account = Account.create
 account.errors[:phrase]  # => ["can't be blank"]

 account = Account.new(:name => "david", :password => "", :password_confirmation => "nomatch")
 account.save  # => false, password required
 account.password = "mUc3m00RsqyRe"
 account.save  # => false, confirmation doesn't match
 account.password_confirmation = "mUc3m00RsqyRe"
 account.save  # => true
 account.authenticate("notright")  # => false
 account.authenticate("mUc3m00RsqyRe")  # => account 
 Account.find_by_name("david").try(:authenticate, "notright") # => nil 
 Account.find_by_name("david").try(:authenticate, "mUc3m00RsqyRe") # => account
