### PR TITLE
Accept application.js/.css to exist in a deeper directory depth by default

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -34,7 +34,7 @@ module Rails
         @assets = ActiveSupport::OrderedOptions.new
         @assets.enabled    = false
         @assets.paths      = []
-        @assets.precompile = [ /\w+\.(?!js|css).+/, "application.js", "application.css" ]
+        @assets.precompile = [ /\w+\.(?!js|css).+/, /application.(css|js)$/ ]
         @assets.prefix     = "/assets"
 
         @assets.js_compressor  = nil

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -37,14 +37,17 @@ module ApplicationTests
 
     test "assets are compiled properly" do
       app_file "app/assets/javascripts/application.js", "alert();"
+      app_file "app/assets/javascripts/foo/application.js", "alert();"
 
       capture(:stdout) do
         Dir.chdir(app_path){ `bundle exec rake assets:precompile` }
       end
-
-      file = Dir["#{app_path}/public/assets/application-*.js"][0]
-      assert_not_nil file, "Expected application.js asset to be generated, but none found"
-      assert_equal "alert();\n", File.read(file)
+      files = Dir["#{app_path}/public/assets/application-*.js"]
+      files << Dir["#{app_path}/public/assets/foo/application-*.js"].first
+      files.each do |file|
+        assert_not_nil file, "Expected application.js asset to be generated, but none found"
+        assert_equal "alert();\n", File.read(file)
+      end
     end
 
     test "assets are cleaned up properly" do


### PR DESCRIPTION
/cc @dhh /cc @josh /cc /cc @josevalim

This is for example useful for engines having their own application.js/.css

See: https://github.com/rails/rails/issues/1520
