### PR TITLE
ActiveResource::Base.delete should pass headers

### DIFF
--- a/activeresource/lib/active_resource/base.rb
+++ b/activeresource/lib/active_resource/base.rb
@@ -848,7 +848,7 @@ module ActiveResource
       #   # Let's assume a request to events/5/cancel.json
       #   Event.delete(params[:id]) # sends DELETE /events/5
       def delete(id, options = {})
-        connection.delete(element_path(id, options))
+        connection.delete(element_path(id, options), headers)
       end
 
       # Asserts the existence of a resource, returning <tt>true</tt> if the resource is found.


### PR DESCRIPTION
I've committed a fix for the issue described in the following ticket.
https://github.com/rails/rails/issues/2479
