### PR TITLE
Only used detailed schema introspection when doing a schema dump.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -576,6 +576,13 @@ module ActiveRecord
 
       # Returns a table's primary key and belonging sequence.
       def pk_and_sequence_for(table)
+        execute_and_free("DESCRIBE #{quote_table_name(table)}", 'SCHEMA') do |result|
+          keys = each_hash(result).select { |row| row[:Key] == 'PRI' }.map { |row| row[:Field] }
+          keys.length == 1 ? [keys.first, nil] : nil
+        end
+      end
+
+      def detailed_pk_and_sequence_for(table)
         sql = <<-SQL
           SELECT t.constraint_type, k.column_name
           FROM information_schema.table_constraints t

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -86,7 +86,9 @@ HEADER
           tbl = StringIO.new
 
           # first dump primary key column
-          if @connection.respond_to?(:pk_and_sequence_for)
+          if @connection.respond_to?(:detailed_pk_and_sequence_for)
+            pk, _ = @connection.detailed_pk_and_sequence_for(table)
+          elsif @connection.respond_to?(:pk_and_sequence_for)
             pk, _ = @connection.pk_and_sequence_for(table)
           elsif @connection.respond_to?(:primary_key)
             pk = @connection.primary_key(table)


### PR DESCRIPTION
This fixes the slowdown every time the primary key is extracted from a table introduced by #3526 in order to fix #3440

Fixes #3678
