### PR TITLE
Fixes issue #3749: nested_attributes_for does not work with STI

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -180,7 +180,11 @@ module ActiveRecord
       # Returns a new, unsaved instance of the associated class. +options+ will
       # be passed to the class's constructor.
       def build_association(*options, &block)
-        klass.new(*options, &block)
+        if options.first.is_a?(Hash) && options.first[klass.inheritance_column]
+          klass.find_sti_class(options.first[klass.inheritance_column]).new(*options, &block)
+        else
+          klass.new(*options, &block)
+        end
       end
 
       def table_name

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -69,6 +69,13 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
     assert_equal 1, pirate.birds_with_reject_all_blank.count
     assert_equal 'Tweetie', pirate.birds_with_reject_all_blank.first.name
   end
+  
+  def test_should_build_correcty_typed_sti_record
+    pirate = Pirate.create!(:catchphrase => "Don' botharrr talkin' like one, savvy?")
+    pirate.parrots_attributes = [{:name => 'Tweetie', :parrot_sti_class => 'LiveParrot'}]
+    assert_equal 1, pirate.parrots.length
+    assert_equal LiveParrot, pirate.parrots.first.class
+  end
 
   def test_should_raise_an_ArgumentError_for_non_existing_associations
     assert_raise_with_message ArgumentError, "No association found for name `honesty'. Has it been defined yet?" do


### PR DESCRIPTION
When using the *_attributes= method generated by `nested_attributes_for1 to create new models, the newly created models always have the base class. The`type` attribute is ignored.

This patch includes a failing test and my first attempt at a fix. I know the fix isn't too pretty, and I'm hoping to get guidance on building a better patch.

Thank you!
