### PR TITLE
Further simplify singleton_class checking in class_attribute

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -81,21 +81,13 @@ class Class
             define_method(:#{name}) { val }
           end
 
-          if singleton_class?
-            class_eval do
-              remove_possible_method(:#{name})
-              def #{name}
-                defined?(@#{name}) ? @#{name} : singleton_class.#{name}
-              end
-            end
-          end
           val
         end
 
         if instance_reader
           remove_possible_method :#{name}
           def #{name}
-            defined?(@#{name}) ? @#{name} : self.class.#{name}
+            defined?(@#{name}) ? @#{name} : singleton_class.#{name}
           end
 
           def #{name}?
@@ -106,10 +98,5 @@ class Class
 
       attr_writer name if instance_writer
     end
-  end
-
-  private
-  def singleton_class?
-    !name || '' == name
   end
 end


### PR DESCRIPTION
We were having issues with the `!name || '' == name` simplification that @tenderlove committed for checking if we're in a singleton class.  Though I was unable to come up with a failing test case, I was able to fix the issue and clean up the rails code a bit with this change.

If it's ok, I'd like to get this ported to 3-2-stable as well.  Thanks!
