### PR TITLE
Postgres schema_search_path shouldn't be fixed to "public" in rake

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -102,7 +102,7 @@ db_namespace = namespace :db do
       when /postgresql/
         @encoding = config['encoding'] || ENV['CHARSET'] || 'utf8'
         begin
-          ActiveRecord::Base.establish_connection(config.merge('database' => 'postgres', 'schema_search_path' => 'public'))
+          ActiveRecord::Base.establish_connection(config.merge('database' => 'postgres'))
           ActiveRecord::Base.connection.create_database(config['database'], config.merge('encoding' => @encoding))
           ActiveRecord::Base.establish_connection(config)
         rescue Exception => e
@@ -534,7 +534,7 @@ def drop_database(config)
 
     FileUtils.rm(file)
   when /postgresql/
-    ActiveRecord::Base.establish_connection(config.merge('database' => 'postgres', 'schema_search_path' => 'public'))
+    ActiveRecord::Base.establish_connection(config.merge('database' => 'postgres'))
     ActiveRecord::Base.connection.drop_database config['database']
   end
 end


### PR DESCRIPTION
schema_search_path is fixed to "public" in the testing environment, due to [this commit](https://github.com/rails/rails/commit/3fee2378edd45188e41a7d14d4ca0a88280b541e) in response to [this issue](https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/170-postgresql-update-rake-tasks-to-use-full-settings-from-database-yml-bugfix)

I'm working with a very complex postgres database, which must respect all of my postgres schemas in the test environment in order to adequately test. Forcing schema to always be "public" is very limiting.
