### PR TITLE
Make sure require_tzinfo only calls Kernel#require if TZInfo isn't already present

### DIFF
--- a/activesupport/CHANGELOG
+++ b/activesupport/CHANGELOG
@@ -1,5 +1,7 @@
 *Rails 3.1.1 (unreleased)*
 
+* Fixed performance issue where TimeZone lookups would require tzinfo each time [Tim Lucas]
+
 * ActiveSupport::OrderedHash is now marked as extractable when using Array#extract_options! [Prem Sichanugrist]
 
 *Rails 3.1.0 (August 30, 2011)*

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -373,7 +373,7 @@ module ActiveSupport
       protected
 
         def require_tzinfo
-          require 'tzinfo'
+          require 'tzinfo' unless defined?(::TZInfo)
         rescue LoadError
           $stderr.puts "You don't have tzinfo installed in your application. Please add it to your Gemfile and run bundle install"
           raise


### PR DESCRIPTION
Make sure require_tzinfo only calls Kernel#require if TZInfo isn't already present.

This wasn't a problem when require_tzinfo was only called from TimeZone#initialize, but now it's being called for every lookup to TimeZone.[](via lazy_zones_map)

TimeZone lookup can occur when unmarshalling TimeWithZone objects, which is where I first saw the big slowdown (500ms for each Rails action that loaded from Rails.cache)
