### PR TITLE
Add railties to the load path if it's not already there

### DIFF
--- a/railties/test/railties/generators_test.rb
+++ b/railties/test/railties/generators_test.rb
@@ -1,7 +1,8 @@
 RAILS_ISOLATED_ENGINE = true
 require "isolation/abstract_unit"
 
-require "#{RAILS_FRAMEWORK_ROOT}/railties/lib/rails/generators/test_case"
+require 'generators/generators_test_helper'
+require "rails/generators/test_case"
 
 module RailtiesTests
   class GeneratorTest < Rails::Generators::TestCase


### PR DESCRIPTION
Railties tests fail because it can't find `rails/generators`.
Adding railties to the load path fixes it.

And master is green on my machine with this commit.
