### PR TITLE
3-1-stable schema dumper test fix

### DIFF
--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -1,5 +1,5 @@
 require "cases/helper"
-require 'stringio'
+require 'active_support/core_ext/string/encoding'
 
 
 class SchemaDumperTest < ActiveRecord::TestCase
@@ -14,9 +14,10 @@ class SchemaDumperTest < ActiveRecord::TestCase
     @stream.string
   end
 
-  def test_magic_comment
-    skip "only test magic comments on 1.9" if RUBY_VERSION < '1.9'
-    assert_match "# encoding: #{@stream.external_encoding.name}", standard_dump
+  if "string".encoding_aware?
+    def test_magic_comment
+      assert_match "# encoding: #{@stream.external_encoding.name}", standard_dump
+    end
   end
 
   def test_schema_dump


### PR DESCRIPTION
Loading AS encoding in helper.

In master it's AS encoding loaded by blank.rb but here we need to load for test.
