### PR TITLE
Do not validate associated records marked for destruction

### DIFF
--- a/activerecord/lib/active_record/validations/associated.rb
+++ b/activerecord/lib/active_record/validations/associated.rb
@@ -2,8 +2,9 @@ module ActiveRecord
   module Validations
     class AssociatedValidator < ActiveModel::EachValidator
       def validate_each(record, attribute, value)
-        return if (value.is_a?(Array) ? value : [value]).collect{ |r| r.nil? || r.valid? }.all?
-        record.errors.add(attribute, :invalid, options.merge(:value => value))
+        if Array.wrap(value).reject {|r| r.marked_for_destruction? || r.valid?}.any?
+          record.errors.add(attribute, :invalid, options.merge(:value => value))
+        end
       end
     end
 

--- a/activerecord/test/cases/validations/association_validation_test.rb
+++ b/activerecord/test/cases/validations/association_validation_test.rb
@@ -61,6 +61,16 @@ class AssociationValidationTest < ActiveRecord::TestCase
     assert r.valid?
   end
 
+  def test_validates_associated_marked_for_destruction
+    Topic.validates_associated(:replies)
+    Reply.validates_presence_of(:content)
+    t = Topic.new
+    t.replies << Reply.new
+    assert t.invalid?
+    t.replies.first.mark_for_destruction
+    assert t.valid?
+  end
+
   def test_validates_associated_with_custom_message_using_quotes
     Reply.validates_associated :topic, :message=> "This string contains 'single' and \"double\" quotes"
     Topic.validates_presence_of :content


### PR DESCRIPTION
The main reason for this change is to fix a bug where
`validates_associated` would prevent `accepts_nested_attributes_for`
with `allow_destroy: true` from destroying invalid associated records.
