### PR TITLE
fix Helpers::DateHelper with :use_hidden - hide separators

### DIFF
--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -953,6 +953,8 @@ module ActionView
 
         # Returns the separator for a given datetime component.
         def separator(type)
+          return "" if @options[:use_hidden]
+
           case type
             when :year
               @options[:discard_year] ? "" : @options[:date_separator]

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -930,6 +930,15 @@ class DateHelperTest < ActionView::TestCase
     assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), { :date_separator => " / ", :discard_month => true, :discard_day => true, :start_year => 2003, :end_year => 2005, :prefix => "date[first]"})
   end
 
+  def test_select_date_with_hidden
+    expected =  %(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003"/>\n)
+    expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" />\n)
+    expected << %(<input id="date_first_day" name="date[first][day]" type="hidden" value="16" />\n)
+
+    assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), { :prefix => "date[first]", :use_hidden => true })
+    assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), { :date_separator => " / ", :prefix => "date[first]", :use_hidden => true })
+  end
+
   def test_select_datetime
     expected =  %(<select id="date_first_year" name="date[first][year]">\n)
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
@@ -1167,6 +1176,18 @@ class DateHelperTest < ActionView::TestCase
       :prompt => {:day => 'Choose day', :month => 'Choose month', :year => 'Choose year', :hour => 'Choose hour', :minute => 'Choose minute'})
   end
 
+  def test_select_datetime_with_hidden
+    expected =  %(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" />\n)
+    expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" />\n)
+    expected << %(<input id="date_first_day" name="date[first][day]" type="hidden" value="16" />\n)
+    expected << %(<input id="date_first_hour" name="date[first][hour]" type="hidden" value="8" />\n)
+    expected << %(<input id="date_first_minute" name="date[first][minute]" type="hidden" value="4" />\n)
+
+    assert_dom_equal expected, select_datetime(Time.mktime(2003, 8, 16, 8, 4, 18), :prefix => "date[first]", :use_hidden => true)
+    assert_dom_equal expected, select_datetime(Time.mktime(2003, 8, 16, 8, 4, 18), :datetime_separator => "&mdash;", :date_separator => "/",
+      :time_separator => ":", :prefix => "date[first]", :use_hidden => true)
+  end
+
   def test_select_time
     expected = %(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n)
     expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" />\n)
@@ -1340,6 +1361,17 @@ class DateHelperTest < ActionView::TestCase
 
     assert_dom_equal expected, select_time(Time.mktime(2003, 8, 16, 8, 4, 18), :prompt => true, :include_seconds => true,
       :prompt => {:hour => 'Choose hour', :minute => 'Choose minute', :second => 'Choose seconds'})
+  end
+
+  def test_select_time_with_hidden
+    expected =  %(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" />\n)
+    expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" />\n)
+    expected << %(<input id="date_first_day" name="date[first][day]" type="hidden" value="16" />\n)
+    expected << %(<input id="date_first_hour" name="date[first][hour]" type="hidden" value="8" />\n)
+    expected << %(<input id="date_first_minute" name="date[first][minute]" type="hidden" value="4" />\n)
+
+    assert_dom_equal expected, select_time(Time.mktime(2003, 8, 16, 8, 4, 18), :prefix => "date[first]", :use_hidden => true)
+    assert_dom_equal expected, select_time(Time.mktime(2003, 8, 16, 8, 4, 18), :time_separator => ":", :prefix => "date[first]", :use_hidden => true)
   end
 
   def test_date_select


### PR DESCRIPTION
Hi,
I've fixed DateHelper. It was rendering separators with :use_hidden => true.

``` ruby
<%= f.select_datetime :created_at, :use_hidden => true %>
```

Produced:

``` html
<input id="a_created_at_3i" name="a[created_at(3i)]" type="hidden" value="22">
<input id="a_created_at_2i" name="a[created_at(2i)]" type="hidden" value="11">
<input id="a_created_at_1i" name="a[created_at(1i)]" type="hidden" value="2011">
 — <input id="a_created_at_4i" name="a[created_at(4i)]" type="hidden" value="22">
 : <input id="a_created_at_5i" name="a[created_at(5i)]" type="hidden" value="16">
```

Now separators are not shown if  `@options[:use_hidden] == true`.
