### PR TITLE
added optional count and plural arguments to String#pluralize

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -9,14 +9,26 @@ require 'active_support/inflector/transliterate'
 class String
   # Returns the plural form of the word in the string.
   #
-  #   "post".pluralize             # => "posts"
-  #   "octopus".pluralize          # => "octopi"
-  #   "sheep".pluralize            # => "sheep"
-  #   "words".pluralize            # => "words"
-  #   "the blue mailman".pluralize # => "the blue mailmen"
-  #   "CamelOctopus".pluralize     # => "CamelOctopi"
-  def pluralize
-    ActiveSupport::Inflector.pluralize(self)
+  # If the optional parameter +count+ is specified,
+  # the singular form will be returned if <tt>count == 1</tt>.
+  #
+  # If the optional parameter +plural+ is specified,
+  # that string will be returned when plural.
+  #
+  # Examples
+  #   "post".pluralize                  # => "posts"
+  #   "octopus".pluralize               # => "octopi"
+  #   "sheep".pluralize                 # => "sheep"
+  #   "words".pluralize                 # => "words"
+  #   "the blue mailman".pluralize      # => "the blue mailmen"
+  #   "CamelOctopus".pluralize          # => "CamelOctopi"
+  #   "count".pluralize(2, "counters")  # => "counters"
+  #   "count".pluralize(1)              # => "count"
+  def pluralize(count = 2, plural = nil)
+    case count
+      when 1 then self
+      else plural || ActiveSupport::Inflector.pluralize(self)
+    end
   end
 
   # The reverse of +pluralize+, returns the singular form of a word in a string.
@@ -42,7 +54,7 @@ class String
   def constantize
     ActiveSupport::Inflector.constantize(self)
   end
-  
+
   # +safe_constantize+ tries to find a declared constant with the name specified
   # in the string. It returns nil when the name is not in CamelCase
   # or is not initialized.  See ActiveSupport::Inflector.safe_constantize

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -20,7 +20,7 @@ end
 class StringInflectionsTest < Test::Unit::TestCase
   include InflectorTestCases
   include ConstantizeTestCases
-  
+
   def test_erb_escape
     string = [192, 60].pack('CC')
     expected = 192.chr + "&lt;"
@@ -61,6 +61,12 @@ class StringInflectionsTest < Test::Unit::TestCase
   def test_pluralize
     SingularToPlural.each do |singular, plural|
       assert_equal(plural, singular.pluralize)
+      assert_equal(plural, singular.pluralize(0, plural))
+      assert_equal(plural, singular.pluralize(nil, plural))
+      assert_equal(plural, singular.pluralize(2, plural))
+
+      assert_equal(singular, singular.pluralize(1))
+      assert_equal(singular, singular.pluralize(1, plural))
     end
 
     assert_equal("plurals", "plurals".pluralize)
@@ -301,13 +307,13 @@ class StringInflectionsTest < Test::Unit::TestCase
         "\354\225\204\353\246\254\353\236\221 \354\225\204\353\246\254 \354\225\204\353\235\274\353\246\254\354\230\244".force_encoding('UTF-8').truncate(10)
     end
   end
-  
+
   def test_constantize
     run_constantize_tests_on do |string|
       string.constantize
     end
   end
-  
+
   def test_safe_constantize
     run_safe_constantize_tests_on do |string|
       string.safe_constantize
@@ -381,7 +387,7 @@ class OutputSafetyTest < ActiveSupport::TestCase
   test "A fixnum is safe by default" do
     assert 5.html_safe?
   end
-  
+
   test "a float is safe by default" do
     assert 5.7.html_safe?
   end


### PR DESCRIPTION
Following on discussion from #3151, this is an implementation of `String#pluralize` that includes updated tests an an additional `plural` argument to override the inflector.
