### PR TITLE
Fix TimeWithZone#to_time to return self instead of utc

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -379,9 +379,10 @@ class Time
   # Layers additional behavior on Time#<=> so that DateTime and ActiveSupport::TimeWithZone instances
   # can be chronologically compared with a Time
   def compare_with_coercion(other)
+    other = other.comparable_time if other.respond_to?(:comparable_time)
     # we're avoiding Time#to_datetime cause it's expensive
     if other.is_a?(Time)
-      compare_without_coercion(other.to_time)
+      compare_without_coercion(other)
     else
       to_datetime <=> other
     end

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -279,7 +279,7 @@ module ActiveSupport
 
     # A TimeWithZone acts like a Time, so just return +self+.
     def to_time
-      utc
+      self
     end
 
     def to_datetime

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -38,7 +38,7 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
   def test_to_date
     date = Date.new(2005, 2, 21)
 
-    assert date.equal?(date)
+    assert date.equal?(date.to_date)
   end
 
   def test_change

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -36,7 +36,9 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
   end
 
   def test_to_date
-    assert_equal Date.new(2005, 2, 21), Date.new(2005, 2, 21).to_date
+    date = Date.new(2005, 2, 21)
+
+    assert date.equal?(date)
   end
 
   def test_change

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -37,8 +37,7 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
 
   def test_to_date
     date = Date.new(2005, 2, 21)
-
-    assert date.equal?(date.to_date)
+    assert_same date.to_date, date
   end
 
   def test_change

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -30,7 +30,9 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
   end
 
   def test_to_datetime
-    assert_equal DateTime.new(2005, 2, 21, 14, 30, 0), DateTime.new(2005, 2, 21, 14, 30, 0).to_datetime
+    datetime = DateTime.new(2005, 2, 21, 14, 30, 0)
+
+    assert datetime.equal?(datetime.to_datetime)
   end
 
   def test_to_time

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -32,7 +32,7 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
   def test_to_datetime
     datetime = DateTime.new(2005, 2, 21, 14, 30, 0)
 
-    assert datetime.equal?(datetime.to_datetime)
+    assert datetime.to_datetime, datetime
   end
 
   def test_to_time

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -587,15 +587,8 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal ::Date::ITALY, Time.utc(2005, 2, 21, 17, 44, 30).to_datetime.start # use Ruby's default start value
   end
 
-  if RUBY_VERSION < '1.9'
-    def test_to_time
-      time = Time.local(2005, 2, 21, 17, 44, 30)
-      assert time.equal?(time.to_time)
-    end
-  else
-    def test_to_time
-      assert_equal Time.local(2005, 2, 21, 17, 44, 30), Time.local(2005, 2, 21, 17, 44, 30).to_time
-    end
+  def test_to_time
+    assert_equal Time.local(2005, 2, 21, 17, 44, 30).to_time, Time.local(2005, 2, 21, 17, 44, 30)
   end
 
   # NOTE: this test seems to fail (changeset 1958) only on certain platforms,

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -588,7 +588,13 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
   end
 
   def test_to_time
-    assert_equal Time.local(2005, 2, 21, 17, 44, 30).to_time, Time.local(2005, 2, 21, 17, 44, 30)
+    with_env_tz 'US/Eastern' do
+      # Ruby 1.9 Time#to_time returns getlocal, which deviates from the original
+      # AS implementation returning self. The core Time class method is unchanged.
+      time = Time.utc(2005, 2, 21, 17, 44, 30)
+      # Compare as strings with values and zone
+      assert_equal time.to_time.to_s(:rfc822), time.getlocal.to_s(:rfc822)
+    end
   end
 
   # NOTE: this test seems to fail (changeset 1958) only on certain platforms,

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -587,8 +587,15 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal ::Date::ITALY, Time.utc(2005, 2, 21, 17, 44, 30).to_datetime.start # use Ruby's default start value
   end
 
-  def test_to_time
-    assert_equal Time.local(2005, 2, 21, 17, 44, 30), Time.local(2005, 2, 21, 17, 44, 30).to_time
+  if RUBY_VERSION < '1.9'
+    def test_to_time
+      time = Time.local(2005, 2, 21, 17, 44, 30)
+      assert time.equal?(time.to_time)
+    end
+  else
+    def test_to_time
+      assert_equal Time.local(2005, 2, 21, 17, 44, 30), Time.local(2005, 2, 21, 17, 44, 30).to_time
+    end
   end
 
   # NOTE: this test seems to fail (changeset 1958) only on certain platforms,

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -319,7 +319,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
   end
 
   def test_to_time
-    assert_equal @twz, @twz.to_time
+    assert @twz.equal?(@twz.to_time)
   end
 
   def test_to_date

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -319,7 +319,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
   end
 
   def test_to_time
-    assert @twz.equal?(@twz.to_time)
+    assert_same @twz.to_time, @twz
   end
 
   def test_to_date


### PR DESCRIPTION
A previous change to TimeWithZone#to_time returned utc. This is unexpected and doesn't match the comment above the method. The original change was made to simplify the <=> override on Time. Using a different technique achieves the same result while preserving the expected to_time behaviour.

Also added better tests for the temporal classes when they should return self i.e. Time#to_time, Date#to_date and DateTime#to_datetime.

Inexplicably Ruby 1.9 does not return self from Time#to_time, but getlocal instead. I wonder if we should override this?
