### PR TITLE
Remove warnings...

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -385,11 +385,11 @@ class FixturesFileNotFound < StandardError; end
 #
 #   first:
 #     name: Smurf
-#     <<: *DEFAULTS
+#     *DEFAULTS
 #
 #   second:
 #     name: Fraggle
-#     <<: *DEFAULTS
+#     *DEFAULTS
 #
 # Any fixture labeled "DEFAULTS" is safely ignored.
 

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -27,7 +27,7 @@ db_namespace = namespace :db do
         #
         #  development:
         #    database: blog_development
-        #    <<: *defaults
+        #    *DEFAULTS
         next unless config['database']
         # Only connect to local databases
         local_database?(config) { create_database(config) }

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1866,6 +1866,6 @@ class BasicsTest < ActiveRecord::TestCase
   def test_cache_key_format_for_existing_record_with_nil_updated_at
     dev = Developer.first
     dev.update_attribute(:updated_at, nil)
-    assert_match /\/#{dev.id}$/, dev.cache_key
+    assert_match %r(/#{dev.id}$), dev.cache_key
   end
 end

--- a/activerecord/test/fixtures/parrots.yml
+++ b/activerecord/test/fixtures/parrots.yml
@@ -24,4 +24,4 @@ DEFAULTS: &DEFAULTS
   parrot_sti_class: LiveParrot
 
 davey:
-  <<: *DEFAULTS
+  *DEFAULTS


### PR DESCRIPTION
Removing some warnings.

47f60dee8be11c9d4e36 -> Remove fixture warning. "<<: *DEFAULTS" is no longer supported
fc51c227bdeedc0a8bd0 -> Remove ambiguous first argument warning.
