### PR TITLE
fix exists? to return false if passed nil (which may come from a missing 

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -180,7 +180,9 @@ module ActiveRecord
     #   Person.exists?(:name => "David")
     #   Person.exists?(['name LIKE ?', "%#{query}%"])
     #   Person.exists?
-    def exists?(id = nil)
+    def exists?(id = false)
+      return false if id.nil?
+
       id = id.id if ActiveRecord::Base === id
 
       join_dependency = construct_join_dependency_for_association_find

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -48,6 +48,15 @@ class FinderTest < ActiveRecord::TestCase
     assert Topic.exists?
   end
 
+  # exists? should handle nil for id's that come from URLs and always return false
+  # (example: Topic.exists?(params[:id])) where params[:id] is nil
+  def test_exists_with_nil_arg
+    assert !Topic.exists?(nil)
+    assert Topic.exists?
+    assert !Topic.first.replies.exists?(nil)
+    assert Topic.first.replies.exists?
+  end
+
   def test_does_not_exist_with_empty_table_and_no_args_given
     Topic.delete_all
     assert !Topic.exists?


### PR DESCRIPTION
fixes exists? on ActiveRecord classes to return false if passed nil (which may come from a missing URL param)

Before:
Topic.exists?(nil) => true

After:
Topic.exists?(nil) => false

This is the behaviour that Rails 2.x had and should be how Rails 3.x works as well.

Please backport to Rails 3-0 stable.
