### PR TITLE
fixes error when can't unmarshal session contents

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
@@ -65,6 +65,9 @@ module ActionDispatch
               "(Original exception: #{const_error.message} [#{const_error.class}])\n"
           end
           retry
+        elsif argument_error.message =~ %r{dump format error \(user class\)}
+          # Error unmarshalling object from session.
+          {}
         else
           raise
         end


### PR DESCRIPTION
Hi there,

when Marshal.load can't read an object, it raises an ArgumentError. This is happening after migrating from rails 3.0.x to 3.1, when the session contains a FlashHash object. That's because FlashHash doesn't inherit from Hash anymore (see 76c2ea7882a83159408bdf1f7c363f442a65c4f1) - related issue: https://github.com/rails/rails/issues/2509

I couldn't write a test to reproduce it, unfortunately - and I couldn't find any test exercising this portion of the code. Maybe somebody more used to the codebase?

Best!
Bruno
