### PR TITLE
default_asset_host_protocol should not default to :relative

### DIFF
--- a/actionpack/lib/sprockets/railtie.rb
+++ b/actionpack/lib/sprockets/railtie.rb
@@ -10,8 +10,6 @@ module Sprockets
 
   # TODO: Get rid of config.assets.enabled
   class Railtie < ::Rails::Railtie
-    config.action_controller.default_asset_host_protocol = :relative
-
     rake_tasks do
       load "sprockets/assets.rake"
     end


### PR DESCRIPTION
Hi,

I've been running into a number of problems with 3.1's protocol-relative urls.  They've been fine when used in stylesheets & javascript (which is fortunate, or we'd have to have a different asset cache for http & https), but I'm less convinced about their benefit when used in templates.

Many RSS readers seem completely flummoxed by them, and a number of our api clients don't behave nicely with them.

I came across default_asset_host_protocol - https://github.com/rails/rails/commit/0e5891ad918ea975f8687d6d47aed5543afc7441.  The commit even mentions that it's best to keep it unset, yet the Sprockets railtie sets it to :relative (https://github.com/rails/rails/blob/master/actionpack/lib/sprockets/railtie.rb)

I've set `config.action_controller.default_asset_host_protocol = nil` in my own config, which seems to work fine - assets are still generated referencing "//example.com/foo.jpg" images, and templates use the request protocol for their asset paths.  Any thoughts on just deleting the railtie setting as in the attached commit?
