### PR TITLE
Define sqlite3_version only when current_adapter is SQLite3Adapter.

### DIFF
--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -148,7 +148,7 @@ class QueryCacheTest < ActiveRecord::TestCase
 
   def test_cache_does_not_wrap_string_results_in_arrays
     require 'sqlite3/version' if current_adapter?(:SQLite3Adapter)
-    sqlite3_version = RUBY_PLATFORM =~ /java/ ? Jdbc::SQLite3::VERSION : SQLite3::VERSION
+    sqlite3_version = RUBY_PLATFORM =~ /java/ ? Jdbc::SQLite3::VERSION : SQLite3::VERSION if current_adapter?(:SQLite3Adapter)
 
     Task.cache do
       # Oracle adapter returns count() as Fixnum or Float


### PR DESCRIPTION
rake test fails when mysql, mysql2 and postgresql tested. It finishes successfully for sqlite.
because SQLite3::VERSION value cannot be get unless current adapter is SQLite3Adapter.

``` ruby

$ cd activerecord
$ rake test
... snip ...
Using mysql with Identity Map off

  1) Error:
test_cache_does_not_wrap_string_results_in_arrays(QueryCacheTest):
NameError: uninitialized constant QueryCacheTest::SQLite3
    /home/yahonda/Dropbox/git/rails/activerecord/test/cases/query_cache_test.rb:151:in `test_cache_does_not_wrap_string_results_in_arrays'
    /home/yahonda/.rvm/gems/ruby-1.9.2-p290@rails_master/gems/mocha-0.10.0/lib/mocha/integration/mini_test/version_142_to_172.rb:27:in `run'
    /home/yahonda/Dropbox/git/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:35:in `block in run'
    /home/yahonda/Dropbox/git/rails/activesupport/lib/active_support/callbacks.rb:408:in `_run_setup_callbacks'
    /home/yahonda/Dropbox/git/rails/activesupport/lib/active_support/callbacks.rb:81:in `run_callbacks'
    /home/yahonda/Dropbox/git/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:34:in `run'

3150 tests, 9670 assertions, 0 failures, 1 errors, 0 skips

... snip ...
Using mysql2 with Identity Map off

  1) Error:
test_cache_does_not_wrap_string_results_in_arrays(QueryCacheTest):
NameError: uninitialized constant QueryCacheTest::SQLite3
    /home/yahonda/Dropbox/git/rails/activerecord/test/cases/query_cache_test.rb:151:in `test_cache_does_not_wrap_string_results_in_arrays'
    /home/yahonda/.rvm/gems/ruby-1.9.2-p290@rails_master/gems/mocha-0.10.0/lib/mocha/integration/mini_test/version_142_to_172.rb:27:in `run'
    /home/yahonda/Dropbox/git/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:35:in `block in run'
    /home/yahonda/Dropbox/git/rails/activesupport/lib/active_support/callbacks.rb:408:in `_run_setup_callbacks'
    /home/yahonda/Dropbox/git/rails/activesupport/lib/active_support/callbacks.rb:81:in `run_callbacks'
    /home/yahonda/Dropbox/git/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:34:in `run'

3134 tests, 9638 assertions, 0 failures, 1 errors, 0 skips

... snip ...
Using postgresql with Identity Map off

  1) Error:
test_cache_does_not_wrap_string_results_in_arrays(QueryCacheTest):
NameError: uninitialized constant QueryCacheTest::SQLite3
    /home/yahonda/Dropbox/git/rails/activerecord/test/cases/query_cache_test.rb:151:in `test_cache_does_not_wrap_string_results_in_arrays'
    /home/yahonda/.rvm/gems/ruby-1.9.2-p290@rails_master/gems/mocha-0.10.0/lib/mocha/integration/mini_test/version_142_to_172.rb:27:in `run'
    /home/yahonda/Dropbox/git/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:35:in `block in run'
    /home/yahonda/Dropbox/git/rails/activesupport/lib/active_support/callbacks.rb:408:in `_run_setup_callbacks'
    /home/yahonda/Dropbox/git/rails/activesupport/lib/active_support/callbacks.rb:81:in `run_callbacks'
    /home/yahonda/Dropbox/git/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:34:in `run'

3218 tests, 9959 assertions, 0 failures, 1 errors, 0 skips

Test run options: --seed 3894
Errors running test_mysql, test_mysql2, test_postgresql
```
