### PR TITLE
Fix AssetNotPrecompiledError behavior

### DIFF
--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -124,7 +124,7 @@ module Sprockets
           end
 
           if compile_assets
-            if asset = asset_environment[logical_path]
+            if digest_assets && asset = asset_environment[logical_path]
               return asset.digest_path
             end
             return logical_path
@@ -137,7 +137,7 @@ module Sprockets
           if source[0] == ?/
             source
           else
-            source = digest_for(source) if digest_assets
+            source = digest_for(source)
             source = File.join(dir, source)
             source = "/#{source}" unless source =~ /^\//
             source


### PR DESCRIPTION
AssetNotPrecompiledError should be raise when config.assets.digest = false, config.assets.compile = false and asset isn't present in manifest file

Actual result: assets aren't digested, but are being compiled by Sprockets (the compile flag is being ignored)

Expected result: AssetNotPrecompiledError must be raised since the user is trying to request a not precompiled asset and compile flag is false.

This can be merged safely in 3-1-stable and master
