### PR TITLE
Add dependency status (a la build status) to the README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -67,7 +67,9 @@ We encourage you to contribute to Ruby on Rails! Please check out the {Contribut
 guide}[http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html] for guidelines about how
 to proceed. {Join us}[http://contributors.rubyonrails.org]!
 
-== Travis Build Status {<img src="https://secure.travis-ci.org/rails/rails.png"/>}[http://travis-ci.org/rails/rails]
+== Build Status {<img src="https://secure.travis-ci.org/rails/rails.png"/>}[http://travis-ci.org/rails/rails]
+
+== Dependency Status {<img src="https://gemnasium.com/rails/rails.png?travis"/>}[https://gemnasium.com/rails/rails]
 
 == License
 

--- a/Rakefile
+++ b/Rakefile
@@ -77,9 +77,10 @@ RDoc::Task.new do |rdoc|
     rdoc_main.gsub!(/^(?=\S).*?\b(?=Rails)\b/) { "#$&\\" }
     rdoc_main.gsub!(%r{link:/rails/rails/blob/master/(\w+)/README\.rdoc}, "link:files/\\1/README_rdoc.html")
 
-    # Remove Travis build status image from API pages. Only GitHub README page gets this image
-    # https build image is used to avoid GitHub caching: http://about.travis-ci.org/docs/user/status-images
-    rdoc_main.gsub!(%r{^== Travis.*}, '')
+    # Remove Travis and Gemnasium status images from API pages. Only GitHub
+    # README page gets this image. Travis' https build image is used to avoid
+    # GitHub caching: http://about.travis-ci.org/docs/user/status-images
+    rdoc_main.gsub!(%r{^== (Build|Dependency) Status.*}, '')
 
     File.open(RDOC_MAIN, 'w') do |f|
       f.write(rdoc_main)


### PR DESCRIPTION
This is a good way to ensure (and show) that the Rails gem dependencies are up-to-date with the latest versions. These status images are popping up for gems like twitter, omniauth, faraday, etc.
