### PR TITLE
Issue #3427 - asset_path_conflicts

### DIFF
--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -26,10 +26,10 @@ module Sprockets
         sources.collect do |source|
           if debug && asset = asset_paths.asset_for(source, 'js')
             asset.to_a.map { |dep|
-              super(dep.to_s, { :src => asset_path(dep, :ext => 'js', :body => true, :digest => digest) }.merge!(options))
+              super(dep.to_s, { :src => path_to_asset(dep, :ext => 'js', :body => true, :digest => digest) }.merge!(options))
             }
           else
-            super(source.to_s, { :src => asset_path(source, :ext => 'js', :body => body, :digest => digest) }.merge!(options))
+            super(source.to_s, { :src => path_to_asset(source, :ext => 'js', :body => body, :digest => digest) }.merge!(options))
           end
         end.join("\n").html_safe
       end
@@ -43,10 +43,10 @@ module Sprockets
         sources.collect do |source|
           if debug && asset = asset_paths.asset_for(source, 'css')
             asset.to_a.map { |dep|
-              super(dep.to_s, { :href => asset_path(dep, :ext => 'css', :body => true, :protocol => :request, :digest => digest) }.merge!(options))
+              super(dep.to_s, { :href => path_to_asset(dep, :ext => 'css', :body => true, :protocol => :request, :digest => digest) }.merge!(options))
             }
           else
-            super(source.to_s, { :href => asset_path(source, :ext => 'css', :body => body, :protocol => :request, :digest => digest) }.merge!(options))
+            super(source.to_s, { :href => path_to_asset(source, :ext => 'css', :body => body, :protocol => :request, :digest => digest) }.merge!(options))
           end
         end.join("\n").html_safe
       end
@@ -56,19 +56,20 @@ module Sprockets
         path = asset_paths.compute_public_path(source, asset_prefix, options.merge(:body => true))
         options[:body] ? "#{path}?body=1" : path
       end
-
+      alias_method :path_to_asset, :asset_path # aliased to avoid conflicts with an asset_path named route
+      
       def image_path(source)
-        asset_path(source)
+        path_to_asset(source)
       end
       alias_method :path_to_image, :image_path # aliased to avoid conflicts with an image_path named route
 
       def javascript_path(source)
-        asset_path(source)
+        path_to_asset(source)
       end
       alias_method :path_to_javascript, :javascript_path # aliased to avoid conflicts with an javascript_path named route
 
       def stylesheet_path(source)
-        asset_path(source)
+        path_to_asset(source)
       end
       alias_method :path_to_stylesheet, :stylesheet_path # aliased to avoid conflicts with an stylesheet_path named route
 

--- a/actionpack/test/template/sprockets_helper_with_routes_test.rb
+++ b/actionpack/test/template/sprockets_helper_with_routes_test.rb
@@ -1,0 +1,57 @@
+require 'abstract_unit'
+require 'sprockets'
+require 'sprockets/helpers/rails_helper'
+require 'mocha'
+
+class SprocketsHelperWithRoutesTest < ActionView::TestCase
+  include Sprockets::Helpers::RailsHelper
+
+  # Let's bring in some named routes to test namespace conflicts with potential *_paths.
+  # We have to do this after we bring in the Sprockets RailsHelper so if there are conflicts,
+  # they'll fail in the way we expect in a real live Rails app.
+  routes = ActionDispatch::Routing::RouteSet.new
+  routes.draw do
+    resources :assets
+  end
+  include routes.url_helpers
+
+  def setup
+    super
+    @controller         = BasicController.new
+
+    @assets = Sprockets::Environment.new
+    @assets.append_path(FIXTURES.join("sprockets/app/javascripts"))
+    @assets.append_path(FIXTURES.join("sprockets/app/stylesheets"))
+    @assets.append_path(FIXTURES.join("sprockets/app/images"))
+
+    application = Struct.new(:config, :assets).new(config, @assets)
+    Rails.stubs(:application).returns(application)
+    @config = config
+    @config.perform_caching = true
+    @config.assets.digest = true
+    @config.assets.compile = true
+  end
+
+  test "namespace conflicts on a named route called asset_path" do
+    # Testing this for sanity - asset_path is now a named route!
+    assert_match asset_path('test_asset'), '/assets/test_asset'
+
+    assert_match %r{/assets/logo-[0-9a-f]+.png},
+      path_to_asset("logo.png")
+    assert_match %r{/assets/logo-[0-9a-f]+.png},
+      path_to_asset("logo.png", :digest => true)
+    assert_match %r{/assets/logo.png},
+      path_to_asset("logo.png", :digest => false)
+  end
+
+  test "javascript_include_tag with a named_route named asset_path" do
+    assert_match %r{<script src="/assets/application-[0-9a-f]+.js" type="text/javascript"></script>},
+      javascript_include_tag(:application)
+  end
+
+  test "stylesheet_link_tag with a named_route named asset_path" do
+    assert_match %r{<link href="/assets/application-[0-9a-f]+.css" media="screen" rel="stylesheet" type="text/css" />},
+      stylesheet_link_tag(:application)
+  end
+
+end


### PR DESCRIPTION
Let's do the same trick for asset_path that we do for [image,javascript,stylesheet,video]_path to avoid namespace conflicts on named routes.

See also asset_tag_helper#275 and similar comments.

Can anybody else think of places asset_path is used that should get changed over?

Thanks in advance for thoughts/comments/feedback!
