### PR TITLE
'criterion'.pluralize => 'criteria'

### DIFF
--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -21,6 +21,7 @@ module ActiveSupport
     inflect.plural(/^(ox)$/i, '\1en')
     inflect.plural(/^(oxen)$/i, '\1')
     inflect.plural(/(quiz)$/i, '\1zes')
+    inflect.plural(/(criteri)on$/i, '\1a')
 
     inflect.singular(/s$/i, '')
     inflect.singular(/(n)ews$/i, '\1ews')
@@ -47,6 +48,7 @@ module ActiveSupport
     inflect.singular(/(matr)ices$/i, '\1ix')
     inflect.singular(/(quiz)zes$/i, '\1')
     inflect.singular(/(database)s$/i, '\1')
+    inflect.singular(/(criteri)a$/i, '\1on')
 
     inflect.irregular('person', 'people')
     inflect.irregular('man', 'men')

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -104,7 +104,8 @@ module InflectorTestCases
     "edge"        => "edges",
 
     "cow"         => "kine",
-    "database"    => "databases"
+    "database"    => "databases",
+    "criterion"    => "criteria"
   }
 
   CamelToUnderscore = {


### PR DESCRIPTION
Added a pluralization rule for 'criterion' <=> 'criteria'

I occasionally use this term in real world business applications (at least, far more often than 'octopus' or 'zombie'), so I hope this rule to be supported by default.
