### PR TITLE
Add config.allow_debugging option

### DIFF
--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -70,9 +70,10 @@ module Sprockets
 
     private
       def debug_assets?
-        params[:debug_assets] == '1' ||
-        params[:debug_assets] == 'true' ||
-        Rails.application.config.assets.debug
+        Rails.application.config.assets.allow_debugging &&
+         (Rails.application.config.assets.debug ||
+          params[:debug_assets] == '1' ||
+          params[:debug_assets] == 'true')
       end
 
       # Override to specify an alternative prefix for asset path generation.

--- a/actionpack/test/template/sprockets_helper_test.rb
+++ b/actionpack/test/template/sprockets_helper_test.rb
@@ -157,6 +157,7 @@ class SprocketsHelperTest < ActionView::TestCase
     assert_match %r{<script src="/assets/xmlhr-[0-9a-f]+.js\?body=1" type="text/javascript"></script>\n<script src="/assets/application-[0-9a-f]+.js\?body=1" type="text/javascript"></script>},
       javascript_include_tag(:application, :debug => true)
 
+    @config.assets.allow_debugging = true
     @config.assets.debug = true
     assert_match %r{<script src="/assets/xmlhr-[0-9a-f]+.js\?body=1" type="text/javascript"></script>\n<script src="/assets/application-[0-9a-f]+.js\?body=1" type="text/javascript"></script>},
       javascript_include_tag(:application)
@@ -197,6 +198,7 @@ class SprocketsHelperTest < ActionView::TestCase
     assert_match %r{<link href="/assets/style-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />\n<link href="/assets/application-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />},
       stylesheet_link_tag(:application, :debug => true)
 
+    @config.assets.allow_debugging = true
     @config.assets.debug = true
     assert_match %r{<link href="/assets/style-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />\n<link href="/assets/application-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />},
       stylesheet_link_tag(:application)

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -33,12 +33,13 @@ module Rails
         @cache_store                 = [ :file_store, "#{root}/tmp/cache/" ]
 
         @assets = ActiveSupport::OrderedOptions.new
-        @assets.enabled    = false
-        @assets.paths      = []
-        @assets.precompile = [ /\w+\.(?!js|css).+/, /application.(css|js)$/ ]
-        @assets.prefix     = "/assets"
-        @assets.version    = ''
-        @assets.debug      = false
+        @assets.enabled         = false
+        @assets.paths           = []
+        @assets.precompile      = [ /\w+\.(?!js|css).+/, /application.(css|js)$/ ]
+        @assets.prefix          = "/assets"
+        @assets.version         = ''
+        @assets.debug           = false
+        @assets.allow_debugging = false
 
         @assets.cache_store    = [ :file_store, "#{root}/tmp/cache/assets/" ]
         @assets.js_compressor  = nil

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -30,6 +30,9 @@
   # Do not compress assets
   config.assets.compress = false
 
+  # Allow pass debug_assets=true as a query parameter to load pages with unpackaged assets
+  config.assets.allow_debugging = true
+
   # Expands the lines which load the assets
   config.assets.debug = true
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -41,4 +41,7 @@
 
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
+
+  # Allow pass debug_assets=true as a query parameter to load pages with unpackaged assets
+  config.assets.allow_debugging = true
 end


### PR DESCRIPTION
Add config.allow_debugging option to determine if the debug_assets query param can be passed by user and if debug option can be used in stylesheet_link_tag and javascript_include_tag
