### PR TITLE
sqlite transactions in log files

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
@@ -238,15 +238,15 @@ module ActiveRecord
       end
 
       def begin_db_transaction #:nodoc:
-        @connection.transaction
+        log('begin transaction',nil) { @connection.transaction }
       end
 
       def commit_db_transaction #:nodoc:
-        @connection.commit
+        log('commit transaction',nil) { @connection.commit }
       end
 
       def rollback_db_transaction #:nodoc:
-        @connection.rollback
+        log('rollback transaction',nil) { @connection.rollback }
       end
 
       # SCHEMA STATEMENTS ========================================


### PR DESCRIPTION
Before this change, when using sqlite, I could not see the begin, commit or rollbacks in the log files.  With MySQL this information is shown and it is very useful when debugging transactions. 

This is how it all started:
http://stackoverflow.com/questions/6892630/sqlite-transactions-not-showing-in-test-log
