### PR TITLE
adhere to submission port (587) instead of relay (25) by convention, espe

### DIFF
--- a/actionmailer/README.rdoc
+++ b/actionmailer/README.rdoc
@@ -126,12 +126,14 @@ The Base class has the full list of configuration options. Here's an example:
 
   ActionMailer::Base.smtp_settings = {
     :address        => 'smtp.yourserver.com', # default: localhost
-    :port           => '25',                  # default: 25
+    :port           => '587',                 # default: 25
     :user_name      => 'user',
     :password       => 'pass',
     :authentication => :plain                 # :plain, :login or :cram_md5
   }
 
+Note the change in port from 25 to 587. Mail servers requiring a username and password frequently listen
+on port 587.
 
 == Download and installation
 

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -283,7 +283,8 @@ module ActionMailer #:nodoc:
   # * <tt>smtp_settings</tt> - Allows detailed configuration for <tt>:smtp</tt> delivery method:
   #   * <tt>:address</tt> - Allows you to use a remote mail server. Just change it from its default
   #     "localhost" setting.
-  #   * <tt>:port</tt> - On the off chance that your mail server doesn't run on port 25, you can change it.
+  #   * <tt>:port</tt> - Allows you to change the port used to connect to your mail server. Mail servers
+  #     requiring a username and password frequently listen on port 587. The default is port 25.
   #   * <tt>:domain</tt> - If you need to specify a HELO domain, you can do it here.
   #   * <tt>:user_name</tt> - If your mail server requires authentication, set the username in this setting.
   #   * <tt>:password</tt> - If your mail server requires authentication, set the password in this setting.


### PR DESCRIPTION
adhere to submission port (587) instead of relay (25) by convention, especially when using user / pass

re:
- http://tools.ietf.org/html/rfc4409
- http://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol
- http://mostlygeek.com/tech/smtp-on-port-587/
