### PR TITLE
Fix reference to old sql format schema location

### DIFF
--- a/railties/guides/source/migrations.textile
+++ b/railties/guides/source/migrations.textile
@@ -814,7 +814,7 @@ replaying the entire migration history. It is much simpler and faster to just
 load into the database a description of the current schema.
 
 For example, this is how the test database is created: the current development
-database is dumped (either to +db/schema.rb+ or +db/development.sql+) and then
+database is dumped (either to +db/schema.rb+ or +db/structure.sql+) and then
 loaded into the test database.
 
 Schema files are also useful if you want a quick look at what attributes an


### PR DESCRIPTION
After 15fb430 the default location of the :sql schema_format location was changed from environment_name.sql to structure.sql. This pull request updates a reference to the old schema format location in the migration guides.
