### PR TITLE
Fixed file store to handle delete_matched being called before cache dir is created.

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -161,6 +161,7 @@ module ActiveSupport
         end
 
         def search_dir(dir, &callback)
+          return if !File.exist?(dir)
           Dir.foreach(dir) do |d|
             next if d == "." || d == ".."
             name = File.join(dir, d)

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -567,11 +567,12 @@ class FileStoreTest < ActiveSupport::TestCase
     assert_equal 'B', File.basename(path)
   end
 
-  def test_search_dir_when_directory_does_not_exist
-    ActiveSupport::Cache::FileStore.new('test').send(:search_dir, 'dir_does_not_exist') do |path|
-      flunk "search_dir yielded but should have done nothing"
+  # If nothing has been stored in the cache, there is a chance the cache directory does not yet exist
+  # Ensure delete_matched gracefully handles this case
+  def test_delete_matched_when_cache_directory_does_not_exist
+    assert_nothing_raised(Exception) do
+      ActiveSupport::Cache::FileStore.new('/test/cache/directory').delete_matched(/does_not_exist/)
     end
-    assert true
   end
 end
 

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -566,6 +566,13 @@ class FileStoreTest < ActiveSupport::TestCase
     assert path.split('/').all? { |dir_name| dir_name.size <= ActiveSupport::Cache::FileStore::FILENAME_MAX_SIZE}
     assert_equal 'B', File.basename(path)
   end
+
+  def test_search_dir_when_directory_does_not_exist
+    ActiveSupport::Cache::FileStore.new('test').send(:search_dir, 'dir_does_not_exist') do |path|
+      flunk "search_dir yielded but should have done nothing"
+    end
+    assert true
+  end
 end
 
 class MemoryStoreTest < ActiveSupport::TestCase


### PR DESCRIPTION
Added fix so that file store does not raise an exception when cache dir does not exist yet. This can happen if a delete_matched is called before anything is saved in the cache.
