### PR TITLE
reintroduce patch from #726 to handle nested eager loading via associations

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -184,7 +184,7 @@ module ActiveRecord
 
         macro = join_part.reflection.macro
         if macro == :has_one
-          return if record.association_cache.key?(join_part.reflection.name)
+          return record.association(join_part.reflection.name).target if record.association_cache.key?(join_part.reflection.name)
           association = join_part.instantiate(row) unless row[join_part.aliased_primary_key].nil?
           set_target_and_inverse(join_part, association, record)
         else

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -252,6 +252,41 @@ class EagerAssociationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_nested_loading_through_has_one_association
+    aa = AuthorAddress.find(author_addresses(:david_address).id, :include => {:author => :posts})
+    assert_equal aa.author.posts.count, aa.author.posts.length
+  end
+
+  def test_nested_loading_through_has_one_association_with_order
+    aa = AuthorAddress.find(author_addresses(:david_address).id, :include => {:author => :posts}, :order => 'author_addresses.id')
+    assert_equal aa.author.posts.count, aa.author.posts.length
+  end
+
+  def test_nested_loading_through_has_one_association_with_order_on_association
+    aa = AuthorAddress.find(author_addresses(:david_address).id, :include => {:author => :posts}, :order => 'authors.id')
+    assert_equal aa.author.posts.count, aa.author.posts.length
+  end
+
+  def test_nested_loading_through_has_one_association_with_order_on_nested_association
+    aa = AuthorAddress.find(author_addresses(:david_address).id, :include => {:author => :posts}, :order => 'posts.id')
+    assert_equal aa.author.posts.count, aa.author.posts.length
+  end
+
+  def test_nested_loading_through_has_one_association_with_conditions
+    aa = AuthorAddress.find(author_addresses(:david_address).id, :include => {:author => :posts}, :conditions => "author_addresses.id > 0")
+    assert_equal aa.author.posts.count, aa.author.posts.length
+  end
+
+  def test_nested_loading_through_has_one_association_with_conditions_on_association
+    aa = AuthorAddress.find(author_addresses(:david_address).id, :include => {:author => :posts}, :conditions => "authors.id > 0")
+    assert_equal aa.author.posts.count, aa.author.posts.length
+  end
+
+  def test_nested_loading_through_has_one_association_with_conditions_on_nested_association
+    aa = AuthorAddress.find(author_addresses(:david_address).id, :include => {:author => :posts}, :conditions => "posts.id > 0")
+    assert_equal aa.author.posts.count, aa.author.posts.length
+  end
+
   def test_eager_association_loading_with_belongs_to_and_foreign_keys
     pets = Pet.find(:all, :include => :owner)
     assert_equal 3, pets.length


### PR DESCRIPTION
This got missed in the lighthouse -> github transition..

Eager loading a nested has_many association with conditions or order on the nested table loads only the first record.

```
class AuthorAddress < ActiveRecord::Base
  has_one :author
end

class Author < ActiveRecord::Base
  has_many :posts
  belongs_to :author_address
end

class Post < ActiveRecord::Base
  belongs_to :author
end

author_address = AuthorAddress.find(1, :include => {:author => :posts}, :order => "authors.id")
```

Using an order or conditions clause on a different table than the base one uses legacy SQL (LEFT OUTER JOIN) to load, but it incorrectly (eagerly) loads posts. Only one, of the many posts, is eagerly loaded and unfortunately the association thinks it is fully loaded.

Therefore doing something like this:

```
author_address.author.posts.length
```

returns a different answer than this:

```
author_address.author.posts.count
```

(which of course hits the database again to get the correct answer)

This was apparently fixed in 2.3 but never in 3.x.  Failing tests and patch included.

Also too: gratutious mention of #726 to link the issues on github.
