### PR TITLE
Ensure Date header on expires_in

### DIFF
--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -70,11 +70,14 @@ module ActionController
     #
     # This method will overwrite an existing Cache-Control header.
     # See http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html for more possibilities.
+    #
+    # The method will also ensure a HTTP Date header for client compatibility.
     def expires_in(seconds, options = {}) #:doc:
       response.cache_control.merge!(:max_age => seconds, :public => options.delete(:public))
       options.delete(:private)
 
       response.cache_control[:extras] = options.map {|k,v| "#{k}=#{v}"}
+      response.date = Time.now unless response.date?
     end
 
     # Sets a HTTP 1.1 Cache-Control header of <tt>no-cache</tt> so no caching should occur by the browser or

--- a/actionpack/lib/action_dispatch/http/cache.rb
+++ b/actionpack/lib/action_dispatch/http/cache.rb
@@ -56,6 +56,20 @@ module ActionDispatch
           headers['Last-Modified'] = utc_time.httpdate
         end
 
+        def date
+          if date_header = headers['Date']
+            Time.httpdate(date_header)
+          end
+        end
+
+        def date?
+          headers.include?('Date')
+        end
+
+        def date=(utc_time)
+          headers['Date'] = utc_time.httpdate
+        end
+
         def etag=(etag)
           key = ActiveSupport::Cache.expand_cache_key(etag)
           @etag = self["ETag"] = %("#{Digest::MD5.hexdigest(key)}")

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -1401,6 +1401,13 @@ class ExpiresInRenderTest < ActionController::TestCase
     get :conditional_hello_with_expires_now
     assert_equal "no-cache", @response.headers["Cache-Control"]
   end
+
+  def test_date_header_when_expires_in
+    time = Time.mktime(2011,10,30)
+    Time.stubs(:now).returns(time)
+    get :conditional_hello_with_expires_in
+    assert_equal Time.now.httpdate, @response.headers["Date"]
+  end
 end
 
 class LastModifiedRenderTest < ActionController::TestCase


### PR DESCRIPTION
**Background:** Some webservers (thin and passenger for example) don't add a HTTP Date header to the response. This is not a problem for modern browsers but it can cause problems with other HTTP clients, for example Amazon's CloudFront [expects a Date header](https://forums.aws.amazon.com/thread.jspa?messageID=284053) when it gets a Cache-Control max-age value and .Net's HttpWebRequest's have [some similar issue](http://stackoverflow.com/questions/4328439/httpwebrequest-with-caching-enabled-throws-exceptions).
From what I understand the HTTP spec says that the client should use the Date header when calculating how a long a cached response is valid.

I can see that the Date header might not be Rails responsibility, but I think it would be good if `#expires_in` ensures that the client can use Cache-Control's max-age value by setting a Date header in the response. What you think about this?
