### PR TITLE
Fix ActiveSupport::Gzip under Ruby 1.8.7. Closes #2416

### DIFF
--- a/activesupport/lib/active_support/gzip.rb
+++ b/activesupport/lib/active_support/gzip.rb
@@ -1,5 +1,6 @@
 require 'zlib'
 require 'stringio'
+require 'active_support/core_ext/string/encoding'
 
 module ActiveSupport
   # A convenient wrapper for the zlib standard library that allows compression/decompression of strings with gzip.


### PR DESCRIPTION
This can be backported to 3-1-stable and 3-0-stable
