### PR TITLE
incorrect to_formatted_s example

### DIFF
--- a/activesupport/lib/active_support/core_ext/range/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/range/conversions.rb
@@ -7,7 +7,7 @@ class Range
   #
   # ==== Example
   #
-  #   [1..100].to_formatted_s # => "1..100"
+  #   (1..100).to_formatted_s # => "1..100"
   def to_formatted_s(format = :default)
     if formatter = RANGE_FORMATS[format]
       formatter.call(first, last)


### PR DESCRIPTION
the `to_formatted_s` instance method example is using an Array instead of a Range
