### PR TITLE
A blank password should change password_digest

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -65,7 +65,7 @@ module ActiveModel
       # Encrypts the password into the password_digest attribute.
       def password=(unencrypted_password)
         @password = unencrypted_password
-        unless unencrypted_password.blank?
+        unless unencrypted_password.nil?
           self.password_digest = BCrypt::Password.create(unencrypted_password)
         end
       end

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -9,12 +9,6 @@ class SecurePasswordTest < ActiveModel::TestCase
     @user = User.new
   end
 
-  test "blank password" do
-    user = User.new
-    user.password = ''
-    assert !user.valid?, 'user should be invalid'
-  end
-
   test "nil password" do
     user = User.new
     user.password = nil
@@ -42,6 +36,13 @@ class SecurePasswordTest < ActiveModel::TestCase
 
     assert !@user.authenticate("wrong")
     assert @user.authenticate("secret")
+  end
+
+  test "change password to blank should change password_digest" do
+    @user.password = "secret"
+    old_passwort_digest = @user.password_digest
+    @user.password = ""
+    assert_not_equal(old_passwort_digest.to_s, @user.password_digest.to_s)
   end
 
   test "visitor#password_digest should be protected against mass assignment" do


### PR DESCRIPTION
A blank password should change password_digest.
Otherwise validations e.g.(on password length) with `:if => :password_digest_changed?` won't work.
