### PR TITLE
travis status image added

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -62,7 +62,7 @@ can read more about Action Pack in its {README}[link:/rails/rails/blob/master/ac
 * The {API Documentation}[http://api.rubyonrails.org].
 
 
-== Contributing
+== Contributing http://travis-ci.org/rails/rails.png
 
 We encourage you to contribute to Ruby on Rails! Please check out the {Contributing to Rails
 guide}[http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html] for guidelines about how

--- a/Rakefile
+++ b/Rakefile
@@ -76,6 +76,9 @@ RDoc::Task.new do |rdoc|
     rdoc_main.gsub!(/^(?=\S).*?\b(?=Rails)\b/) { "#$&\\" }
     rdoc_main.gsub!(%r{link:/rails/rails/blob/master/(\w+)/README\.rdoc}, "link:files/\\1/README_rdoc.html")
 
+    # Remove Travis build status image from API pages. Only GitHub README page gets this image
+    rdoc_main.gsub!("http://travis-ci.org/rails/rails.png", "")
+
     File.open(RDOC_MAIN, 'w') do |f|
       f.write(rdoc_main)
     end


### PR DESCRIPTION
Lets added the travis build status image to our README. Will be a clear indicator of the status of rails codebase, right in the project repo page.
