### PR TITLE
fix url_for when passing a hash to prevent unwanted additional values being added to the hash (backport to 3-0-stable)

### DIFF
--- a/actionpack/CHANGELOG
+++ b/actionpack/CHANGELOG
@@ -2,6 +2,8 @@
 
 * Fix assert_select_email to work on multipart and non-multipart emails as the method stopped working correctly in Rails 3.x due to changes in the new mail gem.
 
+* Fix url_for when passed a hash to prevent additional options (eg. :host, :protocol) from being added to the hash after calling it.
+
 
 *Rails 3.0.10 (August 31, 2011)*
 

--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -128,7 +128,7 @@ module ActionDispatch
         when String
           options
         when nil, Hash
-          _routes.url_for((options || {}).reverse_merge!(url_options).symbolize_keys)
+          _routes.url_for((options.dup || {}).reverse_merge!(url_options).symbolize_keys)
         else
           polymorphic_url(options)
         end

--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -128,7 +128,7 @@ module ActionDispatch
         when String
           options
         when nil, Hash
-          _routes.url_for((options.dup || {}).reverse_merge!(url_options).symbolize_keys)
+          _routes.url_for((options || {}).reverse_merge(url_options).symbolize_keys)
         else
           polymorphic_url(options)
         end

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -771,6 +771,18 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     end
   end
 
+  # tests the use of dup in url_for
+  def test_url_for_with_no_side_effects
+    # without dup, additional (and possibly unwanted) values will be present in the options (eg. :host)
+    original_options = {:controller => 'projects', :action => 'status'}
+    options = original_options.dup
+
+    url_for options
+
+    # verify that the options passed in have not changed from the original ones
+    assert_equal original_options, options
+  end
+
   def test_projects_status
     with_test_routes do
       assert_equal '/projects/status', url_for(:controller => 'projects', :action => 'status', :only_path => true)


### PR DESCRIPTION
This PR is a combination of this original PR...
https://github.com/rails/rails/pull/2497

And a better fix from this commit...
https://github.com/rails/rails/commit/8196c842b6f32271c23cba6b97918d32747018d8#actionpack/lib/action_dispatch/routing/url_for.rb

This PR backports the fix to 3-0-stable using the cleaner solution.  This cleaner fix already exists in master and 3-1-stable.
