### PR TITLE
fix method redefined warnings in tests

### DIFF
--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -351,3 +351,8 @@ module ActionDispatch
   end
 end
 
+module RoutingTestHelpers
+  def url_for(set, options, recall = nil)
+    set.send(:url_for, options.merge(:only_path => true, :_path_segments => recall))
+  end
+end

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -11,12 +11,6 @@ end
 
 ROUTING = ActionDispatch::Routing
 
-module RoutingTestHelpers
-  def url_for(set, options, recall = nil)
-    set.send(:url_for, options.merge(:only_path => true, :_path_segments => recall))
-  end
-end
-
 # See RFC 3986, section 3.3 for allowed path characters.
 class UriReservedCharactersRoutingTest < Test::Unit::TestCase
   include RoutingTestHelpers

--- a/actionpack/test/controller/url_for_integration_test.rb
+++ b/actionpack/test/controller/url_for_integration_test.rb
@@ -3,12 +3,6 @@ require 'abstract_unit'
 require 'controller/fake_controllers'
 require 'active_support/core_ext/object/with_options'
 
-module RoutingTestHelpers
-  def url_for(set, options, recall = nil)
-    set.send(:url_for, options.merge(:only_path => true, :_path_segments => recall))
-  end
-end
-
 module ActionPack
   class URLForIntegrationTest < ActiveSupport::TestCase
     include RoutingTestHelpers

--- a/activemodel/test/cases/serializable/json_test.rb
+++ b/activemodel/test/cases/serializable/json_test.rb
@@ -14,9 +14,11 @@ class Contact
     end
   end
 
+  remove_method :attributes if method_defined?(:attributes)
+
   def attributes
     instance_values
-  end unless method_defined?(:attributes)
+  end
 end
 
 class JsonSerializationTest < ActiveModel::TestCase

--- a/activemodel/test/cases/serializable/xml_test.rb
+++ b/activemodel/test/cases/serializable/xml_test.rb
@@ -9,6 +9,8 @@ class Contact
 
   attr_accessor :address, :friends
 
+  remove_method :attributes if method_defined?(:attributes)
+
   def attributes
     instance_values.except("address", "friends")
   end

--- a/activeresource/lib/active_resource/base.rb
+++ b/activeresource/lib/active_resource/base.rb
@@ -1477,7 +1477,7 @@ module ActiveResource
     extend ActiveModel::Naming
     include CustomMethods, Observing, Validations
     include ActiveModel::Conversion
-    include ActiveModel::Serializers::JSON
-    include ActiveModel::Serializers::Xml
+    include ActiveModel::Serializable::JSON
+    include ActiveModel::Serializable::XML
   end
 end

--- a/activeresource/lib/active_resource/custom_methods.rb
+++ b/activeresource/lib/active_resource/custom_methods.rb
@@ -85,37 +85,35 @@ module ActiveResource
       end
     end
 
-    module InstanceMethods
-      def get(method_name, options = {})
-        self.class.format.decode(connection.get(custom_method_element_url(method_name, options), self.class.headers).body)
-      end
-
-      def post(method_name, options = {}, body = nil)
-        request_body = body.blank? ? encode : body
-        if new?
-          connection.post(custom_method_new_element_url(method_name, options), request_body, self.class.headers)
-        else
-          connection.post(custom_method_element_url(method_name, options), request_body, self.class.headers)
-        end
-      end
-
-      def put(method_name, options = {}, body = '')
-        connection.put(custom_method_element_url(method_name, options), body, self.class.headers)
-      end
-
-      def delete(method_name, options = {})
-        connection.delete(custom_method_element_url(method_name, options), self.class.headers)
-      end
-
-
-      private
-        def custom_method_element_url(method_name, options = {})
-          "#{self.class.prefix(prefix_options)}#{self.class.collection_name}/#{id}/#{method_name}.#{self.class.format.extension}#{self.class.__send__(:query_string, options)}"
-        end
-
-        def custom_method_new_element_url(method_name, options = {})
-          "#{self.class.prefix(prefix_options)}#{self.class.collection_name}/new/#{method_name}.#{self.class.format.extension}#{self.class.__send__(:query_string, options)}"
-        end
+    def get(method_name, options = {})
+      self.class.format.decode(connection.get(custom_method_element_url(method_name, options), self.class.headers).body)
     end
+
+    def post(method_name, options = {}, body = nil)
+      request_body = body.blank? ? encode : body
+      if new?
+        connection.post(custom_method_new_element_url(method_name, options), request_body, self.class.headers)
+      else
+        connection.post(custom_method_element_url(method_name, options), request_body, self.class.headers)
+      end
+    end
+
+    def put(method_name, options = {}, body = '')
+      connection.put(custom_method_element_url(method_name, options), body, self.class.headers)
+    end
+
+    def delete(method_name, options = {})
+      connection.delete(custom_method_element_url(method_name, options), self.class.headers)
+    end
+
+
+    private
+      def custom_method_element_url(method_name, options = {})
+        "#{self.class.prefix(prefix_options)}#{self.class.collection_name}/#{id}/#{method_name}.#{self.class.format.extension}#{self.class.__send__(:query_string, options)}"
+      end
+
+      def custom_method_new_element_url(method_name, options = {})
+        "#{self.class.prefix(prefix_options)}#{self.class.collection_name}/new/#{method_name}.#{self.class.format.extension}#{self.class.__send__(:query_string, options)}"
+      end
   end
 end


### PR DESCRIPTION
Fix

```
actionpack/test/controller/url_for_integration_test.rb:7: warning: method redefined; discarding old url_for
actionpack/test/controller/routing_test.rb:15: warning: previous definition of url_for was here
```

and

```
actionpack/test/template/record_tag_helper_test.rb:9: warning: method redefined; discarding old initialize
actionpack/test/lib/controller/fake_models.rb:59: warning: previous definition of initialize was here
```

/cc @josevalim
