### PR TITLE
Remove case statement changes from 2e0840d and 56ac32a. Inheritance FTW.

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -307,7 +307,7 @@ module ActiveRecord
 
       order_query.map do |o|
         case o
-        when Arel::Nodes::Ascending, Arel::Nodes::Descending
+        when Arel::Nodes::Ordering
           o.reverse
         when String, Symbol
           o.to_s.split(',').collect do |s|


### PR DESCRIPTION
So, somehow a pointless change to a case statement slipped in with some other commits, recently. I think the committer meant well, but didn't realize the case statement (which I wrote) already passed tests as-is. Could always just revert those two commits, as well, but I figured merging a pull request was probably quicker. :)
