### PR TITLE
Improve in-memory checking on has_many :through members

### DIFF
--- a/activerecord/lib/active_record/associations/association_collection.rb
+++ b/activerecord/lib/active_record/associations/association_collection.rb
@@ -368,7 +368,8 @@ module ActiveRecord
         return include_in_memory?(record) if record.new_record?
         load_target if @reflection.options[:finder_sql] && !loaded?
         return @target.include?(record) if loaded?
-        exists?(record)
+        return true if exists?(record)
+        include_in_memory?(record)
       end
 
       def proxy_respond_to?(method, include_private = false)

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -452,6 +452,13 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert person.jobs.include?(job)
   end
 
+  def test_include_method_in_association_through_should_return_true_when_instance_exists_but_through_is_new
+    person = Person.new
+    job = Job.create
+    reference = person.references.build(:job => job)
+    assert person.jobs.include?(job)
+  end
+
   def test_include_method_in_association_through_should_return_true_for_instance_added_with_nested_builds
     author = Author.new
     post = author.posts.build


### PR DESCRIPTION
Allow checking the in-memory inclusion of has_many :through members when those members are persisted. 

Since this works when all records are new, we expected this to also work when just the parent and join record are new.

The implementation isn't great but is the least intrusive change we found that fixed our test case.
