### PR TITLE
[3-1-stable] Fix for complex ordering of multiple columns on postgresql

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -929,7 +929,7 @@ module ActiveRecord
 
         # Construct a clean list of column names from the ORDER BY clause, removing
         # any ASC/DESC modifiers
-        order_columns = orders.collect { |s| s =~ /^(.+)\s+(ASC|DESC)\s*$/i ? $1 : s }
+        order_columns = orders.collect { |s| s.gsub(/\s+(ASC|DESC)\s*/i, '') }
         order_columns.delete_if { |c| c.blank? }
         order_columns = order_columns.zip((0...order_columns.size).to_a).map { |s,i| "#{s} AS alias_#{i}" }
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -164,6 +164,13 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal entrants(:first).name, entrants.first.name
   end
 
+  def test_finding_with_cross_table_order_and_limit
+    tags = Tag.includes(:taggings) \
+              .order("tags.name asc, taggings.taggable_id asc, REPLACE('abc', taggings.taggable_type, taggings.taggable_type)") \
+              .limit(1).to_a
+    assert_equal 1, tags.length
+  end
+
   def test_finding_with_complex_order_and_limit
     tags = Tag.includes(:taggings).order("REPLACE('abc', taggings.taggable_type, taggings.taggable_type)").limit(1).to_a
     assert_equal 1, tags.length


### PR DESCRIPTION
Cherry-pick on [master](https://github.com/rails/rails/commit/9734a416faaa8149fa5914b0afe2e6761ad5ec20) for 3-1-stable branch
