### PR TITLE
Fix AR test suite error under Rubinius 2.0 #rbxday

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -1,5 +1,6 @@
 require 'active_support/duration'
 require 'active_support/core_ext/time/zones'
+require 'active_support/core_ext/time/conversions'
 
 class Time
   COMMON_YEAR_DAYS_IN_MONTH = [nil, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]


### PR DESCRIPTION
I got this error running AR tests under Rubinius:

```

undefined method `to_time' on an instance of Time. (NoMethodError)

Backtrace:
  Kernel(Time)#to_time (method_missing) at kernel/delta/kernel.rb:79
     Time#<=> (compare_with_coercion) at /Users/guille/code/rails/activesupport
                                         /lib/active_support/core_ext/time
                                         /calculations.rb:310
```

The error is fixed including a missing require
