### PR TITLE
don't encode an UTF-8 encoded template

### DIFF
--- a/actionpack/lib/action_view/template/error.rb
+++ b/actionpack/lib/action_view/template/error.rb
@@ -94,7 +94,7 @@ module ActionView
           "#{indent}#{line_counter}: #{line}\n"
         end
 
-        extract.encode! if extract.respond_to?(:encode!)
+        extract.force_encoding("UTF-8") if extract.respond_to?(:encode!)
 
         extract
       end

--- a/railties/test/application/middleware/exceptions_test.rb
+++ b/railties/test/application/middleware/exceptions_test.rb
@@ -99,7 +99,7 @@ module ApplicationTests
 
       app_file 'app/views/foo/index.html.erb', <<-ERB
         <% raise 'boooom' %>
-        ✓
+        ✓測試テスト시험
       ERB
 
       app_file 'config/routes.rb', <<-RUBY
@@ -110,6 +110,7 @@ module ApplicationTests
 
       post '/foo', :utf8 => '✓'
       assert_match(/boooom/, last_response.body)
+      assert_match(/測試テスト시험/, last_response.body)
     end
   end
 end


### PR DESCRIPTION
After updated to 3.2.0.rc1, I find that Chinese characters in extracted source become unreadable.

The corresponding commit is #3816
here is the problem line:

``` ruby
extract.encode! if extract.respond_to?(:encode!)
```

my template file is saved in utf-8, 
before this line, `extract.encoding` returns ASCII-US
I guess the reason is `extract.encode!` convert all utf-8 encoded characters again using an ASCII-US->UTF-8 converter.
I'm new to ruby/rails, If I'm wrong, please correct me
\cc @lest
