### PR TITLE
Fix for complex ordering of multiple columns on postgresql

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -940,7 +940,7 @@ module ActiveRecord
 
         # Construct a clean list of column names from the ORDER BY clause, removing
         # any ASC/DESC modifiers
-        order_columns = orders.collect { |s| s =~ /^(.+)\s+(ASC|DESC)\s*$/i ? $1 : s }
+        order_columns = orders.collect { |s| s.gsub(/\s+(ASC|DESC)\s*/i, '') }
         order_columns.delete_if { |c| c.blank? }
         order_columns = order_columns.zip((0...order_columns.size).to_a).map { |s,i| "#{s} AS alias_#{i}" }
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -176,6 +176,13 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal entrants(:first).name, entrants.first.name
   end
 
+  def test_finding_with_cross_table_order_and_limit
+    tags = Tag.includes(:taggings) \
+              .order("tags.name asc, taggings.taggable_id asc, REPLACE('abc', taggings.taggable_type, taggings.taggable_type)") \
+              .limit(1).to_a
+    assert_equal 1, tags.length
+  end
+
   def test_finding_with_complex_order_and_limit
     tags = Tag.includes(:taggings).order("REPLACE('abc', taggings.taggable_type, taggings.taggable_type)").limit(1).to_a
     assert_equal 1, tags.length


### PR DESCRIPTION
- Test included only fails with postresql
- Related to commit: [fix for postgresql](https://github.com/rails/rails/commit/6709078eb1f61a1f8d54fcd82e9a07e96383ec8a)
- Closes #1720
