### PR TITLE
The :converter Proc from #composed_of can return nil

### DIFF
--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -234,16 +234,16 @@ module ActiveRecord
 
         def writer_method(name, class_name, mapping, allow_nil, converter)
           define_method("#{name}=") do |part|
+            unless part.is_a?(class_name.constantize) || converter.nil?
+              part = converter.respond_to?(:call) ?
+                converter.call(part) :
+                class_name.constantize.send(converter, part)
+            end
+
             if part.nil? && allow_nil
               mapping.each { |pair| self[pair.first] = nil }
               @aggregation_cache[name] = nil
             else
-              unless part.is_a?(class_name.constantize) || converter.nil?
-                part = converter.respond_to?(:call) ?
-                  converter.call(part) :
-                  class_name.constantize.send(converter, part)
-              end
-
               mapping.each { |pair| self[pair.first] = part.send(pair.last) }
               @aggregation_cache[name] = part.freeze
             end

--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -234,7 +234,7 @@ module ActiveRecord
 
         def writer_method(name, class_name, mapping, allow_nil, converter)
           define_method("#{name}=") do |part|
-            unless part.is_a?(class_name.constantize) || converter.nil?
+            unless part.is_a?(class_name.constantize) || converter.nil? || part.nil?
               part = converter.respond_to?(:call) ?
                 converter.call(part) :
                 class_name.constantize.send(converter, part)

--- a/activerecord/test/cases/aggregations_test.rb
+++ b/activerecord/test/cases/aggregations_test.rb
@@ -122,6 +122,11 @@ class AggregationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_do_not_run_the_converter_when_nil_was_set
+    customers(:david).non_blank_gps_location = nil
+    assert_nil Customer.gps_conversion_was_run
+  end
+
   def test_custom_constructor
     assert_equal 'Barney GUMBLE', customers(:barney).fullname.to_s
     assert_kind_of Fullname, customers(:barney).fullname

--- a/activerecord/test/cases/aggregations_test.rb
+++ b/activerecord/test/cases/aggregations_test.rb
@@ -109,6 +109,19 @@ class AggregationsTest < ActiveRecord::TestCase
     assert_nil customers(:david).gps_location
   end
 
+  def test_nil_return_from_converter_is_respected_when_allow_nil_is_true
+    customers(:david).non_blank_gps_location = ""
+    customers(:david).save
+    customers(:david).reload
+    assert_nil customers(:david).non_blank_gps_location
+  end
+
+  def test_nil_return_from_converter_results_in_failure_when_allow_nil_is_false
+    assert_raises(NoMethodError) do
+      customers(:barney).gps_location = ""
+    end
+  end
+
   def test_custom_constructor
     assert_equal 'Barney GUMBLE', customers(:barney).fullname.to_s
     assert_kind_of Fullname, customers(:barney).fullname

--- a/activerecord/test/models/customer.rb
+++ b/activerecord/test/models/customer.rb
@@ -2,6 +2,7 @@ class Customer < ActiveRecord::Base
   composed_of :address, :mapping => [ %w(address_street street), %w(address_city city), %w(address_country country) ], :allow_nil => true
   composed_of :balance, :class_name => "Money", :mapping => %w(balance amount), :converter => Proc.new { |balance| balance.to_money }
   composed_of :gps_location, :allow_nil => true
+  composed_of :non_blank_gps_location, :class_name => "GpsLocation", :converter => lambda {|gps| gps.blank? ? nil : GpsLocation.new(gps) }, :allow_nil => true, :mapping => %w(gps_location gps_location)
   composed_of :fullname, :mapping => %w(name to_s), :constructor => Proc.new { |name| Fullname.parse(name) }, :converter => :parse
 end
 

--- a/activerecord/test/models/customer.rb
+++ b/activerecord/test/models/customer.rb
@@ -1,8 +1,12 @@
 class Customer < ActiveRecord::Base
+
+  cattr_accessor :gps_conversion_was_run
+
   composed_of :address, :mapping => [ %w(address_street street), %w(address_city city), %w(address_country country) ], :allow_nil => true
   composed_of :balance, :class_name => "Money", :mapping => %w(balance amount), :converter => Proc.new { |balance| balance.to_money }
   composed_of :gps_location, :allow_nil => true
-  composed_of :non_blank_gps_location, :class_name => "GpsLocation", :converter => lambda {|gps| gps.blank? ? nil : GpsLocation.new(gps) }, :allow_nil => true, :mapping => %w(gps_location gps_location)
+  composed_of :non_blank_gps_location, :class_name => "GpsLocation", :allow_nil => true, :mapping => %w(gps_location gps_location),
+              :converter => lambda { |gps| self.gps_conversion_was_run = true; gps.blank? ? nil : GpsLocation.new(gps)}
   composed_of :fullname, :mapping => %w(name to_s), :constructor => Proc.new { |name| Fullname.parse(name) }, :converter => :parse
 end
 


### PR DESCRIPTION
We have very sensible value objects, which can't be created with invalid data. I supplied a patch to allow the `:converter` Proc to return nil. Before the patch, returning nil resulted in a confusing `NoMethodError` on `NilClass` when ActiveRecord tried to set the mapped properties to the corresponding value. The patch uses the  `:allow_nil` options to decide, whether the `:conversion` Proc can return nil values.

The patch changed the code in a way that the conversion Proc was run also for nil values. This backward compatibility issue wasn't caught by a test so I wrote one in a separate commit.
