### PR TITLE
Added environment rake task to engines

### DIFF
--- a/railties/lib/rails/tasks/engine.rake
+++ b/railties/lib/rails/tasks/engine.rake
@@ -2,6 +2,7 @@ task "load_app" do
   namespace :app do
     load APP_RAKEFILE
   end
+  task :environment => "app:environment"
 
   if !defined?(ENGINE_PATH) || !ENGINE_PATH
     ENGINE_PATH = find_engine_path(APP_RAKEFILE)

--- a/railties/test/railties/shared_tests.rb
+++ b/railties/test/railties/shared_tests.rb
@@ -21,6 +21,23 @@ module RailtiesTest
       assert_match "alert()", last_response.body
     end
 
+    def test_rake_environment_can_be_called_in_the_engine_or_plugin
+      boot_rails
+
+      @plugin.write "Rakefile", <<-RUBY
+        APP_RAKEFILE = '#{app_path}/Rakefile'
+        load 'rails/tasks/engine.rake'
+        task :foo => :environment do
+          puts "Task ran"
+        end
+      RUBY
+
+      Dir.chdir(@plugin.path) do
+        output = `bundle exec rake foo`
+        assert_match "Task ran", output
+      end
+    end
+
     def test_copying_migrations
       @plugin.write "db/migrate/1_create_users.rb", <<-RUBY
         class CreateUsers < ActiveRecord::Migration


### PR DESCRIPTION
Some gems/plugins require the rake :environment task to load the rails stack to do their stuff, but this isn't available in engines.

In the past I have fixed this by modifying things to check if :environment exists as a task, and if not use app:environment.

I think it makes sense however to fix this in one place - gems shouldn't have to worry about whether they are being used by an engine or not as much as possible.

I couldn't find any tests for this - please direct me to them if I've missed it and I'll add a test.
