### PR TITLE
treat fullwidth whitespace as a blank character

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -86,14 +86,18 @@ class Hash
 end
 
 class String
+  # 0x3000: fullwidth whitespace
+  NON_WHITESPACE_REGEXP = %r![^\s#{[0x3000].pack("U")}]!
+
   # A string is blank if it's empty or contains whitespaces only:
   #
   #   "".blank?                 # => true
   #   "   ".blank?              # => true
+  #   "　".blank?               # => true
   #   " something here ".blank? # => false
   #
   def blank?
-    self !~ /\S/
+    self !~ NON_WHITESPACE_REGEXP
   end
 end
 

--- a/activesupport/test/core_ext/blank_test.rb
+++ b/activesupport/test/core_ext/blank_test.rb
@@ -2,7 +2,7 @@ require 'abstract_unit'
 require 'active_support/core_ext/object/blank'
 
 class BlankTest < Test::Unit::TestCase
-  BLANK = [ EmptyTrue.new, nil, false, '', '   ', "  \n\t  \r ", [], {} ]
+  BLANK = [ EmptyTrue.new, nil, false, '', '   ', "  \n\t  \r ", '　', [], {} ]
   NOT   = [ EmptyFalse.new, Object.new, true, 0, 1, 'a', [nil], { nil => 0 } ]
 
   def test_blank


### PR DESCRIPTION
String#blank? doesn't treat fullwidth whitespace char as a blank character, but we CJK speakers usually DO regard it as a blank char. Thus we often have to monkey patch String#blank? method.
This patch makes String#blank? to do so by default.
