### PR TITLE
Test activerecord/lib/test/relations_test.rb:reverse_sql_order fails because 'reverse' is not defined as an instance method of Arel::Nodes::Ordering

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -308,7 +308,13 @@ module ActiveRecord
       order_query.map do |o|
         case o
         when Arel::Nodes::Ordering
-          o.reverse
+          #this is a Kludge. Something like this should probably happen when ActiveRecord is lazy loaded
+          begin
+            o.reverse
+          rescue NoMethodError
+            Arel::Nodes::Ordering.send :define_method, :reverse, lambda { direction = direction == :asc ? :desc : :asc }
+            o.reverse
+          end
         when String, Symbol
           o.to_s.split(',').collect do |s|
             s.gsub!(/\sasc\Z/i, ' DESC') || s.gsub!(/\sdesc\Z/i, ' ASC') || s.concat(' DESC')


### PR DESCRIPTION
This is monkeypatch to add Arel::Nodes::Ordering#reverse to activerecord/../query_methods.rb
when 'reverse' is called on an instance.

This is clearly the wrong place to do the patch. It should be performed
in a callback when Arel is lazily loaded, but it works and allows
the test to pass (this point)
