### PR TITLE
Removing image/gif from this test.

### DIFF
--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -86,12 +86,12 @@ class MimeTypeTest < ActiveSupport::TestCase
 
   test "custom type" do
     begin
-      Mime::Type.register("image/gif", :gif)
+      Mime::Type.register("image/foo", :foo)
       assert_nothing_raised do
-        assert_equal Mime::GIF, Mime::SET.last
+        assert_equal Mime::FOO, Mime::SET.last
       end
     ensure
-      Mime::Type.unregister(:gif)
+      Mime::Type.unregister(:FOO)
     end
   end
 


### PR DESCRIPTION
We have to remove this from test or we need to set it again. The reason is that in mime_type_tests we are are doing Mime::Type.unregister(:gif).

We can handle in two ways.
1. Register again here using Mime::Type.register("image/gif", :gif)
2. Or remove the image/gif check from this test.

When you run single while it wil pass. But in whole it will fail.

I think we can also remove some code from mime_types_test.rb

https://github.com/rails/rails/blob/master/actionpack/test/dispatch/mime_type_test.rb#LC=94

/cc @josevalim 
