### PR TITLE
Assets are still compiled when config.assets.compile set false (including in production)

### DIFF
--- a/actionpack/lib/sprockets/assets.rake
+++ b/actionpack/lib/sprockets/assets.rake
@@ -44,9 +44,11 @@ namespace :assets do
             asset_path = config.assets.digest ? asset.digest_path : logical_path
             manifest[logical_path] = asset_path
             filename = target.join(asset_path)
+
             mkdir_p filename.dirname
             asset.write_to(filename)
             asset.write_to("#{filename}.gz") if filename.to_s =~ /\.(css|js)$/
+
             if config.assets.digest && undigested_as
               undigested = target.join(logical_path)
               case undigested_as

--- a/actionpack/lib/sprockets/railtie.rb
+++ b/actionpack/lib/sprockets/railtie.rb
@@ -50,7 +50,7 @@ module Sprockets
     # are compiled, and so that other Railties have an opportunity to
     # register compressors.
     config.after_initialize do |app|
-      next unless app.assets
+      next unless app.assets && app.config.assets.compile
       config = app.config
 
       config.assets.paths.each { |path| app.assets.append_path(path) }
@@ -66,15 +66,13 @@ module Sprockets
           app.assets.css_compressor = LazyCompressor.new { expand_css_compressor(config.assets.css_compressor) }
         end
       end
-
-      if config.assets.compile
-        app.routes.prepend do
-          mount app.assets => config.assets.prefix
-        end
-
-        if config.action_controller.perform_caching
-          app.assets = app.assets.index
-        end
+      
+      app.routes.prepend do
+        mount app.assets => config.assets.prefix
+      end
+      
+      if config.action_controller.perform_caching
+        app.assets = app.assets.index
       end
     end
 

--- a/actionpack/lib/sprockets/railtie.rb
+++ b/actionpack/lib/sprockets/railtie.rb
@@ -67,12 +67,14 @@ module Sprockets
         end
       end
 
-      app.routes.prepend do
-        mount app.assets => config.assets.prefix
-      end
+      if config.assets.compile
+        app.routes.prepend do
+          mount app.assets => config.assets.prefix
+        end
 
-      if config.action_controller.perform_caching
-        app.assets = app.assets.index
+        if config.action_controller.perform_caching
+          app.assets = app.assets.index
+        end
       end
     end
 

--- a/actionpack/lib/sprockets/railtie.rb
+++ b/actionpack/lib/sprockets/railtie.rb
@@ -66,11 +66,11 @@ module Sprockets
           app.assets.css_compressor = LazyCompressor.new { expand_css_compressor(config.assets.css_compressor) }
         end
       end
-      
+
       app.routes.prepend do
         mount app.assets => config.assets.prefix
       end
-      
+
       if config.action_controller.perform_caching
         app.assets = app.assets.index
       end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -47,6 +47,7 @@ module Rails
         @assets.cache_store     = [ :file_store, "#{root}/tmp/cache/assets/" ]
         @assets.js_compressor   = nil
         @assets.css_compressor  = nil
+        @assets.undigested_as   = :duplicate
       end
 
       def compiled_asset_path

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -22,7 +22,7 @@
 
   # Method to use to additionally create assets without digests
   # Valid values are :duplicate, :none, :symlink, :hardlink
-  # config.assets.digest = :duplicate
+  # config.assets.undigested_as = :duplicate
 
   # Defaults to Rails.root.join("public/assets")
   # config.assets.manifest = YOUR_PATH

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -20,6 +20,10 @@
   # Generate digests for assets URLs
   config.assets.digest = true
 
+  # Method to use to additionally create assets without digests
+  # Valid values are :duplicate, :none, :symlink, :hardlink
+  # config.assets.digest = :duplicate
+
   # Defaults to Rails.root.join("public/assets")
   # config.assets.manifest = YOUR_PATH
 

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -137,6 +137,7 @@ module ApplicationTests
 
     test "assets do not require any assets group gem when manifest file is present" do
       app_file "app/assets/javascripts/application.js", "alert();"
+      app_file "config/initializers/serve_static_assets.rb", "Rails.application.config.serve_static_assets = true"
 
       ENV["RAILS_ENV"] = "production"
       capture(:stdout) do
@@ -241,6 +242,17 @@ module ApplicationTests
 
       files = Dir["#{app_path}/public/assets/**/*", "#{app_path}/tmp/cache/*"]
       assert_equal 0, files.length, "Expected no assets, but found #{files.join(', ')}"
+    end
+
+    test "assets routes are not drawn when compilation is disabled" do
+      app_file "app/assets/javascripts/demo.js.erb", "<%= :alert %>();"
+      app_file "config/initializers/compile.rb", "Rails.application.config.assets.compile = false"
+
+      ENV["RAILS_ENV"] = "production"
+      require "#{app_path}/config/environment"
+
+      get "/assets/demo.js"
+      assert_equal 404, last_response.status
     end
 
     test "does not stream session cookies back" do


### PR DESCRIPTION
During discussions on `#RubyOnRails`, it was discovered that when `config.assets.compile` is set to `false`, assets are still compiled under the following conditions:
1. `config.serve_static_assets` is set to `false` (the default in production) and any request is made for an asset
2. any request is made for an asset without digest (irrespective of the value of `config.serve_static_assets`)

This pull request contains a patch to only mount the asset server if `config.assets.compile` is set to `true`.  In the instance that it is set to `false`, and a request is made as outlined above, the user agent will receive a 404.

A test for the patch, _"assets routes are not drawn when compilation is disabled"_, is included, as is a small change to the existing test _"assets do not require any assets group gem when manifest file is present"_ which now serves the precompiled asset statically rather than via the assets server.

(Additional credit due to `cachemoney` on `#RubyOnRails` for working on this with me.)
