### PR TITLE
Removing YAML deprecated DEFAULTS.

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -385,11 +385,11 @@ class FixturesFileNotFound < StandardError; end
 #
 #   first:
 #     name: Smurf
-#     <<: *DEFAULTS
+#     *DEFAULTS
 #
 #   second:
 #     name: Fraggle
-#     <<: *DEFAULTS
+#     *DEFAULTS
 #
 # Any fixture labeled "DEFAULTS" is safely ignored.
 

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -27,7 +27,7 @@ db_namespace = namespace :db do
         #
         #  development:
         #    database: blog_development
-        #    <<: *defaults
+        #    *DEFAULTS
         next unless config['database']
         # Only connect to local databases
         local_database?(config) { create_database(config) }

--- a/activerecord/test/fixtures/parrots.yml
+++ b/activerecord/test/fixtures/parrots.yml
@@ -24,4 +24,4 @@ DEFAULTS: &DEFAULTS
   parrot_sti_class: LiveParrot
 
 davey:
-  <<: *DEFAULTS
+  *DEFAULTS


### PR DESCRIPTION
Remove fixture warning. "<<: *DEFAULTS" is no longer supported
