### PR TITLE
Fix wildcard route code example in changelog

### DIFF
--- a/actionpack/CHANGELOG
+++ b/actionpack/CHANGELOG
@@ -101,11 +101,11 @@
 
   For example if you have this route:
 
-    map '*pages' => 'pages#show'
+    match '*pages' => 'pages#show'
 
   by requesting '/foo/bar.json', your `params[:pages]` will be equals to "foo/bar" with the request format of JSON. If you want the old 3.0.x behavior back, you could supply `:format => false` like this:
 
-    map '*pages' => 'pages#show', :format => false
+    match '*pages' => 'pages#show', :format => false
 
 * Added Base.http_basic_authenticate_with to do simple http basic authentication with a single class method call [DHH]
 


### PR DESCRIPTION
`map` should be `match`. The relevant entry in the changelog is part of Rails 3.1.
