### PR TITLE
Fix ActiveSupport::Cache::FileStore.cleanup to actually work.

### DIFF
--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -557,6 +557,29 @@ class FileStoreTest < ActiveSupport::TestCase
     key = @cache_with_pathname.send(:key_file_path, "views/index?id=1")
     assert_equal "views/index?id=1", @cache_with_pathname.send(:file_path_key, key)
   end
+
+  def test_cleanup_with_not_accessed_in
+    @cache.write(1, "aaaaaaaaaa")
+    @cache.write(2, "bbbbbbbbbb")
+    @cache.write(3, "cccccccccc")
+    sleep(2)
+    @cache.read(2)
+    @cache.cleanup(:not_accessed_in => 1)
+    assert_equal false, @cache.exist?(1)
+    assert_equal true, @cache.exist?(2)
+    assert_equal false, @cache.exist?(3)
+  end
+
+  def test_cleanup_with_expired_only
+    @cache.write(1, "aaaaaaaaaa", :expires_in => 0.001)
+    @cache.write(2, "bbbbbbbbbb")
+    @cache.write(3, "cccccccccc", :expires_in => 0.001)
+    sleep(0.002)
+    @cache.cleanup(:expired_only => 0.001)
+    assert_equal false, @cache.exist?(1)
+    assert_equal true, @cache.exist?(2)
+    assert_equal false, @cache.exist?(3)
+  end
   
   # Because file systems have a maximum filename size, filenames > max size should be split in to directories
   # If filename is 'AAAAB', where max size is 4, the returned path should be AAAA/B
@@ -645,6 +668,17 @@ class MemoryStoreTest < ActiveSupport::TestCase
     assert_equal true, @cache.exist?(3)
     assert_equal true, @cache.exist?(2)
     assert_equal false, @cache.exist?(1)
+  end
+
+  def test_cleanup_removes_expired_entries
+    @cache.write(1, "aaaaaaaaaa", :expires_in => 0.001)
+    @cache.write(2, "bbbbbbbbbb")
+    @cache.write(3, "cccccccccc", :expires_in => 0.001)
+    sleep(0.002)
+    @cache.cleanup
+    assert_equal false, @cache.exist?(1)
+    assert_equal true, @cache.exist?(2)
+    assert_equal false, @cache.exist?(3)
   end
 end
 

--- a/railties/guides/source/caching_with_rails.textile
+++ b/railties/guides/source/caching_with_rails.textile
@@ -289,7 +289,11 @@ ActionController::Base.cache_store = :file_store, "/path/to/cache/directory"
 
 With this cache store, multiple server processes on the same host can share a cache. Servers processes running on different hosts could share a cache by using a shared file system, but that set up would not be ideal and is not recommended. The cache store is appropriate for low to medium traffic sites that are served off one or two hosts.
 
-Note that the cache will grow until the disk is full unless you periodically clear out old entries.
+Note that the cache will grow until the disk is full unless you periodically clear out old entries. You can call +ActiveSupport::Cache::FileStore#cleanup+ to remove entries older than a specified time.
+
+<ruby>
+Rails.cache.cleanup(:not_accessed_in => 2.days)
+</ruby>
 
 h4. ActiveSupport::Cache::MemCacheStore
 


### PR DESCRIPTION
The cleanup method on ActiveSupport::Cache::FileStore on the 3.0 branch is defined but doesn't actually work. I have fixed the implementation so it can be used to clean up old cache entries either by expiration time or by how recently they've been used and added tests.

This method is needed to keep the cache from growing without bound until if fills up the disk.

The syntax is:

``` ruby
Rails.cache.cleanup(:expired_only => true)
```

or

``` ruby
Rails.cache.cleanup(:not_accessed_in => 2.days)
```

(Note: this request was originally opened in Lighthouse at https://rails.lighthouseapp.com/projects/8994/tickets/6308)
