### PR TITLE
escape options for the stylesheet_link_tag method

### DIFF
--- a/actionpack/lib/action_view/helpers/asset_tag_helpers/stylesheet_tag_helpers.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helpers/stylesheet_tag_helpers.rb
@@ -17,7 +17,7 @@ module ActionView
 
         def asset_tag(source, options)
           # We force the :request protocol here to avoid a double-download bug in IE7 and IE8
-          tag("link", { "rel" => "stylesheet", "type" => Mime::CSS, "media" => "screen", "href" => ERB::Util.html_escape(path_to_asset(source, :protocol => :request)) }.merge(options), false, false)
+          tag("link", { "rel" => "stylesheet", "type" => Mime::CSS, "media" => "screen", "href" => path_to_asset(source, :protocol => :request) }.merge(options))
         end
 
         def custom_dir

--- a/actionpack/test/template/asset_tag_helper_test.rb
+++ b/actionpack/test/template/asset_tag_helper_test.rb
@@ -366,6 +366,10 @@ class AssetTagHelperTest < ActionView::TestCase
     assert stylesheet_link_tag('dir/other/file', 'dir/file2').html_safe?
   end
 
+  def test_stylesheet_link_tag_escapes_options
+    assert_dom_equal %(<link href="/file.css" media="&lt;script&gt;" rel="stylesheet" type="text/css" />), stylesheet_link_tag('/file', :media => '<script>')
+  end
+
   def test_custom_stylesheet_expansions
     ENV["RAILS_ASSET_ID"] = ''
     ActionView::Helpers::AssetTagHelper::register_stylesheet_expansion :robbery => ["bank", "robber"]


### PR DESCRIPTION
Hello!

I noticed a difference between 2 very similar method implementations:

https://github.com/rails/rails/blob/master/actionpack/lib/action_view/helpers/asset_tag_helpers/javascript_tag_helpers.rb#L19

https://github.com/rails/rails/blob/master/actionpack/lib/action_view/helpers/asset_tag_helpers/stylesheet_tag_helpers.rb#L20

The commits 871b87a, 8db51ee3c created this difference. But at 2007 html safe buffers didn't exist at all. Stylesheet link implementation with manual escaping of path traveled from one file to another. Now it's dangerous, because it's possible to pass unsafe options as in the test in my commit.
