### PR TITLE
re-enable eager-casting for mysql2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ platforms :ruby do
   group :db do
     gem "pg", ">= 0.11.0"
     gem "mysql", ">= 2.8.1"
-    gem "mysql2", ">= 0.3.3"
+    gem "mysql2", ">= 0.3.4"
   end
 end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -629,7 +629,7 @@ module ActiveRecord
         end
 
         def configure_connection
-          @connection.query_options.merge!(:as => :array, :cast => false)
+          @connection.query_options.merge!(:as => :array)
 
           # By default, MySQL 'where id is null' selects the last inserted id.
           # Turn this off. http://dev.rubyonrails.org/ticket/6778

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-gem 'mysql2', '~> 0.3.3'
+gem 'mysql2', '~> 0.3.4'
 require 'mysql2'
 
 module ActiveRecord


### PR DESCRIPTION
Users can disable this by setting `cast: false` in database.yml
