### PR TITLE
Give precedence to `config.digest = false` over the existence of manifest.yml asset digests

### DIFF
--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -114,7 +114,7 @@ module Sprockets
         end
 
         def digest_for(logical_path)
-          if asset_digests && (digest = asset_digests[logical_path])
+          if digest_assets && asset_digests && (digest = asset_digests[logical_path])
             return digest
           end
 

--- a/actionpack/test/template/sprockets_helper_test.rb
+++ b/actionpack/test/template/sprockets_helper_test.rb
@@ -262,4 +262,12 @@ class SprocketsHelperTest < ActionView::TestCase
 
     assert_not_equal prod_path, dev_path
   end
+
+  test "precedence of `config.digest = false` over manifest.yml asset digests" do
+    Rails.application.config.assets.digests = {'logo.png' => 'logo-d1g3st.png'}
+    @config.assets.digest = false
+
+    assert_match %r{/assets/logo.png},
+      asset_path("logo.png")
+  end
 end


### PR DESCRIPTION
It would seem that if one precompiles an application's assets, thus creating a `manifest.yml` file, the value of `config.digest` is ignored.

This issue might go unnoticed in **production** (assets are precompiled) or in **development** (assets are compiled on-demand) but it has caused me considerable pain in **test**. Given the following in `test.rb`

```
 config.serve_static_assets = true
 config.assets.digest = false
```

...calling `asset_path` appends a digest to the asset path, making all views un-testable for the presence of said asset.

This patch fixes this.

Do I need to back port this against **3-1-stable**? I can open another pull request but as it currently applies cleanly, it might be unnecessary...
