### PR TITLE
Fix a failure in railties on ruby 1.8.x

### DIFF
--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -137,9 +137,10 @@ module ApplicationTests
     end
 
     test "assignment config.encoding to default_charset" do
-      add_to_config "config.encoding = 'Shift_JIS'"
+      charset = "ruby".respond_to?(:force_encoding) ? 'Shift_JIS' : 'UTF8'
+      add_to_config "config.encoding = '#{charset}'"
       require "#{app_path}/config/environment"
-      assert_equal 'Shift_JIS', ActionDispatch::Response.default_charset
+      assert_equal charset, ActionDispatch::Response.default_charset
     end
 
     # AS


### PR DESCRIPTION
In Ruby 1.8.x, config.encoding sets $KCODE.
Therefore, the possible values are UTF8, SJIS, or EUC.
And, if we set SJIS, we'll has the error. Because some rails sources are written in utf-8 encoding.

I have tested this patch on ruby-1.9.2 and ree-2011.03
