### PR TITLE
simple_selector: attributes with brackets in double quotes not recognized

### DIFF
--- a/actionpack/lib/action_controller/vendor/html-scanner/html/selector.rb
+++ b/actionpack/lib/action_controller/vendor/html-scanner/html/selector.rb
@@ -558,7 +558,7 @@ module HTML
         end
 
         # Attribute value.
-        next if statement.sub!(/^\[\s*([[:alpha:]][\w\-:]*)\s*((?:[~|^$*])?=)?\s*('[^']*'|"[^*]"|[^\]]*)\s*\]/) do |match|
+        next if statement.sub!(/^\[\s*([[:alpha:]][\w\-:]*)\s*((?:[~|^$*])?=)?\s*('[^']*'|"[^"]*"|[^\]]*)\s*\]/) do |match|
           name, equality, value = $1, $2, $3
           if value == "?"
             value = values.shift

--- a/actionpack/test/controller/selector_test.rb
+++ b/actionpack/test/controller/selector_test.rb
@@ -102,7 +102,7 @@ class SelectorTest < Test::Unit::TestCase
 
 
   def test_attribute_quoted
-    parse(%Q{<div id="1" title="foo"></div><div id="2" title="bar"></div><div id="3" title="  bar  "></div>})
+    parse(%Q{<div id="1" title="foo"></div><div id="2" title="bar"></div><div id="3" title="  bar  "></div><div id="4" name="item[baz]"></div>})
     # Match without quotes.
     select("[title = bar]")
     assert_equal 1, @matches.size
@@ -119,6 +119,14 @@ class SelectorTest < Test::Unit::TestCase
     select("[title = \"  bar  \" ]")
     assert_equal 1, @matches.size
     assert_equal "3", @matches[0].attributes["id"]
+    # Match brackets in single quotes.
+    select("[name = 'item[baz]' ]")
+    assert_equal 1, @matches.size
+    assert_equal "4", @matches[0].attributes["id"]
+    # Match brackets in double quotes.
+    select("[name = \"item[baz]\" ]")
+    assert_equal 1, @matches.size
+    assert_equal "4", @matches[0].attributes["id"]
   end
 
 


### PR DESCRIPTION
simple_selector: attributes with brackets in double quotes not recognized

HTML::Selector#simple_selector can recognize attributes in single and
double quotes. But when the attribute value contains square brackets,
and the value is enclosed in double quotes, an exception
`ArgumentError: Invalid selector: "]` is thrown.

Related to issue #2412.
