### PR TITLE
Make SingletonResource implementaion more straightforward

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -939,14 +939,10 @@ module ActionDispatch
           def initialize(entities, options)
             super
 
-            @as         = nil
-            @controller = (options[:controller] || plural).to_s
-            @as         = options[:as]
+            @controller = (options[:controller] || @name.to_s.pluralize).to_s
           end
 
-          def plural
-            @plural ||= name.to_s.pluralize
-          end
+          undef_method :plural
 
           def singular
             @singular ||= name.to_s


### PR DESCRIPTION
After series of commits (ccbb3bb3d87a48c8763a8afff4c9b21a9bf2539e, bb2f53b4090768e4750af66c6fed15d6596bb11c, 9a6fc9a540cd23af3ca061cb7406a6cdd5ad4294) the implementation of SingletonResource constructor became too complicated:

https://github.com/rails/rails/blob/1afe269a4aa18a815c509d3f0348ed99a9b4b560/actionpack/lib/action_dispatch/routing/mapper.rb

``` ruby
class Resource #:nodoc:
  def initialize(entities, options = {})
    @name = entities.to_s
    @controller = (options[:controller] || @name).to_s
    @as = options[:as]
    # ...
  end

  def name
    @as || @name
  end

  def plural
    @plural ||= name.to_s
  end
  # ...
end
```

``` ruby
class SingletonResource < Resource #:nodoc:
  def initialize(entities, options)
    super

    @as = nil
    @controller = (options[:controller] || plural).to_s
    @as = options[:as]
  end

  def plural
    @plural ||= name.to_s.pluralize
  end

  def singular
    @singular ||= name.to_s
  end

  # ....
end
```

In singleton resource we get such code flow

```
SingletonResource#initialize
  Resource#initalize
    @as = options[:as]
    return
  @as = nil
  @controller = ... # <-- in this point executed #plural, 
                    # which calls Resource#name 
                    # and returns @name because @as == nil. 
                    # plural is cached to @plural instance method
  @as = options[:as]
```

So behaviour of initalize + plural is rather non-trivial. And what is more, method #plural is not used anywhere.
