### PR TITLE
Include affected record when raising an ActiveRecord::StaleObjectError

### DIFF
--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -99,6 +99,15 @@ module ActiveRecord
   #
   # Read more about optimistic locking in ActiveRecord::Locking module RDoc.
   class StaleObjectError < ActiveRecordError
+    attr_reader :record
+
+    def initialize(record)
+      @record = record
+    end
+
+    def message
+      "Attempted to update a stale object: #{record.class.name}"
+    end    
   end
 
   # Raised when association is being configured improperly or

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -99,15 +99,16 @@ module ActiveRecord
   #
   # Read more about optimistic locking in ActiveRecord::Locking module RDoc.
   class StaleObjectError < ActiveRecordError
-    attr_reader :record
+    attr_reader :record, :attempted_action
 
-    def initialize(record)
+    def initialize(record, attempted_action)
       @record = record
+      @attempted_action = attempted_action
     end
 
     def message
-      "Attempted to update a stale object: #{record.class.name}"
-    end    
+      "Attempted to #{attempted_action} a stale object: #{record.class.name}"
+    end
   end
 
   # Raised when association is being configured improperly or

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -103,7 +103,7 @@ module ActiveRecord
             affected_rows = connection.update stmt
 
             unless affected_rows == 1
-              raise ActiveRecord::StaleObjectError, self
+              raise ActiveRecord::StaleObjectError.new(self, "update")
             end
 
             affected_rows
@@ -127,7 +127,7 @@ module ActiveRecord
             affected_rows = self.class.unscoped.where(predicate).delete_all
 
             unless affected_rows == 1
-              raise ActiveRecord::StaleObjectError, self
+              raise ActiveRecord::StaleObjectError.new(self, "destroy")
             end
           end
 

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -103,7 +103,7 @@ module ActiveRecord
             affected_rows = connection.update stmt
 
             unless affected_rows == 1
-              raise ActiveRecord::StaleObjectError, "Attempted to update a stale object: #{self.class.name}"
+              raise ActiveRecord::StaleObjectError, self
             end
 
             affected_rows
@@ -127,7 +127,7 @@ module ActiveRecord
             affected_rows = self.class.unscoped.where(predicate).delete_all
 
             unless affected_rows == 1
-              raise ActiveRecord::StaleObjectError, "Attempted to delete a stale object: #{self.class.name}"
+              raise ActiveRecord::StaleObjectError, self
             end
           end
 


### PR DESCRIPTION
Hey there,

I added a `record` attribute to the `ActiveRecord::StaleObjectError` exception.
Instead of a string, now the record raising this exception is passed to the constructor.

This becomes pretty handy, for example when you want to reload the `record` before rendering a form again.

Example:

``` ruby
rescue_from 'ActiveRecord::StaleObjectError' do |exception|
  respond_to do |format|
    format.html do
      exception.record.reload
      render :action => :edit
    end
  end
end
```
