### PR TITLE
Set the Content-Type header as text/plain by default when rendering text. Fixes #3234

### DIFF
--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -34,7 +34,11 @@ module ActionController
       _renderers.each do |name, value|
         if options.key?(name.to_sym)
           _process_options(options)
-          return send("_render_option_#{name}", options.delete(name.to_sym), options)
+          if name == :text
+            self.content_type ||= Mime::TEXT
+          else
+            return send("_render_option_#{name}", options.delete(name.to_sym), options)
+          end
         end
       end
       nil

--- a/actionpack/test/controller/content_type_test.rb
+++ b/actionpack/test/controller/content_type_test.rb
@@ -66,14 +66,14 @@ class ContentTypeTest < ActionController::TestCase
   def test_render_defaults
     get :render_defaults
     assert_equal "utf-8", @response.charset
-    assert_equal Mime::HTML, @response.content_type
+    assert_equal Mime::TEXT, @response.content_type
   end
 
   def test_render_changed_charset_default
     OldContentTypeController.default_charset = "utf-16"
     get :render_defaults
     assert_equal "utf-16", @response.charset
-    assert_equal Mime::HTML, @response.content_type
+    assert_equal Mime::TEXT, @response.content_type
   ensure
     OldContentTypeController.default_charset = "utf-8"
   end
@@ -95,14 +95,14 @@ class ContentTypeTest < ActionController::TestCase
   # :ported:
   def test_charset_from_body
     get :render_charset_from_body
-    assert_equal Mime::HTML, @response.content_type
+    assert_equal Mime::TEXT, @response.content_type
     assert_equal "utf-16", @response.charset
   end
 
   # :ported:
   def test_nil_charset_from_body
     get :render_nil_charset_from_body
-    assert_equal Mime::HTML, @response.content_type
+    assert_equal Mime::TEXT, @response.content_type
     assert_equal "utf-8", @response.charset, @response.headers.inspect
   end
 

--- a/actionpack/test/controller/new_base/base_test.rb
+++ b/actionpack/test/controller/new_base/base_test.rb
@@ -51,7 +51,7 @@ module Dispatching
 
       assert_body "success"
       assert_status 200
-      assert_content_type "text/html; charset=utf-8"
+      assert_content_type "text/plain; charset=utf-8"
     end
 
     # :api: plugin

--- a/actionpack/test/controller/new_base/content_type_test.rb
+++ b/actionpack/test/controller/new_base/content_type_test.rb
@@ -49,7 +49,7 @@ module ContentType
         get "/content_type/base"
 
         assert_body "Hello world!"
-        assert_header "Content-Type", "text/html; charset=utf-8"
+        assert_header "Content-Type", "text/plain; charset=utf-8"
       end
     end
 
@@ -99,14 +99,14 @@ module ContentType
       get "/content_type/charset/set_on_response_obj"
 
       assert_body   "Hello world!"
-      assert_header "Content-Type", "text/html; charset=utf-16"
+      assert_header "Content-Type", "text/plain; charset=utf-16"
     end
 
     test "setting the charset of the response as nil directly on the response object" do
       get "/content_type/charset/set_as_nil_on_response_obj"
 
       assert_body   "Hello world!"
-      assert_header "Content-Type", "text/html; charset=utf-8"
+      assert_header "Content-Type", "text/plain; charset=utf-8"
     end
   end
 end

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -914,6 +914,11 @@ class RenderTest < ActionController::TestCase
     assert_equal "application/xml", @response.content_type
   end
 
+  def test_render_text_content_type
+    get :render_text_hello_world
+    assert_equal "text/plain", @response.content_type
+  end
+
   # :ported:
   def test_render_xml_as_string_template
     get :render_xml_hello_as_string_template


### PR DESCRIPTION
Its a little bit hacky but I think it works until some refactoring. First I tried to resolve it creating a renderer:

https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/metal/renderers.rb#L85

but there is a test that renders text with a layout and was failing because the layout wasn't being called.

This commit fixes this issue:

https://github.com/rails/rails/issues/3234
