### PR TITLE
3 0 stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ end
 
 platforms :mri_19 do
   # TODO: Remove the conditional when ruby-debug19 supports Ruby >= 1.9.3
-  gem "ruby-debug19", :require => 'ruby-debug' unless > "1.9.2" || ENV['TRAVIS']
+  gem "ruby-debug19", :require => 'ruby-debug' unless RUBY_VERSION > "1.9.2" || ENV['TRAVIS']
 end
 
 platforms :ruby do

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -499,8 +499,7 @@ module ActiveRecord #:nodoc:
         if attributes.is_a?(Array)
           attributes.collect { |attr| create(attr, &block) }
         else
-          object = new(attributes)
-          yield(object) if block_given?
+          object = new(attributes, &block)
           object.save
           object
         end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -19,6 +19,7 @@ require 'models/minimalistic'
 require 'models/warehouse_thing'
 require 'models/parrot'
 require 'models/loose_person'
+require 'models/wholesale_product'
 require 'rexml/document'
 require 'active_support/core_ext/exception'
 
@@ -232,6 +233,28 @@ class BasicsTest < ActiveRecord::TestCase
       assert_equal(1, ex.errors.size)
       assert_equal("last_read", ex.errors[0].attribute)
     end
+  end
+
+  def test_create_with_after_initialize
+    wp1 = WholesaleProduct.create(:msrp => 10)
+    assert_equal(10, wp1.msrp)
+    assert_equal(5, wp1.wholesale)
+
+    wp2 = WholesaleProduct.create(:wholesale => 10)
+    assert_equal(20, wp2.msrp)
+    assert_equal(10, wp2.wholesale)
+
+    wp3 = WholesaleProduct.create do |wp|
+      wp.msrp = 10
+    end
+    assert_equal(10, wp3.msrp)
+    assert_equal(5, wp3.wholesale)
+
+    wp4 = WholesaleProduct.create do |wp|
+      wp.wholesale = 10
+    end
+    assert_equal(20, wp4.msrp)
+    assert_equal(10, wp4.wholesale)
   end
 
   def test_load

--- a/activerecord/test/models/wholesale_product.rb
+++ b/activerecord/test/models/wholesale_product.rb
@@ -1,0 +1,13 @@
+class WholesaleProduct < ActiveRecord::Base
+
+  after_initialize :set_prices
+
+  def set_prices
+    if msrp.nil? && !wholesale.nil?
+      self.msrp = 2 * wholesale
+    elsif !msrp.nil? && wholesale.nil?
+      self.wholesale = msrp / 2
+    end
+  end
+
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -621,6 +621,11 @@ ActiveRecord::Schema.define do
     t.references :wheelable, :polymorphic => true
   end
 
+  create_table :wholesale_products, :force => true do |t|
+    t.integer :msrp
+    t.integer :wholesale
+  end
+
   create_table :zines, :force => true do |t|
     t.string :title
   end


### PR DESCRIPTION
Resolution for Issue 2074

Default values that are dependent on other attributes aren't getting set in after_initialize if create is called with a block to set the initial attributes.
