### PR TITLE
ActiveRecord::Migrator.bulk_migration option

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -319,6 +319,17 @@ module ActiveRecord
   #
   # For a list of commands that are reversible, please see
   # <tt>ActiveRecord::Migration::CommandRecorder</tt>.
+  #
+  # == DDL transactions
+  #
+  # If your database supports DDL transaction migrations will be run in transaction.
+  # <tt>ActiveRecord::Migrator.bulk_migration</tt> option can be used to specify
+  # whether you want to apply all migrations under one transaction or each migration under separated transaction.
+  # This option is suppose to be <tt>true</tt> in production environment where you want to rollback all DB changes
+  # in case of failure.
+  #
+  # This option is <tt>false</tt> by default.
+  #
   class Migration
     autoload :CommandRecorder, 'active_record/migration/command_recorder'
 
@@ -514,6 +525,9 @@ module ActiveRecord
   end
 
   class Migrator#:nodoc:
+
+    class_attribute :bulk_migration
+
     class << self
       attr_writer :migrations_paths
       alias :migrations_path= :migrations_paths=
@@ -662,29 +676,33 @@ module ActiveRecord
       runnable.pop if down? && target
 
       ran = []
-      runnable.each do |migration|
-        Base.logger.info "Migrating to #{migration.name} (#{migration.version})" if Base.logger
+      ddl_transaction(self.bulk_migration) do
+        runnable.each do |migration|
+          Base.logger.info "Migrating to #{migration.name} (#{migration.version})" if Base.logger
 
-        seen = migrated.include?(migration.version.to_i)
+          seen = migrated.include?(migration.version.to_i)
 
-        # On our way up, we skip migrating the ones we've already migrated
-        next if up? && seen
+          # On our way up, we skip migrating the ones we've already migrated
+          next if up? && seen
 
-        # On our way down, we skip reverting the ones we've never migrated
-        if down? && !seen
-          migration.announce 'never migrated, skipping'; migration.write
-          next
-        end
-
-        begin
-          ddl_transaction do
-            migration.migrate(@direction)
-            record_version_state_after_migrating(migration.version)
+          # On our way down, we skip reverting the ones we've never migrated
+          if down? && !seen
+            migration.announce 'never migrated, skipping'; migration.write
+            next
           end
-          ran << migration
-        rescue => e
-          canceled_msg = Base.connection.supports_ddl_transactions? ? "this and " : ""
-          raise StandardError, "An error has occurred, #{canceled_msg}all later migrations canceled:\n\n#{e}", e.backtrace
+
+          begin
+            ddl_transaction(!self.bulk_migration) do
+              migration.migrate(@direction)
+              record_version_state_after_migrating(migration.version)
+            end
+            ran << migration
+          rescue => e
+            canceled_msg_prefix = Base.connection.supports_ddl_transactions? && !self.bulk_migration ? "this and " : ""
+            canceled_msg_suffix = Base.connection.supports_ddl_transactions? && self.bulk_migration ? "" : "later "
+
+            raise StandardError, "An error has occurred, #{canceled_msg_prefix}all #{canceled_msg_suffix}migrations canceled:\n\n#{e}", e.backtrace
+          end
         end
       end
       ran
@@ -731,8 +749,8 @@ module ActiveRecord
       end
 
       # Wrap the migration in a transaction only if supported by the adapter.
-      def ddl_transaction(&block)
-        if Base.connection.supports_ddl_transactions?
+      def ddl_transaction(perform, &block)
+        if perform && Base.connection.supports_ddl_transactions?
           Base.transaction { block.call }
         else
           block.call

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1275,6 +1275,27 @@ if ActiveRecord::Base.connection.supports_migrations?
 
         Person.reset_column_information
         assert !Person.column_methods_hash.include?(:last_name)
+      ensure
+        ActiveRecord::Migrator.down(MIGRATIONS_ROOT + "/broken", 98)
+      end
+
+      def test_migrator_two_up_with_exception_and_rollback
+        ActiveRecord::Migrator.bulk_migration = true
+        assert !Person.column_methods_hash.include?(:phone)
+        assert !Person.column_methods_hash.include?(:last_name)
+
+        e = assert_raise(StandardError) do
+          ActiveRecord::Migrator.up(MIGRATIONS_ROOT + "/broken", 100)
+        end
+
+
+        Person.reset_column_information
+        assert !Person.column_methods_hash.include?(:last_name)
+        assert !Person.column_methods_hash.include?(:phone)
+        assert_equal "An error has occurred, all migrations canceled:\n\nSomething broke", e.message
+      ensure
+        ActiveRecord::Migrator.down(MIGRATIONS_ROOT + "/broken", 98)
+        ActiveRecord::Migrator.bulk_migration = false
       end
     end
 

--- a/activerecord/test/migrations/broken/098_base_migration.rb
+++ b/activerecord/test/migrations/broken/098_base_migration.rb
@@ -1,0 +1,7 @@
+class BaseMigration < ActiveRecord::Migration
+  def self.up
+  end
+
+  def self.down
+  end
+end

--- a/activerecord/test/migrations/broken/099_valid_migration.rb
+++ b/activerecord/test/migrations/broken/099_valid_migration.rb
@@ -1,0 +1,9 @@
+class ValidMigration < ActiveRecord::Migration
+  def self.up
+    add_column "people", "phone", :string
+  end
+
+  def self.down
+    remove_column "people", "phone"
+  end
+end


### PR DESCRIPTION
Example: let's say that we need to apply two migration on production. First one delete unused column A. Second one does complicated data migration that failed during migration. In this case source code will be rollback to previous working version, but only the last migration got reverted. Production will run previous working version of source code that expects column A to exists, but it is not.

The thing that `ActiveRecord::Migrator` rollbacks only last applied migration will create inconsistency between data and code. It could be sensitive in some cases in production mode.

In order to control whether all migrations should be run under one transaction or separated transaction
Implemented ActiveRecord::Migrator.bulk_migration option that supposed to be enabled in production
