### PR TITLE
AR::Relation#order: reverse all applied orders

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -59,7 +59,7 @@ module ActiveRecord
       return self if args.blank?
 
       relation = clone
-      relation.order_values += args.flatten
+      relation.order_values = args.flatten + relation.order_values
       relation
     end
 

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -552,7 +552,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
 
   def test_find_should_append_to_association_order
     ordered_developers = projects(:active_record).developers.order('projects.id')
-    assert_equal ['developers.name desc, developers.id desc', 'projects.id'], ordered_developers.order_values
+    assert_equal ['projects.id', 'developers.name desc, developers.id desc' ], ordered_developers.order_values
   end
 
   def test_dynamic_find_all_should_respect_association_limit

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -244,7 +244,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_find_should_append_to_association_order
     ordered_clients =  companies(:first_firm).clients_sorted_desc.order('companies.id')
-    assert_equal ['id DESC', 'companies.id'], ordered_clients.order_values
+    assert_equal [ 'companies.id','id DESC'], ordered_clients.order_values
   end
 
   def test_dynamic_find_last_without_specified_order

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1508,8 +1508,8 @@ class BasicsTest < ActiveRecord::TestCase
       Developer.find(:all, :order => 'salary DESC')
     end
     # Test scope order + find order, order has priority
-    scoped_developers = Developer.send(:with_scope, :find => { :limit => 3, :order => 'id DESC' }) do
-      Developer.find(:all, :order => 'salary ASC')
+    scoped_developers = Developer.send(:with_scope, :find => { :limit => 3, :order => 'salary ASC' }) do
+      Developer.find(:all, :order => 'id DESC')
     end
     assert scoped_developers.include?(developers(:poor_jamis))
     assert ! scoped_developers.include?(developers(:david))

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -158,7 +158,7 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_finding_with_order_concatenated
-    topics = Topic.order('author_name').order('title')
+    topics = Topic.order('title').order('author_name')
     assert_equal 4, topics.to_a.size
     assert_equal topics(:fourth).title, topics.first.title
   end


### PR DESCRIPTION
Rails 3.0.x implementation of `AR::Relation#order` is confusing to me - new orders do not overwrite previous.
There is `#reorder` method that suppose to do that.

For people that are actively using `default_scope :order => ..` or `has_many :..., :order =>` this behavior makes `#order` completely unusable. 

``` ruby
class Account
  default_scope :order => "title"
end
Account.order("created_at DESC") 
    # => SELECT `accounts`.* FROM `accounts` ORDER BY title, accounts.created_at desc LIMIT 1
```

No chance to change the default. That is why `#reorder` should be used every where.
Similar problem described for associations #1660.

If there is any other reason why Rails team made this approach can you please explain.

In order be able to overwrite order specified before
(e.g. by `default_scope` or `has_many` association order)
Make `order` method to always apply new order on top of previous

``` ruby
Account.order("created_at DESC") 
    # => SELECT `accounts`.* FROM `accounts` ORDER BY accounts.created_at desc, title LIMIT 1
```

In this case orders applied naturally and more close to classical OOP (overwrite property with new value).

When you need to apply non reverse order you always can pass them as one call:

``` ruby
Account.order([:name, "created_at desc"])
    # => SELECT `accounts`.* FROM `accounts` ORDER BY title, accounts.created_at desc LIMIT 1
```

I understand this is kinda sensible change, but I think this is where AR should be one day.
