### PR TITLE
Calling `request.params` in routing constraints cannot interfere with subsequent routes. [Closes #2510] 

### DIFF
--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -6,7 +6,7 @@ module ActionDispatch
     module Parameters
       # Returns both GET and POST \parameters in a single hash.
       def parameters
-        @env["action_dispatch.request.parameters"] ||= begin
+        @env["action_dispatch.request.parameters"] = begin
           params = request_parameters.merge(query_parameters)
           params.merge!(path_parameters)
           encode_params(params).with_indifferent_access

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -14,6 +14,13 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     end
   end
 
+  class RequestLookup
+    def self.matches?(request)
+      request.params
+      return false
+    end
+  end
+
   class YoutubeFavoritesRedirector
     def self.call(params, request)
       "http://www.youtube.com/watch?v=#{params[:youtube_id]}"
@@ -25,6 +32,8 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     Routes.draw do
       default_url_options :host => "rubyonrails.org"
       resources_path_names :correlation_indexes => "info_about_correlation_indexes"
+
+      match ':something' => 'foo#something', :constraints => RequestLookup
 
       controller :sessions do
         get  'login' => :new


### PR DESCRIPTION
As the same request is reused thru all the routing constraints,
accessing a memoized form of `params` would prevent the router from
redefining it with a new set of parameters (the current route
parameters).

Another solution could be to `dup` the `env` [here](https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/routing/mapper.rb#L40), but I' not sure this is a good idea in terms of memory.
