### PR TITLE
bypass preloading for ids_reader

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -50,7 +50,7 @@ module ActiveRecord
         else
           column  = "#{reflection.quoted_table_name}.#{reflection.association_primary_key}"
 
-          scoped.select(column).map! do |record|
+          scoped.select(column).to_array(false).map! do |record|
             record.send(reflection.association_primary_key)
           end
         end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -528,6 +528,12 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal [posts(:welcome).id, posts(:authorless).id].sort, people(:michael).post_ids.sort
   end
 
+  def test_get_ids_for_has_many_through_with_conditions_should_not_preload
+    Tagging.create!(:taggable_type => 'Post', :taggable_id => posts(:welcome).id, :tag => tags(:misc))
+    ActiveRecord::Associations::Preloader.expects(:new).never
+    posts(:welcome).misc_tag_ids
+  end
+
   def test_get_ids_for_loaded_associations
     person = people(:michael)
     person.posts(true)


### PR DESCRIPTION
- When fetching ids for a collection, bypass preloading to avoid the unnecessary performance overhead.
- As a side effect, also allow for bypassing preloading in other cases where the preloading may also not be desired (e.g., some_big_association.select(:email_address) ) by invoking to_array with with_preload=false.

Loosely related to #2020 and #3868.
