### PR TITLE
remove extra require for 'stringio' as it is required in helper.rb

### DIFF
--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -1,5 +1,4 @@
 require "cases/helper"
-require 'stringio'
 
 
 class SchemaDumperTest < ActiveRecord::TestCase


### PR DESCRIPTION
remove extra require for 'stringio' as it is required in helper.rb
