### PR TITLE
Make #extract_schema_and_table an instance method in Utils

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -948,6 +948,8 @@ module ActiveRecord
       end
 
       module Utils
+        extend self
+
         # Returns an array of <tt>[schema_name, table_name]</tt> extracted from +name+.
         # +schema_name+ is nil if not specified in +name+.
         # +schema_name+ and +table_name+ exclude surrounding quotes (regardless of whether provided in +name+)
@@ -958,7 +960,7 @@ module ActiveRecord
         # * <tt>schema_name.table_name</tt>
         # * <tt>schema_name."table.name"</tt>
         # * <tt>"schema.name"."table name"</tt>
-        def self.extract_schema_and_table(name)
+        def extract_schema_and_table(name)
           table, schema = name.scan(/[^".\s]+|"[^"]*"/)[0..1].collect{|m| m.gsub(/(^"|"$)/,'') }.reverse
           [schema, table]
         end

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -219,21 +219,6 @@ class SchemaTest < ActiveRecord::TestCase
     end
   end
 
-  def test_extract_schema_and_table
-    {
-      %(table_name)            => [nil,'table_name'],
-      %("table.name")          => [nil,'table.name'],
-      %(schema.table_name)     => %w{schema table_name},
-      %("schema".table_name)   => %w{schema table_name},
-      %(schema."table_name")   => %w{schema table_name},
-      %("schema"."table_name") => %w{schema table_name},
-      %("even spaces".table)   => ['even spaces','table'],
-      %(schema."table.name")   => ['schema', 'table.name']
-    }.each do |given, expect|
-      assert_equal expect, ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::Utils.extract_schema_and_table(given)
-    end
-  end
-
   def test_current_schema
     {
       %('$user',public)                        => 'public',

--- a/activerecord/test/cases/adapters/postgresql/utils_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/utils_test.rb
@@ -1,0 +1,18 @@
+class PostgreSQLUtilsTest < ActiveSupport::TestCase
+  include ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::Utils
+
+  def test_extract_schema_and_table
+    {
+      %(table_name)            => [nil,'table_name'],
+      %("table.name")          => [nil,'table.name'],
+      %(schema.table_name)     => %w{schema table_name},
+      %("schema".table_name)   => %w{schema table_name},
+      %(schema."table_name")   => %w{schema table_name},
+      %("schema"."table_name") => %w{schema table_name},
+      %("even spaces".table)   => ['even spaces','table'],
+      %(schema."table.name")   => ['schema', 'table.name']
+    }.each do |given, expect|
+      assert_equal expect, extract_schema_and_table(given)
+    end
+  end
+end


### PR DESCRIPTION
Also, move the utils test into its own test case.

This cleans up the refactoring from #2012 a bit.

@tenderlove, can you merge this in as well?
