### PR TITLE
Add the .rdoc extension to the README that Rails generates for a new app

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -38,7 +38,7 @@ module Rails
     end
 
     def readme
-      copy_file "README"
+      copy_file "README", "README.rdoc"
     end
 
     def gemfile

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -114,7 +114,7 @@ class ActionsTest < Rails::Generators::TestCase
     action :gem_group, :test do
       gem 'fakeweb'
     end
-    
+
     assert_file 'Gemfile', /\ngroup :development, :test do\n  gem "rspec-rails"\nend\n\ngroup :test do\n  gem "fakeweb"\nend/
   end
 
@@ -233,14 +233,14 @@ class ActionsTest < Rails::Generators::TestCase
   def test_readme
     run_generator
     Rails::Generators::AppGenerator.expects(:source_root).times(2).returns(destination_root)
-    assert_match(/Welcome to Rails/, action(:readme, "README"))
+    assert_match(/Welcome to Rails/, action(:readme, "README.rdoc"))
   end
 
   def test_readme_with_quiet
     generator(default_arguments, :quiet => true)
     run_generator
     Rails::Generators::AppGenerator.expects(:source_root).times(2).returns(destination_root)
-    assert_no_match(/Welcome to Rails/, action(:readme, "README"))
+    assert_no_match(/Welcome to Rails/, action(:readme, "README.rdoc"))
   end
 
   def test_log


### PR DESCRIPTION
I know it's just meant to be a placeholder but everybody's apps are up on GitHub these days. For a Rails n00b, it would be nice to see GitHub nicely format the generated README as a good starting point for their own.
