### PR TITLE
Inconsistencies when eager loading with fully-qualified table names using Oracle

### DIFF
--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -83,9 +83,8 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal 2, posts.first.comments.size
   end
 
-  def test_with_full_qualified_table_name
+  def test_with_fully_qualified_table_name
     assert_equal "Research", Emp.find(1, :include => :dept).dept.nombre
-    assert_equal "Research", Emp.find(:first, :include => :dept).dept.nombre
   end
 
   def test_loading_with_multiple_associations

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -22,12 +22,15 @@ require 'models/membership'
 require 'models/club'
 require 'models/categorization'
 require 'models/sponsor'
+require 'models/emp'
+require 'models/dept'
 
 class EagerAssociationTest < ActiveRecord::TestCase
   fixtures :posts, :comments, :authors, :author_addresses, :categories, :categories_posts,
             :companies, :accounts, :tags, :taggings, :people, :readers, :categorizations,
             :owners, :pets, :author_favorites, :jobs, :references, :subscribers, :subscriptions, :books,
-            :developers, :projects, :developers_projects, :members, :memberships, :clubs, :sponsors
+            :developers, :projects, :developers_projects, :members, :memberships, :clubs, :sponsors,
+            :emps, :depts
 
   def setup
     # preheat table existence caches
@@ -78,6 +81,11 @@ class EagerAssociationTest < ActiveRecord::TestCase
   def test_with_two_tables_in_from_without_getting_double_quoted
     posts = Post.select("posts.*").from("authors, posts").eager_load(:comments).where("posts.author_id = authors.id").order("posts.id").to_a
     assert_equal 2, posts.first.comments.size
+  end
+
+  def test_with_full_qualified_table_name
+    assert_equal "Research", Emp.find(1, :include => :dept).dept.nombre
+    assert_equal "Research", Emp.find(:first, :include => :dept).dept.nombre
   end
 
   def test_loading_with_multiple_associations

--- a/activerecord/test/fixtures/depts.yml
+++ b/activerecord/test/fixtures/depts.yml
@@ -1,0 +1,3 @@
+research:
+  id: 1
+  name: Research

--- a/activerecord/test/fixtures/emps.yml
+++ b/activerecord/test/fixtures/emps.yml
@@ -1,0 +1,4 @@
+doej:
+  id: 1
+  name: John Doe
+  dept_id: 1

--- a/activerecord/test/models/dept.rb
+++ b/activerecord/test/models/dept.rb
@@ -1,0 +1,5 @@
+class Dept < ActiveRecord::Base
+  if connection.class.to_s == "ActiveRecord::ConnectionAdapters::OracleAdapter"
+    set_table_name "#{connection.current_user.downcase}.depts"
+  end
+end

--- a/activerecord/test/models/emp.rb
+++ b/activerecord/test/models/emp.rb
@@ -1,0 +1,6 @@
+class Emp < ActiveRecord::Base
+  if connection.class.to_s == "ActiveRecord::ConnectionAdapters::OracleAdapter"
+    set_table_name "#{connection.current_user.downcase}.emps"
+  end
+  belongs_to :dept, :select => "id, name nombre"
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -712,6 +712,14 @@ ActiveRecord::Schema.define do
     t.string 'a$b'
   end
 
+  create_table :emps, :force => true do |t|
+    t.string :name
+    t.integer :dept_id
+  end
+  create_table :depts, :force => true do |t|
+    t.string :name
+  end
+
   except 'SQLite' do
     # fk_test_has_fk should be before fk_test_has_pk
     create_table :fk_test_has_fk, :force => true do |t|


### PR DESCRIPTION
This pull request adds a test demonstrating how table names are not correctly detected by ActiveRecord::Relation.  I've sketched out an insufficient patch (b039f1b3f781cd60a9c60d469c7fff1b744f9cb0) which allows the new test to pass for Oracle but breaks the test suite in other places, especially for other databases (or at least SQLite3).

In order to get the test to fail, run 'rake test_oracle' after setting up test/config.yml to use an Oracle database with a username like 'ops$user', or any valid variation that has non-word characters in it.  It should pass otherwise.
## Discussion

Eager loading will revert to the left-outer-join strategy when using fully-qualified table names on Oracle. For example:

``` ruby
  class Dept < ActiveRecord::Base
    set_table_name "dept"
  end

  class Emp < ActiveRecord::Base
    set_table_name "emp"
    belongs_to :dept, :select => "id, name nombre"
  end

  Emp.find(1, :include => :dept).dept.nombre       # ok
  Emp.find(:first, :include => :dept).dept.nombre  # ok
```

This code works as written because the default one-query-per-association strategy is used; as a result the select is used and nombre gets set on the dept record. However if you qualify the table name then the select is not used in some cases; find using an id breaks but find :first still works.

``` ruby
  class Dept < ActiveRecord::Base
    set_table_name "schema_name.dept"
  end

  class Emp < ActiveRecord::Base
    set_table_name "schema_name.emp"
    belongs_to :dept, :select => "id, name nombre"
  end

  Emp.find(1, :include => :dept).dept.nombre       # NoMethodError
  Emp.find(:first, :include => :dept).dept.nombre  # ok
```

In the id case eager loading reverts to the left-outer-join strategy and the select is ignored. The difference can be traced to the `tables_in_string` method which is responsible for extracting tables from the select string. This is how it's written in 2.3.5:

``` ruby
  # [active_record/association.rb]
  def tables_in_string(string)
    return [] if string.blank?
    string.scan(/([\.a-zA-Z_]+).?\./).flatten
  end
```

Turns out the regexp doesn't handle the fully-qualified names properly. There were [some patches](https://rails.lighthouseapp.com/projects/8994/tickets/4770-patch-patches-for-activerecord-oracle-enhanced-adapter-compatibility) that partially fix this in 3.0.0 but the fix isn't complete. This is how the same method is currently:

``` ruby
  # [active_record/relation.rb]
  def tables_in_string(string)
    return [] if string.blank?
    # always convert table names to downcase as in Oracle quoted table names are in uppercase
    # ignore raw_sql_ that is used by Oracle adapter as alias for limit/offset subqueries
    string.scan(/([a-zA-Z_][.\w]+).?\./).flatten.map{ |s| s.downcase }.uniq - ['raw_sql_']
  end
```

This handles word-based schemas, but it will not handle other valid Oracle schemas like 'schema$name' nor will it handle tables with a db link. The method can be kind-of fixed with a fancier regexp:

``` ruby
  class ActiveRecord::Relation
    NONQUOTED_OBJECT_NAME   = /[A-Za-z][A-z0-9$#]{0,29}/
    NONQUOTED_DATABASE_LINK = /[A-Za-z][A-z0-9$#\.@]{0,127}/
    TABLES_IN_STRING = /((?:#{NONQUOTED_OBJECT_NAME}\.)?#{NONQUOTED_OBJECT_NAME}(?:@#{NONQUOTED_DATABASE_LINK})?)\..?/

    def tables_in_string(string)
      return [] if string.blank?
      string.scan(TABLES_IN_STRING).flatten.map {|str| str.downcase }.uniq - ['raw_sql_']
    end
  end

  class Dept < ActiveRecord::Base
    set_table_name "schema_name.dept"
  end

  class Emp < ActiveRecord::Base
    set_table_name "schema_name.emp"
    belongs_to :dept, :select => "id, name nombre"
  end

  Emp.find(1, :include => :dept).dept.nombre       # ok
  Emp.find(:first, :include => :dept).dept.nombre  # ok
```

But this is getting kinda wild. Moreover it's not correct for other databases.

A couple links:
- [a test of the regexp above](https://gist.github.com/490817)
- [a more thorough study of the select issue](https://gist.github.com/486750)

And note that this reproduces and addresses [issue 5200](https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/5200-inconsistencies-when-eager-loading-with-fully-qualified-table-names-using-oracle) from lighthouse, which was not migrated to github.
