### PR TITLE
Reenable strict default sanitizer in test env app template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -34,6 +34,11 @@
   # like if you have constraints or database-specific column types
   # config.active_record.schema_format = :sql
 
+  <%- unless options.skip_active_record? -%>
+  # Raise exception on mass assignment protection for ActiveRecord models
+  config.active_record.mass_assignment_sanitizer = :strict
+  <%- end -%>
+
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
 end

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
@@ -19,7 +19,7 @@ class <%= controller_class_name %>ControllerTest < ActionController::TestCase
 
   test "should create <%= singular_table_name %>" do
     assert_difference('<%= class_name %>.count') do
-      post :create, <%= key_value singular_table_name, "@#{singular_table_name}.attributes" %>
+      post :create, <%= key_value singular_table_name, "@#{singular_table_name}.attributes.except(\"id\")" %>
     end
 
     assert_redirected_to <%= singular_table_name %>_path(assigns(:<%= singular_table_name %>))
@@ -36,7 +36,7 @@ class <%= controller_class_name %>ControllerTest < ActionController::TestCase
   end
 
   test "should update <%= singular_table_name %>" do
-    put :update, <%= key_value :id, "@#{singular_table_name}.to_param" %>, <%= key_value singular_table_name, "@#{singular_table_name}.attributes" %>
+    put :update, <%= key_value :id, "@#{singular_table_name}.to_param" %>, <%= key_value singular_table_name, "@#{singular_table_name}.attributes.except(\"id\")" %>
     assert_redirected_to <%= singular_table_name %>_path(assigns(:<%= singular_table_name %>))
   end
 


### PR DESCRIPTION
As discussed here https://github.com/rails/rails/commit/2a24bcc6cf97fa9ecb78fa21ec23b25438d20371#commitcomment-470614

Bringing back `:strict` default mass assignment sanitizer in test environment.

@josevalim, I am not sure I understand what problem did you mention with ActiveResource in the comment above. Can you please exaplain?
