### PR TITLE
start transaction only when necessary.

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -137,8 +137,10 @@ module ActiveRecord
       #     # same effect as calling Book.transaction
       #   end
       def transaction(*args)
-        reflection.klass.transaction(*args) do
-          yield
+        if block_given?
+          reflection.klass.transaction(*args) do
+            yield
+          end
         end
       end
 


### PR DESCRIPTION
We found in our log empty transactions that consume unnecessary time, like this:
D, [2011-12-13T22:14:57.804757 #88645] DEBUG -- :    (0.2ms)  BEGIN
D, [2011-12-13T22:14:57.805285 #88645] DEBUG -- :    (0.1ms)  COMMIT

And a little analysis led me to this block of code, hope this change can help optimization.
