### PR TITLE
multipart emails missing content-type boundary

### DIFF
--- a/actionmailer/lib/action_mailer/old_api.rb
+++ b/actionmailer/lib/action_mailer/old_api.rb
@@ -167,6 +167,7 @@ module ActionMailer
         if real_content_type =~ /multipart/
           ctype_attrs.delete "charset"
           m.content_type([main_type, sub_type, ctype_attrs])
+          m.body.boundary = ctype_attrs["boundary"] if ctype_attrs.has_key?("boundary")
         end
       end
 
@@ -206,8 +207,8 @@ module ActionMailer
           @parts << create_inline_part(render(:template => template), template.mime_type)
         end
 
-        if @parts.size > 1
-          @content_type = "multipart/alternative" if @content_type !~ /^multipart/
+        if @parts.size > 1 && @content_type !~ /^multipart/
+          @content_type = Mail::ContentTypeField.with_boundary("multipart/alternative").value
         end
 
         # If this is a multipart e-mail add the mime_version if it is not

--- a/actionmailer/test/old_base/mail_service_test.rb
+++ b/actionmailer/test/old_base/mail_service_test.rb
@@ -935,7 +935,7 @@ EOF
   def test_implicitly_multipart_messages_with_charset
     mail = TestMailer.implicitly_multipart_example(@recipient, 'iso-8859-1')
 
-    assert_equal "multipart/alternative", mail.header['content-type'].content_type
+    assert_match %r{^multipart/alternative; boundary="--==_mimepart_.+"$}, mail.header['content-type'].to_s
 
     assert_equal 'iso-8859-1', mail.parts[0].content_type_parameters[:charset]
     assert_equal 'iso-8859-1', mail.parts[1].content_type_parameters[:charset]


### PR DESCRIPTION
See also: https://github.com/rails/rails/issues/985
And: http://stackoverflow.com/questions/7499172/html-emails-sent-through-rails-arrive-as-attachment
