### PR TITLE
fix escape_javascript for unicode character \u2028.

### DIFF
--- a/actionpack/lib/action_view/helpers/javascript_helper.rb
+++ b/actionpack/lib/action_view/helpers/javascript_helper.rb
@@ -10,7 +10,8 @@ module ActionView
         "\n"    => '\n',
         "\r"    => '\n',
         '"'     => '\\"',
-        "'"     => "\\'" }
+        "'"     => "\\'",
+        "\342\200\250" => '&#x2028;' }
 
       # Escape carrier returns and single and double quotes for JavaScript segments.
       # Also available through the alias j(). This is particularly helpful in JavaScript responses, like:
@@ -18,7 +19,7 @@ module ActionView
       #   $('some_element').replaceWith('<%=j render 'some/element_template' %>');
       def escape_javascript(javascript)
         if javascript
-          result = javascript.gsub(/(\\|<\/|\r\n|[\n\r"'])/) {|match| JS_ESCAPE_MAP[match] }
+          result = javascript.gsub(/(\\|<\/|\r\n|\342\200\250|[\n\r"'])/) {|match| JS_ESCAPE_MAP[match] }
           javascript.html_safe? ? result.html_safe : result
         else
           ''

--- a/actionpack/test/template/javascript_helper_test.rb
+++ b/actionpack/test/template/javascript_helper_test.rb
@@ -27,6 +27,7 @@ class JavaScriptHelperTest < ActionView::TestCase
     assert_equal %(This \\"thing\\" is really\\n netos\\'), escape_javascript(%(This "thing" is really\n netos'))
     assert_equal %(backslash\\\\test), escape_javascript( %(backslash\\test) )
     assert_equal %(dont <\\/close> tags), escape_javascript(%(dont </close> tags))
+    assert_equal %(unicode &#x2028; newline), escape_javascript(%(unicode \342\200\250 newline))
     assert_equal %(dont <\\/close> tags), j(%(dont </close> tags))
   end
 


### PR DESCRIPTION
This is to fix issue #2587.
