### PR TITLE
prompt message for gem ruby-debug19 for console error if ruby-debug19 not found

### DIFF
--- a/railties/lib/rails/commands/console.rb
+++ b/railties/lib/rails/commands/console.rb
@@ -31,7 +31,7 @@ module Rails
           require 'ruby-debug'
           puts "=> Debugger enabled"
         rescue Exception
-          puts "You need to install ruby-debug to run the console in debugging mode. With gems, use 'gem install ruby-debug'"
+          puts "You need to install ruby-debug19 to run the console in debugging mode. With gems, use 'gem install ruby-debug19'"
           exit
         end
       end


### PR DESCRIPTION
prompt message for gem ruby-debug19 for console error if ruby-debug19 not found
