### PR TITLE
Debug assets by config

### DIFF
--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -70,10 +70,12 @@ module Sprockets
 
     private
       def debug_assets?
-        Rails.env.development? || Rails.env.test? ||
-          params[:debug_assets] == '1' || params[:debug_assets] == 'true'
-      rescue NoMethodError
-        false
+        begin
+          params[:debug_assets] == '1' ||
+            params[:debug_assets] == 'true'
+        rescue NoMethodError
+          false
+        end || Rails.application.config.assets.debug
       end
 
       # Override to specify an alternative prefix for asset path generation.

--- a/actionpack/test/template/sprockets_helper_test.rb
+++ b/actionpack/test/template/sprockets_helper_test.rb
@@ -141,8 +141,6 @@ class SprocketsHelperTest < ActionView::TestCase
   end
 
   test "javascript include tag" do
-    Rails.env.stubs(:test?).returns(false)
-
     assert_match %r{<script src="/assets/application-[0-9a-f]+.js" type="text/javascript"></script>},
       javascript_include_tag(:application)
 
@@ -156,14 +154,12 @@ class SprocketsHelperTest < ActionView::TestCase
     assert_match %r{<script src=\"/assets/xmlhr-[0-9a-f]+.js" type=\"text/javascript\"></script>\n<script src=\"/assets/extra-[0-9a-f]+.js" type=\"text/javascript\"></script>},
       javascript_include_tag("xmlhr", "extra")
 
-    Rails.env.stubs(:test?).returns(true)
+    assert_match %r{<script src="/assets/xmlhr-[0-9a-f]+.js\?body=1" type="text/javascript"></script>\n<script src="/assets/application-[0-9a-f]+.js\?body=1" type="text/javascript"></script>},
+      javascript_include_tag(:application, :debug => true)
 
+    @config.assets.debug = true
     assert_match %r{<script src="/assets/xmlhr-[0-9a-f]+.js\?body=1" type="text/javascript"></script>\n<script src="/assets/application-[0-9a-f]+.js\?body=1" type="text/javascript"></script>},
       javascript_include_tag(:application)
-
-    assert_match %r{<script src="/assets/application-[0-9a-f]+.js\" type="text/javascript"></script>},
-      javascript_include_tag(:application, :debug => false)
-
   end
 
   test "stylesheet path" do
@@ -180,8 +176,6 @@ class SprocketsHelperTest < ActionView::TestCase
   end
 
   test "stylesheet link tag" do
-    Rails.env.stubs(:test?).returns(false)
-
     assert_match %r{<link href="/assets/application-[0-9a-f]+.css" media="screen" rel="stylesheet" type="text/css" />},
       stylesheet_link_tag(:application)
 
@@ -200,14 +194,12 @@ class SprocketsHelperTest < ActionView::TestCase
     assert_match %r{<link href="/assets/style-[0-9a-f]+.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/assets/extra-[0-9a-f]+.css" media="screen" rel="stylesheet" type="text/css" />},
       stylesheet_link_tag("style", "extra")
 
-    Rails.env.stubs(:test?).returns(true)
+    assert_match %r{<link href="/assets/style-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />\n<link href="/assets/application-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />},
+      stylesheet_link_tag(:application, :debug => true)
 
+    @config.assets.debug = true
     assert_match %r{<link href="/assets/style-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />\n<link href="/assets/application-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />},
       stylesheet_link_tag(:application)
-
-    assert_match %r{<link href="/assets/application-[0-9a-f]+.css" media="screen" rel="stylesheet" type="text/css" />},
-      stylesheet_link_tag(:application, :debug => false)
-
   end
 
   test "alternate asset prefix" do

--- a/railties/guides/source/asset_pipeline.textile
+++ b/railties/guides/source/asset_pipeline.textile
@@ -224,7 +224,7 @@ If any of the files in the manifest have changed between requests, the server re
 
 h4. Debugging Assets
 
-You can put +?debug_assets=true+ or +?debug_assets=1+ at the end of a URL and Sprockets expands the lines which load the assets. For example, if you had an +app/assets/javascripts/application.js+ file containing these lines:
+You can put +?debug_assets=true+ or +?debug_assets=1+ at the end of a URL or set +config.assets.debug+ and Sprockets expands the lines which load the assets. For example, if you had an +app/assets/javascripts/application.js+ file containing these lines:
 
 <plain>
 //= require "projects"

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -38,6 +38,7 @@ module Rails
         @assets.precompile = [ /\w+\.(?!js|css).+/, /application.(css|js)$/ ]
         @assets.prefix     = "/assets"
         @assets.version    = ''
+        @assets.debug      = false
 
         @assets.cache_store    = [ :file_store, "#{root}/tmp/cache/assets/" ]
         @assets.js_compressor  = nil

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -29,4 +29,7 @@
 
   # Do not compress assets
   config.assets.compress = false
+
+  # Expands the lines which load the assets
+  config.assets.debug = true
 end


### PR DESCRIPTION
Rails Asset Pipeline is awesome, but when I came from Jammit I was upset, that Sprockets joins all JS files in development too, because I can’t find troublesome JS files just by error messages in console (I need to open huge application.js and try to understand which CoffeeScript file corresponds to line 1046).

So I was very happy to find `?debug_assets=1` option in Assets Pipeline docs, but I want it for every development request (we include all subfiles in top of `application.js` and we use CoffeeScript without `;`-problem, so we haven’t side effects). I understand that `debug_assets` have some side effects for some developers, so I add non-default options `config.assets.debug` to make ex-Jammit users more happy.
