### PR TITLE
Fix bad options order in AR::Migration::CommandRecorder#invert_rename_index

### DIFF
--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -71,7 +71,7 @@ module ActiveRecord
       end
 
       def invert_rename_index(args)
-        [:rename_index, args.reverse]
+        [:rename_index, [args.first] + args.last(2).reverse]
       end
 
       def invert_rename_column(args)

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -104,9 +104,9 @@ module ActiveRecord
       end
 
       def test_invert_rename_index
-        @recorder.record :rename_index, [:old, :new]
+        @recorder.record :rename_index, [:table, :old, :new]
         rename = @recorder.inverse.first
-        assert_equal [:rename_index, [:new, :old]], rename
+        assert_equal [:rename_index, [:table, :new, :old]], rename
       end
 
       def test_invert_add_timestamps


### PR DESCRIPTION
This patch fixes a bad options order in ActiveRecord::Migration::CommandRecorder#invert_rename_index

`ActiveRecord::ConnectionAdapters::SchemaStatements#rename_index` always had the same signature : `rename_index(table_name, old_name, new_name)`.

When using the new reversible migrations in Rails 3.1.rc6, I found it was unfortunately inverted to `rename_index(new_name, old_name, table_name)`, which is wrong. It should have been  `rename_index(table_name, new_name, old_name)` instead. Hence this patch, which copies the way `rename_column` is inverted. Please let me know if I'm not clear.

All tests are green on sqlite3, mysql, mysql2 and postgresql.

Since it's a defect, the patch is tiny and shouldn't have any side effect, I think it could be safely merged into master and 3.1-stable.
