### PR TITLE
Fix lookup on HashWithIndifferentAccess for array values.

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -153,7 +153,8 @@ module ActiveSupport
         if value.is_a? Hash
           value.nested_under_indifferent_access
         elsif value.is_a?(Array)
-          value.dup.replace(value.map { |e| convert_value(e) })
+          value = value.dup if value.frozen?
+          value.replace(value.map { |e| convert_value(e) })
         else
           value
         end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -268,6 +268,13 @@ class HashExtTest < Test::Unit::TestCase
     assert_equal '1234', roundtrip.default
   end
 
+  def test_lookup_returns_the_same_object_that_is_stored_in_hash_indifferent_access
+    hash = HashWithIndifferentAccess.new {|h, k| h[k] = []}
+    hash[:a] << 1
+
+    assert_equal [1], hash[:a]
+  end
+
   def test_indifferent_hash_with_array_of_hashes
     hash = { "urls" => { "url" => [ { "address" => "1" }, { "address" => "2" } ] }}.with_indifferent_access
     assert_equal "1", hash[:urls][:url].first[:address]


### PR DESCRIPTION
Currently HashWithIndifferentAccess has some odd behaviour that differs from Hash.

**The problem:**
Accessing a HashWithIndifferentAccess does not return the the same object that is stored in the hash (i.e. equal?) causing unexpected results:

``` ruby
hash = HashWithIndifferentAccess.new {|h, k| h[k] = []}
hash[:a] << 1  # => [1]
hash[:a]       # => [], expected [1]
```

**The cause:**
When a block is provided to generate default values the generated values are duped if they are arrays. The duped value is stored in the hash but the original value is returned when the hash is accessed.

**My fix:**
The duping is there for allowing frozen arrays containing hashes to be modified. My fix restricts the duping to this case. Note that if default function generates a frozen array an error will be raised on assignment before and after my patch.
