### PR TITLE
Improve the legacy wild controller route in app templates

### DIFF
--- a/actionpack/lib/action_dispatch/routing.rb
+++ b/actionpack/lib/action_dispatch/routing.rb
@@ -161,7 +161,7 @@ module ActionDispatch
   # Consider the following route, which you will find commented out at the
   # bottom of your generated <tt>config/routes.rb</tt>:
   #
-  #   match ':controller(/:action(/:id(.:format)))'
+  #   match ':controller(/:action(/:id))(.:format)'
   #
   # This route states that it expects requests to consist of a
   # <tt>:controller</tt> followed optionally by an <tt>:action</tt> that in

--- a/railties/lib/rails/generators/rails/app/templates/config/routes.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/routes.rb
@@ -54,5 +54,5 @@
 
   # This is a legacy wild controller route that's not recommended for RESTful applications.
   # Note: This route will make all actions in every controller accessible via GET requests.
-  # match ':controller(/:action(/:id(.:format)))'
+  # match ':controller(/:action(/:id))(.:format)'
 end


### PR DESCRIPTION
The original version matchs as follows
- /foo
- /foo/bar
- /foo/bar/1
- /foo.json  (Routing Error)
- /foo/bar.json  (Routing Error)
- /foo/bar/1.json

This pull request corrects these two routing erros.
