### PR TITLE
Use log.warn instead of debug for CSRF token warning

### DIFF
--- a/actionpack/CHANGELOG
+++ b/actionpack/CHANGELOG
@@ -1,5 +1,7 @@
 *Rails 3.2.0 (unreleased)*
 
+* Changed log level of warning for missing CSRF token from :debug to :warn. Fixes #2972 [Mike Dillon]
+
 * content_tag_for and div_for can now take the collection of records. It will also yield the record as the first argument if you set a receiving argument in your block [Prem Sichanugrist]
 
   So instead of having to do this:

--- a/actionpack/CHANGELOG
+++ b/actionpack/CHANGELOG
@@ -1,6 +1,6 @@
 *Rails 3.2.0 (unreleased)*
 
-* Changed log level of warning for missing CSRF token from :debug to :warn. Fixes #2972 [Mike Dillon]
+* Changed log level of warning for missing CSRF token from :debug to :warn. [Mike Dillon]
 
 * content_tag_for and div_for can now take the collection of records. It will also yield the record as the first argument if you set a receiving argument in your block [Prem Sichanugrist]
 

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -74,7 +74,7 @@ module ActionController #:nodoc:
       # The actual before_filter that is used. Modify this to change how you handle unverified requests.
       def verify_authenticity_token
         unless verified_request?
-          logger.debug "WARNING: Can't verify CSRF token authenticity" if logger
+          logger.warn "WARNING: Can't verify CSRF token authenticity" if logger
           handle_unverified_request
         end
       end

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -1,6 +1,7 @@
 require 'abstract_unit'
 require 'digest/sha1'
 require 'active_support/core_ext/string/strip'
+require "active_support/log_subscriber/test_helper"
 
 # common controller actions
 module RequestForgeryProtectionActions
@@ -155,6 +156,21 @@ module RequestForgeryProtectionTests
   def test_should_allow_put_with_token_in_header
     @request.env['HTTP_X_CSRF_TOKEN'] = @token
     assert_not_blocked { put :index }
+  end
+
+  def test_should_warn_on_missing_csrf_token
+    old_logger = ActionController::Base.logger
+    logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new
+    ActionController::Base.logger = logger
+
+    begin
+      assert_blocked { post :index }
+
+      assert_equal 1, logger.logged(:warn).size
+      assert_match(/CSRF token authenticity/, logger.logged(:warn).last)
+    rescue
+      ActionController::Base.logger = old_logger
+    end
   end
 
   def assert_blocked


### PR DESCRIPTION
We had a situation where the CSRF token additions in jquery_ujs were lost in a refactor and had a hell of a time tracking down why every post was logging the user out (we have a GET-heavy site and the pattern wasn't immediately clear since it manifested in the one broadly-used POST-based feature).

I poked around and saw the session clearing stuff in the CSRF protection code and realized what our problem was, but then I noticed that the big scary "WARNING" message was being logged with logger.debug. If we had seen that warning message in the development logs, it would have been immediately clear what was happening.
