### PR TITLE
Fix lack of newline for <textarea> tag in form helpers

### DIFF
--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -16,6 +16,10 @@ module ActionView
                            defer reversed ismap seemless muted required
                            autofocus novalidate formnovalidate open pubdate).to_set
       BOOLEAN_ATTRIBUTES.merge(BOOLEAN_ATTRIBUTES.map {|attribute| attribute.to_sym })
+      
+      PRE_CONTENT_STRINGS = {
+        "textarea" => "\n"
+      }
 
       # Returns an empty HTML tag of type +name+ which by default is XHTML
       # compliant. Set +open+ to true to create an open tag compatible
@@ -125,7 +129,7 @@ module ActionView
 
         def content_tag_string(name, content, options, escape = true)
           tag_options = tag_options(options, escape) if options
-          "<#{name}#{tag_options}>#{escape ? ERB::Util.h(content) : content}</#{name}>".html_safe
+          "<#{name}#{tag_options}>#{PRE_CONTENT_STRINGS[name]}#{escape ? ERB::Util.h(content) : content}</#{name}>".html_safe
         end
 
         def tag_options(options, escape = true)

--- a/actionpack/test/template/active_model_helper_test.rb
+++ b/actionpack/test/template/active_model_helper_test.rb
@@ -27,7 +27,7 @@ class ActiveModelHelperTest < ActionView::TestCase
 
   def test_text_area_with_errors
     assert_dom_equal(
-      %(<div class="field_with_errors"><textarea cols="40" id="post_body" name="post[body]" rows="20">Back to the hill and over it again!</textarea></div>),
+      %(<div class="field_with_errors"><textarea cols="40" id="post_body" name="post[body]" rows="20">\nBack to the hill and over it again!</textarea></div>),
       text_area("post", "body")
     )
   end

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -434,7 +434,7 @@ class FormHelperTest < ActionView::TestCase
 
   def test_text_area
     assert_dom_equal(
-      '<textarea cols="40" id="post_body" name="post[body]" rows="20">Back to the hill and over it again!</textarea>',
+      "<textarea cols='40' id='post_body' name='post[body]' rows='20'>\nBack to the hill and over it again!</textarea>",
       text_area("post", "body")
     )
   end
@@ -442,14 +442,14 @@ class FormHelperTest < ActionView::TestCase
   def test_text_area_with_escapes
     @post.body        = "Back to <i>the</i> hill and over it again!"
     assert_dom_equal(
-      '<textarea cols="40" id="post_body" name="post[body]" rows="20">Back to &lt;i&gt;the&lt;/i&gt; hill and over it again!</textarea>',
+      "<textarea cols='40' id='post_body' name='post[body]' rows='20'>\nBack to &lt;i&gt;the&lt;/i&gt; hill and over it again!</textarea>",
       text_area("post", "body")
     )
   end
 
   def test_text_area_with_alternate_value
     assert_dom_equal(
-      '<textarea cols="40" id="post_body" name="post[body]" rows="20">Testing alternate values.</textarea>',
+      "<textarea cols='40' id='post_body' name='post[body]' rows='20'>\nTesting alternate values.</textarea>",
       text_area("post", "body", :value => 'Testing alternate values.')
     )
   end
@@ -457,14 +457,14 @@ class FormHelperTest < ActionView::TestCase
   def test_text_area_with_html_entities
     @post.body        = "The HTML Entity for & is &amp;"
     assert_dom_equal(
-      '<textarea cols="40" id="post_body" name="post[body]" rows="20">The HTML Entity for &amp; is &amp;amp;</textarea>',
+      "<textarea cols='40' id='post_body' name='post[body]' rows='20'>\nThe HTML Entity for &amp; is &amp;amp;</textarea>",
       text_area("post", "body")
     )
   end
 
   def test_text_area_with_size_option
     assert_dom_equal(
-      '<textarea cols="183" id="post_body" name="post[body]" rows="820">Back to the hill and over it again!</textarea>',
+      "<textarea cols='183' id='post_body' name='post[body]' rows='820'>\nBack to the hill and over it again!</textarea>",
       text_area("post", "body", :size => "183x820")
     )
   end
@@ -508,7 +508,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_title" name="dont guess" size="30" type="text" value="Hello World" />', text_field("post", "title", "name" => "dont guess")
     )
     assert_dom_equal(
-      '<textarea cols="40" id="post_body" name="really!" rows="20">Back to the hill and over it again!</textarea>',
+      "<textarea cols='40' id='post_body' name='really!' rows='20'>\nBack to the hill and over it again!</textarea>",
       text_area("post", "body", "name" => "really!")
     )
     assert_dom_equal(
@@ -528,7 +528,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="dont guess" name="post[title]" size="30" type="text" value="Hello World" />', text_field("post", "title", "id" => "dont guess")
     )
     assert_dom_equal(
-      '<textarea cols="40" id="really!" name="post[body]" rows="20">Back to the hill and over it again!</textarea>',
+      "<textarea cols='40' id='really!' name='post[body]' rows='20'>\nBack to the hill and over it again!</textarea>",
       text_area("post", "body", "id" => "really!")
     )
     assert_dom_equal(
@@ -548,7 +548,7 @@ class FormHelperTest < ActionView::TestCase
       '<input name="post[title]" size="30" type="text" value="Hello World" />', text_field("post", "title", "id" => nil)
     )
     assert_dom_equal(
-      '<textarea cols="40" name="post[body]" rows="20">Back to the hill and over it again!</textarea>',
+      "<textarea cols='40' name='post[body]' rows='20'>\nBack to the hill and over it again!</textarea>",
       text_area("post", "body", "id" => nil)
     )
     assert_dom_equal(
@@ -579,7 +579,7 @@ class FormHelperTest < ActionView::TestCase
       text_field("post", "title", "index" => 5)
     )
     assert_dom_equal(
-      '<textarea cols="40" name="post[5][body]" id="post_5_body" rows="20">Back to the hill and over it again!</textarea>',
+      "<textarea cols='40' name='post[5][body]' id='post_5_body' rows='20'>\nBack to the hill and over it again!</textarea>",
       text_area("post", "body", "index" => 5)
     )
     assert_dom_equal(
@@ -606,7 +606,7 @@ class FormHelperTest < ActionView::TestCase
       text_field("post", "title", "index" => 5, 'id' => nil)
     )
     assert_dom_equal(
-      '<textarea cols="40" name="post[5][body]" rows="20">Back to the hill and over it again!</textarea>',
+      "<textarea cols='40' name='post[5][body]' rows='20'>\nBack to the hill and over it again!</textarea>",
       text_area("post", "body", "index" => 5, 'id' => nil)
     )
     assert_dom_equal(
@@ -637,7 +637,7 @@ class FormHelperTest < ActionView::TestCase
       "<input id=\"post_#{pid}_title\" name=\"post[#{pid}][title]\" size=\"30\" type=\"text\" value=\"Hello World\" />", text_field("post[]","title")
     )
     assert_dom_equal(
-      "<textarea cols=\"40\" id=\"post_#{pid}_body\" name=\"post[#{pid}][body]\" rows=\"20\">Back to the hill and over it again!</textarea>",
+      "<textarea cols=\"40\" id=\"post_#{pid}_body\" name=\"post[#{pid}][body]\" rows=\"20\">\nBack to the hill and over it again!</textarea>",
       text_area("post[]", "body")
     )
     assert_dom_equal(
@@ -660,7 +660,7 @@ class FormHelperTest < ActionView::TestCase
       text_field("post[]","title", :id => nil)
     )
     assert_dom_equal(
-      "<textarea cols=\"40\" name=\"post[#{pid}][body]\" rows=\"20\">Back to the hill and over it again!</textarea>",
+      "<textarea cols=\"40\" name=\"post[#{pid}][body]\" rows=\"20\">\nBack to the hill and over it again!</textarea>",
       text_area("post[]", "body", :id => nil)
     )
     assert_dom_equal(
@@ -695,7 +695,7 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/posts/123", "create-post" , "edit_post", :method => "put") do
       "<label for='post_title'>The Title</label>" +
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />" +
       "<input name='commit' type='submit' value='Create post' />" +
@@ -774,7 +774,7 @@ class FormHelperTest < ActionView::TestCase
     expected =  whole_form("/posts/123", "create-post", "edit_other_name", :method => "put") do
       "<label for='other_name_title' class='post_title'>Title</label>" +
       "<input name='other_name[title]' size='30' id='other_name_title' value='Hello World' type='text' />" +
-      "<textarea name='other_name[body]' id='other_name_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='other_name[body]' id='other_name_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='other_name[secret]' value='0' type='hidden' />" +
       "<input name='other_name[secret]' checked='checked' id='other_name_secret' value='1' type='checkbox' />" +
       "<input name='commit' value='Create post' type='submit' />"
@@ -792,7 +792,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected =  whole_form("/", "create-post", "edit_post", "delete") do
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
@@ -809,7 +809,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected =  whole_form("/", "create-post", "edit_post", "delete") do
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
@@ -840,7 +840,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected =  whole_form("/", "create-post", "edit_post", :method => "put", :remote => true) do
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
@@ -857,7 +857,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected =  whole_form("/", "create-post", "edit_post", :method => "put", :remote => true) do
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
@@ -875,7 +875,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected =  whole_form("/posts", 'new_post', 'new_post', :remote => true) do
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
@@ -892,7 +892,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form("/", "create-post") do
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
@@ -911,7 +911,7 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form('/posts/123', 'edit_post[]', 'edit_post[]', 'put') do
       "<label for='post_123_title'>Title</label>" +
       "<input name='post[123][title]' size='30' type='text' id='post_123_title' value='Hello World' />" +
-      "<textarea name='post[123][body]' id='post_123_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[123][body]' id='post_123_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[123][secret]' type='hidden' value='0' />" +
       "<input name='post[123][secret]' checked='checked' type='checkbox' id='post_123_secret' value='1' />"
     end
@@ -928,7 +928,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form('/posts/123', 'edit_post[]', 'edit_post[]', 'put') do
       "<input name='post[][title]' size='30' type='text' id='post__title' value='Hello World' />" +
-      "<textarea name='post[][body]' id='post__body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[][body]' id='post__body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[][secret]' type='hidden' value='0' />" +
       "<input name='post[][secret]' checked='checked' type='checkbox' id='post__secret' value='1' />"
     end
@@ -945,7 +945,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form('/posts/123', 'namespace_edit_post_123', 'edit_post', 'put') do
       "<input name='post[title]' size='30' type='text' id='namespace_post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='namespace_post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='namespace_post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='namespace_post_secret' value='1' />"
     end
@@ -1005,7 +1005,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form('/posts/123', 'namespace_edit_post_123', 'edit_post', 'put') do
       "<input name='post[title]' size='30' type='text' id='namespace_post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='namespace_post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='namespace_post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[comment][body]' size='30' type='text' id='namespace_post_comment_body' value='Hello World' />"
     end
 
@@ -1739,7 +1739,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected =
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
 
@@ -1755,7 +1755,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected =
       "<input name='post[123][title]' size='30' type='text' id='post_123_title' value='Hello World' />" +
-      "<textarea name='post[123][body]' id='post_123_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[123][body]' id='post_123_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[123][secret]' type='hidden' value='0' />" +
       "<input name='post[123][secret]' checked='checked' type='checkbox' id='post_123_secret' value='1' />"
 
@@ -1771,7 +1771,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected =
       "<input name='post[][title]' size='30' type='text' id='post__title' value='Hello World' />" +
-      "<textarea name='post[][body]' id='post__body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[][body]' id='post__body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[][secret]' type='hidden' value='0' />" +
       "<input name='post[][secret]' checked='checked' type='checkbox' id='post__secret' value='1' />"
 
@@ -1787,7 +1787,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected =
       "<input name='post[abc][title]' size='30' type='text' id='post_abc_title' value='Hello World' />" +
-      "<textarea name='post[abc][body]' id='post_abc_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[abc][body]' id='post_abc_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[abc][secret]' type='hidden' value='0' />" +
       "<input name='post[abc][secret]' checked='checked' type='checkbox' id='post_abc_secret' value='1' />"
 
@@ -1803,7 +1803,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected =
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
 
@@ -1819,7 +1819,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected =
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
 
@@ -1864,7 +1864,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form('/posts/123', 'create-post', 'edit_post', :method => 'put') do
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='parent_post[secret]' type='hidden' value='0' />" +
       "<input name='parent_post[secret]' checked='checked' type='checkbox' id='parent_post_secret' value='1' />"
     end
@@ -1884,7 +1884,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form('/posts/123', 'create-post', 'edit_post', :method => 'put') do
       "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea>" +
+      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[comment][name]' type='text' id='post_comment_name' value='new comment' size='30' />"
     end
 
@@ -1924,7 +1924,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
       "<label for='title'>Title:</label> <input name='post[title]' size='30' type='text' id='post_title' value='Hello World' /><br/>" +
-      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea><br/>" +
+      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea><br/>" +
       "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' /><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' /><br/>"
     end
 
@@ -1974,7 +1974,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'put') do
       "<label for='title'>Title:</label> <input name='post[title]' size='30' type='text' id='post_title' value='Hello World' /><br/>" +
-      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea><br/>" +
+      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea><br/>" +
       "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' /><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' /><br/>"
     end
 
@@ -1992,7 +1992,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected =
       "<label for='title'>Title:</label> <input name='post[title]' size='30' type='text' id='post_title' value='Hello World' /><br/>" +
-      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body' rows='20' cols='40'>Back to the hill and over it again!</textarea><br/>" +
+      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea><br/>" +
       "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' /><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' /><br/>"
 
     assert_dom_equal expected, output_buffer

--- a/actionpack/test/template/tag_helper_test.rb
+++ b/actionpack/test/template/tag_helper_test.rb
@@ -87,6 +87,11 @@ class TagHelperTest < ActionView::TestCase
     assert_equal "<p class=\"song play>\">limelight</p>", str
   end
 
+  def test_content_tag_with_newline
+    str = content_tag('textarea', "limelight", {})
+    assert_dom_equal "<textarea>\nlimelight</textarea>", str
+  end
+
   def test_cdata_section
     assert_equal "<![CDATA[<hello world>]]>", cdata_section("<hello world>")
   end


### PR DESCRIPTION
For issue #393. This one doesn't modify the param list of the content_tag method.
