### PR TITLE
Add button_tag support to ActionView::Helpers::FormBuilder

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Rails 3.2.0 (unreleased) ##
 
+*   Add `button_tag` support to ActionView::Helpers::FormBuilder.
+
+    This support mimics the default behavior of `submit_tag`.
+
+    Example:
+
+        <%= form_for @post do |f| %>
+          <%= f.button %>
+        <% end %>
+
 *   Make ActiveSupport::Benchmarkable a default module for ActionController::Base, so the #benchmark method is once again available in the controller context like it used to be *DHH*
 
 *   Deprecated implied layout lookup in controllers whose parent had a explicit layout set:

--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -1364,6 +1364,39 @@ module ActionView
         @template.submit_tag(value, options)
       end
 
+      # Add the submit button for the given form. When no value is given, it checks
+      # if the object is a new resource or not to create the proper label:
+      #
+      #   <%= form_for @post do |f| %>
+      #     <%= f.button %>
+      #   <% end %>
+      #
+      # In the example above, if @post is a new record, it will use "Create Post" as
+      # submit button label, otherwise, it uses "Update Post".
+      #
+      # Those labels can be customized using I18n, under the helpers.submit key and accept
+      # the %{model} as translation interpolation:
+      #
+      #   en:
+      #     helpers:
+      #       button:
+      #         create: "Create a %{model}"
+      #         update: "Confirm changes to %{model}"
+      #
+      # It also searches for a key specific for the given object:
+      #
+      #   en:
+      #     helpers:
+      #       button:
+      #         post:
+      #           create: "Add %{model}"
+      #
+      def button(value=nil, options={})
+        value, options = nil, value if value.is_a?(Hash)
+        value ||= submit_default_value
+        @template.button_tag(value, options)
+      end
+
       def emitted_hidden_id?
         @emitted_hidden_id ||= nil
       end

--- a/actionpack/lib/action_view/locale/en.yml
+++ b/actionpack/lib/action_view/locale/en.yml
@@ -152,3 +152,9 @@
       update: 'Update %{model}'
       submit: 'Save %{model}'
 
+    # Default translation keys for button FormHelper
+    button:
+      create: 'Create %{model}'
+      update: 'Update %{model}'
+      submit: 'Save %{model}'
+

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -689,6 +689,7 @@ class FormHelperTest < ActionView::TestCase
       concat f.text_area(:body)
       concat f.check_box(:secret)
       concat f.submit('Create post')
+      concat f.button('Create post')
     end
 
     expected = whole_form("/posts/123", "create-post" , "edit_post", :method => "put") do
@@ -697,7 +698,8 @@ class FormHelperTest < ActionView::TestCase
       "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />" +
-      "<input name='commit' type='submit' value='Create post' />"
+      "<input name='commit' type='submit' value='Create post' />" +
+      "<button name='button' type='submit'>Create post</button>"
     end
 
     assert_dom_equal expected, output_buffer


### PR DESCRIPTION
Working on a project I attempted to use a button inside of a form builder and noticed that `ActionView::Helpers::FormBuilder` lacks support for generating `button_tag` though it covers most everything else.

This pull request adds support for generating `button_tag` inside of form builders, and the default behavior mirrors that of the existing `submit_tag` support.

Example:

```
<%= form_for @post do |f| %>
  <%= f.button %>
<% end %>
```

Generates HTML like:

```
<form accept-charset="UTF-8" action="/posts/123" class="edit_post" id="create-post" method="post">
  <div style="margin:0;padding:0;display:inline">
    <input name="utf8" type="hidden" value="&#x2713;" />
    <input name="_method" type="hidden" value="put" />
  </div>
  <button name="button" type="submit">Create post</button>
</form>
```
