### PR TITLE
Turn off mysql2's eager-casting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ platforms :ruby do
   group :db do
     gem "pg", ">= 0.11.0"
     gem "mysql", ">= 2.8.1"
-    gem "mysql2", ">= 0.3.0"
+    gem "mysql2", ">= 0.3.3"
   end
 end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -629,7 +629,7 @@ module ActiveRecord
         end
 
         def configure_connection
-          @connection.query_options.merge!(:as => :array)
+          @connection.query_options.merge!(:as => :array, :cast => false)
 
           # By default, MySQL 'where id is null' selects the last inserted id.
           # Turn this off. http://dev.rubyonrails.org/ticket/6778

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-gem 'mysql2', '~> 0.3.0'
+gem 'mysql2', '~> 0.3.3'
 require 'mysql2'
 
 module ActiveRecord


### PR DESCRIPTION
As of mysql2 0.2.8 and 0.3.3, eager-casting down in C can be disabled.

This should help performance by allowing ActiveRecord to lazily cast row values upon access (like the mysql adapter is doing). My rudimentary benchmarks show it performing about on-par with the mysql adapter, but has the added benefit of being fully thread-safe, even in Ruby 1.8 (and 1.9 obviously).
