### PR TITLE
let StringInquirer match _or_ separated multiple words

### DIFF
--- a/activesupport/lib/active_support/string_inquirer.rb
+++ b/activesupport/lib/active_support/string_inquirer.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/object/inclusion'
+
 module ActiveSupport
   # Wrapping a string in this class gives you a prettier way to test
   # for equality. The value returned by <tt>Rails.env</tt> is wrapped
@@ -11,8 +13,12 @@ module ActiveSupport
   #
   class StringInquirer < String
     def method_missing(method_name, *arguments)
-      if method_name.to_s[-1,1] == "?"
-        self == method_name.to_s[0..-2]
+      if method_name.to_s[-1, 1] == "?"
+        s = method_name.to_s[0..-2]
+        return true if self == s
+        return false unless s.include?('_or_')
+        return true if s.include?('_or_or_or_') || s.start_with?('or_or_') || s.end_with?('_or_or')
+        self.in?(s.split('_or_'))
       else
         super
       end

--- a/activesupport/test/string_inquirer_test.rb
+++ b/activesupport/test/string_inquirer_test.rb
@@ -1,8 +1,20 @@
 require 'abstract_unit'
 
 class StringInquirerTest < Test::Unit::TestCase
-  def test_match
+  def test_match_exactly
     assert ActiveSupport::StringInquirer.new("production").production?
+  end
+
+  def test_match_one
+    assert ActiveSupport::StringInquirer.new("trick").trick_or_treat?
+    assert ActiveSupport::StringInquirer.new("treat").trick_or_treat?
+    assert ActiveSupport::StringInquirer.new("heinemeier").david_or_heinemeier_or_hansson?
+  end
+
+  def test_match_or
+    assert ActiveSupport::StringInquirer.new("or").or_or_and?
+    assert ActiveSupport::StringInquirer.new("or").and_or_or?
+    assert ActiveSupport::StringInquirer.new("or").and_or_or_or_xor_or_not?
   end
 
   def test_miss


### PR DESCRIPTION
I'm sort of tired of writing codes like this:

``` ruby
if Rails.env.development? || Rails.env.test?
  ...
end
```

I want StringInquirer to comprehend what I mean by this:

``` ruby
if Rails.env.development_or_test?
  ...
end
```

so, here's the patch.
