### PR TITLE
Postgresql adapter: added current_schema check for table_exists?

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -717,7 +717,7 @@ module ActiveRecord
             SELECT COUNT(*)
             FROM pg_tables
             WHERE tablename = $1
-            #{schema ? "AND schemaname = $2" : ''}
+           AND schemaname = #{schema ? "'#{schema}'" : "ANY (current_schemas(false))"}
         SQL
       end
 

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -68,7 +68,9 @@ class SchemaTest < ActiveRecord::TestCase
   end
 
   def test_table_exists_quoted_table
-    assert(@connection.table_exists?('"things.table"'), "table should exist")
+    with_schema_search_path(SCHEMA_NAME) do
+        assert(@connection.table_exists?('"things.table"'), "table should exist")
+    end
   end
 
   def test_with_schema_prefixed_table_name


### PR DESCRIPTION
Fixes Issue #1604 https://github.com/rails/rails/pull/1604 for 3-1-stable
Thanks https://github.com/bradrobertson

modified table_exists? in the postgresql adapter to always use the current search_path unless a explicit schema is specified.

Currently one cannot load schema.rb into a new (empty) postgresql schema. create_table forces a table drop which checks table_exists? first. This returns true even though the table doesn't actually exist in the current schema. Thus a PG error is thrown when it tries to drop the nonexistent table.
