### PR TITLE
skiping magic comment test for < 1.9

### DIFF
--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -14,9 +14,10 @@ class SchemaDumperTest < ActiveRecord::TestCase
     @stream.string
   end
 
-  def test_magic_comment
-    skip "only test magic comments on 1.9" if RUBY_VERSION < '1.9'
-    assert_match "# encoding: #{@stream.external_encoding.name}", standard_dump
+  if "string".encoding_aware?
+    def test_magic_comment
+      assert_match "# encoding: #{@stream.external_encoding.name}", standard_dump
+    end
   end
 
   def test_schema_dump


### PR DESCRIPTION
We need to write return skip. 

Was giving error in 1.8.7 

<pre>
NoMethodError: undefined method `external_encoding' for #<StringIO:0xb538b778>
</pre>
