### PR TITLE
make Tempfile unduplicable

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/duplicable.rb
+++ b/activesupport/lib/active_support/core_ext/object/duplicable.rb
@@ -93,3 +93,15 @@ class BigDecimal
     # can't dup, so use superclass implementation
   end
 end
+
+require 'tempfile' unless defined?(Tempfile)
+class Tempfile
+  # Tempfiles are not duplicable:
+  #
+  #   t = Tempfile.new('foo.txt') # => #<File:0x101bf2438>
+  #   t.dup                       # => #<File:0x101bf2438>
+  #
+  def duplicable?
+    false
+  end
+end

--- a/activesupport/test/core_ext/duplicable_test.rb
+++ b/activesupport/test/core_ext/duplicable_test.rb
@@ -6,7 +6,7 @@ require 'active_support/core_ext/numeric/time'
 class DuplicableTest < ActiveSupport::TestCase
   RAISE_DUP  = [nil, false, true, :symbol, 1, 2.3, 5.seconds]
   YES = ['1', Object.new, /foo/, [], {}, Time.now, Class.new, Module.new]
-  NO = []
+  NO = [Tempfile.new('temporary.txt')]
 
   begin
     bd = BigDecimal.new('4.56')
@@ -14,7 +14,6 @@ class DuplicableTest < ActiveSupport::TestCase
   rescue TypeError
     RAISE_DUP << bd
   end
-
 
   def test_duplicable
     (RAISE_DUP + NO).each do |v|


### PR DESCRIPTION
GCing a Tempfile object deletes the actual file on the filesystem. So, two (or more) Tempfiles pointing to one same actual file should better not exist.
However, we found this actually happens in our real world applications because Tempfiles are duped in parameter_filter here https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/http/parameter_filter.rb#L39

Because of this, a request with an attachment very rarely dies with `IOError: closed stream`.

Attached a patch and test that changes Tempfile unduplicable.
