### PR TITLE
Overrode Hash#nested_under_indifferent_access in HashWithIndifferentAccess

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -16,6 +16,10 @@ module ActiveSupport
       dup
     end
 
+    def nested_under_indifferent_access
+      self
+    end
+
     def initialize(constructor = {})
       if constructor.is_a?(Hash)
         super()

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -121,6 +121,9 @@ class HashExtTest < Test::Unit::TestCase
 
     foo = { "foo" => NonIndifferentHash.new.tap { |h| h["bar"] = "baz" } }.with_indifferent_access
     assert_kind_of NonIndifferentHash, foo["foo"]
+
+    foo = { "foo" => IndifferentHash.new.tap { |h| h["bar"] = "baz" } }.with_indifferent_access
+    assert_kind_of IndifferentHash, foo["foo"]
   end
 
   def test_indifferent_assorted


### PR DESCRIPTION
...to return self.

Includes an assertion that fails without the fix.

This fixes a bug where if a subclass of HashWithIndifferentAccess is a value in a hash, and that hash has .with_indifferent_access called upon it, then it becomes a direct instance of HashWithIndifferentAccess instead of the subclass, losing any methods defined in that subclass.  This is because Hash#nested_under_indifferent_access creates an instance of HashWithIndifferentAccess directly.

Here's an example of the bug from a rails console:

irb(main):001:0> class HockeyHash < HashWithIndifferentAccess
irb(main):002:1>   def hockey_versus opponent
irb(main):003:2>     "hockey > #{opponent}"
irb(main):004:2>   end
irb(main):005:1> end
=> nil
irb(main):007:0> hash = {:a => HockeyHash.new}
=> {:a=>{}}
irb(main):008:0> hash[:a].hockey_versus("you")
=> "hockey > you"
irb(main):009:0> indifferent_hash = hash.with_indifferent_access
=> {"a"=>{}}
irb(main):010:0> indifferent_hash[:a].hockey_versus("you")
NoMethodError: undefined method `hockey_versus' for {}:ActiveSupport::HashWithIn
differentAccess
        from (irb):10
        from :0
