### PR TITLE
Allow layout fallback when using `layout` method

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Rails 3.2.0 (unreleased) ##
 
+*   Rails will now use your default layout (such as "layouts/application") when you specify a layout with `:only` and `:except` condition, and those conditions fail. *Prem Sichanugrist*
+
+    For example, consider this snippet:
+
+        class CarsController
+          layout 'single_car', :only => :show
+        end
+
+    Rails will use 'layouts/single_car' when a request comes in `:show` action, and use 'layouts/application' (or 'layouts/cars', if exists) when a request comes in for any other actions.
+
 *   form_for with +:as+ option uses "#{action}_#{as}" as css class and id:
 
     Before:

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -86,6 +86,21 @@ module ActionController
           end
         end
       when Hash
+        if expected_layout = options[:layout]
+          msg = build_message(message,
+                  "expecting layout <?> but action rendered <?>",
+                  expected_layout, @layouts.keys)
+
+          case expected_layout
+          when String
+            assert(@layouts.keys.include?(expected_layout), msg)
+          when Regexp
+            assert(@layouts.keys.any? {|l| l =~ expected_layout }, msg)
+          when nil
+            assert(@layouts.empty?, msg)
+          end
+        end
+
         if expected_partial = options[:partial]
           if expected_locals = options[:locals]
             actual_locals = @locals[expected_partial.to_s.sub(/^_/,'')]
@@ -98,19 +113,6 @@ module ActionController
                     "expecting ? to be rendered ? time(s) but rendered ? time(s)",
                      expected_partial, expected_count, actual_count)
             assert(actual_count == expected_count.to_i, msg)
-          elsif options.key?(:layout)
-            msg = build_message(message,
-                    "expecting layout <?> but action rendered <?>",
-                    expected_layout, @layouts.keys)
-
-            case layout = options[:layout]
-            when String
-              assert(@layouts.include?(expected_layout), msg)
-            when Regexp
-              assert(@layouts.any? {|l| l =~ layout }, msg)
-            when nil
-              assert(@layouts.empty?, msg)
-            end
           else
             msg = build_message(message,
                     "expecting partial <?> but action rendered <?>",

--- a/actionpack/test/abstract/layouts_test.rb
+++ b/actionpack/test/abstract/layouts_test.rb
@@ -141,6 +141,30 @@ module AbstractControllerTests
       end
     end
 
+    class WithOnlyConditional < WithStringImpliedChild
+      layout "overwrite", :only => :show
+
+      def index
+        render :template => ActionView::Template::Text.new("Hello index!")
+      end
+
+      def show
+        render :template => ActionView::Template::Text.new("Hello show!")
+      end
+    end
+
+    class WithExceptConditional < WithStringImpliedChild
+      layout "overwrite", :except => :show
+
+      def index
+        render :template => ActionView::Template::Text.new("Hello index!")
+      end
+
+      def show
+        render :template => ActionView::Template::Text.new("Hello show!")
+      end
+    end
+
     class TestBase < ActiveSupport::TestCase
       test "when no layout is specified, and no default is available, render without a layout" do
         controller = Blank.new
@@ -259,6 +283,30 @@ module AbstractControllerTests
             end
           end
         end
+      end
+
+      test "when specify an :only option which match current action name" do
+        controller = WithOnlyConditional.new
+        controller.process(:show)
+        assert_equal "Overwrite Hello show!", controller.response_body
+      end
+
+      test "when specify an :only option which does not match current action name" do
+        controller = WithOnlyConditional.new
+        controller.process(:index)
+        assert_equal "With Implied Hello index!", controller.response_body
+      end
+
+      test "when specify an :except option which match current action name" do
+        controller = WithExceptConditional.new
+        controller.process(:show)
+        assert_equal "With Implied Hello show!", controller.response_body
+      end
+
+      test "when specify an :except option which does not match current action name" do
+        controller = WithExceptConditional.new
+        controller.process(:index)
+        assert_equal "Overwrite Hello index!", controller.response_body
       end
     end
   end

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -71,6 +71,10 @@ class ActionPackAssertionsController < ActionController::Base
     render :text => "Hello!", :content_type => Mime::RSS
   end
 
+  def render_with_layout
+    render "test/hello_world", :layout => "layouts/standard"
+  end
+
   def session_stuffing
     session['xmas'] = 'turkey'
     render :text => "ho ho ho"
@@ -469,6 +473,18 @@ class AssertTemplateTest < ActionController::TestCase
     assert_raise(ActiveSupport::TestCase::Assertion) do
       assert_template :hello_planet
     end
+  end
+
+  def test_fails_with_wrong_layout
+    get :render_with_layout
+    assert_raise(ActiveSupport::TestCase::Assertion) do
+      assert_template :layout => "application"
+    end
+  end
+
+  def test_passes_with_correct_layout
+    get :render_with_layout
+    assert_template :layout => "layouts/standard"
   end
 
   def test_assert_template_reset_between_requests

--- a/actionpack/test/controller/layout_test.rb
+++ b/actionpack/test/controller/layout_test.rb
@@ -167,7 +167,7 @@ class LayoutSetInResponseTest < ActionController::TestCase
   def test_layout_is_picked_from_the_controller_instances_view_path
     @controller = PrependsViewPathController.new
     get :hello
-    assert_template :layout => /layouts\/alt\.\w+/
+    assert_template :layout => /layouts\/alt/
   end
 
   def test_absolute_pathed_layout


### PR DESCRIPTION
Rails will now use your default layout (such as "layouts/application") when you specify a layout with `:only` and `:except` condition, and those conditions fail.

For example, consider this snippet:

```
class CarsController
  layout 'single_car', :only => :show
end
```

Rails will use 'layouts/single_car' when a request comes in `:show` action, and use 'layouts/application' (or 'layouts/cars', if exists) when a request comes in for any other actions.

---

Bonus point: I found out that `assert_template :layout => 'blahhhhhh'` will returns true regardless of layout that got rendered. I've fixed that as well.
