### PR TITLE
New #added? method on ActiveModel::Errors

### DIFF
--- a/activemodel/CHANGELOG
+++ b/activemodel/CHANGELOG
@@ -1,3 +1,5 @@
+* Added ActiveModel::Errors#added? to check if a specific error has been added [Martin Svalin]
+
 * Add ability to define strict validation(with :strict => true option) that always raises exception when fails [Bogdan Gusiev]
 
 * Deprecate "Model.model_name.partial_path" in favor of "model.to_partial_path" [Grant Hutchins, Peter Jaros]

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -80,6 +80,49 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal ["can not be blank"], person.errors[:name]
   end
 
+  test "added? should be true if that error was added" do
+    person = Person.new
+    person.errors.add(:name, "can not be blank")
+    assert person.errors.added?(:name, "can not be blank")
+  end
+
+  test "added? should handle when message is a symbol" do
+    person = Person.new
+    person.errors.add(:name, :blank)
+    assert person.errors.added?(:name, :blank)
+  end
+
+  test "added? should handle when message is a proc" do
+    person = Person.new
+    message = Proc.new { "can not be blank" }
+    person.errors.add(:name, message)
+    assert person.errors.added?(:name, message)
+  end
+
+  test "added? should default message to :invalid" do
+    person = Person.new
+    person.errors.add(:name, :invalid)
+    assert person.errors.added?(:name)
+  end
+
+  test "added? should be true when several errors are present, and we ask for one of them" do
+    person = Person.new
+    person.errors.add(:name, "can not be blank")
+    person.errors.add(:name, "is invalid")
+    assert person.errors.added?(:name, "can not be blank")
+  end
+
+  test "added? should be false if no errors are present" do
+    person = Person.new
+    assert !person.errors.added?(:name)
+  end
+
+  test "added? should be false when an error is present, but we check for another error" do
+    person = Person.new
+    person.errors.add(:name, "is invalid")
+    assert !person.errors.added?(:name, "can not be blank")
+  end
+
   test 'should respond to size' do
     person = Person.new
     person.errors.add(:name, "can not be blank")


### PR DESCRIPTION
The `#added?` method makes it possible to check if a specific error has been added, using the same parameters as for `#add`.

This is useful if you need different behaviour depending on what errors are present on an object. My use case was when adding email addresses to a list. Some errors are permanent (e.g. already subscribed) while other errors are not permanent (e.g. invalid formatting), so the user can be given a chance to remedy the error.

I had a mix of errors on the same attribute, so I could not simply check for the presence of errors on that attribute. Checking for key-value-pairs was also made difficult, as my app is translated into five languages.

I ended up monkey patching ActiveModel::Errors, as have others:
http://stackoverflow.com/questions/6826820/default-activerecord-activemodel-errors-are-anonymous
http://stackoverflow.com/questions/3671098/better-way-to-access-individual-rails-activerecord-error

I'm not an experienced Rails contributor, so if you have comments on coding style, please let me know. I'll be happy to make modifications.
