### PR TITLE
Fixed digest authentication for requests with a query string [#3158]

### DIFF
--- a/activeresource/lib/active_resource/connection.rb
+++ b/activeresource/lib/active_resource/connection.rb
@@ -238,8 +238,11 @@ module ActiveResource
       def digest_auth_header(http_method, uri)
         params = extract_params_from_response
 
+        request_uri = uri.path
+        request_uri << "?#{uri.query}" if uri.query
+
         ha1 = Digest::MD5.hexdigest("#{@user}:#{params['realm']}:#{@password}")
-        ha2 = Digest::MD5.hexdigest("#{http_method.to_s.upcase}:#{uri.path}")
+        ha2 = Digest::MD5.hexdigest("#{http_method.to_s.upcase}:#{request_uri}")
 
         params.merge!('cnonce' => client_nonce)
         request_digest = Digest::MD5.hexdigest([ha1, params['nonce'], "0", params['cnonce'], params['qop'], ha2].join(":"))

--- a/activeresource/test/cases/authorization_test.rb
+++ b/activeresource/test/cases/authorization_test.rb
@@ -131,6 +131,12 @@ class AuthorizationTest < Test::Unit::TestCase
     assert_equal blank_digest_auth_header("/people/2.json", "fad396f6a34aeba28e28b9b96ddbb671"), authorization_header['Authorization']
   end
 
+  def test_authorization_header_with_query_string_if_auth_type_is_digest
+    @authenticated_conn.auth_type = :digest
+    authorization_header = @authenticated_conn.__send__(:authorization_header, :get, URI.parse('/people/2.json?only=name'))
+    assert_equal blank_digest_auth_header("/people/2.json?only=name", "f8457b0b5d21b6b80737a386217afb24"), authorization_header['Authorization']
+  end
+
   def test_get
     david = decode(@authenticated_conn.get("/people/2.json"))
     assert_equal "David", david["name"]


### PR DESCRIPTION
This fixes issue #3158, wherein digest authentication headers weren't including the query string when generating the request digest.
