### PR TITLE
add has_key? to ActiveModel::Errors

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -88,6 +88,7 @@ module ActiveModel
     def include?(error)
       (v = messages[error]) && v.any?
     end
+    alias :has_key? :include?
 
     # Get messages for +key+
     def get(key)

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -33,6 +33,12 @@ class ErrorsTest < ActiveModel::TestCase
     assert errors.include?(:foo), 'errors should include :foo'
   end
 
+  def test_has_key?
+    errors = ActiveModel::Errors.new(self)
+    errors[:foo] = 'omg'
+    assert errors.has_key?(:foo), 'errors should have key :foo'
+  end
+
   test "should return true if no errors" do
     person = Person.new
     person.errors[:foo]


### PR DESCRIPTION
This allows to use `should have_key` on error models in specs.
