### PR TITLE
Make AM::Errors#to_json usable

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -202,7 +202,11 @@ module ActiveModel
     end
 
     def to_hash
-      messages.dup
+      messages.dup.each do |key, array|
+        array.map! do |message|
+          full_message(key, message)
+        end
+      end
     end
 
     # Adds +message+ to the error messages on +attribute+, which will be returned on a call to

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -108,8 +108,8 @@ class ErrorsTest < ActiveModel::TestCase
     person.errors.add(:name, "can not be nil")
     person.errors.add(:email, "is invalid")
     hash = person.errors.as_json
-    assert_equal ["can not be blank", "can not be nil"], hash[:name]
-    assert_equal ["is invalid"], hash[:email]
+    assert_equal ["name can not be blank", "name can not be nil"], hash[:name]
+    assert_equal ["email is invalid"], hash[:email]
   end
 
 end

--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -135,8 +135,8 @@ class JsonSerializationTest < ActiveModel::TestCase
     contact.errors.add :age, "must be 16 or over"
 
     hash = ActiveSupport::OrderedHash.new
-    hash[:name] = ["can't be blank", "is too short (minimum is 2 characters)"]
-    hash[:age]  = ["must be 16 or over"]
+    hash[:name] = ["Name can't be blank", "Name is too short (minimum is 2 characters)"]
+    hash[:age]  = ["Age must be 16 or over"]
     assert_equal hash.to_json, contact.errors.to_json
   end
 

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -182,8 +182,8 @@ class ValidationsTest < ActiveModel::TestCase
     assert_match %r{<error>Content can't be blank</error>}, xml
 
     hash = ActiveSupport::OrderedHash.new
-    hash[:title] = ["can't be blank"]
-    hash[:content] = ["can't be blank"]
+    hash[:title] = ["Title can't be blank"]
+    hash[:content] = ["Content can't be blank"]
     assert_equal t.errors.to_json, hash.to_json
   end
 


### PR DESCRIPTION
Current implementation of ActiveModel::Errors#to_json returns hash
without full messages. 

``` ruby
@model.errors.to_json 
  # => "{\"subdomain\":[\"can't be blank\"],\"title\":[\"is too short (minimum is 2 characters)\"]}"
```

But frontend has no clue how to humanize the attribute name and create full message.
(assuming that to_json is in most cases used to pass data to another context e.g. to Web frontend or API client)
This makes #to_json method useless and require to create own serializer.

In order to fix that changed the behavior so that #to_json returns full messages.

I would say that any serializer of `AM::Errors` should return full message because generate full messages from that serialization without errors object is impossible. But this is still a point to discuss.
