### PR TITLE
Fix NumberHelper to check fallback locales before defaulting to empty hash

### DIFF
--- a/actionpack/lib/action_view/helpers/number_helper.rb
+++ b/actionpack/lib/action_view/helpers/number_helper.rb
@@ -111,8 +111,12 @@ module ActionView
 
         options.symbolize_keys!
 
-        defaults  = I18n.translate(:'number.format', :locale => options[:locale], :default => {})
-        currency  = I18n.translate(:'number.currency.format', :locale => options[:locale], :default => {})
+        begin
+          defaults  = I18n.translate(:'number.format', :locale => options[:locale], :raise => true)
+          currency  = I18n.translate(:'number.currency.format', :locale => options[:locale], :raise => true)
+        rescue I18n::MissingTranslationData
+          defaults = currency = {}
+        end
 
         defaults  = DEFAULT_CURRENCY_VALUES.merge(defaults).merge!(currency)
         defaults[:negative_format] = "-" + options[:format] if options[:format]
@@ -162,8 +166,12 @@ module ActionView
 
         options.symbolize_keys!
 
-        defaults   = I18n.translate(:'number.format', :locale => options[:locale], :default => {})
-        percentage = I18n.translate(:'number.percentage.format', :locale => options[:locale], :default => {})
+        begin
+          defaults   = I18n.translate(:'number.format', :locale => options[:locale], :raise => true)
+          percentage = I18n.translate(:'number.percentage.format', :locale => options[:locale], :raise => true)
+        rescue I18n::MissingTranslationData
+          defaults = percentage = {}
+        end
         defaults  = defaults.merge(percentage)
 
         options = options.reverse_merge(defaults)
@@ -208,7 +216,11 @@ module ActionView
           end
         end
 
-        defaults = I18n.translate(:'number.format', :locale => options[:locale], :default => {})
+        begin
+          defaults = I18n.translate(:'number.format', :locale => options[:locale], :raise => true)
+        rescue I18n::MissingTranslationData
+          defaults = {}
+        end
         options = options.reverse_merge(defaults)
 
         parts = number.to_s.to_str.split('.')
@@ -256,8 +268,12 @@ module ActionView
           end
         end
 
-        defaults           = I18n.translate(:'number.format', :locale => options[:locale], :default => {})
-        precision_defaults = I18n.translate(:'number.precision.format', :locale => options[:locale], :default => {})
+        begin
+          defaults           = I18n.translate(:'number.format', :locale => options[:locale], :raise => true)
+          precision_defaults = I18n.translate(:'number.precision.format', :locale => options[:locale], :raise => true)
+        rescue I18n::MissingTranslationData
+          defaults = precision_defaults = {}
+        end
         defaults           = defaults.merge(precision_defaults)
 
         options = options.reverse_merge(defaults)  # Allow the user to unset default values: Eg.: :significant => false
@@ -333,8 +349,12 @@ module ActionView
           end
         end
 
-        defaults = I18n.translate(:'number.format', :locale => options[:locale], :default => {})
-        human    = I18n.translate(:'number.human.format', :locale => options[:locale], :default => {})
+        begin
+          defaults = I18n.translate(:'number.format', :locale => options[:locale], :raise => true)
+          human    = I18n.translate(:'number.human.format', :locale => options[:locale], :raise => true)
+        rescue I18n::MissingTranslationData
+          defaults = human = {}
+        end
         defaults = defaults.merge(human)
 
         options = options.reverse_merge(defaults)
@@ -452,8 +472,12 @@ module ActionView
           end
         end
 
-        defaults = I18n.translate(:'number.format', :locale => options[:locale], :default => {})
-        human    = I18n.translate(:'number.human.format', :locale => options[:locale], :default => {})
+        begin
+          defaults = I18n.translate(:'number.format', :locale => options[:locale], :raise => true)
+          human    = I18n.translate(:'number.human.format', :locale => options[:locale], :raise => true)
+        rescue I18n::MissingTranslationData
+          defaults = human = {}
+        end
         defaults = defaults.merge(human)
 
         options = options.reverse_merge(defaults)

--- a/actionpack/test/template/number_helper_i18n_test.rb
+++ b/actionpack/test/template/number_helper_i18n_test.rb
@@ -102,6 +102,18 @@ class NumberHelperTest < ActionView::TestCase
     assert_equal "4.3 cm", number_to_human(0.0432, :locale => 'ts', :units => :custom_units_for_number_to_human)
   end
 
+  def test_number_helpers_with_locale_fallback
+    I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
+    I18n.fallbacks.map(:tq => :ts)
+
+    assert_equal "&$ - 10.00", number_to_currency(10, :locale => 'tq')
+    assert_equal "12434%", number_to_percentage(12434, :locale => 'tq')
+    assert_equal "1,000,000.234", number_with_delimiter(1000000.234, :locale => 'tq')
+    assert_equal "10000", number_with_precision(10000, :locale => 'tq')
+    assert_equal "1.2 k", number_to_human_size(1184, :locale => 'tq')
+    assert_equal "1.3 Tenth", number_to_human(0.134, :locale => 'tq')
+  end
+
   private
     def clean_i18n
       load_path = I18n.load_path.dup


### PR DESCRIPTION
In the number helper, using an empty hash as the default when calling I18n.translate will not fallback to other locales first when the translation is missing, it will just use the empty hash.

This means using a locale such as :"en-GB" would need to have all the number formats copied from :en, even if they are all the same.

Using a Proc which returns an empty hash will first check the fallbacks, then evaluate the Proc and use it as the default if the translation is still missing.

See https://github.com/svenfuchs/i18n/wiki/Fallbacks
