### PR TITLE
Fix namespaced models attributes translation.

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1394,7 +1394,7 @@ module ActiveRecord #:nodoc:
       # Specify +options+ with additional translating options.
       def human_attribute_name(attribute_key_name, options = {})
         defaults = self_and_descendants_from_active_record.map do |klass|
-          :"#{klass.name.underscore}.#{attribute_key_name}"
+          :"#{klass.name.underscore.gsub("/", "_")}.#{attribute_key_name}"
         end
         defaults << options[:default] if options[:default]
         defaults.flatten!

--- a/activerecord/test/cases/i18n_test.rb
+++ b/activerecord/test/cases/i18n_test.rb
@@ -1,21 +1,27 @@
 require "cases/helper"
 require 'models/topic'
 require 'models/reply'
+require 'models/namespaced_model'
 
 class ActiveRecordI18nTests < Test::Unit::TestCase
 
   def setup
     I18n.backend = I18n::Backend::Simple.new
   end
-  
+
   def test_translated_model_attributes
     I18n.backend.store_translations 'en', :activerecord => {:attributes => {:topic => {:title => 'topic title attribute'} } }
     assert_equal 'topic title attribute', Topic.human_attribute_name('title')
   end
-  
+
   def test_translated_model_attributes_with_symbols
     I18n.backend.store_translations 'en', :activerecord => {:attributes => {:topic => {:title => 'topic title attribute'} } }
     assert_equal 'topic title attribute', Topic.human_attribute_name(:title)
+  end
+
+  def test_translated_model_attributes_of_namespaced_models
+    I18n.backend.store_translations 'en', :activerecord => {:attributes => {:namespaced_model => {:title => 'some namespaced model title attribute'} } }
+    assert_equal 'some namespaced model title attribute', Namespaced::Model.human_attribute_name(:title)
   end
 
   def test_translated_model_attributes_with_sti

--- a/activerecord/test/models/namespaced_model.rb
+++ b/activerecord/test/models/namespaced_model.rb
@@ -1,0 +1,2 @@
+class Namespaced::Model < ActiveRecord::Base
+end


### PR DESCRIPTION
Fix for attributes translation of namespaced models like Some::Complicated::Model. Because of .underscore turns it in some/complicated/model" and this cannot be concatenated via "." with attribute_key_name.
