### PR TITLE
Fixing a schema:load when using a prefix and suffix on the tables

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -442,7 +442,7 @@ module ActiveRecord
 
       say_with_time "#{method}(#{arg_list})" do
         unless arguments.empty? || method == :execute
-          arguments[0] = Migrator.proper_table_name(arguments.first)
+          arguments[0] = Migrator.proper_table_name(arguments.first) unless method == :assume_migrated_upto_version
           arguments[1] = Migrator.proper_table_name(arguments.second) if method == :rename_table
         end
         return super unless connection.respond_to?(method)

--- a/activerecord/test/cases/ar_schema_test.rb
+++ b/activerecord/test/cases/ar_schema_test.rb
@@ -11,21 +11,28 @@ if ActiveRecord::Base.connection.supports_migrations?
 
     def teardown
       @connection.drop_table :fruits rescue nil
+      @connection.drop_table "_pre_fruits_suf_" rescue nil
     end
 
     def test_schema_define
-      ActiveRecord::Schema.define(:version => 7) do
-        create_table :fruits do |t|
-          t.column :color, :string
-          t.column :fruit_size, :string  # NOTE: "size" is reserved in Oracle
-          t.column :texture, :string
-          t.column :flavor, :string
-        end
-      end
+      perform_schema_define!
 
       assert_nothing_raised { @connection.select_all "SELECT * FROM fruits" }
       assert_nothing_raised { @connection.select_all "SELECT * FROM schema_migrations" }
       assert_equal 7, ActiveRecord::Migrator::current_version
+    end
+
+    def test_schema_define_with_table_prefix_and_suffix
+      ActiveRecord::Base.table_name_prefix = "_pre_"
+      ActiveRecord::Base.table_name_suffix = "_suf_"
+
+      perform_schema_define!
+
+      assert_equal 7, ActiveRecord::Migrator::current_version
+
+    ensure
+      ActiveRecord::Base.table_name_prefix = ""
+      ActiveRecord::Base.table_name_suffix = ""
     end
 
     def test_schema_raises_an_error_for_invalid_column_type
@@ -37,6 +44,18 @@ if ActiveRecord::Base.connection.supports_migrations?
         end
       end
     end
+
+    private
+      def perform_schema_define!
+        ActiveRecord::Schema.define(:version => 7) do
+          create_table :fruits do |t|
+            t.column :color, :string
+            t.column :fruit_size, :string  # NOTE: "size" is reserved in Oracle
+            t.column :texture, :string
+            t.column :flavor, :string
+          end
+        end
+      end
   end
 
 end


### PR DESCRIPTION
In the cases where one wants to work with schemas in their databases, they would want to load the schema file on each schema to keep it up to date.  Since the ConnectionAdapter#table_exists? method disregards the schema_search_path, we must alter ActiveRecord::Base#table_name_prefix to include the proper scoping.  Doing this works up until the point of updating the schema_migrations table when assuming the new version.  

This bug occurs because when assume_migration_upto_version goes through Migration's method_missing, it appends the table_name_prefix to the version number. Eg, when arriving at the assume_migration_upto_version, the version number is "schema.#####".  The next step in the line is to turn that number into an integer, which is always 0 since it is a string.  This makes the version in the schema_migrations table on that schema equal to 0 and not the correct value in the schema file.

This fix patches that in the method missing so that we do not munge the number.

cbarton
