### PR TITLE
Improve for scaffold controller generator

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/erb/scaffold/scaffold_generator.rb
@@ -22,7 +22,7 @@ module Erb
     protected
 
       def available_views
-        %w(index edit show new _form)
+        %w(index edit show new _form _base)
       end
     end
   end

--- a/railties/lib/rails/generators/erb/scaffold/templates/_base.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/_base.html.erb
@@ -1,0 +1,1 @@
+... base html for controller

--- a/railties/lib/rails/generators/erb/scaffold/templates/edit.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/edit.html.erb
@@ -1,3 +1,4 @@
+<%%= render "base" %>
 <h1>Editing <%= singular_table_name %></h1>
 
 <%%= render 'form' %>

--- a/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb
@@ -1,3 +1,4 @@
+<%%= render "base" %>
 <h1>Listing <%= plural_table_name %></h1>
 
 <table>

--- a/railties/lib/rails/generators/erb/scaffold/templates/new.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/new.html.erb
@@ -1,3 +1,4 @@
+<%%= render "base" %>
 <h1>New <%= singular_table_name %></h1>
 
 <%%= render 'form' %>

--- a/railties/lib/rails/generators/erb/scaffold/templates/show.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/show.html.erb
@@ -1,3 +1,4 @@
+<%%= render "base" %>
 <p id="notice"><%%= notice %></p>
 
 <% attributes.each do |attribute| -%>

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -72,6 +72,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       new
       show
       _form
+      _base
     ).each { |view| assert_file "app/views/product_lines/#{view}.html.erb" }
     assert_no_file "app/views/layouts/product_lines.html.erb"
 
@@ -181,6 +182,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       new
       show
       _form
+      _base
     ).each { |view| assert_file "app/views/admin/roles/#{view}.html.erb" }
     assert_no_file "app/views/layouts/admin/roles.html.erb"
 


### PR DESCRIPTION
added _base.html.erb for every page, then we can define some common html(CSS/JS include, Javascript) in it.

for example:

There have a messages controller

_base.html.erb

```
<%= content_for :breadcrumb do %>
  <a href="<%= messages_path %>">Messages</a> &gt; 
<% end %>
<%= content_for :css do %>
  <%= stylesheet_link_tag "messages"  %>
<% end %>
<%= content_for :js do %>
  <%= javascript_include_tag "messages"  %>
<% end %>
```

new.html.erb

```
<%= content_for :breadcrumb do %>
  <span class="current">New</span>
<% end %>
<%= render "base" %>
<%= render "form" %>
```

index.html.erb

```
<%= content_for :breadcrumb do %>
  <span class="current">List</span>
<% end %>
<%= render "base" %>
```

show.html.ern

```
<%= content_for :breadcrumb do %>
  <span class="current">View</span>
<% end %>
<%= render "base" %>
```

And in the Layout
application.html.erb

```
<head>
<%= stylesheet_link_tag "application" %>
<%= yield :css %>
<%= javascript_include_tag "application" %>
<%= yield :js %>
</head>
<body>
<div id="breadcrumb">
  Location: <a href="/">Root</a> &gt; <%= yield :breadcrumb %>
</div>
</body>
```
