### PR TITLE
use classify in ParamsWrapper to derive model name from controller name

### DIFF
--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -141,7 +141,7 @@ module ActionController
       # try to find Foo::Bar::User, Foo::User and finally User.
       def _default_wrap_model #:nodoc:
         return nil if self.anonymous?
-        model_name = self.name.sub(/Controller$/, '').singularize
+        model_name = self.name.sub(/Controller$/, '').classify
 
         begin
           if model_klass = model_name.safe_constantize


### PR DESCRIPTION
I've added test to reproduce issue #2410 and fixed it.

/cc @josevalim
