### PR TITLE
Mangaled sql on order with functions

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -311,7 +311,7 @@ module ActiveRecord
           o.reverse
         when String, Symbol
           o.to_s.split(',').collect do |s|
-            s.gsub!(/\sasc\Z/i, ' DESC') || s.gsub!(/\sdesc\Z/i, ' ASC') || s.concat(' DESC')
+            (s if s =~/\(/) || s.gsub!(/\sasc\Z/i, ' DESC') || s.gsub!(/\sdesc\Z/i, ' ASC') || s.concat(' DESC')
           end
         else
           o


### PR DESCRIPTION
Fix for https://github.com/rails/rails/issues/1697

This fix allows for functions to be used in the order clause when calling .last 
