### PR TITLE
Properly cache value when it is "false"

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -557,7 +557,7 @@ module ActiveSupport
         @expires_in = options[:expires_in]
         @expires_in = @expires_in.to_f if @expires_in
         @created_at = Time.now.to_f
-        if value
+        if defined?(value)
           if should_compress?(value, options)
             @value = Zlib::Deflate.deflate(Marshal.dump(value))
             @compressed = true
@@ -576,7 +576,7 @@ module ActiveSupport
 
       # Get the value stored in the cache.
       def value
-        if @value
+        if defined?(@value)
           val = compressed? ? Marshal.load(Zlib::Inflate.inflate(@value)) : @value
           unless val.frozen?
             val.freeze rescue nil

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -188,6 +188,11 @@ module CacheStoreBehavior
     assert_equal nil, @cache.read('foo')
   end
 
+  def test_should_read_and_write_false
+    assert_equal true, @cache.write('foo', false)
+    assert_equal false, @cache.read('foo')
+  end
+
   def test_read_multi
     @cache.write('foo', 'bar')
     @cache.write('fu', 'baz')


### PR DESCRIPTION
Rails.cache does not properly cache "false", it returns nil instead. 

This is because the value is checked with an 

if value
  # ...
else
  value = nil  # => sets false values to nil
end

I changed it to:
if defined?(value)

Example:

Rails.cache.fetch('foo') { false }
=> false  # uncached value

Rails.cache.fetch('foo') { false }
=> nil  # from cache
