### PR TITLE
Trusted proxies are configurable

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -18,11 +18,13 @@ module ActionDispatch
     def initialize(app, check_ip_spoofing = true, custom_proxies = nil)
       @app = app
       @check_ip = check_ip_spoofing
-      if custom_proxies
-        custom_regexp = Regexp.new(custom_proxies)
-        @proxies = Regexp.union(TRUSTED_PROXIES, custom_regexp)
+      @proxies = case custom_proxies
+      when Regexp
+        custom_proxies
+      when nil
+        TRUSTED_PROXIES
       else
-        @proxies = TRUSTED_PROXIES
+        Regexp.union(TRUSTED_PROXIES, custom_proxies)
       end
     end
 

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -94,8 +94,8 @@ class RequestTest < ActiveSupport::TestCase
     assert_equal '127.0.0.1', request.remote_ip
   end
 
-  test "remote ip with user specified trusted proxies" do
-    @trusted_proxies = /^67\.205\.106\.73$/i
+  test "remote ip with user specified trusted proxies String" do
+    @trusted_proxies = "67.205.106.73"
 
     request = stub_request 'REMOTE_ADDR' => '67.205.106.73',
                            'HTTP_X_FORWARDED_FOR' => '3.4.5.6'
@@ -118,6 +118,17 @@ class RequestTest < ActiveSupport::TestCase
 
     request = stub_request 'HTTP_X_FORWARDED_FOR' => '9.9.9.9, 3.4.5.6, 10.0.0.1, 67.205.106.73'
     assert_equal '3.4.5.6', request.remote_ip
+  end
+
+  test "remote ip with user specified trusted proxies Regexp" do
+    @trusted_proxies = /^67\.205\.106\.73$/i
+
+    request = stub_request 'REMOTE_ADDR' => '67.205.106.73',
+                           'HTTP_X_FORWARDED_FOR' => '3.4.5.6'
+    assert_equal '3.4.5.6', request.remote_ip
+
+    request = stub_request 'HTTP_X_FORWARDED_FOR' => '9.9.9.9, 3.4.5.6, 10.0.0.1, 67.205.106.73'
+    assert_equal '10.0.0.1', request.remote_ip
   end
 
   test "domains" do


### PR DESCRIPTION
With this change, the default `trusted_proxies` pattern can be replaced entirely when configured with a Regexp, or appended to when configured with a String.

This allows developers to create a more specific pattern for their network, preventing local clients from being filtered as proxies.

---

When configured with a Regexp

```
HelloWorld::Application.config.action_dispatch.trusted_proxies = /1\.2\.3\.4/
```

The ActionDispatch::RemoteIp middleware instance (and its RemoteIpGetter) will have the Regexp above assigned to its `@trusted_proxies` instance variable.

```
/1\.2\.3\.4/
```

---

When configured with `nil`, or not explicitly configured

```
HelloWorld::Application.config.action_dispatch.trusted_proxies = nil
```

The default Regexp matching private IP addresses will be assigned to `@trusted_proxies`.

```
/(^127\.0\.0\.1$|^(10|172\.(1[6-9]|2[0-9]|30|31)|192\.168)\.)/
```

---

When configured with a String

```
HelloWorld::Application.config.action_dispatch.trusted_proxies = "1.2.3.4"
```

The String will be combined with the default Regexp matching private IP addresses and assigned to `@trusted_proxies`.

```
/(^127\.0\.0\.1$|^(10|172\.(1[6-9]|2[0-9]|30|31)|192\.168)\.)|(1\.2\.3\.4)/
```
