### PR TITLE
Nil values uniquines validation

### DIFF
--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -54,7 +54,7 @@ module ActiveRecord
 
       def build_relation(klass, table, attribute, value) #:nodoc:
         column = klass.columns_hash[attribute.to_s]
-        value = column.limit ? value.to_s[0, column.limit] : value.to_s if column.text?
+        value = column.limit ? value.to_s[0, column.limit] : value.to_s if value && column.text?
 
         if !options[:case_sensitive] && value && column.text?
           # will use SQL LOWER function before comparison, unless it detects a case insensitive collation

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -45,6 +45,18 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     assert t2.save, "Should now save t2 as unique"
   end
 
+  def test_validates_uniqueness_with_nil_value
+    Topic.validates_uniqueness_of(:title)
+
+    t = Topic.new("title" => nil)
+    assert t.save, "Should save t as unique"
+
+    t2 = Topic.new("title" => nil)
+    assert !t2.valid?, "Shouldn't be valid"
+    assert !t2.save, "Shouldn't save t2 as unique"
+    assert_equal ["has already been taken"], t2.errors[:title]
+  end
+
   def test_validates_uniqueness_with_validates
     Topic.validates :title, :uniqueness => true
     Topic.create!('title' => 'abc')


### PR DESCRIPTION
It casts all nil values to blank string. I think, it is a bug, because rails < 3.1 didn't do it. Here is solution. Thanks.
