### PR TITLE
Notify A User they Have Pending Migrations On Specific Exceptions

### DIFF
--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -85,7 +85,7 @@ module ActiveRecord
             send("#{k}=", v)
           end
         else
-          msg =  "unknown attribute: '#{k}'"
+          msg =  "unknown attribute: '#{k}' for #{self}"
           msg << ", try running 'rake db:migrate' to resolve pending migrations" if ActiveRecord::Migrator.needs_migration?
           raise(UnknownAttributeError, msg)
         end

--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -85,7 +85,9 @@ module ActiveRecord
             send("#{k}=", v)
           end
         else
-          raise(UnknownAttributeError, "unknown attribute: #{k}")
+          msg =  "unknown attribute: '#{k}'"
+          msg << ", try running 'rake db:migrate' to resolve pending migrations" if ActiveRecord::Migrator.needs_migration?
+          raise(UnknownAttributeError, msg)
         end
       end
 

--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -86,7 +86,7 @@ module ActiveRecord
           end
         else
           msg =  "unknown attribute: '#{k}' for #{self}"
-          msg << ", try running 'rake db:migrate' to resolve pending migrations" if ActiveRecord::Migrator.needs_migration?
+          msg << ", try running 'bundle exec rake db:migrate' to resolve pending migrations" if ActiveRecord::Migrator.needs_migration?
           raise(UnknownAttributeError, msg)
         end
       end

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -129,6 +129,10 @@ module ActiveRecord
       else
         super
       end
+    rescue NoMethodError => ex
+      message = ex.message
+      message <<  ", try running 'rake db:migrate' to resolve pending migrations" if ActiveRecord::Migrator.needs_migration?
+      raise ex.exception(message)
     end
 
     def attribute_missing(match, *args, &block)

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -131,7 +131,7 @@ module ActiveRecord
       end
     rescue NoMethodError => ex
       message = ex.message
-      message <<  ", try running 'rake db:migrate' to resolve pending migrations" if ActiveRecord::Migrator.needs_migration?
+      message <<  ", try running 'bundle exec rake db:migrate' to resolve pending migrations" if ActiveRecord::Migrator.needs_migration?
       raise ex.exception(message)
     end
 

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -570,6 +570,14 @@ module ActiveRecord
         Base.connection.select_values(table.project(table['version'])).map{ |v| v.to_i }.sort
       end
 
+      def needs_migration?
+        current_version != last_version
+      end
+
+      def last_version
+        migrations(migrations_paths).last.try(:version)||0
+      end
+
       def current_version
         sm_table = schema_migrations_table_name
         if Base.connection.table_exists?(sm_table)

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -651,10 +651,24 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   def test_bulk_update_respects_access_control
     privatize("title=(value)")
-
     assert_raise(ActiveRecord::UnknownAttributeError) { @target.new(:title => "Rants about pants") }
     assert_raise(ActiveRecord::UnknownAttributeError) { @target.new.attributes = { :title => "Ants in pants" } }
   end
+
+  def test_custom_migration_error_message_on_attribute
+    privatize("title=(value)")
+    ActiveRecord::Migrator.stubs(:needs_migration?).returns(true)
+    exception = assert_raise(ActiveRecord::UnknownAttributeError) { @target.new(:title => "Rants about pants") }
+    assert exception.message.include?("rake db:migrate")
+  end
+
+  def test_default_error_message_on_attribute
+    privatize("title=(value)")
+    ActiveRecord::Migrator.stubs(:needs_migration?).returns(false)
+    exception = assert_raise(ActiveRecord::UnknownAttributeError) { @target.new(:title => "Rants about pants") }
+    assert !exception.message.include?("rake db:migrate")
+  end
+
 
   def test_read_attribute_overwrites_private_method_not_considered_implemented
     # simulate a model with a db column that shares its name an inherited

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -65,6 +65,20 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_raise(NoMethodError) { t.title2 }
   end
 
+  def test_custom_migration_error_message_on_method
+    t = Topic.new
+    ActiveRecord::Migrator.stubs(:needs_migration?).returns(true)
+    exception = assert_raise(NoMethodError) { t.title2 }
+    assert exception.message.include?("rake db:migrate")
+  end
+
+  def test_default_error_message_on_method
+    t = Topic.new
+    ActiveRecord::Migrator.stubs(:needs_migration?).returns(false)
+    exception = assert_raise(NoMethodError) { t.title2 }
+    assert !exception.message.include?("rake db:migrate")
+  end
+
   def test_boolean_attributes
     assert ! Topic.find(1).approved?
     assert Topic.find(2).approved?

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1219,9 +1219,13 @@ if ActiveRecord::Base.connection.supports_migrations?
       assert !Person.column_methods_hash.include?(:last_name)
       assert !Reminder.table_exists?
 
-      ActiveRecord::Migrator.up(MIGRATIONS_ROOT + "/valid")
+      migrations_path = MIGRATIONS_ROOT + "/valid"
+      ActiveRecord::Migrator.migrations_paths = migrations_path
+      ActiveRecord::Migrator.up(migrations_path)
 
       assert_equal 3, ActiveRecord::Migrator.current_version
+      assert_equal 3, ActiveRecord::Migrator.last_version
+      assert_equal false, ActiveRecord::Migrator.needs_migration?
       Person.reset_column_information
       assert Person.column_methods_hash.include?(:last_name)
       assert Reminder.create("content" => "hello world", "remind_at" => Time.now)
@@ -1230,6 +1234,7 @@ if ActiveRecord::Base.connection.supports_migrations?
       ActiveRecord::Migrator.down(MIGRATIONS_ROOT + "/valid")
 
       assert_equal 0, ActiveRecord::Migrator.current_version
+      assert_equal true, ActiveRecord::Migrator.needs_migration?
       Person.reset_column_information
       assert !Person.column_methods_hash.include?(:last_name)
       assert_raise(ActiveRecord::StatementInvalid) { Reminder.find(:first) }
@@ -1269,6 +1274,11 @@ if ActiveRecord::Base.connection.supports_migrations?
         @went_down = true
         super
       end
+    end
+
+    def test_migrations_last_version_on_empty_directory
+      ActiveRecord::Migrator.migrations_path = MIGRATIONS_ROOT + "/empty"
+      assert_equal 0, ActiveRecord::Migrator.last_version
     end
 
     def test_instance_based_migration_up
@@ -2276,6 +2286,7 @@ if ActiveRecord::Base.connection.supports_migrations?
       clear
       Dir.delete(@migrations_path)
     end
+
 
     def test_copying_migrations_to_empty_directory
       @migrations_path = MIGRATIONS_ROOT + "/empty"


### PR DESCRIPTION
After a member of a team adds commits new code and a migration to go along with it, other developers might not notice the migration and will get `NoMethodError` or `UnknownAttributeError` raised. 

Rather than chase down the line of code only to figure out later that migrations need to be run, we can intelligently add the information to `try running 'rake db:migrate'`  to the error message. 

Once the coder runs the migration then the current_version and last_version will match and any subsequent `NoMethodError` or `UnknownAttributeError` messages will not have the additional text.

`UnknownAttributeError` with pending migrations: http://cl.ly/2r0e403r2r381B2G161Q
`NoMethodError` with pending migrations: http://cl.ly/3F2E0d2A0K1h101N3H1F
`NoMethodError` with **NO** pending migrations: http://cl.ly/353k0S2f1M2D2o123z2l

ATP for ActiveRecord:

Happy Holidays to the Rails Team!
