### PR TITLE
Raise error when setting aggregation to nil when nil is not allowed

### DIFF
--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -1,4 +1,11 @@
 module ActiveRecord
+  
+  class AggregationNilNotPermittedError < ActiveRecordError # :nodoc:
+    def initialize(name)
+      super("Nil is not permitted for aggregation #{name.inspect}")
+    end
+  end
+  
   # = Active Record Aggregations
   module Aggregations # :nodoc:
     extend ActiveSupport::Concern
@@ -234,9 +241,13 @@ module ActiveRecord
 
         def writer_method(name, class_name, mapping, allow_nil, converter)
           define_method("#{name}=") do |part|
-            if part.nil? && allow_nil
-              mapping.each { |pair| self[pair.first] = nil }
-              @aggregation_cache[name] = nil
+            if part.nil?
+              if allow_nil
+                mapping.each { |pair| self[pair.first] = nil }
+                @aggregation_cache[name] = nil
+              else
+                raise AggregationNilNotPermittedError.new(name)
+              end
             else
               unless part.is_a?(class_name.constantize) || converter.nil?
                 part = converter.respond_to?(:call) ?

--- a/activerecord/test/cases/aggregations_test.rb
+++ b/activerecord/test/cases/aggregations_test.rb
@@ -91,7 +91,7 @@ class AggregationsTest < ActiveRecord::TestCase
   end
 
   def test_nil_raises_error_when_allow_nil_is_false
-    assert_raise(NoMethodError) { customers(:david).balance = nil }
+    assert_raise(ActiveRecord::AggregationNilNotPermittedError) { customers(:david).balance = nil }
   end
 
   def test_allow_nil_address_loaded_when_only_some_attributes_are_nil
@@ -114,10 +114,16 @@ class AggregationsTest < ActiveRecord::TestCase
     assert_kind_of Fullname, customers(:barney).fullname
   end
 
-  def test_custom_converter
+  def test_custom_converter_using_symbol
     customers(:barney).fullname = 'Barnoit Gumbleau'
     assert_equal 'Barnoit GUMBLEAU', customers(:barney).fullname.to_s
     assert_kind_of Fullname, customers(:barney).fullname
+  end
+  
+  def test_custom_converter_using_proc
+    customers(:barney).balance = 1
+    assert_kind_of Money, customers(:barney).balance
+    assert_equal 1, customers(:barney).balance.amount
   end
 end
 

--- a/activerecord/test/models/customer.rb
+++ b/activerecord/test/models/customer.rb
@@ -1,6 +1,6 @@
 class Customer < ActiveRecord::Base
   composed_of :address, :mapping => [ %w(address_street street), %w(address_city city), %w(address_country country) ], :allow_nil => true
-  composed_of :balance, :class_name => "Money", :mapping => %w(balance amount), :converter => Proc.new { |balance| balance.to_money }
+  composed_of :balance, :class_name => "Money", :mapping => %w(balance amount), :converter => Proc.new { |balance| Money.new(balance) }
   composed_of :gps_location, :allow_nil => true
   composed_of :fullname, :mapping => %w(name to_s), :constructor => Proc.new { |name| Fullname.parse(name) }, :converter => :parse
 end


### PR DESCRIPTION
The test test_nil_raises_error_when_allow_nil_is_false is only passing because the convert proc is throwing an error. If this proc did not throw an error, then no exception would be raised when assigning nil to an aggregation that does not allow nil.

This changes assigning nil to an aggregation that does not allow it to raise a ActiveRecord::AggregationNilNotPermittedError.
