### PR TITLE
Fix disable referential integrity for postgresql

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -446,13 +446,13 @@ module ActiveRecord
       end
 
       def disable_referential_integrity #:nodoc:
-        if supports_disable_referential_integrity? then
-          execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL" }.join(";"))
+        if supports_disable_referential_integrity?
+          execute "SET CONSTRAINTS ALL DEFERRED"
         end
         yield
       ensure
-        if supports_disable_referential_integrity? then
-          execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
+        if supports_disable_referential_integrity?
+          execute "SET CONSTRAINTS ALL IMMEDIATE"
         end
       end
 


### PR DESCRIPTION
Using "SET CONSTRAINTS ALL DEFERRED" and "SET CONSTRAINTS ALL IMMEDIATE" to disable foreign keys on postgresql adapter we can disable foreign keys without issues for non admin users on postgresql.

I didn't write a test case for this issue because I don't know how.

I need to connect to a postgresql database using tables with foreign keys, and try to disable foreign keys on this connection.

How can we do this on rails test suite?
