### PR TITLE
Fixing asset number for asset_path with %d to be consistent in ruby 1.9

### DIFF
--- a/actionpack/lib/action_view/asset_paths.rb
+++ b/actionpack/lib/action_view/asset_paths.rb
@@ -111,7 +111,8 @@ module ActionView
           args << current_request if (arity > 1 || arity < 0) && has_request?
           host.call(*args)
         else
-          (host =~ /%d/) ? host % (source.hash % 4) : host
+          source_num = source.bytes.sum
+          (host =~ /%d/) ? host % (source_num % 4) : host
         end
       end
     end

--- a/actionpack/test/template/asset_tag_helper_test.rb
+++ b/actionpack/test/template/asset_tag_helper_test.rb
@@ -689,9 +689,9 @@ class AssetTagHelperTest < ActionView::TestCase
     @controller.config.asset_host = 'http://a%d.example.com'
     config.perform_caching = true
 
-    hash = '/javascripts/cache/money.js'.hash % 4
+    number = '/javascripts/cache/money.js'.bytes.sum % 4
     assert_dom_equal(
-      %(<script src="http://a#{hash}.example.com/javascripts/cache/money.js" type="text/javascript"></script>),
+      %(<script src="http://a#{number}.example.com/javascripts/cache/money.js" type="text/javascript"></script>),
       javascript_include_tag(:all, :cache => "cache/money")
     )
 
@@ -1129,6 +1129,7 @@ class AssetTagHelperNonVhostTest < ActionView::TestCase
   end
 
   def test_should_wildcard_asset_host_between_zero_and_four
+    String.any_instance.expects(:hash).times(0)
     @controller.config.asset_host = 'http://a%d.example.com'
     assert_match(%r(http://a[0123].example.com/collaboration/hieraki/images/xml.png), image_path('xml.png'))
   end


### PR DESCRIPTION
When using wildcard %d in assets path is suposed to have a random-like number between [0-3].
It works using String.hash instance method, but in ruby 1.9 this method is not returning always the same hash for the same string. 
Just run "hi".hash twice in two different irb consoles. (In the same it works, I read that have some random seed...)

So in production, every server instance have a different asset number. Or with one server, every restart has a different number too.

The asset is still available but in the browser side is better to have the same asset ID because the browser can cache the asset just once and not 4 times.

I've changed this to use a String.bytes.sum instead of String.hash
