### PR TITLE
3 2 stable marshalling

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -578,7 +578,17 @@ module ActiveSupport
         # it is marshalled and eventually compressed. Both operations yield
         # strings.
         if @value
-          Marshal.load(compressed? ? Zlib::Inflate.inflate(@value) : @value)
+          # In rails 3.1 and earlier values in entries did not marshaled without
+          # options[:compress] and if it's Numeric.
+          # But after commit a263f377978fc07515b42808ebc1f7894fafaa3a
+          # all values in entries are marshalled. And after that code below expects
+          # that all values in entries will be marshaled (and will be strings). 
+          # So here we need a check for old ones.
+          begin
+            Marshal.load(compressed? ? Zlib::Inflate.inflate(@value) : @value)
+          rescue TypeError
+            compressed? ? Zlib::Inflate.inflate(@value) : @value
+          end
         end
       end
 

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -220,6 +220,21 @@ module CacheStoreBehavior
     assert_equal false, @cache.read('foo')
   end
 
+  def test_should_read_cached_numeric_from_previous_rails_versions
+    @old_cache = ActiveSupport::Cache::Entry.create( 1, Time.now )
+    assert_equal( 1, @old_cache.value )
+  end
+
+  def test_should_read_cached_hash_from_previous_rails_versions
+    @old_cache = ActiveSupport::Cache::Entry.create( {}, Time.now )
+    assert_equal( {}, @old_cache.value )
+  end
+
+  def test_should_read_cached_string_from_previous_rails_versions
+    @old_cache = ActiveSupport::Cache::Entry.create( 'string', Time.now )
+    assert_equal( 'string', @old_cache.value )
+  end
+
   def test_read_multi
     @cache.write('foo', 'bar')
     @cache.write('fu', 'baz')


### PR DESCRIPTION
@tenderlove the problem was in rescue for ArgumentError when class serialized with :: on the end. So I fixed it with adding TypeError type of exception to the rescue for marshalling not marshalled values. All tests pass for me.
