### PR TITLE
before add should allow the developer to return false to prevent addition

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -401,7 +401,7 @@ module ActiveRecord
     #
     # Possible callbacks are: +before_add+, +after_add+, +before_remove+ and +after_remove+.
     #
-    # Should any of the +before_add+ callbacks throw an exception, the object does not get
+    # Should any of the +before_add+ callbacks return false or throw an exception, the object does not get
     # added to the collection. Same with the +before_remove+ callbacks; if an exception is
     # thrown the object doesn't get removed.
     #

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -323,7 +323,7 @@ module ActiveRecord
       end
 
       def add_to_target(record)
-        callback(:before_add, record)
+        callback(:before_add, record) {|return_value| return if return_value == false }
         yield(record) if block_given?
 
         if options[:uniq] && index = @target.index(record)
@@ -479,7 +479,7 @@ module ActiveRecord
 
         def callback(method, record)
           callbacks_for(method).each do |callback|
-            case callback
+            return_value = case callback
             when Symbol
               owner.send(callback, record)
             when Proc
@@ -487,6 +487,8 @@ module ActiveRecord
             else
               callback.send(method, owner, record)
             end
+
+            yield(return_value) if block_given?
           end
         end
 

--- a/activerecord/test/cases/associations/callbacks_test.rb
+++ b/activerecord/test/cases/associations/callbacks_test.rb
@@ -165,4 +165,44 @@ class AssociationCallbacksTest < ActiveRecord::TestCase
     @david.reload
     assert !@david.unchangable_posts.include?(@authorless)
   end
+
+  def test_add_if_before_callback_returns_true
+    assert !@david.conditionally_changeable_posts.include?(@authorless)
+    @david.changable = true
+    @david.conditionally_changeable_posts << @authorless
+    assert !@david.post_log.empty?
+    assert @david.conditionally_changeable_posts.include?(@authorless)
+    @david.reload
+    assert @david.conditionally_changeable_posts.include?(@authorless)
+  end
+
+  def test_add_if_before_callback_returns_object
+    assert !@david.conditionally_changeable_posts.include?(@authorless)
+    @david.changable = @authorless
+    @david.conditionally_changeable_posts << @authorless
+    assert !@david.post_log.empty?
+    assert @david.conditionally_changeable_posts.include?(@authorless)
+    @david.reload
+    assert @david.conditionally_changeable_posts.include?(@authorless)
+  end
+
+  def test_dont_add_if_before_callback_returns_false
+    assert !@david.conditionally_changeable_posts.include?(@authorless)
+    @david.changable = false
+    @david.conditionally_changeable_posts << @authorless
+    assert @david.post_log.empty?
+    assert !@david.conditionally_changeable_posts.include?(@authorless)
+    @david.reload
+    assert !@david.conditionally_changeable_posts.include?(@authorless)
+  end
+
+  def test_add_if_before_callback_returns_nil
+    assert !@david.conditionally_changeable_posts.include?(@authorless)
+    @david.changable = nil
+    @david.conditionally_changeable_posts << @authorless
+    assert !@david.post_log.empty?
+    assert @david.conditionally_changeable_posts.include?(@authorless)
+    @david.reload
+    assert @david.conditionally_changeable_posts.include?(@authorless)
+  end
 end

--- a/activerecord/test/cases/associations/callbacks_test.rb
+++ b/activerecord/test/cases/associations/callbacks_test.rb
@@ -168,7 +168,7 @@ class AssociationCallbacksTest < ActiveRecord::TestCase
 
   def test_add_if_before_callback_returns_true
     assert !@david.conditionally_changeable_posts.include?(@authorless)
-    @david.changable = true
+    @david.changeable = true
     @david.conditionally_changeable_posts << @authorless
     assert !@david.post_log.empty?
     assert @david.conditionally_changeable_posts.include?(@authorless)
@@ -178,7 +178,7 @@ class AssociationCallbacksTest < ActiveRecord::TestCase
 
   def test_add_if_before_callback_returns_object
     assert !@david.conditionally_changeable_posts.include?(@authorless)
-    @david.changable = @authorless
+    @david.changeable = @authorless
     @david.conditionally_changeable_posts << @authorless
     assert !@david.post_log.empty?
     assert @david.conditionally_changeable_posts.include?(@authorless)
@@ -188,7 +188,7 @@ class AssociationCallbacksTest < ActiveRecord::TestCase
 
   def test_dont_add_if_before_callback_returns_false
     assert !@david.conditionally_changeable_posts.include?(@authorless)
-    @david.changable = false
+    @david.changeable = false
     @david.conditionally_changeable_posts << @authorless
     assert @david.post_log.empty?
     assert !@david.conditionally_changeable_posts.include?(@authorless)
@@ -198,7 +198,7 @@ class AssociationCallbacksTest < ActiveRecord::TestCase
 
   def test_add_if_before_callback_returns_nil
     assert !@david.conditionally_changeable_posts.include?(@authorless)
-    @david.changable = nil
+    @david.changeable = nil
     @david.conditionally_changeable_posts << @authorless
     assert !@david.post_log.empty?
     assert @david.conditionally_changeable_posts.include?(@authorless)

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -75,6 +75,7 @@ class Author < ActiveRecord::Base
            :before_add => [:log_before_adding, Proc.new {|o, r| o.post_log << "before_adding_proc#{r.id || '<new>'}"}],
            :after_add  => [:log_after_adding,  Proc.new {|o, r| o.post_log << "after_adding_proc#{r.id || '<new>'}"}]
   has_many :unchangable_posts, :class_name => "Post", :before_add => :raise_exception, :after_add => :log_after_adding
+  has_many :conditionally_changeable_posts, :class_name => "Post", :before_add => :check_if_changealbe, :after_add => :log_after_adding
 
   has_many :categorizations
   has_many :categories, :through => :categorizations
@@ -145,6 +146,7 @@ class Author < ActiveRecord::Base
   scope :relation_include_tags, includes(:tags)
 
   attr_accessor :post_log
+  attr_accessor :changable
   after_initialize :set_post_log
 
   def set_post_log
@@ -180,6 +182,10 @@ class Author < ActiveRecord::Base
 
     def raise_exception(object)
       raise Exception.new("You can't add a post")
+    end
+    
+    def check_if_changealbe(object)
+      changable
     end
 end
 

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -75,7 +75,7 @@ class Author < ActiveRecord::Base
            :before_add => [:log_before_adding, Proc.new {|o, r| o.post_log << "before_adding_proc#{r.id || '<new>'}"}],
            :after_add  => [:log_after_adding,  Proc.new {|o, r| o.post_log << "after_adding_proc#{r.id || '<new>'}"}]
   has_many :unchangable_posts, :class_name => "Post", :before_add => :raise_exception, :after_add => :log_after_adding
-  has_many :conditionally_changeable_posts, :class_name => "Post", :before_add => :check_if_changealbe, :after_add => :log_after_adding
+  has_many :conditionally_changeable_posts, :class_name => "Post", :before_add => :check_if_changeable, :after_add => :log_after_adding
 
   has_many :categorizations
   has_many :categories, :through => :categorizations
@@ -146,7 +146,7 @@ class Author < ActiveRecord::Base
   scope :relation_include_tags, includes(:tags)
 
   attr_accessor :post_log
-  attr_accessor :changable
+  attr_accessor :changeable
   after_initialize :set_post_log
 
   def set_post_log
@@ -183,9 +183,9 @@ class Author < ActiveRecord::Base
     def raise_exception(object)
       raise Exception.new("You can't add a post")
     end
-    
-    def check_if_changealbe(object)
-      changable
+
+    def check_if_changeable(object)
+      changeable
     end
 end
 


### PR DESCRIPTION
before add should allow the developer to return false to prevent addition of the object to the association

if the developer wants to add objects with possible rejection criteria, in tests for example, communication via exception is not appropriate.
in general there should be a mechanism by which before_add callbacks for associations should be able to halt addition silently.
