### PR TITLE
Fix bug in `ActionController::Request#remote_ip`

### DIFF
--- a/actionpack/lib/action_controller/request.rb
+++ b/actionpack/lib/action_controller/request.rb
@@ -225,7 +225,7 @@ module ActionController
         not_trusted_addrs = remote_addr_list.reject {|addr| addr =~ TRUSTED_PROXIES}
         return not_trusted_addrs.first unless not_trusted_addrs.empty?
       end
-      remote_ips = @env['HTTP_X_FORWARDED_FOR'] && @env['HTTP_X_FORWARDED_FOR'].split(',')
+      remote_ips = @env['HTTP_X_FORWARDED_FOR'].present? && @env['HTTP_X_FORWARDED_FOR'].split(',')
 
       if @env.include? 'HTTP_CLIENT_IP'
         if ActionController::Base.ip_spoofing_check && remote_ips && !remote_ips.include?(@env['HTTP_CLIENT_IP'])

--- a/actionpack/test/controller/request_test.rb
+++ b/actionpack/test/controller/request_test.rb
@@ -20,6 +20,9 @@ class RequestTest < ActiveSupport::TestCase
       'HTTP_X_FORWARDED_FOR' => '3.4.5.6'
     assert_equal '1.2.3.4', request.remote_ip
 
+    request = stub_request 'HTTP_X_FORWARDED_FOR' => ''
+    assert_nil request.remote_ip
+
     request = stub_request 'REMOTE_ADDR' => '127.0.0.1',
       'HTTP_X_FORWARDED_FOR' => '3.4.5.6'
     assert_equal '3.4.5.6', request.remote_ip


### PR DESCRIPTION
If `HTTP_X_FORWARDED_FOR` only contains whitespace, don't try to extract a
list of IP addresses from it. Previously, calling `#remote_ip` when `HTTP_X_FORWARDED_FOR` was e.g. `""` would cause "NoMethodError: undefined method strip for nil:NilClass".
