### PR TITLE
Patch assets related helpers when digest is false and compile is false

### DIFF
--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -128,7 +128,7 @@ module Sprockets
         end
 
         def digest_for(logical_path)
-          if digest_assets && asset_digests && (digest = asset_digests[logical_path])
+          if asset_digests && (digest = asset_digests[logical_path])
             return digest
           end
 

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -27,6 +27,29 @@ module ApplicationTests
       end
     end
 
+    test "assets can be read when fingerprinting and compile are disabled, " do
+      app_file "app/views/posts/index.html.erb", "<%= javascript_include_tag 'application' %><%= image_path('rails.png').inspect %>"
+
+      add_to_config "config.assets.digest = false"
+      add_to_config "config.assets.compile = false"
+      add_to_config "config.assets.prefix = 'assets_prefix'"
+      app_file "config/routes.rb", <<-RUBY
+        AppTemplate::Application.routes.draw do
+          match '/posts', :to => "posts#index"
+        end
+      RUBY
+
+      ENV["RAILS_ENV"] = "development"
+
+      precompile!
+
+      require "#{app_path}/config/environment"
+      class ::PostsController < ActionController::Base ; end
+
+      get '/posts'
+      assert_match("<script src=\"/assets_prefix/application.js\" type=\"text/javascript\"></script>&quot;/assets_prefix/rails.png&quot;\n", last_response.body)
+    end
+
     test "assets routes have higher priority" do
       app_file "app/assets/javascripts/demo.js.erb", "a = <%= image_path('rails.png').inspect %>;"
 


### PR DESCRIPTION
There seem to be a confusion with digests, fingerprinting and precompilation: 

```
config.assets.digest = false
```

removes fingerprinting (as it should), but then adding

```
config.assets.compile = false
```

(in prod., for example) removes all possibility to access any asset.
It raises an unwanted

```
Sprockets::Helpers::RailsHelper::AssetPaths::AssetNotPrecompiledError
```

Incoherent, since:
- asset is compiled and present in public/assets/..
- asset is correctly referenced in manifest

Disabling digest should not disable precompilation pattern. 

This patch intends to fix this.
