### PR TITLE
Ensure that the format isn't applied twice to the cache key.

### DIFF
--- a/actionpack/lib/action_controller/caching/actions.rb
+++ b/actionpack/lib/action_controller/caching/actions.rb
@@ -175,7 +175,7 @@ module ActionController #:nodoc:
       private
         def normalize!(path)
           path << 'index' if path[-1] == ?/
-          path << ".#{extension}" if extension and !path.ends_with?(extension)
+          path << ".#{extension}" if extension and !path.split('?').first.try(:ends_with?, ".#{extension}")
           URI.parser.unescape(path)
         end
       end

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -194,6 +194,7 @@ class ActionCachingTestController < CachingController
   caches_action :show, :cache_path => 'http://test.host/custom/show'
   caches_action :edit, :cache_path => Proc.new { |c| c.params[:id] ? "http://test.host/#{c.params[:id]};edit" : "http://test.host/edit" }
   caches_action :with_layout
+  caches_action :with_format_and_http_param, :cache_path => Proc.new { |c| { :key => 'value' } } 
   caches_action :layout_false, :layout => false
   caches_action :record_not_found, :four_oh_four, :simple_runtime_error
 
@@ -219,6 +220,11 @@ class ActionCachingTestController < CachingController
     render :text => @cache_this, :layout => true
   end
 
+  def with_format_and_http_param
+    @cache_this = MockTime.now.to_f.to_s
+    render :text => @cache_this
+  end
+  
   def record_not_found
     raise ActiveRecord::RecordNotFound, "oops!"
   end
@@ -357,6 +363,13 @@ class ActionCacheTest < ActionController::TestCase
     get :index
     assert_response :success
     assert !fragment_exist?('hostname.com/action_caching_test')
+  end
+
+  def test_action_cache_with_format_and_http_param
+    get :with_format_and_http_param, :format => 'json'
+    assert_response :success
+    assert !fragment_exist?('hostname.com/action_caching_test/with_format_and_http_param.json?key=value.json')
+    assert fragment_exist?('hostname.com/action_caching_test/with_format_and_http_param.json?key=value')
   end
 
   def test_action_cache_with_store_options


### PR DESCRIPTION
I'm running into a problem where I have a caches_action in one of my controllers, adding an optional parameter to the cache_path, and I'm seeing the format added twice.  For instance:

```
action.xml?thing=value.xml 
```

instead of:

```
action.xml?thing=value
```

This also makes it extremely difficult to target with expires_action, as the format is appended only when infer_extension is true.  This patch fixes the key generation to not include the extension if it's already been included.
