### PR TITLE
Remove unnecessary require (happened after fcbde454f6)

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -1,5 +1,3 @@
-require "active_support/core_ext/module/remove_method"
-
 class Module
   # Provides a delegate class method to easily expose contained objects' methods
   # as your own. Pass one or more methods (specified as symbols or strings)


### PR DESCRIPTION
After closing #1937 with fcbde454f6 there is an unnecessary require in `active_support/core_ext/module/delegate.rb`

Patch removes the unnecessary lines.
