### PR TITLE
assets:clean task now cleans up images

### DIFF
--- a/railties/lib/rails/tasks/assets.rake
+++ b/railties/lib/rails/tasks/assets.rake
@@ -12,7 +12,7 @@ namespace :assets do
   task :clean => :environment do
     assets = Rails.application.config.assets
     public_asset_path = Rails.public_path + assets.prefix
-    file_list = FileList.new("#{public_asset_path}/*.js", "#{public_asset_path}/*.css")
+    file_list = FileList.new("#{public_asset_path}/**/*")
     file_list.each do |file|
       rm file
       rm "#{file}.gz", :force => true


### PR DESCRIPTION
`rake assets:clean` will now clean up any image files (*.png, *.gif, *.jpg, *.jpeg, *.ico) in addition to CSS and JS.
