### PR TITLE
Deprecate delegation to private methods

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -147,7 +147,7 @@ class Module
           #{to}.#{method}(#{definition})                                         #   client.name(*args, &block)
         rescue NoMethodError => e                                                # rescue NoMethodError => e
           begin                                                                  #   begin
-            #{to}.__send__(#{method.inspect}, #{definition})                     #     client.__send__(:name, *args, &block)
+            result = #{to}.__send__(#{method.inspect}, #{definition})            #     result = client.__send__(:name, *args, &block)
           rescue NoMethodError                                                   #   rescue NoMethodError
             if #{to}.nil?                                                        #     if client.nil?
               #{on_nil}                                                          #       return # depends on :allow_nil
@@ -157,6 +157,7 @@ class Module
           else                                                                   #   else
             ActiveSupport::Deprecation.warn(                                     #     ActiveSupport::Deprecation.warn(
               'Delegating to non-public methods is deprecated.', caller)         #       'Delegating to non-public methods is deprecated.', caller)
+            result                                                               #     result
           end                                                                    #   end
         end                                                                      # end
       EOS

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -126,10 +126,28 @@ class Module
           %(raise "#{self}##{prefix}#{method} delegated to #{to}.#{method}, but #{to} is nil: \#{self.inspect}")
         end
 
-      if method.to_s =~ /[^\]]=/
-        # The method is an attribute writer, so we can't do `method=(*args)`.
-        module_eval(<<-EOS, file, line - 2)
-          def #{prefix}#{method}(*args, &block)                                    # def customer_name(*args, &block)
+      rescue_clause = <<-EOS
+        rescue NoMethodError => e                                                # rescue NoMethodError => e
+          raise unless e.name == #{method.inspect}                               #   raise unless e.name == :name
+          begin                                                                  #   begin
+            result = #{to}.__send__(#{method.inspect}, *args, &block)            #     result = client.__send__(:name, *args, &block)
+          rescue NoMethodError => e2                                             #   rescue NoMethodError => e2
+            raise unless e2.name == #{method.inspect}                            #     raise unless e2.name == :name
+            if #{to}.nil?                                                        #     if client.nil?
+              #{on_nil}                                                          #       return # depends on :allow_nil
+            else                                                                 #     else
+              raise(e)                                                           #       raise(e)
+            end                                                                  #     end
+          else                                                                   #   else
+            ActiveSupport::Deprecation.warn(                                     #     ActiveSupport::Deprecation.warn(
+              'Delegating to non-public methods is deprecated.', caller)         #       'Delegating to non-public methods is deprecated.', caller)
+            result                                                               #     result
+          end                                                                    #   end
+      EOS
+
+      method_body =
+        if method.to_s =~ /[^\]]=/
+          <<-EOS
             if args.length > 1 || block_given?                                     #   if args.length > 1 || block_given?
               ActiveSupport::Deprecation.warn(                                     #     ActiveSupport::Deprecation.warn(
                 'Writer methods should only accept one argument. Support ' +       #       'Writer methods should only accept one argument. Support ' +
@@ -138,47 +156,19 @@ class Module
             else                                                                   #   else
               #{to}.#{method}(args.first)                                          #     client.invoices=(args.first)
             end                                                                    #   end
-          rescue NoMethodError => e                                                # rescue NoMethodError => e
-            raise unless e.name == #{method.inspect}                               #   raise unless e.name == :name
-            begin                                                                  #   begin
-              result = #{to}.__send__(#{method.inspect}, *args, &block)            #     result = client.__send__(:name, *args, &block)
-            rescue NoMethodError => e2                                             #   rescue NoMethodError => e2
-              raise unless e2.name == #{method.inspect}                            #     raise unless e2.name == :name
-              if #{to}.nil?                                                        #     if client.nil?
-                #{on_nil}                                                          #       return # depends on :allow_nil
-              else                                                                 #     else
-                raise(e)                                                           #       raise(e)
-              end                                                                  #     end
-            else                                                                   #   else
-              ActiveSupport::Deprecation.warn(                                     #     ActiveSupport::Deprecation.warn(
-                'Delegating to non-public methods is deprecated.', caller)         #       'Delegating to non-public methods is deprecated.', caller)
-              result                                                               #     result
-            end                                                                    #   end
-          end                                                                      # end
-        EOS
-      else
-        module_eval(<<-EOS, file, line - 1)
-          def #{prefix}#{method}(*args, &block)                                    # def customer_name(*args, &block)
+          EOS
+        else
+          <<-EOS
             #{to}.#{method}(*args, &block)                                         #   client.name(*args, &block)
-          rescue NoMethodError => e                                                # rescue NoMethodError => e
-            raise unless e.name == #{method.inspect}                               #   raise unless e.name == :name
-            begin                                                                  #   begin
-              result = #{to}.__send__(#{method.inspect}, *args, &block)            #     result = client.__send__(:name, *args, &block)
-            rescue NoMethodError => e2                                             #   rescue NoMethodError => e2
-              raise unless e2.name == #{method.inspect}                            #     raise unless e2.name == :name
-              if #{to}.nil?                                                        #     if client.nil?
-                #{on_nil}                                                          #       return # depends on :allow_nil
-              else                                                                 #     else
-                raise(e)                                                           #       raise(e)
-              end                                                                  #     end
-            else                                                                   #   else
-              ActiveSupport::Deprecation.warn(                                     #     ActiveSupport::Deprecation.warn(
-                'Delegating to non-public methods is deprecated.', caller)         #       'Delegating to non-public methods is deprecated.', caller)
-              result                                                               #     result
-            end                                                                    #   end
-          end                                                                      # end
-        EOS
-      end
+          EOS
+        end
+
+      module_eval(<<-EOS, file, line - 1)
+        def #{prefix}#{method}(*args, &block)                                    # def customer_name(*args, &block)
+          #{method_body}
+          #{rescue_clause}
+        end                                                                      # end
+      EOS
     end
   end
 end

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -119,6 +119,8 @@ class Module
     line = line.to_i
 
     methods.each do |method|
+      method_name = ":#{method}"
+
       on_nil =
         if options[:allow_nil]
           'return'
@@ -128,11 +130,11 @@ class Module
 
       rescue_clause = <<-EOS
         rescue NoMethodError => e                                                # rescue NoMethodError => e
-          raise unless e.name == #{method.inspect}                               #   raise unless e.name == :name
+          raise unless e.name == #{method_name}                                  #   raise unless e.name == :name
           begin                                                                  #   begin
-            result = #{to}.__send__(#{method.inspect}, *args, &block)            #     result = client.__send__(:name, *args, &block)
+            result = #{to}.__send__(#{method_name}, *args, &block)               #     result = client.__send__(:name, *args, &block)
           rescue NoMethodError => e2                                             #   rescue NoMethodError => e2
-            raise unless e2.name == #{method.inspect}                            #     raise unless e2.name == :name
+            raise unless e2.name == #{method_name}                               #     raise unless e2.name == :name
             if #{to}.nil?                                                        #     if client.nil?
               #{on_nil}                                                          #       return # depends on :allow_nil
             else                                                                 #     else
@@ -152,7 +154,7 @@ class Module
               ActiveSupport::Deprecation.warn(                                     #     ActiveSupport::Deprecation.warn(
                 'Writer methods should only accept one argument. Support ' +       #       'Writer methods should only accept one argument. Support ' +
                 'for multiple arguments will be removed in the future.', caller)   #       'for multiple arguments will be removed in the future.', caller)
-              #{to}.__send__(#{method.inspect}, *args, &block)                     #     client.__send__(:invoices=, *args, &block)
+              #{to}.__send__(#{method_name}, *args, &block)                        #     client.__send__(:invoices=, *args, &block)
             else                                                                   #   else
               #{to}.#{method}(args.first)                                          #     client.invoices=(args.first)
             end                                                                    #   end

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -152,8 +152,10 @@ class Module
           <<-EOS
             if args.length > 1 || block_given?                                     #   if args.length > 1 || block_given?
               ActiveSupport::Deprecation.warn(                                     #     ActiveSupport::Deprecation.warn(
-                'Writer methods should only accept one argument. Support ' +       #       'Writer methods should only accept one argument. Support ' +
-                'for multiple arguments will be removed in the future.', caller)   #       'for multiple arguments will be removed in the future.', caller)
+                "Support for using Module#delegate with writer methods and " +     #       "Support for using Module#delegate with writer methods and " +
+                "multiple arguments, or block arguments, is going to be " +        #       "multiple arguments, or block arguments, is going to be " +
+                "removed. If you need this functionality, please define your " +   #       "removed. If you need this functionality, please define your " +
+                "own delegation manually.", caller)                                #       "own delegation manually.", caller)
               #{to}.__send__(#{method_name}, *args, &block)                        #     client.__send__(:invoices=, *args, &block)
             else                                                                   #   else
               #{to}.#{method}(args.first)                                          #     client.invoices=(args.first)

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -156,7 +156,7 @@ class Module
             end                                                                  #     end
           else                                                                   #   else
             ActiveSupport::Deprecation.warn(                                     #     ActiveSupport::Deprecation.warn(
-              'Delegating to private methods is deprecated.', caller)            #       'Delegating to private methods is deprecated.', caller)
+              'Delegating to non-public methods is deprecated.', caller)         #       'Delegating to non-public methods is deprecated.', caller)
           end                                                                    #   end
         end                                                                      # end
       EOS

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -145,9 +145,11 @@ class Module
           def #{prefix}#{method}(*args, &block)                                    # def customer_name(*args, &block)
             #{to}.#{method}(*args, &block)                                         #   client.name(*args, &block)
           rescue NoMethodError => e                                                # rescue NoMethodError => e
+            raise unless e.name == #{method.inspect}                               #   raise unless e.name == :name
             begin                                                                  #   begin
               result = #{to}.__send__(#{method.inspect}, *args, &block)            #     result = client.__send__(:name, *args, &block)
-            rescue NoMethodError                                                   #   rescue NoMethodError
+            rescue NoMethodError => e2                                             #   rescue NoMethodError => e2
+              raise unless e2.name == #{method.inspect}                            #     raise unless e2.name == :name
               if #{to}.nil?                                                        #     if client.nil?
                 #{on_nil}                                                          #       return # depends on :allow_nil
               else                                                                 #     else

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -126,7 +126,7 @@ class Module
           %(raise "#{self}##{prefix}#{method} delegated to #{to}.#{method}, but #{to} is nil: \#{self.inspect}")
         end
 
-      if method.to_s =~ /[^]]=/
+      if method.to_s =~ /[^\]]=/
         # The method is an attribute writer, so we can't do `method=(*args)`.
         module_eval(<<-EOS, file, line - 2)
           def #{prefix}#{method}(*args, &block)                                    # def customer_name(*args, &block)

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -138,6 +138,22 @@ class Module
             else                                                                   #   else
               #{to}.#{method}(args.first)                                          #     client.invoices=(args.first)
             end                                                                    #   end
+          rescue NoMethodError => e                                                # rescue NoMethodError => e
+            raise unless e.name == #{method.inspect}                               #   raise unless e.name == :name
+            begin                                                                  #   begin
+              result = #{to}.__send__(#{method.inspect}, *args, &block)            #     result = client.__send__(:name, *args, &block)
+            rescue NoMethodError => e2                                             #   rescue NoMethodError => e2
+              raise unless e2.name == #{method.inspect}                            #     raise unless e2.name == :name
+              if #{to}.nil?                                                        #     if client.nil?
+                #{on_nil}                                                          #       return # depends on :allow_nil
+              else                                                                 #     else
+                raise(e)                                                           #       raise(e)
+              end                                                                  #     end
+            else                                                                   #   else
+              ActiveSupport::Deprecation.warn(                                     #     ActiveSupport::Deprecation.warn(
+                'Delegating to non-public methods is deprecated.', caller)         #       'Delegating to non-public methods is deprecated.', caller)
+              result                                                               #     result
+            end                                                                    #   end
           end                                                                      # end
         EOS
       else

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -60,7 +60,7 @@ class Someone < Struct.new(:name, :place)
 
   def raises_no_method_error_in_private
     @raise_calls += 1
-    raise NoMethodError.new("no method!", :foodle)
+    raise NoMethodError.new("no method!")
   end
 
   protected
@@ -158,10 +158,12 @@ class ModuleTest < ActiveSupport::TestCase
     @tester = Tester.new(@david)
 
     error = assert_raise(NoMethodError) do
-      @tester.raises_no_method_error_in_private
+      assert_deprecated do
+        @tester.raises_no_method_error_in_private
+      end
     end
 
-    assert_equal :foodle, error.name
+    assert_equal :raises_no_method_error_in_private, error.name
     assert_equal 1, @david.raise_calls
   end
 

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -36,6 +36,7 @@ class Someone < Struct.new(:name, :place)
   delegate :foo, :to => :place
 
   def occupation=(a, b)
+    "WRITER"
   end
 
   private
@@ -118,7 +119,7 @@ class ModuleTest < ActiveSupport::TestCase
 
   def test_deprecates_delegation_to_attr_writer_with_multiple_args
     assert_deprecated do
-      Tester.new(@david).send(:occupation=, 1, 2)
+      assert_equal "WRITER", Tester.new(@david).send(:occupation=, 1, 2)
     end
   end
 

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -103,13 +103,13 @@ class ModuleTest < ActiveSupport::TestCase
 
   def test_deprecates_delegation_to_private_methods
     assert_deprecated do
-      Tester.new(@david).something_private
+      assert_equal "PRIVATE", Tester.new(@david).something_private
     end
   end
 
   def test_deprecates_delegation_to_protected_methods
     assert_deprecated do
-      Tester.new(@david).something_protected
+      assert_equal "PROTECTED", Tester.new(@david).something_protected
     end
   end
 

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -34,6 +34,16 @@ class Someone < Struct.new(:name, :place)
 
   FAILED_DELEGATE_LINE = __LINE__ + 1
   delegate :foo, :to => :place
+
+  private
+  def something_private
+    "PRIVATE"
+  end
+
+  protected
+  def something_protected
+    "PROTECTED"
+  end
 end
 
 Invoice   = Struct.new(:client) do
@@ -52,6 +62,7 @@ end
 
 Tester = Struct.new(:client) do
   delegate :name, :to => :client, :prefix => false
+  delegate :something_private, :something_protected, :to => :client
 end
 
 class Name
@@ -62,7 +73,7 @@ class Name
   end
 end
 
-class ModuleTest < Test::Unit::TestCase
+class ModuleTest < ActiveSupport::TestCase
   def setup
     @david = Someone.new("David", Somewhere.new("Paulina", "Chicago"))
   end
@@ -87,6 +98,18 @@ class ModuleTest < Test::Unit::TestCase
     end
     assert_raise(ArgumentError) do
       Name.send :delegate, :noplace, :tos => :hollywood
+    end
+  end
+
+  def test_deprecates_delegation_to_private_methods
+    assert_deprecated do
+      Tester.new(@david).something_private
+    end
+  end
+
+  def test_deprecates_delegation_to_protected_methods
+    assert_deprecated do
+      Tester.new(@david).something_protected
     end
   end
 

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -35,7 +35,17 @@ class Someone < Struct.new(:name, :place)
   FAILED_DELEGATE_LINE = __LINE__ + 1
   delegate :foo, :to => :place
 
+  def raise_calls
+    @raise_calls
+  end
+
+  def initialize(*args)
+    @raise_calls = 0
+    super
+  end
+
   def raises_no_method_error
+    @raise_calls += 1
     raise NoMethodError.new("no method!", :fizzle)
   end
 
@@ -49,6 +59,7 @@ class Someone < Struct.new(:name, :place)
   end
 
   def raises_no_method_error_in_private
+    @raise_calls += 1
     raise NoMethodError.new("no method!", :foodle)
   end
 
@@ -133,19 +144,25 @@ class ModuleTest < ActiveSupport::TestCase
   end
 
   def test_does_not_swallow_no_method_errors
+    @tester = Tester.new(@david)
+
     error = assert_raise(NoMethodError) do
-      Tester.new(@david).raises_no_method_error
+      @tester.raises_no_method_error
     end
 
     assert_equal :fizzle, error.name
+    assert_equal 1, @david.raise_calls
   end
 
   def test_does_not_swallow_no_method_errors_from_private_methods
+    @tester = Tester.new(@david)
+
     error = assert_raise(NoMethodError) do
-      Tester.new(@david).raises_no_method_error_in_private
+      @tester.raises_no_method_error_in_private
     end
 
     assert_equal :foodle, error.name
+    assert_equal 1, @david.raise_calls
   end
 
   def test_delegation_prefix

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -35,6 +35,9 @@ class Someone < Struct.new(:name, :place)
   FAILED_DELEGATE_LINE = __LINE__ + 1
   delegate :foo, :to => :place
 
+  def occupation=(a, b)
+  end
+
   private
   def something_private
     "PRIVATE"
@@ -62,7 +65,7 @@ end
 
 Tester = Struct.new(:client) do
   delegate :name, :to => :client, :prefix => false
-  delegate :something_private, :something_protected, :to => :client
+  delegate :something_private, :something_protected, :occupation=, :to => :client
 end
 
 class Name
@@ -110,6 +113,12 @@ class ModuleTest < ActiveSupport::TestCase
   def test_deprecates_delegation_to_protected_methods
     assert_deprecated do
       assert_equal "PROTECTED", Tester.new(@david).something_protected
+    end
+  end
+
+  def test_deprecates_delegation_to_attr_writer_with_multiple_args
+    assert_deprecated do
+      Tester.new(@david).send(:occupation=, 1, 2)
     end
   end
 


### PR DESCRIPTION
This pull request accompanies #2733, and provides two deprecations related to the use of `delegate`:
1. Delegating to a private method on the target object
2. Delegating to an attribute writer method (e.g. `foo=`) that accepts multiple arguments

The code is a bit tricky, so you're welcome to reviewing it. However, the acceptance of this request should be predicated upon the successful inclusion of #2733.
