### PR TITLE
All numerics should be html_safe

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -67,7 +67,7 @@ class Object
   end
 end
 
-class Fixnum
+class Numeric
   def html_safe?
     true
   end

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -353,6 +353,10 @@ class OutputSafetyTest < ActiveSupport::TestCase
   test "A fixnum is safe by default" do
     assert 5.html_safe?
   end
+  
+  test "a float is safe by default" do
+    assert 5.7.html_safe?
+  end
 
   test "An object is unsafe by default" do
     assert !@object.html_safe?


### PR DESCRIPTION
Currently, only Fixnums are. Floats and other numeric classes should too.
