### PR TITLE
Test helpers in erb using erb

### DIFF
--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -73,6 +73,14 @@ module RackTestUtils
 end
 
 module RenderERBUtils
+  def view
+    @view ||= begin
+      path = ActionView::FileSystemResolver.new(FIXTURE_LOAD_PATH)
+      view_paths = ActionView::PathSet.new([path])
+      ActionView::Base.new(view_paths)
+    end
+  end
+
   def render_erb(string)
     template = ActionView::Template.new(
       string.strip,

--- a/actionpack/test/fixtures/test/_content_tag_nested_in_content_tag.erb
+++ b/actionpack/test/fixtures/test/_content_tag_nested_in_content_tag.erb
@@ -1,0 +1,3 @@
+<%= content_tag 'p' do %>
+  <%= content_tag 'b', 'Hello' %>
+<% end %>

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -3,6 +3,8 @@ require 'controller/fake_models'
 require 'active_support/core_ext/object/inclusion'
 
 class FormHelperTest < ActionView::TestCase
+  include RenderERBUtils
+
   tests ActionView::Helpers::FormHelper
 
   def form_for(*)
@@ -231,9 +233,6 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_label_with_block_in_erb
-    path = ActionView::FileSystemResolver.new(FIXTURE_LOAD_PATH)
-    view_paths = ActionView::PathSet.new([path])
-    view = ActionView::Base.new(view_paths)
     assert_equal "<label for=\"post_message\">\n  Message\n  <input id=\"post_message\" name=\"post[message]\" size=\"30\" type=\"text\" />\n</label>", view.render("test/label_with_block")
   end
 

--- a/actionpack/test/template/form_tag_helper_test.rb
+++ b/actionpack/test/template/form_tag_helper_test.rb
@@ -2,6 +2,8 @@ require 'abstract_unit'
 require 'active_support/core_ext/object/inclusion'
 
 class FormTagHelperTest < ActionView::TestCase
+  include RenderERBUtils
+
   tests ActionView::Helpers::FormTagHelper
 
   def setup
@@ -104,14 +106,14 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_form_tag_with_block_in_erb
-    output_buffer = form_tag("http://www.example.com") { concat "Hello world!" }
+    output_buffer = render_erb("<%= form_tag('http://www.example.com') do %>Hello world!<% end %>")
 
     expected = whole_form { "Hello world!" }
     assert_dom_equal expected, output_buffer
   end
 
   def test_form_tag_with_block_and_method_in_erb
-    output_buffer = form_tag("http://www.example.com", :method => :put) { concat "Hello world!" }
+    output_buffer = render_erb("<%= form_tag('http://www.example.com', :method => :put) do %>Hello world!<% end %>")
 
     expected = whole_form("http://www.example.com", :method => "put") do
       "Hello world!"
@@ -485,27 +487,27 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_field_set_tag_in_erb
-    output_buffer = field_set_tag("Your details") { concat "Hello world!" }
+    output_buffer = render_erb("<%= field_set_tag('Your details') do %>Hello world!<% end %>")
 
     expected = %(<fieldset><legend>Your details</legend>Hello world!</fieldset>)
     assert_dom_equal expected, output_buffer
 
-    output_buffer = field_set_tag { concat "Hello world!" }
+    output_buffer = render_erb("<%= field_set_tag do %>Hello world!<% end %>")
 
     expected = %(<fieldset>Hello world!</fieldset>)
     assert_dom_equal expected, output_buffer
 
-    output_buffer = field_set_tag('') { concat "Hello world!" }
+    output_buffer = render_erb("<%= field_set_tag('') do %>Hello world!<% end %>")
 
     expected = %(<fieldset>Hello world!</fieldset>)
     assert_dom_equal expected, output_buffer
 
-    output_buffer = field_set_tag('', :class => 'format') { concat "Hello world!" }
+    output_buffer = render_erb("<%= field_set_tag('', :class => 'format') do %>Hello world!<% end %>")
 
     expected = %(<fieldset class="format">Hello world!</fieldset>)
     assert_dom_equal expected, output_buffer
   end
-  
+
   def test_text_area_tag_options_symbolize_keys_side_effects
     options = { :option => "random_option" }
     text_area_tag "body", "hello world", options

--- a/actionpack/test/template/record_tag_helper_test.rb
+++ b/actionpack/test/template/record_tag_helper_test.rb
@@ -22,6 +22,8 @@ class Post
 end
 
 class RecordTagHelperTest < ActionView::TestCase
+  include RenderERBUtils
+
   tests ActionView::Helpers::RecordTagHelper
 
   def setup
@@ -58,13 +60,13 @@ class RecordTagHelperTest < ActionView::TestCase
 
   def test_block_works_with_content_tag_for_in_erb
     expected = %(<tr class="post" id="post_45">#{@post.body}</tr>)
-    actual = content_tag_for(:tr, @post) { concat @post.body }
+    actual = render_erb("<%= content_tag_for(:tr, @post) do %><%= @post.body %><% end %>")
     assert_dom_equal expected, actual
   end
 
   def test_div_for_in_erb
     expected = %(<div class="post bar" id="post_45">#{@post.body}</div>)
-    actual = div_for(@post, :class => "bar") { concat @post.body }
+    actual = render_erb("<%= div_for(@post, :class => 'bar') do %><%= @post.body %><% end %>")
     assert_dom_equal expected, actual
   end
 

--- a/actionpack/test/template/tag_helper_test.rb
+++ b/actionpack/test/template/tag_helper_test.rb
@@ -1,6 +1,8 @@
 require 'abstract_unit'
 
 class TagHelperTest < ActionView::TestCase
+  include RenderERBUtils
+
   tests ActionView::Helpers::TagHelper
 
   def test_tag
@@ -44,12 +46,12 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_content_tag_with_block_in_erb
-    buffer = content_tag(:div) { concat "Hello world!" }
+    buffer = render_erb("<%= content_tag(:div) do %>Hello world!<% end %>")
     assert_dom_equal "<div>Hello world!</div>", buffer
   end
 
   def test_content_tag_with_block_and_options_in_erb
-    buffer = content_tag(:div, :class => "green") { concat "Hello world!" }
+    buffer = render_erb("<%= content_tag(:div, :class => 'green') do %>Hello world!<% end %>")
     assert_dom_equal %(<div class="green">Hello world!</div>), buffer
   end
 
@@ -68,10 +70,8 @@ class TagHelperTest < ActionView::TestCase
                  output_buffer
   end
 
-  # TAG TODO: Move this into a real template
   def test_content_tag_nested_in_content_tag_in_erb
-    buffer = content_tag("p") { concat content_tag("b", "Hello") }
-    assert_equal '<p><b>Hello</b></p>', buffer
+    assert_equal "<p>\n  <b>Hello</b>\n</p>", view.render("test/content_tag_nested_in_content_tag")
   end
 
   def test_content_tag_with_escaped_array_class


### PR DESCRIPTION
Refactor helper tests to use ActionView::Base#render instead of erb emulation.

/cc @josevalim
