### PR TITLE
Solving the problem of links being broken in GitHub for the sake of api site

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -18,7 +18,7 @@ you to present the data from database rows as objects and embellish these data o
 with business logic methods. Although most Rails models are backed by a database, models 
 can also be ordinary Ruby classes, or Ruby classes that implement a set of interfaces as
 provided by the ActiveModel module. You can read more about Active Record in its
-{README}[link:files/activerecord/README_rdoc.html].
+{README}[link:blob/master/activerecord/README.rdoc].
 
 The Controller layer is responsible for handling incoming HTTP requests and providing a 
 suitable response.  Usually this means returning HTML, but Rails controllers can also 
@@ -29,7 +29,7 @@ In Rails, the Controller and View layers are handled together by Action Pack.
 These two layers are bundled in a single package due to their heavy interdependence. 
 This is unlike the relationship between the Active Record and Action Pack which are
 independent. Each of these packages can be used independently outside of Rails. You 
-can read more about Action Pack in its {README}[link:files/actionpack/README_rdoc.html].
+can read more about Action Pack in its {README}[link:blob/master/actionpack/README.rdoc].
 
 == Getting Started
 

--- a/Rakefile
+++ b/Rakefile
@@ -71,6 +71,7 @@ RDoc::Task.new do |rdoc|
     # since no autolinking happens there and RDoc displays the backslash
     # otherwise.
     rdoc_main.gsub!(/^(?=\S).*?\b(?=Rails)\b/) { "#$&\\" }
+    rdoc_main.gsub!(/link:blob\/master\/(\w+)\/README.rdoc/, "link:files/\\1/README_rdoc.html")
 
     File.open(RDOC_MAIN, 'w') do |f|
       f.write(rdoc_main)


### PR DESCRIPTION
As discussed in https://github.com/lifo/docrails/commit/2fbb7504e2c2b0a95398d1ef0c97ea4a403d831d, replacing the readme links of AR/AP during rdoc generation so that they are not broken in README.rdoc on GitHub.
