### PR TITLE
fix indent for generator environment method

### DIFF
--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -97,7 +97,7 @@ module Rails
 
         in_root do
           if options[:env].nil?
-            inject_into_file 'config/application.rb', "\n  #{data}", :after => sentinel, :verbose => false
+            inject_into_file 'config/application.rb', "\n    #{data}", :after => sentinel, :verbose => false
           else
             Array.wrap(options[:env]).each do |env|
               inject_into_file "config/environments/#{env}.rb", "\n  #{data}", :after => env_file_sentinel, :verbose => false

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -106,7 +106,7 @@ class ActionsTest < Rails::Generators::TestCase
     run_generator
     autoload_paths = 'config.autoload_paths += %w["#{Rails.root}/app/extras"]'
     action :environment, autoload_paths
-    assert_file 'config/application.rb', /#{Regexp.escape(autoload_paths)}/
+    assert_file 'config/application.rb', /  class Application < Rails::Application\n    #{Regexp.escape(autoload_paths)}/
   end
 
   def test_environment_should_include_data_in_environment_initializer_block_with_env_option


### PR DESCRIPTION
After migrate from config/environent.rb to config/application.rb we should use 4-space indent instead 2-space.

```
  module CustomApp
    class Application < Rails::Application
      # some code from generator
      # ...
```
