### PR TITLE
ActiveRecord as_json doesn't consider :include's as_json

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -83,7 +83,8 @@ module ActiveModel
         hash[association] = if records.is_a?(Enumerable)
           records.map { |a| a.serializable_hash(opts) }
         else
-          records.serializable_hash(opts)
+          #records.serializable_hash(opts)
+          records.as_json(opts.merge(:root => false))
         end
       end
 

--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -83,7 +83,6 @@ module ActiveModel
         hash[association] = if records.is_a?(Enumerable)
           records.map { |a| a.serializable_hash(opts) }
         else
-          #records.serializable_hash(opts)
           records.as_json(opts.merge(:root => false))
         end
       end

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -23,6 +23,7 @@ class SerializationTest < ActiveModel::TestCase
 
   class Address
     include ActiveModel::Serialization
+    include ActiveModel::Serializers::JSON
 
     attr_accessor :street, :city, :state, :zip
 

--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -194,7 +194,6 @@ class JsonSerializationTest < ActiveModel::TestCase
     end
   end
 
-
   test "from_json should set the object's attributes" do
     json = @contact.to_json
     result = Contact.new.from_json(json)
@@ -244,8 +243,6 @@ class JsonSerializationTest < ActiveModel::TestCase
   end
 
   test "as_json should use include's as_json" do
-    #expected =  {"name"=>"David", "gender"=>"male", "email"=>"david@example.com",
-                 #"address"=>{"street"=>"123 Lane", "city"=>"Springfield", "state"=>"CA", "zip"=>11111}}
     expected =  {"name"=>"David", "email"=>"david@example.com",
                  "address"=>{"street"=>"123 Lane", "state"=>"CA"}}
     json = @user.to_json


### PR DESCRIPTION
When using active record's as_json to customize the to_json output, the included association's as_json is not considered. This patch fixes it 

/cc @josevalim
