### PR TITLE
Fix set_fixture_class by fixing create_fixtures

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -445,7 +445,7 @@ module ActiveRecord
     def self.create_fixtures(fixtures_directory, table_names, class_names = {})
       table_names = [table_names].flatten.map { |n| n.to_s }
       table_names.each { |n|
-        class_names[n.tr('/', '_').to_sym] = n.classify if n.include?('/')
+        class_names[n.tr('/', '_').to_sym] ||= n.classify if n.include?('/')
       }
 
       # FIXME: Apparently JK uses this.


### PR DESCRIPTION
Properly check the `class_names` hash parameter of `create_fixtures`
method to not overwrite passed fixture classes.

I might have done something stupid: i amended my commit and force pushed it.  This is an update to my previous pull request #3821, it does not seem to fail, but i do not think it is ready.  Just for review and comments.  Before going to bed.  It is about issue #2572.
