### PR TITLE
Should be checking if file exists or not.

### DIFF
--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -121,10 +121,16 @@ namespace :test do
       models      = changed_since_checkin.select { |path| path =~ /app[\\\/]models[\\\/].*\.rb$/ }
       controllers = changed_since_checkin.select { |path| path =~ /app[\\\/]controllers[\\\/].*\.rb$/ }
 
-      unit_tests       = models.map { |model| "test/unit/#{File.basename(model, '.rb')}_test.rb" }
-      functional_tests = controllers.map { |controller| "test/functional/#{File.basename(controller, '.rb')}_test.rb" }
+      unit_tests = models.map do |model|
+        file = "test/unit/#{File.basename(model, '.rb')}_test.rb"
+        file if File.exist?(file)
+      end
+      functional_tests = controllers.map do |controller|
+        file = "test/functional/#{File.basename(controller, '.rb')}_test.rb"
+        file if File.exist?(file)
+      end
 
-      unit_tests.uniq + functional_tests.uniq
+      (unit_tests.uniq + functional_tests.uniq).compact
     end
 
     t.libs << 'test'


### PR DESCRIPTION
I found this bug when running rake test:uncommitted 
on a newly generated rails app which don't have
test file for application_controller.
Can see detail here #3461
