### PR TITLE
deprecate Array#uniq_by and Array#uniq_by!

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/uniq_by.rb
+++ b/activesupport/lib/active_support/core_ext/array/uniq_by.rb
@@ -3,14 +3,16 @@ class Array
   #
   #   [1, 2, 3, 4].uniq_by { |i| i.odd? } # => [1, 2]
   #
-  def uniq_by
-    hash, array = {}, []
-    each { |i| hash[yield(i)] ||= (array << i) }
-    array
+  def uniq_by(&block)
+    ActiveSupport::Deprecation.warn "uniq_by " \
+      "is deprecated. Use Array#uniq instead", caller
+    uniq(&block)
   end
 
   # Same as uniq_by, but modifies self.
-  def uniq_by!
-    replace(uniq_by{ |i| yield(i) })
+  def uniq_by!(&block)
+    ActiveSupport::Deprecation.warn "uniq_by! " \
+      "is deprecated. Use Array#uniq! instead", caller
+    uniq!(&block)
   end
 end

--- a/activesupport/test/core_ext/array_ext_test.rb
+++ b/activesupport/test/core_ext/array_ext_test.rb
@@ -343,22 +343,30 @@ end
 
 class ArrayUniqByTests < Test::Unit::TestCase
   def test_uniq_by
-    assert_equal [1,2], [1,2,3,4].uniq_by { |i| i.odd? }
-    assert_equal [1,2], [1,2,3,4].uniq_by(&:even?)
-    assert_equal((-5..0).to_a, (-5..5).to_a.uniq_by{ |i| i**2 })
+    ActiveSupport::Deprecation.silence do
+      assert_equal [1,2], [1,2,3,4].uniq_by { |i| i.odd? }
+      assert_equal [1,2], [1,2,3,4].uniq_by(&:even?)
+      assert_equal((-5..0).to_a, (-5..5).to_a.uniq_by{ |i| i**2 })
+    end
   end
 
   def test_uniq_by!
     a = [1,2,3,4]
-    a.uniq_by! { |i| i.odd? }
+    ActiveSupport::Deprecation.silence do
+      a.uniq_by! { |i| i.odd? }
+    end
     assert_equal [1,2], a
 
     a = [1,2,3,4]
-    a.uniq_by! { |i| i.even? }
+    ActiveSupport::Deprecation.silence do
+      a.uniq_by! { |i| i.even? }
+    end
     assert_equal [1,2], a
 
     a = (-5..5).to_a
-    a.uniq_by! { |i| i**2 }
+    ActiveSupport::Deprecation.silence do
+      a.uniq_by! { |i| i**2 }
+    end
     assert_equal((-5..0).to_a, a)
   end
 end


### PR DESCRIPTION
deprecate Array#uniq_by and Array#uniq_by! in favor of Array#uniq and Array#uniq! from ruby 1.9
