### PR TITLE
fix warning in tests when using render_erb helper

### DIFF
--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -82,6 +82,8 @@ module RenderERBUtils
   end
 
   def render_erb(string)
+    @virtual_path = nil
+
     template = ActionView::Template.new(
       string.strip,
       "test template",


### PR DESCRIPTION
There was `warning: instance variable @virtual_path not initialized` in tests when using `render_erb` helper from `RenderERBUtils` module.

/cc @josevalim
