### PR TITLE
Fix MSSQL and Firebird .exists? problem (issue #1623)

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -185,7 +185,7 @@ module ActiveRecord
 
       join_dependency = construct_join_dependency_for_association_find
       relation = construct_relation_for_association_find(join_dependency)
-      relation = relation.except(:select).select("1").limit(1)
+      relation = relation.except(:select).select("1 as o").limit(1)
 
       case id
       when Array, Hash


### PR DESCRIPTION
MSSQL and Firebird DBs require the fake column to named.
