### PR TITLE
current_page? returns false for non-GET requests

### DIFF
--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -569,12 +569,20 @@ module ActionView
       #
       #   current_page?(:controller => 'library', :action => 'checkout')
       #   # => false
+      #
+      # Let's say we're in the <tt>/products</tt> action with method POST in case of invalid product.
+      #
+      #   current_page?(:controller => 'product', :action => 'index')
+      #   # => false
+      #
       def current_page?(options)
         unless request
           raise "You cannot use helpers that need to determine the current " \
                 "page unless your view context provides a Request object " \
                 "in a #request method"
         end
+
+        return false unless request.get?
 
         url_string = url_for(options)
 

--- a/actionpack/test/template/url_helper_test.rb
+++ b/actionpack/test/template/url_helper_test.rb
@@ -304,8 +304,8 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert_equal "Showing", link_to_if(false, "Showing", url_hash)
   end
 
-  def request_for_url(url)
-    env = Rack::MockRequest.env_for("http://www.example.com#{url}")
+  def request_for_url(url, opts = {})
+    env = Rack::MockRequest.env_for("http://www.example.com#{url}", opts)
     ActionDispatch::Request.new(env)
   end
 
@@ -327,6 +327,12 @@ class UrlHelperTest < ActiveSupport::TestCase
 
     assert current_page?(hash_for([:order, "desc", :page, "1"]))
     assert current_page?("http://www.example.com/?order=desc&page=1")
+  end
+
+  def test_current_page_with_not_get_verb
+    @request = request_for_url("/events", :method => :post)
+
+    assert !current_page?('/events')
   end
 
   def test_link_unless_current


### PR DESCRIPTION
I used <tt>link_to_unless_current('events', events_path)</tt> in my project. But if new <tt>Event</tt> object is invalid link to <tt>'events'</tt> is not created.

I suppose <tt>current_page?</tt> should return false for all non-GET requests. But I'm not sure that this solution has no side effects.

What do you think about this commit? Thanks in an advice.
