### PR TITLE
convert multiple Date parameters into a nil if any of its bits were blank

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -2026,15 +2026,18 @@ MSG
         # If Date bits were not provided, error
         raise "Missing Parameter" if [1,2,3].any?{|position| !values_hash_from_param.has_key?(position)}
         max_position = extract_max_param_for_multiparameter_attributes(values_hash_from_param, 6)
+        # If Date bits were provided but blank, then return nil
+        return nil if (1..3).any? {|position| values_hash_from_param[position].blank?}
+
         set_values = (1..max_position).collect{|position| values_hash_from_param[position] }
-        # If Date bits were provided but blank, then default to 1
         # If Time bits are not there, then default to 0
-        [1,1,1,0,0,0].each_with_index{|v,i| set_values[i] = set_values[i].blank? ? v : set_values[i]}
+        (3..5).each {|i| set_values[i] = set_values[i].blank? ? 0 : set_values[i]}
         instantiate_time_object(name, set_values)
       end
 
       def read_date_parameter_value(name, values_hash_from_param)
-        set_values = (1..3).collect{|position| values_hash_from_param[position].blank? ? 1 : values_hash_from_param[position]}
+        return nil if (1..3).any? {|position| values_hash_from_param[position].blank?}
+        set_values = [values_hash_from_param[1], values_hash_from_param[2], values_hash_from_param[3]]
         begin
           Date.new(*set_values)
         rescue ArgumentError # if Date.new raises an exception on an invalid date

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -540,7 +540,7 @@ class BasicsTest < ActiveRecord::TestCase
     topic.attributes = attributes
     # note that extra #to_date call allows test to pass for Oracle, which
     # treats dates/times the same
-    assert_date_from_db Date.new(1, 6, 24), topic.last_read.to_date
+    assert_nil topic.last_read
   end
 
   def test_multiparameter_attributes_on_date_with_empty_month
@@ -549,7 +549,7 @@ class BasicsTest < ActiveRecord::TestCase
     topic.attributes = attributes
     # note that extra #to_date call allows test to pass for Oracle, which
     # treats dates/times the same
-    assert_date_from_db Date.new(2004, 1, 24), topic.last_read.to_date
+    assert_nil topic.last_read
   end
 
   def test_multiparameter_attributes_on_date_with_empty_day
@@ -558,7 +558,7 @@ class BasicsTest < ActiveRecord::TestCase
     topic.attributes = attributes
     # note that extra #to_date call allows test to pass for Oracle, which
     # treats dates/times the same
-    assert_date_from_db Date.new(2004, 6, 1), topic.last_read.to_date
+    assert_nil topic.last_read
   end
 
   def test_multiparameter_attributes_on_date_with_empty_day_and_year
@@ -567,7 +567,7 @@ class BasicsTest < ActiveRecord::TestCase
     topic.attributes = attributes
     # note that extra #to_date call allows test to pass for Oracle, which
     # treats dates/times the same
-    assert_date_from_db Date.new(1, 6, 1), topic.last_read.to_date
+    assert_nil topic.last_read
   end
 
   def test_multiparameter_attributes_on_date_with_empty_day_and_month
@@ -576,7 +576,7 @@ class BasicsTest < ActiveRecord::TestCase
     topic.attributes = attributes
     # note that extra #to_date call allows test to pass for Oracle, which
     # treats dates/times the same
-    assert_date_from_db Date.new(2004, 1, 1), topic.last_read.to_date
+    assert_nil topic.last_read
   end
 
   def test_multiparameter_attributes_on_date_with_empty_year_and_month
@@ -585,7 +585,7 @@ class BasicsTest < ActiveRecord::TestCase
     topic.attributes = attributes
     # note that extra #to_date call allows test to pass for Oracle, which
     # treats dates/times the same
-    assert_date_from_db Date.new(1, 1, 24), topic.last_read.to_date
+    assert_nil topic.last_read
   end
 
   def test_multiparameter_attributes_on_date_with_all_empty
@@ -678,12 +678,7 @@ class BasicsTest < ActiveRecord::TestCase
     }
     topic = Topic.find(1)
     topic.attributes = attributes
-    assert_equal 1, topic.written_on.year
-    assert_equal 1, topic.written_on.month
-    assert_equal 1, topic.written_on.day
-    assert_equal 0, topic.written_on.hour
-    assert_equal 12, topic.written_on.min
-    assert_equal 2, topic.written_on.sec
+    assert_nil topic.written_on
   end
 
   def test_multiparameter_attributes_on_time_will_ignore_date_if_empty
@@ -693,12 +688,7 @@ class BasicsTest < ActiveRecord::TestCase
     }
     topic = Topic.find(1)
     topic.attributes = attributes
-    assert_equal 1, topic.written_on.year
-    assert_equal 1, topic.written_on.month
-    assert_equal 1, topic.written_on.day
-    assert_equal 16, topic.written_on.hour
-    assert_equal 24, topic.written_on.min
-    assert_equal 0, topic.written_on.sec
+    assert_nil topic.written_on
   end
   def test_multiparameter_attributes_on_time_with_seconds_will_ignore_date_if_empty
     attributes = {
@@ -707,12 +697,7 @@ class BasicsTest < ActiveRecord::TestCase
     }
     topic = Topic.find(1)
     topic.attributes = attributes
-    assert_equal 1, topic.written_on.year
-    assert_equal 1, topic.written_on.month
-    assert_equal 1, topic.written_on.day
-    assert_equal 16, topic.written_on.hour
-    assert_equal 12, topic.written_on.min
-    assert_equal 02, topic.written_on.sec
+    assert_nil topic.written_on
   end
 
   def test_multiparameter_attributes_on_time_with_utc


### PR DESCRIPTION
Currently, if any of multiple Date parameters' bits were provided but blank, then defaulted to 1.

Consequently, this request params

```
"birthday(1i)"=>"2007", "birthday(2i)"=>"", "birthday(3i)"=>""
```

is converted into this, even if `User.validates_presence_of :birthday`.

```
Mon, 01 Jan 2007
```

Don't you think this is strange? Still not?

Then how about this?
![What date should it be?](https://img.skitch.com/20110715-bm8k89b95jhw9r1ug8bn2yw7w2.png)

```
"birthday(1i)"=>"", "birthday(2i)"=>"5", "birthday(3i)"=>""
```

=>

```
Sun, 01 May 0001
```

**OMG this is totally stupid**, isn't it?

Attached patch turns this into nil. Isn't this the most "least surprise" behavior?
