### PR TITLE
Added option to pass block to link_to_function

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -241,8 +241,8 @@ module ActionDispatch
         end
 
         # Performs the actual request.
-        def process(method, path, parameters = nil, env = nil)
-          env ||= {}
+        def process(method, path, parameters = nil, rack_env = nil)
+          rack_env ||= {}
           if path =~ %r{://}
             location = URI.parse(path)
             https! URI::HTTPS === location if location.scheme
@@ -258,7 +258,7 @@ module ActionDispatch
 
           hostname, port = host.split(':')
 
-          default_env = {
+          env = {
             :method => method,
             :params => parameters,
 
@@ -276,7 +276,7 @@ module ActionDispatch
 
           session = Rack::Test::Session.new(_mock_session)
 
-          env.reverse_merge!(default_env)
+          env.merge!(rack_env)
 
           # NOTE: rack-test v0.5 doesn't build a default uri correctly
           # Make sure requested path is always a full uri

--- a/actionpack/lib/action_view/helpers/javascript_helper.rb
+++ b/actionpack/lib/action_view/helpers/javascript_helper.rb
@@ -101,7 +101,7 @@ module ActionView
       #
       # You can use a block as well if your link target is hard to fit into the name parameter. ERB example:
       #
-      #   <%= link_to_function "alert('Hello there!')", :class => "nav_link" %>
+      #   <%= link_to_function "alert('Hello there!')", :class => "nav_link" do %>
       #     Hello, <strong><%= @profile.name %></strong>
       #   <% end %>
       #   # => <a class="nav_link" href="#" onclick="alert('Hello there!'); return false;">

--- a/actionpack/lib/action_view/helpers/javascript_helper.rb
+++ b/actionpack/lib/action_view/helpers/javascript_helper.rb
@@ -89,8 +89,8 @@ module ActionView
 
       # Returns a link whose +onclick+ handler triggers the passed JavaScript.
       #
-      # The helper receives a name, JavaScript code, and an optional hash of HTML options. The
-      # name is used as the link text and the JavaScript code goes into the +onclick+ attribute.
+      # The helper receives a name or block, JavaScript code, and an optional hash of HTML options. The
+      # name is used as the link text or you can pass a block, and the JavaScript code goes into the +onclick+ attribute.
       # If +html_options+ has an <tt>:onclick</tt>, that one is put before +function+. Once all
       # the JavaScript is set, the helper appends "; return false;".
       #
@@ -99,7 +99,24 @@ module ActionView
       #   link_to_function "Greeting", "alert('Hello world!')", :class => "nav_link"
       #   # => <a class="nav_link" href="#" onclick="alert('Hello world!'); return false;">Greeting</a>
       #
-      def link_to_function(name, function, html_options={})
+      # You can use a block as well if your link target is hard to fit into the name parameter. ERB example:
+      #
+      #   <%= link_to_function "alert('Hello there!')", :class => "nav_link" %>
+      #     Hello, <strong><%= @profile.name %></strong>
+      #   <% end %>
+      #   # => <a class="nav_link" href="#" onclick="alert('Hello there!'); return false;">
+      #          Hello, <strong>David</strong>
+      #        </a>
+      #
+      def link_to_function(*args, &block)
+        if block_given?
+          return link_to_function(capture(&block), *args)
+        end
+
+        name         = args.first
+        function     = args.second
+        html_options = args.third || {}
+
         onclick = "#{"#{html_options[:onclick]}; " if html_options[:onclick]}#{function}; return false;"
         href = html_options[:href] || '#'
 

--- a/actionpack/lib/sprockets/assets.rake
+++ b/actionpack/lib/sprockets/assets.rake
@@ -1,9 +1,6 @@
 namespace :assets do
   desc "Compile all the assets named in config.assets.precompile"
   task :precompile do
-    # let rails know we're precompiling assets
-    ENV["RAILS_ASSETS_PRECOMPILE"] = 'true'
-
     # We need to do this dance because RAILS_GROUPS is used
     # too early in the boot process and changing here is already too late.
     if ENV["RAILS_GROUPS"].to_s.empty? || ENV["RAILS_ENV"].to_s.empty?

--- a/actionpack/lib/sprockets/assets.rake
+++ b/actionpack/lib/sprockets/assets.rake
@@ -11,8 +11,9 @@ namespace :assets do
       ENV["RAILS_ENV"]    ||= "production"
       Kernel.exec $0, *ARGV
     else
-      Rake::Task["environment"].invoke
       Rake::Task["tmp:cache:clear"].invoke
+      Rails.application.initialize!(:assets)
+      Sprockets::Bootstrap.new(Rails.application).run
 
       # Ensure that action view is loaded and the appropriate sprockets hooks get executed
       ActionView::Base

--- a/actionpack/lib/sprockets/bootstrap.rb
+++ b/actionpack/lib/sprockets/bootstrap.rb
@@ -1,0 +1,65 @@
+module Sprockets
+  class Bootstrap
+    def initialize(app)
+      @app = app
+    end
+
+    # TODO: Get rid of config.assets.enabled
+    def run
+      app, config = @app, @app.config
+      return unless app.assets
+
+      config.assets.paths.each { |path| app.assets.append_path(path) }
+
+      if config.assets.compress
+        # temporarily hardcode default JS compressor to uglify. Soon, it will work
+        # the same as SCSS, where a default plugin sets the default.
+        unless config.assets.js_compressor == false
+          app.assets.js_compressor = LazyCompressor.new { expand_js_compressor(config.assets.js_compressor || :uglifier) }
+        end
+
+        unless config.assets.css_compressor == false
+          app.assets.css_compressor = LazyCompressor.new { expand_css_compressor(config.assets.css_compressor) }
+        end
+      end
+
+      if config.assets.compile
+        app.routes.prepend do
+          mount app.assets => config.assets.prefix
+        end
+      end
+
+      if config.assets.digest
+        app.assets = app.assets.index
+      end
+    end
+
+    protected
+
+    def expand_js_compressor(sym)
+      case sym
+      when :closure
+        require 'closure-compiler'
+        Closure::Compiler.new
+      when :uglifier
+        require 'uglifier'
+        Uglifier.new
+      when :yui
+        require 'yui/compressor'
+        YUI::JavaScriptCompressor.new
+      else
+        sym
+      end
+    end
+
+    def expand_css_compressor(sym)
+      case sym
+      when :yui
+        require 'yui/compressor'
+        YUI::CssCompressor.new
+      else
+        sym
+      end
+    end
+  end
+end

--- a/actionpack/lib/sprockets/railtie.rb
+++ b/actionpack/lib/sprockets/railtie.rb
@@ -1,5 +1,6 @@
 module Sprockets
-  autoload :Helpers, "sprockets/helpers"
+  autoload :Bootstrap,      "sprockets/bootstrap"
+  autoload :Helpers,        "sprockets/helpers"
   autoload :LazyCompressor, "sprockets/compressors"
   autoload :NullCompressor, "sprockets/compressors"
   autoload :StaticCompiler, "sprockets/static_compiler"
@@ -12,7 +13,7 @@ module Sprockets
       load "sprockets/assets.rake"
     end
 
-    initializer "sprockets.environment" do |app|
+    initializer "sprockets.environment", :group => :assets do |app|
       config = app.config
       next unless config.assets.enabled
 
@@ -51,59 +52,7 @@ module Sprockets
     # are compiled, and so that other Railties have an opportunity to
     # register compressors.
     config.after_initialize do |app|
-      next unless app.assets
-      config = app.config
-
-      config.assets.paths.each { |path| app.assets.append_path(path) }
-
-      if config.assets.compress
-        # temporarily hardcode default JS compressor to uglify. Soon, it will work
-        # the same as SCSS, where a default plugin sets the default.
-        unless config.assets.js_compressor == false
-          app.assets.js_compressor = LazyCompressor.new { expand_js_compressor(config.assets.js_compressor || :uglifier) }
-        end
-
-        unless config.assets.css_compressor == false
-          app.assets.css_compressor = LazyCompressor.new { expand_css_compressor(config.assets.css_compressor) }
-        end
-      end
-
-      if config.assets.compile
-        app.routes.prepend do
-          mount app.assets => config.assets.prefix
-        end
-      end
-
-      if config.assets.digest
-        app.assets = app.assets.index
-      end
+      Sprockets::Bootstrap.new(app).run
     end
-
-    protected
-      def expand_js_compressor(sym)
-        case sym
-        when :closure
-          require 'closure-compiler'
-          Closure::Compiler.new
-        when :uglifier
-          require 'uglifier'
-          Uglifier.new
-        when :yui
-          require 'yui/compressor'
-          YUI::JavaScriptCompressor.new
-        else
-          sym
-        end
-      end
-
-      def expand_css_compressor(sym)
-        case sym
-        when :yui
-          require 'yui/compressor'
-          YUI::CssCompressor.new
-        else
-          sym
-        end
-      end
   end
 end

--- a/actionpack/lib/sprockets/static_compiler.rb
+++ b/actionpack/lib/sprockets/static_compiler.rb
@@ -1,5 +1,4 @@
 require 'fileutils'
-require 'pathname'
 
 module Sprockets
   class StaticCompiler
@@ -26,8 +25,8 @@ module Sprockets
 
     def compile(asset)
       asset_path = digest_asset(asset)
-      filename = target.join(asset_path)
-      FileUtils.mkdir_p filename.dirname
+      filename = File.join(target, asset_path)
+      FileUtils.mkdir_p File.dirname(filename)
       asset.write_to(filename)
       asset.write_to("#{filename}.gz") if filename.to_s =~ /\.(css|js)$/
       asset_path

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -493,7 +493,7 @@ class ApplicationIntegrationTest < ActionDispatch::IntegrationTest
 
   routes.draw do
     match '',    :to => 'application_integration_test/test#index', :as => :empty_string
-    
+
     match 'foo', :to => 'application_integration_test/test#index', :as => :foo
     match 'bar', :to => 'application_integration_test/test#index', :as => :bar
   end
@@ -511,7 +511,7 @@ class ApplicationIntegrationTest < ActionDispatch::IntegrationTest
   test "route helpers after controller access" do
     get '/'
     assert_equal '/', empty_string_path
-    
+
     get '/foo'
     assert_equal '/foo', foo_path
 
@@ -528,11 +528,10 @@ class ApplicationIntegrationTest < ActionDispatch::IntegrationTest
     assert_raise(NameError) { missing_path }
   end
 
-  test "process reuse the env we pass as argument" do
+  test "process do not modify the env passed as argument" do
     env = { :SERVER_NAME => 'server', 'action_dispatch.custom' => 'custom' }
+    old_env = env.dup
     get '/foo', nil, env
-    assert_equal :get, env[:method]
-    assert_equal 'server', env[:SERVER_NAME]
-    assert_equal 'custom', env['action_dispatch.custom']
+    assert_equal old_env, env
   end
 end

--- a/actionpack/test/template/javascript_helper_test.rb
+++ b/actionpack/test/template/javascript_helper_test.rb
@@ -4,6 +4,8 @@ require 'active_support/core_ext/string/encoding'
 class JavaScriptHelperTest < ActionView::TestCase
   tests ActionView::Helpers::JavaScriptHelper
 
+  include RenderERBUtils
+
   def _evaluate_assigns_and_ivars() end
 
   attr_accessor :formats, :output_buffer
@@ -73,6 +75,11 @@ class JavaScriptHelperTest < ActionView::TestCase
   def test_function_with_href
     assert_dom_equal %(<a href="http://example.com/" onclick="alert('Hello world!'); return false;">Greeting</a>),
       link_to_function("Greeting", "alert('Hello world!')", :href => 'http://example.com/')
+  end
+
+  def test_link_to_function_tag_using_block_in_erb
+    out = render_erb %{<%= link_to_function("alert('Hello world!')", :href => "http://example.com") do %>Example site<% end %>}
+    assert_equal '<a href="http://example.com" onclick="alert(\'Hello world!\'); return false;">Example site</a>', out
   end
 
   def test_javascript_tag

--- a/railties/CHANGELOG
+++ b/railties/CHANGELOG
@@ -10,6 +10,18 @@
 
 * Removed old 'config.paths.app.controller' API in favor of 'config.paths["app/controller"]' API. [Guillermo Iguaran]
 
+
+*Rails 3.1.1
+
+* `rake assets:precompile` loads the application but does not initialize it.
+
+  To the app developer, this means configuration add in
+  config/initializers/* will not be executed.
+
+  Plugins developers need to special case their initializers that are
+  meant to be run in the assets group by adding :group => :assets.
+
+
 *Rails 3.1.0 (August 30, 2011)*
 
 * The default database schema file is written as UTF-8. [Aaron Patterson]

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -83,7 +83,6 @@ module Rails
       require environment if environment
     end
 
-
     def reload_routes!
       routes_reloader.reload!
     end
@@ -92,9 +91,9 @@ module Rails
       @routes_reloader ||= RoutesReloader.new
     end
 
-    def initialize!
+    def initialize!(group=nil)
       raise "Application has been already initialized." if @initialized
-      run_initializers(self)
+      run_initializers(group, self)
       @initialized = true
       self
     end

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -7,21 +7,21 @@ module Rails
     module Bootstrap
       include Initializable
 
-      initializer :load_environment_hook do end
+      initializer :load_environment_hook, :group => :all do end
 
-      initializer :load_active_support do
+      initializer :load_active_support, :group => :all do
         require "active_support/all" unless config.active_support.bare
       end
 
       # Preload all frameworks specified by the Configuration#frameworks.
       # Used by Passenger to ensure everything's loaded before forking and
       # to avoid autoload race conditions in JRuby.
-      initializer :preload_frameworks do
+      initializer :preload_frameworks, :group => :all do
         ActiveSupport::Autoload.eager_autoload! if config.preload_frameworks
       end
 
       # Initialize the logger early in the stack in case we need to log some deprecation.
-      initializer :initialize_logger do
+      initializer :initialize_logger, :group => :all do
         Rails.logger ||= config.logger || begin
           path = config.paths["log"].first
           logger = ActiveSupport::BufferedLogger.new(path)
@@ -41,7 +41,7 @@ module Rails
       end
 
       # Initialize cache early in the stack so railties can make use of it.
-      initializer :initialize_cache do
+      initializer :initialize_cache, :group => :all do
         unless defined?(RAILS_CACHE)
           silence_warnings { Object.const_set "RAILS_CACHE", ActiveSupport::Cache.lookup_store(config.cache_store) }
 
@@ -51,7 +51,7 @@ module Rails
         end
       end
 
-      initializer :set_clear_dependencies_hook do
+      initializer :set_clear_dependencies_hook, :group => :all do
         ActionDispatch::Reloader.to_cleanup do
           ActiveSupport::DescendantsTracker.clear
           ActiveSupport::Dependencies.clear
@@ -60,11 +60,11 @@ module Rails
 
       # Sets the dependency loading mechanism.
       # TODO: Remove files from the $" and always use require.
-      initializer :initialize_dependency_mechanism do
+      initializer :initialize_dependency_mechanism, :group => :all do
         ActiveSupport::Dependencies.mechanism = config.cache_classes ? :require : :load
       end
 
-      initializer :bootstrap_hook do |app|
+      initializer :bootstrap_hook, :group => :all do |app|
         ActiveSupport.run_load_hooks(:before_initialize, app)
       end
     end

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -537,12 +537,12 @@ module Rails
       end
     end
 
-    initializer :load_environment_config, :before => :load_environment_hook do
+    initializer :load_environment_config, :before => :load_environment_hook, :group => :all do
       environment = paths["config/environments"].existent.first
       require environment if environment
     end
 
-    initializer :append_assets_path do |app|
+    initializer :append_assets_path, :group => :assets do |app|
       app.config.assets.paths.unshift(*paths["vendor/assets"].existent_directories)
       app.config.assets.paths.unshift(*paths["lib/assets"].existent_directories)
       app.config.assets.paths.unshift(*paths["app/assets"].existent_directories)

--- a/railties/lib/rails/initializable.rb
+++ b/railties/lib/rails/initializable.rb
@@ -21,6 +21,10 @@ module Rails
         @options[:after]
       end
 
+      def belongs_to?(group)
+        @options[:group] == group || @options[:group] == :all
+      end
+
       def run(*args)
         @context.instance_exec(*args, &block)
       end
@@ -44,10 +48,10 @@ module Rails
       end
     end
 
-    def run_initializers(*args)
+    def run_initializers(group=nil, *args)
       return if instance_variable_defined?(:@ran)
       initializers.tsort.each do |initializer|
-        initializer.run(*args)
+        initializer.run(*args) if group.nil? || initializer.belongs_to?(group)
       end
       @ran = true
     end

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -106,16 +106,6 @@ module ApplicationTests
       assert !File.exists?("#{app_path}/public/assets/something.min.css")
     end
 
-    test "precompile sets flag notifying rails its precompiling" do
-      add_to_config = <<-RUBY
-        initializer :check_assets_precompile, :group => :assets do
-          raise "ENV RAILS_ASSETS_PRECOMPILE not set" unless ENV["RAILS_ASSETS_PRECOMPILE"]
-        end
-      RUBY
-      precompile!
-      assert $?.success?
-    end
-
     test "asset pipeline should use a Sprockets::Index when config.assets.digest is true" do
       add_to_config "config.assets.digest = true"
       add_to_config "config.action_controller.perform_caching = false"

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -21,6 +21,12 @@ module ApplicationTests
       @app ||= Rails.application
     end
 
+    def precompile!
+      capture(:stdout) do
+        Dir.chdir(app_path){ `bundle exec rake assets:precompile` }
+      end
+    end
+
     test "assets routes have higher priority" do
       app_file "app/assets/javascripts/demo.js.erb", "<%= :alert %>();"
 
@@ -38,7 +44,7 @@ module ApplicationTests
 
     test "assets do not require compressors until it is used" do
       app_file "app/assets/javascripts/demo.js.erb", "<%= :alert %>();"
-      app_file "config/initializers/compile.rb", "Rails.application.config.assets.compile = true"
+      add_to_env_config "production", "config.assets.compile = true"
 
       ENV["RAILS_ENV"] = "production"
       require "#{app_path}/config/environment"
@@ -54,9 +60,8 @@ module ApplicationTests
       app_file "app/assets/javascripts/foo/application.js", "alert();"
 
       ENV["RAILS_ENV"] = nil
-      capture(:stdout) do
-        Dir.chdir(app_path){ `bundle exec rake assets:precompile` }
-      end
+      precompile!
+
       files = Dir["#{app_path}/public/assets/application-*.js"]
       files << Dir["#{app_path}/public/assets/foo/application-*.js"].first
       files.each do |file|
@@ -80,13 +85,12 @@ module ApplicationTests
                                "happy.happy.face.png", "happy", "happy.face", "-happyface",
                                "-happy.png", "-happy.face.png", "_happyface", "_happy.face.png",
                                "_happy.png"]
+
       images_should_compile.each do |filename|
         app_file "app/assets/images/#{filename}", "happy"
       end
 
-      capture(:stdout) do
-        Dir.chdir(app_path){ `bundle exec rake assets:precompile` }
-      end
+      precompile!
 
       images_should_compile.each do |filename|
         assert File.exists?("#{app_path}/public/assets/#{filename}")
@@ -103,11 +107,12 @@ module ApplicationTests
     end
 
     test "precompile sets flag notifying rails its precompiling" do
-      compile = <<COMPILE
-raise "ENV RAILS_ASSETS_PRECOMPILE not set" unless ENV["RAILS_ASSETS_PRECOMPILE"]
-COMPILE
-      app_file "config/initializers/compile.rb", compile
-      Dir.chdir(app_path){ `bundle exec rake assets:precompile` }
+      add_to_config = <<-RUBY
+        initializer :check_assets_precompile, :group => :assets do
+          raise "ENV RAILS_ASSETS_PRECOMPILE not set" unless ENV["RAILS_ASSETS_PRECOMPILE"]
+        end
+      RUBY
+      precompile!
       assert $?.success?
     end
 
@@ -127,9 +132,7 @@ COMPILE
       # digest is default in false, we must enable it for test environment
       add_to_config "config.assets.digest = true"
 
-      capture(:stdout) do
-        Dir.chdir(app_path){ `bundle exec rake assets:precompile` }
-      end
+      precompile!
 
       manifest = "#{app_path}/public/assets/manifest.yml"
 
@@ -146,9 +149,7 @@ COMPILE
       add_to_config "config.assets.manifest = '#{app_path}/shared'"
       FileUtils.mkdir "#{app_path}/shared"
 
-      capture(:stdout) do
-        Dir.chdir(app_path){ `bundle exec rake assets:precompile` }
-      end
+      precompile!
 
       manifest = "#{app_path}/shared/manifest.yml"
 
@@ -164,9 +165,7 @@ COMPILE
       add_to_config "config.assets.digest = true"
       add_to_config "config.assets.prefix = '/x'"
 
-      capture(:stdout) do
-        Dir.chdir(app_path){ `bundle exec rake assets:precompile` }
-      end
+      precompile!
 
       manifest = "#{app_path}/public/x/manifest.yml"
       assets = YAML.load_file(manifest)
@@ -178,9 +177,7 @@ COMPILE
       app_file "app/assets/javascripts/application.js", "alert();"
       add_to_config "config.assets.digest = false"
 
-      capture(:stdout) do
-        Dir.chdir(app_path){ `bundle exec rake assets:precompile` }
-      end
+      precompile!
 
       assert File.exists?("#{app_path}/public/assets/application.js")
       assert File.exists?("#{app_path}/public/assets/application.css")
@@ -194,12 +191,11 @@ COMPILE
 
     test "assets do not require any assets group gem when manifest file is present" do
       app_file "app/assets/javascripts/application.js", "alert();"
-      app_file "config/initializers/serve_static_assets.rb", "Rails.application.config.serve_static_assets = true"
+      add_to_env_config "production", "config.serve_static_assets = true"
 
       ENV["RAILS_ENV"] = "production"
-      capture(:stdout) do
-        Dir.chdir(app_path){ `bundle exec rake assets:precompile` }
-      end
+      precompile!
+
       manifest = "#{app_path}/public/assets/manifest.yml"
       assets = YAML.load_file(manifest)
       asset_path = assets["application.js"]
@@ -223,9 +219,7 @@ COMPILE
       RUBY
 
       ENV["RAILS_ENV"] = "production"
-      capture(:stdout) do
-        Dir.chdir(app_path){ `bundle exec rake assets:precompile` }
-      end
+      precompile!
 
       # Create file after of precompile
       app_file "app/assets/javascripts/app.js", "alert();"
@@ -249,9 +243,7 @@ COMPILE
       RUBY
 
       ENV["RAILS_ENV"] = "development"
-      capture(:stdout) do
-        Dir.chdir(app_path){ `bundle exec rake assets:precompile` }
-      end
+      precompile!
 
       # Create file after of precompile
       app_file "app/assets/javascripts/app.js", "alert();"
@@ -292,10 +284,7 @@ COMPILE
       app_file "app/assets/images/レイルズ.png", "not a image really"
       add_to_config "config.assets.precompile = [ /\.png$$/, /application.(css|js)$/ ]"
 
-      capture(:stdout) do
-        Dir.chdir(app_path){ `bundle exec rake assets:precompile` }
-      end
-
+      precompile!
       assert File.exists?("#{app_path}/public/assets/レイルズ.png")
 
       manifest = "#{app_path}/public/assets/manifest.yml"
@@ -366,6 +355,51 @@ COMPILE
       get "/assets/demo.js"
       assert_match "alert();", last_response.body
       assert_equal 200, last_response.status
+    end
+
+    test "assets are concatenated when debug is off and compile is off either if debug_assets param is provided" do
+      app_with_assets_in_view
+
+      # config.assets.debug and config.assets.compile are false for production environment
+      ENV["RAILS_ENV"] = "production"
+      precompile!
+
+      require "#{app_path}/config/environment"
+
+      class ::PostsController < ActionController::Base ; end
+
+      # the debug_assets params isn't used if compile is off
+      get '/posts?debug_assets=true'
+      assert_match(/<script src="\/assets\/application-([0-z]+)\.js" type="text\/javascript"><\/script>/, last_response.body)
+      assert_no_match(/<script src="\/assets\/xmlhr-([0-z]+)\.js" type="text\/javascript"><\/script>/, last_response.body)
+    end
+
+    test "assets aren't concatened when compile is true is on and debug_assets params is true" do
+      app_with_assets_in_view
+      add_to_env_config "production", "config.assets.compile  = true"
+      add_to_env_config "production", "config.assets.allow_debugging = true"
+
+      ENV["RAILS_ENV"] = "production"
+      require "#{app_path}/config/environment"
+
+      class ::PostsController < ActionController::Base ; end
+
+      get '/posts?debug_assets=true'
+      assert_match(/<script src="\/assets\/application-([0-z]+)\.js\?body=1" type="text\/javascript"><\/script>/, last_response.body)
+      assert_match(/<script src="\/assets\/xmlhr-([0-z]+)\.js\?body=1" type="text\/javascript"><\/script>/, last_response.body)
+    end
+
+    private
+    def app_with_assets_in_view
+      app_file "app/assets/javascripts/application.js", "//= require_tree ."
+      app_file "app/assets/javascripts/xmlhr.js", "function f1() { alert(); }"
+      app_file "app/views/posts/index.html.erb", "<%= javascript_include_tag 'application' %>"
+
+      app_file "config/routes.rb", <<-RUBY
+        AppTemplate::Application.routes.draw do
+          match '/posts', :to => "posts#index"
+        end
+      RUBY
     end
   end
 end

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -123,7 +123,6 @@ module ApplicationTests
       add_to_config "config.assets.digest = true"
 
       precompile!
-
       manifest = "#{app_path}/public/assets/manifest.yml"
 
       assets = YAML.load_file(manifest)
@@ -137,17 +136,14 @@ module ApplicationTests
       # digest is default in false, we must enable it for test environment
       add_to_config "config.assets.digest = true"
       add_to_config "config.assets.manifest = '#{app_path}/shared'"
-      FileUtils.mkdir "#{app_path}/shared"
 
       precompile!
-
       manifest = "#{app_path}/shared/manifest.yml"
 
       assets = YAML.load_file(manifest)
       assert_match(/application-([0-z]+)\.js/, assets["application.js"])
       assert_match(/application-([0-z]+)\.css/, assets["application.css"])
     end
-
 
     test "the manifest file should be saved by default in the same assets folder" do
       app_file "app/assets/javascripts/application.js", "alert();"

--- a/railties/test/initializable_test.rb
+++ b/railties/test/initializable_test.rb
@@ -216,7 +216,7 @@ module InitializableTests
   class WithArgsTest < ActiveSupport::TestCase
     test "running initializers with args" do
       $with_arg = nil
-      WithArgs.new.run_initializers('foo')
+      WithArgs.new.run_initializers(nil, 'foo')
       assert_equal 'foo', $with_arg
     end
   end

--- a/railties/test/initializable_test.rb
+++ b/railties/test/initializable_test.rb
@@ -61,7 +61,7 @@ module InitializableTests
   class Instance
     include Rails::Initializable
 
-    initializer :one do
+    initializer :one, :group => :assets do
       $arr << 1
     end
 
@@ -69,7 +69,7 @@ module InitializableTests
       $arr << 2
     end
 
-    initializer :three do
+    initializer :three, :group => :all do
       $arr << 3
     end
 
@@ -210,6 +210,13 @@ module InitializableTests
       instance = Instance.new
       instance.run_initializers
       assert_equal [1, 2, 3, 4], $arr
+    end
+
+    test "running locals with groups" do
+      $arr = []
+      instance = Instance.new
+      instance.run_initializers(:assets)
+      assert_equal [1, 3], $arr
     end
   end
 

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -224,6 +224,15 @@ module TestHelpers
       end
     end
 
+    def add_to_env_config(env, str)
+      environment = File.read("#{app_path}/config/environments/#{env}.rb")
+      if environment =~ /(\n\s*end\s*)\Z/
+        File.open("#{app_path}/config/environments/#{env}.rb", 'w') do |f|
+          f.puts $` + "\n#{str}\n" + $1
+        end
+      end
+    end
+
     def remove_from_config(str)
       file = "#{app_path}/config/application.rb"
       contents = File.read(file)


### PR DESCRIPTION
Patch to solve issue here: https://github.com/rails/rails/issues/3093

Allows you to pass a block to link_to_function (similar to link_to) if the link text is too complex to be passed as a string argument.
