### PR TITLE
A version of #3844 for 3-1-stable

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -518,15 +518,13 @@ module ActiveRecord
       if class_name.is_a?(Class)
         @connection   = class_name.connection
         @model_class  = class_name
-        @table_name   = @model_class.table_name
       else
         @model_class  = class_name.constantize rescue nil
-        @table_name   = "#{ActiveRecord::Base.table_name_prefix}#{@name}#{ActiveRecord::Base.table_name_suffix}"
-        # FIXME: i think the following should work here, but it does not pass one test:
-        # @table_name = ( @model_class.respond_to?(:table_name) ?
-        #                 @model_class.table_name :
-        #                 "#{ActiveRecord::Base.table_name_prefix}#{@name}#{ActiveRecord::Base.table_name_suffix}" )
       end
+
+      @table_name = ( model_class.respond_to?(:table_name) ?
+                      model_class.table_name :
+                      "#{ActiveRecord::Base.table_name_prefix}#{name}#{ActiveRecord::Base.table_name_suffix}" )
 
       read_fixture_files
     end

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -392,10 +392,10 @@ module ActiveRecord
 
     @@all_cached_fixtures = Hash.new { |h,k| h[k] = {} }
 
-    def self.find_table_name(table_name) # :nodoc:
+    def self.default_fixture_class_name(fixture_name) # :nodoc:
       ActiveRecord::Base.pluralize_table_names ?
-        table_name.to_s.singularize.camelize :
-        table_name.to_s.camelize
+        fixture_name.to_s.singularize.camelize :
+        fixture_name.to_s.camelize
     end
 
     def self.reset_cache
@@ -443,17 +443,14 @@ module ActiveRecord
     cattr_accessor :all_loaded_fixtures
     self.all_loaded_fixtures = {}
 
-    def self.create_fixtures(fixtures_directory, table_names, class_names = {})
-      table_names = [table_names].flatten.map { |n| n.to_s }
-      table_names.each { |n|
-        class_names[n.tr('/', '_').to_sym] = n.classify if n.include?('/')
-      }
+    def self.create_fixtures(fixtures_directory, table_names, fixture_classes = {})
+      table_names = [table_names].flatten.map(&:to_s)
 
       # FIXME: Apparently JK uses this.
       connection = block_given? ? yield : ActiveRecord::Base.connection
 
-      files_to_read = table_names.reject { |table_name|
-        fixture_is_cached?(connection, table_name)
+      files_to_read = table_names.reject { |name|
+        fixture_is_cached?(connection, name)
       }
 
       unless files_to_read.empty?
@@ -461,13 +458,11 @@ module ActiveRecord
           fixtures_map = {}
 
           fixture_files = files_to_read.map do |path|
-            table_name = path.tr '/', '_'
-
-            fixtures_map[path] = ActiveRecord::Fixtures.new(
+            fixtures_map[path] = new(
               connection,
-              table_name,
-              class_names[table_name.to_sym] || table_name.classify,
-              File.join(fixtures_directory, path))
+              table_name = path.tr('/', '_'), # FIXME: shouldn't table_name be defined by the model?
+              fixture_classes[path.to_sym] || path.classify,
+              ::File.join(fixtures_directory, path))
           end
 
           all_loaded_fixtures.update(fixtures_map)
@@ -490,8 +485,8 @@ module ActiveRecord
 
             # Cap primary key sequences to max(pk).
             if connection.respond_to?(:reset_pk_sequence!)
-              table_names.each do |table_name|
-                connection.reset_pk_sequence!(table_name.tr('/', '_'))
+              table_names.each do |name|
+                connection.reset_pk_sequence!(name.tr('/', '_'))
               end
             end
           end
@@ -512,21 +507,20 @@ module ActiveRecord
 
     def initialize(connection, table_name, class_name, fixture_path)
       @connection   = connection
-      @table_name   = table_name
       @fixture_path = fixture_path
       @name         = table_name # preserve fixture base name
       @class_name   = class_name
 
       @fixtures     = ActiveSupport::OrderedHash.new
-      @table_name   = "#{ActiveRecord::Base.table_name_prefix}#{@table_name}#{ActiveRecord::Base.table_name_suffix}"
 
       # Should be an AR::Base type class
       if class_name.is_a?(Class)
-        @table_name   = class_name.table_name
         @connection   = class_name.connection
         @model_class  = class_name
+        @table_name   = @model_class.table_name
       else
         @model_class  = class_name.constantize rescue nil
+        @table_name   = "#{ActiveRecord::Base.table_name_prefix}#{table_name}#{ActiveRecord::Base.table_name_suffix}"
       end
 
       read_fixture_files
@@ -782,14 +776,26 @@ module ActiveRecord
       self.use_instantiated_fixtures = false
       self.pre_loaded_fixtures = false
 
-      self.fixture_class_names = Hash.new do |h, table_name|
-        h[table_name] = ActiveRecord::Fixtures.find_table_name(table_name)
+      self.fixture_class_names = Hash.new do |h, fixture_name|
+        h[fixture_name] = ActiveRecord::Fixtures.default_fixture_class_name(fixture_name)
       end
     end
 
     module ClassMethods
+      # Sets the model class for a fixture when the class name cannot be inferred from the fixture name.
+      #
+      # Examples:
+      #
+      #   set_fixture_class 'some_fixture'        => SomeModel
+      #   set_fixture_class :'namespaced/fixture' => Another::Model
+      #--
+      # Currently it is possible to pass the class name instead of the class:
+      #   set_fixture_class 'some_fixture' => 'SomeModel'
+      # I think this option is redundant, i propose to deprecate it.
+      # Isn't it easier to always pass the class itself?
+      #++
       def set_fixture_class(class_names = {})
-        self.fixture_class_names = self.fixture_class_names.merge(class_names)
+        self.fixture_class_names = self.fixture_class_names.merge(class_names.symbolize_keys)
       end
 
       def fixtures(*fixture_names)
@@ -797,7 +803,7 @@ module ActiveRecord
           fixture_names = Dir["#{fixture_path}/**/*.{yml,csv}"]
           fixture_names.map! { |f| f[(fixture_path.size + 1)..-5] }
         else
-          fixture_names = fixture_names.flatten.map { |n| n.to_s }
+          fixture_names = fixture_names.flatten.map(&:to_s)
         end
 
         self.fixture_table_names |= fixture_names
@@ -858,7 +864,7 @@ module ActiveRecord
 
       def uses_transaction(*methods)
         @uses_transaction = [] unless defined?(@uses_transaction)
-        @uses_transaction.concat methods.map { |m| m.to_s }
+        @uses_transaction.concat methods.map(&:to_s)
       end
 
       def uses_transaction?(method)

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -115,6 +115,10 @@ class FixturesTest < ActiveRecord::TestCase
       ActiveRecord::Base.table_name_prefix = 'prefix_'
       ActiveRecord::Base.table_name_suffix = '_suffix'
 
+      # This is the best way i've found to reset the table name, other then using Topic.send(:reset_table_name)
+      old_table_name = Topic.table_name
+      Topic.table_name = "prefix_topics_suffix" # TODO: see if setting prefix and suffix was needed at all.
+
       topics = create_fixtures("topics")
 
       first_row = ActiveRecord::Base.connection.select_one("SELECT * FROM prefix_topics_suffix WHERE author_name = 'David'")
@@ -127,6 +131,9 @@ class FixturesTest < ActiveRecord::TestCase
       # class-level configuration helper.
       assert_not_nil topics, "Fixture data inserted, but fixture objects not returned from create"
     ensure
+      # Restore table_name to its previous value
+      Topic.table_name = old_table_name
+
       # Restore prefix/suffix to its previous values
       ActiveRecord::Base.table_name_prefix = old_prefix
       ActiveRecord::Base.table_name_suffix = old_suffix

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -715,3 +715,32 @@ class FixtureLoadingTest < ActiveRecord::TestCase
     ActiveRecord::TestCase.try_to_load_dependency(:works_out_fine)
   end
 end
+
+class CustomNameForFixtureOrModelTest < ActiveRecord::TestCase
+  require File.expand_path('../../models/randomly_named_c1', __FILE__)
+  require File.expand_path('../../models/admin/randomly_named_c1', __FILE__)
+
+  ActiveRecord::Fixtures.reset_cache
+
+  set_fixture_class :randomly_named_a9         =>
+                        ClassNameThatDoesNotFollowCONVENTIONS,
+                    :'admin/randomly_named_a9' =>
+                        Admin::ClassNameThatDoesNotFollowCONVENTIONS,
+                    'admin/randomly_named_b0'  =>
+                        Admin::ClassNameThatDoesNotFollowCONVENTIONS
+
+  fixtures :randomly_named_a9, 'admin/randomly_named_a9',
+           :'admin/randomly_named_b0'
+
+  def test_named_accessor_for_randomly_named_fixture_and_class
+    assert_kind_of ClassNameThatDoesNotFollowCONVENTIONS,
+                   randomly_named_a9(:first_instance)
+  end
+
+  def test_named_accessor_for_randomly_named_namespaced_fixture_and_class
+    assert_kind_of Admin::ClassNameThatDoesNotFollowCONVENTIONS,
+                   admin_randomly_named_a9(:first_instance)
+    assert_kind_of Admin::ClassNameThatDoesNotFollowCONVENTIONS,
+                   admin_randomly_named_b0(:second_instance)
+  end
+end

--- a/activerecord/test/fixtures/admin/randomly_named_a9.yml
+++ b/activerecord/test/fixtures/admin/randomly_named_a9.yml
@@ -1,0 +1,7 @@
+first_instance:
+  some_attribute: AAA
+  another_attribute: 000
+
+second_instance:
+  some_attribute: BBB
+  another_attribute: 999

--- a/activerecord/test/fixtures/admin/randomly_named_b0.yml
+++ b/activerecord/test/fixtures/admin/randomly_named_b0.yml
@@ -1,0 +1,7 @@
+first_instance:
+  some_attribute: AAA
+  another_attribute: 000
+
+second_instance:
+  some_attribute: BBB
+  another_attribute: 999

--- a/activerecord/test/fixtures/randomly_named_a9.yml
+++ b/activerecord/test/fixtures/randomly_named_a9.yml
@@ -1,0 +1,7 @@
+first_instance:
+  some_attribute: CCC
+  another_attribute: 111
+
+second_instance:
+  some_attribute: DDD
+  another_attribute: 888

--- a/activerecord/test/models/admin/randomly_named_c1.rb
+++ b/activerecord/test/models/admin/randomly_named_c1.rb
@@ -1,0 +1,3 @@
+class Admin::ClassNameThatDoesNotFollowCONVENTIONS < ActiveRecord::Base
+  self.table_name = :randomly_named_table
+end

--- a/activerecord/test/models/randomly_named_c1.rb
+++ b/activerecord/test/models/randomly_named_c1.rb
@@ -1,0 +1,3 @@
+class ClassNameThatDoesNotFollowCONVENTIONS < ActiveRecord::Base
+  self.table_name = :randomly_named_table
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -499,6 +499,11 @@ ActiveRecord::Schema.define do
     t.string :type
   end
 
+  create_table :randomly_named_table, :force => true do |t|
+    t.string  :some_attribute
+    t.integer :another_attribute
+  end
+
   create_table :ratings, :force => true do |t|
     t.integer :comment_id
     t.integer :value


### PR DESCRIPTION
This is a rebased version of my pull request #3844 which should apply cleanly to 3-1-stable.

This fixes issue #2572 with `set_fixture_class` and allows to use `set_fixture_class` with "namespaced" fixtures:

``` ruby
set_fixture_class :"admin/users" => User, "admin/known_ips" => Admin::KnownIP
```
