### PR TITLE
Reset postgreSQL search path in db:test:clone_structure.

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -387,6 +387,7 @@ db_namespace = namespace :db do
         end
         `pg_dump -i -s -x -O -f #{filename} #{search_path} #{abcs[Rails.env]['database']}`
         raise 'Error dumping database' if $?.exitstatus == 1
+        File.open(filename, "a") { |f| f << "SET search_path TO #{ActiveRecord::Base.connection.schema_search_path};\n\n" }
       when /sqlite/
         dbfile = abcs[Rails.env]['database']
         `sqlite3 #{dbfile} .schema > #{filename}`


### PR DESCRIPTION
This patch resets the postgres search path in the structure.sql after
the structure is dumped in order to find schema_migrations table when
multiples schemas are used.

Fixes #945

See also #1094. It was marked as merged (and closed) by github when in fact it wasn't. 
