### PR TITLE
#1892 Clear query cache after a migration

### DIFF
--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -136,6 +136,18 @@ class QueryCacheTest < ActiveRecord::TestCase
       end
     end
   end
+
+  def test_cache_gets_cleared_after_migration
+    # warm the cache
+    Topic.find(1)
+
+    # change the column definition
+    Topic.connection.change_column :topics, :title, :string, :limit => 80
+    assert_nothing_raised { Topic.find(1) }
+
+    # restore the old definition
+    Topic.connection.change_column :topics, :title, :string
+  end
 end
 
 class QueryCacheExpiryTest < ActiveRecord::TestCase


### PR DESCRIPTION
Some methods like PREPARE and DEALLOCATE have also been extracted to introduce `reset_cache!`.
