### PR TITLE
CSS fix to prevent error output from being breaking out of body element.

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -16,6 +16,7 @@
       background-color: #eee;
       padding: 10px;
       font-size: 11px;
+      white-space: pre-wrap;
     }
 
     a { color: #000; }


### PR DESCRIPTION
Using the white-space: pre-wrap adds extra line breaks to prevent the text from breaking out of the element's box. In this case single line output can be extremely long, breaking out the <body> element.

See for reference: http://www.quirksmode.org/css/whitespace.html

**Before**
![Before](http://stage.f.cl.ly/items/3I323m2c1Z3H0P2l3202/Screen%20Shot%202011-11-03%20at%209.55.57%20AM.png)

**After**
![After](http://stage.f.cl.ly/items/3C452A250c3C2T0c2X0x/Screen%20Shot%202011-11-03%20at%209.55.28%20AM.png)

Note: This CSS property will be ignored in IE6 and 7, it is compatible with all other browsers (see prior reference).
