### PR TITLE
Make the Rack::SSL middleware configurable

### DIFF
--- a/railties/guides/source/configuring.textile
+++ b/railties/guides/source/configuring.textile
@@ -179,7 +179,7 @@ h4. Configuring Middleware
 
 Every Rails application comes with a standard set of middleware which it uses in this order in the development environment:
 
-* +Rack::SSL+ Will force every request to be under HTTPS protocol. Will be available if +config.force_ssl+ is set to +true+.
+* +Rack::SSL+ Will force every request to be under HTTPS protocol. Will be available if +config.force_ssl+ is set to +true+.  Options passed to this can be configured by using +config.ssl_options+.
 * +ActionDispatch::Static+ is used to serve static assets. Disabled if +config.serve_static_assets+ is +true+.
 * +Rack::Lock+ Will wrap the app in mutex so it can only be called by a single thread at a time. Only enabled if +config.action_controller.allow_concurrency+ is set to +false+, which it is by default.
 * +ActiveSupport::Cache::Strategy::LocalCache+ Serves as a basic memory backed cache. This cache is not thread safe and is intended only for serving as a temporary memory cache for a single thread.

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -154,7 +154,7 @@ module Rails
 
         if config.force_ssl
           require "rack/ssl"
-          middleware.use ::Rack::SSL
+          middleware.use ::Rack::SSL, config.ssl_options
         end
 
         if config.serve_static_assets

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -10,7 +10,8 @@ module Rails
                     :dependency_loading, :filter_parameters,
                     :force_ssl, :helpers_paths, :logger, :preload_frameworks,
                     :reload_plugins, :secret_token, :serve_static_assets,
-                    :static_cache_control, :session_options, :time_zone, :whiny_nils
+                    :ssl_options, :static_cache_control, :session_options, 
+                    :time_zone, :whiny_nils
 
       attr_writer :log_level
       attr_reader :encoding
@@ -26,6 +27,7 @@ module Rails
         @serve_static_assets         = true
         @static_cache_control        = nil
         @force_ssl                   = false
+        @ssl_options                 = {}
         @session_store               = :cookie_store
         @session_options             = {}
         @time_zone                   = "UTC"

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -69,6 +69,14 @@ module ApplicationTests
       assert middleware.include?("Rack::SSL")
     end
 
+    test "Rack::SSL is configured with options when given" do
+      add_to_config "config.force_ssl = true"
+      add_to_config "config.ssl_options = { :host => 'example.com' }"
+      boot!
+      
+      assert_equal AppTemplate::Application.middleware.first.args, [{:host => 'example.com'}]
+    end
+
     test "removing Active Record omits its middleware" do
       use_frameworks []
       boot!


### PR DESCRIPTION
The Rails configuration option "enforce_ssl" is handy but is currently unable to take advantage of features in Rack::SSL, such as passing a Proc to the middleware to exclude certain urls or url patterns from being redirected to https.  This patch allows the user to specify ssl_options which are passed directly to the Rack::SSL middleware on initialization if enforce_ssl is set to true.

Without this patch the user must insert the Rack::SSL middleware onto the stack manually in order to add configuration options.

This patch also adds a test for the passing of options to the Rack::SSL middleware and adds mention of the ability to configure Rack::SSL to configuring.textile.
