### PR TITLE
do not compute table names for abstract classes

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -624,6 +624,8 @@ module ActiveRecord #:nodoc:
 
       # Computes the table name, (re)sets it internally, and returns it.
       def reset_table_name #:nodoc:
+        return if abstract_class?
+
         self.table_name = compute_table_name
       end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1625,6 +1625,10 @@ class BasicsTest < ActiveRecord::TestCase
     assert !LooseDescendant.abstract_class?
   end
 
+  def test_abstract_class_table_name
+    assert_nil AbstractCompany.table_name
+  end
+
   def test_base_class
     assert_equal LoosePerson,     LoosePerson.base_class
     assert_equal LooseDescendant, LooseDescendant.base_class


### PR DESCRIPTION
I found a trivial inconsistency on AR table_name computing behavior.

While there are an abstract_class model and its child:

``` ruby
class User < ActiveRecord::Base
  self.abstract_class = true
end

class Admin < User
end
```

The child's table_name changes depending on whether the abstract model's table_name were called or not.

``` ruby
User.table_name
=> "users"
User.scoped.to_sql
=> SELECT "users".* FROM "users"
Admin.table_name
=> "users"
Admin.scoped.to_sql
=> SELECT "users".* FROM "users"

Admin.table_name
=> "admins"
Admin.scoped.to_sql
=> SELECT "admins".* FROM "admins"
```

This doesn't matter for normal use, but sometimes causes weird errors, for example, when dealing with an AR extension plugin that scans through descendants of AR::Base on Railtie hook.

Here's a patch that makes abstract models always skip compute_table_name.
