### PR TITLE
Fix trouble using :subdomain in development environment when using numeric addresses.

### DIFF
--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -64,7 +64,7 @@ module ActionDispatch
         end
 
         def host_or_subdomain_and_domain(options)
-          return options[:host] if options[:subdomain].nil? && options[:domain].nil?
+          return options[:host] if !named_host?(options[:host]) || (options[:subdomain].nil? && options[:domain].nil?)
 
           tld_length = options[:tld_length] || @@tld_length
 

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -16,6 +16,10 @@ module AbstractController
         W.default_url_options[:host] = 'www.basecamphq.com'
       end
 
+      def add_numeric_host!
+        W.default_url_options[:host] = '127.0.0.1'
+      end
+
       def test_exception_is_thrown_without_host
         assert_raise ArgumentError do
           W.new.url_for :controller => 'c', :action => 'a', :id => 'i'
@@ -78,6 +82,13 @@ module AbstractController
         W.default_url_options[:host] = 'mobile.www.api.basecamphq.com'
         assert_equal('http://basecamphq.com/c/a/i',
           W.new.url_for(:subdomain => false, :controller => 'c', :action => 'a', :id => 'i')
+        )
+      end
+
+      def test_subdomain_may_be_accepted_with_numeric_host
+        add_numeric_host!
+        assert_equal('http://127.0.0.1/c/a/i',
+          W.new.url_for(:subdomain => 'api', :controller => 'c', :action => 'a', :id => 'i')
         )
       end
 


### PR DESCRIPTION
See-also pull request #3561 from 3-1-stable
