### PR TITLE
Added destroy alias to rails generator

### DIFF
--- a/railties/guides/source/command_line.textile
+++ b/railties/guides/source/command_line.textile
@@ -325,6 +325,8 @@ h4. +rails destroy+
 
 Think of +destroy+ as the opposite of +generate+. It'll figure out what generate did, and undo it.
 
+You can also use the alias "d" to invoke the destroy command: <tt>rails d</tt>.
+
 <shell>
 $ rails generate model Oops
       exists  app/models/

--- a/railties/lib/rails/commands.rb
+++ b/railties/lib/rails/commands.rb
@@ -4,6 +4,7 @@ ARGV << '--help' if ARGV.empty?
 
 aliases = {
   "g"  => "generate",
+  "d"  => "destroy",
   "c"  => "console",
   "s"  => "server",
   "db" => "dbconsole",
@@ -87,7 +88,7 @@ The most common rails commands are:
 
 In addition to those, there are:
  application  Generate the Rails application code
- destroy      Undo code generated with "generate"
+ destroy      Undo code generated with "generate" (short-cut alias: "d")
  benchmarker  See how fast a piece of code runs
  profiler     Get profile information from a piece of code
  plugin       Install a plugin


### PR DESCRIPTION
Strange a bit, that here is no alias for `rails destroy` action. Lots of people write `rails g` every day, but are not able to write `rails d` instead of `rails destroy`. 

![](http://i.qkme.me/5tzy.jpg)
