### PR TITLE
fragment_for assumes ActionView::OutputBuffer.

### DIFF
--- a/actionpack/lib/action_view/helpers/cache_helper.rb
+++ b/actionpack/lib/action_view/helpers/cache_helper.rb
@@ -51,8 +51,9 @@ module ActionView
           # This dance is needed because Builder can't use capture
           pos = output_buffer.length
           yield
+          output_safe = output_buffer.html_safe?
           fragment = output_buffer.slice!(pos..-1)
-          if output_buffer.kind_of?(ActiveSupport::SafeBuffer)
+          if output_safe
             self.output_buffer = output_buffer.html_safe
           end
           controller.write_fragment(name, fragment, options)

--- a/actionpack/lib/action_view/helpers/cache_helper.rb
+++ b/actionpack/lib/action_view/helpers/cache_helper.rb
@@ -51,12 +51,9 @@ module ActionView
           # This dance is needed because Builder can't use capture
           pos = output_buffer.length
           yield
-          if output_buffer.is_a?(ActionView::OutputBuffer)
-            safe_output_buffer = output_buffer.to_str
-            fragment = safe_output_buffer.slice!(pos..-1)
-            self.output_buffer = ActionView::OutputBuffer.new(safe_output_buffer)
-          else
-            fragment = output_buffer.slice!(pos..-1)
+          fragment = output_buffer.slice!(pos..-1)
+          if output_buffer.kind_of?(ActiveSupport::SafeBuffer)
+            self.output_buffer = output_buffer.html_safe
           end
           controller.write_fragment(name, fragment, options)
         end


### PR DESCRIPTION
Handle for cases where the buffer is a SafeBuffer, or a particular subclass of SafeBuffer.

If this looks good, I'll make a patch for the other release branches.

Thanks!
