### PR TITLE
deprecate Base64.encode64s from AS

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -145,7 +145,7 @@ module ActionController
       end
 
       def encode_credentials(user_name, password)
-        "Basic #{ActiveSupport::Base64.encode64s("#{user_name}:#{password}")}"
+        "Basic #{ActiveSupport::Base64.strict_encode64("#{user_name}:#{password}")}"
       end
 
       def authentication_request(controller, realm)
@@ -289,7 +289,7 @@ module ActionController
         t = time.to_i
         hashed = [t, secret_key]
         digest = ::Digest::MD5.hexdigest(hashed.join(":"))
-        ActiveSupport::Base64.encode64("#{t}:#{digest}").gsub("\n", '')
+        ActiveSupport::Base64.strict_encode64("#{t}:#{digest}")
       end
 
       # Might want a shorter timeout depending on whether the request

--- a/activesupport/lib/active_support/base64.rb
+++ b/activesupport/lib/active_support/base64.rb
@@ -3,12 +3,16 @@ require 'base64'
 module ActiveSupport
   Base64 = ::Base64
 
+  # *DEPRECATED*: Use +Base64.strict_encode64+ instead.
+  #
   # Encodes the value as base64 without the newline breaks. This makes the base64 encoding readily usable as URL parameters
   # or memcache keys without further processing.
   #
   #  ActiveSupport::Base64.encode64s("Original unencoded string")
   #  # => "T3JpZ2luYWwgdW5lbmNvZGVkIHN0cmluZw=="
   def Base64.encode64s(value)
-    encode64(value).gsub(/\n/, '')
+    ActiveSupport::Deprecation.warn "encode64s " \
+      "is deprecated. Use Base64.strict_encode64 instead", caller
+    strict_encode64(value)
   end
 end

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -56,7 +56,7 @@ module ActiveSupport
       encrypted_data = cipher.update(@serializer.dump(value))
       encrypted_data << cipher.final
 
-      [encrypted_data, iv].map {|v| ActiveSupport::Base64.encode64s(v)}.join("--")
+      [encrypted_data, iv].map {|v| ActiveSupport::Base64.strict_encode64(v)}.join("--")
     end
 
     def _decrypt(encrypted_message)

--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -18,7 +18,7 @@ module ActiveSupport
   #     self.current_user = User.find(id)
   #   end
   #
-  # By default it uses Marshal to serialize the message. If you want to use another 
+  # By default it uses Marshal to serialize the message. If you want to use another
   # serialization method, you can set the serializer attribute to something that responds
   # to dump and load, e.g.:
   #
@@ -44,7 +44,7 @@ module ActiveSupport
     end
 
     def generate(value)
-      data = ActiveSupport::Base64.encode64s(@serializer.dump(value))
+      data = ActiveSupport::Base64.strict_encode64(@serializer.dump(value))
       "#{data}--#{generate_digest(data)}"
     end
 

--- a/activesupport/test/core_ext/base64_ext_test.rb
+++ b/activesupport/test/core_ext/base64_ext_test.rb
@@ -2,7 +2,9 @@ require 'abstract_unit'
 
 class Base64Test < Test::Unit::TestCase
   def test_no_newline_in_encoded_value
-    assert_match(/\n/,    ActiveSupport::Base64.encode64("oneverylongstringthatwouldnormallybesplitupbynewlinesbytheregularbase64"))
-    assert_no_match(/\n/, ActiveSupport::Base64.encode64s("oneverylongstringthatwouldnormallybesplitupbynewlinesbytheregularbase64"))
+    ActiveSupport::Deprecation.silence do
+      assert_match(/\n/,    ActiveSupport::Base64.encode64("oneverylongstringthatwouldnormallybesplitupbynewlinesbytheregularbase64"))
+      assert_no_match(/\n/, ActiveSupport::Base64.encode64s("oneverylongstringthatwouldnormallybesplitupbynewlinesbytheregularbase64"))
+    end
   end
 end

--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -78,7 +78,7 @@ class MessageEncryptorTest < ActiveSupport::TestCase
   def munge(base64_string)
     bits = ActiveSupport::Base64.decode64(base64_string)
     bits.reverse!
-    ActiveSupport::Base64.encode64s(bits)
+    ActiveSupport::Base64.strict_encode64(bits)
   end
 end
 


### PR DESCRIPTION
Use Base64.strict_encode64 instead.
BTW, should we use plain encode64, decode64, etc from Base64 not from ActiveSupport::Base64?
