### PR TITLE
Refactor sprockets asset paths to allow for alternate asset environments

### DIFF
--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -79,10 +79,19 @@ module Sprockets
           params[:debug_assets] == 'true'
       end
 
+      # Override to specify an alternative prefix for asset path generation.
+      # When combined with a custom +asset_environment+, this can be used to
+      # implement themes that can take advantage of the asset pipeline.
+      #
+      # If you only want to change where the assets are mounted, refer to
+      # +config.assets.prefix+ instead.
       def asset_prefix
         Rails.application.config.assets.prefix
       end
 
+      # Override to specify an alternative asset environment for asset
+      # path generation. The environment should already have been mounted
+      # at the prefix returned by +asset_prefix+.
       def asset_environment
         Rails.application.assets
       end

--- a/actionpack/test/fixtures/sprockets/alternate/stylesheets/style.css
+++ b/actionpack/test/fixtures/sprockets/alternate/stylesheets/style.css
@@ -1,0 +1,1 @@
+/* Different from other style.css */

--- a/actionpack/test/template/sprockets_helper_test.rb
+++ b/actionpack/test/template/sprockets_helper_test.rb
@@ -197,4 +197,16 @@ class SprocketsHelperTest < ActionView::TestCase
     assert_equal "<link href=\"/assets/style-d41d8cd98f00b204e9800998ecf8427e.css\" media=\"screen\" rel=\"stylesheet\" type=\"text/css\" />\n<link href=\"/assets/extra-d41d8cd98f00b204e9800998ecf8427e.css\" media=\"screen\" rel=\"stylesheet\" type=\"text/css\" />",
       stylesheet_link_tag("style", "extra")
   end
+
+  test "alternate asset prefix" do
+    stubs(:asset_prefix).returns("/themes/test")
+    assert_equal "/themes/test/style-d41d8cd98f00b204e9800998ecf8427e.css", asset_path("style", "css")
+  end
+
+  test "alternate asset environment" do
+    assets = Sprockets::Environment.new
+    assets.paths << FIXTURES.join("sprockets/alternate/stylesheets")
+    stubs(:asset_environment).returns(assets)
+    assert_equal "/assets/style-df0b97ad35a8e1f7f61097461f77c19a.css", asset_path("style", "css")
+  end
 end


### PR DESCRIPTION
This patch refactors the Sprockets asset path helpers to make it easier to integrate alternate asset environments and prefixes. In my specific case, this makes integrating themes using the asset pipeline a whole lot easier.

The main change is to source the asset environment and prefix from helper-level methods (<code>asset_environment</code> and <code>asset_prefix</code>), rather than hard-coded within the <code>AssetPaths</code> class.
