### PR TITLE
ActiveResource::Base#create data is not loaded if the transfer-encoding is chunked

### DIFF
--- a/activeresource/lib/active_resource/base.rb
+++ b/activeresource/lib/active_resource/base.rb
@@ -1357,7 +1357,11 @@ module ActiveResource
       end
 
       def load_attributes_from_response(response)
-        if !response['Content-Length'].blank? && response['Content-Length'] != "0" && !response.body.nil? && response.body.strip.size > 0
+        has_content_length = !response['Content-Length'].blank? && response['Content-Length'] != "0"
+        has_body = !response.body.nil? && response.body.strip.size > 0
+        is_chunked = response["Transfer-Encoding"] == "chunked"
+
+        if has_body && (has_content_length || is_chunked)
           load(self.class.format.decode(response.body), true)
           @persisted = true
         end


### PR DESCRIPTION
Fixing bug in ActiveResource::Base#create where returned data is not loaded if the transfer-encoding is chunked.  Includes tests & all ActiveResource tests pass.

Commit 154081f0f74988bdb8979f0447ff5816ab83d8fd created this bug, with the goal of fixing 204 responses.  There were no tests with this patch, so I added new tests to cover this & my own issue.  Refactored the `load_attributes_from_response` method to make the logic around when to load attributes more obvious.
