### PR TITLE
query cache being left enabled after routing error - second try

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -53,6 +53,8 @@ module ActionDispatch
            raise ActionController::RoutingError, "No route matches [#{env['REQUEST_METHOD']}] #{env['PATH_INFO'].inspect}"
         end
       rescue Exception => exception
+        # won't pass on body, so make sure to close it if required
+        body.close if body.respond_to?(:close)
         raise exception if env['action_dispatch.show_exceptions'] == false
       end
 


### PR DESCRIPTION
Ok, here we go again, this time with just one commit.

After a 404 error triggered by a routing error, ActiveRecord's query cache stays enabled.

We observed this issue through something similar as described in issue #2333, where some model test cases started to fail when run after testing a 404 error page. In that case nobody is calling ActiveRecord::QueryCache::BodyProxy#close.

I tracked the issue down to actionpack/lib/action_dispatch/middleware/show_exceptions.rb#call. That one isn't calling close on body.
