### PR TITLE
handle '*/*;q=0.1' style single but has qvalue acceptline.

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -82,6 +82,7 @@ module Mime
     class << self
 
       TRAILING_STAR_REGEXP = /(text|application)\/\*/
+      QVALUE_SEP_REGEXP = /;\s*q=/
 
       def lookup(string)
         LOOKUP[string]
@@ -108,6 +109,7 @@ module Mime
 
       def parse(accept_header)
         if accept_header !~ /,/
+          accept_header, ignore = accept_header.split(QVALUE_SEP_REGEXP)
           if accept_header =~ TRAILING_STAR_REGEXP
             parse_data_with_trailing_star($1)
           else
@@ -117,7 +119,7 @@ module Mime
           # keep track of creation order to keep the subsequent sort stable
           list, index = [], 0
           accept_header.split(/,/).each do |header|
-            params, q = header.split(/;\s*q=/)
+            params, q = header.split(QVALUE_SEP_REGEXP)
             if params.present?
               params.strip!
 

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -84,8 +84,7 @@ class MimeTypeTest < ActiveSupport::TestCase
     assert_equal expect, Mime::Type.parse(accept).collect { |c| c.to_s }
   end
 
-  # tig, http://www.misuzilla.org/dist/net/twitterircgateway/
-  test "parse more other broken acceptlines" do
+  test "parse single with q" do
     assert_equal [Mime::ALL], Mime::Type.parse('*/*;q=0.1')
     assert_equal [Mime::HTML], Mime::Type.parse('text/html;q=0.1')
   end

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -84,6 +84,12 @@ class MimeTypeTest < ActiveSupport::TestCase
     assert_equal expect, Mime::Type.parse(accept).collect { |c| c.to_s }
   end
 
+  # tig, http://www.misuzilla.org/dist/net/twitterircgateway/
+  test "parse more other broken acceptlines" do
+    assert_equal [Mime::ALL], Mime::Type.parse('*/*;q=0.1')
+    assert_equal [Mime::HTML], Mime::Type.parse('text/html;q=0.1')
+  end
+
   test "custom type" do
     begin
       Mime::Type.register("image/foo", :foo)


### PR DESCRIPTION
Some client send broken accept line and the accept line breaks Rails' template resolver mechanism from bothering Mime::Type.parse().

This patch lets Mime::Type.parse() ignore qvalue when accept line has only one mime-type.
