### PR TITLE
ActiveRecord calculation fail when having contains conditions based on select values

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -250,6 +250,7 @@ module ActiveRecord
           operation,
           distinct).as(aggregate_alias)
       ]
+      select_values += @select_values unless @having_values.empty?
 
       select_values.concat group_fields.zip(group_aliases).map { |field,aliaz|
         "#{field} AS #{aliaz}"

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -170,6 +170,13 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 60,  c[2]
   end
 
+  def test_should_group_by_summed_field_having_condition_from_select
+    c = Account.select("MIN(credit_limit) AS min_credit_limit").group(:firm_id).having("min_credit_limit > 50").sum(:credit_limit)
+    assert_nil       c[1]
+    assert_equal 60, c[2]
+    assert_equal 53, c[9]
+  end
+
   def test_should_group_by_summed_association
     c = Account.sum(:credit_limit, :group => :firm)
     assert_equal 50,   c[companies(:first_firm)]


### PR DESCRIPTION
Current implementation of `ActiveRecord#calculate` is that it drops provided `select` values. This ruins query when calling calculate on a relation with `having` conditions based on `select`.

Example:

``` ruby
class User < ActiveRecord::Base
  has_many :operations
end

class Operation < ActiveRecord::Base
  belongs_to :user
end

relation = User.joins(:operations).select("sum(operations.amount) AS deposit").group("users.id").having("deposit > 100")
relation.count # raises sql error "no such column 'deposit'"
```

Provided patch fixes the error by keeping `select` values untouched if there is `having` clause in query.

Bug occurs in master, 3-1-stable and 3-0-stable
