### PR TITLE
Fix argument error message for length validation

### DIFF
--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -23,7 +23,7 @@ module ActiveModel
         keys = CHECKS.keys & options.keys
 
         if keys.empty?
-          raise ArgumentError, 'Range unspecified. Specify the :within, :maximum, :minimum, or :is option.'
+          raise ArgumentError, 'Range unspecified. Specify the :in, :within, :maximum, :minimum, or :is option.'
         end
 
         keys.each do |key|


### PR DESCRIPTION
[activemodel/lib/active_model/validations/length.rb](https://github.com/rails/rails/blob/a604983f8b8b873558fe7838d0bfcf0e0594daa6/activemodel/lib/active_model/validations/length.rb#L13) supports both <tt>:in</tt> and <tt>:within</tt>
