### PR TITLE
The first IP address in the X-Forwarded-For header is the originating IP

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -57,7 +57,7 @@ module ActionDispatch
             "HTTP_X_FORWARDED_FOR=#{@env['HTTP_X_FORWARDED_FOR'].inspect}"
         end
 
-        not_proxy = client_ip || forwarded_ips.last || remote_addrs.first
+        not_proxy = client_ip || forwarded_ips.first || remote_addrs.first
 
         # Return first REMOTE_ADDR if there are no other options
         not_proxy || ips_from('REMOTE_ADDR', :allow_proxies).first

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -42,7 +42,7 @@ class RequestTest < ActiveSupport::TestCase
       'HTTP_X_FORWARDED_FOR' => '3.4.5.6'
     assert_equal '3.4.5.6', request.remote_ip
 
-    request = stub_request 'HTTP_X_FORWARDED_FOR' => 'unknown,3.4.5.6'
+    request = stub_request 'HTTP_X_FORWARDED_FOR' => '3.4.5.6,unknown'
     assert_equal '3.4.5.6', request.remote_ip
 
     request = stub_request 'HTTP_X_FORWARDED_FOR' => '172.16.0.1,3.4.5.6'
@@ -63,7 +63,7 @@ class RequestTest < ActiveSupport::TestCase
     request = stub_request 'HTTP_X_FORWARDED_FOR' => 'unknown,192.168.0.1'
     assert_equal 'unknown', request.remote_ip
 
-    request = stub_request 'HTTP_X_FORWARDED_FOR' => '9.9.9.9, 3.4.5.6, 10.0.0.1, 172.31.4.4'
+    request = stub_request 'HTTP_X_FORWARDED_FOR' => '3.4.5.6, 9.9.9.9, 10.0.0.1, 172.31.4.4'
     assert_equal '3.4.5.6', request.remote_ip
 
     request = stub_request 'HTTP_X_FORWARDED_FOR' => '1.1.1.1',
@@ -85,7 +85,7 @@ class RequestTest < ActiveSupport::TestCase
                            :ip_spoofing_check => false
     assert_equal '2.2.2.2', request.remote_ip
 
-    request = stub_request 'HTTP_X_FORWARDED_FOR' => '8.8.8.8, 9.9.9.9'
+    request = stub_request 'HTTP_X_FORWARDED_FOR' => '9.9.9.9, 8.8.8.8'
     assert_equal '9.9.9.9', request.remote_ip
   end
 
@@ -116,7 +116,7 @@ class RequestTest < ActiveSupport::TestCase
     request = stub_request 'HTTP_X_FORWARDED_FOR' => 'unknown,67.205.106.73'
     assert_equal 'unknown', request.remote_ip
 
-    request = stub_request 'HTTP_X_FORWARDED_FOR' => '9.9.9.9, 3.4.5.6, 10.0.0.1, 67.205.106.73'
+    request = stub_request 'HTTP_X_FORWARDED_FOR' => '3.4.5.6, 9.9.9.9, 10.0.0.1, 67.205.106.73'
     assert_equal '3.4.5.6', request.remote_ip
   end
 


### PR DESCRIPTION
When geocoding IP addresses, I found that remote_ip values for requests coming through multiple proxies were incorrect.

Currently RemoteIpGetter instances are looking at the **right-most** IP address in the X-Forwarded-For header for the originating remote IP.

Wikipedia's [X-Forwarded-For article](http://en.wikipedia.org/wiki/X-Forwarded-For) describes the format of the (non-RFC-standard) field as "a comma+space separated list of IP addresses, the **left-most** being the farthest downstream client", which is consistent with what I'm seeing.

Have you seen otherwise in the wild?

Thanks!
