### PR TITLE
Fix enumerable

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -20,6 +20,7 @@ module Enumerable
   #   "2006-02-24 -> Transcript, Transcript"
   #   "2006-02-23 -> Transcript"
   def group_by
+    return to_enum :group_by unless block_given?
     assoc = ActiveSupport::OrderedHash.new
 
     each do |element|
@@ -76,6 +77,7 @@ module Enumerable
   #   (1..5).each_with_object(1) { |value, memo| memo *= value } # => 1
   #
   def each_with_object(memo, &block)
+    return to_enum :each_with_object, memo unless block_given?
     each do |element|
       block.call(element, memo)
     end
@@ -90,6 +92,7 @@ module Enumerable
   #     => { "Chade- Fowlersburg-e" => <Person ...>, "David Heinemeier Hansson" => <Person ...>, ...}
   #
   def index_by
+    return to_enum :index_by unless block_given?
     Hash[map { |elem| [yield(elem), elem] }]
   end
 

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -95,9 +95,16 @@ module Enumerable
 
   # Returns true if the enumerable has more than 1 element. Functionally equivalent to enum.to_a.size > 1.
   # Can be called with a block too, much like any?, so people.many? { |p| p.age > 26 } returns true if more than 1 person is over 26.
-  def many?(&block)
-    size = block_given? ? count(&block) : to_a.size
-    size > 1
+  def many?
+    cnt = 0
+    if block_given?
+      any? do |element|
+        cnt += 1 if yield element
+        cnt > 1
+      end
+    else
+      any?{ (cnt += 1) > 1 }
+    end
   end
 
   # The negative of the Enumerable#include?. Returns true if the collection does not include the object.

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -93,10 +93,10 @@ module Enumerable
     Hash[map { |elem| [yield(elem), elem] }]
   end
 
-  # Returns true if the collection has more than 1 element. Functionally equivalent to collection.size > 1.
+  # Returns true if the enumerable has more than 1 element. Functionally equivalent to enum.to_a.size > 1.
   # Can be called with a block too, much like any?, so people.many? { |p| p.age > 26 } returns true if more than 1 person is over 26.
   def many?(&block)
-    size = block_given? ? count(&block) : self.size
+    size = block_given? ? count(&block) : to_a.size
     size > 1
   end
 

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -76,10 +76,10 @@ module Enumerable
   #
   #   (1..5).each_with_object(1) { |value, memo| memo *= value } # => 1
   #
-  def each_with_object(memo, &block)
+  def each_with_object(memo)
     return to_enum :each_with_object, memo unless block_given?
     each do |element|
-      block.call(element, memo)
+      yield element, memo
     end
     memo
   end unless [].respond_to?(:each_with_object)

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -29,10 +29,10 @@ class EnumerableTests < Test::Unit::TestCase
 
   def test_sums
     assert_equal 30, [5, 15, 10].sum
-    assert_equal 30, [5, 15, 10].sum { |i| i }
+    assert_equal 60, [5, 15, 10].sum { |i| i * 2}
 
     assert_equal 'abc', %w(a b c).sum
-    assert_equal 'abc', %w(a b c).sum { |i| i }
+    assert_equal 'aabbcc', %w(a b c).sum { |i| i * 2 }
 
     payments = [ Payment.new(5), Payment.new(15), Payment.new(10) ]
     assert_equal 30, payments.sum(&:price)
@@ -56,11 +56,11 @@ class EnumerableTests < Test::Unit::TestCase
 
   def test_empty_sums
     assert_equal 0, [].sum
-    assert_equal 0, [].sum { |i| i }
+    assert_equal 0, [].sum { |i| i + 10 }
     assert_equal Payment.new(0), [].sum(Payment.new(0))
   end
 
-  def test_enumerable_sums
+  def test_range_sums
     assert_equal 20, (1..4).sum { |i| i * 2 }
     assert_equal 10, (1..4).sum
     assert_equal 10, (1..4.5).sum
@@ -80,18 +80,18 @@ class EnumerableTests < Test::Unit::TestCase
   end
 
   def test_many
-    assert ![].many?
-    assert ![ 1 ].many?
-    assert [ 1, 2 ].many?
+    assert_equal false, [].many?
+    assert_equal false, [ 1 ].many?
+    assert_equal true,  [ 1, 2 ].many?
 
-    assert ![].many? {|x| x > 1 }
-    assert ![ 2 ].many? {|x| x > 1 }
-    assert ![ 1, 2 ].many? {|x| x > 1 }
-    assert [ 1, 2, 2 ].many? {|x| x > 1 }
+    assert_equal false, [].many? {|x| x > 1 }
+    assert_equal false, [ 2 ].many? {|x| x > 1 }
+    assert_equal false, [ 1, 2 ].many? {|x| x > 1 }
+    assert_equal true,  [ 1, 2, 2 ].many? {|x| x > 1 }
   end
 
   def test_exclude?
-    assert [ 1 ].exclude?(2)
-    assert ![ 1 ].exclude?(1)
+    assert_equal true,  [ 1 ].exclude?(2)
+    assert_equal false, [ 1 ].exclude?(1)
   end
 end

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -104,6 +104,13 @@ class EnumerableTests < Test::Unit::TestCase
     assert_equal true,  GenericEnumerable.new([ 1, 2, 2 ]).many? {|x| x > 1 }
   end
 
+  def test_many_iterates_only_on_what_is_needed
+    infinity = 1.0/0.0
+    very_long_enum = 0..infinity
+    assert_equal true, very_long_enum.many?
+    assert_equal true, very_long_enum.many?{|x| x > 100}
+  end
+
   def test_exclude?
     assert_equal true,  GenericEnumerable.new([ 1 ]).exclude?(2)
     assert_equal false, GenericEnumerable.new([ 1 ]).exclude?(1)

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -8,6 +8,17 @@ class SummablePayment < Payment
 end
 
 class EnumerableTests < Test::Unit::TestCase
+  class GenericEnumerable
+    include Enumerable
+    def initialize(values = [1, 2, 3])
+      @values = values
+    end
+
+    def each
+      @values.each{|v| yield v}
+    end
+  end
+
   def test_group_by
     names = %w(marcel sam david jeremy)
     klass = Struct.new(:name)
@@ -17,7 +28,7 @@ class EnumerableTests < Test::Unit::TestCase
       people << p
     end
 
-    grouped = objects.group_by { |object| object.name }
+    grouped = GenericEnumerable.new(objects).group_by { |object| object.name }
 
     grouped.each do |name, group|
       assert group.all? { |person| person.name == name }
@@ -28,17 +39,19 @@ class EnumerableTests < Test::Unit::TestCase
   end
 
   def test_sums
-    assert_equal 30, [5, 15, 10].sum
-    assert_equal 60, [5, 15, 10].sum { |i| i * 2}
+    enum = GenericEnumerable.new([5, 15, 10])
+    assert_equal 30, enum.sum
+    assert_equal 60, enum.sum { |i| i * 2}
 
-    assert_equal 'abc', %w(a b c).sum
-    assert_equal 'aabbcc', %w(a b c).sum { |i| i * 2 }
+    enum = GenericEnumerable.new(%w(a b c))
+    assert_equal 'abc', enum.sum
+    assert_equal 'aabbcc', enum.sum { |i| i * 2 }
 
-    payments = [ Payment.new(5), Payment.new(15), Payment.new(10) ]
+    payments = GenericEnumerable.new([ Payment.new(5), Payment.new(15), Payment.new(10) ])
     assert_equal 30, payments.sum(&:price)
     assert_equal 60, payments.sum { |p| p.price * 2 }
 
-    payments = [ SummablePayment.new(5), SummablePayment.new(15) ]
+    payments = GenericEnumerable.new([ SummablePayment.new(5), SummablePayment.new(15) ])
     assert_equal SummablePayment.new(20), payments.sum
     assert_equal SummablePayment.new(20), payments.sum { |p| p }
   end
@@ -46,18 +59,18 @@ class EnumerableTests < Test::Unit::TestCase
   def test_nil_sums
     expected_raise = TypeError
 
-    assert_raise(expected_raise) { [5, 15, nil].sum }
+    assert_raise(expected_raise) { GenericEnumerable.new([5, 15, nil]).sum }
 
-    payments = [ Payment.new(5), Payment.new(15), Payment.new(10), Payment.new(nil) ]
+    payments = GenericEnumerable.new([ Payment.new(5), Payment.new(15), Payment.new(10), Payment.new(nil) ])
     assert_raise(expected_raise) { payments.sum(&:price) }
 
     assert_equal 60, payments.sum { |p| p.price.to_i * 2 }
   end
 
   def test_empty_sums
-    assert_equal 0, [].sum
-    assert_equal 0, [].sum { |i| i + 10 }
-    assert_equal Payment.new(0), [].sum(Payment.new(0))
+    assert_equal 0, GenericEnumerable.new([]).sum
+    assert_equal 0, GenericEnumerable.new([]).sum { |i| i + 10 }
+    assert_equal Payment.new(0), GenericEnumerable.new([]).sum(Payment.new(0))
   end
 
   def test_range_sums
@@ -69,29 +82,30 @@ class EnumerableTests < Test::Unit::TestCase
   end
 
   def test_each_with_object
-    result = %w(foo bar).each_with_object({}) { |str, hsh| hsh[str] = str.upcase }
+    enum = GenericEnumerable.new(%w(foo bar))
+    result = enum.each_with_object({}) { |str, hsh| hsh[str] = str.upcase }
     assert_equal({'foo' => 'FOO', 'bar' => 'BAR'}, result)
   end
 
   def test_index_by
-    payments = [ Payment.new(5), Payment.new(15), Payment.new(10) ]
+    payments = GenericEnumerable.new([ Payment.new(5), Payment.new(15), Payment.new(10) ])
     assert_equal({ 5 => payments[0], 15 => payments[1], 10 => payments[2] },
                  payments.index_by { |p| p.price })
   end
 
   def test_many
-    assert_equal false, [].many?
-    assert_equal false, [ 1 ].many?
-    assert_equal true,  [ 1, 2 ].many?
+    assert_equal false, GenericEnumerable.new([]         ).many?
+    assert_equal false, GenericEnumerable.new([ 1 ]      ).many?
+    assert_equal true,  GenericEnumerable.new([ 1, 2 ]   ).many?
 
-    assert_equal false, [].many? {|x| x > 1 }
-    assert_equal false, [ 2 ].many? {|x| x > 1 }
-    assert_equal false, [ 1, 2 ].many? {|x| x > 1 }
-    assert_equal true,  [ 1, 2, 2 ].many? {|x| x > 1 }
+    assert_equal false, GenericEnumerable.new([]         ).many? {|x| x > 1 }
+    assert_equal false, GenericEnumerable.new([ 2 ]      ).many? {|x| x > 1 }
+    assert_equal false, GenericEnumerable.new([ 1, 2 ]   ).many? {|x| x > 1 }
+    assert_equal true,  GenericEnumerable.new([ 1, 2, 2 ]).many? {|x| x > 1 }
   end
 
   def test_exclude?
-    assert_equal true,  [ 1 ].exclude?(2)
-    assert_equal false, [ 1 ].exclude?(1)
+    assert_equal true,  GenericEnumerable.new([ 1 ]).exclude?(2)
+    assert_equal false, GenericEnumerable.new([ 1 ]).exclude?(1)
   end
 end

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -89,7 +89,7 @@ class EnumerableTests < Test::Unit::TestCase
 
   def test_index_by
     payments = GenericEnumerable.new([ Payment.new(5), Payment.new(15), Payment.new(10) ])
-    assert_equal({ 5 => payments[0], 15 => payments[1], 10 => payments[2] },
+    assert_equal({ 5 => Payment.new(5), 15 => Payment.new(15), 10 => Payment.new(10) },
                  payments.index_by { |p| p.price })
   end
 


### PR DESCRIPTION
As per issue 1580:

I got burned by the fact that `Enumerable#index_by` does not return an `Enumerator` if called without block, so I took a moment to fix the issues I could find in the `Enumerable` extension, namely:

`#index_by`, `#group_by` and `#each_with_object` now return `Enumerator`s as they should.

`#many?` iterates only as much as needed to determine the result. It also doesn't rely on `#size` (which not all `Enumerable`s respond to).

The patch also improves the robustness of the tests. `#each_with_object` is also optimized by not capturing the block.

Problems not addressed:
- most extensions assume that the `Enumerable` yields only one argument.
- the definition of `#many?` can be confusing because the form without block doesn't test for truthiness. Thus `foo.many?` is not necessarily equal to `foo.many?{|x| x}`, and `foo.any?` can be false while `foo.many?` can be true (e.g. `foo = [nil, nil]`). Discounting `nil`/`false` would be ideal, except that it could break compatibility, so I leave this up to the powers that be.

Patch & comments to be found in the [imported issue](https://github.com/rails/rails/issues/893)
