### PR TITLE
Sqlite drops unconventional pks when copying/altering tables

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
@@ -352,7 +352,10 @@ module ActiveRecord
         end
 
         def copy_table(from, to, options = {}) #:nodoc:
-          options = options.merge(:id => (!columns(from).detect{|c| c.name == 'id'}.nil? && 'id' == primary_key(from).to_s))
+          options.merge!(:primary_key => primary_key(from)) if primary_key(from) != 'id'
+          unless options[:primary_key]
+            options.merge!(:id => (!columns(from).detect{|c| c.name == 'id'}.nil? && 'id' == primary_key(from).to_s))
+          end
           create_table(to, options) do |definition|
             @definition = definition
             columns(from).each do |column|

--- a/activerecord/test/cases/copy_table_test_sqlite.rb
+++ b/activerecord/test/cases/copy_table_test_sqlite.rb
@@ -56,6 +56,14 @@ class CopyTableTest < ActiveRecord::TestCase
       assert_equal original_id.primary, copied_id.primary
     end
   end
+  
+  def test_copy_table_with_unconventional_primary_key
+    test_copy_table('owners', 'owners_unconventional') do |from, to, options|
+      original_pk = @connection.primary_key('owners') 
+      copied_pk = @connection.primary_key('owners_unconventional')
+      assert_equal original_pk, copied_pk
+    end
+  end
 
 protected
   def copy_table(from, to, options = {})


### PR DESCRIPTION
When schema is altered using the sqlite3 adapter, if you are using an unconventional primary key, that key can be lost. This is because the :id option is set during a table copy, but the :primary_key option is ignored. This can cause your schema.rb file to drift from the intended/original table schema.

Instructions to reproduce the bug is located here and applies to rails 2.3.11 and rails 3.0.9: https://gist.github.com/1109790 .

I have included a test that exposes the bug and the commit that fixes it.
