### PR TITLE
expire_action can expire by the custom path directly

### DIFF
--- a/actionpack/lib/action_controller/caching/actions.rb
+++ b/actionpack/lib/action_controller/caching/actions.rb
@@ -116,9 +116,8 @@ module ActionController #:nodoc:
       def expire_action(options = {})
         return unless cache_configured?
 
-        actions = options[:action]
-        if actions.is_a?(Array)
-          actions.each {|action| expire_action(options.merge(:action => action)) }
+        if options.is_a?(Hash) && options[:action].is_a?(Array)
+          options[:action].each {|action| expire_action(options.merge(:action => action)) }
         else
           expire_fragment(ActionCachePath.new(self, options, false).path)
         end

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -245,6 +245,11 @@ class ActionCachingTestController < CachingController
     expire_action :controller => 'action_caching_test', :action => 'index', :format => 'xml'
     render :nothing => true
   end
+
+  def expire_custom_path
+    expire_action("http://test.host/custom/show")
+    render :nothing => true
+  end
 end
 
 class MockTime < Time
@@ -430,6 +435,30 @@ class ActionCacheTest < ActionController::TestCase
     get :index
     assert_response :success
     assert_not_equal cached_time, @response.body
+  end
+
+  def test_cache_expiration_with_custom_cache_path
+    get :show
+    assert_response :success
+    cached_time = content_to_cache
+    reset!
+
+    get :show
+    assert_response :success
+    assert_equal cached_time, @response.body
+
+    get :expire_custom_path
+    assert_response :success
+    reset!
+
+    get :show
+    assert_response :success
+    new_cached_time = content_to_cache
+    assert_not_equal cached_time, @response.body
+
+    get :show
+    assert_response :success
+    assert_equal new_cached_time, @response.body
   end
 
   def test_cache_is_scoped_by_subdomain


### PR DESCRIPTION
expire_action can expire the custom path directly instead of passing :controller/:action for url generator.

For example, 

``` ruby
caches_action :feed, :cache_path => proc do
    if params[:user_id]
      user_list_url(params[:user_id, params[:id])
    else
      list_url(params[:id])
    end
 end
```

So we can use **expire_action(list_url(params[:id]))** to expire the cache.
