### PR TITLE
Allow a route to have :format => true

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -119,6 +119,8 @@ module ActionDispatch
               path
             elsif path.include?(":format") || path.end_with?('/')
               path
+            elsif @options[:format] == true
+              "#{path}.:format"
             else
               "#{path}(.:format)"
             end

--- a/actionpack/test/dispatch/mapper_test.rb
+++ b/actionpack/test/dispatch/mapper_test.rb
@@ -83,6 +83,13 @@ module ActionDispatch
         assert_equal '/*path', fakeset.conditions.first[:path_info]
         assert_nil fakeset.requirements.first[:path]
       end
+
+      def test_map_wildcard_with_format_true
+        fakeset = FakeSet.new
+        mapper = Mapper.new fakeset
+        mapper.match '/*path', :to => 'pages#show', :format => true
+        assert_equal '/*path.:format', fakeset.conditions.first[:path_info]
+      end
     end
   end
 end

--- a/railties/guides/source/routing.textile
+++ b/railties/guides/source/routing.textile
@@ -569,6 +569,12 @@ NOTE: By requesting +"/foo/bar.json"+, your +params[:pages]+ will be equals to +
 match '*pages' => 'pages#show', :format => false
 </ruby>
 
+NOTE: If you want to make the format segment mandatory, so it cannot be omitted, you can supply +:format => true+ like this:
+
+<ruby>
+match '*pages' => 'pages#show', :format => true
+</ruby>
+
 h4. Redirection
 
 You can redirect any path to another path using the +redirect+ helper in your router:


### PR DESCRIPTION
When format is true, it is mandatory (as opposed to `:format => false`). This is currently not possible with resource routes, which automatically make format optional by default.
