### PR TITLE
MassAssignmentProtection: consider 'id' insensetive in StrictSanitizer

### DIFF
--- a/activemodel/lib/active_model/mass_assignment_security/sanitizer.rb
+++ b/activemodel/lib/active_model/mass_assignment_security/sanitizer.rb
@@ -44,7 +44,12 @@ module ActiveModel
 
     class StrictSanitizer < Sanitizer
       def process_removed_attributes(attrs)
+        return if (attrs - insensitive_attributes).empty?
         raise ActiveModel::MassAssignmentSecurity::Error, "Can't mass-assign protected attributes: #{attrs.join(', ')}"
+      end
+
+      def insensitive_attributes
+        ['id']
       end
     end
 

--- a/activemodel/test/cases/mass_assignment_security/sanitizer_test.rb
+++ b/activemodel/test/cases/mass_assignment_security/sanitizer_test.rb
@@ -7,7 +7,7 @@ class SanitizerTest < ActiveModel::TestCase
 
   class Authorizer < ActiveModel::MassAssignmentSecurity::PermissionSet
     def deny?(key)
-      key.in?(['admin'])
+      ['admin', 'id'].include?(key)
     end
   end
 
@@ -36,6 +36,14 @@ class SanitizerTest < ActiveModel::TestCase
   test "debug mass assignment removal with StrictSanitizer" do
     original_attributes = { 'first_name' => 'allowed', 'admin' => 'denied' }
     assert_raise ActiveModel::MassAssignmentSecurity::Error do
+      @strict_sanitizer.sanitize(original_attributes, @authorizer)
+    end
+  end
+
+  test "mass assignment insensitive attributes" do
+    original_attributes = {'id' => 1, 'first_name' => 'allowed'}
+
+    assert_nothing_raised do
       @strict_sanitizer.sanitize(original_attributes, @authorizer)
     end
   end

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -34,6 +34,11 @@
   # like if you have constraints or database-specific column types
   # config.active_record.schema_format = :sql
 
+  <%- unless options.skip_active_record? -%>
+  # Raise exception on mass assignment protection for ActiveRecord models
+  config.active_record.mass_assignment_sanitizer = :strict
+  <%- end -%>
+
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
 end


### PR DESCRIPTION
In order to use StrictSanitizer in test mode
Consider :id as not sensetive attribute that can be filtered from
mass assignement without exception.

cc @josevalim

Original discussion #2067
