### PR TITLE
avoid url started with "/" for the rails.png in public/index.html

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/public/index.html
+++ b/railties/lib/rails/generators/rails/app/templates/public/index.html
@@ -59,7 +59,7 @@
 
 
       #header {
-        background-image: url("/assets/rails.png");
+        background-image: url("assets/rails.png");
         background-repeat: no-repeat;
         background-position: top left;
         height: 64px;

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -55,6 +55,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "app/views/layouts/application.html.erb", /javascript_include_tag\s+"application"/
     assert_file "app/assets/stylesheets/application.css"
     assert_file "config/application.rb", /config\.assets\.enabled = true/
+    assert_file "public/index.html", /url\("assets\/rails.png"\);/
   end
 
   def test_invalid_application_name_raises_an_error


### PR DESCRIPTION
When I generated new rails app to test relative_url_root issue, I met this issue.

```
$ rails new demo 
$ demo
$ (edit Gemfile)
uncommented unicorn (I want to use unicorn's --path option.)

$ bundle install

$ (edit config.ru)

require ::File.expand_path('../config/environment',  __FILE__)
map ActionController::Base.config.relative_url_root || "/" do
  run Demo::Application
end

$ unicorn_rails -E development --path /demo -p 3000
$ (browse http://localhost:3000/demo/)

=> I couldn't see the rails.png !
```
