### PR TITLE
Add bin/rails executable to railties gem.

### DIFF
--- a/railties/bin/rails
+++ b/railties/bin/rails
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+
+require "rails/cli"

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -16,6 +16,9 @@ Gem::Specification.new do |s|
   s.files              = Dir['CHANGELOG', 'README.rdoc', 'bin/**/*', 'guides/**/*', 'lib/**/{*,.[a-z]*}']
   s.require_path       = 'lib'
 
+  s.bindir             = 'bin'
+  s.executables        = ['rails']
+
   s.rdoc_options << '--exclude' << '.'
 
   s.add_dependency('rake',          '>= 0.8.7')


### PR DESCRIPTION
This grants access to the rails command without having to accept the full set of Rails-related frameworks depended upon by the rails gem. 

This is a simple backport to `3-0-stable` of @josevalim's recent patch (e3053ee753c3035e9d8337680212aba525c27376).
