### PR TITLE
dump_schema_information: explicitly order inserts into schema_migrations 

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -405,7 +405,7 @@ module ActiveRecord
 
       def dump_schema_information #:nodoc:
         sm_table = ActiveRecord::Migrator.schema_migrations_table_name
-        migrated = select_values("SELECT version FROM #{sm_table}")
+        migrated = select_values("SELECT version FROM #{sm_table} ORDER BY version")
         migrated.map { |v| "INSERT INTO #{sm_table} (version) VALUES ('#{v}');" }.join("\n\n")
       end
 


### PR DESCRIPTION
dump_schema_information: explicitly order inserts into schema_migrations table by version value

This is to reduce churn in the db/development_structure.sql file when using :sql as active_record.schema_format. When using postgresql in particular, the order of versions is somewhat arbitrary. Now only added/removed migrations will create changes to the schema dump file.
