### PR TITLE
AR::Base.becomes should not change the STI type

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Don't change STI type when calling ActiveRecord::Base#becomes, add
+    ActiveRecord::Base#becomes!
+
+    See #3023.
+
+    *Thomas Hollstegge*
+
 *   `#pluck` can be used on a relation with `select` clause. Fix #7551
 
     Example:

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -155,7 +155,18 @@ module ActiveRecord
       became.instance_variable_set("@new_record", new_record?)
       became.instance_variable_set("@destroyed", destroyed?)
       became.instance_variable_set("@errors", errors)
-      became.public_send("#{klass.inheritance_column}=", klass.name) unless self.class.descends_from_active_record?
+      became
+    end
+
+    # Wrapper around +becomes+ that also changes the instance's sti column value.
+    # This is especially useful if you want to persist the changed class in your
+    # database.
+    #
+    # Note: The old instance's sti column value will be changed too, as both objects
+    # share the same set of attributes.
+    def becomes!(klass)
+      became = becomes(klass)
+      became.public_send("#{klass.inheritance_column}=", klass.sti_name) unless self.class.descends_from_active_record?
       became
     end
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -280,10 +280,21 @@ class PersistencesTest < ActiveRecord::TestCase
   def test_update_sti_type
     assert_instance_of Reply, topics(:second)
 
-    topic = topics(:second).becomes(Topic)
+    topic = topics(:second).becomes!(Topic)
     assert_instance_of Topic, topic
     topic.save!
     assert_instance_of Topic, Topic.find(topic.id)
+  end
+
+  def test_preserve_original_sti_type
+    reply = topics(:second)
+    assert_equal "Reply", reply.type
+
+    topic = reply.becomes(Topic)
+    assert_equal "Reply", reply.type
+
+    assert_instance_of Topic, topic
+    assert_equal "Reply", topic.type
   end
 
   def test_delete


### PR DESCRIPTION
The current implementation of AR::Base.becomes doesn't work as expected. Calling `subclass_instance.becomes(SuperClass)` changes `subclass_instance.type` to `SuperClass`, i.e.:

``` ruby
class SuperClass < ActiveRecord::Base
end
class SubClass < SuperClass
end

subclass_instance = SubClass.new
subclass_instance.type # => "SubClass"
subclass_instance.becomes(SuperClass)
subclass_instance.type # => "SuperClass"
```

I've added the method `becomes!` to AR::Base which resembles the current behavior and changed AR::Base.becomes back to the old behavior (before e781853).

Refs #98 and https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/5953
