### PR TITLE
Fix warning for params_wrapper_test.rb

### DIFF
--- a/actionpack/test/controller/params_wrapper_test.rb
+++ b/actionpack/test/controller/params_wrapper_test.rb
@@ -26,7 +26,7 @@ class ParamsWrapperTest < ActionController::TestCase
       self.class.last_parameters = request.params.except(:controller, :action)
       head :ok
     end
-end
+  end
 
   class User; end
   class Person; end


### PR DESCRIPTION
I found below warning, and fixed it.

```
warning: mismatched indentations at 'end' with 'class' at 20
```
