### PR TITLE
Refactor Module.delegate

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -109,7 +109,7 @@ class Module
       raise ArgumentError, "Delegation needs a target. Supply an options hash with a :to key as the last argument (e.g. delegate :hello, :to => :greeter)."
     end
 
-    if options[:prefix] == true && options[:to].to_s =~ /^[^a-z_]/
+    if options[:prefix] == true && to.to_s =~ /^[^a-z_]/
       raise ArgumentError, "Can only automatically set the delegation prefix when delegating to a method."
     end
 
@@ -119,24 +119,25 @@ class Module
     line = line.to_i
 
     methods.each do |method|
-      on_nil =
-        if options[:allow_nil]
-          'return'
-        else
-          %(raise "#{self}##{prefix}#{method} delegated to #{to}.#{method}, but #{to} is nil: \#{self.inspect}")
+      method_name = prefix + method.to_s
+      module_eval(<<-EOS, file, line - 1)
+        def #{method_name}(*args, &block)
+          Delegation.perform(self, #{to}, #{method.inspect}, #{method_name.inspect}, #{options[:allow_nil].inspect}, #{options[:to].inspect}, args, block)
         end
-
-      module_eval(<<-EOS, file, line - 5)
-        def #{prefix}#{method}(*args, &block)               # def customer_name(*args, &block)
-          #{to}.__send__(#{method.inspect}, *args, &block)  #   client.__send__(:name, *args, &block)
-        rescue NoMethodError                                # rescue NoMethodError
-          if #{to}.nil?                                     #   if client.nil?
-            #{on_nil}                                       #     return # depends on :allow_nil
-          else                                              #   else
-            raise                                           #     raise
-          end                                               #   end
-        end                                                 # end
       EOS
+    end
+  end
+end
+
+class Delegation
+  def self.perform(object, target, method, method_name, allow_nil, to, args, block)
+    target.__send__(method, *args, &block)
+  rescue NoMethodError
+    if target.nil?
+      return nil if allow_nil
+      raise "#{object.class}##{method_name} delegated to #{to}.#{method}, but #{to} is nil: #{object.inspect}"
+    else
+      raise
     end
   end
 end


### PR DESCRIPTION
Current implementation of `Module.delegate` have some evil in constructing ruby code too match.
This patch rewrites the method to have minimal amount of eval,  that I suppose always a good idea e.g. more code reused, less strings to construct.

Diff says it all.
