### PR TITLE
Fix Hash#to_query edge case with html_safe string on 1.8 ruby

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/to_query.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_query.rb
@@ -7,7 +7,7 @@ class Object
   # Note: This method is defined as a default implementation for all Objects for Hash#to_query to work.
   def to_query(key)
     require 'cgi' unless defined?(CGI) && defined?(CGI::escape)
-    "#{CGI.escape(key.to_s)}=#{CGI.escape(to_param.to_s)}"
+    "#{CGI.escape(key.to_param)}=#{CGI.escape(to_param.to_s)}"
   end
 end
 

--- a/activesupport/test/core_ext/object/to_query_test.rb
+++ b/activesupport/test/core_ext/object/to_query_test.rb
@@ -1,6 +1,7 @@
 require 'abstract_unit'
 require 'active_support/ordered_hash'
 require 'active_support/core_ext/object/to_query'
+require 'active_support/core_ext/string/output_safety.rb'
 
 class ToQueryTest < Test::Unit::TestCase
   def test_simple_conversion
@@ -9,6 +10,14 @@ class ToQueryTest < Test::Unit::TestCase
 
   def test_cgi_escaping
     assert_query_equal 'a%3Ab=c+d', 'a:b' => 'c d'
+  end
+
+  def test_html_safe_parameter_key
+    assert_query_equal 'a%3Ab=c+d', 'a:b'.html_safe => 'c d'
+  end
+
+  def test_html_safe_parameter_value
+    assert_query_equal 'a=%5B10%5D', 'a' => '[10]'.html_safe
   end
 
   def test_nil_parameter_value


### PR DESCRIPTION
As follows from #1555 `ActiveSupport::SafeBuffer#sub/gsub` won't set method-local globals for block on 1.8 ruby.  

Because of that Hash#to_query breaks when safe string is used as key (underneath CGI.escape invokes gsub with block on all items of hash):

```
  >> { '^^'.html_safe => ':(' }.to_query
  NoMethodError: You have a nil object when you didn't expect it!
  You might have expected an instance of Array.
  The error occurred while evaluating nil.size
```

The fix is simple use `to_param` on key instead of `to_s` since it is an alias of `to_s` for simple objects and alias of `to_str` for `ActiveSupport::SafeBuffer`.

I've provided test to show behavior.
