### PR TITLE
Fixed test for 3-1-stable. Abstract class is having nil class name.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -672,6 +672,7 @@ module ActiveRecord
 
       def table_exists?(name)
         schema, table = extract_schema_and_table(name.to_s)
+        return false unless table # Abstract classes is having nil table name
 
         binds = [[nil, table.gsub(/(^"|"$)/,'')]]
         binds << [nil, schema] if schema


### PR DESCRIPTION
We need to check here for the table name.
Abstract classes are having nil class name.
So nil.gsub will give a error here.

<pre>
1) Error:
test_include_polymorphic_has_one_defined_in_abstract_parent(AssociationsJoinModelTest):
NoMethodError: undefined method `gsub' for nil:NilClass
</pre>
