### PR TITLE
TagHelper creates invalid data attributes when value is a BigDecimal

### DIFF
--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -154,8 +154,9 @@ module ActionView
 
         def data_tag_option(key, value, escape)
           key   = "data-#{key.to_s.dasherize}"
-          value = value.to_json if !value.is_a?(String) && !value.is_a?(Symbol)
-
+          unless value.is_a?(String) || value.is_a?(Symbol) || value.is_a?(BigDecimal)
+            value = value.to_json
+          end
           tag_option(key, value, escape)
         end
 

--- a/actionpack/test/template/tag_helper_test.rb
+++ b/actionpack/test/template/tag_helper_test.rb
@@ -118,8 +118,8 @@ class TagHelperTest < ActionView::TestCase
 
   def test_data_attributes
     ['data', :data].each { |data|
-      assert_dom_equal '<a data-a-number="1" data-array="[1,2,3]" data-hash="{&quot;key&quot;:&quot;value&quot;}" data-string="hello" data-symbol="foo" />',
-        tag('a', { data => { :a_number => 1, :string => 'hello', :symbol => :foo, :array => [1, 2, 3], :hash => { :key => 'value'} } })
+      assert_dom_equal '<a data-a-float="3.14" data-a-big-decimal="-123.456" data-a-number="1" data-array="[1,2,3]" data-hash="{&quot;key&quot;:&quot;value&quot;}" data-string="hello" data-symbol="foo" />',
+        tag('a', { data => { :a_float => 3.14, :a_big_decimal => BigDecimal.new("-123.456"), :a_number => 1, :string => 'hello', :symbol => :foo, :array => [1, 2, 3], :hash => { :key => 'value'} } })
     }
   end
 end


### PR DESCRIPTION
Hi all

I ran into this issue yesterday:

User model has `latitude` and `longitude` attributes which are both decimal fields

When using these attributes to create data attribute tags, the quotations were added twice (as a result of calling to_json).

``` rhtml
<%= content_tag(:div, "", :data => {:latitude => @user.latitude, :longitude => @user.longitude} %>

# => <div data-latitude=""123.000"" data-longitude=""123.000""></div>
```

Fixed this by adding BigDecimal to the list of class types which should not be converted to a JSON string
