### PR TITLE
Find in batch fix

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -62,7 +62,7 @@ module ActiveRecord
       start = options.delete(:start).to_i
       batch_size = options.delete(:batch_size) || 1000
 
-      relation = relation.except(:order).order(batch_order).limit(batch_size)
+      relation = relation.reorder(batch_order).limit(batch_size)
       records = relation.where(table[primary_key].gteq(start)).all
 
       while records.any?

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -100,4 +100,26 @@ class EachTest < ActiveRecord::TestCase
       end
     end
   end
+
+  def test_find_in_batches_should_ignore_the_order_default_scope
+    # First post is with title scope
+    first_post = PostWithDefaultScope.first
+    posts = []
+    PostWithDefaultScope.find_in_batches  do |batch|
+      posts.concat(batch)
+    end
+    # posts.first will be ordered using id only. Title order scope should not apply here
+    assert_not_equal first_post, posts.first
+    assert_equal posts(:welcome), posts.first
+  end
+
+  def test_find_in_batches_should_not_ignore_the_default_scope_if_it_is_other_then_order
+    special_posts_ids = SpecialPostWithDefaultScope.all.map(&:id)
+    posts = []
+    SpecialPostWithDefaultScope.find_in_batches do |batch|
+      posts.concat(batch)
+    end
+    assert_equal special_posts_ids, posts.map(&:id)
+  end
+
 end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -168,3 +168,13 @@ class PostWithDefaultInclude < ActiveRecord::Base
   default_scope includes(:comments)
   has_many :comments, :foreign_key => :post_id
 end
+
+class PostWithDefaultScope < ActiveRecord::Base
+  self.table_name = 'posts'
+  default_scope :order => :title
+end
+
+class SpecialPostWithDefaultScope < ActiveRecord::Base
+  self.table_name = 'posts'
+  default_scope where(:id => [1, 5,6])
+end


### PR DESCRIPTION
Ok.. so this issue is about find_in_batch. 

We should not include any default scope of that class in find_in_batch. 

Because we do last.id for the next batch start. If any default_scope is present in that class then it should be ignored. 

If we include that default scope in query then the result will go wrong.

Here we need to do 

``` ruby
relation.default_scope = nil
```

we cannot call unscoped here other wise all the scope will go and user will not get any exception if he is providing any select or other things in find_each method

I have some queries which i have taken from the logs of two application.

Rails 3.1.0

``` ruby
Scoped order and limit are ignored, it's forced to be batch order and batch size
  Blog Load (22.6ms)  SELECT "blogs".* FROM "blogs" WHERE ("blogs"."id" >= 0) ORDER BY title, title2, "blogs"."id" ASC LIMIT 1000
  Blog Load (0.4ms)  SELECT "blogs".* FROM "blogs" WHERE ("blogs"."id" > 2000) ORDER BY title, title2, "blogs"."id" ASC LIMIT 1000

```

Rails 3.0.10

``` ruby
Scoped order and limit are ignored, it's forced to be batch order and batch size
  SQL (0.5ms)   SELECT name
 FROM sqlite_master
 WHERE type = 'table' AND NOT name = 'sqlite_sequence'

  Blog Load (11.1ms)  SELECT "blogs".* FROM "blogs" WHERE ("blogs"."id" >= 0) ORDER BY "blogs"."id" ASC LIMIT 1000
  Blog Load (0.2ms)  SELECT "blogs".* FROM "blogs" WHERE ("blogs"."id" > 2001) ORDER BY "blogs"."id" ASC LIMIT 1000
```

The default scope in code added here 8572ae6671c6ec7c2524f327cee82215896e5648 for except method.

Fixed issue #2832

If it's looks ok then i will do it for master also. :-)

/cc @jonleighton

/cc @tenderlove 
