### PR TITLE
Make subject auto lookup in ActionMailer work as advertised

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -673,7 +673,7 @@ module ActionMailer #:nodoc:
     # humanized version of the <tt>action_name</tt>.
     def default_i18n_subject #:nodoc:
       mailer_scope = self.class.mailer_name.gsub('/', '.')
-      I18n.t(:subject, :scope => [mailer_scope, action_name], :default => action_name.humanize)
+      I18n.t(:subject, :scope => [:actionmailer, mailer_scope, action_name], :default => action_name.humanize)
     end
 
     def collect_responses_and_parts_order(headers) #:nodoc:


### PR DESCRIPTION
I don't know why the scope :actionmailer got removed in a previous commit, but after some fiddling I'm pretty certain that, according to documentation, it should be there.

http://repo.or.cz/w/ruby-on-rails.git/blobdiff/4b05de19aaebcbe20941e8b13aaed2060759ed1c..bf7429041e64ee0f347764a4579c8c1d14d5b391:/actionmailer/lib/action_mailer/base.rb (sorry for the link, googled it)

I had a very quick look at the tests and did not find trace about this auto lookup feature, but is documented in guides and code comments.

Otherwise if it's intended we should tweak the code comments and guides instead.
