### PR TITLE
remove_method tests and changes

### DIFF
--- a/activemodel/lib/active_model/observing.rb
+++ b/activemodel/lib/active_model/observing.rb
@@ -187,8 +187,7 @@ module ActiveModel
       def observe(*models)
         models.flatten!
         models.collect! { |model| model.respond_to?(:to_sym) ? model.to_s.camelize.constantize : model }
-        remove_possible_method(:observed_classes)
-        define_method(:observed_classes) { models }
+        redefine_method(:observed_classes) { models }
       end
 
       # Returns an array of Classes to observe.

--- a/activesupport/test/core_ext/module/remove_method_test.rb
+++ b/activesupport/test/core_ext/module/remove_method_test.rb
@@ -1,0 +1,29 @@
+require 'abstract_unit'
+require 'active_support/core_ext/module/remove_method'
+
+module RemoveMethodTests
+  class A
+    def do_something
+      return 1
+    end
+    
+  end
+end
+
+class RemoveMethodTest < ActiveSupport::TestCase
+  
+  def test_remove_method_from_an_object
+    RemoveMethodTests::A.class_eval{
+      self.remove_possible_method(:do_something)
+    }
+    assert !RemoveMethodTests::A.new.respond_to?(:do_something)
+  end
+  
+  def test_redefine_method_in_an_object
+    RemoveMethodTests::A.class_eval{
+      self.redefine_method(:do_something) { return 100 }
+    }
+    assert_equal 100, RemoveMethodTests::A.new.do_something
+  end
+
+end


### PR DESCRIPTION
Replaced two separate calls to remove and define into one => redefine call

And, there were no tests for the core_ext methods remove_possible_method and redefine_method  methods of class Module. Added them too in activesupport/tests.

I've run the activemodel and active support test suite. All are passing. Please merge these commits.
