### PR TITLE
Add parameter to #classify singular table names

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -133,9 +133,11 @@ module ActiveSupport
     #
     # Singular names are not handled correctly:
     #   "business".classify     # => "Busines"
-    def classify(table_name)
+    def classify(table_name, singular = false)
       # strip out any leading schema name
-      camelize(singularize(table_name.to_s.sub(/.*\./, '')))
+      underscored_name = table_name.to_s.sub(/.*\./, '')
+      underscored_name = singularize(underscored_name) unless singular
+      camelize(underscored_name)
     end
 
     # Replaces underscores with dashes in the string.


### PR DESCRIPTION
Allow `ActiveSupport::Inflector.classify` to treat singular table names by adding a parameter `singular` with default value `false`:

``` ruby
def classify(table_name, singular = false)
  # strip out any leading schema name
  underscored_name = table_name.to_s.sub(/.*\./, '')
  underscored_name = singularize(underscored_name) unless singular
  camelize(underscored_name)
end
```

See
https://github.com/rails/rails/blob/a5fa310f406e299a1ac54d1a227bde93b7ce282b/activesupport/lib/active_support/core_ext/string/inflections.rb#L175-177
and a possible use of this in
https://github.com/rails/rails/blob/a5fa310f406e299a1ac54d1a227bde93b7ce282b/activerecord/lib/active_record/fixtures.rb#L391-395
