### PR TITLE
make ActiveModel::Name fail gracefully with anonymous classes

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -12,6 +12,9 @@ module ActiveModel
 
     def initialize(klass, namespace = nil, name = nil)
       name ||= klass.name
+
+      raise ArgumentError, "Class name cannot be blank. You need to supply a name argument when anonymous class given" if name.blank?
+
       super(name)
 
       @unnamespaced = self.sub(/^#{namespace.name}::/, '') if namespace

--- a/activemodel/test/cases/naming_test.rb
+++ b/activemodel/test/cases/naming_test.rb
@@ -247,3 +247,16 @@ class NamingHelpersTest < Test::Unit::TestCase
       ActiveModel::Naming.send(method, *args)
     end
 end
+
+class NameWithAnonymousClassTest < Test::Unit::TestCase
+  def test_anonymous_class_without_name_argument
+    assert_raises(ArgumentError) do
+      model_name = ActiveModel::Name.new(Class.new)
+    end
+  end
+
+  def test_anonymous_class_with_name_argument
+    model_name = ActiveModel::Name.new(Class.new, nil, "Anonymous")
+    assert_equal "Anonymous", model_name
+  end
+end


### PR DESCRIPTION
Defines behavior for cases described in #2586. Without the patch the behavior is different on Ruby 1.8 and 1.9:

```
ArgumentError: interning empty string # 1.8
TypeError: can't convert nil into String # 1.9
```

... which is not really helpful. ActiveModel::Name can be used with anonymous classes only when a name argument is given.
