### PR TITLE
Cherry-picking patch for https://github.com/rails/rails/issues/1460 from 3-1-stable to master

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -78,10 +78,6 @@ module Rails
       require environment if environment
     end
 
-    def eager_load! #:nodoc:
-      railties.all(&:eager_load!)
-      super
-    end
 
     def reload_routes!
       routes_reloader.reload!
@@ -100,14 +96,12 @@ module Rails
 
     def load_tasks(app=self)
       initialize_tasks
-      railties.all { |r| r.load_tasks(app) }
       super
       self
     end
 
     def load_console(app=self)
       initialize_console
-      railties.all { |r| r.load_console(app) }
       super
       self
     end

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -395,12 +395,20 @@ module Rails
     delegate :middleware, :root, :paths, :to => :config
     delegate :engine_name, :isolated?, :to => "self.class"
 
-    def load_tasks(*)
+    def load_tasks(app=self)
+      railties.all { |r| r.load_tasks(app) }
       super
       paths["lib/tasks"].existent.sort.each { |ext| load(ext) }
     end
-
+    
+    def load_console(app=self)
+      railties.all { |r| r.load_console(app) }
+      super
+    end
+    
     def eager_load!
+      railties.all(&:eager_load!)
+      
       config.eager_load_paths.each do |load_path|
         matcher = /\A#{Regexp.escape(load_path)}\/(.*)\.rb\Z/
         Dir.glob("#{load_path}/**/*.rb").sort.each do |file|


### PR DESCRIPTION
[3.1.0.rc1] Plugins inside engines not eager-loaded properly and their
rake tasks ignored

Working with the new support for plugins inside engines in Rails 3.1,
I found that certain things that work for regular plugins don't work
for these new nested plugins. In particular, these methods in
Rails::Engine don't seem to understand that an engine could have
nested plugins:
# load_tasks
# load_generators
# load_console
# eager_load!

A solution which worked out for me is to move the calls to
railties.all { ... } from the overriding methods in Rails::Application
into Rails::Engine.
