### PR TITLE
Never return stored content from content_for when a block is given

### DIFF
--- a/actionpack/lib/action_view/helpers/capture_helper.rb
+++ b/actionpack/lib/action_view/helpers/capture_helper.rb
@@ -134,9 +134,9 @@ module ActionView
       # WARNING: content_for is ignored in caches. So you shouldn't use it
       # for elements that will be fragment cached.
       def content_for(name, content = nil, &block)
-        content = capture(&block) if block_given?
-        if content
-          @view_flow.append(name, content)
+        if content || block_given?
+          content = capture(&block) if block_given?
+          @view_flow.append(name, content) if content
           nil
         else
           @view_flow.get(name)

--- a/actionpack/test/template/capture_helper_test.rb
+++ b/actionpack/test/template/capture_helper_test.rb
@@ -46,6 +46,34 @@ class CaptureHelperTest < ActionView::TestCase
     assert_equal "bar", content_for(:bar)
   end
 
+  def test_content_for_with_multiple_calls
+    assert ! content_for?(:title)
+    content_for :title, 'foo'
+    content_for :title, 'bar'
+    assert_equal 'foobar', content_for(:title)
+  end
+
+  def test_content_for_with_block
+    assert ! content_for?(:title)
+    content_for :title do
+      output_buffer << 'foo'
+      output_buffer << 'bar'
+      nil
+    end
+    assert_equal 'foobar', content_for(:title)
+  end
+
+  def test_content_for_with_whitespace_block
+    assert ! content_for?(:title)
+    content_for :title, 'foo'
+    content_for :title do
+      output_buffer << "  \n  "
+      nil
+    end
+    content_for :title, 'bar'
+    assert_equal 'foobar', content_for(:title)
+  end
+
   def test_content_for_question_mark
     assert ! content_for?(:title)
     content_for :title, 'title'

--- a/actionpack/test/template/capture_helper_test.rb
+++ b/actionpack/test/template/capture_helper_test.rb
@@ -74,6 +74,14 @@ class CaptureHelperTest < ActionView::TestCase
     assert_equal 'foobar', content_for(:title)
   end
 
+  def test_content_for_returns_nil_when_writing
+    assert ! content_for?(:title)
+    assert_equal nil, content_for(:title, 'foo')
+    assert_equal nil, content_for(:title) { output_buffer << 'bar'; nil }
+    assert_equal nil, content_for(:title) { output_buffer << "  \n  "; nil }
+    assert_equal 'foobar', content_for(:title)
+  end
+
   def test_content_for_question_mark
     assert ! content_for?(:title)
     content_for :title, 'title'


### PR DESCRIPTION
There is a bug in `content_for`. It should only return stored content when no block has been provided, but instead it returns stored content when the block generates a blank buffer and has a `nil` return value, which is what happens in a situation like this:

```
<% content_for :foo do %>
  <% if something_falsy %>
    foo
  <% end %>
  <% if something_else_falsy %>
    bar
  <% end %>
<% end %>
```

Ultimately this is because `capture` returns `nil` (vs `''`) when the resulting buffer is `blank?`, but that's apparently intended behaviour, so it's better to fix `content_for` to explicitly check `block_given?` rather than relying on the truthiness of `capture(&block)`.

The bug provokes a deprecation warning in 3.0.x (see #2794); there is no such warning in 3.1.x, but it's still unintended behaviour.
