### PR TITLE
Read digests from asset manifest yml

### DIFF
--- a/actionpack/lib/sprockets/assets.rake
+++ b/actionpack/lib/sprockets/assets.rake
@@ -16,7 +16,11 @@ namespace :assets do
       assets = Rails.application.config.assets.precompile
       # Always perform caching so that asset_path appends the timestamps to file references.
       Rails.application.config.action_controller.perform_caching = true
-      Rails.application.assets.precompile(*assets)
+      manifest = Rails.application.assets.precompile(*assets)
+
+      File.open("#{Rails.application.assets.static_root}/manifest.yml", 'w') do |f|
+        YAML.dump(manifest, f)
+      end
     end
   end
 

--- a/actionpack/lib/sprockets/railtie.rb
+++ b/actionpack/lib/sprockets/railtie.rb
@@ -27,6 +27,10 @@ module Sprockets
         end
       end
 
+      if File.exist?(path = "#{app.assets.static_root}/manifest.yml")
+        config.assets.digests = YAML.load(File.read(path))
+      end
+
       ActiveSupport.on_load(:action_view) do
         include ::Sprockets::Helpers::RailsHelper
 


### PR DESCRIPTION
The current sprocket cache system is designed to speed up compiles on your system. It seems like people want to hack it into a way to do offline compiles. This is just a fucking mess and impossible to debug.

The current cache stuff is still useful, but there should be a simple way to load computed digests into your environment.

On `assets:precompile`, a `manifest.yml` gets written out to `public/assets`. On boot that gets read and we just use that to do the lookup, no sprockets needed.

**Caveats**

This only works if you are completely replacing the public/assets directory on deploy. This isn't going to be for everyone like people doing rolling git deploys (github does this). So it should probably be opt in or opt out.

It requires sprockets/master for now, need to do another release soon.

Please test this shit.
