### PR TITLE
Asset pipeline fixes: clear out tmp cache and use environment in digest generation

### DIFF
--- a/actionpack/lib/sprockets/assets.rake
+++ b/actionpack/lib/sprockets/assets.rake
@@ -16,7 +16,7 @@ namespace :assets do
   end
 
   desc "Remove compiled assets"
-  task :clean => :environment do
+  task :clean => [:environment, 'tmp:cache:clear'] do
     assets = Rails.application.config.assets
     public_asset_path = Rails.public_path + assets.prefix
     rm_rf public_asset_path, :secure => true

--- a/actionpack/lib/sprockets/railtie.rb
+++ b/actionpack/lib/sprockets/railtie.rb
@@ -20,7 +20,7 @@ module Sprockets
       app.assets = Sprockets::Environment.new(app.root.to_s) do |env|
         env.static_root = File.join(app.root.join('public'), config.assets.prefix)
         env.logger = ::Rails.logger
-        env.version = ::Rails.env + '-' + env.version
+        env.version = ::Rails.env + '-' + config.assets.version
 
         if config.assets.cache_store != false
           env.cache = ActiveSupport::Cache.lookup_store(config.assets.cache_store) || ::Rails.cache

--- a/actionpack/lib/sprockets/railtie.rb
+++ b/actionpack/lib/sprockets/railtie.rb
@@ -20,6 +20,7 @@ module Sprockets
       app.assets = Sprockets::Environment.new(app.root.to_s) do |env|
         env.static_root = File.join(app.root.join('public'), config.assets.prefix)
         env.logger = ::Rails.logger
+        env.version = ::Rails.env + '-' + env.version
 
         if config.assets.cache_store != false
           env.cache = ActiveSupport::Cache.lookup_store(config.assets.cache_store) || ::Rails.cache

--- a/actionpack/test/template/sprockets_helper_test.rb
+++ b/actionpack/test/template/sprockets_helper_test.rb
@@ -205,4 +205,17 @@ class SprocketsHelperTest < ActionView::TestCase
     stubs(:asset_environment).returns(assets)
     assert_match %r{/assets/style-[0-9a-f]+.css}, asset_path("style", "css")
   end
+
+  test "alternate hash based on environment" do
+    assets = Sprockets::Environment.new
+    assets.version = 'development'
+    assets.append_path(FIXTURES.join("sprockets/alternate/stylesheets"))
+    stubs(:asset_environment).returns(assets)
+    dev_path = asset_path("style", "css")
+
+    assets.version = 'production'
+    prod_path = asset_path("style", "css")
+
+    assert_not_equal prod_path, dev_path
+  end
 end

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -80,7 +80,7 @@ module ApplicationTests
         Dir.chdir(app_path){ `bundle exec rake assets:clean` }
       end
 
-      files = Dir["#{app_path}/public/assets/**/*"]
+      files = Dir["#{app_path}/public/assets/**/*", "#{app_path}/tmp/cache/*"]
       assert_equal 0, files.length, "Expected no assets, but found #{files.join(', ')}"
     end
 


### PR DESCRIPTION
A couple of small fixes for asset pipeline, as per discussion in: https://github.com/rails/rails/issues/2211
- update `rake assets:clean` to also invoke `rake tmp:clear` to dump the tmp cache and force a full recompile
- update digest generation for assets to include current environment + version number to avoid accidentally serving the wrong version
