### PR TITLE
Fix fragment cache helper regression on cache miss introduced with 03d01e

### DIFF
--- a/actionpack/lib/action_view/helpers/cache_helper.rb
+++ b/actionpack/lib/action_view/helpers/cache_helper.rb
@@ -54,7 +54,7 @@ module ActionView
           output_safe = output_buffer.html_safe?
           fragment = output_buffer.slice!(pos..-1)
           if output_safe
-            self.output_buffer = output_buffer.html_safe
+            self.output_buffer = output_buffer.class.new(output_buffer)
           end
           controller.write_fragment(name, fragment, options)
         end

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -745,6 +745,7 @@ class FunctionalFragmentCachingTest < ActionController::TestCase
     expected_body = <<-CACHED
 Hello
 This bit's fragment cached
+Ciao
 CACHED
     assert_equal expected_body, @response.body
 
@@ -785,4 +786,52 @@ CACHED
 
     assert_equal "  <p>Builder</p>\n", @store.read('views/test.host/functional_caching/formatted_fragment_cached')
   end
+end
+
+class CacheHelperOutputBufferTest < ActionController::TestCase
+
+  class MockController
+    def read_fragment(name, options)
+      return false
+    end
+
+    def write_fragment(name, fragment, options)
+      fragment
+    end
+  end
+
+  def setup
+    super
+  end
+
+  def test_output_buffer
+    output_buffer = ActionView::OutputBuffer.new
+    controller = MockController.new
+    cache_helper = Object.new
+    cache_helper.extend(ActionView::Helpers::CacheHelper)
+    cache_helper.expects(:controller).returns(controller).at_least(0)
+    cache_helper.expects(:output_buffer).returns(output_buffer).at_least(0)
+    # if the output_buffer is changed, the new one should be html_safe and of the same type
+    cache_helper.expects(:output_buffer=).with(responds_with(:html_safe?, true)).with(instance_of(output_buffer.class)).at_least(0)
+
+    assert_nothing_raised do
+      cache_helper.send :fragment_for, 'Test fragment name', 'Test fragment', &Proc.new{ nil }
+    end
+  end
+
+  def test_safe_buffer
+    output_buffer = ActiveSupport::SafeBuffer.new
+    controller = MockController.new
+    cache_helper = Object.new
+    cache_helper.extend(ActionView::Helpers::CacheHelper)
+    cache_helper.expects(:controller).returns(controller).at_least(0)
+    cache_helper.expects(:output_buffer).returns(output_buffer).at_least(0)
+    # if the output_buffer is changed, the new one should be html_safe and of the same type
+    cache_helper.expects(:output_buffer=).with(responds_with(:html_safe?, true)).with(instance_of(output_buffer.class)).at_least(0)
+
+    assert_nothing_raised do
+      cache_helper.send :fragment_for, 'Test fragment name', 'Test fragment', &Proc.new{ nil }
+    end
+  end
+
 end

--- a/actionpack/test/fixtures/functional_caching/fragment_cached.html.erb
+++ b/actionpack/test/fixtures/functional_caching/fragment_cached.html.erb
@@ -1,2 +1,3 @@
 Hello
 <%= cache do %>This bit's fragment cached<% end %>
+<%= 'Ciao' %>


### PR DESCRIPTION
Ported pull request #2219 to master as requested by @spastorino.

Fix fragment cache helper regression on cache miss introduced with 03d01ec7.

Contains following patches cherry-picked from @lhahne's 3-0-stable branch:
- Added tests for the output_buffer returned by CacheHelper (c476a6b)
  The output_buffer returned by CacheHelper should be html_safe if the original buffer is html_safe.
- made sure that the possible new output_buffer created by CacheHelper is of the same type as the original (39a4f67)
