### PR TITLE
RAILS_ENV environment variable is ignored when running rake from thor script using Rails::Generators::Actions

### DIFF
--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -252,7 +252,7 @@ module Rails
       #
       def rake(command, options={})
         log :rake, command
-        env  = options[:env] || 'development'
+        env  = options[:env] || ENV["RAILS_ENV"] || 'development'
         sudo = options[:sudo] && RbConfig::CONFIG['host_os'] !~ /mswin|mingw/ ? 'sudo ' : ''
         in_root { run("#{sudo}#{extify(:rake)} #{command} RAILS_ENV=#{env}", :verbose => false) }
       end

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -189,6 +189,22 @@ class ActionsTest < Rails::Generators::TestCase
     action :rake, 'log:clear', :env => 'production'
   end
 
+  def test_rake_with_rails_env_variable_should_run_rake_command_in_env
+    generator.expects(:run).once.with('rake log:clear RAILS_ENV=production', :verbose => false)
+    old_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "production"
+    action :rake, 'log:clear'
+  ensure
+    ENV["RAILS_ENV"] = old_env
+  end
+
+  def test_env_option_should_win_over_rails_env_variable_when_running_rake
+    generator.expects(:run).once.with('rake log:clear RAILS_ENV=production', :verbose => false)
+    old_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "staging"
+    action :rake, 'log:clear', :env => 'production'
+  ensure
+    ENV["RAILS_ENV"] = old_env
+  end
+
   def test_rake_with_sudo_option_should_run_rake_command_with_sudo
     generator.expects(:run).once.with('sudo rake log:clear RAILS_ENV=development', :verbose => false)
     action :rake, 'log:clear', :sudo => true


### PR DESCRIPTION
Hi all.

Current implementation of `Rails::Generators::Actions#rake` disregards set `RAILS_ENV` environment. Not sure if this is intentional, but there are some use cases where this behavior is harmful. E.g., ponder on writing a thor script, including `Rails::Generators::Actions` to it and calling rake from it. Like this:

``` ruby
class Setup < Thor
  include Rails::Generators::Actions

  desc "db", "initialize db and load schema"
  def db
    rake "db:setup"
    rake "db:test:clone"
  end
```

If you call it from command line like `RAILS_ENV=staging thor setup:db`, you'll surprisingly find out, that rake is being explicitly run in development environment, and this definitely violates the [POLA](http://en.wikipedia.org/wiki/Principle_of_least_astonishment).

Suggested patch just honors `RAILS_ENV` variable set.
