### PR TITLE
Don't html-escape <a> links in the development mode's stack trace.

### DIFF
--- a/actionpack/lib/action_controller/templates/rescues/_trace.erb
+++ b/actionpack/lib/action_controller/templates/rescues/_trace.erb
@@ -20,7 +20,7 @@
 
   <% traces.each do |name, trace| %>
     <div id="<%= name.gsub /\s/, '-' %>" style="display: <%= name == "Application Trace" ? 'block' : 'none' %>;">
-      <pre><code><%=h trace.join "\n" %></code></pre>
+      <pre><code><%= trace.join "\n" %></code></pre>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
In 2.3, the application trace displayed in the browser when an error occurs, contains literally "<a href=..." instead of a clickable link to the offending line. This patch simply removes the incorrect "h" escaping call.
