### PR TITLE
Fixes an issue when creating a date select with too many options.

### DIFF
--- a/actionpack/CHANGELOG
+++ b/actionpack/CHANGELOG
@@ -1,5 +1,7 @@
 *Rails 3.2.0 (unreleased)*
 
+* Limited the amount of options for select_year to 1000 by default. It's also possible to provide the :max_years_allowed parameter in order to override the 1000 limit. [Libo Cannici]
+
 * Changed log level of warning for missing CSRF token from :debug to :warn. [Mike Dillon]
 
 * content_tag_for and div_for can now take the collection of records. It will also yield the record as the first argument if you set a receiving argument in your block [Prem Sichanugrist]

--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -765,11 +765,16 @@ module ActionView
         if @options[:use_hidden] || @options[:discard_year]
           build_hidden(:year, val)
         else
-          options                 = {}
-          options[:start]         = @options[:start_year] || middle_year - 5
-          options[:end]           = @options[:end_year] || middle_year + 5
-          options[:step]          = options[:start] < options[:end] ? 1 : -1
-          options[:leading_zeros] = false
+          options                     = {}
+          options[:start]             = @options[:start_year] || middle_year - 5
+          options[:end]               = @options[:end_year] || middle_year + 5
+          options[:step]              = options[:start] < options[:end] ? 1 : -1
+          options[:leading_zeros]     = false
+          options[:max_years_allowed] = @options[:max_years_allowed] || 1000
+
+          if (options[:end] - options[:start]).abs > options[:max_years_allowed]
+            raise ArgumentError,  "There're too many years options to be built. Are you sure you haven't mistyped something? You can provide the :max_years_allowed parameter"
+          end
 
           build_options_and_select(:year, val, options)
         end

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -664,6 +664,15 @@ class DateHelperTest < ActionView::TestCase
     assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), :start_year => 2003, :end_year => 2005, :prefix => "date[first]")
   end
 
+  def test_select_date_with_too_big_range_between_start_year_and_end_year
+    assert_raise(ArgumentError) { select_date(Time.mktime(2003, 8, 16), :start_year => 2000, :end_year => 20000, :prefix => "date[first]", :order => [:month, :day, :year]) }
+    assert_raise(ArgumentError) { select_date(Time.mktime(2003, 8, 16), :start_year => Date.today.year - 100.years, :end_year => 2000, :prefix => "date[first]", :order => [:month, :day, :year]) }
+  end
+
+  def test_select_date_can_have_more_then_1000_years_interval_if_forced_via_parameter
+    assert_nothing_raised { select_date(Time.mktime(2003, 8, 16), :start_year => 2000, :end_year => 3100, :max_years_allowed => 2000) }
+  end
+
   def test_select_date_with_order
     expected = %(<select id="date_first_month" name="date[first][month]">\n)
     expected << %(<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7">July</option>\n<option value="8" selected="selected">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n)


### PR DESCRIPTION
Inspired by dlt https://github.com/dlt/rails/commit/9e615634745dc81598e7b880d52411338d3a7a93

This should close https://rails.lighthouseapp.com/projects/8994/tickets/6627-server-hanging-when-using-extreme-values-for-date_select-start_year
