### PR TITLE
Fix for empty string assigned to _type column of polymorphic association

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -75,7 +75,7 @@ module ActiveRecord
         end
 
         def association_class
-          @owner[@reflection.options[:foreign_type]] ? @owner[@reflection.options[:foreign_type]].constantize : nil
+          @owner[@reflection.options[:foreign_type]].present? ? @owner[@reflection.options[:foreign_type]].constantize : nil
         end
     end
   end

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -161,6 +161,13 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_nil sponsor.sponsorable_with_conditions
   end
 
+  def test_polymorphic_with_empty_string_for_type
+    sponsor = Sponsor.create
+    sponsor.sponsorable_type = ""
+
+    assert_nil sponsor.sponsorable
+  end
+
   def test_with_select
     assert_equal Company.find(2).firm_with_select.attributes.size, 1
     assert_equal Company.find(2, :include => :firm_with_select ).firm_with_select.attributes.size, 1


### PR DESCRIPTION
Fix issue where assigning a empty string to the _type column of a polymorphic association throws an error.  Now it returns nil for the association as one would expect.

[Fixes #1824]
