### PR TITLE
Failing test for assets:clean task issue

### DIFF
--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -438,6 +438,19 @@ module ApplicationTests
       assert_equal 1, files.length, "Expected digested application.js asset to be generated, but none found"
     end
 
+    test "digested assets are removed from configured path" do
+      app_file "public/production_assets/application.js", "alert();"
+      add_to_env_config "production", "config.assets.prefix = 'production_assets'"
+
+      ENV["RAILS_ENV"] = nil
+      quietly do
+        Dir.chdir(app_path){ `bundle exec rake assets:clean` }
+      end
+
+      files = Dir["#{app_path}/public/production_assets/application.js"]
+      assert_equal 0, files.length, "Expected application.js asset to be removed, but still exists"
+    end
+
     private
 
     def app_with_assets_in_view

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -426,7 +426,7 @@ module ApplicationTests
     end
 
     test "digested assets are not mistakenly removed" do
-      app_file "public/assets/application.js", "alert();"
+      app_file "app/assets/application.js", "alert();"
       add_to_config "config.assets.compile = true"
       add_to_config "config.assets.digest = true"
 


### PR DESCRIPTION
This is a failing test case for the issue first described at https://github.com/rails/rails/pull/3199#issuecomment-2283644 namely 'assets:clean initializes the wrong environment so assumes the asset prefix of development, rather than the asset prefix definied in production'.

As a bonus, this patch also contains a small fix to the test I wrote yesterday for #3198. :)
