### PR TITLE
Change mysql2 wait_timeout default value to avoid exceeding the max value allowed by MySQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -274,7 +274,7 @@ module ActiveRecord
 
         # increase timeout so mysql server doesn't disconnect us
         wait_timeout = @config[:wait_timeout]
-        wait_timeout = 2592000 unless wait_timeout.is_a?(Fixnum)
+        wait_timeout = 2147483 unless wait_timeout.is_a?(Fixnum) && wait_timeout < 2147484
         variable_assignments << "@@wait_timeout = #{wait_timeout}"
 
         execute("SET #{variable_assignments.join(', ')}", :skip_logging)


### PR DESCRIPTION
I had some trouble with the mysql2 gem and my remote database : it kept losing the connection (`Mysql2::Error: MySQL server has gone away`). I discovered that the default time_out value set by activerecord for mysql2 [2592000](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#LC277) exceed the max value allowed by MySQL : [2147483](http://dev.mysql.com/doc/refman/5.0/en/server-system-variables.html#sysvar_wait_timeout). Perhaps it should cap it to this max value...

It's my very first pull request so be indulgent if I don't respect some basic rules I may not know...

Everything is explained here :
http://stackoverflow.com/questions/8610426/rails-3-1-mysql2-error-mysql-server-has-gone-away/8617733#8617733
https://github.com/brianmario/mysql2/issues/213

Julien
