### PR TITLE
fix for issue #1872

### DIFF
--- a/actionpack/lib/action_controller/metal/url_for.rb
+++ b/actionpack/lib/action_controller/metal/url_for.rb
@@ -1,7 +1,7 @@
-# Includes +url_for+ into the host class. The class has to provide a +RouteSet+ by implementing 
+# Includes +url_for+ into the host class. The class has to provide a +RouteSet+ by implementing
 # the <tt>_routes</tt> method. Otherwise, an exception will be raised.
 #
-# In addition to <tt>AbstractController::UrlFor</tt>, this module accesses the HTTP layer to define 
+# In addition to <tt>AbstractController::UrlFor</tt>, this module accesses the HTTP layer to define
 # url options like the +host+. In order to do so, this module requires the host class
 # to implement +env+ and +request+, which need to be a Rack-compatible.
 #
@@ -18,7 +18,7 @@
 #       @url        = root_path # named route from the application.
 #     end
 #   end
-# => 
+# =>
 module ActionController
   module UrlFor
     extend ActiveSupport::Concern
@@ -26,7 +26,7 @@ module ActionController
     include AbstractController::UrlFor
 
     def url_options
-      @_url_options ||= super.reverse_merge(
+      options_super = super.reverse_merge(
         :host => request.host,
         :port => request.optional_port,
         :protocol => request.protocol,
@@ -34,12 +34,12 @@ module ActionController
       ).freeze
 
       if _routes.equal?(env["action_dispatch.routes"])
-        @_url_options.dup.tap do |options|
+        options_super.dup.tap do |options|
           options[:script_name] = request.script_name.dup
           options.freeze
         end
       else
-        @_url_options
+        options_super
       end
     end
 

--- a/actionpack/test/controller/default_url_options_test.rb
+++ b/actionpack/test/controller/default_url_options_test.rb
@@ -20,15 +20,7 @@ class DefaultUrlOptionsController < ActionController::Base
 end
 
 class DefaultUrlOptionsControllerTest < ActionController::TestCase
-
-  def setup
-    @routes = ActionDispatch::Routing::RouteSet.new
-    @routes.draw do
-      get "/default_url_options/target" => "default_url_options#target"
-      get "/default_url_options/redirect" => "default_url_options#redirect"
-    end
-  end
-
+  
   # This test has it´s roots in issue #1872 
   test "should redirect with correct locale :de" do
     get :redirect, :locale => "de"

--- a/actionpack/test/controller/default_url_options_test.rb
+++ b/actionpack/test/controller/default_url_options_test.rb
@@ -1,0 +1,40 @@
+require 'abstract_unit'
+
+
+class DefaultUrlOptionsController < ActionController::Base
+
+  before_filter { I18n.locale = params[:locale] }
+
+  def redirect_target
+    render :text => "index1"
+  end
+
+  def redirect
+    redirect_to :action => "redirect_target"
+  end
+
+  def default_url_options(options={})
+    {:locale => I18n.locale}.merge(options)
+  end
+
+end
+
+class DefaultUrlOptionsControllerTest < ActionController::TestCase
+
+  def setup
+    @controller = DefaultUrlOptionsController.new
+    @routes = ActionDispatch::Routing::RouteSet.new
+    @routes.draw do
+      get "/default_url_options/redirect_target" => "default_url_options#redirect_target"
+      get "/default_url_options/redirect" => "default_url_options#redirect"
+    end
+  end
+
+  # This test has it´s roots in issue #1872 
+  test "should redirect with correct locale :de" do
+    get :redirect, :locale => "de"
+    assert_redirected_to "/default_url_options/redirect_target?locale=de"
+  end
+end
+
+

--- a/actionpack/test/controller/default_url_options_test.rb
+++ b/actionpack/test/controller/default_url_options_test.rb
@@ -5,12 +5,12 @@ class DefaultUrlOptionsController < ActionController::Base
 
   before_filter { I18n.locale = params[:locale] }
 
-  def redirect_target
-    render :text => "index1"
+  def target
+    render :text => "final response"
   end
 
   def redirect
-    redirect_to :action => "redirect_target"
+    redirect_to :action => "target"
   end
 
   def default_url_options(options={})
@@ -22,10 +22,9 @@ end
 class DefaultUrlOptionsControllerTest < ActionController::TestCase
 
   def setup
-    @controller = DefaultUrlOptionsController.new
     @routes = ActionDispatch::Routing::RouteSet.new
     @routes.draw do
-      get "/default_url_options/redirect_target" => "default_url_options#redirect_target"
+      get "/default_url_options/target" => "default_url_options#target"
       get "/default_url_options/redirect" => "default_url_options#redirect"
     end
   end
@@ -33,7 +32,7 @@ class DefaultUrlOptionsControllerTest < ActionController::TestCase
   # This test has it´s roots in issue #1872 
   test "should redirect with correct locale :de" do
     get :redirect, :locale => "de"
-    assert_redirected_to "/default_url_options/redirect_target?locale=de"
+    assert_redirected_to "/default_url_options/target?locale=de"
   end
 end
 


### PR DESCRIPTION
fix for issue #1872: the method build_request_uri in action_controller/test_case.rb called url_options, which finally delegates to default_url_options, for the first time. This call is too early but it seems also necessary as there is no change between 3.0.x and 3-1-stable. memoizing this first call in action_controller/metal/url_for.rb then prevents future calls to reach default_url_options again, which was the problem. memoization also doesn´t happen in 3.0.x. 
