### PR TITLE
Fix Issue #2639: "Served asset log messages are pretty annoying!" by adding config variable

### DIFF
--- a/actionpack/lib/sprockets/railtie.rb
+++ b/actionpack/lib/sprockets/railtie.rb
@@ -21,8 +21,9 @@ module Sprockets
 
       require 'sprockets'
 
+      # Don't display Sprockets log messages if config.assets.logger is false in envrionment
       app.assets = Sprockets::Environment.new(app.root.to_s) do |env|
-        env.logger  = ::Rails.logger
+        env.logger  = ::Rails.logger unless config.assets.logger == false
         env.version = ::Rails.env + "-#{config.assets.version}"
 
         if config.assets.cache_store != false

--- a/railties/lib/rails/rack/logger.rb
+++ b/railties/lib/rails/rack/logger.rb
@@ -21,8 +21,12 @@ module Rails
         request = ActionDispatch::Request.new(env)
         path = request.filtered_path
 
-        info "\n\nStarted #{request.request_method} \"#{path}\" " \
-             "for #{request.ip} at #{Time.now.to_default_s}"
+        # If config.assets.logger is set to false, only log non-assets related requests
+        if ((Rails.application.config.assets.logger != false) || 
+          (env['PATH_INFO'].index("/assets/") != 0))
+          info "\n\nStarted #{request.request_method} \"#{path}\"" \
+              " for #{request.ip} at #{Time.now.to_default_s}"
+        end
       end
 
       def after_dispatch(env)


### PR DESCRIPTION
Addresses issue #2639 (https://github.com/rails/rails/issues/2639) -- there are many assets related log messages and no config variable to hide them. Example log lines:

> Started GET "/assets/logo.png" for 127.0.0.1 at 2011-11-24 01:22:02 -0800
> Served asset /logo.png - 200 OK (1ms)

With these commits, both asset related logger messages (Sprockets and Rack) can be hidden with a config variable. By default the messages still appear.

To hide the messages, add this line to e.g. _application.rb_:

`config.assets.logger = false`

Note: This is a replacement for https://github.com/rails/rails/pull/3741 (closed), squashed into one commit and no longer hiding the messages by default.
