### PR TITLE
Fix OrderedHash merging with block given.

### DIFF
--- a/activesupport/lib/active_support/ordered_hash.rb
+++ b/activesupport/lib/active_support/ordered_hash.rb
@@ -130,14 +130,18 @@ module ActiveSupport
       end
 
       def merge!(other_hash)
-        other_hash.each {|k,v| self[k] = v }
+        if block_given?
+          other_hash.each { |k, v| self[k] = key?(k) ? yield(k, self[k], v) : v }
+        else
+          other_hash.each { |k, v| self[k] = v }
+        end
         self
       end
 
       alias_method :update, :merge!
 
-      def merge(other_hash)
-        dup.merge!(other_hash)
+      def merge(other_hash, &block)
+        dup.merge!(other_hash, &block)
       end
 
       # When replacing with another hash, the initial order of our keys must come from the other hash -ordered or not.

--- a/activesupport/test/ordered_hash_test.rb
+++ b/activesupport/test/ordered_hash_test.rb
@@ -147,6 +147,32 @@ class OrderedHashTest < Test::Unit::TestCase
     assert_equal @ordered_hash.keys, merged.keys
   end
 
+  def test_merge_with_block
+    hash = ActiveSupport::OrderedHash.new
+    hash[:a] = 0
+    hash[:b] = 0
+    merged = hash.merge(:b => 2, :c => 7) do |key, old_value, new_value|
+      new_value + 1
+    end
+
+    assert_equal 0, merged[:a]
+    assert_equal 3, merged[:b]
+    assert_equal 7, merged[:c]
+  end
+
+  def test_merge_bang_with_block
+    hash = ActiveSupport::OrderedHash.new
+    hash[:a] = 0
+    hash[:b] = 0
+    hash.merge!(:a => 1, :c => 7) do |key, old_value, new_value|
+      new_value + 3
+    end
+
+    assert_equal 4, hash[:a]
+    assert_equal 0, hash[:b]
+    assert_equal 7, hash[:c]
+  end
+
   def test_shift
     pair = @ordered_hash.shift
     assert_equal [@keys.first, @values.first], pair


### PR DESCRIPTION
Code taken from Rails 3 branch. Now OrderedHash merging can accept a block.
