### PR TITLE
warning removed "warning: instance variable @variable_for_layout not ini...

### DIFF
--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -72,6 +72,7 @@ class ActionPackAssertionsController < ActionController::Base
   end
 
   def render_with_layout
+    @variable_for_layout = nil
     render "test/hello_world", :layout => "layouts/standard"
   end
 


### PR DESCRIPTION
warning removed "warning: instance variable @variable_for_layout not initialized"

"@variable_for_layout" is used in standard layout
