### PR TITLE
ruby 1.8 ActiveSupport BasicObject no longer available

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -10,7 +10,6 @@ module ActiveSupport
   #   1.month.ago       # equivalent to Time.now.advance(:months => -1)
   class Duration < BasicObject
     attr_accessor :value, :parts
-    delegate :duplicable?, :to => :value # required when using ActiveSupport's BasicObject on 1.8
 
     def initialize(value, parts) #:nodoc:
       @value, @parts = value, parts


### PR DESCRIPTION
ruby 1.8 ActiveSupport BasicObject no longer available
