### PR TITLE
Rake tasks generator

### DIFF
--- a/railties/lib/rails/generators/rails/task/USAGE
+++ b/railties/lib/rails/generators/rails/task/USAGE
@@ -1,0 +1,9 @@
+Description:
+    Stubs out a new Rake task. Pass the namespace name, and a list of tasks as arguments.
+
+    This generates a task file in lib/tasks.
+
+Example:
+    `rails generate task feeds fetch erase add`
+
+        Task:      lib/tasks/feeds.rake

--- a/railties/lib/rails/generators/rails/task/task_generator.rb
+++ b/railties/lib/rails/generators/rails/task/task_generator.rb
@@ -1,0 +1,12 @@
+module Rails
+  module Generators
+    class TaskGenerator < NamedBase
+      argument :actions, :type => :array, :default => [], :banner => "action action"
+
+      def create_task_files
+        template 'task.rb', File.join('lib/tasks', "#{file_name}.rake")
+      end
+
+    end
+  end
+end

--- a/railties/lib/rails/generators/rails/task/templates/task.rb
+++ b/railties/lib/rails/generators/rails/task/templates/task.rb
@@ -1,0 +1,8 @@
+namespace :<%= file_name %> do
+<% actions.each do |action| -%>
+  desc "TODO"
+  task :<%= action %> => :environment do
+  end
+
+<% end -%>
+end

--- a/railties/test/generators/task_generator_test.rb
+++ b/railties/test/generators/task_generator_test.rb
@@ -1,0 +1,12 @@
+require 'generators/generators_test_helper'
+require 'rails/generators/rails/task/task_generator'
+
+class TaskGeneratorTest < Rails::Generators::TestCase
+  include GeneratorsTestHelper
+  arguments %w(feeds foo bar)
+
+  def test_controller_skeleton_is_created
+    run_generator
+    assert_file "lib/tasks/feeds.rake", /namespace :feeds/
+  end
+end


### PR DESCRIPTION
This generator stubs out a new Rake task. Pass the namespace name, and a list of tasks as arguments.

Example: `rails generate task feeds fetch erase add`
will create `lib/tasks/feeds.rake` with such code:

``` ruby
namespace :feeds do
  task :fetch => :environment do
  end

  task :erase => :environment do
  end

  task :add => :environment do
  end

end
```
