### PR TITLE
Add arel to Gemfile on apps generated in edge Rails

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -139,11 +139,13 @@ module Rails
           <<-GEMFILE.strip_heredoc
             gem 'rails',     :path => '#{Rails::Generators::RAILS_DEV_PATH}'
             gem 'journey',   :git => 'git://github.com/rails/journey.git'
+            gem 'arel',      :git => 'git://github.com/rails/arel.git'
           GEMFILE
         elsif options.edge?
           <<-GEMFILE.strip_heredoc
             gem 'rails',     :git => 'git://github.com/rails/rails.git'
             gem 'journey',   :git => 'git://github.com/rails/journey.git'
+            gem 'arel',      :git => 'git://github.com/rails/arel.git'
           GEMFILE
         else
           <<-GEMFILE.strip_heredoc


### PR DESCRIPTION
Without this you will get:

undefined method `distinct' for #Arel::SelectManager:0x7ff8918495b8

The error is reproducible in Sam´s CI: http://intertwingly.net/projects/AWDwR4/checkdepot/section-6.1.html
