### PR TITLE
ActiveResource shouldn't rely on the presence of Content-Length 

### DIFF
--- a/activeresource/test/cases/base_test.rb
+++ b/activeresource/test/cases/base_test.rb
@@ -636,13 +636,37 @@ class BaseTest < Test::Unit::TestCase
     assert_nil p.__send__(:id_from_response, resp)
   end
 
-  def test_load_attributes_from_response
-    p = Person.new
+  def test_not_persisted_with_no_body_and_positive_content_length
     resp = ActiveResource::Response.new(nil)
     resp['Content-Length'] = "100"
-    assert_nil p.__send__(:load_attributes_from_response, resp)
+    Person.connection.expects(:post).returns(resp)
+    assert !Person.create.persisted?
   end
 
+  def test_not_persisted_with_body_and_zero_content_length
+    resp = ActiveResource::Response.new(@rick)
+    resp['Content-Length'] = "0"
+    Person.connection.expects(:post).returns(resp)
+    assert !Person.create.persisted?
+  end
+
+  # These response codes aren't allowed to have bodies per HTTP spec
+  def test_not_persisted_with_empty_response_codes
+    [100,101,204,304].each do |status_code|
+      resp = ActiveResource::Response.new(@rick, status_code)
+      Person.connection.expects(:post).returns(resp)
+      assert !Person.create.persisted?
+    end
+  end
+
+  # Content-Length is not required by HTTP 1.1, so we should read
+  # the body anyway in its absence.
+  def test_persisted_with_no_content_length
+    resp = ActiveResource::Response.new(@rick)
+    resp['Content-Length'] = nil
+    Person.connection.expects(:post).returns(resp)
+    assert Person.create.persisted?
+  end
 
   def test_create_with_custom_prefix
     matzs_house = StreetAddress.new(:person_id => 1)


### PR DESCRIPTION
Hi,

I recently ran into issues using ActiveResource against another Rails app running out of Pow.  Rails doesn't use the ContentLength middleware by default when started from `config.ru`, so if the rack server (in Pow's case nack) doesn't add a Content-Length header on its own (which nack doesn't, but many servers do), ActiveResource ignores the response body of a `save`, preventing me from reading the server state (which in the case of `create`s means you lose track of the new object's ID).

The [relevant part of the HTTP 1.1 spec](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13) says that the Content-Length header "SHOULD be sent whenever the message's length can be determined prior to being transferred," but SHOULD isn't MUST, and even if it were, it's conceivable that a custom JSON API might start streaming before it has finished counting bytes, so requiring a Content-Length header as evidence that a response body exists seems incorrect.

The current behavior came about [in this commit](https://github.com/rails/rails/commit/154081f0f74988bdb8979f0447ff5816ab83d8fd) from @malyk, associated with [lighthouse ticket #5038](https://rails.lighthouseapp.com/projects/8994/tickets/5038).  The [test case from that thread](https://github.com/rails/rails/commit/39debfc854c782f263a8340b63c9d8892f92a94b) provided by @neerajdotname still passes, so this patch doesn't alter any tested behavior, and presumably satisfies #5038.

This patch also provides better resilience by ignoring the body of an HTTP response that [isn't allowed to have one](http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.4) as another way of preventing parse errors if the server sends a garbage body along with a 204 response.

#5038 didn't make it into 3.0, so this bug only manifests on 3-1-stable and onward.  I'd be happy to provide a pull request for 3-1-stable as well.
