### PR TITLE
AC::Metal#response_body= stores different value in Ruby 1.8 and 1.9

### DIFF
--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -182,7 +182,13 @@ module ActionController
     end
 
     def response_body=(val)
-      body = val.nil? ? nil : (val.respond_to?(:each) ? val : [val])
+      body = if val.is_a?(String)
+        [val]
+      elsif val.nil? || val.respond_to?(:each)
+        val
+      else
+        [val]
+      end
       super body
     end
 

--- a/actionpack/test/controller/new_base/bare_metal_test.rb
+++ b/actionpack/test/controller/new_base/bare_metal_test.rb
@@ -23,6 +23,12 @@ module BareMetalTest
 
       assert_equal "Hello world", string
     end
+
+    test "response_body value is wrapped in an array when the value is a String" do
+      controller = BareController.new
+      controller.index
+      assert_equal ["Hello world"], controller.response_body
+    end
   end
 
   class HeadController < ActionController::Metal


### PR DESCRIPTION
```
AC::Metal#response_body = 'foo'
```

stores `['foo']` in Ruby 1.9 but stores `'foo'` in 1.8, because `String#respond_to?(:each)` differs in 1.8 and 1.9.

Although this is just an internal API, app developers sometimes need to directly refer to this value in some cases like monkey patching and testing. So it's nicer if this value doesn't be affected by Ruby version.
