### PR TITLE
has_secure_password should allow optional password confirmation

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -8,6 +8,7 @@ module ActiveModel
       #
       # Validations for presence of password, confirmation of password (using
       # a "password_confirmation" attribute) are automatically added.
+      # You can disable confirmation of password validation by passing :password_confirmation => false
       # You can add more validations by hand if need be.
       #
       # You need to add bcrypt-ruby (~> 3.0.0) to Gemfile to use has_secure_password:
@@ -31,15 +32,28 @@ module ActiveModel
       #   user.authenticate("mUc3m00RsqyRe")                             # => user
       #   User.find_by_name("david").try(:authenticate, "notright")      # => nil
       #   User.find_by_name("david").try(:authenticate, "mUc3m00RsqyRe") # => user
-      def has_secure_password
+      #
+      # Example with password confirmation validation disabled
+      #
+      #   class User < ActiveRecord::Base
+      #     has_secure_password :password_confirmation => false
+      #   end
+      #
+      #   user = User.new(:name => "david", :password => "secure")
+      #   user.save                        # => true
+      #   user.authenticate("secure")      # => user
+      def has_secure_password(options = {})
         # Load bcrypt-ruby only when has_secured_password is used to avoid make ActiveModel
         # (and by extension the entire framework) dependent on a binary library.
         gem 'bcrypt-ruby', '~> 3.0.0'
         require 'bcrypt'
 
+        options.reverse_merge!(:password_confirmation => true)
         attr_reader :password
 
-        validates_confirmation_of :password
+        if options[:password_confirmation]
+          validates_confirmation_of :password
+        end
         validates_presence_of     :password_digest
 
         include InstanceMethodsOnActivation

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -31,15 +31,18 @@ module ActiveModel
       #   user.authenticate("mUc3m00RsqyRe")                             # => user
       #   User.find_by_name("david").try(:authenticate, "notright")      # => nil
       #   User.find_by_name("david").try(:authenticate, "mUc3m00RsqyRe") # => user
-      def has_secure_password
+      def has_secure_password(options = {})
         # Load bcrypt-ruby only when has_secured_password is used to avoid make ActiveModel
         # (and by extension the entire framework) dependent on a binary library.
         gem 'bcrypt-ruby', '~> 3.0.0'
         require 'bcrypt'
 
+        options.reverse_merge!(:password_confirmation => true)
         attr_reader :password
 
-        validates_confirmation_of :password
+        if options[:password_confirmation]
+          validates_confirmation_of :password
+        end
         validates_presence_of     :password_digest
 
         include InstanceMethodsOnActivation

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -8,6 +8,7 @@ module ActiveModel
       #
       # Validations for presence of password, confirmation of password (using
       # a "password_confirmation" attribute) are automatically added.
+      # You can disable confirmation of password validation by passing :password_confirmation => false
       # You can add more validations by hand if need be.
       #
       # You need to add bcrypt-ruby (~> 3.0.0) to Gemfile to use has_secure_password:
@@ -31,6 +32,16 @@ module ActiveModel
       #   user.authenticate("mUc3m00RsqyRe")                             # => user
       #   User.find_by_name("david").try(:authenticate, "notright")      # => nil
       #   User.find_by_name("david").try(:authenticate, "mUc3m00RsqyRe") # => user
+      #
+      # Example with password confirmation validation disabled
+      #
+      #   class User < ActiveRecord::Base
+      #     has_secure_password :password_confirmation => false
+      #   end
+      #
+      #   user = User.new(:name => "david", :password => "secure")
+      #   user.save                        # => true
+      #   user.authenticate("secure")      # => user
       def has_secure_password(options = {})
         # Load bcrypt-ruby only when has_secured_password is used to avoid make ActiveModel
         # (and by extension the entire framework) dependent on a binary library.

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -1,5 +1,6 @@
 require 'cases/helper'
 require 'models/user'
+require 'models/user_without_password_confirmation'
 require 'models/visitor'
 require 'models/administrator'
 
@@ -26,7 +27,7 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert_equal 1, @user.errors.size
   end
 
-  test "password must match confirmation" do
+  test "password must match confirmation when confirmation is required" do
     @user.password = "thiswillberight"
     @user.password_confirmation = "wrong"
 
@@ -35,6 +36,16 @@ class SecurePasswordTest < ActiveModel::TestCase
     @user.password_confirmation = "thiswillberight"
 
     assert @user.valid?
+  end
+
+  test "password confirmation must no be asked" do
+    user = UserWithoutPasswordConfirmation.new
+
+    user.password = "thiswillberight"
+
+    assert !user.respond_to?(:password_confirmation)
+    
+    assert user.valid?
   end
 
   test "authenticate" do

--- a/activemodel/test/models/user_without_password_confirmation.rb
+++ b/activemodel/test/models/user_without_password_confirmation.rb
@@ -1,0 +1,8 @@
+class UserWithoutPasswordConfirmation
+  include ActiveModel::Validations
+  include ActiveModel::SecurePassword
+
+  has_secure_password :password_confirmation => false
+
+  attr_accessor :password_digest, :password_salt
+end


### PR DESCRIPTION
I don't think password_confirmation should be a must on all sign ups, if you implement the reset password functionality you don't need to confirm the user's password.

That''s better for a usability point of view since you save time to the user on the sign up, don't make them type more.
