### PR TITLE
New records should load has_many relationships with custom primary keys

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -235,7 +235,7 @@ module ActiveRecord
       # This method is abstract in the sense that it relies on
       # +count_records+, which is a method descendants have to provide.
       def size
-        if owner.new_record? || (loaded? && !options[:uniq])
+        if !find_target? || (loaded? && !options[:uniq])
           target.size
         elsif !loaded? && options[:group]
           load_target.size

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -103,6 +103,10 @@ module ActiveRecord
             end
           end
         end
+        
+        def foreign_key_present?
+          owner.attribute_present?(reflection.association_primary_key)
+        end
     end
   end
 end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -8,6 +8,7 @@ require 'models/reply'
 require 'models/category'
 require 'models/post'
 require 'models/author'
+require 'models/essay'
 require 'models/comment'
 require 'models/person'
 require 'models/reader'
@@ -61,7 +62,7 @@ end
 class HasManyAssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :categories, :companies, :developers, :projects,
            :developers_projects, :topics, :authors, :comments,
-           :people, :posts, :readers, :taggings, :cars
+           :people, :posts, :readers, :taggings, :cars, :essays
 
   def setup
     Client.destroyed_client_ids.clear
@@ -1388,6 +1389,32 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_no_queries do
       firm.clients.first
       firm.clients.last
+    end
+  end
+  
+  def test_custom_primary_key_on_new_record_should_fetch_with_query
+    author = Author.new(:name => "David")
+    assert !author.essays.loaded?
+    
+    assert_queries 1 do 
+      assert_equal 1, author.essays.size
+    end
+    
+    assert_equal author.essays, Essay.find_all_by_writer_id("David")
+    
+  end
+  
+  def test_has_many_custom_primary_key
+    david = authors(:david)
+    assert_equal david.essays, Essay.find_all_by_writer_id("David")
+  end
+  
+  def test_blank_custom_primary_key_on_new_record_should_not_run_queries
+    author = Author.new
+    assert !author.essays.loaded?
+    
+    assert_queries 0 do 
+      assert_equal 0, author.essays.size
     end
   end
 


### PR DESCRIPTION
If a has_many relationship is defined with a custom primary key, a new, unsaved record with that key set will not load the association.  This is because AR checks new_record? and assumes (correctly in normal situations) that an unsaved record couldn't possibly have any related records, so it skips the round trip to the database.  

I believe this is an error, and the association should be loaded from the database.

``` ruby
class Author < ActiveRecord::Base 
  has_many :essays, :primary_key => :name, :as => :writer
end

Author.new(:name => "David").essays # => []
                                    # => Should return [#<Essay ...>]
```

This pull request fixes this issue.  I tested the 4 big connection adapters and added 2 tests.  

I overrode the foreign_key_defined? method in has_many_association to handle this since that seemed to be written almost specifically for this purpose in has_many_through, but if that isn't the best way to handle this I'm open to discussion.  

Thanks
