### PR TITLE
Include TagHelper but don't explicitly require it

### DIFF
--- a/actionpack/lib/action_view/helpers/sanitize_helper.rb
+++ b/actionpack/lib/action_view/helpers/sanitize_helper.rb
@@ -1,6 +1,5 @@
 require 'active_support/core_ext/object/try'
 require 'action_controller/vendor/html-scanner'
-require 'action_view/helpers/tag_helper'
 
 module ActionView
   # = Action View Sanitize Helpers

--- a/actionpack/lib/action_view/helpers/text_helper.rb
+++ b/actionpack/lib/action_view/helpers/text_helper.rb
@@ -1,6 +1,5 @@
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/string/filters'
-require 'action_view/helpers/tag_helper'
 
 module ActionView
   # = Action View Text Helpers
@@ -31,6 +30,7 @@ module ActionView
       extend ActiveSupport::Concern
 
       include SanitizeHelper
+      include TagHelper
       # The preferred method of outputting text in your views is to use the
       # <%= "text" %> eRuby syntax. The regular _puts_ and _print_ methods
       # do not operate as expected in an eRuby code block. If you absolutely must


### PR DESCRIPTION
Allow autoloading to work as intended and avoid multiple requires.
