### PR TITLE
Rails 3.1 throws a Errno::ENOTDIR if files are put in assets directories

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -538,9 +538,9 @@ module Rails
     end
 
     initializer :append_assets_path do |app|
-      app.config.assets.paths.unshift(*paths["vendor/assets"].existent)
-      app.config.assets.paths.unshift(*paths["lib/assets"].existent)
-      app.config.assets.paths.unshift(*paths["app/assets"].existent)
+      app.config.assets.paths.unshift(*paths["vendor/assets"].existent_directories)
+      app.config.assets.paths.unshift(*paths["lib/assets"].existent_directories)
+      app.config.assets.paths.unshift(*paths["app/assets"].existent_directories)
     end
 
     initializer :prepend_helpers_path do |app|

--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -193,6 +193,10 @@ module Rails
       def existent
         expanded.select { |f| File.exists?(f) }
       end
+      
+      def existent_directories
+        expanded.select {|d| Dir.exists?(d) }
+      end
 
       def paths
         ActiveSupport::Deprecation.warn "paths is deprecated. Please call expand instead."

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -86,5 +86,19 @@ module ApplicationTests
       assert_match "alert()", last_response.body
       assert_equal nil, last_response.headers["Set-Cookie"]
     end
+
+    test "files in any assets/ directories are not added to Sprockets" do
+      %w[app lib vendor].each do |dir|
+        app_file "#{dir}/assets/#{dir}_test.erb", "testing"
+      end
+
+      app_file "app/assets/javascripts/demo.js", "alert();"
+
+      require "#{app_path}/config/environment"
+
+      get "/assets/demo.js"
+      assert_match "alert();", last_response.body
+      assert_equal 200, last_response.status
+    end
   end
 end


### PR DESCRIPTION
Hi,

We were writing documentation for the Toronto Ruby Hack Fest for Rails 3.1 when I noticed that putting a file in any `assets/` directory will display an error as Sprockets is expecting a directory.

After further inspection, Rails only checks if the file exists and not if they are directories.

I've modified the code to make it only accept directories, however I'm not sure where to write tests for it. Can someone point me in the right direction?

I'll continue to look at tests to find an appropriate spot and I'll include the tests once I figure out where to put them :P
