### PR TITLE
- fix Template::Error causing a memory leak

### DIFF
--- a/actionpack/lib/action_view/context.rb
+++ b/actionpack/lib/action_view/context.rb
@@ -30,7 +30,7 @@ module ActionView
     # :api: plugin
     def _layout_for(name=nil)
       name ||= :layout
-      view_flow.get(name).html_safe
+      view_flow.get(name).try(:html_safe)
     end
   end
 end


### PR DESCRIPTION
Should fix issue described here:
https://github.com/rails/rails/issues/1525

When a Template:Error is raised, the content of the rendered template will be nil, which in turn causes the .html_safe to throw another error, which in turns causes the same loop to go forever until the host machine runs out of memory.
