### PR TITLE
Add missing require 'set'

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module ActiveRecord
   # :stopdoc:
   module ConnectionAdapters


### PR DESCRIPTION
Lines 6-7 of `active_record/lib/active_record/connection_adapters/column.rb` invoke the `to_set` method on array objects. This method is not available unless `require "set"` is available. Since the require is not provided directly in the file in question, it is sensitive to load order.

For example:

```
% irb
ruby-1.9.2-p180 :001 > require 'active_record'
 => true 
ruby-1.9.2-p180 :002 > ::ActiveRecord::ConnectionAdapters::AbstractAdapter
NoMethodError: undefined method `to_set' for [true, 1, "1", "t", "T", "true", "TRUE"]:Array
    from /Users/dazuma/.rvm/gems/ruby-1.9.2-p180@rails31/gems/activerecord-3.1.0.rc4/lib/active_record/connection_adapters/column.rb:6:in `<class:Column>'
    from /Users/dazuma/.rvm/gems/ruby-1.9.2-p180@rails31/gems/activerecord-3.1.0.rc4/lib/active_record/connection_adapters/column.rb:5:in `<module:ConnectionAdapters>'
    from /Users/dazuma/.rvm/gems/ruby-1.9.2-p180@rails31/gems/activerecord-3.1.0.rc4/lib/active_record/connection_adapters/column.rb:3:in `<module:ActiveRecord>'
    from /Users/dazuma/.rvm/gems/ruby-1.9.2-p180@rails31/gems/activerecord-3.1.0.rc4/lib/active_record/connection_adapters/column.rb:1:in `<top (required)>'
    from /Users/dazuma/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/dazuma/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/dazuma/.rvm/gems/ruby-1.9.2-p180@rails31/gems/activerecord-3.1.0.rc4/lib/active_record/connection_adapters/abstract_adapter.rb:7:in `<top (required)>'
    from (irb):2
    from /Users/dazuma/.rvm/rubies/ruby-1.9.2-p180/bin/irb:16:in `<main>'
```

This is a 3.1 regression (reproduced in 3.1.0.rc4). The above irb commands do not raise NoMethodError in 3.0.9.

This 1-line pull request fixes the issue by adding the necessary require.
