### PR TITLE
Object#in? also accepts multiple parameters

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/inclusion.rb
+++ b/activesupport/lib/active_support/core_ext/object/inclusion.rb
@@ -1,15 +1,25 @@
 class Object
-  # Returns true if this object is included in the argument. Argument must be
-  # any object which responds to +#include?+. Usage:
+  # Returns true if this object is included in the argument(s). Argument must be
+  # any object which responds to +#include?+ or optionally, multiple arguments can be passed in. Usage:
   #
   #   characters = ["Konata", "Kagami", "Tsukasa"]
   #   "Konata".in?(characters) # => true
+  #   
+  #   character = "Konata"
+  #   character.in?("Konata", "Kagami", "Tsukasa") # => true
   #
-  # This will throw an ArgumentError if the argument doesn't respond
+  # This will throw an ArgumentError if a single argument is passed in and it doesn't respond
   # to +#include?+.
-  def in?(another_object)
-    another_object.include?(self)
-  rescue NoMethodError
-    raise ArgumentError.new("The parameter passed to #in? must respond to #include?")
+  def in?(*args)
+    if args.length > 1
+      args.include? self
+    else
+      another_object = args.first
+      if another_object.respond_to? :include?
+        another_object.include? self
+      else
+        raise ArgumentError.new("The single parameter passed to #in? must respond to #include?")
+      end
+    end
   end
 end

--- a/activesupport/test/core_ext/object/inclusion_test.rb
+++ b/activesupport/test/core_ext/object/inclusion_test.rb
@@ -2,6 +2,16 @@ require 'abstract_unit'
 require 'active_support/core_ext/object/inclusion'
 
 class InTest < Test::Unit::TestCase
+  def test_in_multiple_args
+    assert :b.in?(:a,:b)
+    assert !:c.in?(:a,:b)
+  end
+  
+  def test_in_multiple_arrays
+    assert [1,2].in?([1,2],[2,3])
+    assert ![1,2].in?([1,3],[2,1])
+  end
+  
   def test_in_array
     assert 1.in?([1,2])
     assert !3.in?([1,2])


### PR DESCRIPTION
This is just a suggestion, but since the change is quite simple, I've created a pull request. The idea is to allow passing multiple arguments to Object#in? method, like:

``` ruby
animal = "cat"
animal.in?("dog", "cat", "rat")
```

currently, you'd have to do something like this:

``` ruby
animal = "cat"
animal.in?(["bat", "cat", "rat"])
```

which is not very nice. Implementation also preserves current behaviour. 
Do you think it would be useful?
