### PR TITLE
Reset @dirty to false when slicing an instance of SafeBuffer

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -86,6 +86,12 @@ module ActiveSupport #:nodoc:
       end
     end
 
+    def[](*args)
+      new_safe_buffer = super
+      new_safe_buffer.instance_eval { @dirty = false }
+      new_safe_buffer
+    end
+
     def safe_concat(value)
       raise SafeConcatError if dirty?
       original_concat(value)

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -106,4 +106,10 @@ class SafeBufferTest < ActiveSupport::TestCase
   test "should not fail if the returned object is not a string" do
     assert_kind_of NilClass, @buffer.slice("chipchop")
   end
+
+  test "Should initialize @dirty to false for new instance when sliced" do
+    dirty = @buffer[0,0].send(:dirty?)
+    assert_not_nil dirty
+    assert !dirty
+  end
 end


### PR DESCRIPTION
This resolves the warning being throw in `actionpack/capture_helper_test#test_flush_output_buffer_concats_output_buffer_to_response`

After the OutputBuffer was being flushed by calling `[0,0]` on it the `@dirty` instance variable was not initialized in the new instance. This was throwing a warning.

The fix here will set the `@dirty` instance variable to `false` on the new instance when the slice method is invoked.
