### PR TITLE
Support backwards compatible interface for migration down/up with rails 3.0.x.

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -329,6 +329,7 @@ module ActiveRecord
     end
 
     def self.method_missing(name, *args, &block) # :nodoc:
+      self.delegate = self.new
       (delegate || superclass.delegate).send(name, *args, &block)
     end
 

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -329,8 +329,8 @@ module ActiveRecord
     end
 
     def self.method_missing(name, *args, &block) # :nodoc:
-      self.delegate = self.new
-      (delegate || superclass.delegate).send(name, *args, &block)
+      self.delegate ||= self.new
+      delegate.send(name, *args, &block)
     end
 
     cattr_accessor :verbose

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -54,13 +54,13 @@ module ActiveRecord
       end
     end
 
-    def test_up
+    def test_migrate_up
       migration = InvertibleMigration.new
       migration.migrate(:up)
       assert migration.connection.table_exists?("horses"), "horses should exist"
     end
 
-    def test_down
+    def test_migrate_down
       migration = InvertibleMigration.new
       migration.migrate :up
       migration.migrate :down
@@ -75,6 +75,17 @@ module ActiveRecord
     def test_legacy_down
       LegacyMigration.migrate :up
       LegacyMigration.migrate :down
+      assert !ActiveRecord::Base.connection.table_exists?("horses"), "horses should not exist"
+    end
+
+    def test_up
+      LegacyMigration.up
+      assert ActiveRecord::Base.connection.table_exists?("horses"), "horses should exist"
+    end
+
+    def test_down
+      LegacyMigration.up
+      LegacyMigration.down
       assert !ActiveRecord::Base.connection.table_exists?("horses"), "horses should not exist"
     end
   end

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -27,6 +27,19 @@ module ActiveRecord
       end
     end
 
+    class LegacyMigration < ActiveRecord::Migration
+      def self.up
+        create_table("horses") do |t|
+          t.column :content, :text
+          t.column :remind_at, :datetime
+        end
+      end
+
+      def self.down
+        drop_table("horses")
+      end
+    end
+
     def teardown
       if ActiveRecord::Base.connection.table_exists?("horses")
         ActiveRecord::Base.connection.drop_table("horses")
@@ -52,6 +65,17 @@ module ActiveRecord
       migration.migrate :up
       migration.migrate :down
       assert !migration.connection.table_exists?("horses")
+    end
+
+    def test_legacy_up
+      LegacyMigration.migrate :up
+      assert ActiveRecord::Base.connection.table_exists?("horses"), "horses should exist"
+    end
+
+    def test_legacy_down
+      LegacyMigration.migrate :up
+      LegacyMigration.migrate :down
+      assert !ActiveRecord::Base.connection.table_exists?("horses"), "horses should not exist"
     end
   end
 end


### PR DESCRIPTION
Support backwards compatible interface for migration down/up with rails 3.0.x.

Please see issue: #2348.  

If this looks good, I'll backport to 3-1-stable.
