### PR TITLE
Updated the docs for the has_many :finder_sql option

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1087,7 +1087,8 @@ module ActiveRecord
       #
       # [:finder_sql]
       #   Specify a complete SQL statement to fetch the association. This is a good way to go for complex
-      #   associations that depend on multiple tables. Note: When this option is used, +find_in_collection+
+      #   associations that depend on multiple tables. May be supplied as a string or a proc where interpolation is
+      #   required. Note: When this option is used, +find_in_collection+
       #   is _not_ added.
       # [:counter_sql]
       #   Specify a complete SQL statement to fetch the size of the association. If <tt>:finder_sql</tt> is
@@ -1162,11 +1163,14 @@ module ActiveRecord
       #   has_many :tags, :as => :taggable
       #   has_many :reports, :readonly => true
       #   has_many :subscribers, :through => :subscriptions, :source => :user
-      #   has_many :subscribers, :class_name => "Person", :finder_sql =>
-      #       'SELECT DISTINCT people.* ' +
-      #       'FROM people p, post_subscriptions ps ' +
-      #       'WHERE ps.post_id = #{id} AND ps.person_id = p.id ' +
-      #       'ORDER BY p.first_name'
+      #   has_many :subscribers, :class_name => "Person", :finder_sql => Proc.new {
+      #       %Q{
+      #         SELECT DISTINCT people.*
+      #         FROM people p, post_subscriptions ps
+      #         WHERE ps.post_id = #{id} AND ps.person_id = p.id
+      #         ORDER BY p.first_name
+      #       }
+      #   }
       def has_many(name, options = {}, &extension)
         Builder::HasMany.build(self, name, options, &extension)
       end


### PR DESCRIPTION
Updated the docs for the has_many :finder_sql option to reflect changes made in rails/rails@a7e19b30ca71f62af516, i.e. the use of Procs when interpolation of the SQL is required.

Sorry to add it directly to the code but docrails is down at the moment.
