### PR TITLE
Bump sprockets to 2.0.0.beta.14

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency('rack',             '~> 1.3.2')
   s.add_dependency('rack-test',        '~> 0.6.0')
   s.add_dependency('rack-mount',       '~> 0.8.1')
-  s.add_dependency('sprockets',        '~> 2.0.0.beta.12')
+  s.add_dependency('sprockets',        '~> 2.0.0.beta.14')
   s.add_dependency('erubis',           '~> 2.7.0')
 
   s.add_development_dependency('tzinfo',           '~> 0.3.29')


### PR DESCRIPTION
Sprockets 2.0.0.beta.14 contains some fixes for assets precompilation
