### PR TITLE
Fix rails/generators/base.rb documentation for hook_for

### DIFF
--- a/railties/lib/rails/generators/base.rb
+++ b/railties/lib/rails/generators/base.rb
@@ -91,7 +91,7 @@ module Rails
       #
       # The lookup in this case for test_unit as input is:
       #
-      #   "test_framework:awesome", "test_framework"
+      #   "test_unit:awesome", "test_unit"
       #
       # Which is not the desired the lookup. You can change it by providing the
       # :as option:
@@ -102,7 +102,7 @@ module Rails
       #
       # And now it will lookup at:
       #
-      #   "test_framework:controller", "test_framework"
+      #   "test_unit:controller", "test_unit"
       #
       # Similarly, if you want it to also lookup in the rails namespace, you just
       # need to provide the :base value:
@@ -113,7 +113,7 @@ module Rails
       #
       # And the lookup is exactly the same as previously:
       #
-      #   "rails:test_framework", "test_framework:controller", "test_framework"
+      #   "rails:test_unit", "test_unit:controller", "test_unit"
       #
       # ==== Switches
       #


### PR DESCRIPTION
make a namespace example more consistent:

```
"test_unit:awesome", "test_unit"
instead
"test_framework:awesome", "test_framework"
```
