### PR TITLE
Fix human_attribute_name to handle names with dots

### DIFF
--- a/activemodel/lib/active_model/translation.rb
+++ b/activemodel/lib/active_model/translation.rb
@@ -43,8 +43,12 @@ module ActiveModel
     #
     # Specify +options+ with additional translating options.
     def human_attribute_name(attribute, options = {})
-      defaults = lookup_ancestors.map do |klass|
-        :"#{self.i18n_scope}.attributes.#{klass.model_name.i18n_key}.#{attribute}"
+      defaults = []
+      lookup_ancestors.each do |klass|
+        if attribute.match(/\./)
+          defaults << :"#{self.i18n_scope}.attributes.#{klass.model_name.i18n_key}.#{attribute.gsub(/\./, '/')}"
+        end
+        defaults << :"#{self.i18n_scope}.attributes.#{klass.model_name.i18n_key}.#{attribute}"
       end
 
       defaults << :"attributes.#{attribute}"

--- a/activemodel/test/cases/translation_test.rb
+++ b/activemodel/test/cases/translation_test.rb
@@ -56,6 +56,16 @@ class ActiveModelI18nTests < ActiveModel::TestCase
     assert_equal 'person gender attribute', Person::Gender.human_attribute_name('attribute')
   end
 
+  def test_translated_nested_model_attributes
+    I18n.backend.store_translations 'en', :activemodel => {:attributes => {:person => {:"addresses/street" => 'Street'}}}
+    assert_equal 'Street', Person.human_attribute_name('addresses.street')
+  end
+
+  def test_translated_nested_model_attributes_with_deprecated_lookup_style
+    I18n.backend.store_translations 'en', :activemodel => {:attributes => {:person => {:addresses => {:street => 'Street'}}}}
+    assert_equal 'Street', Person.human_attribute_name('addresses.street')
+  end
+
   def test_translated_model_names
     I18n.backend.store_translations 'en', :activemodel => {:models => {:person => 'person model'} }
     assert_equal 'person model', Person.model_name.human


### PR DESCRIPTION
Nested I18n namespace lookup under activerecord.models is deprecated now (c19bd4f).
But when a model uses accepts_nested_attributes_for, its Errors object can have
an attribute name with "addresses.street" style. In this case, the dots should be
substituted with slashes so that we can provide the translation under the
"activemodel.attributes.person.addresses/street" key.
