### PR TITLE
Backports SecureRandom.uuid from Ruby 1.9

### DIFF
--- a/activesupport/CHANGELOG
+++ b/activesupport/CHANGELOG
@@ -1,12 +1,14 @@
 *Rails 3.2.0 (unreleased)*
 
+* Backports SecureRandom.uuid from Ruby 1.9 [Guillermo Iguaran]
+
 * Added ActiveSupport:TaggedLogging that can wrap any standard Logger class to provide tagging capabilities [DHH]
 
     Logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
     Logger.tagged("BCX") { Logger.info "Stuff" }                            # Logs "[BCX] Stuff"
     Logger.tagged("BCX", "Jason") { Logger.info "Stuff" }                   # Logs "[BCX] [Jason] Stuff"
     Logger.tagged("BCX") { Logger.tagged("Jason") { Logger.info "Stuff" } } # Logs "[BCX] [Jason] Stuff"
-  
+
 * Added safe_constantize that constantizes a string but returns nil instead of an exception if the constant (or part of it) does not exist [Ryan Oblak]
 
 * ActiveSupport::OrderedHash is now marked as extractable when using Array#extract_options! [Prem Sichanugrist]

--- a/activesupport/lib/active_support/core_ext/securerandom.rb
+++ b/activesupport/lib/active_support/core_ext/securerandom.rb
@@ -1,0 +1,10 @@
+require 'securerandom'
+
+module SecureRandom
+  def self.uuid
+    ary = self.random_bytes(16).unpack("NnnnnN")
+    ary[2] = (ary[2] & 0x0fff) | 0x4000
+    ary[3] = (ary[3] & 0x3fff) | 0x8000
+    "%08x-%04x-%04x-%04x-%04x%08x" % ary
+  end unless respond_to?(:uuid)
+end

--- a/activesupport/test/core_ext/securerandom_ext_test.rb
+++ b/activesupport/test/core_ext/securerandom_ext_test.rb
@@ -1,0 +1,8 @@
+require 'abstract_unit'
+require 'active_support/core_ext/securerandom'
+
+class SecureRandomTest < Test::Unit::TestCase
+  def test_uuid
+    assert_match(/\w{8}-\w{4}-\w{4}-\w{4}-\w{12}/, SecureRandom.uuid)
+  end
+end


### PR DESCRIPTION
I just saw ada78066fdbc and I remembered that I backported it in a project some months ago
