### PR TITLE
Resolve warnings by instantizing @attrubtes as nil

### DIFF
--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -113,6 +113,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   # by inspecting it.
   def test_allocated_object_can_be_inspected
     topic = Topic.allocate
+    topic.instance_eval { @attributes = nil }
     assert_nothing_raised { topic.inspect }
     assert topic.inspect, "#<Topic not initialized>"
   end


### PR DESCRIPTION
Resubmitted per @josevalim's suggestion in #2363
