### PR TITLE
allow reorder to affect eager loading correctly

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -249,7 +249,7 @@ module ActiveRecord
     end
 
     def construct_limited_ids_condition(relation)
-      orders = relation.order_values.map { |val| val.presence }.compact
+      orders = (relation.reorder_value || relation.order_values).map { |val| val.presence }.compact
       values = @klass.connection.distinct("#{@klass.connection.quote_table_name table_name}.#{primary_key}", orders)
 
       relation = relation.dup

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -57,6 +57,16 @@ class HasManyAssociationsTestForCountDistinctWithFinderSql < ActiveRecord::TestC
   end
 end
 
+class HasManyAssociationsTestForReorderWithJoinDependency < ActiveRecord::TestCase
+  fixtures :authors, :posts, :comments
+
+  def test_should_generate_valid_sql
+    author = authors(:david)
+    # this can fail on adapters which require ORDER BY expressions to be included in the SELECT expression
+    # if the reorder clauses are not correctly handled
+    assert author.posts_with_comments_sorted_by_comment_id.where('comments.id > 0').reorder('posts.comments_count DESC', 'posts.taggings_count DESC').last
+  end
+end
 
 
 class HasManyAssociationsTest < ActiveRecord::TestCase


### PR DESCRIPTION
(master-based version of https://github.com/rails/rails/pull/4082)

Calling `last` on an association that's scoped with `reorder` can cause some adapters to fail (particularly oracle_enhanced and postgres). The underlying cause is that `connection.distinct` expects the desired order, but the relation's `reorder_values` are not passed along, since `construct_limited_ids` explicitly grabs `order_values`.

See the attached commit for additional details - this bug does not affect the mysql or sqlite adapters, as those use the default order-agnostic implementation of `distinct`.
