### PR TITLE
config.ignore_force_ssl_filter so filter can be ignored in any desired 

### DIFF
--- a/actionpack/lib/action_controller/metal/force_ssl.rb
+++ b/actionpack/lib/action_controller/metal/force_ssl.rb
@@ -25,7 +25,7 @@ module ActionController
       # * <tt>except<tt>  - The callback should be run for all actions except this action
       def force_ssl(options = {})
         before_filter(options) do
-          if !request.ssl? && !Rails.env.development?
+          if !request.ssl? && !Rails.configuration.ignore_force_ssl_filter
             redirect_to :protocol => 'https://', :status => :moved_permanently
           end
         end

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -43,6 +43,9 @@ module Rails
     def env
       @_env ||= ActiveSupport::StringInquirer.new(ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "test")
     end
+    def configuration
+      @_configuration ||= FakeConfiguration.new
+    end
   end
 end
 
@@ -304,6 +307,14 @@ module ActionView
     setup do
       @routes = SharedTestRoutes
     end
+  end
+end
+
+
+class FakeConfiguration
+  attr_accessor :ignore_force_ssl_filter
+  def initialize
+    @ignore_force_ssl_filter = false
   end
 end
 

--- a/actionpack/test/controller/force_ssl_test.rb
+++ b/actionpack/test/controller/force_ssl_test.rb
@@ -76,7 +76,7 @@ class ForceSSLExcludeDevelopmentTest < ActionController::TestCase
   end
 
   def test_development_environment_not_redirects_to_https
-    Rails.env.stubs(:development?).returns(true)
+    Rails.configuration.stubs(:ignore_force_ssl_filter).returns(true)
     get :banana
     assert_response 200
   end

--- a/railties/guides/source/configuring.textile
+++ b/railties/guides/source/configuring.textile
@@ -84,6 +84,8 @@ NOTE. The +config.asset_path+ configuration is ignored if the asset pipeline is 
 
 * +config.force_ssl+ forces all requests to be under HTTPS protocol by using +Rack::SSL+ middleware.
 
+* +config.ignore_force_ssl_filter+ ignores the force_ssl controller filter. This option defaults to false for all modes except production.
+
 * +config.log_level+ defines the verbosity of the Rails logger. This option defaults to +:debug+ for all modes except production, where it defaults to +:info+.
 
 * +config.logger+ accepts a logger conforming to the interface of Log4r or the default Ruby +Logger+ class. Defaults to an instance of +ActiveSupport::BufferedLogger+, with auto flushing off in production mode.

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -11,7 +11,7 @@ module Rails
                     :reload_plugins, :secret_token, :serve_static_assets,
                     :static_cache_control, :session_options, :time_zone, :whiny_nils
 
-      attr_writer :log_level
+      attr_writer :log_level, :ignore_force_ssl_filter
 
       def initialize(*)
         super
@@ -24,6 +24,7 @@ module Rails
         @serve_static_assets         = true
         @static_cache_control        = nil
         @force_ssl                   = false
+        @ignore_force_ssl_filter     = nil
         @session_store               = :cookie_store
         @session_options             = {}
         @time_zone                   = "UTC"
@@ -99,6 +100,11 @@ module Rails
 
       def log_level
         @log_level ||= Rails.env.production? ? :info : :debug
+      end
+      
+      def ignore_force_ssl_filter
+        @ignore_force_ssl_filter = !Rails.env.production? if @ignore_force_ssl_filter.nil?
+        @ignore_force_ssl_filter
       end
 
       def colorize_logging

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -525,5 +525,17 @@ module ApplicationTests
       assert_equal      app.env_config['action_dispatch.secret_token'],     app.config.secret_token
       assert_equal      app.env_config['action_dispatch.show_exceptions'],  app.config.action_dispatch.show_exceptions
     end
+
+    test "config.ignore_force_ssl_filter = false in production" do
+      make_basic_app
+      Rails.env = "production"
+      assert_equal  false, app.config.ignore_force_ssl_filter
+    end
+    
+    test "config.ignore_force_ssl_filter = true in non production" do
+      make_basic_app
+      Rails.env = "development"
+      assert_equal  true, app.config.ignore_force_ssl_filter
+    end
   end
 end


### PR DESCRIPTION
This is  revised request of:  https://github.com/rails/rails/pull/2617 (which simply hard-coded the production environment). Not sure about grabbing Rails.configuration from force_ssl, works, but nothing else seems to be doing that...

config.force_ssl (the name which was suggested) already exists (for globally forcing ssl).
