### PR TITLE
make gsub and sub unavailable in SafeBuffers - Closes #1555

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -21,7 +21,7 @@ module ActiveSupport
     #   "words".pluralize            # => "words"
     #   "CamelOctopus".pluralize     # => "CamelOctopi"
     def pluralize(word)
-      result = word.to_s.dup
+      result = word.to_str.dup
 
       if word.empty? || inflections.uncountables.include?(result.downcase)
         result
@@ -40,7 +40,7 @@ module ActiveSupport
     #   "word".singularize             # => "word"
     #   "CamelOctopi".singularize      # => "CamelOctopus"
     def singularize(word)
-      result = word.to_s.dup
+      result = word.to_str.dup
 
       if inflections.uncountables.any? { |inflection| result =~ /\b(#{inflection})\Z/i }
         result
@@ -66,7 +66,7 @@ module ActiveSupport
     #
     #   "SSLError".underscore.camelize # => "SslError"
     def camelize(term, uppercase_first_letter = true)
-      string = term.to_s
+      string = term.to_str
       if uppercase_first_letter
         string = string.sub(/^[a-z\d]*/) { inflections.acronyms[$&] || $&.capitalize }
       else
@@ -88,7 +88,7 @@ module ActiveSupport
     #
     #   "SSLError".underscore.camelize # => "SslError"
     def underscore(camel_cased_word)
-      word = camel_cased_word.to_s.dup
+      word = camel_cased_word.to_str.dup
       word.gsub!(/::/, '/')
       word.gsub!(/(?:([A-Za-z\d])|^)(#{inflections.acronym_regex})(?=\b|[^a-z])/) { "#{$1}#{$1 && '_'}#{$2.downcase}" }
       word.gsub!(/([A-Z\d]+)([A-Z][a-z])/,'\1_\2')
@@ -105,7 +105,7 @@ module ActiveSupport
     #   "employee_salary" # => "Employee salary"
     #   "author_id"       # => "Author"
     def humanize(lower_case_and_underscored_word)
-      result = lower_case_and_underscored_word.to_s.dup
+      result = lower_case_and_underscored_word.to_str.dup
       inflections.humans.each { |(rule, replacement)| break if result.gsub!(rule, replacement) }
       result.gsub!(/_id$/, "")
       result.gsub(/(_)?([a-z\d]*)/i) { "#{$1 && ' '}#{inflections.acronyms[$2] || $2.downcase}" }.gsub(/^\w/) { $&.upcase }
@@ -149,7 +149,7 @@ module ActiveSupport
     #   "business".classify     # => "Busines"
     def classify(table_name)
       # strip out any leading schema name
-      camelize(singularize(table_name.to_s.sub(/.*\./, '')))
+      camelize(singularize(table_name.to_str.sub(/.*\./, '')))
     end
 
     # Replaces underscores with dashes in the string.
@@ -157,7 +157,7 @@ module ActiveSupport
     # Example:
     #   "puni_puni" # => "puni-puni"
     def dasherize(underscored_word)
-      underscored_word.gsub(/_/, '-')
+      underscored_word.to_str.gsub(/_/, '-')
     end
 
     # Removes the module part from the expression in the string.
@@ -166,7 +166,7 @@ module ActiveSupport
     #   "ActiveRecord::CoreExtensions::String::Inflections".demodulize # => "Inflections"
     #   "Inflections".demodulize                                       # => "Inflections"
     def demodulize(class_name_in_module)
-      class_name_in_module.to_s.gsub(/^.*::/, '')
+      class_name_in_module.to_str.gsub(/^.*::/, '')
     end
 
     # Creates a foreign key name from a class name.

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -21,6 +21,7 @@ module ActiveSupport
     #   "words".pluralize            # => "words"
     #   "CamelOctopus".pluralize     # => "CamelOctopi"
     def pluralize(word)
+      word = deprecate_symbol(word)
       result = word.to_str.dup
 
       if word.empty? || inflections.uncountables.include?(result.downcase)
@@ -40,6 +41,7 @@ module ActiveSupport
     #   "word".singularize             # => "word"
     #   "CamelOctopi".singularize      # => "CamelOctopus"
     def singularize(word)
+      word = deprecate_symbol(word)
       result = word.to_str.dup
 
       if inflections.uncountables.any? { |inflection| result =~ /\b(#{inflection})\Z/i }
@@ -66,6 +68,7 @@ module ActiveSupport
     #
     #   "SSLError".underscore.camelize # => "SslError"
     def camelize(term, uppercase_first_letter = true)
+      term = deprecate_symbol(term)
       string = term.to_str
       if uppercase_first_letter
         string = string.sub(/^[a-z\d]*/) { inflections.acronyms[$&] || $&.capitalize }
@@ -88,6 +91,7 @@ module ActiveSupport
     #
     #   "SSLError".underscore.camelize # => "SslError"
     def underscore(camel_cased_word)
+      camel_cased_word = deprecate_symbol(camel_cased_word)
       word = camel_cased_word.to_str.dup
       word.gsub!(/::/, '/')
       word.gsub!(/(?:([A-Za-z\d])|^)(#{inflections.acronym_regex})(?=\b|[^a-z])/) { "#{$1}#{$1 && '_'}#{$2.downcase}" }
@@ -105,6 +109,7 @@ module ActiveSupport
     #   "employee_salary" # => "Employee salary"
     #   "author_id"       # => "Author"
     def humanize(lower_case_and_underscored_word)
+      lower_case_and_underscored_word = deprecate_symbol(lower_case_and_underscored_word)
       result = lower_case_and_underscored_word.to_str.dup
       inflections.humans.each { |(rule, replacement)| break if result.gsub!(rule, replacement) }
       result.gsub!(/_id$/, "")
@@ -148,6 +153,7 @@ module ActiveSupport
     # Singular names are not handled correctly:
     #   "business".classify     # => "Busines"
     def classify(table_name)
+      table_name = deprecate_symbol(table_name)
       # strip out any leading schema name
       camelize(singularize(table_name.to_str.sub(/.*\./, '')))
     end
@@ -157,6 +163,7 @@ module ActiveSupport
     # Example:
     #   "puni_puni" # => "puni-puni"
     def dasherize(underscored_word)
+      underscored_word = deprecate_symbol(underscored_word)
       underscored_word.to_str.gsub(/_/, '-')
     end
 
@@ -166,6 +173,7 @@ module ActiveSupport
     #   "ActiveRecord::CoreExtensions::String::Inflections".demodulize # => "Inflections"
     #   "Inflections".demodulize                                       # => "Inflections"
     def demodulize(class_name_in_module)
+      class_name_in_module = deprecate_symbol(class_name_in_module)
       class_name_in_module.to_str.gsub(/^.*::/, '')
     end
 
@@ -245,6 +253,14 @@ module ActiveSupport
           else    "#{number}th"
         end
       end
+    end
+
+    def deprecate_symbol(symbol)
+      if symbol.is_a?(Symbol)
+        symbol = symbol.to_s
+        ActiveSupport::Deprecation.warn("Using symbols in inflections is deprecated. Please use to_s to have a string.")
+      end
+      symbol
     end
   end
 end

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -10,7 +10,7 @@ module Ace
   end
 end
 
-class InflectorTest < Test::Unit::TestCase
+class InflectorTest < ActiveSupport::TestCase
   include InflectorTestCases
 
   def test_pluralize_plurals
@@ -248,12 +248,6 @@ class InflectorTest < Test::Unit::TestCase
     end
   end
 
-  def test_classify_with_symbol
-    assert_nothing_raised do
-      assert_equal 'FooBar', ActiveSupport::Inflector.classify(:foo_bars)
-    end
-  end
-
   def test_classify_with_leading_schema_name
     assert_equal 'FooBar', ActiveSupport::Inflector.classify('schema.foo_bar')
   end
@@ -319,12 +313,6 @@ class InflectorTest < Test::Unit::TestCase
     end
   end
 
-  def test_symbol_to_lower_camel
-    SymbolToLowerCamel.each do |symbol, lower_camel|
-      assert_equal(lower_camel, ActiveSupport::Inflector.camelize(symbol, false))
-    end
-  end
-
   %w{plurals singulars uncountables humans}.each do |inflection_type|
     class_eval <<-RUBY, __FILE__, __LINE__ + 1
       def test_clear_#{inflection_type}
@@ -378,6 +366,14 @@ class InflectorTest < Test::Unit::TestCase
     ActiveSupport::Inflector.inflections.instance_variable_set :@singulars, cached_values[1]
     ActiveSupport::Inflector.inflections.instance_variable_set :@uncountables, cached_values[2]
     ActiveSupport::Inflector.inflections.instance_variable_set :@humans, cached_values[3]
+  end
+
+  [:pluralize, :singularize, :camelize, :underscore, :humanize, :titleize, :tableize, :classify, :dasherize, :demodulize].each do |method|
+    test "should deprecate symbols on #{method}" do
+      assert_deprecated(/Using symbols in inflections is deprecated/) do
+        ActiveSupport::Inflector.send(method, :foo)
+      end
+    end
   end
 
   Irregularities.each do |irregularity|

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -120,13 +120,6 @@ module InflectorTestCases
     "area51_controller"      => "area51Controller"
   }
 
-  SymbolToLowerCamel = {
-    :product                => 'product',
-    :special_guest          => 'specialGuest',
-    :application_controller => 'applicationController',
-    :area51_controller      => 'area51Controller'
-  }
-
   CamelToUnderscoreWithoutReverse = {
     "HTMLTidy"              => "html_tidy",
     "HTMLTidyGenerator"     => "html_tidy_generator",


### PR DESCRIPTION
Following #1555, gsub and sub can't be used with Safe Buffers because of incorrect behavior with global variables when using blocks.
I have therefore disabled gsub and sub for safe strings, inviting people to use it on unsafe strings only.
