### PR TITLE
ActiveSupport::Cache::FileStore#file_path_key does not work if initialized with Pathname

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -16,7 +16,7 @@ module ActiveSupport
 
       def initialize(cache_path, options = nil)
         super(options)
-        @cache_path = cache_path
+        @cache_path = cache_path.to_s
         extend Strategy::LocalCache
       end
 

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -516,6 +516,7 @@ class FileStoreTest < ActiveSupport::TestCase
     Dir.mkdir(cache_dir) unless File.exist?(cache_dir)
     @cache = ActiveSupport::Cache.lookup_store(:file_store, cache_dir, :expires_in => 60)
     @peek = ActiveSupport::Cache.lookup_store(:file_store, cache_dir, :expires_in => 60)
+    @cache_with_pathname = ActiveSupport::Cache.lookup_store(:file_store, Pathname.new(cache_dir), :expires_in => 60)
   end
 
   def teardown
@@ -554,6 +555,12 @@ class FileStoreTest < ActiveSupport::TestCase
   def test_key_transformation
     key = @cache.send(:key_file_path, "views/index?id=1")
     assert_equal "views/index?id=1", @cache.send(:file_path_key, key)
+  end
+
+  def test_key_transformation_with_pathname
+    FileUtils.touch(File.join(cache_dir, "foo"))
+    key = @cache_with_pathname.send(:key_file_path, "views/index?id=1")
+    assert_equal "views/index?id=1", @cache_with_pathname.send(:file_path_key, key)
   end
 end
 


### PR DESCRIPTION
This fixes the issue reported on the following pull request: https://github.com/rails/rails/pull/2209
