### PR TITLE
automatic client side validation with HTML 5 "required" attribute

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -1013,6 +1013,10 @@ module ActionView
 
       def to_input_field_tag(field_type, options = {})
         options = options.stringify_keys
+        if object.class.ancestors.include?(ActiveModel::Validations)
+          options["required"] ||= object.class.attribute_required?(method_name)
+          options["maxlength"] ||= object.class.attribute_maxlength(method_name)
+        end
         options["size"] = options["maxlength"] || DEFAULT_FIELD_OPTIONS["size"] unless options.key?("size")
         options = DEFAULT_FIELD_OPTIONS.merge(options)
         if field_type == "hidden"
@@ -1021,9 +1025,6 @@ module ActionView
         options["type"]  ||= field_type
         options["value"] = options.fetch("value"){ value_before_type_cast(object) } unless field_type == "file"
         options["value"] &&= ERB::Util.html_escape(options["value"])
-        if object.class.ancestors.include?(ActiveModel::Validations)
-          options["required"] ||= object.class.attribute_required?(method_name)
-        end
         add_default_name_and_id(options)
         tag("input", options)
       end

--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -1016,6 +1016,7 @@ module ActionView
         if object.class.ancestors.include?(ActiveModel::Validations)
           options["required"] ||= object.class.attribute_required?(method_name)
           options["maxlength"] ||= object.class.attribute_maxlength(method_name)
+          options["max"] ||= object.class.attribute_max(method_name)
         end
         options["size"] = options["maxlength"] || DEFAULT_FIELD_OPTIONS["size"] unless options.key?("size")
         options = DEFAULT_FIELD_OPTIONS.merge(options)

--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -1017,6 +1017,7 @@ module ActionView
           options["required"] ||= object.class.attribute_required?(method_name)
           options["maxlength"] ||= object.class.attribute_maxlength(method_name)
           options["max"] ||= object.class.attribute_max(method_name)
+          options["min"] ||= object.class.attribute_min(method_name)
         end
         options["size"] = options["maxlength"] || DEFAULT_FIELD_OPTIONS["size"] unless options.key?("size")
         options = DEFAULT_FIELD_OPTIONS.merge(options)

--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -1021,6 +1021,9 @@ module ActionView
         options["type"]  ||= field_type
         options["value"] = options.fetch("value"){ value_before_type_cast(object) } unless field_type == "file"
         options["value"] &&= ERB::Util.html_escape(options["value"])
+        if object.class.ancestors.include?(ActiveModel::Validations)
+          options["required"] ||= object.class.attribute_required?(method_name)
+        end
         add_default_name_and_id(options)
         tag("input", options)
       end
@@ -1046,6 +1049,9 @@ module ActionView
           checked = self.class.radio_button_checked?(value(object), tag_value)
         end
         options["checked"]  = "checked" if checked
+        if object.class.ancestors.include?(ActiveModel::Validations)
+          options["required"] ||= object.class.attribute_required?(method_name)
+        end
         add_default_name_and_id_for_value(tag_value, options)
         tag("input", options)
       end
@@ -1056,6 +1062,9 @@ module ActionView
 
         if size = options.delete("size")
           options["cols"], options["rows"] = size.split("x") if size.respond_to?(:split)
+        end
+        if object.class.ancestors.include?(ActiveModel::Validations)
+          options["required"] ||= object.class.attribute_required?(method_name)
         end
 
         content_tag("textarea", ERB::Util.html_escape(options.delete('value') || value_before_type_cast(object)), options)
@@ -1077,6 +1086,9 @@ module ActionView
           options.delete("multiple")
         else
           add_default_name_and_id(options)
+        end
+        if object.class.ancestors.include?(ActiveModel::Validations)
+          options["required"] ||= object.class.attribute_required?(method_name)
         end
         hidden = tag("input", "name" => options["name"], "type" => "hidden", "value" => options['disabled'] && checked ? checked_value : unchecked_value)
         checkbox = tag("input", options)

--- a/actionpack/test/lib/controller/fake_models.rb
+++ b/actionpack/test/lib/controller/fake_models.rb
@@ -52,6 +52,7 @@ class Post < Struct.new(:title, :author_name, :body, :secret, :persisted, :writt
   extend ActiveModel::Naming
   include ActiveModel::Conversion
   extend ActiveModel::Translation
+  include ActiveModel::Validations
 
   alias_method :secret?, :secret
   alias_method :persisted?, :persisted

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -317,7 +317,7 @@ class FormHelperTest < ActionView::TestCase
     )
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
-      check_box("post", "secret" ,{"checked"=>"checked"})
+      check_box("post", "secret", {"checked" => "checked"})
     )
     @post.secret = true
     assert_dom_equal(
@@ -350,7 +350,7 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_check_box_with_multiple_behavior
-    @post.comment_ids = [2,3]
+    @post.comment_ids = [2, 3]
     assert_dom_equal(
       '<input name="post[comment_ids][]" type="hidden" value="0" /><input id="post_comment_ids_1" name="post[comment_ids][]" type="checkbox" value="1" />',
       check_box("post", "comment_ids", { :multiple => true }, 1)
@@ -400,7 +400,7 @@ class FormHelperTest < ActionView::TestCase
 
   def test_radio_button_respects_passed_in_id
      assert_dom_equal('<input checked="checked" id="foo" name="post[secret]" type="radio" value="1" />',
-       radio_button("post", "secret", "1", :id=>"foo")
+       radio_button("post", "secret", "1", :id => "foo")
     )
   end
 
@@ -630,7 +630,7 @@ class FormHelperTest < ActionView::TestCase
       label("post[]", "title")
     )
     assert_dom_equal(
-      "<input id=\"post_#{pid}_title\" name=\"post[#{pid}][title]\" size=\"30\" type=\"text\" value=\"Hello World\" />", text_field("post[]","title")
+      "<input id=\"post_#{pid}_title\" name=\"post[#{pid}][title]\" size=\"30\" type=\"text\" value=\"Hello World\" />", text_field("post[]", "title")
     )
     assert_dom_equal(
       "<textarea cols=\"40\" id=\"post_#{pid}_body\" name=\"post[#{pid}][body]\" rows=\"20\">Back to the hill and over it again!</textarea>",
@@ -653,7 +653,7 @@ class FormHelperTest < ActionView::TestCase
     pid = @post.id
     assert_dom_equal(
       "<input name=\"post[#{pid}][title]\" size=\"30\" type=\"text\" value=\"Hello World\" />",
-      text_field("post[]","title", :id => nil)
+      text_field("post[]", "title", :id => nil)
     )
     assert_dom_equal(
       "<textarea cols=\"40\" name=\"post[#{pid}][body]\" rows=\"20\">Back to the hill and over it again!</textarea>",
@@ -687,7 +687,7 @@ class FormHelperTest < ActionView::TestCase
       concat f.submit('Create post')
     end
 
-    expected = whole_form("/posts/123", "create-post" , "edit_post", :method => "put") do
+    expected = whole_form("/posts/123", "create-post", "edit_post", :method => "put") do
       "<label for='post_title'>The Title</label>" +
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
       "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
@@ -706,7 +706,7 @@ class FormHelperTest < ActionView::TestCase
       concat f.file_field(:file)
     end
 
-    expected = whole_form("/posts/123", "create-post" , "edit_post", :method => "put", :multipart => true) do
+    expected = whole_form("/posts/123", "create-post", "edit_post", :method => "put", :multipart => true) do
       "<input name='post[file]' type='file' id='post_file' />"
     end
 
@@ -722,7 +722,7 @@ class FormHelperTest < ActionView::TestCase
       }
     end
 
-    expected = whole_form("/posts/123", "edit_post_123" , "edit_post", :method => "put", :multipart => true) do
+    expected = whole_form("/posts/123", "edit_post_123", "edit_post", :method => "put", :multipart => true) do
       "<input name='post[comment][file]' type='file' id='post_comment_file' />"
     end
 
@@ -735,7 +735,7 @@ class FormHelperTest < ActionView::TestCase
       concat f.label(:title)
     end
 
-    expected = whole_form("/posts/123.json", "edit_post_123" , "edit_post", :method => "put") do
+    expected = whole_form("/posts/123.json", "edit_post_123", "edit_post", :method => "put") do
       "<label for='post_title'>Title</label>"
     end
 
@@ -748,7 +748,7 @@ class FormHelperTest < ActionView::TestCase
       concat f.submit('Edit post')
     end
 
-    expected = whole_form("/posts/44", "edit_post_44" , "edit_post", :method => "put") do
+    expected = whole_form("/posts/44", "edit_post_44", "edit_post", :method => "put") do
       "<input name='post[title]' size='30' type='text' id='post_title' value='And his name will be forty and four.' />" +
       "<input name='commit' type='submit' value='Edit post' />"
     end
@@ -2059,5 +2059,4 @@ class FormHelperTest < ActionView::TestCase
     def protect_against_forgery?
       false
     end
-
 end

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -277,6 +277,13 @@ class FormHelperTest < ActionView::TestCase
       text_field("user", "email", :type => "email")
   end
 
+  def test_text_field_with_presence_validator
+    Post.stubs(:attribute_required?).with("title").returns(true)
+    assert_dom_equal(
+      '<input id="post_title" name="post[title]" size="30" type="text" required="required" value="Hello World" />', text_field("post", "title")
+    )
+  end
+
   def test_check_box
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
@@ -333,11 +340,17 @@ class FormHelperTest < ActionView::TestCase
     )
   end
 
-
-  def test_checkbox_disabled_still_submits_checked_value
+  def test_check_box_disabled_still_submits_checked_value
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="1" /><input checked="checked" disabled="disabled" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
       check_box("post", "secret", { :disabled => :true })
+    )
+  end
+
+  def test_check_box_with_presence_validator
+    Post.stubs(:attribute_required?).with("secret").returns(true)
+    assert_dom_equal(
+      '<input name="post[secret]" type="hidden" value="0" /><input name="post[secret]" checked="checked" id="post_secret" required="required" type="checkbox" value="1" />', check_box("post", "secret")
     )
   end
 
@@ -380,6 +393,13 @@ class FormHelperTest < ActionView::TestCase
     )
   end
 
+  def test_radio_button_with_presence_validator
+    Post.stubs(:attribute_required?).with("secret").returns(true)
+    assert_dom_equal(
+      '<input checked="checked" id="post_secret_1" name="post[secret]" required="required" type="radio" value="1" />', radio_button("post", "secret", "1")
+    )
+  end
+
   def test_text_area
     assert_dom_equal(
       '<textarea cols="40" id="post_body" name="post[body]" rows="20">Back to the hill and over it again!</textarea>',
@@ -414,6 +434,13 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal(
       '<textarea cols="183" id="post_body" name="post[body]" rows="820">Back to the hill and over it again!</textarea>',
       text_area("post", "body", :size => "183x820")
+    )
+  end
+
+  def test_text_area_with_presence_validator
+    Post.stubs(:attribute_required?).with("body").returns(true)
+    assert_dom_equal(
+      '<textarea name="post[body]" id="post_body" rows="20" cols="40" required="required">Back to the hill and over it again!</textarea>', text_area("post", "body")
     )
   end
 

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -291,6 +291,13 @@ class FormHelperTest < ActionView::TestCase
     )
   end
 
+  def test_text_field_with_numericality_validator_max
+    Post.stubs(:attribute_max).with("cost").returns(1000)
+    assert_dom_equal(
+      '<input id="post_cost" name="post[cost]" size="30" max="1000" type="text" />', text_field("post", "cost")
+    )
+  end
+
   def test_check_box
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -298,6 +298,13 @@ class FormHelperTest < ActionView::TestCase
     )
   end
 
+  def test_text_field_with_numericality_validator_max
+    Post.stubs(:attribute_min).with("cost").returns(500)
+    assert_dom_equal(
+      '<input id="post_cost" name="post[cost]" size="30" min="500" type="text" />', text_field("post", "cost")
+    )
+  end
+
   def test_check_box
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -284,6 +284,13 @@ class FormHelperTest < ActionView::TestCase
     )
   end
 
+  def test_text_field_with_length_validator_maxlength
+    Post.stubs(:attribute_maxlength).with("title").returns(12)
+    assert_dom_equal(
+      '<input id="post_title" name="post[title]" size="12" maxlength="12" type="text" value="Hello World" />', text_field("post", "title")
+    )
+  end
+
   def test_check_box
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',

--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -103,6 +103,12 @@ module ActiveModel
       end
 
       alias_method :validates_size_of, :validates_length_of
+
+      def attribute_maxlength(attribute)
+        self.validators.grep(LengthValidator).select {|v|
+          v.attributes.include?(attribute.to_sym) && (v.options.keys & [:maximum, :is]).any? && (v.options.keys & [:if, :unless, :allow_nil, :allow_blank, :tokenizer]).empty?
+        }.map {|v| v.options.slice(:maximum, :is)}.map(&:values).flatten.max
+      end
     end
   end
 end

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -131,6 +131,12 @@ module ActiveModel
           v.attributes.include?(attribute.to_sym) && (v.options.keys & [:less_than, :less_than_or_equal_to]).any? && (v.options.keys & [:if, :unless, :allow_nil, :allow_blank]).empty?
         }.map {|v| v.options.slice(:less_than, :less_than_or_equal_to)}.map(&:values).flatten.max
       end
+
+      def attribute_min(attribute)
+        self.validators.grep(NumericalityValidator).select {|v|
+          v.attributes.include?(attribute.to_sym) && (v.options.keys & [:greater_than, :greater_than_or_equal_to]).any? && (v.options.keys & [:if, :unless, :allow_nil, :allow_blank]).empty?
+        }.map {|v| v.options.slice(:greater_than, :greater_than_or_equal_to)}.map(&:values).flatten.min
+      end
     end
   end
 end

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -125,6 +125,12 @@ module ActiveModel
       def validates_numericality_of(*attr_names)
         validates_with NumericalityValidator, _merge_attributes(attr_names)
       end
+
+      def attribute_max(attribute)
+        self.validators.grep(NumericalityValidator).select {|v|
+          v.attributes.include?(attribute.to_sym) && (v.options.keys & [:less_than, :less_than_or_equal_to]).any? && (v.options.keys & [:if, :unless, :allow_nil, :allow_blank]).empty?
+        }.map {|v| v.options.slice(:less_than, :less_than_or_equal_to)}.map(&:values).flatten.max
+      end
     end
   end
 end

--- a/activemodel/lib/active_model/validations/presence.rb
+++ b/activemodel/lib/active_model/validations/presence.rb
@@ -41,6 +41,12 @@ module ActiveModel
       def validates_presence_of(*attr_names)
         validates_with PresenceValidator, _merge_attributes(attr_names)
       end
+
+      def attribute_required?(attribute)
+        self.validators.grep(PresenceValidator).any? do |v|
+          v.attributes.include?(attribute.to_sym) && (v.options.keys & [:if, :unless]).empty?
+        end
+      end
     end
   end
 end

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -5,7 +5,6 @@ require 'models/topic'
 require 'models/person'
 
 class LengthValidationTest < ActiveModel::TestCase
-
   def teardown
     Topic.reset_callbacks(:validate)
   end
@@ -366,5 +365,33 @@ class LengthValidationTest < ActiveModel::TestCase
     assert p.valid?
   ensure
     Person.reset_callbacks(:validate)
+  end
+
+  def test_attribute_maxlength_using_maximum
+    Topic.validates_length_of :title, :maximum => 30
+    assert_equal 30, Topic.attribute_maxlength(:title)
+  end
+
+  def test_attribute_maxlength_using_is
+    Topic.validates_length_of :title, :is => 40
+    assert_equal 40, Topic.attribute_maxlength(:title)
+  end
+
+  def test_attribute_maxlength_using_in
+    Topic.validates_length_of :title, :in => (13..26)
+    assert_equal 26, Topic.attribute_maxlength(:title)
+  end
+
+  def test_attribute_maxlength_with_if_or_unless_or_allow_nil_or_allow_blank_or_tokenizer
+    Topic.validates_length_of :title, :is => 20, :if => lambda {|u| true}
+    assert_nil Topic.attribute_maxlength(:title)
+    Topic.validates_length_of :title, :is => 20, :unless => lambda {|u| false}
+    assert_nil Topic.attribute_maxlength(:title)
+    Topic.validates_length_of :title, :is => 20, :allow_nil => true
+    assert_nil Topic.attribute_maxlength(:title)
+    Topic.validates_length_of :title, :is => 20, :allow_nil => true
+    assert_nil Topic.attribute_maxlength(:title)
+    Topic.validates_length_of :title, :is => 20, :tokenizer => lambda {|s| s.scan(/\w+/)}
+    assert_nil Topic.attribute_maxlength(:title)
   end
 end

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -7,6 +7,7 @@ require 'models/person'
 class LengthValidationTest < ActiveModel::TestCase
   def teardown
     Topic.reset_callbacks(:validate)
+    Topic._validators = Hash.new {|h, k| h[k] = []}
   end
 
   def test_validates_length_of_with_allow_nil

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -9,6 +9,7 @@ require 'bigdecimal'
 class NumericalityValidationTest < ActiveModel::TestCase
   def teardown
     Topic.reset_callbacks(:validate)
+    Topic._validators = Hash.new {|h, k| h[k] = []}
   end
 
   NIL = [nil]

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -7,7 +7,6 @@ require 'models/person'
 require 'bigdecimal'
 
 class NumericalityValidationTest < ActiveModel::TestCase
-
   def teardown
     Topic.reset_callbacks(:validate)
   end
@@ -159,6 +158,27 @@ class NumericalityValidationTest < ActiveModel::TestCase
     assert_raise(ArgumentError){ Topic.validates_numericality_of :approved, :greater_than => "foo" }
     assert_raise(ArgumentError){ Topic.validates_numericality_of :approved, :less_than => "foo" }
     assert_raise(ArgumentError){ Topic.validates_numericality_of :approved, :equal_to => "foo" }
+  end
+
+  def test_attribute_max_using_less_than
+    Topic.validates_numericality_of :approved, :less_than => 20
+    assert_equal 20, Topic.attribute_max(:approved)
+  end
+
+  def test_attribute_max_using_less_than_or_equal_to
+    Topic.validates_numericality_of :approved, :less_than_or_equal_to => 40
+    assert_equal 40, Topic.attribute_max(:approved)
+  end
+
+  def test_attribute_max_with_if_or_unless_or_allow_nil_or_allow_blank
+    Topic.validates_numericality_of :approved, :less_than => 20, :if => lambda {|u| true}
+    assert_nil Topic.attribute_max(:approved)
+    Topic.validates_numericality_of :approved, :less_than => 20, :unless => lambda {|u| false}
+    assert_nil Topic.attribute_max(:approved)
+    Topic.validates_numericality_of :approved, :less_than => 20, :allow_nil => true
+    assert_nil Topic.attribute_max(:approved)
+    Topic.validates_numericality_of :approved, :less_than => 20, :allow_nil => true
+    assert_nil Topic.attribute_max(:approved)
   end
 
   private

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -181,6 +181,27 @@ class NumericalityValidationTest < ActiveModel::TestCase
     assert_nil Topic.attribute_max(:approved)
   end
 
+  def test_attribute_min_using_greater_than
+    Topic.validates_numericality_of :approved, :greater_than => 20
+    assert_equal 20, Topic.attribute_min(:approved)
+  end
+
+  def test_attribute_min_using_greater_than_or_equal_to
+    Topic.validates_numericality_of :approved, :greater_than_or_equal_to => 40
+    assert_equal 40, Topic.attribute_min(:approved)
+  end
+
+  def test_attribute_min_with_if_or_unless_or_allow_nil_or_allow_blank
+    Topic.validates_numericality_of :approved, :greater_than => 20, :if => lambda {|u| true}
+    assert_nil Topic.attribute_min(:approved)
+    Topic.validates_numericality_of :approved, :greater_than => 20, :unless => lambda {|u| false}
+    assert_nil Topic.attribute_min(:approved)
+    Topic.validates_numericality_of :approved, :greater_than => 20, :allow_nil => true
+    assert_nil Topic.attribute_min(:approved)
+    Topic.validates_numericality_of :approved, :greater_than => 20, :allow_nil => true
+    assert_nil Topic.attribute_min(:approved)
+  end
+
   private
 
   def invalid!(values, error = nil)

--- a/activemodel/test/cases/validations/presence_validation_test.rb
+++ b/activemodel/test/cases/validations/presence_validation_test.rb
@@ -6,9 +6,9 @@ require 'models/person'
 require 'models/custom_reader'
 
 class PresenceValidationTest < ActiveModel::TestCase
-
   teardown do
     Topic.reset_callbacks(:validate)
+    Topic._validators = Hash.new {|h, k| h[k] = []}
     Person.reset_callbacks(:validate)
     CustomReader.reset_callbacks(:validate)
   end
@@ -69,5 +69,18 @@ class PresenceValidationTest < ActiveModel::TestCase
 
     p[:karma] = "Cold"
     assert p.valid?
+  end
+
+  def test_attribute_required
+    assert !Topic.attribute_required?(:title)
+    Topic.validates_presence_of :title
+    assert Topic.attribute_required?(:title)
+  end
+
+  def test_attribute_required_with_if_or_unless
+    Topic.validates_presence_of :title, :if => lambda {|u| true}
+    assert !Topic.attribute_required?(:title)
+    Topic.validates_presence_of :title, :unless => lambda {|u| false}
+    assert !Topic.attribute_required?(:title)
   end
 end


### PR DESCRIPTION
This patch was actually written more than a year ago, but unfortunately had lost in somewhere between [Lighthouse](https://rails.lighthouseapp.com/projects/8994/tickets/5120) and GitHub. So let me propose here again...

HTML5 has a new feature called [Client-side form validation](http://www.w3.org/TR/html5/forms.html#client-side-form-validation) and ActiveModel::Validators lets us easily know what kind of validations are defined on our models.

So, I came up with another new feature combining these two technologies.

Now, when creating a form with a model which has a `validates_presence_of` field,

``` ruby
class User < ActiveRecord::Base
  validates_presence_of :name
end
```

``` erb
<%= form_for User.new do |f| %>
  <%= f.text_field :name %>
  <%= f.submit %>
<% end %>
```

the `required="required"` attribute are automagically injected into the generated input field.

``` html
<input id="user_name" name="user[name]" required="required" size="30" type="text" />
```

This enables seamless client-side validation without any extra JavaScript coding.

I baked this feature into a gem for Rails 3, so please take a look at https://github.com/amatsuda/html5_validators for more documentations, and give it a try to see how it actually works.
