### PR TITLE
Fix autoload_once_paths when using Pathnames & ruby 1.9

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -421,7 +421,8 @@ module ActiveSupport #:nodoc:
     end
 
     def load_once_path?(path)
-      autoload_once_paths.any? { |base| path.starts_with? base }
+      # to_s works around a ruby1.9 issue where #starts_with?(Pathname) will always return false
+      autoload_once_paths.any? { |base| path.starts_with? base.to_s }
     end
 
     # Attempt to autoload the provided module name by searching for a directory

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -520,6 +520,24 @@ class DependenciesTest < Test::Unit::TestCase
     ActiveSupport::Dependencies.autoload_once_paths = []
   end
 
+  def test_autoload_once_pathnames_do_not_add_to_autoloaded_constants
+    with_autoloading_fixtures do
+      pathnames = ActiveSupport::Dependencies.autoload_paths.collect{|p| Pathname.new(p)}
+      ActiveSupport::Dependencies.autoload_paths = pathnames
+      ActiveSupport::Dependencies.autoload_once_paths = pathnames
+
+      assert ! ActiveSupport::Dependencies.autoloaded?("ModuleFolder")
+      assert ! ActiveSupport::Dependencies.autoloaded?("ModuleFolder::NestedClass")
+      assert ! ActiveSupport::Dependencies.autoloaded?(ModuleFolder)
+
+      1 if ModuleFolder::NestedClass # 1 if to avoid warning
+      assert ! ActiveSupport::Dependencies.autoloaded?(ModuleFolder::NestedClass)
+    end
+  ensure
+    Object.class_eval { remove_const :ModuleFolder }
+    ActiveSupport::Dependencies.autoload_once_paths = []
+  end
+
   def test_application_should_special_case_application_controller
     with_autoloading_fixtures do
       require_dependency 'application'


### PR DESCRIPTION
Heya,
I ran into a fun issue on ruby 1.9 where my autoload_once stuff was geting reloaded on each request. Turns out that under 1.9, "/var/log".start_with?(Pathname("/var")) returns false, and I was using :

`config.autoload_once_paths += [config.root.join('lib')]`

Converting to strings fixed the issue. The attached patch just calls to_s on the autoload_once pathnames in load_once_path?, which is the only problem-point I've discovered when using Pathnames instead of regular strings.

Any thoughts?

-Jonathan
