### PR TITLE
Updating newline fix to maintain existing linebreaks and indentation and...

### DIFF
--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -68,8 +68,9 @@ module Rails
         end
 
         in_root do
-          str = "\ngem #{parts.join(", ")}\n"
+          str = "gem #{parts.join(", ")}"
           str = "  " + str if @in_group
+          str = "\n" + str
           append_file "Gemfile", str, :verbose => false
         end
       end
@@ -87,13 +88,13 @@ module Rails
         log :gemfile, "group #{name}"
 
         in_root do
-          append_file "Gemfile", "\ngroup #{name} do\n", :force => true
+          append_file "Gemfile", "\ngroup #{name} do", :force => true
 
           @in_group = true
           instance_eval(&block)
           @in_group = false
 
-          append_file "Gemfile", "end\n", :force => true
+          append_file "Gemfile", "\nend\n", :force => true
         end
       end
 

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -95,11 +95,13 @@ class ActionsTest < Rails::Generators::TestCase
   def test_gem_should_insert_on_separate_lines
     run_generator
 
+    File.open('Gemfile', 'a') {|f| f.write('# Some content...') }
+
     action :gem, 'rspec'
     action :gem, 'rspec-rails'
 
-    assert_file 'Gemfile', /gem "rspec"$/
-    assert_file 'Gemfile', /gem "rspec-rails"$/
+    assert_file 'Gemfile', /^gem "rspec"$/
+    assert_file 'Gemfile', /^gem "rspec-rails"$/
   end
 
   def test_gem_group_should_wrap_gems_in_a_group
@@ -112,8 +114,8 @@ class ActionsTest < Rails::Generators::TestCase
     action :gem_group, :test do
       gem 'fakeweb'
     end
-
-    assert_file 'Gemfile', /\ngroup :development, :test do\n  \ngem "rspec-rails"\nend\n\ngroup :test do\n  \ngem "fakeweb"\nend/
+    
+    assert_file 'Gemfile', /\ngroup :development, :test do\n  gem "rspec-rails"\nend\n\ngroup :test do\n  gem "fakeweb"\nend/
   end
 
   def test_environment_should_include_data_in_environment_initializer_block


### PR DESCRIPTION
RE: [#3751](https://github.com/rails/rails/pull/3751)

Pull request [#3752](https://github.com/rails/rails/pull/3752) only added a 2 `\n`'s to make the test passing.

This will produce and pass on the following `gem group`:

```
group :development, :test do

gem "rspec-rails"
end

group :test do

gem "fakeweb"
end
```

This pull request reverts changes to `test_gem_group_should_wrap_gems_in_a_group` so it expects the original:

```
group :development, :test do
  gem "rspec-rails"
end

group :test do
  gem "fakeweb"
end
```

It also builds on `test_gem_should_insert_on_separate_lines` to actually insert new content without a trailing newline and insure the gems begin on newlines:

```
File.open('Gemfile', 'a') {|f| f.write('# Some content...') }

...

assert_file 'Gemfile', /^gem "rspec"$/
assert_file 'Gemfile', /^gem "rspec-rails"$/
```

Let me know if this makes sense. Thanks.
