### PR TITLE
Added generation for change_field migration

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -14,7 +14,7 @@ module ActiveRecord
         attr_reader :migration_action
 
         def set_local_assigns!
-          if file_name =~ /^(add|remove)_.*_(?:to|from)_(.*)/
+          if file_name =~ /^(add|change|remove)_.*_(?:to|in|from)_(.*)/
             @migration_action = $1
             @table_name       = $2.pluralize
           end

--- a/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
@@ -9,14 +9,16 @@ class <%= migration_class_name %> < ActiveRecord::Migration
   def up
 <% attributes.each do |attribute| -%>
   <%- if migration_action -%>
-    <%= migration_action %>_column :<%= table_name %>, :<%= attribute.name %><% if migration_action == 'add' %>, :<%= attribute.type %><% end %>
+    <%= migration_action %>_column :<%= table_name %>, :<%= attribute.name %><% if ['add', 'change'].include? migration_action %>, :<%= attribute.type %><% end %>
   <%- end -%>
 <%- end -%>
   end
 
   def down
 <% attributes.reverse.each do |attribute| -%>
-  <%- if migration_action -%>
+  <%- if migration_action == 'change' -%>
+    <%= migration_action %>_column :<%= table_name %>, :<%= attribute.name %>, 'previous_field_type'
+  <%- elsif migration_action -%>
     <%= migration_action == 'add' ? 'remove' : 'add' %>_column :<%= table_name %>, :<%= attribute.name %><% if migration_action == 'remove' %>, :<%= attribute.type %><% end %>
   <%- end -%>
 <%- end -%>

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -41,6 +41,23 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_change_migration_with_attributes
+    migration = "change_title_body_in_posts"
+    run_generator [migration, "title:string", "body:text"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :up, content do |up|
+        assert_match(/change_column :posts, :title, :string/, up)
+        assert_match(/change_column :posts, :body, :text/, up)
+      end
+      
+      assert_method :down, content do |down|
+        assert_match(/change_column :posts, :title, \'previous_field_type\'/, down)
+        assert_match(/change_column :posts, :body, \'previous_field_type\'/, down)
+      end
+    end
+  end
+
   def test_remove_migration_with_attributes
     migration = "remove_title_body_from_posts"
     run_generator [migration, "title:string", "body:text"]
@@ -58,7 +75,7 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_should_create_empty_migrations_if_name_not_start_with_add_or_remove
+  def test_should_create_empty_migrations_if_name_not_start_with_add_or_change_or_remove
     migration = "create_books"
     run_generator [migration, "title:string", "content:text"]
 


### PR DESCRIPTION
Hi, guys!
What do you think about adding special syntax for generating migration for changing columns in tables?
By analogy with add new column:

```
rails g migration change_some_field_in_posts some_field:string
```

will generate:

``` ruby
class ChangeSomeFieldInPosts < ActiveRecord::Migration
  def up
    change_column :posts, :some_field, :string
  end

  def down
    change_column :posts, :some_field, 'previous_field_type'
  end
end
```

And if you like this idea - what you can suggest about 'previous_field_type' part? I don't like this solution..
