### PR TITLE
Do not change a frozen text passed to simple_format text helper 

### DIFF
--- a/actionpack/lib/action_view/helpers/text_helper.rb
+++ b/actionpack/lib/action_view/helpers/text_helper.rb
@@ -256,6 +256,7 @@ module ActionView
       #   # => "<p><span>I'm allowed!</span> It's true.</p>"
       def simple_format(text, html_options={}, options={})
         text = '' if text.nil?
+        text = text.dup if text.frozen?
         start_tag = tag('p', html_options, true)
         text = sanitize(text) unless options[:sanitize] == false
         text = text.to_str

--- a/actionpack/test/template/text_helper_test.rb
+++ b/actionpack/test/template/text_helper_test.rb
@@ -36,8 +36,8 @@ class TextHelperTest < ActionView::TestCase
     text = "A\r\n  \nB\n\n\r\n\t\nC\nD".freeze
     assert_equal "<p>A\n<br />  \n<br />B</p>\n\n<p>\t\n<br />C\n<br />D</p>", simple_format(text)
 
-     assert_equal %q(<p class="test">This is a classy test</p>), simple_format("This is a classy test", :class => 'test')
-     assert_equal %Q(<p class="test">para 1</p>\n\n<p class="test">para 2</p>), simple_format("para 1\n\npara 2", :class => 'test')
+    assert_equal %q(<p class="test">This is a classy test</p>), simple_format("This is a classy test", :class => 'test')
+    assert_equal %Q(<p class="test">para 1</p>\n\n<p class="test">para 2</p>), simple_format("para 1\n\npara 2", :class => 'test')
   end
 
   def test_simple_format_should_sanitize_input_when_sanitize_option_is_not_false
@@ -46,6 +46,13 @@ class TextHelperTest < ActionView::TestCase
 
   def test_simple_format_should_not_sanitize_input_when_sanitize_option_is_false
     assert_equal "<p><b> test with unsafe string </b><script>code!</script></p>", simple_format("<b> test with unsafe string </b><script>code!</script>", {}, :sanitize => false)
+  end
+
+  def test_simple_format_should_not_change_the_frozen_text_passed
+    text = "<b>Ok</b><script>code!</script>"
+    text_clone = text.dup
+    simple_format(text.freeze)
+    assert_equal text_clone, text
   end
 
   def test_truncate_should_not_be_html_safe


### PR DESCRIPTION
Say configuration yml is loaded and cached to an instance variable, then string from it is passed to simple_format helper. Currently it is changed.
It shouldn't happen if passed string is frozen.

I added a test and fix for this case.

It's also worth considering to not change passed argument in all cases.
