### PR TITLE
Fix: habtm doesn't respect select query method

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -42,10 +42,6 @@ module ActiveRecord
           select_value ||= options[:uniq] && "DISTINCT #{reflection.quoted_table_name}.*"
         end
 
-        if reflection.macro == :has_and_belongs_to_many
-          select_value ||= reflection.klass.arel_table[Arel.star]
-        end
-
         select_value
       end
 

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -647,6 +647,14 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_respond_to categories(:technology).select_testing_posts.find(:first), :correctness_marker
   end
 
+  def test_habtm_selects_all_columns_by_default
+    assert_equal Project.column_names, developers(:david).projects.first.attributes.keys
+  end
+
+  def test_habtm_respects_select_query_method
+    assert_equal ['id'], developers(:david).projects.select(:id).first.attributes.keys
+  end
+
   def test_join_table_alias
     assert_equal 3, Developer.find(:all, :include => {:projects => :developers}, :conditions => 'developers_projects_join.joined_on IS NOT NULL').size
   end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -485,6 +485,14 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 0, authors(:mary).popular_grouped_posts.length
   end
 
+  def test_default_select
+    assert_equal Comment.column_names, posts(:welcome).comments.first.attributes.keys
+  end
+
+  def test_select_query_method
+    assert_equal ['id'], posts(:welcome).comments.select(:id).first.attributes.keys
+  end
+
   def test_adding
     force_signal37_to_load_all_clients_of_firm
     natural = Client.new("name" => "Natural Company")


### PR DESCRIPTION
This is a patch for issue #2923.

The removed code is redundant because https://github.com/rails/rails/blob/7abf4413366c5bf2b9462ef9dfbd710038b41a6c/activerecord/lib/active_record/relation/query_methods.rb#L289 will reapply the rule.
