### PR TITLE
normalize arg for AC::TestCase tests class method

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -333,9 +333,21 @@ module ActionController
       module ClassMethods
 
         # Sets the controller class name. Useful if the name can't be inferred from test class.
-        # Expects +controller_class+ as a constant. Example: <tt>tests WidgetController</tt>.
+        # Normalizes +controller_class+ before using. Examples:
+        #
+        #   tests WidgetController
+        #   tests :widget
+        #   tests 'widget'
+        #
         def tests(controller_class)
-          self.controller_class = controller_class
+          case controller_class
+          when String, Symbol
+            self.controller_class = "#{controller_class.to_s.underscore}_controller".camelize.constantize
+          when Class
+            self.controller_class = controller_class
+          else
+            raise ArgumentError, "controller class must be a String, Symbol, or Class"
+          end
         end
 
         def controller_class=(new_class)

--- a/actionpack/test/controller/test_test.rb
+++ b/actionpack/test/controller/test_test.rb
@@ -774,6 +774,22 @@ class CrazyNameTest < ActionController::TestCase
   end
 end
 
+class CrazySymbolNameTest < ActionController::TestCase
+  tests :content
+
+  def test_set_controller_class_using_symbol
+    assert_equal ContentController, self.class.controller_class
+  end
+end
+
+class CrazyStringNameTest < ActionController::TestCase
+  tests 'content'
+
+  def test_set_controller_class_using_string
+    assert_equal ContentController, self.class.controller_class
+  end
+end
+
 class NamedRoutesControllerTest < ActionController::TestCase
   tests ContentController
 


### PR DESCRIPTION
Suggest improve a little syntax for ActionController::TestCase test method.

If it's ok I create similar commits for ActionMailer and ActionView (not create pull requests yet): 33168c5a1c7cbdbfb6be0a78cb01cd52bf5633f2 and 9a8a3230dd907e79309f576135b6bde160b764a2
