### PR TITLE
Checking the arity of the block passed to create_table

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -158,7 +158,13 @@ module ActiveRecord
         td = table_definition
         td.primary_key(options[:primary_key] || Base.get_primary_key(table_name.to_s.singularize)) unless options[:id] == false
 
-        td.instance_eval(&blk) if blk
+        if block_given?
+          if blk.arity == 1
+            yield td
+          else
+            td.instance_eval(&blk)
+          end
+        end
 
         if options[:force] && table_exists?(table_name)
           drop_table(table_name)

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1742,6 +1742,21 @@ if ActiveRecord::Base.connection.supports_migrations?
     ensure
       Person.connection.drop_table :testings rescue nil
     end
+
+    def test_create_table_should_not_have_mixed_syntax
+      assert_raise(NoMethodError) do
+        Person.connection.create_table :testings, :force => true do |t|
+          t.string :foo
+          integer :bar
+        end
+      end
+      assert_raise(NameError) do
+        Person.connection.create_table :testings, :force => true do
+          t.string :foo
+          integer :bar
+        end
+      end
+    end
   end # SexierMigrationsTest
 
   class MigrationLoggerTest < ActiveRecord::TestCase


### PR DESCRIPTION
A recent change made to create_table does away with the need for the block argument. Checking the arity will prevent the mixing up of the two syntaxes.

This is in line with https://github.com/rails/rails/pull/1163#issuecomment-2633129
