### PR TITLE
Ruby 1.9.2 minitest is now applying our backtrace cleaner in tests fixes #1575

### DIFF
--- a/railties/lib/rails/mini_test_backtrace_cleaner.rb
+++ b/railties/lib/rails/mini_test_backtrace_cleaner.rb
@@ -1,0 +1,15 @@
+require 'rails/backtrace_cleaner'
+
+module MiniTest
+
+  def self.filter_backtrace_with_rails(backtrace)
+    filter_backtrace_without_rails(Rails.backtrace_cleaner.clean(backtrace))
+  end
+
+  class << self
+    alias :filter_backtrace_without_rails :filter_backtrace
+    alias :filter_backtrace :filter_backtrace_with_rails
+  end
+
+end
+

--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -14,6 +14,8 @@ if defined?(Test::Unit::Util::BacktraceFilter) && ENV['BACKTRACE'].nil?
 end
 
 if defined?(MiniTest)
+  require 'rails/mini_test_backtrace_cleaner'
+
   # Enable turn if it is available
   begin
     require 'turn'


### PR DESCRIPTION
Ruby 1.9.2 minitest is now applying our backtrace cleaner in tests fixes #1575

If looks good then port it to master also.

/cc @dhh
