### PR TITLE
log at debug level what line caused the redirect_to

### DIFF
--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -59,6 +59,7 @@ module ActionController
     def redirect_to(options = {}, response_status = {}) #:doc:
       raise ActionControllerError.new("Cannot redirect to nil!") if options.nil?
       raise AbstractController::DoubleRenderError if response_body
+      logger.debug { "Redirected by #{caller(1).first rescue "unknown"}" } if logger
 
       self.status        = _extract_redirect_to_status(options, response_status)
       self.location      = _compute_redirect_to_location(options)


### PR DESCRIPTION
I've found this hugely helpful in development. I looked for another $DEBUG type flag to check against, but decided to just use .debug and if it's appropriate, it'll log. Any thoughts?

If you're not convinced, throw this in your application controller and see how helpful it is:

``` ruby
  # show helpful info on why we redirected in logs
  def redirect_to(options = {}, response_status = {})
    ::Rails.logger.error("Redirected by #{caller(1).first rescue "unknown"}")
    super(options, response_status)
  end
```

Also, happy to add a test, just didn't have a strong feeling on what would be a good method. 
