### PR TITLE
Add optional host option to force_ssl

### DIFF
--- a/actionpack/lib/action_controller/metal/force_ssl.rb
+++ b/actionpack/lib/action_controller/metal/force_ssl.rb
@@ -24,9 +24,12 @@ module ActionController
       # * <tt>only</tt>   - The callback should be run only for this action
       # * <tt>except<tt>  - The callback should be run for all actions except this action
       def force_ssl(options = {})
+        host = options.delete(:host)
         before_filter(options) do
           if !request.ssl? && !Rails.env.development?
-            redirect_to :protocol => 'https://', :status => :moved_permanently
+            redirect_options = {:protocol => 'https://', :status => :moved_permanently}
+            redirect_options.merge!(:host => host) if host
+            redirect_to redirect_options
           end
         end
       end

--- a/actionpack/test/controller/force_ssl_test.rb
+++ b/actionpack/test/controller/force_ssl_test.rb
@@ -14,6 +14,10 @@ class ForceSSLControllerLevel < ForceSSLController
   force_ssl
 end
 
+class ForceSSLCustomDomain < ForceSSLController
+  force_ssl :host => "secure.test.host"
+end
+
 class ForceSSLOnlyAction < ForceSSLController
   force_ssl :only => :cheeseburger
 end
@@ -35,6 +39,22 @@ class ForceSSLControllerLevelTest < ActionController::TestCase
     get :cheeseburger
     assert_response 301
     assert_equal "https://test.host/force_ssl_controller_level/cheeseburger", redirect_to_url
+  end
+end
+
+class ForceSSLCustomDomainTest < ActionController::TestCase
+  tests ForceSSLCustomDomain
+
+  def test_banana_redirects_to_https_with_custom_host
+    get :banana
+    assert_response 301
+    assert_equal "https://secure.test.host/force_ssl_custom_domain/banana", redirect_to_url
+  end
+  
+  def test_cheeseburger_redirects_to_https_with_custom_host
+    get :cheeseburger
+    assert_response 301
+    assert_equal "https://secure.test.host/force_ssl_custom_domain/cheeseburger", redirect_to_url
   end
 end
 


### PR DESCRIPTION
I wanted to be able to take advantage of custom subdomains for secure URLs, such as "https://secure.mysite.com" or piggy-back on Heroku's SSL.

Usage:

``` ruby
class FooController < ApplicationController
   force_ssl :host => "secure.mysite.com", :only => :index
   # ... 
end
```

It strips out the `:host` key before passing off the options to the `before_filter` method.
