### PR TITLE
docs: Add the Initialization guide to the index.

### DIFF
--- a/railties/guides/source/index.html.erb
+++ b/railties/guides/source/index.html.erb
@@ -131,6 +131,10 @@ Ruby on Rails Guides
 <%= guide("Caching with Rails", 'caching_with_rails.html', :work_in_progress => true) do %>
   <p>Various caching techniques provided by Rails.</p>
 <% end %>
+
+<%= guide("The Rails Initialization Process", 'initialization.html') do %>
+  <p>This guide explains the internals of the initialization process in Rails as of Rails 3.1.</p>
+<% end %>
 </dl>
 
 <h3>Extending Rails</h3>

--- a/railties/guides/source/layout.html.erb
+++ b/railties/guides/source/layout.html.erb
@@ -71,6 +71,7 @@
               <dd><a href="configuring.html">Configuring Rails Applications</a></dd>
               <dd><a href="command_line.html">Rails Command Line Tools and Rake Tasks</a></dd>
               <dd><a href="caching_with_rails.html">Caching with Rails</a></dd>
+              <dd><a href="initialization.html">The Rails Initialization Process</a></dd>
 
               <dt>Extending Rails</dt>
               <dd><a href="plugins.html">The Basics of Creating Rails Plugins</a></dd>


### PR DESCRIPTION
Before this change, the only way to find the Rails Initialization Guide was through Google. :-)

This commit adds it to the index.html and to the "Index" dropdown menu.
