### PR TITLE
Bug fix: Updating Time columns by String with no timezone doesn't work correctly

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -41,7 +41,7 @@ module ActiveRecord
                     time = time.is_a?(String) ? Time.zone.parse(time) : time.to_time rescue time
                   end
                   time = time.in_time_zone rescue nil if time
-                  write_attribute(:#{attr_name}, original_time)
+                  write_attribute(:#{attr_name}, time.in_time_zone('UTC').to_s)
                   @attributes_cache["#{attr_name}"] = time
                 end
               EOV


### PR DESCRIPTION
When updating Time/Datetime with time represented by a String with no timezone (e.g. "Wed, 21 Dec 2011 6:00:00"). 

Example (assume timezone = +02:00)

What should happen:
  Since Rails claims to assume all provided String times are in local timezone, 
    User.time = "Wed, 21 Dec 2011 6:00:00"  
  should really mean
    User.time = "Wed, 21 Dec 2011 6:00:00 +02:00"
  and be saved to @attributes as
    User.time = "Wed, 21 Dec 2011 4:00:00 +00:00"

What happens now:
    User.time = "Wed, 21 Dec 2011 6:00:00"  
  cached as
    User.time = "Wed, 21 Dec 2011 6:00:00 +02:00"
  saved to @attributes as
    User.time = "Wed, 21 Dec 2011 6:00:00 +00:00"  <------ WRONG !

The above change makes sure that the value provided to the attribute_setter is parsed with current timezone and saved as UTC.
