### PR TITLE
Further monkey-patching to avoid deprecation warnings

### DIFF
--- a/railties/lib/rails/tasks/documentation.rake
+++ b/railties/lib/rails/tasks/documentation.rake
@@ -8,6 +8,8 @@ end
 
 # Monkey-patch to remove redoc'ing and clobber descriptions to cut down on rake -T noise
 class RDocTaskWithoutDescriptions < RDoc::Task
+  include ::Rake::DSL
+
   def define
     task rdoc_task_name
 


### PR DESCRIPTION
Include Rake::DSL into monkey-patch to remove more warnings.
