### PR TITLE
Fix obviously breakage of Time.=== for Time subclasses

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -9,7 +9,7 @@ class Time
   class << self
     # Overriding case equality method so that it returns true for ActiveSupport::TimeWithZone instances
     def ===(other)
-      other.is_a?(::Time)
+      super || (self == Time && other.is_a?(ActiveSupport::TimeWithZone))
     end
 
     # Return the number of days in the given month.

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -764,7 +764,10 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
   def test_case_equality
     assert Time === Time.utc(2000)
     assert Time === ActiveSupport::TimeWithZone.new(Time.utc(2000), ActiveSupport::TimeZone['UTC'])
+    assert Time === Class.new(Time).utc(2000)
     assert_equal false, Time === DateTime.civil(2000)
+    assert_equal false, Class.new(Time) === Time.utc(2000)
+    assert_equal false, Class.new(Time) === ActiveSupport::TimeWithZone.new(Time.utc(2000), ActiveSupport::TimeZone['UTC'])
   end
 
   def test_all_day


### PR DESCRIPTION
Obvious breakage is obvious:

```
case Time.now
when Class.new(Time)
  :ffffuuuuuuuuu
when Time
  :yay
end
```
