### PR TITLE
Doc patch, DrbStore no more exists in rails

### DIFF
--- a/actionpack/lib/action_controller/caching.rb
+++ b/actionpack/lib/action_controller/caching.rb
@@ -24,7 +24,6 @@ module ActionController #:nodoc:
   #
   #   config.action_controller.cache_store = :memory_store
   #   config.action_controller.cache_store = :file_store, "/path/to/cache/directory"
-  #   config.action_controller.cache_store = :drb_store, "druby://localhost:9192"
   #   config.action_controller.cache_store = :mem_cache_store, "localhost"
   #   config.action_controller.cache_store = :mem_cache_store, Memcached::Rails.new("localhost:11211")
   #   config.action_controller.cache_store = MyOwnStore.new("parameter")


### PR DESCRIPTION
Because DrbStore removed from rails, i remove :drb_store from documentation
