### PR TITLE
added --skip-ignore and --skip-keeps options to generators

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -34,6 +34,12 @@ module Rails
         class_option :skip_git,           :type => :boolean, :aliases => "-G", :default => false,
                                           :desc => "Skip Git ignores and keeps"
 
+        class_option :skip_ignore,        :type => :boolean, :default => false,
+                                          :desc => "Skip Git ignore file"
+
+        class_option :skip_keeps,         :type => :boolean, :default => false,
+                                          :desc => "Skip source control keep files"
+
         class_option :skip_active_record, :type => :boolean, :aliases => "-O", :default => false,
                                           :desc => "Skip Active Record files"
 
@@ -247,13 +253,13 @@ module Rails
         bundle_command('install') unless options[:skip_gemfile] || options[:skip_bundle] || options[:pretend]
       end
 
-      def empty_directory_with_gitkeep(destination, config = {})
+      def empty_directory_with_keep_file(destination, config = {})
         empty_directory(destination, config)
-        git_keep(destination)
+        keep_file(destination)
       end
 
-      def git_keep(destination)
-        create_file("#{destination}/.gitkeep") unless options[:skip_git]
+      def keep_file(destination)
+        create_file("#{destination}/.keep") unless options[:skip_git] || options[:skip_keeps]
       end
 
       # Returns Ruby 1.9 style key-value pair.

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -11,7 +11,7 @@ module Rails
 
     private
       %w(template copy_file directory empty_directory inside
-         empty_directory_with_gitkeep create_file chmod shebang).each do |method|
+         empty_directory_with_keep_file create_file chmod shebang).each do |method|
         class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def #{method}(*args, &block)
             @generator.send(:#{method}, *args, &block)
@@ -55,8 +55,8 @@ module Rails
 
     def app
       directory 'app'
-      git_keep  'app/mailers'
-      git_keep  'app/models'
+      keep_file  'app/mailers'
+      keep_file  'app/models'
     end
 
     def config
@@ -87,12 +87,12 @@ module Rails
 
     def lib
       empty_directory "lib"
-      empty_directory_with_gitkeep "lib/tasks"
-      empty_directory_with_gitkeep "lib/assets"
+      empty_directory_with_keep_file "lib/tasks"
+      empty_directory_with_keep_file "lib/assets"
     end
 
     def log
-      empty_directory_with_gitkeep "log"
+      empty_directory_with_keep_file "log"
     end
 
     def public_directory
@@ -107,10 +107,10 @@ module Rails
     end
 
     def test
-      empty_directory_with_gitkeep "test/fixtures"
-      empty_directory_with_gitkeep "test/functional"
-      empty_directory_with_gitkeep "test/integration"
-      empty_directory_with_gitkeep "test/unit"
+      empty_directory_with_keep_file "test/fixtures"
+      empty_directory_with_keep_file "test/functional"
+      empty_directory_with_keep_file "test/integration"
+      empty_directory_with_keep_file "test/unit"
 
       template "test/performance/browsing_test.rb"
       template "test/test_helper.rb"
@@ -127,13 +127,12 @@ module Rails
     end
 
     def vendor_javascripts
-      empty_directory_with_gitkeep "vendor/assets/javascripts"
-    end
+      empty_directory_with_keep_file "vendor/assets/javascripts"
+	end
 
     def vendor_stylesheets
-      empty_directory_with_gitkeep "vendor/assets/stylesheets"
+      empty_directory_with_keep_file "vendor/assets/stylesheets"
     end
-  end
 
   module Generators
     # We need to store the RAILS_DEV_PATH in a constant, otherwise the path
@@ -164,7 +163,7 @@ module Rails
         build(:readme)
         build(:rakefile)
         build(:configru)
-        build(:gitignore) unless options[:skip_git]
+        build(:gitignore) unless options[:skip_git] || options[:skip_ignore]
         build(:gemfile)   unless options[:skip_gemfile]
       end
 

--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -11,14 +11,14 @@ module Rails
     def app
       if mountable?
         directory "app"
-        empty_directory_with_gitkeep "app/assets/images/#{name}"
+        empty_directory_with_keep_file "app/assets/images/#{name}"
       elsif full?
-        empty_directory_with_gitkeep "app/models"
-        empty_directory_with_gitkeep "app/controllers"
-        empty_directory_with_gitkeep "app/views"
-        empty_directory_with_gitkeep "app/helpers"
-        empty_directory_with_gitkeep "app/mailers"
-        empty_directory_with_gitkeep "app/assets/images/#{name}"
+        empty_directory_with_keep_file "app/models"
+        empty_directory_with_keep_file "app/controllers"
+        empty_directory_with_keep_file "app/views"
+        empty_directory_with_keep_file "app/helpers"
+        empty_directory_with_keep_file "app/mailers"
+        empty_directory_with_keep_file "app/assets/images/#{name}"
       end
     end
 
@@ -110,7 +110,7 @@ task :default => :test
         copy_file "#{app_templates_dir}/app/assets/stylesheets/application.css",
                   "app/assets/stylesheets/#{name}/application.css"
       elsif full?
-        empty_directory_with_gitkeep "app/assets/stylesheets/#{name}"
+        empty_directory_with_keep_file "app/assets/stylesheets/#{name}"
       end
     end
 
@@ -121,7 +121,7 @@ task :default => :test
         template "#{app_templates_dir}/app/assets/javascripts/application.js.tt",
                   "app/assets/javascripts/#{name}/application.js"
       elsif full?
-        empty_directory_with_gitkeep "app/assets/javascripts/#{name}"
+        empty_directory_with_keep_file "app/assets/javascripts/#{name}"
       end
     end
 
@@ -181,7 +181,7 @@ task :default => :test
         build(:rakefile)
         build(:gemspec)   unless options[:skip_gemspec]
         build(:license)
-        build(:gitignore) unless options[:skip_git]
+        build(:gitignore) unless options[:skip_git] || options[:skip_ignore]
         build(:gemfile)   unless options[:skip_gemfile]
       end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -360,6 +360,24 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_match(/run  bundle install/, output)
   end
 
+  def test_generator_if_skip_git_is_given
+    run_generator [destination_root, "--skip-git"]
+    assert_no_file(".gitignore")
+    assert_no_file("app/mailers/.keep")
+  end
+
+  def test_generator_if_skip_ignore_is_given
+    run_generator [destination_root, "--skip-ignore"]
+    assert_no_file(".gitignore")
+    assert_file("app/mailers/.keep")
+  end
+
+  def test_generator_if_skip_keeps_is_given
+    run_generator [destination_root, "--skip-keeps"]
+    assert_no_file("app/mailers/.keep")
+    assert_file(".gitignore")
+  end
+
 protected
 
   def action(*args, &block)

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -295,6 +295,24 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
   end
 
 
+  def test_generator_if_skip_git_is_given
+    run_generator [destination_root, "--full", "--skip-git"]
+    assert_no_file(".gitignore")
+    assert_no_file("app/mailers/.keep")
+  end
+
+  def test_generator_if_skip_ignore_is_given
+    run_generator [destination_root, "--full", "--skip-ignore"]
+    assert_no_file(".gitignore")
+    assert_file("app/mailers/.keep")
+  end
+
+  def test_generator_if_skip_keeps_is_given
+    run_generator [destination_root, "--full", "--skip-keeps"]
+    assert_no_file("app/mailers/.keep")
+    assert_file(".gitignore")
+  end
+
 protected
 
   def action(*args, &block)


### PR DESCRIPTION
Added test coverage for both as well as --skip-git. Renames .gitkeep to .keep. This makes the rails command a bit more SCM agnostic. Tests pass.

This closes #2800. Users of other SCM's can now generate rails apps that will add the "empty" directories to source control, but will not have a useless .gitignore or mis-named .gitkeep files.
