### PR TITLE
Memoizing @blocks & disposing of constraints options properly

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -190,13 +190,12 @@ module ActionDispatch
           end
 
           def blocks
-            block = @scope[:blocks] || []
-
-            if @options[:constraints].present? && !@options[:constraints].is_a?(Hash)
-              block << @options[:constraints]
+            constraints = @options[:constraints]
+            if constraints.present? && !constraints.is_a?(Hash)
+              [constraints]
+            else
+              @scope[:blocks] || []
             end
-
-            block
           end
 
           def constraints


### PR DESCRIPTION
addresses issue #1907 - any routes that follow a route with a constraints
  block are inheriting the previous route's constraints.

An example of this:
https://github.com/spaghetticode/constraints/blob/master/config/routes.rb

and the gist of the resulting @named_routes instance variable:
https://gist.github.com/1103314
