### PR TITLE
Allow to_json output to embed within <script> tags in HTML output.

### DIFF
--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -124,6 +124,7 @@ module ActiveSupport
           end
           json = string.
             gsub(escape_regex) { |s| ESCAPED_CHARS[s] }.
+            gsub("</", "<\\/").
             gsub(/([\xC0-\xDF][\x80-\xBF]|
                    [\xE0-\xEF][\x80-\xBF]{2}|
                    [\xF0-\xF7][\x80-\xBF]{3})+/nx) { |s|

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -58,6 +58,7 @@ class TestJSONEncoding < Test::Unit::TestCase
   StandardTimeTests     = [[ Time.utc(2005,2,1,15,15,10), %("2005-02-01T15:15:10Z") ]]
   StandardDateTimeTests = [[ DateTime.civil(2005,2,1,15,15,10), %("2005-02-01T15:15:10+00:00") ]]
   StandardStringTests   = [[ 'this is the <string>', %("this is the <string>")]]
+  StandardEmbeddedScriptStringTests = [[ "<script>alert('foo');</script>", %("<script>alert('foo');<\\/script>")]]
 
   def sorted_json(json)
     return json unless json =~ /^\{.*\}$/


### PR DESCRIPTION
In single-page-designs an oft-used pattern is to embed the initialisation data as JSON within the HTML page output. E.g.:

```
<script>App.reset(<%= raw @people.to_json %>);</script>
```

This could result in the following output:

```
<script>App.reset([{"name":"<script>alert('foo');</script>"}]);</script>
```

Browsers will complain about this, because within `<script>` tags the `</` characters aren't allowed. This patch always escapes the `</` characters as `<\/`. So the example output above would become:

```
<script>App.reset([{"name":"<script>alert('foo');<\/script>"}]);</script>
```
