### PR TITLE
db:test:clone_structure if path to .sql file contains spaces or dashes

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -424,10 +424,10 @@ db_namespace = namespace :db do
         ENV['PGHOST']     = abcs['test']['host'] if abcs['test']['host']
         ENV['PGPORT']     = abcs['test']['port'].to_s if abcs['test']['port']
         ENV['PGPASSWORD'] = abcs['test']['password'].to_s if abcs['test']['password']
-        `psql -U "#{abcs['test']['username']}" -f #{Rails.root}/db/#{Rails.env}_structure.sql #{abcs['test']['database']} #{abcs['test']['template']}`
+        `psql -U "#{abcs['test']['username']}" -f "#{Rails.root}/db/#{Rails.env}_structure.sql" #{abcs['test']['database']} #{abcs['test']['template']}`
       when /sqlite/
         dbfile = abcs['test']['database'] || abcs['test']['dbfile']
-        `sqlite3 #{dbfile} < #{Rails.root}/db/#{Rails.env}_structure.sql`
+        `sqlite3 #{dbfile} < "#{Rails.root}/db/#{Rails.env}_structure.sql"`
       when 'sqlserver'
         `sqlcmd -S #{abcs['test']['host']} -d #{abcs['test']['database']} -U #{abcs['test']['username']} -P #{abcs['test']['password']} -i db\\#{Rails.env}_structure.sql`
       when 'oci', 'oracle'


### PR DESCRIPTION
Quoted path to <Rails.env>_structure.sql file in db:test:clone_structure task.

Leaving the path unquoted causes errors in paths containing spaces or dashes. So far as I can tell Rails doesn't have tests for rake tasks otherwise I would have written one.
