### PR TITLE
Avoid extra call to Cache#read in case of a fragment cache hit (3-0-stable)

### DIFF
--- a/actionpack/lib/action_view/helpers/cache_helper.rb
+++ b/actionpack/lib/action_view/helpers/cache_helper.rb
@@ -46,8 +46,8 @@ module ActionView
     private
       # TODO: Create an object that has caching read/write on it
       def fragment_for(name = {}, options = nil, &block) #:nodoc:
-        if controller.fragment_exist?(name, options)
-          controller.read_fragment(name, options)
+        if fragment = controller.read_fragment(name, options)
+          fragment
         else
           # VIEW TODO: Make #capture usable outside of ERB
           # This dance is needed because Builder can't use capture

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -153,7 +153,7 @@ class ACLogSubscriberTest < ActionController::TestCase
     wait
 
     assert_equal 4, logs.size
-    assert_match /Exist fragment\? views\/foo/, logs[1]
+    assert_match /Read fragment views\/foo/, logs[1]
     assert_match /Write fragment views\/foo/, logs[2]
   ensure
     @controller.config.perform_caching = true


### PR DESCRIPTION
This for #1893
