### PR TITLE
Fixed CollectionAssociation#find to be compatible with Array#find

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -78,7 +78,7 @@ module ActiveRecord
       end
 
       def find(*args, &block)
-        if block
+        if block_given?
           load_target.find(*args, &block)
         else
           if options[:finder_sql]

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -77,9 +77,9 @@ module ActiveRecord
         end
       end
 
-      def find(*args, &block)
+      def find(*args)
         if block_given?
-          load_target.find(*args, &block)
+          load_target.find(*args) { |*block_args| yield(*block_args) }
         else
           if options[:finder_sql]
             find_by_scan(*args)

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -77,11 +77,15 @@ module ActiveRecord
         end
       end
 
-      def find(*args)
-        if options[:finder_sql]
-          find_by_scan(*args)
+      def find(*args, &block)
+        if block
+          load_target.find(*args, &block)
         else
-          scoped.find(*args)
+          if options[:finder_sql]
+            find_by_scan(*args)
+          else
+            scoped.find(*args)
+          end
         end
       end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -226,6 +226,10 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 2, Firm.find(:first, :order => "id").clients.length
   end
 
+  def test_finding_array_compatibility
+    assert_equal 2, Firm.order(:id).find{|f| f.id > 0}.clients.length
+  end
+
   def test_find_with_blank_conditions
     [[], {}, nil, ""].each do |blank|
       assert_equal 2, Firm.find(:first, :order => "id").clients.find(:all, :conditions => blank).size


### PR DESCRIPTION
Currently `AR::Relation#find` is compatible with `Array#find`: 
if no block given - acts as AR finder, if block given - load result and delegate to `Array#find` 

But collection association doesn't work like this:

``` ruby
Project.order(:id).find {|p| p.id > 3} # => Project
User.first.projects.find{|p| p.id > 3} # => ArgumentError
```

In order to make CollectionAssociation behave closer to Array
Add ability to pass block to #find method just like Array#find does.
