### PR TITLE
Remove ruby 1.8 code. 

### DIFF
--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -106,8 +106,7 @@ class BaseTest < ActiveSupport::TestCase
     email = BaseMailer.attachment_with_hash
     assert_equal(1, email.attachments.length)
     assert_equal('invoice.jpg', email.attachments[0].filename)
-    expected = "\312\213\254\232)b"
-    expected.force_encoding(Encoding::BINARY) if '1.9'.respond_to?(:force_encoding)
+    expected = "\312\213\254\232)b".force_encoding(Encoding::BINARY)
     assert_equal expected, email.attachments['invoice.jpg'].decoded
   end
 
@@ -115,8 +114,7 @@ class BaseTest < ActiveSupport::TestCase
     email = BaseMailer.attachment_with_hash_default_encoding
     assert_equal(1, email.attachments.length)
     assert_equal('invoice.jpg', email.attachments[0].filename)
-    expected = "\312\213\254\232)b"
-    expected.force_encoding(Encoding::BINARY) if '1.9'.respond_to?(:force_encoding)
+    expected = "\312\213\254\232)b".force_encoding(Encoding::BINARY)
     assert_equal expected, email.attachments['invoice.jpg'].decoded
   end
 

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -189,7 +189,7 @@ module ActionDispatch
     # variable is already set, wrap it in a StringIO.
     def body
       if raw_post = @env['RAW_POST_DATA']
-        raw_post.force_encoding(Encoding::BINARY) if raw_post.respond_to?(:force_encoding)
+        raw_post.force_encoding(Encoding::BINARY)
         StringIO.new(raw_post)
       else
         @env['rack.input']

--- a/actionpack/lib/action_view/helpers/capture_helper.rb
+++ b/actionpack/lib/action_view/helpers/capture_helper.rb
@@ -181,7 +181,7 @@ module ActionView
       def with_output_buffer(buf = nil) #:nodoc:
         unless buf
           buf = ActionView::OutputBuffer.new
-          buf.force_encoding(output_buffer.encoding) if output_buffer.respond_to?(:encoding) && buf.respond_to?(:force_encoding)
+          buf.force_encoding(output_buffer.encoding) if output_buffer.respond_to?(:encoding)
         end
         self.output_buffer, old_buffer = buf, output_buffer
         yield

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -457,8 +457,7 @@ class LegacyRouteSetTests < Test::Unit::TestCase
     assert_equal '/page/foo', url_for(rs, { :controller => 'content', :action => 'show_page', :id => 'foo' })
     assert_equal({ :controller => "content", :action => 'show_page', :id => 'foo' }, rs.recognize_path("/page/foo"))
 
-    token = "\321\202\320\265\320\272\321\201\321\202" # 'text' in Russian
-    token.force_encoding(Encoding::BINARY) if token.respond_to?(:force_encoding)
+    token = "\321\202\320\265\320\272\321\201\321\202".force_encoding(Encoding::BINARY) # 'text' in Russian
     escaped_token = CGI::escape(token)
 
     assert_equal '/page/' + escaped_token, url_for(rs, { :controller => 'content', :action => 'show_page', :id => token })

--- a/actionpack/test/controller/send_file_test.rb
+++ b/actionpack/test/controller/send_file_test.rb
@@ -61,7 +61,7 @@ class SendFileTest < ActionController::TestCase
     require 'stringio'
     output = StringIO.new
     output.binmode
-    output.string.force_encoding(file_data.encoding) if output.string.respond_to?(:force_encoding)
+    output.string.force_encoding(file_data.encoding)
     assert_nothing_raised { response.body_parts.each { |part| output << part.to_s } }
     assert_equal file_data, output.string
   end

--- a/actionpack/test/controller/test_test.rb
+++ b/actionpack/test/controller/test_test.rb
@@ -672,8 +672,7 @@ XML
     filename = 'mona_lisa.jpg'
     path = "#{FILES_DIR}/#{filename}"
     content_type = 'image/png'
-    expected = File.read(path)
-    expected.force_encoding(Encoding::BINARY) if expected.respond_to?(:force_encoding)
+    expected = File.read(path).force_encoding(Encoding::BINARY)
 
     file = Rack::Test::UploadedFile.new(path, content_type)
     assert_equal filename, file.original_filename

--- a/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
@@ -88,8 +88,7 @@ class MultipartParamsParsingTest < ActionDispatch::IntegrationTest
     assert_equal 'bar', params['foo']
 
     # Rack doesn't handle multipart/mixed for us.
-    files = params['files']
-    files.force_encoding('ASCII-8BIT') if files.respond_to?(:force_encoding)
+    files = params['files'].force_encoding('ASCII-8BIT')
     assert_equal 19756, files.size
   end
 

--- a/actionpack/test/template/output_buffer_test.rb
+++ b/actionpack/test/template/output_buffer_test.rb
@@ -39,15 +39,13 @@ class OutputBufferTest < ActionController::TestCase
     assert_equal ['foo', 'bar'], body_parts
   end
 
-  if '1.9'.respond_to?(:force_encoding)
-    test 'flushing preserves output buffer encoding' do
-      original_buffer = ' '.force_encoding(Encoding::EUC_JP)
-      @vc.output_buffer = original_buffer
-      @vc.flush_output_buffer
-      assert_equal ['foo', original_buffer], body_parts
-      assert_not_equal original_buffer, output_buffer
-      assert_equal Encoding::EUC_JP, output_buffer.encoding
-    end
+  test 'flushing preserves output buffer encoding' do
+    original_buffer = ' '.force_encoding(Encoding::EUC_JP)
+    @vc.output_buffer = original_buffer
+    @vc.flush_output_buffer
+    assert_equal ['foo', original_buffer], body_parts
+    assert_not_equal original_buffer, output_buffer
+    assert_equal Encoding::EUC_JP, output_buffer.encoding
   end
 
   protected

--- a/actionpack/test/template/render_test.rb
+++ b/actionpack/test/template/render_test.rb
@@ -403,51 +403,49 @@ class LazyViewRenderTest < ActiveSupport::TestCase
     GC.start
   end
 
-  if '1.9'.respond_to?(:force_encoding)
-    def test_render_utf8_template_with_magic_comment
-      with_external_encoding Encoding::ASCII_8BIT do
-        result = @view.render(:file => "test/utf8_magic", :formats => [:html], :layouts => "layouts/yield")
-        assert_equal Encoding::UTF_8, result.encoding
-        assert_equal "\nРусский \nтекст\n\nUTF-8\nUTF-8\nUTF-8\n", result
+  def test_render_utf8_template_with_magic_comment
+    with_external_encoding Encoding::ASCII_8BIT do
+      result = @view.render(:file => "test/utf8_magic", :formats => [:html], :layouts => "layouts/yield")
+      assert_equal Encoding::UTF_8, result.encoding
+      assert_equal "\nРусский \nтекст\n\nUTF-8\nUTF-8\nUTF-8\n", result
+    end
+  end
+
+  def test_render_utf8_template_with_default_external_encoding
+    with_external_encoding Encoding::UTF_8 do
+      result = @view.render(:file => "test/utf8", :formats => [:html], :layouts => "layouts/yield")
+      assert_equal Encoding::UTF_8, result.encoding
+      assert_equal "Русский текст\n\nUTF-8\nUTF-8\nUTF-8\n", result
+    end
+  end
+
+  def test_render_utf8_template_with_incompatible_external_encoding
+    with_external_encoding Encoding::SHIFT_JIS do
+      begin
+        @view.render(:file => "test/utf8", :formats => [:html], :layouts => "layouts/yield")
+        flunk 'Should have raised incompatible encoding error'
+      rescue ActionView::Template::Error => error
+        assert_match 'Your template was not saved as valid Shift_JIS', error.original_exception.message
       end
     end
+  end
 
-    def test_render_utf8_template_with_default_external_encoding
-      with_external_encoding Encoding::UTF_8 do
-        result = @view.render(:file => "test/utf8", :formats => [:html], :layouts => "layouts/yield")
-        assert_equal Encoding::UTF_8, result.encoding
-        assert_equal "Русский текст\n\nUTF-8\nUTF-8\nUTF-8\n", result
+  def test_render_utf8_template_with_partial_with_incompatible_encoding
+    with_external_encoding Encoding::SHIFT_JIS do
+      begin
+        @view.render(:file => "test/utf8_magic_with_bare_partial", :formats => [:html], :layouts => "layouts/yield")
+        flunk 'Should have raised incompatible encoding error'
+      rescue ActionView::Template::Error => error
+        assert_match 'Your template was not saved as valid Shift_JIS', error.original_exception.message
       end
     end
+  end
 
-    def test_render_utf8_template_with_incompatible_external_encoding
-      with_external_encoding Encoding::SHIFT_JIS do
-        begin
-          @view.render(:file => "test/utf8", :formats => [:html], :layouts => "layouts/yield")
-          flunk 'Should have raised incompatible encoding error'
-        rescue ActionView::Template::Error => error
-          assert_match 'Your template was not saved as valid Shift_JIS', error.original_exception.message
-        end
-      end
-    end
-
-    def test_render_utf8_template_with_partial_with_incompatible_encoding
-      with_external_encoding Encoding::SHIFT_JIS do
-        begin
-          @view.render(:file => "test/utf8_magic_with_bare_partial", :formats => [:html], :layouts => "layouts/yield")
-          flunk 'Should have raised incompatible encoding error'
-        rescue ActionView::Template::Error => error
-          assert_match 'Your template was not saved as valid Shift_JIS', error.original_exception.message
-        end
-      end
-    end
-
-    def with_external_encoding(encoding)
-      old = Encoding.default_external
-      silence_warnings { Encoding.default_external = encoding }
-      yield
-    ensure
-      silence_warnings { Encoding.default_external = old }
-    end
+  def with_external_encoding(encoding)
+    old = Encoding.default_external
+    silence_warnings { Encoding.default_external = encoding }
+    yield
+  ensure
+    silence_warnings { Encoding.default_external = old }
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
@@ -16,7 +16,7 @@ module ActiveRecord
         end
 
         def binary_to_string(value)
-          if value.respond_to?(:force_encoding) && value.encoding != Encoding::ASCII_8BIT
+          if value.encoding != Encoding::ASCII_8BIT
             value = value.force_encoding(Encoding::ASCII_8BIT)
           end
 

--- a/activerecord/test/cases/binary_test.rb
+++ b/activerecord/test/cases/binary_test.rb
@@ -11,8 +11,7 @@ unless current_adapter?(:SybaseAdapter, :DB2Adapter, :FirebirdAdapter)
     FIXTURES = %w(flowers.jpg example.log)
 
     def test_mixed_encoding
-      str = "\x80"
-      str.force_encoding('ASCII-8BIT') if str.respond_to?(:force_encoding)
+      str = "\x80".force_encoding('ASCII-8BIT')
 
       binary = Binary.new :name => 'いただきます！', :data => str
       binary.save!
@@ -23,7 +22,7 @@ unless current_adapter?(:SybaseAdapter, :DB2Adapter, :FirebirdAdapter)
 
       # Mysql adapter doesn't properly encode things, so we have to do it
       if current_adapter?(:MysqlAdapter)
-        name.force_encoding('UTF-8') if name.respond_to?(:force_encoding)
+        name.force_encoding('UTF-8')
       end
       assert_equal 'いただきます！', name
     end
@@ -33,7 +32,7 @@ unless current_adapter?(:SybaseAdapter, :DB2Adapter, :FirebirdAdapter)
 
       FIXTURES.each do |filename|
         data = File.read(ASSETS_ROOT + "/#{filename}")
-        data.force_encoding('ASCII-8BIT') if data.respond_to?(:force_encoding)
+        data.force_encoding('ASCII-8BIT')
         data.freeze
 
         bin = Binary.new(:data => data)

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -213,7 +213,7 @@ class FixturesTest < ActiveRecord::TestCase
 
   def test_binary_in_fixtures
     data = File.open(ASSETS_ROOT + "/flowers.jpg", 'rb') { |f| f.read }
-    data.force_encoding('ASCII-8BIT') if data.respond_to?(:force_encoding)
+    data.force_encoding('ASCII-8BIT')
     data.freeze
     assert_equal data, @flowers.data
   end

--- a/activesupport/lib/active_support/core_ext/string/access.rb
+++ b/activesupport/lib/active_support/core_ext/string/access.rb
@@ -1,99 +1,35 @@
 require "active_support/multibyte"
 
 class String
-  unless '1.9'.respond_to?(:force_encoding)
-    # Returns the character at the +position+ treating the string as an array (where 0 is the first character).
-    #
-    # Examples:
-    #   "hello".at(0)  # => "h"
-    #   "hello".at(4)  # => "o"
-    #   "hello".at(10) # => ERROR if < 1.9, nil in 1.9
-    def at(position)
-      mb_chars[position, 1].to_s
-    end
+  def at(position)
+    self[position]
+  end
 
-    # Returns the remaining of the string from the +position+ treating the string as an array (where 0 is the first character).
-    #
-    # Examples:
-    #   "hello".from(0)  # => "hello"
-    #   "hello".from(2)  # => "llo"
-    #   "hello".from(10) # => "" if < 1.9, nil in 1.9
-    def from(position)
-      mb_chars[position..-1].to_s
-    end
+  def from(position)
+    self[position..-1]
+  end
 
-    # Returns the beginning of the string up to the +position+ treating the string as an array (where 0 is the first character).
-    #
-    # Examples:
-    #   "hello".to(0)  # => "h"
-    #   "hello".to(2)  # => "hel"
-    #   "hello".to(10) # => "hello"
-    def to(position)
-      mb_chars[0..position].to_s
-    end
+  def to(position)
+    self[0..position]
+  end
 
-    # Returns the first character of the string or the first +limit+ characters.
-    #
-    # Examples:
-    #   "hello".first     # => "h"
-    #   "hello".first(2)  # => "he"
-    #   "hello".first(10) # => "hello"
-    def first(limit = 1)
-      if limit == 0
-        ''
-      elsif limit >= size
-        self
-      else
-        mb_chars[0...limit].to_s
-      end
+  def first(limit = 1)
+    if limit == 0
+      ''
+    elsif limit >= size
+      self
+    else
+      to(limit - 1)
     end
+  end
 
-    # Returns the last character of the string or the last +limit+ characters.
-    #
-    # Examples:
-    #   "hello".last     # => "o"
-    #   "hello".last(2)  # => "lo"
-    #   "hello".last(10) # => "hello"
-    def last(limit = 1)
-      if limit == 0
-        ''
-      elsif limit >= size
-        self
-      else
-        mb_chars[(-limit)..-1].to_s
-      end
-    end
-  else
-    def at(position)
-      self[position]
-    end
-
-    def from(position)
-      self[position..-1]
-    end
-
-    def to(position)
-      self[0..position]
-    end
-
-    def first(limit = 1)
-      if limit == 0
-        ''
-      elsif limit >= size
-        self
-      else
-        to(limit - 1)
-      end
-    end
-
-    def last(limit = 1)
-      if limit == 0
-        ''
-      elsif limit >= size
-        self
-      else
-        from(-limit)
-      end
+  def last(limit = 1)
+    if limit == 0
+      ''
+    elsif limit >= size
+      self
+    else
+      from(-limit)
     end
   end
 end

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -119,9 +119,7 @@ module ActiveSupport
         end
 
         def escape(string)
-          if string.respond_to?(:force_encoding)
-            string = string.encode(::Encoding::UTF_8, :undef => :replace).force_encoding(::Encoding::BINARY)
-          end
+          string = string.encode(::Encoding::UTF_8, :undef => :replace).force_encoding(::Encoding::BINARY)
           json = string.
             gsub(escape_regex) { |s| ESCAPED_CHARS[s] }.
             gsub(/([\xC0-\xDF][\x80-\xBF]|
@@ -129,9 +127,7 @@ module ActiveSupport
                    [\xF0-\xF7][\x80-\xBF]{3})+/nx) { |s|
             s.unpack("U*").pack("n*").unpack("H*")[0].gsub(/.{4}/n, '\\\\u\&')
           }
-          json = %("#{json}")
-          json.force_encoding(::Encoding::UTF_8) if json.respond_to?(:force_encoding)
-          json
+          %("#{json}").force_encoding(::Encoding::UTF_8)
         end
       end
 

--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -282,9 +282,7 @@ module ActiveSupport #:nodoc:
           return nil if byte_offset.nil?
           return 0   if @wrapped_string == ''
 
-          if @wrapped_string.respond_to?(:force_encoding)
-            @wrapped_string = @wrapped_string.dup.force_encoding(Encoding::ASCII_8BIT)
-          end
+          @wrapped_string = @wrapped_string.dup.force_encoding(Encoding::ASCII_8BIT)
 
           begin
             @wrapped_string[0...byte_offset].unpack('U*').length

--- a/activesupport/lib/active_support/multibyte/utils.rb
+++ b/activesupport/lib/active_support/multibyte/utils.rb
@@ -2,36 +2,14 @@
 
 module ActiveSupport #:nodoc:
   module Multibyte #:nodoc:
-    if Kernel.const_defined?(:Encoding)
-      # Returns a regular expression that matches valid characters in the current encoding
-      def self.valid_character
-        VALID_CHARACTER[Encoding.default_external.to_s]
-      end
-    else
-      def self.valid_character
-        case $KCODE
-        when 'UTF8'
-          VALID_CHARACTER['UTF-8']
-        when 'SJIS'
-          VALID_CHARACTER['Shift_JIS']
-        end
-      end
+    # Returns a regular expression that matches valid characters in the current encoding
+    def self.valid_character
+      VALID_CHARACTER[Encoding.default_external.to_s]
     end
 
-    if 'string'.respond_to?(:valid_encoding?)
-      # Verifies the encoding of a string
-      def self.verify(string)
-        string.valid_encoding?
-      end
-    else
-      def self.verify(string)
-        if expression = valid_character
-          # Splits the string on character boundaries, which are determined based on $KCODE.
-          string.split(//).all? { |c| expression =~ c }
-        else
-          true
-        end
-      end
+    # Verifies the encoding of a string
+    def self.verify(string)
+      string.valid_encoding?
     end
 
     # Verifies the encoding of the string and raises an exception when it's not valid
@@ -39,22 +17,11 @@ module ActiveSupport #:nodoc:
       raise EncodingError.new("Found characters with invalid encoding") unless verify(string)
     end
 
-    if 'string'.respond_to?(:force_encoding)
-      # Removes all invalid characters from the string.
-      #
-      # Note: this method is a no-op in Ruby 1.9
-      def self.clean(string)
-        string
-      end
-    else
-      def self.clean(string)
-        if expression = valid_character
-          # Splits the string on character boundaries, which are determined based on $KCODE.
-          string.split(//).grep(expression).join
-        else
-          string
-        end
-      end
+    # Removes all invalid characters from the string.
+    #
+    # Note: this method is a no-op in Ruby 1.9
+    def self.clean(string)
+      string
     end
   end
 end

--- a/activesupport/test/buffered_logger_test.rb
+++ b/activesupport/test/buffered_logger_test.rb
@@ -31,10 +31,7 @@ class BufferedLoggerTest < Test::Unit::TestCase
     logger = Logger.new f
     logger.level = Logger::DEBUG
 
-    str = "\x80"
-    if str.respond_to?(:force_encoding)
-      str.force_encoding("ASCII-8BIT")
-    end
+    str = "\x80".force_encoding("ASCII-8BIT")
 
     logger.add Logger::DEBUG, str
   ensure
@@ -51,10 +48,7 @@ class BufferedLoggerTest < Test::Unit::TestCase
     logger = Logger.new f
     logger.level = Logger::DEBUG
 
-    str = "\x80"
-    if str.respond_to?(:force_encoding)
-      str.force_encoding("ASCII-8BIT")
-    end
+    str = "\x80".force_encoding("ASCII-8BIT")
 
     logger.add Logger::DEBUG, str
   ensure
@@ -123,10 +117,7 @@ class BufferedLoggerTest < Test::Unit::TestCase
     @logger.info(UNICODE_STRING)
     @logger.info(BYTE_STRING)
     assert @output.string.include?(UNICODE_STRING)
-    byte_string = @output.string.dup
-    if byte_string.respond_to?(:force_encoding)
-      byte_string.force_encoding("ASCII-8BIT")
-    end
+    byte_string = @output.string.dup.force_encoding("ASCII-8BIT")
     assert byte_string.include?(BYTE_STRING)
   end
 end

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -91,11 +91,11 @@ class TestJSONEncoding < Test::Unit::TestCase
   def test_utf8_string_encoded_properly
     result = ActiveSupport::JSON.encode('€2.99')
     assert_equal '"\\u20ac2.99"', result
-    assert_equal(Encoding::UTF_8, result.encoding) if result.respond_to?(:encoding)
+    assert_equal(Encoding::UTF_8, result.encoding)
 
     result = ActiveSupport::JSON.encode('✎☺')
     assert_equal '"\\u270e\\u263a"', result
-    assert_equal(Encoding::UTF_8, result.encoding) if result.respond_to?(:encoding)
+    assert_equal(Encoding::UTF_8, result.encoding)
   end
 
   def test_non_utf8_string_transcodes

--- a/activesupport/test/multibyte_test_helpers.rb
+++ b/activesupport/test/multibyte_test_helpers.rb
@@ -3,10 +3,7 @@
 module MultibyteTestHelpers
   UNICODE_STRING = 'こにちわ'
   ASCII_STRING = 'ohayo'
-  BYTE_STRING = "\270\236\010\210\245"
-  if BYTE_STRING.respond_to?(:force_encoding)
-    BYTE_STRING.force_encoding("ASCII-8BIT")
-  end
+  BYTE_STRING = "\270\236\010\210\245".force_encoding("ASCII-8BIT")
 
   def chars(str)
     ActiveSupport::Multibyte::Chars.new(str)

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -137,7 +137,7 @@ module ApplicationTests
     end
 
     test "assignment config.encoding to default_charset" do
-      charset = "ruby".respond_to?(:force_encoding) ? 'Shift_JIS' : 'UTF8'
+      charset = 'Shift_JIS'
       add_to_config "config.encoding = '#{charset}'"
       require "#{app_path}/config/environment"
       assert_equal charset, ActionDispatch::Response.default_charset


### PR DESCRIPTION
I think that we don't need to call respond_to?(:force_encoding) method (and related) in ruby 1.9.
