### PR TITLE
Default to the semantically correct HTML5 'mark' element for text highlighting

### DIFF
--- a/actionpack/lib/action_view/helpers/text_helper.rb
+++ b/actionpack/lib/action_view/helpers/text_helper.rb
@@ -90,11 +90,11 @@ module ActionView
       # Highlights one or more +phrases+ everywhere in +text+ by inserting it into
       # a <tt>:highlighter</tt> string. The highlighter can be specialized by passing <tt>:highlighter</tt>
       # as a single-quoted string with \1 where the phrase is to be inserted (defaults to
-      # '<strong class="highlight">\1</strong>')
+      # '<mark>\1</mark>')
       #
       # ==== Examples
       #   highlight('You searched for: rails', 'rails')
-      #   # => You searched for: <strong class="highlight">rails</strong>
+      #   # => You searched for: <mark>rails</mark>
       #
       #   highlight('You searched for: ruby, rails, dhh', 'actionpack')
       #   # => You searched for: ruby, rails, dhh
@@ -111,9 +111,9 @@ module ActionView
       def highlight(text, phrases, *args)
         options = args.extract_options!
         unless args.empty?
-          options[:highlighter] = args[0] || '<strong class="highlight">\1</strong>'
+          options[:highlighter] = args[0] || '<mark>\1</mark>'
         end
-        options.reverse_merge!(:highlighter => '<strong class="highlight">\1</strong>')
+        options.reverse_merge!(:highlighter => '<mark>\1</mark>')
 
         text = sanitize(text) unless options[:sanitize] == false
         if text.blank? || phrases.blank?

--- a/actionpack/test/template/text_helper_test.rb
+++ b/actionpack/test/template/text_helper_test.rb
@@ -109,12 +109,12 @@ class TextHelperTest < ActionView::TestCase
 
   def test_highlight
     assert_equal(
-      "This is a <strong class=\"highlight\">beautiful</strong> morning",
+      "This is a <mark>beautiful</mark> morning",
       highlight("This is a beautiful morning", "beautiful")
     )
 
     assert_equal(
-      "This is a <strong class=\"highlight\">beautiful</strong> morning, but also a <strong class=\"highlight\">beautiful</strong> day",
+      "This is a <mark>beautiful</mark> morning, but also a <mark>beautiful</mark> day",
       highlight("This is a beautiful morning, but also a beautiful day", "beautiful")
     )
 
@@ -133,31 +133,31 @@ class TextHelperTest < ActionView::TestCase
 
   def test_highlight_should_sanitize_input
     assert_equal(
-      "This is a <strong class=\"highlight\">beautiful</strong> morning",
+      "This is a <mark>beautiful</mark> morning",
       highlight("This is a beautiful morning<script>code!</script>", "beautiful")
     )
   end
 
   def test_highlight_should_not_sanitize_if_sanitize_option_if_false
     assert_equal(
-      "This is a <strong class=\"highlight\">beautiful</strong> morning<script>code!</script>",
+      "This is a <mark>beautiful</mark> morning<script>code!</script>",
       highlight("This is a beautiful morning<script>code!</script>", "beautiful", :sanitize => false)
     )
   end
 
   def test_highlight_with_regexp
     assert_equal(
-      "This is a <strong class=\"highlight\">beautiful!</strong> morning",
+      "This is a <mark>beautiful!</mark> morning",
       highlight("This is a beautiful! morning", "beautiful!")
     )
 
     assert_equal(
-      "This is a <strong class=\"highlight\">beautiful! morning</strong>",
+      "This is a <mark>beautiful! morning</mark>",
       highlight("This is a beautiful! morning", "beautiful! morning")
     )
 
     assert_equal(
-      "This is a <strong class=\"highlight\">beautiful? morning</strong>",
+      "This is a <mark>beautiful? morning</mark>",
       highlight("This is a beautiful? morning", "beautiful? morning")
     )
   end
@@ -175,23 +175,23 @@ class TextHelperTest < ActionView::TestCase
 
   def test_highlight_with_html
     assert_equal(
-      "<p>This is a <strong class=\"highlight\">beautiful</strong> morning, but also a <strong class=\"highlight\">beautiful</strong> day</p>",
+      "<p>This is a <mark>beautiful</mark> morning, but also a <mark>beautiful</mark> day</p>",
       highlight("<p>This is a beautiful morning, but also a beautiful day</p>", "beautiful")
     )
     assert_equal(
-      "<p>This is a <em><strong class=\"highlight\">beautiful</strong></em> morning, but also a <strong class=\"highlight\">beautiful</strong> day</p>",
+      "<p>This is a <em><mark>beautiful</mark></em> morning, but also a <mark>beautiful</mark> day</p>",
       highlight("<p>This is a <em>beautiful</em> morning, but also a beautiful day</p>", "beautiful")
     )
     assert_equal(
-      "<p>This is a <em class=\"error\"><strong class=\"highlight\">beautiful</strong></em> morning, but also a <strong class=\"highlight\">beautiful</strong> <span class=\"last\">day</span></p>",
+      "<p>This is a <em class=\"error\"><mark>beautiful</mark></em> morning, but also a <mark>beautiful</mark> <span class=\"last\">day</span></p>",
       highlight("<p>This is a <em class=\"error\">beautiful</em> morning, but also a beautiful <span class=\"last\">day</span></p>", "beautiful")
     )
     assert_equal(
-      "<p class=\"beautiful\">This is a <strong class=\"highlight\">beautiful</strong> morning, but also a <strong class=\"highlight\">beautiful</strong> day</p>",
+      "<p class=\"beautiful\">This is a <mark>beautiful</mark> morning, but also a <mark>beautiful</mark> day</p>",
       highlight("<p class=\"beautiful\">This is a beautiful morning, but also a beautiful day</p>", "beautiful")
     )
     assert_equal(
-      "<p>This is a <strong class=\"highlight\">beautiful</strong> <a href=\"http://example.com/beautiful#top?what=beautiful%20morning&amp;when=now+then\">morning</a>, but also a <strong class=\"highlight\">beautiful</strong> day</p>",
+      "<p>This is a <mark>beautiful</mark> <a href=\"http://example.com/beautiful#top?what=beautiful%20morning&amp;when=now+then\">morning</a>, but also a <mark>beautiful</mark> day</p>",
       highlight("<p>This is a beautiful <a href=\"http://example.com/beautiful\#top?what=beautiful%20morning&when=now+then\">morning</a>, but also a beautiful day</p>", "beautiful")
     )
   end


### PR DESCRIPTION
This might be controversial as the `mark` element would not be supported in older browsers but obviously the default can be overridden. (or suggest the HTML5 shim)

In addition, I removed the `highlight` class as this is implied with the `mark` element.
