### PR TITLE
Skip app/assets/images/rails.png when --skip-public-assets is given.

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -49,6 +49,9 @@ module Rails
         class_option :skip_javascript,    :type => :boolean, :aliases => "-J", :default => false,
                                           :desc => "Skip JavaScript files"
 
+        class_option :skip_public_assets, :type => :boolean, :aliases => '-A', :default => false,
+                                          :desc => "Skip app/assets/images/rails.png file"
+
         class_option :dev,                :type => :boolean, :default => false,
                                           :desc => "Setup the #{name} with Gemfile pointing to your Rails checkout"
 

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -55,6 +55,10 @@ module Rails
 
     def app
       directory 'app'
+      if options[:skip_public_assets]
+        remove_file 'app/assets/images/rails.png'
+        git_keep 'app/assets/images'
+      end
       git_keep  'app/mailers'
       git_keep  'app/models'
     end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -198,6 +198,12 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "test/performance/browsing_test.rb"
   end
 
+  def test_generator_if_skip_public_assets_is_given
+    run_generator [destination_root, "--skip-public-assets"]
+    assert_no_file 'app/assets/images/rails.png'
+    assert_file 'app/assets/images/.gitkeep'
+  end
+
   def test_creation_of_a_test_directory
     run_generator
     assert_file 'test'


### PR DESCRIPTION
This comes from a suggestion in the comments of #2649
