### PR TITLE
Handle nil logger in sqlite adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
@@ -208,7 +208,7 @@ module ActiveRecord
 
         value = super
         if column.type == :string && value.encoding == Encoding::ASCII_8BIT
-          @logger.error "Binary data inserted for `string` type on column `#{column.name}`"
+          @logger.error "Binary data inserted for `string` type on column `#{column.name}`" if @logger
           value.encode! 'utf-8'
         end
         value

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -33,6 +33,9 @@ module ActiveRecord
         esql
 
         assert(!result.rows.first.include?("blob"), "should not store blobs")
+
+        Owner.connection.instance_variable_set(:@logger, nil)
+        assert_nothing_raised { Owner.create!(:name => "hello".encode('ascii-8bit')) }
       end
 
       def test_exec_insert


### PR DESCRIPTION
@logger might be nil as it is possible to instantiate an instance of a
connection adapter without a logger.
