### PR TITLE
Ensure that app/mailers gets created in new plugins

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -19,6 +19,7 @@ module Rails
         empty_directory_with_gitkeep "app/controllers"
         empty_directory_with_gitkeep "app/views"
         empty_directory_with_gitkeep "app/helpers"
+        empty_directory_with_gitkeep "app/mailers"
         empty_directory_with_gitkeep "app/assets/images/#{name}"
       end
     end


### PR DESCRIPTION
When calling "rails plugin new [plugin_name] --full", an app/mailers directory was not created in the resultant plugin. This pull request corrects that.
