### PR TITLE
Don't require a specific value for the ?debug flag

### DIFF
--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -59,9 +59,7 @@ module Sprockets
     private
       def debug_assets?
         config = Rails.application.config.assets
-        param  = params[:debug_assets]
-
-        config.allow_debugging && (config.debug || param == '1' || param == 'true')
+        config.allow_debugging && (config.debug || params[:debug_assets])
       end
 
       # Override to specify an alternative prefix for asset path generation.


### PR DESCRIPTION
Previously, only "1" and "true" were accepted. This change makes any value, or no value at all, have the same effect.
