### PR TITLE
Update variable's name in the test case to reflect the class we're testing

### DIFF
--- a/activemodel/test/cases/validations/exclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/exclusion_validation_test.rb
@@ -46,12 +46,12 @@ class ExclusionValidationTest < ActiveModel::TestCase
   def test_validates_exclusion_of_with_lambda
     Topic.validates_exclusion_of :title, :in => lambda{ |topic| topic.author_name == "sikachu" ? %w( monkey elephant ) : %w( abe wasabi ) }
 
-    p = Topic.new
-    p.title = "elephant"
-    p.author_name = "sikachu"
-    assert p.invalid?
+    t = Topic.new
+    t.title = "elephant"
+    t.author_name = "sikachu"
+    assert t.invalid?
 
-    p.title = "wasabi"
-    assert p.valid?
+    t.title = "wasabi"
+    assert t.valid?
   end
 end

--- a/activemodel/test/cases/validations/format_validation_test.rb
+++ b/activemodel/test/cases/validations/format_validation_test.rb
@@ -101,25 +101,25 @@ class PresenceValidationTest < ActiveModel::TestCase
   def test_validates_format_of_with_lambda
     Topic.validates_format_of :content, :with => lambda{ |topic| topic.title == "digit" ? /\A\d+\Z/ : /\A\S+\Z/ }
 
-    p = Topic.new
-    p.title = "digit"
-    p.content = "Pixies"
-    assert p.invalid?
+    t = Topic.new
+    t.title = "digit"
+    t.content = "Pixies"
+    assert t.invalid?
 
-    p.content = "1234"
-    assert p.valid?
+    t.content = "1234"
+    assert t.valid?
   end
 
   def test_validates_format_of_without_lambda
     Topic.validates_format_of :content, :without => lambda{ |topic| topic.title == "characters" ? /\A\d+\Z/ : /\A\S+\Z/ }
 
-    p = Topic.new
-    p.title = "characters"
-    p.content = "1234"
-    assert p.invalid?
+    t = Topic.new
+    t.title = "characters"
+    t.content = "1234"
+    assert t.invalid?
 
-    p.content = "Pixies"
-    assert p.valid?
+    t.content = "Pixies"
+    assert t.valid?
   end
 
   def test_validates_format_of_for_ruby_class

--- a/activemodel/test/cases/validations/inclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/inclusion_validation_test.rb
@@ -78,12 +78,12 @@ class InclusionValidationTest < ActiveModel::TestCase
   def test_validates_inclusion_of_with_lambda
     Topic.validates_inclusion_of :title, :in => lambda{ |topic| topic.author_name == "sikachu" ? %w( monkey elephant ) : %w( abe wasabi ) }
 
-    p = Topic.new
-    p.title = "wasabi"
-    p.author_name = "sikachu"
-    assert p.invalid?
+    t = Topic.new
+    t.title = "wasabi"
+    t.author_name = "sikachu"
+    assert t.invalid?
 
-    p.title = "elephant"
-    assert p.valid?
+    t.title = "elephant"
+    assert t.valid?
   end
 end


### PR DESCRIPTION
A while back I've fixed `format_validator`, `inclusion_validator` and `exclusion_validator`. I just realized that in the test case I was using a variable name `t` to reference to `Person`. This should fix that.
