### PR TITLE
Named routes are modifying passed options

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -165,13 +165,14 @@ module ActionDispatch
               remove_possible_method :#{selector}
               def #{selector}(*args)
                 options = args.extract_options!
+                result = #{options.inspect}
 
                 if args.any?
-                  options[:_positional_args] = args
-                  options[:_positional_keys] = #{route.segment_keys.inspect}
+                  result[:_positional_args] = args
+                  result[:_positional_keys] = #{route.segment_keys.inspect}
                 end
 
-                options ? #{options.inspect}.merge(options) : #{options.inspect}
+                result.merge(options)
               end
               protected :#{selector}
             END_EVAL

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -863,6 +863,17 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal original_options, options
   end
 
+  # tests the arguments modification free version of define_hash_access
+  def test_named_route_with_no_side_effects
+    original_options = { :host => 'test.host' }
+    options = original_options.dup
+
+    profile_customer_url("customer_model", options)
+
+    # verify that the options passed in have not changed from the original ones
+    assert_equal original_options, options
+  end
+
   def test_projects_status
     with_test_routes do
       assert_equal '/projects/status', url_for(:controller => 'projects', :action => 'status', :only_path => true)


### PR DESCRIPTION
When passing objects and options to named routes like profile_customer_url options are modified.
New keys are added: :_positional_args, :_positional_keys, because given options are first modified and then merged to returned hash.
This bug was introduced by version 3.1.0, this pull request corrects this behavior, it contains test and fixed code .
