### PR TITLE
This conditions is required to work with database create task. 1.9.2 is h

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -115,7 +115,8 @@ db_namespace = namespace :db do
         end
       end
     else
-      $stderr.puts "#{config['database']} already exists"
+      # Bug with 1.9.2 Calling return within begin still executes else
+      $stderr.puts "#{config['database']} already exists" unless config['adapter'] =~ /sqlite/
     end
   end
 


### PR DESCRIPTION
This conditions is required to work with database create task. 1.9.2 is having a bug with "Calling return within begin still executes else". 

http://redmine.ruby-lang.org/issues/4473

This fixes #899 
