### PR TITLE
(Fix) Asset pipeline unexpectedly removes digest assets - 3.1.1.rc2

### DIFF
--- a/actionpack/lib/sprockets/assets.rake
+++ b/actionpack/lib/sprockets/assets.rake
@@ -4,9 +4,15 @@ namespace :assets do
     # We need to do this dance because RAILS_GROUPS is used
     # too early in the boot process and changing here is already too late.
     if ENV["RAILS_GROUPS"].to_s.empty? || ENV["RAILS_ENV"].to_s.empty?
+      unless ARGV.index('assets:precompile') == (ARGV.length - 1)
+        # assets:precompile is not the last task, but we're about to
+        # exit early, so let's fail fast here and show an explanatory
+        # message.
+        raise "The assets:precompile may not be followed by other tasks. Please run multiple rake invocations instead."
+      end
       ENV["RAILS_GROUPS"] ||= "assets"
       ENV["RAILS_ENV"]    ||= "production"
-      ruby $0, 'assets:precompile'
+      ruby $0, *([Rake.application.options.trace ? '--trace' : nil, 'assets:precompile'].compact)
       exit
     else
       require "fileutils"
@@ -42,7 +48,7 @@ namespace :assets do
           YAML.dump(manifest, f)
         end
         ENV["RAILS_ASSETS_NONDIGEST"] = "true"
-        ruby $0, 'assets:precompile'
+        ruby $0, *([Rake.application.options.trace ? '--trace' : nil, 'assets:precompile'].compact)
         exit
       end
     end

--- a/actionpack/lib/sprockets/assets.rake
+++ b/actionpack/lib/sprockets/assets.rake
@@ -6,7 +6,7 @@ namespace :assets do
     if ENV["RAILS_GROUPS"].to_s.empty? || ENV["RAILS_ENV"].to_s.empty?
       ENV["RAILS_GROUPS"] ||= "assets"
       ENV["RAILS_ENV"]    ||= "production"
-      ruby $0, *ARGV
+      ruby $0, 'assets:precompile'
       exit
     else
       require "fileutils"
@@ -42,7 +42,7 @@ namespace :assets do
           YAML.dump(manifest, f)
         end
         ENV["RAILS_ASSETS_NONDIGEST"] = "true"
-        ruby $0, *ARGV
+        ruby $0, 'assets:precompile'
         exit
       end
     end

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -425,6 +425,19 @@ module ApplicationTests
       assert_equal 1, output.scan("enhancement").size
     end
 
+    test "digested assets are not mistakenly removed" do
+      app_file "public/assets/application.js", "alert();"
+      add_to_config "config.assets.compile = true"
+      add_to_config "config.assets.digest = true"
+
+      quietly do
+        Dir.chdir(app_path){ `bundle exec rake assets:clean assets:precompile` }
+      end
+
+      files = Dir["#{app_path}/public/assets/application-*.js"]
+      assert_equal 1, files.length, "Expected digested application.js asset to be generated, but none found"
+    end
+
     private
 
     def app_with_assets_in_view


### PR DESCRIPTION
Patch and associated test to fix #3198.
