### PR TITLE
3 1 stable

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -187,13 +187,12 @@ module ActionDispatch
           end
 
           def blocks
-            block = @scope[:blocks] || []
-
-            if @options[:constraints].present? && !@options[:constraints].is_a?(Hash)
-              block << @options[:constraints]
+            constraints = @options[:constraints]
+            if constraints.present? && !constraints.is_a?(Hash)
+              [constraints]
+            else
+              @scope[:blocks] || []
             end
-
-            block
           end
 
           def constraints


### PR DESCRIPTION
addresses issue #1907 - any routes that follow a route with a constraints
  block are inheriting the previous route's constraints.

note: backport for 3-1-stable for pull request here: https://github.com/rails/rails/pull/2245#issuecomment-1646998.
