### PR TITLE
Fix assert_select_email to work on non-multipart emails as well as converting the Mail::Body to a string to prevent errors.

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/selector.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/selector.rb
@@ -415,9 +415,9 @@ module ActionDispatch
         assert !deliveries.empty?, "No e-mail in delivery list"
 
         for delivery in deliveries
-          for part in delivery.parts
+          for part in (delivery.parts.empty? ? [delivery] : delivery.parts)
             if part["Content-Type"].to_s =~ /^text\/html\W/
-              root = HTML::Document.new(part.body).root
+              root = HTML::Document.new(part.body.to_s).root
               assert_select root, ":root", &block
             end
           end

--- a/actionpack/test/controller/assert_select_test.rb
+++ b/actionpack/test/controller/assert_select_test.rb
@@ -20,6 +20,15 @@ class AssertSelectTest < ActionController::TestCase
     end
   end
 
+  class AssertMultipartSelectMailer < ActionMailer::Base
+    def test(options)
+      mail :subject => "Test e-mail", :from => "test@test.host", :to => "test <test@test.host>" do |format|
+        format.text { render :text => options[:text] }
+        format.html { render :text => options[:html] }
+      end
+    end
+  end
+
   class AssertSelectController < ActionController::Base
     def response_with=(content)
       @content = content
@@ -305,6 +314,16 @@ EOF
   def test_assert_select_email
     assert_raise(Assertion) { assert_select_email {} }
     AssertSelectMailer.test("<div><p>foo</p><p>bar</p></div>").deliver
+    assert_select_email do
+      assert_select "div:root" do
+        assert_select "p:first-child", "foo"
+        assert_select "p:last-child", "bar"
+      end
+    end
+  end
+
+  def test_assert_select_email_multipart
+    AssertMultipartSelectMailer.test(:html => "<div><p>foo</p><p>bar</p></div>", :text => 'foo bar').deliver
     assert_select_email do
       assert_select "div:root" do
         assert_select "p:first-child", "foo"


### PR DESCRIPTION
Fix assert_select_email to work on non-multipart emails as well as converting the Mail::Body to a string to prevent errors.

assert_select_email didn't work at all on emails that weren't multipart.  Emails with one text/html part were simply skipped and nothing was tested at all.  The original test for assert_select_email also didn't report any errors because it didn't perform any of the inner assert_select tests.

assert_select_email now works on both single-part and multipart emails.

This patch also fixes the body passed to the HTML::Document.new which expects a string.  The body is a Mail::Body class which threw this error if passed...

```
NoMethodError: undefined method `encoding_aware?' for <div><p>foo</p><p>bar</p></div>:Mail::Body
```

Converting the body to a string with to_s fixes that issue.

Please backport to Rails 3-0 stable as well.
