### PR TITLE
Backporting a Ruby 1.9.3 fix for MissingSourceFile

### DIFF
--- a/activesupport/lib/active_support/core_ext/load_error.rb
+++ b/activesupport/lib/active_support/core_ext/load_error.rb
@@ -18,6 +18,7 @@ class MissingSourceFile < LoadError #:nodoc:
   end
 
   REGEXPS = [
+    [/^cannot load such file -- (.+)$/i, 1],
     [/^no such file to load -- (.+)$/i, 1],
     [/^Missing \w+ (file\s*)?([^\s]+.rb)$/i, 2],
     [/^Missing API definition file in (.+)$/i, 1]


### PR DESCRIPTION
I backported a Ruby 1.9.3 fix in MissingSourceFile from Rails master. 
In Ruby 1.9.3 a new error message was added when the LoadFile exception is thrown; this was fixed in Rails Master but not in 2-3-stable, rendering 2-3-stable unusable with Ruby 1.9.3

This is the specific line from master: https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/load_error.rb#L6
