### PR TITLE
Null store

### DIFF
--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -19,8 +19,9 @@ module ActionMailer
       options.stylesheets_dir ||= paths["public/stylesheets"].first
 
       # make sure readers methods get compiled
-      options.asset_path      ||= app.config.asset_path
-      options.asset_host      ||= app.config.asset_host
+      options.asset_path          ||= app.config.asset_path
+      options.asset_host          ||= app.config.asset_host
+      options.relative_url_root   ||= app.config.relative_url_root
 
       ActiveSupport.on_load(:action_mailer) do
         include AbstractController::UrlFor

--- a/actionpack/lib/abstract_controller/asset_paths.rb
+++ b/actionpack/lib/abstract_controller/asset_paths.rb
@@ -4,7 +4,7 @@ module AbstractController
 
     included do
       config_accessor :asset_host, :asset_path, :assets_dir, :javascripts_dir,
-        :stylesheets_dir, :default_asset_host_protocol
+        :stylesheets_dir, :default_asset_host_protocol, :relative_url_root
     end
   end
 end

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -31,6 +31,7 @@ module ActionController
       # make sure readers methods get compiled
       options.asset_path           ||= app.config.asset_path
       options.asset_host           ||= app.config.asset_host
+      options.relative_url_root    ||= app.config.relative_url_root
 
       ActiveSupport.on_load(:action_controller) do
         include app.routes.mounted_helpers

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -146,6 +146,10 @@
     during :reject_if => :all_blank (fixes #2937)
 
     *Aaron Christy*
+    
+*   Add ActiveSupport::Cache::NullStore for use in development and testing.
+
+    *Brian Durand*
 
 ## Rails 3.1.3 (unreleased) ##
 

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -16,6 +16,7 @@ module ActiveSupport
     autoload :FileStore, 'active_support/cache/file_store'
     autoload :MemoryStore, 'active_support/cache/memory_store'
     autoload :MemCacheStore, 'active_support/cache/mem_cache_store'
+    autoload :NullStore, 'active_support/cache/null_store'
 
     # These options mean something to all cache implementations. Individual cache
     # implementations may support additional options.
@@ -67,7 +68,7 @@ module ActiveSupport
             end
           store_class.new(*parameters)
         when nil
-          ActiveSupport::Cache::MemoryStore.new
+          ActiveSupport::Cache::NullStore.new
         else
           store
         end

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -16,6 +16,7 @@ module ActiveSupport
     autoload :FileStore, 'active_support/cache/file_store'
     autoload :MemoryStore, 'active_support/cache/memory_store'
     autoload :MemCacheStore, 'active_support/cache/mem_cache_store'
+    autoload :NullStore, 'active_support/cache/null_store'
     autoload :SynchronizedMemoryStore, 'active_support/cache/synchronized_memory_store'
     autoload :CompressedMemCacheStore, 'active_support/cache/compressed_mem_cache_store'
 
@@ -68,7 +69,7 @@ module ActiveSupport
           end
         store_class.new(*parameters)
       when nil
-        ActiveSupport::Cache::MemoryStore.new
+        ActiveSupport::Cache::NullStore.new
       else
         store
       end

--- a/activesupport/lib/active_support/cache/null_store.rb
+++ b/activesupport/lib/active_support/cache/null_store.rb
@@ -3,9 +3,14 @@ module ActiveSupport
     # A cache store implementation which doesn't actually store anything. Useful in
     # development and test environments where you don't want caching turned on but
     # need to go through the caching interface.
+    #
+    # This cache does implement the local cache strategy, so values will actually
+    # be cached inside blocks that utilize this strategy. See
+    # ActiveSupport::Cache::Strategy::LocalCache for more details.
     class NullStore < Store
       def initialize(options = nil)
         super(options)
+        extend Strategy::LocalCache
       end
 
       def clear(options = nil)

--- a/activesupport/lib/active_support/cache/null_store.rb
+++ b/activesupport/lib/active_support/cache/null_store.rb
@@ -1,0 +1,39 @@
+module ActiveSupport
+  module Cache
+    # A cache store implementation which doesn't actually store anything. Useful in
+    # development and test environments where you don't want caching turned on but
+    # need to go through the caching interface.
+    class NullStore < Store
+      def initialize(options = nil)
+        super(options)
+      end
+
+      def clear(options = nil)
+      end
+
+      def cleanup(options = nil)
+      end
+
+      def increment(name, amount = 1, options = nil)
+      end
+
+      def decrement(name, amount = 1, options = nil)
+      end
+
+      def delete_matched(matcher, options = nil)
+      end
+
+      protected
+        def read_entry(key, options) # :nodoc:
+        end
+
+        def write_entry(key, entry, options) # :nodoc:
+          true
+        end
+
+        def delete_entry(key, options) # :nodoc:
+          false
+        end
+    end
+  end
+end

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -218,7 +218,7 @@ module CacheStoreBehavior
     @cache.write('fud', 'biz')
     assert_equal({"foo" => "bar", "fu" => "baz"}, @cache.read_multi('foo', 'fu'))
   end
-  
+
   def test_read_multi_with_expires
     @cache.write('foo', 'bar', :expires_in => 0.001)
     @cache.write('fu', 'baz')
@@ -576,12 +576,12 @@ class FileStoreTest < ActiveSupport::TestCase
     key = @cache_with_pathname.send(:key_file_path, "views/index?id=1")
     assert_equal "views/index?id=1", @cache_with_pathname.send(:file_path_key, key)
   end
-  
+
   # Because file systems have a maximum filename size, filenames > max size should be split in to directories
   # If filename is 'AAAAB', where max size is 4, the returned path should be AAAA/B
   def test_key_transformation_max_filename_size
     key = "#{'A' * ActiveSupport::Cache::FileStore::FILENAME_MAX_SIZE}B"
-    path = @cache.send(:key_file_path, key)    
+    path = @cache.send(:key_file_path, key)
     assert path.split('/').all? { |dir_name| dir_name.size <= ActiveSupport::Cache::FileStore::FILENAME_MAX_SIZE}
     assert_equal 'B', File.basename(path)
   end
@@ -689,14 +689,14 @@ uses_memcached 'memcached backed store' do
       cache.write("foo", 2)
       assert_equal "2", cache.read("foo")
     end
-    
+
     def test_raw_values_with_marshal
       cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, :raw => true)
       cache.clear
       cache.write("foo", Marshal.dump([]))
-      assert_equal [], cache.read("foo")      
+      assert_equal [], cache.read("foo")
     end
-    
+
     def test_local_cache_raw_values
       cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, :raw => true)
       cache.clear
@@ -721,47 +721,58 @@ class NullStoreTest < ActiveSupport::TestCase
   def setup
     @cache = ActiveSupport::Cache.lookup_store(:null_store)
   end
-  
+
   def test_clear
     @cache.clear
   end
-  
+
   def test_cleanup
     @cache.cleanup
   end
-  
+
   def test_write
     assert_equal true, @cache.write("name", "value")
   end
-  
+
   def test_read
     @cache.write("name", "value")
     assert_nil @cache.read("name")
   end
-  
+
   def test_delete
     @cache.write("name", "value")
     assert_equal false, @cache.delete("name")
   end
-  
+
   def test_increment
     @cache.write("name", 1, :raw => true)
     assert_nil @cache.increment("name")
   end
-  
+
   def test_decrement
     @cache.write("name", 1, :raw => true)
     assert_nil @cache.increment("name")
   end
-  
+
   def test_delete_matched
     @cache.write("name", "value")
     @cache.delete_matched(/name/)
-  end 
-  
+  end
+
+  def test_local_store_strategy
+    @cache.with_local_cache do
+      @cache.write("name", "value")
+      assert_equal "value", @cache.read("name")
+      @cache.delete("name")
+      assert_nil @cache.read("name")
+      @cache.write("name", "value")
+    end
+    assert_nil @cache.read("name")
+  end
+
   def test_setting_nil_cache_store
     assert ActiveSupport::Cache.lookup_store.class.name, ActiveSupport::Cache::NullStore.name
-  end 
+  end
 end
 
 class CacheStoreLoggerTest < ActiveSupport::TestCase

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -717,6 +717,53 @@ uses_memcached 'memcached backed store' do
   end
 end
 
+class NullStoreTest < ActiveSupport::TestCase
+  def setup
+    @cache = ActiveSupport::Cache.lookup_store(:null_store)
+  end
+  
+  def test_clear
+    @cache.clear
+  end
+  
+  def test_cleanup
+    @cache.cleanup
+  end
+  
+  def test_write
+    assert_equal true, @cache.write("name", "value")
+  end
+  
+  def test_read
+    @cache.write("name", "value")
+    assert_nil @cache.read("name")
+  end
+  
+  def test_delete
+    @cache.write("name", "value")
+    assert_equal false, @cache.delete("name")
+  end
+  
+  def test_increment
+    @cache.write("name", 1, :raw => true)
+    assert_nil @cache.increment("name")
+  end
+  
+  def test_decrement
+    @cache.write("name", 1, :raw => true)
+    assert_nil @cache.increment("name")
+  end
+  
+  def test_delete_matched
+    @cache.write("name", "value")
+    @cache.delete_matched(/name/)
+  end 
+  
+  def test_setting_nil_cache_store
+    assert ActiveSupport::Cache.lookup_store.class.name, ActiveSupport::Cache::NullStore.name
+  end 
+end
+
 class CacheStoreLoggerTest < ActiveSupport::TestCase
   def setup
     @cache = ActiveSupport::Cache.lookup_store(:memory_store)

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -698,6 +698,53 @@ uses_memcached 'memcached backed store' do
   end
 end
 
+class NullStoreTest < ActiveSupport::TestCase
+  def setup
+    @cache = ActiveSupport::Cache.lookup_store(:null_store)
+  end
+  
+  def test_clear
+    @cache.clear
+  end
+  
+  def test_cleanup
+    @cache.cleanup
+  end
+  
+  def test_write
+    assert_equal true, @cache.write("name", "value")
+  end
+  
+  def test_read
+    @cache.write("name", "value")
+    assert_nil @cache.read("name")
+  end
+  
+  def test_delete
+    @cache.write("name", "value")
+    assert_equal false, @cache.delete("name")
+  end
+  
+  def test_increment
+    @cache.write("name", 1, :raw => true)
+    assert_nil @cache.increment("name")
+  end
+  
+  def test_decrement
+    @cache.write("name", 1, :raw => true)
+    assert_nil @cache.increment("name")
+  end
+  
+  def test_delete_matched
+    @cache.write("name", "value")
+    @cache.delete_matched(/name/)
+  end 
+  
+  def test_setting_nil_cache_store
+    assert ActiveSupport::Cache.lookup_store.class.name, ActiveSupport::Cache::NullStore.name
+  end 
+end
+
 class CacheStoreLoggerTest < ActiveSupport::TestCase
   def setup
     @cache = ActiveSupport::Cache.lookup_store(:memory_store)

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -199,7 +199,7 @@ module CacheStoreBehavior
     @cache.write('fud', 'biz')
     assert_equal({"foo" => "bar", "fu" => "baz"}, @cache.read_multi('foo', 'fu'))
   end
-  
+
   def test_read_multi_with_expires
     @cache.write('foo', 'bar', :expires_in => 0.001)
     @cache.write('fu', 'baz')
@@ -557,12 +557,12 @@ class FileStoreTest < ActiveSupport::TestCase
     key = @cache_with_pathname.send(:key_file_path, "views/index?id=1")
     assert_equal "views/index?id=1", @cache_with_pathname.send(:file_path_key, key)
   end
-  
+
   # Because file systems have a maximum filename size, filenames > max size should be split in to directories
   # If filename is 'AAAAB', where max size is 4, the returned path should be AAAA/B
   def test_key_transformation_max_filename_size
     key = "#{'A' * ActiveSupport::Cache::FileStore::FILENAME_MAX_SIZE}B"
-    path = @cache.send(:key_file_path, key)    
+    path = @cache.send(:key_file_path, key)
     assert path.split('/').all? { |dir_name| dir_name.size <= ActiveSupport::Cache::FileStore::FILENAME_MAX_SIZE}
     assert_equal 'B', File.basename(path)
   end
@@ -670,14 +670,14 @@ uses_memcached 'memcached backed store' do
       cache.write("foo", 2)
       assert_equal "2", cache.read("foo")
     end
-    
+
     def test_raw_values_with_marshal
       cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, :raw => true)
       cache.clear
       cache.write("foo", Marshal.dump([]))
-      assert_equal [], cache.read("foo")      
+      assert_equal [], cache.read("foo")
     end
-    
+
     def test_local_cache_raw_values
       cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, :raw => true)
       cache.clear
@@ -702,47 +702,58 @@ class NullStoreTest < ActiveSupport::TestCase
   def setup
     @cache = ActiveSupport::Cache.lookup_store(:null_store)
   end
-  
+
   def test_clear
     @cache.clear
   end
-  
+
   def test_cleanup
     @cache.cleanup
   end
-  
+
   def test_write
     assert_equal true, @cache.write("name", "value")
   end
-  
+
   def test_read
     @cache.write("name", "value")
     assert_nil @cache.read("name")
   end
-  
+
   def test_delete
     @cache.write("name", "value")
     assert_equal false, @cache.delete("name")
   end
-  
+
   def test_increment
     @cache.write("name", 1, :raw => true)
     assert_nil @cache.increment("name")
   end
-  
+
   def test_decrement
     @cache.write("name", 1, :raw => true)
     assert_nil @cache.increment("name")
   end
-  
+
   def test_delete_matched
     @cache.write("name", "value")
     @cache.delete_matched(/name/)
-  end 
-  
+  end
+
+  def test_local_store_strategy
+    @cache.with_local_cache do
+      @cache.write("name", "value")
+      assert_equal "value", @cache.read("name")
+      @cache.delete("name")
+      assert_nil @cache.read("name")
+      @cache.write("name", "value")
+    end
+    assert_nil @cache.read("name")
+  end
+
   def test_setting_nil_cache_store
     assert ActiveSupport::Cache.lookup_store.class.name, ActiveSupport::Cache::NullStore.name
-  end 
+  end
 end
 
 class CacheStoreLoggerTest < ActiveSupport::TestCase

--- a/railties/guides/source/caching_with_rails.textile
+++ b/railties/guides/source/caching_with_rails.textile
@@ -332,6 +332,14 @@ caches_action :index, :expires_in => 60.seconds, :unless_exist => true
 For more information about Ehcache, see "http://ehcache.org/":http://ehcache.org/ .
 For more information about Ehcache for JRuby and Rails, see "http://ehcache.org/documentation/jruby.html":http://ehcache.org/documentation/jruby.html
 
+h4. ActiveSupport::Cache::NullStore
+
+This cache store implementation is meant to be used only in development or test environments and it never stores anything. This can be very useful in development when you have code that interacts directly with +Rails.cache+, but caching may interfere with being able to see the results of code changes. With this cache store, all +fetch+ and +read+ operations will result in a miss.
+
+<ruby>
+ActionController::Base.cache_store = nil
+</ruby>
+
 h4. Custom Cache Stores
 
 You can create your own custom cache store by simply extending +ActiveSupport::Cache::Store+ and implementing the appropriate methods. In this way, you can swap in any number of caching technologies into your Rails application.

--- a/railties/guides/source/caching_with_rails.textile
+++ b/railties/guides/source/caching_with_rails.textile
@@ -337,7 +337,7 @@ h4. ActiveSupport::Cache::NullStore
 This cache store implementation is meant to be used only in development or test environments and it never stores anything. This can be very useful in development when you have code that interacts directly with +Rails.cache+, but caching may interfere with being able to see the results of code changes. With this cache store, all +fetch+ and +read+ operations will result in a miss.
 
 <ruby>
-ActionController::Base.cache_store = nil
+ActionController::Base.cache_store = :null
 </ruby>
 
 h4. Custom Cache Stores

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -9,7 +9,7 @@ module Rails
                     :cache_classes, :cache_store, :consider_all_requests_local,
                     :dependency_loading, :filter_parameters,
                     :force_ssl, :helpers_paths, :logger, :log_tags, :preload_frameworks,
-                    :reload_plugins, :secret_token, :serve_static_assets,
+                    :relative_url_root, :reload_plugins, :secret_token, :serve_static_assets,
                     :ssl_options, :static_cache_control, :session_options,
                     :time_zone, :whiny_nils, :railties_order, :all_initializers
 
@@ -37,6 +37,7 @@ module Rails
         @cache_store                 = [ :file_store, "#{root}/tmp/cache/" ]
         @railties_order              = [:all]
         @all_initializers            = []
+        @relative_url_root           = ENV["RAILS_RELATIVE_URL_ROOT"]
 
         @assets = ActiveSupport::OrderedOptions.new
         @assets.enabled                  = false

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -478,6 +478,15 @@ module ApplicationTests
       assert_match 'src="//example.com/assets/rails.png"', File.read("#{app_path}/public/assets/image_loader.js")
     end
 
+    test "asset paths should use RAILS_RELATIVE_URL_ROOT by default" do
+      ENV["RAILS_RELATIVE_URL_ROOT"] = "/sub/uri"
+
+      app_file "app/assets/javascripts/app.js.erb", 'var src="<%= image_path("rails.png") %>";'
+      add_to_config "config.assets.precompile = %w{app.js}"
+      precompile!
+
+      assert_match 'src="/sub/uri/assets/rails.png"', File.read("#{app_path}/public/assets/app.js")
+    end
 
     private
 

--- a/railties/test/application/middleware/cache_test.rb
+++ b/railties/test/application/middleware/cache_test.rb
@@ -54,9 +54,9 @@ module ApplicationTests
     def test_cache_keeps_if_modified_since
       simple_controller
       expected = "Wed, 30 May 1984 19:43:31 GMT"
-      
+
       get "/expires/keeps_if_modified_since", {}, "HTTP_IF_MODIFIED_SINCE" => expected
-      
+
       assert_equal 200, last_response.status
       assert_equal expected, last_response.body, "cache should have kept If-Modified-Since"
     end


### PR DESCRIPTION
This patch provides a NullStore implementation of ActiveSupport::Cache::Store suitable for use in development and test environments where the code needs to use the cache interface, but actually caching data is not desired.

The cache store will never store data itself. It does implement the LocalCache strategy which will store values for the duration of a request to match the behavior of other cache implementations used in production environments.

It would be used then in the development.rb, for example, as:

``` ruby
config.cache_store = :null_store
```

or alternatively

``` ruby
config.cache_store = nil
```

(Note: this request was originally opened in Lighthouse at https://rails.lighthouseapp.com/projects/8994/tickets/6128)
