### PR TITLE
link_to(model) shorthand for link_to(model.to_title, model)

### DIFF
--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -171,7 +171,8 @@ module ActionView
       #   link_to "Profile", @profile
       #   # => <a href="/profiles/1">Profile</a>
       #
-      # or, if you defined #to_s method for your model, you can do simply
+      # or you can define #to_title method in your model, which returns, for example, it's name,
+      # and then you can do simply:
       #
       #   link_to @product
       #   # => <a href="/products/1">Guitar</a>
@@ -239,8 +240,8 @@ module ActionView
           html_options = args.second
           link_to(capture(&block), options, html_options)
         else
-          name         = args[0]
-          options      = args[1] || name
+          name         = args[0].respond_to?(:to_title) ? args[0].to_title : args[0]
+          options      = args[1] || args[0]
           html_options = args[2]
 
           html_options = convert_options_to_data_attributes(options, html_options)

--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -171,6 +171,11 @@ module ActionView
       #   link_to "Profile", @profile
       #   # => <a href="/profiles/1">Profile</a>
       #
+      # or, if you defined #to_s method for your model, you can do simply
+      #
+      #   link_to @product
+      #   # => <a href="/products/1">Guitar</a>
+      #
       # in place of the older more verbose, non-resource-oriented
       #
       #   link_to "Profile", :controller => "profiles", :action => "show", :id => @profile
@@ -235,7 +240,7 @@ module ActionView
           link_to(capture(&block), options, html_options)
         else
           name         = args[0]
-          options      = args[1] || {}
+          options      = args[1] || name
           html_options = args[2]
 
           html_options = convert_options_to_data_attributes(options, html_options)

--- a/actionpack/test/template/test_test.rb
+++ b/actionpack/test/template/test_test.rb
@@ -44,9 +44,9 @@ class PeopleHelperTest < ActionView::TestCase
     end
   end
 
-  def test_link_to_person_with_use_of_to_s
+  def test_link_to_person_with_use_of_to_title
     with_test_route_set do
-      person = mock(:to_s => "Simon")
+      person = mock(:to_title => "Simon")
       person.class.extend ActiveModel::Naming
       expects(:mocha_mock_path).with(person).returns("/people/1")
       assert_equal '<a href="/people/1">Simon</a>', link_to(person)

--- a/actionpack/test/template/test_test.rb
+++ b/actionpack/test/template/test_test.rb
@@ -44,6 +44,15 @@ class PeopleHelperTest < ActionView::TestCase
     end
   end
 
+  def test_link_to_person_with_use_of_to_s
+    with_test_route_set do
+      person = mock(:to_s => "Simon")
+      person.class.extend ActiveModel::Naming
+      expects(:mocha_mock_path).with(person).returns("/people/1")
+      assert_equal '<a href="/people/1">Simon</a>', link_to(person)
+    end
+  end
+
   private
     def with_test_route_set
       with_routing do |set|


### PR DESCRIPTION
We often use link_to to point to some record, for example:

```
link_to product.name, product
```

I think that it is a good approach to make use of #to_s method in models to point, how that record is represented by string by default, so for example:

```
class Product << ActiveRecord::Base
  def to_s
    name
  end
end
```

That way, we can use that method in all links to that record:

```
link_to product.to_s, product
```

so when we will have to change that default string representation of model (for example in User model, "#{first_name} #{last_name} instead of username), we will have to change it only in #to_s of that model, so for example.

Thanks for features of #to_s, we can shorten it to:

```
link_to product, product
```

So it would be nice, if #link_to would be able to get url from body of link, if no url is given, so we would be able to do just simply:

```
link_to product
```

I thought that maybe #link_to have already such as feature, but for now it produces link to the current page with product name.

I wanted to try add such as feature, but I have problems with running Rails from Github, because of this bug: https://github.com/carlhuda/bundler/issues/1470

So I've just edited files of action_view of Rails 3.1.1.rc1 from my installed gems, and this feature works on application which is using that gem, so I think that it will work with Rails from Github.

When that bug will be fixed, I can add tests for it, but if somebody want, go ahead and check if it is working with Rails from Github and write tests for it.
