### PR TITLE
Becomes includes errors

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -114,6 +114,7 @@ module ActiveRecord
       became.instance_variable_set("@attributes_cache", @attributes_cache)
       became.instance_variable_set("@new_record", new_record?)
       became.instance_variable_set("@destroyed", destroyed?)
+      became.instance_variable_set("@errors", errors)
       became.type = klass.name unless self.class.descends_from_active_record?
       became
     end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1761,6 +1761,14 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal "The First Topic", topics(:first).becomes(Reply).title
   end
 
+  def test_becomes_includes_errors
+    company = Company.new(:name => nil)
+    assert !company.valid?
+    original_errors = company.errors
+    client = company.becomes(Client)
+    assert_equal original_errors, client.errors
+  end
+
   def test_silence_sets_log_level_to_error_in_block
     original_logger = ActiveRecord::Base.logger
     log = StringIO.new


### PR DESCRIPTION
`ActiveRecord::Base#becomes` doesn't copy the errors information to the instance that it creates. This can be a pain if, for example, you're trying to use the returned instance in a form which expects to highlight fields with errors. It seems reasonable to expect that the returned instance share all the state of the original, including errors.

I've split this into two commits in case you'd prefer to use different models in the test (`Company` seemed like the clearest of the existing ones), or use a different implementation to fix it. If not, feel free to squash them.

Thanks!
