### PR TITLE
Bump mysql2 to 0.3.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ platforms :ruby do
   group :db do
     gem "pg", ">= 0.11.0"
     gem "mysql", ">= 2.8.1"
-    gem "mysql2", ">= 0.3.5"
+    gem "mysql2", ">= 0.3.6"
   end
 end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-gem 'mysql2', '~> 0.3.5'
+gem 'mysql2', '~> 0.3.6'
 require 'mysql2'
 
 module ActiveRecord


### PR DESCRIPTION
This version includes the fixes for Time/DateTime range detection across the various Ruby platforms (32bit vs 64bit, 1.8 vs 1.9, *NIX vs Windows)
