### PR TITLE
validates_presence_of on boolean field bug

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -231,11 +231,11 @@ module ActiveModel
       end
     end
 
-    # Will add an error message to each of the attributes in +attributes+ that is blank (using Object#blank?).
+    # Will add an error message to each of the attributes in +attributes+ that is blank (using Object#blank?) and not false.
     def add_on_blank(attributes, options = {})
       [attributes].flatten.each do |attribute|
         value = @base.send(:read_attribute_for_validation, attribute)
-        add(attribute, :blank, options) if value.blank?
+        add(attribute, :blank, options) if value.blank? && value != false
       end
     end
 

--- a/activemodel/test/cases/validations/presence_validation_test.rb
+++ b/activemodel/test/cases/validations/presence_validation_test.rb
@@ -32,6 +32,26 @@ class PresenceValidationTest < ActiveModel::TestCase
     assert t.valid?
   end
 
+  def test_validates_booleans
+    Topic.validates_presence_of(:active)
+
+    t = Topic.new
+    assert t.invalid?
+    assert_equal ["can't be blank"], t.errors[:active]
+
+    t.active = false
+
+    assert t.valid?
+
+    t.active = true
+
+    assert t.valid?
+
+    t.active = nil
+
+    assert t.invalid?
+  end
+
   def test_accepts_array_arguments
     Topic.validates_presence_of %w(title content)
     t = Topic.new

--- a/activemodel/test/models/topic.rb
+++ b/activemodel/test/models/topic.rb
@@ -6,7 +6,7 @@ class Topic
     super | [ :message ]
   end
 
-  attr_accessor :title, :author_name, :content, :approved
+  attr_accessor :title, :author_name, :content, :approved, :active
   attr_accessor :after_validation_performed
 
   after_validation :perform_after_validation


### PR DESCRIPTION
Fixes bug in validates_presence_of which would only allow model to be valid if boolean field was true. That is validates_presence_of would find a model invalid if a boolean field (with a presence validator on it) was set to false. This seems inconsistent with the behavior of this validator with other types of data.
