### PR TITLE
Allow to specify roles for mass-assignment as array

### DIFF
--- a/activemodel/lib/active_model/mass_assignment_security.rb
+++ b/activemodel/lib/active_model/mass_assignment_security.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/class/attribute'
 require 'active_support/core_ext/string/inflections'
+require 'active_support/core_ext/array/wrap'
 require 'active_model/mass_assignment_security/permission_set'
 require 'active_model/mass_assignment_security/sanitizer'
 
@@ -112,7 +113,7 @@ module ActiveModel
 
         self._protected_attributes        = protected_attributes_configs.dup
 
-        Array(role).each do |name|
+        Array.wrap(role).each do |name|
           self._protected_attributes[name] = self.protected_attributes(name) + args
         end
 
@@ -174,7 +175,7 @@ module ActiveModel
 
         self._accessible_attributes       = accessible_attributes_configs.dup
 
-        Array(role).each do |name|
+        Array.wrap(role).each do |name|
           self._accessible_attributes[name] = self.accessible_attributes(name) + args
         end
 

--- a/activemodel/lib/active_model/mass_assignment_security.rb
+++ b/activemodel/lib/active_model/mass_assignment_security.rb
@@ -111,7 +111,10 @@ module ActiveModel
         role = options[:as] || :default
 
         self._protected_attributes        = protected_attributes_configs.dup
-        self._protected_attributes[role] = self.protected_attributes(role) + args
+
+        Array(role).each do |name|
+          self._protected_attributes[name] = self.protected_attributes(name) + args
+        end
 
         self._active_authorizer = self._protected_attributes
       end
@@ -170,7 +173,10 @@ module ActiveModel
         role = options[:as] || :default
 
         self._accessible_attributes       = accessible_attributes_configs.dup
-        self._accessible_attributes[role] = self.accessible_attributes(role) + args
+
+        Array(role).each do |name|
+          self._accessible_attributes[name] = self.accessible_attributes(name) + args
+        end
 
         self._active_authorizer = self._accessible_attributes
       end

--- a/activemodel/test/cases/mass_assignment_security_test.rb
+++ b/activemodel/test/cases/mass_assignment_security_test.rb
@@ -43,6 +43,20 @@ class MassAssignmentSecurityTest < ActiveModel::TestCase
     assert_equal expected, sanitized
   end
 
+  def test_attributes_accessible_with_roles_given_as_array
+    user = Account.new
+    expected = { "name" => "John Smith", "email" => "john@smith.com" }
+    sanitized = user.sanitize_for_mass_assignment(expected.merge("admin" => true))
+    assert_equal expected, sanitized
+  end
+
+  def test_attributes_accessible_with_admin_role_when_roles_given_as_array
+    user = Account.new
+    expected = { "name" => "John Smith", "email" => "john@smith.com", "admin" => true }
+    sanitized = user.sanitize_for_mass_assignment(expected.merge("super_powers" => true), :admin)
+    assert_equal expected, sanitized
+  end
+
   def test_attributes_protected_by_default
     firm = Firm.new
     expected = { }

--- a/activemodel/test/models/mass_assignment_specific.rb
+++ b/activemodel/test/models/mass_assignment_specific.rb
@@ -20,6 +20,14 @@ class Person
   public :sanitize_for_mass_assignment
 end
 
+class Account
+  include ActiveModel::MassAssignmentSecurity
+  attr_accessible :name, :email, :as => [:default, :admin]
+  attr_accessible :admin, :as => :admin
+
+  public :sanitize_for_mass_assignment
+end
+
 class Firm
   include ActiveModel::MassAssignmentSecurity
 


### PR DESCRIPTION
Currently we must write:

<pre>
class User
  attr_accessible :email
  attr_accessible :email, :as => :admin
end
</pre>

I believe alternate syntax is useful:

<pre>
class User
  attr_accessible :email, :as => [:default, :admin]
end
</pre>

