### PR TITLE
Collection singular ids with conditions

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1496,7 +1496,7 @@ module ActiveRecord
               if reflection.through_reflection && reflection.source_reflection.belongs_to?
                 through = reflection.through_reflection
                 primary_key = reflection.source_reflection.primary_key_name
-                send(through.name).select("DISTINCT #{through.quoted_table_name}.#{primary_key}").map! { |r| r.send(primary_key) }
+                send(reflection.name).except(:select).select("DISTINCT #{through.quoted_table_name}.#{primary_key}").map! { |r| r.send(primary_key) }
               else
                 send(reflection.name).select("#{reflection.quoted_table_name}.#{reflection.klass.primary_key}").except(:includes).map! { |r| r.id }
               end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -430,6 +430,14 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_raises(ActiveRecord::RecordNotFound) {company.developer_ids= ids}
   end
 
+  def test_collection_singular_ids_with_conditions
+    david = authors(:david)
+    category = david.categories.create :name => "General"
+    other = david.categories.create :name => "other"
+    assert david.categories_like_general_ids.include? category.id
+    assert !david.categories_like_general_ids.include?(other.id)
+  end
+
   def test_build_a_model_from_hm_through_association_with_where_clause
     assert_nothing_raised { books(:awdr).subscribers.where(:nick => "marklazz").build }
   end


### PR DESCRIPTION
fixed bug when using collection_singular_ids : now considering :conditions, :order on the association reflection

```
class User < ActiveRecord::Base
      has_many  :friendships
      has_many  :friends,
          :through => :friendships,
          :conditions => "state = 'accepted'",
          :order => :lastname
end
```

on rails console :

```
User.last.friend_ids
```

gives

```
SELECT `users`.* FROM `users` ORDER BY users.id DESC LIMIT 1
SELECT DISTINCT `friendships`.friend_id FROM `friendships` WHERE (`friendships`.user_id = 10)
```

should be

```
SELECT `users`.* FROM `users` ORDER BY users.id DESC LIMIT 1
SELECT `users`.* FROM `users` INNER JOIN `friendships` ON `users`.id = `friendships`.friend_id WHERE ((`friendships`.user_id = 10) AND ((state = 'accepted'))) ORDER BY lastname
```
