### PR TITLE
Ensure that the directory 'vendor/assets/javascripts' is created by AppGenerator

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -122,8 +122,13 @@ module Rails
     end
 
     def vendor
+      vendor_javascripts
       vendor_stylesheets
       vendor_plugins
+    end
+
+    def vendor_javascripts
+      empty_directory_with_gitkeep "vendor/assets/javascripts"
     end
 
     def vendor_stylesheets

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -203,6 +203,11 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file 'test'
   end
 
+  def test_creation_of_vendor_assets_javascripts_directory
+    run_generator
+    assert_file "vendor/assets/javascripts"
+  end
+
   def test_jquery_is_the_default_javascript_library
     run_generator
     assert_file "app/assets/javascripts/application.js" do |contents|


### PR DESCRIPTION
The directory 'vendor/assets/javascripts' is referenced in  `railties/lib/rails/generators/rails/app/templates/app/assets/javascripts/application.js.tt`, but isn't actually created as part of the generator suites.

``` javascript
// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
// or vendor/assets/javascripts of plugins, if any, can be referenced here using a relative path.
```

I've added a method to the AppGenerator class and a relevant test to ensure this directory is created.
