### PR TITLE
Calling unsafe methods which don't return a string shouldn't fail

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -137,8 +137,8 @@ module ActiveSupport #:nodoc:
 
     UNSAFE_STRING_METHODS.each do |unsafe_method|
       class_eval <<-EOT, __FILE__, __LINE__
-        def #{unsafe_method}(*args)
-          super.to_str
+        def #{unsafe_method}(*args, &block)
+          to_str.#{unsafe_method}(*args, &block)
         end
 
         def #{unsafe_method}!(*args)

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -104,4 +104,8 @@ class SafeBufferTest < ActiveSupport::TestCase
       @buffer.safe_concat "BUSTED"
     end
   end
+  
+  test "should not fail if the returned object is not a string" do
+    assert_kind_of Enumerator, @buffer.gsub(/.*/)
+  end
 end


### PR DESCRIPTION
Unsafe methods are always calling #to_str when called so the object returned is a new string object.

If the original method doesn't return a string, like gsub with only one argument though, it'll fail as there's no to_str method.
