### PR TITLE
Added default values for remove uninitialized warnings

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1855,7 +1855,7 @@ MSG
 
       # Returns the contents of the record as a nicely formatted string.
       def inspect
-        inspection = if @attributes
+        inspection = if @attributes ||= nil
                        self.class.column_names.collect { |name|
                          if has_attribute?(name)
                            "#{name}: #{attribute_for_inspect(name)}"

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -151,7 +151,7 @@ module ActiveSupport #:nodoc:
     protected
 
     def dirty?
-      @dirty
+      @dirty ||= false
     end
   end
 end


### PR DESCRIPTION
I added default values to result of instance variables - it removed warnings about using uninitialized instant variables from test logs:

```
/Users/gazay/code/rails/activesupport/lib/active_support/core_ext/string/output_safety.rb:154: warning: instance variable @dirty not initialized
/Users/gazay/code/rails/activerecord/lib/active_record/base.rb:1858: warning: instance variable @attributes not initialized
```

but not affected logic
