### PR TITLE
distance_of_time_in_words method accepts args in both directions

### DIFF
--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -67,8 +67,9 @@ module ActionView
       def distance_of_time_in_words(from_time, to_time = 0, include_seconds = false, options = {})
         from_time = from_time.to_time if from_time.respond_to?(:to_time)
         to_time = to_time.to_time if to_time.respond_to?(:to_time)
-        distance_in_minutes = (((to_time - from_time).abs)/60).round
-        distance_in_seconds = ((to_time - from_time).abs).round
+        from_time, to_time = to_time, from_time if from_time > to_time
+        distance_in_minutes = ((to_time - from_time)/60).round
+        distance_in_seconds = (to_time - from_time).round
 
         I18n.with_options :locale => options[:locale], :scope => :'datetime.distance_in_words' do |locale|
           case distance_in_minutes

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -125,6 +125,9 @@ class DateHelperTest < ActionView::TestCase
     start_date = Date.new 1982, 12, 3
     end_date = Date.new 2010, 11, 30
     assert_equal("almost 28 years", distance_of_time_in_words(start_date, end_date))
+
+    # swap arguments
+    assert_equal("almost 28 years", distance_of_time_in_words(end_date, start_date))
   end
 
   def test_distance_in_words_with_integers


### PR DESCRIPTION
Method <tt>distance_of_time_in_words</tt> [date_helper.rb#L70](https://github.com/rails/rails/blob/master/actionpack/lib/action_view/helpers/date_helper.rb#L70) was designed to be symmetrical for arguments swapping. It should also work well for supporting <tt>time_ago_in_words</tt> [date_helper.rb#L132](https://github.com/rails/rails/blob/master/actionpack/lib/action_view/helpers/date_helper.rb#L132)

ae7d0d816db3f9a94008d36ab9efbe7583700981 (Take leap years into account more seriously ...) added unsymmetry for long time periods. I propose to fix it.

PS. The condtion with leap years calculation (<tt>leap_years = (fyear > tyear) ? 0 : ...</tt>) is reasonable. Although <tt>from_time</tt> will be always less or equal than <tt>to_time</tt>. <tt>fyear</tt> can be greater than <tt>tyear</tt> for example at March 1st.
