### PR TITLE
Exclude rack.request.form_vars from request.filtered_env

### DIFF
--- a/actionpack/lib/action_dispatch/http/filter_parameters.rb
+++ b/actionpack/lib/action_dispatch/http/filter_parameters.rb
@@ -50,7 +50,7 @@ module ActionDispatch
       end
 
       def env_filter
-        parameter_filter_for(Array(@env["action_dispatch.parameter_filter"]) << /RAW_POST_DATA/)
+        parameter_filter_for(Array(@env["action_dispatch.parameter_filter"]) + [/RAW_POST_DATA/, "rack.request.form_vars"])
       end
 
       def parameter_filter_for(filters)

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -535,3 +535,36 @@ class ApplicationIntegrationTest < ActionDispatch::IntegrationTest
     assert_equal old_env, env
   end
 end
+
+class EnvironmentFilterIntegrationTest < ActionDispatch::IntegrationTest
+  class TestController < ActionController::Base
+    def post
+      render :text => "Created", :status => 201
+    end
+  end
+
+  def self.call(env)
+    env["action_dispatch.parameter_filter"] = [:password]
+    routes.call(env)
+  end
+
+  def self.routes
+    @routes ||= ActionDispatch::Routing::RouteSet.new
+  end
+
+  routes.draw do
+    match '/post', :to => 'environment_filter_integration_test/test#post', :via => :post
+  end
+
+  def app
+    self.class
+  end
+
+  test "filters rack request form vars" do
+    post "/post", :username => 'cjolly', :password => 'secret'
+
+    assert_equal 'cjolly', request.filtered_parameters['username']
+    assert_equal '[FILTERED]', request.filtered_parameters['password']
+    assert_equal '[FILTERED]', request.filtered_env['rack.request.form_vars']
+  end
+end


### PR DESCRIPTION
Filter `rack.request.form_vars` along with the already excluded `RAW_POST_DATA` from `request.filtered_env` as it is essentially the same potentially sensitive data.

Addresses concerns raised in #337
