### PR TITLE
deprecate String#encoding_aware? and remove its usage

### DIFF
--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -13,14 +13,11 @@ end
 
 require 'active_support/core_ext/kernel/reporting'
 
-require 'active_support/core_ext/string/encoding'
-if "ruby".encoding_aware?
-  # These are the normal settings that will be set up by Railties
-  # TODO: Have these tests support other combinations of these values
-  silence_warnings do
-    Encoding.default_internal = "UTF-8"
-    Encoding.default_external = "UTF-8"
-  end
+# These are the normal settings that will be set up by Railties
+# TODO: Have these tests support other combinations of these values
+silence_warnings do
+  Encoding.default_internal = "UTF-8"
+  Encoding.default_external = "UTF-8"
 end
 
 lib = File.expand_path("#{File.dirname(__FILE__)}/../lib")

--- a/actionpack/lib/action_controller/vendor/html-scanner/html/tokenizer.rb
+++ b/actionpack/lib/action_controller/vendor/html-scanner/html/tokenizer.rb
@@ -23,7 +23,7 @@ module HTML #:nodoc:
 
     # Create a new Tokenizer for the given text.
     def initialize(text)
-      text.encode! if text.encoding_aware?
+      text.encode!
       @scanner = StringScanner.new(text)
       @position = 0
       @line = 0

--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -41,8 +41,6 @@ module ActionDispatch
       # you'll get a weird error down the road, but our form handling
       # should really prevent that from happening
       def encode_params(params)
-        return params unless "ruby".encoding_aware?
-
         if params.is_a?(String)
           return params.force_encoding("UTF-8").encode!
         elsif !params.is_a?(Hash)

--- a/actionpack/lib/action_dispatch/http/upload.rb
+++ b/actionpack/lib/action_dispatch/http/upload.rb
@@ -22,8 +22,8 @@ module ActionDispatch
       
       private
       def encode_filename(filename)
-        # Encode the filename in the utf8 encoding, unless it is nil or we're in 1.8
-        if "ruby".encoding_aware? && filename
+        # Encode the filename in the utf8 encoding, unless it is nil
+        if filename
           filename.force_encoding("UTF-8").encode!
         else
           filename

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -584,7 +584,7 @@ module ActionDispatch
         @router.recognize(req) do |route, matches, params|
           params.each do |key, value|
             if value.is_a?(String)
-              value = value.dup.force_encoding(Encoding::BINARY) if value.encoding_aware?
+              value = value.dup.force_encoding(Encoding::BINARY)
               params[key] = URI.parser.unescape(value)
             end
           end

--- a/actionpack/lib/action_view/buffers.rb
+++ b/actionpack/lib/action_view/buffers.rb
@@ -4,7 +4,7 @@ module ActionView
   class OutputBuffer < ActiveSupport::SafeBuffer #:nodoc:
     def initialize(*)
       super
-      encode! if encoding_aware?
+      encode!
     end
 
     def <<(value)

--- a/actionpack/lib/action_view/helpers/javascript_helper.rb
+++ b/actionpack/lib/action_view/helpers/javascript_helper.rb
@@ -14,11 +14,7 @@ module ActionView
         "'"     => "\\'"
       }
 
-      if "ruby".encoding_aware?
-        JS_ESCAPE_MAP["\342\200\250".force_encoding('UTF-8').encode!] = '&#x2028;'
-      else
-        JS_ESCAPE_MAP["\342\200\250"] = '&#x2028;'
-      end
+      JS_ESCAPE_MAP["\342\200\250".force_encoding('UTF-8').encode!] = '&#x2028;'
 
       # Escapes carriage returns and single and double quotes for JavaScript segments.
       #

--- a/actionpack/lib/action_view/template.rb
+++ b/actionpack/lib/action_view/template.rb
@@ -184,7 +184,7 @@ module ActionView
     # before passing the source on to the template engine, leaving a
     # blank line in its stead.
     def encode!
-      return unless source.encoding_aware? && source.encoding == Encoding::BINARY
+      return unless source.encoding == Encoding::BINARY
 
       # Look for # encoding: *. If we find one, we'll encode the
       # String in that encoding, otherwise, we'll use the
@@ -265,20 +265,18 @@ module ActionView
           end
         end_src
 
-        if source.encoding_aware?
-          # Make sure the source is in the encoding of the returned code
-          source.force_encoding(code.encoding)
+        # Make sure the source is in the encoding of the returned code
+        source.force_encoding(code.encoding)
 
-          # In case we get back a String from a handler that is not in
-          # BINARY or the default_internal, encode it to the default_internal
-          source.encode!
+        # In case we get back a String from a handler that is not in
+        # BINARY or the default_internal, encode it to the default_internal
+        source.encode!
 
-          # Now, validate that the source we got back from the template
-          # handler is valid in the default_internal. This is for handlers
-          # that handle encoding but screw up
-          unless source.valid_encoding?
-            raise WrongEncodingError.new(@source, Encoding.default_internal)
-          end
+        # Now, validate that the source we got back from the template
+        # handler is valid in the default_internal. This is for handlers
+        # that handle encoding but screw up
+        unless source.valid_encoding?
+          raise WrongEncodingError.new(@source, Encoding.default_internal)
         end
 
         begin

--- a/actionpack/lib/action_view/template/handlers/erb.rb
+++ b/actionpack/lib/action_view/template/handlers/erb.rb
@@ -67,23 +67,19 @@ module ActionView
         end
 
         def call(template)
-          if template.source.encoding_aware?
-            # First, convert to BINARY, so in case the encoding is
-            # wrong, we can still find an encoding tag
-            # (<%# encoding %>) inside the String using a regular
-            # expression
-            template_source = template.source.dup.force_encoding("BINARY")
+          # First, convert to BINARY, so in case the encoding is
+          # wrong, we can still find an encoding tag
+          # (<%# encoding %>) inside the String using a regular
+          # expression
+          template_source = template.source.dup.force_encoding("BINARY")
 
-            erb = template_source.gsub(ENCODING_TAG, '')
-            encoding = $2
+          erb = template_source.gsub(ENCODING_TAG, '')
+          encoding = $2
 
-            erb.force_encoding valid_encoding(template.source.dup, encoding)
+          erb.force_encoding valid_encoding(template.source.dup, encoding)
 
-            # Always make sure we return a String in the default_internal
-            erb.encode!
-          else
-            erb = template.source.dup
-          end
+          # Always make sure we return a String in the default_internal
+          erb.encode!
 
           self.class.erb_implementation.new(
             erb,

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -14,14 +14,11 @@ ENV['TMPDIR'] = File.join(File.dirname(__FILE__), 'tmp')
 
 require 'active_support/core_ext/kernel/reporting'
 
-require 'active_support/core_ext/string/encoding'
-if "ruby".encoding_aware?
-  # These are the normal settings that will be set up by Railties
-  # TODO: Have these tests support other combinations of these values
-  silence_warnings do
-    Encoding.default_internal = "UTF-8"
-    Encoding.default_external = "UTF-8"
-  end
+# These are the normal settings that will be set up by Railties
+# TODO: Have these tests support other combinations of these values
+silence_warnings do
+  Encoding.default_internal = "UTF-8"
+  Encoding.default_external = "UTF-8"
 end
 
 require 'test/unit'

--- a/actionpack/test/dispatch/request/url_encoded_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/url_encoded_params_parsing_test.rb
@@ -146,8 +146,6 @@ class UrlEncodedParamsParsingTest < ActionDispatch::IntegrationTest
     end
 
     def assert_utf8(object)
-      return unless "ruby".encoding_aware?
-
       correct_encoding = Encoding.default_internal
 
       unless object.is_a?(Hash)

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -6,9 +6,6 @@ class ResponseTest < ActiveSupport::TestCase
   end
 
   def test_response_body_encoding
-    # FIXME: remove this conditional on Rails 4.0
-    return unless "<3".encoding_aware?
-
     body = ["hello".encode('utf-8')]
     response = ActionDispatch::Response.new 200, {}, body
     assert_equal Encoding::UTF_8, response.body.encoding

--- a/actionpack/test/dispatch/uploaded_file_test.rb
+++ b/actionpack/test/dispatch/uploaded_file_test.rb
@@ -13,11 +13,9 @@ module ActionDispatch
       assert_equal 'foo', uf.original_filename
     end
     
-    if "ruby".encoding_aware?
-      def test_filename_should_be_in_utf_8
-        uf = Http::UploadedFile.new(:filename => 'foo', :tempfile => Object.new)
-        assert_equal "UTF-8", uf.original_filename.encoding.to_s
-      end
+    def test_filename_should_be_in_utf_8
+      uf = Http::UploadedFile.new(:filename => 'foo', :tempfile => Object.new)
+      assert_equal "UTF-8", uf.original_filename.encoding.to_s
     end
 
     def test_content_type

--- a/actionpack/test/template/javascript_helper_test.rb
+++ b/actionpack/test/template/javascript_helper_test.rb
@@ -28,11 +28,7 @@ class JavaScriptHelperTest < ActionView::TestCase
     assert_equal %(This \\"thing\\" is really\\n netos\\'), escape_javascript(%(This "thing" is really\n netos'))
     assert_equal %(backslash\\\\test), escape_javascript( %(backslash\\test) )
     assert_equal %(dont <\\/close> tags), escape_javascript(%(dont </close> tags))
-    if "ruby".encoding_aware?
-      assert_equal %(unicode &#x2028; newline), escape_javascript(%(unicode \342\200\250 newline).force_encoding('UTF-8').encode!)
-    else
-      assert_equal %(unicode &#x2028; newline), escape_javascript(%(unicode \342\200\250 newline))
-    end
+    assert_equal %(unicode &#x2028; newline), escape_javascript(%(unicode \342\200\250 newline).force_encoding('UTF-8').encode!)
     assert_equal %(dont <\\/close> tags), j(%(dont </close> tags))
   end
 

--- a/actionpack/test/template/template_test.rb
+++ b/actionpack/test/template/template_test.rb
@@ -114,67 +114,65 @@ class TestERBTemplate < ActiveSupport::TestCase
     end
   end
 
-  if "ruby".encoding_aware?
-    def test_resulting_string_is_utf8
-      @template = new_template
-      assert_equal Encoding::UTF_8, render.encoding
-    end
+  def test_resulting_string_is_utf8
+    @template = new_template
+    assert_equal Encoding::UTF_8, render.encoding
+  end
 
-    def test_no_magic_comment_word_with_utf_8
-      @template = new_template("hello \u{fc}mlat")
+  def test_no_magic_comment_word_with_utf_8
+    @template = new_template("hello \u{fc}mlat")
+    assert_equal Encoding::UTF_8, render.encoding
+    assert_equal "hello \u{fc}mlat", render
+  end
+
+  # This test ensures that if the default_external
+  # is set to something other than UTF-8, we don't
+  # get any errors and get back a UTF-8 String.
+  def test_default_external_works
+    with_external_encoding "ISO-8859-1" do
+      @template = new_template("hello \xFCmlat")
       assert_equal Encoding::UTF_8, render.encoding
       assert_equal "hello \u{fc}mlat", render
     end
+  end
 
-    # This test ensures that if the default_external
-    # is set to something other than UTF-8, we don't
-    # get any errors and get back a UTF-8 String.
-    def test_default_external_works
-      with_external_encoding "ISO-8859-1" do
-        @template = new_template("hello \xFCmlat")
-        assert_equal Encoding::UTF_8, render.encoding
-        assert_equal "hello \u{fc}mlat", render
-      end
+  def test_encoding_can_be_specified_with_magic_comment
+    @template = new_template("# encoding: ISO-8859-1\nhello \xFCmlat")
+    assert_equal Encoding::UTF_8, render.encoding
+    assert_equal "\nhello \u{fc}mlat", render
+  end
+
+  # TODO: This is currently handled inside ERB. The case of explicitly
+  # lying about encodings via the normal Rails API should be handled
+  # inside Rails.
+  def test_lying_with_magic_comment
+    assert_raises(ActionView::Template::Error) do
+      @template = new_template("# encoding: UTF-8\nhello \xFCmlat", :virtual_path => nil)
+      render
     end
+  end
 
-    def test_encoding_can_be_specified_with_magic_comment
-      @template = new_template("# encoding: ISO-8859-1\nhello \xFCmlat")
+  def test_encoding_can_be_specified_with_magic_comment_in_erb
+    with_external_encoding Encoding::UTF_8 do
+      @template = new_template("<%# encoding: ISO-8859-1 %>hello \xFCmlat", :virtual_path => nil)
       assert_equal Encoding::UTF_8, render.encoding
-      assert_equal "\nhello \u{fc}mlat", render
+      assert_equal "hello \u{fc}mlat", render
     end
+  end
 
-    # TODO: This is currently handled inside ERB. The case of explicitly
-    # lying about encodings via the normal Rails API should be handled
-    # inside Rails.
-    def test_lying_with_magic_comment
-      assert_raises(ActionView::Template::Error) do
-        @template = new_template("# encoding: UTF-8\nhello \xFCmlat", :virtual_path => nil)
-        render
-      end
+  def test_error_when_template_isnt_valid_utf8
+    assert_raises(ActionView::Template::Error, /\xFC/) do
+      @template = new_template("hello \xFCmlat", :virtual_path => nil)
+      render
     end
+  end
 
-    def test_encoding_can_be_specified_with_magic_comment_in_erb
-      with_external_encoding Encoding::UTF_8 do
-        @template = new_template("<%# encoding: ISO-8859-1 %>hello \xFCmlat", :virtual_path => nil)
-        assert_equal Encoding::UTF_8, render.encoding
-        assert_equal "hello \u{fc}mlat", render
-      end
-    end
-
-    def test_error_when_template_isnt_valid_utf8
-      assert_raises(ActionView::Template::Error, /\xFC/) do
-        @template = new_template("hello \xFCmlat", :virtual_path => nil)
-        render
-      end
-    end
-
-    def with_external_encoding(encoding)
-      old = Encoding.default_external
-      Encoding::Converter.new old, encoding if old != encoding
-      silence_warnings { Encoding.default_external = encoding }
-      yield
-    ensure
-      silence_warnings { Encoding.default_external = old }
-    end
+  def with_external_encoding(encoding)
+    old = Encoding.default_external
+    Encoding::Converter.new old, encoding if old != encoding
+    silence_warnings { Encoding.default_external = encoding }
+    yield
+  ensure
+    silence_warnings { Encoding.default_external = old }
   end
 end

--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -60,8 +60,6 @@ module ActiveModel
         if value.kind_of?(String)
           if options[:tokenizer]
             options[:tokenizer].call(value)
-          elsif !value.encoding_aware?
-            value.mb_chars
           end
         end || value
       end

--- a/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
@@ -201,25 +201,17 @@ module ActiveRecord
         end
       end
 
-      if "<3".encoding_aware?
-        def type_cast(value, column) # :nodoc:
-          return value.to_f if BigDecimal === value
-          return super unless String === value
-          return super unless column && value
+      def type_cast(value, column) # :nodoc:
+        return value.to_f if BigDecimal === value
+        return super unless String === value
+        return super unless column && value
 
-          value = super
-          if column.type == :string && value.encoding == Encoding::ASCII_8BIT
-            @logger.error "Binary data inserted for `string` type on column `#{column.name}`"
-            value.encode! 'utf-8'
-          end
-          value
+        value = super
+        if column.type == :string && value.encoding == Encoding::ASCII_8BIT
+          @logger.error "Binary data inserted for `string` type on column `#{column.name}`"
+          value.encode! 'utf-8'
         end
-      else
-        def type_cast(value, column) # :nodoc:
-          return super unless BigDecimal === value
-
-          value.to_f
-        end
+        value
       end
 
       # DATABASE STATEMENTS ======================================

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -23,8 +23,6 @@ module ActiveRecord
       end
 
       def test_column_types
-        return skip('only test encoding on 1.9') unless "<3".encoding_aware?
-
         owner = Owner.create!(:name => "hello".encode('ascii-8bit'))
         owner.reload
         select = Owner.columns.map { |c| "typeof(#{c.name})" }.join ', '

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -13,10 +13,8 @@ class SchemaDumperTest < ActiveRecord::TestCase
     @stream.string
   end
 
-  if "string".encoding_aware?
-    def test_magic_comment
-      assert_match "# encoding: #{@stream.external_encoding.name}", standard_dump
-    end
+  def test_magic_comment
+    assert_match "# encoding: #{@stream.external_encoding.name}", standard_dump
   end
 
   def test_schema_dump

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -165,7 +165,7 @@ module ActiveSupport
         # characters properly.
         def escape_key(key)
           key = key.to_s.dup
-          key = key.force_encoding("BINARY") if key.encoding_aware?
+          key = key.force_encoding("BINARY")
           key = key.gsub(ESCAPE_KEY_CHARS){ |match| "%#{match.getbyte(0).to_s(16).upcase}" }
           key = "#{key[0, 213]}:md5:#{Digest::MD5.hexdigest(key)}" if key.size > 250
           key

--- a/activesupport/lib/active_support/core_ext/string/encoding.rb
+++ b/activesupport/lib/active_support/core_ext/string/encoding.rb
@@ -1,5 +1,8 @@
+require 'active_support/deprecation'
+
 class String
   def encoding_aware?
+    ActiveSupport::Deprecation.warn 'String#encoding_aware? is deprecated', caller
     true
   end
 end

--- a/activesupport/lib/active_support/gzip.rb
+++ b/activesupport/lib/active_support/gzip.rb
@@ -8,7 +8,7 @@ module ActiveSupport
     class Stream < StringIO
       def initialize(*)
         super
-        set_encoding "BINARY" if "".encoding_aware?
+        set_encoding "BINARY"
       end
       def close; rewind; end
     end

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -445,7 +445,9 @@ class OutputSafetyTest < ActiveSupport::TestCase
   end
 
   test 'knows whether it is encoding aware' do
-    assert 'ruby'.encoding_aware?
+    assert_deprecated do
+      assert 'ruby'.encoding_aware?
+    end
   end
 
   test "call to_param returns a normal string" do

--- a/activesupport/test/gzip_test.rb
+++ b/activesupport/test/gzip_test.rb
@@ -9,10 +9,7 @@ class GzipTest < Test::Unit::TestCase
   def test_compress_should_return_a_binary_string
     compressed = ActiveSupport::Gzip.compress('')
 
-    if "".encoding_aware?
-      assert_equal Encoding.find('binary'), compressed.encoding
-    end
-
+    assert_equal Encoding.find('binary'), compressed.encoding
     assert !compressed.blank?, "a compressed blank string should not be blank"
   end
 end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -65,17 +65,9 @@ module Rails
 
       def encoding=(value)
         @encoding = value
-        if "ruby".encoding_aware?
-          silence_warnings do
-            Encoding.default_external = value
-            Encoding.default_internal = value
-          end
-        else
-          $KCODE = value
-          if $KCODE == "NONE"
-            raise "The value you specified for config.encoding is " \
-                  "invalid. The possible values are UTF8, SJIS, or EUC"
-          end
+        silence_warnings do
+          Encoding.default_external = value
+          Encoding.default_internal = value
         end
       end
 


### PR DESCRIPTION
Discussion https://groups.google.com/forum/#!topic/rubyonrails-core/i-3nkLB2EDQ
