### PR TITLE
Fix threading issues with BufferedLogger.

### DIFF
--- a/activesupport/test/buffered_logger_test.rb
+++ b/activesupport/test/buffered_logger_test.rb
@@ -198,4 +198,57 @@ class BufferedLoggerTest < Test::Unit::TestCase
     end
     assert byte_string.include?(BYTE_STRING)
   end
+
+  def test_silence_only_current_thread
+    @logger.auto_flushing = true
+    run_thread_a = false
+
+    a = Thread.new do
+      while !run_thread_a do
+        sleep(0.001)
+      end
+      @logger.info("x")
+      run_thread_a = false
+    end
+
+    @logger.silence do
+      run_thread_a = true
+      @logger.info("a")
+      while run_thread_a do
+        sleep(0.001)
+      end
+    end
+
+    a.join
+
+    assert @output.string.include?("x")
+    assert !@output.string.include?("a")
+  end
+
+  def test_flush_dead_buffers
+    @logger.auto_flushing = false
+
+    a = Thread.new do
+      @logger.info("a")
+    end
+    
+    keep_running = true
+    b = Thread.new do
+      @logger.info("b")
+      while keep_running
+        sleep(0.001)
+      end
+    end
+
+    @logger.info("x")
+    a.join
+    @logger.flush
+
+
+    assert @output.string.include?("x")
+    assert @output.string.include?("a")
+    assert !@output.string.include?("b")
+    
+    keep_running = false
+  end
 end


### PR DESCRIPTION
There are a couple of threading issues with ActiveSupport::BufferedLogger.

If a thread is spawned and logs messages but does not flush the log, the messages will never be written and will remain in the buffer forever.

``` ruby
threads = []
urls.each do |url
threads << Thread.new do

logger.info("fetching #{url}")
fetch(url)
logger.info("#{url} retrieved")
end end
threads.each{|t| t.join}
```

Silencing a logger for a block in one thread will silence it will silence it for all other threads as well. This means in a multi-threaded Rails application, log messages can be lost.

(Note: this pull request was originally opened in Lighthouse at https://rails.lighthouseapp.com/projects/8994/tickets/6671)
