### PR TITLE
Exclude _destroy parameter in :all_blank check (issue #2937)

### DIFF
--- a/activerecord/CHANGELOG
+++ b/activerecord/CHANGELOG
@@ -29,6 +29,11 @@
 
   [Andrés Mejía]
 
+* Fix nested attributes bug where _destroy parameter is taken into account
+  during :reject_if => :all_blank (fixes #2937)
+
+  [Aaron Christy]
+
 *Rails 3.1.1 (October 7, 2011)*
 
 * Add deprecation for the preload_associations method. Fixes #3022.

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -220,7 +220,7 @@ module ActiveRecord
     #     validates_presence_of :member
     #   end
     module ClassMethods
-      REJECT_ALL_BLANK_PROC = proc { |attributes| attributes.all? { |_, value| value.blank? } }
+      REJECT_ALL_BLANK_PROC = proc { |attributes| attributes.all? { |key, value| key == '_destroy' || value.blank? } }
 
       # Defines an attributes writer for the specified association(s). If you
       # are using <tt>attr_protected</tt> or <tt>attr_accessible</tt>, then you
@@ -239,7 +239,8 @@ module ActiveRecord
       #   is specified, a record will be built for all attribute hashes that
       #   do not have a <tt>_destroy</tt> value that evaluates to true.
       #   Passing <tt>:all_blank</tt> instead of a Proc will create a proc
-      #   that will reject a record where all the attributes are blank.
+      #   that will reject a record where all the attributes are blank excluding
+      #   any value for _destroy.
       # [:limit]
       #   Allows you to specify the maximum number of the associated records that
       #   can be processed with the nested attributes. If the size of the

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -45,6 +45,14 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
     end
   end
 
+  def test_should_not_build_a_new_record_using_reject_all_even_if_destroy_is_given
+    pirate = Pirate.create!(:catchphrase => "Don' botharrr talkin' like one, savvy?")
+    pirate.birds_with_reject_all_blank_attributes = [{:name => '', :color => '', :_destroy => '0'}]
+    pirate.save!
+
+    assert pirate.birds_with_reject_all_blank.empty?
+  end
+
   def test_should_not_build_a_new_record_if_reject_all_blank_returns_false
     pirate = Pirate.create!(:catchphrase => "Don' botharrr talkin' like one, savvy?")
     pirate.birds_with_reject_all_blank_attributes = [{:name => '', :color => ''}]


### PR DESCRIPTION
When using accepts_nested_attributes_for and a :reject_if => all_blank, the _destroy parameter is also taken into consideration for blank attributes.  This can present a situation where a user leaves a form blank for a nested model, submits it, and the nested model record is created anyway.
#### A Contrived Example

A sample model:

```
class Pirate < ActiveRecord::Base
  has_many :ships
  accepts_nested_attributes_for :ships, :reject_if => :all_blank,  :allow_destroy => true
end
```

partial rendered html form for pirate:

```
<div>
  <input type="text" value="" name="pirate[ships_attributes][0][name]" />
  <input type="hidden" value="0" name="pirate[ships_attributes][0][_destroy]">
  <input type="checkbox" value="1" id="pirate_ships_attributes_0__destroy" name="pirate[ships_attributes][0][_destroy]">
  <label for="pirate_ships_attributes_0__destroy"> destroy</label>
</div>
```

submitted parameters will contain:

```
 "ships_attributes"=>{"0"=>{"name"=>"", "_destroy"=>"0"}}
```
#### Problem

Although the intention is to reject the ship, the _destroy parameter technically has a non-blank value, therefore the ship record would still be created anyway.
#### Strategy

My recommendation for this pull request is to modify the ALL_BLANK proc to ignore the _destroy meta attribute.  This would preserve the ability to destroy records by setting it truthy, but reject it if all core model attributes are blank.
#### Issue

https://gist.github.com/rails/rails/issues/2937
