### PR TITLE
sprockets x.beta.11 was yanked and actionpack relied on it.

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency('rack',             '~> 1.3.0')
   s.add_dependency('rack-test',        '~> 0.6.0')
   s.add_dependency('rack-mount',       '~> 0.8.1')
-  s.add_dependency('sprockets',        '~> 2.0.0.beta.11')
+  s.add_dependency('sprockets',        '~> 2.0.0.beta.10')
   s.add_dependency('tzinfo',           '~> 0.3.27')
   s.add_dependency('erubis',           '~> 2.7.0')
 end


### PR DESCRIPTION
I just updated the gemspec to rely on x.beta.10 instead of 11. I couldn't bundle install from the rails master branch with it still depending on 11.
