### PR TITLE
remove check for string from request body setter

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -121,14 +121,7 @@ module ActionDispatch # :nodoc:
     def body=(body)
       @blank = true if body == EMPTY
 
-      # Explicitly check for strings. This is *wrong* theoretically
-      # but if we don't check this, the performance on string bodies
-      # is bad on Ruby 1.8 (because strings responds to each then).
-      @body = if body.respond_to?(:to_str) || !body.respond_to?(:each)
-        [body]
-      else
-        body
-      end
+      @body = body.respond_to?(:each) ? body : [body]
     end
 
     def body_parts


### PR DESCRIPTION
it was required on ruby 1.8

/cc @josevalim
