### PR TITLE
Fix deprecation warnings in nested I18n forms

### DIFF
--- a/activemodel/lib/active_model/translation.rb
+++ b/activemodel/lib/active_model/translation.rb
@@ -43,8 +43,10 @@ module ActiveModel
     #
     # Specify +options+ with additional translating options.
     def human_attribute_name(attribute, options = {})
+      nested, attribute = attribute.to_s.split('.') if attribute.to_s.include?('.')
+
       defaults = lookup_ancestors.map do |klass|
-        :"#{self.i18n_scope}.attributes.#{klass.model_name.i18n_key}.#{attribute}"
+        :"#{self.i18n_scope}.attributes.#{[klass.model_name.i18n_key, nested].compact.join("/")}.#{attribute}"
       end
 
       defaults << :"attributes.#{attribute}"

--- a/activemodel/test/cases/translation_test.rb
+++ b/activemodel/test/cases/translation_test.rb
@@ -54,6 +54,7 @@ class ActiveModelI18nTests < ActiveModel::TestCase
 
     assert_equal 'person gender', Person.human_attribute_name('gender')
     assert_equal 'person gender attribute', Person::Gender.human_attribute_name('attribute')
+    assert_equal 'person gender attribute', Person.human_attribute_name('gender.attribute')
   end
 
   def test_translated_model_names


### PR DESCRIPTION
This will work with:

``` ruby
    user:
      name: "Nome"
    user/address: 
      street: "Rua"
```
