### PR TITLE
Fix typo in ActiveModel::Dirty documentation

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -29,7 +29,7 @@ module ActiveModel
   #
   #     include ActiveModel::Dirty
   #
-  #     define_attribute_methods = [:name]
+  #     define_attribute_methods [:name]
   #
   #     def name
   #       @name


### PR DESCRIPTION
Just a tiny fix in the ActiveModel::Dirty documentation. The documentation mentions setting a class attribute, when actually its a method.
