### PR TITLE
Fixed assets precompile regex

### DIFF
--- a/actionpack/lib/sprockets/assets.rake
+++ b/actionpack/lib/sprockets/assets.rake
@@ -26,6 +26,8 @@ namespace :assets do
         env.each_logical_path do |logical_path|
           if path.is_a?(Regexp)
             next unless path.match(logical_path)
+          elsif path.is_a?(Proc)
+            next unless path.call(logical_path)
           else
             next unless File.fnmatch(path.to_s, logical_path)
           end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -37,7 +37,8 @@ module Rails
         @assets = ActiveSupport::OrderedOptions.new
         @assets.enabled         = false
         @assets.paths           = []
-        @assets.precompile      = [ /\w+\.(?!js|css).+/, /application.(css|js)$/ ]
+        @assets.precompile      = [ Proc.new{ |path| !File.extname(path).in?(['.js', '.css']) },
+                                    /application.(css|js)$/ ]
         @assets.prefix          = "/assets"
         @assets.version         = ''
         @assets.debug           = false


### PR DESCRIPTION
The original regex was matching things like `jquery.min.js` and putting a lot of junk (like `jquery-#{digest}.min.js`) in `public/assets/` that shouldn't be there. The new regex matches everything except files _ending_ with .js or .css (as was intended).
