### PR TITLE
removed  deprecated loggers

### DIFF
--- a/activemodel/test/cases/mass_assignment_security/sanitizer_test.rb
+++ b/activemodel/test/cases/mass_assignment_security/sanitizer_test.rb
@@ -28,7 +28,7 @@ class SanitizerTest < ActiveModel::TestCase
   test "debug mass assignment removal with LoggerSanitizer" do
     original_attributes = { 'first_name' => 'allowed', 'admin' => 'denied' }
     log = StringIO.new
-    self.logger = Logger.new(log)
+    self.logger = ActiveSupport::Logger.new(log)
     @logger_sanitizer.sanitize(original_attributes, @authorizer)
     assert_match(/admin/, log.string, "Should log removed attributes: #{log.string}")
   end

--- a/activemodel/test/cases/mass_assignment_security/sanitizer_test.rb
+++ b/activemodel/test/cases/mass_assignment_security/sanitizer_test.rb
@@ -1,5 +1,5 @@
 require "cases/helper"
-require 'logger'
+require 'active_support/logger'
 require 'active_support/core_ext/object/inclusion'
 
 class SanitizerTest < ActiveModel::TestCase


### PR DESCRIPTION
Removed the older way of loggers from activemodel/test/cases/mass_assignment_security/sanitizer_test.rb
