### PR TITLE
Render partial invalid check

### DIFF
--- a/actionpack/lib/action_view/renderer/partial_renderer.rb
+++ b/actionpack/lib/action_view/renderer/partial_renderer.rb
@@ -301,6 +301,12 @@ module ActionView
         paths.map! { |path| retrieve_variable(path).unshift(path) }
       end
 
+      if String === partial && @variable !~ /^[a-z_][a-zA-Z_0-9]*$/
+        raise ArgumentError.new("The partial name (#{partial}) is not a valid Ruby identifier; " +
+                                "make sure your partial name starts with a letter or underscore, " +
+                                "and is followed by any combinations of letters, numbers, or underscores.")
+      end
+
       self
     end
 

--- a/actionpack/test/fixtures/test/_200.html.erb
+++ b/actionpack/test/fixtures/test/_200.html.erb
@@ -1,0 +1,1 @@
+<h1>Invalid partial</h1>

--- a/actionpack/test/template/render_test.rb
+++ b/actionpack/test/template/render_test.rb
@@ -98,6 +98,15 @@ module RenderTestCases
     assert_equal "only partial", @view.render("test/partial_only", :counter_counter => 5)
   end
 
+  def test_render_partial_with_invalid_name
+    @view.render(:partial => "test/200")
+    flunk "Render did not raise ArgumentError"
+  rescue ArgumentError => e
+    assert_equal "The partial name (test/200) is not a valid Ruby identifier; " +
+                                "make sure your partial name starts with a letter or underscore, " +
+                                "and is followed by any combinations of letters, numbers, or underscores.", e.message
+  end
+
   def test_render_partial_with_errors
     @view.render(:partial => "test/raise")
     flunk "Render did not raise Template::Error"


### PR DESCRIPTION
Issue #1967 -- better error message when partial has a name that is not a valid Ruby identifier.
