### PR TITLE
remove Enumerable#each_with_object from core_ext as it is present in ruby 1.9

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -33,27 +33,6 @@ module Enumerable
     collect { |element| element.send(method) }
   end
 
-  # Iterates over a collection, passing the current element *and* the
-  # +memo+ to the block. Handy for building up hashes or
-  # reducing collections down to one object. Examples:
-  #
-  #   %w(foo bar).each_with_object({}) { |str, hsh| hsh[str] = str.upcase }
-  #   # => {'foo' => 'FOO', 'bar' => 'BAR'}
-  #
-  # *Note* that you can't use immutable objects like numbers, true or false as
-  # the memo. You would think the following returns 120, but since the memo is
-  # never changed, it does not.
-  #
-  #   (1..5).each_with_object(1) { |value, memo| memo *= value } # => 1
-  #
-  def each_with_object(memo)
-    return to_enum :each_with_object, memo unless block_given?
-    each do |element|
-      yield element, memo
-    end
-    memo
-  end unless [].respond_to?(:each_with_object)
-
   # Convert an enumerable to a hash. Examples:
   #
   #   people.index_by(&:login)

--- a/activesupport/lib/active_support/ruby/shim.rb
+++ b/activesupport/lib/active_support/ruby/shim.rb
@@ -3,7 +3,7 @@
 #
 # Date        next_year, next_month
 # DateTime    to_date, to_datetime, xmlschema
-# Enumerable  group_by, each_with_object, none?
+# Enumerable  group_by, none?
 # Process     Process.daemon
 # REXML       security fix
 # String      ord

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -86,15 +86,6 @@ class EnumerableTests < Test::Unit::TestCase
     assert_equal 'abc', ('a'..'c').sum
   end
 
-  def test_each_with_object
-    enum = GenericEnumerable.new(%w(foo bar))
-    result = enum.each_with_object({}) { |str, hsh| hsh[str] = str.upcase }
-    assert_equal({'foo' => 'FOO', 'bar' => 'BAR'}, result)
-    assert_equal Enumerator, enum.each_with_object({}).class
-    result2 = enum.each_with_object({}).each{|str, hsh| hsh[str] = str.upcase}
-    assert_equal result, result2
-  end
-
   def test_index_by
     payments = GenericEnumerable.new([ Payment.new(5), Payment.new(15), Payment.new(10) ])
     assert_equal({ 5 => Payment.new(5), 15 => Payment.new(15), 10 => Payment.new(10) },

--- a/railties/guides/source/active_support_core_extensions.textile
+++ b/railties/guides/source/active_support_core_extensions.textile
@@ -2038,32 +2038,6 @@ people.pluck(:name) # => [ "David Heinemeier Hansson", "Jamie Heinemeier Hansson
 
 NOTE: Defined in +active_support/core_ext/enumerable.rb+.
 
-h4. +each_with_object+
-
-The +inject+ method offers iteration with an accumulator:
-
-<ruby>
-[2, 3, 4].inject(1) {|product, i| product*i } # => 24
-</ruby>
-
-The block is expected to return the value for the accumulator in the next iteration, and this makes building mutable objects a bit cumbersome:
-
-<ruby>
-[1, 2].inject({}) {|h, i| h[i] = i**2; h} # => {1 => 1, 2 => 4}
-</ruby>
-
-See that spurious "+; h+"?
-
-Active Support backports +each_with_object+ from Ruby 1.9, which addresses that use case. It iterates over the collection, passes the accumulator, and returns the accumulator when done. You normally modify the accumulator in place. The example above would be written this way:
-
-<ruby>
-[1, 2].each_with_object({}) {|i, h| h[i] = i**2} # => {1 => 1, 2 => 4}
-</ruby>
-
-WARNING. Note that the item of the collection and the accumulator come in different order in +inject+ and +each_with_object+.
-
-NOTE: Defined in +active_support/core_ext/enumerable.rb+.
-
 h4. +index_by+
 
 The method +index_by+ generates a hash with the elements of an enumerable indexed by some key.


### PR DESCRIPTION
/cc @josevalim
