### PR TITLE
3 1 stable fix1872

### DIFF
--- a/actionpack/lib/action_controller/metal/testing.rb
+++ b/actionpack/lib/action_controller/metal/testing.rb
@@ -4,6 +4,11 @@ module ActionController
 
     include RackDelegation
 
+    def recycle!
+      @_url_options = nil
+    end
+
+
     # TODO: Clean this up
     def process_with_new_base_test(request, response)
       @_request = request

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -447,6 +447,7 @@ module ActionController
         @controller.params.merge!(parameters)
         build_request_uri(action, parameters)
         @controller.class.class_eval { include Testing }
+        @controller.recycle! 
         @controller.process_with_new_base_test(@request, @response)
         @assigns = @controller.respond_to?(:view_assigns) ? @controller.view_assigns : {}
         @request.session.delete('flash') if @request.session['flash'].blank?

--- a/actionpack/test/controller/default_url_options_with_filter_test.rb
+++ b/actionpack/test/controller/default_url_options_with_filter_test.rb
@@ -1,0 +1,29 @@
+require 'abstract_unit'
+
+
+class ControllerWithBeforeFilterAndDefaultUrlOptions < ActionController::Base
+
+  before_filter { I18n.locale = params[:locale] }
+  after_filter { I18n.locale = "en" }
+
+  def target
+    render :text => "final response"
+  end
+
+  def redirect
+    redirect_to :action => "target"
+  end
+
+  def default_url_options
+    {:locale => "de"}
+  end 
+end
+
+class ControllerWithBeforeFilterAndDefaultUrlOptionsTest < ActionController::TestCase
+
+  # This test has it´s roots in issue #1872
+  test "should redirect with correct locale :de" do
+    get :redirect, :locale => "de"
+    assert_redirected_to "/controller_with_before_filter_and_default_url_options/target?locale=de"
+  end
+end


### PR DESCRIPTION
fix for issue #1872: the method build_request_uri in action_controller/test_case.rb called url_options, which finally delegates to default_url_options, for the first time. This call is too early but it seems also necessary as there is no change between 3.0.x and 3-1-stable. memoizing this first call in action_controller/metal/url_for.rb then prevents future calls to reach default_url_options again, which was the problem. memoization also doesn´t happen in 3.0.x.

Added test case for the according modification showing that without memoization the :locale´s value is 'de' and not 'en' as noted in the issue´s description.

Closes #2031 and #1872
