### PR TITLE
middlewares should have configurable logger

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/params_parser.rb
+++ b/actionpack/lib/action_dispatch/middleware/params_parser.rb
@@ -52,7 +52,7 @@ module ActionDispatch
           false
         end
       rescue Exception => e # YAML, XML or Ruby code block errors
-        logger.debug "Error occurred while parsing request parameters.\nContents:\n\n#{request.raw_post}"
+        logger(env).debug "Error occurred while parsing request parameters.\nContents:\n\n#{request.raw_post}"
 
         raise e
       end
@@ -68,8 +68,8 @@ module ActionDispatch
         nil
       end
 
-      def logger
-        defined?(Rails.logger) ? Rails.logger : Logger.new($stderr)
+      def logger(env)
+        env['action_dispatch.logger'] || Logger.new($stderr)
       end
   end
 end

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -333,9 +333,9 @@ module ActionDispatch
         "#{FIXTURE_LOAD_PATH}/public"
       end
 
-      remove_method :logger
+      remove_method :stderr_logger
       # Silence logger
-      def logger
+      def stderr_logger
         nil
       end
   end

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -32,16 +32,12 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
 
   test "logs error if parsing unsuccessful" do
     with_test_routing do
-      begin
-        $stderr = StringIO.new
-        json = "[\"person]\": {\"name\": \"David\"}}"
-        post "/parse", json, {'CONTENT_TYPE' => 'application/json', 'action_dispatch.show_exceptions' => true}
-        assert_response :error
-        $stderr.rewind && err = $stderr.read
-        assert err =~ /Error occurred while parsing request parameters/
-      ensure
-        $stderr = STDERR
-      end
+      output = StringIO.new
+      json = "[\"person]\": {\"name\": \"David\"}}"
+      post "/parse", json, {'CONTENT_TYPE' => 'application/json', 'action_dispatch.show_exceptions' => true, 'action_dispatch.logger' => Logger.new(output)}
+      assert_response :error
+      output.rewind && err = output.read
+      assert err =~ /Error occurred while parsing request parameters/
     end
   end
 

--- a/actionpack/test/dispatch/request/xml_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/xml_params_parsing_test.rb
@@ -54,16 +54,12 @@ class XmlParamsParsingTest < ActionDispatch::IntegrationTest
 
   test "logs error if parsing unsuccessful" do
     with_test_routing do
-      begin
-        $stderr = StringIO.new
-        xml = "<person><name>David</name><avatar type='file' name='me.jpg' content_type='image/jpg'>#{ActiveSupport::Base64.encode64('ABC')}</avatar></pineapple>"
-        post "/parse", xml, default_headers.merge('action_dispatch.show_exceptions' => true)
-        assert_response :error
-        $stderr.rewind && err = $stderr.read
-        assert err =~ /Error occurred while parsing request parameters/
-      ensure
-        $stderr = STDERR
-      end
+      output = StringIO.new
+      xml = "<person><name>David</name><avatar type='file' name='me.jpg' content_type='image/jpg'>#{ActiveSupport::Base64.encode64('ABC')}</avatar></pineapple>"
+      post "/parse", xml, default_headers.merge('action_dispatch.show_exceptions' => true, 'action_dispatch.logger' => Logger.new(output))
+      assert_response :error
+      output.rewind && err = output.read
+      assert err =~ /Error occurred while parsing request parameters/
     end
   end
 

--- a/actionpack/test/dispatch/show_exceptions_test.rb
+++ b/actionpack/test/dispatch/show_exceptions_test.rb
@@ -128,4 +128,11 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
     get "/", {}, {'action_dispatch.show_exceptions' => true}
     assert_equal "text/html; charset=utf-8", response.headers["Content-Type"]
   end
+
+  test 'uses logger from env' do
+    @app = ProductionApp
+    output = StringIO.new
+    get "/", {}, {'action_dispatch.show_exceptions' => true, 'action_dispatch.logger' => Logger.new(output)}
+    assert_match(/puke/, output.rewind && output.read)
+  end
 end

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -123,7 +123,8 @@ module Rails
       @env_config ||= super.merge({
         "action_dispatch.parameter_filter" => config.filter_parameters,
         "action_dispatch.secret_token" => config.secret_token,
-        "action_dispatch.show_exceptions" => config.action_dispatch.show_exceptions
+        "action_dispatch.show_exceptions" => config.action_dispatch.show_exceptions,
+        "action_dispatch.logger" => Rails.logger
       })
     end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -524,6 +524,7 @@ module ApplicationTests
       assert_equal      app.env_config['action_dispatch.parameter_filter'], app.config.filter_parameters
       assert_equal      app.env_config['action_dispatch.secret_token'],     app.config.secret_token
       assert_equal      app.env_config['action_dispatch.show_exceptions'],  app.config.action_dispatch.show_exceptions
+      assert_equal      app.env_config['action_dispatch.logger'],           Rails.logger
     end
   end
 end


### PR DESCRIPTION
Allow setting logger for `ParamsParser` and `ShowExceptions` middlewares instead of hardcoded `defined?(Rails.logger) ? Rails.logger : Logger.new($stderr)`

/cc @josevalim
