### PR TITLE
Added gem helper tasks to Rakefile for engine plugins.

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/templates/Rakefile
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/Rakefile
@@ -24,3 +24,7 @@ end
 APP_RAKEFILE = File.expand_path("../<%= dummy_path -%>/Rakefile", __FILE__)
 load 'rails/tasks/engine.rake'
 <% end %>
+<% unless options[:skip_gemspec] -%>
+
+Bundler::GemHelper.install_tasks
+<% end %>


### PR DESCRIPTION
Added gem helper tasks to Rakefile for engine plugins.  It makes sense for this to be there given they're being generated to be gemified.
