### PR TITLE
Fix reorder with limited ids

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.add_dependency('activemodel',   version)
   s.add_dependency('rack-cache',    '~> 1.1')
   s.add_dependency('builder',       '~> 3.0.0')
-  s.add_dependency('i18n',          '~> 0.6')
   s.add_dependency('rack',          '~> 1.3.5')
   s.add_dependency('rack-test',     '~> 0.6.1')
   s.add_dependency('journey',       '~> 1.0.0.rc1')

--- a/actionpack/lib/abstract_controller/layouts.rb
+++ b/actionpack/lib/abstract_controller/layouts.rb
@@ -241,6 +241,7 @@ module AbstractController
       #   the template name
       # false::  There is no layout
       # true::   raise an ArgumentError
+      # nil::    Force default layout behavior with inheritance
       #
       # ==== Parameters
       # * <tt>layout</tt> - The layout to use.
@@ -254,7 +255,7 @@ module AbstractController
         conditions.each {|k, v| conditions[k] = Array(v).map {|a| a.to_s} }
         self._layout_conditions = conditions
 
-        @_layout = layout || false # Converts nil to false
+        @_layout = layout
         _write_layout_method
       end
 

--- a/actionpack/lib/action_view/helpers/active_model_helper.rb
+++ b/actionpack/lib/action_view/helpers/active_model_helper.rb
@@ -1,4 +1,3 @@
-require 'action_view/helpers/form_helper'
 require 'active_support/core_ext/class/attribute_accessors'
 require 'active_support/core_ext/enumerable'
 require 'active_support/core_ext/object/blank'
@@ -46,10 +45,6 @@ module ActionView
       def tag_generate_errors?(options)
         options['type'] != 'hidden'
       end
-    end
-
-    class InstanceTag
-      include ActiveModelInstanceTag
     end
   end
 end

--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -422,7 +422,7 @@ module ActionView
       end
 
       # Returns a select tag with options for each of the seconds 0 through 59 with the current second selected.
-      # The <tt>datetime</tt> can be either a +Time+ or +DateTime+ object or an integer.      
+      # The <tt>datetime</tt> can be either a +Time+ or +DateTime+ object or an integer.
       # Override the field name using the <tt>:field_name</tt> option, 'second' by default.
       #
       # ==== Examples
@@ -448,7 +448,7 @@ module ActionView
 
       # Returns a select tag with options for each of the minutes 0 through 59 with the current minute selected.
       # Also can return a select tag with options by <tt>minute_step</tt> from 0 through 59 with the 00 minute
-      # selected. The <tt>datetime</tt> can be either a +Time+ or +DateTime+ object or an integer. 
+      # selected. The <tt>datetime</tt> can be either a +Time+ or +DateTime+ object or an integer.
       # Override the field name using the <tt>:field_name</tt> option, 'minute' by default.
       #
       # ==== Examples
@@ -473,7 +473,7 @@ module ActionView
       end
 
       # Returns a select tag with options for each of the hours 0 through 23 with the current hour selected.
-      # The <tt>datetime</tt> can be either a +Time+ or +DateTime+ object or an integer.      
+      # The <tt>datetime</tt> can be either a +Time+ or +DateTime+ object or an integer.
       # Override the field name using the <tt>:field_name</tt> option, 'hour' by default.
       #
       # ==== Examples
@@ -868,7 +868,7 @@ module ActionView
             tag_options = { :value => value }
             tag_options[:selected] = "selected" if selected == i
             text = options[:use_two_digit_numbers] ? sprintf("%02d", i) : value
-            text = options[:ampm] ? AMPM_TRANSLATION[i] : text            
+            text = options[:ampm] ? AMPM_TRANSLATION[i] : text
             select_options << content_tag(:option, text, tag_options)
           end
           (select_options.join("\n") + "\n").html_safe
@@ -974,7 +974,7 @@ module ActionView
         end
     end
 
-    class InstanceTag #:nodoc:
+    module DateHelperInstanceTag
       def to_date_select_tag(options = {}, html_options = {})
         datetime_selector(options, html_options).select_date.html_safe
       end
@@ -1028,6 +1028,10 @@ module ActionView
               )
           end
         end
+    end
+
+    class InstanceTag #:nodoc:
+      include DateHelperInstanceTag
     end
 
     class FormBuilder

--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -2,6 +2,7 @@ require 'cgi'
 require 'action_view/helpers/date_helper'
 require 'action_view/helpers/tag_helper'
 require 'action_view/helpers/form_tag_helper'
+require 'action_view/helpers/active_model_helper'
 require 'active_support/core_ext/class/attribute'
 require 'active_support/core_ext/hash/slice'
 require 'active_support/core_ext/module/method_names'
@@ -963,7 +964,7 @@ module ActionView
     end
 
     class InstanceTag
-      include Helpers::TagHelper, Helpers::FormTagHelper
+      include Helpers::ActiveModelInstanceTag, Helpers::TagHelper, Helpers::FormTagHelper
 
       attr_reader :object, :method_name, :object_name
 

--- a/actionpack/lib/action_view/template.rb
+++ b/actionpack/lib/action_view/template.rb
@@ -173,7 +173,7 @@ module ActionView
       @inspect ||= defined?(Rails.root) ? identifier.sub("#{Rails.root}/", '') : identifier
     end
 
-    # This method is responsible for properly setting he encoding of the
+    # This method is responsible for properly setting the encoding of the
     # source. Until this point, we assume that the source is BINARY data.
     # If no additional information is supplied, we assume the encoding is
     # the same as <tt>Encoding.default_external</tt>.
@@ -184,38 +184,36 @@ module ActionView
     # before passing the source on to the template engine, leaving a
     # blank line in its stead.
     def encode!
-      return unless source.encoding == Encoding::BINARY
+      return unless source.encoding_aware? && source.encoding == Encoding::BINARY
 
-      if source.encoding_aware?
-        # Look for # encoding: *. If we find one, we'll encode the
-        # String in that encoding, otherwise, we'll use the
-        # default external encoding.
-        if source.sub!(/\A#{ENCODING_FLAG}/, '')
-          encoding = magic_encoding = $1
-        else
-          encoding = Encoding.default_external
-        end
+      # Look for # encoding: *. If we find one, we'll encode the
+      # String in that encoding, otherwise, we'll use the
+      # default external encoding.
+      if source.sub!(/\A#{ENCODING_FLAG}/, '')
+        encoding = magic_encoding = $1
+      else
+        encoding = Encoding.default_external
+      end
 
-        # Tag the source with the default external encoding
-        # or the encoding specified in the file
-        source.force_encoding(encoding)
+      # Tag the source with the default external encoding
+      # or the encoding specified in the file
+      source.force_encoding(encoding)
 
-        # If the user didn't specify an encoding, and the handler
-        # handles encodings, we simply pass the String as is to
-        # the handler (with the default_external tag)
-        if !magic_encoding && @handler.respond_to?(:handles_encoding?) && @handler.handles_encoding?
-          source
-        # Otherwise, if the String is valid in the encoding,
-        # encode immediately to default_internal. This means
-        # that if a handler doesn't handle encodings, it will
-        # always get Strings in the default_internal
-        elsif source.valid_encoding?
-          source.encode!
-        # Otherwise, since the String is invalid in the encoding
-        # specified, raise an exception
-        else
-          raise WrongEncodingError.new(source, encoding)
-        end
+      # If the user didn't specify an encoding, and the handler
+      # handles encodings, we simply pass the String as is to
+      # the handler (with the default_external tag)
+      if !magic_encoding && @handler.respond_to?(:handles_encoding?) && @handler.handles_encoding?
+        source
+      # Otherwise, if the String is valid in the encoding,
+      # encode immediately to default_internal. This means
+      # that if a handler doesn't handle encodings, it will
+      # always get Strings in the default_internal
+      elsif source.valid_encoding?
+        source.encode!
+      # Otherwise, since the String is invalid in the encoding
+      # specified, raise an exception
+      else
+        raise WrongEncodingError.new(source, encoding)
       end
     end
 

--- a/actionpack/lib/action_view/template.rb
+++ b/actionpack/lib/action_view/template.rb
@@ -173,6 +173,52 @@ module ActionView
       @inspect ||= defined?(Rails.root) ? identifier.sub("#{Rails.root}/", '') : identifier
     end
 
+    # This method is responsible for properly setting he encoding of the
+    # source. Until this point, we assume that the source is BINARY data.
+    # If no additional information is supplied, we assume the encoding is
+    # the same as <tt>Encoding.default_external</tt>.
+    #
+    # The user can also specify the encoding via a comment on the first
+    # line of the template (# encoding: NAME-OF-ENCODING). This will work
+    # with any template engine, as we process out the encoding comment
+    # before passing the source on to the template engine, leaving a
+    # blank line in its stead.
+    def encode!
+      return unless source.encoding == Encoding::BINARY
+
+      if source.encoding_aware?
+        # Look for # encoding: *. If we find one, we'll encode the
+        # String in that encoding, otherwise, we'll use the
+        # default external encoding.
+        if source.sub!(/\A#{ENCODING_FLAG}/, '')
+          encoding = magic_encoding = $1
+        else
+          encoding = Encoding.default_external
+        end
+
+        # Tag the source with the default external encoding
+        # or the encoding specified in the file
+        source.force_encoding(encoding)
+
+        # If the user didn't specify an encoding, and the handler
+        # handles encodings, we simply pass the String as is to
+        # the handler (with the default_external tag)
+        if !magic_encoding && @handler.respond_to?(:handles_encoding?) && @handler.handles_encoding?
+          source
+        # Otherwise, if the String is valid in the encoding,
+        # encode immediately to default_internal. This means
+        # that if a handler doesn't handle encodings, it will
+        # always get Strings in the default_internal
+        elsif source.valid_encoding?
+          source.encode!
+        # Otherwise, since the String is invalid in the encoding
+        # specified, raise an exception
+        else
+          raise WrongEncodingError.new(source, encoding)
+        end
+      end
+    end
+
     protected
 
       # Compile a template. This method ensures a template is compiled
@@ -195,15 +241,7 @@ module ActionView
       end
 
       # Among other things, this method is responsible for properly setting
-      # the encoding of the source. Until this point, we assume that the
-      # source is BINARY data. If no additional information is supplied,
-      # we assume the encoding is the same as <tt>Encoding.default_external</tt>.
-      #
-      # The user can also specify the encoding via a comment on the first
-      # line of the template (# encoding: NAME-OF-ENCODING). This will work
-      # with any template engine, as we process out the encoding comment
-      # before passing the source on to the template engine, leaving a
-      # blank line in its stead.
+      # the encoding of the compiled template.
       #
       # If the template engine handles encodings, we send the encoded
       # String to the engine without further processing. This allows
@@ -215,40 +253,8 @@ module ActionView
       # In general, this means that templates will be UTF-8 inside of Rails,
       # regardless of the original source encoding.
       def compile(view, mod) #:nodoc:
+        encode!
         method_name = self.method_name
-
-        if source.encoding_aware?
-          # Look for # encoding: *. If we find one, we'll encode the
-          # String in that encoding, otherwise, we'll use the
-          # default external encoding.
-          if source.sub!(/\A#{ENCODING_FLAG}/, '')
-            encoding = magic_encoding = $1
-          else
-            encoding = Encoding.default_external
-          end
-
-          # Tag the source with the default external encoding
-          # or the encoding specified in the file
-          source.force_encoding(encoding)
-
-          # If the user didn't specify an encoding, and the handler
-          # handles encodings, we simply pass the String as is to
-          # the handler (with the default_external tag)
-          if !magic_encoding && @handler.respond_to?(:handles_encoding?) && @handler.handles_encoding?
-            source
-          # Otherwise, if the String is valid in the encoding,
-          # encode immediately to default_internal. This means
-          # that if a handler doesn't handle encodings, it will
-          # always get Strings in the default_internal
-          elsif source.valid_encoding?
-            source.encode!
-          # Otherwise, since the String is invalid in the encoding
-          # specified, raise an exception
-          else
-            raise WrongEncodingError.new(source, encoding)
-          end
-        end
-
         code = @handler.call(self)
 
         # Make sure that the resulting String to be evalled is in the
@@ -297,7 +303,11 @@ module ActionView
           raise e
         else
           assigns  = view.respond_to?(:assigns) ? view.assigns : {}
-          template = @virtual_path ? refresh(view) : self
+          template = self
+          unless template.source
+            template = refresh(view)
+            template.encode!
+          end
           raise Template::Error.new(template, assigns, e)
         end
       end

--- a/actionpack/lib/action_view/template/error.rb
+++ b/actionpack/lib/action_view/template/error.rb
@@ -94,7 +94,7 @@ module ActionView
           "#{indent}#{line_counter}: #{line}\n"
         end
 
-        extract.encode! if extract.respond_to?(:encode!)
+        extract.force_encoding("UTF-8") if extract.respond_to?(:encode!)
 
         extract
       end

--- a/actionpack/lib/action_view/template/error.rb
+++ b/actionpack/lib/action_view/template/error.rb
@@ -89,14 +89,10 @@ module ActionView
         line_counter = start_on_line
         return unless source_code = source_code[start_on_line..end_on_line]
 
-        extract = source_code.sum do |line|
+        source_code.sum do |line|
           line_counter += 1
           "#{indent}#{line_counter}: #{line}\n"
         end
-
-        extract.force_encoding("UTF-8") if extract.respond_to?(:encode!)
-
-        extract
       end
 
       def sub_template_of(template_path)

--- a/actionpack/test/abstract/layouts_test.rb
+++ b/actionpack/test/abstract/layouts_test.rb
@@ -14,7 +14,10 @@ module AbstractControllerTests
         "layouts/overwrite.erb"         => "Overwrite <%= yield %>",
         "layouts/with_false_layout.erb" => "False Layout <%= yield %>",
         "abstract_controller_tests/layouts/with_string_implied_child.erb" =>
-                                           "With Implied <%= yield %>"
+                                           "With Implied <%= yield %>",
+        "abstract_controller_tests/layouts/with_grand_child_of_implied.erb" =>
+                                           "With Grand Child <%= yield %>"
+
       )]
     end
 
@@ -57,14 +60,14 @@ module AbstractControllerTests
       layout "hello_override"
     end
 
-    class WithNilChild < WithString
-      layout nil
-    end
-
     class WithStringImpliedChild < WithString
     end
 
     class WithChildOfImplied < WithStringImpliedChild
+    end
+
+    class WithGrandChildOfImplied < WithStringImpliedChild
+      layout nil
     end
 
     class WithProc < Base
@@ -262,17 +265,18 @@ module AbstractControllerTests
         assert_equal "With Implied Hello string!", controller.response_body
       end
 
-      test "when a child controller specifies layout nil, do not use the parent layout" do
-        controller = WithNilChild.new
-        controller.process(:index)
-        assert_equal "Hello string!", controller.response_body
-      end
-
       test "when a grandchild has no layout specified, the child has an implied layout, and the " \
         "parent has specified a layout, use the child controller layout" do
           controller = WithChildOfImplied.new
           assert_deprecated { controller.process(:index) }
           assert_equal "With Implied Hello string!", controller.response_body
+      end
+
+      test "when a grandchild has nil layout specified, the child has an implied layout, and the " \
+        "parent has specified a layout, use the child controller layout" do
+          controller = WithGrandChildOfImplied.new
+          controller.process(:index)
+          assert_equal "With Grand Child Hello string!", controller.response_body
       end
 
       test "raises an exception when specifying layout true" do

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -25,6 +25,8 @@ end
 class TestController < ActionController::Base
   protect_from_forgery
 
+  before_filter :set_variable_for_layout
+
   class LabellingFormBuilder < ActionView::Helpers::FormBuilder
   end
 
@@ -364,17 +366,14 @@ class TestController < ActionController::Base
   end
 
   def layout_test_with_different_layout
-    @variable_for_layout = nil
     render :action => "hello_world", :layout => "standard"
   end
 
   def layout_test_with_different_layout_and_string_action
-    @variable_for_layout = nil
     render "hello_world", :layout => "standard"
   end
 
   def layout_test_with_different_layout_and_symbol_action
-    @variable_for_layout = nil
     render :hello_world, :layout => "standard"
   end
 
@@ -383,7 +382,6 @@ class TestController < ActionController::Base
   end
 
   def layout_overriding_layout
-    @variable_for_layout = nil
     render :action => "hello_world", :layout => "standard"
   end
 
@@ -666,8 +664,11 @@ class TestController < ActionController::Base
 
   private
 
+    def set_variable_for_layout
+      @variable_for_layout = nil
+    end
+
     def determine_layout
-      @variable_for_layout ||= nil
       case action_name
         when "hello_world", "layout_test", "rendering_without_layout",
              "rendering_nothing_on_layout", "render_text_hello_world",

--- a/actionpack/test/template/active_model_helper_test.rb
+++ b/actionpack/test/template/active_model_helper_test.rb
@@ -4,7 +4,7 @@ class ActiveModelHelperTest < ActionView::TestCase
   tests ActionView::Helpers::ActiveModelHelper
 
   silence_warnings do
-    class Post < Struct.new(:author_name, :body)
+    class Post < Struct.new(:author_name, :body, :updated_at)
       include ActiveModel::Conversion
       include ActiveModel::Validations
 
@@ -20,9 +20,11 @@ class ActiveModelHelperTest < ActionView::TestCase
     @post = Post.new
     @post.errors[:author_name] << "can't be empty"
     @post.errors[:body] << "foo"
+    @post.errors[:updated_at] << "bar"
 
     @post.author_name = ""
     @post.body        = "Back to the hill and over it again!"
+    @post.updated_at  = Date.new(2004, 6, 15)
   end
 
   def test_text_area_with_errors
@@ -36,6 +38,27 @@ class ActiveModelHelperTest < ActionView::TestCase
     assert_dom_equal(
       %(<div class="field_with_errors"><input id="post_author_name" name="post[author_name]" size="30" type="text" value="" /></div>),
       text_field("post", "author_name")
+    )
+  end
+
+  def test_date_select_with_errors
+    assert_dom_equal(
+      %(<div class="field_with_errors"><select id="post_updated_at_1i" name="post[updated_at(1i)]">\n<option selected="selected" value="2004">2004</option>\n<option value="2005">2005</option>\n</select>\n<input id="post_updated_at_2i" name="post[updated_at(2i)]" type="hidden" value="6" />\n<input id="post_updated_at_3i" name="post[updated_at(3i)]" type="hidden" value="15" />\n</div>),
+      date_select("post", "updated_at", :discard_month => true, :discard_day => true, :start_year => 2004, :end_year => 2005)
+    )
+  end
+
+  def test_datetime_select_with_errors
+    assert_dom_equal(
+      %(<div class="field_with_errors"><input id="post_updated_at_1i" name="post[updated_at(1i)]" type="hidden" value="2004" />\n<input id="post_updated_at_2i" name="post[updated_at(2i)]" type="hidden" value="6" />\n<input id="post_updated_at_3i" name="post[updated_at(3i)]" type="hidden" value="15" />\n<select id="post_updated_at_4i" name="post[updated_at(4i)]">\n<option selected="selected" value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n</select>\n : <select id="post_updated_at_5i" name="post[updated_at(5i)]">\n<option selected="selected" value="00">00</option>\n</select>\n</div>),
+      datetime_select("post", "updated_at", :discard_year => true, :discard_month => true, :discard_day => true, :minute_step => 60)
+    )
+  end
+
+  def test_time_select_with_errors
+    assert_dom_equal(
+      %(<div class="field_with_errors"><input id="post_updated_at_1i" name="post[updated_at(1i)]" type="hidden" value="2004" />\n<input id="post_updated_at_2i" name="post[updated_at(2i)]" type="hidden" value="6" />\n<input id="post_updated_at_3i" name="post[updated_at(3i)]" type="hidden" value="15" />\n<select id="post_updated_at_4i" name="post[updated_at(4i)]">\n<option selected="selected" value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n</select>\n : <select id="post_updated_at_5i" name="post[updated_at(5i)]">\n<option selected="selected" value="00">00</option>\n</select>\n</div>),
+      time_select("post", "updated_at", :minute_step => 60)
     )
   end
 

--- a/activemodel/activemodel.gemspec
+++ b/activemodel/activemodel.gemspec
@@ -18,5 +18,4 @@ Gem::Specification.new do |s|
 
   s.add_dependency('activesupport', version)
   s.add_dependency('builder',       '~> 3.0.0')
-  s.add_dependency('i18n',          '~> 0.6')
 end

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -249,7 +249,7 @@ module ActiveRecord
     end
 
     def construct_limited_ids_condition(relation)
-      orders = relation.order_values.map { |val| val.presence }.compact
+      orders = (relation.reorder_value || relation.order_values).map { |val| val.presence }.compact
       values = @klass.connection.distinct("#{@klass.connection.quote_table_name table_name}.#{primary_key}", orders)
 
       relation = relation.dup

--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -12,7 +12,7 @@ module ActiveRecord
       end
 
       module ClassMethods
-        # Returns a scope for this class without taking into account the default_scope.
+        # Returns a scope for the model without the default_scope.
         #
         #   class Post < ActiveRecord::Base
         #     def self.default_scope
@@ -23,18 +23,20 @@ module ActiveRecord
         #   Post.all          # Fires "SELECT * FROM posts WHERE published = true"
         #   Post.unscoped.all # Fires "SELECT * FROM posts"
         #
-        # This method also accepts a block meaning that all queries inside the block will
+        # This method also accepts a block. All queries inside the block will
         # not use the default_scope:
         #
         #   Post.unscoped {
         #     Post.limit(10) # Fires "SELECT * FROM posts LIMIT 10"
         #   }
         #
-        # It is recommended to use block form of unscoped because chaining unscoped with <tt>scope</tt>
-        # does not work. Assuming that <tt>published</tt> is a <tt>scope</tt> following two statements are same.
+        # It is recommended to use the block form of unscoped because chaining
+        # unscoped with <tt>scope</tt> does not work.  Assuming that
+        # <tt>published</tt> is a <tt>scope</tt>, the following two statements
+        # are equal: the default_scope is applied on both.
         #
-        # Post.unscoped.published
-        # Post.published
+        #   Post.unscoped.published
+        #   Post.published
         def unscoped #:nodoc:
           block_given? ? relation.scoping { yield } : relation
         end

--- a/railties/guides/source/migrations.textile
+++ b/railties/guides/source/migrations.textile
@@ -814,7 +814,7 @@ replaying the entire migration history. It is much simpler and faster to just
 load into the database a description of the current schema.
 
 For example, this is how the test database is created: the current development
-database is dumped (either to +db/schema.rb+ or +db/development.sql+) and then
+database is dumped (either to +db/schema.rb+ or +db/structure.sql+) and then
 loaded into the test database.
 
 Schema files are also useful if you want a quick look at what attributes an

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -200,8 +200,8 @@ module Rails
             # Gems used only for assets and not required
             # in production environments by default.
             group :assets do
-              gem 'sass-rails',   :git => 'git://github.com/rails/sass-rails.git'
-              gem 'coffee-rails', :git => 'git://github.com/rails/coffee-rails.git'
+              gem 'sass-rails',   :git => 'git://github.com/rails/sass-rails.git',   :branch => '3-2-stable'
+              gem 'coffee-rails', :git => 'git://github.com/rails/coffee-rails.git', :branch => '3-2-stable'
               #{"gem 'therubyrhino'\n" if defined?(JRUBY_VERSION)}
               gem 'uglifier', '>= 1.0.3'
             end

--- a/railties/lib/rails/tasks/documentation.rake
+++ b/railties/lib/rails/tasks/documentation.rake
@@ -63,7 +63,7 @@ namespace :doc do
     rdoc.template = "#{ENV['template']}.rb" if ENV['template']
     rdoc.title    = "Rails Framework Documentation"
     rdoc.options << '--line-numbers'
-    rdoc.rdoc_files.include('README')
+    rdoc.rdoc_files.include('README.rdoc')
 
     gem_path('actionmailer') do |actionmailer|
       %w(README.rdoc CHANGELOG.md MIT-LICENSE lib/action_mailer/base.rb).each do |file|

--- a/railties/test/application/middleware/exceptions_test.rb
+++ b/railties/test/application/middleware/exceptions_test.rb
@@ -99,7 +99,7 @@ module ApplicationTests
 
       app_file 'app/views/foo/index.html.erb', <<-ERB
         <% raise 'boooom' %>
-        ✓
+        ✓測試テスト시험
       ERB
 
       app_file 'config/routes.rb', <<-RUBY
@@ -110,6 +110,7 @@ module ApplicationTests
 
       post '/foo', :utf8 => '✓'
       assert_match(/boooom/, last_response.body)
+      assert_match(/測試テスト시험/, last_response.body)
     end
   end
 end


### PR DESCRIPTION
Calling last on an association that's scoped with reorder can cause some adapters to fail (particularly oracle_enhanced and postgres). The underlying cause is that `connection.distinct` expects the desired order, but the relation's `reorder_values` are not passed along, since `construct_limited_ids` explicitly grabs `order_values`.

See the attached commit for additional details - this bug does not affect the mysql or sqlite adapters, as those use the default order-agnostic implementation of `distinct`.

What's the best way to test this?
