### PR TITLE
TimeZone requires preloading before #freeze

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -289,6 +289,12 @@ module ActiveSupport
       Time.now.utc.in_time_zone(self)
     end
 
+    # Preload information prior to freezing
+    def freeze
+      tzinfo; utc_offset;
+      super
+    end
+
     # Return the current date in this time zone.
     def today
       tzinfo.now.to_date

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -291,7 +291,9 @@ module ActiveSupport
 
     # Preload information prior to freezing
     def freeze
-      tzinfo; utc_offset;
+      tzinfo
+      utc_offset
+
       super
     end
 

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -294,6 +294,23 @@ class TimeZoneTest < Test::Unit::TestCase
     assert_equal ActiveSupport::TimeZone["Central Time (US & Canada)"], ActiveSupport::TimeZone.new("Central Time (US & Canada)")
   end
 
+  def test_freeze
+    @tz = ActiveSupport::TimeZone.new("Arizona")
+    @tz.freeze
+
+    assert @tz.frozen?
+  end
+
+  def test_freeze_preloads_instance_variables
+    @tz = ActiveSupport::TimeZone.new('Alaska')
+
+    assert_nothing_raised do
+      @tz.freeze
+      @tz.utc_offset
+      @tz.tzinfo
+    end
+  end
+
   def test_us_zones
     assert ActiveSupport::TimeZone.us_zones.include?(ActiveSupport::TimeZone["Hawaii"])
     assert !ActiveSupport::TimeZone.us_zones.include?(ActiveSupport::TimeZone["Kuala Lumpur"])


### PR DESCRIPTION
'Can't modify frozen object' when calling #freeze after instantiation

Although I _did_ add tests to this which _should_ have failed, for some reason they didn't.  If someone with more knowledge of Rails dependencies could help me out I would appreciate it.

The issue this fixes is here: https://github.com/rails/rails/issues/1966

There is a 100% repeatable (on the 3 MacBooks I tried) bug wherein executing the following:

```
rails new foo
cd foo
bundle install
rails console
```

And within IRB:

```
ActiveSupport::TimeZone.new('Alaska').freeze
```

Raises a `Can't modify a frozen object` RuntimeError.

Although I can get this error to occur every time, I cannot get it to be reproduced in a test.

I hope this at least puts everyone on the right track to tracking down this problem.
