### PR TITLE
Fix + Failing test for find_or_initialize_ updating has_many collection size.

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -76,9 +76,7 @@ module ActiveRecord
             proxy_association.send :add_to_target, r
             yield(r) if block_given?
           end
-        end
-
-        if target.respond_to?(method) || (!proxy_association.klass.respond_to?(method) && Class.respond_to?(method))
+        elsif target.respond_to?(method) || (!proxy_association.klass.respond_to?(method) && Class.respond_to?(method))
           if load_target
             if target.respond_to?(method)
               target.send(method, *args, &block)
@@ -90,7 +88,6 @@ module ActiveRecord
               end
             end
           end
-
         else
           scoped.readonly(nil).send(method, *args, &block)
         end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -727,6 +727,13 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal number_of_clients + 1, companies(:first_firm).clients_of_firm.size
   end
 
+  def test_find_or_initialize_updates_collection_size_only_once
+    number_of_clients = companies(:first_firm).clients_of_firm.size
+    client = companies(:first_firm).clients_of_firm.find_or_initialize_by_name("name" => "Another Client")
+    client.save
+    assert_equal number_of_clients + 1, companies(:first_firm).clients_of_firm.size
+  end
+
   def test_find_or_create_with_hash
     post = authors(:david).posts.find_or_create_by_title(:title => 'Yet another post', :body => 'somebody')
     assert_equal post, authors(:david).posts.find_or_create_by_title(:title => 'Yet another post', :body => 'somebody')


### PR DESCRIPTION
When a record is initialized through a has_many association, the record is added to the target association.
On a record.save, this record is not updated or replaced in the in-memory association.

e.g.

``` ruby
@tree.apples.size #=> 1
apple = @tree.apples.find_or_initialize_by_color('Red')
@tree.apples.size #=> 2, so it added a record in-memory.
apple.color = 'Green'
apple.save
@tree.apples.size #=> 3 !!! It did reload records from database. It did not clear in-memory records.
@tree.apples.last.color #=> 'Red'
@tree.apples.last.new_record? #=> true
@tree.apples.second.color #=> 'Green'
@tree.apples.second.new_record? #=> false
```
