### PR TITLE
Removing shadowing outer local variables warnings

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -369,7 +369,7 @@ db_namespace = namespace :db do
         ENV['PGPASSWORD'] = abcs[Rails.env]['password'].to_s if abcs[Rails.env]['password']
         search_path = abcs[Rails.env]['schema_search_path']
         unless search_path.blank?
-          search_path = search_path.split(",").map{|search_path| "--schema=#{search_path.strip}" }.join(" ")
+          search_path = search_path.split(",").map{|search_path_part| "--schema=#{search_path_part.strip}" }.join(" ")
         end
         `pg_dump -i -U "#{abcs[Rails.env]['username']}" -s -x -O -f db/#{Rails.env}_structure.sql #{search_path} #{abcs[Rails.env]['database']}`
         raise 'Error dumping database' if $?.exitstatus == 1

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -114,11 +114,11 @@ module Rails
       #   git :add => "this.file that.rb"
       #   git :add => "onefile.rb", :rm => "badfile.cxx"
       #
-      def git(command={})
-        if command.is_a?(Symbol)
-          run "git #{command}"
+      def git(commands={})
+        if commands.is_a?(Symbol)
+          run "git #{commands}"
         else
-          command.each do |command, options|
+          commands.each do |command, options|
             run "git #{command} #{options}"
           end
         end

--- a/railties/lib/rails/generators/base.rb
+++ b/railties/lib/rails/generators/base.rb
@@ -259,9 +259,9 @@ module Rails
             extra << false unless Object.method(:const_defined?).arity == 1
 
             # Extract the last Module in the nesting
-            last = nesting.inject(Object) do |last, nest|
-              break unless last.const_defined?(nest, *extra)
-              last.const_get(nest)
+            last = nesting.inject(Object) do |last_module, nest|
+              break unless last_module.const_defined?(nest, *extra)
+              last_module.const_get(nest)
             end
 
             if last && last.const_defined?(last_name.camelize, *extra)


### PR DESCRIPTION
This will remove warnings about shadowing outer local variables
