### PR TITLE
Add silence_warnings block (GH #3927)

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -20,7 +20,7 @@ class ERB
       if s.html_safe?
         s
       else
-        s.gsub(/[&"><]/n) { |special| HTML_ESCAPE[special] }.html_safe
+        silence_warnings { s.gsub(/[&"><]/n) { |special| HTML_ESCAPE[special] }.html_safe }
       end
     end
 


### PR DESCRIPTION
Now, we got the follow warning:

```
path to/activesupport/lib/active_support/core_ext/string/output_safety.rb:23: warning: regexp match /.../n against to UTF-8 string
```

This PR fix it.
Please see https://github.com/rails/rails/issues/3927 .
I wrote an another fixing plan, and a performance test result.
