### PR TITLE
Assign config.encoding to AD::Response.default_charset at the initialization time.

### DIFF
--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -21,6 +21,7 @@ module ActionDispatch
     initializer "action_dispatch.configure" do |app|
       ActionDispatch::Http::URL.tld_length = app.config.action_dispatch.tld_length
       ActionDispatch::Request.ignore_accept_header = app.config.action_dispatch.ignore_accept_header
+      ActionDispatch::Response.default_charset = app.config.encoding
 
       ActionDispatch::ExceptionWrapper.rescue_responses.merge!(config.action_dispatch.rescue_responses)
       ActionDispatch::ExceptionWrapper.rescue_templates.merge!(config.action_dispatch.rescue_templates)

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -136,6 +136,12 @@ module ApplicationTests
       assert_equal 2, ActionDispatch::Http::URL.tld_length
     end
 
+    test "assignment config.encoding to default_charset" do
+      add_to_config "config.encoding = 'Shift_JIS'"
+      require "#{app_path}/config/environment"
+      assert_equal 'Shift_JIS', ActionDispatch::Response.default_charset
+    end
+
     # AS
     test "if there's no config.active_support.bare, all of ActiveSupport is required" do
       use_frameworks []


### PR DESCRIPTION
Please see https://github.com/rails/rails/pull/3878
