### PR TITLE
Make respond_with return JSON/XML for PUT requests

### DIFF
--- a/actionpack/lib/action_controller/metal/responder.rb
+++ b/actionpack/lib/action_controller/metal/responder.rb
@@ -202,6 +202,8 @@ module ActionController #:nodoc:
         display resource
       elsif post?
         display resource, :status => :created, :location => api_location
+      elsif put?
+        display resource, :status => :ok
       elsif has_empty_resource_definition?
         display empty_resource, :status => :ok
       else

--- a/actionpack/test/controller/mime_responds_test.rb
+++ b/actionpack/test/controller/mime_responds_test.rb
@@ -498,7 +498,7 @@ class RespondToControllerTest < ActionController::TestCase
     assert_equal '<html><div id="iphone">Hello iPhone future from iPhone!</div></html>', @response.body
     assert_equal "text/html", @response.content_type
   end
-  
+
   def test_invalid_format
     get :using_defaults, :format => "invalidformat"
     assert_equal " ", @response.body
@@ -785,7 +785,7 @@ class RespondWithControllerTest < ActionController::TestCase
     put :using_resource
     assert_equal "application/xml", @response.content_type
     assert_equal 200, @response.status
-    assert_equal " ", @response.body
+    assert_equal "<name>david</name>", @response.body
   end
 
   def test_using_resource_for_put_with_json_yields_ok_on_success
@@ -794,7 +794,7 @@ class RespondWithControllerTest < ActionController::TestCase
     put :using_resource
     assert_equal "application/json", @response.content_type
     assert_equal 200, @response.status
-    assert_equal "{}", @response.body
+    assert_equal '{"name": "David"}', @response.body
   end
 
   def test_using_resource_for_put_with_xml_yields_unprocessable_entity_on_failure


### PR DESCRIPTION
I think this lines up more closely with the docs, specifically the example in responder.rb between lines 30-56.

I can't find anywhere in the HTTP spec that takes a position on this. I've found it helpful to have the resulting resource sent back to the client on a PUT request and I've had to get by with render instead of the cleaner respond_with.
