### PR TITLE
Refactor sprockets asset paths to allow for alternate asset environments

### DIFF
--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -79,10 +79,19 @@ module Sprockets
           params[:debug_assets] == 'true'
       end
 
+      # Override to specify an alternative prefix for asset path generation.
+      # When combined with a custom +asset_environment+, this can be used to
+      # implement themes that can take advantage of the asset pipeline.
+      #
+      # If you only want to change where the assets are mounted, refer to
+      # +config.assets.prefix+ instead.
       def asset_prefix
         Rails.application.config.assets.prefix
       end
 
+      # Override to specify an alternative asset environment for asset
+      # path generation. The environment should already have been mounted
+      # at the prefix returned by +asset_prefix+.
       def asset_environment
         Rails.application.assets
       end

--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -16,7 +16,10 @@ module Sprockets
           else
             config.default_asset_host_protocol ||= :relative
           end
-          RailsHelper::AssetPaths.new(config, controller)
+          paths = RailsHelper::AssetPaths.new(config, controller)
+          paths.asset_environment = asset_environment
+          paths.asset_prefix      = asset_prefix
+          paths
         end
       end
 
@@ -76,9 +79,19 @@ module Sprockets
           params[:debug_assets] == 'true'
       end
 
+      def asset_prefix
+        Rails.application.config.assets.prefix
+      end
+
+      def asset_environment
+        Rails.application.assets
+      end
+
       class AssetPaths < ::ActionView::AssetPaths #:nodoc:
-        def compute_public_path(source, dir, ext=nil, include_host=true, protocol = nil)
-          super(source, 'assets', ext, include_host, protocol)
+        attr_accessor :asset_environment, :asset_prefix
+
+        def compute_public_path(source, dir, ext=nil, include_host=true, protocol=nil)
+          super(source, asset_prefix, ext, include_host, protocol)
         end
 
         # Return the filesystem path for the source
@@ -90,14 +103,14 @@ module Sprockets
           source = source.to_s
           return nil if is_uri?(source)
           source = rewrite_extension(source, nil, ext)
-          assets[source]
+          asset_environment[source]
         end
 
         def rewrite_asset_path(source, dir)
           if source[0] == ?/
             source
           else
-            assets.path(source, performing_caching?, dir)
+            asset_environment.path(source, performing_caching?, dir)
           end
         end
 
@@ -107,10 +120,6 @@ module Sprockets
           else
             source
           end
-        end
-
-        def assets
-          Rails.application.assets
         end
 
         # When included in Sprockets::Context, we need to ask the top-level config as the controller is not available

--- a/actionpack/test/fixtures/sprockets/alternate/stylesheets/style.css
+++ b/actionpack/test/fixtures/sprockets/alternate/stylesheets/style.css
@@ -1,0 +1,1 @@
+/* Different from other style.css */

--- a/actionpack/test/template/sprockets_helper_test.rb
+++ b/actionpack/test/template/sprockets_helper_test.rb
@@ -199,4 +199,16 @@ class SprocketsHelperTest < ActionView::TestCase
     assert_equal "<link href=\"/assets/style-d41d8cd98f00b204e9800998ecf8427e.css\" media=\"screen\" rel=\"stylesheet\" type=\"text/css\" />\n<link href=\"/assets/extra-d41d8cd98f00b204e9800998ecf8427e.css\" media=\"screen\" rel=\"stylesheet\" type=\"text/css\" />",
       stylesheet_link_tag("style", "extra")
   end
+
+  test "alternate asset prefix" do
+    stubs(:asset_prefix).returns("/themes/test")
+    assert_equal "/themes/test/style-d41d8cd98f00b204e9800998ecf8427e.css", asset_path("style", "css")
+  end
+
+  test "alternate asset environment" do
+    assets = Sprockets::Environment.new
+    assets.paths << FIXTURES.join("sprockets/alternate/stylesheets")
+    stubs(:asset_environment).returns(assets)
+    assert_equal "/assets/style-df0b97ad35a8e1f7f61097461f77c19a.css", asset_path("style", "css")
+  end
 end


### PR DESCRIPTION
Apply fix for #1925 into 3-1-stable.
