### PR TITLE
Spliting the ouput of git ls-files for running tasks Fixes #713

### DIFF
--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -108,7 +108,7 @@ namespace :test do
   Rake::TestTask.new(:uncommitted => "test:prepare") do |t|
     def t.file_list
       if File.directory?(".svn")
-        changed_since_checkin = silence_stderr { `svn status` }.map { |path| path.chomp[7 .. -1] }
+        changed_since_checkin = silence_stderr { `svn status` }.split.map { |path| path.chomp[7 .. -1] }
       elsif File.directory?(".git")
         changed_since_checkin = silence_stderr { `git ls-files --modified --others` }.split.map { |path| path.chomp }
       else

--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -110,7 +110,7 @@ namespace :test do
       if File.directory?(".svn")
         changed_since_checkin = silence_stderr { `svn status` }.map { |path| path.chomp[7 .. -1] }
       elsif File.directory?(".git")
-        changed_since_checkin = silence_stderr { `git ls-files --modified --others` }.map { |path| path.chomp }
+        changed_since_checkin = silence_stderr { `git ls-files --modified --others` }.split.map { |path| path.chomp }
       else
         abort "Not a Subversion or Git checkout."
       end


### PR DESCRIPTION
Spliting the ouput of git ls-files for running tasks Fixes #713
