### PR TITLE
Use the schema_search_path in prepared statements.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1035,13 +1035,14 @@ module ActiveRecord
         end
 
         def exec_cache(sql, binds)
-          unless @statements.key? sql
+          sql_key = "#{schema_search_path}-#{sql}"
+          unless @statements.key? sql_key
             nextkey = @statements.next_key
             @connection.prepare nextkey, sql
-            @statements[sql] = nextkey
+            @statements[sql_key] = nextkey
           end
 
-          key = @statements[sql]
+          key = @statements[sql_key]
 
           # Clear the queue
           @connection.get_last_result

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -38,6 +38,10 @@ class SchemaTest < ActiveRecord::TestCase
     set_table_name 'test_schema."Things"'
   end
 
+  class Thing5 < ActiveRecord::Base
+    set_table_name 'things'
+  end
+
   def setup
     @connection = ActiveRecord::Base.connection
     @connection.execute "CREATE SCHEMA #{SCHEMA_NAME} CREATE TABLE #{TABLE_NAME} (#{COLUMNS.join(',')})"
@@ -234,6 +238,21 @@ class SchemaTest < ActiveRecord::TestCase
     }.each do |given,expect|
       with_schema_search_path(given) { assert_equal expect, @connection.current_schema }
     end
+  end
+
+  def test_prepared_statements_with_multiple_schemas
+
+    @connection.schema_search_path = SCHEMA_NAME
+    Thing5.create(:id => 1, :name => "thing inside #{SCHEMA_NAME}", :email => "thing1@localhost", :moment => Time.now)
+
+    @connection.schema_search_path = SCHEMA2_NAME
+    Thing5.create(:id => 1, :name => "thing inside #{SCHEMA2_NAME}", :email => "thing1@localhost", :moment => Time.now)
+
+    @connection.schema_search_path = SCHEMA_NAME
+    assert_equal 1, Thing5.count
+
+    @connection.schema_search_path = SCHEMA2_NAME
+    assert_equal 1, Thing5.count
   end
 
   def test_schema_exists?


### PR DESCRIPTION
I'm using postgreSQL with multiple schemas.

Rails 3.1 uses prepared statements and does not take into account the 'schema_search_path'. This is a big problem because the statement is prepared once and then the same prepared statement is executed many times no matter if you changed the schema, i.e, the prepared statement is executed ALWAYS for the same schema, the one set when the statement was prepared.

This patch adds the schema search to the sql key to allow the use of prepared statements when changing schemas in postgreSQL, 

Discussion here:
https://groups.google.com/forum/#!msg/rubyonrails-core/r2VOKcyUyrs/JQj4MB_lhRMJ
