### PR TITLE
Use ensure instead of rescue

### DIFF
--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -168,7 +168,7 @@ module RequestForgeryProtectionTests
 
       assert_equal 1, logger.logged(:warn).size
       assert_match(/CSRF token authenticity/, logger.logged(:warn).last)
-    rescue
+    ensure
       ActionController::Base.logger = old_logger
     end
   end


### PR DESCRIPTION
New pull request per @jonleighton in pull request #2972. Changes erroneous "rescue" to "ensure".
