### PR TITLE
Skip test_should_group_by_summed_field_having_condition_from_select for Oracle

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -172,7 +172,7 @@ class CalculationsTest < ActiveRecord::TestCase
 
   def test_should_group_by_summed_field_having_condition_from_select
     # Oracle does not allow use of aliases from SELECT in HAVING clause
-    return if current_adapter?(:OracleAdapter)
+    return skip "unsupported on Oracle" if current_adapter?(:OracleAdapter)
 
     c = Account.select("MIN(credit_limit) AS min_credit_limit").group(:firm_id).having("min_credit_limit > 50").sum(:credit_limit)
     assert_nil       c[1]

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -171,6 +171,9 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_should_group_by_summed_field_having_condition_from_select
+    # Oracle does not allow use of aliases from SELECT in HAVING clause
+    return if current_adapter?(:OracleAdapter)
+
     c = Account.select("MIN(credit_limit) AS min_credit_limit").group(:firm_id).having("min_credit_limit > 50").sum(:credit_limit)
     assert_nil       c[1]
     assert_equal 60, c[2]


### PR DESCRIPTION
skip test_should_group_by_summed_field_having_condition_from_select on Oracle

Oracle does not allow use of aliases from SELECT in HAVING clause

Replaces previous pull request https://github.com/rails/rails/pull/2751
