### PR TITLE
Ignore by default sqlite3-journal files.

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/gitignore
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore
@@ -1,5 +1,6 @@
 .bundle
 db/*.sqlite3
+db/*.sqlite3-journal
 log/*.log
 tmp/
 .sass-cache/


### PR DESCRIPTION
*.sqlite3-journal files will be created during development and should be ignored by default.
