### PR TITLE
Fix nested fields_for when Hash-based model is passed.

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -1241,7 +1241,7 @@ module ActionView
       end
 
       def fields_for(record_name, record_object = nil, fields_options = {}, &block)
-        fields_options, record_object = record_object, nil if record_object.is_a?(Hash)
+        fields_options, record_object = record_object, nil if record_object.is_a?(Hash) && record_object.extractable_options?
         fields_options[:builder] ||= options[:builder]
         fields_options[:parent_builder] = self
 

--- a/actionpack/test/lib/controller/fake_models.rb
+++ b/actionpack/test/lib/controller/fake_models.rb
@@ -170,6 +170,17 @@ class Author < Comment
   def post_attributes=(attributes); end
 end
 
+class HashBackedAuthor < Hash
+  extend ActiveModel::Naming
+  include ActiveModel::Conversion
+
+  def persisted?; false; end
+
+  def name
+    "hash backed author"
+  end
+end
+
 module Blog
   def self._railtie
     self

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -1690,9 +1690,7 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_nested_fields_for_with_hash_like_model
-    @author = Author.new
-    def @author.is_a?(klass); klass == Hash; end
-    def @author.extractable_options?; false; end
+    @author = HashBackedAuthor.new
 
     form_for(@post) do |f|
       concat f.fields_for(:author, @author) { |af|
@@ -1701,7 +1699,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
-      '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="new author" />'
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="hash backed author" />'
     end
 
     assert_dom_equal expected, output_buffer

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -1689,6 +1689,24 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_nested_fields_for_with_hash_like_model
+    @author = Author.new
+    def @author.is_a?(klass); klass == Hash; end
+    def @author.extractable_options?; false; end
+
+    form_for(@post) do |f|
+      concat f.fields_for(:author, @author) { |af|
+        concat af.text_field(:name)
+      }
+    end
+
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="new author" />'
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_fields_for
     output_buffer = fields_for(:post, @post) do |f|
       concat f.text_field(:title)


### PR DESCRIPTION
This fixes an error when a record object that is a subclass of Hash is passed to fields_for, which is incorrectly interpreted as field options.
