### PR TITLE
Allow without_protection to be set on nested_attributes accessors.

### DIFF
--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -139,6 +139,17 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
     assert man.reload.interests.empty?
   end
 
+  def test_without_protection_id_assignment
+    Man.accepts_nested_attributes_for :interests, :reject_if => proc {|attributes| true }, :allow_destroy => true, :without_protection => false
+    assert_raises ActiveRecord::RecordNotFound do 
+      Man.create(:name => "Jon", :interests_attributes => { :topic => 'the ladies', :id => 2 } )
+    end
+    Man.accepts_nested_attributes_for :interests, :reject_if => proc {|attributes| true }, :allow_destroy => true, :without_protection => true
+    man = Man.create(:name => "Jon", :interests_attributes => { :topic => 'the ladies', :id => 2 } )
+    assert man.interests.map { |i| i.topic.include?('the ladies') } 
+    assert man.interests.find_by_id(2)
+  end
+
   def test_has_many_association_updating_a_single_record
     Man.accepts_nested_attributes_for(:interests)
     man = Man.create(:name => 'John')


### PR DESCRIPTION
As assign_nested_attributes_for_collection_association already supports without_protection coming in as an option (see line 424 in activerecord/lib/active_record/nested_attributes.rb [1]), allow this option to be specified when calling accepts_nested_attributes_for.  Without allowing this option to be specified here, the only way to call it is to call #{association}_attributes directly with an options hash.

[1]

```
    elsif assignment_opts[:without_protection]
      association.build(attributes.except(*unassignable_keys(assignment_opts)), assignment_opts)
    else
```
