### PR TITLE
Faster explain

### DIFF
--- a/activerecord/lib/active_record/explain.rb
+++ b/activerecord/lib/active_record/explain.rb
@@ -9,11 +9,11 @@ module ActiveRecord
       # query, but against the duration of the entire block. This approach is
       # convenient for relations.
       #
-      # available_queries_for_explain collects the queries available for
-      # explain. If the value is nil, it means queries are not being
+      # The available_queries_for_explain thread variable collects the queries
+      # to be explained. If the value is nil, it means queries are not being
       # currently collected. A false value indicates collecting is turned
       # off. Otherwise it is an array of queries.
-      def logging_query_plan(&block) # :nodoc:
+      def logging_query_plan # :nodoc:
         threshold = auto_explain_threshold_in_seconds
         current   = Thread.current
         if threshold && current[:available_queries_for_explain].nil?

--- a/activerecord/lib/active_record/explain.rb
+++ b/activerecord/lib/active_record/explain.rb
@@ -40,6 +40,14 @@ module ActiveRecord
         end
       end
 
+      def collecting_sqls_for_explain
+        current, value = Thread.current, []
+        original, current[:available_queries_for_explain] = current[:available_queries_for_explain], value
+        return yield, value
+      ensure
+        current[:available_queries_for_explain] = original
+      end
+
       # SCHEMA queries cannot be EXPLAINed, also we do not want to run EXPLAIN on
       # our own EXPLAINs now matter how loopingly beautiful that would be.
       SKIP_EXPLAIN_FOR = %w(SCHEMA EXPLAIN)

--- a/activerecord/lib/active_record/explain.rb
+++ b/activerecord/lib/active_record/explain.rb
@@ -2,35 +2,41 @@ module ActiveRecord
   module Explain
     extend ActiveSupport::Concern
 
-    # available_queries_for_explain collects the queries available for
-    # explain. If the value is nil, it means queries are not being
-    # currently collected. A false value indicates collecting is turned
-    # off. Otherwise it is an array of queries.
-    def self.available_queries_for_explain
-      Thread.current[:available_queries_for_explain]
-    end
-
     module ClassMethods
       # If auto explain is enabled, this method triggers EXPLAIN logging for the
       # queries triggered by the block if it takes more than the threshold as a
       # whole. That is, the threshold is not checked against each individual
       # query, but against the duration of the entire block. This approach is
       # convenient for relations.
+      #
+      # available_queries_for_explain collects the queries available for
+      # explain. If the value is nil, it means queries are not being
+      # currently collected. A false value indicates collecting is turned
+      # off. Otherwise it is an array of queries.
       def logging_query_plan(&block) # :nodoc:
         threshold = auto_explain_threshold_in_seconds
         current   = Thread.current
         if threshold && current[:available_queries_for_explain].nil?
           begin
-            current[:available_queries_for_explain] = []
+            value = current[:available_queries_for_explain] = []
             start = Time.now
-            result, sqls, binds = collecting_sqls_for_explain(&block)
-            logger.warn(exec_explain(sqls, binds)) if Time.now - start > threshold
+            result = yield
+            logger.warn(exec_explain(value)) if Time.now - start > threshold
             result
           ensure
             current[:available_queries_for_explain] = nil
           end
         else
           yield
+        end
+      end
+
+      # Receives a payload and check if the SQL query should be collected.
+      def collect_sql_for_explain(payload)
+        if value = Thread.current[:available_queries_for_explain]
+          unless ignore_explain_notification?(payload)
+            value << [payload[:sql], payload[:binds]]
+          end
         end
       end
 
@@ -41,32 +47,10 @@ module ActiveRecord
         payload[:exception] || SKIP_EXPLAIN_FOR.include?(payload[:name])
       end
 
-      # Collects all queries executed while the passed block runs. Returns an
-      # array with three elements, the result of the block, the strings with the
-      # queries, and their respective bindings.
-      def collecting_sqls_for_explain # :nodoc:
-        sqls  = []
-        binds = []
-        callback = lambda do |*args|
-          payload = args.last
-          unless ignore_explain_notification?(payload)
-            sqls  << payload[:sql]
-            binds << payload[:binds]
-          end
-        end
-
-        result = nil
-        ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
-          result = yield
-        end
-
-        [result, sqls, binds]
-      end
-
-      # Makes the adapter execute EXPLAIN for the given queries and bindings.
+      # Makes the adapter execute EXPLAIN for the tuples of queries and bindings.
       # Returns a formatted string ready to be logged.
-      def exec_explain(sqls, binds) # :nodoc:
-        sqls.zip(binds).map do |sql, bind|
+      def exec_explain(value) # :nodoc:
+        value && value.map do |sql, bind|
           [].tap do |msg|
             msg << "EXPLAIN for: #{sql}"
             unless bind.empty?

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -155,8 +155,8 @@ module ActiveRecord
     # Please see further details in the
     # {Active Record Query Interface guide}[http://edgeguides.rubyonrails.org/active_record_querying.html#running-explain].
     def explain
-      _, sqls, binds = collecting_sqls_for_explain { exec_query }
-      exec_explain(sqls, binds)
+      _, values = collecting_sqls_for_explain { exec_query }
+      exec_explain(values)
     end
 
     def to_a

--- a/activerecord/test/cases/explain_test.rb
+++ b/activerecord/test/cases/explain_test.rb
@@ -24,7 +24,7 @@ if ActiveRecord::Base.connection.supports_explain?
       end
     end
 
-    def test_collecting_sqls_for_explain
+    def test_collect_sql_for_explain
       base.auto_explain_threshold_in_seconds = nil
       honda = cars(:honda)
 
@@ -40,6 +40,18 @@ if ActiveRecord::Base.connection.supports_explain?
       assert_equal [], binds
     ensure
       Thread.current[:available_queries_for_explain] = nil
+    end
+
+    def test_collecting_sqls_for_explain
+      result, values = ActiveRecord::Base.collecting_sqls_for_explain do
+        Car.where(:name => 'honda').all
+      end
+
+      sql, binds = values[0]
+      assert_match "SELECT", sql
+      assert_match "honda", sql
+      assert_equal [], binds
+      assert_equal [cars(:honda)], result
     end
 
     def test_exec_explain_with_no_binds

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -2,15 +2,13 @@
 
 *   Added Enumerable#pluck to wrap the common pattern of collect(&:method) *DHH*
 
-*   Module#synchronize is deprecated with no replacement.  Please use `monitor`
+*   Module#synchronize is deprecated with no replacement. Please use `monitor`
     from ruby's standard library.
 
 *   (Date|DateTime|Time)#beginning_of_week accept an optional argument to
     be able to set the day at which weeks are assumed to start.
 
 *   Deprecated ActiveSupport::MessageEncryptor#encrypt and decrypt. *José Valim*
-
-*   ActiveSupport::Notifications.subscribed provides subscriptions to events while a block runs. *fxn*
 
 *   Module#qualified_const_(defined?|get|set) are analogous to the corresponding methods
     in the standard API, but accept qualified constant names. *fxn*

--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -63,26 +63,7 @@ module ActiveSupport
   # and even pass no argument to +subscribe+, in which case you are subscribing
   # to all events.
   #
-  # == Temporary Subscriptions
-  #
-  # Sometimes you do not want to subscribe to an event for the entire life of
-  # the application. There are two ways to unsubscribe.
-  #
-  # === Subscribe While a Block Runs
-  #
-  # You can subscribe to some event temporarily while some block runs. For
-  # example, in
-  #
-  #   callback = lambda {|*args| ... }
-  #   ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
-  #     ...
-  #   end
-  #
-  # the callback will be called for all "sql.active_record" events instrumented
-  # during the execution of the block. The callback is unsubscribed automatically
-  # after that.
-  #
-  # === Manual Unsubscription
+  # == Manual Unsubscription
   #
   # The +subscribe+ method returns a subscriber object:
   #
@@ -126,13 +107,6 @@ module ActiveSupport
         notifier.subscribe(*args, &block).tap do
           @instrumenters.clear
         end
-      end
-
-      def subscribed(callback, *args, &block)
-        subscriber = subscribe(*args, &callback)
-        yield
-      ensure
-        unsubscribe(subscriber)
       end
 
       def unsubscribe(args)

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -24,26 +24,6 @@ module Notifications
     end
   end
 
-  class SubscribedTest < TestCase
-    def test_subscribed
-      name     = "foo"
-      name2    = name * 2
-      expected = [name, name]
-
-      events   = []
-      callback = lambda {|*_| events << _.first}
-      ActiveSupport::Notifications.subscribed(callback, name) do
-        ActiveSupport::Notifications.instrument(name)
-        ActiveSupport::Notifications.instrument(name2)
-        ActiveSupport::Notifications.instrument(name)
-      end
-      assert_equal expected, events
-
-      ActiveSupport::Notifications.instrument(name)
-      assert_equal expected, events
-    end
-  end
-
   class UnsubscribeTest < TestCase
     def test_unsubscribing_removes_a_subscription
       @notifier.publish :foo


### PR DESCRIPTION
This is a bit hard to benchmark and pinpoint as a whole but I did isolation benchmarks. This commit:
- Avoids constant lookups
- Caches the result of Thread.current in local variables
- Avoid &block
- Avoid subscribed blocks (and consequently avoid expiring notifications internal caches). In fact, the API was removed to discourage the behavior.
