### PR TITLE
Improve ActiveRecord changelog

### DIFF
--- a/activerecord/CHANGELOG
+++ b/activerecord/CHANGELOG
@@ -10,6 +10,13 @@
 
   [Jeremy Kemper]
 
+* Add first_or_create, first_or_create!, first_or_initialize methods to Active Record. This is a
+  better approach over the old find_or_create_by dynamic methods because it's clearer which
+  arguments are used to find the record and which are used to create it:
+
+    User.where(:first_name => "Scarlett").first_or_create!(:last_name => "Johansson")
+
+  [Andrés Mejía]
 
 *Rails 3.1.1 (October 7, 2011)*
 
@@ -41,13 +48,7 @@
 	  keys are per process id.
 	* lib/active_record/connection_adapters/sqlite_adapter.rb: ditto
 
-* Add first_or_create, first_or_create!, first_or_initialize methods to Active Record. This is a
-  better approach over the old find_or_create_by dynamic methods because it's clearer which
-  arguments are used to find the record and which are used to create it:
-
-    User.where(:first_name => "Scarlett").first_or_create!(:last_name => "Johansson")
-
-  [Andrés Mejía]
+  [Aaron Patterson]
 
 * Support bulk change_table in mysql2 adapter, as well as the mysql one. [Jon Leighton]
 


### PR DESCRIPTION
I was waiting for new Active Record [first_or_create](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/relation.rb#L121) method (mentioned in [master changelog](https://github.com/rails/rails/blob/master/activerecord/CHANGELOG)) for Rails 3.1.1. But is was not merged into [3.1.1 stable](https://github.com/rails/rails/blob/3-1-stable/activerecord/lib/active_record/relation.rb) yet. Weird is, that this feature is not mentioned in Rails 3-1 branch [changelog](https://github.com/rails/rails/blob/3-1-stable/activerecord/CHANGELOG).
