### PR TITLE
Align rake notes

### DIFF
--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -22,7 +22,7 @@ class SourceAnnotationExtractor
     # If +options+ has a flag <tt>:tag</tt> the tag is shown as in the example above.
     # Otherwise the string contains just line and text.
     def to_s(options={})
-      s = "[%3d] " % line
+      s = "[#{line.to_s.rjust(options[:indent])}]"
       s << "[#{tag}] " if options[:tag]
       s << text
     end
@@ -93,6 +93,7 @@ class SourceAnnotationExtractor
   # Prints the mapping from filenames to annotations in +results+ ordered by filename.
   # The +options+ hash is passed to each annotation's +to_s+.
   def display(results, options={})
+    options[:indent] = results.map { |f, a| a.map(&:line) }.flatten.max.to_s.size
     results.keys.sort.each do |file|
       puts "#{file}:"
       results[file].each do |note|

--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -17,6 +17,7 @@ module ApplicationTests
         app_file "app/views/home/index.html.erb", "<% # TODO: note in erb %>"
         app_file "app/views/home/index.html.haml", "-# TODO: note in haml"
         app_file "app/views/home/index.html.slim", "/ TODO: note in slim"
+        app_file "app/controllers/application_controller.rb", 1000.times.map { "" }.join("\n") << "# TODO: note in ruby"
 
         boot_rails
         require 'rake'
@@ -27,10 +28,18 @@ module ApplicationTests
    
         Dir.chdir(app_path) do
           output = `bundle exec rake notes`
+          lines = output.scan(/\[([0-9\s]+)\]/).flatten
         
           assert_match /note in erb/, output
           assert_match /note in haml/, output
           assert_match /note in slim/, output
+          assert_match /note in ruby/, output
+
+          assert_equal 4, lines.size
+          assert_equal 4, lines[0].size
+          assert_equal 4, lines[1].size
+          assert_equal 4, lines[2].size
+          assert_equal 4, lines[3].size
         end
       
       end


### PR DESCRIPTION
Just a tiny detail thats been bugging me for awhile. Putting notes in your Rails project on lines greater or equal to 1000 ruins the alignment. See example output below.

```
[126] [TODO] This algorithm is simple and clearly correct, make it faster.
[1000] [TODO] This algorithm is complex and clearly ineffecient, make it faster.
```

This commit makes sure all notes are correctly aligned. See example output below.

```
[ 126] [TODO] This algorithm is simple and clearly correct, make it faster.
[1000] [TODO] This algorithm is complex and clearly ineffecient, make it faster.
```

Guess you could argue how often you encounter a file that contains more than 1000 lines. Anyway as stated earlier it's just a tiny detail that's been bugging me.
