### PR TITLE
Implements `ActiveRecord::Base.connection.select_pair`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Rails 3.2.0 (unreleased) ##
 
+*   Implements `AR::Base.connection.select_pair`, which will return a hash.
+    The first column of your result set will be used as a key, and the second
+    column will be used as a value. This is useful in an scenario where you
+    want to map your data with an aggregated function.
+
+    For example:
+
+        Company.connection.select_pair("SELECT group, COUNT(*) FROM users GROUP BY group")
+        # => { "admin" => "2", "moderator" => "5", "user" => "3" }
+
+    *Prem Sichanugrist*
+
 *   Implements `AR::Base.silence_auto_explain`. This method allows the user to
     selectively disable automatic EXPLAINs within a block. *fxn*
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1108,6 +1108,23 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal ["37signals","Summit","Microsoft", "Flamboyant Software", "Ex Nihilo", "RailsCore", "Leetsoft", "Jadedpixel", "Odegy", "Ex Nihilo Part Deux"], Company.connection.select_values("SELECT name FROM companies ORDER BY id")
   end
 
+  def test_select_pair
+    assert_equal({ "Client" => "4", "Firm" => "2", "DependentFirm" => "1", "ExclusivelyDependentFirm" => "1", nil => "2" },
+      Company.connection.select_pair("SELECT type, COUNT(id) FROM companies GROUP BY type"))
+  end
+
+  def test_select_pair_empty_result
+    assert_equal({}, Company.connection.select_pair("SELECT type, COUNT(id) FROM companies WHERE 1=0 GROUP BY type"))
+  end
+
+  def test_select_pair_missing_column
+    assert_raise(ActiveRecord::StatementInvalid){ Company.connection.select_pair("SELECT COUNT(id) FROM companies GROUP BY type") }
+  end
+
+  def test_select_pair_excess_column
+    assert_raise(ActiveRecord::StatementInvalid){ Company.connection.select_pair("SELECT type, COUNT(id), id FROM companies GROUP BY type, id") }
+  end
+
   def test_select_rows
     assert_equal(
       [["1", "1", nil, "37signals"],


### PR DESCRIPTION
This new method will return a hash which use the first column of your result set as a key, and use the second column as a value. This is useful in an scenario where you want to map your data with an aggregated function.

For example:

``` ruby
Company.connection.select_values("SELECT group, COUNT(*) FROM users GROUP BY group")
# => { "admin" => "2", "moderator" => "5", "user" => "3" }
```
