### PR TITLE
Refactor PostgreSQLAdapter a bit

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -229,8 +229,8 @@ class SchemaTest < ActiveRecord::TestCase
       %("schema"."table_name") => %w{schema table_name},
       %("even spaces".table)   => ['even spaces','table'],
       %(schema."table.name")   => ['schema', 'table.name']
-    }.each do |given,expect|
-      assert_equal expect, @connection.send(:extract_schema_and_table, given)
+    }.each do |given, expect|
+      assert_equal expect, ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::Utils.extract_schema_and_table(given)
     end
   end
 


### PR DESCRIPTION
Move the private method `#extract_schema_and_table` into a separate `Utils` module so that it can be tested without resorting to `#send`.

If you'd like, more of these auxiliary methods can be moved out of `PostgreSQLAdapter`.
