### PR TITLE
When calling url_for with a hash, additional (likely unwanted) values (such as :host) would be returned in the hash

### DIFF
--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -140,7 +140,7 @@ module ActionDispatch
         when String
           options
         when nil, Hash
-          _routes.url_for((options || {}).reverse_merge!(url_options).symbolize_keys)
+          _routes.url_for((options.dup || {}).reverse_merge!(url_options).symbolize_keys)
         else
           polymorphic_url(options)
         end

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -851,6 +851,18 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     end
   end
 
+  # tests the use of dup in url_for
+  def test_url_for_with_no_side_effects
+    # without dup, additional (and possibly unwanted) values will be present in the options (eg. :host)
+    original_options = {:controller => 'projects', :action => 'status'}
+    options = original_options.dup
+
+    url_for options
+
+    # verify that the options passed in have not changed from the original ones
+    assert_equal original_options, options
+  end
+
   def test_projects_status
     with_test_routes do
       assert_equal '/projects/status', url_for(:controller => 'projects', :action => 'status', :only_path => true)


### PR DESCRIPTION
When calling url_for with a hash, additional (likely unwanted) values (such as :host) would be returned in the hash... calling #dup on the hash prevents this

Before fix:

options = {:controller => 'projects', :action => 'index'}
url_for(options)
options => {:controller => 'projects', :action => 'index', :host => 'www.example.com', :protocol => 'http'}

After fix:

options = {:controller => 'projects', :action => 'index'}
url_for(options)
options => {:controller => 'projects', :action => 'index'}
