### PR TITLE
Removed :order => "id" from :clients_of_firm to fix ORA-00907 errors.

### DIFF
--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -43,7 +43,7 @@ class Firm < Company
       :after_remove  => :log_after_remove
   has_many :unsorted_clients, :class_name => "Client"
   has_many :clients_sorted_desc, :class_name => "Client", :order => "id DESC"
-  has_many :clients_of_firm, :foreign_key => "client_of", :class_name => "Client", :order => "id"
+  has_many :clients_of_firm, :foreign_key => "client_of", :class_name => "Client"
   has_many :unvalidated_clients_of_firm, :foreign_key => "client_of", :class_name => "Client", :validate => false
   has_many :dependent_clients_of_firm, :foreign_key => "client_of", :class_name => "Client", :order => "id", :dependent => :destroy
   has_many :exclusively_dependent_clients_of_firm, :foreign_key => "client_of", :class_name => "Client", :order => "id", :dependent => :delete_all


### PR DESCRIPTION
Tested with Oracle database, HasManyAssociationsTest got 9 errors as follows.

``` ruby

  4) Error:
test_clearing_an_association_collection(HasManyAssociationsTest):
ActiveRecord::StatementInvalid: OCIError: ORA-00907: missing right parenthesis: UPDATE "COMPANIES" SET "CLIENT_OF" = NULL WHERE "COMPANIES"."ID" IN (SELECT "COMPANIES"."ID" FROM "COMPANIES"  WHERE "COMPANIES"."TYPE" IN ('Client', 'SpecialClient', 'VerySpecialClient') AND "COMPANIES"."CLIENT_OF" = 1 AND "COMPANIES"."ID" IN (3) ORDER BY id)
```

Although this ORA-00907 error message is not straightforward, this error can be fixed by removing "ORDER BY id" from subquery.
:order => "id" argument is removed from :clients_of_firm because update statement result will not be affected by removing order by clause.

All activerecord tests are passed with this fix for PostgreSQL 8.4 and MySQL 5.1.
