### PR TITLE
configuration option to always write cookie

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -243,10 +243,13 @@ module ActionDispatch
         @delete_cookies.clear
       end
 
+      mattr_accessor :always_write_cookie
+      self.always_write_cookie = false
+
       private
 
         def write_cookie?(cookie)
-          @secure || !cookie[:secure] || defined?(Rails.env) && Rails.env.development?
+          @secure || !cookie[:secure] || always_write_cookie
         end
     end
 

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -10,10 +10,12 @@ module ActionDispatch
     config.action_dispatch.tld_length = 1
     config.action_dispatch.ignore_accept_header = false
     config.action_dispatch.rack_cache = {:metastore => "rails:/", :entitystore => "rails:/", :verbose => true}
-
     initializer "action_dispatch.configure" do |app|
       ActionDispatch::Http::URL.tld_length = app.config.action_dispatch.tld_length
       ActionDispatch::Request.ignore_accept_header = app.config.action_dispatch.ignore_accept_header
+
+      config.action_dispatch.always_write_cookie = Rails.env.development? if config.action_dispatch.always_write_cookie.nil?
+      ActionDispatch::Cookies::CookieJar.always_write_cookie = config.action_dispatch.always_write_cookie
     end
   end
 end

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -210,8 +210,8 @@ class CookiesTest < ActionController::TestCase
     assert_equal({"user_name" => "david"}, @response.cookies)
   end
 
-  def test_setting_cookie_with_secure_in_development
-    Rails.env.stubs(:development?).returns(true)
+  def test_setting_cookie_with_secure_when_always_write_cookie_is_true
+    ActionDispatch::Cookies::CookieJar.any_instance.stubs(:always_write_cookie).returns(true)
     get :authenticate_with_secure
     assert_cookie_header "user_name=david; path=/; secure"
     assert_equal({"user_name" => "david"}, @response.cookies)

--- a/railties/test/application/middleware/cookies_test.rb
+++ b/railties/test/application/middleware/cookies_test.rb
@@ -1,0 +1,47 @@
+require 'isolation/abstract_unit'
+
+module ApplicationTests
+  class CookiesTest < Test::Unit::TestCase
+    include ActiveSupport::Testing::Isolation
+
+    def new_app
+      File.expand_path("#{app_path}/../new_app")
+    end
+
+    def setup
+      build_app
+      boot_rails
+      FileUtils.rm_rf("#{app_path}/config/environments")
+    end
+
+    def teardown
+      teardown_app
+      FileUtils.rm_rf(new_app) if File.directory?(new_app)
+    end
+
+    test 'always_write_cookie is true by default in development' do
+      require 'rails'
+      Rails.env = 'development'
+      require "#{app_path}/config/environment"
+      assert_equal true, ActionDispatch::Cookies::CookieJar.always_write_cookie
+    end
+
+    test 'always_write_cookie is false by default in production' do
+      require 'rails'
+      Rails.env = 'production'
+      require "#{app_path}/config/environment"
+      assert_equal false, ActionDispatch::Cookies::CookieJar.always_write_cookie
+    end
+
+    test 'always_write_cookie can be overrided' do
+      add_to_config <<-RUBY
+        config.action_dispatch.always_write_cookie = false
+      RUBY
+
+      require 'rails'
+      Rails.env = 'development'
+      require "#{app_path}/config/environment"
+      assert_equal false, ActionDispatch::Cookies::CookieJar.always_write_cookie
+    end
+  end
+end


### PR DESCRIPTION
Replace `defined?(Rails.env) && Rails.env.development?` with configuration option.

/cc @josevalim
