### PR TITLE
Unneeded require 'active_support/memoizable'

### DIFF
--- a/actionpack/lib/action_dispatch/http/headers.rb
+++ b/actionpack/lib/action_dispatch/http/headers.rb
@@ -1,5 +1,3 @@
-require 'active_support/memoizable'
-
 module ActionDispatch
   module Http
     class Headers < ::Hash


### PR DESCRIPTION
usage of memoizable was removed in f2c0fb32c0dce7f8da0ce446e2d2f0cba5fd44b3
