### PR TITLE
Add Help Text to Routing Error

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/routing_error.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/routing_error.erb
@@ -1,10 +1,15 @@
 <h1>Routing Error</h1>
 <p><pre><%=h @exception.message %></pre></p>
-<% unless @exception.failures.empty? %><p>
-  <h2>Failure reasons:</h2>
-  <ol>
-  <% @exception.failures.each do |route, reason| %>
-    <li><code><%=h route.inspect.gsub('\\', '') %></code> failed because <%=h reason.downcase %></li>
-  <% end %>
-  </ol>
-</p><% end %>
+<% unless @exception.failures.empty? %>
+  <p>
+    <h2>Failure reasons:</h2>
+    <ol>
+    <% @exception.failures.each do |route, reason| %>
+      <li><code><%=h route.inspect.gsub('\\', '') %></code> failed because <%=h reason.downcase %></li>
+    <% end %>
+    </ol>
+  </p>
+<% end %>
+<p>
+  Try running <code>rake routes</code> for more information on available routes.
+</p>


### PR DESCRIPTION
When a newcomer hits the routing error page they
are often confused about how to trouble shoot the
next step. Adding a simple help text can gently 
remind coders where to get more help.

Here is how the text renders in safari: http://cl.ly/2q081C380H3F1J0J3C16
