### PR TITLE
gem requirement without :version => hash is invalid 

### DIFF
--- a/railties/lib/rails/gem_dependency.rb
+++ b/railties/lib/rails/gem_dependency.rb
@@ -78,7 +78,7 @@ module Rails
         spec = Gem.source_index.find { |_,s| s.satisfies_requirement?(dep) }.last
         spec.activate           # a way that exists
       rescue
-        gem self.name, self.requirement # <  1.8 unhappy way
+        gem self.name, :version => (self.respond_to?(:requirement) ? self.requirement : self.version_requirements) # <  1.8 unhappy way
       end
 
       @spec = Gem.loaded_specs[name]


### PR DESCRIPTION
Hi,

Puppet dashboard reveal a problem with Ruby On Rails with a gem_dependency call. It's not compatible with the rubygem packaged version (1.3.0) of Ubuntu Lucid Lynx LTS. It throws this error message :
gem_dependency.rb:81 "undefined method `requirement' for #Rails::GemDependency:0x7f8dbb42dad8"

You can have more information on this issue : 
http://projects.puppetlabs.com/issues/8800

I have already made a patch which seems to fix the problem : 
http://projects.puppetlabs.com/attachments/1466/dashboard-fix-requirements-lucid.patch

Would you please apply it in the next version of Rails 2.3.X ?

Thanks,
