### PR TITLE
Remove trailing "#" on rake routes for controller only routes

### DIFF
--- a/railties/lib/rails/application/route_inspector.rb
+++ b/railties/lib/rails/application/route_inspector.rb
@@ -10,20 +10,21 @@ module Rails
         end
 
         routes = all_routes.collect do |route|
+          route_reqs = route.requirements
 
-          reqs = route.requirements.dup
           rack_app = route.app unless route.app.class.name.to_s =~ /^ActionDispatch::Routing/
 
-          endpoint = rack_app ? rack_app.inspect : "#{reqs[:controller]}##{reqs[:action]}"
-          constraints = reqs.except(:controller, :action)
+          controller = route_reqs[:controller] || ':controller'
+          action     = route_reqs[:action]     || ':action'
 
-          reqs = endpoint == '#' ? '' : endpoint
+          endpoint = rack_app ? rack_app.inspect : "#{controller}##{action}"
+          constraints = route_reqs.except(:controller, :action)
 
-          unless constraints.empty?
-            reqs = reqs.empty? ? constraints.inspect : "#{reqs} #{constraints.inspect}"
-          end
+          reqs = endpoint
+          reqs += " #{constraints.inspect}" unless constraints.empty?
 
           verb = route.verb.source.gsub(/[$^]/, '')
+
           {:name => route.name.to_s, :verb => verb, :path => route.path.spec.to_s, :reqs => reqs}
         end
 

--- a/railties/test/application/route_inspect_test.rb
+++ b/railties/test/application/route_inspect_test.rb
@@ -49,12 +49,20 @@ module ApplicationTests
       assert_equal ["root  / pages#main"], output
     end
 
+    def test_inspect_routes_shows_dynamic_action_route
+      @set.draw do
+        match 'api/:action' => 'api'
+      end
+      output = @inspector.format @set.routes
+      assert_equal ["  /api/:action(.:format) api#:action"], output
+    end
+
     def test_inspect_routes_shows_controller_and_action_only_route
       @set.draw do
         match ':controller/:action'
       end
       output = @inspector.format @set.routes
-      assert_equal ["  /:controller/:action(.:format) "], output
+      assert_equal ["  /:controller/:action(.:format) :controller#:action"], output
     end
 
     def test_inspect_routes_shows_controller_and_action_route_with_constraints
@@ -62,7 +70,7 @@ module ApplicationTests
         match ':controller(/:action(/:id))', :id => /\d+/
       end
       output = @inspector.format @set.routes
-      assert_equal ["  /:controller(/:action(/:id))(.:format) {:id=>/\\d+/}"], output
+      assert_equal ["  /:controller(/:action(/:id))(.:format) :controller#:action {:id=>/\\d+/}"], output
     end
 
     def test_rake_routes_shows_route_with_defaults


### PR DESCRIPTION
When running `rake routes` for controller only route like:

```
match 'api/:action' => 'api'
```

we get:

```
  api/:action(.:format) api#
```

This patch removes the trailing `#`.
