### PR TITLE
Has many through ids conditions

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1490,17 +1490,7 @@ module ActiveRecord
           end
 
           redefine_method("#{reflection.name.to_s.singularize}_ids") do
-            if send(reflection.name).loaded? || reflection.options[:finder_sql]
-              send(reflection.name).map { |r| r.id }
-            else
-              if reflection.through_reflection && reflection.source_reflection.belongs_to?
-                through = reflection.through_reflection
-                primary_key = reflection.source_reflection.primary_key_name
-                send(through.name).select("DISTINCT #{through.quoted_table_name}.#{primary_key}").map! { |r| r.send(primary_key) }
-              else
-                send(reflection.name).select("#{reflection.quoted_table_name}.#{reflection.klass.primary_key}").except(:includes).map! { |r| r.id }
-              end
-            end
+            send(reflection.name).ids_reader
           end
 
         end

--- a/activerecord/lib/active_record/associations/association_proxy.rb
+++ b/activerecord/lib/active_record/associations/association_proxy.rb
@@ -160,6 +160,20 @@ module ActiveRecord
         end
       end
 
+      def ids_reader
+        if loaded? || @reflection.options[:finder_sql]
+          load_target.map do |record|
+            record.send(@reflection.association_primary_key)
+          end
+        else
+          column  = "#{@reflection.quoted_table_name}.#{@reflection.association_primary_key}"
+
+          scoped.except(:select).select(column).to_array(false).map! do |record|
+            record.send(@reflection.association_primary_key)
+          end
+        end
+      end
+
       protected
         # Does the association have a <tt>:dependent</tt> option?
         def dependent?

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -59,13 +59,19 @@ module ActiveRecord
     end
 
     def to_a
+      to_array
+    end
+
+    def to_array(with_preload = true)
       return @records if loaded?
 
       @records = eager_loading? ? find_with_associations : @klass.find_by_sql(arel.to_sql)
 
-      preload = @preload_values
-      preload +=  @includes_values unless eager_loading?
-      preload.each {|associations| @klass.send(:preload_associations, @records, associations) }
+      if with_preload
+        preload = @preload_values
+        preload += @includes_values unless eager_loading?
+        preload.each {|associations| @klass.send(:preload_associations, @records, associations) }
+      end
 
       # @readonly_value is true only if set explicitly. @implicit_readonly is true if there
       # are JOINS and no explicit SELECT.

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -331,8 +331,8 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal 2, people(:michael).jobs.size
   end
 
-  def test_get_ids_for_belongs_to_source
-    assert_sql(/DISTINCT/) { assert_equal [posts(:welcome).id, posts(:authorless).id].sort, people(:michael).post_ids.sort }
+  def test_get_ids
+    assert_equal [posts(:welcome).id, posts(:authorless).id].sort, people(:michael).post_ids.sort
   end
 
   def test_get_ids_for_has_many_source
@@ -353,6 +353,15 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert !person.posts.loaded?
     assert_equal [posts(:welcome).id, posts(:authorless).id].sort, person.post_ids.sort
     assert !person.posts.loaded?
+  end
+
+  def test_get_ids_for_has_many_through_with_conditions
+    Tagging.create!(:taggable_type => 'Post', :taggable_id => posts(:welcome).id, :tag => tags(:misc))
+    assert_equal posts(:welcome).misc_tag_ids,posts(:welcome).misc_tags.map! {|r| r.send(:id)}
+  end
+
+  def test_get_ids_for_has_many_through_with_include_and_conditions
+    assert_equal [posts(:authorless).id], people(:michael).posts_with_no_comment_ids
   end
 
   def test_association_proxy_transaction_method_starts_transaction_in_association_class


### PR DESCRIPTION
Fixes various github issues around has-many-through associations with conditions giving incorrect results when fetching _ids.  (#3836, #2698, #2454, #1005)
- Added tests
- Backported ids_reader approach from 3.1/master.
- Let ids_reader bypass preload logic to work around 3.0 preloader issue with partially-loaded records (and preloading in an _ids fetch doesn't likely make performance sense anyway)
- Added except(:select) to exclude extraneous default select fields from through association scope
