### PR TITLE
Remove redundant blank line at the bottom of generated controller code

### DIFF
--- a/railties/lib/rails/generators/rails/controller/templates/controller.rb
+++ b/railties/lib/rails/generators/rails/controller/templates/controller.rb
@@ -3,7 +3,7 @@ class <%= class_name %>Controller < ApplicationController
 <% actions.each do |action| -%>
   def <%= action %>
   end
-
+<%= "\n" unless action == actions.last -%>
 <% end -%>
 end
 <% end -%>


### PR DESCRIPTION
Every time the controller generator produces controller codes with a redundant blank line at the bottom.
This is because the generator outputs a method definition and a blank line for each actions when iterating over given actions.
Here's (a bit ugly) workaround for removing this.
