### PR TITLE
missing require in buffered logger

### DIFF
--- a/activesupport/lib/active_support/buffered_logger.rb
+++ b/activesupport/lib/active_support/buffered_logger.rb
@@ -1,5 +1,6 @@
 require 'thread'
 require 'logger'
+require 'active_support/core_ext/logger'
 require 'active_support/core_ext/class/attribute_accessors'
 require 'active_support/deprecation'
 require 'fileutils'


### PR DESCRIPTION
It fixes tests when running `rake test:isolated`

/cc @josevalim
