### PR TITLE
Don't tokenize string when counting characters

### DIFF
--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -6,7 +6,6 @@ module ActiveModel
       MESSAGES  = { :is => :wrong_length, :minimum => :too_short, :maximum => :too_long }.freeze
       CHECKS    = { :is => :==, :minimum => :>=, :maximum => :<= }.freeze
 
-      DEFAULT_TOKENIZER = lambda { |value| value.split(//) }
       RESERVED_OPTIONS  = [:minimum, :maximum, :within, :is, :tokenizer, :too_short, :too_long]
 
       def initialize(options)
@@ -36,7 +35,7 @@ module ActiveModel
       end
 
       def validate_each(record, attribute, value)
-        value = (options[:tokenizer] || DEFAULT_TOKENIZER).call(value) if value.kind_of?(String)
+        value = options[:tokenizer].call(value) if value.kind_of?(String) && options[:tokenizer].present?
 
         CHECKS.each do |key, validity_check|
           next unless check_value = options[key]


### PR DESCRIPTION
The length validation in ActiveModel offers a `:tokenizer` option, but when none is given it defaults to using `//` to split the string by character. This adds up to a serious performance hit when validating long strings. AFAICT it's faster, easier, and works just as well to use `String#length` unless a tokenizer is provided.

A simple wall-time benchmark:

``` ruby
class Foo
  include ActiveModel::Validations
  attr_accessor :bar
  validates_length_of :bar, :maximum => 1
end

LONG_STRING = "a" * 100000

100.times do
  f = Foo.new
  f.bar = LONG_STRING
  f.valid?
end
```

Before:

```
real  0m6.196s
user  0m6.113s
sys   0m0.077s
```

After:

```
real  0m0.720s
user  0m0.650s
sys   0m0.063s
```
