### PR TITLE
remove useless rescue

### DIFF
--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -70,12 +70,9 @@ module Sprockets
 
     private
       def debug_assets?
-        begin
-          params[:debug_assets] == '1' ||
-            params[:debug_assets] == 'true'
-        rescue NoMethodError
-          false
-        end || Rails.application.config.assets.debug
+        params[:debug_assets] == '1' ||
+        params[:debug_assets] == 'true' ||
+        Rails.application.config.assets.debug
       end
 
       # Override to specify an alternative prefix for asset path generation.

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -142,7 +142,11 @@ class RoutedRackApp
 end
 
 class BasicController
-  attr_accessor :request
+  attr_accessor :request, :params
+
+  def initialize
+    @params = {}
+  end
 
   def config
     @config ||= ActiveSupport::InheritableOptions.new(ActionController::Base.config).tap do |config|


### PR DESCRIPTION
params is a method, defined in every controller, which always returns a hash.  
If it raises a NoMethodError, it means there's a bug somewhere else, which we want to know about.
