### PR TITLE
Make polymorphic_url calls go through application helpers again.

### DIFF
--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -124,14 +124,7 @@ module ActionDispatch
           args.last.kind_of?(Hash) ? args.last.merge!(url_options) : args << url_options
         end
 
-        if proxy
-          proxy.send(named_route, *args)
-        else
-          # we need to use url_for, because polymorphic_url can be used in context of other than
-          # current routes (e.g. engine's routes). As named routes from engine are not included
-          # calling engine's named route directly would fail.
-          url_for _routes.url_helpers.__send__("hash_for_#{named_route}", *args)
-        end
+        (proxy || self).send(named_route, *args)
       end
 
       # Returns the path component of a URL for the given record. It uses

--- a/actionpack/test/dispatch/prefix_generation_test.rb
+++ b/actionpack/test/dispatch/prefix_generation_test.rb
@@ -50,7 +50,9 @@ module TestGenerationPrefix
             scope "/:omg", :omg => "awesome" do
               mount BlogEngine => "/blog", :as => "blog_engine"
             end
+            match "/posts/:id", :to => "outside_engine_generating#post", :as => :post
             match "/generate", :to => "outside_engine_generating#index"
+            match "/polymorphic_path_for_app", :to => "outside_engine_generating#polymorphic_path_for_app"
             match "/polymorphic_path_for_engine", :to => "outside_engine_generating#polymorphic_path_for_engine"
             match "/polymorphic_with_url_for", :to => "outside_engine_generating#polymorphic_with_url_for"
             match "/conflicting_url", :to => "outside_engine_generating#conflicting"
@@ -101,6 +103,7 @@ module TestGenerationPrefix
 
     class ::OutsideEngineGeneratingController < ActionController::Base
       include BlogEngine.routes.mounted_helpers
+      include RailsApplication.routes.url_helpers
 
       def index
         render :text => blog_engine.post_path(:id => 1)
@@ -108,6 +111,10 @@ module TestGenerationPrefix
 
       def polymorphic_path_for_engine
         render :text => blog_engine.polymorphic_path(Post.new)
+      end
+
+      def polymorphic_path_for_app
+        render :text => polymorphic_path(Post.new)
       end
 
       def polymorphic_with_url_for
@@ -199,6 +206,11 @@ module TestGenerationPrefix
     test "[APP] generating engine's url with polymorphic path" do
       get "/polymorphic_path_for_engine"
       assert_equal "/awesome/blog/posts/1", last_response.body
+    end
+
+    test "polymorphic_path_for_app" do
+      get "/polymorphic_path_for_app"
+      assert_equal "/posts/1", last_response.body
     end
 
     test "[APP] generating engine's url with url_for(@post)" do

--- a/actionpack/test/template/test_test.rb
+++ b/actionpack/test/template/test_test.rb
@@ -39,7 +39,7 @@ class PeopleHelperTest < ActionView::TestCase
     with_test_route_set do
       person = mock(:name => "David")
       person.class.extend ActiveModel::Naming
-      _routes.url_helpers.expects(:hash_for_mocha_mock_path).with(person).returns("/people/1")
+      expects(:mocha_mock_path).with(person).returns("/people/1")
       assert_equal '<a href="/people/1">David</a>', link_to_person(person)
     end
   end

--- a/railties/test/railties/mounted_engine_test.rb
+++ b/railties/test/railties/mounted_engine_test.rb
@@ -15,10 +15,12 @@ module ApplicationTests
 
       app_file 'config/routes.rb', <<-RUBY
         AppTemplate::Application.routes.draw do
+          resources :posts
           match "/engine_route" => "application_generating#engine_route"
           match "/engine_route_in_view" => "application_generating#engine_route_in_view"
           match "/url_for_engine_route" => "application_generating#url_for_engine_route"
           match "/polymorphic_route" => "application_generating#polymorphic_route"
+          match "/application_polymorphic_path" => "application_generating#application_polymorphic_path"
           scope "/:user", :user => "anonymous" do
             mount Blog::Engine => "/blog"
           end
@@ -59,6 +61,7 @@ module ApplicationTests
           resources :posts
           match '/generate_application_route', :to => 'posts#generate_application_route'
           match '/application_route_in_view', :to => 'posts#application_route_in_view'
+          match '/engine_polymorphic_path', :to => 'posts#engine_polymorphic_path'
         end
       RUBY
 
@@ -78,6 +81,10 @@ module ApplicationTests
 
             def application_route_in_view
               render :inline => "<%= main_app.root_path %>"
+            end
+
+            def engine_polymorphic_path
+              render :text => polymorphic_path(Post.new)
             end
           end
         end
@@ -99,6 +106,10 @@ module ApplicationTests
 
           def polymorphic_route
             render :text => polymorphic_url([blog, Blog::Post.new])
+          end
+
+          def application_polymorphic_path
+            render :text => polymorphic_path(Blog::Post.new)
           end
         end
       RUBY
@@ -172,6 +183,14 @@ module ApplicationTests
       # test polymorphic routes
       get "/polymorphic_route"
       assert_equal "http://example.org/anonymous/blog/posts/44", last_response.body
+
+      # test that correct path is generated for the same polymorphic_path call in an engine
+      get "/somone/blog/engine_polymorphic_path"
+      assert_equal "/somone/blog/posts/44", last_response.body
+
+      # and in an application
+      get "/application_polymorphic_path"
+      assert_equal "/posts/44", last_response.body
     end
   end
 end


### PR DESCRIPTION
This brings back the ability to overwrite/extend polymorphic url helpers via application helpers that was present in Rails 2.3 and Rails 3.0.

Thus allowing to do something like this:

```
module ApplicationHelper
  def posts_path(*args)
    do_something(*args)
    super
  end
end
```
