### PR TITLE
Bump sqlite3 in Gemfile to 1.3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ platforms :ruby do
   gem "nokogiri", ">= 1.4.4"
 
   # AR
-  gem "sqlite3", "~> 1.3.3"
+  gem "sqlite3", "~> 1.3.4"
 
   group :db do
     gem "pg", ">= 0.11.0" unless ENV['TRAVIS'] # once pg is on travis this can be removed


### PR DESCRIPTION
ActiveRecord requires sqlite3 to be ~> "1.3.4", but the Gemfile says ~> "1.3.3". This is a commit to bump it so the tests run.
