### PR TITLE
fix exception page when template contains utf-8 and parameters contain utf-8

### DIFF
--- a/actionpack/lib/action_view/template/error.rb
+++ b/actionpack/lib/action_view/template/error.rb
@@ -89,10 +89,14 @@ module ActionView
         line_counter = start_on_line
         return unless source_code = source_code[start_on_line..end_on_line]
 
-        source_code.sum do |line|
+        extract = source_code.sum do |line|
           line_counter += 1
           "#{indent}#{line_counter}: #{line}\n"
         end
+
+        extract.encode! if extract.respond_to?(:encode!)
+
+        extract
       end
 
       def sub_template_of(template_path)

--- a/railties/test/application/middleware/show_exceptions_test.rb
+++ b/railties/test/application/middleware/show_exceptions_test.rb
@@ -1,27 +1,23 @@
+# encoding: utf-8
 require 'isolation/abstract_unit'
+require 'rack/test'
 
 module ApplicationTests
   class ShowExceptionsTest < Test::Unit::TestCase
     include ActiveSupport::Testing::Isolation
+    include Rack::Test::Methods
 
     def setup
       build_app
       boot_rails
-      FileUtils.rm_rf "#{app_path}/config/environments"
     end
 
     def teardown
       teardown_app
     end
 
-    def app
-      @app ||= Rails.application
-    end
-
     test "unspecified route when set action_dispatch.show_exceptions to false" do
-      make_basic_app do |app|
-        app.config.action_dispatch.show_exceptions = false
-      end
+      app.config.action_dispatch.show_exceptions = false
 
       assert_raise(ActionController::RoutingError) do
         get '/foo'
@@ -29,13 +25,36 @@ module ApplicationTests
     end
 
     test "unspecified route when set action_dispatch.show_exceptions to true" do
-      make_basic_app do |app|
-        app.config.action_dispatch.show_exceptions = true
-      end
+      app.config.action_dispatch.show_exceptions = true
 
       assert_nothing_raised(ActionController::RoutingError) do
         get '/foo'
       end
+    end
+
+    test "displays diagnostics message when exception raised in template that contains UTF-8" do
+      app.config.action_dispatch.show_exceptions = true
+
+      controller :foo, <<-RUBY
+        class FooController < ActionController::Base
+          def index
+          end
+        end
+      RUBY
+
+      app_file 'app/views/foo/index.html.erb', <<-ERB
+        <% raise 'boooom' %>
+        ✓
+      ERB
+
+      app_file 'config/routes.rb', <<-RUBY
+        AppTemplate::Application.routes.draw do
+          match ':controller(/:action)'
+        end
+      RUBY
+
+      post '/foo', :utf8 => '✓'
+      assert_match(/boooom/, last_response.body)
     end
   end
 end


### PR DESCRIPTION
There is `Error during failsafe response: incompatible character encodings: ASCII-8BIT and UTF-8` when:
- template contains utf-8 symbols near place where exception raised
- request with post method with utf-8 parameters

/cc @josevalim
