### PR TITLE
Fix inconsistencies with serving images in production mode when ActiveRecord is loaded

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -426,6 +426,14 @@ module ActiveRecord
           @testing = testing
         end
 
+        def method_missing(method_sym, *arguments, &block)
+          @body.send(method_sym, *arguments, &block)
+        end
+
+        def respond_to?(method_sym, include_private = false)
+          super || @body.respond_to?(method_sym)
+        end
+
         def each(&block)
           body.each(&block)
         end

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -33,6 +33,14 @@ module ActiveRecord
         @target               = target
       end
 
+      def method_missing(method_sym, *arguments, &block)
+        @target.send(method_sym, *arguments, &block)
+      end
+
+      def respond_to?(method_sym, include_private = false)
+        super || @target.respond_to?(method_sym)
+      end
+
       def each(&block)
         @target.each(&block)
       end

--- a/activerecord/test/cases/connection_management_test.rb
+++ b/activerecord/test/cases/connection_management_test.rb
@@ -77,6 +77,13 @@ module ActiveRecord
         @management.call(@env)
         assert ActiveRecord::Base.connection_handler.active_connections?
       end
+
+      test "proxy is polite to it's body and responds to it" do
+        body = Class.new(String) { def to_path; "/path"; end }.new
+        proxy = ConnectionManagement::Proxy.new(body)
+        assert proxy.respond_to?(:to_path)
+        assert_equal proxy.to_path, "/path"
+      end
     end
   end
 end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -203,3 +203,14 @@ class QueryCacheExpiryTest < ActiveRecord::TestCase
     end
   end
 end
+
+class QueryCacheBodyProxyTest < ActiveRecord::TestCase
+
+  test "is polite to it's body and responds to it" do
+    body = Class.new(String) { def to_path; "/path"; end }.new
+    proxy = ActiveRecord::QueryCache::BodyProxy.new(nil, body)
+    assert proxy.respond_to?(:to_path)
+    assert_equal proxy.to_path, "/path"
+  end
+
+end


### PR DESCRIPTION
Fix inconsistencies by being polite to the wrapped body. Needed for Rack::Sendfile to function properly. See issue #1761.

When active record isn't loaded assets aren't served in production mode, when it is loaded they are... It's debatable whether this is a bug or a feature, but I think it should behave the same whether active record is loaded or not :)
