### PR TITLE
Make "rake test" display not only task name but also exception message.

### DIFF
--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -79,10 +79,10 @@ task :test do
       Rake::Task[task].invoke
       nil
     rescue => e
-      task
+      { :task => task, :exception => e }
     end
   end.compact
-  abort "Errors running #{errors * ', '}!" if errors.any?
+  abort errors.map { |e| "Errors running #{e[:task]}! #{e[:exception].inspect}" }.join("\n") if errors.any?
 end
 
 namespace :test do

--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -82,7 +82,11 @@ task :test do
       { :task => task, :exception => e }
     end
   end.compact
-  abort errors.map { |e| "Errors running #{e[:task]}! #{e[:exception].inspect}" }.join("\n") if errors.any?
+  
+  if errors.any?
+    puts errors.map { |e| "Errors running #{e[:task]}! #{e[:exception].inspect}" }.join("\n")
+    abort
+  end
 end
 
 namespace :test do


### PR DESCRIPTION
The "rake test" ignores the exception message. This pull request displays not only task name but also the exception message.

For example:

Errors running test:units, test:functionals!

This pull request:

Errors running test:units! Access denied for user ''@'localhost' to database...
Errors running test:functionals! Command failed with status...
