### PR TITLE
redirect_to url with network path reference: Do not escape forward slashes within a curly regexp

### DIFF
--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -81,7 +81,8 @@ module ActionController
         # The scheme name consist of a letter followed by any combination of
         # letters, digits, and the plus ("+"), period ("."), or hyphen ("-")
         # characters; and is terminated by a colon (":").
-        when %r{^(\w[\w+.-]*:|\/\/).*}
+        # The protocol relative scheme starts with a double slash "//"
+        when %r{^(\w[\w+.-]*:|//).*}
           options
         when String
           request.protocol + request.host_with_port + options


### PR DESCRIPTION
I also mentoined the protocol relative scheme in the internal comment
Hat tip to @fxn
