### PR TITLE
Allow last argument to be a boolean in memoized methods

### DIFF
--- a/activesupport/lib/active_support/memoizable.rb
+++ b/activesupport/lib/active_support/memoizable.rb
@@ -79,7 +79,11 @@ module ActiveSupport
           else                                                                     # else
             def #{symbol}(*args)                                                   #   def mime_type(*args)
               #{memoized_ivar} ||= {} unless frozen?                               #     @_memoized_mime_type ||= {} unless frozen?
-              reload = args.pop if args.last == true || args.last == :reload       #     reload = args.pop if args.last == true || args.last == :reload
+              args_length = method(:#{original_method}).arity                      #     args_length = method(:_unmemoized_mime_type).arity
+              if args.length == args_length + 1 &&                                 #     if args.length == args_length + 1 &&
+                (args.last == true || args.last == :reload)                        #       (args.last == true || args.last == :reload)
+                reload = args.pop                                                  #       reload = args.pop
+              end                                                                  #     end
                                                                                    #
               if defined?(#{memoized_ivar}) && #{memoized_ivar}                    #     if defined?(@_memoized_mime_type) && @_memoized_mime_type
                 if !reload && #{memoized_ivar}.has_key?(args)                      #       if !reload && @_memoized_mime_type.has_key?(args)

--- a/activesupport/test/memoizable_test.rb
+++ b/activesupport/test/memoizable_test.rb
@@ -96,6 +96,15 @@ class MemoizableTest < ActiveSupport::TestCase
     end
     memoize :fib
 
+    def add_or_subtract(i, j, add)
+      if add
+        i + j
+      else
+        i - j
+      end
+    end
+    memoize :add_or_subtract
+
     def counter
       @count ||= 0
       @count += 1
@@ -197,6 +206,11 @@ class MemoizableTest < ActiveSupport::TestCase
     assert_equal 12, @calculator.fib_calls
     assert_equal 55, @calculator.fib(10, true)
     assert_equal 13, @calculator.fib_calls
+  end
+
+  def test_memoization_with_boolean_arg
+    assert_equal 4, @calculator.add_or_subtract(2, 2, true)
+    assert_equal 2, @calculator.add_or_subtract(4, 2, false)
   end
 
   def test_object_memoization


### PR DESCRIPTION
See #1704 for the detailed bug report.
