### PR TITLE
Fix Issue #2572 with set_fixture_class by normalizing key format

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -388,10 +388,10 @@ module ActiveRecord
 
     @@all_cached_fixtures = Hash.new { |h,k| h[k] = {} }
 
-    def self.find_table_name(table_name) # :nodoc:
+    def self.default_fixture_model_name(fixture_name) # :nodoc:
       ActiveRecord::Base.pluralize_table_names ?
-        table_name.to_s.singularize.camelize :
-        table_name.to_s.camelize
+        fixture_name.singularize.camelize :
+        fixture_name.camelize
     end
 
     def self.reset_cache
@@ -441,9 +441,6 @@ module ActiveRecord
 
     def self.create_fixtures(fixtures_directory, table_names, class_names = {})
       table_names = [table_names].flatten.map { |n| n.to_s }
-      table_names.each { |n|
-        class_names[n.tr('/', '_').to_sym] = n.classify if n.include?('/')
-      }
 
       # FIXME: Apparently JK uses this.
       connection = block_given? ? yield : ActiveRecord::Base.connection
@@ -458,11 +455,12 @@ module ActiveRecord
 
           fixture_files = files_to_read.map do |path|
             table_name = path.tr '/', '_'
+            fixture_name = path
 
-            fixtures_map[path] = ActiveRecord::Fixtures.new(
+            fixtures_map[fixture_name] = new( # ActiveRecord::Fixtures.new
               connection,
               table_name,
-              class_names[table_name.to_sym] || table_name.classify,
+              class_names[fixture_name] || default_fixture_model_name(fixture_name),
               ::File.join(fixtures_directory, path))
           end
 
@@ -723,14 +721,29 @@ module ActiveRecord
       self.use_instantiated_fixtures = false
       self.pre_loaded_fixtures = false
 
-      self.fixture_class_names = Hash.new do |h, table_name|
-        h[table_name] = ActiveRecord::Fixtures.find_table_name(table_name)
+      self.fixture_class_names = Hash.new do |h, fixture_name|
+        h[fixture_name] = ActiveRecord::Fixtures.default_fixture_model_name(fixture_name)
       end
     end
 
     module ClassMethods
+      # Sets the model class for a fixture when the class name cannot be inferred from the fixture name.
+      #
+      # Examples:
+      #
+      #   set_fixture_class :some_fixture        => SomeModel,
+      #                     'namespaced/fixture' => Another::Model
+      #
+      # The keys must be the fixture names, that coincide with the short paths to the fixture files.
+      #--
+      # It is also possible to pass the class name instead of the class:
+      #   set_fixture_class 'some_fixture' => 'SomeModel'
+      # I think this option is redundant, i propose to deprecate it.
+      # Isn't it easier to always pass the class itself?
+      # (2011-12-20 alexeymuranov)
+      #++
       def set_fixture_class(class_names = {})
-        self.fixture_class_names = self.fixture_class_names.merge(class_names)
+        self.fixture_class_names = self.fixture_class_names.merge(class_names.stringify_keys)
       end
 
       def fixtures(*fixture_names)
@@ -770,7 +783,7 @@ module ActiveRecord
         fixture_names = Array.wrap(fixture_names || fixture_table_names)
         methods = Module.new do
           fixture_names.each do |fixture_name|
-            fixture_name = fixture_name.to_s.tr('./', '_')
+            fixture_name = fixture_name.to_s.tr('./', '_') # TODO: use fixture_name variable for only one form of fixture names ("admin/users" for example)
 
             define_method(fixture_name) do |*fixtures|
               force_reload = fixtures.pop if fixtures.last == true || fixtures.last == :reload

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1,6 +1,7 @@
 require 'cases/helper'
 require 'models/admin'
 require 'models/admin/account'
+require 'models/admin/randomly_named_c1'
 require 'models/admin/user'
 require 'models/binary'
 require 'models/book'
@@ -14,6 +15,7 @@ require 'models/matey'
 require 'models/parrot'
 require 'models/pirate'
 require 'models/post'
+require 'models/randomly_named_c1'
 require 'models/reply'
 require 'models/ship'
 require 'models/task'
@@ -743,5 +745,31 @@ class FixtureLoadingTest < ActiveRecord::TestCase
     ActiveRecord::TestCase.expects(:require_dependency).with(:works_out_fine)
     ActiveRecord::Base.logger.expects(:warn).never
     ActiveRecord::TestCase.try_to_load_dependency(:works_out_fine)
+  end
+end
+
+class CustomNameForFixtureOrModelTest < ActiveRecord::TestCase
+  ActiveRecord::Fixtures.reset_cache
+
+  set_fixture_class :randomly_named_a9         =>
+                        ClassNameThatDoesNotFollowCONVENTIONS,
+                    :'admin/randomly_named_a9' =>
+                        Admin::ClassNameThatDoesNotFollowCONVENTIONS,
+                    'admin/randomly_named_b0'  =>
+                        Admin::ClassNameThatDoesNotFollowCONVENTIONS
+
+  fixtures :randomly_named_a9, 'admin/randomly_named_a9',
+           :'admin/randomly_named_b0'
+
+  def test_named_accessor_for_randomly_named_fixture_and_class
+    assert_kind_of ClassNameThatDoesNotFollowCONVENTIONS,
+                   randomly_named_a9(:first_instance)
+  end
+
+  def test_named_accessor_for_randomly_named_namespaced_fixture_and_class
+    assert_kind_of Admin::ClassNameThatDoesNotFollowCONVENTIONS,
+                   admin_randomly_named_a9(:first_instance)
+    assert_kind_of Admin::ClassNameThatDoesNotFollowCONVENTIONS,
+                   admin_randomly_named_b0(:second_instance)
   end
 end

--- a/activerecord/test/fixtures/admin/randomly_named_a9.yml
+++ b/activerecord/test/fixtures/admin/randomly_named_a9.yml
@@ -1,0 +1,7 @@
+first_instance:
+  some_attribute: AAA
+  another_attribute: 000
+
+second_instance:
+  some_attribute: BBB
+  another_attribute: 999

--- a/activerecord/test/fixtures/admin/randomly_named_b0.yml
+++ b/activerecord/test/fixtures/admin/randomly_named_b0.yml
@@ -1,0 +1,7 @@
+first_instance:
+  some_attribute: AAA
+  another_attribute: 000
+
+second_instance:
+  some_attribute: BBB
+  another_attribute: 999

--- a/activerecord/test/fixtures/randomly_named_a9.yml
+++ b/activerecord/test/fixtures/randomly_named_a9.yml
@@ -1,0 +1,7 @@
+first_instance:
+  some_attribute: AAA
+  another_attribute: 000
+
+second_instance:
+  some_attribute: BBB
+  another_attribute: 999

--- a/activerecord/test/models/admin/randomly_named_c1.rb
+++ b/activerecord/test/models/admin/randomly_named_c1.rb
@@ -1,0 +1,3 @@
+class Admin::ClassNameThatDoesNotFollowCONVENTIONS < ActiveRecord::Base
+  self.table_name = :randomly_named_table
+end

--- a/activerecord/test/models/randomly_named_c1.rb
+++ b/activerecord/test/models/randomly_named_c1.rb
@@ -1,0 +1,3 @@
+class ClassNameThatDoesNotFollowCONVENTIONS < ActiveRecord::Base
+  self.table_name = :randomly_named_table
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -505,6 +505,11 @@ ActiveRecord::Schema.define do
     t.string :type
   end
 
+  create_table :randomly_named_table, :force => true do |t|
+    t.string  :some_attribute
+    t.integer :another_attribute
+  end
+
   create_table :ratings, :force => true do |t|
     t.integer :comment_id
     t.integer :value


### PR DESCRIPTION
"Normalize" how `set_fixture_class` stores the keys: now for a namespaced fixture the fixture name should be passed and stored in the format `"admin/users"` (or `:"admin/users"`) instead of `:admin_users` or `"admin_users"`.  This is consistent with how fixture names are passed to `fixtures` method.  Previously namespaced fixtures were treated separately in some cases which made `set_fixture_class` useless for namespaced fixtures.  Overall, there was a lack of consistency in what was used as a fixture _name_ and identifier: `"foo/bar"` or `:foo_bar`.  This inconsistency is _not_ completely resolved by this patch.

This patch fixes Issue #2572: `set_fixture_class` with namespaced fixtures, like in

``` ruby
set_fixture_class :"admin/known_ips" => Admin::KnownIP, :admin_known_ips => Admin::KnownIP
```

had no effect.
