### PR TITLE
assign_nested_attributes_for_collection_association should work with Ruby 1.9's Symbols

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -383,7 +383,7 @@ module ActiveRecord
         attributes_collection = if keys.include?('id') || keys.include?(:id)
           Array.wrap(attributes_collection)
         else
-          attributes_collection.sort_by { |i, _| i.to_i }.map { |_, attributes| attributes }
+          attributes_collection.sort_by { |i, _| i.respond_to?(:to_i) ? i.to_i : i.object_id }.map { |_, attributes| attributes }
         end
       end
 

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -755,6 +755,11 @@ module NestedAttributesOnACollectionAssociationTests
     Interest.reflect_on_association(:man).options[:inverse_of] = :interests
   end
 
+  def test_can_use_symbols_as_object_identifier
+    @pirate.attributes = { :parrots_attributes => { :foo => { :name => 'Lovely Day' }, :bar => { :name => 'Blown Away' } } }
+    assert_nothing_raised(NoMethodError) { @pirate.save! }
+  end
+
   private
 
   def association_setter


### PR DESCRIPTION
assign_nested_attributes_for_collection_association should work with Ruby 1.9 [Closes #2106]

Ruby 1.9's Symbol won't respond to to_i so let's use object_id to emulate it.
