### PR TITLE
rake assets:precompile should always perform caching - Closes #2199

### DIFF
--- a/actionpack/lib/sprockets/assets.rake
+++ b/actionpack/lib/sprockets/assets.rake
@@ -10,6 +10,7 @@ namespace :assets do
     Sprockets::Helpers::RailsHelper
 
     assets = Rails.application.config.assets.precompile
+    Rails.application.config.action_controller.perform_caching = true
     Rails.application.assets.precompile(*assets)
   end
 


### PR DESCRIPTION
Currently, rake assets:precompile takes the perform_caching option from the current environment.  
This means if we run the task with the default environment (development), the generated javascript files won't build asset_path with the file's timestamp.

This is probably not what the user expects. He precompiles the files, it's to use them !
Therefore, it makes very few sense to build the assets without the timestamps in assets-path.

This makes perform_caching always true when precompiling the assets.
