### PR TITLE
Barckport to 3-1-stable: fixed an issue id false option is ignored on mysql/mysql2 (fix #3440)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -20,6 +20,9 @@
 
     *Jon Leighton*
 
+*   MySQL: use the information_schema than the describe command when we look for a primary key. *GH #3440*
+    *Kenny J*
+
 ## Rails 3.1.1 (October 7, 2011) ##
 
 *   Raise an exception if the primary key of a model in an association is needed

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -239,4 +239,9 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_match %r(:id => false), match[1], "no table id not preserved"
     assert_match %r{t.string[[:space:]]+"id",[[:space:]]+:null => false$}, match[2], "non-primary key id column not preserved"
   end
+
+  def test_schema_dump_keeps_id_false_when_id_is_false_and_unique_not_null_column_added
+    output = standard_dump
+    assert_match %r{create_table "subscribers", :id => false}, output
+  end
 end


### PR DESCRIPTION
The abstract mysql adapter does not exist in 3-1-stable.
Please see https://github.com/rails/rails/pull/3525
