### PR TITLE
AS::Callbacks: improved __define_runner performance

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -381,9 +381,8 @@ module ActiveSupport
         name = __callback_runner_name(nil, symbol)
         undef_method(name) if method_defined?(name)
 
-        silence_warnings do
-          runner_method = "_run_#{symbol}_callbacks" 
-          undef_method runner_method if method_defined?(runner_method)
+        runner_method = "_run_#{symbol}_callbacks" 
+        unless private_method_defined?(runner_method)
           class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
             def #{runner_method}(key = nil, &blk)
               self.class.__run_callback(key, :#{symbol}, self, &blk)


### PR DESCRIPTION
We don't need to Redefine runner method on each `__define_runner` anymore.

Result: **20% perfomance improvement** for `set_callback` method: https://gist.github.com/1519380

```
Rehearsal ----------------------------------------------------
New set_callback   0.450000   0.020000   0.470000 (  0.477188)
Old set_callback   0.580000   0.010000   0.590000 (  0.600057)
------------------------------------------- total: 1.060000sec

                       user     system      total        real
New set_callback   0.470000   0.010000   0.480000 (  0.478684)
Old set_callback   0.580000   0.020000   0.600000 (  0.600981)
************************************************************************************************************************
Rehearsal -----------------------------------------------------
New run_callbacks   0.060000   0.000000   0.060000 (  0.060021)
Old run_callbacks   0.060000   0.000000   0.060000 (  0.060024)
-------------------------------------------- total: 0.120000sec

                        user     system      total        real
New run_callbacks   0.050000   0.010000   0.060000 (  0.059831)
Old run_callbacks   0.060000   0.000000   0.060000 (  0.060878)
```
