### PR TITLE
Support for multiple etags in an If-None-Match header

### DIFF
--- a/actionpack/lib/action_dispatch/http/cache.rb
+++ b/actionpack/lib/action_dispatch/http/cache.rb
@@ -14,12 +14,18 @@ module ActionDispatch
           env['HTTP_IF_NONE_MATCH']
         end
 
+        def if_none_match_etags
+          (if_none_match ? if_none_match.split(/\s*,\s*/) : []).collect do |etag|
+            etag.gsub(/^\"|\"$/, "")
+          end
+        end
+
         def not_modified?(modified_at)
           if_modified_since && modified_at && if_modified_since >= modified_at
         end
 
         def etag_matches?(etag)
-          if_none_match && if_none_match == etag
+          if_none_match_etags.include?(etag)
         end
 
         # Check response freshness (Last-Modified and ETag) against request

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -612,6 +612,45 @@ class RequestTest < ActiveSupport::TestCase
     assert_equal "/authenticate?secret", path
   end
 
+  test "if_none_match_etags none" do
+    request = stub_request
+
+    assert_equal nil, request.if_none_match
+    assert_equal [], request.if_none_match_etags
+    assert !request.etag_matches?("foo")
+    assert !request.etag_matches?(nil)
+  end
+
+  test "if_none_match_etags single" do
+    header = 'the-etag'
+    request = stub_request('HTTP_IF_NONE_MATCH' => header)
+
+    assert_equal header, request.if_none_match
+    assert_equal [header], request.if_none_match_etags
+    assert request.etag_matches?("the-etag")
+  end
+
+  test "if_none_match_etags quoted single" do
+    header = '"the-etag"'
+    request = stub_request('HTTP_IF_NONE_MATCH' => header)
+
+    assert_equal header, request.if_none_match
+    assert_equal ['the-etag'], request.if_none_match_etags
+    assert request.etag_matches?("the-etag")
+  end
+
+  test "if_none_match_etags multiple" do
+    header = 'etag1, etag2, "third etag", "etag4"'
+    expected = ['etag1', 'etag2', 'third etag', 'etag4']
+    request = stub_request('HTTP_IF_NONE_MATCH' => header)
+
+    assert_equal header, request.if_none_match
+    assert_equal expected, request.if_none_match_etags
+    expected.each do |etag|
+      assert request.etag_matches?(etag), etag
+    end
+  end
+
 protected
 
   def stub_request(env = {})


### PR DESCRIPTION
This adds support for multiple etags in an If-None-Match header.

From RFC 2616, Section 14.62

> A client that has **one or more entities** previously obtained from the resource can verify that none of those entities is current by including a list of their associated entity tags in the If-None-Match header field.
