### PR TITLE
Fix a fixtures test case with table prefix/suffix

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -486,8 +486,8 @@ module ActiveRecord
 
             # Cap primary key sequences to max(pk).
             if connection.respond_to?(:reset_pk_sequence!)
-              table_names.each do |table_name|
-                connection.reset_pk_sequence!(table_name.tr('/', '_'))
+              fixture_files.each do |ff|
+                connection.reset_pk_sequence!(ff.table_name)
               end
             end
           end

--- a/activerecord/test/fixtures/other_topics.yml
+++ b/activerecord/test/fixtures/other_topics.yml
@@ -1,0 +1,42 @@
+first:
+  id: 1
+  title: The First Topic
+  author_name: David
+  author_email_address: david@loudthinking.com
+  written_on: 2003-07-16t15:28:11.2233+01:00
+  last_read: 2004-04-15
+  bonus_time: 2005-01-30t15:28:00.00+01:00
+  content: Have a nice day
+  approved: false
+  replies_count: 1
+
+second:
+  id: 2
+  title: The Second Topic of the day
+  author_name: Mary
+  written_on: 2004-07-15t15:28:00.0099+01:00
+  content: Have a nice day
+  approved: true
+  replies_count: 0
+  parent_id: 1
+  type: Reply
+
+third:
+  id: 3
+  title: The Third Topic of the day
+  author_name: Carl
+  written_on: 2005-07-15t15:28:00.0099+01:00
+  content: I'm a troll
+  approved: true
+  replies_count: 1
+
+fourth:
+  id: 4
+  title: The Fourth Topic of the day
+  author_name: Carl
+  written_on: 2006-07-15t15:28:00.0099+01:00
+  content: Why not?
+  approved: true
+  type: Reply
+  parent_id: 3
+


### PR DESCRIPTION
Make sure the table name of a model is reset in a test case after assigning `ActiveRecord::Base.table_name_prefix` and `ActiveRecord::Base.table_name_suffix`.  Before this change, `Topic.table_name` would use the "memoized" value without prefix and suffix.

This change does not currently fix anything, but make the test case to test the right thing.  I plan to submit a patch to make fixtures use the table name defined in the associated model, and there this test would fail without this fix.
