### PR TITLE
Re-launch assets:precompile task using (Rake.)ruby instead of Kernel.exec so it works on Windows

### DIFF
--- a/actionpack/lib/sprockets/assets.rake
+++ b/actionpack/lib/sprockets/assets.rake
@@ -6,7 +6,7 @@ namespace :assets do
     if ENV["RAILS_GROUPS"].to_s.empty? || ENV["RAILS_ENV"].to_s.empty?
       ENV["RAILS_GROUPS"] ||= "assets"
       ENV["RAILS_ENV"]    ||= "production"
-      Kernel.exec $0, *ARGV
+      ruby $0, *ARGV
     else
       require "fileutils"
       Rake::Task["tmp:cache:clear"].invoke


### PR DESCRIPTION
The Kernel.exec method launches the current program ($0) after setting some environment variables.  This current ruby script has a shebang line and no .rb in its name. Launching a script this way does not work on Windows. By using the +ruby+ method that is included in Rake, we can launch the current script with the current ruby version and bypass the identified Windows issue.

This patch should be applied to 3-1-stable and master.
