### PR TITLE
Add an option to model generator to generate classes with ActiveRecord::Model

### DIFF
--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -11,6 +11,8 @@ module ActiveRecord
       class_option :timestamps, :type => :boolean
       class_option :parent,     :type => :string, :desc => "The parent class for the generated model"
       class_option :indexes,    :type => :boolean, :default => true, :desc => "Add indexes for references and belongs_to columns"
+      class_option :with_include,  :type => :boolean, :default => false,
+                                   :desc => "Include `ActiveRecord::Model` instead of inherit from `ActiveRecord::Base`"
 
       def create_migration_file
         return unless options[:migration] && options[:parent].nil?
@@ -18,7 +20,11 @@ module ActiveRecord
       end
 
       def create_model_file
-        template 'model.rb', File.join('app/models', class_path, "#{file_name}.rb")
+        if options[:with_include] && options[:parent].nil?
+          template 'model_with_include.rb', File.join('app/models', class_path, "#{file_name}.rb")
+        else
+          template 'model.rb', File.join('app/models', class_path, "#{file_name}.rb")
+        end
       end
 
       def create_module_file

--- a/activerecord/lib/rails/generators/active_record/model/templates/model_with_include.rb
+++ b/activerecord/lib/rails/generators/active_record/model/templates/model_with_include.rb
@@ -1,0 +1,9 @@
+<% module_namespacing do -%>
+class <%= class_name %>
+  include ActiveRecord::Model
+
+<% attributes.select {|attr| attr.reference? }.each do |attribute| -%>
+  belongs_to :<%= attribute.name %>
+<% end -%>
+end
+<% end -%>

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -34,6 +34,11 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     assert_no_migration "db/migrate/create_accounts.rb"
   end
 
+  def test_model_with_with_include_option
+    run_generator ["account", "--with-include"]
+    assert_file "app/models/account.rb", /class Account\n  include ActiveRecord::Model/
+  end
+
   def test_model_with_underscored_parent_option
     run_generator ["account", "--parent", "admin/account"]
     assert_file "app/models/account.rb", /class Account < Admin::Account/


### PR DESCRIPTION
This add an option to model generator to generate classes that use ActiveRecord::Model. Ex:

```
rails g model Post --with-include
```

will generate:

``` ruby
class Post
  include ActiveRecord::Model
end
```

Please don't merge this inmediatly, I think we can choose a better option name than `--with-include` for this
