### PR TITLE
Nested attribute setters can be overridden.

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -288,7 +288,7 @@ module ActiveRecord
             # def pirate_attributes=(attributes)
             #   assign_nested_attributes_for_one_to_one_association(:pirate, attributes, mass_assignment_options)
             # end
-            class_eval <<-eoruby, __FILE__, __LINE__ + 1
+            generated_feature_methods.module_eval <<-eoruby, __FILE__, __LINE__ + 1
               if method_defined?(:#{association_name}_attributes=)
                 remove_method(:#{association_name}_attributes=)
               end

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -172,6 +172,19 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
     man.interests_attributes = [{:id => interest.id, :topic => 'gardening'}]
     assert_equal man.interests.first.topic, man.interests[0].topic
   end
+
+  def test_allows_class_to_override_setter_and_call_super
+    mean_pirate_class = Class.new(Pirate) do
+      accepts_nested_attributes_for :parrot
+      def parrot_attributes=(attrs)
+        super(attrs.merge(:color => "blue"))
+      end
+    end
+    mean_pirate = mean_pirate_class.new
+    mean_pirate.parrot_attributes = { :name => "James" }
+    assert_equal "James", mean_pirate.parrot.name
+    assert_equal "blue", mean_pirate.parrot.color
+  end
 end
 
 class TestNestedAttributesOnAHasOneAssociation < ActiveRecord::TestCase

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -439,6 +439,7 @@ ActiveRecord::Schema.define do
 
   create_table :parrots, :force => true do |t|
     t.column :name, :string
+    t.column :color, :string
     t.column :parrot_sti_class, :string
     t.column :killer_id, :integer
     t.column :created_at, :datetime


### PR DESCRIPTION
We needed to use some of the features of `accepts_nested_attributes_for` (such as `:_destroy`) but we needed to filter the incoming attributes.  This patch puts the methods `accepts_nested_attributes_for` defines in a module which can sit behind a custom implementation so that it can call `super`.
