### PR TITLE
Last orders the records by id

### DIFF
--- a/activerecord/test/cases/named_scope_test.rb
+++ b/activerecord/test/cases/named_scope_test.rb
@@ -181,8 +181,8 @@ class NamedScopeTest < ActiveRecord::TestCase
   end
 
   def test_first_and_last_should_allow_integers_for_limit
-    assert_equal Topic.base.first(2), Topic.base.to_a.first(2)
-    assert_equal Topic.base.last(2), Topic.base.to_a.last(2)
+    assert_equal Topic.base.first(2), Topic.base.order("id").to_a.first(2)
+    assert_equal Topic.base.last(2), Topic.base.order("id").to_a.last(2)
   end
 
   def test_first_and_last_should_not_use_query_when_results_are_loaded


### PR DESCRIPTION
5f5527c726841cdefb82965a645d554767c5a6a9 order the records by their id in order to properly get the last one.
On some databases though (like postgresql), it seems when the records are not ordered, the order is a bit random.
Therefore, this made the tests fail, on postgresql only.

It makes sense to actually order the records by primary key (except when there's already an order, which last manages) when getting the last record as the last record of something unordered is quite useless.

cc @arunagw @jonleighton
