### PR TITLE
Fix ActiveResource JSON error parser and incorrect tests

### DIFF
--- a/activeresource/lib/active_resource/validations.rb
+++ b/activeresource/lib/active_resource/validations.rb
@@ -25,10 +25,24 @@ module ActiveResource
       end
     end
 
+    def from_hash(messages, save_cache = false)
+      clear unless save_cache
+
+      messages.each do |(key,errors)|
+        errors.each do |error|
+          if @base.attributes.keys.include?(key)
+            add key, error
+          else
+            self[:base] << "#{key.humanize} #{error}"
+          end
+        end
+      end
+    end
+
     # Grabs errors from a json response.
     def from_json(json, save_cache = false)
-      array = Array.wrap(ActiveSupport::JSON.decode(json)['errors']) rescue []
-      from_array array, save_cache
+      hash = ActiveSupport::JSON.decode(json)['errors'] || {} rescue {}
+      from_hash hash, save_cache
     end
 
     # Grabs errors from an XML response.

--- a/activeresource/test/cases/base_errors_test.rb
+++ b/activeresource/test/cases/base_errors_test.rb
@@ -5,7 +5,7 @@ class BaseErrorsTest < Test::Unit::TestCase
   def setup
     ActiveResource::HttpMock.respond_to do |mock|
       mock.post "/people.xml", {}, %q(<?xml version="1.0" encoding="UTF-8"?><errors><error>Age can't be blank</error><error>Name can't be blank</error><error>Name must start with a letter</error><error>Person quota full for today.</error></errors>), 422, {'Content-Type' => 'application/xml; charset=utf-8'}
-      mock.post "/people.json", {}, %q({"errors":["Age can't be blank","Name can't be blank","Name must start with a letter","Person quota full for today."]}), 422, {'Content-Type' => 'application/json; charset=utf-8'}
+      mock.post "/people.json", {}, %q({"errors":{"age":["can't be blank"],"name":["can't be blank", "must start with a letter"],"person":["quota full for today."]}}), 422, {'Content-Type' => 'application/json; charset=utf-8'}
     end
   end
 
@@ -83,7 +83,7 @@ class BaseErrorsTest < Test::Unit::TestCase
   def test_should_mark_as_invalid_when_content_type_is_unavailable_in_response_header
     ActiveResource::HttpMock.respond_to do |mock|
       mock.post "/people.xml", {}, %q(<?xml version="1.0" encoding="UTF-8"?><errors><error>Age can't be blank</error><error>Name can't be blank</error><error>Name must start with a letter</error><error>Person quota full for today.</error></errors>), 422, {}
-      mock.post "/people.json", {}, %q({"errors":["Age can't be blank","Name can't be blank","Name must start with a letter","Person quota full for today."]}), 422, {}
+      mock.post "/people.json", {}, %q({"errors":{"age":["can't be blank"],"name":["can't be blank", "must start with a letter"],"person":["quota full for today."]}}), 422, {}
     end
 
     [ :json, :xml ].each do |format|


### PR DESCRIPTION
The ActiveResource base error tests mock posts with incorrectly structured JSON errors.
This fixes those mocks and patches ActiveResource to correctly parse JSON errors.
