### PR TITLE
Update ActiveRecord#attribute_present? to work as documented

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1771,7 +1771,8 @@ MSG
       # Returns true if the specified +attribute+ has been set by the user or by a database load and is neither
       # nil nor empty? (the latter only applies to objects that respond to empty?, most notably Strings).
       def attribute_present?(attribute)
-        !_read_attribute(attribute).blank?
+        value = _read_attribute(attribute)
+        !value.nil? || (value.respond_to?(:empty?) && !value.empty?)
       end
 
       # Returns the column object for the named attribute.

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -35,6 +35,24 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert !t.attribute_present?("content")
   end
 
+  def test_attribute_present_with_booleans
+    b1 = Boolean.new
+    b1.value = false
+    assert b1.attribute_present?(:value)
+
+    b2 = Boolean.new
+    b2.value = true
+    assert b2.attribute_present?(:value)
+
+    b3 = Boolean.new
+    assert !b3.attribute_present?(:value)
+
+    b4 = Boolean.new
+    b4.value = false
+    b4.save!
+    assert Boolean.find(b4.id).attribute_present?(:value)
+  end
+
   def test_attribute_keys_on_new_instance
     t = Topic.new
     assert_equal nil, t.title, "The topics table has a title column, so it should be nil"


### PR DESCRIPTION
RIght now attribute_present? returns false for "false" values. Since "false" is a value you can set in the db it should return true when it's set.

"Returns true if the specified attribute has been set by the user or by
a database load and is neither nil nor empty?"

Fixes #1613
