### PR TITLE
Empty AM objects are not serialized as a line break string: <model/> instead of <model>\n</model>. Fixes #3268

### DIFF
--- a/activemodel/lib/active_model/serializers/xml.rb
+++ b/activemodel/lib/active_model/serializers/xml.rb
@@ -83,12 +83,16 @@ module ActiveModel
           args << {:xmlns => options[:namespace]} if options[:namespace]
           args << {:type => options[:type]} if options[:type] && !options[:skip_types]
 
-          @builder.tag!(*args) do
-            add_attributes_and_methods
-            add_includes
-            add_extra_behavior
-            add_procs
-            yield @builder if block_given?
+          if serializable_hash.empty?
+            @builder.tag! *args
+          else
+            @builder.tag!(*args) do
+              add_attributes_and_methods
+              add_includes
+              add_extra_behavior
+              add_procs
+              yield @builder if block_given?
+            end
           end
         end
 

--- a/activemodel/test/cases/serializers/xml_serialization_test.rb
+++ b/activemodel/test/cases/serializers/xml_serialization_test.rb
@@ -63,6 +63,11 @@ class XmlSerializationTest < ActiveModel::TestCase
     assert_match %r{</contact>$}, @xml
   end
 
+  test "should not serialize an object without attributes as a new line string" do
+    xml = Address.new.to_xml
+    assert xml.include?("<address/>")
+  end
+
   test "should serialize namespaced root" do
     @xml = Admin::Contact.new(@contact.attributes).to_xml
     assert_match %r{^<contact>},  @xml
@@ -183,14 +188,14 @@ class XmlSerializationTest < ActiveModel::TestCase
   test "include option with plural association" do
     xml = @contact.to_xml :include => :friends, :indent => 0
     assert_match %r{<friends type="array">}, xml
-    assert_match %r{<friend type="Contact">}, xml
+    assert_match %r{<friend type="Contact"/>}, xml
   end
 
   test "multiple includes" do
     xml = @contact.to_xml :indent => 0, :skip_instruct => true, :include => [ :address, :friends ]
     assert xml.include?(@contact.address.to_xml(:indent => 0, :skip_instruct => true))
     assert_match %r{<friends type="array">}, xml
-    assert_match %r{<friend type="Contact">}, xml
+    assert_match %r{<friend type="Contact"/>}, xml
   end
 
   test "include with options" do
@@ -201,6 +206,6 @@ class XmlSerializationTest < ActiveModel::TestCase
   test "propagates skip_types option to included associations" do
     xml = @contact.to_xml :include => :friends, :indent => 0, :skip_types => true
     assert_match %r{<friends>}, xml
-    assert_match %r{<friend>}, xml
+    assert_match %r{<friend/>}, xml
   end
 end


### PR DESCRIPTION
Hey, is this a valid fix for https://github.com/rails/rails/issues/3268 ?

Now the object is being serialized correctly but some tests needed to change: <node></node> for <node/> .
