### PR TITLE
Cherry picks for 3-1-stable

### DIFF
--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -151,6 +151,7 @@ class BasicController
       config.assets_dir = public_dir
       config.javascripts_dir = "#{public_dir}/javascripts"
       config.stylesheets_dir = "#{public_dir}/stylesheets"
+      config.assets          = ActiveSupport::InheritableOptions.new({ :prefix => "assets" })
       config
     end
   end

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -67,7 +67,7 @@ class Object
   end
 end
 
-class Fixnum
+class Numeric
   def html_safe?
     true
   end

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -353,6 +353,10 @@ class OutputSafetyTest < ActiveSupport::TestCase
   test "A fixnum is safe by default" do
     assert 5.html_safe?
   end
+  
+  test "a float is safe by default" do
+    assert 5.7.html_safe?
+  end
 
   test "An object is unsafe by default" do
     assert !@object.html_safe?


### PR DESCRIPTION
I've cherry-picked two commits for 3-1-stable.

One, from @sikachu, which fixes the tests for actionpack and should bring back the CI to green.
One from me, which declares all Numerics as html_safe instead of only Fixnums ( #1935 ).
