### PR TITLE
Make "select" helper handle nested collections

### DIFF
--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -105,7 +105,10 @@ module ActionView
 
       # Create a select tag and a series of contained option tags for the provided object and method.
       # The option currently held by the object will be selected, provided that the object is available.
-      # See options_for_select for the required format of the choices parameter.
+      #
+      # There are two possible formats for the choices parameter, corresponding to other helpers' output:
+      #   * A flat collection: see options_for_select
+      #   * A nested collection: see grouped_options_for_select
       #
       # Example with @post.person_id => 1:
       #   select("post", "person_id", Person.all.collect {|p| [ p.name, p.id ] }, { :include_blank => true })
@@ -575,7 +578,14 @@ module ActionView
 
       def to_select_tag(choices, options, html_options)
         selected_value = options.has_key?(:selected) ? options[:selected] : value(object)
-        select_content_tag(options_for_select(choices, :selected => selected_value, :disabled => options[:disabled]), options, html_options)
+
+        if !choices.empty? && choices.try(:first).try(:second).respond_to?(:each)
+          option_tags = grouped_options_for_select(choices, :selected => selected_value, :disabled => options[:disabled])
+        else
+          option_tags = options_for_select(choices, :selected => selected_value, :disabled => options[:disabled])
+        end
+
+        select_content_tag(option_tags, options, html_options)
       end
 
       def to_collection_select_tag(collection, value_method, text_method, options, html_options)

--- a/actionpack/test/template/form_options_helper_test.rb
+++ b/actionpack/test/template/form_options_helper_test.rb
@@ -385,6 +385,42 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_select_with_grouped_collection_as_nested_array
+    @post = Post.new
+
+    countries_by_continent = [
+      ["<Africa>", [["<South Africa>", "<sa>"], ["Somalia", "so"]]],
+      ["Europe",   [["Denmark", "dk"], ["Ireland", "ie"]]],
+    ]
+
+    assert_dom_equal(
+      [
+        %Q{<select id="post_origin" name="post[origin]"><optgroup label="&lt;Africa&gt;"><option value="&lt;sa&gt;">&lt;South Africa&gt;</option>},
+        %Q{<option value="so">Somalia</option></optgroup><optgroup label="Europe"><option value="dk">Denmark</option>},
+        %Q{<option value="ie">Ireland</option></optgroup></select>},
+      ].join("\n"),
+      select("post", "origin", countries_by_continent)
+    )
+  end
+
+  def test_select_with_grouped_collection_as_hash
+    @post = Post.new
+
+    countries_by_continent = {
+      "<Africa>" => [["<South Africa>", "<sa>"], ["Somalia", "so"]],
+      "Europe"   => [["Denmark", "dk"], ["Ireland", "ie"]],
+    }
+
+    assert_dom_equal(
+      [
+        %Q{<select id="post_origin" name="post[origin]"><optgroup label="&lt;Africa&gt;"><option value="&lt;sa&gt;">&lt;South Africa&gt;</option>},
+        %Q{<option value="so">Somalia</option></optgroup><optgroup label="Europe"><option value="dk">Denmark</option>},
+        %Q{<option value="ie">Ireland</option></optgroup></select>},
+      ].join("\n"),
+      select("post", "origin", countries_by_continent)
+    )
+  end
+
   def test_select_with_boolean_method
     @post = Post.new
     @post.allow_comments = false


### PR DESCRIPTION
The `select` form helper generates a select tag with options from the given `[key, value]` pairs. This works only for "flat" collections, but I'd like to have it work with nested ones as well. An example:

```
@post = Post.new
select("post", "origin", {
  "Africa" => [["South Africa", "sa"], ["Somalia", "so"]],
  "Europe" => [["Denmark", "dk"], ["Ireland", "ie"]],
})
```

Currently, `select` uses "Africa" and "Europe" as the content of the option tags, and calls `to_s` on the arrays for the values. With this pull request, the result would instead be something like this:

```
<select id="post_origin" name="post[origin]">
  <optgroup label="Africa">
    <option value="sa">South Africa</option>
    <option value="so">Somalia</option>
  </optgroup>
  <optgroup label="Europe">
    <option value="dk">Denmark</option>
    <option value="ie">Ireland</option>
  </optgroup>
</select>
```

Internally, the choices are simply handed to `grouped_options_for_select` if the collection is more than one level deep.
