### PR TITLE
Fixed issue #1847

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_types.rb
+++ b/actionpack/lib/action_dispatch/http/mime_types.rb
@@ -7,10 +7,22 @@ Mime::Type.register "text/javascript", :js, %w( application/javascript applicati
 Mime::Type.register "text/css", :css
 Mime::Type.register "text/calendar", :ics
 Mime::Type.register "text/csv", :csv
+
+Mime::Type.register "image/png", :png, [], %w(png)
+Mime::Type.register "image/jpeg", :jpeg, [], %w(jpg jpeg jpe)
+Mime::Type.register "image/gif", :gif, [], %w(gif)
+Mime::Type.register "image/bmp", :bmp, [], %w(bmp)
+Mime::Type.register "image/tiff", :tiff, [], %w(tif tiff)
+
+Mime::Type.register "video/mpeg", :mpeg, [], %w(mpg mpeg mpe)
+
 Mime::Type.register "application/xml", :xml, %w( text/xml application/x-xml )
 Mime::Type.register "application/rss+xml", :rss
 Mime::Type.register "application/atom+xml", :atom
 Mime::Type.register "application/x-yaml", :yaml, %w( text/yaml )
+
+Mime::Type.register "application/pdf", :pdf, [], %w(pdf)
+Mime::Type.register "application/zip", :zip, [], %w(zip)
 
 Mime::Type.register "multipart/form-data", :multipart_form
 Mime::Type.register "application/x-www-form-urlencoded", :url_encoded_form

--- a/actionpack/test/controller/send_file_test.rb
+++ b/actionpack/test/controller/send_file_test.rb
@@ -138,6 +138,25 @@ class SendFileTest < ActionController::TestCase
     @controller.headers = {}
     assert_raise(ArgumentError){ @controller.send(:send_file_headers!, options) }
   end
+  
+  def test_send_file_headers_guess_type_from_extension
+    {
+      'image.png' => 'image/png',
+      'image.jpeg' => 'image/jpeg',
+      'image.jpg' => 'image/jpeg',
+      'image.tif' => 'image/tiff',
+      'image.gif' => 'image/gif',
+      'movie.mpg' => 'video/mpeg',
+      'file.zip' => 'application/zip',
+      'file.unk' => 'application/octet-stream',
+      'zip' => 'application/octet-stream'
+    }.each do |filename,expected_type|
+      options = { :filename => filename }
+      @controller.headers = {}
+      @controller.send(:send_file_headers!, options)
+      assert_equal expected_type, @controller.content_type
+    end
+  end
 
   %w(file data).each do |method|
     define_method "test_send_#{method}_status" do


### PR DESCRIPTION
Make send_file guess content type from file extension, if available
