### PR TITLE
Wrting JSON gem for once. It's only required when 1.8.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,6 @@ platforms :ruby do
   if ENV["RB_FSEVENT"]
     gem "rb-fsevent"
   end
-  gem "json"
   gem "yajl-ruby"
   gem "nokogiri", ">= 1.4.5"
 
@@ -74,7 +73,6 @@ end
 
 platforms :jruby do
   gem "ruby-debug", ">= 0.10.3"
-  gem "json"
   gem "activerecord-jdbcsqlite3-adapter"
 
   # This is needed by now to let tests work on JRuby


### PR DESCRIPTION
mri_18 => mri AND version 1.8

It can just included into mri_18 block and will available for JRuby
also.

Problem : I was just changing the JSON gem version to older one.
And found that i have to change it two places.
