### PR TITLE
GC::Profiler available in ruby19

### DIFF
--- a/activesupport/lib/active_support/testing/performance/ruby/yarv.rb
+++ b/activesupport/lib/active_support/testing/performance/ruby/yarv.rb
@@ -4,15 +4,12 @@ module ActiveSupport
       module Metrics
         class Base
           protected
-            # Ruby 1.9 with GC::Profiler
-            if defined?(GC::Profiler)
-              def with_gc_stats
-                GC::Profiler.enable
-                GC.start
-                yield
-              ensure
-                GC::Profiler.disable
-              end
+            def with_gc_stats
+              GC::Profiler.enable
+              GC.start
+              yield
+            ensure
+              GC::Profiler.disable
             end
         end
 


### PR DESCRIPTION
GC::Profiler available in ruby19 condition removed
