### PR TITLE
Fix MissingTemplate issue

### DIFF
--- a/actionpack/lib/action_controller/metal/implicit_render.rb
+++ b/actionpack/lib/action_controller/metal/implicit_render.rb
@@ -1,8 +1,15 @@
 module ActionController
   module ImplicitRender
+
     def send_action(method, *args)
       ret = super
-      default_render unless response_body
+      unless response_body
+        if template_exists?(action_name.to_s, _prefixes)
+          default_render
+        else
+          process_not_found_template
+        end
+      end
       ret
     end
 
@@ -14,6 +21,21 @@ module ActionController
       super || if template_exists?(action_name.to_s, _prefixes)
         "default_render"
       end
+    end
+
+    protected
+
+    # if lookup template not exist then go to check if any template existed,
+    # if so show 406, if not, go render, it will give MissingTemplate error.
+    def process_not_found_template(*args)
+      provided_any_template = begin
+                                old_formats, lookup_context.formats = lookup_context.formats, Mime::SET.symbols
+                                template_exists?(action_name.to_s, _prefixes)
+                              ensure
+                                lookup_context.formats = old_formats
+                              end
+
+      provided_any_template ? head(:not_acceptable) : render(*args)
     end
   end
 end

--- a/actionpack/test/controller/new_base/render_implicit_action_test.rb
+++ b/actionpack/test/controller/new_base/render_implicit_action_test.rb
@@ -9,9 +9,20 @@ module RenderImplicitAction
     )]
 
     def hello_world() end
+    def unexisted_template() end
   end
 
   class RenderImplicitActionTest < Rack::TestCase
+    test "render a action without any template " do
+      get "/render_implicit_action/simple/unexisted_template"
+      assert_status 500
+    end
+
+    test "render a unexisted format of template" do
+      get "/render_implicit_action/simple/hello_world.json"
+      assert_status 406
+    end
+
     test "render a simple action with new explicit call to render" do
       get "/render_implicit_action/simple/hello_world"
 


### PR DESCRIPTION
when request header http_accept = text/html, but template only provide text/json, so it raise MissingTemplate error instead of returning 406.
It should raise MissingTemplate when there isn't any template and explicit render method is gaven.
