### PR TITLE
Support a context for update_attributes / update_attributes! methods.

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -209,8 +209,9 @@ module ActiveRecord
       # The following transaction covers any possible database side-effects of the
       # attributes assignment. For example, setting the IDs of a child collection.
       with_transaction_returning_status do
+        context = options.delete(:context)
         self.assign_attributes(attributes, options)
-        save
+        context ? save(:context => context) : save
       end
     end
 
@@ -220,8 +221,9 @@ module ActiveRecord
       # The following transaction covers any possible database side-effects of the
       # attributes assignment. For example, setting the IDs of a child collection.
       with_transaction_returning_status do
+        context = options.delete(:context)
         self.assign_attributes(attributes, options)
-        save!
+        context ? save!(:context => context) : save!
       end
     end
 

--- a/activerecord/test/cases/validations_test.rb
+++ b/activerecord/test/cases/validations_test.rb
@@ -58,6 +58,23 @@ class ValidationsTest < ActiveRecord::TestCase
     assert r.save(:context => :special_case)
   end
 
+  def test_error_on_given_context_passed_to_update_attributes
+    r = WrongReply.new
+    assert !r.update_attributes({:title => "Valid title"}, :context => :special_case)
+    assert_equal "Invalid", r.errors[:author_name].join
+
+    assert r.update_attributes({:author_name => "secret", :content => "Good" }, :context => :special_case)
+  end
+
+  def test_error_on_given_context_passed_to_update_attributes!
+    r = WrongReply.new
+    assert_raise(ActiveRecord::RecordInvalid) { r.update_attributes!({:title => "Valid title"}, :context => :special_case) }
+    assert_equal "Invalid", r.errors[:author_name].join
+
+    r.update_attributes!({:author_name => "secret", :content => "Good" }, :context => :special_case)
+    assert r.errors.empty?
+  end
+
   def test_invalid_record_exception
     assert_raise(ActiveRecord::RecordInvalid) { WrongReply.create! }
     assert_raise(ActiveRecord::RecordInvalid) { WrongReply.new.save! }


### PR DESCRIPTION
Currently, the update_attributes / update_attributes! method can't specify a validation context.
This patch allow above methods to specify the context.
