### PR TITLE
Ability to get single full error message

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -180,6 +180,7 @@ module ActiveModel
       all? { |k, v| v && v.empty? }
     end
     alias_method :blank?, :empty?
+
     # Returns an xml formatted representation of the Errors hash.
     #
     #   p.errors.add(:name, "can't be blank")
@@ -254,20 +255,22 @@ module ActiveModel
     #   company.errors.full_messages # =>
     #     ["Name is too short (minimum is 5 characters)", "Name can't be blank", "Email can't be blank"]
     def full_messages
-      map { |attribute, message|
-        if attribute == :base
-          message
-        else
-          attr_name = attribute.to_s.gsub('.', '_').humanize
-          attr_name = @base.class.human_attribute_name(attribute, :default => attr_name)
+      map { |attribute, message| full_message(attribute, message) }
+    end
 
-          I18n.t(:"errors.format", {
-            :default   => "%{attribute} %{message}",
-            :attribute => attr_name,
-            :message   => message
-          })
-        end
-      }
+    # Returns a full message for a given attribute.
+    #
+    #   company.errors.full_message(:name, "is invalid")  # =>
+    #     "Name is invalid"
+    def full_message(attribute, message)
+      return message if attribute == :base
+      attr_name = attribute.to_s.gsub('.', '_').humanize
+      attr_name = @base.class.human_attribute_name(attribute, :default => attr_name)
+      I18n.t(:"errors.format", {
+        :default   => "%{attribute} %{message}",
+        :attribute => attr_name,
+        :message   => message
+      })
     end
 
     # Translates an error message in its default scope

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -102,4 +102,15 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal "name can not be blank", person.errors.full_message(:name, "can not be blank")
   end
 
+  test 'should return a JSON hash representation of the errors' do
+    person = Person.new
+    person.errors.add(:name, "can not be blank")
+    person.errors.add(:name, "can not be nil")
+    person.errors.add(:email, "is invalid")
+    hash = person.errors.as_json
+    assert_equal ["can not be blank", "can not be nil"], hash[:name]
+    assert_equal ["is invalid"], hash[:email]
+  end
+
 end
+

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -52,7 +52,6 @@ class ErrorsTest < ActiveModel::TestCase
     person.validate!
     assert_equal ["name can not be nil"], person.errors.full_messages
     assert_equal ["can not be nil"], person.errors[:name]
-
   end
 
   test 'should be able to assign error' do
@@ -78,7 +77,6 @@ class ErrorsTest < ActiveModel::TestCase
     person.errors.add(:name, "can not be blank")
     person.errors.add(:name, "can not be nil")
     assert_equal ["name can not be blank", "name can not be nil"], person.errors.to_a
-
   end
 
   test 'to_hash should return an ordered hash' do
@@ -86,4 +84,22 @@ class ErrorsTest < ActiveModel::TestCase
     person.errors.add(:name, "can not be blank")
     assert_instance_of ActiveSupport::OrderedHash, person.errors.to_hash
   end
+
+  test 'full_messages should return an array of error messages, with the attribute name included' do
+    person = Person.new
+    person.errors.add(:name, "can not be blank")
+    person.errors.add(:name, "can not be nil")
+    assert_equal ["name can not be blank", "name can not be nil"], person.errors.to_a
+  end
+
+  test 'full_message should return the given message if attribute equals :base' do
+    person = Person.new
+    assert_equal "press the button", person.errors.full_message(:base, "press the button")
+  end
+
+  test 'full_message should return the given message with the attribute name included' do
+    person = Person.new
+    assert_equal "name can not be blank", person.errors.full_message(:name, "can not be blank")
+  end
+
 end


### PR DESCRIPTION
At the moment you can only get an array of full messages. The link with their attributes are lost.

I'd like clients to be able to relate full error messages to their corresponding fields.

So I'd like to get e.g. :

```
 [ [:name, "Name is invalid"], [:name, "Name is too short"], [:email, "Email can't be blank"] ]
```

With this patch it makes the implementation possible with:

```
 obj.errors.map { |attr, msg| [attr, obj.errors.full_message(attr, msg)] }
```
