### PR TITLE
has_secure_password allows saving of a new password even when password_confirmation is nil

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -40,6 +40,8 @@ module ActiveModel
         attr_reader :password
 
         validates_confirmation_of :password
+        validates                 :password_confirmation, :presence => true,
+                                                          :if       => :password_digest_changed?
         validates_presence_of     :password_digest
 
         include InstanceMethodsOnActivation

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -5,8 +5,22 @@ require 'models/administrator'
 
 class SecurePasswordTest < ActiveModel::TestCase
 
+  class DirtyUser < User
+    include ActiveModel::Dirty
+    define_attribute_methods [:password_digest]
+
+    def password_digest
+      @password_digest
+    end
+
+    def password_digest=(val)
+      password_digest_will_change! unless @password_digest == val
+      @password_digest = val
+    end
+  end
+
   setup do
-    @user = User.new
+    @user = DirtyUser.new
   end
 
   test "blank password" do
@@ -22,6 +36,12 @@ class SecurePasswordTest < ActiveModel::TestCase
   test "password must be present" do
     assert !@user.valid?
     assert_equal 1, @user.errors.size
+  end
+
+  test "password confirmation must be present" do
+    @user.password = "thiswillberight"
+    @user.password_confirmation = nil
+    assert !@user.valid?, 'user should be invalid'
   end
 
   test "password must match confirmation" do


### PR DESCRIPTION
Here's the setup:
The schema is a User model with fields first_name:string, last_name:string, email:string, password_digest:string.
The User model has_secure_password.  It also specifies attr_accessible :password, :password_confirmation.

I can then do the following at the console:

```
1.9.2p290 :069 > u = User.create! :first_name => 'Foo', :last_name => 'Bar', :email => 'foobar@foobar.com', :password => 'foobar', :password_confirmation => 'foobar'
   (0.2ms)  SELECT 1 FROM "users" WHERE LOWER("users"."email") = LOWER('foobar@foobar.com') LIMIT 1
Binary data inserted for `string` type on column `password_digest`
  SQL (0.8ms)  INSERT INTO "users" ("created_at", "email", "first_name", "last_name", "password_digest", "updated_at") VALUES (?, ?, ?, ?, ?, ?)  [["created_at", Fri, 23 Dec 2011 12:04:24 UTC +00:00], ["email", "foobar@foobar.com"], ["first_name", "Foo"], ["last_name", "Bar"], ["password_digest", "$2a$10$3DiPzn9jPi.7hHMc82NsmOnh.I88F0jufbtxR4zyllWh.MGH97O2y"], ["updated_at", Fri, 23 Dec 2011 12:04:24 UTC +00:00]]
 => #<User id: 4, created_at: "2011-12-23 12:04:24", updated_at: "2011-12-23 12:04:24", first_name: "Foo", last_name: "Bar", email: "foobar@foobar.com", password_digest: "$2a$10$3DiPzn9jPi.7hHMc82NsmOnh.I88F0jufbtxR4zyllWh..."> 

1.9.2p290 :070 > u = User.find(4)
  User Load (0.3ms)  SELECT "users".* FROM "users" WHERE "users"."id" = ? LIMIT 1  [["id", 4]]
 => #<User id: 4, created_at: "2011-12-23 12:04:24", updated_at: "2011-12-23 12:04:24", first_name: "Foo", last_name: "Bar", email: "foobar@foobar.com", password_digest: "$2a$10$3DiPzn9jPi.7hHMc82NsmOnh.I88F0jufbtxR4zyllWh..."> 

1.9.2p290 :071 > u.password = 'foofoo'
 => "foofoo" 

1.9.2p290 :072 > u.password
 => "foofoo" 

1.9.2p290 :073 > u.password_confirmation
 => nil 

1.9.2p290 :074 > u.password_digest_changed?
 => true 

1.9.2p290 :075 > u.save!
   (0.2ms)  SELECT 1 FROM "users" WHERE (LOWER("users"."email") = LOWER('foobar@foobar.com') AND "users"."id" != 4) LIMIT 1
   (0.4ms)  UPDATE "users" SET "password_digest" = '$2a$10$qjkWkaGYgRH9EogPsj/3AOM3/NiuQrAd79V4THCzqyWxxBhsFTVVS', "updated_at" = '2011-12-23 12:04:44.189911' WHERE "users"."id" = 4
 => true
```

This seems like a bug to me.  has_secure_password should, as I understand it, validate the presence of both password and password_confirmation before saving a new value of password_digest.  Even if the presence of password_confirmation is not explicitly validated, the presence of a password is validated and the matching of password and password_confirmation is validated, so allowing a non-nil password with a nil password_confirmation seems like a bug.

Let me know if I'm thinking about this the wrong way.
