### PR TITLE
Read digests of assets from manifest.yml when precompile is used

### DIFF
--- a/actionpack/lib/sprockets/assets.rake
+++ b/actionpack/lib/sprockets/assets.rake
@@ -46,10 +46,8 @@ namespace :assets do
         env.precompile(*assets)
       end
 
-      if config.assets.manifest
-        File.open("#{target}/manifest.yml", 'w') do |f|
-          YAML.dump(manifest, f)
-        end
+      File.open("#{target}/manifest.yml", 'w') do |f|
+        YAML.dump(manifest, f)
       end
     end
   end

--- a/actionpack/lib/sprockets/assets.rake
+++ b/actionpack/lib/sprockets/assets.rake
@@ -18,7 +18,8 @@ namespace :assets do
 
       config = Rails.application.config
       env    = Rails.application.assets
-      target = Rails.root.join("public#{config.assets.prefix}")
+      target = Pathname.new(File.join(Rails.public_path, config.assets.prefix))
+      manifest = {}
 
       if env.respond_to?(:each_logical_path)
         config.assets.precompile.each do |path|
@@ -30,6 +31,7 @@ namespace :assets do
             end
 
             if asset = env.find_asset(logical_path)
+              manifest[logical_path] = asset.digest_path
               filename = target.join(asset.digest_path)
               mkdir_p filename.dirname
               asset.write_to(filename)
@@ -42,6 +44,12 @@ namespace :assets do
         assets = config.assets.precompile.dup
         assets << {:to => target}
         env.precompile(*assets)
+      end
+
+      if config.assets.manifest
+        File.open("#{target}/manifest.yml", 'w') do |f|
+          YAML.dump(manifest, f)
+        end
       end
     end
   end

--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -14,6 +14,7 @@ module Sprockets
           paths = RailsHelper::AssetPaths.new(config, controller)
           paths.asset_environment = asset_environment
           paths.asset_prefix      = asset_prefix
+          paths.asset_digests     = asset_digests
           paths
         end
       end
@@ -74,6 +75,10 @@ module Sprockets
         Rails.application.config.assets.prefix
       end
 
+      def asset_digests
+        Rails.application.config.assets.digests
+      end
+
       # Override to specify an alternative asset environment for asset
       # path generation. The environment should already have been mounted
       # at the prefix returned by +asset_prefix+.
@@ -82,7 +87,9 @@ module Sprockets
       end
 
       class AssetPaths < ::ActionView::AssetPaths #:nodoc:
-        attr_accessor :asset_environment, :asset_prefix
+        attr_accessor :asset_environment, :asset_prefix, :asset_digests
+
+        class AssetNotPrecompiledError < StandardError; end
 
         def compute_public_path(source, dir, ext=nil, include_host=true, protocol=nil)
           super(source, asset_prefix, ext, include_host, protocol)
@@ -101,6 +108,14 @@ module Sprockets
         end
 
         def digest_for(logical_path)
+          if asset_digests && (digest = asset_digests[logical_path])
+            return digest
+          end
+
+          if digest.nil? && Rails.application.config.assets.precompile_only
+            raise AssetNotPrecompiledError
+          end
+
           if asset = asset_environment[logical_path]
             return asset.digest_path
           end

--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -108,12 +108,10 @@ module Sprockets
         end
 
         def digest_for(logical_path)
-          if asset_digests && (digest = asset_digests[logical_path])
+          if asset_digests
+            digest = asset_digests[logical_path]
+            raise AssetNotPrecompiledError unless digest
             return digest
-          end
-
-          if digest.nil? && Rails.application.config.assets.precompile_only
-            raise AssetNotPrecompiledError
           end
 
           if asset = asset_environment[logical_path]

--- a/actionpack/lib/sprockets/railtie.rb
+++ b/actionpack/lib/sprockets/railtie.rb
@@ -26,10 +26,8 @@ module Sprockets
         end
       end
 
-      if config.assets.manifest
-        if File.exist?(path = File.join(Rails.public_path, config.assets.prefix, "manifest.yml"))
-          config.assets.digests = YAML.load_file(path)
-        end
+      if File.exist?(path = File.join(Rails.public_path, config.assets.prefix, "manifest.yml"))
+        config.assets.digests = YAML.load_file(path)
       end
 
       ActiveSupport.on_load(:action_view) do

--- a/actionpack/lib/sprockets/railtie.rb
+++ b/actionpack/lib/sprockets/railtie.rb
@@ -26,6 +26,12 @@ module Sprockets
         end
       end
 
+      if config.assets.manifest
+        if File.exist?(path = File.join(Rails.public_path, config.assets.prefix, "manifest.yml"))
+          config.assets.digests = YAML.load_file(path)
+        end
+      end
+
       ActiveSupport.on_load(:action_view) do
         include ::Sprockets::Helpers::RailsHelper
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -42,10 +42,11 @@ module Rails
         @assets.version         = ''
         @assets.debug           = false
         @assets.allow_debugging = false
-
-        @assets.cache_store    = [ :file_store, "#{root}/tmp/cache/assets/" ]
-        @assets.js_compressor  = nil
-        @assets.css_compressor = nil
+        @assets.manifest        = true
+        @assets.precompile_only = false
+        @assets.cache_store     = [ :file_store, "#{root}/tmp/cache/assets/" ]
+        @assets.js_compressor   = nil
+        @assets.css_compressor  = nil
       end
 
       def compiled_asset_path

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -42,8 +42,6 @@ module Rails
         @assets.version         = ''
         @assets.debug           = false
         @assets.allow_debugging = false
-        @assets.manifest        = true
-        @assets.precompile_only = false
         @assets.cache_store     = [ :file_store, "#{root}/tmp/cache/assets/" ]
         @assets.js_compressor   = nil
         @assets.css_compressor  = nil

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -52,6 +52,10 @@ module <%= app_const_base %>
 <% unless options.skip_sprockets? -%>
     # Enable the asset pipeline
     config.assets.enabled = true
+
+    # Create a manifest with the hashes of your assets when you run "rake assets:precompile".
+    # Use this if you don't have a JavaScript engine in your production servers
+    config.assets.manifest = true
 <% end -%>
   end
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -52,10 +52,6 @@ module <%= app_const_base %>
 <% unless options.skip_sprockets? -%>
     # Enable the asset pipeline
     config.assets.enabled = true
-
-    # Create a manifest with the hashes of your assets when you run "rake assets:precompile".
-    # Use this if you don't have a JavaScript engine in your production servers
-    config.assets.manifest = true
 <% end -%>
   end
 end

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -62,18 +62,7 @@ module ApplicationTests
       end
     end
 
-    test "precompile don't create a manifest file when manifest option is off" do
-      app_file "app/assets/javascripts/application.js", "alert();"
-      app_file "config/initializers/manifest.rb", "Rails.application.config.assets.manifest = false"
-
-      capture(:stdout) do
-        Dir.chdir(app_path){ `bundle exec rake assets:precompile` }
-      end
-
-      assert !File.exist?("#{app_path}/public/assets/manifest.yml")
-    end
-
-    test "precompile creates a manifest file with all the assets listed when manifest option is on" do
+    test "precompile creates a manifest file with all the assets listed" do
       app_file "app/assets/stylesheets/application.css.erb", "<%= asset_path('rails.png') %>"
       app_file "app/assets/javascripts/application.js", "alert();"
 
@@ -88,7 +77,7 @@ module ApplicationTests
       assert_match /application-([0-z]+)\.css/, assets["application.css"]
     end
 
-    test "assets do not require any assets group gem when manifest option is on and manifest file is present" do
+    test "assets do not require any assets group gem when manifest file is present" do
       app_file "app/assets/javascripts/application.js", "alert();"
 
       ENV["RAILS_ENV"] = "production"
@@ -108,10 +97,8 @@ module ApplicationTests
       assert !defined?(Uglifier)
     end
 
-    test "assets raise AssetNotPrecompiledError if config.assets.precompile_only is on and file isn't precompiled" do
-      app_file "app/assets/javascripts/app.js", "alert();"
+    test "assets raise AssetNotPrecompiledError when manifest file is present and requested file isn't precompiled" do
       app_file "app/views/posts/index.html.erb", "<%= javascript_include_tag 'app' %>"
-      app_file "config/initializers/precompile_only.rb", "Rails.application.config.assets.precompile_only = true"
 
       app_file "config/routes.rb", <<-RUBY
         AppTemplate::Application.routes.draw do
@@ -120,6 +107,13 @@ module ApplicationTests
       RUBY
 
       ENV["RAILS_ENV"] = "production"
+      capture(:stdout) do
+        Dir.chdir(app_path){ `bundle exec rake assets:precompile` }
+      end
+
+      # Create file after of precompile
+      app_file "app/assets/javascripts/app.js", "alert();"
+
       require "#{app_path}/config/environment"
       class ::PostsController < ActionController::Base ; end
 


### PR DESCRIPTION
Same #2741 but for 3-1-stable
