### PR TITLE
Fix regexp in generators for right catching error message

### DIFF
--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -299,9 +299,6 @@ module Rails
               return
             rescue LoadError => e
               raise unless e.message =~ /#{Regexp.escape(path)}$/
-            rescue NameError => e
-              raise unless e.message =~ /Rails::Generator(\s|::|$)/
-              warn "[WARNING] Could not load generator #{path.inspect} because it's a Rails 2.x generator, which is not supported anymore. Error: #{e.message}.\n#{e.backtrace.join("\n")}"
             rescue Exception => e
               warn "[WARNING] Could not load generator #{path.inspect}. Error: #{e.message}.\n#{e.backtrace.join("\n")}"
             end

--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -300,7 +300,7 @@ module Rails
             rescue LoadError => e
               raise unless e.message =~ /#{Regexp.escape(path)}$/
             rescue NameError => e
-              raise unless e.message =~ /Rails::Generator([\s(::)]|$)/
+              raise unless e.message =~ /Rails::Generator(\s|::|$)/
               warn "[WARNING] Could not load generator #{path.inspect} because it's a Rails 2.x generator, which is not supported anymore. Error: #{e.message}.\n#{e.backtrace.join("\n")}"
             rescue Exception => e
               warn "[WARNING] Could not load generator #{path.inspect}. Error: #{e.message}.\n#{e.backtrace.join("\n")}"

--- a/railties/test/fixtures/lib/generators/wrong_generator.rb
+++ b/railties/test/fixtures/lib/generators/wrong_generator.rb
@@ -1,3 +1,0 @@
-# Old generator version
-class WrongGenerator < Rails::Generator::NamedBase
-end

--- a/railties/test/generators_test.rb
+++ b/railties/test/generators_test.rb
@@ -88,12 +88,6 @@ class GeneratorsTest < Rails::Generators::TestCase
     assert Rails::Generators.find_by_namespace(:model)
   end
 
-  def test_find_by_namespace_show_warning_if_generator_cant_be_loaded
-    output = capture(:stderr) { Rails::Generators.find_by_namespace(:wrong) }
-    assert_match(/\[WARNING\] Could not load generator/, output)
-    assert_match(/Rails 2\.x generator/, output)
-  end
-
   def test_invoke_with_nested_namespaces
     model_generator = mock('ModelGenerator') do
       expects(:start).with(["Account"], {})


### PR DESCRIPTION
There was a warning:

```
/Users/gazay/code/rails/railties/lib/rails/generators.rb:303: warning: character class has duplicated range: /Rails::Generator([\s(::)]|$)/
```

I think it was not right regexp because it can catch some strange lines like

```
'Rails::Generator('
'Rails::Generator)'
'Rails::Generator:'
```

But in fact the purpose of this expression has been catch follow lines:

```
'Rails::Generator '
'Rails::Generator::'
'Rails::Generator'
```
