### PR TITLE
bug in find_in_batches with scoped_methods

### DIFF
--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -78,4 +78,11 @@ class EachTest < ActiveRecord::TestCase
       end
     end
   end
+
+  def test_find_in_batches_should_not_have_conflict_with_scope
+    ActiveRecord::Base.uncached { @posts = Post.all }
+    Post.containing_the_letter_a.find_in_batches(:batch_size => 1) do |posts|
+      assert @posts == Post.all
+    end
+  end
 end


### PR DESCRIPTION
Doing a find in a batch seems to mixin the find_in_batches scope :

```
named_scope :containing_the_letter_a, :conditions => "body LIKE '%a%'"
Post.containing_the_letter_a.find_in_batches(:batch_size => 1) do |posts|
 Post.all
end
```

Post.all would have done :

```
 SELECT * FROM `posts` 
```

but it did

```
SELECT * FROM `posts` WHERE (body LIKE '%a%')
```

The issue is coming from ActiveRecord::Base#scoped_methods which return the find_in_batches conditions when calling Post.all.
This have been fixed in master but not in 2-3-stable.
