### PR TITLE
Version comparison using strings can be faulty.

### DIFF
--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -11,6 +11,8 @@ ensure
   $VERBOSE = old
 end
 
+require 'active_support/core_ext/rubygems'
+
 require 'active_support/core_ext/kernel/reporting'
 
 require 'active_support/core_ext/string/encoding'

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -12,6 +12,8 @@ $:.unshift(File.dirname(__FILE__) + '/fixtures/alternate_helpers')
 
 ENV['TMPDIR'] = File.join(File.dirname(__FILE__), 'tmp')
 
+require 'active_support/core_ext/rubygems'
+
 require 'active_support/core_ext/kernel/reporting'
 
 require 'active_support/core_ext/string/encoding'

--- a/activemodel/test/cases/helper.rb
+++ b/activemodel/test/cases/helper.rb
@@ -5,9 +5,11 @@ $:.unshift(lib) unless $:.include?('lib') || $:.include?(lib)
 
 require 'config'
 require 'active_model'
+require 'active_support/core_ext/rubygems'
 require 'active_support/core_ext/string/access'
 
 # Show backtraces for deprecated behavior for quicker cleanup.
 ActiveSupport::Deprecation.debug = true
 
 require 'test/unit'
+

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -22,6 +22,7 @@ require 'models/person'
 require 'models/edge'
 require 'models/joke'
 require 'rexml/document'
+require 'active_support/core_ext/rubygems'
 require 'active_support/core_ext/exception'
 
 class Category < ActiveRecord::Base; end

--- a/activeresource/test/abstract_unit.rb
+++ b/activeresource/test/abstract_unit.rb
@@ -6,6 +6,7 @@ $:.unshift(lib) unless $:.include?('lib') || $:.include?(lib)
 require 'test/unit'
 require 'active_resource'
 require 'active_support'
+require 'active_support/core_ext/rubygems'
 require 'active_support/test_case'
 
 require 'setter_trap'

--- a/activesupport/lib/active_support/core_ext/date/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date/calculations.rb
@@ -7,7 +7,7 @@ require 'active_support/core_ext/time/zones'
 class Date
   DAYS_INTO_WEEK = { :monday => 0, :tuesday => 1, :wednesday => 2, :thursday => 3, :friday => 4, :saturday => 5, :sunday => 6 }
 
-  if RUBY_VERSION < '1.9'
+  if Gem.ruby_version < '1.9'
     undef :>>
 
     # Backported from 1.9. The one in 1.8 leads to incorrect next_month and
@@ -251,3 +251,4 @@ class Date
     self + 1
   end
 end
+

--- a/activesupport/lib/active_support/core_ext/date/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date/conversions.rb
@@ -67,7 +67,7 @@ class Date
   # In this case, it simply returns +self+.
   def to_date
     self
-  end if RUBY_VERSION < '1.9'
+  end if Gem.ruby_version < '1.9'
 
   # Converts a Date instance to a Time, where the time is set to the beginning of the day.
   # The timezone can be either :local or :utc (default :local).
@@ -92,15 +92,16 @@ class Date
   #   date.to_datetime               # => Sat, 10 Nov 2007 00:00:00 0000
   def to_datetime
     ::DateTime.civil(year, month, day, 0, 0, 0, 0)
-  end if RUBY_VERSION < '1.9'
+  end if Gem.ruby_version < '1.9'
 
   def iso8601
     strftime('%F')
-  end if RUBY_VERSION < '1.9'
+  end if Gem.ruby_version < '1.9'
 
-  alias_method :rfc3339, :iso8601 if RUBY_VERSION < '1.9'
+  alias_method :rfc3339, :iso8601 if Gem.ruby_version < '1.9'
 
   def xmlschema
     to_time_in_current_zone.xmlschema
   end
 end
+

--- a/activesupport/lib/active_support/core_ext/date/freeze.rb
+++ b/activesupport/lib/active_support/core_ext/date/freeze.rb
@@ -9,7 +9,7 @@
 #
 # Ruby 1.9 uses a preinitialized instance variable so it's unaffected.
 # This hack is as close as we can get to feature detection:
-if RUBY_VERSION < '1.9'
+if Gem.ruby_version < '1.9'
   require 'date'
   begin
     ::Date.today.freeze.jd
@@ -31,3 +31,4 @@ if RUBY_VERSION < '1.9'
     end
   end
 end
+

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -1,4 +1,4 @@
-require 'rational' unless RUBY_VERSION >= '1.9.2'
+require 'rational' unless Gem.ruby_version >= '1.9.2'
 
 class DateTime
   class << self
@@ -130,3 +130,4 @@ class DateTime
     super other.to_datetime
   end
 end
+

--- a/activesupport/lib/active_support/core_ext/date_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/conversions.rb
@@ -66,7 +66,7 @@ class DateTime
   # Attempts to convert self to a Ruby Time object; returns self if out of range of Ruby Time class.
   # If self has an offset other than 0, self will just be returned unaltered, since there's no clean way to map it to a Time.
   def to_time
-    self.offset == 0 ? ::Time.utc_time(year, month, day, hour, min, sec, sec_fraction * (RUBY_VERSION < '1.9' ? 86400000000 : 1000000)) : self
+    self.offset == 0 ? ::Time.utc_time(year, month, day, hour, min, sec, sec_fraction * (Gem.ruby_version < '1.9' ? 86400000000 : 1000000)) : self
   end
 
   # To be able to keep Times, Dates and DateTimes interchangeable on conversions.
@@ -101,3 +101,4 @@ class DateTime
     (self - ::DateTime.civil(1970)) * seconds_per_day
   end
 end
+

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -2,7 +2,7 @@ require 'active_support/ordered_hash'
 
 module Enumerable
   # Ruby 1.8.7 introduces group_by, but the result isn't ordered. Override it.
-  remove_method(:group_by) if [].respond_to?(:group_by) && RUBY_VERSION < '1.9'
+  remove_method(:group_by) if [].respond_to?(:group_by) && Gem.ruby_version < '1.9'
 
   # Collect an enumerable into sets, grouped by the result of a block. Useful,
   # for example, for grouping records by date.
@@ -115,3 +115,4 @@ class Range #:nodoc:
     (actual_last - first + 1) * (actual_last + first) / 2
   end
 end
+

--- a/activesupport/lib/active_support/core_ext/exception.rb
+++ b/activesupport/lib/active_support/core_ext/exception.rb
@@ -1,3 +1,4 @@
 module ActiveSupport
-  FrozenObjectError = RUBY_VERSION < '1.9' ? TypeError : RuntimeError
+  FrozenObjectError = Gem.ruby_version < '1.9' ? TypeError : RuntimeError
 end
+

--- a/activesupport/lib/active_support/core_ext/float/rounding.rb
+++ b/activesupport/lib/active_support/core_ext/float/rounding.rb
@@ -16,4 +16,5 @@ class Float
       precisionless_round
     end
   end
-end if RUBY_VERSION < '1.9'
+end if Gem.ruby_version < '1.9'
+

--- a/activesupport/lib/active_support/core_ext/module/introspection.rb
+++ b/activesupport/lib/active_support/core_ext/module/introspection.rb
@@ -57,7 +57,7 @@ class Module
     parents
   end
 
-  if RUBY_VERSION < '1.9'
+  if Gem.ruby_version < '1.9'
     # Returns the constants that have been defined locally by this object and
     # not in an ancestor. This method is exact if running under Ruby 1.9. In
     # previous versions it may miss some constants if their definition in some
@@ -86,3 +86,4 @@ class Module
     local_constants.map { |c| c.to_s }
   end
 end
+

--- a/activesupport/lib/active_support/core_ext/object/instance_variables.rb
+++ b/activesupport/lib/active_support/core_ext/object/instance_variables.rb
@@ -23,7 +23,7 @@ class Object
   #   end
   #
   #   C.new(0, 1).instance_variable_names # => ["@y", "@x"]
-  if RUBY_VERSION >= '1.9'
+  if Gem.ruby_version >= '1.9'
     def instance_variable_names
       instance_variables.map { |var| var.to_s }
     end
@@ -31,3 +31,4 @@ class Object
     alias_method :instance_variable_names, :instance_variables
   end
 end
+

--- a/activesupport/lib/active_support/core_ext/rubygems.rb
+++ b/activesupport/lib/active_support/core_ext/rubygems.rb
@@ -1,0 +1,1 @@
+require 'active_support/core_ext/rubygems/version'

--- a/activesupport/lib/active_support/core_ext/rubygems/version.rb
+++ b/activesupport/lib/active_support/core_ext/rubygems/version.rb
@@ -1,0 +1,61 @@
+module Gem
+  class Version
+    # Checks if this version is inferior than the other.
+    #
+    #   Gem::Version.new("1.8.7") < "1.9.2" #=> true
+    #   Gem::Version.new("1.9") < "1.8.7"   #=> false
+    #
+    # <tt>Gem.ruby_version < "1.9.2"</tt> can be handy, as <tt>Gem.ruby_version</tt> returns
+    # an object of <tt>Gem::Version</tt>
+    def < other_version
+      (self <=> Version.new(other_version)) == -1
+    end
+
+    # Checks if this version is superior than the other.
+    #
+    #   Gem::Version.new("1.8.7") > "1.9.2" #=> false
+    #   Gem::Version.new("1.9") > "1.8.7"   #=> true
+    #
+    # <tt>Gem.ruby_version > "1.9.2"</tt> can be handy, as <tt>Gem.ruby_version</tt> returns
+    # an object of <tt>Gem::Version</tt>
+    def > other_version
+      (self <=> Version.new(other_version)) == 1
+    end
+
+    # Checks if both the versions are similar.
+    #
+    #   Gem::Version.new("1.9.2") == "1.9.2" #=> true
+    #   Gem::Version.new("1.9") == "1.8.7"   #=> false
+    #
+    # <tt>Gem.ruby_version == "1.9.2"</tt> can be handy, as <tt>Gem.ruby_version</tt> returns
+    # an object of <tt>Gem::Version</tt>
+    def == other_version
+      (self <=> Version.new(other_version)) == 0
+    end
+
+    # Checks if this version is superior or similar to the other.
+    #
+    #   Gem::Version.new("1.8.7") >= "1.9.2" #=> false
+    #   Gem::Version.new("1.9") >= "1.8.7"   #=> true
+    #   Gem::Version.new("1.9") >= "1.9"     #=> true
+    #
+    # <tt>Gem.ruby_version >= "1.9.2"</tt> can be handy, as <tt>Gem.ruby_version</tt> returns
+    # an object of <tt>Gem::Version</tt>
+    def >= other_version
+      (self > other_version) || (self == other_version)
+    end
+
+    # Checks if this version is inferior or similar to the other.
+    #
+    #   Gem::Version.new("1.8.7") <= "1.9.2"  #=> true
+    #   Gem::Version.new("1.8.7") <= "1.8.7"  #=> true
+    #   Gem::Version.new("1.9") <= "1.8.7"    #=> false
+    #
+    # <tt>Gem.ruby_version <= "1.9.2"</tt> can be handy, as <tt>Gem.ruby_version</tt> returns
+    # an object of <tt>Gem::Version</tt>
+    def <= other_version
+      (self < other_version) || (self == other_version)
+    end
+  end
+end
+

--- a/activesupport/lib/active_support/core_ext/string/multibyte.rb
+++ b/activesupport/lib/active_support/core_ext/string/multibyte.rb
@@ -1,8 +1,9 @@
 # encoding: utf-8
+require 'active_support/core_ext/rubygems'
 require 'active_support/multibyte'
 
 class String
-  if RUBY_VERSION >= "1.9"
+  if Gem.ruby_version >= "1.9"
     # == Multibyte proxy
     #
     # +mb_chars+ is a multibyte safe proxy for string methods.
@@ -70,3 +71,4 @@ class String
     end
   end
 end
+

--- a/activesupport/lib/active_support/core_ext/uri.rb
+++ b/activesupport/lib/active_support/core_ext/uri.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-if RUBY_VERSION >= '1.9'
+if Gem.ruby_version >= '1.9'
   require 'uri'
 
   str = "\xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E" # Ni-ho-nn-go in UTF-8, means Japanese.
@@ -28,3 +28,4 @@ module URI
     end
   end
 end
+

--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -38,7 +38,7 @@ module ActiveSupport #:nodoc:
       alias to_s wrapped_string
       alias to_str wrapped_string
 
-      if RUBY_VERSION >= "1.9"
+      if Gem.ruby_version >= "1.9"
         # Creates a new Chars instance by wrapping _string_.
         def initialize(string)
           @wrapped_string = string
@@ -94,7 +94,7 @@ module ActiveSupport #:nodoc:
         @wrapped_string <=> other.to_s
       end
 
-      if RUBY_VERSION < "1.9"
+      if Gem.ruby_version < "1.9"
         # Returns +true+ if the Chars class can and should act as a proxy for the string _string_. Returns
         # +false+ otherwise.
         def self.wants?(string)
@@ -475,3 +475,4 @@ module ActiveSupport #:nodoc:
     end
   end
 end
+

--- a/activesupport/lib/active_support/ordered_hash.rb
+++ b/activesupport/lib/active_support/ordered_hash.rb
@@ -4,6 +4,7 @@ rescue LoadError
 end
 
 require 'yaml'
+require 'active_support/core_ext/rubygems'
 
 YAML.add_builtin_type("omap") do |type, val|
   ActiveSupport::OrderedHash[val.map(&:to_a).map(&:first)]
@@ -48,7 +49,7 @@ module ActiveSupport
     end
 
     # Hash is ordered in Ruby 1.9!
-    if RUBY_VERSION < '1.9'
+    if Gem.ruby_version < '1.9'
 
       # In MRI the Hash class is core and written in C. In particular, methods are
       # programmed with explicit C function calls and polymorphism is not honored.
@@ -215,3 +216,4 @@ module ActiveSupport
     end
   end
 end
+

--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -7,6 +7,8 @@ ensure
   $VERBOSE = old
 end
 
+require 'active_support/core_ext/rubygems'
+
 lib = File.expand_path("#{File.dirname(__FILE__)}/../lib")
 $:.unshift(lib) unless $:.include?('lib') || $:.include?(lib)
 
@@ -31,7 +33,7 @@ ENV['NO_RELOAD'] = '1'
 require 'active_support'
 
 # Include shims until we get off 1.8.6
-require 'active_support/ruby/shim' if RUBY_VERSION < '1.8.7'
+require 'active_support/ruby/shim' if Gem.ruby_version < '1.8.7'
 
 def uses_memcached(test_name)
   require 'memcache'
@@ -44,7 +46,7 @@ def uses_memcached(test_name)
 end
 
 def with_kcode(code)
-  if RUBY_VERSION < '1.9'
+  if Gem.ruby_version < '1.9'
     begin
       old_kcode, $KCODE = $KCODE, code
       yield
@@ -59,6 +61,7 @@ end
 # Show backtraces for deprecated behavior for quicker cleanup.
 ActiveSupport::Deprecation.debug = true
 
-if RUBY_VERSION < '1.9'
+if Gem.ruby_version < '1.9'
   $KCODE = 'UTF8'
 end
+

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -374,7 +374,7 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
-  if RUBY_VERSION < '1.9'
+  if Gem.ruby_version < '1.9'
     def test_rfc3339
       assert_equal('1980-02-28', Date.new(1980, 2, 28).rfc3339)
     end
@@ -461,3 +461,4 @@ class DateExtBehaviorTest < Test::Unit::TestCase
     end
   end
 end
+

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -9,7 +9,7 @@ require 'active_support/inflections'
 class HashExtTest < Test::Unit::TestCase
   class IndifferentHash < HashWithIndifferentAccess
   end
-  
+
   class SubclassingArray < Array
   end
 
@@ -27,7 +27,7 @@ class HashExtTest < Test::Unit::TestCase
     @symbols = { :a  => 1, :b  => 2 }
     @mixed   = { :a  => 1, 'b' => 2 }
     @fixnums = {  0  => 1,  1  => 2 }
-    if RUBY_VERSION < '1.9.0'
+    if Gem.ruby_version < '1.9.0'
       @illegal_symbols = { "\0" => 1, "" => 2, [] => 3 }
     else
       @illegal_symbols = { [] => 3 }
@@ -272,14 +272,14 @@ class HashExtTest < Test::Unit::TestCase
     hash = { "urls" => { "url" => [ { "address" => "1" }, { "address" => "2" } ] }}.with_indifferent_access
     assert_equal "1", hash[:urls][:url].first[:address]
   end
-  
+
   def test_should_preserve_array_subclass_when_value_is_array
     array = SubclassingArray.new
     array << { "address" => "1" }
     hash = { "urls" => { "url" => array }}.with_indifferent_access
     assert_equal SubclassingArray, hash[:urls][:url].class
   end
-  
+
   def test_should_preserve_array_class_when_hash_value_is_frozen_array
     array = SubclassingArray.new
     array << { "address" => "1" }
@@ -906,13 +906,13 @@ class HashToXmlTest < Test::Unit::TestCase
     hash = Hash.from_xml(xml)
     assert_equal "bacon is the best", hash['blog']['name']
   end
-  
+
   def test_empty_cdata_from_xml
     xml = "<data><![CDATA[]]></data>"
-    
+
     assert_equal "", Hash.from_xml(xml)["data"]
   end
-  
+
   def test_xsd_like_types_from_xml
     bacon_xml = <<-EOT
     <bacon>
@@ -955,7 +955,7 @@ class HashToXmlTest < Test::Unit::TestCase
 
     assert_equal expected_product_hash, Hash.from_xml(product_xml)["product"]
   end
-  
+
   def test_should_use_default_value_for_unknown_key
     hash_wia = HashWithIndifferentAccess.new(3)
     assert_equal 3, hash_wia[:new_key]
@@ -1103,3 +1103,4 @@ class HashToXmlTest < Test::Unit::TestCase
     end
   end
 end
+

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -63,7 +63,7 @@ class RangeTest < Test::Unit::TestCase
     assert_equal [1,3,5,7,9], array
   end
 
-  if RUBY_VERSION < '1.9'
+  if Gem.ruby_version < '1.9'
     def test_cover
       assert((1..3).cover?(2))
       assert !(1..3).cover?(4)
@@ -75,3 +75,4 @@ class RangeTest < Test::Unit::TestCase
     end
   end
 end
+

--- a/activesupport/test/core_ext/rubygems_ext_test.rb
+++ b/activesupport/test/core_ext/rubygems_ext_test.rb
@@ -1,0 +1,42 @@
+require 'abstract_unit'
+
+class RubygemsVersionTests < Test::Unit::TestCase
+  def test_with_different_versions_for_greater_than_symbol
+    assert(Gem::Version.new('1.9') > '1.8.7')
+    assert(!(Gem::Version.new('1.8.7') > '1.9'))
+    assert(Gem::Version.new('10.9') > '9.10')
+    assert(!(Gem::Version.new('9.10') > '10.9'))
+    assert(Gem::Version.new('1.10.9') > '1.9.10')
+    assert(!(Gem::Version.new('1.9.10') > '1.10.9'))
+  end
+
+  def test_with_different_versions_for_less_than_symbol
+    assert(!(Gem::Version.new('1.9') < '1.8.7'))
+    assert(Gem::Version.new('1.8.7') < '1.9')
+    assert(!(Gem::Version.new('10.9') < '9.10'))
+    assert(Gem::Version.new('9.10') < '10.9')
+    assert(!(Gem::Version.new('1.10.9') < '1.9.10'))
+    assert(Gem::Version.new('1.9.10') < '1.10.9')
+  end
+
+  def test_with_different_versions_for_equals_to_symbol
+    assert(!(Gem::Version.new('1.9') == '1.8.7'))
+    assert(Gem::Version.new('1.8.7') == '1.8.7')
+    assert(!(Gem::Version.new('10.9') == '9.10'))
+  end
+
+
+  def test_with_different_versions_for_greater_than_equals_to_symbol
+    assert(Gem::Version.new('1.9') >= '1.9')
+    assert(!(Gem::Version.new('1.8.7') >= '1.9'))
+    assert(Gem::Version.new('10.9') >= '9.10')
+  end
+
+
+  def test_with_different_versions_for_less_than_equals_to_symbol
+    assert(Gem::Version.new('1.9') <= '1.9')
+    assert(Gem::Version.new('1.8.7') <= '1.9')
+    assert(!(Gem::Version.new('10.9') <= '9.10'))
+  end
+end
+

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -143,7 +143,7 @@ class StringInflectionsTest < Test::Unit::TestCase
     assert_equal 97, 'abc'.ord
   end
 
-  if RUBY_VERSION < '1.9'
+  if Gem.ruby_version < '1.9'
     def test_getbyte
       assert_equal 97, 'a'.getbyte(0)
       assert_equal 99, 'abc'.getbyte(2)
@@ -270,7 +270,7 @@ class StringInflectionsTest < Test::Unit::TestCase
     assert_equal "Hello Big[...]", "Hello Big World!".truncate(15, :omission => "[...]", :separator => ' ')
   end
 
-  if RUBY_VERSION < '1.9.0'
+  if Gem.ruby_version < '1.9.0'
     def test_truncate_multibyte
       with_kcode 'none' do
         assert_equal "\354\225\210\353\205\225\355...", "\354\225\210\353\205\225\355\225\230\354\204\270\354\232\224".truncate(10)
@@ -309,7 +309,7 @@ class CoreExtStringMultibyteTest < ActiveSupport::TestCase
     assert !BYTE_STRING.is_utf8?
   end
 
-  if RUBY_VERSION < '1.9'
+  if Gem.ruby_version < '1.9'
     def test_mb_chars_returns_self_when_kcode_not_set
       with_kcode('none') do
         assert_kind_of String, UNICODE_STRING.mb_chars
@@ -354,7 +354,7 @@ class OutputSafetyTest < ActiveSupport::TestCase
   test "A fixnum is safe by default" do
     assert 5.html_safe?
   end
-  
+
   test "a float is safe by default" do
     assert 5.7.html_safe?
   end
@@ -450,7 +450,7 @@ class OutputSafetyTest < ActiveSupport::TestCase
   end
 
   test 'knows whether it is encoding aware' do
-    if RUBY_VERSION >= "1.9"
+    if Gem.ruby_version >= "1.9"
       assert 'ruby'.encoding_aware?
     else
       assert !'ruby'.encoding_aware?
@@ -470,3 +470,4 @@ class StringExcludeTest < ActiveSupport::TestCase
     assert_equal true, 'foo'.exclude?('p')
   end
 end
+

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -434,7 +434,7 @@ class TimeWithZoneTest < Test::Unit::TestCase
   end
 
   def test_ruby_19_weekday_name_query_methods
-    ruby_19_or_greater = RUBY_VERSION >= '1.9'
+    ruby_19_or_greater = Gem.ruby_version >= '1.9'
     %w(sunday? monday? tuesday? wednesday? thursday? friday? saturday?).each do |name|
       assert_equal ruby_19_or_greater, @twz.respond_to?(name)
     end
@@ -917,3 +917,4 @@ class TimeWithZoneMethodsForTimeAndDateTimeTest < Test::Unit::TestCase
       old_tz ? ENV['TZ'] = old_tz : ENV.delete('TZ')
     end
 end
+

--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -102,7 +102,7 @@ class MultibyteCharsUTF8BehaviourTest < Test::Unit::TestCase
   def setup
     @chars = UNICODE_STRING.dup.mb_chars
 
-    if RUBY_VERSION < '1.9'
+    if Gem.ruby_version < '1.9'
       # Multibyte support all kinds of whitespace (ie. NEWLINE, SPACE, EM SPACE)
       @whitespace = "\n\t#{[32, 8195].pack('U*')}"
     else
@@ -150,7 +150,7 @@ class MultibyteCharsUTF8BehaviourTest < Test::Unit::TestCase
     assert_not_equal original, proxy.to_s
   end
 
-  if RUBY_VERSION >= '1.9'
+  if Gem.ruby_version >= '1.9'
     def test_unicode_string_should_have_utf8_encoding
       assert_equal Encoding::UTF_8, UNICODE_STRING.encoding
     end
@@ -701,3 +701,4 @@ class MultibyteInternalsTest < ActiveSupport::TestCase
     end
   end
 end
+

--- a/activesupport/test/multibyte_utils_test.rb
+++ b/activesupport/test/multibyte_utils_test.rb
@@ -57,7 +57,7 @@ class MultibyteUtilsTest < ActiveSupport::TestCase
     end
   end
 
-  if RUBY_VERSION < '1.9'
+  if Gem.ruby_version < '1.9'
     test "clean leaves ASCII strings intact" do
       with_encoding('None') do
         [
@@ -136,3 +136,4 @@ class MultibyteUtilsTest < ActiveSupport::TestCase
     alias with_encoding with_kcode
   end
 end
+

--- a/activesupport/test/ordered_hash_test.rb
+++ b/activesupport/test/ordered_hash_test.rb
@@ -81,7 +81,7 @@ class OrderedHashTest < Test::Unit::TestCase
     keys = []
     assert_equal @ordered_hash, @ordered_hash.each_key { |k| keys << k }
     assert_equal @keys, keys
-    expected_class = RUBY_VERSION < '1.9' ? Enumerable::Enumerator : Enumerator
+    expected_class = Gem.ruby_version < '1.9' ? Enumerable::Enumerator : Enumerator
     assert_kind_of expected_class, @ordered_hash.each_key
   end
 
@@ -89,7 +89,7 @@ class OrderedHashTest < Test::Unit::TestCase
     values = []
     assert_equal @ordered_hash, @ordered_hash.each_value { |v| values << v }
     assert_equal @values, values
-    expected_class = RUBY_VERSION < '1.9' ? Enumerable::Enumerator : Enumerator
+    expected_class = Gem.ruby_version < '1.9' ? Enumerable::Enumerator : Enumerator
     assert_kind_of expected_class, @ordered_hash.each_value
   end
 
@@ -97,7 +97,7 @@ class OrderedHashTest < Test::Unit::TestCase
     values = []
     assert_equal @ordered_hash, @ordered_hash.each {|key, value| values << value}
     assert_equal @values, values
-    expected_class = RUBY_VERSION < '1.9' ? Enumerable::Enumerator : Enumerator
+    expected_class = Gem.ruby_version < '1.9' ? Enumerable::Enumerator : Enumerator
     assert_kind_of expected_class, @ordered_hash.each
   end
 
@@ -115,7 +115,7 @@ class OrderedHashTest < Test::Unit::TestCase
     assert_equal @values, values
     assert_equal @keys, keys
 
-    expected_class = RUBY_VERSION < '1.9' ? Enumerable::Enumerator : Enumerator
+    expected_class = Gem.ruby_version < '1.9' ? Enumerable::Enumerator : Enumerator
     assert_kind_of expected_class, @ordered_hash.each_pair
   end
 
@@ -330,3 +330,4 @@ class OrderedHashTest < Test::Unit::TestCase
     assert_equal @values.zip(@keys), @ordered_hash.invert.to_a
   end
 end
+


### PR DESCRIPTION
Version comparison using strings (in the situations like `RUBY_VERSION < '1.9.2'`) can be faulty at times. 
Gem::Version is now equipped with symbols for version comparison. It can be used like `Gem.ruby_version < '1.9.2'`.
