### PR TITLE
#first doesn't take an order in this test

### DIFF
--- a/activerecord/test/cases/named_scope_test.rb
+++ b/activerecord/test/cases/named_scope_test.rb
@@ -181,7 +181,7 @@ class NamedScopeTest < ActiveRecord::TestCase
   end
 
   def test_first_and_last_should_allow_integers_for_limit
-    assert_equal Topic.base.first(2), Topic.base.order("id").to_a.first(2)
+    assert_equal Topic.base.first(2), Topic.base.to_a.first(2)
     assert_equal Topic.base.last(2), Topic.base.order("id").to_a.last(2)
   end
 


### PR DESCRIPTION
I'm deeply sorry, I failed when pushing #2877, test of #first shouldn't take any order.

This happens because #first just adds a LIMIT to the SQL query, therefore not changing the records' order.  
When #last orders the records by id (unless there's already an order provided) and takes the first elements (which were the last ones).

Therefore in postgresql, #last must be ordered by id in this test. Otherwise, the database will return them in a different, unpredictable order.

cc @arunagw @spastorino
