### PR TITLE
Allow default options for `as_json` method on models

### DIFF
--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -206,4 +206,14 @@ class JsonSerializationTest < ActiveModel::TestCase
     assert_no_match %r{"preferences":}, json
   end
 
+  test "custom as_json options should be extendible" do
+    def @contact.as_json(options = {}); super(options.merge(:only => [:name])); end
+    json = @contact.to_json
+
+    assert_match %r{"name":"Konata Izumi"}, json
+    assert_no_match %r{"created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))}}, json
+    assert_no_match %r{"awesome":}, json
+    assert_no_match %r{"preferences":}, json
+  end
+
 end

--- a/activesupport/lib/active_support/core_ext/object/to_json.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_json.rb
@@ -12,7 +12,7 @@ end
 [Object, Array, FalseClass, Float, Hash, Integer, NilClass, String, TrueClass].each do |klass|
   klass.class_eval <<-RUBY, __FILE__, __LINE__
     # Dumps object in JSON (JavaScript Object Notation). See www.json.org for more info.
-    def to_json(options = nil)
+    def to_json(options = {})
       ActiveSupport::JSON.encode(self, options)
     end
   RUBY


### PR DESCRIPTION
This is a clone of pull request #3172  but sending it to master instead.

When you've got an AR Model and you override the `as_json` method, you should be able to add default options to the renderer, like this:

``` ruby
class User < ActiveRecord::Base
  def as_json(options = {})
    super(options.merge(:except => [:password_digest]))
  end
end
```

This was not possible before this commit. See the added test case.

Thanks
