### PR TITLE
handle 1.9.3 LoadError messages in MissingSourceFile

### DIFF
--- a/activesupport/lib/active_support/core_ext/load_error.rb
+++ b/activesupport/lib/active_support/core_ext/load_error.rb
@@ -20,7 +20,8 @@ class MissingSourceFile < LoadError #:nodoc:
   REGEXPS = [
     [/^no such file to load -- (.+)$/i, 1],
     [/^Missing \w+ (file\s*)?([^\s]+.rb)$/i, 2],
-    [/^Missing API definition file in (.+)$/i, 1]
+    [/^Missing API definition file in (.+)$/i, 1],
+    [/^cannot load such file -- (.+)$/i, 1]
   ] unless defined?(REGEXPS)
 end
 


### PR DESCRIPTION
The LoadError message in 1.9.3 is 'cannot load such file' instead of 'no such file to load'.
