### PR TITLE
allow using orm_instance without invoking orm_class in generators

### DIFF
--- a/railties/lib/rails/generators/resource_helpers.rb
+++ b/railties/lib/rails/generators/resource_helpers.rb
@@ -73,7 +73,7 @@ module Rails
 
         # Initialize ORM::Generators::ActiveModel to access instance methods.
         def orm_instance(name=singular_table_name)
-          @orm_instance ||= @orm_class.new(name)
+          @orm_instance ||= orm_class.new(name)
         end
     end
   end


### PR DESCRIPTION
The patch allows using orm_instance method, without invoking orm_class before. It solves #3653 I guess.
