### PR TITLE
Remove unused require in activerecord/test/cases/attribute_methods_test.rb

### DIFF
--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -8,7 +8,6 @@ require 'models/computer'
 require 'models/topic'
 require 'models/company'
 require 'models/category'
-require 'models/reply'
 require 'models/contact'
 require 'models/keyboard'
 


### PR DESCRIPTION
`require 'models/reply'` is not referenced anywhere and the tests run fine without it.
