### PR TITLE
add special case inflection for 'save' -> 'saves'

### DIFF
--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -55,6 +55,7 @@ module ActiveSupport
     inflect.irregular('move', 'moves')
     inflect.irregular('cow', 'kine')
     inflect.irregular('zombie', 'zombies')
+    inflect.irregular('save', 'saves')
 
     inflect.uncountable(%w(equipment information rice money species series fish sheep jeans))
   end

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -27,7 +27,6 @@ module InflectorTestCases
     "index"       => "indices",
 
     "wife"        => "wives",
-    "safe"        => "saves",
     "half"        => "halves",
 
     "move"        => "moves",
@@ -298,5 +297,6 @@ module InflectorTestCases
     'child'  => 'children',
     'sex'    => 'sexes',
     'move'   => 'moves',
+    'save'   => 'saves'
   }
 end


### PR DESCRIPTION
The noun 'saves' should be singularized as 'save' (as in "the pitcher now has 43 saves on the season, since he earned another save last night"). It was being singularized as 'safe'. This commit fixes this issue.
