### PR TITLE
callback methods are Class methods

### DIFF
--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -262,7 +262,7 @@ module ActiveRecord
 
     def deprecated_callback_method(symbol) #:nodoc:
       if respond_to?(symbol, true)
-        ActiveSupport::Deprecation.warn("Overwriting #{symbol} in your models has been deprecated, please use Base##{symbol} :method_name instead")
+        ActiveSupport::Deprecation.warn("Overwriting #{symbol} in your models has been deprecated, please use Base.#{symbol} :method_name instead")
         send(symbol)
       end
     end


### PR DESCRIPTION
Fixed a small typo in deprecation error message.
This only applies to 3-0-stable branch.
