### PR TITLE
Set config.assets.debug to false by default in development.rb  

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -31,5 +31,5 @@
   config.assets.compress = false
 
   # Expands the lines which load the assets
-  config.assets.debug = true
+  config.assets.debug = false
 end


### PR DESCRIPTION
Follow the guide ,I think its value  should set false by default . disable it can increase the speed of the request time in development mode.
