### PR TITLE
3-0-stable ActiveModel::Dirty patch for multiple assignments to the same attribute

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -157,7 +157,7 @@ module ActiveModel
         rescue TypeError, NoMethodError
         end
 
-        changed_attributes[attr] = value
+        changed_attributes[attr] = value unless changed_attributes.include?(attr)
       end
 
       # Handle <tt>reset_*!</tt> for +method_missing+.

--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -106,4 +106,12 @@ class DirtyTest < ActiveModel::TestCase
     assert_equal [nil, "Jericho Cane"], @model.previous_changes['name']
   end
 
+  test "changing the same attribute multiple times retains the correct original value" do
+    @model.name = "Otto"
+    @model.save
+    @model.name = "DudeFella ManGuy"
+    @model.name = "Mr. Manfredgensonton"
+    assert_equal ["Otto", "Mr. Manfredgensonton"], @model.name_change
+    assert_equal @model.name_was, "Otto"
+  end
 end


### PR DESCRIPTION
This is required here also. Let this fix come with 3.0.10. 

Just saw this is got fixed in master as well.
