### PR TITLE
Support reversal of ARel orderings in reverse_sql_order

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -305,9 +305,18 @@ module ActiveRecord
     def reverse_sql_order(order_query)
       order_query = ["#{quoted_table_name}.#{quoted_primary_key} ASC"] if order_query.empty?
 
-      order_query.join(', ').split(',').collect do |s|
-        s.gsub!(/\sasc\Z/i, ' DESC') || s.gsub!(/\sdesc\Z/i, ' ASC') || s.concat(' DESC')
-      end
+      order_query.map do |o|
+        case o
+        when Arel::Nodes::Ordering
+          o.reverse
+        when String, Symbol
+          o.to_s.split(',').collect do |s|
+            s.gsub!(/\sasc\Z/i, ' DESC') || s.gsub!(/\sdesc\Z/i, ' ASC') || s.concat(' DESC')
+          end
+        else
+          o
+        end
+      end.flatten
     end
 
     def array_of_strings?(o)

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -145,6 +145,18 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal topics(:first).title, topics.first.title
   end
 
+
+  def test_finding_with_arel_order
+    topics = Topic.order(Topic.arel_table[:id].asc)
+    assert_equal 4, topics.to_a.size
+    assert_equal topics(:first).title, topics.first.title
+  end
+
+  def test_finding_last_with_arel_order
+    topics = Topic.order(Topic.arel_table[:id].asc)
+    assert_equal topics(:fourth).title, topics.last.title
+  end
+
   def test_finding_with_order_concatenated
     topics = Topic.order('author_name').order('title')
     assert_equal 4, topics.to_a.size


### PR DESCRIPTION
This fixes reverse_sql_order's assumption that order_values are always strings/symbols, and relies upon the corresponding ARel pull request at https://github.com/rails/arel/pull/64
