### PR TITLE
beginning_of_week and end_of_week extended to work with any week start

### DIFF
--- a/activesupport/lib/active_support/core_ext/date/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date/calculations.rb
@@ -174,19 +174,27 @@ class Date
     months_since(1)
   end unless method_defined?(:next_month)
 
-  # Returns a new Date/DateTime representing the "start" of this week (i.e, Monday; DateTime objects will have time set to 0:00).
-  def beginning_of_week
-    days_to_monday = self.wday!=0 ? self.wday-1 : 6
-    result = self - days_to_monday
+  # Returns number of days to start of this week, week starts on start_day (default is Monday)
+  def days_to_week_start(start_day = :monday)
+    start_day_number = DAYS_INTO_WEEK[start_day]
+    current_day_number = wday != 0 ? wday - 1 : 6
+    days_span = current_day_number - start_day_number
+    days_span >= 0 ? days_span : 7 + days_span
+  end
+
+  # Returns a new Date/DateTime representing the "start" of this week, week starts on start_day (i.e, Monday; DateTime objects will have time set to 0:00).
+  def beginning_of_week(start_day = :monday)
+    days_to_start = days_to_week_start(start_day)
+    result = self - days_to_start
     self.acts_like?(:time) ? result.midnight : result
   end
   alias :monday :beginning_of_week
   alias :at_beginning_of_week :beginning_of_week
 
-  # Returns a new Date/DateTime representing the end of this week (Sunday, DateTime objects will have time set to 23:59:59).
-  def end_of_week
-    days_to_sunday = self.wday!=0 ? 7-self.wday : 0
-    result = self + days_to_sunday.days
+  # Returns a new Date/DateTime representing the end of this week, week starts on start_day (Sunday, DateTime objects will have time set to 23:59:59).
+  def end_of_week(start_day = :monday)
+    days_to_end = 6 - days_to_week_start(start_day)
+    result = self + days_to_end.days
     self.acts_like?(:time) ? result.end_of_day : result
   end
   alias :sunday :end_of_week

--- a/activesupport/lib/active_support/core_ext/date/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date/calculations.rb
@@ -174,7 +174,7 @@ class Date
     months_since(1)
   end unless method_defined?(:next_month)
 
-  # Returns number of days to start of this week, week starts on start_day (default is Monday)
+  # Returns number of days to start of this week, week starts on start_day (default is :monday).
   def days_to_week_start(start_day = :monday)
     start_day_number = DAYS_INTO_WEEK[start_day]
     current_day_number = wday != 0 ? wday - 1 : 6
@@ -182,7 +182,7 @@ class Date
     days_span >= 0 ? days_span : 7 + days_span
   end
 
-  # Returns a new Date/DateTime representing the "start" of this week, week starts on start_day (i.e, Monday; DateTime objects will have time set to 0:00).
+  # Returns a new Date/DateTime representing the "start" of this week, week starts on start_day (default is :monday, i.e. Monday; DateTime objects will have time set to 0:00).
   def beginning_of_week(start_day = :monday)
     days_to_start = days_to_week_start(start_day)
     result = self - days_to_start
@@ -191,7 +191,7 @@ class Date
   alias :monday :beginning_of_week
   alias :at_beginning_of_week :beginning_of_week
 
-  # Returns a new Date/DateTime representing the end of this week, week starts on start_day (Sunday, DateTime objects will have time set to 23:59:59).
+  # Returns a new Date/DateTime representing the end of this week, week starts on start_day (default is :monday, i.e. Sunday, DateTime objects will have time set to 23:59:59).
   def end_of_week(start_day = :monday)
     days_to_end = 6 - days_to_week_start(start_day)
     result = self + days_to_end.days

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -161,7 +161,7 @@ class Time
     months_since(1)
   end
 
-  # Returns number of days to start of this week, week starts on start_day (default is Monday)
+  # Returns number of days to start of this week, week starts on start_day (default is :monday).
   def days_to_week_start(start_day = :monday)
     start_day_number = DAYS_INTO_WEEK[start_day]
     current_day_number = wday != 0 ? wday - 1 : 6
@@ -169,7 +169,7 @@ class Time
     days_span >= 0 ? days_span : 7 + days_span
   end
 
-  # Returns a new Time representing the "start" of this week, week starts on start_day (deafult is Monday, e.g. Monday, 0:00)
+  # Returns a new Time representing the "start" of this week, week starts on start_day (default is :monday, i.e. Monday, 0:00).
   def beginning_of_week(start_day = :monday)
     days_to_start = days_to_week_start(start_day)
     (self - days_to_start.days).midnight
@@ -177,7 +177,7 @@ class Time
   alias :monday :beginning_of_week
   alias :at_beginning_of_week :beginning_of_week
 
-  # Returns a new Time representing the end of this week, week starts on start_day (deafult is Monday, end of Sunday)
+  # Returns a new Time representing the end of this week, week starts on start_day (default is :monday, i.e. end of Sunday).
   def end_of_week(start_day = :monday)
     days_to_end =  6 - days_to_week_start(start_day)
     (self + days_to_end.days).end_of_day

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -161,18 +161,26 @@ class Time
     months_since(1)
   end
 
-  # Returns a new Time representing the "start" of this week (Monday, 0:00)
-  def beginning_of_week
-    days_to_monday = wday!=0 ? wday-1 : 6
-    (self - days_to_monday.days).midnight
+  # Returns number of days to start of this week, week starts on start_day (default is Monday)
+  def days_to_week_start(start_day = :monday)
+    start_day_number = DAYS_INTO_WEEK[start_day]
+    current_day_number = wday != 0 ? wday - 1 : 6
+    days_span = current_day_number - start_day_number
+    days_span >= 0 ? days_span : 7 + days_span
+  end
+
+  # Returns a new Time representing the "start" of this week, week starts on start_day (deafult is Monday, e.g. Monday, 0:00)
+  def beginning_of_week(start_day = :monday)
+    days_to_start = days_to_week_start(start_day)
+    (self - days_to_start.days).midnight
   end
   alias :monday :beginning_of_week
   alias :at_beginning_of_week :beginning_of_week
 
-  # Returns a new Time representing the end of this week, (end of Sunday)
-  def end_of_week
-    days_to_sunday = wday!=0 ? 7-wday : 0
-    (self + days_to_sunday.days).end_of_day
+  # Returns a new Time representing the end of this week, week starts on start_day (deafult is Monday, end of Sunday)
+  def end_of_week(start_day = :monday)
+    days_to_end =  6 - days_to_week_start(start_day)
+    (self + days_to_end.days).end_of_day
   end
   alias :at_end_of_week :end_of_week
 

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -54,6 +54,24 @@ class DateTimeExtCalculationsTest < Test::Unit::TestCase
     assert_equal 86399,DateTime.civil(2005,1,1,23,59,59).seconds_since_midnight
   end
 
+  def test_days_to_week_start
+    assert_equal 0, Time.local(2011,11,01,0,0,0).days_to_week_start(:tuesday)
+    assert_equal 1, Time.local(2011,11,02,0,0,0).days_to_week_start(:tuesday)
+    assert_equal 2, Time.local(2011,11,03,0,0,0).days_to_week_start(:tuesday)
+    assert_equal 3, Time.local(2011,11,04,0,0,0).days_to_week_start(:tuesday)
+    assert_equal 4, Time.local(2011,11,05,0,0,0).days_to_week_start(:tuesday)
+    assert_equal 5, Time.local(2011,11,06,0,0,0).days_to_week_start(:tuesday)
+    assert_equal 6, Time.local(2011,11,07,0,0,0).days_to_week_start(:tuesday)
+
+    assert_equal 3, Time.local(2011,11,03,0,0,0).days_to_week_start(:monday)
+    assert_equal 3, Time.local(2011,11,04,0,0,0).days_to_week_start(:tuesday)
+    assert_equal 3, Time.local(2011,11,05,0,0,0).days_to_week_start(:wednesday)
+    assert_equal 3, Time.local(2011,11,06,0,0,0).days_to_week_start(:thursday)
+    assert_equal 3, Time.local(2011,11,07,0,0,0).days_to_week_start(:friday)
+    assert_equal 3, Time.local(2011,11,8,0,0,0).days_to_week_start(:saturday)
+    assert_equal 3, Time.local(2011,11,9,0,0,0).days_to_week_start(:sunday)
+  end
+
   def test_beginning_of_week
     assert_equal DateTime.civil(2005,1,31), DateTime.civil(2005,2,4,10,10,10).beginning_of_week
     assert_equal DateTime.civil(2005,11,28), DateTime.civil(2005,11,28,0,0,0).beginning_of_week #monday

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -59,7 +59,27 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal Time.local(2005,11,28), Time.local(2005,12,02,0,0,0).beginning_of_week #friday
     assert_equal Time.local(2005,11,28), Time.local(2005,12,03,0,0,0).beginning_of_week #saturday
     assert_equal Time.local(2005,11,28), Time.local(2005,12,04,0,0,0).beginning_of_week #sunday
+
   end
+
+  def test_days_to_week_start
+    assert_equal 0, Time.local(2011,11,01,0,0,0).days_to_week_start(:tuesday)
+    assert_equal 1, Time.local(2011,11,02,0,0,0).days_to_week_start(:tuesday)
+    assert_equal 2, Time.local(2011,11,03,0,0,0).days_to_week_start(:tuesday)
+    assert_equal 3, Time.local(2011,11,04,0,0,0).days_to_week_start(:tuesday)
+    assert_equal 4, Time.local(2011,11,05,0,0,0).days_to_week_start(:tuesday)
+    assert_equal 5, Time.local(2011,11,06,0,0,0).days_to_week_start(:tuesday)
+    assert_equal 6, Time.local(2011,11,07,0,0,0).days_to_week_start(:tuesday)
+
+    assert_equal 3, Time.local(2011,11,03,0,0,0).days_to_week_start(:monday)
+    assert_equal 3, Time.local(2011,11,04,0,0,0).days_to_week_start(:tuesday)
+    assert_equal 3, Time.local(2011,11,05,0,0,0).days_to_week_start(:wednesday)
+    assert_equal 3, Time.local(2011,11,06,0,0,0).days_to_week_start(:thursday)
+    assert_equal 3, Time.local(2011,11,07,0,0,0).days_to_week_start(:friday)
+    assert_equal 3, Time.local(2011,11,8,0,0,0).days_to_week_start(:saturday)
+    assert_equal 3, Time.local(2011,11,9,0,0,0).days_to_week_start(:sunday)
+  end
+
 
   def test_beginning_of_day
     assert_equal Time.local(2005,2,4,0,0,0), Time.local(2005,2,4,10,10,10).beginning_of_day

--- a/railties/guides/source/active_support_core_extensions.textile
+++ b/railties/guides/source/active_support_core_extensions.textile
@@ -3039,12 +3039,14 @@ Active Support defines these methods as well for Ruby 1.8.
 
 h6. +beginning_of_week+, +end_of_week+
 
-The methods +beginning_of_week+ and +end_of_week+ return the dates for the beginning and end of week, assuming weeks start on Monday:
+The methods +beginning_of_week+ and +end_of_week+ receive a symbol with a day name in English (in lowercase, default is :monday) and return the dates for the beginning and end of week, assuming weeks start on day, passed as parameter:
 
 <ruby>
-d = Date.new(2010, 5, 8) # => Sat, 08 May 2010
-d.beginning_of_week      # => Mon, 03 May 2010
-d.end_of_week            # => Sun, 09 May 2010
+d = Date.new(2010, 5, 8)     # => Sat, 08 May 2010
+d.beginning_of_week          # => Mon, 03 May 2010
+d.beginning_of_week(:sunday) # => Sun, 02 May 2010
+d.end_of_week                # => Sun, 09 May 2010
+d.end_of_week(:sunday)       # => Sat, 08 May 2010
 </ruby>
 
 +beginning_of_week+ is aliased to +monday+ and +at_beginning_of_week+. +end_of_week+ is aliased to +sunday+ and +at_end_of_week+.


### PR DESCRIPTION
In rails week starts from Monday and there's no built-in way to get beginning of week, that starts from another day.
That's especially important for people in US, where week starts from Sunday. Also ruby considers Sunday as a week start. 

Me and many others (http://bit.ly/v4H8RB, http://bit.ly/vclIEd) faced this problem, so I re-write beginning_of_week (and end_of_week) to take week start day symbol as an argument and return week start (end) based on that day. days_to_week_start method added (return number of days to week start) and it's used in both beginning_of_week and end_of_week.
