### PR TITLE
Fixed test_disable_referential_integrity on Oracle

### DIFF
--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -151,6 +151,9 @@ class AdapterTest < ActiveRecord::TestCase
         else
           @connection.execute "INSERT INTO fk_test_has_fk (fk_id) VALUES (0)"
         end
+        # should deleted created record as otherwise disable_referential_integrity will try to enable contraints after executed block
+        # and will fail (at least on Oracle)
+        @connection.execute "DELETE FROM fk_test_has_fk"
       end
     end
   end


### PR DESCRIPTION
On Oracle disable_referential_integrity before execution of block will disable foreign key constraints and after block will enable them but when constraints are enabled then they are validated. Therefore created record with invalid foreign key should be deleted before enabling foreign key constraints.
