### PR TITLE
assets rake task refactoring work

### DIFF
--- a/actionpack/lib/sprockets/assets.rake
+++ b/actionpack/lib/sprockets/assets.rake
@@ -28,8 +28,8 @@ namespace :assets do
       @assets_config ||= app.config.assets
     end
 
-    def compiler(mode)
-      Sprockets::StaticCompiler.compiler_for(assets, app.assets, mode)
+    def compile(mode)
+      Sprockets::StaticCompiler.compiler_for(assets, app.assets, mode).compile
     end
 
     def invoke_digestless?
@@ -51,12 +51,12 @@ namespace :assets do
 
     task :compile, [:mode] => ["assets:internal:environment", "tmp:cache:clear"] do |t, args|
       mode = args[:mode] || 'primary'
-      compiler(mode).compile
+      compile(mode)
       if mode == 'primary' && invoke_digestless?
         # We need to reinvoke in order to run the secondary asset
         # compilation run - a fresh Sprockets environment is
         # required in order to compile digestless assets.
-        reinvoke_for("compile[digestless]") if invoke_digestless?
+        reinvoke_for("compile[digestless]")
       end
     end
 

--- a/actionpack/lib/sprockets/assets.rake
+++ b/actionpack/lib/sprockets/assets.rake
@@ -3,7 +3,7 @@ require "fileutils"
 namespace :assets do
   desc "Compile all the assets named in config.assets.precompile"
   task :precompile do
-    Rake::Task["assets:internal:invoke"].invoke("compile[primary]")
+    Rake::Task["assets:internal:invoke"].invoke("compile:all")
   end
 
   desc "Remove compiled assets"
@@ -20,22 +20,6 @@ namespace :assets do
       ruby *args
     end
 
-    def app
-      @app ||= Rails.application
-    end
-
-    def assets
-      @assets_config ||= app.config.assets
-    end
-
-    def compile(mode)
-      Sprockets::StaticCompiler.compiler_for(assets, app.assets, mode).compile
-    end
-
-    def invoke_digestless?
-      assets.digest && !assets.skip_digestless
-    end
-
     task :invoke, [:task] do |this, args|
       task = args[:task]
       if ENV['RAILS_GROUPS'].to_s.empty? || ENV['RAILS_ENV'].to_s.empty?
@@ -49,14 +33,70 @@ namespace :assets do
       this.reenable
     end
 
-    task :compile, [:mode] => ["assets:internal:environment", "tmp:cache:clear"] do |t, args|
-      mode = args[:mode] || 'primary'
-      compile(mode)
-      if mode == 'primary' && invoke_digestless?
-        # We need to reinvoke in order to run the secondary asset
-        # compilation run - a fresh Sprockets environment is
-        # required in order to compile digestless assets.
-        reinvoke_for("compile[digestless]")
+    def app
+      @app ||= Rails.application
+    end
+
+    def assets
+      @assets_config ||= app.config.assets
+    end
+
+    namespace :compile do
+      def mode=(mode)
+        unless [:primary, :digestless].include?(mode)
+          raise "Unknown asset compilation mode: #{mode}. Please use one of: primary, digestless"
+        end
+        @mode = ActiveSupport::StringInquirer.new(mode.to_s)
+      end
+
+      def mode
+        @mode ||= ActiveSupport::StringInquirer.new('primary')
+      end
+
+      def compile
+        unless assets.enabled
+          raise "Cannot precompile assets if sprockets is disabled. Please set config.assets.enabled to true"
+        end
+        
+        # Ensure that action view is loaded and the appropriate
+        # sprockets hooks get executed
+        _ = ActionView::Base
+        
+        assets.digest = false if mode.digestless?
+        assets.compile = true
+        assets.digests = {}
+
+        target = File.join(Rails.public_path, assets.prefix)
+        compiler = Sprockets::StaticCompiler.new(app.assets, 
+                                                 target,
+                                                 assets.precompile,
+                                                 :manifest_path => assets.manifest,
+                                                 :digest => assets.digest,
+                                                 :manifest => mode.primary?)
+        compiler.compile
+      end
+
+      def invoke_digestless?
+        assets.digest && !assets.skip_digestless
+      end
+
+      task :all => ["assets:internal:environment", "tmp:cache:clear"] do
+        Rake::Task["assets:internal:compile:primary"].invoke
+        # We need to reinvoke in order to run the secondary digestless
+        # asset compilation run - a fresh Sprockets environment is
+        # required in order to compile digestless assets as the
+        # environment has already cached the assets on the primary
+        # run.
+        reinvoke_for("compile:digestless") if invoke_digestless?
+      end
+
+      task :primary => ["assets:internal:environment", "tmp:cache:clear"] do 
+        compile
+      end
+
+      task :digestless => ["assets:internal:environment", "tmp:cache:clear"] do 
+        self.mode = :digestless
+        compile
       end
     end
 

--- a/actionpack/lib/sprockets/assets.rake
+++ b/actionpack/lib/sprockets/assets.rake
@@ -1,75 +1,77 @@
 require "fileutils"
 
 namespace :assets do
-  def ruby_rake_task(task)
-    args = [$0, task]
-    args << "--trace" if Rake.application.options.trace
-    ruby *args
-  end
-
   desc "Compile all the assets named in config.assets.precompile"
   task :precompile do
-    ENV["RAILS_GROUPS"] ||= "assets"
-    ENV["RAILS_ENV"]    ||= "production"
-    ruby_rake_task "assets:precompile:all"
-  end
-
-  namespace :precompile do
-    def internal_precompile(digest=nil)
-      unless Rails.application.config.assets.enabled
-        warn "Cannot precompile assets if sprockets is disabled. Please set config.assets.enabled to true"
-        exit
-      end
-
-      # Ensure that action view is loaded and the appropriate
-      # sprockets hooks get executed
-      _ = ActionView::Base
-
-      config = Rails.application.config
-      config.assets.compile = true
-      config.assets.digest  = digest unless digest.nil?
-      config.assets.digests = {}
-
-      env    = Rails.application.assets
-      target = File.join(Rails.public_path, config.assets.prefix)
-      static_compiler = Sprockets::StaticCompiler.new(env, target, :digest => config.assets.digest)
-      static_compiler.precompile(config.assets.precompile)
-    end
-
-    task :all do
-      Rake::Task["assets:precompile:digest"].invoke
-      ruby_rake_task "assets:precompile:nondigest"
-    end
-
-    task :digest => ["assets:environment", "tmp:cache:clear"] do
-      manifest      = internal_precompile
-      config        = Rails.application.config
-      manifest_path = config.assets.manifest || File.join(Rails.public_path, config.assets.prefix)
-      FileUtils.mkdir_p(manifest_path)
-
-      File.open("#{manifest_path}/manifest.yml", 'wb') do |f|
-        YAML.dump(manifest, f)
-      end
-    end
-
-    task :nondigest => ["assets:environment", "tmp:cache:clear"] do
-      internal_precompile(false)
-    end
+    Rake::Task["assets:internal:invoke"].invoke("compile[primary]")
   end
 
   desc "Remove compiled assets"
-  task :clean => ["assets:environment", "tmp:cache:clear"] do
-    config = Rails.application.config
-    public_asset_path = File.join(Rails.public_path, config.assets.prefix)
-    rm_rf public_asset_path, :secure => true
+  task :clean do
+    Rake::Task["assets:internal:invoke"].invoke("clean")
   end
 
-  task :environment do
-    if Rails.application.config.assets.initialize_on_precompile
-      Rake::Task["environment"].invoke
-    else
-      Rails.application.initialize!(:assets)
-      Sprockets::Bootstrap.new(Rails.application).run
+  namespace :internal do
+    def reinvoke_for(task)
+      env = ENV['RAILS_ENV'] || 'production'
+      groups = ENV['RAILS_GROUPS'] || 'assets'
+      args = [$0, "assets:internal:#{task}","RAILS_ENV=#{env}","RAILS_GROUPS=#{groups}"]
+      args << "--trace" if Rake.application.options.trace
+      ruby *args
+    end
+
+    def app
+      @app ||= Rails.application
+    end
+
+    def assets
+      @assets_config ||= app.config.assets
+    end
+
+    def compiler(mode)
+      Sprockets::StaticCompiler.compiler_for(assets, app.assets, mode)
+    end
+
+    def invoke_digestless?
+      assets.digest && !assets.skip_digestless
+    end
+
+    task :invoke, [:task] do |this, args|
+      task = args[:task]
+      if ENV['RAILS_GROUPS'].to_s.empty? || ENV['RAILS_ENV'].to_s.empty?
+        # We are currently running with no explicit bundler group
+        # and/or no explicit environment - we have to reinvoke rake to
+        # execute this task.
+        reinvoke_for(task)
+      else
+        Rake::Task["assets:internal:#{task}"].invoke
+      end
+      this.reenable
+    end
+
+    task :compile, [:mode] => ["assets:internal:environment", "tmp:cache:clear"] do |t, args|
+      mode = args[:mode] || 'primary'
+      compiler(mode).compile
+      if mode == 'primary' && invoke_digestless?
+        # We need to reinvoke in order to run the secondary asset
+        # compilation run - a fresh Sprockets environment is
+        # required in order to compile digestless assets.
+        reinvoke_for("compile[digestless]") if invoke_digestless?
+      end
+    end
+
+    task :clean => ["assets:internal:environment", "tmp:cache:clear"] do
+      public_asset_path = File.join(Rails.public_path, assets.prefix)
+      rm_rf(public_asset_path, :secure => true)
+    end
+    
+    task :environment do
+      if assets.initialize_on_precompile
+        Rake::Task["environment"].invoke
+      else
+        app.initialize!(:assets)
+        Sprockets::Bootstrap.new(app).run
+      end
     end
   end
 end

--- a/actionpack/lib/sprockets/static_compiler.rb
+++ b/actionpack/lib/sprockets/static_compiler.rb
@@ -2,43 +2,6 @@ require 'fileutils'
 
 module Sprockets
   class StaticCompiler
-    MODES = ['primary', 'digestless']
-    class << self
-      def assert_valid_configuration(assets, mode)
-        unless assets.enabled
-          raise "Cannot precompile assets if sprockets is disabled. Please set config.assets.enabled to true"
-        end
-        
-        unless MODES.include?(mode)
-          raise "Unknown asset compilation mode: #{mode}. Please use one of #{MODES.join}"
-        end
-      end
-
-      def configure_assets!(assets,mode)
-        assets.digest = false if mode == 'digestless'
-        assets.compile = true
-        assets.digests = {}
-      end
-
-      def compiler_for(assets, env, mode = 'primary')
-        assert_valid_configuration(assets, mode)
-
-        # Ensure that action view is loaded and the appropriate
-        # sprockets hooks get executed
-        _ = ActionView::Base
-        
-        configure_assets!(assets,mode)
-
-        target = File.join(Rails.public_path, assets.prefix)
-        Sprockets::StaticCompiler.new(env, 
-                                      target,
-                                      assets.precompile,
-                                      :manifest_path => assets.manifest,
-                                      :digest => assets.digest,
-                                      :manifest => (mode == 'primary'))
-      end
-    end
-
     attr_accessor :env, :target, :paths
 
     def initialize(env, target, paths, options = {})

--- a/actionpack/lib/sprockets/static_compiler.rb
+++ b/actionpack/lib/sprockets/static_compiler.rb
@@ -2,41 +2,91 @@ require 'fileutils'
 
 module Sprockets
   class StaticCompiler
-    attr_accessor :env, :target, :digest
-
-    def initialize(env, target, options = {})
-      @env = env
-      @target = target
-      @digest = options.key?(:digest) ? options.delete(:digest) : true
-    end
-
-    def precompile(paths)
-      Rails.application.config.assets.digest = digest
-      manifest = {}
-
-      env.each_logical_path do |logical_path|
-        next unless precompile_path?(logical_path, paths)
-        if asset = env.find_asset(logical_path)
-          manifest[logical_path] = compile(asset)
+    MODES = ['primary', 'digestless']
+    class << self
+      def assert_valid_configuration(assets, mode)
+        unless assets.enabled
+          raise "Cannot precompile assets if sprockets is disabled. Please set config.assets.enabled to true"
+        end
+        
+        unless MODES.include?(mode)
+          raise "Unknown asset compilation mode: #{mode}. Please use one of #{MODES.join}"
         end
       end
-      manifest
+
+      def configure_assets!(assets,mode)
+        assets.digest = false if mode == 'digestless'
+        assets.compile = true
+        assets.digests = {}
+      end
+
+      def compiler_for(assets, env, mode = 'primary')
+        assert_valid_configuration(assets, mode)
+
+        # Ensure that action view is loaded and the appropriate
+        # sprockets hooks get executed
+        _ = ActionView::Base
+        
+        configure_assets!(assets,mode)
+
+        target = File.join(Rails.public_path, assets.prefix)
+        Sprockets::StaticCompiler.new(env, 
+                                      target,
+                                      assets.precompile,
+                                      :manifest_path => assets.manifest,
+                                      :digest => assets.digest,
+                                      :manifest => (mode == 'primary'))
+      end
     end
 
-    def compile(asset)
-      asset_path = digest_asset(asset)
-      filename = File.join(target, asset_path)
-      FileUtils.mkdir_p File.dirname(filename)
-      asset.write_to(filename)
-      asset.write_to("#{filename}.gz") if filename.to_s =~ /\.(css|js)$/
-      asset_path
+    attr_accessor :env, :target, :paths
+
+    def initialize(env, target, paths, options = {})
+      @env = env
+      @target = target
+      @paths = paths
+      @digest = options.key?(:digest) ? options.delete(:digest) : true
+      @manifest = options.key?(:manifest) ? options.delete(:manifest) : true
+      @manifest_path = options.delete(:manifest_path) || target
     end
 
-    def precompile_path?(logical_path, paths)
+    def compile_generating_manifest
+      write_manifest(compile)
+    end
+
+    def compile
+      manifest = {}
+      env.each_logical_path do |logical_path|
+        next unless compile_path?(logical_path)
+        if asset = env.find_asset(logical_path)
+          manifest[logical_path] = write_asset(asset)
+        end
+      end
+      write_manifest(manifest) if @manifest
+    end
+
+    def write_manifest(manifest)
+      FileUtils.mkdir_p(@manifest_path)
+      File.open("#{@manifest_path}/manifest.yml", 'wb') do |f|
+        YAML.dump(manifest, f)
+      end
+    end
+
+    def write_asset(asset)
+      path_for(asset).tap do |path|
+        filename = File.join(target, path)
+        FileUtils.mkdir_p File.dirname(filename)
+        asset.write_to(filename)
+        asset.write_to("#{filename}.gz") if filename.to_s =~ /\.(css|js)$/
+      end
+    end
+
+    def compile_path?(logical_path)
       paths.each do |path|
-        if path.is_a?(Regexp)
+        case path
+        when Regexp
           return true if path.match(logical_path)
-        elsif path.is_a?(Proc)
+        when Proc
           return true if path.call(logical_path)
         else
           return true if File.fnmatch(path.to_s, logical_path)
@@ -45,8 +95,8 @@ module Sprockets
       false
     end
 
-    def digest_asset(asset)
-      digest ? asset.digest_path : asset.logical_path
+    def path_for(asset)
+      @digest ? asset.digest_path : asset.logical_path
     end
   end
 end

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -438,6 +438,19 @@ module ApplicationTests
       assert_equal 1, files.length, "Expected digested application.js asset to be generated, but none found"
     end
 
+    test "digested assets are removed from configured path" do
+      app_file "public/production_assets/application.js", "alert();"
+      add_to_env_config "production", "config.assets.prefix = 'production_assets'"
+
+      ENV["RAILS_ENV"] = nil
+      quietly do
+        Dir.chdir(app_path){ `bundle exec rake assets:clean` }
+      end
+
+      files = Dir["#{app_path}/public/production_assets/application.js"]
+      assert_equal 0, files.length, "Expected application.js asset to be removed, but still exists"
+    end
+
     private
 
     def app_with_assets_in_view

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -426,7 +426,7 @@ module ApplicationTests
     end
 
     test "digested assets are not mistakenly removed" do
-      app_file "public/assets/application.js", "alert();"
+      app_file "app/assets/application.js", "alert();"
       add_to_config "config.assets.compile = true"
       add_to_config "config.assets.digest = true"
 


### PR DESCRIPTION
This pull request incorporates the aforementioned failing test case in #3221, as well as significant refactoring to both the assets rake task and the `Sprockets::StaticCompiler` class.

All tests from assets_tests.rb pass in my environment (including the newly added test case).

I think these changes whip the assets rake task into a bit of a better shape and also open up the doors to creating some more fine-grained tests for the `StaticCompiler`.
