### PR TITLE
Simple fix to the NoMethodError noted in #2177.

### DIFF
--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -72,6 +72,8 @@ module Sprockets
       def debug_assets?
         params[:debug_assets] == '1' ||
           params[:debug_assets] == 'true'
+      rescue NoMethodError
+        false
       end
 
       # Override to specify an alternative prefix for asset path generation.

--- a/actionpack/test/template/sprockets_helper_test.rb
+++ b/actionpack/test/template/sprockets_helper_test.rb
@@ -12,7 +12,6 @@ class SprocketsHelperTest < ActionView::TestCase
     super
 
     @controller = BasicController.new
-    @controller.stubs(:params).returns({})
 
     @request = Class.new do
       def protocol() 'http://' end


### PR DESCRIPTION
Unfortunately #respond_to?(:controller) won't work as suggested, nor will respond_to?(:params), as #controller is present and #params is delegated to #controller. #delegate's implementation makes respond_to? return true regardless whether the target responds to it.

I did something slightly different with the tests in 4901c5147b66e.  There I duplicated the stylesheet and javascript link tag test with and without #params provided, in the style of asset_tag_helper_test.  Doesn't seem to be justified, given it doesn't really give us any new coverage.

A better fix, but far more far-reaching fix might be to have #delegate override respond_to? to check the target's #respond_to?, so we could use #respond_to?(:params) here.
