### PR TITLE
Removed warning about not initialized instance variable @dirty

### DIFF
--- a/actionpack/lib/action_view/helpers/capture_helper.rb
+++ b/actionpack/lib/action_view/helpers/capture_helper.rb
@@ -194,7 +194,7 @@ module ActionView
       def flush_output_buffer #:nodoc:
         if output_buffer && !output_buffer.empty?
           response.body_parts << output_buffer
-          self.output_buffer = output_buffer[0,0]
+          self.output_buffer = ActionView::OutputBuffer.new.force_encoding(output_buffer.encoding)
           nil
         end
       end


### PR DESCRIPTION
It will remove warning about not uninitialized instance variable @dirty only with replacing content of output_buffer
