### PR TITLE
Use LIMIT SQL word in first - Closes #2783

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -134,7 +134,11 @@ module ActiveRecord
     def last(*args)
       if args.any?
         if args.first.kind_of?(Integer) || (loaded? && !args.first.kind_of?(Hash))
-          to_a.last(*args)
+          if order_values.empty? && reorder_value.nil?
+            order("#{primary_key} DESC").limit(*args).reverse
+          else
+            to_a.last(*args)
+          end
         else
           apply_finder_options(args.first).last
         end

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -114,7 +114,7 @@ module ActiveRecord
     def first(*args)
       if args.any?
         if args.first.kind_of?(Integer) || (loaded? && !args.first.kind_of?(Hash))
-          to_a.first(*args)
+          limit(*args).to_a
         else
           apply_finder_options(args.first).first
         end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -243,6 +243,15 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
+  def test_first_with_integer_should_use_sql_limit
+    assert_sql(/LIMIT 2/) { Topic.first(2).entries }
+  end
+
+  def test_first_and_last_with_integer_should_return_an_array
+    assert_kind_of Array, Topic.first(5)
+    assert_kind_of Array, Topic.last(5)
+  end
+
   def test_unexisting_record_exception_handling
     assert_raise(ActiveRecord::RecordNotFound) {
       Topic.find(1).parent

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -243,8 +243,25 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
-  def test_first_with_integer_should_use_sql_limit
+  def test_first_and_last_with_integer_should_use_sql_limit
     assert_sql(/LIMIT 2/) { Topic.first(2).entries }
+    assert_sql(/LIMIT 5/) { Topic.last(5).entries }
+  end
+
+  def test_last_with_integer_and_order_should_keep_the_order
+    assert_equal Topic.order("title").to_a.last(2), Topic.order("title").last(2)
+  end
+
+  def test_last_with_integer_and_order_should_not_use_sql_limit
+    query = assert_sql { Topic.order("title").last(5).entries }
+    assert_equal 1, query.length
+    assert_no_match(/LIMIT/, query.first)
+  end
+
+  def test_last_with_integer_and_reorder_should_not_use_sql_limit
+    query = assert_sql { Topic.reorder("title").last(5).entries }
+    assert_equal 1, query.length
+    assert_no_match(/LIMIT/, query.first)
   end
 
   def test_first_and_last_with_integer_should_return_an_array


### PR DESCRIPTION
Currently, #first and #last are using `to_a`, which retrieves all entries from the database and loads them in memory.  
That's quite inefficient and useless.

This PR changes this behavior, to only retrieve the required entries.
