### PR TITLE
When running plugin new the generated .gitignore should include non-project files in test dummy

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -39,7 +39,7 @@ module Rails
     end
 
     def gitignore
-      copy_file "gitignore", ".gitignore"
+      template "gitignore", ".gitignore"
     end
 
     def lib

--- a/railties/lib/rails/generators/rails/plugin_new/templates/gitignore
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/gitignore
@@ -1,6 +1,6 @@
 .bundle/
 log/*.log
 pkg/
-test/dummy/db/*.sqlite3
-test/dummy/log/*.log
-test/dummy/tmp/
+<%= dummy_path %>/db/*.sqlite3
+<%= dummy_path %>/log/*.log
+<%= dummy_path %>/tmp/

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -237,6 +237,20 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
     assert_no_file "test"
   end
 
+  def test_ensure_gitignore_file_includes_non_project_files_in_test_dummy
+    run_generator [destination_root]
+    assert_file ".gitignore", /test\/dummy\/db\/\*\.sqlite3/
+    assert_file ".gitignore", /test\/dummy\/log\/\*\.log/
+    assert_file ".gitignore", /test\/dummy\/tmp\//
+  end
+
+  def test_ensure_gitignore_file_includes_non_project_files_in_test_dummy_with_dummy_path
+    run_generator [destination_root, "--dummy_path", "spec/dummy"]
+    assert_file ".gitignore", /spec\/dummy\/db\/\*\.sqlite3/
+    assert_file ".gitignore", /spec\/dummy\/log\/\*\.log/
+    assert_file ".gitignore", /spec\/dummy\/tmp\//
+  end
+
   def test_skipping_test_unit
     run_generator [destination_root, "--skip-test-unit"]
     assert_no_file "test"


### PR DESCRIPTION
The current behavior is that the ignored non-project files are hardcoded to test/dummy in the generated .gitignore. The patch makes .gitignore a template and ensures that the test dummy directory corresponds to the supplied path if the --dummy-path option is supplied (or not).

I included a sanity check test that passes for the current behavior and one for the new behavior.

Mike

P.s. First time committing, hope things look OK. Thanks!
