### PR TITLE
Force calculation of remote IP before using || operator

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -157,7 +157,8 @@ module ActionDispatch
 
     # Originating IP address, usually set by the RemoteIp middleware.
     def remote_ip
-      @remote_ip ||= (@env["action_dispatch.remote_ip"] || ip).to_s
+      # Coerce the remote_ip object into a string, because to_s could return nil
+      @remote_ip ||= @env["action_dispatch.remote_ip"].to_s || ip
     end
 
     # Returns the unique request id, which is based off either the X-Request-Id header that can

--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -13,16 +13,16 @@ module ActionDispatch
        )\.
     }x
 
-    attr_reader :check_ip_spoofing, :trusted_proxies
+    attr_reader :check_ip, :proxies
 
     def initialize(app, check_ip_spoofing = true, custom_proxies = nil)
       @app = app
-      @check_ip_spoofing = check_ip_spoofing
+      @check_ip = check_ip_spoofing
       if custom_proxies
         custom_regexp = Regexp.new(custom_proxies)
-        @trusted_proxies = Regexp.union(TRUSTED_PROXIES, custom_regexp)
+        @proxies = Regexp.union(TRUSTED_PROXIES, custom_regexp)
       else
-        @trusted_proxies = TRUSTED_PROXIES
+        @proxies = TRUSTED_PROXIES
       end
     end
 
@@ -47,7 +47,7 @@ module ActionDispatch
         forwarded_ips = ips_from('HTTP_X_FORWARDED_FOR')
         remote_addrs  = ips_from('REMOTE_ADDR')
 
-        check_ip = client_ip && @middleware.check_ip_spoofing
+        check_ip = client_ip && @middleware.check_ip
         if check_ip && !forwarded_ips.include?(client_ip)
           # We don't know which came from the proxy, and which from the user
           raise IpSpoofAttackError, "IP spoofing attack?!" \
@@ -62,7 +62,7 @@ module ActionDispatch
 
       def ips_from(header)
         ips = @env[header] ? @env[header].strip.split(/[,\s]+/) : []
-        ips.reject{|ip| ip =~ @middleware.trusted_proxies }
+        ips.reject{|ip| ip =~ @middleware.proxies }
       end
     end
 

--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -42,7 +42,7 @@ module ActionDispatch
       # HTTP_X_FORWARDED_FOR may be a comma-delimited list in the case of
       # multiple chained proxies. The last address which is not a known proxy
       # will be the originating IP.
-      def to_s
+      def calculate_ip
         client_ip     = @env['HTTP_CLIENT_IP']
         forwarded_ips = ips_from('HTTP_X_FORWARDED_FOR')
         remote_addrs  = ips_from('REMOTE_ADDR')
@@ -56,6 +56,12 @@ module ActionDispatch
         end
 
         client_ip || forwarded_ips.last || remote_addrs.first
+      end
+
+      def to_s
+        return @ip if @calculated_ip
+        @calculated_ip = true
+        @ip = calculate_ip
       end
 
     protected


### PR DESCRIPTION
This is a fix for the bug that @jonleighton found in 317f4e2, where remote_ip would sometimes return nil when it ought to have returned "127.0.0.1" (or any other IP that matches the "trusted proxies to ignore" regex).
