### PR TITLE
activeresource should treat HTTP status 307 (Temporary Redirect) as redirection, same as 301 a

### DIFF
--- a/activeresource/lib/active_resource/base.rb
+++ b/activeresource/lib/active_resource/base.rb
@@ -170,8 +170,8 @@ module ActiveResource
   # <tt>404</tt> is just one of the HTTP error response codes that Active Resource will handle with its own exception. The
   # following HTTP response codes will also result in these exceptions:
   #
-  # * 200..399 - Valid response, no exception (other than 301, 302)
-  # * 301, 302 - ActiveResource::Redirection
+  # * 200..399 - Valid response, no exception (other than 301, 302 and 307)
+  # * 301, 302, 307 - ActiveResource::Redirection
   # * 400 - ActiveResource::BadRequest
   # * 401 - ActiveResource::UnauthorizedAccess
   # * 403 - ActiveResource::ForbiddenAccess

--- a/activeresource/lib/active_resource/connection.rb
+++ b/activeresource/lib/active_resource/connection.rb
@@ -122,7 +122,7 @@ module ActiveResource
       # Handles response and error codes from the remote service.
       def handle_response(response)
         case response.code.to_i
-          when 301,302
+          when 301,302,307
             raise(Redirection.new(response))
           when 200...400
             response

--- a/activeresource/test/cases/connection_test.rb
+++ b/activeresource/test/cases/connection_test.rb
@@ -38,6 +38,15 @@ class ConnectionTest < Test::Unit::TestCase
       assert_equal expected, handle_response(expected)
     end
 
+    # 301 is moved permanently (redirect)
+    assert_response_raises ActiveResource::Redirection, 301
+
+    # 302 is found (redirect)
+    assert_response_raises ActiveResource::Redirection, 302
+
+    # 307 is temporary redirect
+    assert_response_raises ActiveResource::Redirection, 307
+
     # 400 is a bad request (e.g. malformed URI or missing request parameter)
     assert_response_raises ActiveResource::BadRequest, 400
 


### PR DESCRIPTION
Since some web servers / load balancers use 307, activeresource should treat HTTP status 307 (Temporary Redirect) as redirection, same as 301 and 302; added missing test cases for statii 301 and 302.
