### PR TITLE
Small missing information added to command description. --help also works

### DIFF
--- a/railties/lib/rails/commands.rb
+++ b/railties/lib/rails/commands.rb
@@ -93,7 +93,7 @@ In addition to those, there are:
  plugin       Install a plugin
  runner       Run a piece of code in the application environment (short-cut alias: "r")
 
-All commands can be run with -h for more information.
+All commands can be run with -h (or --help) for more information.
   EOT
   exit(1)
 end


### PR DESCRIPTION
Command line information for `rails --help` shows `All commands can be run with -h for more information.`
It doesn't include `--help`. Now it's like `All commands can be run with -h (or --help) for more information.`.
