### PR TITLE
Allow comparison on model objects - Closes #1858

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1804,6 +1804,11 @@ MSG
         @attributes.frozen?
       end
 
+      # Allows sort on objects
+      def <=>(other_object)
+        self.to_key <=> other_object.to_key
+      end
+
       # Backport dup from 1.9 so that initialize_dup() gets called
       unless Object.respond_to?(:initialize_dup)
         def dup # :nodoc:

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1806,7 +1806,11 @@ MSG
 
       # Allows sort on objects
       def <=>(other_object)
-        self.to_key <=> other_object.to_key
+        if other_object.is_a?(self.class)
+          self.to_key <=> other_object.to_key
+        else
+          nil
+        end
       end
 
       # Backport dup from 1.9 so that initialize_dup() gets called

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -486,6 +486,12 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal [topic_2, topic_1].sort, [topic_1, topic_2]
   end
 
+  def test_comparison_with_different_objects
+    topic = Topic.create
+    category = Category.create(:name => "comparison")
+    assert_nil topic <=> category
+  end
+
   def test_readonly_attributes
     assert_equal Set.new([ 'title' , 'comments_count' ]), ReadonlyTitlePost.readonly_attributes
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -478,6 +478,13 @@ class BasicsTest < ActiveRecord::TestCase
   def test_hashing
     assert_equal [ Topic.find(1) ], [ Topic.find(2).topic ] & [ Topic.find(1) ]
   end
+  
+  def test_comparison
+    topic_1 = Topic.create!
+    topic_2 = Topic.create!
+    
+    assert_equal [topic_2, topic_1].sort, [topic_1, topic_2]
+  end
 
   def test_readonly_attributes
     assert_equal Set.new([ 'title' , 'comments_count' ]), ReadonlyTitlePost.readonly_attributes


### PR DESCRIPTION
ActiveRecord object can't be sorted because they can't be compared, as reported in #1858.
This fixes it.

It does the comparison on the object's id, because that's the only field which will be available anyway in all models.
If required to sort on an other field, it should be provided in the block option of the sort method.
