### PR TITLE
Fixed DataMapper namings in symbols and constants.

### DIFF
--- a/railties/lib/rails/engine/configuration.rb
+++ b/railties/lib/rails/engine/configuration.rb
@@ -21,7 +21,7 @@ module Rails
       # Holds generators configuration:
       #
       #   config.generators do |g|
-      #     g.orm             :datamapper, :migration => true
+      #     g.orm             :data_mapper, :migration => true
       #     g.template_engine :haml
       #     g.test_framework  :rspec
       #   end

--- a/railties/lib/rails/generators/active_model.rb
+++ b/railties/lib/rails/generators/active_model.rb
@@ -11,7 +11,7 @@ module Rails
     #   ActiveRecord::Generators::ActiveModel.find(Foo, "params[:id]")
     #   # => "Foo.find(params[:id])"
     #
-    #   Datamapper::Generators::ActiveModel.find(Foo, "params[:id]")
+    #   DataMapper::Generators::ActiveModel.find(Foo, "params[:id]")
     #   # => "Foo.get(params[:id])"
     #
     # On initialization, the ActiveModel accepts the instance name that will

--- a/railties/test/application/generators_test.rb
+++ b/railties/test/application/generators_test.rb
@@ -45,10 +45,10 @@ module ApplicationTests
 
     test "generators set rails options" do
       with_bare_config do |c|
-        c.generators.orm            = :datamapper
+        c.generators.orm            = :data_mapper
         c.generators.test_framework = :rspec
         c.generators.helper         = false
-        expected = { :rails => { :orm => :datamapper, :test_framework => :rspec, :helper => false } }
+        expected = { :rails => { :orm => :data_mapper, :test_framework => :rspec, :helper => false } }
         assert_equal(expected, c.generators.options)
       end
     end
@@ -64,7 +64,7 @@ module ApplicationTests
     test "generators aliases, options, templates and fallbacks on initialization" do
       add_to_config <<-RUBY
         config.generators.rails :aliases => { :test_framework => "-w" }
-        config.generators.orm :datamapper
+        config.generators.orm :data_mapper
         config.generators.test_framework :rspec
         config.generators.fallbacks[:shoulda] = :test_unit
         config.generators.templates << "some/where"
@@ -95,15 +95,15 @@ module ApplicationTests
     test "generators with hashes for options and aliases" do
       with_bare_config do |c|
         c.generators do |g|
-          g.orm    :datamapper, :migration => false
+          g.orm    :data_mapper, :migration => false
           g.plugin :aliases => { :generator => "-g" },
                    :generator => true
         end
 
         expected = {
-          :rails => { :orm => :datamapper },
+          :rails => { :orm => :data_mapper },
           :plugin => { :generator => true },
-          :datamapper => { :migration => false }
+          :data_mapper => { :migration => false }
         }
 
         assert_equal expected, c.generators.options
@@ -114,12 +114,12 @@ module ApplicationTests
     test "generators with string and hash for options should generate symbol keys" do
       with_bare_config do |c|
         c.generators do |g|
-          g.orm    'datamapper', :migration => false
+          g.orm    'data_mapper', :migration => false
         end
 
         expected = {
-          :rails => { :orm => :datamapper },
-          :datamapper => { :migration => false }
+          :rails => { :orm => :data_mapper },
+          :data_mapper => { :migration => false }
         }
 
         assert_equal expected, c.generators.options

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -524,7 +524,7 @@ module RailtiesTest
         module Bukkits
           class Engine < ::Rails::Engine
             config.generators do |g|
-              g.orm             :datamapper
+              g.orm             :data_mapper
               g.template_engine :haml
               g.test_framework  :rspec
             end
@@ -553,7 +553,7 @@ module RailtiesTest
       assert_equal :test_unit, app_generators[:test_framework]
 
       generators = Bukkits::Engine.config.generators.options[:rails]
-      assert_equal :datamapper, generators[:orm]
+      assert_equal :data_mapper, generators[:orm]
       assert_equal :haml      , generators[:template_engine]
       assert_equal :rspec     , generators[:test_framework]
     end


### PR DESCRIPTION
The correct constant naming is `DataMapper`. Applied that to symbol and constant-namings throughout the source.
