### PR TITLE
Cycle helper method accepts nil as arguments

### DIFF
--- a/actionpack/lib/action_view/helpers/text_helper.rb
+++ b/actionpack/lib/action_view/helpers/text_helper.rb
@@ -318,7 +318,7 @@ module ActionView
         unless cycle && cycle.values == values
           cycle = set_cycle(name, Cycle.new(*values))
         end
-        cycle.to_s
+        cycle.next!
       end
 
       # Returns the current cycle string after a cycle has been started. Useful
@@ -375,11 +375,17 @@ module ActionView
         end
 
         def current_value
-          @values[previous_index].to_s
+          unless @values[previous_index].nil?
+            @values[previous_index].to_s
+          end
         end
 
-        def to_s
-          value = @values[@index].to_s
+        def next!
+          if @values[@index].nil?
+            value = nil
+          else
+            value = @values[@index].to_s
+          end
           @index = next_index
           return value
         end

--- a/actionpack/test/template/text_helper_test.rb
+++ b/actionpack/test/template/text_helper_test.rb
@@ -287,14 +287,14 @@ class TextHelperTest < ActionView::TestCase
 
   def test_cycle_class
     value = Cycle.new("one", 2, "3")
-    assert_equal("one", value.to_s)
-    assert_equal("2", value.to_s)
-    assert_equal("3", value.to_s)
-    assert_equal("one", value.to_s)
+    assert_equal("one", value.next!)
+    assert_equal("2", value.next!)
+    assert_equal("3", value.next!)
+    assert_equal("one", value.next!)
     value.reset
-    assert_equal("one", value.to_s)
-    assert_equal("2", value.to_s)
-    assert_equal("3", value.to_s)
+    assert_equal("one", value.next!)
+    assert_equal("2", value.next!)
+    assert_equal("3", value.next!)
   end
 
   def test_cycle_class_with_no_arguments
@@ -400,5 +400,11 @@ class TextHelperTest < ActionView::TestCase
     assert_equal("blue", cycle("red", "blue"))
     assert_equal("red", cycle("red", "blue"))
     assert_equal(%w{Specialized Fuji Giant}, @cycles)
+  end
+
+  def test_cycle_with_nil_as_value
+    assert_equal("odd", cycle("odd", nil))
+    assert_equal(nil, cycle("odd", nil))
+    assert_equal(nil, current_cycle)
   end
 end


### PR DESCRIPTION
Not <tt>cycle</tt> method converts nil to blank string.

``` ruby
cycle(nil) # => ""
```

Moreover current <tt>Cycle::to_s</tt> a little bit confusing it changes internal state of object.

I suggest to tune cycle helper class implementation.

_Pros:_

It makes such haml template cleaner:

``` haml
%tr{:class => cycle('odd', nil)} # => <tr> instead <tr class=""> on the second iteration
  = #...
```

This commit doens't affect documented behaviour, an example below will work fine.

``` erb
<tr class="<%= cycle('odd', nil) %>">
```

_Cons:_

If someone used undocumented trick <tt>cycle('odd', nil) + " some-another-class"</tt> he or she should update to <tt>cycle('odd', '') + " some-another-class</tt>. I think it's reasonalbe.
