### PR TITLE
remove extra require for 'active_support/dependencies' as it is required 

### DIFF
--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 require 'abstract_unit'
 require 'controller/fake_controllers'
-require 'active_support/dependencies'
 require 'active_support/core_ext/object/with_options'
 
 class MilestonesController < ActionController::Base


### PR DESCRIPTION
remove extra require for 'active_support/dependencies' as it is required in abstract_unit.rb
