### PR TITLE
stylesheet_tag default's media is "screen"

### DIFF
--- a/actionpack/lib/action_view/helpers/asset_tag_helpers/stylesheet_tag_helpers.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helpers/stylesheet_tag_helpers.rb
@@ -68,6 +68,9 @@ module ActionView
         # Returns a stylesheet link tag for the sources specified as arguments. If
         # you don't specify an extension, <tt>.css</tt> will be appended automatically.
         # You can modify the link attributes by passing a hash as the last argument.
+        # For historical reasons, the 'media' attribute will always be present and defaults
+        # to "screen", so you must explicitely set it to "all" for the stylesheet(s) to
+        # apply to all media types.
         #
         # ==== Examples
         #   stylesheet_link_tag "style" # =>

--- a/railties/guides/code/getting_started/app/views/layouts/application.html.erb
+++ b/railties/guides/code/getting_started/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>Blog</title>
-  <%= stylesheet_link_tag    "application" %>
+  <%= stylesheet_link_tag    "application", :media => "all" %>
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
 </head>

--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title><%= camelized %></title>
-  <%%= stylesheet_link_tag    "application" %>
+  <%%= stylesheet_link_tag    "application", :media => "all" %>
   <%%= javascript_include_tag "application" %>
   <%%= csrf_meta_tags %>
 </head>

--- a/railties/lib/rails/generators/rails/plugin_new/templates/app/views/layouts/%name%/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/app/views/layouts/%name%/application.html.erb.tt
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title><%= camelized %></title>
-  <%%= stylesheet_link_tag    "<%= name %>/application" %>
+  <%%= stylesheet_link_tag    "<%= name %>/application", :media => "all" %>
   <%%= javascript_include_tag "<%= name %>/application" %>
   <%%= csrf_meta_tags %>
 </head>


### PR DESCRIPTION
I expect that any website I visit will, at worst, print exactly the way it looks on screen.

Rails doesn't default to that since
1) `stylesheet_tag`'s media default is set to "screen", and
2) the generated default layout calls `stylesheet_tag` without a `media` option.

I would favor removing the default media type altogether, but I suspect that for compatibility reasons it will be judged that this can't be done.

So my patch changes (2) above by specifying `:media => "all"` in the default generated layout, and improves the documentation.

Thanks.
