### PR TITLE
Allow blocks for count with ActiveRecord::Relation like we do with sum

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -3,12 +3,13 @@ require 'active_support/core_ext/object/try'
 
 module ActiveRecord
   module Calculations
-    # Count operates using three different approaches.
+    # Count operates using four different approaches.
     #
     # * Count all: By not passing any parameters to count, it will return a count of all the rows for the model.
     # * Count using column: By passing a column name to count, it will return a count of all the
     #   rows for the model with supplied column present.
     # * Count using options will find the row count matched by the options used.
+    # * Count using a block will acts as Array#count
     #
     # The third approach, count using options, accepts an option hash as the only parameter. The options are:
     #
@@ -51,11 +52,21 @@ module ActiveRecord
     #   Person.count('id', :conditions => "age > 26") # Performs a COUNT(id)
     #   Person.count(:all, :conditions => "age > 26") # Performs a COUNT(*) (:all is an alias for '*')
     #
+    # Examples for count with a block:
+    #   Person.where(:conditions => "age > 26").count{|person| gender=='female' }
+    
     # Note: <tt>Person.count(:all)</tt> will not work because it will use <tt>:all</tt> as the condition.
     # Use Person.count instead.
+    #
+    # Note: passing a block to the base ActiveRecord Class will not work <tt>Person.count{|person| gender=='female' }</tt>.
+    # Use <tt>Person.all.count{|person| gender=='female'}</tt>
     def count(column_name = nil, options = {})
-      column_name, options = nil, column_name if column_name.is_a?(Hash)
-      calculate(:count, column_name, options)
+      if block_given?
+        self.to_a.count {|*block_args| yield(*block_args)}
+      else
+        column_name, options = nil, column_name if column_name.is_a?(Hash)
+        calculate(:count, column_name, options)
+      end
     end
 
     # Calculates the average value on a given column. Returns +nil+ if there's
@@ -84,6 +95,12 @@ module ActiveRecord
       calculate(:maximum, column_name, options)
     end
 
+    # Sum operates using two different approaches:
+    # * Sum using a block will act as Array#sum
+    #
+    #   Person.where('age > 100').sum{|person| person.age - 100} # => 11
+    #
+    # * Sum as a Calculation on a given column.
     # Calculates the sum of values on a given column. The value is returned
     # with the same data type of the column, 0 if there's no row. See
     # +calculate+ for examples with options.

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -53,18 +53,22 @@ module ActiveRecord
     #   Person.count(:all, :conditions => "age > 26") # Performs a COUNT(*) (:all is an alias for '*')
     #
     # Examples for count with a block:
-    #   Person.where(:conditions => "age > 26").count{|person| gender=='female' }
-    
-    # Note: <tt>Person.count(:all)</tt> will not work because it will use <tt>:all</tt> as the condition.
-    # Use Person.count instead.
+    #   Person.where(:conditions => "age > 26").count{|person| person.gender=='female' }
     #
-    # Note: passing a block to the base ActiveRecord Class will not work <tt>Person.count{|person| gender=='female' }</tt>.
-    # Use <tt>Person.all.count{|person| gender=='female'}</tt>
-    def count(column_name = nil, options = {})
+    #   Person.count{|person| person.age > 26 && person.gender=='female' }
+    def count(*args)
       if block_given?
         self.to_a.count {|*block_args| yield(*block_args)}
       else
-        column_name, options = nil, column_name if column_name.is_a?(Hash)
+        raise ArgumentError, "Too many arguments. No more than 2 are allowed." if args.size > 2
+        if args.blank?
+          column_name, options = nil, {}
+        elsif args.first.is_a?(Hash)
+          column_name, options = nil, args.first
+        else
+          column_name = args.shift
+          options = args.shift || {}
+        end
         calculate(:count, column_name, options)
       end
     end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -398,6 +398,22 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal Company.count(:type, :conditions => {:type => "Firm"}),
         Company.count(:type, :conditions => {:type => "Firm"}, :from => 'companies')
   end
+  
+  def test_count_with_block_acts_as_array
+    accounts = Account.where('id > 0')
+    assert_equal Account.count, accounts.count{ true }
+    assert_equal 0, accounts.count{ false }
+    assert_equal Account.where('credit_limit > 50').size, accounts.count{|account| account.credit_limit > 50}
+    assert_equal Account.count, Account.count{true}
+    assert_equal Account.count, Account.count{false}
+  end
+
+  def test_sum_with_block_acts_as_array
+    accounts = Account.where('id > 0')
+    assert_equal Account.sum(:credit_limit), accounts.sum{|account| account.credit_limit }
+    assert_equal Account.sum(:credit_limit) + Account.count, accounts.sum{|account| account.credit_limit + 1 }
+    assert_equal 0, accounts.sum{|account| 0 }
+  end
 
   def test_sum_with_from_option
     assert_equal Account.sum(:credit_limit), Account.sum(:credit_limit, :from => 'accounts')

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -404,8 +404,9 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal Account.count, accounts.count{ true }
     assert_equal 0, accounts.count{ false }
     assert_equal Account.where('credit_limit > 50').size, accounts.count{|account| account.credit_limit > 50}
+    assert_equal Account.where('credit_limit > 50').size, Account.count{|account| account.credit_limit > 50}
     assert_equal Account.count, Account.count{true}
-    assert_equal Account.count, Account.count{false}
+    assert_equal 0, Account.count{false}
   end
 
   def test_sum_with_block_acts_as_array


### PR DESCRIPTION
also added tests and documentation about sum allowing a block.

I've been burned too many times by thinking I'm working with an Array. If we can sum on ActiveRecord::Relations like we do with Arrays, why not count with a block as well?

```
persons = Person.where(:gender=>'male')
persons.count{|person| false} # should equal 0, but will equal persons.size
```
