### PR TITLE
refactor Range#include? to handle ranges with floats

### DIFF
--- a/activesupport/lib/active_support/core_ext/range/include_range.rb
+++ b/activesupport/lib/active_support/core_ext/range/include_range.rb
@@ -9,7 +9,8 @@ class Range
   #  (5..9).include?(11) # => false
   def include_with_range?(value)
     if value.is_a?(::Range)
-      min <= value.min && max >= value.max
+      operator = exclude_end? && !value.exclude_end? ? :< : :<=
+      include_without_range?(value.first) && value.last.send(operator, last)
     else
       include_without_range?(value)
     end

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -53,6 +53,10 @@ class RangeTest < Test::Unit::TestCase
     assert !(2..8).include?(5..9)
   end
 
+  def test_should_include_identical_exclusive_with_floats
+    assert (1.0...10.0).include?(1.0...10.0)
+  end
+
   def test_blockless_step
     assert_equal [1,3,5,7,9], (1..10).step(2)
   end


### PR DESCRIPTION
It was previously refactored in 3f642c9, but both previous implementations don't handle ranges with floats.
