### PR TITLE
remove ruby 1.8 stuff method skip to support ruby 1.8 series

### DIFF
--- a/activerecord/lib/active_record/test_case.rb
+++ b/activerecord/lib/active_record/test_case.rb
@@ -13,13 +13,6 @@ module ActiveRecord
       ActiveRecord::IdentityMap.clear
     end
 
-    # Backport skip to Ruby 1.8. test/unit doesn't support it, so just
-    # make it a noop.
-    unless instance_methods.map(&:to_s).include?("skip")
-      def skip(message)
-      end
-    end
-
     def assert_date_from_db(expected, actual, message = nil)
       # SybaseAdapter doesn't have a separate column type just for dates,
       # so the time is in the string and incorrectly formatted


### PR DESCRIPTION
remove ruby 1.8 stuff method skip to support ruby 1.8 series
