### PR TITLE
Ensure correct ordering of results in test_update_all_with_joins_and_offset_and_order 

### DIFF
--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1005,7 +1005,7 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_update_all_with_joins_and_offset_and_order
-    all_comments = Comment.joins(:post).where('posts.id' => posts(:welcome).id).order('posts.id')
+    all_comments = Comment.joins(:post).where('posts.id' => posts(:welcome).id).order('posts.id', 'comments.id')
     count        = all_comments.count
     comments     = all_comments.offset(1)
 


### PR DESCRIPTION
Last two asserts in this test assume that all_comments are ordered by posts.id and then by comments.id therefore additional ordering is added. Without it test was failing on Oracle which returned results in different order.
