### PR TITLE
Fixed issue #2119: XHR without Accept and Content-Type header gets 500 error

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -98,7 +98,8 @@ module ActionDispatch
       BROWSER_LIKE_ACCEPTS = /,\s*\*\/\*|\*\/\*\s*,/
 
       def valid_accept_header
-        xhr? || (accept && accept !~ BROWSER_LIKE_ACCEPTS)
+        (xhr? && (accept || content_mime_type)) ||
+          (accept && accept !~ BROWSER_LIKE_ACCEPTS)
       end
 
       def use_accept_header

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -468,6 +468,12 @@ class RequestTest < ActiveSupport::TestCase
     assert request.formats.empty?
   end
 
+  test "formats with xhr request" do
+    request = stub_request 'HTTP_X_REQUESTED_WITH' => "XMLHttpRequest"
+    request.expects(:parameters).at_least_once.returns({})
+    assert_equal [Mime::JS], request.formats
+  end
+
   test "ignore_accept_header" do
     ActionDispatch::Request.ignore_accept_header = true
 


### PR DESCRIPTION
Check Accept and Content-Type headers before evaluating them in xhr requests. Closes #2119

An xhr request must have an "Accept" or "Content-type" header in order to be considered a request with valid_accept_header.
