### PR TITLE
Postgres: Do not attempt to deallocate a statement if the connection is no longer active.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -285,7 +285,13 @@ module ActiveRecord
         end
 
         def dealloc(key)
-          @connection.query "DEALLOCATE #{key}"
+          @connection.query "DEALLOCATE #{key}" if connection_active?
+        end
+
+        def connection_active?
+          @connection.status == PGconn::CONNECTION_OK
+        rescue PGError
+          false
         end
       end
 

--- a/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
@@ -2,6 +2,16 @@ require 'cases/helper'
 
 module ActiveRecord::ConnectionAdapters
   class PostgreSQLAdapter < AbstractAdapter
+    class InactivePGconn
+      def query(*args)
+        raise PGError
+      end
+
+      def status
+        PGconn::CONNECTION_BAD
+      end
+    end
+
     class StatementPoolTest < ActiveRecord::TestCase
       def test_cache_is_per_pid
         return skip('must support fork') unless Process.respond_to?(:fork)
@@ -17,6 +27,12 @@ module ActiveRecord::ConnectionAdapters
 
         Process.waitpid pid
         assert $?.success?, 'process should exit successfully'
+      end
+
+      def test_dealloc_does_not_raise_on_inactive_connection
+        cache = StatementPool.new InactivePGconn.new, 10
+        cache['foo'] = 'bar'
+        assert_nothing_raised { cache.clear }
       end
     end
   end


### PR DESCRIPTION
The PostgreSQL adapter attempts to clear out the statement cache on `reconnect!`, which in turn issues a `DEALLOCATE` query for each cached statement. If the connection has been lost, the query results in an `PGError` being raised.

This change first checks the connection is OK before attempting to `DEALLOCATE` the statement.

Fixes issue #3160
