### PR TITLE
Find ips in the passed header

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -72,7 +72,7 @@ module ActionDispatch
     protected
 
       def ips_from(header, allow_proxies = false)
-        ips = @env[header] ? @env[header].strip.split(/[,\s]+/) : []
+        ips = @env[header] ? @env[header].strip.split(/[,\s]+/).grep(/\d\./) : []
         allow_proxies ? ips : ips.reject{|ip| ip =~ @middleware.proxies }
       end
     end


### PR DESCRIPTION
This little addition is needed to ensure that only a list of IPs is returned. The server I'm using is using Passenger standalone, which is using a server socket. It sets REMOTE_ADDR to 'unix:', which is clearly not an IP, but is however treated like one in RemoteIp. Note that Rack::Request does the same thing.
