### PR TITLE
Added support for LC_COLLATE and LC_CTYPE for PostgreSQL adapter.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -683,6 +683,10 @@ module ActiveRecord
             " TEMPLATE = \"#{value}\""
           when :encoding
             " ENCODING = '#{value}'"
+          when :lc_collate
+            " LC_COLLATE = '#{value}'"
+          when :lc_ctype
+            " LC_CTYPE = '#{value}'"
           when :tablespace
             " TABLESPACE = \"#{value}\""
           when :connection_limit


### PR DESCRIPTION
Since version 8.4, PostgreSQL supports specifying custom LC_COLLATE and LC_CTYPE for CREATE DATABASE, so one database cluster can now contain databases with different collations.

This adds support for lc_collate and lc_ctype options for database.yml
