### PR TITLE
Fix underscore can't work with html safe string

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -46,7 +46,7 @@ module ActiveSupport
     #
     #   "SSLError".underscore.camelize # => "SslError"
     def underscore(camel_cased_word)
-      word = camel_cased_word.to_s.dup
+      word = camel_cased_word.to_str.dup
       word.gsub!(/::/, '/')
       word.gsub!(/([A-Z]+)([A-Z][a-z])/,'\1_\2')
       word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -103,6 +103,15 @@ class InflectorTest < Test::Unit::TestCase
     end
   end
 
+  def test_underscore_with_safe_buffer
+    CamelToUnderscore.each do |camel, underscore|
+      assert_equal(underscore, ActiveSupport::Inflector.underscore(ActiveSupport::SafeBuffer.new(camel)))
+    end
+    CamelToUnderscoreWithoutReverse.each do |camel, underscore|
+      assert_equal(underscore, ActiveSupport::Inflector.underscore(ActiveSupport::SafeBuffer.new(camel)))
+    end
+  end
+
   def test_camelize_with_module
     CamelWithModuleToUnderscoreWithSlash.each do |camel, underscore|
       assert_equal(camel, ActiveSupport::Inflector.camelize(underscore))


### PR DESCRIPTION
In #underscore gsub! is used to modify string, when the string is a SafeBuffer instance an exception will be raised. It cause errors when you use radio_button with translated string:

```
ActionView::Template::Error (Cannot modify SafeBuffer in place):
    25:     <%= f.radio_button :signup_type, t('site.account_signup_close_label') %>
```
