### PR TITLE
Use mysql_creation_options inside rescue block

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -94,7 +94,7 @@ db_namespace = namespace :db do
               "IDENTIFIED BY '#{config['password']}' WITH GRANT OPTION;"
             ActiveRecord::Base.establish_connection(config.merge(
                 'database' => nil, 'username' => 'root', 'password' => root_password))
-            ActiveRecord::Base.connection.create_database(config['database'], creation_options)
+            ActiveRecord::Base.connection.create_database(config['database'], mysql_creation_options(config))
             ActiveRecord::Base.connection.execute grant_statement
             ActiveRecord::Base.establish_connection(config)
           else


### PR DESCRIPTION
Commit ecd37084b28a05f05251 did not take into account the use of creation_options inside the access denied exception handler. This causes the mysql user provisioning feature to fail:

```
$ rake db:create:all
Access denied for user 'user'@'localhost' (using password: YES). 
Please provide the root password for your mysql installation
>
rake aborted!
undefined local variable or method `creation_options' for main:Object
```

I believe this fixes the problem.
