### PR TITLE
Regexp fixup

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/request_id.rb
+++ b/actionpack/lib/action_dispatch/middleware/request_id.rb
@@ -28,7 +28,7 @@ module ActionDispatch
     private
       def external_request_id(env)
         if request_id = env["HTTP_X_REQUEST_ID"].presence
-          request_id.gsub(/[^\w\d\-]/, "").first(255)
+          request_id.gsub(/[^\w\-]/, "").first(255)
         end
       end
 


### PR DESCRIPTION
As per [Regexp](http://www.ruby-doc.org/core-1.9.2/Regexp.html), `\w` includes `[0-9]`, thus making `\d` redundant.
