### PR TITLE
Fix for SqlBypass session store (for master)

### DIFF
--- a/activerecord/lib/active_record/session_store.rb
+++ b/activerecord/lib/active_record/session_store.rb
@@ -183,11 +183,6 @@ module ActiveRecord
 
       ##
       # :singleton-method:
-      # Use the ActiveRecord::Base.connection by default.
-      cattr_accessor :connection
-
-      ##
-      # :singleton-method:
       # The table name defaults to 'sessions'.
       cattr_accessor :table_name
       @@table_name = 'sessions'
@@ -206,10 +201,19 @@ module ActiveRecord
 
       class << self
         alias :data_column_name :data_column
+        
+        # Use the ActiveRecord::Base.connection by default.
+        attr_writer :connection
+        
+        # Use the ActiveRecord::Base.connection_pool by default.
+        attr_writer :connection_pool
 
-        remove_method :connection
         def connection
-          @@connection ||= ActiveRecord::Base.connection
+          @connection ||= ActiveRecord::Base.connection
+        end
+
+        def connection_pool
+          @connection_pool ||= ActiveRecord::Base.connection_pool
         end
 
         # Look up a session by id and unmarshal its data if found.
@@ -219,6 +223,8 @@ module ActiveRecord
           end
         end
       end
+      
+      delegate :connection, :connection=, :connection_pool, :connection_pool=, :to => self
 
       attr_reader :session_id, :new_record
       alias :new_record? :new_record


### PR DESCRIPTION
Fix for SqlBypass session store - for master, see #2040, #2016

Two issues fixed:
1) connection_pool is not defined - needed by SessionStore#drop_table!
and create_table! since c94651f

2) initialization of connection to the default of AR::Base.connection
only occurred at the singleton level - the instance level method defined
by cattr_accessor did not have this logic
