### PR TITLE
Missing require array/wrap in serialization

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -1,5 +1,7 @@
 require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/hash/slice'
+require 'active_support/core_ext/array/wrap'
+
 
 module ActiveModel
   # == Active Model Serialization


### PR DESCRIPTION
Array wrap() is getting used in almost all of the  ActiveModel::Serialization methods. There was no require for array wrap, so added them for extra safety.
