### PR TITLE
raise an appropriate ArgumentError when the date couldn't be parsed

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/string/conversions.rb
@@ -43,6 +43,8 @@ class String
   def to_date
     return nil if self.blank?
     ::Date.new(*::Date._parse(self, false).values_at(:year, :mon, :mday))
+  rescue NoMethodError
+    raise ArgumentError, "invalid date"
   end
 
   def to_datetime

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -179,6 +179,9 @@ class StringInflectionsTest < Test::Unit::TestCase
   def test_string_to_date
     assert_equal Date.new(2005, 2, 27), "2005-02-27".to_date
     assert_nil "".to_date
+    assert_raise(ArgumentError, "invalid date") do
+      "hello world".to_date
+    end
   end
 
   def test_access


### PR DESCRIPTION
Closes #3088

The error on 1.9.2 is raised here.
https://github.com/ruby/ruby/blob/ruby_1_9_2/lib/date.rb#L615

I'm going to send a pull request to fix this in ruby, but this pr has the goal to bring the fix to older versions or ruby too.
