### PR TITLE
Fixes 3483

### DIFF
--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -375,7 +375,7 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_find_on_hash_conditions_with_array_of_integers_and_ranges
-    assert_equal [1,2,3], Comment.find(:all, :conditions => { :post_id => [1..2, 3, 4, 5..10]}).map(&:id).sort
+    assert_equal [1,2,3,5,6,7,8,9], Comment.find(:all, :conditions => {:id => [1..2, 3, 5, 6..8, 9]}).map(&:id).sort
   end
 
   def test_find_on_multiple_hash_conditions

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -374,6 +374,10 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal [1], Comment.find(:all, :conditions => { :id => 1..1, :post_id => 1..10 }).map(&:id).sort
   end
 
+  def test_find_on_hash_conditions_with_array_of_integers_and_ranges
+    assert_equal [1,2,3], Comment.find(:all, :conditions => { :post_id => [1..2, 3, 4, 5..10]}).map(&:id).sort
+  end
+
   def test_find_on_multiple_hash_conditions
     assert Topic.find(1, :conditions => { :author_name => "David", :title => "The First Topic", :replies_count => 1, :approved => false })
     assert_raise(ActiveRecord::RecordNotFound) { Topic.find(1, :conditions => { :author_name => "David", :title => "The First Topic", :replies_count => 1, :approved => true }) }


### PR DESCRIPTION
Fixes issue #3483.

The AR find conditions could not correctly handle the combination of a range and discrete values.  We modified predicate_builder.rb such that when an array contains ranges, separate predicates for the ranges (one for the discrete values, another for each range value) are created.  
