### PR TITLE
Add license field to gemspecs

### DIFF
--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Email composition, delivery, and receiving framework (part of Rails).'
   s.description = 'Email on Rails. Compose, deliver, receive, and test emails using the familiar controller/view pattern. First-class support for multipart email and attachments.'
   s.required_ruby_version = '>= 1.9.3'
+  s.license     = 'MIT'
 
   s.author            = 'David Heinemeier Hansson'
   s.email             = 'david@loudthinking.com'

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Web-flow and rendering framework putting the VC in MVC (part of Rails).'
   s.description = 'Web apps on Rails. Simple, battle-tested conventions for building and testing MVC web applications. Works with any Rack-compatible server.'
   s.required_ruby_version = '>= 1.9.3'
+  s.license     = 'MIT'
 
   s.author            = 'David Heinemeier Hansson'
   s.email             = 'david@loudthinking.com'

--- a/activemodel/activemodel.gemspec
+++ b/activemodel/activemodel.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |s|
   s.description = 'A toolkit for building modeling frameworks like Active Record and Active Resource. Rich support for attributes, callbacks, validations, observers, serialization, internationalization, and testing.'
 
   s.required_ruby_version = '>= 1.9.3'
+  s.license     = 'MIT'
 
   s.author            = 'David Heinemeier Hansson'
   s.email             = 'david@loudthinking.com'

--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |s|
   s.description = 'Databases on Rails. Build a persistent domain model by mapping database tables to Ruby classes. Strong conventions for associations, validations, aggregations, migrations, and testing come baked-in.'
 
   s.required_ruby_version = '>= 1.9.3'
+  s.license     = 'MIT'
 
   s.author            = 'David Heinemeier Hansson'
   s.email             = 'david@loudthinking.com'

--- a/activeresource/activeresource.gemspec
+++ b/activeresource/activeresource.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |s|
   s.description = 'REST on Rails. Wrap your RESTful web app with Ruby classes and work with them like Active Record models.'
 
   s.required_ruby_version = '>= 1.9.3'
+  s.license     = 'MIT'
 
   s.author            = 'David Heinemeier Hansson'
   s.email             = 'david@loudthinking.com'

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |s|
   s.description = 'A toolkit of support libraries and Ruby core extensions extracted from the Rails framework. Rich support for multibyte strings, internationalization, time zones, and testing.'
 
   s.required_ruby_version = '>= 1.9.3'
+  s.license     = 'MIT'
 
   s.author       = 'David Heinemeier Hansson'
   s.email        = 'david@loudthinking.com'

--- a/rails.gemspec
+++ b/rails.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version     = '>= 1.9.3'
   s.required_rubygems_version = ">= 1.8.11"
+  s.license     = 'MIT'
 
   s.author            = 'David Heinemeier Hansson'
   s.email             = 'david@loudthinking.com'

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Tools for creating, working with, and running Rails applications.'
   s.description = 'Rails internals: application bootup, plugins, generators, and rake tasks.'
   s.required_ruby_version = '>= 1.9.3'
+  s.license     = 'MIT'
 
   s.author            = 'David Heinemeier Hansson'
   s.email             = 'david@loudthinking.com'


### PR DESCRIPTION
Added license = "MIT" to all gemspecs. 

Life would be simpler if all gems declared their license but currently few do. This is important information when declaring the licenses an application is dependent upon in due-diligence scenarios (such as startup funding.)
