### PR TITLE
We cannot dup on nil.

### DIFF
--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -140,7 +140,7 @@ module ActionDispatch
         when String
           options
         when nil, Hash
-          _routes.url_for((options.dup || {}).reverse_merge!(url_options).symbolize_keys)
+          _routes.url_for((options || {}).reverse_merge(url_options).symbolize_keys)
         else
           polymorphic_url(options)
         end


### PR DESCRIPTION
Added in previous commit. 

We cannot dup on nil. First we will check then do the dup 

fixed failing test 

``` ruby


  1) Error:
test_ensure_url_for_works_as_expected_when_called_with_no_options_if_default_url_options_is_not_set(EmptyUrlOptionsTest):
TypeError: can't dup NilClass
    /Users/arun/checkouts/rails/actionpack/lib/action_dispatch/routing/url_for.rb:143:in `dup'
    /Users/arun/checkouts/rails/actionpack/lib/action_dispatch/routing/url_for.rb:143:in `url_for'
    /Users/arun/checkouts/rails/actionpack/test/controller/base_test.rb:289:in `test_ensure_url_for_works_as_expected_when_called_with_no_options_if_default_url_options_is_not_set'
    /Users/arun/checkouts/rails/bundle/ruby/1.9.1/gems/mocha-0.9.12/lib/mocha/integration/mini_test/version_142_to_172.rb:27:in `run'
    /Users/arun/checkouts/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:35:in `block in run'
    /Users/arun/checkouts/rails/activesupport/lib/active_support/callbacks.rb:426:in `_run_setup_callbacks'
    /Users/arun/checkouts/rails/activesupport/lib/active_support/callbacks.rb:81:in `run_callbacks'
    /Users/arun/checkouts/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:34:in `run'
```
