### PR TITLE
small fix of small issue #2057

### DIFF
--- a/actionpack/lib/action_view/base.rb
+++ b/actionpack/lib/action_view/base.rb
@@ -135,7 +135,7 @@ module ActionView #:nodoc:
 
     # Specify the proc used to decorate input tags that refer to attributes with errors.
     cattr_accessor :field_error_proc
-    @@field_error_proc = Proc.new{ |html_tag, instance| "<div class=\"field_with_errors\">#{html_tag}</div>".html_safe }
+    @@field_error_proc = Proc.new{ |html_tag, instance| "<span class=\"field_with_errors\">#{html_tag}</span>".html_safe }
 
     # How to complete the streaming when an exception occurs.
     # This is our best guess: first try to close the attribute, then the tag.


### PR DESCRIPTION
usage of DIV tag for 'field_with_error' output brakes paragraph tags in some forms
SPAN tag is less 'intrusive', so it is used instead
