### PR TITLE
notextile tag in rails guides generator has been placed with ascii quotes

### DIFF
--- a/railties/guides/rails_guides/generator.rb
+++ b/railties/guides/rails_guides/generator.rb
@@ -227,13 +227,13 @@ module RailsGuides
         end
 
         code_blocks.push(<<HTML)
-<notextile>
+&lt;notextile&gt;
 <div class="code_container">
 <pre class="brush: #{brush}; gutter: false; toolbar: false">
 #{ERB::Util.h($2).strip}
 </pre>
 </div>
-</notextile>
+&lt;/notextile&gt;
 HTML
         "\ndirty_workaround_for_notextile_#{code_blocks.size - 1}\n"
       end
@@ -280,3 +280,4 @@ HTML
     end
   end
 end
+

--- a/railties/guides/rails_guides/textile_extensions.rb
+++ b/railties/guides/rails_guides/textile_extensions.rb
@@ -25,7 +25,7 @@ module RailsGuides
 
     def plusplus(body)
       body.gsub!(/\+(.*?)\+/) do |m|
-        "<notextile><tt>#{$1}</tt></notextile>"
+        "&lt;notextile&gt;<tt>#{$1}</tt>&lt;/notextile&gt;"
       end
 
       # The real plus sign
@@ -36,8 +36,9 @@ module RailsGuides
       body.gsub!(%r{<(yaml|shell|ruby|erb|html|sql|plain)>(.*?)</\1>}m) do |m|
         es = ERB::Util.h($2)
         css_class = $1.in?(['erb', 'shell']) ? 'html' : $1
-        %{<notextile><div class="code_container"><code class="#{css_class}">#{es}</code></div></notextile>}
+        %{&lt;notextile&gt;<div class="code_container"><code class="#{css_class}">#{es}</code></div>&lt;/notextile&gt;}
       end
     end
   end
 end
+


### PR DESCRIPTION
Rails guides seems to be having validation errors with tags <notextile> & </notextile>.For more details 
http://validator.w3.org/check?verbose=1&uri=http%3A%2F%2Fedgeguides.rubyonrails.org%2Fsecurity.html

So, i have changed the notextile tags with ascii quotes on generator.rb & textile_extensions.rb.

Previously it was <notextile>, now it  is &lt;notextile&gt;
