### PR TITLE
More jruby gem for database fixes

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -10,7 +10,7 @@ module Rails
   module Generators
     class AppBase < Base
       DATABASES = %w( mysql oracle postgresql sqlite3 frontbase ibm_db )
-      JDBC_DATABASES = %w( jdbcmysql jdbcsqlite3 jdbcpostgresql )
+      JDBC_DATABASES = %w( jdbcmysql jdbcsqlite3 jdbcpostgresql jdbc )
       DATABASES.concat(JDBC_DATABASES)
 
       attr_accessor :rails_template
@@ -157,9 +157,10 @@ module Rails
         when "postgresql" then "pg"
         when "frontbase"  then "ruby-frontbase"
         when "mysql"      then "mysql2"
-        when "jdbcmysql"  then "activerecord-jdbcmysql-adapter"
-        when "jdbcsqlite3"  then "activerecord-jdbcsqlite3-adapter"
-        when "jdbcpostgresql"  then "activerecord-jdbcpostgresql-adapter"
+        when "jdbcmysql"      then "activerecord-jdbcmysql-adapter"
+        when "jdbcsqlite3"    then "activerecord-jdbcsqlite3-adapter"
+        when "jdbcpostgresql" then "activerecord-jdbcpostgresql-adapter"
+        when "jdbc"           then "activerecord-jdbc-adapter"
         else options[:database]
         end
       end

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -64,8 +64,8 @@ module Rails
 
       def initialize(*args)
         @original_wd = Dir.pwd
-
         super
+        convert_database_option_for_jruby
       end
 
     protected
@@ -162,6 +162,17 @@ module Rails
         when "jdbcpostgresql" then "activerecord-jdbcpostgresql-adapter"
         when "jdbc"           then "activerecord-jdbc-adapter"
         else options[:database]
+        end
+      end
+
+      def convert_database_option_for_jruby
+        if defined?(JRUBY_VERSION)
+          case options[:database]
+          when "oracle"     then options[:database].replace "jdbc"
+          when "postgresql" then options[:database].replace "jdbcpostgresql"
+          when "mysql"      then options[:database].replace "jdbcmysql"
+          when "sqlite3"    then options[:database].replace "jdbcsqlite3"
+          end
         end
       end
 

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml
@@ -1,0 +1,62 @@
+# If you are using mssql, derby, hsqldb, or h2 with one of the
+# ActiveRecord JDBC adapters, install the appropriate driver, e.g.,:
+#   gem install activerecord-jdbcmssql-adapter
+#
+# Configure using Gemfile:
+#   gem 'activerecord-jdbcmssql-adapter'
+#
+#development:
+#  adapter: mssql
+#  username: <%= app_name %>
+#  password:
+#  host: localhost
+#  database: <%= app_name %>_development
+#
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+#
+#test:
+#  adapter: mssql
+#  username: <%= app_name %>
+#  password:
+#  host: localhost
+#  database: <%= app_name %>_test
+#
+#production:
+#  adapter: mssql
+#  username: <%= app_name %>
+#  password:
+#  host: localhost
+#  database: <%= app_name %>_production
+
+# If you are using oracle, db2, sybase, informix or prefer to use the plain
+# JDBC adapter, configure your database setting as the example below (requires
+# you to download and manually install the database vendor's JDBC driver .jar
+# file). See your driver documentation for the apropriate driver class and
+# connection string:
+
+development:
+  adapter: jdbc
+  username: <%= app_name %>
+  password:
+  driver:
+  url: jdbc:db://localhost/<%= app_name %>_development
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+
+test:
+  adapter: jdbc
+  username: <%= app_name %>
+  password:
+  driver:
+  url: jdbc:db://localhost/<%= app_name %>_test
+
+production:
+  adapter: jdbc
+  username: <%= app_name %>
+  password:
+  driver:
+  url: jdbc:db://localhost/<%= app_name %>_production

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml
@@ -9,7 +9,7 @@
 # And be sure to use new-style password hashing:
 #   http://dev.mysql.com/doc/refman/5.0/en/old-client.html
 development:
-  adapter: jdbcmysql
+  adapter: mysql
   database: <%= app_name %>_development
   username: root
   password:
@@ -19,14 +19,14 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: jdbcmysql
+  adapter: mysql
   database: <%= app_name %>_test
   username: root
   password:
   host: localhost
 
 production:
-  adapter: jdbcmysql
+  adapter: mysql
   database: <%= app_name %>_production
   username: root
   password:

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
@@ -1,14 +1,5 @@
 # PostgreSQL. Versions 7.4 and 8.x are supported.
 #
-# Install the pg driver:
-#   gem install pg
-# On Mac OS X with macports:
-#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
-# On Windows:
-#   gem install pg
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
-#
 # Configure Using Gemfile
 # gem 'activerecord-jdbcpostgresql-adapter'
 

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
@@ -4,7 +4,7 @@
 # gem 'activerecord-jdbcpostgresql-adapter'
 
 development:
-  adapter: jdbcpostgresql
+  adapter: postgresql
   encoding: unicode
   database: <%= app_name %>_development
   username: <%= app_name %>
@@ -29,14 +29,14 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: jdbcpostgresql
+  adapter: postgresql
   encoding: unicode
   database: <%= app_name %>_test
   username: <%= app_name %>
   password:
 
 production:
-  adapter: jdbcpostgresql
+  adapter: postgresql
   encoding: unicode
   database: <%= app_name %>_production
   username: <%= app_name %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml
@@ -5,16 +5,16 @@
 # gem 'activerecord-jdbcsqlite3-adapter'
 #
 development:
-  adapter: jdbcsqlite3
+  adapter: sqlite3
   database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: jdbcsqlite3
+  adapter: sqlite3
   database: db/test.sqlite3
 
 production:
-  adapter: jdbcsqlite3
+  adapter: sqlite3
   database: db/production.sqlite3


### PR DESCRIPTION
These changes update the JRuby/JDBC database support to be a little friendlier.
- You will be able to use `rails new app` with no arguments and get a proper JRuby/sqlite3-based Rails app.
- `rails new app -d sqlite3` and `rails new app -d jdbcsqlite3` will do the same thing.
- Add a `rails new app -d jdbc` template for all other databases.
