### PR TITLE
Reversing the changes related to CommandRecorder

### DIFF
--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -14,11 +14,9 @@ module ActiveRecord
         assert recorder.respond_to?(:america)
       end
 
-      def test_non_existing_method_records_and_raises_on_inversion
-        @recorder.send(:non_existing_method, :horses)
-        assert_equal 1, @recorder.commands.length
-        assert_raises(ActiveRecord::IrreversibleMigration) do
-          @recorder.inverse
+      def test_send_calls_super
+        assert_raises(NoMethodError) do
+          @recorder.send(:non_existing_method, :horses)
         end
       end
 


### PR DESCRIPTION
The changes broke bulk migration tests and were fixed in 4d256bc6; however that brought back the issue of #1857 and so this commit goes back to the original scenario and just adds change_table to the list
of methods which are to be recorded in the CommandRecorder. The method_missing now delegates all calls to the underlying connection as before. 

cc: @jonleighton
