### PR TITLE
Active model patch 3 0 stable

### DIFF
--- a/activemodel/lib/active_model/validations/confirmation.rb
+++ b/activemodel/lib/active_model/validations/confirmation.rb
@@ -10,7 +10,9 @@ module ActiveModel
       end
 
       def setup(klass)
-        klass.send(:attr_accessor, *attributes.map { |attribute| :"#{attribute}_confirmation" })
+        klass.send(:attr_accessor, *attributes.map do |attribute|
+          :"#{attribute}_confirmation" unless klass.method_defined?(:"#{attribute}_confirmation")
+        end.compact)
       end
     end
 


### PR DESCRIPTION
If you have an ActiveModel class that has a 
method email_address_confirmation. 
This method is being overwritten by the 
method defined in the Confirmation validator.

Fixes #1152

/cc @josevalim
