### PR TITLE
remove Kernel#singleton_class from core_ext as it is present in ruby 1.9

### DIFF
--- a/activesupport/lib/active_support/core_ext/kernel/singleton_class.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/singleton_class.rb
@@ -1,11 +1,4 @@
 module Kernel
-  # Returns the object's singleton class.
-  def singleton_class
-    class << self
-      self
-    end
-  end unless respond_to?(:singleton_class) # exists in 1.9.2
-
   # class_eval on an object acts like singleton_class.class_eval.
   def class_eval(*args, &block)
     singleton_class.class_eval(*args, &block)

--- a/activesupport/test/core_ext/kernel_test.rb
+++ b/activesupport/test/core_ext/kernel_test.rb
@@ -42,11 +42,6 @@ class KernelTest < Test::Unit::TestCase
     assert_equal 1, silence_stderr { 1 }
   end
 
-  def test_singleton_class
-    o = Object.new
-    assert_equal class << o; self end, o.singleton_class
-  end
-
   def test_class_eval
     o = Object.new
     class << o; @x = 1; end

--- a/railties/guides/source/active_support_core_extensions.textile
+++ b/railties/guides/source/active_support_core_extensions.textile
@@ -177,19 +177,6 @@ end
 
 NOTE: Defined in +active_support/core_ext/object/try.rb+.
 
-h4. +singleton_class+
-
-The method +singleton_class+ returns the singleton class of the receiver:
-
-<ruby>
-String.singleton_class     # => #<Class:String>
-String.new.singleton_class # => #<Class:#<String:0x17a1d1c>>
-</ruby>
-
-WARNING: Fixnums and symbols have no singleton classes, +singleton_class+ raises +TypeError+ on them. Moreover, the singleton classes of +nil+, +true+, and +false+, are +NilClass+, +TrueClass+, and +FalseClass+, respectively.
-
-NOTE: Defined in +active_support/core_ext/kernel/singleton_class.rb+.
-
 h4. +class_eval(*args, &block)+
 
 You can evaluate code in the context of any object's singleton class using +class_eval+:


### PR DESCRIPTION
/cc @josevalim
