### PR TITLE
:use_two_digit_numbers option

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Rails 3.2.0 (unreleased) ##
 
+*   Date helpers accept a new option, `:use_two_digit_numbers = true`, that renders select boxes for months and days with a leading zero without changing the respective values. 
+    For example, this is useful for displaying ISO8601-style dates such as '2011-08-01'. *Lennart Fridén and Kim Persson*
+
 *   Make ActiveSupport::Benchmarkable a default module for ActionController::Base, so the #benchmark method is once again available in the controller context like it used to be *DHH*
 
 *   Deprecated implied layout lookup in controllers whose parent had a explicit layout set:

--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -736,7 +736,7 @@ module ActionView
         if @options[:use_hidden] || @options[:discard_day]
           build_hidden(:day, day)
         else
-          build_options_and_select(:day, day, :start => 1, :end => 31, :leading_zeros => false)
+          build_options_and_select(:day, day, :start => 1, :end => 31, :leading_zeros => false, :use_two_digit_numbers => @options[:use_two_digit_numbers])
         end
       end
 
@@ -822,6 +822,8 @@ module ActionView
         def month_name(number)
           if @options[:use_month_numbers]
             number
+          elsif @options[:use_two_digit_numbers]
+            sprintf "%02d", number
           elsif @options[:add_month_numbers]
             "#{number} - #{month_names[number]}"
           else
@@ -857,7 +859,7 @@ module ActionView
           start         = options.delete(:start) || 0
           stop          = options.delete(:end) || 59
           step          = options.delete(:step) || 1
-          options.reverse_merge!({:leading_zeros => true, :ampm => false})
+          options.reverse_merge!({:leading_zeros => true, :ampm => false, :use_two_digit_numbers => false})
           leading_zeros = options.delete(:leading_zeros)
 
           select_options = []
@@ -865,7 +867,8 @@ module ActionView
             value = leading_zeros ? sprintf("%02d", i) : i
             tag_options = { :value => value }
             tag_options[:selected] = "selected" if selected == i
-            text = options[:ampm] ? AMPM_TRANSLATION[i] : value
+            text = options[:use_two_digit_numbers] ? sprintf("%02d", i) : value
+            text = options[:ampm] ? AMPM_TRANSLATION[i] : text            
             select_options << content_tag(:option, text, tag_options)
           end
           (select_options.join("\n") + "\n").html_safe

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -164,6 +164,15 @@ class DateHelperTest < ActionView::TestCase
     assert_dom_equal expected, select_day(nil, :include_blank => true)
   end
 
+  def test_select_day_with_two_digit_numbers
+    expected = %(<select id="date_day" name="date[day]">\n)
+    expected << %(<option value="1">01</option>\n<option selected="selected" value="2">02</option>\n<option value="3">03</option>\n<option value="4">04</option>\n<option value="5">05</option>\n<option value="6">06</option>\n<option value="7">07</option>\n<option value="8">08</option>\n<option value="9">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n)
+    expected << "</select>\n"
+
+    assert_dom_equal expected, select_day(Time.mktime(2011, 8, 2), :use_two_digit_numbers => true)
+    assert_dom_equal expected, select_day(2, :use_two_digit_numbers => true)
+  end
+
   def test_select_day_with_html_options
     expected = %(<select id="date_day" name="date[day]" class="selector">\n)
     expected << %(<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16" selected="selected">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n)
@@ -196,6 +205,15 @@ class DateHelperTest < ActionView::TestCase
 
     assert_dom_equal expected, select_month(Time.mktime(2003, 8, 16))
     assert_dom_equal expected, select_month(8)
+  end
+
+  def test_select_month_with_two_digit_numbers
+    expected = %(<select id="date_month" name="date[month]">\n)
+    expected << %(<option value="1">01</option>\n<option value="2">02</option>\n<option value="3">03</option>\n<option value="4">04</option>\n<option value="5">05</option>\n<option value="6">06</option>\n<option value="7">07</option>\n<option value="8" selected="selected">08</option>\n<option value="9">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n)
+    expected << "</select>\n"
+
+    assert_dom_equal expected, select_month(Time.mktime(2011, 8, 16), :use_two_digit_numbers => true)
+    assert_dom_equal expected, select_month(8, :use_two_digit_numbers => true)
   end
 
   def test_select_month_with_disabled
@@ -985,7 +1003,6 @@ class DateHelperTest < ActionView::TestCase
 
     assert_dom_equal expected, select_datetime(Time.mktime(2003, 8, 16, 8, 4, 18), :start_year => 2003, :end_year => 2005, :prefix => "date[first]", :ampm => true)
   end
-
 
   def test_select_datetime_with_separators
     expected =  %(<select id="date_first_year" name="date[first][year]">\n)


### PR DESCRIPTION
Me and github user [Lavinia](https://github.com/lavinia) have been pair-programming on this to add an option 'use_two_digit_numbers' for creating select tags displaying months and days with leading zeros without changing the values.

This is especially helpful for e.g. ISO8601-style dates, 2011-08-01. We've seen a number of cases where this itch has popped up (especially outside the US), but not found a really simple way to scratch it:

http://stackoverflow.com/questions/6609340/is-it-possible-to-add-leading-zeros-to-the-day-and-month-in-rails-date-select-a

We're both first-time contributors so any feedback is warmly welcome!
