### PR TITLE
Backport load and require fixes to 3 0

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -236,7 +236,9 @@ module ActiveSupport #:nodoc:
       end
 
       def require(file, *)
-        load_dependency(file) { super }
+        result = false
+        load_dependency(file) { result = super }
+        result
       end
 
       # Mark the given constant as unloadable. Unloadable constants are removed each

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -232,7 +232,9 @@ module ActiveSupport #:nodoc:
       end
 
       def load(file, *)
-        load_dependency(file) { super }
+        result = false
+        load_dependency(file) { result = super }
+        result
       end
 
       def require(file, *)

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -306,6 +306,14 @@ class DependenciesTest < Test::Unit::TestCase
     $:.replace(original_path)
   end
 
+  def test_require_raises_load_error_when_file_not_found
+    with_loading do
+      assert_raise(LoadError) { require 'this_file_dont_exist_dude' }
+    end
+  ensure
+    remove_constants(:LoadedConstant)
+  end
+
   def test_load_returns_true_when_file_found
     path = File.expand_path("../autoloading_fixtures/load_path", __FILE__)
     original_path = $:.dup
@@ -320,6 +328,14 @@ class DependenciesTest < Test::Unit::TestCase
     remove_constants(:LoadedConstant)
     $".replace(original_features)
     $:.replace(original_path)
+  end
+
+  def test_load_raises_load_error_when_file_not_found
+    with_loading do
+      assert_raise(LoadError) { load 'this_file_dont_exist_dude.rb' }
+    end
+  ensure
+    remove_constants(:LoadedConstant)
   end
 
   def failing_test_access_thru_and_upwards_fails

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -265,7 +265,7 @@ class DependenciesTest < Test::Unit::TestCase
     original_features = $".dup
     $:.push(path)
 
-    with_loading('autoloading_fixtures/load_path') do
+    with_loading do
       assert_equal true, require('loaded_constant')
     end
   ensure
@@ -280,7 +280,7 @@ class DependenciesTest < Test::Unit::TestCase
     original_features = $".dup
     $:.push(path)
 
-    with_loading('autoloading_fixtures/load_path') do
+    with_loading do
       Object.module_eval "module LoadedConstant; end"
       assert_equal true, require('loaded_constant')
     end
@@ -296,7 +296,7 @@ class DependenciesTest < Test::Unit::TestCase
     original_features = $".dup
     $:.push(path)
 
-    with_loading('autoloading_fixtures/load_path') do
+    with_loading do
       require 'loaded_constant'
       assert_equal false, require('loaded_constant')
     end
@@ -320,7 +320,7 @@ class DependenciesTest < Test::Unit::TestCase
     original_features = $".dup
     $:.push(path)
 
-    with_loading('autoloading_fixtures/load_path') do
+    with_loading do
       assert_equal true, load('loaded_constant.rb')
       assert_equal true, load('loaded_constant.rb')
     end

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -306,6 +306,22 @@ class DependenciesTest < Test::Unit::TestCase
     $:.replace(original_path)
   end
 
+  def test_load_returns_true_when_file_found
+    path = File.expand_path("../autoloading_fixtures/load_path", __FILE__)
+    original_path = $:.dup
+    original_features = $".dup
+    $:.push(path)
+
+    with_loading('autoloading_fixtures/load_path') do
+      assert_equal true, load('loaded_constant.rb')
+      assert_equal true, load('loaded_constant.rb')
+    end
+  ensure
+    remove_constants(:LoadedConstant)
+    $".replace(original_features)
+    $:.replace(original_path)
+  end
+
   def failing_test_access_thru_and_upwards_fails
     with_autoloading_fixtures do
       assert ! defined?(ModuleFolder)

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -259,6 +259,53 @@ class DependenciesTest < Test::Unit::TestCase
     $:.replace(original_path)
   end
 
+  def test_require_returns_true_when_file_not_yet_required
+    path = File.expand_path("../autoloading_fixtures/load_path", __FILE__)
+    original_path = $:.dup
+    original_features = $".dup
+    $:.push(path)
+
+    with_loading('autoloading_fixtures/load_path') do
+      assert_equal true, require('loaded_constant')
+    end
+  ensure
+    remove_constants(:LoadedConstant)
+    $".replace(original_features)
+    $:.replace(original_path)
+  end
+
+  def test_require_returns_true_when_file_not_yet_required_even_when_no_new_constants_added
+    path = File.expand_path("../autoloading_fixtures/load_path", __FILE__)
+    original_path = $:.dup
+    original_features = $".dup
+    $:.push(path)
+
+    with_loading('autoloading_fixtures/load_path') do
+      Object.module_eval "module LoadedConstant; end"
+      assert_equal true, require('loaded_constant')
+    end
+  ensure
+    remove_constants(:LoadedConstant)
+    $".replace(original_features)
+    $:.replace(original_path)
+  end
+
+  def test_require_returns_false_when_file_already_required
+    path = File.expand_path("../autoloading_fixtures/load_path", __FILE__)
+    original_path = $:.dup
+    original_features = $".dup
+    $:.push(path)
+
+    with_loading('autoloading_fixtures/load_path') do
+      require 'loaded_constant'
+      assert_equal false, require('loaded_constant')
+    end
+  ensure
+    remove_constants(:LoadedConstant)
+    $".replace(original_features)
+    $:.replace(original_path)
+  end
+
   def failing_test_access_thru_and_upwards_fails
     with_autoloading_fixtures do
       assert ! defined?(ModuleFolder)


### PR DESCRIPTION
These fixes have been applied to master and 3-1-stable.  It would be nice to backport them for the next 3.0.x release as well.

See #3845 for more details.
