### PR TITLE
Upgrade Sprockets to 2.1.0

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency('rack',          '~> 1.3.5')
   s.add_dependency('rack-test',     '~> 0.6.1')
   s.add_dependency('journey',       '~> 1.0.0')
-  s.add_dependency('sprockets',     '~> 2.1.0.beta')
+  s.add_dependency('sprockets',     '~> 2.1.0')
   s.add_dependency('erubis',        '~> 2.7.0')
 
   s.add_development_dependency('tzinfo', '~> 0.3.29')


### PR DESCRIPTION
This version brings bug fixes for performance and caching.

Also looks like 2.0.x won't be supported anymore and could be a good idea bump version also in 3-1-stable.
