### PR TITLE
Fix multiple includes with options

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -126,7 +126,7 @@ module ActiveModel
         return unless include = options[:include]
 
         unless include.is_a?(Hash)
-          include = Hash[Array.wrap(include).map { |n| [n, {}] }]
+          include = Hash[Array.wrap(include).map { |n| n.is_a?(Hash) ? n.to_a.first : [n, {}] }]
         end
 
         include.each do |association, opts|

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -140,4 +140,12 @@ class SerializationTest < ActiveModel::TestCase
     assert_equal expected , @user.serializable_hash(:except => :gender, :include => {:friends => {:except => :gender}})
   end
 
+  def test_multiple_includes_with_options
+    expected =  {"email"=>"david@example.com", "gender"=>"male", "name"=>"David",
+                 :address=>{"street"=>"123 Lane"},
+                 :friends=>[{"name"=>'Joe', "email"=>'joe@example.com', "gender"=>'male'},
+                            {"name"=>'Sue', "email"=>'sue@example.com', "gender"=>'female'}]}
+    assert_equal expected , @user.serializable_hash(:include => [{:address => {:only => "street"}}, :friends])
+  end
+
 end


### PR DESCRIPTION
We can specify an array of included associations like `user.as_json(:include => [:asso1, :asso2])`
However if we specify options for an association, then it doesn't work 

`user.as_json(:include => [{:asso1 => {:only => :field1}} , :asso2])` will throw

`TypeError: {:asso1 => {:only => :field1}} is not a symbol`

This fixes the above issue.
