### PR TITLE
having() raises NoMethodError: undefined method `empty?' when the given argument does not respond to empty?

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -96,11 +96,11 @@ module ActiveRecord
       relation
     end
 
-    def having(*args)
-      return self if args.blank?
+    def having(opts, *rest)
+      return self if opts.blank?
 
       relation = clone
-      relation.having_values += build_where(*args)
+      relation.having_values += build_where(opts, rest)
       relation
     end
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -140,23 +140,23 @@ class FinderTest < ActiveRecord::TestCase
 
 
   def test_find_with_group
-    developers =  Developer.find(:all, :group => "salary", :select => "salary")
+    developers = Developer.find(:all, :group => "salary", :select => "salary")
     assert_equal 4, developers.size
     assert_equal 4, developers.map(&:salary).uniq.size
   end
 
   def test_find_with_group_and_having
-    developers =  Developer.find(:all, :group => "salary", :having => "sum(salary) >  10000", :select => "salary")
+    developers = Developer.find(:all, :group => "salary", :having => "sum(salary) > 10000", :select => "salary")
     assert_equal 3, developers.size
     assert_equal 3, developers.map(&:salary).uniq.size
-    assert developers.all? { |developer|  developer.salary > 10000 }
+    assert developers.all? { |developer| developer.salary > 10000 }
   end
 
   def test_find_with_group_and_sanitized_having
-    developers =  Developer.find(:all, :group => "salary", :having => ["sum(salary) > ?", 10000], :select => "salary")
+    developers = Developer.find(:all, :group => "salary", :having => ["sum(salary) > ?", 10000], :select => "salary")
     assert_equal 3, developers.size
     assert_equal 3, developers.map(&:salary).uniq.size
-    assert developers.all? { |developer|  developer.salary > 10000 }
+    assert developers.all? { |developer| developer.salary > 10000 }
   end
 
   def test_find_with_group_and_sanitized_having_method

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -159,6 +159,13 @@ class FinderTest < ActiveRecord::TestCase
     assert developers.all? { |developer|  developer.salary > 10000 }
   end
 
+  def test_find_with_group_and_sanitized_having_method
+    developers = Developer.group(:salary).having("sum(salary) > ?", 10000).select('salary').all
+    assert_equal 3, developers.size
+    assert_equal 3, developers.map(&:salary).uniq.size
+    assert developers.all? { |developer| developer.salary > 10000 }
+  end
+
   def test_find_with_entire_select_statement
     topics = Topic.find_by_sql "SELECT * FROM topics WHERE author_name = 'Mary'"
 


### PR DESCRIPTION
The following query fails because 10000 does not respond_to empty?

```
Developer.group(:name).having('sum(salary) > ?', 10000)
```

This behavior is obviously not consistent with `where()` which woks with the following parameters

```
Developer.where('salary > ?', 10000)
```

This pull request includes a failing test case and the fix.
