### PR TITLE
ActiveSupport::TimeWithZone#today? does not respect an instance-based time zone

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -41,25 +41,25 @@ class Time
     end
 
     # Returns <tt>Time.zone.now</tt> when <tt>Time.zone</tt> or <tt>config.time_zone</tt> are set, otherwise just returns <tt>Time.now</tt>.
-    def current
+    def current(time_zone = nil)
+      return ::Time.now.in_time_zone(time_zone) if time_zone
       ::Time.zone ? ::Time.zone.now : ::Time.now
     end
   end
 
   # Tells whether the Time object's time lies in the past
-  def past?
-    self < ::Time.current
+  def past?(time_zone = nil)
+    self < ::Time.current(time_zone)
   end
 
   # Tells whether the Time object's time is today
   def today?(time_zone = nil)
-    now = time_zone ? ::Time.current.in_time_zone(time_zone) : ::Time.current
-    to_date == now.to_date
+    to_date == ::Time.current(time_zone).to_date
   end
 
   # Tells whether the Time object's time lies in the future
-  def future?
-    self > ::Time.current
+  def future?(time_zone = nil)
+    self > ::Time.current(time_zone)
   end
 
   # Seconds since midnight: Time.now.seconds_since_midnight

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -52,8 +52,9 @@ class Time
   end
 
   # Tells whether the Time object's time is today
-  def today?
-    to_date == ::Date.current
+  def today?(time_zone = nil)
+    now = time_zone ? ::Time.current.in_time_zone(time_zone) : ::Time.current
+    to_date == now.to_date
   end
 
   # Tells whether the Time object's time lies in the future

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -195,7 +195,7 @@ module ActiveSupport
     end
 
     def today?
-      time.today?
+      time.today?(time_zone)
     end
 
     def future?

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -191,7 +191,7 @@ module ActiveSupport
     end
 
     def past?
-      utc.past?
+      utc.past?(time_zone)
     end
 
     def today?
@@ -199,7 +199,7 @@ module ActiveSupport
     end
 
     def future?
-      utc.future?
+      utc.future?(time_zone)
     end
 
     def eql?(other)

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -642,7 +642,7 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
   end
 
   def test_today_with_time_local
-    Date.stubs(:current).returns(Date.new(2000, 1, 1))
+    Time.stubs(:current).returns(Time.new(2000, 1, 1))
     assert_equal false, Time.local(1999,12,31,23,59,59).today?
     assert_equal true,  Time.local(2000,1,1,0).today?
     assert_equal true,  Time.local(2000,1,1,23,59,59).today?
@@ -650,7 +650,7 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
   end
 
   def test_today_with_time_utc
-    Date.stubs(:current).returns(Date.new(2000, 1, 1))
+    Time.stubs(:current).returns(Time.new(2000, 1, 1))
     assert_equal false, Time.utc(1999,12,31,23,59,59).today?
     assert_equal true,  Time.utc(2000,1,1,0).today?
     assert_equal true,  Time.utc(2000,1,1,23,59,59).today?

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -158,7 +158,7 @@ class TimeWithZoneTest < Test::Unit::TestCase
   end
 
   def test_today
-    Date.stubs(:current).returns(Date.new(2000, 1, 1))
+    Time.stubs(:current).returns(Time.new(2000, 1, 1))
     assert_equal false, ActiveSupport::TimeWithZone.new( nil, @time_zone, Time.utc(1999,12,31,23,59,59) ).today?
     assert_equal true,  ActiveSupport::TimeWithZone.new( nil, @time_zone, Time.utc(2000,1,1,0) ).today?
     assert_equal true,  ActiveSupport::TimeWithZone.new( nil, @time_zone, Time.utc(2000,1,1,23,59,59) ).today?

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -165,6 +165,11 @@ class TimeWithZoneTest < Test::Unit::TestCase
     assert_equal false, ActiveSupport::TimeWithZone.new( nil, @time_zone, Time.utc(2000,1,2,0) ).today?
   end
 
+  def test_today_with_zone
+    current_time = Time.now.in_time_zone('Asia/Shanghai')
+    assert_equal true, current_time.today?
+  end
+
   def test_past_with_time_current_as_time_local
     with_env_tz 'US/Eastern' do
       Time.stubs(:current).returns(Time.local(2005,2,10,15,30,45))


### PR DESCRIPTION
We ran into this issue in production where the following was not working as expected:

t = Time.now.in_time_zone(...)
t.today?

The reason is that the existing implementation of ActiveSupport::TimeWithZone#today? delegates to the redefined Time#today?, which was just comparing the current instance's #to_date with ::Date.current, which of course has no idea that the compared instance had a timezone configured via #in_time_zone. The attached pull request fixes this.
