### PR TITLE
Fix inconsistencies with Time{WithZone}#{hash,eql?}

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -312,4 +312,14 @@ class Time
   end
   alias_method :compare_without_coercion, :<=>
   alias_method :<=>, :compare_with_coercion
+
+  # Layers additional behavior on Time#eql? so that ActiveSupport::TimeWithZone instances
+  # can be eql? to an equivalent Time
+  def eql_with_coercion(other)
+    # if other is an ActiveSupport::TimeWithZone, coerce a Time instance from it so we can do eql? comparison
+    other = other.comparable_time if other.respond_to?(:comparable_time)
+    eql_without_coercion(other)
+  end
+  alias_method :eql_without_coercion, :eql?
+  alias_method :eql?, :eql_with_coercion
 end

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -203,7 +203,11 @@ module ActiveSupport
     end
 
     def eql?(other)
-      utc == other
+      utc.eql?(other)
+    end
+
+    def hash
+      utc.hash
     end
 
     def +(other)
@@ -277,7 +281,6 @@ module ActiveSupport
     def to_i
       utc.to_i
     end
-    alias_method :hash, :to_i
     alias_method :tv_sec, :to_i
 
     # A TimeWithZone acts like a Time, so just return +self+.

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -744,6 +744,12 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal(-1, Time.utc(2000) <=> ActiveSupport::TimeWithZone.new( Time.utc(2000, 1, 1, 0, 0, 1), ActiveSupport::TimeZone['UTC'] ))
   end
 
+  def test_eql?
+    assert_equal true, Time.utc(2000).eql?( ActiveSupport::TimeWithZone.new(Time.utc(2000), ActiveSupport::TimeZone['UTC']) )
+    assert_equal true, Time.utc(2000).eql?( ActiveSupport::TimeWithZone.new(Time.utc(2000), ActiveSupport::TimeZone["Hawaii"]) )
+    assert_equal false,Time.utc(2000, 1, 1, 0, 0, 1).eql?( ActiveSupport::TimeWithZone.new(Time.utc(2000), ActiveSupport::TimeZone['UTC']) )
+  end
+
   def test_minus_with_time_with_zone
     assert_equal  86_400.0, Time.utc(2000, 1, 2) - ActiveSupport::TimeWithZone.new( Time.utc(2000, 1, 1), ActiveSupport::TimeZone['UTC'] )
   end

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -200,8 +200,15 @@ class TimeWithZoneTest < Test::Unit::TestCase
   end
 
   def test_eql?
-    assert @twz.eql?(Time.utc(2000))
-    assert @twz.eql?( ActiveSupport::TimeWithZone.new(Time.utc(2000), ActiveSupport::TimeZone["Hawaii"]) )
+    assert_equal true, @twz.eql?(Time.utc(2000))
+    assert_equal true, @twz.eql?( ActiveSupport::TimeWithZone.new(Time.utc(2000), ActiveSupport::TimeZone["Hawaii"]) )
+    assert_equal false, @twz.eql?( Time.utc(2000, 1, 1, 0, 0, 1) )
+    assert_equal false, @twz.eql?( DateTime.civil(1999, 12, 31, 23, 59, 59) )
+  end
+
+  def test_hash
+    assert_equal Time.utc(2000).hash, @twz.hash
+    assert_equal Time.utc(2000).hash, ActiveSupport::TimeWithZone.new(Time.utc(2000), ActiveSupport::TimeZone["Hawaii"]).hash
   end
 
   def test_plus_with_integer


### PR DESCRIPTION
If `foo.eql?(bar)` returns `true` then so should `bar.eql?(foo)`.
Moreover, `foo.hash` must then be the same as `bar.hash`.
Otherwise the Hash lookup will fail. `TimeWithZone` wants to act like a `Time`, but currently:

```
bar = Time.utc(2000)
foo = bar.in_time_zone

foo.eql?(bar) # => true
bar.eql?(foo) # => false
foo.hash == bar.hash # => false (only in Ruby 1.9)
```

This pull request fixes this. Since `TimeWithZone` wants to be freely replaceable with a `Time`:

```
bar.eql?(foo) # => now true
foo.hash == bar.hash # => now true (even in Ruby 1.9)
```

There is also a problem with DateTime vs TimeWithZone:

```
dt = foo.to_datetime
foo.eql?(dt)  # => true
dt.eql?(foo)  # => false
dt.hash == foo # => false.
```

Since `DateTime` and a `Time` are both builtin classes and that a `Time` is never `eql?` to a `DateTime` or vice-versa (as per the doc and the implementation), the patch also insures that a `TimeWithZone` can no longer be `eql?` to a `DateTime`:

```
foo.eql?(dt)  # => now false
```

Thanks

Extended discussion at https://github.com/rails/rails/issues/905
