### PR TITLE
Simple_format should not edit it in place. (Fixes https://github.com/rails/rails/issues/1980)

### DIFF
--- a/actionpack/lib/action_view/helpers/text_helper.rb
+++ b/actionpack/lib/action_view/helpers/text_helper.rb
@@ -256,7 +256,7 @@ module ActionView
       #   # => "<p><span>I'm allowed!</span> It's true.</p>"
       def simple_format(text, html_options={}, options={})
         text = '' if text.nil?
-        text = text.dup if text.frozen?
+        text = text.dup
         start_tag = tag('p', html_options, true)
         text = sanitize(text) unless options[:sanitize] == false
         text = text.to_str

--- a/actionpack/test/template/text_helper_test.rb
+++ b/actionpack/test/template/text_helper_test.rb
@@ -48,10 +48,10 @@ class TextHelperTest < ActionView::TestCase
     assert_equal "<p><b> test with unsafe string </b><script>code!</script></p>", simple_format("<b> test with unsafe string </b><script>code!</script>", {}, :sanitize => false)
   end
 
-  def test_simple_format_should_not_change_the_frozen_text_passed
+  def test_simple_format_should_not_change_the_text_passed
     text = "<b>Ok</b><script>code!</script>"
     text_clone = text.dup
-    simple_format(text.freeze)
+    simple_format(text)
     assert_equal text_clone, text
   end
 


### PR DESCRIPTION
ActionView::Helpers::TextHelper#simple_format should not change the text in place. Now it duplicates it.

simple_format should not edit the string in place, but rather should duplicate and return a modified copy. We were running into the cumulative paragraphs error (see https://github.com/rails/rails/issues/1980). Also note that this was changing the string pointed to by the model, if only for the duration of the request. This is bad.
