### PR TITLE
Fix url_for options[:subdomain] to allow objects as values

### DIFF
--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -70,7 +70,7 @@ module ActionDispatch
 
           host = ""
           unless options[:subdomain] == false
-            host << (options[:subdomain] || extract_subdomain(options[:host], tld_length))
+            host << (options[:subdomain] || extract_subdomain(options[:host], tld_length)).to_param
             host << "."
           end
           host << (options[:domain] || extract_domain(options[:host], tld_length))

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -71,6 +71,14 @@ module AbstractController
         )
       end
 
+      def test_subdomain_may_be_object
+        model = mock(:to_param => 'api')
+        add_host!
+        assert_equal('http://api.basecamphq.com/c/a/i',
+          W.new.url_for(:subdomain => model, :controller => 'c', :action => 'a', :id => 'i')
+        )
+      end
+
       def test_subdomain_may_be_removed
         add_host!
         assert_equal('http://basecamphq.com/c/a/i',


### PR DESCRIPTION
e.g.

`blog_url(subdomain: current_user)` instead of `blog_url(subdomain: current_user.to_param)`
