### PR TITLE
Require rel remove 3 0 stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,9 +21,6 @@ gem "memcache-client", ">= 1.8.5"
 
 platforms :mri_18 do
   gem "system_timer"
-  # ruby-debug requires linecache which depends on require_relative but doesn't explicitly
-  # declare this in its gemspec
-  gem "require_relative"
   gem "ruby-debug", ">= 0.10.3"
   gem 'ruby-prof'
 end


### PR DESCRIPTION
Removing require_relative gem. Linecache new version 0.46 is out and it's loading rbx-require-relative > 0.0.4
