### PR TITLE
Performance issues using tables with no primary key

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -13,7 +13,8 @@ module ActiveRecord
         # Defines the primary key field -- can be overridden in subclasses. Overwriting will negate any effect of the
         # primary_key_prefix_type setting, though.
         def primary_key
-          @primary_key ||= reset_primary_key
+          @primary_key = reset_primary_key unless defined? @primary_key
+          @primary_key
         end
 
         # Returns a quoted version of the primary key name, used to construct SQL statements.

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -53,6 +53,11 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert Boolean.find(b4.id).attribute_present?(:value)
   end
 
+  def test_caching_nil_primary_key
+    Minimalistic.expects(:reset_primary_key).returns(nil).once
+    Minimalistic.create!
+  end
+
   def test_attribute_keys_on_new_instance
     t = Topic.new
     assert_equal nil, t.title, "The topics table has a title column, so it should be nil"


### PR DESCRIPTION
Operations like create for a model which table has no primary keys has horrible performance. ActiveRecord is doing queries like `SHOW INDEX FROM 'table_name' WHERE Key_name = 'PRIMARY'` 20-30 times per action. It will really affect performance with lots of requests per minute.

Now here's a quick fix to the problem, that sets the @primary_key variable only once, even when the database returns no primary keys.
