### PR TITLE
Add require ActiveSupport delegation to ActiveRecord::Relation class.

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/object/blank'
+require 'active_support/core_ext/module/delegation'
 
 module ActiveRecord
   # = Active Record Relation


### PR DESCRIPTION
After `require active_record` reference to `ActiveRecord::Relation` causes error "undefined method 'delegate' for Relation class". You must also `require active_record/base` or just fake refer `ActiveRecord::Base`.

Suggest requiring delegation stuff from ActiveSupport explicitly.
