### PR TITLE
Fix Issue #2639: "Served asset log messages are pretty annoying!" by adding config variable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ platforms :ruby do
   group :db do
     gem "pg", ">= 0.11.0" unless ENV['TRAVIS'] # once pg is on travis this can be removed
     gem "mysql", ">= 2.8.1"
-    gem "mysql2", ">= 0.3.6"
+    gem "mysql2", ">= 0.3.10"
   end
 end
 

--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -52,7 +52,7 @@ module ActionDispatch
     #
     # For convenience reasons, mailers provide a shortcut for ActionController::UrlFor#url_for.
     # So within mailers, you only have to type 'url_for' instead of 'ActionController::UrlFor#url_for'
-    # in full. However, mailers don't have hostname information, and what's why you'll still
+    # in full. However, mailers don't have hostname information, and that's why you'll still
     # have to specify the <tt>:host</tt> argument when generating URLs in mailers.
     #
     #

--- a/actionpack/lib/sprockets/railtie.rb
+++ b/actionpack/lib/sprockets/railtie.rb
@@ -21,8 +21,9 @@ module Sprockets
 
       require 'sprockets'
 
+      # Don't display Sprockets log messages if config.assets.logger is false in envrionment
       app.assets = Sprockets::Environment.new(app.root.to_s) do |env|
-        env.logger  = ::Rails.logger
+        env.logger  = ::Rails.logger unless config.assets.logger == false
         env.version = ::Rails.env + "-#{config.assets.version}"
 
         if config.assets.cache_store != false

--- a/activemodel/lib/active_model/callbacks.rb
+++ b/activemodel/lib/active_model/callbacks.rb
@@ -41,7 +41,7 @@ module ActiveModel
   # You can choose not to have all three callbacks by passing a hash to the
   # define_model_callbacks method.
   #
-  #   define_model_callbacks :create, :only => :after, :before
+  #   define_model_callbacks :create, :only => [:after, :before]
   #
   # Would only create the after_create and before_create callback methods in your
   # class.

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-gem 'mysql2', '~> 0.3.6'
+gem 'mysql2', '~> 0.3.10'
 require 'mysql2'
 
 module ActiveRecord

--- a/activeresource/lib/active_resource/custom_methods.rb
+++ b/activeresource/lib/active_resource/custom_methods.rb
@@ -23,7 +23,7 @@ module ActiveResource
   #     self.site = "http://37s.sunrise.i:3000"
   #   end
   #
-  #   Person.new(:name => 'Ryan).post(:register)  # POST /people/new/register.json
+  #   Person.new(:name => 'Ryan').post(:register)  # POST /people/new/register.json
   #   # => { :id => 1, :name => 'Ryan' }
   #
   #   Person.find(1).put(:promote, :position => 'Manager') # PUT /people/1/promote.json

--- a/railties/guides/source/configuring.textile
+++ b/railties/guides/source/configuring.textile
@@ -263,6 +263,8 @@ h4. Configuring Active Record
 
 * +config.active_record.whitelist_attributes+ will create an empty whitelist of attributes available for mass-assignment security for all models in your app.
 
+* +config.active_record.identity_map+ controls whether the identity map is enabled, and is false by default.
+
 The MySQL adapter adds one additional configuration option:
 
 * +ActiveRecord::ConnectionAdapters::MysqlAdapter.emulate_booleans+ controls whether Active Record will consider all +tinyint(1)+ columns in a MySQL database to be booleans and is true by default.

--- a/railties/lib/rails/rack/logger.rb
+++ b/railties/lib/rails/rack/logger.rb
@@ -21,8 +21,12 @@ module Rails
         request = ActionDispatch::Request.new(env)
         path = request.filtered_path
 
-        info "\n\nStarted #{request.request_method} \"#{path}\" " \
-             "for #{request.ip} at #{Time.now.to_default_s}"
+        # If config.assets.logger is set to false, only log non-assets related requests
+        if ((Rails.application.config.assets.logger != false) || 
+          (env['PATH_INFO'].index("/assets/") != 0))
+          info "\n\nStarted #{request.request_method} \"#{path}\"" \
+              " for #{request.ip} at #{Time.now.to_default_s}"
+        end
       end
 
       def after_dispatch(env)


### PR DESCRIPTION
Addresses issue #2639 (https://github.com/rails/rails/issues/2639) -- there are many assets related log messages and no config variable to hide them. Example log lines:

> Started GET "/assets/logo.png" for 127.0.0.1 at 2011-11-24 01:22:02 -0800
> Served asset /logo.png - 200 OK (1ms)

With these commits, by default both "assets" related log messages (sprockets and rack) are not logged.

Users can add a config variable set to true (_config.assets.logger = true_) to their application.rb or environment.rb files to restore the log messages.
