### PR TITLE
3 1 stable schema dumper fix

### DIFF
--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -15,7 +15,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
   end
 
   def test_magic_comment
-    skip "only test magic comments on 1.9" if RUBY_VERSION < '1.9'
+    return skip "only test magic comments on 1.9" if RUBY_VERSION < '1.9'
     assert_match "# encoding: #{@stream.external_encoding.name}", standard_dump
   end
 


### PR DESCRIPTION
Need a return before skip. can't use encoding_aware? here. 
