### PR TITLE
Prevent generators from creating controllers which are reserved by Rails

### DIFF
--- a/railties/lib/rails/generators/base.rb
+++ b/railties/lib/rails/generators/base.rb
@@ -263,6 +263,10 @@ module Rails
               break unless last_module.const_defined?(nest, *extra)
               last_module.const_get(nest)
             end
+            
+            if class_name =~ /(Rails|Properties|Assets)Controller/
+              raise Error, "The name '#{class_name}' is reserved for use by Rails"
+            end
 
             if last && last.const_defined?(last_name.camelize, *extra)
               raise Error, "The name '#{class_name}' is either already used in your application " <<

--- a/railties/test/generators/controller_generator_test.rb
+++ b/railties/test/generators/controller_generator_test.rb
@@ -24,6 +24,15 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
   ensure
     Object.send :remove_const, :ObjectController
   end
+  
+  def test_reserved_controller_names_are_prevented
+    content = capture(:stderr){ run_generator ["rails"] }
+    assert_match(/The name 'RailsController' is reserved for use by Rails/, content)
+    content = capture(:stderr){ run_generator ["assets"] }
+    assert_match(/The name 'AssetsController' is reserved for use by Rails/, content)
+    content = capture(:stderr){ run_generator ["my_assets"] }
+    assert_match("", content)
+  end
 
   def test_invokes_helper
     run_generator


### PR DESCRIPTION
As discussed here: https://github.com/rails/rails/issues/1836#issuecomment-1453167

This is a first (and probably bad attempt) at implementing this, at least in a way that will stop people making controllers with reserved names.

I would guess that the list of reserved names isn't complete, but this is all I could see from the routes.  If there are others, feel free to mess.
