### PR TITLE
Add config.assets.digest_exclusions config option [fixes #2294]

### DIFF
--- a/actionpack/lib/sprockets/assets.rake
+++ b/actionpack/lib/sprockets/assets.rake
@@ -30,7 +30,7 @@ namespace :assets do
       config.assets.digests = {}
 
       target = File.join(Rails.public_path, config.assets.prefix)
-      static_compiler = Sprockets::StaticCompiler.new(env, target, :digest => config.assets.digest)
+      static_compiler = Sprockets::StaticCompiler.new(env, target, :digest => config.assets.digest, :digest_exclusions => config.assets.digest_exclusions)
 
       manifest = static_compiler.precompile(config.assets.precompile)
       manifest_path = config.assets.manifest || target

--- a/actionpack/test/template/sprockets_helper_test.rb
+++ b/actionpack/test/template/sprockets_helper_test.rb
@@ -298,4 +298,13 @@ class SprocketsHelperTest < ActionView::TestCase
     assert_equal '/assets/logo.png',
       asset_path("logo.png")
   end
+
+  test "asset path matches config.assets.digest_exclusions" do
+    @config.assets.digest_exclusions = ["logo.*", /style/, Proc.new { |path| path.starts_with?('extra') } ]
+
+    assert_equal "/assets/logo.png", asset_path("logo.png")
+    assert_equal "/assets/style.css", asset_path("style.css")
+    assert_equal "/assets/extra.js", asset_path("extra.js")
+    assert_match %r{/assets/application-[0-9a-f]+.js}, asset_path("application.js")
+  end
 end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -50,6 +50,7 @@ module Rails
         @assets.cache_store     = [ :file_store, "#{root}/tmp/cache/assets/" ]
         @assets.js_compressor   = nil
         @assets.css_compressor  = nil
+        @assets.digest_exclusions = []
       end
 
       def compiled_asset_path


### PR DESCRIPTION
See previous discussion here: https://github.com/rails/rails/issues/2294

Since this functionality can now be added without changes to the Sprockets codebase, I want to again propose that this functionality is added. It is a port of my digestion gem (https://github.com/spohlenz/digestion) that allows specific asset paths to be excluded from digest fingerprinting.
