### PR TITLE
Fix impractical I18n lookup in nested fields_for

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -995,8 +995,16 @@ module ActionView
           label_tag(name_and_id["id"], options, &block)
         else
           content = if text.blank?
+            object_name.gsub!(/\[(.*)_attributes\]\[\d\]/, '.\1')
             method_and_value = tag_value.present? ? "#{method_name}.#{tag_value}" : method_name
-            I18n.t("helpers.label.#{object_name}.#{method_and_value}", :default => "").presence
+
+            if object.respond_to?(:to_model)
+              key = object.class.model_name.i18n_key
+              i18n_default = ["#{key}.#{method_and_value}".to_sym, ""]
+            end
+
+            i18n_default ||= ""
+            I18n.t("#{object_name}.#{method_and_value}", :default => i18n_default, :scope => "helpers.label").presence
           else
             text.to_s
           end

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -27,7 +27,13 @@ class FormHelperTest < ActionView::TestCase
             :body => "Write entire text here",
             :color => {
               :red => "Rojo"
+            },
+            :comments => {
+              :body => "Write body here"
             }
+          },
+          :tag => {
+            :value => "Tag"
           }
         }
       }
@@ -67,6 +73,12 @@ class FormHelperTest < ActionView::TestCase
     @post.body        = "Back to the hill and over it again!"
     @post.secret      = 1
     @post.written_on  = Date.new(2004, 6, 15)
+
+    @post.comments = []
+    @post.comments << @comment
+
+    @post.tags = []
+    @post.tags << Tag.new
 
     @blog_post = Blog::Post.new("And his name will be forty and four.", 44)
   end
@@ -147,6 +159,40 @@ class FormHelperTest < ActionView::TestCase
   def test_label_with_locales_and_value
     old_locale, I18n.locale = I18n.locale, :label
     assert_dom_equal('<label for="post_color_red">Rojo</label>', label(:post, :color, :value => "red"))
+  ensure
+    I18n.locale = old_locale
+  end
+
+  def test_label_with_locales_and_nested_attributes
+    old_locale, I18n.locale = I18n.locale, :label
+    form_for(@post, :html => { :id => 'create-post' }) do |f|
+      f.fields_for(:comments) do |cf|
+        concat cf.label(:body)
+      end
+    end
+
+    expected = whole_form("/posts/123", "create-post" , "edit_post", :method => "put") do
+      "<label for=\"post_comments_attributes_0_body\">Write body here</label>"
+    end
+
+    assert_dom_equal expected, output_buffer
+  ensure
+    I18n.locale = old_locale
+  end
+
+  def test_label_with_locales_fallback_and_nested_attributes
+    old_locale, I18n.locale = I18n.locale, :label
+    form_for(@post, :html => { :id => 'create-post' }) do |f|
+      f.fields_for(:tags) do |cf|
+        concat cf.label(:value)
+      end
+    end
+
+    expected = whole_form("/posts/123", "create-post" , "edit_post", :method => "put") do
+      "<label for=\"post_tags_attributes_0_value\">Tag</label>"
+    end
+
+    assert_dom_equal expected, output_buffer
   ensure
     I18n.locale = old_locale
   end


### PR DESCRIPTION
This patch fixes #2437.

> When using nested fields_for, the label method of the FormBuilder object looks up the translation for the label using object_name, which is very impractical.

The I18n key for label will be "helpers.label.parent.children.name" with a fallback to "helpers.label.child.name" instead of insane "helpers.label.parent[children_attributes][0].name".
