### PR TITLE
unescape URL before it is processed, otherwise, there would be a problem with non-english character URL. 

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -10,7 +10,7 @@ module ActionDispatch
     end
 
     def call(env)
-      path   = env['PATH_INFO'].chomp('/')
+      path   = Rack::Utils.unescape(env['PATH_INFO'].chomp('/'))
       method = env['REQUEST_METHOD']
 
       if FILE_METHODS.include?(method)


### PR DESCRIPTION
unescape URL before it is processed, otherwise, there would be a problem with non-english character URL. Please see: https://github.com/rails/rails/issues/2703#issuecomment-1977252
