### PR TITLE
Added assert_required_keys to Hash

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -58,7 +58,8 @@ class Hash
   #   {:age => 28 }.assert_required_keys(:name) # => raises ArgumentError
   #   {'name' => 'Phil'}.assert_required_keys(:name) # => raises ArgumentError
   def assert_required_keys(*required_keys)
-    keys_not_passed = [required_keys].flatten - keys
+    required_keys.flatten!
+    keys_not_passed = required_keys - keys
     raise(ArgumentError, "The following keys are required but were not set: #{keys_not_passed.map(&:inspect).join(", ")}") unless keys_not_passed.empty?
   end
 end

--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -44,4 +44,21 @@ class Hash
       raise(ArgumentError, "Unknown key: #{k}") unless valid_keys.include?(k)
     end
   end
+
+  # Validate that all *required_keys are included in hash, otherwise it will raise an ArgumentError.
+  # Note that keys are NOT treated indifferently, meaning if you use strings for keys but assert symbols
+  # as keys, this will fail.
+  #
+  # *required_keys*: list of keys that must be present in hash for it to be valid
+  #
+  # ==== Examples
+  #   {:name => 'Phil'}.assert_required_keys(:name) # => will not raise error
+  #   {:name => nil}.assert_required_keys(:name) # => will not raise error
+  #
+  #   {:age => 28 }.assert_required_keys(:name) # => raises ArgumentError
+  #   {'name' => 'Phil'}.assert_required_keys(:name) # => raises ArgumentError
+  def assert_required_keys(*required_keys)
+    keys_not_passed = [required_keys].flatten - keys
+    raise(ArgumentError, "The following keys are required but were not set: #{keys_not_passed.map(&:inspect).join(", ")}") unless keys_not_passed.empty?
+  end
 end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -340,6 +340,7 @@ class HashExtTest < Test::Unit::TestCase
     assert_nothing_raised do
       { :name => "Phil", :age => 28 }.assert_required_keys(:name, :age)
       { :name => nil, :age => 28 }.assert_required_keys(:name, :age) # does not care about value, just that key exists
+      { :name => "Phil", :age => 28 }.assert_required_keys(:name) # giving more than the required keys
     end
 
     assert_raise(ArgumentError) do

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -336,6 +336,18 @@ class HashExtTest < Test::Unit::TestCase
     end
   end
 
+  def test_assert_required_keys
+    assert_nothing_raised do
+      { :name => "Phil", :age => 28 }.assert_required_keys(:name, :age)
+      { :name => nil, :age => 28 }.assert_required_keys(:name, :age) # does not care about value, just that key exists
+    end
+
+    assert_raise(ArgumentError) do
+      { :name => "Phil" }.assert_required_keys(:name, :age)
+      { 'name' => "Phil" }.assert_required_keys(:name) # required symbol, but string key was included instead
+    end
+  end
+
   def test_assorted_keys_not_stringified
     original = {Object.new => 2, 1 => 2, [] => true}
     indiff = original.with_indifferent_access

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -343,7 +343,10 @@ class HashExtTest < Test::Unit::TestCase
     end
 
     assert_raise(ArgumentError) do
-      { :name => "Phil" }.assert_required_keys(:name, :age)
+      { :name => "Phil" }.assert_required_keys(:name, :age) # required key is not present
+    end
+    
+    assert_raise(ArgumentError) do
       { 'name' => "Phil" }.assert_required_keys(:name) # required symbol, but string key was included instead
     end
   end


### PR DESCRIPTION
assert_required_keys will raise an ArgumentError if the calling hash does not include every key passed to the method.

This hopefully will allow cleaner usage of hashes as a stand-in for named parameters.

``` ruby
def deposit(options={})
  options.assert_required_keys :account_number, :amount
  ...
end

deposit :amount => 100 
# => ArgumentError: The following keys are required but were not set: :account_number
```
