### PR TITLE
Add HTTP_HOST information to RoutingError for multi-domain apps

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -51,7 +51,7 @@ module ActionDispatch
         # Only this middleware cares about RoutingError. So, let's just raise
         # it here.
         if headers['X-Cascade'] == 'pass'
-           raise ActionController::RoutingError, "No route matches [#{env['REQUEST_METHOD']}] #{env['PATH_INFO'].inspect}"
+           raise ActionController::RoutingError, "No route matches [#{env['REQUEST_METHOD']}] #{env['PATH_INFO'].inspect} on #{env['HTTP_HOST']}"
         end
       rescue Exception => exception
         raise exception if env['action_dispatch.show_exceptions'] == false


### PR DESCRIPTION
This is my first commit (ever), so not sure if this is something that Rails could use, and if this needs testing (guessing no), but it helped me out a lot during testing, so perhaps it's useful for others as well.

This adds the `HTTP_HOST` env variable to the `ActionController::RoutingError` error message. For me this proved invaluable for use during testing multi-domain apps to understand why routes which are domain-constraint won't work as expected.

It basically changes this:

`No route matches [POST] "/signup" (ActionController::RoutingError)`

into this:

`No route matches [POST] "/signup" on mydomain.dev (ActionController::RoutingError)`
