### PR TITLE
ActiveResource::Base.build should send headers

### DIFF
--- a/activeresource/lib/active_resource/base.rb
+++ b/activeresource/lib/active_resource/base.rb
@@ -707,7 +707,7 @@ module ActiveResource
       # Returns the new resource instance.
       #
       def build(attributes = {})
-        attrs = self.format.decode(connection.get("#{new_element_path}").body).merge(attributes)
+        attrs = self.format.decode(connection.get("#{new_element_path}", headers).body).merge(attributes)
         self.new(attrs)
       end
 

--- a/activeresource/test/abstract_unit.rb
+++ b/activeresource/test/abstract_unit.rb
@@ -105,6 +105,8 @@ def setup_response
     mock.get    "/people/Greg.json",            {}, @greg
     mock.get    "/people/6.json",               {}, @joe
     mock.get    "/people/4.json",               { 'key' => 'value' }, nil, 404
+    mock.get    "/people/new.json",             {}, Person.new.to_json
+    mock.get    "/people/new.json",             { 'key' => 'value' }, Person.new.to_json, 404
     mock.put    "/people/1.json",               {}, nil, 204
     mock.delete "/people/1.json",               {}, nil, 200
     mock.delete "/people/2.xml",                {}, nil, 400

--- a/activeresource/test/cases/base_test.rb
+++ b/activeresource/test/cases/base_test.rb
@@ -609,6 +609,13 @@ class BaseTest < Test::Unit::TestCase
     Person.headers.delete('key')
   end
 
+  def test_custom_header_on_build
+    Person.headers['key'] = 'value'
+    assert_raise(ActiveResource::ResourceNotFound) { Person.build }
+  ensure
+    Person.headers.delete('key')
+  end
+
   def test_save
     rick = Person.new
     assert rick.save


### PR DESCRIPTION
The ActiveResource::Base.build method currently doesn't send the custom headers with the request for the /new resource. This is required when ARes is interacting with a REST API which uses HTTP header authentication instead of HTTP basic authentication.
