### PR TITLE
Safe join array arg in capture and content_tag methods

### DIFF
--- a/actionpack/lib/action_view/helpers/capture_helper.rb
+++ b/actionpack/lib/action_view/helpers/capture_helper.rb
@@ -35,11 +35,23 @@ module ActionView
       #   <b><%= @greeting %></b>
       #   </body></html>
       #
+      # You can pass an array as argument. It will be joined using safe_join.
+      #
+      #   @html = capture do
+      #     [
+      #       content_tag(:h1, "Title"),
+      #       content_tag(:p, "The text.")
+      #     ]
+      #   end
+      #
       def capture(*args)
         value = nil
         buffer = with_output_buffer { value = yield(*args) }
-        if string = buffer.presence || value and string.is_a?(String)
+        string = buffer.presence || value
+        if string.is_a?(String)
           ERB::Util.html_escape string
+        elsif string.is_a?(Array)
+          safe_join value
         end
       end
 

--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -85,6 +85,15 @@ module ActionView
       #     Hello world!
       #   <% end -%>
       #    # => <div class="strong">Hello world!</div>
+      #
+      #   # array will be joined via safe_join
+      #   content_tag :ul do
+      #     @posts.map{|post| content_tag(:li, post.title)}
+      #   end
+      #   # => <ul><li>title 1</li><li>title 2</li></ul>
+      #
+      #   content_tag(:ul, @posts.map{|post| content_tag(:li, post.title)})
+      #   # => <ul><li>title 1</li><li>title 2</li></ul>
       def content_tag(name, content_or_options_with_block = nil, options = nil, escape = true, &block)
         if block_given?
           options = content_or_options_with_block if content_or_options_with_block.is_a?(Hash)
@@ -125,7 +134,12 @@ module ActionView
 
         def content_tag_string(name, content, options, escape = true)
           tag_options = tag_options(options, escape) if options
-          "<#{name}#{tag_options}>#{escape ? ERB::Util.h(content) : content}</#{name}>".html_safe
+          if content.is_a?(Array)
+            content = escape ? safe_join(content) : content.join
+          else
+            content = escape ? ERB::Util.h(content) : content
+          end
+          "<#{name}#{tag_options}>#{content}</#{name}>".html_safe
         end
 
         def tag_options(options, escape = true)

--- a/actionpack/test/template/capture_helper_test.rb
+++ b/actionpack/test/template/capture_helper_test.rb
@@ -28,6 +28,11 @@ class CaptureHelperTest < ActionView::TestCase
     assert_nil @av.capture { 1 }
   end
 
+  def test_capture_safe_join_array
+    string = @av.capture { ['<br>'.html_safe, '<br>'.html_safe] }
+    assert_equal '<br><br>', string
+  end
+
   def test_capture_escapes_html
     string = @av.capture { '<em>bar</em>' }
     assert_equal '&lt;em&gt;bar&lt;/em&gt;', string

--- a/actionpack/test/template/tag_helper_test.rb
+++ b/actionpack/test/template/tag_helper_test.rb
@@ -41,6 +41,8 @@ class TagHelperTest < ActionView::TestCase
                  content_tag(:p, '<script>evil_js</script>')
     assert_equal "<p><script>evil_js</script></p>",
                  content_tag(:p, '<script>evil_js</script>', nil, false)
+    assert_equal "<ul><li>1</li><li>2</li></ul>",
+                 content_tag(:ul, [1, 2].map{|i| content_tag(:li, i)})
   end
 
   def test_content_tag_with_block_in_erb
@@ -52,6 +54,12 @@ class TagHelperTest < ActionView::TestCase
     buffer = content_tag(:div, :class => "green") { concat "Hello world!" }
     assert_dom_equal %(<div class="green">Hello world!</div>), buffer
   end
+
+  def test_content_tag_safe_join_array
+    html = content_tag(:div) { [content_tag(:h1, 'Title'), content_tag(:p, 'text')] }
+    assert_equal %(<div><h1>Title</h1><p>text</p></div>), html
+  end
+
 
   def test_content_tag_with_block_and_options_out_of_erb
     assert_dom_equal %(<div class="green">Hello world!</div>), content_tag(:div, :class => "green") { "Hello world!" }


### PR DESCRIPTION
I think it helps to build html in helpers and libraries likes:

``` ruby
content_tag :ul do
  @posts.map{|post| content_tag(:li, post.title)}
end
```

or

``` ruby
content_tag :div do
  [].tap do |out|
    out << content_tag(:h1, 'Title')
    out << content_tag(:p, 'text') if some_condition
  end
end
```

I'm using this pattern often with <tt>safe_join</tt> method.
