### PR TITLE
Do not escape # sign for interpolation

### DIFF
--- a/actionpack/lib/action_controller/session/abstract_store.rb
+++ b/actionpack/lib/action_controller/session/abstract_store.rb
@@ -262,7 +262,7 @@ module ActionController
                 # Note that the regexp does not allow $1 to end with a ':'
                 $1.constantize
               rescue LoadError, NameError => const_error
-                raise ActionController::SessionRestoreError, "Session contains objects whose class definition isn\\'t available.\nRemember to require the classes for all objects kept in the session.\n(Original exception: \#{const_error.message} [\#{const_error.class}])\n"
+                raise ActionController::SessionRestoreError, "Session contains objects whose class definition isn't available.\nRemember to require the classes for all objects kept in the session.\n(Original exception: #{const_error.message} [#{const_error.class}])\n"
               end
               retry
             else


### PR DESCRIPTION
Current Rails 2.3 outputs a meaningless error log like this:

```
Session contains objects whose class definition isn\'t available.
Remember to require the classes for all objects kept in the session.
(Original exception: #{const_error.message} [#{const_error.class}])
```

I found this was fixed in Rails 3, so this patch applies to 2-3-stable only.
