### PR TITLE
Inline resources router fix

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -879,9 +879,9 @@ module ActionDispatch
 
           def initialize(entities, options = {})
             @name       = entities.to_s
-            @path       = (options.delete(:path) || @name).to_s
-            @controller = (options.delete(:controller) || @name).to_s
-            @as         = options.delete(:as)
+            @path       = (options[:path] || @name).to_s
+            @controller = (options[:controller] || @name).to_s
+            @as         = options[:as]
             @options    = options
           end
 
@@ -945,9 +945,9 @@ module ActionDispatch
           def initialize(entities, options)
             @as         = nil
             @name       = entities.to_s
-            @path       = (options.delete(:path) || @name).to_s
-            @controller = (options.delete(:controller) || plural).to_s
-            @as         = options.delete(:as)
+            @path       = (options[:path] || @name).to_s
+            @controller = (options[:controller] || plural).to_s
+            @as         = options[:as]
             @options    = options
           end
 

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -943,12 +943,11 @@ module ActionDispatch
           DEFAULT_ACTIONS = [:show, :create, :update, :destroy, :new, :edit]
 
           def initialize(entities, options)
+            super
+
             @as         = nil
-            @name       = entities.to_s
-            @path       = (options[:path] || @name).to_s
             @controller = (options[:controller] || plural).to_s
             @as         = options[:as]
-            @options    = options
           end
 
           def plural

--- a/actionpack/test/controller/resources_test.rb
+++ b/actionpack/test/controller/resources_test.rb
@@ -91,6 +91,15 @@ class ResourcesTest < ActionController::TestCase
     end
   end
 
+  def test_multiple_resources_with_options
+    expected_options = {:controller => 'threads', :action => 'index'}
+
+    with_restful_routing :messages, :comments, expected_options.slice(:controller) do
+      assert_recognizes(expected_options, :path => 'comments')
+      assert_recognizes(expected_options, :path => 'messages')
+    end
+  end
+
   def test_with_custom_conditions
     with_restful_routing :messages, :conditions => { :subdomain => 'app' } do
       assert @routes.recognize_path("/messages", :method => :get, :subdomain => 'app')


### PR DESCRIPTION
This fixes a bug for inline resource declarations with options:

```
resources :messages, :comments, :controller => 'threads'
```
