### PR TITLE
Fix regression in select form helper when options are non-string values

### DIFF
--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -584,7 +584,7 @@ module ActionView
         #   [nil, []]
         #   { nil => [] }
         #
-        if !choices.empty? && Array === choices.first.last
+        if !choices.empty? && choices.first.respond_to?(:first) && Array === choices.first.last
           option_tags = grouped_options_for_select(choices, :selected => selected_value, :disabled => options[:disabled])
         else
           option_tags = options_for_select(choices, :selected => selected_value, :disabled => options[:disabled])

--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -584,7 +584,7 @@ module ActionView
         #   [nil, []]
         #   { nil => [] }
         #
-        if !choices.empty? && choices.first.respond_to?(:first) && Array === choices.first.last
+        if !choices.empty? && choices.first.respond_to?(:last) && Array === choices.first.last
           option_tags = grouped_options_for_select(choices, :selected => selected_value, :disabled => options[:disabled])
         else
           option_tags = options_for_select(choices, :selected => selected_value, :disabled => options[:disabled])

--- a/actionpack/test/template/form_options_helper_test.rb
+++ b/actionpack/test/template/form_options_helper_test.rb
@@ -596,6 +596,24 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_select_with_nil
+    @post = Post.new
+    @post.category = "othervalue"
+    assert_dom_equal(
+      "<select id=\"post_category\" name=\"post[category]\"><option value=\"\"></option>\n<option value=\"othervalue\" selected=\"selected\">othervalue</option></select>",
+      select("post", "category", [nil, "othervalue"])
+    )
+  end
+
+  def test_select_with_fixnum
+    @post = Post.new
+    @post.category = ""
+    assert_dom_equal(
+      "<select id=\"post_category\" name=\"post[category]\"><option value=\"\">Please select</option>\n<option value=\"\"></option>\n<option value=\"1\">1</option></select>",
+      select("post", "category", [1], :prompt => true, :include_blank => true)
+    )
+  end
+
   def test_list_of_lists
     @post = Post.new
     @post.category = ""


### PR DESCRIPTION
This is a fix for #4048
