### PR TITLE
fix destructive stringify_keys for label_tag

### DIFF
--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -179,9 +179,9 @@ module ActionView
       def label_tag(name = nil, content_or_options = nil, options = nil, &block)
         options = content_or_options if block_given? && content_or_options.is_a?(Hash)
         options ||= {}
-        options.stringify_keys!
+        options = options.stringify_keys
         options["for"] = sanitize_to_id(name) unless name.blank? || options.has_key?("for")
-        content_tag :label, content_or_options || name.to_s.humanize, options, &block
+        content_tag :label, content_or_options.is_a?(Hash) ? options : (content_or_options || name.to_s.humanize), options, &block
       end
 
       # Creates a hidden form input field used to transmit data that would be lost due to HTTP's statelessness or

--- a/actionpack/test/template/form_tag_helper_test.rb
+++ b/actionpack/test/template/form_tag_helper_test.rb
@@ -530,6 +530,12 @@ class FormTagHelperTest < ActionView::TestCase
     assert_equal options, { :option => "random_option" }
   end
 
+  def test_image_label_tag_options_symbolize_keys_side_effects
+    options = { :option => "random_option" }
+    actual = label_tag "submit source", "title", options
+    assert_equal options, { :option => "random_option" }
+  end
+
   def protect_against_forgery?
     false
   end


### PR DESCRIPTION
I previously fixed the stringify_keys for all the other functions in form_tag_helper but couldn't figure out how to fix label_tag (and so left it out). I believe this fixes that now.
