### PR TITLE
Make `ActiveSupport::OrderedHash` extractable when using `Array#extract_options!

### DIFF
--- a/activesupport/CHANGELOG
+++ b/activesupport/CHANGELOG
@@ -1,5 +1,7 @@
 *Rails 3.2.0 (unreleased)*
 
+* ActiveSupport::OrderedHash is now marked as extractable when using Array#extract_options! [Prem Sichanugrist]
+
 * Added Array#prepend as an alias for Array#unshift and Array#append as an alias for Array#<< [DHH]
 
 * The definition of blank string for Ruby 1.9 has been extended to Unicode whitespace.

--- a/activesupport/lib/active_support/ordered_hash.rb
+++ b/activesupport/lib/active_support/ordered_hash.rb
@@ -47,6 +47,11 @@ module ActiveSupport
       self
     end
 
+    # Returns true to make sure that this hash is extractable via <tt>Array#extract_options!</tt>
+    def extractable_options?
+      true
+    end
+
     # Hash is ordered in Ruby 1.9!
     if RUBY_VERSION < '1.9'
 

--- a/activesupport/test/ordered_hash_test.rb
+++ b/activesupport/test/ordered_hash_test.rb
@@ -329,4 +329,9 @@ class OrderedHashTest < Test::Unit::TestCase
     assert_equal expected, @ordered_hash.invert
     assert_equal @values.zip(@keys), @ordered_hash.invert.to_a
   end
+
+  def test_extractable
+    @ordered_hash[:rails] = "snowman"
+    assert_equal @ordered_hash, [1, 2, @ordered_hash].extract_options!
+  end
 end


### PR DESCRIPTION
Make `ActiveSupport::OrderedHash` extractable when using `Array#extract_options!`

`ActiveSupport::OrderedHash` is actually a subclass of the hash, so it does make sense that it should be extractable from the array list.

I think this is a bug, so if there's a backport necessary please let me know. Thanks!
