### PR TITLE
Named indicies too long

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -374,18 +374,22 @@ module ActiveRecord
         add_index(table_name, old_index_def.columns, :name => new_name, :unique => old_index_def.unique)
       end
 
-      def index_name(table_name, options) #:nodoc:
-        if Hash === options # legacy support
-          if options[:column]
-            "index_#{table_name}_on_#{Array.wrap(options[:column]) * '_and_'}"
-          elsif options[:name]
-            options[:name]
-          else
-            raise ArgumentError, "You must specify the index name"
-          end
-        else
-          index_name(table_name, :column => options)
+      def index_name(table_name, options = {}) #:nodoc:
+        return index_name(table_name, :column => options) unless Hash === options # legacy support
+        
+        raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' is too long for the current adapter!" unless options[:column] || options[:name]
+        the_index_name = "index_#{table_name}_on_#{Array.wrap(options[:column]) * '_and_'}" if options[:column]
+        the_index_name = options[:name] if options[:name]
+        this_index_name = the_index_name.to_s if RUBY_VERSION < '1.9'
+        
+        if the_index_name.length > index_name_length
+          raise ArgumentError, "Index name '#{the_index_name}' on table '#{table_name}' is too long for the current adapter!" if options[:name]
+          
+          the_index_name = the_index_name[0...index_name_length]
+          warn("warning: index name was too long for the current adapter. It has been shortened to '#{the_index_name}'")
         end
+        
+        the_index_name
       end
 
       # Verify the existence of an index with a given name.
@@ -531,19 +535,16 @@ module ActiveRecord
 
         def add_index_options(table_name, column_name, options = {})
           column_names = Array.wrap(column_name)
-          index_name   = index_name(table_name, :column => column_names)
+          index_name   = index_name(table_name, :column => column_names, :name => options[:name])
 
           if Hash === options # legacy support, since this param was a string
             index_type = options[:unique] ? "UNIQUE" : ""
-            index_name = options[:name].to_s if options.key?(:name)
           else
             index_type = options
           end
-
-          if index_name.length > index_name_length
-            raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' is too long; the limit is #{index_name_length} characters"
-          end
+          
           if index_name_exists?(table_name, index_name, false)
+            # raise an exception if the index already exists
             raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' already exists"
           end
           index_columns = quoted_columns_for_index(column_names, options).join(", ")

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -130,14 +130,30 @@ if ActiveRecord::Base.connection.supports_migrations?
       assert !Person.connection.index_exists?(:people, :primary_contact_id, :name => :symbol_index_name)
     end
 
+    def test_auto_index_name_truncates
+      index_name_length = Person.connection.index_name_length
+      columns = (['x']*index_name_length) << 'x' # length + 1 columns
+      long_index_name = Person.connection.index_name('people', :column => columns)
+      long_index_name_truncated = "index_people_on_#{columns.join('_and_')}"[0...index_name_length]
+      assert long_index_name == long_index_name_truncated, 'auto-named index_name should have been truncated'
+    end
+
+    def test_user_index_name_raises_exception
+      index_name_length = Person.connection.index_name_length
+      name = 'x'*(index_name_length+1)
+      assert_raise(ArgumentError) { Person.connection.index_name('people', {:column => [:first_name], :name => name}) }
+    end
+
     def test_add_index_length_limit
       good_index_name = 'x' * Person.connection.index_name_length
       too_long_index_name = good_index_name + 'x'
-      assert_raise(ArgumentError)  { Person.connection.add_index("people", "first_name", :name => too_long_index_name) }
-      assert !Person.connection.index_name_exists?("people", too_long_index_name, false)
-      assert_nothing_raised { Person.connection.add_index("people", "first_name", :name => good_index_name) }
-      assert Person.connection.index_name_exists?("people", good_index_name, false)
-      Person.connection.remove_index("people", :name => good_index_name)
+
+      assert_nothing_raised { Person.connection.add_index('people', 'first_name', :name => good_index_name) }
+      assert Person.connection.index_name_exists?('people', good_index_name, false)
+      Person.connection.remove_index('people', :name => good_index_name)
+
+      assert_raise(ArgumentError) { Person.connection.add_index('people', 'first_name', :name => too_long_index_name) }
+      assert !Person.connection.index_name_exists?('people', too_long_index_name, false)
     end
 
     def test_remove_nonexistent_index


### PR DESCRIPTION
When creating a migration with a lot of primary keys (or one with a long table):

```
create_table :really_long_table_name do |t|
  t.integer :another_column_thats_long
  t.integer :this_is_a_column
end

add_index :really_long_table_name, [:another_column_thats_long, :this_is_a_column]
```

causes SQLite (and some other db packages) to take a fit because Index Names can't be > 64 characters in length. Could you just truncate the index names at 64 characters?
