### PR TITLE
remove requires of core_ext/array/random_access that no longer exists

### DIFF
--- a/activerecord/test/cases/associations/eager_load_nested_include_test.rb
+++ b/activerecord/test/cases/associations/eager_load_nested_include_test.rb
@@ -6,7 +6,6 @@ require 'models/comment'
 require 'models/category'
 require 'models/categorization'
 require 'models/tagging'
-require 'active_support/core_ext/array/random_access'
 
 module Remembered
   extend ActiveSupport::Concern

--- a/activerecord/test/cases/named_scope_test.rb
+++ b/activerecord/test/cases/named_scope_test.rb
@@ -1,5 +1,4 @@
 require "cases/helper"
-require 'active_support/core_ext/array/random_access'
 require 'models/post'
 require 'models/topic'
 require 'models/comment'


### PR DESCRIPTION
It fixes failing tests in travis

/cc @josevalim
