### PR TITLE
Remove user-specified delimiter from start when no area code is present (in number_to_phone)

### DIFF
--- a/actionpack/lib/action_view/helpers/number_helper.rb
+++ b/actionpack/lib/action_view/helpers/number_helper.rb
@@ -69,7 +69,7 @@ module ActionView
           number.gsub!(/(\d{1,3})(\d{3})(\d{4}$)/,"(\\1) \\2#{delimiter}\\3")
         else
           number.gsub!(/(\d{0,3})(\d{3})(\d{4})$/,"\\1#{delimiter}\\2#{delimiter}\\3")
-          number.slice!(0, 1) if number.starts_with?('-')
+          number.slice!(0, 1) if number.starts_with?(delimiter) && !delimiter.blank?
         end
 
         str = []

--- a/actionpack/test/template/number_helper_test.rb
+++ b/actionpack/test/template/number_helper_test.rb
@@ -27,6 +27,7 @@ class NumberHelperTest < ActionView::TestCase
     assert_equal("800 555 1212", number_to_phone(8005551212, {:delimiter => " "}))
     assert_equal("(800) 555-1212 x 123", number_to_phone(8005551212, {:area_code => true, :extension => 123}))
     assert_equal("800-555-1212", number_to_phone(8005551212, :extension => "  "))
+    assert_equal("555.1212", number_to_phone(5551212, :delimiter => '.'))
     assert_equal("800-555-1212", number_to_phone("8005551212"))
     assert_equal("+1-800-555-1212", number_to_phone(8005551212, :country_code => 1))
     assert_equal("+18005551212", number_to_phone(8005551212, :country_code => 1, :delimiter => ''))


### PR DESCRIPTION
Previously, specifying a delimiter to number_to_phone when no area code is present would result in the delimiter at the start of the resulting phone number:

For example:

number_to_phone("5550000", :delimiter => ".") 
would become: .555.0000
but should be: 555.0000

(notice, the leading '.')

This pull request fixes that. All existing tests pass and new test added.
