### PR TITLE
javascript_include_tag should add '.js' to sources that contain '.'

### DIFF
--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -154,7 +154,7 @@ module Sprockets
         end
 
         def rewrite_extension(source, dir, ext)
-          if ext && File.extname(source).empty?
+          if ext && File.extname(source) != ".#{ext}"
             "#{source}.#{ext}"
           else
             source

--- a/actionpack/test/template/sprockets_helper_test.rb
+++ b/actionpack/test/template/sprockets_helper_test.rb
@@ -217,6 +217,9 @@ class SprocketsHelperTest < ActionView::TestCase
     assert_match %r{<script src="/assets/xmlhr-[0-9a-f]+.js\?body=1" type="text/javascript"></script>\n<script src="/assets/application-[0-9a-f]+.js\?body=1" type="text/javascript"></script>},
       javascript_include_tag(:application, :debug => true)
 
+    assert_match %r{<script src="/assets/jquery.plugin.js" type="text/javascript"></script>},
+      javascript_include_tag('jquery.plugin', :digest => false)
+
     @config.assets.compile = true
     @config.assets.debug = true
     assert_match %r{<script src="/javascripts/application.js" type="text/javascript"></script>},


### PR DESCRIPTION
Original issue #3715
