### PR TITLE
Added i18n support for placeholder attribute on inputs

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -1029,6 +1029,10 @@ module ActionView
         options["type"]  ||= field_type
         options["value"] = options.fetch("value"){ value_before_type_cast(object) } unless field_type == "file"
         options["value"] &&= ERB::Util.html_escape(options["value"])
+        if options["placeholder"].blank?
+          i18n_placeholder = I18n.t("#{object_name}.#{method_name}", :default => '', :scope => "helpers.placeholder")
+          options["placeholder"] = ERB::Util.html_escape(i18n_placeholder) unless i18n_placeholder.blank?
+        end
         add_default_name_and_id(options)
         tag("input", options)
       end

--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -1029,9 +1029,9 @@ module ActionView
         options["type"]  ||= field_type
         options["value"] = options.fetch("value"){ value_before_type_cast(object) } unless field_type == "file"
         options["value"] &&= ERB::Util.html_escape(options["value"])
-        if options["placeholder"].blank?
+        if options["placeholder"] == true
           i18n_placeholder = I18n.t("#{object_name}.#{method_name}", :default => '', :scope => "helpers.placeholder")
-          options["placeholder"] = ERB::Util.html_escape(i18n_placeholder) unless i18n_placeholder.blank?
+          options["placeholder"] = ERB::Util.html_escape(i18n_placeholder)
         end
         add_default_name_and_id(options)
         tag("input", options)

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -53,6 +53,17 @@ class FormHelperTest < ActionView::TestCase
       }
     }
 
+    # Create placeholder locale for testing i18n placeholder helpers
+    I18n.backend.store_translations 'placeholder', {
+      :helpers => {
+        :placeholder => {
+          :post => {
+            :body => 'text...'
+          }
+        }
+      }
+    }
+
     @post = Post.new
     @comment = Comment.new
     def @post.errors()
@@ -264,6 +275,26 @@ class FormHelperTest < ActionView::TestCase
     expected = '<input id="post_title" name="post[title]" size="35" type="text" value="Hello World" />'
     assert_dom_equal expected, text_field("post", "title", "size" => 35)
     assert_dom_equal expected, text_field("post", "title", :size => 35)
+  end
+
+  def test_text_field_with_placeholder_locale
+    old_body, @post.body = @post.body, ""
+    old_locale, I18n.locale = I18n.locale, :placeholder
+    expected = '<input id="post_body" name="post[body]" placeholder="text..." size="30" type="text" value="" />'
+    assert_dom_equal expected, text_field("post", "body")
+  ensure
+    @post.body = old_body
+    I18n.locale = old_locale
+  end
+
+  def test_text_field_with_placeholder_locale_and_option
+    old_body, @post.body = @post.body, ""
+    old_locale, I18n.locale = I18n.locale, :placeholder
+    expected = '<input id="post_body" name="post[body]" placeholder="type body..." size="30" type="text" value="" />'
+    assert_dom_equal expected, text_field("post", "body", :placeholder => "type body...")
+  ensure
+    @post.body = old_body
+    I18n.locale = old_locale
   end
 
   def test_text_field_assuming_size

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -277,17 +277,17 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, text_field("post", "title", :size => 35)
   end
 
-  def test_text_field_with_placeholder_locale
+  def test_text_field_with_placeholder_locale_and_option_true
     old_body, @post.body = @post.body, ""
     old_locale, I18n.locale = I18n.locale, :placeholder
     expected = '<input id="post_body" name="post[body]" placeholder="text..." size="30" type="text" value="" />'
-    assert_dom_equal expected, text_field("post", "body")
+    assert_dom_equal expected, text_field("post", "body", :placeholder => true)
   ensure
     @post.body = old_body
     I18n.locale = old_locale
   end
 
-  def test_text_field_with_placeholder_locale_and_option
+  def test_text_field_with_placeholder_locale_and_option_string
     old_body, @post.body = @post.body, ""
     old_locale, I18n.locale = I18n.locale, :placeholder
     expected = '<input id="post_body" name="post[body]" placeholder="type body..." size="30" type="text" value="" />'


### PR DESCRIPTION
If no :placeholder option is supplied to the input field tag helper
it will attempt to look up a translation from
helpers.placeholder.object.attribute

Users can now add that tranlation information to their locales and save
themselves from adding the wordy and possibly repetitive ":placeholder =>
'helpers.placeholder.object.attribute" option to input fields.

Passing tests included.
