### PR TITLE
Document debugging assets set by default for dev and test envs on guides

### DIFF
--- a/railties/guides/source/asset_pipeline.textile
+++ b/railties/guides/source/asset_pipeline.textile
@@ -247,6 +247,8 @@ When the +debug_assets+ parameter is set, this line is expanded out into three s
 
 This allows the individual parts of an asset to be rendered and debugged separately.
 
+NOTE. Assets debugging is turned on by default in development and test environments.
+
 h3. In Production
 
 In the production environment, assets are served slightly differently.


### PR DESCRIPTION
Documenting this change on the asset_pipeline Guide. https://github.com/rails/rails/commit/7223f10acda3d5683e6de817bc7131ca109f3f28

@fxn, think this is all yours :)
