### PR TITLE
[3.1.0.rc1] App plugins initialized before engines and plugins inside engines

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -78,10 +78,6 @@ module Rails
       require environment if environment
     end
 
-    def eager_load! #:nodoc:
-      railties.all(&:eager_load!)
-      super
-    end
 
     def reload_routes!
       routes_reloader.reload!
@@ -100,22 +96,18 @@ module Rails
 
     def load_tasks(app=self)
       initialize_tasks
-      railties.all { |r| r.load_tasks(app) }
       super
       self
     end
 
     def load_generators(app=self)
       initialize_generators
-      railties.all { |r| r.load_generators(app) }
-
       super
       self
     end
 
     def load_console(app=self)
       initialize_console
-      railties.all { |r| r.load_console(app) }
       super
       self
     end

--- a/railties/lib/rails/application/railties.rb
+++ b/railties/lib/rails/application/railties.rb
@@ -4,9 +4,9 @@ module Rails
   class Application < Engine
     class Railties < Rails::Engine::Railties
       def all(&block)
-        @all ||= railties + engines + super
-        @all.each(&block) if block
-        @all
+        @railties_plus_engines ||= railties + engines
+        @railties_plus_engines.each(&block) if block
+        @railties_plus_engines + super
       end
     end
   end

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -387,12 +387,25 @@ module Rails
     delegate :middleware, :root, :paths, :to => :config
     delegate :engine_name, :isolated?, :to => "self.class"
 
-    def load_tasks(*)
+    def load_tasks(app=self)
+      railties.all { |r| r.load_tasks(app) }
       super
       paths["lib/tasks"].existent.sort.each { |ext| load(ext) }
     end
+    
+    def load_generators(app=self)
+      railties.all { |r| r.load_generators(app) }
+      super
+    end
 
+    def load_console(app=self)
+      railties.all { |r| r.load_console(app) }
+      super
+    end
+    
     def eager_load!
+      railties.all(&:eager_load!)
+      
       config.eager_load_paths.each do |load_path|
         matcher = /\A#{Regexp.escape(load_path)}\/(.*)\.rb\Z/
         Dir.glob("#{load_path}/**/*.rb").sort.each do |file|


### PR DESCRIPTION
It seems that plugins inside a Rails 3.1 application proper (i.e. in /vendor/plugins) are initialized **before** engines and plugins inside engines.

After some debugging, I found the culprit in `Rails::Application::Railties#all`:

```
  def all(&block)
    @all ||= railties + engines + super
    @all.each(&block) if block
    @all
  end
```

The call to `super` here implicitly passes the `&block` argument, which has the unfortunate side-effect of adding the plugin initializers **first** (in front of other railties and engines) in the case of `Rails::Engine#initializers`:

```
def initializers
  initializers = []
  railties.all { |r| initializers += r.initializers }
  initializers += super
  initializers
end
```

One solution that works here is to change how `super` is called, e.g. this works:

```
  def all(&block)
    @railties_plus_engines ||= railties + engines
    @railties_plus_engines.each(&block) if block
    @railties_plus_engines + super
  end
```

(Here I'm deliberately not memoizing the result so that `super` is always called, and that the block is run against the plugins **after** it has been run against the railties and engines first.)

This is one of the issues blocking our efforts to migrate to Rails 3.1.
