### PR TITLE
Make ActionController::TestCase#recycle! set @protocol to nil

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -180,7 +180,7 @@ module ActionController
       @env.delete_if { |k, v| k =~ /^action_dispatch\.rescue/ }
       @symbolized_path_params = nil
       @method = @request_method = nil
-      @fullpath = @ip = @remote_ip = nil
+      @fullpath = @ip = @remote_ip = @protocol = nil
       @env['action_dispatch.request.query_parameters'] = {}
       @set_cookies ||= {}
       @set_cookies.update(Hash[cookie_jar.instance_variable_get("@set_cookies").map{ |k,o| [k,o[:value]] }])


### PR DESCRIPTION
This ensures that the protocol does not get carried over when there are
two or more requests in functional tests. This was a problem when e.g.
the first request was HTTP and the second request was HTTPS.

Closes #2654.
