### PR TITLE
Action pack logger methods changed to active supoort Logger methods

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -76,7 +76,7 @@ module ActionDispatch
     end
 
     def stderr_logger
-      @stderr_logger ||= Logger.new($stderr)
+      @stderr_logger ||= ActiveSupport::Logger.new($stderr)
     end
   end
 end

--- a/actionpack/lib/action_dispatch/middleware/params_parser.rb
+++ b/actionpack/lib/action_dispatch/middleware/params_parser.rb
@@ -69,7 +69,7 @@ module ActionDispatch
       end
 
       def logger(env)
-        env['action_dispatch.logger'] || Logger.new($stderr)
+        env['action_dispatch.logger'] || ActiveSupport::Logger.new($stderr)
       end
   end
 end


### PR DESCRIPTION
Action pack logger methods changed to active support Logger methods (I am doing the small commits because shouldn't messed with others)
