### PR TITLE
Backport "ActiveRecord::Persistence#touch should not use default_scope" (pull request #1519) to 3.0

### DIFF
--- a/activerecord/CHANGELOG
+++ b/activerecord/CHANGELOG
@@ -3,6 +3,8 @@
 * Psych errors with poor yaml formatting are proxied. Fixes GH #2645 and
   GH #2731
 
+* Backport "ActiveRecord::Persistence#touch should not use default_scope" (GH #1519)
+
 * Rails 3.0.10
 
 * Magic encoding comment added to schema.rb files

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -242,7 +242,7 @@ module ActiveRecord
 
         @changed_attributes.except!(*changes.keys)
         primary_key = self.class.primary_key
-        self.class.update_all(changes, { primary_key => self[primary_key] }) == 1
+        self.class.unscoped.update_all(changes, { primary_key => self[primary_key] }) == 1
       end
     end
 

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -11,6 +11,7 @@ class TimestampTest < ActiveRecord::TestCase
 
   def setup
     @developer = Developer.first
+    @developer.update_attribute(:updated_at, Time.now.prev_month)
     @previously_updated_at = @developer.updated_at
   end
 

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -66,6 +66,15 @@ class TimestampTest < ActiveRecord::TestCase
     assert_equal previous_salary, @developer.salary
   end
 
+  def test_touching_a_record_with_default_scope_that_exludes_it_updates_its_timestamp
+    developer = @developer.becomes(DeveloperCalledJamis)
+
+    developer.touch
+    assert_not_equal @previously_updated_at, developer.updated_at
+    developer.reload
+    assert_not_equal @previously_updated_at, developer.updated_at
+  end
+
   def test_saving_when_record_timestamps_is_false_doesnt_update_its_timestamp
     Developer.record_timestamps = false
     @developer.name = "John Smith"


### PR DESCRIPTION
Hi,

Today I was bitten by exactly this: https://github.com/rails/rails/pull/1519

I'm glad to see it's fixed in 3.1 but I think that pull request should be merged into 3.0-stable, which is which I just did. It's just the same commits by @dmitriy-kiriyenko, unmodified. Tests are passing.

(I didn't know if I should have reopened that pull request or send this new one; sorry if I chose badly and feel free to do whatever should have been done).
