### PR TITLE
Log instrumentation name for exists? queries

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -193,8 +193,8 @@ module ActiveRecord
       else
         relation = relation.where(table[primary_key].eq(id)) if id
       end
-
-      connection.select_value(relation.to_sql) ? true : false
+      
+      connection.select_value(relation.to_sql, "#{name} Exists") ? true : false
     end
 
     protected

--- a/activerecord/test/cases/log_subscriber_test.rb
+++ b/activerecord/test/cases/log_subscriber_test.rb
@@ -63,6 +63,14 @@ class LogSubscriberTest < ActiveRecord::TestCase
     assert_match(/SELECT .*?FROM .?developers.?/i, @logger.logged(:debug).last)
   end
 
+  def test_exists_query_logging
+    Developer.exists? 1
+    wait
+    assert_equal 1, @logger.logged(:debug).size
+    assert_match(/Developer Exists/, @logger.logged(:debug).last)
+    assert_match(/SELECT .*?FROM .?developers.?/i, @logger.logged(:debug).last)
+  end
+
   def test_cached_queries
     ActiveRecord::Base.cache do
       Developer.all


### PR DESCRIPTION
Hi,

I noticed that as of 3.1 exists? queries stopped reporting an instrumentation name in their log entry.  Here's a proposed patch for that.

Thanks,
Jon
Ruby Agent Engineer
New Relic
