### PR TITLE
Current transaction records retained by transactional fixtures (master)

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -217,8 +217,7 @@ module ActiveRecord
             else
               release_savepoint
               save_point_records = @_current_transaction_records.pop
-              unless save_point_records.blank?
-                @_current_transaction_records.push([]) if @_current_transaction_records.empty?
+              unless save_point_records.blank? || @_current_transaction_records.empty?
                 @_current_transaction_records.last.concat(save_point_records)
               end
             end

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -162,13 +162,18 @@ module ActiveRecord
       #     end  # RELEASE SAVEPOINT active_record_1  <--- BOOM! database error!
       #   end
       def transaction(options = {})
-        options.assert_valid_keys :requires_new, :joinable
+        options.assert_valid_keys :requires_new, :joinable, :remember_record_state
 
         last_transaction_joinable = defined?(@transaction_joinable) ? @transaction_joinable : nil
         if options.has_key?(:joinable)
           @transaction_joinable = options[:joinable]
         else
           @transaction_joinable = true
+        end
+        if options.has_key?(:remember_record_state)
+          remember_record_state = options[:remember_record_state]
+        else
+          remember_record_state = true
         end
         requires_new = options[:requires_new] || !last_transaction_joinable
 
@@ -185,7 +190,7 @@ module ActiveRecord
               end
               increment_open_transactions
               transaction_open = true
-              @_current_transaction_records.push([])
+              @_current_transaction_records.push(remember_record_state ? [] : nil)
             end
             yield
           end


### PR DESCRIPTION
As discussed on the mailing list, this fixes the memory bloat when using transactional fixtures to run large test suites, which is basically a regression since 2.3 due to the side effects of the better record rollback code.  This substantially improves test runtime too if you save a lot of objects in tests.

This branch also exposes the option to not retain references to the records saved in transactions, which is useful for applications that have large transactions that save a lot of objects but don't need their state in memory to be rolled back if the transaction fails nor need the transaction callbacks.
