### PR TITLE
move Rails console top level methods to IRB context

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -205,6 +205,8 @@ module Rails
       require "pp"
       require "rails/console/app"
       require "rails/console/helpers"
+
+      IRB::ExtendCommandBundle.send :include, Rails::ConsoleMethods
     end
   end
 end

--- a/railties/lib/rails/console/app.rb
+++ b/railties/lib/rails/console/app.rb
@@ -5,28 +5,32 @@ require 'action_controller'
 # work around the at_exit hook in test/unit, which kills IRB
 Test::Unit.run = true if Test::Unit.respond_to?(:run=)
 
-# reference the global "app" instance, created on demand. To recreate the
-# instance, pass a non-false value as the parameter.
-def app(create=false)
-  @app_integration_instance = nil if create
-  @app_integration_instance ||= new_session do |sess|
-    sess.host! "www.example.com"
+module IRB
+  module ExtendCommandBundle
+    # reference the global "app" instance, created on demand. To recreate the
+    # instance, pass a non-false value as the parameter.
+    def app(create=false)
+      @app_integration_instance = nil if create
+      @app_integration_instance ||= new_session do |sess|
+        sess.host! "www.example.com"
+      end
+    end
+
+    # create a new session. If a block is given, the new session will be yielded
+    # to the block before being returned.
+    def new_session
+      app = Rails.application
+      session = ActionDispatch::Integration::Session.new(app)
+      yield session if block_given?
+      session
+    end
+
+    # reloads the environment
+    def reload!(print=true)
+      puts "Reloading..." if print
+      ActionDispatch::Reloader.cleanup!
+      ActionDispatch::Reloader.prepare!
+      true
+    end
   end
-end
-
-# create a new session. If a block is given, the new session will be yielded
-# to the block before being returned.
-def new_session
-  app = Rails.application
-  session = ActionDispatch::Integration::Session.new(app)
-  yield session if block_given?
-  session
-end
-
-# reloads the environment
-def reload!(print=true)
-  puts "Reloading..." if print
-  ActionDispatch::Reloader.cleanup!
-  ActionDispatch::Reloader.prepare!
-  true
 end

--- a/railties/lib/rails/console/app.rb
+++ b/railties/lib/rails/console/app.rb
@@ -5,8 +5,8 @@ require 'action_controller'
 # work around the at_exit hook in test/unit, which kills IRB
 Test::Unit.run = true if Test::Unit.respond_to?(:run=)
 
-module IRB
-  module ExtendCommandBundle
+module Rails
+  module ConsoleMethods
     # reference the global "app" instance, created on demand. To recreate the
     # instance, pass a non-false value as the parameter.
     def app(create=false)

--- a/railties/lib/rails/console/helpers.rb
+++ b/railties/lib/rails/console/helpers.rb
@@ -1,5 +1,5 @@
-module IRB
-  module ExtendCommandBundle
+module Rails
+  module ConsoleMethods
     def helper
       @helper ||= ApplicationController.helpers
     end

--- a/railties/lib/rails/console/helpers.rb
+++ b/railties/lib/rails/console/helpers.rb
@@ -1,7 +1,11 @@
-def helper
-  @helper ||= ApplicationController.helpers
-end
+module IRB
+  module ExtendCommandBundle
+    def helper
+      @helper ||= ApplicationController.helpers
+    end
 
-def controller
-  @controller ||= ApplicationController.new
+    def controller
+      @controller ||= ApplicationController.new
+    end
+  end
 end

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -19,7 +19,7 @@ class ConsoleTest < Test::Unit::TestCase
   end
 
   def irb_context
-    Object.new.extend(IRB::ExtendCommandBundle)
+    Object.new.extend(Rails::ConsoleMethods)
   end
 
   def test_app_method_should_return_integration_session

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -18,16 +18,20 @@ class ConsoleTest < Test::Unit::TestCase
     Rails.application.load_console
   end
 
+  def irb_context
+    Object.new.extend(IRB::ExtendCommandBundle)
+  end
+
   def test_app_method_should_return_integration_session
     TestHelpers::Rack.send :remove_method, :app
     load_environment
-    console_session = app
+    console_session = irb_context.app
     assert_instance_of ActionDispatch::Integration::Session, console_session
   end
 
   def test_new_session_should_return_integration_session
     load_environment
-    session = new_session
+    session = irb_context.new_session
     assert_instance_of ActionDispatch::Integration::Session, session
   end
 
@@ -41,7 +45,7 @@ class ConsoleTest < Test::Unit::TestCase
     ActionDispatch::Reloader.to_prepare { c = 3 }
 
     # Hide Reloading... output
-    silence_stream(STDOUT) { reload! }
+    silence_stream(STDOUT) { irb_context.reload! }
 
     assert_equal 1, a
     assert_equal 2, b
@@ -66,12 +70,14 @@ class ConsoleTest < Test::Unit::TestCase
     MODEL
 
     assert !User.new.respond_to?(:age)
-    silence_stream(STDOUT) { reload! }
+    silence_stream(STDOUT) { irb_context.reload! }
+    session = irb_context.new_session
     assert User.new.respond_to?(:age)
   end
 
   def test_access_to_helpers
     load_environment
+    helper = irb_context.helper
     assert_not_nil helper
     assert_instance_of ActionView::Base, helper
     assert_equal 'Once upon a time in a world...',


### PR DESCRIPTION
Currently, methods available in Rails console (such as `app`, `helper`, `reload!`, etc.) are defined on Ruby's top level.
That means, these methods are injected into all Objects. In fact, we can do something funny like this on our Rails console.

```
> puts 'foobar'.send(:app)
#<ActionDispatch::Integration::Session:0x007ff67c0f8f28>
```

```
> puts nil.send(:controller)
#<ApplicationController:0x007ff681bdf5e0>
```

Reading IRB code, I found the IRB way is, to define this sort of methods in a module named IRB::ExtendCommandBundle, then IRB automatically includes (extends) these methods in IRB console's context.
For example, you see, you can call `irb_jobs` method in your IRB but the following code raises `NoMethodError: undefined method`irb_jobs'`, because this method is mixed into IRB's "main" context via IRB::ExtendCommandBundle.

```
Object.new.send(:irb_jobs)
```

Attached a patch and tests for Rails console to follow this IRB way. I confirmed it runs on MRI 1.8, 1.9, JRuby and Rubinius.
