### PR TITLE
fixed a typo in a travis message

### DIFF
--- a/ci/travis.rb
+++ b/ci/travis.rb
@@ -132,7 +132,7 @@ failures = results.select { |key, value| value == false }
 
 if failures.empty?
   puts
-  puts "Rails build finished sucessfully"
+  puts "Rails build finished successfully"
   exit(true)
 else
   puts


### PR DESCRIPTION
fixed a typo in a message "Rails build finished successfully"
