### PR TITLE
Allow string as url for expire_action

### DIFF
--- a/actionpack/lib/action_controller/caching/actions.rb
+++ b/actionpack/lib/action_controller/caching/actions.rb
@@ -116,9 +116,8 @@ module ActionController #:nodoc:
       def expire_action(options = {})
         return unless cache_configured?
 
-        actions = options[:action]
-        if actions.is_a?(Array)
-          actions.each {|action| expire_action(options.merge(:action => action)) }
+        if options.is_a?(Hash) && options[:action].is_a?(Array)
+          options[:action].each {|action| expire_action(options.merge(:action => action)) }
         else
           expire_fragment(ActionCachePath.new(self, options, false).path)
         end

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -251,6 +251,11 @@ class ActionCachingTestController < CachingController
     expire_action :controller => 'action_caching_test', :action => 'index', :format => 'xml'
     render :nothing => true
   end
+
+  def expire_with_url_string
+    expire_action url_for(:controller => 'action_caching_test', :action => 'index')
+    render :nothing => true
+  end
 end
 
 class MockTime < Time
@@ -437,6 +442,21 @@ class ActionCacheTest < ActionController::TestCase
 
     @request.request_uri = "/action_caching_test/expire.xml"
     get :expire, :format => :xml
+    assert_response :success
+    reset!
+
+    get :index
+    assert_response :success
+    assert_not_equal cached_time, @response.body
+  end
+
+  def test_cache_expiration_with_url_string
+    get :index
+    cached_time = content_to_cache
+    reset!
+
+    @request.request_uri = "/action_caching_test/expire_with_url_string"
+    get :expire_with_url_string
     assert_response :success
     reset!
 


### PR DESCRIPTION
`expire_action` only accepts a hash as url options. So one cannot pass a url helper to expire_action. This is unintuitive and not needed, because `ActionCachePath` passes the options to `url_for`, that takes a string.

Further there are circumstances where this a serious blocker:

Mountable apps.

One cannot pass an url from a mounted app to `expire_action` like this:

`expire_action(engine_name.named_path)`

So submitted a patch that fixes this.
