### PR TITLE
Fix grammatical error

### DIFF
--- a/activemodel/lib/active_model/mass_assignment_security/permission_set.rb
+++ b/activemodel/lib/active_model/mass_assignment_security/permission_set.rb
@@ -13,7 +13,7 @@ module ActiveModel
       end
 
       def deny?(key)
-        raise NotImplementedError, "#deny?(key) suppose to be overwritten"
+        raise NotImplementedError, "#deny?(key) supposed to be overwritten"
       end
 
     protected


### PR DESCRIPTION
Fix grammatical error in ActiveModel::MassAssignmentSecurity::PermissionSet#deny? NotImplementedError message
