### PR TITLE
Fix load_error.rb to include regex to catch errors from ruby 1.9.3

### DIFF
--- a/activesupport/lib/active_support/core_ext/load_error.rb
+++ b/activesupport/lib/active_support/core_ext/load_error.rb
@@ -20,7 +20,8 @@ class MissingSourceFile < LoadError #:nodoc:
   REGEXPS = [
     [/^no such file to load -- (.+)$/i, 1],
     [/^Missing \w+ (file\s*)?([^\s]+.rb)$/i, 2],
-    [/^Missing API definition file in (.+)$/i, 1]
+    [/^Missing API definition file in (.+)$/i, 1],
+    [/^cannot load such file -- (.+)$/i, 1] 
   ] unless defined?(REGEXPS)
 end
 


### PR DESCRIPTION
Add regex to match message from ruby 1.9.3.  Regex taken from Rails 3 stable.
