### PR TITLE
Backport config.action_controller.include_all_helpers to 3-0-stable

### DIFF
--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -225,7 +225,7 @@ module ActionController
 
     def self.inherited(klass)
       super
-      klass.helper :all if klass.superclass == ActionController::Base
+      klass.helper :all if klass.superclass == ActionController::Base && ActionController::Base.include_all_helpers
     end
 
     require "action_controller/deprecated/base"

--- a/actionpack/lib/action_controller/metal/helpers.rb
+++ b/actionpack/lib/action_controller/metal/helpers.rb
@@ -53,8 +53,9 @@ module ActionController
     include AbstractController::Helpers
 
     included do
-      config_accessor :helpers_path
+      config_accessor :helpers_path, :include_all_helpers
       self.helpers_path ||= []
+      self.include_all_helpers = true
     end
 
     module ClassMethods

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -10,6 +10,10 @@ module ApplicationTests
       FileUtils.rm_rf "#{app_path}/config/environments"
     end
 
+    def app
+      @app ||= Rails.application
+    end
+
     def teardown
       teardown_app
     end
@@ -66,6 +70,67 @@ module ApplicationTests
       require "#{app_path}/config/environment"
       assert Foo.method_defined?(:foo_path)
       assert_equal ["notify"], Foo.action_methods
+    end
+
+    test "allows to not load all helpers for controllers" do
+      add_to_config "config.action_controller.include_all_helpers = false"
+
+      app_file "app/controllers/application_controller.rb", <<-RUBY
+        class ApplicationController < ActionController::Base
+        end
+      RUBY
+
+      app_file "app/controllers/foo_controller.rb", <<-RUBY
+        class FooController < ApplicationController
+          def included_helpers
+            render :inline => "<%= from_app_helper -%> <%= from_foo_helper %>"
+          end
+
+          def not_included_helper
+            render :inline => "<%= respond_to?(:from_bar_helper) -%>"
+          end
+        end
+      RUBY
+
+      app_file "app/helpers/application_helper.rb", <<-RUBY
+        module ApplicationHelper
+          def from_app_helper
+            "from_app_helper"
+          end
+        end
+      RUBY
+
+      app_file "app/helpers/foo_helper.rb", <<-RUBY
+        module FooHelper
+          def from_foo_helper
+            "from_foo_helper"
+          end
+        end
+      RUBY
+
+      app_file "app/helpers/bar_helper.rb", <<-RUBY
+        module BarHelper
+          def from_bar_helper
+            "from_bar_helper"
+          end
+        end
+      RUBY
+
+      app_file "config/routes.rb", <<-RUBY
+        AppTemplate::Application.routes.draw do
+          match "/:controller(/:action)"
+        end
+      RUBY
+
+      require "#{app_path}/config/environment"
+      require 'rack/test'
+      extend Rack::Test::Methods
+
+      get "/foo/included_helpers"
+      assert_equal "from_app_helper from_foo_helper", last_response.body
+
+      get "/foo/not_included_helper"
+      assert_equal "false", last_response.body
     end
 
     # AS


### PR DESCRIPTION
Can we please backport #106 to 3-0-stable ? I have made the necessary changes for it to work on this branch, and all tests seem to run successfully.

This will be very useful for the cases when clear_helpers do not work.
