### PR TITLE
Fix a fixtures test case with table prefix/suffix

### DIFF
--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1,31 +1,32 @@
-require "cases/helper"
-require 'models/post'
-require 'models/binary'
-require 'models/topic'
-require 'models/computer'
-require 'models/developer'
-require 'models/company'
-require 'models/task'
-require 'models/reply'
-require 'models/joke'
-require 'models/course'
-require 'models/category'
-require 'models/parrot'
-require 'models/pirate'
-require 'models/treasure'
-require 'models/traffic_light'
-require 'models/matey'
-require 'models/ship'
-require 'models/book'
+require 'cases/helper'
 require 'models/admin'
 require 'models/admin/account'
 require 'models/admin/user'
+require 'models/binary'
+require 'models/book'
+require 'models/category'
+require 'models/company'
+require 'models/computer'
+require 'models/course'
+require 'models/developer'
+require 'models/joke'
+require 'models/matey'
+require 'models/parrot'
+require 'models/pirate'
+require 'models/post'
+require 'models/reply'
+require 'models/ship'
+require 'models/task'
+require 'models/topic'
+require 'models/traffic_light'
+require 'models/treasure'
 require 'tempfile'
 
 class FixturesTest < ActiveRecord::TestCase
   self.use_instantiated_fixtures = true
   self.use_transactional_fixtures = false
 
+  # other_topics fixture should not be included here
   fixtures :topics, :developers, :accounts, :tasks, :categories, :funny_jokes, :binaries, :traffic_lights
 
   FIXTURES = %w( accounts binaries companies customers
@@ -93,7 +94,7 @@ class FixturesTest < ActiveRecord::TestCase
       # Reset cache to make finds on the new table work
       ActiveRecord::Fixtures.reset_cache
 
-      ActiveRecord::Base.connection.create_table :prefix_topics_suffix do |t|
+      ActiveRecord::Base.connection.create_table :prefix_other_topics_suffix do |t|
         t.column :title, :string
         t.column :author_name, :string
         t.column :author_email_address, :string
@@ -115,23 +116,35 @@ class FixturesTest < ActiveRecord::TestCase
       ActiveRecord::Base.table_name_prefix = 'prefix_'
       ActiveRecord::Base.table_name_suffix = '_suffix'
 
-      topics = create_fixtures("topics")
+      other_topic_klass = Class.new(ActiveRecord::Base) do
+        def self.name
+          "OtherTopic"
+        end
+      end
 
-      first_row = ActiveRecord::Base.connection.select_one("SELECT * FROM prefix_topics_suffix WHERE author_name = 'David'")
-      assert_equal("The First Topic", first_row["title"])
-
-      second_row = ActiveRecord::Base.connection.select_one("SELECT * FROM prefix_topics_suffix WHERE author_name = 'Mary'")
-      assert_nil(second_row["author_email_address"])
+      topics = create_fixtures("other_topics")
 
       # This checks for a caching problem which causes a bug in the fixtures
       # class-level configuration helper.
       assert_not_nil topics, "Fixture data inserted, but fixture objects not returned from create"
+
+      first_row = ActiveRecord::Base.connection.select_one("SELECT * FROM prefix_other_topics_suffix WHERE author_name = 'David'")
+      assert_equal("The First Topic", first_row["title"])
+
+      second_row = ActiveRecord::Base.connection.select_one("SELECT * FROM prefix_other_topics_suffix WHERE author_name = 'Mary'")
+      assert_nil(second_row["author_email_address"])
+
+      assert_equal "prefix_other_topics_suffix", ActiveRecord::Fixtures::all_loaded_fixtures["other_topics"].table_name
+      # This assertion should be the last in the list, because calling
+      # other_topic_klass.table_name sets a class-level instance variable
+      assert_equal "prefix_other_topics_suffix", other_topic_klass.table_name
+
     ensure
       # Restore prefix/suffix to its previous values
       ActiveRecord::Base.table_name_prefix = old_prefix
       ActiveRecord::Base.table_name_suffix = old_suffix
 
-      ActiveRecord::Base.connection.drop_table :prefix_topics_suffix rescue nil
+      ActiveRecord::Base.connection.drop_table :prefix_other_topics_suffix rescue nil
     end
   end
 

--- a/activerecord/test/fixtures/other_topics.yml
+++ b/activerecord/test/fixtures/other_topics.yml
@@ -1,0 +1,42 @@
+first:
+  id: 1
+  title: The First Topic
+  author_name: David
+  author_email_address: david@loudthinking.com
+  written_on: 2003-07-16t15:28:11.2233+01:00
+  last_read: 2004-04-15
+  bonus_time: 2005-01-30t15:28:00.00+01:00
+  content: Have a nice day
+  approved: false
+  replies_count: 1
+
+second:
+  id: 2
+  title: The Second Topic of the day
+  author_name: Mary
+  written_on: 2004-07-15t15:28:00.0099+01:00
+  content: Have a nice day
+  approved: true
+  replies_count: 0
+  parent_id: 1
+  type: Reply
+
+third:
+  id: 3
+  title: The Third Topic of the day
+  author_name: Carl
+  written_on: 2005-07-15t15:28:00.0099+01:00
+  content: I'm a troll
+  approved: true
+  replies_count: 1
+
+fourth:
+  id: 4
+  title: The Fourth Topic of the day
+  author_name: Carl
+  written_on: 2006-07-15t15:28:00.0099+01:00
+  content: Why not?
+  approved: true
+  type: Reply
+  parent_id: 3
+


### PR DESCRIPTION
Make sure the table name of a model is reset in a test case after assigning `ActiveRecord::Base.table_name_prefix` and `ActiveRecord::Base.table_name_suffix`.  Before this change, `Topic.table_name` would use the "memoized" value without prefix and suffix.

This change does not currently fix anything, but make the test case to test the right thing.  I plan to submit a patch to make fixtures use the table name defined in the associated model, and there this test would fail without this fix.

This was somebody else's test case, so an independent opinion on the change can be helpful.
