### PR TITLE
Object#return_if - designed to simplify common pattern similar to Object#try

### DIFF
--- a/activesupport/lib/active_support/core_ext/object.rb
+++ b/activesupport/lib/active_support/core_ext/object.rb
@@ -3,6 +3,7 @@ require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/object/duplicable'
 require 'active_support/core_ext/object/try'
 require 'active_support/core_ext/object/inclusion'
+require 'active_support/core_ext/object/return_if'
 
 require 'active_support/core_ext/object/conversions'
 require 'active_support/core_ext/object/instance_variables'

--- a/activesupport/lib/active_support/core_ext/object/return_if.rb
+++ b/activesupport/lib/active_support/core_ext/object/return_if.rb
@@ -17,6 +17,27 @@ class Object
 end
 
 class NilClass
+  # Calling +return_if+ on +nil+ always returns +nil+.
+  # It becomes specially helpful when combining predicates that may return +false+, and thus +return_if+ would return +nil+.
+  #
+  # === Examples
+  #
+  #   nil.return_if(:valid?) # => nil
+  #   nil.return_if('children.include?', joe) # => nil
+  #
+  # Without +return_if+
+  #   if @person && @person.valid?
+  #     @person
+  #   else
+  #     nil
+  #   end
+  #
+  # Slightly better with +try+
+  #   @person.try(:valid?) && @person
+  #
+  # With +return_if+
+  #   @person.return_if(:valid?)
+  #
   def return_if(*args, &block)
     nil
   end

--- a/activesupport/lib/active_support/core_ext/object/return_if.rb
+++ b/activesupport/lib/active_support/core_ext/object/return_if.rb
@@ -1,0 +1,5 @@
+class Object
+  def return_if(&block)
+    (yield(self) || nil) && self
+  end
+end

--- a/activesupport/lib/active_support/core_ext/object/return_if.rb
+++ b/activesupport/lib/active_support/core_ext/object/return_if.rb
@@ -1,4 +1,47 @@
 class Object
+  # Invokes the predicate method identified by the symbol or string +method+, passing it any arguments
+  # and/or the block specified, just like the Rails <tt>Object#try</tt> does, but returning the receiver
+  # if the predicate is evaluated to +true+ or +nil+ if it is +false+.
+  #
+  # Similar to the <tt>Object#try</tt> method, a +NoMethodError+ exception will *not* be raised
+  # and +nil+ will be returned instead, if the receiving object is a +nil+ object or NilClass.
+  #
+  # If return_if is called without a method to call, it will yield any given block with the object.
+  #
+  # ==== Examples
+  #
+  # Array.return_if(:is_a?, Class) # => Array
+  # 'flask'.return_if(:is_a?, Class) # => nil
+  #
+  # ('a'..'z').return_if(:any?) { |c| c == 'n' } # => ('a'..'z')
+  # @user.return_if(:active?).return_if(:verified?)
+  #
+  #
+  # Without +return_if+
+  #   if @person && @person.valid?
+  #     @person
+  #   else
+  #     nil
+  #   end
+  #
+  # or using +try+ is better
+  #
+  #   @person.try(:valid?) && @person
+  #
+  #
+  # With +return_if+
+  #   @person.return_if(:valid?)
+  #
+  # +return_if+ accepts arguments and/or a block for the method it is trying
+  #   @person.return_if(:forehead_size_is?, :massive)
+  #   @people.return_if(:all?) {|p| p.awesome?}
+  #
+  # +return_if+ also accepts a string of method names sepearted by a dot '.' if you
+  # want to return the parent object based on a predicate of an association
+  #   @person.return_if('friends.empty?') # :(
+  #
+  # Without a method argument +return_if+ will yield to the block unless the receiver is nil.
+  #   @user.return_if { |u| u.activated? || u.too_cool_for_activation? }
   def return_if(*args, &block)
     unless args.empty?
       methods     = args.first.to_s.split('.')

--- a/activesupport/lib/active_support/core_ext/object/return_if.rb
+++ b/activesupport/lib/active_support/core_ext/object/return_if.rb
@@ -1,7 +1,15 @@
 class Object
   def return_if(*args, &block)
     unless args.empty?
-      return return_if { |obj| obj.__send__(*args) }
+      methods     = args.first.to_s.split('.')
+      params      = args[1..-1]
+      last_method = methods.pop
+
+      result = methods.inject(self) do |acc, method_name|
+        acc.try(method_name)
+      end
+
+      return return_if { result.try(last_method, *params, &block) }
     end
 
     (yield(self) || nil) && self

--- a/activesupport/lib/active_support/core_ext/object/return_if.rb
+++ b/activesupport/lib/active_support/core_ext/object/return_if.rb
@@ -1,5 +1,15 @@
 class Object
-  def return_if(&block)
+  def return_if(*args, &block)
+    unless args.empty?
+      return return_if { |obj| obj.__send__(*args) }
+    end
+
     (yield(self) || nil) && self
+  end
+end
+
+class NilClass
+  def return_if(*args, &block)
+    nil
   end
 end

--- a/activesupport/test/core_ext/object_and_class_ext_test.rb
+++ b/activesupport/test/core_ext/object_and_class_ext_test.rb
@@ -101,7 +101,7 @@ class ObjectTryTest < Test::Unit::TestCase
     assert !@string.respond_to?(method)
     assert_nil @string.try(method)
   end
-  
+
   def test_nonexisting_method_with_arguments
     method = :undefined_method
     assert !@string.respond_to?(method)
@@ -137,5 +137,23 @@ class ObjectTryTest < Test::Unit::TestCase
     ran = false
     nil.try { ran = true }
     assert_equal false, ran
+  end
+end
+
+class ObjectReturnIfTest < Test::Unit::TestCase
+  def setup
+    @string = "Hello"
+  end
+
+  def test_return_if_only_block_when_true
+    assert_equal @string, @string.return_if { |str| str == "Hello" }
+  end
+
+  def test_return_if_only_block_when_false
+    assert_nil @string.return_if { |str| str == "Not Hello" }
+  end
+
+  def test_return_if_only_block_nil
+    assert_nil nil.return_if { true }
   end
 end

--- a/activesupport/test/core_ext/object_and_class_ext_test.rb
+++ b/activesupport/test/core_ext/object_and_class_ext_test.rb
@@ -156,4 +156,20 @@ class ObjectReturnIfTest < Test::Unit::TestCase
   def test_return_if_only_block_nil
     assert_nil nil.return_if { true }
   end
+
+  def test_return_if_method_symbol_passed_when_true
+    assert_equal "", "".return_if( :empty? )
+  end
+
+  def test_return_if_method_symbol_passed_when_false
+    assert_nil @string.return_if( :empty? )
+  end
+
+  def test_return_if_method_symbol_passed_nil
+    assert_nil nil.return_if( :empty? )
+  end
+
+  def test_return_if_method_symbol_passed_with_arguments
+    assert_equal @string, @string.return_if( :==, @string )
+  end
 end

--- a/activesupport/test/core_ext/object_and_class_ext_test.rb
+++ b/activesupport/test/core_ext/object_and_class_ext_test.rb
@@ -145,6 +145,11 @@ class ObjectReturnIfTest < Test::Unit::TestCase
     @string = "Hello"
   end
 
+  def test_nonexisting_method
+    assert !@string.respond_to?(:undefined_method)
+    assert_nil @string.return_if(:undefined_method)
+  end
+
   def test_return_if_only_block_when_true
     assert_equal @string, @string.return_if { |str| str == "Hello" }
   end
@@ -166,10 +171,35 @@ class ObjectReturnIfTest < Test::Unit::TestCase
   end
 
   def test_return_if_method_passed_nil
-    assert_nil nil.return_if(:empty?)
+    assert_nil nil.return_if(:undefined_method)
   end
 
   def test_return_if_method_passed_with_arguments
     assert_equal @string, @string.return_if(:==, @string)
+  end
+
+  def test_return_if_method_passed_with_block_when_true
+    assert_equal [1,2,3], [1,2,3].return_if(:all?) { |c| c > 0 }
+  end
+
+  def test_return_if_method_passed_with_block_when_false
+    assert_nil [1,2,3].return_if(:any?) { |c| c < 0 }
+  end
+
+  def test_return_if_nil_method_passed_with_block
+    assert_nil nil.return_if(:all?) { |nothing| nothing.amazing? }
+  end
+
+  def test_return_if_scope_passed_when_true
+    arr = ('a'..'z')
+    assert_equal arr, arr.return_if("to_a.join.chop.chop.clear.empty?")
+  end
+
+  def test_return_if_scope_passed_when_false
+    assert_nil ['a', 'b'].return_if("join.empty?")
+  end
+
+  def test_return_if_nil_scope_passed
+    assert_nil nil.return_if("to_s.clear.empty?")
   end
 end

--- a/activesupport/test/core_ext/object_and_class_ext_test.rb
+++ b/activesupport/test/core_ext/object_and_class_ext_test.rb
@@ -157,19 +157,19 @@ class ObjectReturnIfTest < Test::Unit::TestCase
     assert_nil nil.return_if { true }
   end
 
-  def test_return_if_method_symbol_passed_when_true
-    assert_equal "", "".return_if( :empty? )
+  def test_return_if_method_passed_when_true
+    assert_equal "", "".return_if(:empty?)
   end
 
-  def test_return_if_method_symbol_passed_when_false
-    assert_nil @string.return_if( :empty? )
+  def test_return_if_method_passed_when_false
+    assert_nil @string.return_if(:empty?)
   end
 
-  def test_return_if_method_symbol_passed_nil
-    assert_nil nil.return_if( :empty? )
+  def test_return_if_method_passed_nil
+    assert_nil nil.return_if(:empty?)
   end
 
-  def test_return_if_method_symbol_passed_with_arguments
-    assert_equal @string, @string.return_if( :==, @string )
+  def test_return_if_method_passed_with_arguments
+    assert_equal @string, @string.return_if(:==, @string)
   end
 end

--- a/activesupport/test/core_ext/object_and_class_ext_test.rb
+++ b/activesupport/test/core_ext/object_and_class_ext_test.rb
@@ -167,6 +167,7 @@ class ObjectReturnIfTest < Test::Unit::TestCase
   end
 
   def test_return_if_method_passed_when_false
+    assert !@string.empty?
     assert_nil @string.return_if(:empty?)
   end
 
@@ -186,8 +187,8 @@ class ObjectReturnIfTest < Test::Unit::TestCase
     assert_nil [1,2,3].return_if(:any?) { |c| c < 0 }
   end
 
-  def test_return_if_nil_method_passed_with_block
-    assert_nil nil.return_if(:all?) { |nothing| nothing.amazing? }
+  def test_return_if_method_passed_with_block_nil
+    assert_nil nil.return_if(:all?) { |obj| obj.amazing? }
   end
 
   def test_return_if_scope_passed_when_true
@@ -199,7 +200,7 @@ class ObjectReturnIfTest < Test::Unit::TestCase
     assert_nil ['a', 'b'].return_if("join.empty?")
   end
 
-  def test_return_if_nil_scope_passed
+  def test_return_if_scope_passed_nil
     assert_nil nil.return_if("to_s.clear.empty?")
   end
 end


### PR DESCRIPTION
Designed to remove the need to do something like this:

  var = complex_expression
  var.some_predicate? ? var : nil

  @user.try(:valid?) && @user

Instead, expressed in terms of return_if, becomes:

  complex_expression.return_if(:some_predicate?)

  @user.return_if(:valid?)

Which will return _nil_ if the predicate evaluates to false, or the receiver if the predicate evaluates to true. Also accepts scopes in the form of a string, with method names separated by a dot '.'. Such as:

  @user.return_if("pages.all?") { |page| page.has_title? } # => @user/nil

Calls the block passed with the receiver if no method is given. 

  @user.return_if { |u| u.activated? }

Recommend checking out the documentation provided for more details.
