### PR TITLE
Changed JSON 2 bytes clipping to 4 bytes clipping. This way, we can have emojis that were included in Unicode 6.0 

### DIFF
--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -127,7 +127,7 @@ module ActiveSupport
             gsub(/([\xC0-\xDF][\x80-\xBF]|
                    [\xE0-\xEF][\x80-\xBF]{2}|
                    [\xF0-\xF7][\x80-\xBF]{3})+/nx) { |s|
-            s.unpack("U*").pack("n*").unpack("H*")[0].gsub(/.{4}/n, '\\\\u\&')
+            s.unpack("U*").pack("N*").unpack("H*")[0].gsub(/.{4}/n, '\\\\u\&')
           }
           json = %("#{json}")
           json.force_encoding(::Encoding::UTF_8) if json.respond_to?(:force_encoding)


### PR DESCRIPTION
... 4 bytes to allow UTF-8 with 4 bytes wide
