### PR TITLE
Add tests for the return value of require

### DIFF
--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -258,6 +258,53 @@ class DependenciesTest < Test::Unit::TestCase
     $:.replace(original_path)
   end
 
+  def test_require_returns_true_when_file_not_yet_required
+    path = File.expand_path("../autoloading_fixtures/load_path", __FILE__)
+    original_path = $:.dup
+    original_features = $".dup
+    $:.push(path)
+
+    with_loading('autoloading_fixtures/load_path') do
+      assert_equal true, require('loaded_constant')
+    end
+  ensure
+    remove_constants(:LoadedConstant)
+    $".replace(original_features)
+    $:.replace(original_path)
+  end
+
+  def test_require_returns_true_when_file_not_yet_required_even_when_no_new_constants_added
+    path = File.expand_path("../autoloading_fixtures/load_path", __FILE__)
+    original_path = $:.dup
+    original_features = $".dup
+    $:.push(path)
+
+    with_loading('autoloading_fixtures/load_path') do
+      Object.module_eval "module LoadedConstant; end"
+      assert_equal true, require('loaded_constant')
+    end
+  ensure
+    remove_constants(:LoadedConstant)
+    $".replace(original_features)
+    $:.replace(original_path)
+  end
+
+  def test_require_returns_false_when_file_already_required
+    path = File.expand_path("../autoloading_fixtures/load_path", __FILE__)
+    original_path = $:.dup
+    original_features = $".dup
+    $:.push(path)
+
+    with_loading('autoloading_fixtures/load_path') do
+      require 'loaded_constant'
+      assert_equal false, require('loaded_constant')
+    end
+  ensure
+    remove_constants(:LoadedConstant)
+    $".replace(original_features)
+    $:.replace(original_path)
+  end
+
   def failing_test_access_thru_and_upwards_fails
     with_autoloading_fixtures do
       assert ! defined?(ModuleFolder)

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -305,6 +305,22 @@ class DependenciesTest < Test::Unit::TestCase
     $:.replace(original_path)
   end
 
+  def test_load_returns_true_when_file_found
+    path = File.expand_path("../autoloading_fixtures/load_path", __FILE__)
+    original_path = $:.dup
+    original_features = $".dup
+    $:.push(path)
+
+    with_loading('autoloading_fixtures/load_path') do
+      assert_equal true, load('loaded_constant.rb')
+      assert_equal true, load('loaded_constant.rb')
+    end
+  ensure
+    remove_constants(:LoadedConstant)
+    $".replace(original_features)
+    $:.replace(original_path)
+  end
+
   def failing_test_access_thru_and_upwards_fails
     with_autoloading_fixtures do
       assert ! defined?(ModuleFolder)

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -264,7 +264,7 @@ class DependenciesTest < Test::Unit::TestCase
     original_features = $".dup
     $:.push(path)
 
-    with_loading('autoloading_fixtures/load_path') do
+    with_loading do
       assert_equal true, require('loaded_constant')
     end
   ensure
@@ -279,7 +279,7 @@ class DependenciesTest < Test::Unit::TestCase
     original_features = $".dup
     $:.push(path)
 
-    with_loading('autoloading_fixtures/load_path') do
+    with_loading do
       Object.module_eval "module LoadedConstant; end"
       assert_equal true, require('loaded_constant')
     end
@@ -295,7 +295,7 @@ class DependenciesTest < Test::Unit::TestCase
     original_features = $".dup
     $:.push(path)
 
-    with_loading('autoloading_fixtures/load_path') do
+    with_loading do
       require 'loaded_constant'
       assert_equal false, require('loaded_constant')
     end
@@ -319,7 +319,7 @@ class DependenciesTest < Test::Unit::TestCase
     original_features = $".dup
     $:.push(path)
 
-    with_loading('autoloading_fixtures/load_path') do
+    with_loading do
       assert_equal true, load('loaded_constant.rb')
       assert_equal true, load('loaded_constant.rb')
     end

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -305,6 +305,14 @@ class DependenciesTest < Test::Unit::TestCase
     $:.replace(original_path)
   end
 
+  def test_require_raises_load_error_when_file_not_found
+    with_loading do
+      assert_raise(LoadError) { require 'this_file_dont_exist_dude' }
+    end
+  ensure
+    remove_constants(:LoadedConstant)
+  end
+
   def test_load_returns_true_when_file_found
     path = File.expand_path("../autoloading_fixtures/load_path", __FILE__)
     original_path = $:.dup
@@ -319,6 +327,14 @@ class DependenciesTest < Test::Unit::TestCase
     remove_constants(:LoadedConstant)
     $".replace(original_features)
     $:.replace(original_path)
+  end
+
+  def test_load_raises_load_error_when_file_not_found
+    with_loading do
+      assert_raise(LoadError) { load 'this_file_dont_exist_dude.rb' }
+    end
+  ensure
+    remove_constants(:LoadedConstant)
   end
 
   def failing_test_access_thru_and_upwards_fails


### PR DESCRIPTION
Following 4da45060a2e839fec4a7e9238cbc9d8de62b1b69 on 20110214, RubyInline no longer worked with config.cache_classes = false.  This was due to a change in the return value from require:
- Prior to the change, require returned an array of new constants added by the required file.
  - While this was not consistent with Kernel#require, the result was always truthy.
- Following the change, require returned either an array of new constants added by the required file or nil if requiring the file did not cause any new constants to be defined.
  - This change was incompatible with RubyInline since it first requires a Ruby source file (which defines the constants), then requires a shared object file (which includes implementation but doesn't necessarily define any additional constants).

Ryan Davis submitted a fix for this bug (merged on 20110823).
- a10606c490471d8e1483acb3b31d7f2d51e9ebbe (master)
- b359628f18cd0830654e239ee56845c29be13989 (3-1-stable)
- 7c5cd40710228a027c26335a711b728e9322caac (3-1-stable)

This patch adds tests to ensure Loadable#require remains consistent with Kernel#require sementics, and protect against future regressions in require's return value behavior.
