### PR TITLE
fix #except and #only with `default_scope`

### DIFF
--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -72,7 +72,6 @@ module ActiveRecord
     #
     def except(*skips)
       result = self.class.new(@klass, table)
-      result.default_scoped = default_scoped
 
       ((Relation::ASSOCIATION_METHODS + Relation::MULTI_VALUE_METHODS) - skips).each do |method|
         result.send(:"#{method}_values=", send(:"#{method}_values"))
@@ -97,7 +96,6 @@ module ActiveRecord
     #
     def only(*onlies)
       result = self.class.new(@klass, table)
-      result.default_scoped = default_scoped
 
       ((Relation::ASSOCIATION_METHODS + Relation::MULTI_VALUE_METHODS) & onlies).each do |method|
         result.send(:"#{method}_values=", send(:"#{method}_values"))

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -876,6 +876,7 @@ class RelationTest < ActiveRecord::TestCase
   def test_except_with_default_scope
     # We compare attributes because the class names will be different
     assert_equal DeveloperCalledDavid.except(:where).all.collect(&:attributes), Developer.all.collect(&:attributes)
+    assert_equal DeveloperCalledDavid.except(:order).all, DeveloperCalledDavid.all
   end
 
   def test_extensions_with_except
@@ -896,6 +897,7 @@ class RelationTest < ActiveRecord::TestCase
   def test_only_with_default_scope
     # We compare attributes because the class names will be different
     assert_equal DeveloperCalledDavid.scoped.only(:order).all.collect(&:attributes), Developer.all.collect(&:attributes)
+    assert_equal DeveloperCalledDavid.scoped.only(:except).all, DeveloperCalledDavid.all
   end
 
   def test_extensions_with_only

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -873,6 +873,11 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal Post.all, all_posts.all
   end
 
+  def test_except_with_default_scope
+    # We compare attributes because the class names will be different
+    assert_equal DeveloperCalledDavid.except(:where).all.collect(&:attributes), Developer.all.collect(&:attributes)
+  end
+
   def test_extensions_with_except
     assert_equal 2, Topic.named_extension.order(:author_name).except(:order).two
   end
@@ -886,6 +891,11 @@ class RelationTest < ActiveRecord::TestCase
 
     all_posts = relation.only(:limit)
     assert_equal Post.limit(1).all.first, all_posts.first
+  end
+
+  def test_only_with_default_scope
+    # We compare attributes because the class names will be different
+    assert_equal DeveloperCalledDavid.scoped.only(:order).all.collect(&:attributes), Developer.all.collect(&:attributes)
   end
 
   def test_extensions_with_only


### PR DESCRIPTION
Before this fix Model.except(something) wouldn't get rid of 'something'
clauses in the query. Same thing for Model.only().

The two deleted lines were introduced [here](https://github.com/rails/rails/commit/8572ae6671c6ec7c2524f327cee82215896e5648#L5R75) to "evaluate default scopes at the last possible moment" and that made impossible to remove conditions from the default scope. The behavior after this fix is the same we had before Rails 3.1, which means #except and #only can modify the default_scope.
