### PR TITLE
Refactored remove_column

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -408,7 +408,7 @@ module ActiveRecord
       #  t.remove(:qualification)
       #  t.remove(:qualification, :experience)
       def remove(*column_names)
-        @base.remove_column(@table_name, column_names)
+        @base.remove_column(@table_name, *column_names)
       end
 
       # Removes the given index from the table.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -618,8 +618,6 @@ module ActiveRecord
         end
 
         def columns_for_remove(table_name, *column_names)
-          column_names = column_names.flatten
-
           raise ArgumentError.new("You must specify at least one column name. Example: remove_column(:people, :first_name)") if column_names.blank?
           column_names.map {|column_name| quote_column_name(column_name) }
         end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -446,7 +446,7 @@ module ActiveRecord
 
       def remove_column(table_name, *column_names) #:nodoc:
         raise ArgumentError.new("You must specify at least one column name. Example: remove_column(:people, :first_name)") if column_names.empty?
-        column_names.flatten.each do |column_name|
+        column_names.each do |column_name|
           alter_table(table_name) do |definition|
             definition.columns.delete(definition[column_name])
           end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -588,14 +588,14 @@ class ChangeTableMigrationsTest < ActiveRecord::TestCase
 
   def test_remove_drops_single_column
     with_change_table do |t|
-      @connection.expects(:remove_column).with(:delete_me, [:bar])
+      @connection.expects(:remove_column).with(:delete_me, :bar)
       t.remove :bar
     end
   end
 
   def test_remove_drops_multiple_columns
     with_change_table do |t|
-      @connection.expects(:remove_column).with(:delete_me, [:bar, :baz])
+      @connection.expects(:remove_column).with(:delete_me, :bar, :baz)
       t.remove :bar, :baz
     end
   end


### PR DESCRIPTION
ActiveRecord::Table#remove should use `*column_names` instead of `column_names`.

So, I have removed unnecessary flatten for column_names that also caused issues [here](https://github.com/rsim/oracle-enhanced/issues/124).
