### PR TITLE
Meaningful errors for unexpected partial arguments. Fixes #3573

### DIFF
--- a/actionpack/lib/action_view/renderer/partial_renderer.rb
+++ b/actionpack/lib/action_view/renderer/partial_renderer.rb
@@ -366,8 +366,13 @@ module ActionView
       path = if object.respond_to?(:to_partial_path)
         object.to_partial_path
       else
-        ActiveSupport::Deprecation.warn "ActiveModel-compatible objects whose classes return a #model_name that responds to #partial_path are deprecated. Please respond to #to_partial_path directly instead."
-        object.class.model_name.partial_path
+        klass = object.class
+        if klass.respond_to?(:model_name)
+          ActiveSupport::Deprecation.warn "ActiveModel-compatible objects whose classes return a #model_name that responds to #partial_path are deprecated. Please respond to #to_partial_path directly instead."
+          klass.model_name.partial_path
+        else
+          raise ArgumentError.new("'#{object.inspect}' is not an ActiveModel-compatible object that returns a valid partial path.")
+        end
       end
 
       @partial_names[path] ||= path.dup.tap do |object_path|

--- a/actionpack/test/template/render_test.rb
+++ b/actionpack/test/template/render_test.rb
@@ -142,6 +142,13 @@ module RenderTestCases
                                 "and is followed by any combinations of letters, numbers, or underscores.", e.message
   end
 
+  def test_render_partial_with_incompatible_object
+    @view.render(:partial => nil)
+    flunk "Render did not raise ArgumentError"
+  rescue ArgumentError => e
+    assert_equal "'#{nil.inspect}' is not an ActiveModel-compatible object that returns a valid partial path.", e.message
+  end
+
   def test_render_partial_with_errors
     @view.render(:partial => "test/raise")
     flunk "Render did not raise Template::Error"


### PR DESCRIPTION
GitHub issue #3573

I've wrapped the whole thing into an if block so it wont raise the error AND issue the deprecation warning, which would be confusing. This can obviously be refactored nicely once support for objects whose classes return a #model_name that responds to #partial_path will be dropped.
