### PR TITLE
Remove needless to_param in scaffold functional test

### DIFF
--- a/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
@@ -26,23 +26,23 @@ class <%= controller_class_name %>ControllerTest < ActionController::TestCase
   end
 
   test "should show <%= singular_table_name %>" do
-    get :show, <%= key_value :id, "@#{singular_table_name}.to_param" %>
+    get :show, <%= key_value :id, "@#{singular_table_name}" %>
     assert_response :success
   end
 
   test "should get edit" do
-    get :edit, <%= key_value :id, "@#{singular_table_name}.to_param" %>
+    get :edit, <%= key_value :id, "@#{singular_table_name}" %>
     assert_response :success
   end
 
   test "should update <%= singular_table_name %>" do
-    put :update, <%= key_value :id, "@#{singular_table_name}.to_param" %>, <%= key_value singular_table_name, "@#{singular_table_name}.attributes" %>
+    put :update, <%= key_value :id, "@#{singular_table_name}" %>, <%= key_value singular_table_name, "@#{singular_table_name}.attributes" %>
     assert_redirected_to <%= singular_table_name %>_path(assigns(:<%= singular_table_name %>))
   end
 
   test "should destroy <%= singular_table_name %>" do
     assert_difference('<%= class_name %>.count', -1) do
-      delete :destroy, <%= key_value :id, "@#{singular_table_name}.to_param" %>
+      delete :destroy, <%= key_value :id, "@#{singular_table_name}" %>
     end
 
     assert_redirected_to <%= index_helper %>_path


### PR DESCRIPTION
Functional test to scaffold was introduced at July 1, 2009 - 86ff07410145430d08e97a8296486c4cd4304cde.

A coupe months ago David added paramify_values method  in ActionController::TestCase - 3f0c71c8524856c32bc056bdb38136b3d18f2aaf. Now #to_param is superfluous.
