### PR TITLE
URI.escape is obsolete : wanring removed

### DIFF
--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -296,7 +296,7 @@ module ApplicationTests
       precompile!
       require "#{app_path}/config/environment"
 
-      get "/assets/#{URI.escape(filename)}"
+      get "/assets/#{URI.parser.escape(filename)}"
       assert_match "not a image really", last_response.body
       assert File.exists?("#{app_path}/public/assets/#{filename}")
     end


### PR DESCRIPTION
URI.escape is obsolete : wanring removed
