### PR TITLE
safe_constantize

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -33,13 +33,26 @@ class String
 
   # +constantize+ tries to find a declared constant with the name specified
   # in the string. It raises a NameError when the name is not in CamelCase
-  # or is not initialized.
+  # or is not initialized.  See ActiveSupport::Inflector.constantize
   #
   # Examples
-  #   "Module".constantize # => Module
-  #   "Class".constantize  # => Class
+  #   "Module".constantize       # => Module
+  #   "Class".constantize        # => Class
+  #   "blargle".safe_constantize # => NameError: wrong constant name blargle
   def constantize
     ActiveSupport::Inflector.constantize(self)
+  end
+  
+  # +safe_constantize+ tries to find a declared constant with the name specified
+  # in the string. It returns nil when the name is not in CamelCase
+  # or is not initialized.  See ActiveSupport::Inflector.safe_constantize
+  #
+  # Examples
+  #   "Module".safe_constantize  # => Module
+  #   "Class".safe_constantize   # => Class
+  #   "blargle".safe_constantize # => nil
+  def safe_constantize
+    ActiveSupport::Inflector.safe_constantize(self)
   end
 
   # By default, +camelize+ converts strings to UpperCamelCase. If the argument to camelize

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -224,6 +224,33 @@ module ActiveSupport
       end
     end
 
+    # Tries to find a constant with the name specified in the argument string:
+    #
+    #   "Module".safe_constantize     # => Module
+    #   "Test::Unit".safe_constantize # => Test::Unit
+    #
+    # The name is assumed to be the one of a top-level constant, no matter whether
+    # it starts with "::" or not. No lexical context is taken into account:
+    #
+    #   C = 'outside'
+    #   module M
+    #     C = 'inside'
+    #     C                    # => 'inside'
+    #     "C".safe_constantize # => 'outside', same as ::C
+    #   end
+    #
+    # nil is returned when the name is not in CamelCase or the constant is
+    # unknown.
+    #
+    #   "blargle".safe_constantize  # => nil
+    def safe_constantize(camel_cased_word)
+      begin
+        camel_cased_word.constantize
+      rescue NameError
+        nil
+      end
+    end
+    
     # Turns a number into an ordinal string used to denote the position in an
     # ordered sequence such as 1st, 2nd, 3rd, 4th.
     #

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -182,46 +182,54 @@ module ActiveSupport
     end
 
     # Ruby 1.9 introduces an inherit argument for Module#const_get and
-    # #const_defined? and changes their default behavior.
+    # #const_defined? and changes their default behavior.  Used in
+    # constantize below.
     if Module.method(:const_get).arity == 1
-      # Tries to find a constant with the name specified in the argument string:
-      #
-      #   "Module".constantize     # => Module
-      #   "Test::Unit".constantize # => Test::Unit
-      #
-      # The name is assumed to be the one of a top-level constant, no matter whether
-      # it starts with "::" or not. No lexical context is taken into account:
-      #
-      #   C = 'outside'
-      #   module M
-      #     C = 'inside'
-      #     C               # => 'inside'
-      #     "C".constantize # => 'outside', same as ::C
-      #   end
-      #
-      # NameError is raised when the name is not in CamelCase or the constant is
-      # unknown.
-      def constantize(camel_cased_word)
-        names = camel_cased_word.split('::')
-        names.shift if names.empty? || names.first.empty?
-
-        constant = Object
-        names.each do |name|
-          constant = constant.const_defined?(name) ? constant.const_get(name) : constant.const_missing(name)
-        end
-        constant
+      def const_defined?(constant, name)
+        constant.const_defined?(name)
       end
     else
-      def constantize(camel_cased_word) #:nodoc:
-        names = camel_cased_word.split('::')
-        names.shift if names.empty? || names.first.empty?
-
-        constant = Object
-        names.each do |name|
-          constant = constant.const_defined?(name, false) ? constant.const_get(name) : constant.const_missing(name)
-        end
-        constant
+      def const_defined?(constant, name)
+        constant.const_defined?(name, false)
       end
+    end
+
+    private :const_defined?
+
+    # Tries to find a constant with the name specified in the argument string:
+    #
+    #   "Module".constantize     # => Module
+    #   "Test::Unit".constantize # => Test::Unit
+    #
+    # The name is assumed to be the one of a top-level constant, no matter whether
+    # it starts with "::" or not. No lexical context is taken into account:
+    #
+    #   C = 'outside'
+    #   module M
+    #     C = 'inside'
+    #     C               # => 'inside'
+    #     "C".constantize # => 'outside', same as ::C
+    #   end
+    #
+    # NameError is raised when the name is not in CamelCase or the constant is
+    # unknown.
+    def constantize(camel_cased_word)
+      names = camel_cased_word.split('::')
+      names.shift if names.empty? || names.first.empty?
+
+      constant = Object
+      names.each do |name|
+        constant = begin
+                     if const_defined?(constant, name)
+                       constant.const_get(name)
+                     else
+                       constant.const_missing(name)
+                     end
+                   rescue NameError => e
+                     raise NameError.new(e.message, camel_cased_word)
+                   end
+      end
+      constant
     end
 
     # Tries to find a constant with the name specified in the argument string:
@@ -244,10 +252,12 @@ module ActiveSupport
     #
     #   "blargle".safe_constantize  # => nil
     def safe_constantize(camel_cased_word)
-      begin
-        camel_cased_word.constantize
-      rescue NameError
+      camel_cased_word.constantize
+    rescue NameError => e
+      if e.name == camel_cased_word
         nil
+      else
+        raise e
       end
     end
     

--- a/activesupport/test/constantize_test_cases.rb
+++ b/activesupport/test/constantize_test_cases.rb
@@ -1,0 +1,31 @@
+module Ace
+  module Base
+    class Case
+    end
+  end
+end
+
+module ConstantizeTestCases
+  def run_constantize_tests_on
+    assert_nothing_raised { assert_equal Ace::Base::Case, yield("Ace::Base::Case") }
+    assert_nothing_raised { assert_equal Ace::Base::Case, yield("::Ace::Base::Case") }
+    assert_nothing_raised { assert_equal ConstantizeTestCases, yield("ConstantizeTestCases") }
+    assert_nothing_raised { assert_equal ConstantizeTestCases, yield("::ConstantizeTestCases") }
+    assert_raise(NameError) { yield("UnknownClass") }
+    assert_raise(NameError) { yield("An invalid string") }
+    assert_raise(NameError) { yield("InvalidClass\n") }
+    assert_raise(NameError) { yield("Ace::Base::ConstantizeTestCases") }
+  end
+  
+  def run_safe_constantize_tests_on
+    assert_nothing_raised { assert_equal Ace::Base::Case, yield("Ace::Base::Case") }
+    assert_nothing_raised { assert_equal Ace::Base::Case, yield("::Ace::Base::Case") }
+    assert_nothing_raised { assert_equal ConstantizeTestCases, yield("ConstantizeTestCases") }
+    assert_nothing_raised { assert_equal ConstantizeTestCases, yield("::ConstantizeTestCases") }
+    assert_nothing_raised { assert_equal nil, yield("UnknownClass") }
+    assert_nothing_raised { assert_equal nil, yield("An invalid string") }
+    assert_nothing_raised { assert_equal nil, yield("InvalidClass\n") }
+    assert_nothing_raised { assert_equal nil, yield("blargle") }
+    assert_nothing_raised { assert_equal nil, yield("Ace::Base::ConstantizeTestCases") }
+  end
+end

--- a/activesupport/test/constantize_test_cases.rb
+++ b/activesupport/test/constantize_test_cases.rb
@@ -15,6 +15,14 @@ module ConstantizeTestCases
     assert_raise(NameError) { yield("An invalid string") }
     assert_raise(NameError) { yield("InvalidClass\n") }
     assert_raise(NameError) { yield("Ace::Base::ConstantizeTestCases") }
+    
+    # any NameError it raises should have name set to the full specified String (not just part of it)
+    begin
+      yield("Ace::Base::Blargle")
+      assert false
+    rescue NameError => e
+      assert_equal "Ace::Base::Blargle", e.name
+    end
   end
   
   def run_safe_constantize_tests_on
@@ -27,5 +35,14 @@ module ConstantizeTestCases
     assert_nothing_raised { assert_equal nil, yield("InvalidClass\n") }
     assert_nothing_raised { assert_equal nil, yield("blargle") }
     assert_nothing_raised { assert_equal nil, yield("Ace::Base::ConstantizeTestCases") }
+    
+    # should re-raise any NameError it encounters that doesn't correspond to the specified String
+    NameError.any_instance.stubs(:name).returns("not-blargle")
+    begin
+      yield("blargle")
+      assert false
+    rescue NameError => e
+      assert_equal "not-blargle", e.name
+    end
   end
 end

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -2,6 +2,7 @@
 require 'date'
 require 'abstract_unit'
 require 'inflector_test_cases'
+require 'constantize_test_cases'
 
 require 'active_support/inflector'
 require 'active_support/core_ext/string'
@@ -9,9 +10,17 @@ require 'active_support/time'
 require 'active_support/core_ext/string/strip'
 require 'active_support/core_ext/string/output_safety'
 
+module Ace
+  module Base
+    class Case
+    end
+  end
+end
+
 class StringInflectionsTest < Test::Unit::TestCase
   include InflectorTestCases
-
+  include ConstantizeTestCases
+  
   def test_erb_escape
     string = [192, 60].pack('CC')
     expected = 192.chr + "&lt;"
@@ -290,6 +299,18 @@ class StringInflectionsTest < Test::Unit::TestCase
     def test_truncate_multibyte
       assert_equal "\354\225\204\353\246\254\353\236\221 \354\225\204\353\246\254 ...".force_encoding('UTF-8'),
         "\354\225\204\353\246\254\353\236\221 \354\225\204\353\246\254 \354\225\204\353\235\274\353\246\254\354\230\244".force_encoding('UTF-8').truncate(10)
+    end
+  end
+  
+  def test_constantize
+    run_constantize_tests_on do |string|
+      string.constantize
+    end
+  end
+  
+  def test_safe_constantize
+    run_safe_constantize_tests_on do |string|
+      string.safe_constantize
     end
   end
 end

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -2,16 +2,11 @@ require 'abstract_unit'
 require 'active_support/inflector'
 
 require 'inflector_test_cases'
-
-module Ace
-  module Base
-    class Case
-    end
-  end
-end
+require 'constantize_test_cases'
 
 class InflectorTest < Test::Unit::TestCase
   include InflectorTestCases
+  include ConstantizeTestCases
 
   def test_pluralize_plurals
     assert_equal "plurals", ActiveSupport::Inflector.pluralize("plurals")
@@ -282,17 +277,15 @@ class InflectorTest < Test::Unit::TestCase
   end
 
   def test_constantize
-    assert_nothing_raised { assert_equal Ace::Base::Case, ActiveSupport::Inflector.constantize("Ace::Base::Case") }
-    assert_nothing_raised { assert_equal Ace::Base::Case, ActiveSupport::Inflector.constantize("::Ace::Base::Case") }
-    assert_nothing_raised { assert_equal InflectorTest, ActiveSupport::Inflector.constantize("InflectorTest") }
-    assert_nothing_raised { assert_equal InflectorTest, ActiveSupport::Inflector.constantize("::InflectorTest") }
-    assert_raise(NameError) { ActiveSupport::Inflector.constantize("UnknownClass") }
-    assert_raise(NameError) { ActiveSupport::Inflector.constantize("An invalid string") }
-    assert_raise(NameError) { ActiveSupport::Inflector.constantize("InvalidClass\n") }
+    run_constantize_tests_on do |string|
+      ActiveSupport::Inflector.constantize(string)
+    end
   end
-
-  def test_constantize_does_lexical_lookup
-    assert_raise(NameError) { ActiveSupport::Inflector.constantize("Ace::Base::InflectorTest") }
+  
+  def test_safe_constantize
+    run_safe_constantize_tests_on do |string|
+      ActiveSupport::Inflector.safe_constantize(string)
+    end
   end
 
   def test_ordinal


### PR DESCRIPTION
`safe_constantize` is similar to `constantize` except that it returns `nil` when the given `String` does not correspond to a defined constant (instead of raising a `NameError`).  This was inspired by some discussion around my proposal for a `String#is_a_class_name?` method.  José Valim suggested `safe_constantize` as more flexible alternative to `is_a_class_name?`-- the equivalent syntax would be `my_string.safe_constantize.is_a?(Class)`.

I also refactored the `ActiveSupport::Inflector.*constantize` tests so that both the `ActiveSupport::Inflector` and the `String` `*constantize` methods are tested.
