### PR TITLE
add missing require to html sanitizer

### DIFF
--- a/actionpack/lib/action_controller/vendor/html-scanner/html/sanitizer.rb
+++ b/actionpack/lib/action_controller/vendor/html-scanner/html/sanitizer.rb
@@ -1,4 +1,5 @@
 require 'set'
+require 'cgi'
 require 'active_support/core_ext/class/attribute'
 
 module HTML


### PR DESCRIPTION
CGI is used here (line 166) : https://github.com/rails/rails/tree/master/actionpack/lib/action_controller/vendor/html-scanner/html/sanitizer.rb#L166
