### PR TITLE
call scope within unscoped to prevent duplication of where values

### DIFF
--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -177,7 +177,7 @@ module ActiveRecord
           extension = Module.new(&Proc.new) if block_given?
 
           scope_proc = lambda do |*args|
-            options = scope_options.respond_to?(:call) ? scope_options.call(*args) : scope_options
+            options = scope_options.respond_to?(:call) ? unscoped { scope_options.call(*args) } : scope_options
             options = scoped.apply_finder_options(options) if options.is_a?(Hash)
 
             relation = scoped.merge(options)

--- a/activerecord/test/cases/named_scope_test.rb
+++ b/activerecord/test/cases/named_scope_test.rb
@@ -337,6 +337,11 @@ class NamedScopeTest < ActiveRecord::TestCase
     end
   end
 
+  def test_should_not_duplicates_where_values
+    where_values = Topic.where("1=1").scope_with_lambda.where_values
+    assert_equal ["1=1"], where_values
+  end
+
   def test_chaining_with_duplicate_joins
     join = "INNER JOIN comments ON comments.post_id = posts.id"
     post = Post.find(1)

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -8,6 +8,8 @@ class Topic < ActiveRecord::Base
   scope :approved, :conditions => {:approved => true}
   scope :rejected, :conditions => {:approved => false}
 
+  scope :scope_with_lambda, lambda { scoped }
+
   scope :by_lifo, :conditions => {:author_name => 'lifo'}
 
   scope :approved_as_hash_condition, :conditions => {:topics => {:approved => true}}


### PR DESCRIPTION
Original issue #3923

/cc @jonleighton
