### PR TITLE
Modify change_table to remove the need for the block argument

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -241,14 +241,19 @@ module ActiveRecord
       #
       # See also Table for details on
       # all of the various column transformation
-      def change_table(table_name, options = {})
-        if supports_bulk_alter? && options[:bulk]
-          recorder = ActiveRecord::Migration::CommandRecorder.new(self)
-          yield Table.new(table_name, recorder)
-          bulk_change_table(table_name, recorder.commands)
-        else
-          yield Table.new(table_name, self)
+      def change_table(table_name, options = {}, &blk)
+        bulk_change = supports_bulk_alter? && options[:bulk]
+        recorder = bulk_change ? ActiveRecord::Migration::CommandRecorder.new(self) : self
+        table = Table.new(table_name, recorder)
+
+        if block_given?
+          if blk.arity == 1
+            yield table
+          else
+            table.instance_eval(&blk)
+          end
         end
+        bulk_change_table(table_name, recorder.commands) if bulk_change
       end
 
       # Renames a table.


### PR DESCRIPTION
To maintain consistency, change_table should also be modified to the newer syntax where the block argument can be omitted.

The changes done are very similar to the changes done to create_table in #1163 and #3600
