### PR TITLE
Remove sorting of hash keys since ruby 1.9 hash is ordered.

### DIFF
--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -671,7 +671,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_habtm_selects_all_columns_by_default
-    assert_equal Project.column_names.sort, developers(:david).projects.first.attributes.keys.sort
+    assert_equal Project.column_names, developers(:david).projects.first.attributes.keys
   end
 
   def test_habtm_respects_select_query_method

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -502,7 +502,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_default_select
-    assert_equal Comment.column_names.sort, posts(:welcome).comments.first.attributes.keys.sort
+    assert_equal Comment.column_names, posts(:welcome).comments.first.attributes.keys
   end
 
   def test_select_query_method


### PR DESCRIPTION
This is related to #3030 and basically just reverts 85f8458e1bd41dfa87b33eafc5e097deeb370f13.
