### PR TITLE
has_one through doesn't work properly when Identity Map is enabled

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -370,7 +370,9 @@ module ActiveRecord
         else
           key = reflection.options[:primary_key] ? send(reflection.options[:primary_key]) : id
           if autosave != false && (new_record? || record.new_record? || record[reflection.foreign_key] != key || autosave)
-            record[reflection.foreign_key] = key
+            unless reflection.through_reflection
+              record[reflection.foreign_key] = key
+            end
             saved = record.save(:validate => !autosave)
             raise ActiveRecord::Rollback if !saved && autosave
             saved

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -15,10 +15,13 @@ require 'models/essay'
 require 'models/owner'
 require 'models/post'
 require 'models/comment'
+require 'models/organization'
+require 'models/organization_connection'
 
 class HasOneThroughAssociationsTest < ActiveRecord::TestCase
   fixtures :member_types, :members, :clubs, :memberships, :sponsors, :organizations, :minivans,
-           :dashboards, :speedometers, :authors, :posts, :comments, :categories, :essays, :owners
+           :dashboards, :speedometers, :authors, :posts, :comments, :categories, :essays, :owners,
+           :organizations
 
   def setup
     @member = members(:groucho)
@@ -313,5 +316,16 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_has_one_through_with_custom_select_on_join_model_default_scope
     assert_equal clubs(:boring_club), members(:groucho).selected_club
+  end
+
+  def test_has_one_through_with_belongs_to_on_join_model
+    randax  = Organization.create(:name => "Randax")
+    kanware = Organization.create(:name => "Kanware")
+
+    randax.parent = kanware
+    randax.save
+
+    assert_equal kanware, randax.parent
+    assert_nil kanware.parent
   end
 end

--- a/activerecord/test/models/organization.rb
+++ b/activerecord/test/models/organization.rb
@@ -8,5 +8,8 @@ class Organization < ActiveRecord::Base
   has_one :author, :primary_key => :name
   has_one :author_owned_essay_category, :through => :author, :source => :owned_essay_category
 
+  has_one :parent_connection, :foreign_key => :child_id, :class_name => "OrganizationConnection"
+  has_one :parent, :through => :parent_connection, :class_name => "Organization"
+
   scope :clubs, { :from => 'clubs' }
 end

--- a/activerecord/test/models/organization_connection.rb
+++ b/activerecord/test/models/organization_connection.rb
@@ -1,0 +1,4 @@
+class OrganizationConnection < ActiveRecord::Base
+  belongs_to :parent, :class_name => "Organization"
+  belongs_to :from, :class_name => "Organization"
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -405,6 +405,11 @@ ActiveRecord::Schema.define do
     t.string :name
   end
 
+  create_table :organization_connections, :force => true do |t|
+    t.integer :parent_id
+    t.integer :child_id
+  end
+
   create_table :owners, :primary_key => :owner_id ,:force => true do |t|
     t.string :name
     t.column :updated_at, :datetime


### PR DESCRIPTION
I added a failing test case. 

works:
 IM=false ruby -Itest test/cases/associations/has_one_through_associations_test.rb

fails:
 IM=true ruby -Itest test/cases/associations/has_one_through_associations_test.rb

This bug seems to come from active_record/associations/association.rb (def load target).
