### PR TITLE
Correctly override image_path in sprockets rails_helper

### DIFF
--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -60,9 +60,10 @@ module Sprockets
         options[:body] ? "#{path}?body=1" : path
       end
 
-      def path_to_image(source)
+      def image_path(source)
         asset_paths.compute_public_path(source, asset_prefix)
       end
+      alias_method :path_to_image, :image_path # aliased to avoid conflicts with an image_path named route
 
     private
       def debug_assets?

--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -61,7 +61,7 @@ module Sprockets
       end
 
       def image_path(source)
-        asset_paths.compute_public_path(source, asset_prefix)
+        asset_path(source)
       end
       alias_method :path_to_image, :image_path # aliased to avoid conflicts with an image_path named route
 

--- a/actionpack/test/template/sprockets_helper_test.rb
+++ b/actionpack/test/template/sprockets_helper_test.rb
@@ -126,6 +126,14 @@ class SprocketsHelperTest < ActionView::TestCase
     assert_dom_equal '<img alt="Xml" src="/assets/xml.png" />', image_tag("xml.png")
   end
 
+  test "image_path" do
+    assert_match %r{/assets/logo-[0-9a-f]+.png},
+      image_path("logo.png")
+
+    assert_match %r{/assets/logo-[0-9a-f]+.png},
+      path_to_image("logo.png")
+  end
+
   test "stylesheets served without a controller in do not use asset hosts when the default protocol is :request" do
     @controller = nil
     @config.action_controller.asset_host = "assets-%d.example.com"


### PR DESCRIPTION
This commit https://github.com/rails/rails/commit/0cb84f18d646dda6e46bab86a2c817ded0da0d10 broke the `image_path` helper when the assets pipeline is enabled. 

Instead of `/assets` it would prepend `/images` when `image_path()` was used. This is due to the way `image_path` and `path_to_image` are aliased to each other in `asset_tag_helper`

This patch fixes the `image_path` helper.

I am perplexed as to why in `sprockets_helper_text` what is tested is `asset_path`, an undocumented method, and not `image_path` which is the publish API (along with `video_path`, `audio_path` and all its siblings)

Shouldn't the test be refactored somehow?
