### PR TITLE
Bring back the ability to provide :order for update_all

### DIFF
--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -29,6 +29,26 @@ class PersistencesTest < ActiveRecord::TestCase
       end
     end
 
+    def test_update_all_doesnt_ignore_order
+      assert_equal authors(:david).id + 1, authors(:mary).id # make sure there is going to be a duplicate PK error
+      test_update_with_order_succeeds = lambda do |order|
+        begin
+          Author.order(order).update_all('id = id + 1')
+        rescue ActiveRecord::ActiveRecordError
+          false
+        end
+      end
+
+      if test_update_with_order_succeeds.call('id DESC')
+        assert !test_update_with_order_succeeds.call('id ASC') # test that this wasn't a fluke and using an incorrect order results in an exception
+      else
+        # test that we're failing because the current Arel's engine doesn't support UPDATE ORDER BY queries is using subselects instead
+        assert_sql(/\AUPDATE .+ \(SELECT .* ORDER BY id DESC\)\Z/i) do
+          test_update_with_order_succeeds.call('id DESC')
+        end
+      end
+    end
+
     def test_update_all_with_order_and_limit_updates_subset_only
       author = authors(:david)
       assert_nothing_raised do


### PR DESCRIPTION
Having UPDATE ... ORDER BY is sometimes necessary when performing incremental updates on UNIQUE indexed columns.
