### PR TITLE
ActiveModel::Errors#generate_message without i18n_scope, and more test cases for #add

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -300,13 +300,17 @@ module ActiveModel
     def generate_message(attribute, type = :invalid, options = {})
       type = options.delete(:message) if options[:message].is_a?(Symbol)
 
-      defaults = @base.class.lookup_ancestors.map do |klass|
-        [ :"#{@base.class.i18n_scope}.errors.models.#{klass.model_name.i18n_key}.attributes.#{attribute}.#{type}",
-          :"#{@base.class.i18n_scope}.errors.models.#{klass.model_name.i18n_key}.#{type}" ]
+      if @base.class.respond_to?(:i18n_scope)
+        defaults = @base.class.lookup_ancestors.map do |klass|
+          [ :"#{@base.class.i18n_scope}.errors.models.#{klass.model_name.i18n_key}.attributes.#{attribute}.#{type}",
+            :"#{@base.class.i18n_scope}.errors.models.#{klass.model_name.i18n_key}.#{type}" ]
+        end
+      else
+        defaults = []
       end
 
       defaults << options.delete(:message)
-      defaults << :"#{@base.class.i18n_scope}.errors.messages.#{type}"
+      defaults << :"#{@base.class.i18n_scope}.errors.messages.#{type}" if @base.class.respond_to?(:i18n_scope)
       defaults << :"errors.attributes.#{attribute}.#{type}"
       defaults << :"errors.messages.#{type}"
 

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -66,6 +66,20 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal ["can not be blank"], person.errors[:name]
   end
 
+  test "should be able to add an error with a symbol" do
+    person = Person.new
+    person.errors.add(:name, :blank)
+    message = person.errors.generate_message(:name, :blank)
+    assert_equal [message], person.errors[:name]
+  end
+
+  test "should be able to add an error with a proc" do
+    person = Person.new
+    message = Proc.new { "can not be blank" }
+    person.errors.add(:name, message)
+    assert_equal ["can not be blank"], person.errors[:name]
+  end
+
   test 'should respond to size' do
     person = Person.new
     person.errors.add(:name, "can not be blank")
@@ -112,5 +126,12 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal ["is invalid"], hash[:email]
   end
 
+  test "generate_message should work without i18n_scope" do
+    person = Person.new
+    assert !Person.respond_to?(:i18n_scope)
+    assert_nothing_raised {
+      person.errors.generate_message(:name, :blank)
+    }
+  end
 end
 


### PR DESCRIPTION
ActiveModel::Errors#generate_message requires that the model we're adding errors to implements i18n_scope. This is not obvious from the documentation, and it is also not necessary as there are translation fallbacks that don't use i18n_scope.

The first of the three commits skips the translation defaults where i18n_scope is used if the model doesn't respond to it.

I also noticed that there were no tests on ActiveModel::Errors#add when message is a Symbol, or when message is a Proc. I wrote tests for these cases, each in it's own commit to make it easier if you'd like to pull these but not the commit dealing with i18n_scope.

Please bear in mind that, if you'd like to keep the requirement for 18n_scope on the model, the test case for when message is a Symbol won't pass. If generate_message doesn't check if the model responds, the test needs a minimal implementation of Person.i18n_scope to pass. I'll be happy to fix this.

PS. This is my first contribution to Rails. Yay! \o/
I attended an Open Source Hack Night in Stockholm on October 11. Kudos to Valtech for organizing it.
