### PR TITLE
Rename field_changed? to _field_changed? so that users can create a field named field

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -55,12 +55,12 @@ module ActiveRecord
         # The attribute already has an unsaved change.
         if attribute_changed?(attr)
           old = @changed_attributes[attr]
-          @changed_attributes.delete(attr) unless field_changed?(attr, old, value)
+          @changed_attributes.delete(attr) unless _field_changed?(attr, old, value)
         else
           old = clone_attribute_value(:read_attribute, attr)
           # Save Time objects as TimeWithZone if time_zone_aware_attributes == true
           old = old.in_time_zone if clone_with_time_zone_conversion_attribute?(attr, old)
-          @changed_attributes[attr] = old if field_changed?(attr, old, value)
+          @changed_attributes[attr] = old if _field_changed?(attr, old, value)
         end
 
         # Carry on.
@@ -77,7 +77,7 @@ module ActiveRecord
         end
       end
 
-      def field_changed?(attr, old, value)
+      def _field_changed?(attr, old, value)
         if column = column_for_attribute(attr)
           if column.number? && column.null && (old.nil? || old == 0) && value.blank?
             # For nullable numeric columns, NULL gets stored in database for blank (i.e. '') values.

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -223,7 +223,7 @@ module ActiveRecord
 
       @changed_attributes = {}
       self.class.column_defaults.each do |attr, orig_value|
-        @changed_attributes[attr] = orig_value if field_changed?(attr, orig_value, @attributes[attr])
+        @changed_attributes[attr] = orig_value if _field_changed?(attr, orig_value, @attributes[attr])
       end
 
       @aggregation_cache = {}

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -497,6 +497,20 @@ class DirtyTest < ActiveRecord::TestCase
     assert !pirate.previous_changes.key?('created_on')
   end
 
+  if ActiveRecord::Base.connection.supports_migrations?
+    class Testings < ActiveRecord::Base; end
+    def test_field_named_field
+      ActiveRecord::Base.connection.create_table :testings do |t|
+        t.string :field
+      end
+      assert_nothing_raised do
+        Testings.new.attributes
+      end
+    ensure
+      ActiveRecord::Base.connection.drop_table :testings rescue nil
+    end
+  end
+
   private
     def with_partial_updates(klass, on = true)
       old = klass.partial_updates?


### PR DESCRIPTION
This patch allows users to create a field named `field` in AR models.

Without this patch, AR raises `ActiveRecord::DangerousAttributeError: field_changed? is defined by ActiveRecord` when trying to define a "_changed?" suffixed method for every attribute https://github.com/rails/rails/blob/b454601/activemodel/lib/active_model/dirty.rb#L92

This should be fixed because
1) "field" fields didn't cause any error on AR 2. So, this is a regression.
2) AR's `field_changed?` is a private method. Why should attribute names be restricted by the framework's internal method name?
