### PR TITLE
fix inconsistent alignment in Gemfile generator

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -150,7 +150,7 @@ module Rails
             gem 'rails', '#{Rails::VERSION::STRING}'
 
             # Bundle edge Rails instead:
-            # gem 'rails',     :git => 'git://github.com/rails/rails.git'
+            # gem 'rails', :git => 'git://github.com/rails/rails.git'
           GEMFILE
         end
       end
@@ -158,11 +158,11 @@ module Rails
       def gem_for_database
         # %w( mysql oracle postgresql sqlite3 frontbase ibm_db sqlserver jdbcmysql jdbcsqlite3 jdbcpostgresql )
         case options[:database]
-        when "oracle"     then "ruby-oci8"
-        when "postgresql" then "pg"
-        when "frontbase"  then "ruby-frontbase"
-        when "mysql"      then "mysql2"
-        when "sqlserver"  then "activerecord-sqlserver-adapter"
+        when "oracle"         then "ruby-oci8"
+        when "postgresql"     then "pg"
+        when "frontbase"      then "ruby-frontbase"
+        when "mysql"          then "mysql2"
+        when "sqlserver"      then "activerecord-sqlserver-adapter"
         when "jdbcmysql"      then "activerecord-jdbcmysql-adapter"
         when "jdbcsqlite3"    then "activerecord-jdbcsqlite3-adapter"
         when "jdbcpostgresql" then "activerecord-jdbcpostgresql-adapter"


### PR DESCRIPTION
I got tired of seeing this inconsistently aligned code that is produced by `rails new` in `Gemfile`:

```
# Bundle edge Rails instead:
# gem 'rails',     :git => 'git://github.com/rails/rails.git'
```

Just to be clear, I'm talking about the whitespace after the comma and before the `:git` above.

This commit fixes it.
