### PR TITLE
No need to check ruby version here as rake 9.2.2 is out with the same fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,12 +19,7 @@ end
 # it being automatically loaded by sprockets
 gem "uglifier", ">= 1.0.3", :require => false
 
-# Temp fix until rake 0.9.3 is out
-if RUBY_VERSION >= "1.9.3"
-  gem "rake", "0.9.3.beta.1"
-else
-  gem "rake", ">= 0.8.7"
-end
+gem "rake", ">= 0.8.7"
 gem "mocha", ">= 0.9.8"
 
 group :doc do


### PR DESCRIPTION
No need to check ruby version now. 

rake 9.2.2 is out with the fix which we want to run the test!
