### PR TITLE
Fixed AR::Relation#sum compatibility with Array#sum

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -89,8 +89,12 @@ module ActiveRecord
     # +calculate+ for examples with options.
     #
     #   Person.sum('age') # => 4562
-    def sum(column_name, options = {})
-      calculate(:sum, column_name, options)
+    def sum(*args)
+      if block_given?
+        self.to_a.sum(*args) {|*block_args| yield(*block_args)}
+      else
+        calculate(:sum, *args)
+      end
     end
 
     # This calculates aggregate values in the given column. Methods for count, sum, average,

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -397,6 +397,10 @@ class CalculationsTest < ActiveRecord::TestCase
         Account.sum(:credit_limit, :from => 'accounts', :conditions => "credit_limit > 50")
   end
 
+  def test_sum_array_compatibility
+    assert_equal Account.sum(:credit_limit), Account.sum(&:credit_limit)
+  end
+
   def test_average_with_from_option
     assert_equal Account.average(:credit_limit), Account.average(:credit_limit, :from => 'accounts')
     assert_equal Account.average(:credit_limit, :conditions => "credit_limit > 50"),


### PR DESCRIPTION
In order make Relation behavior closer to Array
Made Relation#sum to accept block and delegate it to Array#sum

``` ruby
TeamMember.has_many :time_sheets

TeamMember.first.time_sheets.class  # => Array
TeamMember.first.time_sheets.sum(&:hours) # raises ArgumentError
```

And this patch makes it all work.
