### PR TITLE
Issue 2802

### DIFF
--- a/actionpack/lib/action_view/helpers/number_helper.rb
+++ b/actionpack/lib/action_view/helpers/number_helper.rb
@@ -17,6 +17,9 @@ module ActionView
     # unchanged if can't be converted into a valid number.
     module NumberHelper
 
+      DEFAULT_NUMBER_VALUES = { :precision => 3, :separator => ".", :delimiter => "", :significant => false, :strip_insignificant_zeros => false }
+
+
       DEFAULT_CURRENCY_VALUES = { :format => "%u%n", :negative_format => "-%u%n", :unit => "$", :separator => ".", :delimiter => ",",
                                   :precision => 2, :significant => false, :strip_insignificant_zeros => false }
 
@@ -260,7 +263,7 @@ module ActionView
 
         defaults           = I18n.translate(:'number.format', :locale => options[:locale], :default => {})
         precision_defaults = I18n.translate(:'number.precision.format', :locale => options[:locale], :default => {})
-        defaults           = defaults.merge(precision_defaults)
+        defaults           = DEFAULT_NUMBER_VALUES.merge(defaults).merge(precision_defaults)
 
         options = options.reverse_merge(defaults)  # Allow the user to unset default values: Eg.: :significant => false
         precision = options.delete :precision

--- a/actionpack/test/template/number_helper_i18n_test.rb
+++ b/actionpack/test/template/number_helper_i18n_test.rb
@@ -63,6 +63,15 @@ class NumberHelperTest < ActionView::TestCase
 
   end
 
+  def test_number_with_empty_i18n_store
+    I18n.backend.store_translations 'empty', {}
+
+    #Precision should be defaulted to 3, separator to ".", delimiter to ""
+    assert_equal("123456789.123", number_with_precision(123456789.123456789, :locale => 'empty'))
+    #Significant and strip_insignificant_zeros should be defaulted to false
+    assert_equal("1.000", number_with_precision(1.0000, :locale => 'empty'))
+  end
+
   def test_number_with_i18n_delimiter
     #Delimiter "," and separator "."
     assert_equal("1,000,000.234", number_with_delimiter(1000000.234, :locale => 'ts'))


### PR DESCRIPTION
Added default number values to avoid precision/separator/delimiter bug when locale != :en

With default_locale different from :en and no region locale file, precision, separator and delimiter where not defaulted, resulting in errors such as :

```
wrong argument type nil (expected Fixnum)

actionpack (3.1.0) lib/action_view/helpers/number_helper.rb:281:in `round'
actionpack (3.1.0) lib/action_view/helpers/number_helper.rb:281:in `number_with_precision'
actionpack (3.1.0) lib/action_view/helpers/number_helper.rb:362:in `number_to_human_size'
```
