### PR TITLE
Fixes the README links in README.rdoc on GitHub

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -18,7 +18,7 @@ you to present the data from database rows as objects and embellish these data o
 with business logic methods. Although most Rails models are backed by a database, models 
 can also be ordinary Ruby classes, or Ruby classes that implement a set of interfaces as
 provided by the ActiveModel module. You can read more about Active Record in its
-{README}[link:blob/master/activerecord/README.rdoc].
+{README}[link:/rails/rails/blob/master/activerecord/README.rdoc].
 
 The Controller layer is responsible for handling incoming HTTP requests and providing a 
 suitable response. Usually this means returning HTML, but Rails controllers can also
@@ -29,7 +29,7 @@ In Rails, the Controller and View layers are handled together by Action Pack.
 These two layers are bundled in a single package due to their heavy interdependence. 
 This is unlike the relationship between Active Record and Action Pack which are
 independent. Each of these packages can be used independently outside of Rails. You 
-can read more about Action Pack in its {README}[link:blob/master/actionpack/README.rdoc].
+can read more about Action Pack in its {README}[link:/rails/rails/blob/master/actionpack/README.rdoc].
 
 == Getting Started
 

--- a/Rakefile
+++ b/Rakefile
@@ -74,7 +74,7 @@ RDoc::Task.new do |rdoc|
     # since no autolinking happens there and RDoc displays the backslash
     # otherwise.
     rdoc_main.gsub!(/^(?=\S).*?\b(?=Rails)\b/) { "#$&\\" }
-    rdoc_main.gsub!(%r{link:blob/master/(\w+)/README\.rdoc}, "link:files/\\1/README_rdoc.html")
+    rdoc_main.gsub!(%r{link:/rails/rails/blob/master/(\w+)/README\.rdoc}, "link:files/\\1/README_rdoc.html")
 
     File.open(RDOC_MAIN, 'w') do |f|
       f.write(rdoc_main)


### PR DESCRIPTION
The two README links on the GitHub page are broken when the current page is anything other than _github.com/rails/rails/_. Even _github.com/rails/rails_ (without the trailing slash) broke the links. Fixed this by making the links absolute.

The fix also meant a change in the Rakefile and that's the reason for this PR instead of a docrails commit.

Reference: 96c57d4bd0678103d28a87b455e4aef2a7e285b4 (This was the commit that made the original change in order to make these links work on GitHub as well)
