### PR TITLE
Delegate id should give nil when allow_nil

### DIFF
--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -44,6 +44,7 @@ end
 Project   = Struct.new(:description, :person) do
   delegate :name, :to => :person, :allow_nil => true
   delegate :to_f, :to => :description, :allow_nil => true
+  delegate :id, :to => :person, :allow_nil => true, :prefix => true
 end
 
 class Name
@@ -153,6 +154,11 @@ class ModuleTest < Test::Unit::TestCase
   def test_delegation_to_method_that_exists_on_nil_when_allowing_nil
     nil_project = Project.new(nil)
     assert_equal 0.0, nil_project.to_f
+  end
+
+  def test_delegation_id_with_allow_nil_and_nil_value_and_prefix
+    nil_project = Project.new(nil)
+    assert_nil nil_project.person_id
   end
 
   def test_parent


### PR DESCRIPTION
When I delegete id and pass `allow_nil` as `true` I should get nil according documentation.

I have polymorphic associations for customer: `belongs_to :shipping_location`, `belongs_to :billing_location` (default locations for customer) and `has_many :locations`:

``` ruby
class Customer < ActiveRecord::Base
      has_one :billing_location, :as => :locationable, :class_name => 'Location', :conditions => { :default_billing => true }
      has_one :shipping_location, :as => :locationable, :class_name => 'Location', :conditions => { :default_shipping => true }
      has_many :locations, :as => :location able
      with_options(:prefix => true, :allow_nil => true) do |options|
          options.delegate :id, :to => :shipping_location, :prefix => true, :allow_nil => true
          options.delegate :id, :to => :billing_location, :prefix => true, :allow_nil => true
      end
end
```

I want to fill in the form like this to set default locations:

``` erb
<% fields_for @customer do |fc| %>
    <%= fc.label "#{location_type}_location_id", 'Saved Address', {:id => nil} %>
    <%= fc.collection_select "#{location_type}_location_id", @customer.locations, :id, :template_name,
        {:include_blank => 'Please choose...'},
        {:id => "saved-#{location_type}-location", :class => 'selectbox', :rel => customer_location_template_path(':id')} %>
<% end %>
```

where `location_type` is either 'shipping' or 'billing'. But I have raise `RuntimeError` instead of get nil when shipping_location is nil or billing_location is nil
