### PR TITLE
StringToParameterizeWithNoSeparator: dashed parameter will not change.

### DIFF
--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -168,7 +168,7 @@ module InflectorTestCases
 
   StringToParameterizeWithNoSeparator = {
     "Donald E. Knuth"                     => "donaldeknuth",
-    "With-some-dashes"                    => "withsomedashes",
+    "With-some-dashes"                    => "with-some-dashes",
     "Random text with *(bad)* characters" => "randomtextwithbadcharacters",
     "Trailing bad characters!@#"          => "trailingbadcharacters",
     "!@#Leading bad characters"           => "leadingbadcharacters",


### PR DESCRIPTION
StringToParameterizeWithNoSeparator: dashed parameter will not change.
