### PR TITLE
Added a generator option to remove the public/index.html file when generating a new application

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -50,7 +50,7 @@ module Rails
                                           :desc => "Skip JavaScript files"
 
         class_option :skip_index_html,    :type => :boolean, :aliases => "-I", :default => false,
-                                          :desc => "Skip public/index.html file"
+                                          :desc => "Skip public/index.html and app/assets/images/rails.png files"
 
         class_option :dev,                :type => :boolean, :default => false,
                                           :desc => "Setup the #{name} with Gemfile pointing to your Rails checkout"

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -49,6 +49,9 @@ module Rails
         class_option :skip_javascript,    :type => :boolean, :aliases => "-J", :default => false,
                                           :desc => "Skip JavaScript files"
 
+        class_option :skip_index_html,    :type => :boolean, :aliases => "-i", :default => false,
+                                          :desc => "Skip public/index.html file"
+
         class_option :dev,                :type => :boolean, :default => false,
                                           :desc => "Setup the #{name} with Gemfile pointing to your Rails checkout"
 

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -49,7 +49,7 @@ module Rails
         class_option :skip_javascript,    :type => :boolean, :aliases => "-J", :default => false,
                                           :desc => "Skip JavaScript files"
 
-        class_option :skip_index_html,    :type => :boolean, :aliases => "-i", :default => false,
+        class_option :skip_index_html,    :type => :boolean, :aliases => "-I", :default => false,
                                           :desc => "Skip public/index.html file"
 
         class_option :dev,                :type => :boolean, :default => false,

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -97,7 +97,11 @@ module Rails
 
     def public_directory
       directory "public", "public", :recursive => false
-      remove_file "public/index.html" if options[:skip_index_html]
+      if options[:skip_index_html]
+        remove_file "public/index.html"
+        remove_file 'app/assets/images/rails.png'
+        git_keep 'app/assets/images'
+      end
     end
 
     def script

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -97,6 +97,7 @@ module Rails
 
     def public_directory
       directory "public", "public", :recursive => false
+      remove_file "public/index.html" if options[:skip_index_html]
     end
 
     def script

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -201,6 +201,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_generator_if_skip_index_html_is_given
     run_generator [destination_root, "--skip-index-html"]
     assert_no_file "public/index.html"
+    assert no_file "app/assets/images/rails.png"
+    assert_file "app/assets/images/.gitkeep"
   end
 
   def test_creation_of_a_test_directory

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -198,6 +198,11 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "test/performance/browsing_test.rb"
   end
 
+  def test_generator_if_skip_index_html_is_given
+    run_generator [destination_root, "--skip-index-html"]
+    assert_no_file "public/index.html"
+  end
+
   def test_creation_of_a_test_directory
     run_generator
     assert_file 'test'


### PR DESCRIPTION
Unless you'e new to Rails you know what the index.html file says and you don't look at it, and more often than not you forget to remove it before firing up `rails server` expecting to see your freshly crafted index view for welcome_controller. 

So isn't it about time we had an option to remove it along with being able to skip-javascript and skip-bundle?

The option I've added is:
`-I, [--skip-index-html]        # Skip public/index.html file`

Thanks to @parndt for pointing me to right files, and @radar for annoyance.

**I know I targeted `master` (It's my first patch) but can we have this in Rails 3.1.1? or sooner?**
