### PR TITLE
Support symbol and string actions in AC#respond_to options

### DIFF
--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -42,8 +42,8 @@ module ActionController #:nodoc:
       def respond_to(*mimes)
         options = mimes.extract_options!
 
-        only_actions   = Array(options.delete(:only))
-        except_actions = Array(options.delete(:except))
+        only_actions   = Array(options.delete(:only)).map(&:to_s)
+        except_actions = Array(options.delete(:except)).map(&:to_s)
 
         new = mimes_for_respond_to.dup
         mimes.each do |mime|
@@ -245,7 +245,7 @@ module ActionController #:nodoc:
     # current action.
     #
     def collect_mimes_from_class_level #:nodoc:
-      action = action_name.to_sym
+      action = action_name.to_s
 
       self.class.mimes_for_respond_to.keys.select do |mime|
         config = self.class.mimes_for_respond_to[mime]

--- a/actionpack/test/controller/mime_responds_test.rb
+++ b/actionpack/test/controller/mime_responds_test.rb
@@ -509,7 +509,7 @@ end
 class RespondWithController < ActionController::Base
   respond_to :html, :json
   respond_to :xml, :except => :using_resource_with_block
-  respond_to :js,  :only => [ :using_resource_with_block, :using_resource, :using_hash_resource ]
+  respond_to :js,  :only => [ :using_resource_with_block, :using_resource, 'using_hash_resource' ]
 
   def using_resource
     respond_with(resource)


### PR DESCRIPTION
``` ruby
class HomeController < ApplicationController
  before_filter :some, :only => [:aaa, 'bbb'] # Works well
  respond_to :xml, :only => [:aaa, 'bbb']     # <-- Should also work

  def aaa
    respond_with :aaa => 3
  end

  def bbb
    respond_with :bbb => 3
  end

  private
  def some
    # ...
  end
end
```
