### PR TITLE
Fixed an issue id false option is ignored on mysql/mysql2 (fix #3440)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -67,6 +67,10 @@
 
     *Jon Leighton*
 
+*   MySQL: use the information_schema than the describe command when we look for a primary key. *GH #3440*
+
+    *Kenny J*
+
 ## Rails 3.1.1 (October 7, 2011) ##
 
 *   Add deprecation for the preload_associations method. Fixes #3022.

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -496,8 +496,17 @@ module ActiveRecord
 
       # Returns a table's primary key and belonging sequence.
       def pk_and_sequence_for(table)
-        execute_and_free("DESCRIBE #{quote_table_name(table)}", 'SCHEMA') do |result|
-          keys = each_hash(result).select { |row| row[:Key] == 'PRI' }.map { |row| row[:Field] }
+        sql = <<-SQL
+          SELECT t.constraint_type, k.column_name
+          FROM information_schema.table_constraints t
+          JOIN information_schema.key_column_usage k
+          USING (constraint_name, table_schema, table_name)
+          WHERE t.table_schema = DATABASE()
+            AND t.table_name   = '#{table}'
+        SQL
+
+        execute_and_free(sql, 'SCHEMA') do |result|
+          keys = each_hash(result).select { |row| row[:constraint_type] == 'PRIMARY KEY' }.map { |row| row[:column_name] }
           keys.length == 1 ? [keys.first, nil] : nil
         end
       end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -238,4 +238,9 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_match %r(:id => false), match[1], "no table id not preserved"
     assert_match %r{t.string[[:space:]]+"id",[[:space:]]+:null => false$}, match[2], "non-primary key id column not preserved"
   end
+
+  def test_schema_dump_keeps_id_false_when_id_is_false_and_unique_not_null_column_added
+    output = standard_dump
+    assert_match %r{create_table "subscribers", :id => false}, output
+  end
 end


### PR DESCRIPTION
In mysql, to look for a primary key, we should use the information_schema than the describe command.
Because when there is no primary key, the describe command reports the not null unique key as primary key.

Please see also
https://github.com/rails/rails/issues/3440
