### PR TITLE
AS::Callbacks.__run_keyed_callback: remove unused cache

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -394,16 +394,12 @@ module ActiveSupport
       #
       def __run_keyed_callback(key, kind, object, &blk) #:nodoc:
         name = "_run__#{self.name.hash.abs}__#{kind}__#{key.hash.abs}__callbacks"
-        unless respond_to?(name)
-          @_keyed_callbacks ||= {}
-          @_keyed_callbacks[name] ||= begin
-            str = send("_#{kind}_callbacks").compile(name, object)
-            class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
-              def #{name}() #{str} end
-              protected :#{name}
-            RUBY_EVAL
-            true
-          end
+        unless object.respond_to?(name)
+          str = send("_#{kind}_callbacks").compile(name, object)
+          class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
+            def #{name}() #{str} end
+            protected :#{name}
+          RUBY_EVAL
         end
         object.send(name, &blk)
       end


### PR DESCRIPTION
`__run_keyed_callback` defines the callback method on the first run and checks if it was defined (with `object.respond_to?`). This makes `@_keyed_callbacks` cache never used:

In order to check that I've add the debug code that indicates cache usage and run test suite for AS and AR - no usages found so far.

/cc @josevalim: sorry for that bug with object/instance context. This PR also fixes one more bug from previous PR.
