### PR TITLE
Fix several warnings: change version of nokogiri gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ platforms :ruby do
   end
   gem "json"
   gem "yajl-ruby"
-  gem "nokogiri", ">= 1.4.4"
+  gem "nokogiri", ">= 1.4.5"
 
   group :test do
     gem "ruby-prof" if RUBY_VERSION < "1.9.3"


### PR DESCRIPTION
When you run 'rake test' there are several warnings about mismatched indentations at 'end' and 'def' or 'module' etc:

```
/Users/gazay/code/rails/actionpack/lib/action_dispatch/routing/mapper.rb:90: warning: mismatched indentations at 'end' with 'def' at 69
/Users/gazay/.rvm/gems/ruby-1.9.2-p180/gems/nokogiri-1.4.4/lib/nokogiri/css/generated_parser.rb:675: warning: mismatched indentations at 'end' with 'module' at 11
```

So the problem was in nokogiri gem 1.4.4 version, i found it was fixed (https://github.com/tenderlove/nokogiri/commit/f1e3133b0c689e619964217e2a5b3e055bbb2cc7) and bumped version to 1.4.5 stable. I suggest change version in Gemfile to 1.4.5, it solves this problem.
