### PR TITLE
Bump Arel

### DIFF
--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency('activesupport', version)
   s.add_dependency('activemodel',   version)
-  s.add_dependency('arel',          '~> 2.2.1')
+  s.add_dependency('arel',          '~> 3.0.0.pre')
   s.add_dependency('tzinfo',        '~> 0.3.29')
 end


### PR DESCRIPTION
Rails Build fails because Arel gemspec got changed 

https://github.com/rails/arel/commit/6525b409c2a753488681f4cd955cfda29a06b1ac

This will allow to run Rails Build
