### PR TITLE
Add public/assets folder to gitignore template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/gitignore
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore
@@ -3,3 +3,4 @@ db/*.sqlite3
 log/*.log
 tmp/
 .sass-cache/
+public/assets/


### PR DESCRIPTION
Ignore public/assets folder in git by default for new application. It allows to get clean output status from git status command on production environment (after reake assets:precompile)
