### PR TITLE
Dry up CookieJar by using delegate instead of redefining methods

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -118,25 +118,16 @@ module ActionDispatch
         @host = host
         @secure = secure
         @closed = false
-        @cookies = {}
+        @cookies = HashWithIndifferentAccess.new
       end
 
-      attr_reader :closed
+      attr_reader :closed, :cookies
       alias :closed? :closed
       def close!; @closed = true end
 
-      def each(&block)
-        @cookies.each(&block)
-      end
-
-      # Returns the value of the cookie by +name+, or +nil+ if no such cookie exists.
-      def [](name)
-        @cookies[name.to_s]
-      end
-
-      def key?(name)
-        @cookies.key?(name.to_s)
-      end
+      delegate :each, :to => :cookies
+      delegate :[], :to => :cookies
+      delegate :key?, :to => :cookies
       alias :has_key? :key?
 
       def update(other_hash)


### PR DESCRIPTION
Following fdd619e9a7a5b9457f77e6322c920b99c3c09599, I noticed there's no need to manually define `each`, `[]` and `has_key?` in the cookie jar.

This PR improves it, using delegate instead of manually defining the methods.
