### PR TITLE
rake assets:clean also removes directories

### DIFF
--- a/railties/lib/rails/tasks/assets.rake
+++ b/railties/lib/rails/tasks/assets.rake
@@ -19,8 +19,8 @@ namespace :assets do
     public_asset_path = Rails.public_path + assets.prefix
     file_list = FileList.new("#{public_asset_path}/**/*")
     file_list.each do |file|
-      rm file, :force => true
-      rm "#{file}.gz", :force => true
+      rm_rf file
+      rm_rf "#{file}.gz"
     end
   end
 end

--- a/railties/lib/rails/tasks/assets.rake
+++ b/railties/lib/rails/tasks/assets.rake
@@ -19,7 +19,7 @@ namespace :assets do
     public_asset_path = Rails.public_path + assets.prefix
     file_list = FileList.new("#{public_asset_path}/**/*")
     file_list.each do |file|
-      rm file
+      rm file, :force => true
       rm "#{file}.gz", :force => true
     end
   end

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -43,7 +43,21 @@ module ApplicationTests
       end
 
       file = Dir["#{app_path}/public/assets/application-*.js"][0]
+      assert_not_nil file, "Expected application.js asset to be generated, but none found"
       assert_equal "alert();\n", File.read(file)
+    end
+
+    test "assets are cleaned up properly" do
+      app_file "public/assets/application.js", "alert();"
+      app_file "public/assets/application.css", "a { color: green; }"
+      app_file "public/assets/subdir/broken.png", "not really an image file"
+
+      capture(:stdout) do
+        Dir.chdir(app_path){ `bundle exec rake assets:clean` }
+      end
+
+      files = Dir["#{app_path}/public/assets/**/*"]
+      assert_equal 0, files.length, "Expected no assets, but found #{files.join(', ')}"
     end
 
     test "does not stream session cookies back" do


### PR DESCRIPTION
See [#1776](https://github.com/rails/rails/pull/1776#issuecomment-1402894), 2df2bfdb4b1165dce4b5bc3fe046147d793fead4, and 7440a254c4e724a5bbf6a0f4c8edb6d8d0432433.
