### PR TITLE
remove require since autoloaded in active_record.rb

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1,4 +1,3 @@
-require 'active_record/connection_adapters/abstract_adapter'
 require 'active_support/core_ext/object/blank'
 require 'active_record/connection_adapters/statement_pool'
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
@@ -1,4 +1,3 @@
-require 'active_record/connection_adapters/abstract_adapter'
 require 'active_record/connection_adapters/statement_pool'
 require 'active_support/core_ext/string/encoding'
 


### PR DESCRIPTION
autoloading ConnectionAdapters in active_record.rb. here(https://github.com/castlerock/rails/commit/1efd88283ef68d912df215125951a87526768a51).

No need to have a explicit require in sqlite and postgresql adapters.
