### PR TITLE
remove condition since to_time always available in ruby19 DateTime

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/conversions.rb
@@ -6,7 +6,7 @@ require 'active_support/values/time_zone'
 class DateTime
   # Ruby 1.9 has DateTime#to_time which internally relies on Time. We define our own #to_time which allows
   # DateTimes outside the range of what can be created with Time.
-  remove_method :to_time if instance_methods.include?(:to_time)
+  remove_method :to_time
 
   # Convert to a formatted string. See Time::DATE_FORMATS for predefined formats.
   #


### PR DESCRIPTION
remove condition since to_time always available in ruby19 DateTime
