### PR TITLE
Autosave association doesn't save all records on a new record for a collection association if there are records marked for destruction

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -328,13 +328,14 @@ module ActiveRecord
         autosave = reflection.options[:autosave]
 
         if records = associated_records_to_validate_or_save(association, @new_record_before_save, autosave)
+          records_to_destroy = []
           records.each do |record|
             next if record.destroyed?
 
             saved = true
 
             if autosave && record.marked_for_destruction?
-              association.proxy.destroy(record)
+              records_to_destroy << record
             elsif autosave != false && (@new_record_before_save || record.new_record?)
               if autosave
                 saved = association.insert_record(record, false)
@@ -346,6 +347,10 @@ module ActiveRecord
             end
 
             raise ActiveRecord::Rollback unless saved
+          end
+
+          records_to_destroy.each do |record|
+            association.proxy.destroy(record)
           end
         end
 

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -767,6 +767,16 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
     assert_equal before, @pirate.reload.birds
   end
 
+  def test_when_new_record_a_child_marked_for_destruction_should_not_affect_other_records_from_saving
+    @pirate = @ship.build_pirate(:catchphrase => "Arr' now I shall keep me eye on you matey!") # new record
+
+    3.times { |i| @pirate.birds.build(:name => "birds_#{i}") }
+    @pirate.birds[1].mark_for_destruction
+    @pirate.save!
+
+    assert_equal 2, @pirate.birds.reload.length
+  end
+
   # Add and remove callbacks tests for association collections.
   %w{ method proc }.each do |callback_type|
     define_method("test_should_run_add_callback_#{callback_type}s_for_has_many") do


### PR DESCRIPTION
The issue seems to be that, if the record is a new record, the internal collection array is being iterated when autosaving associated records.

Since association destroy/delete now removes records from the internal array via Array#delete (https://github.com/rails/rails/blob/3-1-stable/activerecord/lib/active_record/associations/collection_association.rb#L449), this has side-effects on the iteration within `save_collection_association` in autosave. Namely, the record after the record removed from the collection is skipped during the autosave.
