### PR TITLE
Fix has_migrations? check in Rails::Engine

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -586,7 +586,7 @@ module Rails
     end
 
     def has_migrations?
-      paths["db/migrate"].first.present?
+      paths["db/migrate"].existent.any?
     end
 
     def find_root_with_flag(flag, default=nil)

--- a/railties/test/railties/shared_tests.rb
+++ b/railties/test/railties/shared_tests.rb
@@ -84,6 +84,15 @@ module RailtiesTest
       end
     end
 
+    def test_no_rake_task_without_migrations
+      boot_rails
+      require 'rake'
+      require 'rdoc/task'
+      require 'rake/testtask'
+      Rails.application.load_tasks
+      assert !Rake::Task.task_defined?('bukkits:install:migrations')
+    end
+
     def test_puts_its_lib_directory_on_load_path
       boot_rails
       require "another"


### PR DESCRIPTION
Currently the install:migrations rake task for an engine is added even if no migrations directory exists, due to a broken check in the has_migrations? method.
