### PR TITLE
Use uglifier from rubygems instead of git repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ end
 
 gem "coffee-script"
 gem "sass"
-gem "uglifier", :git => "git://github.com/lautis/uglifier.git"
+gem "uglifier", ">= 1.0.0"
 
 gem "rake",  ">= 0.8.7"
 gem "mocha", ">= 0.9.8"


### PR DESCRIPTION
New version of Uglifier gem (1.0.0) is out and we can use it directly from rubygems instead of Git repository
