### PR TITLE
Make Sprockets::Helpers::RailsHelper#debug_assets? more readable

### DIFF
--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -58,10 +58,10 @@ module Sprockets
 
     private
       def debug_assets?
-        Rails.application.config.assets.allow_debugging &&
-         (Rails.application.config.assets.debug ||
-          params[:debug_assets] == '1' ||
-          params[:debug_assets] == 'true')
+        config = Rails.application.config.assets
+        param  = params[:debug_assets]
+
+        config.allow_debugging && (config.debug || param == '1' || param == 'true')
       end
 
       # Override to specify an alternative prefix for asset path generation.


### PR DESCRIPTION
Remove some redundant calls and make the code more readable.
