### PR TITLE
rewrite DateTime.local_offset to return current offset

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -4,7 +4,8 @@ class DateTime
   class << self
     # DateTimes aren't aware of DST rules, so use a consistent non-DST offset when creating a DateTime with an offset in the local zone
     def local_offset
-      ::Time.local(2007).utc_offset.to_r / 86400
+      time = ::Time.now
+      (time.dst? ? time.utc_offset - 3600 : time.utc_offset).to_r / 86400
     end
 
     # Returns <tt>Time.zone.now.to_datetime</tt> when <tt>Time.zone</tt> or <tt>config.time_zone</tt> are set, otherwise returns <tt>Time.now.to_datetime</tt>.


### PR DESCRIPTION
ActiveSupport tests is failing now for some time zones (e.g. Europe/Minsk and Europe/Moscow):

```
cd activesupport
TZ=Europe/Minsk rake test
```

This happens because current time zone is +03:00 but in 2007 year it was +02:00 (for Europe/Minsk).
It means that we need to return current non-DST offset in `DateTime.local` instead of historical one.
