### PR TITLE
Never return stored content from content_for when a block is given

### DIFF
--- a/actionpack/lib/action_view/helpers/capture_helper.rb
+++ b/actionpack/lib/action_view/helpers/capture_helper.rb
@@ -134,9 +134,13 @@ module ActionView
       # WARNING: content_for is ignored in caches. So you shouldn't use it
       # for elements that will be fragment cached.
       def content_for(name, content = nil, &block)
-        content = capture(&block) if block_given?
-        @_content_for[name] << content if content
-        @_content_for[name] unless content
+        if content || block_given?
+          content = capture(&block) if block_given?
+          @_content_for[name] << content if content
+          nil
+        else
+          @_content_for[name]
+        end
       end
 
       # content_for? simply checks whether any content has been captured yet using content_for

--- a/actionpack/test/template/capture_helper_test.rb
+++ b/actionpack/test/template/capture_helper_test.rb
@@ -64,6 +64,14 @@ class CaptureHelperTest < ActionView::TestCase
     assert_equal 'foobar', content_for(:title)
   end
 
+  def test_content_for_returns_nil_when_writing
+    assert ! content_for?(:title)
+    assert_equal nil, content_for(:title, 'foo')
+    assert_equal nil, content_for(:title) { output_buffer << 'bar'; nil }
+    assert_equal nil, content_for(:title) { output_buffer << "  \n  "; nil }
+    assert_equal 'foobar', content_for(:title)
+  end
+
   def test_with_output_buffer_swaps_the_output_buffer_given_no_argument
     assert_nil @av.output_buffer
     buffer = @av.with_output_buffer do

--- a/actionpack/test/template/capture_helper_test.rb
+++ b/actionpack/test/template/capture_helper_test.rb
@@ -47,6 +47,23 @@ class CaptureHelperTest < ActionView::TestCase
     assert ! content_for?(:something_else)
   end
 
+  def test_content_for_with_multiple_calls
+    assert ! content_for?(:title)
+    content_for :title, 'foo'
+    content_for :title, 'bar'
+    assert_equal 'foobar', content_for(:title)
+  end
+
+  def test_content_for_with_block
+    assert ! content_for?(:title)
+    content_for :title do
+      output_buffer << 'foo'
+      output_buffer << 'bar'
+      nil
+    end
+    assert_equal 'foobar', content_for(:title)
+  end
+
   def test_with_output_buffer_swaps_the_output_buffer_given_no_argument
     assert_nil @av.output_buffer
     buffer = @av.with_output_buffer do


### PR DESCRIPTION
Using `content_for` in Rails 3.0.x can result in a bogus deprecation warning ("`<% %> style block helpers are deprecated`") because of a bug in how `content_for` works. `content_for` should only return stored content when no block has been provided, but instead it returns stored content when the block generates a blank buffer and has a `nil` return value, which is what happens in a situation like this:

```
<% content_for :foo do %>
  <% if something_falsy %>
    foo
  <% end %>
  <% if something_else_falsy %>
    bar
  <% end %>
<% end %>
```

Ultimately this is because `capture` returns `nil` (vs `''`) when the resulting buffer is `blank?`, but that's apparently intended behaviour, so it's better to fix `content_for` to explicitly check `block_given?` rather than relying on the truthiness of `capture(&block)`.
