### PR TITLE
ActiveSupport::Cache::FileStore#file_path_key does not work if initialized with Pathname

### DIFF
--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -516,6 +516,7 @@ class FileStoreTest < ActiveSupport::TestCase
     Dir.mkdir(cache_dir) unless File.exist?(cache_dir)
     @cache = ActiveSupport::Cache.lookup_store(:file_store, cache_dir, :expires_in => 60)
     @peek = ActiveSupport::Cache.lookup_store(:file_store, cache_dir, :expires_in => 60)
+    @cache_with_pathname = ActiveSupport::Cache.lookup_store(:file_store, Pathname.new(cache_dir), :expires_in => 60)
   end
 
   def teardown
@@ -554,6 +555,12 @@ class FileStoreTest < ActiveSupport::TestCase
   def test_key_transformation
     key = @cache.send(:key_file_path, "views/index?id=1")
     assert_equal "views/index?id=1", @cache.send(:file_path_key, key)
+  end
+
+  def test_key_transformation_with_pathname
+    FileUtils.touch(File.join(cache_dir, "foo"))
+    key = @cache_with_pathname.send(:key_file_path, "views/index?id=1")
+    assert_equal "views/index?id=1", @cache_with_pathname.send(:file_path_key, key)
   end
 end
 


### PR DESCRIPTION
When you initialize ActiveSupport::Cache::FileStore with a Pathname instance (e.g., Rails.root.join('tmp', 'cache')), #file_path_key does not work correctly--it expects cache_path to be a String, so cache_path.size is the length of the path. When cache_path is a Pathname, cache_path.size is the size of the referenced file or directory on disk.

This appears to have been introduced on 2010-04-27 by commit ee51b51b60f9e6cce9ba.

See also:
- #181
- #816
