### PR TITLE
Raise a rescuable exception, rather than responding with a head :not_acceptable (406)

### DIFF
--- a/actionpack/lib/action_controller/metal/exceptions.rb
+++ b/actionpack/lib/action_controller/metal/exceptions.rb
@@ -38,4 +38,7 @@ module ActionController
 
   class UnknownHttpMethod < ActionControllerError #:nodoc:
   end
+  
+  class UnknownFormat < ActionControllerError #:nodoc:
+  end
 end

--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -375,7 +375,7 @@ module ActionController #:nodoc:
         lookup_context.rendered_format = lookup_context.formats.first
         collector
       else
-        raise ActionController::UnknownFormat.new
+        raise ActionController::UnknownFormat
       end
     end
 

--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -375,8 +375,7 @@ module ActionController #:nodoc:
         lookup_context.rendered_format = lookup_context.formats.first
         collector
       else
-        head :not_acceptable
-        nil
+        raise ActionController::UnknownFormat.new
       end
     end
 

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -10,6 +10,7 @@ module ActionDispatch
       'AbstractController::ActionNotFound'         => :not_found,
       'ActionController::MethodNotAllowed'         => :method_not_allowed,
       'ActionController::NotImplemented'           => :not_implemented,
+      'ActionController::UnknownFormat'            => :not_acceptable,
       'ActionController::InvalidAuthenticityToken' => :unprocessable_entity
     )
 

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -405,6 +405,15 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_request_with_bad_format
+    with_test_route_set do
+      xhr :get, '/get.php'
+      assert_equal 406, status
+      assert_response 406
+      assert_response :not_acceptable
+    end
+  end
+
   def test_get_with_query_string
     with_test_route_set do
       get '/get_with_params?foo=bar'

--- a/actionpack/test/controller/mime_responds_test.rb
+++ b/actionpack/test/controller/mime_responds_test.rb
@@ -207,8 +207,9 @@ class RespondToControllerTest < ActionController::TestCase
     get :html_or_xml
     assert_equal 'HTML', @response.body
 
-    get :just_xml
-    assert_response 406
+    assert_raises(ActionController::UnknownFormat) do
+      get :just_xml
+    end
   end
 
   def test_all
@@ -239,8 +240,10 @@ class RespondToControllerTest < ActionController::TestCase
     assert_equal 'HTML', @response.body
 
     @request.accept = "text/javascript, text/html"
-    xhr :get, :just_xml
-    assert_response 406
+    
+    assert_raises(ActionController::UnknownFormat) do
+      xhr :get, :just_xml
+    end
   end
 
   def test_json_or_yaml_with_leading_star_star
@@ -495,9 +498,9 @@ class RespondToControllerTest < ActionController::TestCase
   end
 
   def test_invalid_format
-    get :using_defaults, :format => "invalidformat"
-    assert_equal " ", @response.body
-    assert_equal "text/html", @response.content_type
+    assert_raises(ActionController::UnknownFormat) do
+      get :using_defaults, :format => "invalidformat"
+    end
   end
 end
 
@@ -701,12 +704,14 @@ class RespondWithControllerTest < ActionController::TestCase
 
   def test_not_acceptable
     @request.accept = "application/xml"
-    get :using_resource_with_block
-    assert_equal 406, @response.status
+    assert_raises(ActionController::UnknownFormat) do
+      get :using_resource_with_block
+    end
 
     @request.accept = "text/javascript"
-    get :using_resource_with_overwrite_block
-    assert_equal 406, @response.status
+    assert_raises(ActionController::UnknownFormat) do
+      get :using_resource_with_overwrite_block
+    end
   end
 
   def test_using_resource_for_post_with_html_redirects_on_success
@@ -984,8 +989,9 @@ class RespondWithControllerTest < ActionController::TestCase
   def test_clear_respond_to
     @controller = InheritedRespondWithController.new
     @request.accept = "text/html"
-    get :index
-    assert_equal 406, @response.status
+    assert_raises(ActionController::UnknownFormat) do
+      get :index
+    end
   end
 
   def test_first_in_respond_to_has_higher_priority


### PR DESCRIPTION
Raise a rescuable exception when Rails doesn't know what to do with the format, rather than responding with a head :not_acceptable (406)

Otherwise it's impossible for rails apps to use rescue_from to customize Rails behavior when someone visits /products.php and you really just want to redirect them to /products.

Without this patch, you'd have to do one of: 
1. register a mime type for every extension someone hits your site with
2. alias method chain the head() method in a super ugly Rails hack.
