### PR TITLE
3 1 stable

### DIFF
--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -7,10 +7,14 @@ namespace :rails do
     template = ENV["LOCATION"]
     template = File.expand_path(template) if template !~ %r{\A[A-Za-z][A-Za-z0-9+\-\.]*://}
 
-    require 'rails/generators'
-    require 'rails/generators/rails/app/app_generator'
-    generator = Rails::Generators::AppGenerator.new [ Rails.root ], {}, :destination_root => Rails.root
-    generator.apply template, :verbose => false
+    if template.present?
+      require 'rails/generators'
+      require 'rails/generators/rails/app/app_generator'
+      generator = Rails::Generators::AppGenerator.new [ Rails.root ], {}, :destination_root => Rails.root
+      generator.apply template, :verbose => false
+    else
+      puts "Do not know where template file is. Define LOCATION=/path/to/template variable and add it to end of command line."
+    end
   end
 
   namespace :templates do


### PR DESCRIPTION
Given you type this command without an argument:
       **rake rails:template**  
instead of:
      **rake rails:template LOCATION=~/template.rb**

Before the fix, you get the following:
    **rake aborted!
    can't convert nil into String**
Now you will get this error message:
    **Do not know where template file is. Define LOCATION=/path/to/template variable and add it to end of command line**

Background material: http://m.onkey.org/rails-templates
