### PR TITLE
Make button_to helper support "form" option

### DIFF
--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -279,6 +279,7 @@ module ActionView
       #   processed normally, otherwise no action is taken.
       # * <tt>:remote</tt> -  If set to true, will allow the Unobtrusive JavaScript drivers to control the
       #   submit behavior. By default this behavior is an ajax submit.
+      # * <tt>:form</tt> - This hash will be form attributes
       # * <tt>:form_class</tt> - This controls the class of the form within which the submit button will
       #   be placed
       #
@@ -295,6 +296,12 @@ module ActionView
       #   #    </form>"
       #
       #
+      #   <%= button_to "Create", :action => "create", :remote => true, :form => { "data-type" => "json" } %>
+      #   # => "<form method="post" action="/images/create" class="button_to" data-remote="true" data-type="json">
+      #   #      <div><input value="Create" type="submit" /></div>
+      #   #    </form>"
+      #
+      #      
       #   <%= button_to "Delete Image", { :action => "delete", :id => @image.id },
       #             :confirm => "Are you sure?", :method => :delete %>
       #   # => "<form method="post" action="/images/delete/1" class="button_to">
@@ -324,10 +331,11 @@ module ActionView
         end
 
         form_method = method.to_s == 'get' ? 'get' : 'post'
-        form_class = html_options.delete('form_class') || 'button_to'
-
+        form_options = html_options.delete('form') || {}
+        form_options[:class] ||= html_options.delete('form_class') || 'button_to'
+        
         remote = html_options.delete('remote')
-
+        
         request_token_tag = ''
         if form_method == 'post' && protect_against_forgery?
           request_token_tag = tag(:input, :type => "hidden", :name => request_forgery_protection_token.to_s, :value => form_authenticity_token)
@@ -340,8 +348,10 @@ module ActionView
 
         html_options.merge!("type" => "submit", "value" => name)
 
-        ("<form method=\"#{form_method}\" action=\"#{ERB::Util.html_escape(url)}\" #{"data-remote=\"true\"" if remote} class=\"#{ERB::Util.html_escape(form_class)}\"><div>" +
-          method_tag + tag("input", html_options) + request_token_tag + "</div></form>").html_safe
+        form_options.merge!(:method => form_method, :action => url)
+        form_options.merge!("data-remote" => "true") if remote
+        
+        "#{tag(:form, form_options, true)}<div>#{method_tag}#{tag("input", html_options)}#{request_token_tag}</div></form>".html_safe
       end
 
 

--- a/actionpack/test/template/url_helper_test.rb
+++ b/actionpack/test/template/url_helper_test.rb
@@ -88,6 +88,10 @@ class UrlHelperTest < ActiveSupport::TestCase
     )
   end
 
+  def test_button_to_with_remote_and_form_options
+    assert_dom_equal "<form method=\"post\" action=\"http://www.example.com\" class=\"custom-class\" data-remote=\"true\" data-type=\"json\"><div><input type=\"submit\" value=\"Hello\" /></div></form>", button_to("Hello", "http://www.example.com", :remote => true, :form => { :class => "custom-class", "data-type" => "json" } )
+  end
+  
   def test_button_to_with_remote_and_javascript_confirm
     assert_dom_equal(
       "<form method=\"post\" action=\"http://www.example.com\" class=\"button_to\" data-remote=\"true\"><div><input data-confirm=\"Are you sure?\" type=\"submit\" value=\"Hello\" /></div></form>",


### PR DESCRIPTION
see #3154, we need a way can add attributes to form tag:

```
<%= button_to "foo", "/foo", :remote => true, :form => { "data-type" => "json" } %>
```

will generate

```
<form method="post" action="/foo" class="button_to" data-remote="true" data-type="json"><div><input  type="submit" value="foo" />...</div></form>
```

p.s. there is a "form_class" option may become redundant since we can pass :form => { :class => "custom_class" }
