### PR TITLE
dump_schema_information: explicitly order inserts into schema_migrations 

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -405,7 +405,7 @@ module ActiveRecord
 
       def dump_schema_information #:nodoc:
         sm_table = ActiveRecord::Migrator.schema_migrations_table_name
-        migrated = select_values("SELECT version FROM #{sm_table}")
+        migrated = select_values("SELECT version FROM #{sm_table} ORDER BY version")
         migrated.map { |v| "INSERT INTO #{sm_table} (version) VALUES ('#{v}');" }.join("\n\n")
       end
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1339,6 +1339,15 @@ if ActiveRecord::Base.connection.supports_migrations?
       end
     end
 
+    def test_dump_schema_information_outputs_lexically_ordered_versions
+      migration_path = MIGRATIONS_ROOT + '/valid_with_timestamps'
+      ActiveRecord::Migrator.run(:up, migration_path, 20100301010101)
+      ActiveRecord::Migrator.run(:up, migration_path, 20100201010101)
+
+      schema_info = ActiveRecord::Base.connection.dump_schema_information
+      assert_match schema_info, /20100201010101.*20100301010101/m
+    end
+
     def test_finds_pending_migrations
       ActiveRecord::Migrator.up(MIGRATIONS_ROOT + "/interleaved/pass_2", 1)
       migrations = ActiveRecord::Migrator.new(:up, MIGRATIONS_ROOT + "/interleaved/pass_2").pending_migrations


### PR DESCRIPTION
`dump_schema_information`: now explicitly orders inserts into schema_migrations table by version value

We use `active_record.schema_format = :sql` as our schema dump format, and the `db/development_structure.sql` sees quite a bit of trivial churn in the git history due to migrations having run in different orders, as migrations are created on different feature branches over time. With this trivial fix, only added/removed migrations will create changes to the schema dump file.

The complete activerecord test suite with all database drivers pass with this change. Unfortunately, that doesn't say a big deal, as `dump_schema_information` is only called by the `db:structure:dump` rake-task. Local manual testing does confirm the change, though.

Comments on this change?
