### PR TITLE
Cherrypick for 3-1-stable - adding w3c_validators gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :doc do
   gem "rdoc",  "~> 3.4"
   gem "horo",  "= 1.0.3"
   gem "RedCloth", "~> 4.2" if RUBY_VERSION < "1.9.3"
+  gem "w3c_validators"
 end
 
 # AS


### PR DESCRIPTION
Add w3c_validators gem to the doc group to fix failing validation of guides. (see 8b25b55)
