### PR TITLE
Fix button_to helper for data-type option

### DIFF
--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -327,7 +327,8 @@ module ActionView
         form_class = html_options.delete('form_class') || 'button_to'
 
         remote = html_options.delete('remote')
-
+        data_type = html_options.delete('data-type')
+        
         request_token_tag = ''
         if form_method == 'post' && protect_against_forgery?
           request_token_tag = tag(:input, :type => "hidden", :name => request_forgery_protection_token.to_s, :value => form_authenticity_token)
@@ -340,7 +341,7 @@ module ActionView
 
         html_options.merge!("type" => "submit", "value" => name)
 
-        ("<form method=\"#{form_method}\" action=\"#{ERB::Util.html_escape(url)}\" #{"data-remote=\"true\"" if remote} class=\"#{ERB::Util.html_escape(form_class)}\"><div>" +
+        ("<form method=\"#{form_method}\" action=\"#{ERB::Util.html_escape(url)}\" #{"data-remote=\"true\"" if remote} #{"data-type=\"#{data_type}\"" if data_type} class=\"#{ERB::Util.html_escape(form_class)}\"><div>" +
           method_tag + tag("input", html_options) + request_token_tag + "</div></form>").html_safe
       end
 

--- a/actionpack/test/template/url_helper_test.rb
+++ b/actionpack/test/template/url_helper_test.rb
@@ -109,6 +109,13 @@ class UrlHelperTest < ActiveSupport::TestCase
     )
   end
 
+  def test_button_to_with_remote_and_data_type
+    assert_dom_equal(
+      "<form method=\"post\" action=\"http://www.example.com\" class=\"button_to\" data-remote=\"true\" data-type=\"json\"><div><input type=\"submit\" value=\"Hello\" /></div></form>",
+      button_to("Hello", "http://www.example.com", :remote => true, "data-type" => "json")
+    )
+  end
+  
   def test_button_to_with_remote_false
     assert_dom_equal(
       "<form method=\"post\" action=\"http://www.example.com\" class=\"button_to\"><div><input type=\"submit\" value=\"Hello\" /></div></form>",


### PR DESCRIPTION
We may use data-type attribute to set Ajax request type for "data-remote" requests. (see [jquery-ujs wiki](https://github.com/rails/jquery-ujs/wiki/Unobtrusive-scripting-support-for-jQuery))
link_to helper has no problem, but button_to will add "data-type" to the wrong input tag and does not work:

```
 <%= button_to "foo", "/bar", :remote => true, "data-type" => "json" %>

 <form method="post" action="/bar" data-remote="true" class="button_to"><div><input data-type="json" type="submit" value="foo" />...</div></form>
```

The "data-type" should be in form tag with "data-remote" , not input tag. This patch result:

```
<form method="post" action="/bar" data-remote="true" data-type="json" class="button_to"><div><input  type="submit" value="foo" />...</div></form>
```

It will be nice also backport to 3-1-stable branch.
