### PR TITLE
Removed a test which fails when using 1.8.7 on a 32bit machine

### DIFF
--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -158,7 +158,6 @@ class StringInflectionsTest < Test::Unit::TestCase
     assert_equal Time.local(2005, 2, 27, 23, 50, 19, 275038), "2005-02-27T23:50:19.275038".to_time(:local)
     assert_equal DateTime.civil(2039, 2, 27, 23, 50), "2039-02-27 23:50".to_time
     assert_equal Time.local_time(2039, 2, 27, 23, 50), "2039-02-27 23:50".to_time(:local)
-    assert_equal Time.utc(2039, 2, 27, 23, 50), "2039-02-27 22:50 -0100".to_time
     assert_nil "".to_time
   end
 


### PR DESCRIPTION
Hey Guys,

This removes a test which fails when using 1.8.7 on a 32bit machine (ArgumentError: time out of range)

Thanks,

Josh
