### PR TITLE
remove ForClassicTestUnit support for ruby 1.8 in performance and setup and teardown

### DIFF
--- a/activesupport/lib/active_support/testing/performance.rb
+++ b/activesupport/lib/active_support/testing/performance.rb
@@ -13,12 +13,7 @@ module ActiveSupport
       included do
         superclass_delegating_accessor :profile_options
         self.profile_options = {}
-
-        if defined?(MiniTest::Assertions) && TestCase < MiniTest::Assertions
-          include ForMiniTest
-        else
-          include ForClassicTestUnit
-        end
+        include ForMiniTest
       end
 
       # each implementation should define metrics and freeze the defaults
@@ -74,48 +69,6 @@ module ActiveSupport
             end
           end
           result
-        end
-      end
-
-      module ForClassicTestUnit
-        def run(result)
-          return if method_name =~ /^default_test$/
-
-          yield(self.class::STARTED, name)
-          @_result = result
-
-          run_warmup
-          if full_profile_options && metrics = full_profile_options[:metrics]
-            metrics.each do |metric_name|
-              if klass = Metrics[metric_name.to_sym]
-                run_profile(klass.new)
-                result.add_run
-              else
-                puts '%20s: unsupported' % metric_name
-              end
-            end
-          end
-
-          yield(self.class::FINISHED, name)
-        end
-
-        def run_test(metric, mode)
-          run_callbacks :setup
-          setup
-          metric.send(mode) { __send__ @method_name }
-        rescue ::Test::Unit::AssertionFailedError => e
-        add_failure(e.message, e.backtrace)
-        rescue StandardError, ScriptError => e
-          add_error(e)
-        ensure
-          begin
-            teardown
-            run_callbacks :teardown, :enumerator => :reverse_each
-          rescue ::Test::Unit::AssertionFailedError => e
-            add_failure(e.message, e.backtrace)
-          rescue StandardError, ScriptError => e
-            add_error(e)
-          end
         end
       end
 

--- a/activesupport/lib/active_support/testing/setup_and_teardown.rb
+++ b/activesupport/lib/active_support/testing/setup_and_teardown.rb
@@ -10,11 +10,7 @@ module ActiveSupport
         include ActiveSupport::Callbacks
         define_callbacks :setup, :teardown
 
-        if defined?(MiniTest::Assertions) && TestCase < MiniTest::Assertions
-          include ForMiniTest
-        else
-          include ForClassicTestUnit
-        end
+        include ForMiniTest
       end
 
       module ClassMethods
@@ -44,65 +40,6 @@ module ActiveSupport
             end
           end
           result
-        end
-      end
-
-      module ForClassicTestUnit
-        # For compatibility with Ruby < 1.8.6
-        PASSTHROUGH_EXCEPTIONS = Test::Unit::TestCase::PASSTHROUGH_EXCEPTIONS rescue [NoMemoryError, SignalException, Interrupt, SystemExit]
-
-        # This redefinition is unfortunate but test/unit shows us no alternative.
-        # Doubly unfortunate: hax to support Mocha's hax.
-        def run(result)
-          return if @method_name.to_s == "default_test"
-
-          mocha_counter = retrieve_mocha_counter(result)
-          yield(Test::Unit::TestCase::STARTED, name)
-          @_result = result
-
-          begin
-            begin
-              run_callbacks :setup do
-                setup
-                __send__(@method_name)
-                mocha_verify(mocha_counter) if mocha_counter
-              end
-            rescue Mocha::ExpectationError => e
-              add_failure(e.message, e.backtrace)
-            rescue Test::Unit::AssertionFailedError => e
-              add_failure(e.message, e.backtrace)
-            rescue Exception => e
-              raise if PASSTHROUGH_EXCEPTIONS.include?(e.class)
-              add_error(e)
-            ensure
-              begin
-                teardown
-                run_callbacks :teardown
-              rescue Test::Unit::AssertionFailedError => e
-                add_failure(e.message, e.backtrace)
-              rescue Exception => e
-                raise if PASSTHROUGH_EXCEPTIONS.include?(e.class)
-                add_error(e)
-              end
-            end
-          ensure
-            mocha_teardown if mocha_counter
-          end
-
-          result.add_run
-          yield(Test::Unit::TestCase::FINISHED, name)
-        end
-
-        protected
-
-        def retrieve_mocha_counter(result) #:nodoc:
-          if respond_to?(:mocha_verify) # using mocha
-            if defined?(Mocha::TestCaseAdapter::AssertionCounter)
-              Mocha::TestCaseAdapter::AssertionCounter.new(result)
-            else
-              Mocha::Integration::TestUnit::AssertionCounter.new(result)
-            end
-          end
         end
       end
 


### PR DESCRIPTION
remove ForClassicTestUnit support for ruby 1.8 in performance and setup and teardown
