### PR TITLE
Remove j alias for ERB::Util.json_escape

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -45,18 +45,11 @@ class ERB
     #   json_escape('{"name":"john","created_at":"2010-04-28T01:39:31Z","id":1}')
     #   # => {name:john,created_at:2010-04-28T01:39:31Z,id:1}
     #
-    # This method is also aliased as +j+, and available as a helper
-    # in Rails templates:
-    #
-    #   <%=j @person.to_json %>
-    #
     def json_escape(s)
       result = s.to_s.gsub(/[&"><]/) { |special| JSON_ESCAPE[special] }
       s.html_safe? ? result.html_safe : result
     end
 
-    alias j json_escape
-    module_function :j
     module_function :json_escape
   end
 end


### PR DESCRIPTION
I noticed that this newly added `j` method https://github.com/rails/rails/blob/6e87281b5f/actionpack/lib/action_view/helpers/javascript_helper.rb#L37
overwrites existing another `j` method 
https://github.com/rails/rails/blob/6e87281b5f/activesupport/lib/active_support/core_ext/string/output_safety.rb#L58
in ActionView context.

FYI: It seems this global `j` is called in other contexts. https://github.com/flori/json/blob/b50b1bdeae/lib/json/common.rb#L395

Attached a patch that removes `j` alias for `json_escape` because this `j` is no longer available for app developers, and not used inside the framework (maybe those who are using output_safety.rb out of the Rails box would be affected... but who does?).
