### PR TITLE
remove_possible_method: test if method exists

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/remove_method.rb
+++ b/activesupport/lib/active_support/core_ext/module/remove_method.rb
@@ -1,7 +1,12 @@
 class Module
   def remove_possible_method(method)
-    remove_method(method)
+    if method_defined?(method) || private_method_defined?(method)
+      remove_method(method)
+    end
   rescue NameError
+    # If the requested method is defined on a superclass or included module,
+    # method_defined? returns true but remove_method throws a NameError.
+    # Ignore this.
   end
 
   def redefine_method(method, &block)


### PR DESCRIPTION
This speeds up remove_possible_method substantially since it doesn't
have to rescue a NameError in the common case.

Closes #2346.
