### PR TITLE
Adding Enumerator support to find_in_batches / find_each

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -45,7 +45,7 @@ module ActiveRecord
     #     sleep(50) # Make sure it doesn't get too crowded in there!
     #     group.each { |person| person.party_all_night! }
     #   end
-    def find_in_batches(options = {})
+    def find_in_batches(options = {}, &block)
       relation = self
 
       unless arel.orders.blank? && arel.taken.blank?
@@ -65,20 +65,22 @@ module ActiveRecord
       relation = relation.reorder(batch_order).limit(batch_size)
       records = relation.where(table[primary_key].gteq(start)).all
 
-      while records.any?
-        records_size = records.size
-        primary_key_offset = records.last.id
+      Enumerator.new do |yielder|
+        while records.any?
+          records_size = records.size
+          primary_key_offset = records.last.id
 
-        yield records
+          yielder.yield records
 
-        break if records_size < batch_size
+          break if records_size < batch_size
 
-        if primary_key_offset
-          records = relation.where(table[primary_key].gt(primary_key_offset)).to_a
-        else
-          raise "Primary key not included in the custom select clause"
+          if primary_key_offset
+            records = relation.where(table[primary_key].gt(primary_key_offset)).to_a
+          else
+            raise "Primary key not included in the custom select clause"
+          end
         end
-      end
+      end.tap{|enum| enum.each(&block) if block_given?}
     end
 
     private

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -16,10 +16,12 @@ module ActiveRecord
     # large amounts of records that wouldn't fit in memory all at once. If
     # you just need to loop over less than 1000 records, it's probably
     # better just to use the regular find methods.
-    def find_each(options = {})
-      find_in_batches(options) do |records|
-        records.each { |record| yield record }
-      end
+    def find_each(options = {}, &block)
+      Enumerator.new do |yielder|
+        find_in_batches(options) do |records|
+          records.each { |record| yielder.yield record }
+        end
+      end.tap{|enum| enum.each(&block) if block_given?}
     end
 
     # Yields each batch of records that was found by the find +options+ as

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -18,10 +18,10 @@ class EachTest < ActiveRecord::TestCase
     end
   end
 
-  def test_each_should_not_return_query_chain_and_execcute_only_one_query
+  def test_each_should_not_return_query_chain_and_execute_only_one_query
     assert_queries(1) do
       result = Post.find_each(:batch_size => 100000){ }
-      assert_nil result
+      assert_kind_of Enumerator, result
     end
   end
 
@@ -134,6 +134,21 @@ class EachTest < ActiveRecord::TestCase
       posts.concat(batch)
     end
     assert_equal special_posts_ids, posts.map(&:id)
+  end
+
+
+  def test_find_in_batches_without_a_block_should_return_an_enumerator
+    enumerator = Post.find_in_batches(:batch_size=>1000000)
+    assert_kind_of Enumerator, enumerator
+
+    batches = {}
+    enumerator.each_with_index do |batch, i|
+      assert_kind_of Array, batch
+      assert_kind_of Post, batch.first
+      batches[i] = batch.length
+    end
+    assert_equal 1, batches.keys.length
+    assert_equal @total, batches[0]
   end
 
 end

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -151,4 +151,14 @@ class EachTest < ActiveRecord::TestCase
     assert_equal @total, batches[0]
   end
 
+  def test_find_each_without_a_block_should_return_an_enumerator
+    enumerator = Post.find_each
+    assert_kind_of Enumerator, enumerator
+    each_post = []
+    enumerator.each do |post|
+      each_post << post
+    end
+    assert_equal Post.count, each_post.length
+  end
+
 end


### PR DESCRIPTION
Any thoughts on something like this?  Obviously an alternative would be for the client to rely on enum_for - 

```
Post.enum_for(:find_in_batches).each_with_index do |posts, i|
...
end
```

but this seems nicer.
