### PR TITLE
Improve dependency management and gemspec file for plugins

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -46,6 +46,7 @@ module Rails
     def lib
       template "lib/%name%.rb"
       template "lib/tasks/%name%_tasks.rake"
+      template "lib/%name%/version.rb"
       if full?
         template "lib/%name%/engine.rb"
       end

--- a/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
@@ -1,12 +1,16 @@
 # Provide a simple gemspec so you can easily use your
 # project in your rails apps through git.
 Gem::Specification.new do |s|
-  s.name = "<%= name %>"
-  s.summary = "Insert <%= camelized %> summary."
-  s.description = "Insert <%= camelized %> description."
+  s.name        = "<%= name %>"
+  s.version     = "0.0.1"
+  s.authors     = ["TODO: Your name"]
+  s.email       = ["TODO: Your email"]
+  s.homepage    = "TODO"
+  s.summary     = "TODO: Summary of <%= camelized %>."
+  s.description = "TODO: Description of <%= camelized %>."
+
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
 <% unless options.skip_test_unit? -%>
   s.test_files = Dir["test/**/*"]
 <% end -%>
-  s.version = "0.0.1"
 end

--- a/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
@@ -1,8 +1,12 @@
-# Provide a simple gemspec so you can easily use your
-# project in your rails apps through git.
+$:.push File.expand_path("../lib", __FILE__)
+
+# Maintain your gem's version:
+require "<%= name %>/version"
+
+# Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
   s.name        = "<%= name %>"
-  s.version     = "0.0.1"
+  s.version     = <%= camelized %>::VERSION
   s.authors     = ["TODO: Your name"]
   s.email       = ["TODO: Your email"]
   s.homepage    = "TODO"

--- a/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
@@ -17,4 +17,15 @@ Gem::Specification.new do |s|
 <% unless options.skip_test_unit? -%>
   s.test_files = Dir["test/**/*"]
 <% end -%>
+
+  # If your gem is dependent on a specific version (or higher) of Rails:
+  <%= '# ' if options.dev? || options.edge? -%>s.add_dependency "rails", ">= <%= Rails::VERSION::STRING %>"
+
+<% unless options[:skip_javascript] || !full? -%>
+  # If your gem contains any <%= "#{options[:javascript]}-specific" %> javascript:
+  # s.add_dependency "<%= "#{options[:javascript]}-rails" %>"
+
+<% end -%>
+  # Declare development-specific dependencies:
+  s.add_development_dependency "<%= gem_for_database %>"
 end

--- a/railties/lib/rails/generators/rails/plugin_new/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/Gemfile
@@ -1,14 +1,20 @@
 source "http://rubygems.org"
 
+# Declare your gem's dependencies in <%= name %>.gemspec.
+# Bundler will treat runtime dependencies like base dependencies, and
+# development dependencies will be added by default to the :development group.
+gemspec
+
+# Declare any dependencies that are still in development here instead of in
+# your gemspec. These might include edge Rails or gems from your path or
+# Git. Remember to move these dependencies to your gemspec before releasing
+# your gem to rubygems.org.
+
+<% if options.dev? || options.edge? -%>
+# Your gem is dependent on dev or edge Rails. Once you can lock this
+# dependency down to a specific version, move it to your gemspec.
 <%= rails_gemfile_entry -%>
 
-<% if full? -%>
-<%= database_gemfile_entry -%>
 <% end -%>
-
-<% if mountable? -%>
-<%= javascript_gemfile_entry -%>
-<% end -%>
-
 # To use debugger
 # <%= ruby_debugger_gemfile_entry %>

--- a/railties/lib/rails/generators/rails/plugin_new/templates/lib/%name%/version.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/lib/%name%/version.rb
@@ -1,0 +1,3 @@
+module <%= camelized %>
+  VERSION = "0.0.1"
+end


### PR DESCRIPTION
The current gemspec files generated by "rails plugin new" are not optimal for creating gems. They do not include full meta-information, nor do they include dependencies.

Bundler can now manage dependencies declared in the .gemspec file through the addition of a simple "gemspec" directive in your Gemfile. This allows dependencies to be declared once, and applies to both base and development dependencies. For more information, check out:
http://gembundler.com/rubygems.html
http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/

This pull request includes a refactoring of the Gemfile and .gemspec files generated by "rails plugin new". Dependencies are now managed in the .gemspec file where possible. Comments have been added to both files explaining dependency management choices.

In addition, the .gemspec file has been updated to include more meta-information, such as author and email. Defaults have been added that include "TODO", which prevents gems from being built without review. The version has been extracted into a separate file, to be consistent with bundler and svenfuchs/gem-release.

Hopefully, all of these changes will eliminate the need to run a separate tool such as Bundler or Jeweler to create a gem template which then needs to be merged with the output of "rails plugin new". Merging is a messy, error-prone process that leaves you wishing for a cleaner alternative.

---

These changes were originally proposed in https://github.com/rails/rails/pull/2282. I'm following the recommendation to submit these changes to master in the form of several atomic commits.
