### PR TITLE
ActiveModel::Serialization now accepts parameters for methods

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -81,8 +81,8 @@ module ActiveModel
       hash = {}
       attribute_names.each { |n| hash[n] = read_attribute_for_serialization(n) }
 
-      method_names = Array.wrap(options[:methods]).select { |n| respond_to?(n) }
-      method_names.each { |n| hash[n] = send(n) }
+      method_names = Array.wrap(options[:methods]).select { |n| respond_to?(Array.wrap(n).first) }
+      method_names.each { |n| hash[Array.wrap(n).first] = send(*Array.wrap(n)) }
 
       serializable_add_includes(options) do |association, records, opts|
         hash[association] = if records.is_a?(Enumerable)

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -19,6 +19,10 @@ class SerializationTest < ActiveModel::TestCase
     def foo
       'i_am_foo'
     end
+
+    def echo_args(*args)
+      args
+    end
   end
 
   class Address
@@ -60,6 +64,22 @@ class SerializationTest < ActiveModel::TestCase
   def test_method_serializable_hash_should_work_with_methods_option
     expected =  {"name"=>"David", "gender"=>"male", :foo=>"i_am_foo", "email"=>"david@example.com"}
     assert_equal expected , @user.serializable_hash(:methods => [:foo])
+  end
+
+  def test_method_serializable_hash_should_work_with_methods_and_parameters_option
+    expected =  {"name"=>"David", "gender"=>"male", :echo_args=>[1,2,3], "email"=>"david@example.com"}
+    assert_equal expected , @user.serializable_hash(:methods => [[:echo_args, 1, 2, 3]])
+  end
+
+  def test_method_serializable_hash_should_work_with_methods_with_parameters_and_methods_without_parameters
+    expected =  {"name"=>"David", "gender"=>"male", :echo_args=>[1,2,3], :foo=>"i_am_foo", "email"=>"david@example.com"}
+    assert_equal expected , @user.serializable_hash(:methods => [[:echo_args, 1, 2, 3], :foo])
+  end
+
+  def test_method_serializable_hash_should_raise_argument_error_if_passed_improper_arguments
+    assert_raise(ArgumentError) do
+      @user.serializable_hash(:methods => [[:foo, 1]])
+    end
   end
 
   def test_method_serializable_hash_should_work_with_only_and_methods

--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -126,6 +126,20 @@ class JsonSerializationTest < ActiveModel::TestCase
     methods_json = @contact.to_json(:only => :name, :methods => [:label, :favorite_quote])
     assert_match %r{"label":"Has cheezburger"}, methods_json
     assert_match %r{"favorite_quote":"Constraints are liberating"}, methods_json
+
+    # Method with parameters.
+    assert_match %r{"echo_args":\[1,2,3\]}, @contact.to_json(:only => :name, :methods => [[:echo_args, 1, 2, 3]])
+
+    # All methods.
+    methods_json = @contact.to_json(:only => :name, :methods => [:label, :favorite_quote, [:echo_args, 1, 2, 3]])
+    assert_match %r{"label":"Has cheezburger"}, methods_json
+    assert_match %r{"favorite_quote":"Constraints are liberating"}, methods_json
+    assert_match %r{"echo_args":\[1,2,3\]}, methods_json
+
+    # Improper parameters passed to method should raise ArgumentError.
+    assert_raise(ArgumentError) do
+      @contact.to_json(:only => :name, :methods => [[:label, "Doesn't hav cheezburger :("]])
+    end
   end
 
   test "should return OrderedHash for errors" do

--- a/activemodel/test/cases/serializers/xml_serialization_test.rb
+++ b/activemodel/test/cases/serializers/xml_serialization_test.rb
@@ -130,7 +130,9 @@ class XmlSerializationTest < ActiveModel::TestCase
   end
 
   test "should serialize nil" do
-    assert_match %r{<pseudonyms nil=\"true\"></pseudonyms>}, @contact.to_xml(:methods => :pseudonyms)
+    contact_xml = @contact.to_xml(:methods => [:pseudonyms, [:echo_args, nil]])
+    assert_match %r{<pseudonyms nil=\"true\"></pseudonyms>}, contact_xml
+    assert_match %r{<echo-arg nil=\"true\"></echo-arg>}, contact_xml
   end
 
   test "should serialize integer" do
@@ -146,11 +148,16 @@ class XmlSerializationTest < ActiveModel::TestCase
   end
 
   test "should serialize array" do
-    assert_match %r{<social type=\"array\">\s*<social>twitter</social>\s*<social>github</social>\s*</social>}, @contact.to_xml(:methods => :social)
+    contact_xml = @contact.to_xml(:methods => [:social, [:echo_args, %w[twitter github]]])
+    assert_match %r{<social type=\"array\">\s*<social>twitter</social>\s*<social>github</social>\s*</social>}, contact_xml
+    assert_match %r{<echo-arg type=\"array\">\s*<echo-arg>twitter</echo-arg>\s*<echo-arg>github</echo-arg>\s*</echo-arg>},
+                 contact_xml
   end
 
   test "should serialize hash" do
-    assert_match %r{<network>\s*<git type=\"symbol\">github</git>\s*</network>}, @contact.to_xml(:methods => :network)
+    contact_xml = @contact.to_xml(:methods => [:network, [:echo_args, { :git => :github }]])
+    assert_match %r{<network>\s*<git type=\"symbol\">github</git>\s*</network>}, contact_xml
+    assert_match %r{<echo-arg>\s*<git type=\"symbol\">github</git>\s*</echo-arg>}, contact_xml
   end
 
   test "should serialize yaml" do

--- a/activemodel/test/models/contact.rb
+++ b/activemodel/test/models/contact.rb
@@ -23,4 +23,8 @@ class Contact
   def persisted?
     id
   end
+
+  def echo_args(*args)
+    args
+  end
 end


### PR DESCRIPTION
We've had the need to pass parameters to methods when being serialized.

Take a look at my tests to see how I've implemented it, but it's basically accepting an Array which is being splatted into `send` (i.e. send(*[:method_name, arg1, arg2, ...]) ).

Please let me know if anything needs to be done. Thanks.
