### PR TITLE
Restore performance of ERB::Util.html_escape

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -20,7 +20,7 @@ class ERB
       if s.html_safe?
         s
       else
-        s.gsub(/&/, "&amp;").gsub(/\"/, "&quot;").gsub(/>/, "&gt;").gsub(/</, "&lt;").html_safe
+        s.gsub(/[&"><]/n) { |special| HTML_ESCAPE[special] }.html_safe
       end
     end
 

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -21,12 +21,6 @@ class StringInflectionsTest < Test::Unit::TestCase
   include InflectorTestCases
   include ConstantizeTestCases
 
-  def test_erb_escape
-    string = [192, 60].pack('CC')
-    expected = 192.chr + "&lt;"
-    assert_equal expected, ERB::Util.html_escape(string)
-  end
-
   def test_strip_heredoc_on_an_empty_string
     assert_equal '', ''.strip_heredoc
   end
@@ -496,6 +490,23 @@ class OutputSafetyTest < ActiveSupport::TestCase
     string = @string.html_safe
     assert string.html_safe?
     assert !string.to_param.html_safe?
+  end
+
+  test "ERB::Util.html_escape should escape unsafe characters" do
+    string = '<>&"'
+    expected = '&lt;&gt;&amp;&quot;'
+    assert_equal expected, ERB::Util.html_escape(string)
+  end
+
+  test "ERB::Util.html_escape should correctly handle invalid UTF-8 strings" do
+    string = [192, 60].pack('CC')
+    expected = 192.chr + "&lt;"
+    assert_equal expected, ERB::Util.html_escape(string)
+  end
+
+  test "ERB::Util.html_escape should not escape safe strings" do
+    string = "<b>hello</b>".html_safe
+    assert_equal string, ERB::Util.html_escape(string)
   end
 end
 


### PR DESCRIPTION
This commit reverts html_escape so we do a single gsub again, **but it also adds the "n" flag** (no
language, i.e. not multi-byte) so that we still protect against XSS via invalid utf8. The output of html_escape should be identical to the bfc4325 version, but it should just run more quickly like it used to.

I moved the existing test into a slightly better spot, and added a couple others. I'm definitely open to better/additional ways of testing this if needed. I've tested it under ruby 1.8.7 and 1.9.2.
