### PR TITLE
remove Rails application fallback from AD::IntegrationTest

### DIFF
--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -29,6 +29,7 @@ $:.unshift(activemodel_path) if File.directory?(activemodel_path) && !$:.include
 
 require 'active_support'
 require 'active_support/dependencies/autoload'
+require 'active_support/core_ext/module/attribute_accessors'
 
 require 'action_pack'
 require 'active_model'
@@ -87,6 +88,8 @@ module ActionDispatch
     autoload :MemCacheStore, 'action_dispatch/middleware/session/mem_cache_store'
     autoload :CacheStore,    'action_dispatch/middleware/session/cache_store'
   end
+
+  mattr_accessor :test_app
 
   autoload_under 'testing' do
     autoload :Assertions

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -28,6 +28,8 @@ module ActionDispatch
 
       config.action_dispatch.always_write_cookie = Rails.env.development? if config.action_dispatch.always_write_cookie.nil?
       ActionDispatch::Cookies::CookieJar.always_write_cookie = config.action_dispatch.always_write_cookie
+
+      ActionDispatch.test_app = app
     end
   end
 end

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -463,9 +463,12 @@ module ActionDispatch
     @@app = nil
 
     def self.app
-      # DEPRECATE Rails application fallback
-      # This should be set by the initializer
-      @@app || (defined?(Rails.application) && Rails.application) || nil
+      if !@@app && !ActionDispatch.test_app
+        ActiveSupport::Deprecation.warn "Rails application fallback is deprecated " \
+          "and no longer works, please set ActionDispatch.test_app", caller
+      end
+
+      @@app || ActionDispatch.test_app
     end
 
     def self.app=(app)

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -282,6 +282,11 @@ module ApplicationTests
       assert_equal res, last_response.body # value should be unchanged
     end
 
+    test "sets ActionDispatch.test_app" do
+      make_basic_app
+      assert_equal Rails.application, ActionDispatch.test_app
+    end
+
     test "sets all Active Record models to whitelist all attributes by default" do
       add_to_config <<-RUBY
         config.active_record.whitelist_attributes = true


### PR DESCRIPTION
set AD::IntegrationTest.app in railtie initializer
