### PR TITLE
Fixes #2368. rake about not showing a few properties

### DIFF
--- a/railties/lib/rails/tasks/misc.rake
+++ b/railties/lib/rails/tasks/misc.rake
@@ -14,7 +14,7 @@ task :secret do
 end
 
 desc 'List versions of all Rails frameworks and the environment'
-task :about do
+task :about => :environment do
   puts Rails::Info
 end
 


### PR DESCRIPTION
<code>rake about</code> is not showing the middleware information (#2368) as well as the db adapter and db schema version. Those items were raising exceptions which are silently rescued. 

Having the task load the environment ensures that ActiveRecord is loaded fine (for the db adapter and schema version to be found properly).

As for the middleware, I'm not sure how that got fixed :). As @arunagw says in #2368, <code>Rails.configuration.middleware</code> seems to be of different classes in different places.
