### PR TITLE
Security fix in TranslationHelper: _html translation should escape interpolated arguments

### DIFF
--- a/actionpack/lib/action_view/helpers/translation_helper.rb
+++ b/actionpack/lib/action_view/helpers/translation_helper.rb
@@ -45,11 +45,16 @@ module ActionView
       # you know what kind of output to expect when you call translate in a template.
       def translate(key, options = {})
         options.merge!(:rescue_format => :html) unless options.key?(:rescue_format)
-        translation = I18n.translate(scope_key_by_partial(key), options)
-        if html_safe_translation_key?(key) && translation.respond_to?(:html_safe)
-          translation.html_safe
+        if html_safe_translation_key?(key)
+          html_safe_options = options.dup
+          options.except(*I18n::RESERVED_KEYS).each do |name, value|
+            html_safe_options[name] = value.respond_to?(:html_safe) ? ERB::Util.html_escape(value) : value
+          end
+          translation = I18n.translate(scope_key_by_partial(key), html_safe_options)
+
+          translation.respond_to?(:html_safe) ? translation.html_safe : translation
         else
-          translation
+          I18n.translate(scope_key_by_partial(key), options)
         end
       end
       alias :t :translate

--- a/actionpack/test/template/translation_helper_test.rb
+++ b/actionpack/test/template/translation_helper_test.rb
@@ -17,6 +17,7 @@ class TranslationHelperTest < ActiveSupport::TestCase
         :hello => '<a>Hello World</a>',
         :html => '<a>Hello World</a>',
         :hello_html => '<a>Hello World</a>',
+        :interpolated_html => '<a>Hello %{word}</a>',
         :array_html => %w(foo bar),
         :array => %w(foo bar)
       }
@@ -81,6 +82,10 @@ class TranslationHelperTest < ActiveSupport::TestCase
 
   def test_translate_marks_translations_with_a_html_suffix_as_safe_html
     assert translate(:'translations.hello_html').html_safe?
+  end
+
+  def test_translate_escapes_interpolations_in_translations_with_a_html_suffix
+    assert_equal '<a>Hello &lt;World&gt;</a>', translate(:'translations.interpolated_html', :word => '<World>')
   end
 
   def test_translation_returning_an_array_ignores_html_suffix


### PR DESCRIPTION
References #3515
