### PR TITLE
Set relative url root in assets when controller isn't available for Sprockets

### DIFF
--- a/actionpack/CHANGELOG
+++ b/actionpack/CHANGELOG
@@ -48,6 +48,8 @@
 
 *Rails 3.1.1 (unreleased)*
 
+* Set relative url root in assets when controller isn't available for Sprockets (eg. Sass files using asset_path). Fixes #2435 [Guillermo Iguaran]
+
 * Fixed the behavior of asset pipeline when config.assets.digest and config.assets.compile are false and requested asset isn't precompiled.
   Before the requested asset were compiled anyway ignoring that the config.assets.compile flag is false. [Guillermo Iguaran]
 

--- a/actionpack/test/template/sprockets_helper_test.rb
+++ b/actionpack/test/template/sprockets_helper_test.rb
@@ -124,6 +124,13 @@ class SprocketsHelperTest < ActionView::TestCase
      asset_path("/images/logo.gif")
   end
 
+  test "asset path with relative url root when controller isn't present but relative_url_root is" do
+    @controller = nil
+    @config.action_controller.relative_url_root = "/collaboration/hieraki"
+    assert_equal "/collaboration/hieraki/images/logo.gif",
+     asset_path("/images/logo.gif")
+  end
+
   test "javascript path" do
     assert_match %r{/assets/application-[0-9a-f]+.js},
       asset_path(:application, "js")


### PR DESCRIPTION
Set relative url root in assets when controller isn't available for Sprockets. Fix #2435

See https://github.com/rails/sass-rails/issues/42 for details
