### PR TITLE
Added irregular zombie inflection, so zombies != zomby

### DIFF
--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -54,6 +54,7 @@ module ActiveSupport
     inflect.irregular('sex', 'sexes')
     inflect.irregular('move', 'moves')
     inflect.irregular('cow', 'kine')
+    inflect.irregular('zombie', 'zombies')
 
     inflect.uncountable(%w(equipment information rice money species series fish sheep jeans))
   end


### PR DESCRIPTION
Over 50k people have received their first taste of Rails by playing through "Rails for Zombies" (http://railsforzombies.org).  Only problem is when they start to play around using a zombie scaffold:

rails generate scaffold zombie name:string

This generates controller which improperly singularizes zombies, so the instance variables are all @zomby.  As a side-effect of this form attributes don't work.  The parameters properly send "zombie"=>{"name"=>"test"}", but the controller is looking for params[:zomby].

For the sake of new people trying to learn Rails who email me wondering why their first app doesn't work, and... well.. for the sake of the zombies, can we fix this tragedy?

![Zombies were people too](https://img.skitch.com/20110807-rk3rjabfkyxx2gwsnru1tsrgdy.png)
