### PR TITLE
fix String#blank? on binary strings

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -99,7 +99,12 @@ class String
   #   " something here ".blank? # => false
   #
   def blank?
-    self !~ NON_WHITESPACE_REGEXP
+    # 1.8 does not takes [:space:] properly
+    if encoding_aware?
+      self !~ /[^[:space:]]/
+    else
+      self !~ NON_WHITESPACE_REGEXP
+    end
   end
 end
 


### PR DESCRIPTION
In 1.9, the NON_WHITESPACE_REGEXP will always be UTF-8.
So encode the string in utf-8 for proper comparison.

If the string is binary, we won't be able to encode it in UTF-8.
Then, it's never blank (because it's binary, there's a test about that : https://github.com/rails/rails/blob/master/activesupport/test/gzip_test.rb#L16 ).
