### PR TITLE
Improve AM::Errors#include?

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -86,7 +86,7 @@ module ActiveModel
 
     # Do the error messages include an error with key +error+?
     def include?(error)
-      messages.include? error
+      (v = messages[error]) && v.any?
     end
 
     # Get messages for +key+

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -38,6 +38,7 @@ class ErrorsTest < ActiveModel::TestCase
     person.errors[:foo]
     assert person.errors.empty?
     assert person.errors.blank?
+    assert !person.errors.include?(:foo)
   end
 
   test "method validate! should work" do


### PR DESCRIPTION
As of right now `AM::Errors#include?` is pretty much useless.
