### PR TITLE
add humans.txt

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/public/humans.txt.tt
+++ b/railties/lib/rails/generators/rails/app/templates/public/humans.txt.tt
@@ -1,0 +1,9 @@
+# See more about this file at: http://humanstxt.org/
+# For format suggestions, see: http://humanstxt.org/Standard.html
+/* TEAM */
+  <%= ENV['USER'].titlecase %>
+
+/* APP */
+  Name: <%= app_const_base %>
+  Date Created: <%= Date.today.strftime("%B %d, %Y") %>
+  Software: Ruby on Rails


### PR DESCRIPTION
I'm a big fan of the idea of http://humanstxt.org and I noticed during the week that Google have a pretty nice humans.txt http://www.google.com/humans.txt

As DHH said at RailsConf, the best thing that Rails provides is empty files, so adding humans.txt to the base rails generator would hopefully encourage the adoption of humans.txt.

Including the Rails Core team by default seems obvious and, I think, appropriate.

What do you think?
