### PR TITLE
Resolve warnings by checking if @attributes is defined

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1865,7 +1865,7 @@ MSG
 
       # Returns the contents of the record as a nicely formatted string.
       def inspect
-        inspection = if @attributes
+        inspection = if defined?(@attributes) && @attributes
                        self.class.column_names.collect { |name|
                          if has_attribute?(name)
                            "#{name}: #{attribute_for_inspect(name)}"


### PR DESCRIPTION
When @attributes is undefined (in the case of some of the tests using `.allocate` instead of `.new` on an AR class) a warning will be thrown.

As this adds an extra conditional it could be a performance hit but I suspect the only time anybody is really calling `#inspect` on an AR object is from within the console so it shouldn't be a big deal.
