### PR TITLE
distance_of_time_in_words should correct process time periods longer than 1 year defined in seconds

### DIFF
--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -94,20 +94,27 @@ module ActionView
             when 43200..86399    then locale.t :about_x_months, :count => 1
             when 86400..525599   then locale.t :x_months,       :count => (distance_in_minutes.to_f / 43200.0).round
             else
-              fyear = from_time.year
-              fyear += 1 if from_time.month >= 3
-              tyear = to_time.year
-              tyear -= 1 if to_time.month < 3
-              leap_years = (fyear > tyear) ? 0 : (fyear..tyear).count{|x| Date.leap?(x)}
-              minute_offset_for_leap_year = leap_years * 1440
-              # Discount the leap year days when calculating year distance.
-              # e.g. if there are 20 leap year days between 2 dates having the same day
-              # and month then the based on 365 days calculation
-              # the distance in years will come out to over 80 years when in written
-              # english it would read better as about 80 years.
-              minutes_with_offset         = distance_in_minutes - minute_offset_for_leap_year
-              remainder                   = (minutes_with_offset % 525600)
-              distance_in_years           = (minutes_with_offset / 525600)
+              # check only from_time, because from_time and to_time should be both date/time or both integer
+              if from_time.is_a?(Time) || from_time.is_a?(DateTime)
+                fyear = from_time.year
+                fyear += 1 if from_time.month >= 3
+                tyear = to_time.year
+                tyear -= 1 if to_time.month < 3
+                leap_years = (fyear > tyear) ? 0 : (fyear..tyear).count{|x| Date.leap?(x)}
+                minute_offset_for_leap_year = leap_years * 1440
+                # Discount the leap year days when calculating year distance.
+                # e.g. if there are 20 leap year days between 2 dates having the same day
+                # and month then the based on 365 days calculation
+                # the distance in years will come out to over 80 years when in written
+                # english it would read better as about 80 years.
+                minutes_with_offset         = distance_in_minutes - minute_offset_for_leap_year
+                remainder                   = (minutes_with_offset % 525600)
+                distance_in_years           = (minutes_with_offset / 525600)
+              else
+                # 525960 = 365.25*24*60 (ActiveSupport years method use 365.25 days for one year duration also)
+                remainder                   = (distance_in_minutes % 525960)
+                distance_in_years           = (distance_in_minutes / 525960)
+              end
               if remainder < 131400
                 locale.t(:about_x_years,  :count => distance_in_years)
               elsif remainder < 394200

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -132,6 +132,10 @@ class DateHelperTest < ActionView::TestCase
     assert_equal "about 1 hour", distance_of_time_in_words(60*60)
     assert_equal "less than a minute", distance_of_time_in_words(0, 59)
     assert_equal "about 1 hour", distance_of_time_in_words(60*60, 0)
+    assert_equal "almost 10 years", distance_of_time_in_words(10*365*24*60*60)
+    assert_equal "almost 10 years", distance_of_time_in_words(0, 10*365*24*60*60)
+    assert_equal "about 10 years", distance_of_time_in_words(10*366*24*60*60)
+    assert_equal "about 10 years", distance_of_time_in_words(0, 10*366*24*60*60)
   end
 
   def test_time_ago_in_words


### PR DESCRIPTION
It differs from #3530 :)

Here I fix side an effect after ae7d0d816db3f9a94008d36ab9efbe7583700981 also.

<tt>distance_of_time_in_words</tt> accepts args as integer (seconds), Date, Time, DateTime or something that responds to <tt>:to_time</tt> method. If <tt>from_time</tt> and <tt>to_time</tt> are seconds for periods more than 1 year [date_helper.rb#L97](https://github.com/rails/rails/blob/ae7d0d816db3f9a94008d36ab9efbe7583700981/actionpack/lib/action_view/helpers/date_helper.rb#L97) is interpreted as [ActiveSupport year method](http://api.rubyonrails.org/classes/Integer.html#method-i-year). In this case creating Range object <tt>(fyear..tyear)</tt> failes.

I did change nothing in [date_helper.rb#L97-110](https://github.com/rails/rails/blob/ae7d0d816db3f9a94008d36ab9efbe7583700981/actionpack/lib/action_view/helpers/date_helper.rb#L97-110) except indent.
