### PR TITLE
Fix for session ID fixation issue in ActiveRecord::SessionStore

### DIFF
--- a/activerecord/lib/active_record/session_store.rb
+++ b/activerecord/lib/active_record/session_store.rb
@@ -183,11 +183,6 @@ module ActiveRecord
 
       ##
       # :singleton-method:
-      # Use the ActiveRecord::Base.connection by default.
-      cattr_accessor :connection
-
-      ##
-      # :singleton-method:
       # The table name defaults to 'sessions'.
       cattr_accessor :table_name
       @@table_name = 'sessions'
@@ -206,10 +201,19 @@ module ActiveRecord
 
       class << self
         alias :data_column_name :data_column
+        
+        # Use the ActiveRecord::Base.connection by default.
+        attr_writer :connection
+        
+        # Use the ActiveRecord::Base.connection_pool by default.
+        attr_writer :connection_pool
 
-        remove_method :connection
         def connection
-          @@connection ||= ActiveRecord::Base.connection
+          @connection ||= ActiveRecord::Base.connection
+        end
+
+        def connection_pool
+          @connection_pool ||= ActiveRecord::Base.connection_pool
         end
 
         # Look up a session by id and unmarshal its data if found.
@@ -219,6 +223,8 @@ module ActiveRecord
           end
         end
       end
+      
+      delegate :connection, :connection=, :connection_pool, :connection_pool=, :to => self
 
       attr_reader :session_id, :new_record
       alias :new_record? :new_record

--- a/activerecord/lib/active_record/session_store.rb
+++ b/activerecord/lib/active_record/session_store.rb
@@ -297,8 +297,12 @@ module ActiveRecord
     private
       def get_session(env, sid)
         Base.silence do
-          sid ||= generate_sid
-          session = find_session(sid)
+          unless sid and session = @@session_class.find_by_session_id(sid)
+            # If the sid was nil or if there is no pre-existing session under the sid,
+            # force the generation of a new sid and associate a new session associated with the new sid
+            sid = generate_sid
+            session = @@session_class.new(:session_id => sid, :data => {})
+          end
           env[SESSION_RECORD_KEY] = session
           [sid, session.data]
         end


### PR DESCRIPTION
I have found that Rails will take an invalid session ID specified by the client and materialize a session based on that session ID. This means that it is possible, among other things, for a client to use an arbitrarily weak session ID or for a client to resurrect a previous used session ID. In other words, we cannot guarantee that all session IDs are generated by the server and that they are (statistically) unique through time.

The fix is to always generate a new session ID in #get_session if an existing session cannot be found under the incoming session ID.

@NZKoz here's the pull request as per our earlier emails
