### PR TITLE
Rename variables and remove unused code in fixtures.rb

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -411,7 +411,7 @@ module ActiveRecord
       cache_for_connection(connection).update(fixtures_map)
     end
 
-    def self.instantiate_fixtures(object, fixture_name, fixtures, load_instances = true)
+    def self.instantiate_fixtures(object, fixtures, load_instances = true)
       if load_instances
         fixtures.each do |name, fixture|
           begin
@@ -424,8 +424,8 @@ module ActiveRecord
     end
 
     def self.instantiate_all_loaded_fixtures(object, load_instances = true)
-      all_loaded_fixtures.each do |table_name, fixtures|
-        ActiveRecord::Fixtures.instantiate_fixtures(object, table_name, fixtures, load_instances)
+      all_loaded_fixtures.each_value do |fixtures|
+        instantiate_fixtures(object, fixtures, load_instances)
       end
     end
 
@@ -901,8 +901,8 @@ module ActiveRecord
           ActiveRecord::Fixtures.instantiate_all_loaded_fixtures(self, load_instances?)
         else
           raise RuntimeError, 'Load fixtures before instantiating them.' if @loaded_fixtures.nil?
-          @loaded_fixtures.each do |fixture_name, fixtures|
-            ActiveRecord::Fixtures.instantiate_fixtures(self, fixture_name, fixtures, load_instances?)
+          @loaded_fixtures.each_value do |fixtures|
+            ActiveRecord::Fixtures.instantiate_fixtures(self, fixtures, load_instances?)
           end
         end
       end

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -651,9 +651,6 @@ module ActiveRecord
         "#{@fixture_path}.yml"
       end
 
-      def yaml_fixtures_key(path)
-        ::File.basename(@fixture_path).split(".").first
-      end
   end
 
   class Fixture #:nodoc:

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -80,8 +80,8 @@ class ActiveSupport::TestCase
   self.use_instantiated_fixtures  = false
   self.use_transactional_fixtures = true
 
-  def create_fixtures(*table_names, &block)
-    ActiveRecord::Fixtures.create_fixtures(ActiveSupport::TestCase.fixture_path, table_names, fixture_class_names, &block)
+  def create_fixtures(*fixture_set_names, &block)
+    ActiveRecord::Fixtures.create_fixtures(ActiveSupport::TestCase.fixture_path, fixture_set_names, fixture_class_names, &block)
   end
 end
 


### PR DESCRIPTION
Rename local variables and parameters to have more consistent names.  In particular, instances of `ActiveRecord::Fixtures` be called `fixture_set`'s.

Remove unused private method `yaml_fixtures_key`.

Change arity of `instantiate_fixtures` by removing an unused parameter. (Tests are passing.)
