### PR TITLE
Fix #3365. Default config.relative_url_root to ENV["RAILS_RELATIVE_URL_ROOT"].

### DIFF
--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -19,8 +19,9 @@ module ActionMailer
       options.stylesheets_dir ||= paths["public/stylesheets"].first
 
       # make sure readers methods get compiled
-      options.asset_path      ||= app.config.asset_path
-      options.asset_host      ||= app.config.asset_host
+      options.asset_path          ||= app.config.asset_path
+      options.asset_host          ||= app.config.asset_host
+      options.relative_url_root   ||= app.config.relative_url_root
 
       ActiveSupport.on_load(:action_mailer) do
         include AbstractController::UrlFor

--- a/actionpack/lib/abstract_controller/asset_paths.rb
+++ b/actionpack/lib/abstract_controller/asset_paths.rb
@@ -4,7 +4,7 @@ module AbstractController
 
     included do
       config_accessor :asset_host, :asset_path, :assets_dir, :javascripts_dir,
-        :stylesheets_dir, :default_asset_host_protocol
+        :stylesheets_dir, :default_asset_host_protocol, :relative_url_root
     end
   end
 end

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -31,6 +31,7 @@ module ActionController
       # make sure readers methods get compiled
       options.asset_path           ||= app.config.asset_path
       options.asset_host           ||= app.config.asset_host
+      options.relative_url_root    ||= app.config.relative_url_root
 
       ActiveSupport.on_load(:action_controller) do
         include app.routes.mounted_helpers

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -9,7 +9,7 @@ module Rails
                     :cache_classes, :cache_store, :consider_all_requests_local,
                     :dependency_loading, :filter_parameters,
                     :force_ssl, :helpers_paths, :logger, :log_tags, :preload_frameworks,
-                    :reload_plugins, :secret_token, :serve_static_assets,
+                    :relative_url_root, :reload_plugins, :secret_token, :serve_static_assets,
                     :ssl_options, :static_cache_control, :session_options,
                     :time_zone, :whiny_nils, :railties_order, :all_initializers
 
@@ -37,6 +37,7 @@ module Rails
         @cache_store                 = [ :file_store, "#{root}/tmp/cache/" ]
         @railties_order              = [:all]
         @all_initializers            = []
+        @relative_url_root           = ENV["RAILS_RELATIVE_URL_ROOT"]
 
         @assets = ActiveSupport::OrderedOptions.new
         @assets.enabled                  = false

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -478,6 +478,15 @@ module ApplicationTests
       assert_match 'src="//example.com/assets/rails.png"', File.read("#{app_path}/public/assets/image_loader.js")
     end
 
+    test "asset paths should use RAILS_RELATIVE_URL_ROOT by default" do
+      ENV["RAILS_RELATIVE_URL_ROOT"] = "/sub/uri"
+
+      app_file "app/assets/javascripts/app.js.erb", 'var src="<%= image_path("rails.png") %>";'
+      add_to_config "config.assets.precompile = %w{app.js}"
+      precompile!
+
+      assert_match 'src="/sub/uri/assets/rails.png"', File.read("#{app_path}/public/assets/app.js")
+    end
 
     private
 


### PR DESCRIPTION
This pull request fixes generation of asset paths inside assets when deploying to sub-URI. 
For example when our app is deployed inside `/community` this 

``` css
/* app/assets/stylesheets/application.css.erb */
body{
  background: url(<%= image_path "bg.png" %>);
}
```

Now produces a proper path:

``` css
body{
  background: url(/community/assets/bg.png);
}
```

instead of `/assets/bg.png`.
### Precompilation:

Also works! 

``` bash
RAILS_RELATIVE_URL_ROOT="/community" bundle exec rake assets:precompile
```
