### PR TITLE
postgresql adapter should quote not a number and infinity correctly for float columns

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -415,8 +415,13 @@ module ActiveRecord
 
         case value
         when Float
-          return super unless value.infinite? && column.type == :datetime
-          "'#{value.to_s.downcase}'"
+          if value.infinite? && column.type == :datetime
+            "'#{value.to_s.downcase}'"
+          elsif value.infinite? || value.nan?
+            "'#{value.to_s}'"
+          else
+            super
+          end
         when Numeric
           return super unless column.sql_type == 'money'
           # Not truly string input, so doesn't require (or allow) escape string syntax.

--- a/activerecord/test/cases/adapters/postgresql/quoting_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/quoting_test.rb
@@ -19,6 +19,18 @@ module ActiveRecord
           assert_equal 'f', @conn.type_cast(false, nil)
           assert_equal 'f', @conn.type_cast(false, c)
         end
+
+        def test_quote_float_nan
+          nan = 0.0/0
+          c = Column.new(nil, 1, 'float')
+          assert_equal "'NaN'", @conn.quote(nan, c)
+        end
+
+        def test_quote_float_infinity
+          infinity = 1.0/0
+          c = Column.new(nil, 1, 'float')
+          assert_equal "'Infinity'", @conn.quote(infinity, c)
+        end
       end
     end
   end


### PR DESCRIPTION
a fix to make the postgresql adapter quote NaN and Infinity in float columns. 

P.S. I don't know what the special case with the :datetime column is about, but i've left it in as the first condition, so that it would get triggered before it checks for just infinity? or nan?
