### PR TITLE
Fixed ActionView::FormOptionsHelper#select with :multiple => false

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -1153,7 +1153,7 @@ module ActionView
             options["name"] ||= tag_name_with_index(@auto_index)
             options["id"] = options.fetch("id"){ tag_id_with_index(@auto_index) }
           else
-            options["name"] ||= tag_name + (options.has_key?('multiple') ? '[]' : '')
+            options["name"] ||= tag_name + (options['multiple'] ? '[]' : '')
             options["id"] = options.fetch("id"){ tag_id }
           end
         end

--- a/actionpack/test/template/form_options_helper_test.rb
+++ b/actionpack/test/template/form_options_helper_test.rb
@@ -378,6 +378,13 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_select_without_multiple
+    assert_dom_equal(
+      "<select id=\"post_category\" name=\"post[category]\"></select>",
+      select(:post, :category, "", {}, :multiple => false)
+    )
+  end
+
   def test_select_with_boolean_method
     @post = Post.new
     @post.allow_comments = false


### PR DESCRIPTION
The following code:

``` ruby
select :post, :category_ids, [], {}, :multiple => false
```

Generates the select with name `post[category_id][]`. This is kinda confusing to add `[]` in case of `false` and `nil` for multiple attribute.

In real example with conditional multiple key we need the following:

``` ruby
select ..., {:class => "gg").merge(my_condition ? {:multiple => true}, {})
```

That is not very natural. So fixed default name to add `[]` only when `:multiple` looks truly.
