### PR TITLE
Fix deprecation warnings in action pack render tests

### DIFF
--- a/actionpack/test/template/render_test.rb
+++ b/actionpack/test/template/render_test.rb
@@ -429,7 +429,7 @@ class LazyViewRenderTest < ActiveSupport::TestCase
   if '1.9'.respond_to?(:force_encoding)
     def test_render_utf8_template_with_magic_comment
       with_external_encoding Encoding::ASCII_8BIT do
-        result = @view.render(:file => "test/utf8_magic.html", :layouts => "layouts/yield")
+        result = @view.render(:file => "test/utf8_magic", :formats => [:html], :layouts => "layouts/yield")
         assert_equal Encoding::UTF_8, result.encoding
         assert_equal "\nРусский \nтекст\n\nUTF-8\nUTF-8\nUTF-8\n", result
       end
@@ -437,7 +437,7 @@ class LazyViewRenderTest < ActiveSupport::TestCase
 
     def test_render_utf8_template_with_default_external_encoding
       with_external_encoding Encoding::UTF_8 do
-        result = @view.render(:file => "test/utf8.html", :layouts => "layouts/yield")
+        result = @view.render(:file => "test/utf8", :formats => [:html], :layouts => "layouts/yield")
         assert_equal Encoding::UTF_8, result.encoding
         assert_equal "Русский текст\n\nUTF-8\nUTF-8\nUTF-8\n", result
       end
@@ -446,7 +446,7 @@ class LazyViewRenderTest < ActiveSupport::TestCase
     def test_render_utf8_template_with_incompatible_external_encoding
       with_external_encoding Encoding::SHIFT_JIS do
         begin
-          @view.render(:file => "test/utf8.html", :layouts => "layouts/yield")
+          @view.render(:file => "test/utf8", :formats => [:html], :layouts => "layouts/yield")
           flunk 'Should have raised incompatible encoding error'
         rescue ActionView::Template::Error => error
           assert_match 'Your template was not saved as valid Shift_JIS', error.original_exception.message
@@ -457,7 +457,7 @@ class LazyViewRenderTest < ActiveSupport::TestCase
     def test_render_utf8_template_with_partial_with_incompatible_encoding
       with_external_encoding Encoding::SHIFT_JIS do
         begin
-          @view.render(:file => "test/utf8_magic_with_bare_partial.html", :layouts => "layouts/yield")
+          @view.render(:file => "test/utf8_magic_with_bare_partial", :formats => [:html], :layouts => "layouts/yield")
           flunk 'Should have raised incompatible encoding error'
         rescue ActionView::Template::Error => error
           assert_match 'Your template was not saved as valid Shift_JIS', error.original_exception.message


### PR DESCRIPTION
Fix four deprecation warnings in action pack test suite by passing :formats instead of specifying the format inside the template name.
