### PR TITLE
Rails app template: setup different mass assignment sanitizer for envs

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -45,6 +45,8 @@ module ActiveRecord
       ActiveSupport.on_load(:active_record) { self.logger ||= ::Rails.logger }
     end
 
+    initializer "active_record.mass_assignment_sanitizer"
+
     initializer "active_record.identity_map" do |app|
       config.app_middleware.insert_after "::ActionDispatch::Callbacks",
         "ActiveRecord::IdentityMap::Middleware" if config.active_record.delete(:identity_map)

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -45,8 +45,6 @@ module ActiveRecord
       ActiveSupport.on_load(:active_record) { self.logger ||= ::Rails.logger }
     end
 
-    initializer "active_record.mass_assignment_sanitizer"
-
     initializer "active_record.identity_map" do |app|
       config.app_middleware.insert_after "::ActionDispatch::Callbacks",
         "ActiveRecord::IdentityMap::Middleware" if config.active_record.delete(:identity_map)

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -22,6 +22,9 @@
   # Only use best-standards-support built into browsers
   config.action_dispatch.best_standards_support = :builtin
 
+  # Raise exception on mass assignment protection for ActiveRecord models
+  config.active_record.mass_assignment_sanitizer = :strict
+
   # Do not compress assets
   config.assets.compress = false
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -34,6 +34,9 @@
   # like if you have constraints or database-specific column types
   # config.active_record.schema_format = :sql
 
+  # Raise exception on mass assignment protection for ActiveRecord models
+  config.active_record.mass_assignment_sanitizer = :strict
+
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
 end


### PR DESCRIPTION
As we discussed here:
https://github.com/rails/rails/pull/1334#issuecomment-1247794

For production - leave the default `:logger`.
Set `:strict` for test and dev.
