### PR TITLE
Make a suitable place in Predicate builder for supporting custom types.

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -17,42 +17,46 @@ module ActiveRecord
 
           attribute = table[column.to_sym]
 
-          case value
-          when ActiveRecord::Relation
-            value = value.select(value.klass.arel_table[value.klass.primary_key]) if value.select_values.empty?
-            attribute.in(value.arel.ast)
-          when Array, ActiveRecord::Associations::CollectionProxy
-            values = value.to_a.map {|x| x.is_a?(ActiveRecord::Base) ? x.id : x}
-            ranges, values = values.partition {|v| v.is_a?(Range) || v.is_a?(Arel::Relation)}
-
-            array_predicates = ranges.map {|range| attribute.in(range)}
-
-            if values.include?(nil)
-              values = values.compact
-              if values.empty?
-                array_predicates << attribute.eq(nil)
-              else
-                array_predicates << attribute.in(values.compact).or(attribute.eq(nil))
-              end
-            else
-              array_predicates << attribute.in(values)
-            end
-
-            array_predicates.inject {|composite, predicate| composite.or(predicate)}
-          when Range, Arel::Relation
-            attribute.in(value)
-          when ActiveRecord::Base
-            attribute.eq(value.id)
-          when Class
-            # FIXME: I think we need to deprecate this behavior
-            attribute.eq(value.name)
-          else
-            attribute.eq(value)
-          end
+          predicate_for_attribute_value(attribute, value)
         end
       end
 
       predicates.flatten
+    end
+
+    # This is common place to plugin support for custom value types
+    def self.predicate_for_attribute_value(attribute, value)
+      case value
+      when ActiveRecord::Relation
+        value = value.select(value.klass.arel_table[value.klass.primary_key]) if value.select_values.empty?
+        attribute.in(value.arel.ast)
+      when Array, ActiveRecord::Associations::CollectionProxy
+        values = value.to_a.map {|x| x.is_a?(ActiveRecord::Base) ? x.id : x}
+        ranges, values = values.partition {|v| v.is_a?(Range) || v.is_a?(Arel::Relation)}
+
+        array_predicates = ranges.map {|range| attribute.in(range)}
+        if values.include?(nil)
+          values = values.compact
+          if values.empty?
+            array_predicates << attribute.eq(nil)
+          else
+            array_predicates << attribute.in(values.compact).or(attribute.eq(nil))
+          end
+        else
+          array_predicates << attribute.in(values)
+        end
+
+        array_predicates.inject {|composite, predicate| composite.or(predicate)}
+      when Range, Arel::Relation
+        attribute.in(value)
+      when ActiveRecord::Base
+        attribute.eq(value.id)
+      when Class
+        # FIXME: I think we need to deprecate this behavior
+        attribute.eq(value.name)
+      else
+        attribute.eq(value)
+      end
     end
   end
 end


### PR DESCRIPTION
Currently, supporting for custom value types in Predicate builder force one to rewriting (and monkey patching) whole `PredicateBuilde.build_from_hash`.

This patch proposes move value type detection to a separate method, so that one could easily override it with `alias_method_chain`.
