### PR TITLE
3.2 style migration for generators and tests

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -57,6 +57,16 @@ module ActiveRecord
     #     end
     #   end
     #
+    # Also, the block given to +create_table+ will be evaled inside this object,
+    # so you don't have to pass the `t` block argument.
+    #
+    #   class SomeMigration < ActiveRecord::Migration
+    #     def up
+    #       create_table :foo do
+    #         puts self.class  # => "ActiveRecord::ConnectionAdapters::TableDefinition"
+    #       end
+    #     end
+    #
     # The table definitions
     # The Columns are stored as a ColumnDefinition in the +columns+ attribute.
     class TableDefinition

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -82,19 +82,19 @@ module ActiveRecord
       # form or the regular form, like this:
       #
       # === Block form
-      #  # create_table() passes a TableDefinition object to the block.
+      #  # create_table() runs the given block inside TableDefinition object's context.
       #  # This form will not only create the table, but also columns for the
       #  # table.
       #
-      #  create_table(:suppliers) do |t|
-      #    t.column :name, :string, :limit => 60
+      #  create_table(:suppliers) do
+      #    column :name, :string, :limit => 60
       #    # Other fields here
       #  end
       #
       # === Block form, with shorthand
       #  # You can also use the column types as method calls, rather than calling the column method.
-      #  create_table(:suppliers) do |t|
-      #    t.string :name, :limit => 60
+      #  create_table(:suppliers) do
+      #    string :name, :limit => 60
       #    # Other fields here
       #  end
       #
@@ -133,8 +133,8 @@ module ActiveRecord
       #  ) ENGINE=InnoDB DEFAULT CHARSET=utf8
       #
       # ====== Rename the primary key column
-      #  create_table(:objects, :primary_key => 'guid') do |t|
-      #    t.column :name, :string, :limit => 80
+      #  create_table(:objects, :primary_key => 'guid') do
+      #    string :name, :limit => 80
       #  end
       # generates:
       #  CREATE TABLE objects (
@@ -143,9 +143,9 @@ module ActiveRecord
       #  )
       #
       # ====== Do not add a primary key column
-      #  create_table(:categories_suppliers, :id => false) do |t|
-      #    t.column :category_id, :integer
-      #    t.column :supplier_id, :integer
+      #  create_table(:categories_suppliers, :id => false) do
+      #    integer :category_id
+      #    integer :supplier_id
       #  end
       # generates:
       #  CREATE TABLE categories_suppliers (

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -65,12 +65,12 @@ module ActiveRecord
   #
   #   class AddSystemSettings < ActiveRecord::Migration
   #     def up
-  #       create_table :system_settings do |t|
-  #         t.string  :name
-  #         t.string  :label
-  #         t.text    :value
-  #         t.string  :type
-  #         t.integer :position
+  #       create_table :system_settings do
+  #         string  :name
+  #         string  :label
+  #         text    :value
+  #         string  :type
+  #         integer :position
   #       end
   #
   #       SystemSetting.create  :name => "notice",
@@ -303,8 +303,8 @@ module ActiveRecord
   #   class TenderloveMigration < ActiveRecord::Migration
   #     def change
   #       create_table(:horses) do
-  #         t.column :content, :text
-  #         t.column :remind_at, :datetime
+  #         text :content
+  #         datetime :remind_at
   #       end
   #     end
   #   end

--- a/activerecord/lib/rails/generators/active_record/model/templates/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/model/templates/migration.rb
@@ -1,11 +1,11 @@
 class <%= migration_class_name %> < ActiveRecord::Migration
   def change
-    create_table :<%= table_name %> do |t|
+    create_table :<%= table_name %> do
 <% attributes.each do |attribute| -%>
-      t.<%= attribute.type %> :<%= attribute.name %>
+      <%= attribute.type %> :<%= attribute.name %>
 <% end -%>
 <% if options[:timestamps] %>
-      t.timestamps
+      timestamps
 <% end -%>
     end
 <% if options[:indexes] -%>

--- a/activerecord/lib/rails/generators/active_record/session_migration/templates/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/session_migration/templates/migration.rb
@@ -1,9 +1,9 @@
 class <%= migration_class_name %> < ActiveRecord::Migration
   def change
-    create_table :<%= session_table_name %> do |t|
-      t.string :session_id, :null => false
-      t.text :data
-      t.timestamps
+    create_table :<%= session_table_name %> do
+      string :session_id, :null => false
+      text :data
+      timestamps
     end
 
     add_index :<%= session_table_name %>, :session_id

--- a/activerecord/test/cases/adapters/mysql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql/active_schema_test.rb
@@ -84,8 +84,8 @@ class ActiveSchemaTest < ActiveRecord::TestCase
   def test_remove_timestamps
     with_real_execute do
       begin
-        ActiveRecord::Base.connection.create_table :delete_me do |t|
-          t.timestamps
+        ActiveRecord::Base.connection.create_table :delete_me do
+          timestamps
         end
         ActiveRecord::Base.connection.remove_timestamps :delete_me
         assert !column_present?('delete_me', 'updated_at', 'datetime')

--- a/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
@@ -44,8 +44,8 @@ class MysqlReservedWordTest < ActiveRecord::TestCase
   # create tables with reserved-word names and columns
   def test_create_tables
     assert_nothing_raised {
-      @connection.create_table :order do |t|
-        t.column :group, :string
+      @connection.create_table :order do
+        column :group, :string
       end
     }
   end

--- a/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
@@ -45,7 +45,7 @@ class MysqlReservedWordTest < ActiveRecord::TestCase
   def test_create_tables
     assert_nothing_raised {
       @connection.create_table :order do
-        column :group, :string
+        string :group
       end
     }
   end

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -84,8 +84,8 @@ class ActiveSchemaTest < ActiveRecord::TestCase
   def test_remove_timestamps
     with_real_execute do
       begin
-        ActiveRecord::Base.connection.create_table :delete_me do |t|
-          t.timestamps
+        ActiveRecord::Base.connection.create_table :delete_me do
+          timestamps
         end
         ActiveRecord::Base.connection.remove_timestamps :delete_me
         assert !column_present?('delete_me', 'updated_at', 'datetime')

--- a/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
@@ -44,8 +44,8 @@ class MysqlReservedWordTest < ActiveRecord::TestCase
   # create tables with reserved-word names and columns
   def test_create_tables
     assert_nothing_raised {
-      @connection.create_table :order do |t|
-        t.column :group, :string
+      @connection.create_table :order do
+        column :group, :string
       end
     }
   end

--- a/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
@@ -45,7 +45,7 @@ class MysqlReservedWordTest < ActiveRecord::TestCase
   def test_create_tables
     assert_nothing_raised {
       @connection.create_table :order do
-        column :group, :string
+        string :group
       end
     }
   end

--- a/activerecord/test/cases/ar_schema_test.rb
+++ b/activerecord/test/cases/ar_schema_test.rb
@@ -15,11 +15,11 @@ if ActiveRecord::Base.connection.supports_migrations?
 
     def test_schema_define
       ActiveRecord::Schema.define(:version => 7) do
-        create_table :fruits do |t|
-          t.column :color, :string
-          t.column :fruit_size, :string  # NOTE: "size" is reserved in Oracle
-          t.column :texture, :string
-          t.column :flavor, :string
+        create_table :fruits do
+          column :color, :string
+          column :fruit_size, :string  # NOTE: "size" is reserved in Oracle
+          column :texture, :string
+          column :flavor, :string
         end
       end
 
@@ -31,8 +31,8 @@ if ActiveRecord::Base.connection.supports_migrations?
     def test_schema_raises_an_error_for_invalid_column_type
       assert_raise NoMethodError do
         ActiveRecord::Schema.define(:version => 8) do
-          create_table :vegetables do |t|
-            t.unknown :color
+          create_table :vegetables do
+            unknown :color
           end
         end
       end

--- a/activerecord/test/cases/ar_schema_test.rb
+++ b/activerecord/test/cases/ar_schema_test.rb
@@ -16,10 +16,10 @@ if ActiveRecord::Base.connection.supports_migrations?
     def test_schema_define
       ActiveRecord::Schema.define(:version => 7) do
         create_table :fruits do
-          column :color, :string
-          column :fruit_size, :string  # NOTE: "size" is reserved in Oracle
-          column :texture, :string
-          column :flavor, :string
+          string :color
+          string :fruit_size  # NOTE: "size" is reserved in Oracle
+          string :texture
+          string :flavor
         end
       end
 

--- a/activerecord/test/cases/associations/eager_singularization_test.rb
+++ b/activerecord/test/cases/associations/eager_singularization_test.rb
@@ -48,7 +48,7 @@ class EagerSingularizationTest < ActiveRecord::TestCase
         string :species
       end
       ActiveRecord::Base.connection.create_table :octopi do
-        string :species, :string
+        string :species
       end
       ActiveRecord::Base.connection.create_table :passes do
         integer :bus_id

--- a/activerecord/test/cases/associations/eager_singularization_test.rb
+++ b/activerecord/test/cases/associations/eager_singularization_test.rb
@@ -43,42 +43,42 @@ class EagerSingularizationTest < ActiveRecord::TestCase
 
   def setup
     if ActiveRecord::Base.connection.supports_migrations?
-      ActiveRecord::Base.connection.create_table :viri do |t|
-        t.column :octopus_id, :integer
-        t.column :species, :string
+      ActiveRecord::Base.connection.create_table :viri do
+        integer :octopus_id
+        string :species
       end
-      ActiveRecord::Base.connection.create_table :octopi do |t|
-        t.column :species, :string
+      ActiveRecord::Base.connection.create_table :octopi do
+        string :species, :string
       end
-      ActiveRecord::Base.connection.create_table :passes do |t|
-        t.column :bus_id, :integer
-        t.column :rides, :integer
+      ActiveRecord::Base.connection.create_table :passes do
+        integer :bus_id
+        integer :rides
       end
-      ActiveRecord::Base.connection.create_table :buses do |t|
-        t.column :name, :string
+      ActiveRecord::Base.connection.create_table :buses do
+        string :name
       end
-      ActiveRecord::Base.connection.create_table :crises_messes, :id => false do |t|
-        t.column :crisis_id, :integer
-        t.column :mess_id, :integer
+      ActiveRecord::Base.connection.create_table :crises_messes, :id => false do
+        integer :crisis_id
+        integer :mess_id
       end
-      ActiveRecord::Base.connection.create_table :messes do |t|
-        t.column :name, :string
+      ActiveRecord::Base.connection.create_table :messes do
+        string :name
       end
-      ActiveRecord::Base.connection.create_table :crises do |t|
-        t.column :name, :string
+      ActiveRecord::Base.connection.create_table :crises do
+        string :name
       end
-      ActiveRecord::Base.connection.create_table :successes do |t|
-        t.column :name, :string
+      ActiveRecord::Base.connection.create_table :successes do
+        string :name
       end
-      ActiveRecord::Base.connection.create_table :analyses do |t|
-        t.column :crisis_id, :integer
-        t.column :success_id, :integer
+      ActiveRecord::Base.connection.create_table :analyses do
+        integer :crisis_id
+        integer :success_id
       end
-      ActiveRecord::Base.connection.create_table :dresses do |t|
-        t.column :crisis_id, :integer
+      ActiveRecord::Base.connection.create_table :dresses do
+        integer :crisis_id
       end
-      ActiveRecord::Base.connection.create_table :compresses do |t|
-        t.column :dress_id, :integer
+      ActiveRecord::Base.connection.create_table :compresses do
+        integer :dress_id
       end
       @have_tables = true
     else

--- a/activerecord/test/cases/associations/habtm_join_table_test.rb
+++ b/activerecord/test/cases/associations/habtm_join_table_test.rb
@@ -10,19 +10,19 @@ end
 
 class HabtmJoinTableTest < ActiveRecord::TestCase
   def setup
-    ActiveRecord::Base.connection.create_table :my_books, :force => true do |t|
-      t.string :name
+    ActiveRecord::Base.connection.create_table :my_books, :force => true do
+      string :name
     end
     assert ActiveRecord::Base.connection.table_exists?(:my_books)
 
-    ActiveRecord::Base.connection.create_table :my_readers, :force => true do |t|
-      t.string :name
+    ActiveRecord::Base.connection.create_table :my_readers, :force => true do
+      string :name
     end
     assert ActiveRecord::Base.connection.table_exists?(:my_readers)
 
-    ActiveRecord::Base.connection.create_table :my_books_my_readers, :force => true do |t|
-      t.integer :my_book_id
-      t.integer :my_reader_id
+    ActiveRecord::Base.connection.create_table :my_books_my_readers, :force => true do
+      integer :my_book_id
+      integer :my_reader_id
     end
     assert ActiveRecord::Base.connection.table_exists?(:my_books_my_readers)
   end

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -11,8 +11,8 @@ module ActiveRecord
           # Separate connections to an in-memory database create an entirely new database,
           # with an empty schema etc, so we just stub out this schema on the fly.
           @pool.with_connection do |connection|
-            connection.create_table :posts do |t|
-              t.integer :cololumn
+            connection.create_table :posts do
+              integer :cololumn
             end
           end
         end

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -59,11 +59,11 @@ if current_adapter?(:MysqlAdapter) or current_adapter?(:Mysql2Adapter)
     def test_mysql_text_not_null_defaults
       klass = Class.new(ActiveRecord::Base)
       klass.table_name = 'test_mysql_text_not_null_defaults'
-      klass.connection.create_table klass.table_name do |t|
-        t.column :non_null_text, :text, :null => false
-        t.column :non_null_blob, :blob, :null => false
-        t.column :null_text, :text, :null => true
-        t.column :null_blob, :blob, :null => true
+      klass.connection.create_table klass.table_name do
+        text :non_null_text, :null => false
+        blob :non_null_blob, :null => false
+        text :null_text, :null => true
+        blob :null_blob, :null => true
       end
       assert_equal '', klass.columns_hash['non_null_blob'].default
       assert_equal '', klass.columns_hash['non_null_text'].default
@@ -87,9 +87,9 @@ if current_adapter?(:MysqlAdapter) or current_adapter?(:Mysql2Adapter)
     def test_mysql_integer_not_null_defaults
       klass = Class.new(ActiveRecord::Base)
       klass.table_name = 'test_integer_not_null_default_zero'
-      klass.connection.create_table klass.table_name do |t|
-        t.column :zero, :integer, :null => false, :default => 0
-        t.column :omit, :integer, :null => false
+      klass.connection.create_table klass.table_name do
+        integer :zero, :null => false, :default => 0
+        integer :omit, :null => false
       end
 
       assert_equal 0, klass.columns_hash['zero'].default

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -93,18 +93,18 @@ class FixturesTest < ActiveRecord::TestCase
       # Reset cache to make finds on the new table work
       ActiveRecord::Fixtures.reset_cache
 
-      ActiveRecord::Base.connection.create_table :prefix_topics_suffix do |t|
-        t.column :title, :string
-        t.column :author_name, :string
-        t.column :author_email_address, :string
-        t.column :written_on, :datetime
-        t.column :bonus_time, :time
-        t.column :last_read, :date
-        t.column :content, :string
-        t.column :approved, :boolean, :default => true
-        t.column :replies_count, :integer, :default => 0
-        t.column :parent_id, :integer
-        t.column :type, :string, :limit => 50
+      ActiveRecord::Base.connection.create_table :prefix_topics_suffix do
+        string :title
+        string :author_name
+        string :author_email_address
+        datetime :written_on
+        time :bonus_time
+        date :last_read
+        string :content
+        boolean :approved, :default => true
+        integer :replies_count, :default => 0
+        integer :parent_id
+        string :type, :limit => 50
       end
 
       # Store existing prefix/suffix

--- a/activerecord/test/migrations/duplicate/2_we_need_reminders.rb
+++ b/activerecord/test/migrations/duplicate/2_we_need_reminders.rb
@@ -1,8 +1,8 @@
 class WeNeedReminders < ActiveRecord::Migration
   def self.up
-    create_table("reminders") do |t|
-      t.column :content, :text
-      t.column :remind_at, :datetime
+    create_table :reminders do
+      text :content
+      datetime :remind_at
     end
   end
 

--- a/activerecord/test/migrations/duplicate/3_innocent_jointable.rb
+++ b/activerecord/test/migrations/duplicate/3_innocent_jointable.rb
@@ -1,8 +1,8 @@
 class InnocentJointable < ActiveRecord::Migration
   def self.up
-    create_table("people_reminders", :id => false) do |t|
-      t.column :reminder_id, :integer
-      t.column :person_id, :integer
+    create_table :people_reminders, :id => false do
+      integer :reminder_id
+      integer :person_id
     end
   end
 

--- a/activerecord/test/migrations/interleaved/pass_1/3_interleaved_innocent_jointable.rb
+++ b/activerecord/test/migrations/interleaved/pass_1/3_interleaved_innocent_jointable.rb
@@ -1,8 +1,8 @@
 class InterleavedInnocentJointable < ActiveRecord::Migration
   def self.up
-    create_table("people_reminders", :id => false) do |t|
-      t.column :reminder_id, :integer
-      t.column :person_id, :integer
+    create_table :people_reminders, :id => false do
+      integer :reminder_id
+      integer :person_id
     end
   end
 

--- a/activerecord/test/migrations/interleaved/pass_2/3_interleaved_innocent_jointable.rb
+++ b/activerecord/test/migrations/interleaved/pass_2/3_interleaved_innocent_jointable.rb
@@ -1,8 +1,8 @@
 class InterleavedInnocentJointable < ActiveRecord::Migration
   def self.up
-    create_table("people_reminders", :id => false) do |t|
-      t.column :reminder_id, :integer
-      t.column :person_id, :integer
+    create_table :people_reminders, :id => false do
+      integer :reminder_id
+      integer :person_id
     end
   end
 

--- a/activerecord/test/migrations/interleaved/pass_3/3_interleaved_innocent_jointable.rb
+++ b/activerecord/test/migrations/interleaved/pass_3/3_interleaved_innocent_jointable.rb
@@ -1,8 +1,8 @@
 class InterleavedInnocentJointable < ActiveRecord::Migration
   def self.up
-    create_table("people_reminders", :id => false) do |t|
-      t.column :reminder_id, :integer
-      t.column :person_id, :integer
+    create_table :people_reminders, :id => false do
+      integer :reminder_id
+      integer :person_id
     end
   end
 

--- a/activerecord/test/migrations/missing/3_we_need_reminders.rb
+++ b/activerecord/test/migrations/missing/3_we_need_reminders.rb
@@ -1,8 +1,8 @@
 class WeNeedReminders < ActiveRecord::Migration
   def self.up
-    create_table("reminders") do |t|
-      t.column :content, :text
-      t.column :remind_at, :datetime
+    create_table :reminders do
+      text :content
+      datetime :remind_at
     end
   end
 

--- a/activerecord/test/migrations/missing/4_innocent_jointable.rb
+++ b/activerecord/test/migrations/missing/4_innocent_jointable.rb
@@ -1,8 +1,8 @@
 class InnocentJointable < ActiveRecord::Migration
   def self.up
-    create_table("people_reminders", :id => false) do |t|
-      t.column :reminder_id, :integer
-      t.column :person_id, :integer
+    create_table :people_reminders, :id => false do
+      integer :reminder_id
+      integer :person_id
     end
   end
 

--- a/activerecord/test/migrations/valid/2_we_need_reminders.rb
+++ b/activerecord/test/migrations/valid/2_we_need_reminders.rb
@@ -1,8 +1,8 @@
 class WeNeedReminders < ActiveRecord::Migration
   def self.up
-    create_table("reminders") do |t|
-      t.column :content, :text
-      t.column :remind_at, :datetime
+    create_table :reminders do
+      text :content
+      datetime :remind_at
     end
   end
 

--- a/activerecord/test/migrations/valid/3_innocent_jointable.rb
+++ b/activerecord/test/migrations/valid/3_innocent_jointable.rb
@@ -1,8 +1,8 @@
 class InnocentJointable < ActiveRecord::Migration
   def self.up
-    create_table("people_reminders", :id => false) do |t|
-      t.column :reminder_id, :integer
-      t.column :person_id, :integer
+    create_table :people_reminders, :id => false do
+      integer :reminder_id
+      integer :person_id
     end
   end
 

--- a/activerecord/test/migrations/valid_with_timestamps/20100201010101_valid_with_timestamps_we_need_reminders.rb
+++ b/activerecord/test/migrations/valid_with_timestamps/20100201010101_valid_with_timestamps_we_need_reminders.rb
@@ -1,8 +1,8 @@
 class ValidWithTimestampsWeNeedReminders < ActiveRecord::Migration
   def self.up
-    create_table("reminders") do |t|
-      t.column :content, :text
-      t.column :remind_at, :datetime
+    create_table :reminders do
+      text :content
+      datetime :remind_at
     end
   end
 

--- a/activerecord/test/migrations/valid_with_timestamps/20100301010101_valid_with_timestamps_innocent_jointable.rb
+++ b/activerecord/test/migrations/valid_with_timestamps/20100301010101_valid_with_timestamps_innocent_jointable.rb
@@ -1,8 +1,8 @@
 class ValidWithTimestampsInnocentJointable < ActiveRecord::Migration
   def self.up
-    create_table("people_reminders", :id => false) do |t|
-      t.column :reminder_id, :integer
-      t.column :person_id, :integer
+    create_table :people_reminders, :id => false do
+      integer :reminder_id
+      integer :person_id
     end
   end
 

--- a/activerecord/test/schema/mysql2_specific_schema.rb
+++ b/activerecord/test/schema/mysql2_specific_schema.rb
@@ -1,13 +1,13 @@
 ActiveRecord::Schema.define do
-  create_table :binary_fields, :force => true, :options => 'CHARACTER SET latin1' do |t|
-    t.binary :tiny_blob,   :limit => 255
-    t.binary :normal_blob, :limit => 65535
-    t.binary :medium_blob, :limit => 16777215
-    t.binary :long_blob,   :limit => 2147483647
-    t.text   :tiny_text,   :limit => 255
-    t.text   :normal_text, :limit => 65535
-    t.text   :medium_text, :limit => 16777215
-    t.text   :long_text,   :limit => 2147483647
+  create_table :binary_fields, :force => true, :options => 'CHARACTER SET latin1' do
+    binary :tiny_blob,   :limit => 255
+    binary :normal_blob, :limit => 65535
+    binary :medium_blob, :limit => 16777215
+    binary :long_blob,   :limit => 2147483647
+    text   :tiny_text,   :limit => 255
+    text   :normal_text, :limit => 65535
+    text   :medium_text, :limit => 16777215
+    text   :long_text,   :limit => 2147483647
   end
 
   ActiveRecord::Base.connection.execute <<-SQL

--- a/activerecord/test/schema/mysql_specific_schema.rb
+++ b/activerecord/test/schema/mysql_specific_schema.rb
@@ -1,13 +1,13 @@
 ActiveRecord::Schema.define do
-  create_table :binary_fields, :force => true, :options => 'CHARACTER SET latin1' do |t|
-    t.binary :tiny_blob,   :limit => 255
-    t.binary :normal_blob, :limit => 65535
-    t.binary :medium_blob, :limit => 16777215
-    t.binary :long_blob,   :limit => 2147483647
-    t.text   :tiny_text,   :limit => 255
-    t.text   :normal_text, :limit => 65535
-    t.text   :medium_text, :limit => 16777215
-    t.text   :long_text,   :limit => 2147483647
+  create_table :binary_fields, :force => true, :options => 'CHARACTER SET latin1' do
+    binary :tiny_blob,   :limit => 255
+    binary :normal_blob, :limit => 65535
+    binary :medium_blob, :limit => 16777215
+    binary :long_blob,   :limit => 2147483647
+    text   :tiny_text,   :limit => 255
+    text   :normal_text, :limit => 65535
+    text   :medium_text, :limit => 16777215
+    text   :long_text,   :limit => 2147483647
   end
 
   ActiveRecord::Base.connection.execute <<-SQL

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -25,708 +25,704 @@ ActiveRecord::Schema.define do
   #                                                                     #
   # ------------------------------------------------------------------- #
 
-  create_table :accounts, :force => true do |t|
-    t.integer :firm_id
-    t.string  :firm_name
-    t.integer :credit_limit
+  create_table :accounts, :force => true do
+    integer :firm_id
+    string  :firm_name
+    integer :credit_limit
   end
 
-  create_table :admin_accounts, :force => true do |t|
-    t.string :name
+  create_table :admin_accounts, :force => true do
+    string :name
   end
 
-  create_table :admin_users, :force => true do |t|
-    t.string :name
-    t.text :settings
-    t.references :account
+  create_table :admin_users, :force => true do
+    string :name
+    text :settings
+    references :account
   end
 
-  create_table :aircraft, :force => true do |t|
-    t.string :name
+  create_table :aircraft, :force => true do
+    string :name
   end
 
-  create_table :audit_logs, :force => true do |t|
-    t.column :message, :string, :null=>false
-    t.column :developer_id, :integer, :null=>false
-    t.integer :unvalidated_developer_id
+  create_table :audit_logs, :force => true do
+    string :message, :null => false
+    integer :developer_id, :null => false
+    integer :unvalidated_developer_id
   end
 
-  create_table :authors, :force => true do |t|
-    t.string :name, :null => false
-    t.integer :author_address_id
-    t.integer :author_address_extra_id
-    t.string :organization_id
-    t.string :owned_essay_id
+  create_table :authors, :force => true do
+    string :name, :null => false
+    integer :author_address_id
+    integer :author_address_extra_id
+    string :organization_id
+    string :owned_essay_id
   end
 
-  create_table :author_addresses, :force => true do |t|
+  create_table :author_addresses, :force => true
+
+  create_table :author_favorites, :force => true do
+    integer :author_id
+    integer :favorite_author_id
   end
 
-  create_table :author_favorites, :force => true do |t|
-    t.column :author_id, :integer
-    t.column :favorite_author_id, :integer
+  create_table :auto_id_tests, :force => true, :id => false do
+    primary_key :auto_id
+    integer     :value
   end
 
-  create_table :auto_id_tests, :force => true, :id => false do |t|
-    t.primary_key :auto_id
-    t.integer     :value
+  create_table :binaries, :force => true do
+    string :name
+    binary :data
   end
 
-  create_table :binaries, :force => true do |t|
-    t.string :name
-    t.binary :data
+  create_table :birds, :force => true do
+    string :name
+    string :color
+    integer :pirate_id
   end
 
-  create_table :birds, :force => true do |t|
-    t.string :name
-    t.string :color
-    t.integer :pirate_id
+  create_table :books, :force => true do
+    integer :author_id
+    column :name, :string
   end
 
-  create_table :books, :force => true do |t|
-    t.integer :author_id
-    t.column :name, :string
+  create_table :booleans, :force => true do
+    boolean :value
   end
 
-  create_table :booleans, :force => true do |t|
-    t.boolean :value
+  create_table :bulbs, :force => true do
+    integer :car_id
+    string  :name
+    boolean :frickinawesome
+    string :color
   end
 
-  create_table :bulbs, :force => true do |t|
-    t.integer :car_id
-    t.string  :name
-    t.boolean :frickinawesome
-    t.string :color
+  create_table "CamelCase", :force => true do
+    string :name
   end
 
-  create_table "CamelCase", :force => true do |t|
-    t.string :name
+  create_table :cars, :force => true do
+    string  :name
+    integer :engines_count
+    integer :wheels_count
   end
 
-  create_table :cars, :force => true do |t|
-    t.string  :name
-    t.integer :engines_count
-    t.integer :wheels_count
+  create_table :categories, :force => true do
+    string :name, :null => false
+    string :type
+    integer :categorizations_count
   end
 
-  create_table :categories, :force => true do |t|
-    t.string :name, :null => false
-    t.string :type
-    t.integer :categorizations_count
+  create_table :categories_posts, :force => true, :id => false do
+    integer :category_id, :null => false
+    integer :post_id, :null => false
   end
 
-  create_table :categories_posts, :force => true, :id => false do |t|
-    t.integer :category_id, :null => false
-    t.integer :post_id, :null => false
+  create_table :categorizations, :force => true do
+    integer :category_id
+    string :named_category_name
+    integer :post_id
+    integer :author_id
+    boolean :special
   end
 
-  create_table :categorizations, :force => true do |t|
-    t.column :category_id, :integer
-    t.string :named_category_name
-    t.column :post_id, :integer
-    t.column :author_id, :integer
-    t.column :special, :boolean
+  create_table :citations, :force => true do
+    integer :book1_id
+    integer :book2_id
   end
 
-  create_table :citations, :force => true do |t|
-    t.column :book1_id, :integer
-    t.column :book2_id, :integer
+  create_table :clubs, :force => true do
+    string :name
+    integer :category_id
   end
 
-  create_table :clubs, :force => true do |t|
-    t.string :name
-    t.integer :category_id
+  create_table :collections, :force => true do
+    string :name
   end
 
-  create_table :collections, :force => true do |t|
-    t.string :name
+  create_table :colnametests, :force => true do
+    integer :references, :null => false
   end
 
-  create_table :colnametests, :force => true do |t|
-    t.integer :references, :null => false
-  end
-
-  create_table :comments, :force => true do |t|
-    t.integer :post_id, :null => false
+  create_table :comments, :force => true do
+    integer :post_id, :null => false
     # use VARCHAR2(4000) instead of CLOB datatype as CLOB data type has many limitations in
     # Oracle SELECT WHERE clause which causes many unit test failures
     if current_adapter?(:OracleAdapter)
-      t.string  :body, :null => false, :limit => 4000
+      string  :body, :null => false, :limit => 4000
     else
-      t.text    :body, :null => false
+      text    :body, :null => false
     end
-    t.string  :type
-    t.integer :taggings_count, :default => 0
-    t.integer :children_count, :default => 0
-    t.integer :parent_id
+    string  :type
+    integer :taggings_count, :default => 0
+    integer :children_count, :default => 0
+    integer :parent_id
   end
 
-  create_table :companies, :force => true do |t|
-    t.string  :type
-    t.string  :ruby_type
-    t.integer :firm_id
-    t.string  :firm_name
-    t.string  :name
-    t.integer :client_of
-    t.integer :rating, :default => 1
-    t.integer :account_id
+  create_table :companies, :force => true do
+    string  :type
+    string  :ruby_type
+    integer :firm_id
+    string  :firm_name
+    string  :name
+    integer :client_of
+    integer :rating, :default => 1
+    integer :account_id
   end
 
   add_index :companies, [:firm_id, :type, :rating, :ruby_type], :name => "company_index"
 
-  create_table :computers, :force => true do |t|
-    t.integer :developer, :null => false
-    t.integer :extendedWarranty, :null => false
+  create_table :computers, :force => true do
+    integer :developer, :null => false
+    integer :extendedWarranty, :null => false
   end
 
-  create_table :contracts, :force => true do |t|
-    t.integer :developer_id
-    t.integer :company_id
+  create_table :contracts, :force => true do
+    integer :developer_id
+    integer :company_id
   end
 
-  create_table :customers, :force => true do |t|
-    t.string  :name
-    t.integer :balance, :default => 0
-    t.string  :address_street
-    t.string  :address_city
-    t.string  :address_country
-    t.string  :gps_location
+  create_table :customers, :force => true do
+    string  :name
+    integer :balance, :default => 0
+    string  :address_street
+    string  :address_city
+    string  :address_country
+    string  :gps_location
   end
 
-  create_table :dashboards, :force => true, :id => false do |t|
-    t.string :dashboard_id
-    t.string :name
+  create_table :dashboards, :force => true, :id => false do
+    string :dashboard_id
+    string :name
   end
 
-  create_table :developers, :force => true do |t|
-    t.string   :name
-    t.integer  :salary, :default => 70000
-    t.datetime :created_at
-    t.datetime :updated_at
+  create_table :developers, :force => true do
+    string   :name
+    integer  :salary, :default => 70000
+    datetime :created_at
+    datetime :updated_at
   end
 
-  create_table :developers_projects, :force => true, :id => false do |t|
-    t.integer :developer_id, :null => false
-    t.integer :project_id, :null => false
-    t.date    :joined_on
-    t.integer :access_level, :default => 1
+  create_table :developers_projects, :force => true, :id => false do
+    integer :developer_id, :null => false
+    integer :project_id, :null => false
+    date    :joined_on
+    integer :access_level, :default => 1
   end
 
-  create_table :edges, :force => true, :id => false do |t|
-    t.column :source_id, :integer, :null => false
-    t.column :sink_id,   :integer, :null => false
+  create_table :edges, :force => true, :id => false do
+    column :source_id, :integer, :null => false
+    column :sink_id,   :integer, :null => false
   end
   add_index :edges, [:source_id, :sink_id], :unique => true, :name => 'unique_edge_index'
 
-  create_table :engines, :force => true do |t|
-    t.integer :car_id
+  create_table :engines, :force => true do
+    integer :car_id
   end
 
-  create_table :entrants, :force => true do |t|
-    t.string  :name, :null => false
-    t.integer :course_id, :null => false
+  create_table :entrants, :force => true do
+    string  :name, :null => false
+    integer :course_id, :null => false
   end
 
-  create_table :essays, :force => true do |t|
-    t.string :name
-    t.string :writer_id
-    t.string :writer_type
-    t.string :category_id
-    t.string :author_id
+  create_table :essays, :force => true do
+    string :name
+    string :writer_id
+    string :writer_type
+    string :category_id
+    string :author_id
   end
 
-  create_table :events, :force => true do |t|
-    t.string :title, :limit => 5
+  create_table :events, :force => true do
+    string :title, :limit => 5
   end
 
-  create_table :eyes, :force => true do |t|
+  create_table :eyes, :force => true
+
+  create_table :funny_jokes, :force => true do
+    string :name
   end
 
-  create_table :funny_jokes, :force => true do |t|
-    t.string :name
+  create_table :cold_jokes, :force => true do
+    string :name
   end
 
-  create_table :cold_jokes, :force => true do |t|
-    t.string :name
+  create_table :goofy_string_id, :force => true, :id => false do
+    string :id, :null => false
+    string :info
   end
 
-  create_table :goofy_string_id, :force => true, :id => false do |t|
-    t.string :id, :null => false
-    t.string :info
+  create_table :guids, :force => true do
+    column :key, :string
   end
 
-  create_table :guids, :force => true do |t|
-    t.column :key, :string
+  create_table :inept_wizards, :force => true do
+    string :name, :null => false
+    string :city, :null => false
+    string :type
   end
 
-  create_table :inept_wizards, :force => true do |t|
-    t.column :name, :string, :null => false
-    t.column :city, :string, :null => false
-    t.column :type, :string
-  end
-
-  create_table :integer_limits, :force => true do |t|
-    t.integer :"c_int_without_limit"
+  create_table :integer_limits, :force => true do
+    integer :"c_int_without_limit"
     (1..8).each do |i|
-      t.integer :"c_int_#{i}", :limit => i
+      integer :"c_int_#{i}", :limit => i
     end
   end
 
-  create_table :invoices, :force => true do |t|
-    t.integer :balance
-    t.datetime :updated_at
+  create_table :invoices, :force => true do
+    integer :balance
+    datetime :updated_at
   end
 
-  create_table :iris, :force => true do |t|
-    t.references :eye
-    t.string     :color
+  create_table :iris, :force => true do
+    references :eye
+    string     :color
   end
 
-  create_table :items, :force => true do |t|
-    t.column :name, :string
+  create_table :items, :force => true do
+    string :name
   end
 
-  create_table :jobs, :force => true do |t|
-    t.integer :ideal_reference_id
+  create_table :jobs, :force => true do
+    integer :ideal_reference_id
   end
 
-  create_table :keyboards, :force => true, :id  => false do |t|
-    t.primary_key :key_number
-    t.string      :name
+  create_table :keyboards, :force => true, :id  => false do
+    primary_key :key_number
+    string      :name
   end
 
-  create_table :legacy_things, :force => true do |t|
-    t.integer :tps_report_number
-    t.integer :version, :null => false, :default => 0
+  create_table :legacy_things, :force => true do
+    integer :tps_report_number
+    integer :version, :null => false, :default => 0
   end
 
-  create_table :lessons, :force => true do |t|
-    t.string :name
+  create_table :lessons, :force => true do
+    string :name
   end
 
-  create_table :lessons_students, :id => false, :force => true do |t|
-    t.references :lesson
-    t.references :student
+  create_table :lessons_students, :id => false, :force => true do
+    references :lesson
+    references :student
   end
 
   create_table :lint_models, :force => true
 
-  create_table :line_items, :force => true do |t|
-    t.integer :invoice_id
-    t.integer :amount
+  create_table :line_items, :force => true do
+    integer :invoice_id
+    integer :amount
   end
 
-  create_table :lock_without_defaults, :force => true do |t|
-    t.column :lock_version, :integer
+  create_table :lock_without_defaults, :force => true do
+    integer :lock_version
   end
 
-  create_table :lock_without_defaults_cust, :force => true do |t|
-    t.column :custom_lock_version, :integer
+  create_table :lock_without_defaults_cust, :force => true do
+    integer :custom_lock_version
   end
 
-  create_table :mateys, :id => false, :force => true do |t|
-    t.column :pirate_id, :integer
-    t.column :target_id, :integer
-    t.column :weight, :integer
+  create_table :mateys, :id => false, :force => true do
+    integer :pirate_id
+    integer :target_id
+    integer :weight
   end
 
-  create_table :members, :force => true do |t|
-    t.string :name
-    t.integer :member_type_id
+  create_table :members, :force => true do
+    string :name
+    integer :member_type_id
   end
 
-  create_table :member_details, :force => true do |t|
-    t.integer :member_id
-    t.integer :organization_id
-    t.string :extra_data
+  create_table :member_details, :force => true do
+    integer :member_id
+    integer :organization_id
+    string :extra_data
   end
 
-  create_table :memberships, :force => true do |t|
-    t.datetime :joined_on
-    t.integer :club_id, :member_id
-    t.boolean :favourite, :default => false
-    t.string :type
+  create_table :memberships, :force => true do
+    datetime :joined_on
+    integer :club_id, :member_id
+    boolean :favourite, :default => false
+    string :type
   end
 
-  create_table :member_types, :force => true do |t|
-    t.string :name
+  create_table :member_types, :force => true do
+    string :name
   end
 
-  create_table :minivans, :force => true, :id => false do |t|
-    t.string :minivan_id
-    t.string :name
-    t.string :speedometer_id
-    t.string :color
+  create_table :minivans, :force => true, :id => false do
+    string :minivan_id
+    string :name
+    string :speedometer_id
+    string :color
   end
 
-  create_table :minimalistics, :force => true do |t|
+  create_table :minimalistics, :force => true
+
+  create_table :mixed_case_monkeys, :force => true, :id => false do
+    primary_key :monkeyID
+    integer     :fleaCount
   end
 
-  create_table :mixed_case_monkeys, :force => true, :id => false do |t|
-    t.primary_key :monkeyID
-    t.integer     :fleaCount
+  create_table :mixins, :force => true do
+    integer  :parent_id
+    integer  :pos
+    datetime :created_at
+    datetime :updated_at
+    integer  :lft
+    integer  :rgt
+    integer  :root_id
+    string   :type
   end
 
-  create_table :mixins, :force => true do |t|
-    t.integer  :parent_id
-    t.integer  :pos
-    t.datetime :created_at
-    t.datetime :updated_at
-    t.integer  :lft
-    t.integer  :rgt
-    t.integer  :root_id
-    t.string   :type
+  create_table :movies, :force => true, :id => false do
+    primary_key :movieid
+    string      :name
   end
 
-  create_table :movies, :force => true, :id => false do |t|
-    t.primary_key :movieid
-    t.string      :name
-  end
-
-  create_table :numeric_data, :force => true do |t|
-    t.decimal :bank_balance, :precision => 10, :scale => 2
-    t.decimal :big_bank_balance, :precision => 15, :scale => 2
-    t.decimal :world_population, :precision => 10, :scale => 0
-    t.decimal :my_house_population, :precision => 2, :scale => 0
-    t.decimal :decimal_number_with_default, :precision => 3, :scale => 2, :default => 2.78
-    t.float   :temperature
+  create_table :numeric_data, :force => true do
+    decimal :bank_balance, :precision => 10, :scale => 2
+    decimal :big_bank_balance, :precision => 15, :scale => 2
+    decimal :world_population, :precision => 10, :scale => 0
+    decimal :my_house_population, :precision => 2, :scale => 0
+    decimal :decimal_number_with_default, :precision => 3, :scale => 2, :default => 2.78
+    float   :temperature
     # Oracle/SQLServer supports precision up to 38
     if current_adapter?(:OracleAdapter,:SQLServerAdapter)
-      t.decimal :atoms_in_universe, :precision => 38, :scale => 0
+      decimal :atoms_in_universe, :precision => 38, :scale => 0
     else
-      t.decimal :atoms_in_universe, :precision => 55, :scale => 0
+      decimal :atoms_in_universe, :precision => 55, :scale => 0
     end
   end
 
-  create_table :orders, :force => true do |t|
-    t.string  :name
-    t.integer :billing_customer_id
-    t.integer :shipping_customer_id
+  create_table :orders, :force => true do
+    string  :name
+    integer :billing_customer_id
+    integer :shipping_customer_id
   end
 
-  create_table :organizations, :force => true do |t|
-    t.string :name
+  create_table :organizations, :force => true do
+    string :name
   end
 
-  create_table :owners, :primary_key => :owner_id ,:force => true do |t|
-    t.string :name
-    t.column :updated_at, :datetime
-    t.column :happy_at,   :datetime
-    t.string :essay_id
+  create_table :owners, :primary_key => :owner_id, :force => true do
+    string :name
+    datetime :updated_at
+    datetime :happy_at
+    string :essay_id
   end
 
-  create_table :paint_colors, :force => true do |t|
-    t.integer :non_poly_one_id
+  create_table :paint_colors, :force => true do
+    integer :non_poly_one_id
   end
 
-  create_table :paint_textures, :force => true do |t|
-    t.integer :non_poly_two_id
+  create_table :paint_textures, :force => true do
+    integer :non_poly_two_id
   end
 
-  create_table :parrots, :force => true do |t|
-    t.column :name, :string
-    t.column :parrot_sti_class, :string
-    t.column :killer_id, :integer
-    t.column :created_at, :datetime
-    t.column :created_on, :datetime
-    t.column :updated_at, :datetime
-    t.column :updated_on, :datetime
+  create_table :parrots, :force => true do
+    string :name
+    string :parrot_sti_class
+    integer :killer_id
+    datetime :created_at
+    datetime :created_on
+    datetime :updated_at
+    datetime :updated_on
   end
 
-  create_table :parrots_pirates, :id => false, :force => true do |t|
-    t.column :parrot_id, :integer
-    t.column :pirate_id, :integer
+  create_table :parrots_pirates, :id => false, :force => true do
+    integer :parrot_id
+    integer :pirate_id
   end
 
-  create_table :parrots_treasures, :id => false, :force => true do |t|
-    t.column :parrot_id, :integer
-    t.column :treasure_id, :integer
+  create_table :parrots_treasures, :id => false, :force => true do
+    integer :parrot_id
+    integer :treasure_id
   end
 
-  create_table :people, :force => true do |t|
-    t.string     :first_name, :null => false
-    t.references :primary_contact
-    t.string     :gender, :limit => 1
-    t.references :number1_fan
-    t.integer    :lock_version, :null => false, :default => 0
-    t.string     :comments
-    t.references :best_friend
-    t.references :best_friend_of
-    t.timestamps
+  create_table :people, :force => true do
+    string     :first_name, :null => false
+    references :primary_contact
+    string     :gender, :limit => 1
+    references :number1_fan
+    integer    :lock_version, :null => false, :default => 0
+    string     :comments
+    references :best_friend
+    references :best_friend_of
+    timestamps
   end
 
-  create_table :pets, :primary_key => :pet_id ,:force => true do |t|
-    t.string :name
-    t.integer :owner_id, :integer
-    t.timestamps
+  create_table :pets, :primary_key => :pet_id, :force => true do
+    string :name
+    integer :owner_id, :integer
+    timestamps
   end
 
-  create_table :pirates, :force => true do |t|
-    t.column :catchphrase, :string
-    t.column :parrot_id, :integer
-    t.integer :non_validated_parrot_id
-    t.column :created_on, :datetime
-    t.column :updated_on, :datetime
+  create_table :pirates, :force => true do
+    string :catchphrase
+    integer :parrot_id
+    integer :non_validated_parrot_id
+    datetime :created_on
+    datetime :updated_on
   end
 
-  create_table :posts, :force => true do |t|
-    t.integer :author_id
-    t.string  :title, :null => false
+  create_table :posts, :force => true do
+    integer :author_id
+    string  :title, :null => false
     # use VARCHAR2(4000) instead of CLOB datatype as CLOB data type has many limitations in
     # Oracle SELECT WHERE clause which causes many unit test failures
     if current_adapter?(:OracleAdapter)
-      t.string  :body, :null => false, :limit => 4000
+      string  :body, :null => false, :limit => 4000
     else
-      t.text    :body, :null => false
+      text    :body, :null => false
     end
-    t.string  :type
-    t.integer :comments_count, :default => 0
-    t.integer :taggings_count, :default => 0
-    t.integer :taggings_with_delete_all_count, :default => 0
-    t.integer :taggings_with_destroy_count, :default => 0
-    t.integer :tags_count, :default => 0
-    t.integer :tags_with_destroy_count, :default => 0
-    t.integer :tags_with_nullify_count, :default => 0
+    string  :type
+    integer :comments_count, :default => 0
+    integer :taggings_count, :default => 0
+    integer :taggings_with_delete_all_count, :default => 0
+    integer :taggings_with_destroy_count, :default => 0
+    integer :tags_count, :default => 0
+    integer :tags_with_destroy_count, :default => 0
+    integer :tags_with_nullify_count, :default => 0
   end
 
-  create_table :price_estimates, :force => true do |t|
-    t.string :estimate_of_type
-    t.integer :estimate_of_id
-    t.integer :price
+  create_table :price_estimates, :force => true do
+    string :estimate_of_type
+    integer :estimate_of_id
+    integer :price
   end
 
-  create_table :products, :force => true do |t|
-    t.references :collection
-    t.string     :name
+  create_table :products, :force => true do
+    references :collection
+    string     :name
   end
 
-  create_table :projects, :force => true do |t|
-    t.string :name
-    t.string :type
+  create_table :projects, :force => true do
+    string :name
+    string :type
   end
 
-  create_table :ratings, :force => true do |t|
-    t.integer :comment_id
-    t.integer :value
+  create_table :ratings, :force => true do
+    integer :comment_id
+    integer :value
   end
 
-  create_table :readers, :force => true do |t|
-    t.integer :post_id, :null => false
-    t.integer :person_id, :null => false
-    t.boolean :skimmer, :default => false
+  create_table :readers, :force => true do
+    integer :post_id, :null => false
+    integer :person_id, :null => false
+    boolean :skimmer, :default => false
   end
 
-  create_table :references, :force => true do |t|
-    t.integer :person_id
-    t.integer :job_id
-    t.boolean :favourite
-    t.integer :lock_version, :default => 0
+  create_table :references, :force => true do
+    integer :person_id
+    integer :job_id
+    boolean :favourite
+    integer :lock_version, :default => 0
   end
 
-  create_table :shape_expressions, :force => true do |t|
-    t.string  :paint_type
-    t.integer :paint_id
-    t.string  :shape_type
-    t.integer :shape_id
+  create_table :shape_expressions, :force => true do
+    string  :paint_type
+    integer :paint_id
+    string  :shape_type
+    integer :shape_id
   end
 
-  create_table :ships, :force => true do |t|
-    t.string :name
-    t.integer :pirate_id
-    t.integer :update_only_pirate_id
-    t.datetime :created_at
-    t.datetime :created_on
-    t.datetime :updated_at
-    t.datetime :updated_on
+  create_table :ships, :force => true do
+    string :name
+    integer :pirate_id
+    integer :update_only_pirate_id
+    datetime :created_at
+    datetime :created_on
+    datetime :updated_at
+    datetime :updated_on
   end
 
-  create_table :ship_parts, :force => true do |t|
-    t.string :name
-    t.integer :ship_id
+  create_table :ship_parts, :force => true do
+    string :name
+    integer :ship_id
   end
 
-  create_table :speedometers, :force => true, :id => false do |t|
-    t.string :speedometer_id
-    t.string :name
-    t.string :dashboard_id
+  create_table :speedometers, :force => true, :id => false do
+    string :speedometer_id
+    string :name
+    string :dashboard_id
   end
 
-  create_table :sponsors, :force => true do |t|
-    t.integer :club_id
-    t.integer :sponsorable_id
-    t.string :sponsorable_type
+  create_table :sponsors, :force => true do
+    integer :club_id
+    integer :sponsorable_id
+    string :sponsorable_type
   end
 
-  create_table :string_key_objects, :id => false, :primary_key => :id, :force => true do |t|
-    t.string     :id
-    t.string     :name
-    t.integer    :lock_version, :null => false, :default => 0
+  create_table :string_key_objects, :id => false, :primary_key => :id, :force => true do
+    string :id
+    string :name
+    integer :lock_version, :null => false, :default => 0
   end
 
-  create_table :students, :force => true do |t|
-    t.string :name
+  create_table :students, :force => true do
+    string :name
   end
 
-  create_table :subscribers, :force => true, :id => false do |t|
-    t.string :nick, :null => false
-    t.string :name
+  create_table :subscribers, :force => true, :id => false do
+    string :nick, :null => false
+    string :name
   end
   add_index :subscribers, :nick, :unique => true
 
-  create_table :subscriptions, :force => true do |t|
-    t.string :subscriber_id
-    t.integer :book_id
+  create_table :subscriptions, :force => true do
+    string :subscriber_id
+    integer :book_id
   end
 
-  create_table :tags, :force => true do |t|
-    t.column :name, :string
-    t.column :taggings_count, :integer, :default => 0
+  create_table :tags, :force => true do
+    string :name
+    integer :taggings_count, :default => 0
   end
 
-  create_table :taggings, :force => true do |t|
-    t.column :tag_id, :integer
-    t.column :super_tag_id, :integer
-    t.column :taggable_type, :string
-    t.column :taggable_id, :integer
-    t.string :comment
+  create_table :taggings, :force => true do
+    integer :tag_id
+    integer :super_tag_id
+    string :taggable_type
+    integer :taggable_id
+    string :comment
   end
 
-  create_table :tasks, :force => true do |t|
-    t.datetime :starting
-    t.datetime :ending
+  create_table :tasks, :force => true do
+    datetime :starting
+    datetime :ending
   end
 
-  create_table :topics, :force => true do |t|
-    t.string   :title
-    t.string   :author_name
-    t.string   :author_email_address
-    t.datetime :written_on
-    t.time     :bonus_time
-    t.date     :last_read
+  create_table :topics, :force => true do
+    string   :title
+    string   :author_name
+    string   :author_email_address
+    datetime :written_on
+    time     :bonus_time
+    date     :last_read
     # use VARCHAR2(4000) instead of CLOB datatype as CLOB data type has many limitations in
     # Oracle SELECT WHERE clause which causes many unit test failures
     if current_adapter?(:OracleAdapter)
-      t.string   :content, :limit => 4000
+      string   :content, :limit => 4000
     else
-      t.text     :content
+      text     :content
     end
-    t.boolean  :approved, :default => true
-    t.integer  :replies_count, :default => 0
-    t.integer  :parent_id
-    t.string   :parent_title
-    t.string   :type
-    t.string   :group
-    t.timestamps
+    boolean  :approved, :default => true
+    integer  :replies_count, :default => 0
+    integer  :parent_id
+    string   :parent_title
+    string   :type
+    string   :group
+    timestamps
   end
 
-  create_table :toys, :primary_key => :toy_id ,:force => true do |t|
-    t.string :name
-    t.integer :pet_id, :integer
-    t.timestamps
+  create_table :toys, :primary_key => :toy_id, :force => true do
+    string :name
+    integer :pet_id, :integer
+    timestamps
   end
 
-  create_table :traffic_lights, :force => true do |t|
-    t.string   :location
-    t.string   :state
-    t.datetime :created_at
-    t.datetime :updated_at
+  create_table :traffic_lights, :force => true do
+    string   :location
+    string   :state
+    datetime :created_at
+    datetime :updated_at
   end
 
-  create_table :treasures, :force => true do |t|
-    t.column :name, :string
-    t.column :looter_id, :integer
-    t.column :looter_type, :string
+  create_table :treasures, :force => true do
+    string :name
+    integer :looter_id
+    string :looter_type
   end
 
-  create_table :tyres, :force => true do |t|
-    t.integer :car_id
+  create_table :tyres, :force => true do
+    integer :car_id
   end
 
-  create_table :variants, :force => true do |t|
-    t.references :product
-    t.string     :name
+  create_table :variants, :force => true do
+    references :product
+    string     :name
   end
 
-  create_table :vertices, :force => true do |t|
-    t.column :label, :string
+  create_table :vertices, :force => true do
+    string :label
   end
 
-  create_table 'warehouse-things', :force => true do |t|
-    t.integer :value
+  create_table 'warehouse-things', :force => true do
+    integer :value
   end
 
-  [:circles, :squares, :triangles, :non_poly_ones, :non_poly_twos].each do |t|
-    create_table(t, :force => true) { }
+  [:circles, :squares, :triangles, :non_poly_ones, :non_poly_twos].each do |table|
+    create_table table, :force => true
   end
 
   # NOTE - the following 4 tables are used by models that have :inverse_of options on the associations
-  create_table :men, :force => true do |t|
-    t.string  :name
+  create_table :men, :force => true do
+    string  :name
   end
 
-  create_table :faces, :force => true do |t|
-    t.string  :description
-    t.integer :man_id
-    t.integer :polymorphic_man_id
-    t.string  :polymorphic_man_type
-    t.integer :horrible_polymorphic_man_id
-    t.string  :horrible_polymorphic_man_type
+  create_table :faces, :force => true do
+    string  :description
+    integer :man_id
+    integer :polymorphic_man_id
+    string  :polymorphic_man_type
+    integer :horrible_polymorphic_man_id
+    string  :horrible_polymorphic_man_type
   end
 
-  create_table :interests, :force => true do |t|
-    t.string :topic
-    t.integer :man_id
-    t.integer :polymorphic_man_id
-    t.string :polymorphic_man_type
-    t.integer :zine_id
+  create_table :interests, :force => true do
+    string :topic
+    integer :man_id
+    integer :polymorphic_man_id
+    string :polymorphic_man_type
+    integer :zine_id
   end
 
-  create_table :wheels, :force => true do |t|
-    t.references :wheelable, :polymorphic => true
+  create_table :wheels, :force => true do
+    references :wheelable, :polymorphic => true
   end
 
-  create_table :zines, :force => true do |t|
-    t.string :title
+  create_table :zines, :force => true do
+    string :title
   end
 
-  create_table :countries, :force => true, :id => false, :primary_key => 'country_id' do |t|
-    t.string :country_id
-    t.string :name
+  create_table :countries, :force => true, :id => false, :primary_key => 'country_id' do
+    string :country_id
+    string :name
   end
-  create_table :treaties, :force => true, :id => false, :primary_key => 'treaty_id' do |t|
-    t.string :treaty_id
-    t.string :name
+  create_table :treaties, :force => true, :id => false, :primary_key => 'treaty_id' do
+    string :treaty_id
+    string :name
   end
-  create_table :countries_treaties, :force => true, :id => false do |t|
-    t.string :country_id, :null => false
-    t.string :treaty_id, :null => false
-    t.datetime :created_at
-    t.datetime :updated_at
+  create_table :countries_treaties, :force => true, :id => false do
+    string :country_id, :null => false
+    string :treaty_id, :null => false
+    datetime :created_at
+    datetime :updated_at
   end
 
-  create_table :liquid, :force => true do |t|
-    t.string :name
+  create_table :liquid, :force => true do
+    string :name
   end
-  create_table :molecules, :force => true do |t|
-    t.integer :liquid_id
-    t.string :name
+  create_table :molecules, :force => true do
+    integer :liquid_id
+    string :name
   end
-  create_table :electrons, :force => true do |t|
-    t.integer :molecule_id
-    t.string :name
+  create_table :electrons, :force => true do
+    integer :molecule_id
+    string :name
   end
-  create_table :weirds, :force => true do |t|
-    t.string 'a$b'
+  create_table :weirds, :force => true do
+    string 'a$b'
   end
 
   except 'SQLite' do
     # fk_test_has_fk should be before fk_test_has_pk
-    create_table :fk_test_has_fk, :force => true do |t|
-      t.integer :fk_id, :null => false
+    create_table :fk_test_has_fk, :force => true do
+      integer :fk_id, :null => false
     end
 
-    create_table :fk_test_has_pk, :force => true do |t|
-    end
+    create_table :fk_test_has_pk, :force => true
 
     execute "ALTER TABLE fk_test_has_fk ADD CONSTRAINT fk_name FOREIGN KEY (#{quote_column_name 'fk_id'}) REFERENCES #{quote_table_name 'fk_test_has_pk'} (#{quote_column_name 'id'})"
 
@@ -734,6 +730,6 @@ ActiveRecord::Schema.define do
   end
 end
 
-Course.connection.create_table :courses, :force => true do |t|
-  t.column :name, :string, :null => false
+Course.connection.create_table :courses, :force => true do
+  string :name, :null => false
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -84,7 +84,7 @@ ActiveRecord::Schema.define do
 
   create_table :books, :force => true do
     integer :author_id
-    column :name, :string
+    string :name
   end
 
   create_table :booleans, :force => true do
@@ -212,8 +212,8 @@ ActiveRecord::Schema.define do
   end
 
   create_table :edges, :force => true, :id => false do
-    column :source_id, :integer, :null => false
-    column :sink_id,   :integer, :null => false
+    integer :source_id, :null => false
+    integer :sink_id, :null => false
   end
   add_index :edges, [:source_id, :sink_id], :unique => true, :name => 'unique_edge_index'
 
@@ -254,7 +254,7 @@ ActiveRecord::Schema.define do
   end
 
   create_table :guids, :force => true do
-    column :key, :string
+    string :key
   end
 
   create_table :inept_wizards, :force => true do

--- a/activerecord/test/schema/sqlite_specific_schema.rb
+++ b/activerecord/test/schema/sqlite_specific_schema.rb
@@ -1,8 +1,8 @@
 ActiveRecord::Schema.define do
   # For sqlite 3.1.0+, make a table with a autoincrement column
   if supports_autoincrement?
-    create_table :table_with_autoincrement, :force => true do |t|
-      t.column :name, :string
+    create_table :table_with_autoincrement, :force => true do
+      string :name
     end
   end
 

--- a/railties/guides/code/getting_started/db/migrate/20110901012504_create_posts.rb
+++ b/railties/guides/code/getting_started/db/migrate/20110901012504_create_posts.rb
@@ -1,11 +1,11 @@
 class CreatePosts < ActiveRecord::Migration
   def change
-    create_table :posts do |t|
-      t.string :name
-      t.string :title
-      t.text :content
+    create_table :posts do
+      string :name
+      string :title
+      text :content
 
-      t.timestamps
+      timestamps
     end
   end
 end

--- a/railties/guides/code/getting_started/db/migrate/20110901012815_create_comments.rb
+++ b/railties/guides/code/getting_started/db/migrate/20110901012815_create_comments.rb
@@ -1,11 +1,11 @@
 class CreateComments < ActiveRecord::Migration
   def change
-    create_table :comments do |t|
-      t.string :commenter
-      t.text :body
-      t.references :post
+    create_table :comments do
+      string :commenter
+      text :body
+      references :post
 
-      t.timestamps
+      timestamps
     end
     add_index :comments, :post_id
   end

--- a/railties/guides/code/getting_started/db/migrate/20110901013701_create_tags.rb
+++ b/railties/guides/code/getting_started/db/migrate/20110901013701_create_tags.rb
@@ -1,10 +1,10 @@
 class CreateTags < ActiveRecord::Migration
   def change
-    create_table :tags do |t|
-      t.string :name
-      t.references :post
+    create_table :tags do
+      string :name
+      references :post
 
-      t.timestamps
+      timestamps
     end
     add_index :tags, :post_id
   end

--- a/railties/guides/source/association_basics.textile
+++ b/railties/guides/source/association_basics.textile
@@ -230,15 +230,15 @@ The corresponding migration might look like this:
 <ruby>
 class CreateSuppliers < ActiveRecord::Migration
   def change
-    create_table :suppliers do |t|
-      t.string  :name
-      t.timestamps
+    create_table :suppliers do
+      string  :name
+      timestamps
     end
 
-    create_table :accounts do |t|
-      t.integer :supplier_id
-      t.string  :account_number
-      t.timestamps
+    create_table :accounts do
+      integer :supplier_id
+      string  :account_number
+      timestamps
     end
   end
 end
@@ -310,11 +310,11 @@ If you have an instance of the +Picture+ model, you can get to its parent via +@
 <ruby>
 class CreatePictures < ActiveRecord::Migration
   def change
-    create_table :pictures do |t|
-      t.string  :name
-      t.integer :imageable_id
-      t.string  :imageable_type
-      t.timestamps
+    create_table :pictures do
+      string  :name
+      integer :imageable_id
+      string  :imageable_type
+      timestamps
     end
   end
 end
@@ -325,10 +325,10 @@ This migration can be simplified by using the +t.references+ form:
 <ruby>
 class CreatePictures < ActiveRecord::Migration
   def change
-    create_table :pictures do |t|
-      t.string :name
-      t.references :imageable, :polymorphic => true
-      t.timestamps
+    create_table :pictures do
+      string :name
+      references :imageable, :polymorphic => true
+      timestamps
     end
   end
 end
@@ -401,10 +401,10 @@ This declaration needs to be backed up by the proper foreign key declaration on 
 <ruby>
 class CreateOrders < ActiveRecord::Migration
   def change
-    create_table :orders do |t|
-      t.datetime :order_date
-      t.string   :order_number
-      t.integer  :customer_id
+    create_table :orders do
+      datetime :order_date
+      string   :order_number
+      integer  :customer_id
     end
   end
 end
@@ -435,9 +435,9 @@ These need to be backed up by a migration to create the +assemblies_parts+ table
 <ruby>
 class CreateAssemblyPartJoinTable < ActiveRecord::Migration
   def change
-    create_table :assemblies_parts, :id => false do |t|
-      t.integer :assembly_id
-      t.integer :part_id
+    create_table :assemblies_parts, :id => false do
+      integer :assembly_id
+      integer :part_id
     end
   end
 end

--- a/railties/guides/source/getting_started.textile
+++ b/railties/guides/source/getting_started.textile
@@ -584,12 +584,12 @@ yours will have a slightly different name), here's what you'll find:
 <ruby>
 class CreatePosts < ActiveRecord::Migration
   def change
-    create_table :posts do |t|
-      t.string :name
-      t.string :title
-      t.text :content
+    create_table :posts do
+      string :name
+      string :title
+      text :content
 
-      t.timestamps
+      timestamps
     end
   end
 end
@@ -1142,12 +1142,12 @@ corresponding database table:
 <ruby>
 class CreateComments < ActiveRecord::Migration
   def change
-    create_table :comments do |t|
-      t.string :commenter
-      t.text :body
-      t.references :post
+    create_table :comments do
+      string :commenter
+      text :body
+      references :post
 
-      t.timestamps
+      timestamps
     end
 
     add_index :comments, :post_id

--- a/railties/guides/source/migrations.textile
+++ b/railties/guides/source/migrations.textile
@@ -22,11 +22,11 @@ Before we dive into the details of a migration, here are a few examples of the s
 <ruby>
 class CreateProducts < ActiveRecord::Migration
   def up
-    create_table :products do |t|
-      t.string :name
-      t.text :description
+    create_table :products do
+      string :name
+      text :description
 
-      t.timestamps
+      timestamps
     end
   end
 
@@ -65,11 +65,11 @@ Rails 3.1 makes migrations smarter by providing a new <tt>change</tt> method. Th
 <ruby>
 class CreateProducts < ActiveRecord::Migration
   def change
-    create_table :products do |t|
-      t.string :name
-      t.text :description
+    create_table :products do
+      string :name
+      text :description
 
-      t.timestamps
+      timestamps
     end
   end
 end
@@ -137,8 +137,8 @@ Active Record supports the following types:
 These will be mapped onto an appropriate underlying database type. For example, with MySQL the type +:string+ is mapped to +VARCHAR(255)+. You can create columns of types not supported by Active Record when using the non-sexy syntax, for example
 
 <ruby>
-create_table :products do |t|
-  t.column :name, 'polygon', :null => false
+create_table :products do
+  column :name, 'polygon', :null => false
 end
 </ruby>
 
@@ -159,17 +159,17 @@ will create a migration that looks like this
 <ruby>
 class CreateProducts < ActiveRecord::Migration
   def change
-    create_table :products do |t|
-      t.string :name
-      t.text :description
+    create_table :products do
+      string :name
+      text :description
 
-      t.timestamps
+      timestamps
     end
   end
 end
 </ruby>
 
-You can append as many column name/type pairs as you want. By default +t.timestamps+ (which creates the +updated_at+ and +created_at+ columns that
+You can append as many column name/type pairs as you want. By default +timestamps+ (which creates the +updated_at+ and +created_at+ columns that
 are automatically populated by Active Record) will be added for you.
 
 h4. Creating a Standalone Migration
@@ -255,34 +255,34 @@ h4. Creating a Table
 Migration method +create_table+ will be one of your workhorses. A typical use would be
 
 <ruby>
-create_table :products do |t|
-  t.string :name
+create_table :products do
+  string :name
 end
 </ruby>
 
 which creates a +products+ table with a column called +name+ (and as discussed below, an implicit +id+ column).
 
-The object yielded to the block allows you to create columns on the table. There are two ways of doing it. The first (traditional) form looks like
+The the block given to +create_table+ method  allows you to create columns on the table. There are two ways of doing it. The first (traditional) form looks like
 
 <ruby>
-create_table :products do |t|
-  t.column :name, :string, :null => false
+create_table :products do
+  column :name, :string, :null => false
 end
 </ruby>
 
 The second form, the so called "sexy" migration, drops the somewhat redundant +column+ method. Instead, the +string+, +integer+, etc. methods create a column of that type. Subsequent parameters are the same.
 
 <ruby>
-create_table :products do |t|
-  t.string :name, :null => false
+create_table :products do
+  string :name, :null => false
 end
 </ruby>
 
 By default, +create_table+ will create a primary key called +id+. You can change the name of the primary key with the +:primary_key+ option (don't forget to update the corresponding model) or, if you don't want a primary key at all (for example for a HABTM join table), you can pass the option +:id => false+. If you need to pass database specific options you can place an SQL fragment in the +:options+ option. For example,
 
 <ruby>
-create_table :products, :options => "ENGINE=BLACKHOLE" do |t|
-  t.string :name, :null => false
+create_table :products, :options => "ENGINE=BLACKHOLE" do
+  string :name, :null => false
 end
 </ruby>
 
@@ -318,8 +318,8 @@ h4. Special Helpers
 Active Record provides some shortcuts for common functionality. It is for example very common to add both the +created_at+ and +updated_at+ columns and so there is a method that does exactly that:
 
 <ruby>
-create_table :products do |t|
-  t.timestamps
+create_table :products do
+  timestamps
 end
 </ruby>
 will create a new products table with those two columns (plus the +id+ column) whereas
@@ -334,16 +334,16 @@ adds those columns to an existing table.
 The other helper is called +references+ (also available as +belongs_to+). In its simplest form it just adds some readability
 
 <ruby>
-create_table :products do |t|
-  t.references :category
+create_table :products do
+  references :category
 end
 </ruby>
 
 will create a +category_id+ column of the appropriate type. Note that you pass the model name, not the column name. Active Record adds the +_id+ for you. If you have polymorphic +belongs_to+ associations then +references+ will add both of the columns required:
 
 <ruby>
-create_table :products do |t|
-  t.references :attachment, :polymorphic => {:default => 'Photo'}
+create_table :products do
+  references :attachment, :polymorphic => {:default => 'Photo'}
 end
 </ruby>
 will add an +attachment_id+ column and a string +attachment_type+ column with a default value of 'Photo'.
@@ -375,10 +375,9 @@ The +down+ method of your migration should revert the transformations done by th
 
 <ruby>
 class ExampleMigration < ActiveRecord::Migration
-
   def up
-    create_table :products do |t|
-      t.references :category
+    create_table :products do
+      references :category
     end
     #add a foreign key
     execute <<-SQL
@@ -482,10 +481,10 @@ For example, this migration
 class CreateProducts < ActiveRecord::Migration
   def change
     suppress_messages do
-      create_table :products do |t|
-        t.string :name
-        t.text :description
-        t.timestamps
+      create_table :products do
+        string :name
+        text :description
+        timestamps
       end
     end
     say "Created a table"

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -104,8 +104,8 @@ class LoadingTest < Test::Unit::TestCase
     ActiveRecord::Base.establish_connection(:adapter => "sqlite3", :database => ":memory:")
     ActiveRecord::Migration.verbose = false
     ActiveRecord::Schema.define(:version => 1) do
-      create_table :posts do |t|
-        t.string :title
+      create_table :posts do
+        string :title
       end
     end
   end

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -16,9 +16,9 @@ class ModelGeneratorTest < Rails::Generators::TestCase
 
     assert_migration "db/migrate/create_posts.rb" do |m|
       assert_method :change, m do |up|
-        assert_match(/t\.string :title/, up)
-        assert_match(/t\.text :body/, up)
-        assert_match(/t\.string :author/, up)
+        assert_match(/string :title/, up)
+        assert_match(/text :body/, up)
+        assert_match(/string :author/, up)
       end
     end
   end
@@ -107,8 +107,8 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     assert_migration "db/migrate/create_products.rb" do |m|
       assert_method :change, m do |up|
         assert_match(/create_table :products/, up)
-        assert_match(/t\.string :name/, up)
-        assert_match(/t\.integer :supplier_id/, up)
+        assert_match(/string :name/, up)
+        assert_match(/integer :supplier_id/, up)
       end
     end
   end
@@ -136,7 +136,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
 
   def test_migration_with_timestamps
     run_generator
-    assert_migration "db/migrate/create_accounts.rb", /t.timestamps/
+    assert_migration "db/migrate/create_accounts.rb", /timestamps/
   end
 
   def test_migration_timestamps_are_skipped
@@ -144,7 +144,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
 
     assert_migration "db/migrate/create_accounts.rb" do |m|
       assert_method :change, m do |up|
-        assert_no_match(/t.timestamps/, up)
+        assert_no_match(/timestamps/, up)
       end
     end
   end

--- a/railties/test/generators/resource_generator_test.rb
+++ b/railties/test/generators/resource_generator_test.rb
@@ -27,7 +27,7 @@ class ResourceGeneratorTest < Rails::Generators::TestCase
 
   def test_inherited_invocations_with_attributes
     run_generator ["account", "name:string"]
-    assert_migration "db/migrate/create_accounts.rb", /t.string :name/
+    assert_migration "db/migrate/create_accounts.rb", /string :name/
   end
 
   def test_resource_controller_with_pluralized_class_name

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -269,9 +269,9 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     assert_migration "db/migrate/create_posts.rb" do |m|
       assert_method :change, m do |up|
-        assert_match(/t\.string :title/, up)
-        assert_match(/t\.text :body/, up)
-        assert_match(/t\.string :author/, up)
+        assert_match(/string :title/, up)
+        assert_match(/text :body/, up)
+        assert_match(/string :author/, up)
       end
     end
   end


### PR DESCRIPTION
Changed the generators to output AR 3.2 style migration introduced in #1163, and updated the documents.
Also updated test cases to use the newest syntax.
