### PR TITLE
Simplified ActiveSupport::Array#in_groups_of(n) to avoid the creation of 

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/grouping.rb
+++ b/activesupport/lib/active_support/core_ext/array/grouping.rb
@@ -30,9 +30,7 @@ class Array
     if block_given?
       collection.each_slice(number) { |slice| yield(slice) }
     else
-      groups = []
-      collection.each_slice(number) { |group| groups << group }
-      groups
+      Array(collection.each_slice(number).map)
     end
   end
 


### PR DESCRIPTION
Simplified ActiveSupport::Array#in_groups_of(n) to avoid the creation of a local temporary array
