### PR TITLE
Allow nested attributes in associations to update values in it's owner o...

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -230,6 +230,8 @@ module ActiveRecord
         end
 
         def build_record(attributes, options)
+          attributes = (attributes || {}).reverse_merge(creation_attributes)
+
           reflection.build_association(attributes, options) do |record|
             record.assign_attributes(
               create_scope.except(*record.changed),

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1776,6 +1776,7 @@ MSG
 
         attributes = new_attributes.stringify_keys
         multi_parameter_attributes = []
+        nested_parameter_attributes = []
         @mass_assignment_options = options
 
         unless options[:without_protection]
@@ -1786,10 +1787,19 @@ MSG
           if k.include?("(")
             multi_parameter_attributes << [ k, v ]
           elsif respond_to?("#{k}=")
-            send("#{k}=", v)
+            if v.is_a?(Hash)
+              nested_parameter_attributes << [ k, v ]
+            else
+              send("#{k}=", v)
+            end
           else
             raise(UnknownAttributeError, "unknown attribute: #{k}")
           end
+        end
+
+        # assign any deferred nested attributes after the base attributes have been set
+        nested_parameter_attributes.each do |k,v|
+          send("#{k}=", v)
         end
 
         @mass_assignment_options = nil

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -617,6 +617,11 @@ module NestedAttributesOnACollectionAssociationTests
     assert_equal ['Grace OMalley', 'Privateers Greed'], [@child_1.name, @child_2.name]
   end
 
+  def test_should_take_a_hash_with_owner_attributes_and_assign_the_attributes_to_the_associated_model
+    @pirate.birds.create :name => 'bird', :pirate_attributes => {:id => @pirate.id.to_s, :catchphrase => 'Holla!'}
+    assert_equal 'Holla!', @pirate.reload.catchphrase
+  end
+
   def test_should_raise_RecordNotFound_if_an_id_is_given_but_doesnt_return_a_record
     assert_raise_with_message ActiveRecord::RecordNotFound, "Couldn't find #{@child_1.class.name} with ID=1234567890 for Pirate with ID=#{@pirate.id}" do
       @pirate.attributes = { association_getter => [{ :id => 1234567890 }] }

--- a/activerecord/test/models/bird.rb
+++ b/activerecord/test/models/bird.rb
@@ -1,5 +1,8 @@
 class Bird < ActiveRecord::Base
+  belongs_to :pirate
   validates_presence_of :name
+
+  accepts_nested_attributes_for :pirate
 
   attr_accessor :cancel_save_from_callback
   before_save :cancel_save_callback_method, :if => :cancel_save_from_callback


### PR DESCRIPTION
This patch allow nested attributes on an association to update the owner object.  This worked in Rails 3.0.x, but stopped working in Rails 3.1.

Here's the example between Rails 3.0 and 3.1

``` ruby
class Task < AR
  accepts_nested_attributes_for :project
end

project = Project.find 1
params[:task] = {:name => 'task', :project_attributes => {:id => '1', :name => 'new name'}}
```

This works in rails 3.0.x (the project name is assigned correctly), but it does not work in rails 3.1.x

``` ruby
project.tasks.create params[:task]
puts project.name # 'new name'
```

In rails 3.1.x an exception is raised...
**ActiveRecord::RecordNotFound, "Couldn't find Project with ID=1 for Task with ID="**

The following works in rails 3.1.x even though we're creating the new task from the relation owned by the project object.  We still need to pass the project id in explicitly so that it updates correctly.

``` ruby
project.tasks.create params[:task].merge(:project_id => project.id)
puts project.name # 'new name'
```

The patch allows the association to work as it did in Rails 3.0.

To fix the issue, the patch does the following...
- Merges in the creation attributes of the owner object so that the new association has reference to the owner.
- Defers assignment of any attributes that contain "sub-attributes" (in hashes) and makes sure that the base values (the first level of attribute keys) are assigned first as this is where the owner foreign key and other references for the new object will be set.
- The deferred nested attributes are then assigned now that the first level of data has been set.

The solution given above for 3.1 can work, but has side affects because of possible hash ordering issues.  The :project_id is merged in, but happens to be assigned before the :project_attributes nested attributes are.  This of course would fail if Ruby references the :project_attributes attribute before the :project_id and the exception would again be raised.

This patch prevents this issue altogether since the nested attribute assignment is deferred until the base attributes are first set.
