### PR TITLE
Use default charset when we read content type without charset.

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -69,7 +69,7 @@ module ActionDispatch # :nodoc:
       if content_type = self["Content-Type"]
         type, charset = content_type.split(/;\s*charset=/)
         @content_type = Mime::Type.lookup(type)
-        @charset = charset || "UTF-8"
+        @charset = charset || self.class.default_charset
       end
 
       prepare_cache_control!

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -130,6 +130,17 @@ class ResponseTest < ActiveSupport::TestCase
 
     assert_equal('application/xml; charset=utf-16', resp.headers['Content-Type'])
   end
+
+  test "read content type without charset" do
+    original = ActionDispatch::Response.default_charset
+    begin
+      ActionDispatch::Response.default_charset = 'utf-16'
+      resp = ActionDispatch::Response.new(200, { "Content-Type" => "text/xml" })
+      assert_equal('utf-16', resp.charset)
+    ensure
+      ActionDispatch::Response.default_charset = original
+    end
+  end
 end
 
 class ResponseIntegrationTest < ActionDispatch::IntegrationTest


### PR DESCRIPTION
When we read Content-Type header without charset, we should use Response#default_charset .

The original code is 'UTF-8' (string literal).
But I think that we should use `self.class.default_charset` here.
