### PR TITLE
Warning removed 3 1 stable

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1892,6 +1892,6 @@ class BasicsTest < ActiveRecord::TestCase
   def test_cache_key_format_for_existing_record_with_nil_updated_at
     dev = Developer.first
     dev.update_attribute(:updated_at, nil)
-    assert_match /\/#{dev.id}$/, dev.cache_key
+    assert_match(/\/#{dev.id}$/, dev.cache_key)
   end
 end


### PR DESCRIPTION
<pre>/Users/arunagw/checkouts/rails/activerecord/test/cases/base_test.rb:1895: warning: ambiguous first argument; put parentheses or even spaces</pre>
