### PR TITLE
Stringify parameter values in tests branched off 3-1-stable

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -395,7 +395,26 @@ module ActionController
       end
       alias xhr :xml_http_request
 
+      def paramify_values(hash_or_array_or_value)
+        case hash_or_array_or_value
+        when Hash
+          hash_or_array_or_value.each do |key, value|
+            hash_or_array_or_value[key] = paramify_values(value)
+          end
+        when Array
+          hash_or_array_or_value.map {|i| paramify_values(i)}
+        when Rack::Test::UploadedFile
+          hash_or_array_or_value
+        else
+          hash_or_array_or_value.to_param
+        end
+      end
+
       def process(action, parameters = nil, session = nil, flash = nil, http_method = 'GET')
+        # Ensure that numbers and symbols passed as params are converted to
+        # proper params, as is the case when engaging rack.
+        paramify_values(parameters)
+
         # Sanity check for required instance variables so we can give an
         # understandable error message.
         %w(@routes @controller @request @response).each do |iv_name|

--- a/actionpack/test/controller/test_test.rb
+++ b/actionpack/test/controller/test_test.rb
@@ -493,6 +493,16 @@ XML
     )
   end
 
+  def test_params_passing_with_fixnums
+    get :test_params, :page => {:name => "Page name", :month => 4, :year => 2004, :day => 6}
+    parsed_params = eval(@response.body)
+    assert_equal(
+      {'controller' => 'test_test/test', 'action' => 'test_params',
+       'page' => {'name' => "Page name", 'month' => '4', 'year' => '2004', 'day' => '6'}},
+      parsed_params
+    )
+  end
+
   def test_params_passing_with_frozen_values
     assert_nothing_raised do
       get :test_params, :frozen => 'icy'.freeze, :frozens => ['icy'.freeze].freeze


### PR DESCRIPTION
This was already merged to master, but not yet to 3-1-stable.
