### PR TITLE
Fix improper detection and handling of html_safe buffer in CacheHelper

### DIFF
--- a/actionpack/lib/action_view/helpers/cache_helper.rb
+++ b/actionpack/lib/action_view/helpers/cache_helper.rb
@@ -56,7 +56,7 @@ module ActionView
           if output_buffer.html_safe?
             safe_output_buffer = output_buffer.to_str
             fragment = safe_output_buffer.slice!(pos..-1)
-            self.output_buffer = ActionView::OutputBuffer.new(safe_output_buffer)
+            self.output_buffer = output_buffer.class.new(safe_output_buffer)
           else
             fragment = output_buffer.slice!(pos..-1)
           end

--- a/actionpack/lib/action_view/helpers/cache_helper.rb
+++ b/actionpack/lib/action_view/helpers/cache_helper.rb
@@ -53,7 +53,7 @@ module ActionView
           # This dance is needed because Builder can't use capture
           pos = output_buffer.length
           yield
-          if output_buffer.is_a?(ActionView::OutputBuffer)
+          if output_buffer.html_safe?
             safe_output_buffer = output_buffer.to_str
             fragment = safe_output_buffer.slice!(pos..-1)
             self.output_buffer = ActionView::OutputBuffer.new(safe_output_buffer)

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -809,8 +809,8 @@ class CacheHelperOutputBufferTest < ActionController::TestCase
     cache_helper.extend(ActionView::Helpers::CacheHelper)
     cache_helper.expects(:controller).returns(controller).at_least(0)
     cache_helper.expects(:output_buffer).returns(output_buffer).at_least(0)
-    # if the output_buffer is changed, the new one should be html_safe
-    cache_helper.expects(:output_buffer=).with(responds_with(:html_safe?, true)).returns(true).at_least(0)
+    # if the output_buffer is changed, the new one should be html_safe and of the same type
+    cache_helper.expects(:output_buffer=).with(responds_with(:html_safe?, true)).with(instance_of(output_buffer.class)).at_least(0)
 
     assert_nothing_raised do
       cache_helper.send :fragment_for, 'Test fragment name', 'Test fragment', &Proc.new{ nil }
@@ -825,8 +825,8 @@ class CacheHelperOutputBufferTest < ActionController::TestCase
     cache_helper.extend(ActionView::Helpers::CacheHelper)
     cache_helper.expects(:controller).returns(controller).at_least(0)
     cache_helper.expects(:output_buffer).returns(output_buffer).at_least(0)
-    # if the output_buffer is changed, the new one should be html_safe
-    cache_helper.expects(:output_buffer=).with(responds_with(:html_safe?, true)).returns(true).at_least(0)
+    # if the output_buffer is changed, the new one should be html_safe and of the same type
+    cache_helper.expects(:output_buffer=).with(responds_with(:html_safe?, true)).with(instance_of(output_buffer.class)).at_least(0)
 
     assert_nothing_raised do
       cache_helper.send :fragment_for, 'Test fragment name', 'Test fragment', &Proc.new{ nil }

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -785,3 +785,53 @@ CACHED
     assert_equal "  <p>Builder</p>\n", @store.read('views/test.host/functional_caching/formatted_fragment_cached')
   end
 end
+
+class CacheHelperOutputBufferTest < ActionController::TestCase
+
+  class MockController
+    def read_fragment(name, options)
+      return false
+    end
+
+    def write_fragment(name, fragment, options)
+      fragment
+    end
+  end
+
+  def setup
+    super
+  end
+
+  def test_output_buffer
+    output_buffer = ActionView::OutputBuffer.new
+    controller = MockController.new
+    cache_helper = Object.new
+    cache_helper.extend(ActionView::Helpers::CacheHelper)
+    cache_helper.expects(:controller).returns(controller).at_least(0)
+    cache_helper.expects(:output_buffer).returns(output_buffer).at_least(0)
+    # if the output_buffer is changed, the new one should be html_safe
+    cache_helper.expects(:output_buffer=).with(responds_with(:html_safe?, true)).returns(true).at_least(0)
+
+    assert_nothing_raised do
+      cache_helper.send :fragment_for, 'Test fragment name', 'Test fragment', &Proc.new{ nil }
+      assert output_buffer.html_safe?, "Output buffer should stay html_safe"
+    end
+  end
+
+  def test_safe_buffer
+    output_buffer = ActiveSupport::SafeBuffer.new
+    controller = MockController.new
+    cache_helper = Object.new
+    cache_helper.extend(ActionView::Helpers::CacheHelper)
+    cache_helper.expects(:controller).returns(controller).at_least(0)
+    cache_helper.expects(:output_buffer).returns(output_buffer).at_least(0)
+    # if the output_buffer is changed, the new one should be html_safe
+    cache_helper.expects(:output_buffer=).with(responds_with(:html_safe?, true)).returns(true).at_least(0)
+
+    assert_nothing_raised do
+      cache_helper.send :fragment_for, 'Test fragment name', 'Test fragment', &Proc.new{ nil }
+      assert output_buffer.html_safe?, "Output buffer should stay html_safe"
+    end
+  end
+
+end


### PR DESCRIPTION
This fixes the latest incarnation of https://github.com/rails/rails/issues/1537 where CacheHelper might try to use splice! for a html_safe buffer which converts the buffer unsafe. This change has been tested against Rails's tests and slim-lang which originally raised this issue.
