### PR TITLE
Fixed engine gemspec so that app, config, and db are packaged up

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
@@ -4,6 +4,6 @@ Gem::Specification.new do |s|
   s.name = "<%= name %>"
   s.summary = "Insert <%= camelized %> summary."
   s.description = "Insert <%= camelized %> description."
-  s.files = Dir["lib/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
+  s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.version = "0.0.1"
 end


### PR DESCRIPTION
Engines generated by rails plugin new myengine --mountable do not package up the app, config or db folders as expected.  I have patched the gemspec file to ensure that the app files, config (routes especially important as they are broken in 3.1pre) and the db so that rake railties:install:migrations works.
