### PR TITLE
Global variable `$rails_rake_task' not initialized Warning removed

### DIFF
--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -2,6 +2,7 @@ module Rails
   class Application
     module Finisher
       include Initializable
+      $rails_rake_task = nil
 
       initializer :add_generator_templates do
         config.generators.templates.unshift(*paths["lib/templates"].existent)


### PR DESCRIPTION
Global variable `$rails_rake_task' not initialized Warning removed
