### PR TITLE
Custom serializers and deserializers in MessageVerifier and MessageEncryptor.

### DIFF
--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -8,6 +8,7 @@ rescue LoadError, NameError
 else
 
 require 'active_support/time'
+require 'active_support/json'
 
 class MessageEncryptorTest < Test::Unit::TestCase
   def setup
@@ -38,7 +39,14 @@ class MessageEncryptorTest < Test::Unit::TestCase
     message = @encryptor.encrypt_and_sign(@data)
     assert_equal @data, @encryptor.decrypt_and_verify(message)
   end
-
+  
+  def test_alternative_serialization_method
+    @encryptor.serializer = lambda { |value| ActiveSupport::JSON.encode(value) }
+    @encryptor.deserializer = lambda { |value| ActiveSupport::JSON.decode(value) }
+    
+    message = @encryptor.encrypt_and_sign({ :foo => 123, 'bar' => Time.local(2010) })
+    assert_equal @encryptor.decrypt_and_verify(message), { "foo" => 123, "bar" => "2010-01-01T00:00:00-05:00" }
+  end
 
   private
     def assert_not_decrypted(value)

--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -44,8 +44,8 @@ class MessageEncryptorTest < Test::Unit::TestCase
     @encryptor.serializer = lambda { |value| ActiveSupport::JSON.encode(value) }
     @encryptor.deserializer = lambda { |value| ActiveSupport::JSON.decode(value) }
     
-    message = @encryptor.encrypt_and_sign({ :foo => 123, 'bar' => Time.local(2010) })
-    assert_equal @encryptor.decrypt_and_verify(message), { "foo" => 123, "bar" => "2010-01-01T00:00:00-05:00" }
+    message = @encryptor.encrypt_and_sign({ :foo => 123, 'bar' => Time.utc(2010) })
+    assert_equal @encryptor.decrypt_and_verify(message), { "foo" => 123, "bar" => "2010-01-01T00:00:00Z" }
   end
 
   private

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -37,8 +37,8 @@ class MessageVerifierTest < Test::Unit::TestCase
     @verifier.serializer = lambda { |value| ActiveSupport::JSON.encode(value) }
     @verifier.deserializer = lambda { |value| ActiveSupport::JSON.decode(value) }
     
-    message = @verifier.generate({ :foo => 123, 'bar' => Time.local(2010) })
-    assert_equal @verifier.verify(message), { "foo" => 123, "bar" => "2010-01-01T00:00:00-05:00" }
+    message = @verifier.generate({ :foo => 123, 'bar' => Time.utc(2010) })
+    assert_equal @verifier.verify(message), { "foo" => 123, "bar" => "2010-01-01T00:00:00Z" }
   end
 
   def assert_not_verified(message)

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -8,6 +8,7 @@ rescue LoadError, NameError
 else
 
 require 'active_support/time'
+require 'active_support/json'
 
 class MessageVerifierTest < Test::Unit::TestCase
   def setup
@@ -30,6 +31,14 @@ class MessageVerifierTest < Test::Unit::TestCase
     assert_not_verified("#{data.reverse}--#{hash}")
     assert_not_verified("#{data}--#{hash.reverse}")
     assert_not_verified("purejunk")
+  end
+  
+  def test_alternative_serialization_method
+    @verifier.serializer = lambda { |value| ActiveSupport::JSON.encode(value) }
+    @verifier.deserializer = lambda { |value| ActiveSupport::JSON.decode(value) }
+    
+    message = @verifier.generate({ :foo => 123, 'bar' => Time.local(2010) })
+    assert_equal @verifier.verify(message), { "foo" => 123, "bar" => "2010-01-01T00:00:00-05:00" }
   end
 
   def assert_not_verified(message)


### PR DESCRIPTION
By default, these ActiveSupport classes use Marshal for serializing and deserializing messages. Unfortunately, the Marshal format is closely associated with Ruby internals. This makes the resulting message very hard to unserialize messages generated by these classes in other environments like node.js.

This patch solves this by allowing you to set your own custom serializer and deserializer lambda functions. By default, it still uses Marshal to be backwards compatible. Simple example:

``` ruby
verifier = ActiveSupport::MessageVerifier.new("Hey, I'm a secret!")
verifier.serializer = lambda { |value| ActiveSupport::JSON.encode(value) }
verifier.deserializer = lambda { |value| ActiveSupport::JSON.decode(value) }

message = verifier.generate({ :foo => 123, 'bar' => Time.local(2010) })
p verifier.verify(message) # => { "foo" => 123, "bar" => "2010-01-01T00:00:00-05:00" }
```

Note that based on the serializer and deserializer, it may not be possible to do a lossless roundtrip as seen in the example. That might not be a problem depending on your needs, but using Marshal as the default makes sense so users don't have to worry about that.

The way I implemented it may not be optimal, so I welcome any feedback!
