### PR TITLE
Add therubyracer/therubyrhino to Gemfile when there isn't a JS Runtime available in the system

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -189,6 +189,17 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_javascript_runtime_is_added_to_gemfile
+    win_or_osx = (RUBY_PLATFORM =~ /mswin32/ || RUBY_PLATFORM =~ /darwin/)
+    `which node`
+    node = $?.success?
+
+    if defined?(JRUBY_VERSION) || (!win_or_osx && !node)
+      run_generator([destination_root])
+      assert_file "Gemfile", /gem\s+["']theruby(racer|rhino)["']/
+    end
+  end
+
   def test_generator_if_skip_active_record_is_given
     run_generator [destination_root, "--skip-active-record"]
     assert_no_file "config/database.yml"


### PR DESCRIPTION
This will make the apps usable by default for all Linux users that don't have Node.js installed in the system. (There are a lot of users). See #2963 for details.

Additionally if JRuby is detected therubyrhino is added by default
