### PR TITLE
Test::Unit::Util::BacktraceFilter not available in ruby19 test/unit

### DIFF
--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -27,23 +27,6 @@ module ApplicationTests
       run_test_file 'unit/foo_test.rb'
     end
 
-    # Run just in Ruby < 1.9
-    if defined?(Test::Unit::Util::BacktraceFilter)
-      test "adds backtrace cleaner" do
-        app_file 'test/unit/backtrace_test.rb', <<-RUBY
-          require 'test_helper'
-
-          class FooTest < ActiveSupport::TestCase
-            def test_truth
-              assert Test::Unit::Util::BacktraceFilter.ancestors.include?(Rails::BacktraceFilterForTestUnit)
-            end
-          end
-        RUBY
-
-        run_test_file 'unit/backtrace_test.rb'
-      end
-    end
-
     test "integration test" do
       controller 'posts', <<-RUBY
         class PostsController < ActionController::Base


### PR DESCRIPTION
Test::Unit::Util::BacktraceFilter not available in ruby19 test/unit
