### PR TITLE
Extend IRB right before starting IRB to remove dependency on IRB from Rails::Application

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -205,8 +205,6 @@ module Rails
       require "pp"
       require "rails/console/app"
       require "rails/console/helpers"
-
-      IRB::ExtendCommandBundle.send :include, Rails::ConsoleMethods
     end
   end
 end

--- a/railties/lib/rails/commands/console.rb
+++ b/railties/lib/rails/commands/console.rb
@@ -42,6 +42,8 @@ module Rails
       else
         puts "Loading #{Rails.env} environment (Rails #{Rails.version})"
       end
+
+      IRB::ExtendCommandBundle.send :include, Rails::ConsoleMethods
       IRB.start
     end
   end


### PR DESCRIPTION
refs #3509
A fix for https://github.com/rails/rails/pull/3509#issuecomment-2683558
