### PR TITLE
not allowing QueryCache Rack to fail on database exception (#2142)

### DIFF
--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -61,6 +61,8 @@ module ActiveRecord
 
       status, headers, body = @app.call(env)
       [status, headers, BodyProxy.new(old, body)]
+    rescue Exception
+       @app.call(env)
     end
   end
 end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -31,6 +31,17 @@ class QueryCacheTest < ActiveRecord::TestCase
     mw.call({})
   end
 
+  def test_middleware_fails_but_passes_through
+    called = false
+    ActiveRecord::Base.connection.expects(:query_cache_enabled).raises(Exception)
+    
+    mw = ActiveRecord::QueryCache.new lambda { |env|
+      called = true
+    }
+    mw.call({})
+    assert called, 'middleware should delegate even if connection failure occurs'
+  end
+
   def test_cache_enabled_during_call
     assert !ActiveRecord::Base.connection.query_cache_enabled, 'cache off'
 


### PR DESCRIPTION
I've been testing this (see sample app: https://github.com/skippy/rails31QueryCache) and I actually think this is a bigger issue than raised in #2142.  The query cache is triggered so early in the rack stack that if something goes wrong with the database (such as a misconfiguration or it goes down) it becomes a bit tricky to capture that error... you definitely can't do it from the controller level (it looks like hoptoad works as it monkey patches low enough to grab the error).

I think @pritchie has a valid point so here is my attempt to address it.  if it fails in the `QueryCache` rack layer, let it continue through and if it fails somewhere else (most likely) then so be it; it will throw the same error but higher up on the stack where it can be handled by application-specific logic.

Please comment.

thanks!
