### PR TITLE
dbconsole: Use the app's database_configuration instead of duplicating loading code.

### DIFF
--- a/railties/lib/rails/commands/dbconsole.rb
+++ b/railties/lib/rails/commands/dbconsole.rb
@@ -41,7 +41,7 @@ module Rails
         abort opt.to_s unless (0..1).include?(ARGV.size)
       end
 
-      unless config = YAML::load(ERB.new(IO.read("#{@app.root}/config/database.yml")).result)[Rails.env]
+      unless config = @app.config.database_configuration[Rails.env]
         abort "No database is configured for the environment '#{Rails.env}'"
       end
 


### PR DESCRIPTION
Instead of implementing loading and parsing of database.yml in dbconsole.rb again, just use the app's already configured one.
