### PR TITLE
Application controller test file

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -112,6 +112,7 @@ module Rails
       empty_directory_with_gitkeep "test/integration"
       empty_directory_with_gitkeep "test/unit"
 
+      template "test/functional/application_controller_test.rb"
       template "test/performance/browsing_test.rb"
       template "test/test_helper.rb"
     end

--- a/railties/lib/rails/generators/rails/app/templates/test/functional/application_controller_test.rb
+++ b/railties/lib/rails/generators/rails/app/templates/test/functional/application_controller_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+class ApplicationControllerTest < ActionController::TestCase
+  # Tests for ApplicationController here
+end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -199,6 +199,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "test/performance/browsing_test.rb"
   end
 
+  def test_application_controller_test_file
+    run_generator
+    assert_file "test/functional/application_controller_test.rb" do |content|
+      assert_match(/class ApplicationControllerTest < ActionController::TestCase/, content)
+    end
+  end
+
   def test_generator_if_skip_sprockets_is_given
     run_generator [destination_root, "--skip-sprockets"]
     assert_file "config/application.rb" do |content|


### PR DESCRIPTION
Ok so I was running rake test:uncommitted on a new generated application and I got the error that no such file to load functional/application_controller_test.rb

One way to fix this is fix the task itself to not include <code>ApplicationController</code> in the list. 

But I think we should generate the <code>ApplicationControllerTest</code> file
