### PR TITLE
Fixes an issue where cache sweepers with only after filters would have no controller object

### DIFF
--- a/actionpack/lib/action_controller/caching/sweeping.rb
+++ b/actionpack/lib/action_controller/caching/sweeping.rb
@@ -61,6 +61,7 @@ module ActionController #:nodoc:
         end
 
         def after(controller)
+          self.controller = controller
           callback(:after) if controller.perform_caching
           # Clean up, so that the controller can be collected after this request
           self.controller = nil

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -530,6 +530,11 @@ class FilterTest < ActionController::TestCase
     assert sweeper.before(TestController.new)
   end
 
+  def test_after_method_of_sweeper_should_always_return_nil
+    sweeper = ActionController::Caching::Sweeper.send(:new)
+    assert_nil sweeper.after(TestController.new)
+  end
+
   def test_non_yielding_around_filters_not_returning_false_do_not_raise
     controller = NonYieldingAroundFilterController.new
     controller.instance_variable_set "@filter_return_value", true


### PR DESCRIPTION
It would raise undefined method controller_name for nil while trying to reach controllers where the sweeper was defined.

I do not have tests for this yet...
