### PR TITLE
Make sure video tags with multiple sources works with asset fingerprints.

### DIFF
--- a/actionpack/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helper.rb
@@ -412,7 +412,7 @@ module ActionView
 
         if sources.is_a?(Array)
           content_tag("video", options) do
-            sources.map { |source| tag("source", :src => source) }.join.html_safe
+            sources.map { |source| tag("source", :src => path_to_video(source)) }.join.html_safe
           end
         else
           options[:src] = path_to_video(sources)

--- a/actionpack/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helper.rb
@@ -412,7 +412,7 @@ module ActionView
 
         if sources.is_a?(Array)
           content_tag("video", options) do
-            sources.map { |source| tag("source", :src => path_to_video(source)) }.join.html_safe
+            sources.map { |source| tag("source", :src => path_to_video(source), :type => Mime::Type.lookup_by_extension(source.gsub(/^.*\./, ""))) }.join.html_safe
           end
         else
           options[:src] = path_to_video(sources)


### PR DESCRIPTION
When using a video_tag with multiple sources in production the files are not found if using the asset unique fingerprints. When source is not an array video_tag has the expected result.

Also, I want to add type attribute to each source. The final markup should be

``` html
<source src="/assets/video-afafsafa876fa8f76af6af7a6faaf8f6f.mp4" type="video/mp4" />
```
