### PR TITLE
Fix ArgumentError in ActiveSupport::Cache::CacheStore.read_multi

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -347,7 +347,7 @@ module ActiveSupport
           entry = read_entry(key, options)
           if entry
             if entry.expired?
-              delete_entry(key)
+              delete_entry(key, options)
             else
               results[name] = entry.value
             end

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -199,6 +199,14 @@ module CacheStoreBehavior
     @cache.write('fud', 'biz')
     assert_equal({"foo" => "bar", "fu" => "baz"}, @cache.read_multi('foo', 'fu'))
   end
+  
+  def test_read_multi_with_expires
+    @cache.write('foo', 'bar', :expires_in => 0.001)
+    @cache.write('fu', 'baz')
+    @cache.write('fud', 'biz')
+    sleep(0.002)
+    assert_equal({"fu" => "baz"}, @cache.read_multi('foo', 'fu'))
+  end
 
   def test_read_and_write_compressed_small_data
     @cache.write('foo', 'bar', :compress => true)


### PR DESCRIPTION
There is a call in activesupport-3.0.9/lib/active_support/cache.rb#read_multi to delete entry (on or about line 348). This breaks the call in both 3.0.x and 3.1 branches with any cache other than MemCacheStore.. The change is trivial so the code is below. Also added a test case.

``` ruby
  if entry.expired?
    delete_entry(key)
  else
    results[name] = entry.value
  end
```

Unfortunately, the delete_entry method takes two arguments. It should be:

``` ruby
  if entry.expired?
    delete_entry(key, options)
  else
    results[name] = entry.value
  end
```
