### PR TITLE
Allow ActiveRecord observers to be disabled.

### DIFF
--- a/activemodel/lib/active_model/observing.rb
+++ b/activemodel/lib/active_model/observing.rb
@@ -226,10 +226,10 @@ module ActiveModel
 
     # Send observed_method(object) if the method exists and
     # the observer is enabled for the given object's class.
-    def update(observed_method, object) #:nodoc:
+    def update(observed_method, object, &block) #:nodoc:
       return unless respond_to?(observed_method)
       return if disabled_for?(object)
-      send(observed_method, object)
+      send(observed_method, object, &block)
     end
 
     # Special method sent by the observed class when it is inherited.

--- a/activemodel/test/cases/observing_test.rb
+++ b/activemodel/test/cases/observing_test.rb
@@ -17,6 +17,10 @@ class FooObserver < ActiveModel::Observer
   def on_spec(record)
     stub.event_with(record) if stub
   end
+
+  def around_save(record)
+    yield :in_around_save
+  end
 end
 
 class Foo
@@ -132,5 +136,13 @@ class ObserverTest < ActiveModel::TestCase
   test "skips nonexistent observer event" do
     foo = Foo.new
     Foo.send(:notify_observers, :whatever, foo)
+  end
+
+  test "update passes a block on to the observer" do
+    yielded_value = nil
+    FooObserver.instance.update(:around_save, Foo.new) do |val|
+      yielded_value = val
+    end
+    assert_equal :in_around_save, yielded_value
   end
 end

--- a/activerecord/lib/active_record/observer.rb
+++ b/activerecord/lib/active_record/observer.rb
@@ -111,7 +111,7 @@ module ActiveRecord
           callback_meth = :"_notify_#{observer_name}_for_#{callback}"
           unless klass.respond_to?(callback_meth)
             klass.send(:define_method, callback_meth) do |&block|
-              observer.send(callback, self, &block)
+              observer.update(callback, self, &block)
             end
             klass.send(callback, callback_meth)
           end

--- a/activerecord/test/cases/lifecycle_test.rb
+++ b/activerecord/test/cases/lifecycle_test.rb
@@ -231,6 +231,18 @@ class LifecycleTest < ActiveRecord::TestCase
     assert_not_nil observer.topic_ids.last
   end
 
+  test "able to disable observers" do
+    observer = DeveloperObserver.instance # activate
+    observer.calls.clear
+
+    ActiveRecord::Base.observers.disable DeveloperObserver do
+      Developer.create! :name => 'Ancestor', :salary => 100000
+      SpecialDeveloper.create! :name => 'Descendent', :salary => 100000
+    end
+
+    assert_equal [], observer.calls
+  end
+
   def test_observer_is_called_once
     observer = DeveloperObserver.instance # activate
     observer.calls.clear


### PR DESCRIPTION
This is a fix for #2461.

Is it too late to get this in 3.1?  Let me know and I can submit a pull request to get it in 3.1 as well.  It'd be nice to get it in since this is new behavior for 3.1.
