### PR TITLE
Using middleware name to show proper name in the info

### DIFF
--- a/railties/lib/rails/info.rb
+++ b/railties/lib/rails/info.rb
@@ -91,7 +91,7 @@ module Rails
     end
 
     property 'Middleware' do
-      Rails.configuration.middleware.map(&:inspect)
+      Rails.configuration.middleware.map(&:name)
     end
 
     # The application's location on the filesystem.


### PR DESCRIPTION
Inspect was showing 

``` ruby
<ActiveSupport::Cache::Strategy::LocalCache::Middleware:0x007fc5edba6480
```

But if we use name then it will show simply 

``` ruby
ActiveSupport::Cache::Strategy::LocalCache
```
