### PR TITLE
fix Hash#extract! for HashWithIndifferentAccess and non-existant keys

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/slice.rb
+++ b/activesupport/lib/active_support/core_ext/hash/slice.rb
@@ -30,9 +30,12 @@ class Hash
     omit
   end
 
+  # Extracts the given keys from the hash and create a new Hash with the given 
+  # keys.  In other words, this is the opposite of slice!
   def extract!(*keys)
-    result = {}
-    keys.each {|key| result[key] = delete(key) }
+    keys = keys.map! { |key| convert_key(key) } if respond_to?(:convert_key)
+    result = self.class.new
+    keys.each {|k| result[k] = delete(k) if has_key?(k) }
     result
   end
 end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -487,6 +487,74 @@ class HashExtTest < Test::Unit::TestCase
     assert_equal 'bender', slice['login']
   end
 
+  def test_extract
+    original = { :a => 'x', :b => 'y', :c => 10 }
+    expected_extracted = { :a => 'x', :b => 'y' }
+    expected_remaining = { :c => 10 }
+
+    # Should extract only the given keys into a new array and remove the keys 
+    # from the original hash
+    extracted = original.extract!(:a, :b, :x)
+    assert_equal expected_extracted, extracted
+    assert_equal expected_remaining, original
+  end
+
+  def test_extract_with_an_array_key
+    original = { :a => 'x', :b => 'y', :c => 10, [:a, :b] => "an array key" }
+    expected_extracted = { [:a, :b] => "an array key", :c => 10 }
+    expected_remaining = { :a => 'x', :b => 'y' }
+
+    # Should extract only the given keys into a new array and remove the keys 
+    # from the original hash when given an array key.
+    extracted = original.extract!([:a, :b], :c, :x)
+    assert_equal expected_extracted, extracted
+    assert_equal expected_remaining, original
+  end
+
+  def test_extract_with_splatted_keys
+    original = { :a => 'x', :b => 'y', :c => 10, [:a, :b] => "an array key" }
+    expected_extracted = { :a => 'x', :b => 'y' }
+    expected_remaining = { :c => 10, [:a, :b] => "an array key" }
+
+    # Should extract only the given keys into a new array and remove the keys 
+    # from the original hash
+    extracted = original.extract!(*[:a, :b, :x])
+    assert_equal expected_extracted, extracted
+    assert_equal expected_remaining, original
+  end
+
+  def test_indifferent_extract
+    original = { :a => 'x', :b => 'y', :c => 10 }.with_indifferent_access
+    expected_extracted = { :a => 'x', :b => 'y' }.with_indifferent_access
+    expected_remaining = { :c => 10 }.with_indifferent_access
+
+    # Should extract only the given keys into a new array and remove the keys 
+    # from the original hash
+    [['a', 'b', 'x'], [:a, :b, :x]].each do |keys|
+      original_dupped = original.dup
+      extracted = original_dupped.extract!(*keys)
+      assert_kind_of(HashWithIndifferentAccess, extracted)
+      assert_equal expected_extracted, extracted, keys.inspect
+      assert_equal expected_remaining, original_dupped
+    end
+  end
+
+  def test_indifferent_extract_with_an_array_key
+    original = { :a => 'x', :b => 'y', :c => 10, [:a, :b] => "an array key" }.with_indifferent_access
+    expected_extracted = { [:a, :b] => "an array key", :c => 10 }.with_indifferent_access
+    expected_remaining = { :a => 'x', :b => 'y' }.with_indifferent_access
+
+    # Should extract only the given keys into a new array and remove the keys 
+    # from the original hash
+    [[[:a, :b], 'c', 'x',], [[:a, :b], :c, :x]].each do |keys|
+      original_dupped = original.dup
+      extracted = original_dupped.extract!(*keys)
+      assert_kind_of(HashWithIndifferentAccess, extracted)
+      assert_equal expected_extracted, extracted, keys.inspect
+      assert_equal expected_remaining, original_dupped
+    end
+  end
+
   def test_except
     original = { :a => 'x', :b => 'y', :c => 10 }
     expected = { :a => 'x', :b => 'y' }


### PR DESCRIPTION
fix Hash#extract! to work properly with HashWithIndifferentAccess and to not return nil values for keys that don't exist

This commit fixes 2 issues:

First, `HashWithIndifferentAccess#extract!` used to return a Hash object instead of a HashWithIndifferentAccess object.

Second, Hash#extract! used to include keys with nil values when the original hash didn't have the key.  For example `{:foo => "foo"}.extract!(:bar)` would return `{:bar => nil}`
