### PR TITLE
ActiveSupport::Concern: allow #included to be called multiple times

### DIFF
--- a/activesupport/lib/active_support/concern.rb
+++ b/activesupport/lib/active_support/concern.rb
@@ -125,7 +125,15 @@ module ActiveSupport
 
     def included(base = nil, &block)
       if base.nil?
-        @_included_block = block
+        if defined?(@_included_block)
+          old_included_block = @_included_block
+          @_included_block = proc do
+            instance_eval(&old_included_block)
+            instance_eval(&block)
+          end
+        else
+          @_included_block = block
+        end
       else
         super
       end

--- a/activesupport/test/concern_test.rb
+++ b/activesupport/test/concern_test.rb
@@ -94,4 +94,21 @@ class ConcernTest < Test::Unit::TestCase
     @klass.send(:include, Foo)
     assert_equal [ConcernTest::Foo, ConcernTest::Bar, ConcernTest::Baz::InstanceMethods, ConcernTest::Baz], @klass.included_modules[0..3]
   end
+
+  def test_multiple_included_calls
+    mod = Module.new do
+      extend ActiveSupport::Concern
+    end
+    mod.included do
+      @included1 = true
+    end
+    mod.included do
+      @included2 = true
+    end
+    @klass.send(:include, mod)
+
+    assert @klass.instance_variable_get("@included2")
+    assert @klass.instance_variable_get("@included1")
+    
+  end
 end


### PR DESCRIPTION
### Use case

Suppose we have vendored module `A` (extended with `AS::Concern`). This module suppose to be included in class. We want this module to have some additional functionality from another module `B`. In this case I didn't find other way than alias-method-chain `self.included` (any suggestions?).
### API

After this patch we can just to do this:

``` ruby
A.included do
  include B
end
```

In this case `B` will be included anytime when `A` got included.
### Implementation

I was thinking about 2 ways of doing it:
- store all passed blocks in Array and iterate
- merge new given block to previous by creating new block that calls both (see diff)

Decided prefer second one because there is no performance impact when calling `.included` only once (as it works right now) - no additional objects, no additional method calls. 

Thanks.
