### PR TITLE
Relation#inspect memory failsafe

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -433,7 +433,7 @@ module ActiveRecord
 
     def inspect(force = false)
       c = count
-      if c > 100 and !force
+      if c > 100 && !force
         "WARNING: #{c} #{@klass} objects would be inspected.\nUse .inspect(true) for an actual inspection."
       else
         to_a.inspect

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -431,8 +431,13 @@ module ActiveRecord
       end
     end
 
-    def inspect
-      to_a.inspect
+    def inspect(force = false)
+      c = count
+      if c > 100 and !force
+        "WARNING: #{c} #{@klass} objects would be inspected.\nUse .inspect(true) for an actual inspection."
+      else
+        to_a.inspect
+      end
     end
 
     def with_default_scope #:nodoc:


### PR DESCRIPTION
Added a failsafe so that relation#inspect will not accidentally fill the memory with all the objects from the database on a faulty query.

http://stackoverflow.com/q/6859738/146272
