### PR TITLE
Patch for [3.1.0.rc1] App plugins initialized before engines and plugins inside engines

### DIFF
--- a/railties/lib/rails/application/railties.rb
+++ b/railties/lib/rails/application/railties.rb
@@ -4,7 +4,7 @@ module Rails
   class Application < Engine
     class Railties < Rails::Engine::Railties
       def all(&block)
-        @all ||= railties + engines + super
+        @all ||= railties + engines + plugins
         @all.each(&block) if block
         @all
       end


### PR DESCRIPTION
Patch for #1735 / #1458 - [3.1.0.rc1] App plugins initialized before engines and plugins inside engines.

It seems that plugins inside a Rails 3.1 application proper (i.e. in /vendor/plugins) are initialized before engines and plugins inside engines.

After some debugging, I found the culprit in Rails::Application::Railties#all:

``` ruby
  def all(&block)
    @all ||= railties + engines + super
    @all.each(&block) if block
    @all
  end
```

The call to super here implicitly passes the &block argument, which has the unfortunate side-effect of adding the plugin initializers first (in front of other railties and engines) in the case of Rails::Engine#initializers:

``` ruby
def initializers
  initializers = []
  railties.all { |r| initializers += r.initializers }
  initializers += super
  initializers
end
```

The solution here is to replace the super call with a call to #plugins.
