### PR TITLE
Travis CI testing for alternate Ruby interpreters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ railties/tmp
 .rvmrc
 .rbenv-version
 RDOC_MAIN.rdoc
+.rbx

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ rvm:
   - 1.8.7
   - 1.9.2
   #- 1.9.3 # Disable 1.9.3 builds until Travis is on 1.9.3-rc1.
+  - rbx
+  #- rbx-2.0
+  #- jruby
 env:
   - "GEM=railties"
   - "GEM=ap,am,amo,ares,as"


### PR DESCRIPTION
Rails 3.0.10 broke compatibility with Rubinius 1.2.4. Would be nice to know through CI if something like this happens again. Added rbx, rbx-2.0, and jruby to .travis.yml.
