### PR TITLE
Included TagHelper within TextHelper, since it's used there (so that we c

### DIFF
--- a/actionpack/lib/action_view/helpers/text_helper.rb
+++ b/actionpack/lib/action_view/helpers/text_helper.rb
@@ -31,6 +31,7 @@ module ActionView
       extend ActiveSupport::Concern
 
       include SanitizeHelper
+      include TagHelper
       # The preferred method of outputting text in your views is to use the
       # <%= "text" %> eRuby syntax. The regular _puts_ and _print_ methods
       # do not operate as expected in an eRuby code block. If you absolutely must


### PR DESCRIPTION
Included TagHelper within TextHelper, since it's used there (so that we can include TextHelper in files, i.e., a different helper).
