### PR TITLE
Let run test with ruby 1.9.3-head

### DIFF
--- a/activeresource/Rakefile
+++ b/activeresource/Rakefile
@@ -10,7 +10,7 @@ task :default => [ :test ]
 
 Rake::TestTask.new { |t|
   t.libs << "test"
-  t.pattern = 'test/**/*_test.rb'
+  t.test_files = Dir.glob('test/**/*_test.rb')
   t.warning = true
 }
 

--- a/activesupport/Rakefile
+++ b/activesupport/Rakefile
@@ -4,7 +4,7 @@ require 'rubygems/package_task'
 task :default => :test
 Rake::TestTask.new do |t|
   t.libs << 'test'
-  t.pattern = 'test/**/*_test.rb'
+  t.test_files = Dir.glob('test/**/*_test.rb')
   t.warning = true
   t.verbose = true
 end


### PR DESCRIPTION
--backtrace

.rvm/rubies/ruby-1.9.3-head/lib/ruby/1.9.1/test/unit.rb:167:in `block in non_options': file not found: test/*_/__test.rb (ArgumentError)
