### PR TITLE
fix label with block in erb

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -960,7 +960,7 @@ module ActionView
     end
 
     class InstanceTag
-      include Helpers::CaptureHelper, Context, Helpers::TagHelper, Helpers::FormTagHelper
+      include Helpers::TagHelper, Helpers::FormTagHelper
 
       attr_reader :object, :method_name, :object_name
 
@@ -992,7 +992,7 @@ module ActionView
         options["for"] ||= name_and_id["id"]
 
         if block_given?
-          label_tag(name_and_id["id"], options, &block)
+          @template_object.label_tag(name_and_id["id"], options, &block)
         else
           content = if text.blank?
             object_name.gsub!(/\[(.*)_attributes\]\[\d\]/, '.\1')

--- a/actionpack/test/fixtures/test/_label_with_block.erb
+++ b/actionpack/test/fixtures/test/_label_with_block.erb
@@ -1,0 +1,4 @@
+<%= label 'post', 'message' do %>
+  Message
+  <%= text_field 'post', 'message' %>
+<% end %>

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -230,6 +230,13 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal('<label for="post_title">The title, please:</label>', label(:post, :title) { "The title, please:" })
   end
 
+  def test_label_with_block_in_erb
+    path = ActionView::FileSystemResolver.new(FIXTURE_LOAD_PATH)
+    view_paths = ActionView::PathSet.new([path])
+    view = ActionView::Base.new(view_paths)
+    assert_equal "<label for=\"post_message\">\n  Message\n  <input id=\"post_message\" name=\"post[message]\" size=\"30\" type=\"text\" />\n</label>", view.render("test/label_with_block")
+  end
+
   def test_text_field
     assert_dom_equal(
       '<input id="post_title" name="post[title]" size="30" type="text" value="Hello World" />', text_field("post", "title")


### PR DESCRIPTION
The following template code:

```
<%= label 'post', 'message' do %>
  Message
  <%= text_field 'post', 'message' %>
<% end %>
```

Generates:

```
  Message
  <input id="post_message" name="post[message]" size="30" type="text" />
<label for="post_message">
  Message
  <input id="post_message" name="post[message]" size="30" type="text" />
</label>
```

It happens because of `InstanceTag#to_label_tag` invokes `capture` helper (through `label_tag` and `content_tag`) and `capture` helper can't capture output of block because block is in (ActionView::Base context) and `capture` helper executes in (InstanceTag context).

I've put call `label_tag` from `@template_object` when block is passed. Also `Helpers::CaptureHelper` and `Context` modules aren't longer needed in `InstanceTag`.

It could also could be reason for #3385

/cc @josevalim
