### PR TITLE
Added Capistrano to the development group in Gemfile 

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -20,7 +20,7 @@ source 'https://rubygems.org'
 # gem 'unicorn'
 
 # Deploy with Capistrano
-# gem 'capistrano'
+# gem 'capistrano', :group => :development
 
 # To use debugger
 # <%= ruby_debugger_gemfile_entry %>


### PR DESCRIPTION
There's no need for Capistrano to be install on a server, the extra argument in the comment implies this now.
