### PR TITLE
Add option to omit creating an instance reader method on class_attribute

### DIFF
--- a/activesupport/test/core_ext/class/attribute_test.rb
+++ b/activesupport/test/core_ext/class/attribute_test.rb
@@ -60,6 +60,12 @@ class ClassAttributeTest < ActiveSupport::TestCase
     assert_raise(NoMethodError) { object.setting = 'boom' }
   end
 
+  test 'disabling instance reader' do
+    object = Class.new { class_attribute :setting, :instance_reader => false }.new
+    assert_raise(NoMethodError) { object.setting }
+    assert_raise(NoMethodError) { object.setting? }
+  end
+
   test 'works well with singleton classes' do
     object = @klass.new
     object.singleton_class.setting = 'foo'


### PR DESCRIPTION
In an effort to make `class_attribute` a little more backward compatible with the now-removed `class_inheritable_accessor`, I've added the ability to disable the instance reader method.

Here's an example case of where it's needed:
https://gist.github.com/1033533

TL;DR: You can't override the reader method if the module extends ActiveSupport::Concern because of the order that things get mixed-in.

We're struggling to get Carrierwave running on Rails master as we remove uses of `class_inheritable_attribute` -- if there's any way this can be merged into 3-0-stable and 3-1-stable, that would help a ton.  Thanks.
