### PR TITLE
Add value_of/values_of to AR::Base/AR::Relation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## Rails 3.2.0 (unreleased) ##
 
+*   Added `ActiveRecord::Base#select_column` and `ActiveRecord::Base#select_columns`
+
+    Returns an array (or an array of arrays, in the case of `select_columns`) of
+    type-cast values for a class or relation, without instantiating AR::Base
+    objects.
+        
+      Client.where(:active => true).select_column(:id)
+
+    is the same as
+
+        Client.where(:active => true).select(:id).map(&:id)
+
+    but doesn't require instantiation of multiple Client objects.
+
+    *Ernie Miller*
+
 *   Added ability to run migrations only for given scope, which allows
     to run migrations only from one engine (for example to revert changes
     from engine that you want to remove).
@@ -26,14 +42,6 @@
     PostgreSQL.
 
     *fxn*
-
-*   Implemented ActiveRecord::Relation#pluck method
-
-    Method returns Array of column value from table under ActiveRecord model
-        
-        Client.pluck(:id)
-
-    *Bogdan Gusiev*
 
 *   Automatic closure of connections in threads is deprecated.  For example
     the following code is deprecated:
@@ -233,7 +241,7 @@
 
 *   LRU cache in mysql and sqlite are now per-process caches.
 
-    * lib/active_record/connection_adapters/mysql_adapter.rb: LRU cache  	  keys are per process id.
+    * lib/active_record/connection_adapters/mysql_adapter.rb: LRU cache     keys are per process id.
     * lib/active_record/connection_adapters/sqlite_adapter.rb: ditto
     *Aaron Patterson*
 

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -48,7 +48,6 @@ module ActiveRecord
             record.send(reflection.association_primary_key)
           end
         else
-          column  = "#{reflection.quoted_table_name}.#{reflection.association_primary_key}"
           relation = scoped
 
           including = (relation.eager_load_values + relation.includes_values).uniq
@@ -60,7 +59,7 @@ module ActiveRecord
             end
           end
 
-          relation.uniq.pluck(column)
+          relation.uniq.select_column(reflection.association_primary_key)
         end
       end
 

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -39,7 +39,7 @@ module ActiveRecord
       instance_methods.each { |m| undef_method m unless m.to_s =~ /^(?:nil\?|send|object_id|to_a)$|^__|^respond_to|proxy_/ }
 
       delegate :group, :order, :limit, :joins, :where, :preload, :eager_load, :includes, :from,
-               :lock, :readonly, :having, :pluck, :to => :scoped
+               :lock, :readonly, :having, :select_column, :select_columns, :to => :scoped
 
       delegate :target, :load_target, :loaded?, :to => :@association
 

--- a/railties/guides/source/active_record_querying.textile
+++ b/railties/guides/source/active_record_querying.textile
@@ -1146,19 +1146,19 @@ h3. +select_all+
 Client.connection.select_all("SELECT * FROM clients WHERE id = '1'")
 </ruby>
 
-h3. +pluck+
+h3. +select_column+
 
-<tt>pluck</tt> can be used to query a single column from the underlying table of a model. It accepts a column name as argument and returns an array of values of the specified column with the corresponding data type.
+<tt>select_column</tt> can be used to query a single column from the underlying table of a model. It accepts a column name as argument and returns an array of values of the specified column with the corresponding data type.
 
 <ruby>
-Client.where(:active => true).pluck(:id)
+Client.where(:active => true).select_column(:id)
 # SELECT id FROM clients WHERE active = 1
 
-Client.uniq.pluck(:role)
+Client.uniq.select_column(:role)
 # SELECT DISTINCT role FROM clients
 </ruby>
 
-+pluck+ makes it possible to replace code like
++select_column+ makes it possible to replace code like
 
 <ruby>
 Client.select(:id).map { |c| c.id }
@@ -1167,7 +1167,7 @@ Client.select(:id).map { |c| c.id }
 with
 
 <ruby>
-Client.pluck(:id)
+Client.select_column(:id)
 </ruby>
 
 h3. Existence of Objects


### PR DESCRIPTION
This patch basically amounts to a merge of Valium functionality into Rails core. Implements select_column/select_columnsfunctionality as exists in https://github.com/ernie/valium.

Superset of the recent pluck functionality, with the following enhancements:
- Only runs the DB query if required. If the records have already been loaded, simply maps through them and reads the attributes
- Supports multiple attributes:

``` ruby
User.where(:active => true).select_columns(:name, :email).each do |name, email|
  puts "#{name}'s e-mail address is #{email}"
end
```
- deserializes serialized attributes

Added a few new tests, corrected test names. All tests pass.

[Updated: this part is no longer true since the method names were changed - All Valium specs pass without loading the Valium gem when this code is active, so this should be backwards-compatible for those people who are already using Valium.]

Thanks!
