### PR TITLE
Allow ActiveSupport::Deprecation features to be used by rails applications and library authors

### DIFF
--- a/activesupport/lib/active_support/deprecation.rb
+++ b/activesupport/lib/active_support/deprecation.rb
@@ -5,10 +5,9 @@ require 'active_support/deprecation/proxy_wrappers'
 
 module ActiveSupport
   module Deprecation
-    class << self
-      # The version the deprecated behavior will be removed, by default.
-      attr_accessor :deprecation_horizon
-    end
+    # The version the deprecated behavior will be removed, by default.
+    attr_accessor :deprecation_horizon
+    extend self
     self.deprecation_horizon = '3.2'
 
     # By default, warnings are not silenced and debugging is off.

--- a/activesupport/lib/active_support/deprecation/behaviors.rb
+++ b/activesupport/lib/active_support/deprecation/behaviors.rb
@@ -3,47 +3,45 @@ require "active_support/core_ext/array/wrap"
 
 module ActiveSupport
   module Deprecation
-    class << self
-      # Whether to print a backtrace along with the warning.
-      attr_accessor :debug
+    # Whether to print a backtrace along with the warning.
+    attr_accessor :debug
 
-      # Returns the set behavior or if one isn't set, defaults to +:stderr+
-      def behavior
-        @behavior ||= [DEFAULT_BEHAVIORS[:stderr]]
-      end
+    # Returns the set behavior or if one isn't set, defaults to +:stderr+
+    def behavior
+      @behavior ||= [DEFAULT_BEHAVIORS[:stderr]]
+    end
 
-      # Sets the behavior to the specified value. Can be a single value or an array.
-      #
-      # Examples
-      #
-      #   ActiveSupport::Deprecation.behavior = :stderr
-      #   ActiveSupport::Deprecation.behavior = [:stderr, :log]
-      def behavior=(behavior)
-        @behavior = Array.wrap(behavior).map { |b| DEFAULT_BEHAVIORS[b] || b }
-      end
+    # Sets the behavior to the specified value. Can be a single value or an array.
+    #
+    # Examples
+    #
+    #   ActiveSupport::Deprecation.behavior = :stderr
+    #   ActiveSupport::Deprecation.behavior = [:stderr, :log]
+    def behavior=(behavior)
+      @behavior = Array.wrap(behavior).map { |b| DEFAULT_BEHAVIORS[b] || b }
     end
 
     # Default warning behaviors per Rails.env.
     DEFAULT_BEHAVIORS = {
       :stderr => Proc.new { |message, callstack|
-         $stderr.puts(message)
-         $stderr.puts callstack.join("\n  ") if debug
-       },
+        $stderr.puts(message)
+        $stderr.puts callstack.join("\n  ") if debug
+      },
       :log => Proc.new { |message, callstack|
-         logger =
-           if defined?(Rails) && Rails.logger
-             Rails.logger
-           else
-             require 'logger'
-             Logger.new($stderr)
-           end
-         logger.warn message
-         logger.debug callstack.join("\n  ") if debug
-       },
-       :notify => Proc.new { |message, callstack|
-          ActiveSupport::Notifications.instrument("deprecation.rails",
-            :message => message, :callstack => callstack)
-       }
+        logger =
+          if defined?(Rails) && Rails.logger
+          Rails.logger
+        else
+          require 'logger'
+          Logger.new($stderr)
+        end
+        logger.warn message
+        logger.debug callstack.join("\n  ") if debug
+      },
+      :notify => Proc.new { |message, callstack|
+        ActiveSupport::Notifications.instrument("deprecation.rails",
+          :message => message, :callstack => callstack)
+      }
     }
   end
 end

--- a/activesupport/lib/active_support/deprecation/method_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/method_wrappers.rb
@@ -13,8 +13,9 @@ module ActiveSupport
         target_module.alias_method_chain(method_name, :deprecation) do |target, punctuation|
           target_module.module_eval(<<-end_eval, __FILE__, __LINE__ + 1)
             def #{target}_with_deprecation#{punctuation}(*args, &block)
-              ::ActiveSupport::Deprecation.warn(
-                ::ActiveSupport::Deprecation.deprecated_method_warning(
+              deprecator = respond_to?(:deprecator) ? deprecator() : ActiveSupport::Deprecation
+              deprecator.warn(
+                deprecator.deprecated_method_warning(
                   :#{method_name},
                   #{options[method_name].inspect}),
                 caller

--- a/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
@@ -45,7 +45,7 @@ module ActiveSupport
     # Stand-in for <tt>@request</tt>, <tt>@attributes</tt>, <tt>@params</tt>, etc.
     # which emits deprecation warnings on any method call (except +inspect+).
     class DeprecatedInstanceVariableProxy < DeprecationProxy #:nodoc:
-      def initialize(instance, method, var = "@#{method}", deprecator = nil)
+      def initialize(instance, method, var = :"@#{method}", deprecator = nil)
         @instance = instance
         @method = method
         @var = var

--- a/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
@@ -26,9 +26,10 @@ module ActiveSupport
     end
 
     class DeprecatedObjectProxy < DeprecationProxy #:nodoc:
-      def initialize(object, message)
+      def initialize(object, message, deprecator = ActiveSupport::Deprecation)
         @object = object
         @message = message
+        @deprecator = deprecator
       end
 
       private
@@ -37,15 +38,18 @@ module ActiveSupport
         end
 
         def warn(callstack, called, args)
-          ActiveSupport::Deprecation.warn(@message, callstack)
+          @deprecator.warn(@message, callstack)
         end
     end
 
     # Stand-in for <tt>@request</tt>, <tt>@attributes</tt>, <tt>@params</tt>, etc.
     # which emits deprecation warnings on any method call (except +inspect+).
     class DeprecatedInstanceVariableProxy < DeprecationProxy #:nodoc:
-      def initialize(instance, method, var = "@#{method}")
-        @instance, @method, @var = instance, method, var
+      def initialize(instance, method, var = "@#{method}", deprecator = nil)
+        @instance = instance
+        @method = method
+        @var = var
+        @deprecator = deprecator || (@instance.respond_to?(:deprecator) ? @instance.deprecator : ActiveSupport::Deprecation)
       end
 
       private
@@ -54,14 +58,15 @@ module ActiveSupport
         end
 
         def warn(callstack, called, args)
-          ActiveSupport::Deprecation.warn("#{@var} is deprecated! Call #{@method}.#{called} instead of #{@var}.#{called}. Args: #{args.inspect}", callstack)
+          @deprecator.warn("#{@var} is deprecated! Call #{@method}.#{called} instead of #{@var}.#{called}. Args: #{args.inspect}", callstack)
         end
     end
 
     class DeprecatedConstantProxy < DeprecationProxy #:nodoc:all
-      def initialize(old_const, new_const)
+      def initialize(old_const, new_const, deprecator = ActiveSupport::Deprecation)
         @old_const = old_const
         @new_const = new_const
+        @deprecator = deprecator
       end
 
       def class
@@ -74,7 +79,7 @@ module ActiveSupport
         end
 
         def warn(callstack, called, args)
-          ActiveSupport::Deprecation.warn("#{@old_const} is deprecated! Use #{@new_const} instead.", callstack)
+          @deprecator.warn("#{@old_const} is deprecated! Use #{@new_const} instead.", callstack)
         end
     end
   end

--- a/activesupport/lib/active_support/deprecation/reporting.rb
+++ b/activesupport/lib/active_support/deprecation/reporting.rb
@@ -24,10 +24,10 @@ module ActiveSupport
     def deprecated_method_warning(method_name, message = nil)
       warning = "#{method_name} is deprecated and will be removed from Rails #{deprecation_horizon}"
       case message
-      when Symbol then "#{warning} (use #{message} instead)"
-      when String then "#{warning} (#{message})"
-      else warning
+      when Symbol then warning << " (use #{message} instead)"
+      when String then warning << " (#{message})"
       end
+      warning
     end
 
     private

--- a/activesupport/lib/active_support/deprecation/reporting.rb
+++ b/activesupport/lib/active_support/deprecation/reporting.rb
@@ -1,65 +1,64 @@
 module ActiveSupport
   module Deprecation
-    class << self
-      attr_accessor :silenced
+    attr_accessor :silenced
 
-      # Outputs a deprecation warning to the output configured by <tt>ActiveSupport::Deprecation.behavior</tt>
-      #
-      #   ActiveSupport::Deprecation.warn("something broke!")
-      #   # => "DEPRECATION WARNING: something broke! (called from your_code.rb:1)"
-      def warn(message = nil, callstack = caller)
-        return if silenced
-        deprecation_message(callstack, message).tap do |m|
-          behavior.each { |b| b.call(m, callstack) }
+    # Outputs a deprecation warning to the output configured by <tt>ActiveSupport::Deprecation.behavior</tt>
+    #
+    #   ActiveSupport::Deprecation.warn("something broke!")
+    #   # => "DEPRECATION WARNING: something broke! (called from your_code.rb:1)"
+    def warn(message = nil, callstack = caller)
+      return if silenced
+      deprecation_message(callstack, message).tap do |m|
+        behavior.each { |b| b.call(m, callstack) }
+      end
+    end
+
+    # Silence deprecation warnings within the block.
+    def silence
+      old_silenced, @silenced = @silenced, true
+      yield
+    ensure
+      @silenced = old_silenced
+    end
+
+    def deprecated_method_warning(method_name, message = nil)
+      warning = "#{method_name} is deprecated and will be removed from Rails #{deprecation_horizon}"
+      case message
+      when Symbol then "#{warning} (use #{message} instead)"
+      when String then "#{warning} (#{message})"
+      else warning
+      end
+    end
+
+    private
+    
+    def deprecation_message(callstack, message = nil)
+      message ||= "You are using deprecated behavior which will be removed from the next major or minor release."
+      message += '.' unless message =~ /\.$/
+      "DEPRECATION WARNING: #{message} #{deprecation_caller_message(callstack)}"
+    end
+
+    def deprecation_caller_message(callstack)
+      file, line, method = extract_callstack(callstack)
+      if file
+        if line && method
+          "(called from #{method} at #{file}:#{line})"
+        else
+          "(called from #{file}:#{line})"
         end
       end
+    end
 
-      # Silence deprecation warnings within the block.
-      def silence
-        old_silenced, @silenced = @silenced, true
-        yield
-      ensure
-        @silenced = old_silenced
-      end
-
-      def deprecated_method_warning(method_name, message = nil)
-        warning = "#{method_name} is deprecated and will be removed from Rails #{deprecation_horizon}"
-        case message
-          when Symbol then "#{warning} (use #{message} instead)"
-          when String then "#{warning} (#{message})"
-          else warning
+    def extract_callstack(callstack)
+      rails_gem_root = File.expand_path("../../../../..", __FILE__) + "/"
+      offending_line = callstack.find { |line| !line.start_with?(rails_gem_root) } || callstack.first
+      if offending_line
+        if md = offending_line.match(/^(.+?):(\d+)(?::in `(.*?)')?/)
+          md.captures
+        else
+          offending_line
         end
       end
-
-      private
-        def deprecation_message(callstack, message = nil)
-          message ||= "You are using deprecated behavior which will be removed from the next major or minor release."
-          message += '.' unless message =~ /\.$/
-          "DEPRECATION WARNING: #{message} #{deprecation_caller_message(callstack)}"
-        end
-
-        def deprecation_caller_message(callstack)
-          file, line, method = extract_callstack(callstack)
-          if file
-            if line && method
-              "(called from #{method} at #{file}:#{line})"
-            else
-              "(called from #{file}:#{line})"
-            end
-          end
-        end
-
-        def extract_callstack(callstack)
-          rails_gem_root = File.expand_path("../../../../..", __FILE__) + "/"
-          offending_line = callstack.find { |line| !line.start_with?(rails_gem_root) } || callstack.first
-          if offending_line
-            if md = offending_line.match(/^(.+?):(\d+)(?::in `(.*?)')?/)
-              md.captures
-            else
-              offending_line
-            end
-          end
-        end
     end
   end
 end

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -167,6 +167,21 @@ class DeprecationTest < ActiveSupport::TestCase
     assert_deprecated(/you now need to do something extra for this one/) { @dtc.d }
   end
 
+  def test_deprecation_in_other_module_does_not_interfere
+    messages = []
+
+    m = Module.new
+    m.extend ActiveSupport::Deprecation
+    m.behavior = Proc.new{|message, callstack| messages << message}
+    assert_not_deprecated do # not globally
+      assert_difference("messages.size") do # but locally
+        m.warn("warning")
+      end
+    end
+  end
+
+  # test ze moge nadpisac deprecator...
+
   unless defined?(::MiniTest)
     def test_assertion_failed_error_doesnt_spout_deprecation_warnings
       error_class = Class.new(StandardError) do

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -238,6 +238,30 @@ class DeprecationTest < ActiveSupport::TestCase
     assert_difference("deprecator.messages.size") { klass.new.old_request.to_s }
   end
 
+  def test_included_deprecation_module
+    klass = Class.new() do
+      attr_reader :last_message
+      include ActiveSupport::Deprecation
+      def deprecated_method
+        warn(deprecated_method_warning(:deprecated_method, "You are calling deprecated method"))
+      end
+
+      private
+
+      def deprecated_method_warning(method_name, message = nil)
+        message || "#{method_name} is deprecated and will be removed from This Library"
+      end
+
+      def behavior
+        @behavior ||= [Proc.new { |message| @last_message = message }]
+      end
+    end
+
+    object = klass.new
+    object.deprecated_method
+    assert_match(/You are calling deprecated method/, object.last_message)
+  end
+
   unless defined?(::MiniTest)
     def test_assertion_failed_error_doesnt_spout_deprecation_warnings
       error_class = Class.new(StandardError) do


### PR DESCRIPTION
Currently `ActiveSupport::Deprecation` is a global that can be only used by Rails due to its generated messages. However it is a very nicely written piece of software that could be used by Rails applications (you know some of them last for years and it would be nice for them to have the ability to deprecate their own api) or gems that already depend on `rails` or `active_support`. This patch aims at fixing it.

It let's you use `ActiveSupport::Deprecation` as a module and include it in a class.

And it also adds additional argument to `ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy` and `ActiveSupport::Deprecation::DeprecatedConstantProxy` constructors so that warnings can be generated by other objects than `ActiveSupport::Deprecation` module itself (but that's the default).

I added few more tests to make sure that those features works as advertised.
