### PR TITLE
restore jquery-rails dependency to prevent 'couldn't find jquery' error in newly generated engines

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
 <% end -%>
 
   <%= '# ' if options.dev? || options.edge? -%>s.add_dependency "rails", "~> <%= Rails::VERSION::STRING %>"
-<% if full? && !options[:skip_javascript] -%>
-  # s.add_dependency "<%= "#{options[:javascript]}-rails" %>"
+<% if (mountable? || full?) && !options[:skip_javascript] -%>
+  s.add_dependency "<%= "#{options[:javascript]}-rails" %>"
 <% end -%>
 
   s.add_development_dependency "<%= gem_for_database %>"


### PR DESCRIPTION
restore jquery-rails dependency to prevent 'couldn't find jquery' error in newly generated Rails 3.1 engines (ref: [http://bit.ly/n65tsC](http://bit.ly/n65tsC)); enabled for mountable engines as well.
