### PR TITLE
Fixes bug in ActiveRecord::QueryMethods, #1697

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -305,10 +305,8 @@ module ActiveRecord
         when Arel::Nodes::Ordering
           o.reverse
         when String, Symbol
-          o.to_s.split(',').collect do |s|
-            s.strip!
-            s.gsub!(/\sasc\Z/i, ' DESC') || s.gsub!(/\sdesc\Z/i, ' ASC') || s.concat(' DESC')
-          end
+          s = o.to_s.gsub(/\s((desc)|(asc))\s*(,|\Z)/i) { |m| " #{$2 ? 'ASC' : 'DESC'}#{$4}" }
+          s.match(/\s(de|a)sc\Z/i) ? s : s.concat(" DESC")
         else
           o
         end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -934,6 +934,11 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal 'zyke', FastCar.order_using_old_style.limit(1).first.name
   end
 
+  def test_order_with_function_and_last
+    authors = Author.scoped
+    assert_equal authors(:bob), authors.order( "id asc, COALESCE( organization_id, owned_essay_id)" ).last
+  end
+  
   def test_order_using_scoping
     car1 = CoolCar.order('id DESC').scoping do
       CoolCar.find(:first, :order => 'id asc')


### PR DESCRIPTION
Replace split on comma with a regexp that will reverse all ASC/DESC specifically
#1697 says it was fixed, but that fix was reverted in 971a74b. It seems likely 18d307ed94ee9 was failing on Travis because MAX (the function used in the test scenario) does not actually accept multiple arguments on MySQL.
