### PR TITLE
Empty array in html attributes

### DIFF
--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -143,9 +143,18 @@ module ActionView
               elsif BOOLEAN_ATTRIBUTES.include?(key)
                 attrs << %(#{key}="#{key}") if value
               elsif !value.nil?
-                final_value = value.is_a?(Array) ? value.join(" ") : value
-                final_value = ERB::Util.html_escape(final_value) if escape
-                attrs << %(#{key}="#{final_value}")
+                empty = false
+                if value.is_a?(Array)
+                  if value.empty?
+                    empty = true
+                  else
+                    value = value.join(" ")
+                  end
+                end
+                unless empty
+                  value = ERB::Util.html_escape(value) if escape
+                  attrs << %(#{key}="#{value}")
+                end
               end
             end
             " #{attrs.sort * ' '}".html_safe unless attrs.empty?

--- a/actionpack/test/template/tag_helper_test.rb
+++ b/actionpack/test/template/tag_helper_test.rb
@@ -15,6 +15,16 @@ class TagHelperTest < ActionView::TestCase
     assert_match(/class="elsewhere"/, str)
   end
 
+  def test_tag_options_array
+    str = tag("p", "class" => ["show", "elsewhere"])
+    assert_match(/class="show elsewhere"/, str)
+  end
+
+  def test_tag_options_empty_array
+    str = tag("p", "class" => [])
+    assert_equal "<p />", str
+  end
+
   def test_tag_options_rejects_nil_option
     assert_equal "<p />", tag("p", :ignored => nil)
   end


### PR DESCRIPTION
When you pass empty array to content_tag attribute, the html attribute is rendered with empty value.

Now:

``` ruby
content_tag(:p, "foo", :class => [])
#=> <p class="">foo</p>
```

Fixed:

``` ruby
content_tag(:p, "foo", :class => [])
#=> <p>foo</p>
```
