### PR TITLE
Allow symbols to be passed as extension aliases in Mime::Type.register

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -103,7 +103,7 @@ module Mime
         SET << Mime.const_get(symbol.to_s.upcase)
 
         ([string] + mime_type_synonyms).each { |str| LOOKUP[str] = SET.last } unless skip_lookup
-        ([symbol.to_s] + extension_synonyms).each { |ext| EXTENSION_LOOKUP[ext] = SET.last }
+        ([symbol] + extension_synonyms).each { |ext| EXTENSION_LOOKUP[ext.to_s] = SET.last }
       end
 
       def parse(accept_header)

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -117,6 +117,15 @@ class MimeTypeTest < ActiveSupport::TestCase
     end
   end
 
+  test "register alias" do
+    begin
+      Mime::Type.register_alias "application/xhtml+xml", :foobar
+      assert_equal Mime::HTML, Mime::EXTENSION_LOOKUP['foobar']
+    ensure
+      Mime::Type.unregister(:FOOBAR)
+    end
+  end
+
   test "type should be equal to symbol" do
     assert_equal Mime::HTML, 'application/xhtml+xml'
     assert_equal Mime::HTML, :html

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -95,6 +95,17 @@ class MimeTypeTest < ActiveSupport::TestCase
     end
   end
 
+  test "custom type with extension aliases" do
+    begin
+      Mime::Type.register "text/foobar", :foobar, [], [:foo, "bar"]
+      %w[foobar foo bar].each do |extension|
+        assert_equal Mime::FOOBAR, Mime::EXTENSION_LOOKUP[extension]
+      end
+    ensure
+      Mime::Type.unregister(:FOOBAR)
+    end
+  end
+
   test "type should be equal to symbol" do
     assert_equal Mime::HTML, 'application/xhtml+xml'
     assert_equal Mime::HTML, :html

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -95,6 +95,17 @@ class MimeTypeTest < ActiveSupport::TestCase
     end
   end
 
+  test "custom type with type aliases" do
+    begin
+      Mime::Type.register "text/foobar", :foobar, ["text/foo", "text/bar"]
+      %w[text/foobar text/foo text/bar].each do |type|
+        assert_equal Mime::FOOBAR, type
+      end
+    ensure
+      Mime::Type.unregister(:FOOBAR)
+    end
+  end
+
   test "custom type with extension aliases" do
     begin
       Mime::Type.register "text/foobar", :foobar, [], [:foo, "bar"]


### PR DESCRIPTION
I was trying to do this:

``` rb
Mime::Type.register "text/markdown", :markdown, [], [:md, :mdown]
```

But that didn't work. This did:

``` rb
Mime::Type.register "text/markdown", :markdown, [], ["md", "mdown"]
```

But since the symbol parameter gets turned into the extension, it was confusing to pass strings as extension aliases.

This patch lets you use strings or symbols, and allows the same for `Mime::Type.register_alias`.

I also added some tests.
