### PR TITLE
3 0 mailer text format

### DIFF
--- a/actionmailer/lib/action_mailer/mail_helper.rb
+++ b/actionmailer/lib/action_mailer/mail_helper.rb
@@ -4,7 +4,7 @@ module ActionMailer
     # each line, and wrapped at 72 columns.
     def block_format(text)
       formatted = text.split(/\n\r\n/).collect { |paragraph|
-        simple_format(paragraph)
+        text_format(paragraph)
       }.join("\n")
 
       # Make list points stand on their own line
@@ -30,7 +30,7 @@ module ActionMailer
     end
 
     private
-    def simple_format(text, len = 72, indent = 2)
+    def text_format(text, len = 72, indent = 2)
       sentences = [[]]
 
       text.split.each do |word|


### PR DESCRIPTION
This is a fix for #2568. Ended up being a really simple fix, just renamed `simple_format` to `text_format` in `ActionMailer::MailHelper`.
