### PR TITLE
Replace "=" with "||=" in create_fixtures method

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -445,7 +445,7 @@ module ActiveRecord
     def self.create_fixtures(fixtures_directory, table_names, class_names = {})
       table_names = [table_names].flatten.map { |n| n.to_s }
       table_names.each { |n|
-        class_names[n.tr('/', '_').to_sym] = n.classify if n.include?('/')
+        class_names[n.tr('/', '_').to_sym] ||= n.classify if n.include?('/')
       }
 
       # FIXME: Apparently JK uses this.


### PR DESCRIPTION
Replaced `=` with `||=` operator in `create_fixtures` method, otherwise the values of the parameter `class_names` seem to be overwritten and ignored.  This solves for me the issue #2572 i had with

``` ruby
set_fixture_class 'admin/known_ips' => Admin::KnownIP
```

I have not tested this patch, please review.  It looks to me like it was a typo.

I am not closing Issue #2572 yet because i am not sure this "typo" explains all the strange behavior.
