### PR TITLE
ActiveModel::Name#i18n_key: Fix doc and add tests

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -71,8 +71,8 @@ module ActiveModel
   #   BookCover.model_name        # => "BookCover"
   #   BookCover.model_name.human  # => "Book cover"
   #
-  #   BookCover.model_name.i18n_key              # => "book_cover"
-  #   BookModule::BookCover.model_name.i18n_key  # => "book_module.book_cover"
+  #   BookCover.model_name.i18n_key              # => :book_cover
+  #   BookModule::BookCover.model_name.i18n_key  # => :"book_module/book_cover"
   #
   # Providing the functionality that ActiveModel::Naming provides in your object
   # is required to pass the Active Model Lint test. So either extending the provided

--- a/activemodel/test/cases/naming_test.rb
+++ b/activemodel/test/cases/naming_test.rb
@@ -34,6 +34,10 @@ class NamingTest < ActiveModel::TestCase
   def test_human
     assert_equal 'Track back', @model_name.human
   end
+
+  def test_i18n_key
+    assert_equal :"post/track_back", @model_name.i18n_key
+  end
 end
 
 class NamingWithNamespacedModelInIsolatedNamespaceTest < ActiveModel::TestCase
@@ -73,6 +77,10 @@ class NamingWithNamespacedModelInIsolatedNamespaceTest < ActiveModel::TestCase
 
   def test_param_key
     assert_equal 'post', @model_name.param_key
+  end
+
+  def test_i18n_key
+    assert_equal :"blog/post", @model_name.i18n_key
   end
 end
 
@@ -114,6 +122,10 @@ class NamingWithNamespacedModelInSharedNamespaceTest < ActiveModel::TestCase
   def test_param_key
     assert_equal 'blog_post', @model_name.param_key
   end
+
+  def test_i18n_key
+    assert_equal :"blog/post", @model_name.i18n_key
+  end
 end
 
 class NamingWithSuppliedModelNameTest < ActiveModel::TestCase
@@ -154,6 +166,10 @@ class NamingWithSuppliedModelNameTest < ActiveModel::TestCase
   def test_param_key
     assert_equal 'article', @model_name.param_key
   end
+
+  def test_i18n_key
+    assert_equal :"article", @model_name.i18n_key
+  end
 end
 
 class NamingUsingRelativeModelNameTest < ActiveModel::TestCase
@@ -187,6 +203,10 @@ class NamingUsingRelativeModelNameTest < ActiveModel::TestCase
 
   def test_param_key
     assert_equal 'post', @model_name.param_key
+  end
+
+  def test_i18n_key
+    assert_equal :"blog/post", @model_name.i18n_key
   end
 end
 


### PR DESCRIPTION
Fixes doc for `ActiveModel::Name#i18n_key`, to make it (slightly) easier to figure out how to store i18n'ed model names.

Tests added too, so as to make this pull request much more impressive than it really is ;-)

Thanks
