### PR TITLE
StringInquirer doesn't inherit from string

### DIFF
--- a/activesupport/lib/active_support/string_inquirer.rb
+++ b/activesupport/lib/active_support/string_inquirer.rb
@@ -9,13 +9,25 @@ module ActiveSupport
   #
   #   Rails.env.production?
   #
-  class StringInquirer < String
+  class StringInquirer
+    def initialize(value)
+      @value = value
+    end
+
     def method_missing(method_name, *arguments)
       if method_name.to_s[-1,1] == "?"
         self == method_name.to_s[0..-2]
       else
         super
       end
+    end
+
+    def ==(value)
+      @value == value
+    end
+
+    def to_str
+      @value
     end
   end
 end

--- a/activesupport/test/string_inquirer_test.rb
+++ b/activesupport/test/string_inquirer_test.rb
@@ -9,6 +9,26 @@ class StringInquirerTest < Test::Unit::TestCase
     assert !ActiveSupport::StringInquirer.new("production").development?
   end
 
+  def test_match_string_method
+    assert ActiveSupport::StringInquirer.new("all").all?
+  end
+
+  def test_miss_string_method
+    assert !ActiveSupport::StringInquirer.new("production").all?
+  end
+
+  def test_string_comparison_match
+    assert_equal "all", ActiveSupport::StringInquirer.new("all")
+  end
+
+  def test_string_comparison_match_coerce
+    assert_equal ActiveSupport::StringInquirer.new("all"), "all"
+  end
+
+  def test_string_comparison_miss
+    assert_not_equal "all", ActiveSupport::StringInquirer.new("none")
+  end
+
   def test_missing_question_mark
     assert_raise(NoMethodError) { ActiveSupport::StringInquirer.new("production").production }
   end


### PR DESCRIPTION
This is done so we can ask for values that could clash with string methods
