### PR TITLE
Mime::Type#html? should always return true/false, never nil.

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -253,7 +253,7 @@ module Mime
     end
 
     def html?
-      @@html_types.include?(to_sym) || @string =~ /html/
+      @@html_types.include?(to_sym) || (@string =~ /html/).to_i > 0
     end
 
     def respond_to?(method, include_private = false) #:nodoc:

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1820,6 +1820,12 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
       assert_equal true, @request.format.json?
       assert_equal '/api/1.0/users.json', api_users_path(:version => '1.0', :format => :json)
 
+      get '/api/1.0/users', {}, {'HTTP_ACCEPT' => "application/json", 'CONTENT_TYPE' => "application/json"}
+      assert_equal 'api/users#index', @response.body
+      assert_equal true, @request.format.json?
+      assert_equal false, @request.format.xml?
+      assert_equal false, @request.format.html?
+
       get '/api/1.0/users/first.last'
       assert_equal 'api/users#show', @response.body
       assert_equal 'first.last', @request.params[:id]


### PR DESCRIPTION
I've done a quick fix on this method that returned me `nil` when Mime::Type `@string` is 'application/json'.

The method fail because `@string =~ /html/` return nil when @string do not contains 'html'.
I've updated an existing test in order to check the method when using HTTP_ACCEPT and CONTENT_TYPE, not the route ending with `.json`.
