### PR TITLE
Provide a more explicit message when we try to redirect to a missing location

### DIFF
--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -182,10 +182,12 @@ module ActionDispatch
 
           if record.is_a?(Symbol) || record.is_a?(String)
             route << record
-          else
+          elsif record
             route << ActiveModel::Naming.route_key(record)
             route = [route.join("_").singularize] if inflection == :singular
             route << "index" if ActiveModel::Naming.uncountable?(record) && inflection == :plural
+          else
+            raise ArgumentError, "Nil location provided. Can't build URI."
           end
 
           route << routing_type(options)

--- a/actionpack/test/activerecord/polymorphic_routes_test.rb
+++ b/actionpack/test/activerecord/polymorphic_routes_test.rb
@@ -87,6 +87,14 @@ class PolymorphicRoutesTest < ActionController::TestCase
     end
   end
 
+  def test_with_nil
+    with_test_routes do
+      assert_raise ArgumentError, "Nil location provided. Can't build URI." do
+        polymorphic_url(nil)
+      end
+    end
+  end
+
   def test_with_record
     with_test_routes do
       @project.save

--- a/actionpack/test/controller/mime_responds_test.rb
+++ b/actionpack/test/controller/mime_responds_test.rb
@@ -659,6 +659,13 @@ class RespondWithControllerTest < ActionController::TestCase
     assert_equal %Q[{"result":{"name":"david","id":13}}], @response.body
   end
 
+  def test_using_hash_resource_with_post
+    @request.accept = "application/json"
+    assert_raise ArgumentError, "Nil location provided. Can't build URI." do
+      post :using_hash_resource
+    end
+  end
+
   def test_using_resource_with_block
     @request.accept = "*/*"
     get :using_resource_with_block


### PR DESCRIPTION
This follows the discussion in #1939

Currently, when using respond_with in a POST request without providing any `:location`, the error generated is not explicit at all, generating confusion.

This provides a more helpful error.
