### PR TITLE
Eager loading with 'includes' overrides 'select' in SQL query

### DIFF
--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1013,4 +1013,15 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal posts(:thinking), comments(:more_greetings).post
     assert_equal posts(:welcome),  comments(:greetings).post
   end
+
+  def test_eager_loading_with_includes_and_select
+    scope = Post.select('author_id, COUNT(author_id) AS num_posts, authors.*').group('author_id').includes(:author)
+    result = scope.map do |post|
+      [post.num_posts, post.author.name]
+    end
+
+    expected = [[5, "David"], [3, "Mary"], [2, "Bob"]]
+    assert_equal expected, result
+    assert scope.eager_loading?, "should eager load authors"
+  end
 end


### PR DESCRIPTION
When creating a query with `select` and `includes` like

```
Post.select('author_id, COUNT(author_id) AS num_posts, authors.*').group('author_id').includes(:author)
```

the `select` part is ignored when querying the database.

However, if `to_sql` is called on the Relation, the query gets constructed directly.

to_sql output:

```
SELECT author_id, COUNT(author_id) AS num_posts, authors.* FROM "posts"  GROUP BY author_id
```

query sent to the db:

```
SELECT "posts"."id" AS t0_r0, "posts"."author_id" AS t0_r1, "posts"."title" AS t0_r2, "posts"."body" AS t0_r3, "posts"."type" AS t0_r4, "posts"."comments_count" AS t0_r5, "posts"."taggings_count" AS t0_r6, "posts"."taggings_with_delete_all_count" AS t0_r7, "posts"."taggings_with_destroy_count" AS t0_r8, "posts"."tags_count" AS t0_r9, "posts"."tags_with_destroy_count" AS t0_r10, "posts"."tags_with_nullify_count" AS t0_r11, "authors"."id" AS t1_r0, "authors"."name" AS t1_r1, "authors"."author_address_id" AS t1_r2, "authors"."author_address_extra_id" AS t1_r3, "authors"."organization_id" AS t1_r4, "authors"."owned_essay_id" AS t1_r5 FROM "posts" LEFT OUTER JOIN "authors" ON "authors"."id" = "posts"."author_id" GROUP BY author_id
```

See the attached patch for a complete testcase which currently fails.
