### PR TITLE
Collection proxy loses its proxy_association when scoped further

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,8 @@ platforms :mri_18 do
 end
 
 # Add your own local bundler stuff
-instance_eval File.read '.Gemfile' if File.exists? '.Gemfile'
+local_gemfile = File.dirname(__FILE__) + "/.Gemfile"
+instance_eval File.read local_gemfile if File.exists? local_gemfile
 
 platforms :mri do
   group :test do

--- a/activesupport/lib/active_support/core_ext/kernel/debugger.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/debugger.rb
@@ -2,7 +2,7 @@ module Kernel
   unless respond_to?(:debugger)
     # Starts a debugging session if ruby-debug has been loaded (call rails server --debugger to do load it).
     def debugger
-      message = "\n***** Debugger requested, but was not available (ensure ruby-debug is listed in Gemfile/installed as gem): Start server with --debugger to enable *****\n"
+      message = "\n***** Debugger requested, but was not available (ensure ruby-debug19 is listed in Gemfile/installed as gem): Start server with --debugger to enable *****\n"
       defined?(Rails) ? Rails.logger.info(message) : $stderr.puts(message)
     end
     alias breakpoint debugger unless respond_to?(:breakpoint)

--- a/railties/guides/code/getting_started/README.rdoc
+++ b/railties/guides/code/getting_started/README.rdoc
@@ -86,8 +86,8 @@ programming in general.
 Debugger support is available through the debugger command when you start your
 Mongrel or WEBrick server with --debugger. This means that you can break out of
 execution at any point in the code, investigate and change the model, and then,
-resume execution! You need to install ruby-debug to run the server in debugging
-mode. With gems, use <tt>sudo gem install ruby-debug</tt>. Example:
+resume execution! You need to install ruby-debug19 to run the server in debugging
+mode. With gems, use <tt>sudo gem install ruby-debug19</tt>. Example:
 
   class WeblogController < ActionController::Base
     def index

--- a/railties/lib/rails/generators/rails/app/templates/README
+++ b/railties/lib/rails/generators/rails/app/templates/README
@@ -86,8 +86,8 @@ programming in general.
 Debugger support is available through the debugger command when you start your
 Mongrel or WEBrick server with --debugger. This means that you can break out of
 execution at any point in the code, investigate and change the model, and then,
-resume execution! You need to install ruby-debug to run the server in debugging
-mode. With gems, use <tt>sudo gem install ruby-debug</tt>. Example:
+resume execution! You need to install ruby-debug19 to run the server in debugging
+mode. With gems, use <tt>sudo gem install ruby-debug19</tt>. Example:
 
   class WeblogController < ActionController::Base
     def index

--- a/railties/lib/rails/rack/debugger.rb
+++ b/railties/lib/rails/rack/debugger.rb
@@ -12,7 +12,7 @@ module Rails
         ::Debugger.settings[:autoeval] = true if ::Debugger.respond_to?(:settings)
         puts "=> Debugger enabled"
       rescue LoadError
-        puts "You need to install ruby-debug to run the server in debugging mode. With gems, use 'gem install ruby-debug'"
+        puts "You need to install ruby-debug19 to run the server in debugging mode. With gems, use 'gem install ruby-debug19'"
         exit
       end
 


### PR DESCRIPTION
Say I have these GitHub-style models,

``` ruby
class User < ActiveRecord::Base
  has_many :projects do
    def personal
      where(:owner => proxy_association.owner.name)
    end

    def personal_first
      order("projects.owner <> '#{proxy_association.owner.name}'")
    end

    def visible_to(user)
      user == proxy_association.owner ? scoped : where(:private => false)
    end
  end
end

class Project < ActiveRecord::Base
end
```

Through the `:projects` association, I can get:
- Only personal projects: `@user.projects.personal`
- Projects ordered so the personal projects come first: `@user.projects.personal_first`
- Projects that a user is allowed to see: `@user.projects.visible_to(current_user)`

The problem is that if I combine any two of these methods, it bombs, complaining about there being no `proxy_association` method defined on `ActiveRecord::Relation`.

I've updated the collection proxy to pass its `@association` on to further scopes by opening up a `proxy_association` accessor on `ActiveRecord::Relation`. I'd love to get your feedback. Thank you.
