### PR TITLE
Only call set_owner_attributes for has_one association if target exists. [3.1.0rc4]

### DIFF
--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -19,7 +19,7 @@ module ActiveRecord
 
             if owner.persisted? && save && !record.save
               nullify_owner_attributes(record)
-              set_owner_attributes(target)
+              set_owner_attributes(target) if target
               raise RecordNotSaved, "Failed to save the new associated #{reflection.name}."
             end
           end

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -345,6 +345,17 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert orig_ship.destroyed?
   end
 
+  def test_creation_failure_due_to_new_record_should_raise_error
+    pirate = pirates(:redbeard)
+    new_ship = Ship.new
+
+    assert_raise(ActiveRecord::RecordNotSaved) do
+      pirate.ship = new_ship
+    end
+    assert_nil pirate.ship
+    assert_nil new_ship.pirate_id
+  end
+
   def test_replacement_failure_due_to_existing_record_should_raise_error
     pirate = pirates(:blackbeard)
     pirate.ship.name = nil


### PR DESCRIPTION
For a has_one association, setting an associated object which fails validation, but no previous object was set, _target_ is nil. This causes an "undefined method `[]=' for nil:NilClass" exception, where an ActiveRecord::RecordNotSaved exception is expected. Fixed by only calling set_owner_attributes if we have a target.

With test case.

This affects the current master as well as the 3-1-stable branch.
