### PR TITLE
Call a block passed rake_tasks method in the self context

### DIFF
--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -181,7 +181,7 @@ module Rails
 
     def load_tasks(app=self)
       extend Rake::DSL if defined? Rake::DSL
-      self.class.rake_tasks.each { |block| block.call(app) }
+      self.class.rake_tasks.each { |block| self.instance_exec(app, &block) }
 
       # load also tasks from all superclasses
       klass = self.class.superclass


### PR DESCRIPTION
When I run `rake_test.rb`, I had some warnings. The reproduce step is

```
$ cd railties
$ bundle exec ruby -Itest:lib:../activesupport/lib:../actionpack/lib test/application/rake_test.rb --name=test_initializers_are_executed_in_rake_tasks
...
WARNING: Global access to Rake DSL methods is deprecated.  Please include
    ...  Rake::DSL into classes and modules which use the Rake DSL methods.
WARNING: DSL method Class#task called at /home/kennyj/rails/railties/tmp/app/config/application.rb:58:in `block in <class:Application>'
...
```

We call the global scope task method (deprecated method) in rake_test.rb
Briefly we must call `extend Rake::DSL` only,
but I think that the cause of problem is located another.

In load_tasks method, we call `extend Rake::DSL`. But It seems that we have another context when executing rake_tasks.

```
182     def load_tasks(app=self)
183       extend Rake::DSL if defined? Rake::DSL
184       self.class.rake_tasks.each { |block| block.call(app) }
```

This is related to #1174.

If this is a specification, I'll fix a tastcase.
