### PR TITLE
Added a failing test to verify that assert_template supports specifying bot

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -98,19 +98,6 @@ module ActionController
                     "expecting ? to be rendered ? time(s) but rendered ? time(s)",
                      expected_partial, expected_count, actual_count)
             assert(actual_count == expected_count.to_i, msg)
-          elsif options.key?(:layout)
-            msg = build_message(message,
-                    "expecting layout <?> but action rendered <?>",
-                    expected_layout, @layouts.keys)
-
-            case layout = options[:layout]
-            when String
-              assert(@layouts.include?(expected_layout), msg)
-            when Regexp
-              assert(@layouts.any? {|l| l =~ layout }, msg)
-            when nil
-              assert(@layouts.empty?, msg)
-            end
           else
             msg = build_message(message,
                     "expecting partial <?> but action rendered <?>",
@@ -121,6 +108,26 @@ module ActionController
           assert @partials.empty?,
             "Expected no partials to be rendered"
         end
+       if expected_layout = options[:layout]
+         case expected_layout
+           when String
+             msg = build_message(message,
+                 "expecting layout <?> but action rendered layouts <?>",
+                 expected_layout, @layouts.keys)
+             puts "The layouts variable - keys : #{@layouts.inspect} .. "
+             assert(@layouts.include?(expected_layout), msg)
+           when Regexp
+             msg = build_message(message,
+                 "expecting layout to match <?> but action rendered layouts <?>",
+                 expected_layout, @layouts.keys)
+             assert(@layouts.keys.any? {|l| l =~ expected_layout }, msg)
+           when nil
+             msg = build_message(message,
+                 "expecting no layout but action rendered layouts <?>",
+                 @layouts.keys)
+             assert(@layouts.empty?, msg)
+         end
+       end      
       end
     end
   end

--- a/actionpack/test/template/test_case_test.rb
+++ b/actionpack/test/template/test_case_test.rb
@@ -296,6 +296,12 @@ module ActionView
         assert_template :partial => "_partial_for_use_in_layout", :locals => { :name => "Somebody Else" }
       end
     end
+
+    test "supports specifying partials & layouts (passing)" do
+      controller.controller_path = "test"
+      render(:template => "test/calling_partial_with_layout")
+      assert_template :partial => "_partial_for_use_in_layout", :layout => "layout_for_partial"
+    end
   end
 
   module AHelperWithInitialize


### PR DESCRIPTION
This is related issue #2043 which itself is related to issue #706

Added a failing test to test that assert_template supports specifying both partials and layouts. Also, applied the patch from issue #706 to fix the behavior described. 

The test however fails with a **expecting layout <"layout_for_partial"> but action rendered layouts <[nil]>** error message. 

This is because on [line #22 of actionpack/lib/action_controller/test_case.rb file](https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/test_case.rb#L22), payload[:layout] is nil. No idea how to fix that!
