### PR TITLE
Fix wording and minor typos in the Responder RDoc

### DIFF
--- a/actionpack/lib/action_controller/metal/responder.rb
+++ b/actionpack/lib/action_controller/metal/responder.rb
@@ -84,8 +84,8 @@ module ActionController #:nodoc:
   #
   # === Custom options
   #
-  # <code>respond_with</code> also allow you to pass options that are forwarded
-  # to the underlying render call. Those options are only applied success
+  # <code>respond_with</code> also allows you to pass options that are forwarded
+  # to the underlying render call. Those options are only applied for success
   # scenarios. For instance, you can do the following in the create method above:
   #
   #   def create
@@ -95,7 +95,7 @@ module ActionController #:nodoc:
   #     respond_with(@project, @task, :status => 201)
   #   end
   #
-  # This will return status 201 if the task was saved with success. If not,
+  # This will return status 201 if the task was saved successfully. If not,
   # it will simply ignore the given options and return status 422 and the
   # resource errors. To customize the failure scenario, you can pass a
   # a block to <code>respond_with</code>:
@@ -224,7 +224,7 @@ module ActionController #:nodoc:
     alias :navigation_location :resource_location
     alias :api_location :resource_location
 
-    # If a given response block was given, use it, otherwise call render on
+    # If a response block was given, use it, otherwise call render on
     # controller.
     #
     def default_render


### PR DESCRIPTION
Just some minor RDoc fixes—in the class overview section and one fix in the RDoc for `Responder#default_render`
