### PR TITLE
small change in method documetation

### DIFF
--- a/actionpack/lib/action_view/helpers/translation_helper.rb
+++ b/actionpack/lib/action_view/helpers/translation_helper.rb
@@ -25,7 +25,7 @@ module ActionView
       #   * a titleized version of the last key segment as a text.
       #
       # E.g. the value returned for a missing translation key :"blog.post.title" will be
-      # <span class="translation_missing" title="translation missing: blog.post.title">Title</span>.
+      # <span class="translation_missing" title="translation missing: en.blog.post.title">Title</span>.
       # This way your views will display rather reasonable strings but it will still
       # be easy to spot missing translations.
       #


### PR DESCRIPTION
There was a small error in the documentation for the method translate:
the value returned for a missing translation key :"blog.post.title" is not:

```   <span class="translation_missing" title="translation missing: blog.post.title">Title</span>

``````

but actually it is: 
```   <span class="translation_missing" title="translation missing: en.blog.post.title">Title</span>
``````

I just changed the doc.

Gnagno
