### PR TITLE
Dont assume not having RDoc is an error

### DIFF
--- a/railties/lib/tasks/documentation.rake
+++ b/railties/lib/tasks/documentation.rake
@@ -89,5 +89,5 @@ namespace :doc do
   end
 end
 rescue LoadError
-  $stderr.puts 'Please install RDoc 2.4.2+ to generate documentation.'
+  puts 'Please install RDoc 2.4.2+ to generate documentation.'
 end


### PR DESCRIPTION
Putting this on stderr makes rake tasks in cron completely unusable, as
you can no longer tell the difference between a task that had an error
and one that thinks installing rdoc on production is a great idea.
