### PR TITLE
Remote IP fixes/cleanup

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -51,8 +51,8 @@ module ActionDispatch
         if check_ip && !forwarded_ips.include?(client_ip)
           # We don't know which came from the proxy, and which from the user
           raise IpSpoofAttackError, "IP spoofing attack?!" \
-            "HTTP_CLIENT_IP=#{env['HTTP_CLIENT_IP'].inspect}" \
-            "HTTP_X_FORWARDED_FOR=#{env['HTTP_X_FORWARDED_FOR'].inspect}"
+            "HTTP_CLIENT_IP=#{@env['HTTP_CLIENT_IP'].inspect}" \
+            "HTTP_X_FORWARDED_FOR=#{@env['HTTP_X_FORWARDED_FOR'].inspect}"
         end
 
         client_ip || forwarded_ips.last || remote_addrs.last

--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -19,7 +19,7 @@ module ActionDispatch
       @app = app
       @check_ip_spoofing = check_ip_spoofing
       if custom_proxies
-        custom_regexp = Regexp.new(custom_proxies, "i")
+        custom_regexp = Regexp.new(custom_proxies)
         @trusted_proxies = Regexp.union(TRUSTED_PROXIES, custom_regexp)
       else
         @trusted_proxies = TRUSTED_PROXIES

--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -55,7 +55,7 @@ module ActionDispatch
             "HTTP_X_FORWARDED_FOR=#{@env['HTTP_X_FORWARDED_FOR'].inspect}"
         end
 
-        client_ip || forwarded_ips.last || remote_addrs.last
+        client_ip || forwarded_ips.last || remote_addrs.first
       end
 
     protected

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -36,7 +36,7 @@ class RequestTest < ActiveSupport::TestCase
 
     request = stub_request 'REMOTE_ADDR' => '1.2.3.4',
       'HTTP_X_FORWARDED_FOR' => '3.4.5.6'
-    assert_equal '1.2.3.4', request.remote_ip
+    assert_equal '3.4.5.6', request.remote_ip
 
     request = stub_request 'REMOTE_ADDR' => '127.0.0.1',
       'HTTP_X_FORWARDED_FOR' => '3.4.5.6'
@@ -106,7 +106,7 @@ class RequestTest < ActiveSupport::TestCase
 
     request = stub_request 'REMOTE_ADDR' => '67.205.106.74,172.16.0.1',
                            'HTTP_X_FORWARDED_FOR' => '3.4.5.6'
-    assert_equal '67.205.106.74', request.remote_ip
+    assert_equal '3.4.5.6', request.remote_ip
 
     request = stub_request 'HTTP_X_FORWARDED_FOR' => 'unknown,67.205.106.73'
     assert_equal 'unknown', request.remote_ip


### PR DESCRIPTION
Vijay pointed me at some breaking tests. These commits fix the tests by:
- returning the first REMOTE_ADDR instead of the last one
- not causing an exception while trying to raise IpSpoofAttackError
- changing the tests to expect X-Forwarded-For before REMOTE_ADDR
