### PR TITLE
log exception backtrace when all backtrace lines silenced

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -59,10 +59,13 @@ module ActionDispatch
 
       exception = wrapper.exception
 
+      trace = wrapper.application_trace
+      trace = wrapper.framework_trace if trace.empty?
+
       ActiveSupport::Deprecation.silence do
         message = "\n#{exception.class} (#{exception.message}):\n"
         message << exception.annoted_source_code.to_s if exception.respond_to?(:annoted_source_code)
-        message << "  " << wrapper.application_trace.join("\n  ")
+        message << "  " << trace.join("\n  ")
         logger.fatal("#{message}\n\n")
       end
     end

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -122,4 +122,17 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     get "/", {}, {'action_dispatch.show_exceptions' => true, 'action_dispatch.backtrace_cleaner' => cleaner}
     assert_match(/passed backtrace cleaner/, body)
   end
+
+  test 'logs exception backtrace when all lines silenced' do
+    output = StringIO.new
+    backtrace_cleaner = ActiveSupport::BacktraceCleaner.new
+    backtrace_cleaner.add_silencer { true }
+
+    env = {'action_dispatch.show_exceptions' => true,
+           'action_dispatch.logger' => Logger.new(output),
+           'action_dispatch.backtrace_cleaner' => backtrace_cleaner}
+
+    get "/", {}, env
+    assert_operator (output.rewind && output.read).lines.count, :>, 10
+  end
 end


### PR DESCRIPTION
Fixed case when exception was raised before execution of any application code and its backtraces wasn't logged (e.g. it happens when exception was raised inside rack).

/cc @josevalim
