### PR TITLE
Remove generated whitespace

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -4,12 +4,12 @@ require File.expand_path('../boot', __FILE__)
 require 'rails/all'
 <% else -%>
 # Pick the frameworks you want:
-<%= comment_if :skip_active_record %> require "active_record/railtie"
+<%= comment_if :skip_active_record %>require "active_record/railtie"
 require "action_controller/railtie"
 require "action_mailer/railtie"
 require "active_resource/railtie"
-<%= comment_if :skip_sprockets %> require "sprockets/railtie"
-<%= comment_if :skip_test_unit %> require "rails/test_unit/railtie"
+<%= comment_if :skip_sprockets %>require "sprockets/railtie"
+<%= comment_if :skip_test_unit %>require "rails/test_unit/railtie"
 <% end -%>
 
 # If you have a Gemfile, require the default gems, the ones in the


### PR DESCRIPTION
The 3.1 App Generator leaves leading whitespace for selected optional requires.  Its an aesthetic change, but good for consistency.
