### PR TITLE
Better formatting of rake routes (issue #1991)

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -659,13 +659,13 @@ module ActionDispatch
         #
         # This generates the following routes:
         #
-        #       admin_posts GET    /admin/posts(.:format)          {:action=>"index", :controller=>"admin/posts"}
-        #       admin_posts POST   /admin/posts(.:format)          {:action=>"create", :controller=>"admin/posts"}
-        #    new_admin_post GET    /admin/posts/new(.:format)      {:action=>"new", :controller=>"admin/posts"}
-        #   edit_admin_post GET    /admin/posts/:id/edit(.:format) {:action=>"edit", :controller=>"admin/posts"}
-        #        admin_post GET    /admin/posts/:id(.:format)      {:action=>"show", :controller=>"admin/posts"}
-        #        admin_post PUT    /admin/posts/:id(.:format)      {:action=>"update", :controller=>"admin/posts"}
-        #        admin_post DELETE /admin/posts/:id(.:format)      {:action=>"destroy", :controller=>"admin/posts"}
+        #       admin_posts GET    /admin/posts(.:format)          admin/posts#index
+        #       admin_posts POST   /admin/posts(.:format)          admin/posts#create
+        #    new_admin_post GET    /admin/posts/new(.:format)      admin/posts#new
+        #   edit_admin_post GET    /admin/posts/:id/edit(.:format) admin/posts#edit
+        #        admin_post GET    /admin/posts/:id(.:format)      admin/posts#show
+        #        admin_post PUT    /admin/posts/:id(.:format)      admin/posts#update
+        #        admin_post DELETE /admin/posts/:id(.:format)      admin/posts#destroy
         #
         # === Options
         #

--- a/railties/guides/source/routing.textile
+++ b/railties/guides/source/routing.textile
@@ -823,10 +823,10 @@ If you want a complete list of all of the available routes in your application, 
 For example, here's a small section of the +rake routes+ output for a RESTful route:
 
 <pre>
-          users GET  /users          {:controller=>"users", :action=>"index"}
-formatted_users GET  /users.:format  {:controller=>"users", :action=>"index"}
-                POST /users          {:controller=>"users", :action=>"create"}
-                POST /users.:format  {:controller=>"users", :action=>"create"}
+    users GET    /users(.:format)          users#index
+          POST   /users(.:format)          users#create
+ new_user GET    /users/new(.:format)      users#new
+edit_user GET    /users/:id/edit(.:format) users#edit
 </pre>
 
 You may restrict the listing to the routes that map to a particular controller setting the +CONTROLLER+ environment variable:

--- a/railties/lib/rails/tasks/routes.rake
+++ b/railties/lib/rails/tasks/routes.rake
@@ -11,7 +11,15 @@ task :routes => :environment do
 
     reqs = route.requirements.dup
     reqs[:to] = route.app unless route.app.class.name.to_s =~ /^ActionDispatch::Routing/
-    reqs = reqs.empty? ? "" : reqs.inspect
+
+    controller_action = "#{reqs[:controller]}##{reqs[:action]}"
+    constraints = reqs.except(:controller, :action)
+
+    reqs = controller_action == '#' ? '' : controller_action
+
+    unless constraints.empty?
+      reqs = reqs.empty? ? constraints.inspect : "#{reqs} #{constraints.inspect}"
+    end
 
     {:name => route.name.to_s, :verb => route.verb.to_s, :path => route.path, :reqs => reqs}
   end

--- a/railties/lib/rails/tasks/routes.rake
+++ b/railties/lib/rails/tasks/routes.rake
@@ -10,12 +10,12 @@ task :routes => :environment do
   routes = all_routes.collect do |route|
 
     reqs = route.requirements.dup
-    reqs[:to] = route.app unless route.app.class.name.to_s =~ /^ActionDispatch::Routing/
+    rack_app = route.app unless route.app.class.name.to_s =~ /^ActionDispatch::Routing/
 
-    controller_action = "#{reqs[:controller]}##{reqs[:action]}"
+    endpoint = rack_app ? rack_app.inspect : "#{reqs[:controller]}##{reqs[:action]}"
     constraints = reqs.except(:controller, :action)
 
-    reqs = controller_action == '#' ? '' : controller_action
+    reqs = endpoint == '#' ? '' : endpoint
 
     unless constraints.empty?
       reqs = reqs.empty? ? constraints.inspect : "#{reqs} #{constraints.inspect}"

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -91,7 +91,7 @@ module ApplicationTests
           get '/cart', :to => 'cart#show'
         end
       RUBY
-      assert_match 'cart GET /cart(.:format)', Dir.chdir(app_path){ `rake routes` }
+      assert_equal "cart GET /cart(.:format) cart#show\n", Dir.chdir(app_path){ `rake routes` }
     end
 
     def test_rake_routes_shows_custom_assets
@@ -100,7 +100,70 @@ module ApplicationTests
           get '/custom/assets', :to => 'custom_assets#show'
         end
       RUBY
-      assert_match 'custom_assets GET /custom/assets(.:format)', Dir.chdir(app_path){ `rake routes` }
+      assert_equal "custom_assets GET /custom/assets(.:format) custom_assets#show\n",
+        Dir.chdir(app_path){ `rake routes` }
+    end
+
+    def test_rake_routes_shows_resources_route
+      app_file "config/routes.rb", <<-RUBY
+        AppTemplate::Application.routes.draw do
+          resources :articles
+        end
+      RUBY
+      expected =
+        "    articles GET    /articles(.:format)          articles#index\n" <<
+        "             POST   /articles(.:format)          articles#create\n" <<
+        " new_article GET    /articles/new(.:format)      articles#new\n" <<
+        "edit_article GET    /articles/:id/edit(.:format) articles#edit\n" <<
+        "     article GET    /articles/:id(.:format)      articles#show\n" <<
+        "             PUT    /articles/:id(.:format)      articles#update\n" <<
+        "             DELETE /articles/:id(.:format)      articles#destroy\n"
+      assert_equal expected, Dir.chdir(app_path){ `rake routes` }
+    end
+
+    def test_rake_routes_shows_root_route
+      app_file "config/routes.rb", <<-RUBY
+        AppTemplate::Application.routes.draw do
+          root :to => 'pages#main'
+        end
+      RUBY
+      assert_equal "root  / pages#main\n", Dir.chdir(app_path){ `rake routes` }
+    end
+
+    def test_rake_routes_shows_controller_and_action_only_route
+      app_file "config/routes.rb", <<-RUBY
+        AppTemplate::Application.routes.draw do
+          match ':controller/:action'
+        end
+      RUBY
+      assert_equal "  /:controller/:action(.:format) \n", Dir.chdir(app_path){ `rake routes` }
+    end
+
+    def test_rake_routes_shows_controller_and_action_route_with_constraints
+      app_file "config/routes.rb", <<-RUBY
+        AppTemplate::Application.routes.draw do
+          match ':controller(/:action(/:id))', :id => /\\d+/
+        end
+      RUBY
+      assert_equal "  /:controller(/:action(/:id))(.:format) {:id=>/\\d+/}\n", Dir.chdir(app_path){ `rake routes` }
+    end
+
+    def test_rake_routes_shows_route_with_defaults
+      app_file "config/routes.rb", <<-RUBY
+        AppTemplate::Application.routes.draw do
+          match 'photos/:id' => 'photos#show', :defaults => {:format => 'jpg'}
+        end
+      RUBY
+      assert_equal %Q[  /photos/:id(.:format) photos#show {:format=>"jpg"}\n], Dir.chdir(app_path){ `rake routes` }
+    end
+
+    def test_rake_routes_shows_route_with_constraints
+      app_file "config/routes.rb", <<-RUBY
+        AppTemplate::Application.routes.draw do
+          match 'photos/:id' => 'photos#show', :id => /[A-Z]\\d{5}/
+        end
+      RUBY
+      assert_equal "  /photos/:id(.:format) photos#show {:id=>/[A-Z]\\d{5}/}\n", Dir.chdir(app_path){ `rake routes` }
     end
 
     def test_logger_is_flushed_when_exiting_production_rake_tasks

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -166,6 +166,27 @@ module ApplicationTests
       assert_equal "  /photos/:id(.:format) photos#show {:id=>/[A-Z]\\d{5}/}\n", Dir.chdir(app_path){ `rake routes` }
     end
 
+    def test_rake_routes_shows_route_with_rack_app
+      app_file "lib/rack_app.rb", <<-RUBY
+        class RackApp
+          class << self
+            def call(env)
+            end
+          end
+        end
+      RUBY
+
+      app_file "config/routes.rb", <<-RUBY
+        require 'rack_app'
+
+        AppTemplate::Application.routes.draw do
+          match 'foo/:id' => RackApp, :id => /[A-Z]\\d{5}/
+        end
+      RUBY
+
+      assert_equal "  /foo/:id(.:format) RackApp {:id=>/[A-Z]\\d{5}/}\n", Dir.chdir(app_path){ `rake routes` }
+    end
+
     def test_logger_is_flushed_when_exiting_production_rake_tasks
       add_to_config <<-RUBY
         rake_tasks do


### PR DESCRIPTION
Route requirements are sorted such that :controller and :action are
always first and the rests are sorted alphabetically.

Instead of

```
{:id=>/[A-Z]\d{5}/, :controller=>"photos", :action=>"show"}
```

we get

```
{:controller=>"photos", :action=>"show", :id=>/[A-Z]\d{5}/}
```
