### PR TITLE
exclude ORDER BY clause when querying Relation#exists?

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -191,7 +191,7 @@ module ActiveRecord
 
       join_dependency = construct_join_dependency_for_association_find
       relation = construct_relation_for_association_find(join_dependency)
-      relation = relation.except(:select).select("1").limit(1)
+      relation = relation.except(:select, :order).select("1").limit(1)
 
       case id
       when Array, Hash

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -57,6 +57,11 @@ class FinderTest < ActiveRecord::TestCase
     assert Topic.first.replies.exists?
   end
 
+  # ensures +exists?+ runs valid SQL by excluding order value
+  def test_exists_with_order
+    assert Topic.order(:id).uniq.exists?
+  end
+
   def test_does_not_exist_with_empty_table_and_no_args_given
     Topic.delete_all
     assert !Topic.exists?


### PR DESCRIPTION
Currently, there's a failing test case in activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb

```
PGError: ERROR:  for SELECT DISTINCT, ORDER BY expressions must appear in select list
```

The reason behind this is because it tries to check whether a record `exists?` over the following uniq habtm association:

```
Project.has_and_belongs_to_many :developers, :uniq => true, :order => 'developers.name desc, developers.id desc'
```

then it runs an invalid SQL like this

```
SELECT  DISTINCT 1 FROM "developers" INNER JOIN (snip) ORDER BY developers.name desc, developers.id desc LIMIT 1
```

This pr fixes the `exists?` method to ORDER BY clause which is not needed in this case.
