### PR TITLE
Constantize a regexp in Dependencies#load_missing_constant

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -466,6 +466,7 @@ module ActiveSupport #:nodoc:
     # Load the constant named +const_name+ which is missing from +from_mod+. If
     # it is not possible to load the constant into from_mod, try its parent module
     # using const_missing.
+    THIS_FILE = %r{#{Regexp.escape(__FILE__)}}
     def load_missing_constant(from_mod, const_name)
       log_call from_mod, const_name
 
@@ -478,7 +479,7 @@ module ActiveSupport #:nodoc:
       qualified_name = qualified_name_for from_mod, const_name
       path_suffix = qualified_name.underscore
 
-      trace = caller.reject {|l| l =~ %r{#{Regexp.escape(__FILE__)}}}
+      trace = caller.reject {|l| l =~ THIS_FILE}
       name_error = NameError.new("uninitialized constant #{qualified_name}")
       name_error.set_backtrace(trace)
 


### PR DESCRIPTION
Hi,
I stumbled across a potential optimization in Dependencies#load_missing_constant, which currently instantiates a regexp once for every line in Kernel#caller, each time load_missing_constant is called.

We have a relatively large app with a lot of autoloaded constants.  After making this regexp constant, we see a noticeable difference to request times when running in development on 1.9.2 - dropping from 4.15s to 3.55s. (The difference in REE was less impressive - 4.96s to 4.88s).

Any comments?
-Jonathan
