### PR TITLE
Issue #636 - Parsing an xml file with multiple records and extra attribut

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/hash/conversions.rb
@@ -95,7 +95,7 @@ class Hash
         case value.class.to_s
           when 'Hash'
             if value['type'] == 'array'
-              _, entries = Array.wrap(value.detect { |k,v| k != 'type' })
+              _, entries = Array.wrap(value.detect { |k,v| not v.is_a?(String) })
               if entries.nil? || (c = value['__content__'] && c.blank?)
                 []
               else

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -670,6 +670,55 @@ class HashToXmlTest < Test::Unit::TestCase
     assert_match %r{<local-created-at type=\"datetime\">1999-02-01T19:00:00-05:00</local-created-at>}, xml
   end
 
+  def test_multiple_records_from_xml_with_attributes_other_than_type_ignores_them_without_exploding
+    topics_xml = <<-EOT
+      <topics type="array" page="1" page-count="1000" per-page="2">
+        <topic>
+          <title>The First Topic</title>
+          <author-name>David</author-name>
+          <id type="integer">1</id>
+          <approved type="boolean">false</approved>
+          <replies-count type="integer">0</replies-count>
+          <replies-close-in type="integer">2592000000</replies-close-in>
+          <written-on type="date">2003-07-16</written-on>
+          <viewed-at type="datetime">2003-07-16T09:28:00+0000</viewed-at>
+          <content>Have a nice day</content>
+          <author-email-address>david@loudthinking.com</author-email-address>
+          <parent-id nil="true"></parent-id>
+        </topic>
+        <topic>
+          <title>The Second Topic</title>
+          <author-name>Jason</author-name>
+          <id type="integer">1</id>
+          <approved type="boolean">false</approved>
+          <replies-count type="integer">0</replies-count>
+          <replies-close-in type="integer">2592000000</replies-close-in>
+          <written-on type="date">2003-07-16</written-on>
+          <viewed-at type="datetime">2003-07-16T09:28:00+0000</viewed-at>
+          <content>Have a nice day</content>
+          <author-email-address>david@loudthinking.com</author-email-address>
+          <parent-id></parent-id>
+        </topic>
+      </topics>
+    EOT
+
+    expected_topic_hash = {
+      :title => "The First Topic",
+      :author_name => "David",
+      :id => 1,
+      :approved => false,
+      :replies_count => 0,
+      :replies_close_in => 2592000000,
+      :written_on => Date.new(2003, 7, 16),
+      :viewed_at => Time.utc(2003, 7, 16, 9, 28),
+      :content => "Have a nice day",
+      :author_email_address => "david@loudthinking.com",
+      :parent_id => nil
+    }.stringify_keys
+
+    assert_equal expected_topic_hash, Hash.from_xml(topics_xml)["topics"].first
+  end
+
   def test_single_record_from_xml
     topic_xml = <<-EOT
       <topic>


### PR DESCRIPTION
This is the backported of #1296 to `3-1-stable`, as it was fixed in `master` but not on `v3.1.0`. I hit it hard when I upgraded my application to 3.1.0 and Ruby 1.9.2. 

@tenderlove and @josevalim, please merge this in before release `v3.1.1`. :heart: :heart: :heart:
