### PR TITLE
AR#where with an Array of 2 elements including a nil

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -29,8 +29,11 @@ module ActiveRecord
 
             if values.include?(nil)
               values = values.compact
-              if values.empty?
+              case values.length
+              when 0
                 array_predicates << attribute.eq(nil)
+              when 1
+                array_predicates << attribute.eq(values.first).or(attribute.eq(nil))
               else
                 array_predicates << attribute.in(values).or(attribute.eq(nil))
               end

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -32,7 +32,7 @@ module ActiveRecord
               if values.empty?
                 array_predicates << attribute.eq(nil)
               else
-                array_predicates << attribute.in(values.compact).or(attribute.eq(nil))
+                array_predicates << attribute.in(values).or(attribute.eq(nil))
               end
             else
               array_predicates << attribute.in(values)


### PR DESCRIPTION
With the following code,

``` ruby
Model.where(foo: [1, nil])
```

AR builds an SQL like this:

``` sql
WHERE foo IN (1) OR foo IS NULL
```

Here's a tiny patch that makes it like this:

``` sql
WHERE foo = 1 OR foo IS NULL
```
