### PR TITLE
Configurable objects don't respond_to? if the method hasn't been compiled

### DIFF
--- a/activesupport/lib/active_support/configurable.rb
+++ b/activesupport/lib/active_support/configurable.rb
@@ -23,6 +23,10 @@ module ActiveSupport
           RUBY
         end
       end
+      
+      def respond_to_missing?(name, include_private=false)
+        false
+      end
     end
 
     module ClassMethods

--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -37,6 +37,11 @@ module ActiveSupport #:nodoc:
       end
     end
 
+    def respond_to?(name, include_private=false)
+      # Compatibility with 1.8, which does not support respond_to_missing?
+      super || respond_to_missing?(name, include_private)
+    end
+
     def respond_to_missing?(name, include_private=false)
       true
     end

--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -37,7 +37,7 @@ module ActiveSupport #:nodoc:
       end
     end
 
-    def respond_to?(name)
+    def respond_to_missing?(name, include_private=false)
       true
     end
   end

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -76,4 +76,9 @@ class OrderedOptionsTest < Test::Unit::TestCase
     assert copy.kind_of?(original.class)
     assert_not_equal copy.object_id, original.object_id
   end
+  
+  def test_respond_to_should_be_true
+    object = ActiveSupport::OrderedOptions.new
+    assert object.respond_to?(:foo)
+  end
 end


### PR DESCRIPTION
This fixes the specs in active support.
