### PR TITLE
Warnings removed and use w for railties

### DIFF
--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -938,7 +938,7 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_first_or_create_bang_with_invalid_block
     assert_raise(ActiveRecord::RecordInvalid) do
-      parrot = Bird.where(:color => 'green').first_or_create! { |bird| bird.pirate_id = 1 }
+      Bird.where(:color => 'green').first_or_create! { |bird| bird.pirate_id = 1 }
     end
   end
 

--- a/activeresource/test/cases/base/load_test.rb
+++ b/activeresource/test/cases/base/load_test.rb
@@ -66,11 +66,11 @@ class BaseLoadTest < Test::Unit::TestCase
   end
 
   def test_load_hash_with_integers_as_keys
-    assert_nothing_raised{person = @person.load(@books)}
+    assert_nothing_raised{@person.load(@books)}
   end
 
   def test_load_hash_with_dates_as_keys
-    assert_nothing_raised{person = @person.load(@books_date)}
+    assert_nothing_raised{@person.load(@books_date)}
   end
 
   def test_load_expects_hash

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -18,7 +18,7 @@ namespace :test do
     Dir["test/#{dir}/*_test.rb"].each do |file|
       next true if file.include?("fixtures")
       ruby = File.join(*RbConfig::CONFIG.values_at('bindir', 'RUBY_INSTALL_NAME'))
-      sh(ruby, '-Itest', "-I#{File.dirname(__FILE__)}/../activesupport/lib", file)
+      sh(ruby, '-w', '-Itest', "-I#{File.dirname(__FILE__)}/../activesupport/lib", file)
     end
   end
 end


### PR DESCRIPTION
When we run `bundle exec rake test` for  railties it should show warnings.
