### PR TITLE
Explicitly require Active Support dependencies (master)

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1,3 +1,5 @@
+require "active_support/core_ext/module/delegation"
+require "active_support/core_ext/class/attribute_accessors"
 require "active_support/core_ext/array/wrap"
 
 module ActiveRecord


### PR DESCRIPTION
This fixes errors when using Active Record outside of Rails. In Rails,
these files are required by other classes that are always loaded, so
this error does not happen.

Without core_ext/module/delegation, a NoMethodError is raised because
`delegate` remains undefined.

Without core_ext/class/attribute_acessors, an ArgumentError is raised because
`delegate` does not receive a value for its :to option.
