### PR TITLE
pg does not allow aliases in the having clause, but functions are fine

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -171,7 +171,7 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_should_group_by_summed_field_having_condition_from_select
-    c = Account.select("MIN(credit_limit) AS min_credit_limit").group(:firm_id).having("min_credit_limit > 50").sum(:credit_limit)
+    c = Account.select("MIN(credit_limit) AS min_credit_limit").group(:firm_id).having("MIN(credit_limit) > 50").sum(:credit_limit)
     assert_nil       c[1]
     assert_equal 60, c[2]
     assert_equal 53, c[9]


### PR DESCRIPTION
Fixed tests.

master commit 5a05207d99b7e2678f9b42db2d9ffc21ec2c8c3b

<pre>
test_should_group_by_summed_field_having_condition_from_select(CalculationsTest):
ActiveRecord::StatementInvalid: PGError: ERROR:  column "min_credit_limit" does not exist
LINE 1: ... firm_id FROM "accounts"  GROUP BY firm_id HAVING min_credit...
                                                             ^
: SELECT SUM("accounts"."credit_limit") AS sum_credit_limit, MIN(credit_limit) AS min_credit_limit, firm_id AS firm_id FROM "accounts"  GROUP BY firm_id HAVING min_credit_limit > 50
    /Users/arunagw/checkouts/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:962:in `async_exec'
    /Users/arunagw/checkouts/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:962:in `exec_no_cache'
    /Users/arunagw/checkouts/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:551:in `block in exec_query'
    /Users/arunagw/checkouts/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:244:in `block in log'
    /Users/arunagw/checkouts/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /Users/arunagw/checkouts/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:239:in `log'
    /Users/arunagw/checkouts/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:550:in `exec_query'
    /Users/arunagw/checkouts/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:1031:in `select'
    /Users/arunagw/checkouts/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:18:in `select_all'
    /Users/arunagw/checkouts/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:63:in `select_all'
    /Users/arunagw/checkouts/rails/activerecord/lib/active_record/relation/calculations.rb:258:in `execute_grouped_calculation'
    /Users/arunagw/checkouts/rails/activerecord/lib/active_record/relation/calculations.rb:185:in `perform_calculation'
    /Users/arunagw/checkouts/rails/activerecord/lib/active_record/relation/calculations.rb:155:in `calculate'
    /Users/arunagw/checkouts/rails/activerecord/lib/active_record/relation/calculations.rb:93:in `sum'
    /Users/arunagw/checkouts/rails/activerecord/test/cases/calculations_test.rb:174:in `test_should_group_by_summed_field_having_condition_from_select'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/mocha-0.9.12/lib/mocha/integration/mini_test/version_142_to_172.rb:27:in `run'
    /Users/arunagw/checkouts/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:35:in `block in run'
    /Users/arunagw/checkouts/rails/activesupport/lib/active_support/callbacks.rb:408:in `_run_setup_callbacks'
</pre>
