### PR TITLE
Replace dev.rubyonrails.com plugin url with a dummy url

### DIFF
--- a/railties/lib/rails/commands/plugin.rb
+++ b/railties/lib/rails/commands/plugin.rb
@@ -313,11 +313,11 @@ module Commands
         o.separator ""
         o.separator "EXAMPLES"
         o.separator "  Install a plugin from a subversion URL:"
-        o.separator "    #{@script_name} plugin install http://dev.rubyonrails.com/svn/rails/plugins/continuous_builder\n"
+        o.separator "    #{@script_name} plugin install http://example.com/my_svn_plugin\n"
         o.separator "  Install a plugin from a git URL:"
         o.separator "    #{@script_name} plugin install git://github.com/SomeGuy/my_awesome_plugin.git\n"
         o.separator "  Install a plugin and add a svn:externals entry to vendor/plugins"
-        o.separator "    #{@script_name} plugin install -x continuous_builder\n"
+        o.separator "    #{@script_name} plugin install -x my_svn_plugin\n"
       end
     end
 


### PR DESCRIPTION
Replace dev.rubyonrails.com plugin url with a dummy url
