### PR TITLE
Make the flash sweeper ignore requests for assets

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/flash.rb
+++ b/actionpack/lib/action_dispatch/middleware/flash.rb
@@ -239,9 +239,13 @@ module ActionDispatch
       @app = app
     end
 
+    def asset?(env)
+      env['action_dispatch.asset_prefix'] && env['PATH_INFO'].start_with?(env['action_dispatch.asset_prefix'])
+    end
+
     def call(env)
       if (session = env['rack.session']) && (flash = session['flash'])
-        flash.sweep
+        flash.sweep unless asset?(env)
       end
 
       @app.call(env)

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -310,6 +310,20 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_do_not_sweep_for_asset_requests
+    with_test_route_set do
+      get '/set_flash'
+
+      get '/assets/demo.js', nil, "action_dispatch.asset_prefix" => '/assets'
+
+      get '/use_flash'
+      assert_response :success
+      assert_equal "flash: hello", @response.body
+    end
+
+  end
+
+
   private
 
     # Overwrite get to send SessionSecret in env hash

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -113,9 +113,10 @@ module Rails
     # Rails.application.env_config stores some of the Rails initial environment parameters.
     # Currently stores:
     #
-    #   * action_dispatch.parameter_filter" => config.filter_parameters,
-    #   * action_dispatch.secret_token"     => config.secret_token,
-    #   * action_dispatch.show_exceptions"  => config.action_dispatch.show_exceptions
+    #   * "action_dispatch.parameter_filter" => config.filter_parameters,
+    #   * "action_dispatch.secret_token"     => config.secret_token,
+    #   * "action_dispatch.show_exceptions"  => config.action_dispatch.show_exceptions
+    #   * "action_dispatch.asset_prefix"     => config.action_dispatch.asset_prefix
     #
     # These parameters will be used by middlewares and engines to configure themselves.
     #
@@ -123,7 +124,8 @@ module Rails
       @env_config ||= super.merge({
         "action_dispatch.parameter_filter" => config.filter_parameters,
         "action_dispatch.secret_token" => config.secret_token,
-        "action_dispatch.show_exceptions" => config.action_dispatch.show_exceptions
+        "action_dispatch.show_exceptions" => config.action_dispatch.show_exceptions,
+        "action_dispatch.asset_prefix" => config.assets.enabled && config.assets.prefix
       })
     end
 


### PR DESCRIPTION
The flash is getting cleared by requests for assets.  This is making me sad.

Wasn't sure how best to configure ActionDispatch::Flash, so I followed the existing convention of injecting configuration into the rack env.
