### PR TITLE
Make `ActiveRecord::Batches#find_each` to not return `self`.

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -20,8 +20,6 @@ module ActiveRecord
       find_in_batches(options) do |records|
         records.each { |record| yield record }
       end
-
-      self
     end
 
     # Yields each batch of records that was found by the find +options+ as

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -18,6 +18,13 @@ class EachTest < ActiveRecord::TestCase
     end
   end
 
+  def test_each_should_not_return_query_chain_and_execcute_only_one_query
+    assert_queries(1) do
+      result = Post.find_each(:batch_size => 100000){ }
+      assert_nil result
+    end
+  end
+
   def test_each_should_raise_if_select_is_set_without_id
     assert_raise(RuntimeError) do
       Post.find_each(:select => :title, :batch_size => 1) { |post| post }


### PR DESCRIPTION
This caused that `find_each` may produce extra db call taking all the records from db, return array with all records, and was less efficient than `ActiveRecord::Base#all`. There is no sense to keep _scope_ with this method, as it expects block and having further scopes after `find_each` is not possible.

eg. (notice last query)

<pre>
ruby-1.9.2-p180 :016 > User.find_each{|u| }
  User Load (93.8ms)  SELECT `users`.* FROM `users` WHERE (`users`.`id` >= 0) ORDER BY `users`.`id` ASC LIMIT 1000
  User Load (175.0ms)  SELECT `users`.* FROM `users` WHERE (`users`.`id` > 1000) ORDER BY `users`.`id` ASC LIMIT 1000
  User Load (0.5ms)  SELECT `users`.* FROM `users` WHERE (`users`.`id` > 2000) ORDER BY `users`.`id` ASC LIMIT 1000
  User Load (308.2ms)  SELECT `users`.* FROM `users` 
</pre>
