### PR TITLE
adding html5 input types for datetime, datetime-local, date, month, week...

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -945,6 +945,54 @@ module ActionView
         InstanceTag.new(object_name, method, self, options.delete(:object)).to_number_field_tag("range", options)
       end
 
+      # Returns an input tag of type "datetime".
+      #
+      # ==== Options
+      # * Accepts same options as datetime_field_tag
+      def datetime_field(object_name, method, options = {})
+        InstanceTag.new(object_name, method, self, options.delete(:object)).to_number_field_tag("datetime", options)
+      end
+
+      # Returns an input tag of type "datetime-local".
+      #
+      # ==== Options
+      # * Accepts same options as datetime_local_field_tag
+      def datetime_local_field(object_name, method, options = {})
+        InstanceTag.new(object_name, method, self, options.delete(:object)).to_number_field_tag("datetime-local", options)
+      end
+
+      # Returns an input tag of type "date".
+      #
+      # ==== Options
+      # * Accepts same options as date_field_tag
+      def date_field(object_name, method, options = {})
+        InstanceTag.new(object_name, method, self, options.delete(:object)).to_number_field_tag("date", options)
+      end
+
+      # Returns an input tag of type "month".
+      #
+      # ==== Options
+      # * Accepts same options as month_field_tag
+      def month_field(object_name, method, options = {})
+        InstanceTag.new(object_name, method, self, options.delete(:object)).to_number_field_tag("month", options)
+      end
+
+      # Returns an input tag of type "week".
+      #
+      # ==== Options
+      # * Accepts same options as week_field_tag
+      def week_field(object_name, method, options = {})
+        InstanceTag.new(object_name, method, self, options.delete(:object)).to_number_field_tag("week", options)
+      end
+
+      # Returns an input tag of type "time".
+      #
+      # ==== Options
+      # * Accepts same options as time_field_tag
+      def time_field(object_name, method, options = {})
+        InstanceTag.new(object_name, method, self, options.delete(:object)).to_number_field_tag("time", options)
+      end
+
       private
 
         def instantiate_builder(record_name, record_object, options, &block)

--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -570,6 +570,54 @@ module ActionView
         text_field_tag(name, value, options.stringify_keys.update("type" => "email"))
       end
 
+      # Creates a text field of type "datetime".
+      #
+      # ==== Options
+      # * Accepts the same options as text_field_tag.
+      def datetime_field_tag(name, value = nil, options = {})
+        text_field_tag(name, value, options.stringify_keys.update("type" => "datetime"))
+      end
+
+      # Creates a text field of type "datetime-local".
+      #
+      # ==== Options
+      # * Accepts the same options as text_field_tag.
+      def datetime_local_field_tag(name, value = nil, options = {})
+        text_field_tag(name, value, options.stringify_keys.update("type" => "datetime-local"))
+      end
+
+      # Creates a text field of type "date".
+      #
+      # ==== Options
+      # * Accepts the same options as text_field_tag.
+      def date_field_tag(name, value = nil, options = {})
+        text_field_tag(name, value, options.stringify_keys.update("type" => "date"))
+      end
+
+      # Creates a text field of type "month".
+      #
+      # ==== Options
+      # * Accepts the same options as text_field_tag.
+      def month_field_tag(name, value = nil, options = {})
+        text_field_tag(name, value, options.stringify_keys.update("type" => "month"))
+      end
+
+      # Creates a text field of type "week".
+      #
+      # ==== Options
+      # * Accepts the same options as text_field_tag.
+      def week_field_tag(name, value = nil, options = {})
+        text_field_tag(name, value, options.stringify_keys.update("type" => "week"))
+      end
+
+      # Creates a text field of type "time".
+      #
+      # ==== Options
+      # * Accepts the same options as text_field_tag.
+      def time_field_tag(name, value = nil, options = {})
+        text_field_tag(name, value, options.stringify_keys.update("type" => "time"))
+      end
+
       # Creates a number field.
       #
       # ==== Options

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -503,6 +503,36 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal(expected, range_field("hifi", "volume", :size => 30, :in => 0..11, :step => 0.1))
   end
 
+  def test_datetime_field
+    expected = %{<input id="event_start_at" size="30" name="event[start_at]" type="datetime" />}
+    assert_dom_equal(expected, datetime_field("event", "start_at"))
+  end
+
+  def test_datetime_local_field
+    expected = %{<input id="event_start_at" size="30" name="event[start_at]" type="datetime-local" />}
+    assert_dom_equal(expected, datetime_local_field("event", "start_at"))
+  end
+
+  def test_date_field
+    expected = %{<input id="user_birthday" size="30" name="user[birthday]" type="date" />}
+    assert_dom_equal(expected, date_field("user", "birthday"))
+  end
+
+  def test_month_field
+    expected = %{<input id="report_term" size="30" name="report[term]" type="month" />}
+    assert_dom_equal(expected, month_field("report", "term"))
+  end
+
+  def test_week_field
+    expected = %{<input id="report_term" size="30" name="report[term]" type="week" />}
+    assert_dom_equal(expected, week_field("report", "term"))
+  end
+
+  def test_time_field
+    expected = %{<input id="alarm_ring_at" size="30" name="alarm[ring_at]" type="time" />}
+    assert_dom_equal(expected, time_field("alarm", "ring_at"))
+  end
+
   def test_explicit_name
     assert_dom_equal(
       '<input id="post_title" name="dont guess" size="30" type="text" value="Hello World" />', text_field("post", "title", "name" => "dont guess")

--- a/actionpack/test/template/form_tag_helper_test.rb
+++ b/actionpack/test/template/form_tag_helper_test.rb
@@ -482,6 +482,36 @@ class FormTagHelperTest < ActionView::TestCase
     assert_dom_equal(expected, range_field_tag("volume", nil, :in => 0..11, :step => 0.1))
   end
 
+  def test_datetime_input_tag
+    expected = %{<input name="start_at" id="start_at" type="datetime" />}
+    assert_dom_equal(expected, datetime_field_tag("start_at"))
+  end
+
+  def test_datetime_local_input_tag
+    expected = %{<input name="start_at" id="start_at" type="datetime-local" />}
+    assert_dom_equal(expected, datetime_local_field_tag("start_at"))
+  end
+
+  def test_date_input_tag
+    expected = %{<input name="birthday" id="birthday" type="date" />}
+    assert_dom_equal(expected, date_field_tag("birthday"))
+  end
+
+  def test_month_input_tag
+    expected = %{<input name="period" id="period" type="month" />}
+    assert_dom_equal(expected, month_field_tag("period"))
+  end
+
+  def test_week_input_tag
+    expected = %{<input name="report" id="period" type="week" />}
+    assert_dom_equal(expected, week_field_tag("period"))
+  end
+
+  def test_time_input_tag
+    expected = %{<input name="ring_at" id="ring_at" type="range" />}
+    assert_dom_equal(expected, range_field_tag("ring_at"))
+  end
+
   def test_pass
     assert_equal 1, 1
   end

--- a/railties/guides/source/form_helpers.textile
+++ b/railties/guides/source/form_helpers.textile
@@ -150,7 +150,7 @@ NOTE: Always use labels for checkbox and radio buttons. They associate text with
 
 h4. Other Helpers of Interest
 
-Other form controls worth mentioning are textareas, password fields, hidden fields, search fields, telephone fields, URL fields and email fields:
+Other form controls worth mentioning are textareas, password fields, hidden fields, search fields, telephone fields, URL fields, email fields datetime fields, local datetime fields, date fields, month fields, week fields and time fields:
 
 <erb>
 <%= text_area_tag(:message, "Hi, nice site", :size => "24x6") %>
@@ -160,6 +160,12 @@ Other form controls worth mentioning are textareas, password fields, hidden fiel
 <%= telephone_field(:user, :phone) %>
 <%= url_field(:user, :homepage) %>
 <%= email_field(:user, :address) %>
+<%= datetime_field(:event, :start_at) %>
+<%= datetime_local_field(:event, :start_at) %>
+<%= date_field(:user, :birthday) %>
+<%= month_field(:report, :term) %>
+<%= week_field(:report, :term) %>
+<%= time_field(:alarm, :ring_at) %>
 </erb>
 
 Output:
@@ -172,11 +178,17 @@ Output:
 <input id="user_phone" name="user[phone]" size="30" type="tel" />
 <input id="user_homepage" size="30" name="user[homepage]" type="url" />
 <input id="user_address" size="30" name="user[address]" type="email" />
+<input id="event_start_at" size="30" name="event[start_at]" type="datetime" />
+<input id="event_start_at" size="30" name="event[start_at]" type="datetime-local" />
+<input id="user_birthday" size="30" name="user[birthday]" type="date" />
+<input id="report_term" size="30" name="report[term]" type="month" />
+<input id="report_term" size="30" name="report[term]" type="week" />
+<input id="alarm_ring_at" size="30" name="alarm[ring_at]" type="time" />
 </html>
 
 Hidden inputs are not shown to the user but instead hold data like any textual input. Values inside them can be changed with JavaScript.
 
-IMPORTANT: The search, telephone, URL, and email inputs are HTML5 controls. If you require your app to have a consistent experience in older browsers, you will need an HTML5 polyfill (provided by CSS and/or JavaScript). There is definitely "no shortage of solutions for this":https://github.com/Modernizr/Modernizr/wiki/HTML5-Cross-Browser-Polyfills, although a couple of popular tools at the moment are "Modernizr":http://www.modernizr.com/ and "yepnope":http://yepnopejs.com/, which provide a simple way to add functionality based on the presence of detected HTML5 features.
+IMPORTANT: The search, telephone, URL, email, datetime, datetime-local, date, month, week and time inputs are HTML5 controls. If you require your app to have a consistent experience in older browsers, you will need an HTML5 polyfill (provided by CSS and/or JavaScript). There is definitely "no shortage of solutions for this":https://github.com/Modernizr/Modernizr/wiki/HTML5-Cross-Browser-Polyfills, although a couple of popular tools at the moment are "Modernizr":http://www.modernizr.com/ and "yepnope":http://yepnopejs.com/, which provide a simple way to add functionality based on the presence of detected HTML5 features.
 
 TIP: If you're using password input fields (for any purpose), you might want to configure your application to prevent those parameters from being logged. You can learn about this in the "Security Guide":security.html#logging.
 


### PR DESCRIPTION
... and time to the form and form_tag helpers.

The current form_helper and form_tag_helper in actionpack were not supporting the HTML5 input types for dates and time. 

HTML5 spec reference can be found here: http://dev.w3.org/html5/spec/Overview.html#states-of-the-type-attribute
