### PR TITLE
Fixing issue #2492. ActionView::Base.field_error_proc doesn't call for la

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -1117,9 +1117,16 @@ module ActionView
         @template.fields_for(record_name, record_object, fields_options, &block)
       end
 
-      def label(method, text = nil, options = {}, &block)
-        @template.label(@object_name, method, text, objectify_options(options), &block)
+      def label(method, content_or_options = nil, options = {}, &block)
+        if content_or_options.is_a?(Hash)
+          content_or_options = objectify_options(content_or_options)
+        else
+          options = objectify_options(options)
+        end
+
+        @template.label(@object_name, method, content_or_options, options, &block)
       end
+
 
       def check_box(method, options = {}, checked_value = "1", unchecked_value = "0")
         @template.check_box(@object_name, method, objectify_options(options), checked_value, unchecked_value)

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -1046,6 +1046,28 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_form_for_label_error_wrapping_without_conventional_instance_variable
+    post = remove_instance_variable :@post
+    default_field_error_proc = ActionView::Base.field_error_proc
+    ActionView::Base.field_error_proc = Proc.new{ |html_tag, instance| "<div class='error'>#{html_tag}</div>".html_safe }
+
+    form_for(post) do |f|
+      concat f.label(:author_name, :class => 'label')
+      concat f.text_field(:author_name)
+      concat f.submit('Create post')
+    end
+
+    expected = whole_form('/posts/123', 'edit_post_123' , 'edit_post', 'patch') do
+      "<div class='error'><label for='post_author_name' class='label'>Author name</label></div>" +
+      "<div class='error'><input name='post[author_name]' type='text' id='post_author_name' value='' /></div>" +
+      "<input name='commit' type='submit' value='Create post' />"
+    end
+
+    assert_dom_equal expected, output_buffer
+  ensure
+    ActionView::Base.field_error_proc = default_field_error_proc
+  end
+
   def test_form_for_with_namespace
     form_for(@post, :namespace => 'namespace') do |f|
       concat f.text_field(:title)


### PR DESCRIPTION
Fixing issue #2492. ActionView::Base.field_error_proc doesn't call for label.

objectify_options method should be applied to the proper options arg.
