### PR TITLE
Fixes overriding of options[:html][:remote] in form_for() (Issue #2094)

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -365,7 +365,7 @@ module ActionView
           apply_form_for_options!(record, options)
         end
 
-        options[:html][:remote] = options.delete(:remote)
+        options[:html][:remote] = options.delete(:remote) if options.has_key?(:remote)
         options[:html][:method] = options.delete(:method) if options.has_key?(:method)
         options[:html][:authenticity_token] = options.delete(:authenticity_token)
 

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -791,6 +791,23 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_form_for_with_remote_in_html
+    form_for(@post, :url => '/', :html => { :remote => true, :id => 'create-post', :method => :put }) do |f|
+      concat f.text_field(:title)
+      concat f.text_area(:body)
+      concat f.check_box(:secret)
+    end
+
+    expected =  whole_form("/", "create-post", "edit_post", :method => "put", :remote => true) do
+      "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<input name='post[secret]' type='hidden' value='0' />" +
+      "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_form_for_with_remote_without_html
     @post.persisted = false
     form_for(@post, :remote => true) do |f|


### PR DESCRIPTION
In 3.0.9 and below, form_for() could accept a :remote option passed in either options or options[:html]. However, any :remote option passed in as options[:html][:remote] is ignored because of the line:

``` ruby
options[:html][:remote] = options.delete(:remote)
```

I've changed this to:

``` ruby
options[:html][:remote] = options.delete(:remote) if options.has_key?(:remote)
```

This resolves issue #2094 and keeps Rails 3.1 consistent with prior versions. Furthermore, this change keeps form_for() consistent with other methods such as link_to() that allow the :remote option to be passed in the same hash as other html options.
