### PR TITLE
When a route references a missing controller, raise ActionController::RoutingError with clearer message

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -556,9 +556,13 @@ module ActionDispatch
             dispatcher = dispatcher.app
           end
 
-          if dispatcher.is_a?(Dispatcher) && dispatcher.controller(params, false)
-            dispatcher.prepare_params!(params)
-            return params
+          if dispatcher.is_a?(Dispatcher)
+            if dispatcher.controller(params, false)
+              dispatcher.prepare_params!(params)
+              return params
+            else
+              raise ActionController::RoutingError, "A route matches #{path.inspect}, but references missing controller: #{params[:controller].camelize}Controller"
+            end
           end
         end
 

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -902,6 +902,16 @@ class RouteSetTest < ActiveSupport::TestCase
     end
   end
 
+  def test_route_error_with_missing_controller
+    set.draw do
+      get    "/people" => "missing#index"
+    end
+    
+    assert_raise(ActionController::RoutingError) {
+      set.recognize_path("/people", :method => :get)
+    }
+  end
+
   def test_recognize_with_encoded_id_and_regex
     set.draw do
       match 'page/:id' => 'pages#show', :id => /[a-zA-Z0-9\+]+/


### PR DESCRIPTION
When a route points to an unimplemented controller,  `ActionController::RoutingError` is raised with a message `No route matches ...`, although the route _does_ exist and match.

```
MyApp::Application.routes.draw do
  root :to => 'welcome#index'
end
```

and example spec that fails with misleading error:

```
describe "welcome" do
  it "GET / -> welcome#show" do
    { :get => "/" }.should route_to(:controller => "welcome", :action => 'index')
  end
end
```

This is a pull request version of https://github.com/rails/rails/issues/2546
