### PR TITLE
remove autoload for deleted module

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -105,7 +105,6 @@ module ActiveRecord
       autoload :TimeZoneConversion
       autoload :Write
       autoload :Serialization
-      autoload :DeprecatedUnderscoreRead
     end
   end
 


### PR DESCRIPTION
railties tests fail because of it
