### PR TITLE
Through association should not read-only

### DIFF
--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -459,6 +459,17 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert author.comments.include?(comment)
   end
 
+  def test_through_association_readonly_should_be_false
+    assert !people(:michael).posts.first.readonly?
+    assert !people(:michael).posts.all.first.readonly?
+  end
+
+  def test_can_update_through_association
+    assert_nothing_raised do
+      people(:michael).posts.first.update_attributes!(:title => "Can write")
+    end
+  end
+
   def test_size_of_through_association_should_increase_correctly_when_has_many_association_is_added
     post = posts(:thinking)
     readers = post.readers.size


### PR DESCRIPTION
With Rails 3.0, I'm getting an ActiveRecord::ReadOnlyRecord error on a normal through association. 

``` ruby
people(:michael).posts.first.update_attributes!(:title => "Can write")
```

This is a regression form Rails 2.3. It works fine on master too.

Seems like the problem is the association join is being passed in the the _build_joins_ method as a string - hence it does not recognise it as an association join. In master, it's not a string but an Arel::Node - which is a huge revamp for 3-0-stable

``` ruby
# in lib/active_record/relation/query_methods.rb
      non_association_joins = (joins - association_joins - stashed_association_joins)
      custom_joins = custom_join_sql(*non_association_joins)
```
