### PR TITLE
GetIp#to_s should never return nil. That's icky.

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -155,10 +155,9 @@ module ActionDispatch
       @ip ||= super
     end
 
-    # Originating IP address, usually set by the RemoteIp middleware.
+    # Originating IP address from the RemoteIp middleware.
     def remote_ip
-      # Coerce the remote_ip object into a string, because to_s could return nil
-      @remote_ip ||= @env["action_dispatch.remote_ip"].to_s || ip
+      @remote_ip ||= @env["action_dispatch.remote_ip"]
     end
 
     # Returns the unique request id, which is based off either the X-Request-Id header that can

--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -55,7 +55,10 @@ module ActionDispatch
             "HTTP_X_FORWARDED_FOR=#{@env['HTTP_X_FORWARDED_FOR'].inspect}"
         end
 
-        client_ip || forwarded_ips.last || remote_addrs.first
+        not_proxy = client_ip || forwarded_ips.last || remote_addrs.first
+
+        # Return first REMOTE_ADDR if there are no other options
+        not_proxy || ips_from('REMOTE_ADDR', :all).first
       end
 
       def to_s
@@ -66,9 +69,9 @@ module ActionDispatch
 
     protected
 
-      def ips_from(header)
+      def ips_from(header, allow_proxies = false)
         ips = @env[header] ? @env[header].strip.split(/[,\s]+/) : []
-        ips.reject{|ip| ip =~ @middleware.proxies }
+        allow_proxies ? ips : ips.reject{|ip| ip =~ @middleware.proxies }
       end
     end
 


### PR DESCRIPTION
Okay, so my previous fix for this was to acknowledge that GetIp#to_s could return nil. And that's really, really awful. So this fix returns the first IP value in REMOTE_ADDR instead of nil, and stops assuming that to_s could return nil. All the tests pass, and I'd welcome any feedback on how to make this better/cleaner. Thanks!
