### PR TITLE
In some case ActiveResource fails to handle serialized attributes with Ruby 1.9 and crashes

### DIFF
--- a/activeresource/lib/active_resource/base.rb
+++ b/activeresource/lib/active_resource/base.rb
@@ -955,7 +955,7 @@ module ActiveResource
           prefix_options, query_options = {}, {}
 
           (options || {}).each do |key, value|
-            next if key.blank?
+            next if key.blank? || [Fixnum, Date, Time, Float].include?(key.class)
             (prefix_parameters.include?(key.to_sym) ? prefix_options : query_options)[key.to_sym] = value
           end
 

--- a/activeresource/lib/active_resource/base.rb
+++ b/activeresource/lib/active_resource/base.rb
@@ -955,7 +955,7 @@ module ActiveResource
           prefix_options, query_options = {}, {}
 
           (options || {}).each do |key, value|
-            next if key.blank? || [Fixnum, Date, Time, Float].include?(key.class)
+            next if key.blank? || !key.respond_to?(:to_sym)
             (prefix_parameters.include?(key.to_sym) ? prefix_options : query_options)[key.to_sym] = value
           end
 

--- a/activeresource/test/cases/base/load_test.rb
+++ b/activeresource/test/cases/base/load_test.rb
@@ -51,7 +51,26 @@ class BaseLoadTest < Test::Unit::TestCase
         :votes => [ true, false, true ],
         :places => [ "Columbia City", "Unknown" ]}}}
 
+
+    # List of books formated as [{timestamp_of_publication => name}, ...]
+    @books = {:books => [
+        {1009839600 => "Ruby in a Nutshell"},
+        {1199142000 => "The Ruby Programming Language"}
+      ]}
+
+    @books_date = {:books => [
+        {Time.at(1009839600) => "Ruby in a Nutshell"},
+        {Time.at(1199142000) => "The Ruby Programming Language"}
+    ]}
     @person = Person.new
+  end
+
+  def test_load_hash_with_integers_as_keys
+    assert_nothing_raised{person = @person.load(@books)}
+  end
+
+  def test_load_hash_with_dates_as_keys
+    assert_nothing_raised{person = @person.load(@books_date)}
   end
 
   def test_load_expects_hash


### PR DESCRIPTION
Hi, 

First of all, this is my first attempt at contributing to rails. I tried to follow the Rails guide, but I might be off. Feel free to give me guidelines ^^

I'll take the example of a blog with posts & comments to illustrate the issue.

ActiveResource takes all attributes of an object to create an object out of it. For instance if the JSON passed around is:

``` json
post = {
  id: 123,
  title: "Hey!",
  comments: [{id: 456, content: "Loving this"}]
}
```

It will create the correct `Comment` object associated with the `Post`. This works fine.

The problem is when we try to pass via ARes an object with serialized attributes. Let's say that we have:

``` ruby
class Post
  serialize :updates, Array
end
```

with updates defined as such: `[{:user_updating_id => :update_date_to_i}, ...]`

We could now have something like that:

``` json
post = {
  id: 123,
  title: "Hey!",
  updates: [
    {1 => 5464848414}, {2 => 9787987421}
  ]
}
```

The problem arise when we try to do a .to_sym on the parameters. In 1.8.7 it would just return nil:

``` ruby
ruby-1.8.7-p299 :001 > 1.to_sym
 => nil 
```

But in 1.9.2 it crashes:

``` ruby
ruby-1.9.2-p290 :001 > 1.to_sym
NoMethodError: undefined method `to_sym' for 1:Fixnum
```

I'm suggesting skipping attributes that are not valid to have the same behavior between Ruby 1.8.7 and 1.9.2. I inspired myself from the fact that we "`next`" blank attributes, so why not unsuitable ones?

This is not ideal, since it would be better to be able to determine if something is a serialized attribute or another model embeded and then have a different logic, but at least this would prevent ARes from crashing for Ruby 1.9.2 as it does right now if we have the situation detailed above.

Let me know if you need more detail or if you need something else to accept this patch!
