### PR TITLE
Fix deprecation msg to stderr

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -103,7 +103,8 @@ module ActiveRecord
       if lookup.is_a?(Hash)
         lookup.each do |key, value| 
           if value.is_a?(Hash) && value.any? { |k,v| v.is_a?(Hash) }
-            $stderr.puts "[DEPRECATION WARNING] Nested I18n namespace lookup under \"#{container}.#{key}\" is no longer supported"
+            ActiveSupport::Deprecation.warn "[DEPRECATION WARNING] Nested I18n namespace lookup under \"#{container}.#{key}\" is no longer supported"
+
           end
         end
       end
@@ -113,7 +114,7 @@ module ActiveRecord
       if lookup.is_a?(Hash)
         lookup.each do |key, value|
           if value.is_a?(Hash) && !value.key?(:one)
-            $stderr.puts "[DEPRECATION WARNING] Nested I18n namespace lookup under \"#{container}.#{key}\" is no longer supported"
+            ActiveSupport::Deprecation.warn "[DEPRECATION WARNING] Nested I18n namespace lookup under \"#{container}.#{key}\" is no longer supported"
           end
         end
       end


### PR DESCRIPTION
Use the ActiveSupport::Deprecation methods instead of printing deprecation warning to stderr directly
