### PR TITLE
ActiveRecord::Base subclasses should pass ActiveModel::Lint.

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -53,6 +53,16 @@ class Weird < ActiveRecord::Base; end
 
 class Boolean < ActiveRecord::Base; end
 
+class LintTest < ActiveRecord::TestCase
+  include ActiveModel::Lint::Tests
+
+  class LintModel < ActiveRecord::Base; end
+
+  def setup
+    @model = LintModel.new
+  end
+end
+
 class BasicsTest < ActiveRecord::TestCase
   fixtures :topics, :companies, :developers, :projects, :computers, :accounts, :minimalistics, 'warehouse-things', :authors, :categorizations, :categories, :posts
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -305,6 +305,8 @@ ActiveRecord::Schema.define do
     t.references :student
   end
 
+  create_table :lint_models, :force => true
+
   create_table :line_items, :force => true do |t|
     t.integer :invoice_id
     t.integer :amount


### PR DESCRIPTION
This just adds a test case to make sure it does.
