### PR TITLE
JSON: Encode infinite or NaN floats as `null` to generate valid JSON.

### DIFF
--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -186,6 +186,10 @@ class Numeric
   def encode_json(encoder) to_s end #:nodoc:
 end
 
+class Float
+  def as_json(options = nil) finite? ? self : NilClass::AS_JSON end #:nodoc:
+end
+
 class BigDecimal
   # A BigDecimal would be naturally represented as a JSON number. Most libraries,
   # however, parse non-integer JSON numbers directly as floats. Clients using

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -27,6 +27,9 @@ class TestJSONEncoding < Test::Unit::TestCase
   NilTests      = [[ nil,   %(null)  ]]
   NumericTests  = [[ 1,     %(1)     ],
                    [ 2.5,   %(2.5)   ],
+                   [ 0.0/0.0,   %(null) ],
+                   [ 1.0/0.0,   %(null) ],
+                   [ -1.0/0.0,  %(null) ],
                    [ BigDecimal('2.5'), %("#{BigDecimal('2.5').to_s}") ]]
 
   StringTests   = [[ 'this is the <string>',     %("this is the \\u003Cstring\\u003E")],


### PR DESCRIPTION
Encoding an infinite or NaN number as json returns it as an unescaped/unquoted Infinity or NaN.

``` ruby
  { 'infinite' => 1.0/0.0, 'nan' => 0.0/0.0 }.to_json
  # => { 'infinite' : Infinity, 'nan' : NaN }
```

The resulting JSON is invalid and will break parsing (most notably with the jQuery JSON and AJAX methods). 

I changed the behaviour to return null instead, as this is the recommended solution according to  to www.json.org/json.ppt (slide 16).

``` ruby
  { 'infinite' => 1.0/0.0, 'nan' => 0.0/0.0 }.to_json
  # => { 'infinite' : null, 'nan' : null }
```

Alternative solutions would be to return them as Strings "NaN", "Infinity" (or even "PositiveInfinity"). IMO this is special behaviour that should be implemented on the application-level.
