### PR TITLE
Fix xmlschema output with fraction_digits >0 

### DIFF
--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -109,7 +109,7 @@ module ActiveSupport
 
     def xmlschema(fraction_digits = 0)
       fraction = if fraction_digits > 0
-        ".%i" % time.usec.to_s[0, fraction_digits]
+        (".%06i" % time.usec)[0, fraction_digits + 1]
       end
 
       "#{time.strftime("%Y-%m-%dT%H:%M:%S")}#{fraction}#{formatted_offset(true, 'Z')}"

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -111,6 +111,13 @@ class TimeWithZoneTest < Test::Unit::TestCase
     assert_equal "1999-12-31T19:00:00.123456-05:00", @twz.xmlschema(12)
   end
 
+  def test_xmlschema_with_fractional_seconds_lower_than_hundred_thousand
+    @twz += 0.001234 # advance the time by a fraction
+    assert_equal "1999-12-31T19:00:00.001-05:00", @twz.xmlschema(3)
+    assert_equal "1999-12-31T19:00:00.001234-05:00", @twz.xmlschema(6)
+    assert_equal "1999-12-31T19:00:00.001234-05:00", @twz.xmlschema(12)
+  end
+
   def test_to_yaml
     assert_match(/^--- 2000-01-01 00:00:00(\.0+)?\s*Z\n/, @twz.to_yaml)
   end


### PR DESCRIPTION
Current implementation produce incorrect output when Time#usec returns
integer < 100000, because to_s doesn't add leading zeros.
