### PR TITLE
Add ActiveSupport::Inflector.ordinal and Integer#ordinal

### DIFF
--- a/activesupport/lib/active_support/core_ext/integer/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/integer/inflections.rb
@@ -14,4 +14,18 @@ class Integer
   def ordinalize
     ActiveSupport::Inflector.ordinalize(self)
   end
+
+  # Ordinal returns the suffix used to denote the position
+  # in an ordered sequence such as 1st, 2nd, 3rd, 4th.
+  #
+  #  1.ordinal     # => "st"
+  #  2.ordinal     # => "nd"
+  #  1002.ordinal  # => "nd"
+  #  1003.ordinal  # => "rd"
+  #  -11.ordinal   # => "th"
+  #  -1001.ordinal # => "st"
+  #
+  def ordinal
+    ActiveSupport::Inflector.ordinal(self)
+  end
 end

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -222,6 +222,29 @@ module ActiveSupport
       end
     end
 
+    # Returns the suffix that should be added to a number to denote the position
+    # in an ordered sequence such as 1st, 2nd, 3rd, 4th.
+    #
+    # Examples:
+    #   ordinal(1)     # => "st"
+    #   ordinal(2)     # => "nd"
+    #   ordinal(1002)  # => "nd"
+    #   ordinal(1003)  # => "rd"
+    #   ordinal(-11)   # => "th"
+    #   ordinal(-1021) # => "st"
+    def ordinal(number)
+      if (11..13).include?(number.to_i.abs % 100)
+        "th"
+      else
+        case number.to_i.abs % 10
+          when 1; "st"
+          when 2; "nd"
+          when 3; "rd"
+          else    "th"
+        end
+      end
+    end
+
     # Turns a number into an ordinal string used to denote the position in an
     # ordered sequence such as 1st, 2nd, 3rd, 4th.
     #
@@ -233,16 +256,7 @@ module ActiveSupport
     #   ordinalize(-11)   # => "-11th"
     #   ordinalize(-1021) # => "-1021st"
     def ordinalize(number)
-      if (11..13).include?(number.to_i.abs % 100)
-        "#{number}th"
-      else
-        case number.to_i.abs % 10
-          when 1; "#{number}st"
-          when 2; "#{number}nd"
-          when 3; "#{number}rd"
-          else    "#{number}th"
-        end
-      end
+      "#{number}#{ordinal(number)}"
     end
   end
 end

--- a/activesupport/test/core_ext/integer_ext_test.rb
+++ b/activesupport/test/core_ext/integer_ext_test.rb
@@ -24,4 +24,10 @@ class IntegerExtTest < Test::Unit::TestCase
     assert_equal '8th', 8.ordinalize
     1000000000000000000000000000000000000000000000000000000000000000000000.ordinalize
   end
+
+  def test_ordinal
+    assert_equal 'st', 1.ordinal
+    assert_equal 'th', 8.ordinal
+    1000000000000000000000000000000000000000000000000000000000000000000000.ordinal
+  end
 end

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -297,6 +297,12 @@ class InflectorTest < Test::Unit::TestCase
 
   def test_ordinal
     OrdinalNumbers.each do |number, ordinalized|
+      assert_equal(ordinalized, number + ActiveSupport::Inflector.ordinal(number))
+    end
+  end
+
+  def test_ordinalize
+    OrdinalNumbers.each do |number, ordinalized|
       assert_equal(ordinalized, ActiveSupport::Inflector.ordinalize(number))
     end
   end


### PR DESCRIPTION
I needed to format an ordinalized number with markup, like so:

1&lt;sup&gt;st&lt;/sup&gt;

I found that there was no way to get just the suffix from ActiveSupport short of gsubbing out the original number.

This patch adds ActiveSupport::Inflector.ordinal(number) and Integer#ordinal to support this functionality:

1&lt;sup&gt;#{1.ordinal}&lt;/sup&gt;

Tests and docs are included, all tests are passing.
