### PR TITLE
Increase performance for table_exists?

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -23,7 +23,12 @@ module ActiveRecord
       # === Example
       #   table_exists?(:developers)
       def table_exists?(table_name)
-        tables.include?(table_name.to_s)
+        begin
+          select_value("SELECT 1 FROM #{table_name.to_s} where 1=0")
+          true
+        rescue
+          false
+        end
       end
 
       # Returns an array of indexes for the given table.


### PR DESCRIPTION
At New Relic, we have hundreds of thousands of tables, and our migrations took 30 minutes without a similar patch. This cuts it down to a more reasonable amount of time. The more tables you have, the more efficiency gain you derive from the patch.

The rescue false part is ugly, but necessary as far as I can tell. I don't know of a cross-database statement you can make that will work without trapping and relying on errors.

Tested on MySQL and SQLite, but I believe this should work across any database.
