### PR TITLE
Add possibility to render partial from subfolder with inheritance

### DIFF
--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -21,7 +21,7 @@ class ActionPackAssertionsController < ActionController::Base
     render :template => "test/hello_xml_world"
   end
 
-  def partial() render :partial => 'test/partial'; end
+  def partial() render :partial => '/test/partial'; end
 
   def redirect_internal() redirect_to "/nothing"; end
 

--- a/actionpack/test/controller/new_base/render_partial_test.rb
+++ b/actionpack/test/controller/new_base/render_partial_test.rb
@@ -12,7 +12,13 @@ module RenderPartial
       "render_partial/basic/_final.json.erb"      => "{ final: json }",
       "render_partial/basic/overridden.html.erb"  => "<%= @test_unchanged = 'goodbye' %><%= render :partial => 'overridden' %><%= @test_unchanged %>",
       "render_partial/basic/_overridden.html.erb" => "ParentPartial!",
-      "render_partial/child/_overridden.html.erb" => "OverriddenPartial!"
+      "render_partial/child/_overridden.html.erb" => "OverriddenPartial!",
+      "render_partial/basic/hierarhical.html.erb"               => "<%= @test_unchanged = 'goodbye' %><%= render :partial => 'subfolder/hierarhical' %><%= @test_unchanged %>",
+      "render_partial/basic/subfolder/_hierarhical.html.erb"    => "SubfolderBasicHierarhicalPartial!",
+      "render_partial/basic/hierarhical_with_child.html.erb"               => "<%= @test_unchanged = 'goodbye' %><%= render :partial => 'subfolder/hierarhical_with_child' %><%= @test_unchanged %>",
+      "render_partial/child/subfolder/_hierarhical_with_child.html.erb"    => "SubfolderBasicHierarhicalWithChildPartial!",
+      "render_partial/child/absolute.html.erb"               => "<%= @test_unchanged = 'goodbye' %><%= render :partial => '/render_partial/shared/absolute_partial' %><%= @test_unchanged %>",
+      "render_partial/shared/_absolute_partial.html.erb"    => "AbsolutePartial!"
     )]
 
     def html_with_json_inside_json
@@ -58,6 +64,22 @@ module RenderPartial
       get :overridden
       assert_response("goodbyeOverriddenPartial!goodbye")
     end
+
+    test "partial from contoller from subfolder gets picked" do
+      get :hierarhical
+      assert_response("goodbyeSubfolderBasicHierarhicalPartial!goodbye")
+    end
+
+    test "partial from child contoller from subfolder gets picked" do
+      get :hierarhical_with_child
+      assert_response("goodbyeSubfolderBasicHierarhicalWithChildPartial!goodbye")
+    end
+
+    test "partial with absolute path gets picked" do
+      get :absolute
+      assert_response("goodbyeAbsolutePartial!goodbye")
+    end
+
   end
 
 end

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -690,7 +690,7 @@ class TestController < ActionController::Base
   end
 
   def partial_with_nested_object
-    render :partial => "quiz/questions/question", :object => Quiz::Question.new("first")
+    render :partial => "/quiz/questions/question", :object => Quiz::Question.new("first")
   end
 
   def partial_with_nested_object_shorthand

--- a/actionpack/test/fixtures/test/_partial_with_partial.erb
+++ b/actionpack/test/fixtures/test/_partial_with_partial.erb
@@ -1,2 +1,2 @@
-<%= render 'test/partial' %>
+<%= render 'partial' %>
 partial with partial

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,63 @@
+*   Add possibility to render partial from subfolder with inheritance.
+
+    Partial started with `/` will be found as absolute path. Allow to template inheritance to render partial inside subfolders. Partials with slash in path name can be found only from views root folder.
+
+
+    Before:
+
+    If path will be as `/controller_name/head/menu`, it can be found only in `#{Rails.root}/app/views/controller_name/head/_menu.html.erb`
+    Thus the code `render :partial => "/head/menu"`, obviously raise an exception:
+
+        Missing partial /head/menu with {:handlers=>[:erb, :builder], :formats=>[:html], :locale=>[:en, :en]}. Searched in:
+        * "/path/to/project/app/views"
+
+    Meantime if partial path starts without any slashes (`render :partial => "menu"`), a partial status can be found in several pathes: `#{Rails.root}/app/views/controller_name/_menu.html` or `#{Rails.root}/app/views/controller_name/_menu.html`
+
+    And not possible to set inheritance partial in subfolder.
+
+    After:
+
+    When path is prepended with leading slash, it should be handled 'as is' and calculate from view_path root.
+
+        # For Admin::AccountsController < Admin::BaseController < ApplicationController
+
+        # in view
+        render '/users/account/sidebar' # renders app/views/users/account/_sidebar.html.erb
+
+        # in controller
+        def show
+          render '/something/custom_show' # renders app/views/something/custom_show.html.erb
+        end
+
+        # in controller
+        layout '/socials/facebook' # renders layout from app/views/layouts/socials/facebook.html.erb
+
+    When path is not prepended with leading slash, it should be handled with controller path_prefixes.
+
+        # For Admin::AccountsController < Admin::BaseController < ApplicationController
+
+        # in view
+        render 'users/account/sidebar'
+        # tries app/views/admin/accounts/users/account/_sidebar.html.erb
+        # then app/views/admin/base/users/account/_sidebar.html.erb
+        # then app/views/application/users/account/_sidebar.html.erb
+
+        # in controller
+        def show
+          render 'something/custom_show'
+          # tries app/views/admin/accounts/something/custom_show.html.erb
+          # then app/views/admin/base/something/custom_show.html.erb
+          # then app/views/application/something/custom_show.html.erb
+        end
+
+        # in controller
+        layout 'socials/facebook'
+        # tries layout app/views/layouts/admin/accounts/socials/facebook.html.erb
+        # then layout app/views/layouts/admin/base/socials/facebook.html.erb
+        # then layout app/views/layouts/application/socials/facebook.html.erb
+
+    *Alexey Osipenko*
+
 *   Always escape the result of `link_to_unless` method.
 
     Before:

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -22,8 +22,8 @@ module ActionView
   #     <%= render partial: "ad", locals: { ad: ad } %>
   #   <% end %>
   #
-  # This would first render "advertiser/_account.html.erb" with @buyer passed in as the local variable +account+, then
-  # render "advertiser/_ad.html.erb" and pass the local variable +ad+ to the template for display.
+  # This would first render "/advertiser/_account.html.erb" with @buyer passed in as the local variable +account+, then
+  # render "/advertiser/_ad.html.erb" and pass the local variable +ad+ to the template for display.
   #
   # == The :as and :object options
   #
@@ -55,14 +55,14 @@ module ActionView
   #
   #   <%= render partial: "ad", collection: @advertisements %>
   #
-  # This will render "advertiser/_ad.html.erb" and pass the local variable +ad+ to the template for display. An
+  # This will render "/advertiser/_ad.html.erb" and pass the local variable +ad+ to the template for display. An
   # iteration counter will automatically be made available to the template with a name of the form
   # +partial_name_counter+. In the case of the example above, the template would be fed +ad_counter+.
   #
   # The <tt>:as</tt> option may be used when rendering partials.
   #
   # You can specify a partial to be rendered between elements via the <tt>:spacer_template</tt> option.
-  # The following example will render <tt>advertiser/_ad_divider.html.erb</tt> between each ad partial:
+  # The following example will render <tt>/advertiser/_ad_divider.html.erb</tt> between each ad partial:
   #
   #   <%= render partial: "ad", collection: @advertisements, spacer_template: "ad_divider" %>
   #
@@ -78,7 +78,7 @@ module ActionView
   #
   # Two controllers can share a set of partials and render them like this:
   #
-  #   <%= render partial: "advertisement/ad", locals: { ad: @advertisement } %>
+  #   <%= render partial: "/advertisement/ad", locals: { ad: @advertisement } %>
   #
   # This will render the partial "advertisement/_ad.html.erb" regardless of which controller this is being called from.
   #
@@ -87,13 +87,13 @@ module ActionView
   # Instead of explicitly naming the location of a partial, you can also let PartialRenderer do the work
   # and pick the proper path by checking `to_partial_path` method.
   #
-  #  # @account.to_partial_path returns 'accounts/account', so it can be used to replace:
-  #  # <%= render partial: "accounts/account", locals: { account: @account} %>
+  #  # @account.to_partial_path returns '/accounts/account', so it can be used to replace:
+  #  # <%= render partial: "/accounts/account", locals: { account: @account} %>
   #  <%= render partial: @account %>
   #
   #  # @posts is an array of Post instances, so every post record returns 'posts/post' on `to_partial_path`,
   #  # that's why we can replace:
-  #  # <%= render partial: "posts/post", collection: @posts %>
+  #  # <%= render partial: "/posts/post", collection: @posts %>
   #  <%= render partial: @posts %>
   #
   # == Rendering the default case
@@ -107,13 +107,13 @@ module ActionView
   #  # Instead of <%= render partial: "account", locals: { account: @buyer } %>
   #  <%= render "account", account: @buyer %>
   #
-  #  # @account.to_partial_path returns 'accounts/account', so it can be used to replace:
-  #  # <%= render partial: "accounts/account", locals: { account: @account} %>
+  #  # @account.to_partial_path returns '/accounts/account', so it can be used to replace:
+  #  # <%= render partial: "/accounts/account", locals: { account: @account} %>
   #  <%= render @account %>
   #
   #  # @posts is an array of Post instances, so every post record returns 'posts/post' on `to_partial_path`,
   #  # that's why we can replace:
-  #  # <%= render partial: "posts/post", collection: @posts %>
+  #  # <%= render partial: "/posts/post", collection: @posts %>
   #  <%= render @posts %>
   #
   # == Rendering partials with layouts

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -379,7 +379,7 @@ module ActionView
     end
 
     def find_template(path, locals)
-      prefixes = path.include?(?/) ? [] : @lookup_context.prefixes
+      prefixes = path.start_with?("/") ? [] : @lookup_context.prefixes
       @lookup_context.find_template(path, prefixes, true, locals, @details)
     end
 
@@ -448,7 +448,7 @@ module ActionView
     end
 
     def merge_prefix_into_object_path(prefix, object_path)
-      if prefix.include?(?/) && object_path.include?(?/)
+      if prefix.start_with?("/") && object_path.start_with?("/")
         prefixes = []
         prefix_array = File.dirname(prefix).split('/')
         object_path_array = object_path.split('/')[0..-3] # skip model dir & partial

--- a/actionview/test/fixtures/test/render_partial_inside_directory.html.erb
+++ b/actionview/test/fixtures/test/render_partial_inside_directory.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: 'test/_directory/partial_with_locales', locals: {'name' => 'Jane'} %>
+<%= render partial: '_directory/partial_with_locales', locals: {'name' => 'Jane'} %>

--- a/actionview/test/template/log_subscriber_test.rb
+++ b/actionview/test/template/log_subscriber_test.rb
@@ -26,7 +26,7 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
   end
 
   def test_render_file_template
-    @view.render(:file => "test/hello_world")
+    @view.render(:file => "/test/hello_world")
     wait
 
     assert_equal 1, @logger.logged(:info).size
@@ -50,7 +50,7 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
   end
 
   def test_render_partial_template
-    @view.render(:partial => "test/customer")
+    @view.render(:partial => "/test/customer")
     wait
 
     assert_equal 1, @logger.logged(:info).size
@@ -66,7 +66,7 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
   end
 
   def test_render_collection_template
-    @view.render(:partial => "test/customer", :collection => [ Customer.new("david"), Customer.new("mary") ])
+    @view.render(:partial => "/test/customer", :collection => [ Customer.new("david"), Customer.new("mary") ])
     wait
 
     assert_equal 1, @logger.logged(:info).size

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -119,7 +119,7 @@ module ActionView
       @controller.controller_path = 'test'
 
       @customers = [stub(:name => 'Eloy'), stub(:name => 'Manfred')]
-      assert_match(/Hello: EloyHello: Manfred/, render(:partial => 'test/from_helper'))
+      assert_match(/Hello: EloyHello: Manfred/, render(:partial => '/test/from_helper'))
     end
   end
 

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -330,7 +330,7 @@ module ActionView
 
     test 'raises descriptive error message when template was not rendered' do
       controller.controller_path = "test"
-      render(template: "test/hello_world_with_partial")
+      render(template: "/test/hello_world_with_partial")
       e = assert_raise ActiveSupport::TestCase::Assertion do
         assert_template partial: 'i_was_never_rendered', locals: { 'did_not' => 'happen' }
       end
@@ -341,13 +341,13 @@ module ActionView
     test 'specifying locals works when the partial is inside a directory with underline prefix' do
       controller.controller_path = "test"
       render(template: 'test/render_partial_inside_directory')
-      assert_template partial: 'test/_directory/_partial_with_locales', locals: { 'name' => 'Jane' }
+      assert_template partial: '_directory/_partial_with_locales', locals: { 'name' => 'Jane' }
     end
 
     test 'specifying locals works when the partial is inside a directory without underline prefix' do
       controller.controller_path = "test"
       render(template: 'test/render_partial_inside_directory')
-      assert_template partial: 'test/_directory/partial_with_locales', locals: { 'name' => 'Jane' }
+      assert_template partial: '_directory/partial_with_locales', locals: { 'name' => 'Jane' }
     end
   end
 

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add possibility to render partial from subfolder with inheritance.
+
+    Partial started with `/` will be found as absolute path. Allow to template inheritance to render partial inside subfolders. Partials with slash in path name can be found only from views root folder. To be sure that `to_partial_path` will return path prepended with leading slash. Thus behaviour of rendering model has been not changed.
+
+    *Alexey Osipenko*
+
 *   `inclusion` / `exclusion` validations with ranges will only use the faster
     `Range#cover` for numerical ranges, and the more accurate `Range#include?`
     for non-numerical ones.

--- a/activemodel/lib/active_model/conversion.rb
+++ b/activemodel/lib/active_model/conversion.rb
@@ -85,7 +85,7 @@ module ActiveModel
         @_to_partial_path ||= begin
           element = ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.demodulize(self))
           collection = ActiveSupport::Inflector.tableize(self)
-          "#{collection}/#{element}".freeze
+          "/#{collection}/#{element}".freeze
         end
       end
     end

--- a/activemodel/lib/active_model/conversion.rb
+++ b/activemodel/lib/active_model/conversion.rb
@@ -73,7 +73,7 @@ module ActiveModel
     #   end
     #
     #   person = Person.new
-    #   person.to_partial_path # => "people/person"
+    #   person.to_partial_path # => "/people/person"
     def to_partial_path
       self.class._to_partial_path
     end


### PR DESCRIPTION
The new feature named "template inheritance" don't allow to render partial inside subfolders. Partials with slash in path name can be found only from views root folder. 

My pull request extends behavior of template inheritance, and allow to render partial inside subfolders with inheritance feature. I suggest to use `./` at the start, and this partial will be found with relative path (from current directory). So, 

```
  render :partial => "./head/menu"
```

can be found in several folders, as template inheritance means:

```
 - views
    - application
      - head
        - menu.html.erb
    - controller_name
      - head
        - menu.html.erb
```
