### PR TITLE
write_cookies! nil exception in ActionDispatch::TestRequest

### DIFF
--- a/actionpack/lib/action_dispatch/testing/test_request.rb
+++ b/actionpack/lib/action_dispatch/testing/test_request.rb
@@ -83,7 +83,7 @@ module ActionDispatch
       end
 
       def escape_cookie(name, value)
-        "#{Rack::Utils.escape(name)}=#{Rack::Utils.escape(value)}"
+        "#{Rack::Utils.escape(name)}=#{Rack::Utils.escape(value.to_s)}"
       end
 
       def delete_nil_values!

--- a/actionpack/test/dispatch/test_request_test.rb
+++ b/actionpack/test/dispatch/test_request_test.rb
@@ -41,5 +41,11 @@ class TestRequestTest < ActiveSupport::TestCase
     req.cookies["login"] = "XJ-122"
     assert_equal({"user_name" => "david", "login" => "XJ-122"}, req.cookies)
     assert_equal %w(login=XJ-122 user_name=david), req.env["HTTP_COOKIE"].split(/; /).sort
-  end
+
+		assert_nothing_raised do
+			req.cookies["login"] = nil
+			assert_equal({"user_name" => "david", "login" => nil}, req.cookies)
+			assert_equal %w(login= user_name=david), req.env["HTTP_COOKIE"].split(/; /).sort
+		end
+	end
 end


### PR DESCRIPTION
write_cookies! in ActionDispatch::TestRequest won't write nil value when $KCODE == 'u' on 1.8.7
