### PR TITLE
FileStore key_file_path does not properly limit filenames to 255 characters

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -13,6 +13,7 @@ module ActiveSupport
       attr_reader :cache_path
 
       DIR_FORMATTER = "%03X"
+      FILENAME_MAX_SIZE = 230 # max filename size on file system is 255, minus room for timestamp and random characters appended by Tempfile (used by atomic write)
 
       def initialize(cache_path, options = nil)
         super(options)
@@ -129,15 +130,13 @@ module ActiveSupport
           hash, dir_1 = hash.divmod(0x1000)
           dir_2 = hash.modulo(0x1000)
           fname_paths = []
-          # Make sure file name is < 255 characters so it doesn't exceed file system limits.
-          if fname.size <= 255
-            fname_paths << fname
-          else
-            while fname.size <= 255
-              fname_path << fname[0, 255]
-              fname = fname[255, -1]
-            end
-          end
+        
+          # Make sure file name doesn't exceed file system limits.
+          begin
+            fname_paths << fname[0...FILENAME_MAX_SIZE]
+            fname = fname[FILENAME_MAX_SIZE..-1]
+          end until fname.blank?
+        
           File.join(cache_path, DIR_FORMATTER % dir_1, DIR_FORMATTER % dir_2, *fname_paths)
         end
 

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -557,6 +557,15 @@ class FileStoreTest < ActiveSupport::TestCase
     key = @cache_with_pathname.send(:key_file_path, "views/index?id=1")
     assert_equal "views/index?id=1", @cache_with_pathname.send(:file_path_key, key)
   end
+  
+  # Because file systems have a maximum filename size, filenames > max size should be split in to directories
+  # If filename is 'AAAAB', where max size is 4, the returned path should be AAAA/B
+  def test_key_transformation_max_filename_size
+    key = "#{'A' * ActiveSupport::Cache::FileStore::FILENAME_MAX_SIZE}B"
+    path = @cache.send(:key_file_path, key)    
+    assert path.split('/').all? { |dir_name| dir_name.size <= ActiveSupport::Cache::FileStore::FILENAME_MAX_SIZE}
+    assert_equal 'B', File.basename(path)
+  end
 end
 
 class MemoryStoreTest < ActiveSupport::TestCase

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -357,7 +357,7 @@ module CacheStoreBehavior
 
   def test_really_long_keys
     key = ""
-    1000.times{key << "x"}
+    900.times{key << "x"}
     assert_equal true, @cache.write(key, "bar")
     assert_equal "bar", @cache.read(key)
     assert_equal "bar", @cache.fetch(key)


### PR DESCRIPTION
A few problems with FileStore.

``` ruby
          # Make sure file name is < 255 characters so it doesn't exceed file system limits.
          if fname.size <= 255
            fname_paths << fname
          else
            while fname.size <= 255  #*** 1. This should be frame.size > 255
              fname_path << fname[0, 255]  #*** 2. The variable is called frame_paths not frame_path
              fname = fname[255, -1] #*** 3. This always returns nil, should be frame[255..-1]
            end
          end
```
1. The while loop here will never run because it should be fname.size > 255 not <=.  
2. The variable in the while loop should be fname_path**s** not fname_path
3. fname[255, -1] always returns nil, it should be using frame[255..-1]
4. File.atomic_write hooks into Tempfile, which automatically appends random characters to the end of the filename.  Since atomic_write is called after the filename is broken in to 255 character chunks, there is a chance that Tempfile will append extra characters to the filename so that it exceeds 255 characters.

**tldr; Refactored FileStore#key_file_path so that it properly splits the filename into directories when the filename is too long for the filesystem.**
