### PR TITLE
JSON responder should return errors with :errors root

### DIFF
--- a/actionpack/lib/action_controller/metal/responder.rb
+++ b/actionpack/lib/action_controller/metal/responder.rb
@@ -253,7 +253,7 @@ module ActionController #:nodoc:
     end
 
     def display_errors
-      controller.render format => resource.errors, :status => :unprocessable_entity
+      controller.render format => resource_errors, :status => :unprocessable_entity
     end
 
     # Check whether the resource has errors.
@@ -285,6 +285,14 @@ module ActionController #:nodoc:
     #
     def empty_json_resource
       "{}"
+    end
+
+    def resource_errors
+      respond_to?("#{format}_resource_errors") ? send("#{format}_resource_errors") : resource.errors
+    end
+
+    def json_resource_errors
+      {:errors => resource.errors}
     end
   end
 end

--- a/actionpack/test/controller/mime_responds_test.rb
+++ b/actionpack/test/controller/mime_responds_test.rb
@@ -745,6 +745,20 @@ class RespondWithControllerTest < ActionController::TestCase
     end
   end
 
+  def test_using_resource_for_post_with_json_yields_unprocessable_entity_on_failure
+    with_test_route_set do
+      @request.accept = "application/json"
+      errors = { :name => :invalid }
+      Customer.any_instance.stubs(:errors).returns(errors)
+      post :using_resource
+      assert_equal "application/json", @response.content_type
+      assert_equal 422, @response.status
+      errors = {:errors => errors}
+      assert_equal errors.to_json, @response.body
+      assert_nil @response.location
+    end
+  end
+
   def test_using_resource_for_put_with_html_redirects_on_success
     with_test_route_set do
       put :using_resource
@@ -805,6 +819,18 @@ class RespondWithControllerTest < ActionController::TestCase
     assert_equal "application/xml", @response.content_type
     assert_equal 422, @response.status
     assert_equal errors.to_xml, @response.body
+    assert_nil @response.location
+  end
+
+  def test_using_resource_for_put_with_json_yields_unprocessable_entity_on_failure
+    @request.accept = "application/json"
+    errors = { :name => :invalid }
+    Customer.any_instance.stubs(:errors).returns(errors)
+    put :using_resource
+    assert_equal "application/json", @response.content_type
+    assert_equal 422, @response.status
+    errors = {:errors => errors}
+    assert_equal errors.to_json, @response.body
     assert_nil @response.location
   end
 


### PR DESCRIPTION
JSON responder currently returns errors without an :errors root which I believe it should. I think that's how it is documented to work as well.
