### PR TITLE
Fixes for Request#remote_ip (no middleware, all proxies)

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -155,10 +155,9 @@ module ActionDispatch
       @ip ||= super
     end
 
-    # Originating IP address, usually set by the RemoteIp middleware.
+    # Originating IP address from the RemoteIp middleware.
     def remote_ip
-      # Coerce the remote_ip object into a string, because to_s could return nil
-      @remote_ip ||= @env["action_dispatch.remote_ip"].to_s || ip
+      @remote_ip ||= @env["action_dispatch.remote_ip"]
     end
 
     # Returns the unique request id, which is based off either the X-Request-Id header that can

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -155,9 +155,9 @@ module ActionDispatch
       @ip ||= super
     end
 
-    # Originating IP address from the RemoteIp middleware.
+    # Originating IP address, usually set by the RemoteIp middleware.
     def remote_ip
-      @remote_ip ||= @env["action_dispatch.remote_ip"]
+      @remote_ip ||= @env["action_dispatch.remote_ip"] || ip
     end
 
     # Returns the unique request id, which is based off either the X-Request-Id header that can

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -157,7 +157,7 @@ module ActionDispatch
 
     # Originating IP address, usually set by the RemoteIp middleware.
     def remote_ip
-      @remote_ip ||= @env["action_dispatch.remote_ip"] || ip
+      @remote_ip ||= (@env["action_dispatch.remote_ip"] || ip).to_s
     end
 
     # Returns the unique request id, which is based off either the X-Request-Id header that can

--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -55,7 +55,10 @@ module ActionDispatch
             "HTTP_X_FORWARDED_FOR=#{@env['HTTP_X_FORWARDED_FOR'].inspect}"
         end
 
-        client_ip || forwarded_ips.last || remote_addrs.first
+        not_proxy = client_ip || forwarded_ips.last || remote_addrs.first
+
+        # Return first REMOTE_ADDR if there are no other options
+        not_proxy || ips_from('REMOTE_ADDR', :all).first
       end
 
       def to_s
@@ -66,9 +69,9 @@ module ActionDispatch
 
     protected
 
-      def ips_from(header)
+      def ips_from(header, allow_proxies = false)
         ips = @env[header] ? @env[header].strip.split(/[,\s]+/) : []
-        ips.reject{|ip| ip =~ @middleware.proxies }
+        allow_proxies ? ips : ips.reject{|ip| ip =~ @middleware.proxies }
       end
     end
 

--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -58,7 +58,7 @@ module ActionDispatch
         not_proxy = client_ip || forwarded_ips.last || remote_addrs.first
 
         # Return first REMOTE_ADDR if there are no other options
-        not_proxy || ips_from('REMOTE_ADDR', :all).first
+        not_proxy || ips_from('REMOTE_ADDR', :allow_proxies).first
       end
 
       def to_s


### PR DESCRIPTION
So it turns out that the RemoteIp middleware might not be added to the stack. Hah. Also, when requesting directly from box with a proxy IP, we should return the IP, not filter it.

@jonleighton, this fixes all the test failures you noted from the previous merges. 
