### PR TITLE
Cherry pick ssl config

### DIFF
--- a/railties/guides/source/configuring.textile
+++ b/railties/guides/source/configuring.textile
@@ -181,7 +181,7 @@ h4. Configuring Middleware
 
 Every Rails application comes with a standard set of middleware which it uses in this order in the development environment:
 
-* +Rack::SSL+ Will force every request to be under HTTPS protocol. Will be available if +config.force_ssl+ is set to +true+.
+* +Rack::SSL+ Will force every request to be under HTTPS protocol. Will be available if +config.force_ssl+ is set to +true+.  Options passed to this can be configured by using +config.ssl_options+.
 * +ActionDispatch::Static+ is used to serve static assets. Disabled if +config.serve_static_assets+ is +true+.
 * +Rack::Lock+ Will wrap the app in mutex so it can only be called by a single thread at a time. Only enabled if +config.action_controller.allow_concurrency+ is set to +false+, which it is by default.
 * +ActiveSupport::Cache::Strategy::LocalCache+ Serves as a basic memory backed cache. This cache is not thread safe and is intended only for serving as a temporary memory cache for a single thread.

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -151,7 +151,7 @@ module Rails
 
         if config.force_ssl
           require "rack/ssl"
-          middleware.use ::Rack::SSL
+          middleware.use ::Rack::SSL, config.ssl_options
         end
 
         if config.serve_static_assets

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -10,7 +10,8 @@ module Rails
                     :dependency_loading, :filter_parameters,
                     :force_ssl, :helpers_paths, :logger, :preload_frameworks,
                     :reload_plugins, :secret_token, :serve_static_assets,
-                    :static_cache_control, :session_options, :time_zone, :whiny_nils
+                    :ssl_options, :static_cache_control, :session_options, 
+                    :time_zone, :whiny_nils
 
       attr_writer :log_level
       attr_reader :encoding
@@ -26,6 +27,7 @@ module Rails
         @serve_static_assets         = true
         @static_cache_control        = nil
         @force_ssl                   = false
+        @ssl_options                 = {}
         @session_store               = :cookie_store
         @session_options             = {}
         @time_zone                   = "UTC"

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -61,6 +61,14 @@ module ApplicationTests
       assert middleware.include?("Rack::SSL")
     end
 
+    test "Rack::SSL is configured with options when given" do
+      add_to_config "config.force_ssl = true"
+      add_to_config "config.ssl_options = { :host => 'example.com' }"
+      boot!
+      
+      assert_equal AppTemplate::Application.middleware.first.args, [{:host => 'example.com'}]
+    end
+
     test "removing Active Record omits its middleware" do
       use_frameworks []
       boot!


### PR DESCRIPTION
This cherry-picks cb5c39f8a0af78e933d1fe0456c112db1e97813f
It has not reason not to be included in 3.1.x as it does not break any API and provides a supplementary feature.
