### PR TITLE
Test and fix for Issue 3450

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -264,7 +264,7 @@ module ActiveRecord
     # turned on for the association.
     def validate_single_association(reflection)
       association = association_instance_get(reflection.name)
-      record      = association && association.target
+      record      = association && association.reader
       association_valid?(reflection, record) if record
     end
 

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -347,6 +347,17 @@ class TestDefaultAutosaveAssociationOnABelongsToAssociation < ActiveRecord::Test
     client.save!
     assert_no_queries { assert_equal apple, client.firm }
   end
+
+  def test_validation_does_not_validate_stale_association_target
+    valid_developer   = Developer.create!(:name => "Dude", :salary => 50_000)
+    invalid_developer = Developer.new()
+
+    auditlog = AuditLog.new(:message => "foo")
+    auditlog.developer    = invalid_developer
+    auditlog.developer_id = valid_developer.id
+
+    assert auditlog.valid?
+  end
 end
 
 class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCase


### PR DESCRIPTION
This is a test and fix for rails/rails/#3450

Asssigning a parent id to a belongs_to association actually updates the object that is validated when the association has :validates => true
