### PR TITLE
Time method: time_of_day

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -64,6 +64,12 @@ class Time
   def seconds_since_midnight
     to_i - change(:hour => 0).to_i + (usec / 1.0e+6)
   end
+  
+  # Current time of date. Returns following symbols: :monring, :afternoon and :evening
+  def time_of_day
+    hour = ::Time.current.hour
+    hour >= 0 && hour < 12 ? :morning : hour >= 12 && hour < 17 ? :afternoon : hour >= 17 && h < 23 ? :evening : nil
+  end
 
   # Returns a new Time where one or more of the elements have been changed according to the +options+ parameter. The time options
   # (hour, minute, sec, usec) reset cascadingly, so if only the hour is passed, then minute, sec, and usec is set to 0. If the hour and

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -67,8 +67,7 @@ class Time
   
   # Current time of date. Returns following symbols: :monring, :afternoon and :evening
   def time_of_day
-    hour = ::Time.current.hour
-    hour >= 0 && hour < 12 ? :morning : hour >= 12 && hour < 17 ? :afternoon : hour >= 17 && h < 23 ? :evening : nil
+    self.hour >= 0 && self.hour < 12 ? :morning : self.hour >= 12 && self.hour < 17 ? :afternoon : self.hour >= 17 && self.hour <= 23 ? :evening : nil
   end
 
   # Returns a new Time where one or more of the elements have been changed according to the +options+ parameter. The time options

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -2,6 +2,33 @@ require 'abstract_unit'
 require 'active_support/time'
 
 class TimeExtCalculationsTest < ActiveSupport::TestCase
+  def test_time_of_day
+    assert_equal :morning, Time.local(2011,12,31,0,0,0).time_of_day
+    assert_equal :morning, Time.local(2011,12,31,1,0,0).time_of_day
+    assert_equal :morning, Time.local(2011,12,31,2,0,0).time_of_day
+    assert_equal :morning, Time.local(2011,12,31,3,0,0).time_of_day
+    assert_equal :morning, Time.local(2011,12,31,4,0,0).time_of_day
+    assert_equal :morning, Time.local(2011,12,31,5,0,0).time_of_day
+    assert_equal :morning, Time.local(2011,12,31,6,0,0).time_of_day
+    assert_equal :morning, Time.local(2011,12,31,7,0,0).time_of_day
+    assert_equal :morning, Time.local(2011,12,31,8,0,0).time_of_day
+    assert_equal :morning, Time.local(2011,12,31,9,0,0).time_of_day
+    assert_equal :morning, Time.local(2011,12,31,10,0,0).time_of_day
+    assert_equal :morning, Time.local(2011,12,31,11,0,0).time_of_day
+    assert_equal :afternoon, Time.local(2011,12,31,12,0,0).time_of_day
+    assert_equal :afternoon, Time.local(2011,12,31,13,0,0).time_of_day
+    assert_equal :afternoon, Time.local(2011,12,31,14,0,0).time_of_day
+    assert_equal :afternoon, Time.local(2011,12,31,15,0,0).time_of_day
+    assert_equal :afternoon, Time.local(2011,12,31,16,0,0).time_of_day
+    assert_equal :evening, Time.local(2011,12,31,17,0,0).time_of_day
+    assert_equal :evening, Time.local(2011,12,31,18,0,0).time_of_day
+    assert_equal :evening, Time.local(2011,12,31,19,0,0).time_of_day
+    assert_equal :evening, Time.local(2011,12,31,20,0,0).time_of_day
+    assert_equal :evening, Time.local(2011,12,31,21,0,0).time_of_day
+    assert_equal :evening, Time.local(2011,12,31,22,0,0).time_of_day
+    assert_equal :evening, Time.local(2011,12,31,23,0,0).time_of_day
+  end
+  
   def test_seconds_since_midnight
     assert_equal 1,Time.local(2005,1,1,0,0,1).seconds_since_midnight
     assert_equal 60,Time.local(2005,1,1,0,1,0).seconds_since_midnight

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -3,30 +3,30 @@ require 'active_support/time'
 
 class TimeExtCalculationsTest < ActiveSupport::TestCase
   def test_time_of_day
-    assert_equal :morning, Time.local(2011,12,31,0,0,0).time_of_day
-    assert_equal :morning, Time.local(2011,12,31,1,0,0).time_of_day
-    assert_equal :morning, Time.local(2011,12,31,2,0,0).time_of_day
-    assert_equal :morning, Time.local(2011,12,31,3,0,0).time_of_day
-    assert_equal :morning, Time.local(2011,12,31,4,0,0).time_of_day
-    assert_equal :morning, Time.local(2011,12,31,5,0,0).time_of_day
-    assert_equal :morning, Time.local(2011,12,31,6,0,0).time_of_day
-    assert_equal :morning, Time.local(2011,12,31,7,0,0).time_of_day
-    assert_equal :morning, Time.local(2011,12,31,8,0,0).time_of_day
-    assert_equal :morning, Time.local(2011,12,31,9,0,0).time_of_day
-    assert_equal :morning, Time.local(2011,12,31,10,0,0).time_of_day
-    assert_equal :morning, Time.local(2011,12,31,11,0,0).time_of_day
-    assert_equal :afternoon, Time.local(2011,12,31,12,0,0).time_of_day
-    assert_equal :afternoon, Time.local(2011,12,31,13,0,0).time_of_day
-    assert_equal :afternoon, Time.local(2011,12,31,14,0,0).time_of_day
-    assert_equal :afternoon, Time.local(2011,12,31,15,0,0).time_of_day
-    assert_equal :afternoon, Time.local(2011,12,31,16,0,0).time_of_day
-    assert_equal :evening, Time.local(2011,12,31,17,0,0).time_of_day
-    assert_equal :evening, Time.local(2011,12,31,18,0,0).time_of_day
-    assert_equal :evening, Time.local(2011,12,31,19,0,0).time_of_day
-    assert_equal :evening, Time.local(2011,12,31,20,0,0).time_of_day
-    assert_equal :evening, Time.local(2011,12,31,21,0,0).time_of_day
-    assert_equal :evening, Time.local(2011,12,31,22,0,0).time_of_day
-    assert_equal :evening, Time.local(2011,12,31,23,0,0).time_of_day
+    assert_equal :morning, Time.local(2011,1,1,0,0,0).time_of_day
+    assert_equal :morning, Time.local(2011,1,1,1,0,0).time_of_day
+    assert_equal :morning, Time.local(2011,1,1,2,0,0).time_of_day
+    assert_equal :morning, Time.local(2011,1,1,3,0,0).time_of_day
+    assert_equal :morning, Time.local(2011,1,1,4,0,0).time_of_day
+    assert_equal :morning, Time.local(2011,1,1,5,0,0).time_of_day
+    assert_equal :morning, Time.local(2011,1,1,6,0,0).time_of_day
+    assert_equal :morning, Time.local(2011,1,1,7,0,0).time_of_day
+    assert_equal :morning, Time.local(2011,1,1,8,0,0).time_of_day
+    assert_equal :morning, Time.local(2011,1,1,9,0,0).time_of_day
+    assert_equal :morning, Time.local(2011,1,1,10,0,0).time_of_day
+    assert_equal :morning, Time.local(2011,1,1,11,0,0).time_of_day
+    assert_equal :afternoon, Time.local(2011,1,1,12,0,0).time_of_day
+    assert_equal :afternoon, Time.local(2011,1,1,13,0,0).time_of_day
+    assert_equal :afternoon, Time.local(2011,1,1,14,0,0).time_of_day
+    assert_equal :afternoon, Time.local(2011,1,1,15,0,0).time_of_day
+    assert_equal :afternoon, Time.local(2011,1,1,16,0,0).time_of_day
+    assert_equal :evening, Time.local(2011,1,1,17,0,0).time_of_day
+    assert_equal :evening, Time.local(2011,1,1,18,0,0).time_of_day
+    assert_equal :evening, Time.local(2011,1,1,19,0,0).time_of_day
+    assert_equal :evening, Time.local(2011,1,1,20,0,0).time_of_day
+    assert_equal :evening, Time.local(2011,1,1,21,0,0).time_of_day
+    assert_equal :evening, Time.local(2011,1,1,22,0,0).time_of_day
+    assert_equal :evening, Time.local(2011,1,1,23,0,0).time_of_day
   end
   
   def test_seconds_since_midnight


### PR DESCRIPTION
Added a time_of_day method to the Time class. The method returns one of the following symbols (depending on time of day):

:morning, :afternoon, :evening
