### PR TITLE
Fix fragment caching (squashed commits)

### DIFF
--- a/actionpack/lib/action_view/helpers/cache_helper.rb
+++ b/actionpack/lib/action_view/helpers/cache_helper.rb
@@ -54,7 +54,7 @@ module ActionView
           output_safe = output_buffer.html_safe?
           fragment = output_buffer.slice!(pos..-1)
           if output_safe
-            self.output_buffer = output_buffer.html_safe
+            self.output_buffer = output_buffer.class.new(output_buffer)
           end
           controller.write_fragment(name, fragment, options)
         end

--- a/actionpack/test/fixtures/functional_caching/fragment_cached.html.erb
+++ b/actionpack/test/fixtures/functional_caching/fragment_cached.html.erb
@@ -1,2 +1,3 @@
 Hello
 <%= cache do %>This bit's fragment cached<% end %>
+<%= 'Ciao' %>


### PR DESCRIPTION
As requested by @fxn I squashed the commits from pull request #2150 into one commit.

Fix fragment cache helper regression on cache miss introduced with 03d01ec7.

Contains following patches cherry-picked from @lhahne's 3-0-stable branch:
- Added tests for the output_buffer returned by CacheHelper (c476a6b)
  The output_buffer returned by CacheHelper should be html_safe if the original buffer is html_safe.
- made sure that the possible new output_buffer created by CacheHelper is of the same type as the original (39a4f67)
