### PR TITLE
(for 3-1-stable) Use `show index from`. We could fix `pk_and_sequence_for` method's performance problem (GH #3678)

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -755,26 +755,10 @@ module ActiveRecord
 
       # Returns a table's primary key and belonging sequence.
       def pk_and_sequence_for(table) #:nodoc:
-        execute_and_free("DESCRIBE #{quote_table_name(table)}", 'SCHEMA') do |result|
-          keys = each_hash(result).select { |row| row[:Key] == 'PRI' }.map { |row| row[:Field] }
-          keys.length == 1 ? [keys.first, nil] : nil
-        end
-      end
-
-      def detailed_pk_and_sequence_for(table) #:nodoc:
         keys = []
-        sql = <<-SQL
-          SELECT t.constraint_type, k.column_name
-          FROM information_schema.table_constraints t
-          JOIN information_schema.key_column_usage k
-          USING (constraint_name, table_schema, table_name)
-          WHERE t.table_schema = DATABASE()
-            AND t.table_name   = '#{table}'
-        SQL
-
-        result = execute(sql, 'SCHEMA')
+        result = execute("SHOW INDEX FROM #{quote_table_name(table)} WHERE Key_name = 'PRIMARY'", 'SCHEMA')
         result.each_hash do |h|
-          keys << h["column_name"] if h["constraint_type"] == "PRIMARY KEY"
+          keys << h["Column_name"]
         end
         result.free
         keys.length == 1 ? [keys.first, nil] : nil

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -86,9 +86,7 @@ HEADER
           tbl = StringIO.new
 
           # first dump primary key column
-          if @connection.respond_to?(:detailed_pk_and_sequence_for)
-            pk, _ = @connection.detailed_pk_and_sequence_for(table)
-          elsif @connection.respond_to?(:pk_and_sequence_for)
+          if @connection.respond_to?(:pk_and_sequence_for)
             pk, _ = @connection.pk_and_sequence_for(table)
           elsif @connection.respond_to?(:primary_key)
             pk = @connection.primary_key(table)


### PR DESCRIPTION
#3678 problem is solved by https://github.com/christos/rails/commit/280b2b725b488ef71556970ee895ccaddc315e0c .

But we still have a  little another problem (a schema dump runs rather slowly)

Please see last discussion  https://github.com/rails/rails/issues/3678
