### PR TITLE
V3.0.10 tweak to handle dumping schema for mysql column type "year" as int

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -79,7 +79,7 @@ module ActiveRecord
             else
               super # we could return 65535 here, but we leave it undecorated by default
             end
-          when /^enum$/i;     255
+          when /^enum/i;     255
           when /^bigint/i;    8
           when /^int/i;       4
           when /^mediumint/i; 3

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -79,6 +79,7 @@ module ActiveRecord
             else
               super # we could return 65535 here, but we leave it undecorated by default
             end
+          when /^enum$/i;     255
           when /^bigint/i;    8
           when /^int/i;       4
           when /^mediumint/i; 3

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -62,6 +62,7 @@ module ActiveRecord
         def simplified_type(field_type)
           return :boolean if MysqlAdapter.emulate_booleans && field_type.downcase.index("tinyint(1)")
           return :string  if field_type =~ /enum/i
+          return :integer  if field_type =~ /year/i
           super
         end
 


### PR DESCRIPTION
I have an app that is using a legacy db with "year" column types, not produced via migrations.

This change allows us to produce a schema file from the db.
