### PR TITLE
Removing respond_to? from OrderedOptions. 

### DIFF
--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -37,9 +37,6 @@ module ActiveSupport #:nodoc:
       end
     end
 
-    def respond_to?(name)
-      true
-    end
   end
 
   class InheritableOptions < OrderedOptions


### PR DESCRIPTION
After commit 266b80c7b28c7587ab1c75aae6e3288e2f6c1aba added 

"test_configuration_is_crystalizeable(ConfigurableActiveSupport)" starts failing 

<pre>
  1) Failure:
test_configuration_is_crystalizeable(ConfigurableActiveSupport)
    [test/configurable_test.rb:61:in `test_configuration_is_crystalizeable'
     /Users/arun/checkouts/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:67:in `__send__'
     /Users/arun/checkouts/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:67:in `run'
     /Users/arun/checkouts/rails/activesupport/lib/active_support/callbacks.rb:399:in `_run_setup_callbacks'
     /Users/arun/checkouts/rails/activesupport/lib/active_support/callbacks.rb:81:in `send'
     /Users/arun/checkouts/rails/activesupport/lib/active_support/callbacks.rb:81:in `run_callbacks'
     /Users/arun/checkouts/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:65:in `run']:
<false> is not true.
</pre>


As we are using InheritableOptions here which is inherited from OrderedOptions. In this commit OrderedOptions  got a method respond_to? with return true.

I have just removed it and run all the tests. It passes for "activesupport", "railties", "actionapck" and all.

I am not sure that why this is required. Or may be we need a test for this respond_to here.
Curious to know actually. May be some other fix is required here.

/cc chriseppstein
