### PR TITLE
Fixed error with 'rails generate new plugin' where the .gitignore was not

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -39,7 +39,7 @@ module Rails
     end
 
     def gitignore
-      copy_file "gitignore", ".gitignore"
+      template "gitignore", ".gitignore"
     end
 
     def lib

--- a/railties/lib/rails/generators/rails/plugin_new/templates/gitignore
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/gitignore
@@ -1,6 +1,6 @@
 .bundle/
 log/*.log
 pkg/
-test/dummy/db/*.sqlite3
-test/dummy/log/*.log
-test/dummy/tmp/
+<%= dummy_path %>/db/*.sqlite3
+<%= dummy_path %>/log/*.log
+<%= dummy_path %>/tmp/

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -236,6 +236,14 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
     assert_file "spec/dummy/config/application.rb"
     assert_no_file "test"
   end
+  
+  def test_ensure_that_gitignore_can_be_generated_from_a_template_for_dummy_path
+    FileUtils.cd(Rails.root)
+    run_generator([destination_root, "--dummy_path", "spec/dummy" "--skip-test-unit"])
+    assert_file ".gitignore" do |contents|
+      assert_match(/spec\/dummy/, contents)
+    end
+  end
 
   def test_skipping_test_unit
     run_generator [destination_root, "--skip-test-unit"]


### PR DESCRIPTION
Fixed error with 'rails generate new plugin' where the .gitignore was not properly generated if --dummy-path was used and added test case

This is in regards to Issue #3550
