### PR TITLE
PostgreSQL GIN and GiST index support

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -6,7 +6,7 @@ require 'bigdecimal/util'
 
 module ActiveRecord
   module ConnectionAdapters #:nodoc:
-    class IndexDefinition < Struct.new(:table, :name, :unique, :columns, :lengths, :orders) #:nodoc:
+    class IndexDefinition < Struct.new(:table, :name, :unique, :columns, :lengths, :orders, :type) #:nodoc:
     end
 
     # Abstract representation of a column definition. Instances of this type

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1074,10 +1074,10 @@ module ActiveRecord
       #  CREATE INDEX index_developers_on_name ON developers USING gist(name)
       #
       def add_index(table_name, column_name, options = {})
-        if !!options.delete(:gin)
+        if options[:gin]
           index_name, index_type, index_columns = add_index_options(table_name, column_name, options)
           execute "CREATE INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} USING gin(#{index_columns})" 
-        elsif !!options.delete(:gist)
+        elsif options[:gist]
           index_name, index_type, index_columns = add_index_options(table_name, column_name, options)
           execute "CREATE INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} USING gist(#{index_columns})"
         else

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1014,6 +1014,76 @@ module ActiveRecord
         clear_cache!
         execute "ALTER TABLE #{quote_table_name(table_name)} RENAME COLUMN #{quote_column_name(column_name)} TO #{quote_column_name(new_column_name)}"
       end
+      
+      # Adds a new index to the table. +column_name+ can be a single Symbol, or
+      # an Array of Symbols.
+      #
+      # The index will be named after the table and the first column name,
+      # unless you pass <tt>:name</tt> as an option.
+      #
+      # When creating an index on multiple columns, the first column is used as a name
+      # for the index. For example, when you specify an index on two columns
+      # [<tt>:first</tt>, <tt>:last</tt>], the DBMS creates an index for both columns as well as an
+      # index for the first column <tt>:first</tt>. Using just the first name for this index
+      # makes sense, because you will never have to create a singular index with this
+      # name.
+      #
+      # ===== Examples
+      #
+      # ====== Creating a simple index
+      #  add_index(:suppliers, :name)
+      # generates
+      #  CREATE INDEX suppliers_name_index ON suppliers(name)
+      #
+      # ====== Creating a unique index
+      #  add_index(:accounts, [:branch_id, :party_id], :unique => true)
+      # generates
+      #  CREATE UNIQUE INDEX accounts_branch_id_party_id_index ON accounts(branch_id, party_id)
+      #
+      # ====== Creating a named index
+      #  add_index(:accounts, [:branch_id, :party_id], :unique => true, :name => 'by_branch_party')
+      # generates
+      #  CREATE UNIQUE INDEX by_branch_party ON accounts(branch_id, party_id)
+      #
+      # ====== Creating an index with specific key length
+      #  add_index(:accounts, :name, :name => 'by_name', :length => 10)
+      # generates
+      #  CREATE INDEX by_name ON accounts(name(10))
+      #
+      #  add_index(:accounts, [:name, :surname], :name => 'by_name_surname', :length => {:name => 10, :surname => 15})
+      # generates
+      #  CREATE INDEX by_name_surname ON accounts(name(10), surname(15))
+      #
+      # Note: SQLite doesn't support index length
+      #
+      # ====== Creating an index with a sort order (desc or asc, asc is the default)
+      #  add_index(:accounts, [:branch_id, :party_id, :surname], :order => {:branch_id => :desc, :part_id => :asc})
+      # generates
+      #  CREATE INDEX by_branch_desc_party ON accounts(branch_id DESC, party_id ASC, surname)
+      #
+      # Note: mysql doesn't yet support index order (it accepts the syntax but ignores it)
+      #
+      # ====== Creating an GIN index
+      #  add_index(:developers, :name, :gin => true)
+      # generates
+      #  CREATE INDEX index_developers_on_name ON developers USING gin(name)
+      #
+      # ====== Creating an GiST index
+      #  add_index(:developers, :name, :gist => true)
+      # generates
+      #  CREATE INDEX index_developers_on_name ON developers USING gist(name)
+      #
+      def add_index(table_name, column_name, options = {})
+        if !!options.delete(:gin)
+          index_name, index_type, index_columns = add_index_options(table_name, column_name, options)
+          execute "CREATE INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} USING gin(#{index_columns})" 
+        elsif !!options.delete(:gist)
+          index_name, index_type, index_columns = add_index_options(table_name, column_name, options)
+          execute "CREATE INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} USING gist(#{index_columns})"
+        else
+          super(table_name, column_name, options)
+        end
+      end
 
       def remove_index!(table_name, index_name) #:nodoc:
         execute "DROP INDEX #{quote_table_name(index_name)}"

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -829,8 +829,9 @@ module ActiveRecord
           # add info on sort order for columns (only desc order is explicitly specified, asc is the default)
           desc_order_columns = inddef.scan(/(\w+) DESC/).flatten
           orders = desc_order_columns.any? ? Hash[desc_order_columns.map {|order_column| [order_column, :desc]}] : {}
-      
-          column_names.empty? ? nil : IndexDefinition.new(table_name, index_name, unique, column_names, [], orders)
+          type = inddef.scan(/USING (\w+) /).flatten.compact.first.intern
+
+          column_names.empty? ? nil : IndexDefinition.new(table_name, index_name, unique, column_names, [], orders, type)
         end.compact
       end
 

--- a/activerecord/test/cases/adapters/postgresql/add_index_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/add_index_test.rb
@@ -1,0 +1,39 @@
+require "cases/helper"
+require 'models/developer'
+
+module ActiveRecord
+  module ConnectionAdapters
+    class PostgreSQLAdapter
+      class IndexTest < ActiveRecord::TestCase
+        def setup
+          ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
+            alias_method :real_execute, :execute
+            remove_method :execute
+            def execute(sql, name = nil) sql end
+          end
+          @conn = ActiveRecord::Base.connection
+        end
+
+        def teardown
+          ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
+            remove_method :execute
+            alias_method :execute, :real_execute
+          end
+        end
+
+
+        def test_add_index_type_gin
+          table = :developers
+          column = :name
+          assert_equal %(CREATE INDEX \"#{@conn.index_name(table, column)}\" ON \"#{table}\" USING gin(\"#{column}\")), @conn.add_index(table, column, :gin => true)
+        end
+
+        def test_add_index_type_gist
+          table = :developers
+          column = :name
+          assert_equal %(CREATE INDEX \"#{@conn.index_name(table, column)}\" ON \"#{table}\" USING gist(\"#{column}\")), @conn.add_index(table, column, :gist => true)
+        end
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -11,16 +11,19 @@ class SchemaTest < ActiveRecord::TestCase
   INDEX_B_NAME = 'b_index_things_on_different_columns_in_each_schema'
   INDEX_C_NAME = 'c_index_full_text_search'
   INDEX_D_NAME = 'd_index_things_on_description_desc'
+  INDEX_E_NAME = 'e_index_things_on_name_vector'
   INDEX_A_COLUMN = 'name'
   INDEX_B_COLUMN_S1 = 'email'
   INDEX_B_COLUMN_S2 = 'moment'
   INDEX_C_COLUMN = %q{(to_tsvector('english', coalesce(things.name, '')))}
   INDEX_D_COLUMN = 'description'
+  INDEX_E_COLUMN = 'name_vector'
   COLUMNS = [
     'id integer',
     'name character varying(50)',
     'email character varying(50)',
     'description character varying(100)',
+    'name_vector tsvector',
     'moment timestamp without time zone default now()'
   ]
   PK_TABLE_NAME = 'table_with_pk'
@@ -59,6 +62,8 @@ class SchemaTest < ActiveRecord::TestCase
     @connection.execute "CREATE INDEX #{INDEX_C_NAME} ON #{SCHEMA2_NAME}.#{TABLE_NAME}  USING gin (#{INDEX_C_COLUMN});"
     @connection.execute "CREATE INDEX #{INDEX_D_NAME} ON #{SCHEMA_NAME}.#{TABLE_NAME}  USING btree (#{INDEX_D_COLUMN} DESC);"
     @connection.execute "CREATE INDEX #{INDEX_D_NAME} ON #{SCHEMA2_NAME}.#{TABLE_NAME}  USING btree (#{INDEX_D_COLUMN} DESC);"
+    @connection.execute "CREATE INDEX #{INDEX_E_NAME} ON #{SCHEMA_NAME}.#{TABLE_NAME}  USING gin(#{INDEX_E_COLUMN});"
+    @connection.execute "CREATE INDEX #{INDEX_E_NAME} ON #{SCHEMA2_NAME}.#{TABLE_NAME}  USING gin(#{INDEX_E_COLUMN});"
     @connection.execute "CREATE TABLE #{SCHEMA_NAME}.#{PK_TABLE_NAME} (id serial primary key)"
   end
 
@@ -189,15 +194,15 @@ class SchemaTest < ActiveRecord::TestCase
   end
 
   def test_dump_indexes_for_schema_one
-    do_dump_index_tests_for_schema(SCHEMA_NAME, INDEX_A_COLUMN, INDEX_B_COLUMN_S1, INDEX_D_COLUMN)
+    do_dump_index_tests_for_schema(SCHEMA_NAME, INDEX_A_COLUMN, INDEX_B_COLUMN_S1, INDEX_D_COLUMN, INDEX_E_COLUMN)
   end
 
   def test_dump_indexes_for_schema_two
-    do_dump_index_tests_for_schema(SCHEMA2_NAME, INDEX_A_COLUMN, INDEX_B_COLUMN_S2, INDEX_D_COLUMN)
+    do_dump_index_tests_for_schema(SCHEMA2_NAME, INDEX_A_COLUMN, INDEX_B_COLUMN_S2, INDEX_D_COLUMN, INDEX_E_COLUMN)
   end
 
   def test_dump_indexes_for_schema_multiple_schemas_in_search_path
-    do_dump_index_tests_for_schema("public, #{SCHEMA_NAME}", INDEX_A_COLUMN, INDEX_B_COLUMN_S1, INDEX_D_COLUMN)
+    do_dump_index_tests_for_schema("public, #{SCHEMA_NAME}", INDEX_A_COLUMN, INDEX_B_COLUMN_S1, INDEX_D_COLUMN, INDEX_E_COLUMN)
   end
 
   def test_with_uppercase_index_name
@@ -297,15 +302,20 @@ class SchemaTest < ActiveRecord::TestCase
       @connection.schema_search_path = "'$user', public"
     end
 
-    def do_dump_index_tests_for_schema(this_schema_name, first_index_column_name, second_index_column_name, third_index_column_name)
+    def do_dump_index_tests_for_schema(this_schema_name, first_index_column_name, second_index_column_name, third_index_column_name, fourth_index_column_name)
       with_schema_search_path(this_schema_name) do
         indexes = @connection.indexes(TABLE_NAME).sort_by {|i| i.name}
-        assert_equal 3,indexes.size
+        assert_equal 4,indexes.size
 
         do_dump_index_assertions_for_one_index(indexes[0], INDEX_A_NAME, first_index_column_name)
         do_dump_index_assertions_for_one_index(indexes[1], INDEX_B_NAME, second_index_column_name)
         do_dump_index_assertions_for_one_index(indexes[2], INDEX_D_NAME, third_index_column_name)
+        do_dump_index_assertions_for_one_index(indexes[3], INDEX_E_NAME, fourth_index_column_name)
 
+        indexes.select{|i| i.name != INDEX_E_NAME}.each do |index|
+          assert_equal :btree, index.type
+        end
+        assert_equal :gin, indexes.select{|i| i.name == INDEX_E_NAME}[0].type
         assert_equal :desc, indexes.select{|i| i.name == INDEX_D_NAME}[0].orders[INDEX_D_COLUMN]
       end
     end


### PR DESCRIPTION
Added add_index override in postgresql_adapter to allow for GiST and GIN support.

```
add_index(:wikis, :body, :gin => true)
```

Added PostgresqlAdapter indexes() :type support (specifying :btree, :gin, and :gist index types).
**NOTE:** instead of hacking the IndexDefinition class, I just added a `:type` attribute to the [`abstract/schema_definitions.rb`](https://github.com/chaffeqa/rails/commit/61fd6b6d9c57281f3af1cf2cb4a9373369011384)

```
ActiveRecord::Base.connection.indexes(:wikis) #=> #<struct ActiveRecord::ConnectionAdapters::IndexDefinition table=:wikis, name="index_wikis_on_ancestry", unique=false, columns=["ancestry"], lengths=nil, type=:btree>
```

Added tests for add_index. Updated tests for postgresql/schema_tests to check for index :type.

Let me know if there are other schema related updates I should do.  Would gladly do so :)

(refs [this old pull](https://github.com/rails/rails/pull/3699) )
