### PR TITLE
Allow ActiveModel-compatible instances to define their own partial paths

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -1227,8 +1227,12 @@ module ActionView
         parent_builder.multipart = multipart if parent_builder
       end
 
-      def self.model_name
-        @model_name ||= Struct.new(:partial_path).new(name.demodulize.underscore.sub!(/_builder$/, ''))
+      def self.to_path
+        @_to_path ||= name.demodulize.underscore.sub!(/_builder$/, '')
+      end
+
+      def to_path
+        self.class.to_path
       end
 
       def to_model

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -1874,6 +1874,17 @@ class FormHelperTest < ActionView::TestCase
     assert_equal LabelledFormBuilder, klass
   end
 
+  def test_form_for_with_labelled_builder_path
+    path = nil
+
+    form_for(@post, :builder => LabelledFormBuilder) do |f|
+      path = f.to_path
+      ''
+    end
+
+    assert_equal 'labelled_form', path
+  end
+
   class LabelledFormBuilderSubclass < LabelledFormBuilder; end
 
   def test_form_for_with_labelled_builder_with_nested_fields_for_with_custom_builder

--- a/actionpack/test/template/render_test.rb
+++ b/actionpack/test/template/render_test.rb
@@ -201,6 +201,36 @@ module RenderTestCases
       @controller_view.render(customers, :greeting => "Hello")
   end
 
+  class CustomerWithDeprecatedPartialPath
+    attr_reader :name
+
+    def self.model_name
+      Struct.new(:partial_path).new("customers/customer")
+    end
+
+    def initialize(name)
+      @name = name
+    end
+  end
+
+  def test_render_partial_using_object_with_deprecated_partial_path
+    assert_deprecated(/#model_name.*#partial_path.*#to_path/) do
+      assert_equal "Hello: nertzy",
+        @controller_view.render(CustomerWithDeprecatedPartialPath.new("nertzy"), :greeting => "Hello")
+    end
+  end
+
+  def test_render_partial_using_collection_with_deprecated_partial_path
+    assert_deprecated(/#model_name.*#partial_path.*#to_path/) do
+      customers = [
+        CustomerWithDeprecatedPartialPath.new("nertzy"),
+        CustomerWithDeprecatedPartialPath.new("peeja")
+      ]
+      assert_equal "Hello: nertzyHello: peeja",
+        @controller_view.render(customers, :greeting => "Hello")
+    end
+  end
+
   # TODO: The reason for this test is unclear, improve documentation
   def test_render_partial_and_fallback_to_layout
     assert_equal "Before (Josh)\n\nAfter", @view.render(:partial => "test/layout_for_partial", :locals => { :name => "Josh" })

--- a/activemodel/lib/active_model/conversion.rb
+++ b/activemodel/lib/active_model/conversion.rb
@@ -1,9 +1,12 @@
+require 'active_support/concern'
+require 'active_support/inflector'
+
 module ActiveModel
   # == Active Model Conversions
   #
-  # Handles default conversions: to_model, to_key and to_param.
+  # Handles default conversions: to_model, to_key, to_param, and to_path.
   #
-  # Let's take for example this non persisted object.
+  # Let's take for example this non-persisted object.
   #
   #   class ContactMessage
   #     include ActiveModel::Conversion
@@ -18,8 +21,11 @@ module ActiveModel
   #   cm.to_model == self # => true
   #   cm.to_key           # => nil
   #   cm.to_param         # => nil
+  #   cm.to_path          # => "contact_messages/contact_message"
   #
   module Conversion
+    extend ActiveSupport::Concern
+
     # If your object is already designed to implement all of the Active Model
     # you can use the default <tt>:to_model</tt> implementation, which simply
     # returns self.
@@ -44,6 +50,22 @@ module ActiveModel
     # or nil if <tt>persisted?</tt> is false.
     def to_param
       persisted? ? to_key.join('-') : nil
+    end
+
+    # Returns a string identifying the path associated with the object.
+    # ActionPack uses this to find a suitable partial to represent the object.
+    def to_path
+      self.class.to_path
+    end
+
+    module ClassMethods
+      def to_path
+        @_to_path ||= begin
+          element = ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.demodulize(self))
+          collection = ActiveSupport::Inflector.tableize(self)
+          "#{collection}/#{element}".freeze
+        end
+      end
     end
   end
 end

--- a/activemodel/lib/active_model/lint.rb
+++ b/activemodel/lib/active_model/lint.rb
@@ -43,6 +43,16 @@ module ActiveModel
         assert model.to_param.nil?, "to_param should return nil when `persisted?` returns false"
       end
 
+      # == Responds to <tt>to_path</tt>
+      #
+      # Returns a string giving a relative path.  This is used for looking up
+      # partials. For example, a BlogPost model might return "blog_posts/blog_post"
+      #
+      def test_to_path
+        assert model.respond_to?(:to_path), "The model should respond to to_path"
+        assert_kind_of String, model.to_path
+      end
+
       # == Responds to <tt>valid?</tt>
       #
       # Returns a boolean that specifies whether the object is in a valid or invalid
@@ -66,15 +76,14 @@ module ActiveModel
 
       # == Naming
       #
-      # Model.model_name must return a string with some convenience methods as
-      # :human and :partial_path. Check ActiveModel::Naming for more information.
+      # Model.model_name must return a string with some convenience methods:
+      # :human, :singular, and :plural. Check ActiveModel::Naming for more information.
       #
       def test_model_naming
         assert model.class.respond_to?(:model_name), "The model should respond to model_name"
         model_name = model.class.model_name
         assert_kind_of String, model_name
         assert_kind_of String, model_name.human
-        assert_kind_of String, model_name.partial_path
         assert_kind_of String, model_name.singular
         assert_kind_of String, model_name.plural
       end

--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -1,11 +1,14 @@
 require 'active_support/inflector'
 require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/module/introspection'
+require 'active_support/core_ext/module/deprecation'
 
 module ActiveModel
   class Name < String
     attr_reader :singular, :plural, :element, :collection, :partial_path, :route_key, :param_key, :i18n_key
     alias_method :cache_key, :collection
+
+    deprecate :partial_path => "ActiveModel::Name#partial_path is deprecated. Call #to_path on model instances directly instead."
 
     def initialize(klass, namespace = nil, name = nil)
       name ||= klass.name

--- a/activemodel/test/cases/conversion_test.rb
+++ b/activemodel/test/cases/conversion_test.rb
@@ -1,5 +1,6 @@
 require 'cases/helper'
 require 'models/contact'
+require 'models/helicopter'
 
 class ConversionTest < ActiveModel::TestCase
   test "to_model default implementation returns self" do
@@ -21,5 +22,11 @@ class ConversionTest < ActiveModel::TestCase
 
   test "to_param default implementation returns a string of ids for persisted records" do
     assert_equal "1", Contact.new(:id => 1).to_param
+  end
+
+  test "to_path default implementation returns a string giving a relative path" do
+    assert_equal "contacts/contact", Contact.new.to_path
+    assert_equal "helicopters/helicopter", Helicopter.new.to_path,
+      "ActiveModel::Conversion#to_path caching should be class-specific"
   end
 end

--- a/activemodel/test/cases/naming_test.rb
+++ b/activemodel/test/cases/naming_test.rb
@@ -26,7 +26,9 @@ class NamingTest < ActiveModel::TestCase
   end
 
   def test_partial_path
-    assert_equal 'post/track_backs/track_back', @model_name.partial_path
+    assert_deprecated(/#partial_path.*#to_path/) do
+      assert_equal 'post/track_backs/track_back', @model_name.partial_path
+    end
   end
 
   def test_human
@@ -56,7 +58,9 @@ class NamingWithNamespacedModelInIsolatedNamespaceTest < ActiveModel::TestCase
   end
 
   def test_partial_path
-    assert_equal 'blog/posts/post', @model_name.partial_path
+    assert_deprecated(/#partial_path.*#to_path/) do
+      assert_equal 'blog/posts/post', @model_name.partial_path
+    end
   end
 
   def test_human
@@ -98,7 +102,9 @@ class NamingWithNamespacedModelInSharedNamespaceTest < ActiveModel::TestCase
   end
 
   def test_partial_path
-    assert_equal 'blog/posts/post', @model_name.partial_path
+    assert_deprecated(/#partial_path.*#to_path/) do
+      assert_equal 'blog/posts/post', @model_name.partial_path
+    end
   end
 
   def test_human
@@ -136,7 +142,9 @@ class NamingWithSuppliedModelNameTest < ActiveModel::TestCase
   end
 
   def test_partial_path
-    assert_equal 'articles/article', @model_name.partial_path
+    assert_deprecated(/#partial_path.*#to_path/) do
+      assert_equal 'articles/article', @model_name.partial_path
+    end
   end
 
   def test_human

--- a/activemodel/test/models/helicopter.rb
+++ b/activemodel/test/models/helicopter.rb
@@ -1,0 +1,3 @@
+class Helicopter
+  include ActiveModel::Conversion
+end


### PR DESCRIPTION
The current implementation of `ActionView::PartialRenderer#partial_path` forces all instances of a given class to render the same partial. When you call `<%= render @object %>` in a view, the current implementation asks the object's class for a partial path instead of the instance itself.

Also, defining the partial path for `FormBuilder` uses a strange hack on its `self.model_name` method, which is unexpected.

We propose deprecating `#partial_path` on the return value of `#model_name` on the classes of `ActiveModel` objects. Our replacement is to implement `#to_path` on instances directly. This allows different instances of the same class to use whatever logic they want to pick a partial to render.

We built a default implementation of `#to_path` into `ActiveModel::Conversion`, so `ActiveRecord::Base` subclasses will work correctly without changes to existing application code in most cases. Failing that, the old way will still work but is now deprecated.

In the spirit of the other methods in `ActiveModel::Conversion` (such as `#to_key`), we chose to name our method `#to_path` instead of `#partial_path`. This way, people might be encouraged to use the path in other contexts. The name "partial_path" seems to be too viewy for models to care about.
### Motivation

We wanted to build a `TableBuilder` to display records, analogous to the `FormBuilder`:

``` erb
<%= table_for(@person) do |t| %>
  <%= t.field :name %>
  <%= t.field :age %>
<% end %>
```

We then wanted to be able to reuse the definition of the table in a partial.  The cleanest way to represent this seemed to be:

``` erb
<%= table_for(@person) do |t| %>
  <%= render t %>
<% end %>
```

Or, as a shortcut:

``` erb
<%= table_for(@person) %>
```

Since all `TableBuilder` objects have the same class, they have the same `.class.model_name.partial_path`, and so they render the same partial.  We needed the partial to be based on the object the `TableBuilder` was presenting.

`FormBuilder` objects can be rendered in this way, and they get around the issue by having a partial path of `"form"`.  When the `PeopleController` is rendering its `#edit` action, this resolves to `"people/form"`, which is the right partial.  However, when another controller, say the `AccountsController`, tries to render `account_fields.fields_for(:person)`, it renders `"accounts/form"`, passing it the `Person` form builder.  Therefore, `FormBuilder` has not solved this problem yet.

This commit does not solve the problem for `FormBuilder` because it would be a breaking change, but it does make the solution possible. It also enables us to write a similar solution for our `TableBuilder`.
