### PR TITLE
small [PATCH] to AliasTracker.connection fixes ConnectionNotEstablished

### DIFF
--- a/activerecord/lib/active_record/associations/alias_tracker.rb
+++ b/activerecord/lib/active_record/associations/alias_tracker.rb
@@ -8,8 +8,9 @@ module ActiveRecord
       attr_reader :aliases, :table_joins
 
       # table_joins is an array of arel joins which might conflict with the aliases we assign here
-      def initialize(table_joins = [])
+      def initialize(base, table_joins = [])
         @aliases     = Hash.new { |h,k| h[k] = initial_count_for(k) }
+        @base        = base
         @table_joins = table_joins
       end
 
@@ -72,7 +73,7 @@ module ActiveRecord
         end
 
         def connection
-          ActiveRecord::Base.connection
+          @base.connection
         end
     end
   end

--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -10,7 +10,7 @@ module ActiveRecord
 
       def initialize(association)
         @association   = association
-        @alias_tracker = AliasTracker.new
+        @alias_tracker = AliasTracker.new(association.owner)
       end
 
       def scope

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -13,7 +13,7 @@ module ActiveRecord
         @join_parts    = [JoinBase.new(base)]
         @associations  = {}
         @reflections   = []
-        @alias_tracker = AliasTracker.new(joins)
+        @alias_tracker = AliasTracker.new(base, joins)
         @alias_tracker.aliased_name_for(base.table_name) # Updates the count for base.table_name to 1
         build(associations)
       end

--- a/activerecord/test/cases/no_base_connection_test.rb
+++ b/activerecord/test/cases/no_base_connection_test.rb
@@ -1,0 +1,42 @@
+require "cases/helper"
+
+class IslandModels < ActiveRecord::Base
+  @abstract_class = true
+  establish_connection(:adapter  => "sqlite3",
+                       :database => ":memory:")
+end
+
+IslandModels.connection.create_table "oceans", :force => true do |t|
+  t.string     "name"
+end
+IslandModels.connection.create_table "swells", :force => true do |t|
+  t.references :ocean
+  t.string     "size", "direction"
+end
+
+class Ocean < IslandModels
+  has_many :swells, :dependent => :destroy
+end
+class Swell < IslandModels
+  belongs_to :ocean
+end
+
+class NoBaseConnectionTest < ActiveRecord::TestCase
+
+  def setup
+    @old_val = ActiveRecord::Base.connection_handler.connection_pools["ActiveRecord::Base"]
+    ActiveRecord::Base.connection_handler.connection_pools.delete("ActiveRecord::Base")
+  end
+  def teardown
+    ActiveRecord::Base.connection_handler.connection_pools["ActiveRecord::Base"] = @old_val
+  end
+
+  def test_creation_doesnt_neeed_base_connection
+    pool_keys_before = ActiveRecord::Base.connection_handler.connection_pools.keys
+    ocean = Ocean.create(:name => "Pacific")
+    ocean.swells.create(:size => "big", :direction => "south")
+    pool_keys_after = ActiveRecord::Base.connection_handler.connection_pools.keys
+    assert_equal pool_keys_before, pool_keys_after
+  end
+
+end


### PR DESCRIPTION
SUMMARY:

Active Record purports to support connecting to multiple databases from different models.
Hence, never assume `ActiveRecord::Base.connection` is the correct connection!

This commit patches `ActiveRecord::Associations::AliasTracker` to fetch it's connection from the appropriate base model.

/cc @jonleighton

MORE DETAILS:

I have 2 apps, 1 rails and 1 sinatra. both use active record.  I wrote some integration tests that test the API between the 2 apps over rack/rack-client so they run in the same memory space for these tests.

The apps have separate databases. The sinatra app initializes it's AR connection using an abstract model superclass which calls 'establish_connection'.  When this app runs on it's own, it never sets up (or needs to setup) ActiveRecord::Base.connection.

Recently with the upgrade from 3.0.9 to 3.1, tests where the sinatra app runs in isolation break with:
ActiveRecord::ConnectionNotEstablished

I think this can be traced back to these 2 changes:
https://github.com/rails/rails/commit/6490d65234b89d4d28308b72b13d4834fd44bbb3
https://github.com/rails/rails/commit/e8874318b7a025ffd30df1a53c403eb9d8912c9f

these changes refactor alias_tracking into a new class `ActiveRecord::Associations::AliasTracker`, but introduce the regression of calling `ActiveRecord::Base.connection`.  Where previously it was `join_base.active_record.connection` or in the case of `AssociationScope` perhaps it didn't need a connection?  I get a little lost attempting to follow the code from just the diff.

I attempted to reproduce my scenario as minimally as possible with `no_base_connection_test.rb`.  To reproduce the error simply change the one-line implementation of `connection` in `alias_tracker.rb`, to what it was previously: `ActiveRecord::Base.connection`

I imagine some other convoluted failure scenarios could be contrived in which `ActiveRecord::Base.connection` connects to a database of one type, but another set of models connect to a database of a different type, and strange incorrect table quoting behavior might be observed.
