### PR TITLE
Fixed 500 error message

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/public/500.html
+++ b/railties/lib/rails/generators/rails/app/templates/public/500.html
@@ -20,7 +20,7 @@
   <!-- This file lives in public/500.html -->
   <div class="dialog">
     <h1>We're sorry, but something went wrong.</h1>
-    <p>We've been notified about this issue and we'll take a look at it shortly.</p>
+    <p>If you believe you've seen this page in error, please notify the site owner.</p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
Fixed 500 error message which is misleading by suggesting all rails apps have exception notifications by default. This discourages users from complaining when the site fails for them.
