### PR TITLE
ActiveResource remove_root bug

### DIFF
--- a/activeresource/lib/active_resource/formats.rb
+++ b/activeresource/lib/active_resource/formats.rb
@@ -12,7 +12,7 @@ module ActiveResource
     end
 
     def self.remove_root(data)
-      if data.is_a?(Hash) && data.keys.size == 1
+      if data.is_a?(Hash) && data.keys.size == 1 && [Array,Hash].any?{ |c| data.first.last.is_a?(c) }
         data.values.first
       else
         data

--- a/activeresource/test/cases/format_test.rb
+++ b/activeresource/test/cases/format_test.rb
@@ -102,6 +102,18 @@ class FormatTest < Test::Unit::TestCase
     end
   end
 
+  def test_remove_root
+    assert_equal @matz, ActiveResource::Formats.remove_root({:person => @matz})
+  end
+
+  def test_remove_root_unwrapped
+    assert_equal @matz, ActiveResource::Formats.remove_root(@matz)
+  end
+
+  def test_remove_root_unwrapped_with_single_key
+    assert_equal({:id => 1}, ActiveResource::Formats.remove_root({:id => 1}))
+  end
+
   private
     def using_format(klass, mime_type_reference)
       previous_format = klass.format


### PR DESCRIPTION
ActiveResource attempts to cope with a server that may or may not have :include_root_in_json enabled by heuristically unwrapping the payload if there's a single key in the decoded response hash.  The problem is that it's legitimate for a server to return a single hash key of unwrapped content, though (e.g. `{:id => 1}`), which causes ActiveResource to choke.

This patch enhances the heuristic to only unwrap the content if:
- there is only one key
- and the value of that key is either an Array or Hash

Tests included.  If desired I can provide a pull request for 3-1-stable.
