### PR TITLE
Adding basic callbacks support to ActiveResource

### DIFF
--- a/activeresource/lib/active_resource.rb
+++ b/activeresource/lib/active_resource.rb
@@ -35,6 +35,7 @@ module ActiveResource
   extend ActiveSupport::Autoload
 
   autoload :Base
+  autoload :Callbacks
   autoload :Connection
   autoload :CustomMethods
   autoload :Formats

--- a/activeresource/lib/active_resource/base.rb
+++ b/activeresource/lib/active_resource/base.rb
@@ -1145,7 +1145,9 @@ module ActiveResource
     #   my_company.size = 10
     #   my_company.save # sends PUT /companies/1 (update)
     def save
-      new? ? create : update
+      run_callbacks :save do
+        new? ? create : update
+      end
     end
 
     # Saves the resource.
@@ -1178,7 +1180,9 @@ module ActiveResource
     #   new_person.destroy
     #   Person.find(new_id) # 404 (Resource Not Found)
     def destroy
-      connection.delete(element_path, self.class.headers)
+      run_callbacks :destroy do
+        connection.delete(element_path, self.class.headers)
+      end
     end
 
     # Evaluates to <tt>true</tt> if this resource is not <tt>new?</tt> and is
@@ -1343,16 +1347,20 @@ module ActiveResource
 
       # Update the resource on the remote service.
       def update
-        connection.put(element_path(prefix_options), encode, self.class.headers).tap do |response|
-          load_attributes_from_response(response)
+        run_callbacks :update do
+          connection.put(element_path(prefix_options), encode, self.class.headers).tap do |response|
+            load_attributes_from_response(response)
+          end
         end
       end
 
       # Create (i.e., \save to the remote service) the \new resource.
       def create
-        connection.post(collection_path, encode, self.class.headers).tap do |response|
-          self.id = id_from_response(response)
-          load_attributes_from_response(response)
+        run_callbacks :create do
+          connection.post(collection_path, encode, self.class.headers).tap do |response|
+            self.id = id_from_response(response)
+            load_attributes_from_response(response)
+          end
         end
       end
 
@@ -1455,7 +1463,7 @@ module ActiveResource
 
   class Base
     extend ActiveModel::Naming
-    include CustomMethods, Observing, Validations
+    include Callbacks, CustomMethods, Observing, Validations
     include ActiveModel::Conversion
     include ActiveModel::Serializers::JSON
     include ActiveModel::Serializers::Xml

--- a/activeresource/lib/active_resource/callbacks.rb
+++ b/activeresource/lib/active_resource/callbacks.rb
@@ -1,0 +1,20 @@
+require 'active_support/core_ext/array/wrap'
+
+module ActiveResource
+  module Callbacks
+    extend ActiveSupport::Concern
+
+    CALLBACKS = [
+      :before_validation, :after_validation, :before_save, :around_save, :after_save,
+      :before_create, :around_create, :after_create, :before_update, :around_update,
+      :after_update, :before_destroy, :around_destroy, :after_destroy
+    ]
+
+    included do
+      extend ActiveModel::Callbacks
+      include ActiveModel::Validations::Callbacks
+
+      define_model_callbacks :save, :create, :update, :destroy
+    end
+  end
+end

--- a/activeresource/lib/active_resource/validations.rb
+++ b/activeresource/lib/active_resource/validations.rb
@@ -121,8 +121,10 @@ module ActiveResource
     #   # => false
     #
     def valid?
-      super
-      load_remote_errors(@remote_errors, true) if defined?(@remote_errors) && @remote_errors.present?
+      run_callbacks :validate do
+        super
+        load_remote_errors(@remote_errors, true) if defined?(@remote_errors) && @remote_errors.present?
+      end
       errors.empty?
     end
 

--- a/activeresource/test/cases/callbacks_test.rb
+++ b/activeresource/test/cases/callbacks_test.rb
@@ -1,0 +1,170 @@
+require 'abstract_unit'
+require 'active_support/core_ext/hash/conversions'
+
+class Developer < ActiveResource::Base
+  self.site = 'http://37s.sunrise.i:3000'
+
+  class << self
+    def callback_string(callback_method)
+      "history << [#{callback_method.to_sym.inspect}, :string]"
+    end
+
+    def callback_proc(callback_method)
+      Proc.new { |model| model.history << [callback_method, :proc] }
+    end
+
+    def define_callback_method(callback_method)
+      define_method(callback_method) do
+        self.history << [callback_method, :method]
+      end
+      send(callback_method, :"#{callback_method}")
+    end
+
+    def callback_object(callback_method)
+      klass = Class.new
+      klass.send(:define_method, callback_method) do |model|
+        model.history << [callback_method, :object]
+      end
+      klass.new
+    end
+  end
+
+  ActiveResource::Callbacks::CALLBACKS.each do |callback_method|
+    next if callback_method.to_s =~ /^around_/
+    define_callback_method(callback_method)
+    send(callback_method, callback_string(callback_method))
+    send(callback_method, callback_proc(callback_method))
+    send(callback_method, callback_object(callback_method))
+    send(callback_method) { |model| model.history << [callback_method, :block] }
+  end
+
+  def history
+    @history ||= []
+  end
+end
+
+class CallbacksTest < ActiveModel::TestCase
+  def setup
+    @developer_attrs = {:id => 1, :name => "Guillermo", :salary => 100_000}
+    @developer = {"developer" => @developer_attrs}.to_json
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.post   '/developers.json',   {}, @developer, 201, 'Location' => '/developers/1.json'
+      mock.get    '/developers/1.json', {}, @developer
+      mock.put    '/developers/1.json', {}, nil, 204
+      mock.delete '/developers/1.json', {}, nil, 200
+    end
+  end
+
+  def test_valid?
+    developer = Developer.new
+    developer.valid?
+    assert_equal [
+      [ :before_validation,           :method ],
+      [ :before_validation,           :string ],
+      [ :before_validation,           :proc   ],
+      [ :before_validation,           :object ],
+      [ :before_validation,           :block  ],
+      [ :after_validation,            :method ],
+      [ :after_validation,            :string ],
+      [ :after_validation,            :proc   ],
+      [ :after_validation,            :object ],
+      [ :after_validation,            :block  ],
+    ], developer.history
+  end
+
+  def test_create
+    developer = Developer.create(@developer_attrs)
+    assert_equal [
+      [ :before_validation,           :method ],
+      [ :before_validation,           :string ],
+      [ :before_validation,           :proc   ],
+      [ :before_validation,           :object ],
+      [ :before_validation,           :block  ],
+      [ :after_validation,            :method ],
+      [ :after_validation,            :string ],
+      [ :after_validation,            :proc   ],
+      [ :after_validation,            :object ],
+      [ :after_validation,            :block  ],
+      [ :before_save,                 :method ],
+      [ :before_save,                 :string ],
+      [ :before_save,                 :proc   ],
+      [ :before_save,                 :object ],
+      [ :before_save,                 :block  ],
+      [ :before_create,               :method ],
+      [ :before_create,               :string ],
+      [ :before_create,               :proc   ],
+      [ :before_create,               :object ],
+      [ :before_create,               :block  ],
+      [ :after_create,                :method ],
+      [ :after_create,                :string ],
+      [ :after_create,                :proc   ],
+      [ :after_create,                :object ],
+      [ :after_create,                :block  ],
+      [ :after_save,                  :method ],
+      [ :after_save,                  :string ],
+      [ :after_save,                  :proc   ],
+      [ :after_save,                  :object ],
+      [ :after_save,                  :block  ]
+    ], developer.history
+  end
+
+  def test_update
+    developer = Developer.find(1)
+    developer.save
+    assert_equal [
+      [ :before_validation,           :method ],
+      [ :before_validation,           :string ],
+      [ :before_validation,           :proc   ],
+      [ :before_validation,           :object ],
+      [ :before_validation,           :block  ],
+      [ :after_validation,            :method ],
+      [ :after_validation,            :string ],
+      [ :after_validation,            :proc   ],
+      [ :after_validation,            :object ],
+      [ :after_validation,            :block  ],
+      [ :before_save,                 :method ],
+      [ :before_save,                 :string ],
+      [ :before_save,                 :proc   ],
+      [ :before_save,                 :object ],
+      [ :before_save,                 :block  ],
+      [ :before_update,               :method ],
+      [ :before_update,               :string ],
+      [ :before_update,               :proc   ],
+      [ :before_update,               :object ],
+      [ :before_update,               :block  ],
+      [ :after_update,                :method ],
+      [ :after_update,                :string ],
+      [ :after_update,                :proc   ],
+      [ :after_update,                :object ],
+      [ :after_update,                :block  ],
+      [ :after_save,                  :method ],
+      [ :after_save,                  :string ],
+      [ :after_save,                  :proc   ],
+      [ :after_save,                  :object ],
+      [ :after_save,                  :block  ]
+    ], developer.history
+  end
+
+  def test_destroy
+    developer = Developer.find(1)
+    developer.destroy
+    assert_equal [
+      [ :before_destroy,              :method ],
+      [ :before_destroy,              :string ],
+      [ :before_destroy,              :proc   ],
+      [ :before_destroy,              :object ],
+      [ :before_destroy,              :block  ],
+      [ :after_destroy,               :method ],
+      [ :after_destroy,               :string ],
+      [ :after_destroy,               :proc   ],
+      [ :after_destroy,               :object ],
+      [ :after_destroy,               :block  ]
+    ], developer.history
+  end
+
+  def test_delete
+    developer = Developer.find(1)
+    Developer.delete(developer.id)
+    assert_equal [], developer.history
+  end
+end


### PR DESCRIPTION
This add support for some of the popular ActiveRecord callbacks to ActiveResource: 

before_validation, after_validation, before_save, around_save, after_save, before_create, around_create, after_create, before_update, around_update, after_update, before_destroy, around_destroy, after_destroy.

This an initial work, I will start to work soon adding support for contexts in *_validation callbacks (ex. before_validation :on => create) but first I want do add context support to existing validations (ex. validates :on => :create)
