### PR TITLE
Fixed find_by_sql with join statement

### DIFF
--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -11,7 +11,7 @@ module ActiveRecord
     attr_reader :columns, :rows
 
     def initialize(columns, rows)
-      @columns   = columns
+      @columns   = columns.uniq
       @rows      = rows
       @hash_rows = nil
     end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -189,6 +189,11 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal(topics(:second).title, topics.first.title)
   end
 
+  def test_find_by_sql_with_join_statement
+    posts = Post.find_by_sql("SELECT * from posts INNER JOIN authors ON posts.author_id = authors.id AND authors.id = 1")
+    assert_not_equal(posts[0].id, posts[1].id)
+  end
+
   def test_find_by_sql_with_sti_on_joined_table
     accounts = Account.find_by_sql("SELECT * FROM accounts INNER JOIN companies ON companies.id = accounts.firm_id")
     assert_equal [Account], accounts.collect(&:class).uniq


### PR DESCRIPTION
As shown in the follow example, the results all have id 1. This fixes the problem by removing duplicate id columns from join tables

```
ruby-1.9.2-p290 :024 >  Post.find_by_sql("SELECT * from posts JOIN users ON posts.user_id = users.id")
  Post Load (0.3ms)  SELECT * from posts JOIN users ON posts.user_id = users.id
 => [#<Post id: 1, title: "my first post", body: "Hi!\r\n\r\nThis is a awesome blog!\r\n\r\nZheng\r\n", user_id: 1, created_at: "2011-06-02 04:43:58", updated_at: "2011-06-02 04:43:58">, #<Post id: 1, title: "2nd post", body: "nothing special here", user_id: 1, created_at: "2011-06-02 04:43:58", updated_at: "2011-06-02 04:43:58">] 
```
