### PR TITLE
Use rack-cache 1.1

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('activesupport',    version)
   s.add_dependency('activemodel',      version)
-  s.add_dependency('rack-cache',       '~> 1.0.3')
+  s.add_dependency('rack-cache',       '~> 1.1')
   s.add_dependency('builder',          '~> 3.0.0')
   s.add_dependency('i18n',             '~> 0.6')
   s.add_dependency('rack',             '~> 1.3.2')

--- a/railties/test/application/middleware/cache_test.rb
+++ b/railties/test/application/middleware/cache_test.rb
@@ -31,6 +31,10 @@ module ApplicationTests
             $last_modified ||= Time.now.utc
             render_conditionally(:last_modified => $last_modified)
           end
+
+          def keeps_if_modified_since
+            render :text => request.headers['If-Modified-Since']
+          end
         private
           def render_conditionally(headers)
             if stale?(headers.merge(:public => !params[:private]))
@@ -45,6 +49,16 @@ module ApplicationTests
           match ':controller(/:action)'
         end
       RUBY
+    end
+
+    def test_cache_keeps_if_modified_since
+      simple_controller
+      expected = "Wed, 30 May 1984 19:43:31 GMT"
+      
+      get "/expires/keeps_if_modified_since", {}, "HTTP_IF_MODIFIED_SINCE" => expected
+      
+      assert_equal 200, last_response.status
+      assert_equal expected, last_response.body, "cache should have kept If-Modified-Since"
     end
 
     def test_cache_is_disabled_in_dev_mode


### PR DESCRIPTION
Versions of rack-cache prior to 1.1 delete the If-Modified-Since and If-Not-Modified headers when
`config.action_controller.perform_caching` is true.

This creates  two problems:
- unexpected, inconsistent behaviour between development & production environments
- breaks (production) applications that use of these headers -- really ungood for people trying to develop things that speak sensible HTTP.

I originally opened #3053 about this, but then discovered that Rails wasn't the culprit. The solution is upgrading to 1.1, which doesn't break anything as far as I could tell.

My test & changes are based off of master. I believe rack-cache 1.0.3 first appeared in some beta incarnation of 3.1, so it'd be good to get it into those branches if possible.
