### PR TITLE
Fix test should group by summed field having condition from select for oracle

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -171,6 +171,9 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_should_group_by_summed_field_having_condition_from_select
+    # Oracle does not allow use of aliases from SELECT in HAVING clause
+    return if current_adapter?(:OracleAdapter)
+
     c = Account.select("MIN(credit_limit) AS min_credit_limit").group(:firm_id).having("min_credit_limit > 50").sum(:credit_limit)
     assert_nil       c[1]
     assert_equal 60, c[2]


### PR DESCRIPTION
Use of SQL aggregate function in HAVING clause is supported by all databases therefore better use syntax that is supported by all databases.
