### PR TITLE
Include TagHelper within AssetTagHelper

### DIFF
--- a/actionpack/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helper.rb
@@ -1,6 +1,7 @@
 require 'action_view/helpers/asset_tag_helpers/javascript_tag_helpers'
 require 'action_view/helpers/asset_tag_helpers/stylesheet_tag_helpers'
 require 'action_view/helpers/asset_tag_helpers/asset_paths'
+require 'action_view/helpers/tag_helper'
 
 module ActionView
   # = Action View Asset Tag Helpers
@@ -191,6 +192,7 @@ module ActionView
     #   RewriteEngine On
     #   RewriteRule ^/release-\d+/(images|javascripts|stylesheets)/(.*)$ /$1/$2 [L]
     module AssetTagHelper
+      include TagHelper
       include JavascriptTagHelpers
       include StylesheetTagHelpers
       # Returns a link tag that browsers and news readers can use to auto-detect


### PR DESCRIPTION
The TagHelper module should be included within AV::Helpers::AssetTagHelper as many of its methods depend on the tag method from TagHelper.

In particular, this fixes an error (NoMethodError: undefined method `tag') when image_tag, etc are called from a Sprockets environment (e.g. .js.erb).

I'm unsure of how best to write a test to catch regressions though.

This fix should also be cherry-picked to 3-1-stable.
