### PR TITLE
Don't find belongs_to target when the foreign_key is NULL. Fixes #2828

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -20,6 +20,10 @@ module ActiveRecord
 
       private
 
+        def find_target?
+          !loaded? && foreign_key_present? && klass
+        end
+
         def update_counters(record)
           counter_cache_name = reflection.counter_cache_column
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -352,6 +352,12 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal members(:groucho), sponsor.sponsorable
   end
 
+  def test_dont_find_target_when_foreign_key_is_null
+    tagging = taggings(:thinking_general)
+    queries = assert_sql { tagging.super_tag }
+    assert_equal 0, queries.length
+  end
+
   def test_field_name_same_as_foreign_key
     computer = Computer.find(1)
     assert_not_nil computer.developer, ":foreign key == attribute didn't lock up" # '


### PR DESCRIPTION
Rails 2.3.11 and Rails 3.0 don't query the database for belongs_to associations when the foreign key is NULL.

It looks like this regression has been introduced by a9bed98.

This patch adds a test case and fixes the behavior.
