### PR TITLE
Fix default options argument on ActiveRecord::ConnectionAdaptors::Table#column_exists?

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -328,7 +328,7 @@ module ActiveRecord
       end
 
       # Checks to see if a column exists. See SchemaStatements#column_exists?
-      def column_exists?(column_name, type = nil, options = nil)
+      def column_exists?(column_name, type = nil, options = {})
         @base.column_exists?(@table_name, column_name, type, options)
       end
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1071,6 +1071,18 @@ if ActiveRecord::Base.connection.supports_migrations?
       Person.connection.drop_table :testings rescue nil
     end
 
+    def test_column_exists_on_table_with_no_options_parameter_supplied
+      Person.connection.create_table :testings do |t|
+        t.string :foo
+      end
+      Person.connection.change_table :testings do |t|
+        assert t.column_exists?(:foo)
+        assert !(t.column_exists?(:bar))
+      end
+    ensure
+      Person.connection.drop_table :testings rescue nil
+    end
+
     def test_add_table
       assert !Reminder.table_exists?
 


### PR DESCRIPTION
Changed the default value for the `options` argument on `ActiveRecord::ConnectionAdapters::Table#column_exists?` from `nil` to an empty Hash `{}`.

That method calls through to `ActiveRecord::ConnectionAdapters::SchemaStatements#column_exists?` which expects `options` to be a Hash.

When `options` was `nil`, an error would occur in cases where the column did exist because the called method attempted to perform a key lookup on options.
