### PR TITLE
Module#name returns nil for anonymous class in ruby 1.9

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/anonymous.rb
+++ b/activesupport/lib/active_support/core_ext/module/anonymous.rb
@@ -1,5 +1,3 @@
-require 'active_support/core_ext/object/blank'
-
 class Module
   # A module may or may not have a name.
   #
@@ -7,7 +5,7 @@ class Module
   #   M.name # => "M"
   #
   #   m = Module.new
-  #   m.name # => ""
+  #   m.name # => nil
   #
   # A module gets a name when it is first assigned to a constant. Either
   # via the +module+ or +class+ keyword or by an explicit assignment:
@@ -17,8 +15,6 @@ class Module
   #   m.name         # => "M"
   #
   def anonymous?
-    # Uses blank? because the name of an anonymous class is an empty
-    # string in 1.8, and nil in 1.9.
-    name.blank?
+    name.nil?
   end
 end

--- a/railties/guides/source/active_support_core_extensions.textile
+++ b/railties/guides/source/active_support_core_extensions.textile
@@ -822,7 +822,7 @@ M.name # => "M"
 N = Module.new
 N.name # => "N"
 
-Module.new.name # => "" in 1.8, nil in 1.9
+Module.new.name # => nil
 </ruby>
 
 You can check whether a module has a name with the predicate +anonymous?+:


### PR DESCRIPTION
so there is no need for `blank?` method
