### PR TITLE
Fixed ORA-00972 error

### DIFF
--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -61,7 +61,7 @@ if ActiveRecord::Base.connection.supports_migrations?
       ActiveRecord::Base.connection.initialize_schema_migrations_table
       ActiveRecord::Base.connection.execute "DELETE FROM #{ActiveRecord::Migrator.schema_migrations_table_name}"
 
-      %w(things awesome_things prefix_things_suffix prefix_awesome_things_suffix).each do |table|
+      %w(things awesome_things prefix_things_suffix prefix_awesome_things_suffix p_awesome_things_s).each do |table|
         Thing.connection.drop_table(table) rescue nil
       end
       Thing.reset_column_information
@@ -1572,8 +1572,8 @@ if ActiveRecord::Base.connection.supports_migrations?
 
     def test_rename_table_with_prefix_and_suffix
       assert !Thing.table_exists?
-      ActiveRecord::Base.table_name_prefix = 'prefix_'
-      ActiveRecord::Base.table_name_suffix = '_suffix'
+      ActiveRecord::Base.table_name_prefix = 'p_'
+      ActiveRecord::Base.table_name_suffix = '_s'
       Thing.reset_table_name
       Thing.reset_sequence_name
       WeNeedThings.up
@@ -1582,7 +1582,7 @@ if ActiveRecord::Base.connection.supports_migrations?
       assert_equal "hello world", Thing.find(:first).content
 
       RenameThings.up
-      Thing.table_name = "prefix_awesome_things_suffix"
+      Thing.table_name = "p_awesome_things_s"
 
       assert_equal "hello world", Thing.find(:first).content
     ensure


### PR DESCRIPTION
When activerecord unit tests are execued with Oracle, test_rename_table_with_prefix_and_suffix
got a failure because the new sequence name length exceeds 30 characters, Oracle spec.

This commit address this error, This fix also works with pg, mysql and mysql2 adapters.

``` ruby
$ cd activerecord
$ rake test_oracle
... snip ...
  3) Error:
test_rename_table_with_prefix_and_suffix(MigrationTest):
ArgumentError: New sequence name 'prefix_awesome_things_suffix_seq' is too long; the limit is 30 characters
    /var/lib/jenkins/.rvm/gems/ruby-1.9.3-p0@rails_master/bundler/gems/oracle-enhanced-0c2270624bc8/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:105:in `rename_table'
    /var/lib/jenkins/jobs/rails_test_oracle/workspace/activerecord/lib/active_record/migration.rb:449:in `block in method_missing'
    /var/lib/jenkins/jobs/rails_test_oracle/workspace/activerecord/lib/active_record/migration.rb:423:in `block in say_with_time'
```
