### PR TITLE
new applications enforce whitelist mode for mass assignment

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Rails 4.0.0 (unreleased) ##
+*   New applications enforce whitelist mode for mass assignment using `config.active_record.whitelist_attributes`
+    turned on by default in `config/application.rb`. *Sergey Nartimov*
+
 ## Rails 3.2.0 (unreleased) ##
 
 *   Added `config.exceptions_app` to set the exceptions application invoked by the ShowException middleware when an exception happens. Defaults to `ActionDispatch::PublicExceptions.new(Rails.public_path)`. *José Valim*

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -54,12 +54,14 @@ module <%= app_const_base %>
     # like if you have constraints or database-specific column types
     # config.active_record.schema_format = :sql
 
+<% unless options.skip_active_record? -%>
     # Enforce whitelist mode for mass assignment.
     # This will create an empty whitelist of attributes available for mass-assignment for all models
     # in your app. As such, your models will need to explicitly whitelist or blacklist accessible
     # parameters by using an attr_accessible or attr_protected declaration.
-    # config.active_record.whitelist_attributes = true
+    config.active_record.whitelist_attributes = true
 
+<% end -%>
 <% unless options.skip_sprockets? -%>
     # Enable the asset pipeline
     config.assets.enabled = true

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -283,15 +283,22 @@ module ApplicationTests
     end
 
     test "sets all Active Record models to whitelist all attributes by default" do
-      add_to_config <<-RUBY
-        config.active_record.whitelist_attributes = true
-      RUBY
-
       require "#{app_path}/config/environment"
 
       assert_equal ActiveModel::MassAssignmentSecurity::WhiteList,
                    ActiveRecord::Base.active_authorizers[:default].class
       assert_equal [""], ActiveRecord::Base.active_authorizers[:default].to_a
+    end
+
+    test "sets all Active Record models to blacklist all attributes by default when whitelist is disabled" do
+      add_to_config <<-RUBY
+        config.active_record.whitelist_attributes = false
+      RUBY
+
+      require "#{app_path}/config/environment"
+
+      assert_equal ActiveModel::MassAssignmentSecurity::BlackList,
+                   ActiveRecord::Base.active_authorizers[:default].class
     end
 
     test "registers interceptors with ActionMailer" do

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -19,6 +19,7 @@ class LoadingTest < Test::Unit::TestCase
   test "constants in app are autoloaded" do
     app_file "app/models/post.rb", <<-MODEL
       class Post < ActiveRecord::Base
+        attr_accessible :title
         validates_acceptance_of :title, :accept => "omg"
       end
     MODEL

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -202,7 +202,10 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_generator_if_skip_active_record_is_given
     run_generator [destination_root, "--skip-active-record"]
     assert_no_file "config/database.yml"
-    assert_file "config/application.rb", /#\s+require\s+["']active_record\/railtie["']/
+    assert_file "config/application.rb" do |content|
+      assert_match(/#\s+require\s+["']active_record\/railtie["']/, content)
+      assert_no_match(/config.active_record.whitelist_attributes = true/, content)
+    end
     assert_file "test/test_helper.rb" do |helper_content|
       assert_no_match(/fixtures :all/, helper_content)
     end
@@ -228,6 +231,11 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_no_match(/config\.assets\.compress = true/, content)
     end
     assert_file "test/performance/browsing_test.rb"
+  end
+
+  def test_inclusion_of_activerecord_whitelist_attributes
+    run_generator([destination_root])
+    assert_file "config/application.rb", /config.active_record.whitelist_attributes = true/
   end
 
   def test_inclusion_of_therubyrhino_under_jruby

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -261,6 +261,7 @@ module TestHelpers
                     :activerecord,
                     :activeresource] - arr
       remove_from_config "config.active_record.identity_map = true" if to_remove.include? :activerecord
+      remove_from_config "config.active_record.whitelist_attributes = true" if to_remove.include? :activerecord
       $:.reject! {|path| path =~ %r'/(#{to_remove.join('|')})/' }
     end
 


### PR DESCRIPTION
Previous issues #3453 and #3952, according to discussion it's ok to enable it in 4.0
