### PR TITLE
Datetime coercion

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -126,7 +126,9 @@ class DateTime
   end
 
   # Layers additional behavior on DateTime#<=> so that Time and ActiveSupport::TimeWithZone instances can be compared with a DateTime
-  def <=>(other)
-    super other.to_datetime
+  def compare_with_coercion(other)
+    compare_without_coercion other.to_datetime
   end
+  alias_method :compare_without_coercion, :<=>
+  alias_method :<=>, :compare_with_coercion
 end


### PR DESCRIPTION
Use method aliasing for `DateTime#<=>` to be compatible with other libraries that define `<=>` on DateTime. By calling super, ActiveSupport 3.1 bypasses any `<=>` method defined on DateTime.

For example, if another library wrote this:

``` ruby
class DateTime
  def compare_with_comparability(other)
    compare_without_comparability (other.respond_to?(:comparable_datetime) ? other.comparable_datetime : other)
  end
  alias_method :compare_without_comparability, :<=>
  alias_method :<=>, :compare_with_comparability
end
```

If ActiveSupport 3.1 was loaded after, then it would bypass this extension. If both sides use method aliasing, then both extensions would be used regardless of load order. This also affects the `home_run` DateTime replacement because it defines a `DateTime#<=>` method overriding the `Date#<=>` method.
