### PR TITLE
[3.1.0.rc1] Plugins inside engines not eager-loaded properly and their rake tasks ignored

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -78,10 +78,6 @@ module Rails
       require environment if environment
     end
 
-    def eager_load! #:nodoc:
-      railties.all(&:eager_load!)
-      super
-    end
 
     def reload_routes!
       routes_reloader.reload!
@@ -100,22 +96,18 @@ module Rails
 
     def load_tasks(app=self)
       initialize_tasks
-      railties.all { |r| r.load_tasks(app) }
       super
       self
     end
 
     def load_generators(app=self)
       initialize_generators
-      railties.all { |r| r.load_generators(app) }
-
       super
       self
     end
 
     def load_console(app=self)
       initialize_console
-      railties.all { |r| r.load_console(app) }
       super
       self
     end

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -387,12 +387,25 @@ module Rails
     delegate :middleware, :root, :paths, :to => :config
     delegate :engine_name, :isolated?, :to => "self.class"
 
-    def load_tasks(*)
+    def load_tasks(app=self)
+      railties.all { |r| r.load_tasks(app) }
       super
       paths["lib/tasks"].existent.sort.each { |ext| load(ext) }
     end
+    
+    def load_generators(app=self)
+      railties.all { |r| r.load_generators(app) }
+      super
+    end
 
+    def load_console(app=self)
+      railties.all { |r| r.load_console(app) }
+      super
+    end
+    
     def eager_load!
+      railties.all(&:eager_load!)
+      
       config.eager_load_paths.each do |load_path|
         matcher = /\A#{Regexp.escape(load_path)}\/(.*)\.rb\Z/
         Dir.glob("#{load_path}/**/*.rb").sort.each do |file|


### PR DESCRIPTION
Working with the new support for plugins inside engines in Rails 3.1, I found that certain things that work for regular plugins don't work for these new nested plugins. In particular, these methods in `Rails::Engine` don't seem to understand that an engine could have nested plugins:
- #load_tasks
- #load_generators
- #load_console
- #eager_load!

A solution which worked out for me is to move the calls to `railties.all { ... }` from the overriding methods in `Rails::Application` into `Rails::Engine`, i.e. changing `Rails::Engine` to look like this:

```
def load_tasks
  railties.all { |r| r.load_tasks }
  super
  paths["lib/tasks"].existent.sort.each { |ext| load(ext) }
end

def load_generators
  railties.all { |r| r.load_generators }
  super
end

def load_console(sandbox=false)
  railties.all { |r| r.load_console(sandbox) }
  super
end

def eager_load!
  railties.all(&:eager_load!)

  config.eager_load_paths.each do |load_path|
    matcher = /\A#{Regexp.escape(load_path)}\/(.*)\.rb\Z/
    Dir.glob("#{load_path}/**/*.rb").sort.each do |file|
      require_dependency file.sub(matcher, '\1')
    end
  end
end
```

...and `Rails::Application` to look like this (after also removing `eager_load!` entirely):

```
def load_tasks
  initialize_tasks
  super
  self
end

def load_generators
  initialize_generators
  super
  self
end

def load_console(sandbox=false)
  initialize_console(sandbox)
  super
  self
end
```

(Note also the removal of the `()` from `load_console`'s call to `super` so as to preserve the sandbox argument,)
