### PR TITLE
3 1 stable url subdomain with numeric host

### DIFF
--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -64,7 +64,7 @@ module ActionDispatch
         end
 
         def host_or_subdomain_and_domain(options)
-          return options[:host] unless (options[:subdomain] || options[:domain]) and named_host?(options[:host])
+          return options[:host] unless (options[:subdomain] || options[:domain]) && named_host?(options[:host])
 
           tld_length = options[:tld_length] || @@tld_length
 

--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -64,7 +64,7 @@ module ActionDispatch
         end
 
         def host_or_subdomain_and_domain(options)
-          return options[:host] unless options[:subdomain] || options[:domain]
+          return options[:host] unless (options[:subdomain] || options[:domain]) and named_host?(options[:host])
 
           tld_length = options[:tld_length] || @@tld_length
 

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -16,6 +16,10 @@ module AbstractController
         W.default_url_options[:host] = 'www.basecamphq.com'
       end
 
+      def add_numeric_host!
+        W.default_url_options[:host] = '127.0.0.1'
+      end
+
       def test_exception_is_thrown_without_host
         assert_raise ArgumentError do
           W.new.url_for :controller => 'c', :action => 'a', :id => 'i'
@@ -63,6 +67,13 @@ module AbstractController
       def test_subdomain_may_be_changed
         add_host!
         assert_equal('http://api.basecamphq.com/c/a/i',
+          W.new.url_for(:subdomain => 'api', :controller => 'c', :action => 'a', :id => 'i')
+        )
+      end
+
+      def test_subdomain_may_be_accepted_with_numeric_host
+        add_numeric_host!
+        assert_equal('http://127.0.0.1/c/a/i',
           W.new.url_for(:subdomain => 'api', :controller => 'c', :action => 'a', :id => 'i')
         )
       end


### PR DESCRIPTION
Fix trouble using :subdomain in development environment when using numeric addresses.

Otherwise the following occurs:

TypeError: can't convert nil into String
    /Users/bfolkens/dev/bfolkens-rails-core/actionpack/lib/action_dispatch/http/url.rb:75:in host_or_subdomain_and_domain'
    /Users/bfolkens/dev/bfolkens-rails-core/actionpack/lib/action_dispatch/http/url.rb:37:in url_for'
    /Users/bfolkens/dev/bfolkens-rails-core/actionpack/lib/action_dispatch/routing/url_for.rb:147:in test_subdomain_may_be_accepted_with_numeric_host'
    /Users/bfolkens/dev/bfolkens-rails-core/activesupport/lib/active_support/testing/setup_and_teardown.rb:67:in run'
    /Users/bfolkens/dev/bfolkens-rails-core/activesupport/lib/active_support/callbacks.rb:426:in send'
    /Users/bfolkens/dev/bfolkens-rails-core/activesupport/lib/active_support/callbacks.rb:81:in run'
