### PR TITLE
Use show create table (fix 3678: third time).

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -499,9 +499,14 @@ module ActiveRecord
 
       # Returns a table's primary key and belonging sequence.
       def pk_and_sequence_for(table)
-        execute_and_free("SHOW INDEX FROM #{quote_table_name(table)} WHERE Key_name = 'PRIMARY'", 'SCHEMA') do |result|
-          keys = each_hash(result).map { |row| row[:Column_name] }
-          keys.length == 1 ? [keys.first, nil] : nil
+        execute_and_free("SHOW CREATE TABLE #{quote_table_name(table)}", 'SCHEMA') do |result|
+          create_table = each_hash(result).first[:"Create Table"]
+          if create_table.to_s =~ /PRIMARY KEY\s+\((.+)\)/
+            keys = $1.split(",").map { |key| key.gsub(/`/, "") }
+            keys.length == 1 ? [keys.first, nil] : nil
+          else
+            nil
+          end
         end
       end
 


### PR DESCRIPTION
Stop using `show index from`, and we should use `show create table`.
If necessary, please merge.

Please see also #3678
