### PR TITLE
Fix database tasks in test namespace.

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -446,26 +446,37 @@ db_namespace = namespace :db do
   end
 
   namespace :test do
-    # desc "Recreate the test database from the current schema.rb"
-    task :load => 'db:test:purge' do
-      ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations['test'])
-      ActiveRecord::Schema.verbose = false
-      db_namespace["schema:load"].invoke if ActiveRecord::Base.schema_format == :ruby
 
+    # desc "Recreate the test database from the current schema"
+    task :load => 'db:test:purge' do
+      case ActiveRecord::Base.schema_format
+        when :ruby
+          db_namespace["test:load_schema"].invoke
+        when :sql
+          db_namespace["test:load_structure"].invoke
+        end
+    end
+
+    # desc "Recreate the test database from an existent structure.sql file"
+    task :load_structure => 'db:test:purge' do
       begin
         old_env, ENV['RAILS_ENV'] = ENV['RAILS_ENV'], 'test'
-        db_namespace["structure:load"].invoke if ActiveRecord::Base.schema_format == :sql
+        db_namespace["structure:load"].invoke
       ensure
         ENV['RAILS_ENV'] = old_env
       end
-
     end
 
-    # desc "Recreate the test database from the current environment's database schema"
-    task :clone => %w(db:schema:dump db:test:load)
+    # desc "Recreate the test database from an existent schema.rb file"
+    task :load_schema => 'db:test:purge' do
+      db_namespace["schema:load"].invoke
+    end
 
-    # desc "Recreate the test databases from the structure.sql file"
-    task :clone_structure => [ "db:structure:dump", "db:test:load" ]
+    # desc "Recreate the test database from a fresh schema.rb file"
+    task :clone => %w(db:schema:dump db:test:load_schema)
+
+    # desc "Recreate the test database from a fresh structure.sql file"
+    task :clone_structure => [ "db:structure:dump", "db:test:load_structure" ]
 
     # desc "Empty the test database"
     task :purge => :environment do


### PR DESCRIPTION
Commit 15fb4302b6ff16e641b6279a3530eb8ed97f2899 introduced some issues.

Previously to that commit, when I executed `rake db:test:clone_structure`
the structure was dumped (to structure.sql) and then loaded again no matter whether
the `config.active_record.schema_format` was set to :sql or :ruby. That was OK
because I'm explicitly saying that I want the structure to be cloned.

Now, when I call the same task, although the structure is dumped, the loaded schema
depends on the value of the `config.active_record.schema_format`. So If I have it set
to :ruby and then I call `rake db:test:clone_structure` the loaded file is schema.rb and
not the structure.sql how it is supposed to be according to the name of the task and
its description.

The same thing happens when I call `rake db:test:clone`. When called,
a new schema.rb is created but the file used to load the schema depends on
`config.active_record.schema_format`. If I have it set to :sql, a new schema.rb
is created but the structure.sql file is used to create the database. So it is
not consistent.

This pull request solves the problem. When `db:test:clone_structure` is invoked, the
structure is dumped and then loaded into the test database. When `db:test:clone` is
invoked the schema is dumped and then loaded into the test database. None of these
tasks depends now on the value of `config.active_record.schema_format`
