### PR TITLE
Fix and simplify highlight regexp

### DIFF
--- a/actionpack/lib/action_view/helpers/text_helper.rb
+++ b/actionpack/lib/action_view/helpers/text_helper.rb
@@ -120,7 +120,7 @@ module ActionView
           text
         else
           match = Array(phrases).map { |p| Regexp.escape(p) }.join('|')
-          text.gsub(/(#{match})(?!(?:[^<]*?)(?:["'])[^<>]*>)/i, options[:highlighter])
+          text.gsub(/(#{match})(?![^<]*?>)/i, options[:highlighter])
         end.html_safe
       end
 

--- a/actionpack/test/template/text_helper_test.rb
+++ b/actionpack/test/template/text_helper_test.rb
@@ -194,6 +194,10 @@ class TextHelperTest < ActionView::TestCase
       "<p>This is a <strong class=\"highlight\">beautiful</strong> <a href=\"http://example.com/beautiful#top?what=beautiful%20morning&amp;when=now+then\">morning</a>, but also a <strong class=\"highlight\">beautiful</strong> day</p>",
       highlight("<p>This is a beautiful <a href=\"http://example.com/beautiful\#top?what=beautiful%20morning&when=now+then\">morning</a>, but also a beautiful day</p>", "beautiful")
     )
+    assert_equal(
+      "<div>abc <b>div</b></div>",
+      highlight("<div>abc div</div>", "div", :highlighter => '<b>\1</b>')
+    )
   end
 
   def test_excerpt


### PR DESCRIPTION
<tt>hightlight</tt> text helper method is implemented via too complicated regexp. We can simplify it and fix hightlighting of tag names as a bonus:

``` ruby
highlight("<div>abc div</div>", "div", :highlighter => '<b>\1</b>')
# => should be "<div>abc <b>div</b></div>"
```

I tested my solution on 1.8.7, 1.9.2, 1.9.3. All tests passed well.

Explanation:

Dan Weinand (91eeb0ff119d34d0fcdb44d3d7fcbb7924208e05) modified regexp to not highlight text inside tags. His regexp /(#{match})(?!(?:[^<]_?)(?:["'])[^<>]_>)/i tries to find something not <, quote and nearest >. If matching is positive it means we are inside tag and should ignore highlighting. 

This is too complicated criteria. To be sure we are outside tag, nearest '<' symbol should be before nearest '>' (if they exist). My regexp solves all tasks of Dan and additionaly highlight correct tag names.
