### PR TITLE
Update rack-test to 0.6.1

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency('builder',       '~> 2.1.2')
   s.add_dependency('i18n',          '~> 0.5.0')
   s.add_dependency('rack',          '~> 1.2.1')
-  s.add_dependency('rack-test',     '~> 0.5.7')
+  s.add_dependency('rack-test',     '~> 0.6.1')
   s.add_dependency('rack-mount',    '~> 0.6.14')
   s.add_dependency('tzinfo',        '~> 0.3.23')
   s.add_dependency('erubis',        '~> 2.6.6')


### PR DESCRIPTION
Updating rack-test to include this bugfix brynary/rack-test@edd5bcb98a57686f015c26fc6c0c3dbdc3319d8. Actionpack is requiring an older version of rack-test with this bug, preventing my tests from passing in my rails project.
