### PR TITLE
Ensure that status codes are logged properly

### DIFF
--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -212,16 +212,16 @@ module ActionController
       # also include them at the bottom.
       AbstractController::Callbacks,
 
+      # Append rescue at the bottom to wrap as much as possible.
+      Rescue,
+
       # Add instrumentations hooks at the bottom, to ensure they instrument
       # all the methods properly.
       Instrumentation,
 
       # Params wrapper should come before instrumentation so they are
       # properly showed in logs
-      ParamsWrapper,
-
-      # The same with rescue, append it at the end to wrap as much as possible.
-      Rescue
+      ParamsWrapper
     ]
 
     MODULES.each do |mod|

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -6,6 +6,13 @@ module Another
   class LogSubscribersController < ActionController::Base
     wrap_parameters :person, :include => :name, :format => :json
 
+    class SpecialException < Exception
+    end
+
+    rescue_from SpecialException do
+      head :status => 406
+    end
+
     def show
       render :nothing => true
     end
@@ -37,6 +44,10 @@ module Another
 
     def with_exception
       raise Exception
+    end
+
+    def with_rescued_exception
+      raise SpecialException
     end
 
   end
@@ -193,6 +204,14 @@ class ACLogSubscriberTest < ActionController::TestCase
     end
     assert_equal 2, logs.size
     assert_match(/Completed 500/, logs.last)
+  end
+
+  def test_process_action_with_rescued_exception_includes_http_status_code
+    get :with_rescued_exception
+    wait
+
+    assert_equal 2, logs.size
+    assert_match(/Completed 406/, logs.last)
   end
 
   def logs


### PR DESCRIPTION
Had to move `AC::Metal::Instrumentation` before `AC::Metal::Rescue` so that status codes set by `rescue_from` blocks are logged properly.

Previously, the Rails logger was logging a `Completed 500` for anything that passed through a rescue_from block, even if it set a different status code for the response.
