### PR TITLE
A blank password should be allowed.

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -65,7 +65,7 @@ module ActiveModel
       # Encrypts the password into the password_digest attribute.
       def password=(unencrypted_password)
         @password = unencrypted_password
-        unless unencrypted_password.blank?
+        unless unencrypted_password
           self.password_digest = BCrypt::Password.create(unencrypted_password)
         end
       end


### PR DESCRIPTION
Otherwise, we must see an error message for the `password_digest` column
when a user inputs blank password into a user registration form.

If a developer think this is not secure, he/she should use the
ordinary validation mechanism against the `password` attribute.
