### PR TITLE
Improve tests method for ActionView::TestCase and ActionMailer::TestCase

### DIFF
--- a/actionmailer/lib/action_mailer/test_case.rb
+++ b/actionmailer/lib/action_mailer/test_case.rb
@@ -17,7 +17,14 @@ module ActionMailer
 
       module ClassMethods
         def tests(mailer)
-          self._mailer_class = mailer
+          case mailer
+          when String, Symbol
+            self._mailer_class = mailer.to_s.camelize.constantize
+          when Module
+            self._mailer_class = mailer
+          else
+            raise NonInferrableMailerError.new(mailer)
+          end
         end
 
         def mailer_class

--- a/actionmailer/test/test_test.rb
+++ b/actionmailer/test/test_test.rb
@@ -1,0 +1,28 @@
+require 'abstract_unit'
+
+class TestTestMailer < ActionMailer::Base
+end
+
+class CrazyNameMailerTest < ActionMailer::TestCase
+  tests TestTestMailer
+
+  def test_set_mailer_class_manual
+    assert_equal TestTestMailer, self.class.mailer_class
+  end
+end
+
+class CrazySymbolNameMailerTest < ActionMailer::TestCase
+  tests :test_test_mailer
+
+  def test_set_mailer_class_manual_using_symbol
+    assert_equal TestTestMailer, self.class.mailer_class
+  end
+end
+
+class CrazyStringNameMailerTest < ActionMailer::TestCase
+  tests 'test_test_mailer'
+
+  def test_set_mailer_class_manual_using_string
+    assert_equal TestTestMailer, self.class.mailer_class
+  end
+end

--- a/actionpack/lib/action_view/test_case.rb
+++ b/actionpack/lib/action_view/test_case.rb
@@ -50,7 +50,12 @@ module ActionView
 
       module ClassMethods
         def tests(helper_class)
-          self.helper_class = helper_class
+          case helper_class
+          when String, Symbol
+            self.helper_class = "#{helper_class.to_s.underscore}_helper".camelize.safe_constantize
+          when Module
+            self.helper_class = helper_class
+          end
         end
 
         def determine_default_helper_class(name)

--- a/actionpack/test/template/test_test.rb
+++ b/actionpack/test/template/test_test.rb
@@ -62,3 +62,19 @@ class CrazyHelperTest < ActionView::TestCase
     assert_equal PeopleHelper, self.class.helper_class
   end
 end
+
+class CrazySymbolHelperTest < ActionView::TestCase
+  tests :people
+
+  def test_set_helper_class_using_symbol
+    assert_equal PeopleHelper, self.class.helper_class
+  end
+end
+
+class CrazyStringHelperTest < ActionView::TestCase
+  tests 'people'
+
+  def test_set_helper_class_using_string
+    assert_equal PeopleHelper, self.class.helper_class
+  end
+end


### PR DESCRIPTION
AV::TestCase, AM::TestCase and AC::TestCase classes have class method <tt>tests</tt>. It allow to set manually testing class if it can't be determened from test case name automatically. It's rather hard to find <tt>tests</tt> method in real life but it can be usefull in big projects.

I suggest to make these methods a little bit flexible. @josevalim found 8e946daf6957b46744a90d25266b0ec5e8537079 (changes ActionController::TestCase#tests) suitable. I prepared changes for ActionMailer and ActionView also. 

https://github.com/avakhov/rails/commit/0defbc6bfeff053983ef65739b2dcc080b2ad227#diff-0
AM::TestCase uses <tt>constantize</tt> for conversion and raise NonInferrableMailerError exception in case of error. It almost keeps original behaviour from AM::TestCase#determine_default_mailer: https://github.com/rails/rails/blob/41c8277a9b04dda40972bbafa2dbfc00c5c238fb/actionmailer/lib/action_mailer/test_case.rb#L31

https://github.com/avakhov/rails/commit/8df7fe3f630e13da1585c151f6f2f986ea7dcdfd#diff-0
AV::TestCase uses <tt>safe_constantize</tt> and not raise any exceptions. It's closer to AV behaviour just to check <tt>helper_class</tt>: https://github.com/rails/rails/blob/64b0c8888b908ede5372e0a70cb4cb8731d372ba/actionpack/lib/action_view/test_case.rb#L86
