### PR TITLE
db:migrate:status not looking at all migration paths

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -203,11 +203,13 @@ db_namespace = namespace :db do
       end
       db_list = ActiveRecord::Base.connection.select_values("SELECT version FROM #{ActiveRecord::Migrator.schema_migrations_table_name}")
       file_list = []
-      Dir.foreach(File.join(Rails.root, 'db', 'migrate')) do |file|
-        # only files matching "20091231235959_some_name.rb" pattern
-        if match_data = /^(\d{14})_(.+)\.rb$/.match(file)
-          status = db_list.delete(match_data[1]) ? 'up' : 'down'
-          file_list << [status, match_data[1], match_data[2].humanize]
+      ActiveRecord::Migrator.migrations_paths.each do |path|
+        Dir.foreach(path) do |file|
+          # only files matching "20091231235959_some_name.rb" pattern
+          if match_data = /^(\d{14})_(.+)\.rb$/.match(file)
+            status = db_list.delete(match_data[1]) ? 'up' : 'down'
+            file_list << [status, match_data[1], match_data[2].humanize]
+          end
         end
       end
       db_list.map! do |version|


### PR DESCRIPTION
db:migrate:status only looks in the app's db/migrate directory, which is no good for engines. It should use ActiveRecord::Migrator.migrations_paths instead.
