### PR TITLE
IrreversibleMigration is not raised when a method not supported by reversible migrations is called in the change method of a migration

### DIFF
--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -93,11 +93,11 @@ module ActiveRecord
         [:remove_timestamps, args]
       end
 
-      # Forwards any missing method call to the \target.
+      # Record all the methods called in the +change+ method of a migration.
+      # This will ensure that IrreversibleMigration is raised when the corresponding
+      # invert_method does not exist while the migration is rolled back.
       def method_missing(method, *args, &block)
-        @delegate.send(method, *args, &block)
-      rescue NoMethodError => e
-        raise e, e.message.sub(/ for #<.*$/, " via proxy for #{@delegate}")
+        record(method, args)
       end
 
     end

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -14,9 +14,11 @@ module ActiveRecord
         assert recorder.respond_to?(:america)
       end
 
-      def test_send_calls_super
-        assert_raises(NoMethodError) do
-          @recorder.send(:non_existing_method, :horses)
+      def test_non_existing_method_records_and_raises_on_inversion
+        @recorder.send(:non_existing_method, :horses)
+        assert_equal 1, @recorder.commands.length
+        assert_raises(ActiveRecord::IrreversibleMigration) do
+          @recorder.inverse
         end
       end
 


### PR DESCRIPTION
I came across this issue on @gregg's Twitter timeline which he explained in this screencast: http://bit.ly/iu5ENC

Given a migration like this:
<code>
class AddPhone < ActiveRecord::Migration
  def change
    change_table :companies do |t|
      t.string :phone
    end
  end 
end
</code>

When rolling back this migration, we expect an IrreversibleMigration exception to be raised, because change_table is not supported by CommandRecorder and not reversible. 

But what we get is an error complaining that the column name is a duplicate - SQLite3::SQLException: duplicate column name: phone: ALTER TABLE "companies" ADD "phone" varchar(255)

This happens because of the method_missing method in CommandRecorder which sends the change_table method to the delegate database connection, thereby causing the change method to actually run on the database, even when the migration is rolled back.

As a fix, I've changed method_missing to record the method. This causes the inverse method to raise IrreversibleMigration later when it finds that invert_change_table is not available.

I want to know if this is the right approach to solve this problem. And if my tests are sufficient. Let me know if anything is missing. Thanks!
