### PR TITLE
Fix regression in assets:precompile task when task is enhanced

### DIFF
--- a/actionpack/lib/sprockets/assets.rake
+++ b/actionpack/lib/sprockets/assets.rake
@@ -7,6 +7,7 @@ namespace :assets do
       ENV["RAILS_GROUPS"] ||= "assets"
       ENV["RAILS_ENV"]    ||= "production"
       ruby $0, *ARGV
+      exit
     else
       require "fileutils"
       Rake::Task["tmp:cache:clear"].invoke
@@ -42,6 +43,7 @@ namespace :assets do
         end
         ENV["RAILS_ASSETS_NONDIGEST"] = "true"
         ruby $0, *ARGV
+        exit
       end
     end
   end

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -22,7 +22,7 @@ module ApplicationTests
     end
 
     def precompile!
-      capture(:stdout) do
+      quietly do
         Dir.chdir(app_path){ `bundle exec rake assets:precompile` }
       end
     end
@@ -249,7 +249,7 @@ module ApplicationTests
       # digest is default in false, we must enable it for test environment
       add_to_config "config.assets.digest = true"
 
-      capture(:stdout) do
+      quietly do
         Dir.chdir(app_path){ `bundle exec rake assets:precompile RAILS_ENV=test` }
       end
       file = Dir["#{app_path}/public/assets/application.css"].first
@@ -281,7 +281,7 @@ module ApplicationTests
       add_to_config "config.assets.compile = true"
 
       ENV["RAILS_ENV"] = nil
-      capture(:stdout) do
+      quietly do
         Dir.chdir(app_path){ `bundle exec rake assets:precompile RAILS_GROUPS=assets` }
       end
       file = Dir["#{app_path}/public/assets/application-*.css"].first
@@ -306,7 +306,7 @@ module ApplicationTests
       app_file "public/assets/application.css", "a { color: green; }"
       app_file "public/assets/subdir/broken.png", "not really an image file"
 
-      capture(:stdout) do
+      quietly do
         Dir.chdir(app_path){ `bundle exec rake assets:clean` }
       end
 

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -419,6 +419,12 @@ module ApplicationTests
       assert_equal "NoPost;\n", File.read("#{app_path}/public/assets/application.js")
     end
 
+    test "enhancements to assets:precompile should only run once" do
+      app_file "lib/tasks/enhance.rake", "Rake::Task['assets:precompile'].enhance { puts 'enhancement' }"
+      output = precompile!
+      assert_equal 1, output.scan("enhancement").size
+    end
+
     private
 
     def app_with_assets_in_view


### PR DESCRIPTION
The change in PR #3121 introduces a regression in the behaviour of the `assets:precompile` task when the task is enhanced. e.g.

``` ruby
Rake::Task['assets:precompile'].enhance do
  puts "Precompiling themes..."
  # ...
end
```

Using `ruby` rather than `Kernel.exec` causes the task enhancement to run multiple times (3 times in 3.1.1.rc2) when it should run only once. This is because `ruby` forks and continues running the task (and its enhancements) after it is called, whereas `Kernel.exec` replaces the current process.

Explicitly calling `exit` after calling `ruby` fixes this issue.
