### PR TITLE
Allows assert_redirected_to to accept a regular expression

### DIFF
--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -165,6 +165,7 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
       process :redirect_to_named_route
       assert_redirected_to 'http://test.host/route_one'
       assert_redirected_to route_one_url
+      assert_redirected_to %r(^http://test\.host)
     end
   end
 
@@ -192,6 +193,9 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
       end
       assert_raise(ActiveSupport::TestCase::Assertion) do
         assert_redirected_to route_two_url
+      end
+      assert_raise(ActiveSupport::TestCase::Assertion) do
+        assert_redirected_to %r(#{route_two_url})
       end
     end
   end
@@ -221,6 +225,7 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
       process :redirect_to_top_level_named_route
       # assert_redirected_to "http://test.host/action_pack_assertions/foo" would pass because of exact match early return
       assert_redirected_to "/action_pack_assertions/foo"
+      assert_redirected_to %r(/action_pack_assertions/foo)
     end
   end
 


### PR DESCRIPTION
I have a few places where I really only care to assert that the URL matches a regular expression.

This patch allows it while keeping the semantics the same when a `String` or `Hash` is passed to `assert_redirect_to`
