### PR TITLE
Timezone fixtures test correction

### DIFF
--- a/activerecord/test/fixtures/pirates.yml
+++ b/activerecord/test/fixtures/pirates.yml
@@ -5,5 +5,5 @@ blackbeard:
 redbeard:
   catchphrase: "Avast!"
   parrot: louis
-  created_on: <%= 2.weeks.ago.to_s(:db) %>
-  updated_on: <%= 2.weeks.ago.to_s(:db) %>
+  created_on: <%= 2.weeks.ago.utc.to_s(:db) %>
+  updated_on: <%= 2.weeks.ago.utc.to_s(:db) %>


### PR DESCRIPTION
Hey Guys,

This fixes a brittle test in fixtures_test.rb which fails when you are in a timezone which is ahead of UTC but UTC is in the previous day still.

Here is the failure : http://staging.travis-ci.org/#!/rails/rails/builds/2438/L1786

Enjoy,

Josh
