### PR TITLE
sqlite3 adapter drops :decimal columns precision & scale when migration tries to alter them

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
@@ -413,6 +413,8 @@ module ActiveRecord
             self.limit   = options[:limit] if options.include?(:limit)
             self.default = options[:default] if include_default
             self.null    = options[:null] if options.include?(:null)
+            self.precision = options[:precision] if options.include?(:precision)
+            self.scale   = options[:scale] if options.include?(:scale)
           end
         end
       end
@@ -467,6 +469,7 @@ module ActiveRecord
 
               @definition.column(column_name, column.type,
                 :limit => column.limit, :default => column.default,
+                :precision => column.precision, :scale => column.scale,
                 :null => column.null)
             end
             @definition.primary_key(primary_key(from)) if primary_key(from)


### PR DESCRIPTION
After this change, decimal column attributes :precision and :scale will be preserved through migrations.  Two tests included, specifically:
1. test that changing a decimal column type keeps the new attributes, and
2. test that if you already have a decimal column with precision/scale, that changing another column in the same table doesn't wipe out the precision and scale

Both tests fail on master, and pass with this patch.

In fairness, the code to fix this I got from https://gist.github.com/971639 - this was pulled from lighthouse (see issue #625), and I'm not entirely sure who wrote it originally.  The tests are new.

Ref issues #3399, #625, #3073
