### PR TITLE
ruby193: String#prepend for 3-1-stable

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -75,7 +75,7 @@ end
 
 module ActiveSupport #:nodoc:
   class SafeBuffer < String
-    UNSAFE_STRING_METHODS = ["capitalize", "chomp", "chop", "delete", "downcase", "gsub", "lstrip", "next", "reverse", "rstrip", "slice", "squeeze", "strip", "sub", "succ", "swapcase", "tr", "tr_s", "upcase"].freeze
+    UNSAFE_STRING_METHODS = ["capitalize", "chomp", "chop", "delete", "downcase", "gsub", "lstrip", "next", "reverse", "rstrip", "slice", "squeeze", "strip", "sub", "succ", "swapcase", "tr", "tr_s", "upcase", "prepend"].freeze
 
     alias_method :original_concat, :concat
     private :original_concat

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -136,16 +136,18 @@ module ActiveSupport #:nodoc:
     end
 
     for unsafe_method in UNSAFE_STRING_METHODS
-      class_eval <<-EOT, __FILE__, __LINE__ + 1
-        def #{unsafe_method}(*args)
-          super.to_str
-        end
+      if 'String'.respond_to?(unsafe_method)
+        class_eval <<-EOT, __FILE__, __LINE__ + 1
+          def #{unsafe_method}(*args)
+            super.to_str
+          end
 
-        def #{unsafe_method}!(*args)
-          @dirty = true
-          super
-        end
-      EOT
+          def #{unsafe_method}!(*args)
+            @dirty = true
+            super
+          end
+        EOT
+      end
     end
 
     protected


### PR DESCRIPTION
Ported #3229 for 3-1-stable branch.
