### PR TITLE
Make pluralize follow singularize's logic of uncountability check

### DIFF
--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -14,6 +14,7 @@ module InflectorTestCases
     "fish"        => "fish",
     "jeans"       => "jeans",
     "funky jeans" => "funky jeans",
+    "my money"    => "my money",
 
     "category"    => "categories",
     "query"       => "queries",


### PR DESCRIPTION
I have added a test case which fails prior to the patch. All the tests pass including the new one now.
