### PR TITLE
Handle correctly optional parameters for callable asset_host.

### DIFF
--- a/actionpack/lib/action_view/asset_paths.rb
+++ b/actionpack/lib/action_view/asset_paths.rb
@@ -103,8 +103,8 @@ module ActionView
         if host.respond_to?(:call)
           args = [source]
           arity = arity_of(host)
-          if arity > 1 && !has_request?
-            invalid_asset_host!("Remove the second argument to your asset_host Proc if you do not need the request.")
+          if (arity > 1 || arity < -2) && !has_request?
+            invalid_asset_host!("Remove the second argument to your asset_host Proc if you do not need the request, or make it optional.")
           end
           args << current_request if (arity > 1 || arity < 0) && has_request?
           host.call(*args)

--- a/actionpack/test/template/sprockets_helper_test.rb
+++ b/actionpack/test/template/sprockets_helper_test.rb
@@ -41,6 +41,10 @@ class SprocketsHelperTest < ActionView::TestCase
     @controller ? @controller.config : @config
   end
 
+  def compute_host(source, request, options = {})
+    raise "Should never get here"
+  end
+
   test "asset_path" do
     assert_match %r{/assets/logo-[0-9a-f]+.png},
       asset_path("logo.png")
@@ -122,6 +126,10 @@ class SprocketsHelperTest < ActionView::TestCase
     @config.asset_host = Proc.new do |asset, request|
       fail "This should not have been called."
     end
+    assert_raises ActionController::RoutingError do
+      asset_path("logo.png")
+    end
+    @config.asset_host = method :compute_host
     assert_raises ActionController::RoutingError do
       asset_path("logo.png")
     end


### PR DESCRIPTION
This fixes a bug if ever the `asset_host` is callable with optional parameters and two required parameters. Also the error message now suggests an extra solution to make the request parameter optional.

Thanks
