### PR TITLE
Fixed bug when error message is an empty string.

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -176,8 +176,9 @@ module ActiveModel
     end
 
     # Returns true if no errors are found, false otherwise.
+    # If the error message is a string it can be empty.
     def empty?
-      all? { |k, v| v && v.empty? }
+      all? { |k, v| v && v.empty? && !v.is_a?(String) }
     end
     alias_method :blank?, :empty?
 

--- a/activemodel/test/cases/validations/validates_test.rb
+++ b/activemodel/test/cases/validations/validates_test.rb
@@ -16,6 +16,12 @@ class ValidatesTest < ActiveModel::TestCase
     PersonWithValidator.reset_callbacks(:validate)
   end
 
+  def test_validates_with_messages_empty
+    Person.validates :title, :presence => {:message => "" }
+    person = Person.new(:title => '')
+    assert !person.valid?, 'person should not be valid.'
+  end
+
   def test_validates_with_built_in_validation
     Person.validates :title, :numericality => true
     person = Person.new


### PR DESCRIPTION
This commit fixes a bug when i have a validation with an empty message like: 
validates_presence_of(:name, :message => "")

In this case rails was not validating correctly the model.
