### PR TITLE
Ignore *.gz files that are generated from 'rake assets:precompile'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ debug.log
 /railties/guides/output
 /railties/tmp
 /RDOC_MAIN.rdoc
+*.gz


### PR DESCRIPTION
*.gz files generated from 'rake assets:precompile' are a hassle when deploying your rails app to a production server. These should be ignored by git.
