### PR TITLE
Make Array#join aware of SafeBuffers.

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -169,3 +169,17 @@ class String
     ActiveSupport::SafeBuffer.new(self)
   end
 end
+
+class Array
+  def join_with_safe_buffer_awareness(sep = $,)
+    return join_without_safe_buffer_awareness(sep) unless first.is_a?(ActiveSupport::SafeBuffer)
+    rest = map(&:to_s)
+    first = rest.shift.dup
+    sep = sep.to_s
+    return rest.inject(first, :<<) if sep.empty? # optimization for trivial separator
+    sep = ActiveSupport::SafeBuffer.new << sep unless sep.html_safe?
+    rest.each{|o| first << sep << o}
+    first
+  end
+  alias_method_chain :join, :safe_buffer_awareness
+end

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -112,4 +112,17 @@ class SafeBufferTest < ActiveSupport::TestCase
     assert_not_nil dirty
     assert !dirty
   end
+
+  test "Should be joinable in an Array" do
+    joined = ["<h>".html_safe.freeze, "<foo/>".freeze, "</h>".html_safe.freeze].join
+    assert joined.html_safe?
+    assert_equal joined, "<h>&lt;foo/&gt;</h>"
+
+    joined = ["<h>", "<foo/>".html_safe, "</h>"].join
+    assert !joined.html_safe?
+    assert_equal joined, "<h><foo/></h>"
+
+    assert_equal "<br/>&lt;foo/&gt;<br/></bar>", [@buffer, "<foo/>", "</bar>".html_safe].join("<br/>".html_safe)
+    assert_equal "&lt;br/&gt;", [@buffer, @buffer].join("<br/>")
+  end
 end


### PR DESCRIPTION
Currently, Array#join is not aware of SafeBuffers.

Because of that, `[foo, bar].join` is not the same to `foo+bar` if `foo` is a SafeBuffer.

This can lead many programmers to call `.html_safe` on the resulting string, which can be wrong and/or dangerous. I say "many programmers" judging from code I've seen (from good programmers), from this [accepted answer on StackOverflow](http://stackoverflow.com/questions/4191028/rails-3-0-2-arrayjoin-html-safe), or [warnings on blogs](https://makandracards.com/makandra/954-don-t-mix-array-join-and-string-html_safe).

This has been requested before (at least [here](https://github.com/NZKoz/rails_xss/issues/15) and [here](https://github.com/rails/rails/issues/2544) ), but no implementation was given.

Let me argue why patching `Array#join` is worth it.

1) It should not be too expensive to patch, since only the first element of the array needs to be checked. If it is not a SafeBuffer, we call the original `Array#join` and minimal time is spent (with a similar result as doing `first + second + ...`).

Otherwise we can safely expect that the safe join is what needs to be done (and the cost that is paid is cheap, since the implementation I propose will be more efficient than what many would write rolling their own)

2) Doing a correct and safe join is not easy! Calling `ary.inject(:+)` will be ineficient for large arrays, calling `ary.inject(:<<)` will mutate the first element, calling `ary.inject(:<<, "".html_safe)` is both long, ugly and not obvious for other readers. Note that doing a join with a separator is even more complicated.

3) Let me stress that the downside of leaving Array#join untouched is running the security risk that programmers will use `.join.html_safe` when they shouldn't. If they do, they are unlikely to notice a problem until someone uses that for an XSS attack...

Thanks
