### PR TITLE
Put backtrace_cleaner to env

### DIFF
--- a/actionpack/test/dispatch/show_exceptions_test.rb
+++ b/actionpack/test/dispatch/show_exceptions_test.rb
@@ -135,4 +135,11 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
     get "/", {}, {'action_dispatch.show_exceptions' => true, 'action_dispatch.logger' => Logger.new(output)}
     assert_match(/puke/, output.rewind && output.read)
   end
+
+  test 'uses backtrace cleaner from env' do
+    @app = DevelopmentApp
+    cleaner = stub(:clean => ['passed backtrace cleaner'])
+    get "/", {}, {'action_dispatch.show_exceptions' => true, 'action_dispatch.backtrace_cleaner' => cleaner}
+    assert_match(/passed backtrace cleaner/, body)
+  end
 end

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -124,7 +124,8 @@ module Rails
         "action_dispatch.parameter_filter" => config.filter_parameters,
         "action_dispatch.secret_token" => config.secret_token,
         "action_dispatch.show_exceptions" => config.action_dispatch.show_exceptions,
-        "action_dispatch.logger" => Rails.logger
+        "action_dispatch.logger" => Rails.logger,
+        "action_dispatch.backtrace_cleaner" => Rails.backtrace_cleaner
       })
     end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -521,10 +521,11 @@ module ApplicationTests
       make_basic_app
 
       assert_respond_to app, :env_config
-      assert_equal      app.env_config['action_dispatch.parameter_filter'], app.config.filter_parameters
-      assert_equal      app.env_config['action_dispatch.secret_token'],     app.config.secret_token
-      assert_equal      app.env_config['action_dispatch.show_exceptions'],  app.config.action_dispatch.show_exceptions
-      assert_equal      app.env_config['action_dispatch.logger'],           Rails.logger
+      assert_equal      app.env_config['action_dispatch.parameter_filter'],  app.config.filter_parameters
+      assert_equal      app.env_config['action_dispatch.secret_token'],      app.config.secret_token
+      assert_equal      app.env_config['action_dispatch.show_exceptions'],   app.config.action_dispatch.show_exceptions
+      assert_equal      app.env_config['action_dispatch.logger'],            Rails.logger
+      assert_equal      app.env_config['action_dispatch.backtrace_cleaner'], Rails.backtrace_cleaner
     end
   end
 end


### PR DESCRIPTION
Get `backtrace_cleaner` from env instead of `defined?(Rails) && Rails.respond_to?(:backtrace_cleaner) ...`

/cc @josevalim
