### PR TITLE
3 1 stable

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -28,7 +28,7 @@ module Rails
         class_option :skip_gemfile,       :type => :boolean, :default => false,
                                           :desc => "Don't create a Gemfile"
 
-        class_option :skip_bundle,        :type => :boolean, :default => false,
+        class_option :skip_bundle,        :type => :boolean, :default => true,
                                           :desc => "Don't run bundle install"
 
         class_option :skip_git,           :type => :boolean, :aliases => "-G", :default => false,

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -95,7 +95,7 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_generation_runs_bundle_install_with_full_and_mountable
-    result = run_generator [destination_root, "--mountable", "--full"]
+    result = run_generator [destination_root, "--mountable", "--full", "--skip_bundle=false"]
     assert_equal 1, result.scan("Your bundle is complete").size
   end
 

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -26,11 +26,6 @@ module SharedGeneratorTests
     default_files.each { |path| assert_file path }
   end
 
-  def test_generation_runs_bundle_install
-    generator([destination_root]).expects(:bundle_command).with('install').once
-    quietly { generator.invoke_all }
-  end
-
   def test_plugin_new_generate_pretend
     run_generator ["testapp", "--pretend"]
     default_files.each{ |path| assert_no_file File.join("testapp",path) }
@@ -116,14 +111,14 @@ module SharedGeneratorTests
   end
 
   def test_dev_option
-    generator([destination_root], :dev => true).expects(:bundle_command).with('install').once
+    generator([destination_root], :dev => true).expects(:bundle_command).never 
     quietly { generator.invoke_all }
     rails_path = File.expand_path('../../..', Rails.root)
     assert_file 'Gemfile', /^gem\s+["']rails["'],\s+:path\s+=>\s+["']#{Regexp.escape(rails_path)}["']$/
   end
 
   def test_edge_option
-    generator([destination_root], :edge => true).expects(:bundle_command).with('install').once
+    generator([destination_root], :edge => true).expects(:bundle_command).never
     quietly { generator.invoke_all }
     assert_file 'Gemfile', %r{^gem\s+["']rails["'],\s+:git\s+=>\s+["']#{Regexp.escape("git://github.com/rails/rails.git")}["']$}
   end
@@ -135,7 +130,7 @@ module SharedGeneratorTests
   end
 
   def test_skip_bundle
-    generator([destination_root], :skip_bundle => true).expects(:bundle_command).never
+    generator([destination_root], :skip_bundle => false).expects(:bundle_command).with('install').once
     quietly { generator.invoke_all }
 
     # skip_bundle is only about running bundle install, ensure the Gemfile is still


### PR DESCRIPTION
Made '--skip_bundle=true' the default when generating a new project. This skips automatically installing gems from the project´s Gemfile. Idea from issue #2132.
