### PR TITLE
Engine test fix

### DIFF
--- a/railties/lib/rails/plugin.rb
+++ b/railties/lib/rails/plugin.rb
@@ -74,8 +74,8 @@ module Rails
     initializer :load_init_rb, :before => :load_config_initializers do |app|
       init_rb = File.expand_path("init.rb", root)
       if File.file?(init_rb)
-        # FIXME: do we call this for side effects??
-        app.config
+        # This double assignment is to prevent an "unused variable" warning on Ruby 1.9.3.
+        config = config = app.config
         # TODO: think about evaling initrb in context of Engine (currently it's
         # always evaled in context of Rails::Application)
         eval(File.read(init_rb), binding, init_rb)


### PR DESCRIPTION
Fix broken test test_copying_migrations(RailtiesTest::EngineTest):
NoMethodError: undefined method `log_level' for #Rails::Engine::Configuration:0xb87a98c

this is a revert from c29426d81c641d4ee51d7b4ac8b393c8961238b9  one of change 
