### PR TITLE
Rename test_generator_if_skip_active_record_is_given

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -189,7 +189,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "test/performance/browsing_test.rb"
   end
 
-  def test_generator_if_skip_active_record_is_given
+  def test_generator_if_skip_sprockets_is_given
     run_generator [destination_root, "--skip-sprockets"]
     assert_file "config/application.rb" do |content|
       assert_match(/#\s+require\s+["']sprockets\/railtie["']/, content)


### PR DESCRIPTION
Hi,

There were two instances of `test_generator_if_skip_active_record_is_given` in `railties/test/generators/app_generator_test.rb`. One was doing fine. However other was actually testing skipping of sprockets. Please review the changes.

Thanks!
