### PR TITLE
Get the fixture_path from self.class instead of ActiveSupport::TestCase.

### DIFF
--- a/actionpack/lib/action_dispatch/testing/test_process.rb
+++ b/actionpack/lib/action_dispatch/testing/test_process.rb
@@ -39,7 +39,7 @@ module ActionDispatch
     #
     #   post :change_avatar, :avatar => fixture_file_upload('/files/spongebob.png', 'image/png', :binary)
     def fixture_file_upload(path, mime_type = nil, binary = false)
-      fixture_path = ActionController::TestCase.send(:fixture_path) if ActionController::TestCase.respond_to?(:fixture_path)
+      fixture_path = self.class.fixture_path if self.class.respond_to?(:fixture_path)
       Rack::Test::UploadedFile.new("#{fixture_path}#{path}", mime_type, binary)
     end
   end

--- a/actionpack/test/controller/test_test.rb
+++ b/actionpack/test/controller/test_test.rb
@@ -649,6 +649,13 @@ XML
 
   end
 
+  def test_fixture_path_is_accessed_from_self_instead_of_active_support_test_case
+    TestTest.stubs(:fixture_path).returns(FILES_DIR)
+
+    uploaded_file = fixture_file_upload('/mona_lisa.jpg', 'image/png')
+    assert_equal File.open("#{FILES_DIR}/mona_lisa.jpg", READ_PLAIN).read, uploaded_file.read
+  end
+
   def test_test_uploaded_file_with_binary
     filename = 'mona_lisa.jpg'
     path = "#{FILES_DIR}/#{filename}"


### PR DESCRIPTION
This allows test classes that are not subclasses of
ActiveSupport::TestCase (like those in rspec-rails) to interact with
with this variable without having to reference ActiveSupport::TestCase.
