### PR TITLE
as_json documentation says that as_json returns a string.

### DIFF
--- a/activemodel/lib/active_model/serializers/json.rb
+++ b/activemodel/lib/active_model/serializers/json.rb
@@ -15,7 +15,7 @@ module ActiveModel
         self.include_root_in_json = true
       end
 
-      # Returns a JSON string representing the model. Some configuration can be
+      # Returns a hash representing the model. Some configuration can be
       # passed through +options+.
       #
       # The option <tt>include_root_in_json</tt> controls the top-level behavior


### PR DESCRIPTION
Fixes documentation to say that as_json transforms it into a hash rather than a JSON String.
