### PR TITLE
Revert "This conditions is required to work with database create task.

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -112,8 +112,7 @@ db_namespace = namespace :db do
         end
       end
     else
-      # Bug with 1.9.2 Calling return within begin still executes else
-      $stderr.puts "#{config['database']} already exists" unless config['adapter'] =~ /sqlite/
+      $stderr.puts "#{config['database']} already exists"
     end
   end
 


### PR DESCRIPTION
1.9.2 is having a bug with "Calling return within begin still executes else". "

No need to worry about 1.9.2 with master

This reverts commit fbf4bee6ed3682b361d6fbeca8e185e665e26b81.

Was my commit reverting now because we don't need this anymore in master!!
