### PR TITLE
Add :reject_unless option to accepts_nested_attributes

### DIFF
--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -94,6 +94,14 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
     assert_no_difference('Ship.count') { pirate.save! }
   end
 
+  def test_reject_unless_method_without_arguments
+    Pirate.accepts_nested_attributes_for :ship, :reject_unless => :persisted?
+
+    pirate = Pirate.new(:catchphrase => "Stop wastin' me time")
+    pirate.ship_attributes = { :name => 'Black Pearl' }
+    assert_no_difference('Ship.count') { pirate.save! }
+  end
+
   def test_reject_if_method_with_arguments
     Pirate.accepts_nested_attributes_for :ship, :reject_if => :reject_empty_ships_on_create
 
@@ -107,8 +115,27 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
     assert_difference('Ship.count') { pirate.save! }
   end
 
+  def test_reject_unless_method_with_arguments
+    Pirate.accepts_nested_attributes_for :ship, :reject_unless => :ship_has_all_caps_name?
+
+    pirate = Pirate.new(:catchphrase => "Stop wastin' me time")
+    pirate.ship_attributes = {:name => "Red Pearl"}
+    assert_no_difference('Ship.count') { pirate.save! }
+
+    pirate.ship_attributes = { :name => 'RED PEARL' }
+    assert_difference('Ship.count') { pirate.save! }
+  end
+
   def test_reject_if_with_indifferent_keys
     Pirate.accepts_nested_attributes_for :ship, :reject_if => proc {|attributes| attributes[:name].blank? }
+
+    pirate = Pirate.new(:catchphrase => "Stop wastin' me time")
+    pirate.ship_attributes = { :name => 'Hello Pearl' }
+    assert_difference('Ship.count') { pirate.save! }
+  end
+
+  def test_reject_unless_with_indifferent_keys
+    Pirate.accepts_nested_attributes_for :ship, :reject_unless => proc {|attributes| attributes[:name].present? }
 
     pirate = Pirate.new(:catchphrase => "Stop wastin' me time")
     pirate.ship_attributes = { :name => 'Hello Pearl' }

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -53,6 +53,10 @@ class Pirate < ActiveRecord::Base
     attributes.delete('_reject_me_if_new').present? && !persisted?
   end
 
+  def ship_has_all_caps_name?(attributes)
+    attributes[:name].chars.all? { |c| c.upcase == c }
+  end
+
   attr_accessor :cancel_save_from_callback
   before_save :cancel_save_callback_method, :if => :cancel_save_from_callback
   def cancel_save_callback_method


### PR DESCRIPTION
I've added an option to `accepts_nested_attributes` called `:reject_unless`. It works the same way as `:reject_if`, but using negative conditions. Sometimes this can help you to specify your conditions in a more semantic way, making the code a bit more readable. For example:

``` ruby
accepts_nested_attributes_for :author, :reject_unless => proc {|attributes| attributes[:name].present? && attributes[:age].present?}
```

looks clearer than

``` ruby
accepts_nested_attributes_for :author, :reject_if => proc {|attributes| attributes[:name].blank? || attributes[:age].blank?}
```

I know this is not a significant change, but it adds something similar to those things we like in Ruby and Rails, like the `unless` keyword :)
