### PR TITLE
Fix ActiveSupport Rakefile for Ruby trunk

### DIFF
--- a/activesupport/Rakefile
+++ b/activesupport/Rakefile
@@ -4,7 +4,7 @@ require 'rubygems/package_task'
 task :default => :test
 Rake::TestTask.new do |t|
   t.libs << 'test'
-  t.pattern = 'test/**/*_test.rb'
+  t.test_files = Dir.glob("#{File.dirname(__FILE__)}/test/**/*_test.rb").sort
   t.warning = true
   t.verbose = true
 end


### PR DESCRIPTION
Running 'rake test' (with Rake 0.9.2) in ActiveSupport folder I'm getting error under Ruby trunk:

```
/Users/guille/.rvm/rubies/ruby-head/lib/ruby/1.9.1/test/unit.rb:167:in `block in non_options': file not found: test/**/*_test.rb (ArgumentError)
    from /Users/guille/.rvm/rubies/ruby-head/lib/ruby/1.9.1/test/unit.rb:146:in `map!'
    from /Users/guille/.rvm/rubies/ruby-head/lib/ruby/1.9.1/test/unit.rb:146:in `non_options'
    from /Users/guille/.rvm/rubies/ruby-head/lib/ruby/1.9.1/test/unit.rb:207:in `non_options'
    from /Users/guille/.rvm/rubies/ruby-head/lib/ruby/1.9.1/test/unit.rb:52:in `process_args'
    from /Users/guille/.rvm/rubies/ruby-head/lib/ruby/1.9.1/minitest/unit.rb:891:in `_run'
    from /Users/guille/.rvm/rubies/ruby-head/lib/ruby/1.9.1/minitest/unit.rb:884:in `run'
    from /Users/guille/.rvm/rubies/ruby-head/lib/ruby/1.9.1/test/unit.rb:21:in `run'
    from /Users/guille/.rvm/rubies/ruby-head/lib/ruby/1.9.1/test/unit.rb:326:in `block (2 levels) in autorun'
    from /Users/guille/.rvm/rubies/ruby-head/lib/ruby/1.9.1/test/unit.rb:27:in `run_once'
    from /Users/guille/.rvm/rubies/ruby-head/lib/ruby/1.9.1/test/unit.rb:325:in `block in autorun'
rake aborted!
```

This fixes it.

cc @tenderlove
