### PR TITLE
Removing hard dependency on ActiveModel for BCrypt as per issue #2687

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -1,4 +1,4 @@
-require 'bcrypt'
+autoload :BCrypt, 'bcrypt'
 
 module ActiveModel
   module SecurePassword


### PR DESCRIPTION
https://github.com/rails/rails/issues/2687
