### PR TITLE
fix stringify_keys destructive behavior for most FormTagHelper functions

### DIFF
--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -304,7 +304,7 @@ module ActionView
       #   text_area_tag 'comment', nil, :class => 'comment_input'
       #   # => <textarea class="comment_input" id="comment" name="comment"></textarea>
       def text_area_tag(name, content = nil, options = {})
-        options.stringify_keys!
+        options = options.stringify_keys
 
         if size = options.delete("size")
           options["cols"], options["rows"] = size.split("x") if size.respond_to?(:split)
@@ -407,7 +407,7 @@ module ActionView
       #         data-confirm="Are you sure?" />
       #
       def submit_tag(value = "Save changes", options = {})
-        options.stringify_keys!
+        options = options.stringify_keys
 
         if disable_with = options.delete("disable_with")
           options["data-disable-with"] = disable_with
@@ -458,7 +458,7 @@ module ActionView
       def button_tag(content_or_options = nil, options = nil, &block)
         options = content_or_options if block_given? && content_or_options.is_a?(Hash)
         options ||= {}
-        options.stringify_keys!
+        options = options.stringify_keys
 
         if disable_with = options.delete("disable_with")
           options["data-disable-with"] = disable_with
@@ -497,7 +497,7 @@ module ActionView
       #   image_submit_tag("agree.png", :disabled => true, :class => "agree_disagree_button")
       #   # => <input class="agree_disagree_button" disabled="disabled" src="/images/agree.png" type="image" />
       def image_submit_tag(source, options = {})
-        options.stringify_keys!
+        options = options.stringify_keys
 
         if confirm = options.delete("confirm")
           options["data-confirm"] = confirm

--- a/actionpack/test/template/form_tag_helper_test.rb
+++ b/actionpack/test/template/form_tag_helper_test.rb
@@ -505,6 +505,30 @@ class FormTagHelperTest < ActionView::TestCase
     expected = %(<fieldset class="format">Hello world!</fieldset>)
     assert_dom_equal expected, output_buffer
   end
+  
+  def test_text_area_tag_options_symbolize_keys_side_effects
+    options = { :option => "random_option" }
+    actual = text_area_tag "body", "hello world", options
+    assert_equal options, { :option => "random_option" }
+  end
+
+  def test_submit_tag_options_symbolize_keys_side_effects
+    options = { :option => "random_option" }
+    actual = submit_tag "submit value", options
+    assert_equal options, { :option => "random_option" }
+  end
+
+  def test_button_tag_options_symbolize_keys_side_effects
+    options = { :option => "random_option" }
+    actual = button_tag "button value", options
+    assert_equal options, { :option => "random_option" }
+  end
+
+  def test_image_submit_tag_options_symbolize_keys_side_effects
+    options = { :option => "random_option" }
+    actual = image_submit_tag "submit source", options
+    assert_equal options, { :option => "random_option" }
+  end
 
   def protect_against_forgery?
     false


### PR DESCRIPTION
I've also filed this at https://github.com/rails/rails/issues/2355
