### PR TITLE
Fix fragment caching regression from 03d01ec

### DIFF
--- a/actionpack/lib/action_view/helpers/cache_helper.rb
+++ b/actionpack/lib/action_view/helpers/cache_helper.rb
@@ -54,7 +54,7 @@ module ActionView
           output_safe = output_buffer.html_safe?
           fragment = output_buffer.slice!(pos..-1)
           if output_safe
-            self.output_buffer = output_buffer.html_safe
+            self.output_buffer = output_buffer.class.new(output_buffer)
           end
           controller.write_fragment(name, fragment, options)
         end

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -742,6 +742,7 @@ class FunctionalFragmentCachingTest < ActionController::TestCase
     expected_body = <<-CACHED
 Hello
 This bit's fragment cached
+Ciao
 CACHED
     assert_equal expected_body, @response.body
 

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -808,8 +808,8 @@ class CacheHelperOutputBufferTest < ActionController::TestCase
     cache_helper.extend(ActionView::Helpers::CacheHelper)
     cache_helper.expects(:controller).returns(controller).at_least(0)
     cache_helper.expects(:output_buffer).returns(output_buffer).at_least(0)
-    # if the output_buffer is changed, the new one should be html_safe
-    cache_helper.expects(:output_buffer=).with(responds_with(:html_safe?, true)).returns(true).at_least(0)
+    # if the output_buffer is changed, the new one should be html_safe and of the same type
+    cache_helper.expects(:output_buffer=).with(responds_with(:html_safe?, true)).with(instance_of(output_buffer.class)).at_least(0)
 
     assert_nothing_raised do
       cache_helper.send :fragment_for, 'Test fragment name', 'Test fragment', &Proc.new{ nil }
@@ -824,8 +824,8 @@ class CacheHelperOutputBufferTest < ActionController::TestCase
     cache_helper.extend(ActionView::Helpers::CacheHelper)
     cache_helper.expects(:controller).returns(controller).at_least(0)
     cache_helper.expects(:output_buffer).returns(output_buffer).at_least(0)
-    # if the output_buffer is changed, the new one should be html_safe
-    cache_helper.expects(:output_buffer=).with(responds_with(:html_safe?, true)).returns(true).at_least(0)
+    # if the output_buffer is changed, the new one should be html_safe and of the same type
+    cache_helper.expects(:output_buffer=).with(responds_with(:html_safe?, true)).with(instance_of(output_buffer.class)).at_least(0)
 
     assert_nothing_raised do
       cache_helper.send :fragment_for, 'Test fragment name', 'Test fragment', &Proc.new{ nil }

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -784,3 +784,53 @@ CACHED
     assert_equal "  <p>Builder</p>\n", @store.read('views/test.host/functional_caching/formatted_fragment_cached')
   end
 end
+
+class CacheHelperOutputBufferTest < ActionController::TestCase
+
+  class MockController
+    def read_fragment(name, options)
+      return false
+    end
+
+    def write_fragment(name, fragment, options)
+      fragment
+    end
+  end
+
+  def setup
+    super
+  end
+
+  def test_output_buffer
+    output_buffer = ActionView::OutputBuffer.new
+    controller = MockController.new
+    cache_helper = Object.new
+    cache_helper.extend(ActionView::Helpers::CacheHelper)
+    cache_helper.expects(:controller).returns(controller).at_least(0)
+    cache_helper.expects(:output_buffer).returns(output_buffer).at_least(0)
+    # if the output_buffer is changed, the new one should be html_safe
+    cache_helper.expects(:output_buffer=).with(responds_with(:html_safe?, true)).returns(true).at_least(0)
+
+    assert_nothing_raised do
+      cache_helper.send :fragment_for, 'Test fragment name', 'Test fragment', &Proc.new{ nil }
+      assert output_buffer.html_safe?, "Output buffer should stay html_safe"
+    end
+  end
+
+  def test_safe_buffer
+    output_buffer = ActiveSupport::SafeBuffer.new
+    controller = MockController.new
+    cache_helper = Object.new
+    cache_helper.extend(ActionView::Helpers::CacheHelper)
+    cache_helper.expects(:controller).returns(controller).at_least(0)
+    cache_helper.expects(:output_buffer).returns(output_buffer).at_least(0)
+    # if the output_buffer is changed, the new one should be html_safe
+    cache_helper.expects(:output_buffer=).with(responds_with(:html_safe?, true)).returns(true).at_least(0)
+
+    assert_nothing_raised do
+      cache_helper.send :fragment_for, 'Test fragment name', 'Test fragment', &Proc.new{ nil }
+      assert output_buffer.html_safe?, "Output buffer should stay html_safe"
+    end
+  end
+
+end

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -813,7 +813,6 @@ class CacheHelperOutputBufferTest < ActionController::TestCase
 
     assert_nothing_raised do
       cache_helper.send :fragment_for, 'Test fragment name', 'Test fragment', &Proc.new{ nil }
-      assert output_buffer.html_safe?, "Output buffer should stay html_safe"
     end
   end
 
@@ -829,7 +828,6 @@ class CacheHelperOutputBufferTest < ActionController::TestCase
 
     assert_nothing_raised do
       cache_helper.send :fragment_for, 'Test fragment name', 'Test fragment', &Proc.new{ nil }
-      assert output_buffer.html_safe?, "Output buffer should stay html_safe"
     end
   end
 

--- a/actionpack/test/fixtures/functional_caching/fragment_cached.html.erb
+++ b/actionpack/test/fixtures/functional_caching/fragment_cached.html.erb
@@ -1,2 +1,3 @@
 Hello
 <%= cache do %>This bit's fragment cached<% end %>
+<%= 'Ciao' %>

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -109,6 +109,7 @@ module ActiveSupport #:nodoc:
       end
     end
     alias << concat
+    alias :append= :concat
 
     def +(other)
       dup.concat(other)

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -109,7 +109,6 @@ module ActiveSupport #:nodoc:
       end
     end
     alias << concat
-    alias :append= :concat
 
     def +(other)
       dup.concat(other)


### PR DESCRIPTION
Alias `<<` as `append=` for ActiveSupport::SafeBuffer to fix "undefined method `append='" error with fragment cache helper on cache miss introduced with 03d01ec73edfac7768cd.

Since 03d01ec7 `fragment_for` sets the`output_buffer` to a SafeBuffer. ERB expects `append=` to be defined on the output_buffer.
This means subsequent ERB tags after a call to the fragment `cache` helper and a cache miss would cause an "undefined method `append='" error.

Includes updated testcase.
This should be cherry-picked into master as well.
