### PR TITLE
Allow DateTime comparison to Infinity/-Infinity.

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -125,8 +125,13 @@ class DateTime
     (offset * 86400).to_i
   end
 
-  # Layers additional behavior on DateTime#<=> so that Time and ActiveSupport::TimeWithZone instances can be compared with a DateTime
+  # Layers additional behavior on DateTime#<=> so that Time, ActiveSupport::TimeWithZone, and
+  # Infinity instances can be compared with a DateTime.
   def <=>(other)
-    super other.to_datetime
+    if other.respond_to?(:infinite?)
+      -other.infinite?
+    else
+      super other.to_datetime
+    end
   end
 end

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -99,7 +99,7 @@ class DateTimeExtCalculationsTest < Test::Unit::TestCase
     assert_equal DateTime.civil(2005,5,1,10), DateTime.civil(2005,6,5,10,0,0).weeks_ago(5)
     assert_equal DateTime.civil(2005,4,24,10), DateTime.civil(2005,6,5,10,0,0).weeks_ago(6)
     assert_equal DateTime.civil(2005,2,27,10),  DateTime.civil(2005,6,5,10,0,0).weeks_ago(14)
-    assert_equal DateTime.civil(2004,12,25,10),  DateTime.civil(2005,1,1,10,0,0).weeks_ago(1)    
+    assert_equal DateTime.civil(2004,12,25,10),  DateTime.civil(2005,1,1,10,0,0).weeks_ago(1)
   end
 
   def test_months_ago
@@ -373,6 +373,18 @@ class DateTimeExtCalculationsTest < Test::Unit::TestCase
     assert_equal  1, DateTime.civil(2000) <=> ActiveSupport::TimeWithZone.new( Time.utc(1999, 12, 31, 23, 59, 59), ActiveSupport::TimeZone['UTC'] )
     assert_equal  0, DateTime.civil(2000) <=> ActiveSupport::TimeWithZone.new( Time.utc(2000, 1, 1, 0, 0, 0), ActiveSupport::TimeZone['UTC'] )
     assert_equal(-1, DateTime.civil(2000) <=> ActiveSupport::TimeWithZone.new( Time.utc(2000, 1, 1, 0, 0, 1), ActiveSupport::TimeZone['UTC'] ))
+  end
+
+  # http://www.gnu.org/savannah-checkouts/gnu/libc/manual/html_node/Infinity-and-NaN.html
+  def test_compare_with_infinite
+    big_bang   = -(1.0/0)
+    cold_death =  (1.0/0)
+    assert_equal  1, DateTime.civil(2000) <=> big_bang
+    assert_equal -1, DateTime.civil(2000) <=> cold_death
+    assert_equal  1, cold_death <=> big_bang
+    assert_equal -1, big_bang   <=> cold_death
+    assert_equal  0, big_bang   <=> big_bang
+    assert_equal  0, cold_death <=> cold_death
   end
 
   def test_to_f


### PR DESCRIPTION
A continuation of the fixes in #544 -- @tenderlove let ActiveRecord support Infinite timestamps, but you can't compare them to other DateTime values.  This commit fixes that.
