### PR TITLE
Backport Bug Fix

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -109,14 +109,11 @@ module ActiveRecord
         def construct_scope
           create_scoping = {}
           set_belongs_to_association_for(create_scoping)
-          {
-            :find => { :conditions => @finder_sql,
-                       :readonly => false,
-                       :order => @reflection.options[:order],
-                       :limit => @reflection.options[:limit],
-                       :include => @reflection.options[:include]},
-            :create => create_scoping
-          }
+          { :find => { :conditions => @finder_sql,
+                       :readonly   => false
+                      }.update(
+                        @reflection.options.slice(:select, :readonly, :include, :order, :limit, :joins, :group, :having, :offset) ),
+            :create => create_scoping }
         end
 
         def we_can_set_the_inverse_on_this?(record)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -49,6 +49,11 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     Client.destroyed_client_ids.clear
   end
 
+  def test_chaining_scopes_to_association_proxy_preserves_group_by
+    author = authors(:david)
+    assert_equal (author.grouped_posts.map &:type).size, (author.grouped_posts.limit(Post.all.size).map &:type).size
+  end
+
   def test_create_from_association_should_respect_default_scope
     car = Car.create(:name => 'honda')
     assert_equal 'honda', car.name

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -47,6 +47,7 @@ class Author < ActiveRecord::Base
   has_many :nonexistant_comments, :through => :posts
 
   has_many :hello_posts, :class_name => "Post", :conditions => "posts.body = 'hello'"
+  has_many :grouped_posts, :class_name => "Post", :group => 'type'
   has_many :hello_post_comments, :through => :hello_posts, :source => :comments
   has_many :posts_with_no_comments, :class_name => 'Post', :conditions => 'comments.id is null', :include => :comments
 


### PR DESCRIPTION
Backport Bug Fix: This fixes an issue with attaching scopes to the has-many association proxy. It's already fixed in 3.1 thanks to a substantial refactoring.
