### PR TITLE
HTTP digest authentication fails when request URI ends with '?'

### DIFF
--- a/actionpack/test/controller/http_digest_authentication_test.rb
+++ b/actionpack/test/controller/http_digest_authentication_test.rb
@@ -208,6 +208,16 @@ class HttpDigestAuthenticationTest < ActionController::TestCase
     assert !ActionController::HttpAuthentication::Digest.validate_digest_response(@request, "SuperSecret"){nil}
   end
 
+  test "authentication request with request-uri ending in '?'" do
+    @request.env['HTTP_AUTHORIZATION'] = encode_credentials(:username => 'pretty', :password => 'please',
+                                                            :uri => '/http_digest_authentication_test/dummy_digest?')
+    @request.env['PATH_INFO'] = "/http_digest_authentication_test/dummy_digest?"
+    get :display
+
+    assert_response :success
+    assert_equal 'Definitely Maybe', @response.body
+  end
+
   private
 
   def encode_credentials(options)


### PR DESCRIPTION
Using Rails 3.1 and protecting some controller actions with HTTP digest authentication. Some actions accept filter parameters from the query string, and I have a button to "clear all filters". This 'reset' effectively sets the query string to empty, but leaves the '?' on the URI. (1)

In Chrome, this causes the HTTP authentication to fail, while Firefox silently removes the trailing '?' and continues.

Some code examples follow, but I'm not familiar enough with the HTTP specs to say if this is a bug in `ActionController::HttpAuthentication::Digest#validate_digest_response` or if the bug lies in `Rack::Request#fullpath`. However, I'm filing the issue here as a starting point for discussion.

Here's the gist of my controller

``` ruby
class SecureController
  before_filter :authenticate!

  def secret
    # do some secure stuff
  end

  def authenticate!
    authenticate_or_request_with_http_digest("my_realm") do |username|
      USERS[username]  # assume this is a username/digest hash defined elsewhere
    end
  end

end
```

_STEPS TO REPRODUCE:_

> navigate to `http://localhost:3000/secure/secret`
> _=> prompted for username and password_
> 
> enter valid user credentials
> _=> access granted, page renders_
> 
> filter data with a query, e.g. `http://localhost:3000/secure/secret?foo=bar`
> _=> filtered data is returned_
> 
> reset filter, e.g. `http://localhost:3000/secure/secret?` (2)
> _=> authentication fails, even with valid username/password_

In Chrome, the filter reset leaves the URL with a trailing '?'. In FireFox, the '?' is removed. However, if I manually type in the address `http://localhost:3000/secure/secret?` in FireFox, the authentication failure is replicated.
1. Actually, the filters and button are all generated automatically with Active Admin...
2. The code to reset the filters is actually JavaScript and is as follows:

``` javascript
  $(".clear_filters_btn").click(function(){
    window.location.search = "";
    return false;
  });
```
