### PR TITLE
Patch for issue #2820

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -421,7 +421,7 @@ module ActiveRecord
       # can be used as an argument for establish_connection, for easily
       # re-establishing the connection.
       def remove_connection(klass)
-        pool = @connection_pools[klass.name]
+        pool = @connection_pools.delete(klass.name)
         return nil unless pool
 
         pool.automatic_reconnect = false

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_specification.rb
@@ -100,7 +100,7 @@ module ActiveRecord
       end
 
       def connection_pool
-        connection_handler.retrieve_connection_pool(self)
+        connection_handler.retrieve_connection_pool(self) or raise ConnectionNotEstablished
       end
 
       def retrieve_connection

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -6,7 +6,12 @@ module ActiveRecord
       def setup
         @handler = ConnectionHandler.new
         @handler.establish_connection 'america', Base.connection_pool.spec
-        @klass = Struct.new(:name).new('america')
+        @klass = Class.new do
+          def self.name; 'america'; end
+        end
+        @subklass = Class.new(@klass) do
+          def self.name; 'north america'; end
+        end
       end
 
       def test_retrieve_connection
@@ -27,6 +32,20 @@ module ActiveRecord
 
       def test_retrieve_connection_pool
         assert_not_nil @handler.retrieve_connection_pool(@klass)
+      end
+
+      def test_retrieve_connection_pool_uses_superclass_when_no_subclass_connection
+        assert_not_nil @handler.retrieve_connection_pool(@subklass)
+      end
+
+      def test_retrieve_connection_pool_uses_superclass_pool_after_subclass_establish_and_remove
+        @handler.establish_connection 'north america', Base.connection_pool.spec
+        assert_not_same @handler.retrieve_connection_pool(@klass),
+          @handler.retrieve_connection_pool(@subklass)
+
+        @handler.remove_connection @subklass
+        assert_same @handler.retrieve_connection_pool(@klass),
+          @handler.retrieve_connection_pool(@subklass)
       end
     end
   end


### PR DESCRIPTION
This is a patch for issue #2820 ("ActiveRecord 3.1 does not restore connection inheritance after establish_connection/remove_connection on a model").

It applies the solution described in that ticket. There is also a change in `connection_adapters/abstract/connection_specification.rb` to ensure that a `nil` pool can't leak out and cause `NoMethodError`s.

This pull request is against 3-1-stable. I've verified that the patch also works on master.
