### PR TITLE
ActiveModel JSON serialization bug fix

### DIFF
--- a/activemodel/lib/active_model/serializers/json.rb
+++ b/activemodel/lib/active_model/serializers/json.rb
@@ -88,19 +88,17 @@ module ActiveModel
       #                    "title": "So I was thinking"}]}
 
       def as_json(options = nil)
-        hash = serializable_hash(options)
-
-        include_root = include_root_in_json
-        if options.try(:key?, :root)
-          include_root = options[:root]
+        opts_root = options[:root] if options.try(:key?, :root)
+        if opts_root
+          custom_root = opts_root == true ? self.class.model_name.element : opts_root
+          { custom_root => serializable_hash(options) }
+        elsif opts_root == false
+          serializable_hash(options)
+        elsif include_root_in_json
+          { self.class.model_name.element => serializable_hash(options) }
+        else
+          serializable_hash(options)
         end
-
-        if include_root
-          custom_root = options && options[:root]
-          hash = { custom_root || self.class.model_name.element => hash }
-        end
-
-        hash
       end
 
       def from_json(json, include_root=include_root_in_json)

--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -56,6 +56,16 @@ class JsonSerializationTest < ActiveModel::TestCase
     end
   end
 
+  test "should include root in json (option) even if the default is set to false" do
+    begin
+      Contact.include_root_in_json = false
+      json = @contact.to_json(:root => true)
+      assert_match %r{^\{"contact":\{}, json
+    ensure
+      Contact.include_root_in_json = true
+    end
+  end
+
   test "should not include root in json (option)" do
 
     json = @contact.to_json(:root => false)


### PR DESCRIPTION
I fixed a bug with the json serialization when the class setting is set to not include the root, but an instance is serialized with the root option passed as true.

Test added, existing tests were unmodified and are still passing.
