### PR TITLE
Optimization of ActiveModel's match_attribute_method?

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -410,13 +410,16 @@ module ActiveModel
     private
       # Returns a struct representing the matching attribute method.
       # The struct's attributes are prefix, base and suffix.
+      @@match_attribute_method_cache = {}
       def match_attribute_method?(method_name)
+        cache = @@match_attribute_method_cache[self.class] ||= {}
+        return cache[method_name] if cache.key?(method_name)
         self.class.attribute_method_matchers.each do |method|
           if (match = method.match(method_name)) && attribute_method?(match.attr_name)
-            return match
+            return cache[method_name] = match
           end
         end
-        nil
+        cache[method_name] = nil
       end
 
       # prevent method_missing from calling private methods with #send


### PR DESCRIPTION
In production mode we were measuring the number of objects created, because the GC was working too hard imo, esp. compared to rails2.

Typically we got these numbers per request, the top 5:

 Total: 134949 samples
   20460  15.2%  15.2%    22374  16.6% Object#match_attribute_method?
    6907   5.1%  20.3%    38812  28.8% Array#map
    5662   4.2%  24.5%     5662   4.2% Set#subtract
    4359   3.2%  27.7%     5513   4.1% Set#merge
    3762   2.8%  30.5%    18610  13.8% Object#read_attribute
    3288   2.4%  32.9%    18607  13.8% ActiveRecord::Base#attributes

So for every request about 15% of all objects created, are created by the calls to match_attribute_method? in ActiveModel.

At 10 requests/second, this patch saves over 10 million objects per minute for us in production mode.

I'm however not that familiar with ActiveModel, and this is probably not the best way to solve this. But I thought I put this out there first and work from there. My main question atm is: are there times when this cache would need to be cleared?
