### PR TITLE
Support charset meta tag.

### DIFF
--- a/actionpack/lib/action_view/helpers.rb
+++ b/actionpack/lib/action_view/helpers.rb
@@ -11,6 +11,7 @@ module ActionView #:nodoc:
     autoload :CaptureHelper
     autoload :ControllerHelper
     autoload :CsrfHelper
+    autoload :CharsetHelper
     autoload :DateHelper
     autoload :DebugHelper
     autoload :FormHelper
@@ -41,6 +42,7 @@ module ActionView #:nodoc:
     include CaptureHelper
     include ControllerHelper
     include CsrfHelper
+    include CharsetHelper
     include DateHelper
     include DebugHelper
     include FormHelper

--- a/actionpack/lib/action_view/helpers/charset_helper.rb
+++ b/actionpack/lib/action_view/helpers/charset_helper.rb
@@ -1,0 +1,28 @@
+require 'active_support/core_ext/object/blank'
+require 'active_support/core_ext/string/output_safety'
+require 'action_view/helpers/tag_helper'
+require 'action_dispatch'
+
+module ActionView
+  # = Action View Charset Helper
+  module Helpers
+    module CharsetHelper
+      # Returns meta tags "charset".
+      #
+      #   <head>
+      #     <%= charset_meta_tag %>
+      #     <title>...</title>
+      #   </head>
+      #
+      # This method will return the meta tag with charset value looking for in this order:
+      #   charset argument
+      #   ActionDispatch::Response#charset
+      #   ActionDispatch::Response.default_charset
+      #
+      def charset_meta_tag(charset = nil)
+        tag('meta', :charset => (charset || response.charset || ActionDispatch::Response.default_charset)).html_safe
+      end
+
+    end
+  end
+end

--- a/actionpack/test/controller/charset_test.rb
+++ b/actionpack/test/controller/charset_test.rb
@@ -1,0 +1,38 @@
+require 'abstract_unit'
+
+class CharsetController < ActionController::Base
+
+  def render_from_charset
+    response.charset = 'Shift_JIS'
+    render :inline => "<%= charset_meta_tag %>"
+  end
+
+  def render_from_default_charset
+    render :inline => "<%= charset_meta_tag %>"
+  end
+
+  def render_from_argument
+    render :inline => "<%= charset_meta_tag 'Shift_JIS' %>"
+  end
+
+end
+
+class CharsetTest < ActionController::TestCase
+  tests CharsetController
+
+  def test_render_from_charset
+    get :render_from_charset
+    assert_match(/Shift_JIS/, @response.body)
+  end
+
+  def test_render_from_default_charset
+    get :render_from_default_charset
+    assert_match(/utf-8/, @response.body)
+  end
+
+  def test_render_from_argument
+    get :render_from_argument
+    assert_match(/Shift_JIS/, @response.body)
+  end
+
+end

--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <%%= charset_meta_tag %>
   <title><%= camelized %></title>
   <%%= stylesheet_link_tag    "application", :media => "all" %>
   <%%= javascript_include_tag "application" %>


### PR DESCRIPTION
I know GH #3539 and #149.
But I want to propose it again, because I have another motivation.

I'm Japanese and resident in the multibyte world.
In my experience, if we don't write charset meta tag, we've got trouble in terms of the next.

If we save a page as html file.

When we open the html file, we'll miss a charset .
