### PR TITLE
Checking blank if tag might coming nil or blank

### DIFF
--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -1,3 +1,4 @@
+require 'active_support/core_ext/object/blank'
 require 'logger'
 
 module ActiveSupport
@@ -18,7 +19,7 @@ module ActiveSupport
 
     def tagged(*new_tags)
       tags     = current_tags
-      new_tags = Array.wrap(new_tags).flatten
+      new_tags = Array.wrap(new_tags).flatten.reject(&:blank?)
       tags.concat new_tags
       yield
     ensure

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -29,6 +29,11 @@ class TaggedLoggingTest < ActiveSupport::TestCase
     assert_equal "[BCX] [Jason] [New] Funky time\n", @output.string
   end
 
+  test "tagged once with blank and nil" do
+    @logger.tagged(nil, "", "New") { @logger.info "Funky time" }
+    assert_equal "[New] Funky time\n", @output.string
+  end
+
   test "keeps each tag in their own thread" do
     @logger.tagged("BCX") do
       Thread.new do


### PR DESCRIPTION
If I have defined subdomain as a tag in my config and that some request might not hitting on subdomain so I will get blank <pre>[]</pre> in my log as a tag.

I am not sure if this is a good idea to remove that. But I think showing blank is not required.
