### PR TITLE
V.2.3.8.mysql2

### DIFF
--- a/railties/lib/tasks/databases.rake
+++ b/railties/lib/tasks/databases.rake
@@ -53,7 +53,7 @@ namespace :db do
       end
     rescue
       case config['adapter']
-      when 'mysql'
+      when /^mysql2?$/
         @charset   = ENV['CHARSET']   || 'utf8'
         @collation = ENV['COLLATION'] || 'utf8_unicode_ci'
         begin
@@ -159,7 +159,7 @@ namespace :db do
   task :charset => :environment do
     config = ActiveRecord::Base.configurations[RAILS_ENV || 'development']
     case config['adapter']
-    when 'mysql'
+    when /^mysql2?$/
       ActiveRecord::Base.establish_connection(config)
       puts ActiveRecord::Base.connection.charset
     when 'postgresql'
@@ -174,7 +174,7 @@ namespace :db do
   task :collation => :environment do
     config = ActiveRecord::Base.configurations[RAILS_ENV || 'development']
     case config['adapter']
-    when 'mysql'
+    when /^mysql2?$/
       ActiveRecord::Base.establish_connection(config)
       puts ActiveRecord::Base.connection.collation
     else
@@ -274,7 +274,7 @@ namespace :db do
     task :dump => :environment do
       abcs = ActiveRecord::Base.configurations
       case abcs[RAILS_ENV]["adapter"]
-      when "mysql", "oci", "oracle"
+      when /^mysql2?$/, "oci", "oracle"
         ActiveRecord::Base.establish_connection(abcs[RAILS_ENV])
         File.open("#{RAILS_ROOT}/db/#{RAILS_ENV}_structure.sql", "w+") { |f| f << ActiveRecord::Base.connection.structure_dump }
       when "postgresql"
@@ -320,7 +320,7 @@ namespace :db do
     task :clone_structure => [ "db:structure:dump", "db:test:purge" ] do
       abcs = ActiveRecord::Base.configurations
       case abcs["test"]["adapter"]
-      when "mysql"
+      when /^mysql2?$/
         ActiveRecord::Base.establish_connection(:test)
         ActiveRecord::Base.connection.execute('SET foreign_key_checks = 0')
         IO.readlines("#{RAILS_ROOT}/db/#{RAILS_ENV}_structure.sql").join.split("\n\n").each do |table|
@@ -354,7 +354,7 @@ namespace :db do
     task :purge => :environment do
       abcs = ActiveRecord::Base.configurations
       case abcs["test"]["adapter"]
-      when "mysql"
+      when /^mysql2?$/
         ActiveRecord::Base.establish_connection(:test)
         ActiveRecord::Base.connection.recreate_database(abcs["test"]["database"], abcs["test"])
       when "postgresql"
@@ -408,7 +408,7 @@ end
 def drop_database(config)
   begin
     case config['adapter']
-    when 'mysql'
+    when /^mysql2?$/
       ActiveRecord::Base.establish_connection(config)
       ActiveRecord::Base.connection.drop_database config['database']
     when /^sqlite/


### PR DESCRIPTION
This commit resolves a mysql2 adapter compatibility issue when database rake tasks such as `rake db:test:prepare` etc are invoked (resolves "Task not supported by 'mysql2'" errors).
