### PR TITLE
better support for ActiveSupport::TestCase running over Test::Unit 2.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,3 +92,10 @@ if ENV['ORACLE_ENHANCED_PATH'] || ENV['ORACLE_ENHANCED']
     gem "activerecord-oracle_enhanced-adapter", :git => "git://github.com/rsim/oracle-enhanced.git"
   end
 end
+
+# enables ActiveSupport::TestCase to use the Test::Unit 2.x gem
+group :test do
+  if ENV['TEST_UNIT_VERSION']
+    gem "test-unit", ENV['TEST_UNIT_VERSION']
+  end
+end

--- a/activesupport/lib/active_support/testing/setup_and_teardown.rb
+++ b/activesupport/lib/active_support/testing/setup_and_teardown.rb
@@ -13,7 +13,15 @@ module ActiveSupport
         if defined?(MiniTest::Assertions) && TestCase < MiniTest::Assertions
           include ForMiniTest
         else
-          include ForClassicTestUnit
+          begin
+            require 'test/unit/version'
+          rescue LoadError
+          end
+          if defined?(Test::Unit::VERSION) # Test::Unit 2.x gem
+            include ForTestUnit
+          else # "built-in" Test::Unit 1.2.3
+            include ForClassicTestUnit
+          end
         end
       end
 
@@ -106,6 +114,42 @@ module ActiveSupport
         end
       end
 
+      module ForTestUnit
+
+        def run_setup
+          run_callbacks :setup
+          super
+        end
+        
+        def run_teardown
+          outcome = super
+          run_callbacks :teardown
+          mocha_counter = retrieve_mocha_counter
+          mocha_teardown if mocha_counter
+          outcome
+        end
+        
+        def run_test
+          outcome = super
+          mocha_counter = retrieve_mocha_counter
+          mocha_verify(mocha_counter) if mocha_counter
+          outcome
+        end
+
+        protected
+
+          def retrieve_mocha_counter #:nodoc:
+            if respond_to?(:mocha_verify) # using mocha
+              if defined?(Mocha::TestCaseAdapter::AssertionCounter)
+                Mocha::TestCaseAdapter::AssertionCounter.new(@_result)
+              else
+                Mocha::Integration::TestUnit::AssertionCounter.new(@_result)
+              end
+            end
+          end
+          
+      end
+      
     end
   end
 end

--- a/activesupport/lib/active_support/testing/setup_and_teardown.rb
+++ b/activesupport/lib/active_support/testing/setup_and_teardown.rb
@@ -16,7 +16,7 @@ module ActiveSupport
           begin
             require 'test/unit/version'
           rescue LoadError
-          end
+          end unless defined?(Test::Unit::VERSION)
           if defined?(Test::Unit::VERSION) # Test::Unit 2.x gem
             include ForTestUnit
           else # "built-in" Test::Unit 1.2.3

--- a/activesupport/lib/active_support/testing/setup_and_teardown.rb
+++ b/activesupport/lib/active_support/testing/setup_and_teardown.rb
@@ -116,7 +116,12 @@ module ActiveSupport
 
       module ForTestUnit
 
+        # NOTE: mocha (already) does it's Test::Unit#run hook as we do not 
+        # override the #run method we do not need to worry about mocha here
+        
         def run_setup
+          # a lot of rails test code (e.g. from actionpack) depends on this 
+          # setup order (although it's logically not correct) thus keep it :
           run_callbacks :setup
           super
         end
@@ -124,29 +129,8 @@ module ActiveSupport
         def run_teardown
           outcome = super
           run_callbacks :teardown
-          mocha_counter = retrieve_mocha_counter
-          mocha_teardown if mocha_counter
           outcome
         end
-        
-        def run_test
-          outcome = super
-          mocha_counter = retrieve_mocha_counter
-          mocha_verify(mocha_counter) if mocha_counter
-          outcome
-        end
-
-        protected
-
-          def retrieve_mocha_counter #:nodoc:
-            if respond_to?(:mocha_verify) # using mocha
-              if defined?(Mocha::TestCaseAdapter::AssertionCounter)
-                Mocha::TestCaseAdapter::AssertionCounter.new(@_result)
-              else
-                Mocha::Integration::TestUnit::AssertionCounter.new(@_result)
-              end
-            end
-          end
           
       end
       

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -1,61 +1,228 @@
 require 'abstract_unit'
 
 module ActiveSupport
-  class TestCaseTest < ActiveSupport::TestCase
-    class FakeRunner
-      attr_reader :puked
-
-      def initialize
-        @puked = []
-      end
-
-      def puke(klass, name, e)
-        @puked << [klass, name, e]
-      end
-
-      def options
-        nil
-      end
-    end
+  class TestCaseTest < ::Test::Unit::TestCase
 
     if defined?(MiniTest::Assertions) && TestCase < MiniTest::Assertions
+      
+      class FakeRunner
+        attr_reader :puked
+
+        def initialize
+          @puked = []
+        end
+
+        def puke(klass, name, e)
+          @puked << [klass, name, e]
+        end
+
+        def options
+          nil
+        end
+      end
+      
       def test_callback_with_exception
-        tc = Class.new(TestCase) do
+        test_case = Class.new(TestCase) do
           setup :bad_callback
           def bad_callback; raise 'oh noes' end
           def test_true; assert true end
         end
 
         test_name = 'test_true'
-        fr = FakeRunner.new
+        runner = FakeRunner.new
 
-        test = tc.new test_name
-        test.run fr
-        klass, name, exception = *fr.puked.first
+        test = test_case.new test_name
+        test.run runner
+        klass, name, exception = *runner.puked.first
 
-        assert_equal tc, klass
+        assert_equal test_case, klass
         assert_equal test_name, name
         assert_equal 'oh noes', exception.message
       end
 
       def test_teardown_callback_with_exception
-        tc = Class.new(TestCase) do
+        test_case = Class.new(TestCase) do
           teardown :bad_callback
           def bad_callback; raise 'oh noes' end
           def test_true; assert true end
         end
 
         test_name = 'test_true'
-        fr = FakeRunner.new
+        runner = FakeRunner.new
 
-        test = tc.new test_name
-        test.run fr
-        klass, name, exception = *fr.puked.first
+        test = test_case.new test_name
+        test.run runner
+        klass, name, exception = *runner.puked.first
 
-        assert_equal tc, klass
+        assert_equal test_case, klass
         assert_equal test_name, name
         assert_equal 'oh noes', exception.message
       end
+      
+    else # Test::Unit
+      
+      def test_callback_with_exception
+        test_case = Class.new(TestCase) do
+          setup :bad_callback
+          def bad_callback; raise 'oh noes' end
+          def test_true; assert true end
+        end
+
+        result = Test::Unit::TestResult.new
+        test = test_case.new "test_true"
+        test.run(result) do |channel, value|
+          assert channel; assert value # don't care really
+        end
+        
+        assert ! result.passed?
+        assert_equal 1, result.error_count
+        error = get_test_result_errors(result).first
+        assert_equal error.test_name, "test_true()"
+        assert_equal 'oh noes', error.exception.message
+      end
+
+      def test_teardown_callback_with_exception
+        test_case = Class.new(TestCase) do
+          teardown :bad_callback
+          def bad_callback; raise 'oh noes' end
+          def test_true; assert true end
+        end
+
+        result = Test::Unit::TestResult.new
+        test = test_case.new "test_true"
+        test.run(result) do |channel, value|
+          assert channel; assert value # don't care really
+        end
+
+        assert ! result.passed?
+        assert_equal 1, result.error_count
+        error = get_test_result_errors(result).first
+        assert_equal error.test_name, "test_true()"
+        assert_equal 'oh noes', error.exception.message
+      end
+
+      def test_yields_test_started_and_finished
+        test_case = Class.new(TestCase) do
+          def test_true; assert true end
+        end
+
+        result = Test::Unit::TestResult.new
+        test = test_case.new "test_true"
+        yields = []
+        test.run(result) do |channel, value|
+          yields << [ channel, value ]
+        end
+
+        if new_test_unit?
+          assert_equal 4, yields.size
+          assert_equal Test::Unit::TestCase::STARTED, yields[0][0]
+          assert_equal 'test_true()', yields[0][1]
+          assert_equal Test::Unit::TestCase::FINISHED, yields[2][0]
+          assert_equal 'test_true()', yields[2][1]
+        else
+          assert_equal 2, yields.size
+          assert_equal Test::Unit::TestCase::STARTED, yields[0][0]
+          assert_equal 'test_true()', yields[0][1]
+          assert_equal Test::Unit::TestCase::FINISHED, yields[1][0]
+          assert_equal 'test_true()', yields[1][1]
+        end
+      end
+      
+      def test_yields_test_started_and_finished_with_bad_callbacks
+        test_case = Class.new(TestCase) do
+          setup :bad_callback
+          teardown :bad_callback
+          def bad_callback; raise 'oh noes' end
+          def test_true; assert true end
+        end
+
+        result = Test::Unit::TestResult.new
+        test = test_case.new "test_true"
+        yields = []
+        test.run(result) do |channel, value|
+          yields << [ channel, value ]
+        end
+
+        if new_test_unit?
+          assert_equal 4, yields.size
+          assert_equal Test::Unit::TestCase::STARTED, yields[0][0]
+          assert_equal 'test_true()', yields[0][1]
+          assert_equal Test::Unit::TestCase::FINISHED, yields[2][0]
+          assert_equal 'test_true()', yields[2][1]
+        else
+          assert_equal 2, yields.size
+          assert_equal Test::Unit::TestCase::STARTED, yields[0][0]
+          assert_equal 'test_true()', yields[0][1]
+          assert_equal Test::Unit::TestCase::FINISHED, yields[1][0]
+          assert_equal 'test_true()', yields[1][1]
+        end
+      end
+      
+      def test_mocha_verify
+        test_case = Class.new(TestCase) do
+          def test_mocha_failure
+            Object.new.expects(:foo)
+          end
+        end
+
+        result = Test::Unit::TestResult.new
+        test = test_case.new "test_mocha_failure"
+        test.run(result) { |channel, value| channel && value }
+
+        assert ! result.passed?
+        assert_equal 1, result.failure_count
+        failure = get_test_result_failures(result).first
+        assert_equal failure.test_name, "test_mocha_failure()"
+        
+        mocha_failure = 
+          "not all expectations were satisfied\nunsatisfied expectations:\n- expected exactly once, not yet invoked"
+        assert_equal mocha_failure, failure.message[0,mocha_failure.size]
+      end
+
+      @@moched_object = nil
+      def self.moched_object; @@moched_object; end
+      
+      def test_mocha_teardown
+        @@moched_object = Object.new
+        test_case = Class.new(TestCase) do
+          def test_mocha_success
+            o = ActiveSupport::TestCaseTest.moched_object
+            o.expects(:hash).once
+            o.hash
+          end
+        end
+
+        result = Test::Unit::TestResult.new
+        test = test_case.new "test_mocha_success"
+        test.run(result) { |channel, value| channel && value }
+
+        assert result.passed?
+        assert_nothing_raised do
+          @@moched_object.hash
+        end
+      ensure
+        @@moched_object = nil
+      end
+      
+      private
+      
+        def get_test_result_errors(test_result)
+          test_result.respond_to?(:errors) ? 
+            test_result.errors : # Test::Unit 2.x
+              test_result.instance_variable_get(:'@errors') # classic Test::Unit
+        end
+
+        def get_test_result_failures(test_result)
+          test_result.respond_to?(:failures) ? 
+            test_result.failures : # Test::Unit 2.x
+              test_result.instance_variable_get(:'@failures') # classic Test::Unit
+        end
+        
+        def new_test_unit?
+          Test::Unit::TestResult.new.respond_to?(:faults)
+        end
+        
     end
+    
   end
 end

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -59,7 +59,7 @@ module ActiveSupport
         @@callbacks_memo = nil
       end
       
-      def test_callback_with_exception
+      def test_setup_callback_with_exception
         test_case = Class.new(TestCase) do
           setup :bad_callback
           def bad_callback; raise 'oh noes' end
@@ -129,7 +129,7 @@ module ActiveSupport
         @@callbacks_memo = nil
       end
       
-      def test_callback_with_exception
+      def test_setup_callback_with_exception
         test_case = Class.new(TestCase) do
           setup :bad_callback
           def bad_callback; raise 'oh noes' end
@@ -275,10 +275,6 @@ module ActiveSupport
           test_result.respond_to?(:failures) ? 
             test_result.failures : # Test::Unit 2.x
               test_result.instance_variable_get(:'@failures') # classic Test::Unit
-        end
-        
-        def new_test_unit?
-          Test::Unit::TestResult.new.respond_to?(:faults)
         end
         
     end


### PR DESCRIPTION
I've hit some issues while running tests over the latest 'test-unit' 2.3.2 ... 
as the `Test::Unit#run` code https://github.com/rails/rails/blob/master/activesupport/lib/active_support/testing/setup_and_teardown.rb#L56-94 is far from being perfect for > 1.3.2 (that is all 2.x versions). 
so I wrote an "integration" for it, now the new `Test::Unit` should be much happier as it's `run` method (which has changed since 1.3.2) does not get completely replaced.
all is backward compatible - I've added some tests but I'm no expert in 'test-unit' thus let me know if there's something "smelly".
