### PR TITLE
Ignore sqlnet 3 0 stable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ doc/rdoc
 activemodel/doc
 activeresource/doc
 activerecord/doc
+activerecord/sqlnet.log
 actionpack/doc
 actionmailer/doc
 activesupport/doc


### PR DESCRIPTION
Found when running test with oracle. It's only in Rails gitignore.
