### PR TITLE
Default precompile regex was erroneously matching files

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -38,7 +38,7 @@ module Rails
         @assets.enabled         = false
         @assets.paths           = []
         @assets.precompile      = [ Proc.new{ |path| !File.extname(path).in?(['.js', '.css']) },
-                                    /application.(css|js)$/ ]
+                                    /(?:\/|\\|\A)application\.(css|js)$/ ]
         @assets.prefix          = "/assets"
         @assets.version         = ''
         @assets.debug           = false

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -68,6 +68,10 @@ module ApplicationTests
     test "precompile application.js and application.css and all other files not ending with .js or .css by default" do
       app_file "app/assets/javascripts/application.js", "alert();"
       app_file "app/assets/stylesheets/application.css", "body{}"
+
+      app_file "app/assets/javascripts/someapplication.js", "alert();"
+      app_file "app/assets/stylesheets/someapplication.css", "body{}"
+
       app_file "app/assets/javascripts/something.min.js", "alert();"
       app_file "app/assets/stylesheets/something.min.css", "body{}"
 
@@ -87,8 +91,13 @@ module ApplicationTests
       images_should_compile.each do |filename|
         assert File.exists?("#{app_path}/public/assets/#{filename}")
       end
+
       assert File.exists?("#{app_path}/public/assets/application.js")
       assert File.exists?("#{app_path}/public/assets/application.css")
+
+      assert !File.exists?("#{app_path}/public/assets/someapplication.js")
+      assert !File.exists?("#{app_path}/public/assets/someapplication.css")
+
       assert !File.exists?("#{app_path}/public/assets/something.min.js")
       assert !File.exists?("#{app_path}/public/assets/something.min.css")
     end


### PR DESCRIPTION
Looks like the remaining default regexp (`/application.(css|js)$/`) was matching things like `someapplication.js`. Converted that to a Proc which properly matches what it's supposed to. As this is the second regexp I've fixed, I don't think regexp's are a good idea in this context.
