### PR TITLE
Fix actionpack's test suite

### DIFF
--- a/actionpack/test/template/sprockets_helper_test.rb
+++ b/actionpack/test/template/sprockets_helper_test.rb
@@ -21,9 +21,9 @@ class SprocketsHelperTest < ActionView::TestCase
     @controller.request = MockRequest.new
 
     @assets = Sprockets::Environment.new
-    @assets.paths << FIXTURES.join("sprockets/app/javascripts")
-    @assets.paths << FIXTURES.join("sprockets/app/stylesheets")
-    @assets.paths << FIXTURES.join("sprockets/app/images")
+    @assets.append_path(FIXTURES.join("sprockets/app/javascripts"))
+    @assets.append_path(FIXTURES.join("sprockets/app/stylesheets"))
+    @assets.append_path(FIXTURES.join("sprockets/app/images"))
 
     application = Struct.new(:config, :assets).new(config, @assets)
     Rails.stubs(:application).returns(application)
@@ -37,7 +37,7 @@ class SprocketsHelperTest < ActionView::TestCase
   end
 
   test "asset_path" do
-    assert_equal "/assets/logo-9c0a079bdd7701d7e729bd956823d153.png",
+    assert_match %r{/assets/logo-[0-9a-f]+.png},
       asset_path("logo.png")
   end
 
@@ -112,7 +112,7 @@ class SprocketsHelperTest < ActionView::TestCase
     @config.action_controller.default_asset_host_protocol = :request
     @config.action_controller.perform_caching = true
 
-    assert_equal "/assets/logo-9c0a079bdd7701d7e729bd956823d153.png",
+    assert_match %r{/assets/logo-[0-9a-f]+.png},
       asset_path("logo.png")
   end
 
@@ -123,12 +123,12 @@ class SprocketsHelperTest < ActionView::TestCase
   end
 
   test "javascript path" do
-    assert_equal "/assets/application-d41d8cd98f00b204e9800998ecf8427e.js",
+    assert_match %r{/assets/application-[0-9a-f]+.js},
       asset_path(:application, "js")
 
-    assert_equal "/assets/xmlhr-d41d8cd98f00b204e9800998ecf8427e.js",
+    assert_match %r{/assets/xmlhr-[0-9a-f]+.js},
       asset_path("xmlhr", "js")
-    assert_equal "/assets/dir/xmlhr-d41d8cd98f00b204e9800998ecf8427e.js",
+    assert_match %r{/assets/dir/xmlhr-[0-9a-f]+.js},
       asset_path("dir/xmlhr.js", "js")
 
     assert_equal "/dir/xmlhr.js",
@@ -141,28 +141,28 @@ class SprocketsHelperTest < ActionView::TestCase
   end
 
   test "javascript include tag" do
-    assert_equal '<script src="/assets/application-d41d8cd98f00b204e9800998ecf8427e.js" type="text/javascript"></script>',
+    assert_match %r{<script src="/assets/application-[0-9a-f]+.js" type="text/javascript"></script>},
       javascript_include_tag(:application)
 
-    assert_equal '<script src="/assets/xmlhr-d41d8cd98f00b204e9800998ecf8427e.js" type="text/javascript"></script>',
+    assert_match %r{<script src="/assets/xmlhr-[0-9a-f]+.js" type="text/javascript"></script>},
       javascript_include_tag("xmlhr")
-    assert_equal '<script src="/assets/xmlhr-d41d8cd98f00b204e9800998ecf8427e.js" type="text/javascript"></script>',
+    assert_match %r{<script src="/assets/xmlhr-[0-9a-f]+.js" type="text/javascript"></script>},
       javascript_include_tag("xmlhr.js")
     assert_equal '<script src="http://www.example.com/xmlhr" type="text/javascript"></script>',
       javascript_include_tag("http://www.example.com/xmlhr")
 
-    assert_equal "<script src=\"/assets/xmlhr-d41d8cd98f00b204e9800998ecf8427e.js?body=1\" type=\"text/javascript\"></script>\n<script src=\"/assets/application-d41d8cd98f00b204e9800998ecf8427e.js?body=1\" type=\"text/javascript\"></script>",
+    assert_match %r{<script src="/assets/xmlhr-[0-9a-f]+.js\?body=1" type="text/javascript"></script>\n<script src="/assets/application-[0-9a-f]+.js\?body=1" type="text/javascript"></script>},
       javascript_include_tag(:application, :debug => true)
 
-    assert_equal  "<script src=\"/assets/xmlhr-d41d8cd98f00b204e9800998ecf8427e.js\" type=\"text/javascript\"></script>\n<script src=\"/assets/extra-d41d8cd98f00b204e9800998ecf8427e.js\" type=\"text/javascript\"></script>",
+    assert_match %r{<script src=\"/assets/xmlhr-[0-9a-f]+.js\" type=\"text/javascript\"></script>\n<script src=\"/assets/extra-[0-9a-f]+.js\" type=\"text/javascript\"></script>},
       javascript_include_tag("xmlhr", "extra")
   end
 
   test "stylesheet path" do
-    assert_equal "/assets/application-68b329da9893e34099c7d8ad5cb9c940.css", asset_path(:application, "css")
+    assert_match %r{/assets/application-[0-9a-f]+.css}, asset_path(:application, "css")
 
-    assert_equal "/assets/style-d41d8cd98f00b204e9800998ecf8427e.css", asset_path("style", "css")
-    assert_equal "/assets/dir/style-d41d8cd98f00b204e9800998ecf8427e.css", asset_path("dir/style.css", "css")
+    assert_match %r{/assets/style-[0-9a-f]+.css}, asset_path("style", "css")
+    assert_match %r{/assets/dir/style-[0-9a-f]+.css}, asset_path("dir/style.css", "css")
     assert_equal "/dir/style.css", asset_path("/dir/style.css", "css")
 
     assert_equal "http://www.example.com/css/style",
@@ -172,37 +172,37 @@ class SprocketsHelperTest < ActionView::TestCase
   end
 
   test "stylesheet link tag" do
-    assert_equal '<link href="/assets/application-68b329da9893e34099c7d8ad5cb9c940.css" media="screen" rel="stylesheet" type="text/css" />',
+    assert_match %r{<link href="/assets/application-[0-9a-f]+.css" media="screen" rel="stylesheet" type="text/css" />},
       stylesheet_link_tag(:application)
 
-    assert_equal '<link href="/assets/style-d41d8cd98f00b204e9800998ecf8427e.css" media="screen" rel="stylesheet" type="text/css" />',
+    assert_match %r{<link href="/assets/style-[0-9a-f]+.css" media="screen" rel="stylesheet" type="text/css" />},
       stylesheet_link_tag("style")
-    assert_equal '<link href="/assets/style-d41d8cd98f00b204e9800998ecf8427e.css" media="screen" rel="stylesheet" type="text/css" />',
+    assert_match %r{<link href="/assets/style-[0-9a-f]+.css" media="screen" rel="stylesheet" type="text/css" />},
       stylesheet_link_tag("style.css")
 
     assert_equal '<link href="http://www.example.com/style.css" media="screen" rel="stylesheet" type="text/css" />',
       stylesheet_link_tag("http://www.example.com/style.css")
-    assert_equal '<link href="/assets/style-d41d8cd98f00b204e9800998ecf8427e.css" media="all" rel="stylesheet" type="text/css" />',
+    assert_match %r{<link href="/assets/style-[0-9a-f]+.css" media="all" rel="stylesheet" type="text/css" />},
       stylesheet_link_tag("style", :media => "all")
-    assert_equal '<link href="/assets/style-d41d8cd98f00b204e9800998ecf8427e.css" media="print" rel="stylesheet" type="text/css" />',
+    assert_match %r{<link href="/assets/style-[0-9a-f]+.css" media="print" rel="stylesheet" type="text/css" />},
       stylesheet_link_tag("style", :media => "print")
 
-    assert_equal "<link href=\"/assets/style-d41d8cd98f00b204e9800998ecf8427e.css?body=1\" media=\"screen\" rel=\"stylesheet\" type=\"text/css\" />\n<link href=\"/assets/application-68b329da9893e34099c7d8ad5cb9c940.css?body=1\" media=\"screen\" rel=\"stylesheet\" type=\"text/css\" />",
+    assert_match %r{<link href="/assets/style-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />\n<link href="/assets/application-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />},
       stylesheet_link_tag(:application, :debug => true)
 
-    assert_equal "<link href=\"/assets/style-d41d8cd98f00b204e9800998ecf8427e.css\" media=\"screen\" rel=\"stylesheet\" type=\"text/css\" />\n<link href=\"/assets/extra-d41d8cd98f00b204e9800998ecf8427e.css\" media=\"screen\" rel=\"stylesheet\" type=\"text/css\" />",
+    assert_match %r{<link href="/assets/style-[0-9a-f]+.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/assets/extra-[0-9a-f]+.css" media="screen" rel="stylesheet" type="text/css" />},
       stylesheet_link_tag("style", "extra")
   end
 
   test "alternate asset prefix" do
     stubs(:asset_prefix).returns("/themes/test")
-    assert_equal "/themes/test/style-d41d8cd98f00b204e9800998ecf8427e.css", asset_path("style", "css")
+    assert_match %r{/themes/test/style-[0-9a-f]+.css}, asset_path("style", "css")
   end
 
   test "alternate asset environment" do
     assets = Sprockets::Environment.new
-    assets.paths << FIXTURES.join("sprockets/alternate/stylesheets")
+    assets.append_path(FIXTURES.join("sprockets/alternate/stylesheets"))
     stubs(:asset_environment).returns(assets)
-    assert_equal "/assets/style-df0b97ad35a8e1f7f61097461f77c19a.css", asset_path("style", "css")
+    assert_match %r{/assets/style-[0-9a-f]+.css}, asset_path("style", "css")
   end
 end


### PR DESCRIPTION
This fixes actionpack's test suite.
- Sprockets API has changed. We can't use << on paths anymore.
- The file's hash can't be relied to never change. Use assert_match instead of assert_equal.
