### PR TITLE
Fix assumption of primary key name in PredicateBuilder subquery.

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -19,7 +19,7 @@ module ActiveRecord
 
           case value
           when ActiveRecord::Relation
-            value.select_values = [value.klass.arel_table[value.klass.primary_key]] if value.select_values.empty?
+            value = value.select(value.klass.arel_table[value.klass.primary_key]) if value.select_values.empty?
             attribute.in(value.arel.ast)
           when Array, ActiveRecord::Associations::CollectionProxy
             values = value.to_a.map { |x|

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -19,7 +19,7 @@ module ActiveRecord
 
           case value
           when ActiveRecord::Relation
-            value.select_values = [value.klass.arel_table['id']] if value.select_values.empty?
+            value.select_values = [value.klass.arel_table[value.klass.primary_key]] if value.select_values.empty?
             attribute.in(value.arel.ast)
           when Array, ActiveRecord::Associations::CollectionProxy
             values = value.to_a.map { |x|

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -550,6 +550,19 @@ class RelationTest < ActiveRecord::TestCase
     }
   end
 
+  def test_find_all_using_where_with_relation_does_not_alter_select_values
+    david = authors(:david)
+
+    subquery = Author.where(:id => david.id)
+
+    assert_queries(1) {
+      relation = Author.where(:id => subquery)
+      assert_equal [david], relation.all
+    }
+
+    assert_equal 0, subquery.select_values.size
+  end
+
   def test_find_all_using_where_with_relation_with_joins
     david = authors(:david)
     assert_queries(1) {

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -540,6 +540,16 @@ class RelationTest < ActiveRecord::TestCase
     }
   end
 
+  def test_find_all_using_where_with_relation_and_alternate_primary_key
+    cool_first = minivans(:cool_first)
+    # switching the lines below would succeed in current rails
+    # assert_queries(2) {
+    assert_queries(1) {
+      relation = Minivan.where(:minivan_id => Minivan.where(:name => cool_first.name))
+      assert_equal [cool_first], relation.all
+    }
+  end
+
   def test_find_all_using_where_with_relation_with_joins
     david = authors(:david)
     assert_queries(1) {


### PR DESCRIPTION
In looking through the current implementation of PredicateBuilder, I caught an assumption that a model's primary key is "id" in the automatically-added select clause. This is just a quick fix to honor the primary_key if an alternate is specified.

Also, while looking at that first commit, I noticed we are clobbering select_values in the incoming relation, so that's fixed, too.
