### PR TITLE
allow select to have multiple arguments ie. Post.select(:id,:name,:author)

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -37,12 +37,15 @@ module ActiveRecord
       relation
     end
 
-    def select(value = Proc.new)
+    def select(*args, &blk)
+      if !block_given? && args.blank?
+        raise ArgumentError
+      end
       if block_given?
-        to_a.select {|*block_args| value.call(*block_args) }
+        to_a.select {|*block_args| blk.call(*block_args) }
       else
         relation = clone
-        relation.select_values += Array.wrap(value)
+        relation.select_values += args
         relation
       end
     end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -123,6 +123,11 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal Topic.all.map(&:id).sort, topic_ids
   end
 
+  def test_select_symbol_for_many_arguments
+    topics = Topic.select(:id, :author_name).map{|topic| [topic.id, topic.author_name]}.sort
+    assert_equal Topic.all.map{|topic| [topic.id,topic.author_name]}.sort, topics
+  end
+
   def test_table_exists
     assert !NonExistentTable.table_exists?
     assert Topic.table_exists?


### PR DESCRIPTION
I tried to call select with multiple arguments few times, and now I added it. Such API is much more natural than string for me.
