### PR TITLE
- Resolve issues #3333 and #3348 : Asset pipeline is trying to compute public path of file contents

### DIFF
--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -43,7 +43,7 @@ module Sprockets
         sources.collect do |source|
           if debug && asset = asset_paths.asset_for(source, 'css')
             asset.to_a.map { |dep|
-              super(dep.to_s, { :href => asset_path(dep, :ext => 'css', :body => true, :protocol => :request, :digest => digest) }.merge!(options))
+              super(asset_paths.strip_exts(dep.pathname.basename).to_s, { :href => asset_path(dep, :ext => 'css', :body => true, :protocol => :request, :digest => digest) }.merge!(options))
             }
           else
             super(source.to_s, { :href => asset_path(source, :ext => 'css', :body => body, :protocol => :request, :digest => digest) }.merge!(options))
@@ -159,6 +159,10 @@ module Sprockets
           else
             source
           end
+        end
+        
+        def strip_exts(source)
+          source.to_s.split('.').first
         end
       end
     end


### PR DESCRIPTION
- Resolve issues #3333 and #3348 : Asset pipeline is trying to compute public path of file contents

This issue only occurs in Production mode when 'config.assets.debug = true'

In this case, the asset pipeline uses the contents of the css file as the pathname causing an error that is quite hard to track down. This only occurs with certain css file contents, that seemed pretty arbitrary when I tried to narrow it down.

I have not added any tests for this because I'm not sure how to mimic the Production environment in a test. I'd be happy to do it if anyone can give me some guidance on how to accomplish that. The existing tests however, still all pass.
