### PR TITLE
Coders::YAMLColumn#dump should raise an error

### DIFF
--- a/activerecord/lib/active_record/coders/yaml_column.rb
+++ b/activerecord/lib/active_record/coders/yaml_column.rb
@@ -15,6 +15,10 @@ module ActiveRecord
       end
 
       def dump(obj)
+        unless obj.is_a?(object_class)
+          raise SerializationTypeMismatch,
+            "Attribute was supposed to be a #{object_class}, but was a #{obj.class}. -- #{obj.inspect}"
+        end
         YAML.dump obj
       end
 

--- a/activerecord/test/cases/coders/yaml_column_test.rb
+++ b/activerecord/test/cases/coders/yaml_column_test.rb
@@ -9,6 +9,13 @@ module ActiveRecord
         assert_equal Object, coder.object_class
       end
 
+      def test_type_mismatch_on_different_classes_on_dump
+        coder = YAMLColumn.new(Array)
+        assert_raises(SerializationTypeMismatch) do
+          coder.dump("a")
+        end
+      end
+
       def test_type_mismatch_on_different_classes
         coder = YAMLColumn.new(Array)
         assert_raises(SerializationTypeMismatch) do


### PR DESCRIPTION
``` ruby
class Foo < ActiveRerocd::Base
  serialize :posts, Array
end

foo = Foo.new
foo.posts = "a"
foo.save # It doen't raise an error.

foo.posts # It raises ActiveRecord::SerializationTypeMismatch
```

It's strange, when you save the data, it doesn't raise any error, but when we get the data, it raises an error.

so, in #dump, we should raise an error, too
