### PR TITLE
Cant dup on nil 3 1 stable

### DIFF
--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -140,7 +140,7 @@ module ActionDispatch
         when String
           options
         when nil, Hash
-          _routes.url_for((options.dup || {}).reverse_merge!(url_options).symbolize_keys)
+          _routes.url_for((options || {}).reverse_merge(url_options).symbolize_keys)
         else
           polymorphic_url(options)
         end


### PR DESCRIPTION
Cheery-picked from master. Action pack failing because of nil.dup. 

8196c842b6f32271c23cba6b97918d32747018d8
