### PR TITLE
Short inspect

### DIFF
--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -2,6 +2,7 @@ require 'erubis'
 require 'active_support/configurable'
 require 'active_support/descendants_tracker'
 require 'active_support/core_ext/module/anonymous'
+require 'active_support/short_inspect'
 
 module AbstractController
   class Error < StandardError; end
@@ -16,6 +17,7 @@ module AbstractController
     attr_internal :action_name
     attr_internal :formats
 
+    include ActiveSupport::ShortInspect
     include ActiveSupport::Configurable
     extend ActiveSupport::DescendantsTracker
 

--- a/activesupport/lib/active_support/short_inspect.rb
+++ b/activesupport/lib/active_support/short_inspect.rb
@@ -1,0 +1,22 @@
+module ActiveSupport
+  module ShortInspect
+
+    # Override the default inspect to strip out instance variables. This
+    # is useful on large classes (such as Rails::Engine and AbstractController)
+    # which would normally have kilobytes of data in their inspect output.
+    # This not only obscures other debug output, but takes a long time to
+    # generate.
+    def inspect
+      # The default output contains an identifier which is inaccessible
+      # without dropping into C or other extension code (you may think it's
+      # #object_id but it isn't), so we would have to mangle super rather than
+      # constructing the string ourselves in order to replicate it.
+      #
+      # We don't want to do this though because part of the problem with
+      # long inspects is the time it takes to generate them, so instead
+      # we just include the object id.
+      "#<%s:%i>" % [self.class.to_s, object_id]
+    end
+
+  end
+end

--- a/activesupport/test/short_inspect_test.rb
+++ b/activesupport/test/short_inspect_test.rb
@@ -1,0 +1,11 @@
+require 'abstract_unit'
+require 'active_support/short_inspect'
+
+class ShortInspectTest < Test::Unit::TestCase
+  def test_inspect_excludes_instance_variables
+    o = Object.new
+    o.instance_eval { @a = "hello" }
+    o.extend(ActiveSupport::ShortInspect)
+    assert !o.inspect.include?("hello")
+  end
+end

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -1,5 +1,6 @@
 require 'rails/railtie'
 require 'active_support/core_ext/module/delegation'
+require 'active_support/short_inspect'
 require 'pathname'
 require 'rbconfig'
 require 'rails/engine/railties'
@@ -333,6 +334,8 @@ module Rails
   class Engine < Railtie
     autoload :Configuration, "rails/engine/configuration"
     autoload :Railties,      "rails/engine/railties"
+
+    include ActiveSupport::ShortInspect
 
     class << self
       attr_accessor :called_from, :isolated


### PR DESCRIPTION
The default includes all instance variables which is many kilobytes long
and takes too long to generate, as well as being just plain not useful.

The original impetus for this change was the development 500 page taking
ages to render, in part because of the potentially massive amount of
data that inspect would be generating and displaying. This was mitigated
somewhat by 5b8801442ea02fc942ae0ee8ef81a9120525f5f0, though this commit
fixes one of the root problems and has the added benefit of being more
useful when debugging in console.

References #1525.

(Not sure whether this should be against 3-1-stable or master, it should apply cleanly against either.)
