### PR TITLE
Remove 'size' attribute from number_field form helper fixes #3454

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -1027,6 +1027,8 @@ module ActionView
 
       def to_number_field_tag(field_type, options = {})
         options = options.stringify_keys
+        options['size'] ||= nil
+
         if range = options.delete("in") || options.delete("within")
           options.update("min" => range.min, "max" => range.max)
         end

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -438,12 +438,12 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_number_field
-    expected = %{<input name="order[quantity]" size="30" max="9" id="order_quantity" type="number" min="1" />}
+    expected = %{<input name="order[quantity]" max="9" id="order_quantity" type="number" min="1" />}
     assert_dom_equal(expected, number_field("order", "quantity", :in => 1...10))
   end
 
   def test_range_input
-    expected = %{<input name="hifi[volume]" step="0.1" size="30" max="11" id="hifi_volume" type="range" min="0" />}
+    expected = %{<input name="hifi[volume]" step="0.1" max="11" id="hifi_volume" type="range" min="0" />}
     assert_dom_equal(expected, range_field("hifi", "volume", :in => 0..11, :step => 0.1))
   end
 


### PR DESCRIPTION
f.number_field generates <input type="number", size="30"../> which is invalid HTML5. See: http://dev.w3.org/html5/spec/Overview.html#number-state
