### PR TITLE
Patch for bug on RubyGems 1.3.5 in 2 3 stable

### DIFF
--- a/railties/lib/rails/gem_dependency.rb
+++ b/railties/lib/rails/gem_dependency.rb
@@ -78,7 +78,7 @@ module Rails
         spec = Gem.source_index.find { |_,s| s.satisfies_requirement?(dep) }.last
         spec.activate           # a way that exists
       rescue
-        gem self.name, self.requirement # <  1.8 unhappy way
+        gem self.name, :version => (self.respond_to?(:requirement) ? self.requirement : self.version_requirements) # <  1.8 unhappy way
       end
 
       @spec = Gem.loaded_specs[name]


### PR DESCRIPTION
I'm running the bug mentioned here: http://projects.puppetlabs.com/issues/8800 on several projects when updating from Rails 2.3.10 to Rails 2.3.14 on RubyGems 1.3.5.

The patch mentioned in the pull request here: https://github.com/rails/rails/pull/2818 seems to work properly, although that pull request seems to include a whole load of other commits, so hereby a pull request with one commit.
