### PR TITLE
Patch connection problem

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -182,7 +182,7 @@ module ActiveRecord
         relation = relation.where(table[primary_key.name].eq(id)) if id
       end
 
-      connection.select_value(relation.to_sql) ? true : false
+      @klass.connection.select_value(relation.to_sql) ? true : false
     end
 
     protected
@@ -352,7 +352,7 @@ module ActiveRecord
 
     def column_aliases(join_dependency)
       join_dependency.joins.collect{|join| join.column_names_with_alias.collect{|column_name, aliased_name|
-          "#{connection.quote_table_name join.aliased_table_name}.#{connection.quote_column_name column_name} AS #{aliased_name}"}}.flatten.join(", ")
+          "#{@klass.connection.quote_table_name join.aliased_table_name}.#{@klass.connection.quote_column_name column_name} AS #{aliased_name}"}}.flatten.join(", ")
     end
 
     def using_limitable_reflections?(reflections)

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -179,7 +179,7 @@ module ActiveRecord
 
       arel = arel.having(*@having_values.uniq.reject{|h| h.blank?}) unless @having_values.empty?
 
-      arel = arel.take(connection.sanitize_limit(@limit_value)) if @limit_value
+      arel = arel.take(@klass.connection.sanitize_limit(@limit_value)) if @limit_value
       arel = arel.skip(@offset_value) if @offset_value
 
       arel = arel.group(*@group_values.uniq.reject{|g| g.blank?}) unless @group_values.empty?


### PR DESCRIPTION
without this fix Rails process itself somehow works fine, but rake tasks and migrations fail with error messages like
  undefined method 'quote_table_name' for nil:NilClass

Problem was found/fixed in 3.0 release line, and it looks like 3.1 would benefit from same fix as well.
