### PR TITLE
Use cached column information for the join table of a has_many :through

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -2159,7 +2159,8 @@ module ActiveRecord
                 ]
               when :has_many, :has_one
                 if reflection.options[:through]
-                  join_table = Arel::Table.new(through_reflection.klass.table_name, :as => aliased_join_table_name, :engine => arel_engine)
+                  join_table = Arel::Table.new(through_reflection.klass.table_name, :as => aliased_join_table_name, 
+                                               :engine => arel_engine, :columns => through_reflection.klass.columns)
                   jt_as_conditions = through_reflection.options[:conditions] && process_conditions(through_reflection.options[:conditions], aliased_table_name)
                   jt_as_extra = jt_source_extra = jt_sti_extra = nil
                   first_key = second_key = as_extra = nil

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -54,6 +54,16 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     assert_equal 0, Post.connection.column_calls
   end
 
+  def test_has_many_through_column_caching
+    # pre-heat our cache
+    Author.arel_table.columns
+    Post.arel_table.columns
+    Comment.arel_table.columns
+    Comment.connection.column_calls = 0
+    2.times { Author.joins(:comments).to_a }
+    assert_equal 0, Comment.connection.column_calls
+  end
+
   def test_has_many_uniq_through_find
     assert_equal 1, authors(:mary).unique_categorized_posts.find(:all).size
   end


### PR DESCRIPTION
Use cached column information for the join table of a has_many :through association in ActiveRecord::Associations::ClassMethods::JoinDependency::JoinAssociation#association_join. This prevents us from having to fire off new schema info queries every time we call #joins() with a :through association.

Commit 96bd936 fixed this last year for plain has_many associations, but it still happens for has_many :through's.
