### PR TITLE
Disable mangle temporary in Uglifier since is causing problems with Prototypejs

### DIFF
--- a/actionpack/lib/sprockets/railtie.rb
+++ b/actionpack/lib/sprockets/railtie.rb
@@ -74,7 +74,7 @@ module Sprockets
           Closure::Compiler.new
         when :uglifier
           require 'uglifier'
-          Uglifier.new
+          Uglifier.new(:mangle => false)
         when :yui
           require 'yui/compressor'
           YUI::JavaScriptCompressor.new


### PR DESCRIPTION
Disable mangle temporary in Uglifier since is causing problems with Prototypejs files. Closes #2537
