### PR TITLE
Add magic comment utf-8 by default 

### DIFF
--- a/actionmailer/lib/rails/generators/mailer/templates/mailer.rb
+++ b/actionmailer/lib/rails/generators/mailer/templates/mailer.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 <% module_namespacing do -%>
 class <%= class_name %> < ActionMailer::Base
   default <%= key_value :from, '"from@example.com"' %>

--- a/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class <%= migration_class_name %> < ActiveRecord::Migration
 <%- if migration_action == 'add' -%>
   def change

--- a/activerecord/lib/rails/generators/active_record/model/templates/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/model/templates/migration.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class <%= migration_class_name %> < ActiveRecord::Migration
   def change
     create_table :<%= table_name %> do |t|

--- a/activerecord/lib/rails/generators/active_record/model/templates/model.rb
+++ b/activerecord/lib/rails/generators/active_record/model/templates/model.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 <% module_namespacing do -%>
 class <%= class_name %> < <%= parent_class_name.classify %>
 <% attributes.select {|attr| attr.reference? }.each do |attribute| -%>

--- a/activerecord/lib/rails/generators/active_record/model/templates/module.rb
+++ b/activerecord/lib/rails/generators/active_record/model/templates/module.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 <% module_namespacing do -%>
 module <%= class_path.map(&:camelize).join('::') %>
   def self.table_name_prefix

--- a/activerecord/lib/rails/generators/active_record/observer/templates/observer.rb
+++ b/activerecord/lib/rails/generators/active_record/observer/templates/observer.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 <% module_namespacing do -%>
 class <%= class_name %>Observer < ActiveRecord::Observer
 end

--- a/activerecord/lib/rails/generators/active_record/session_migration/templates/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/session_migration/templates/migration.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class <%= migration_class_name %> < ActiveRecord::Migration
   def change
     create_table :<%= session_table_name %> do |t|

--- a/railties/lib/rails/generators/rails/app/templates/app/controllers/application_controller.rb
+++ b/railties/lib/rails/generators/rails/app/templates/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class ApplicationController < ActionController::Base
   protect_from_forgery
 end

--- a/railties/lib/rails/generators/rails/app/templates/app/helpers/application_helper.rb
+++ b/railties/lib/rails/generators/rails/app/templates/app/helpers/application_helper.rb
@@ -1,2 +1,3 @@
+# -*- encoding : utf-8 -*-
 module ApplicationHelper
 end

--- a/railties/lib/rails/generators/rails/app/templates/config.ru
+++ b/railties/lib/rails/generators/rails/app/templates/config.ru
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment',  __FILE__)

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require File.expand_path('../boot', __FILE__)
 
 <% if include_all_railties? -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/boot.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/boot.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'rubygems'
 
 # Set up gems listed in the Gemfile.

--- a/railties/lib/rails/generators/rails/app/templates/config/environment.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/environment.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # Load the rails application
 require File.expand_path('../application', __FILE__)
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 <%= app_const %>.configure do
   # Settings specified here will take precedence over those in config/application.rb
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 <%= app_const %>.configure do
   # Settings specified here will take precedence over those in config/application.rb
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 <%= app_const %>.configure do
   # Settings specified here will take precedence over those in config/application.rb
 

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/backtrace_silencers.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/inflections.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/inflections.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/mime_types.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/mime_types.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/secret_token.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/secret_token.rb.tt
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # Be sure to restart your server when you modify this file.
 
 # Your secret key for verifying the integrity of signed cookies.

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/session_store.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/session_store.rb.tt
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # Be sure to restart your server when you modify this file.
 
 <%= app_const %>.config.session_store :cookie_store, <%= key_value :key, "'_#{app_name}_session'" %>

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/wrap_parameters.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/wrap_parameters.rb.tt
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # Be sure to restart your server when you modify this file.
 #
 # This file contains settings for ActionController::ParamsWrapper which

--- a/railties/lib/rails/generators/rails/app/templates/config/routes.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/routes.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 <%= app_const %>.routes.draw do
   # The priority is based upon order of creation:
   # first created -> highest priority.

--- a/railties/lib/rails/generators/rails/app/templates/db/seeds.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/db/seeds.rb.tt
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
 #

--- a/railties/lib/rails/generators/rails/app/templates/script/rails
+++ b/railties/lib/rails/generators/rails/app/templates/script/rails
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
 
 APP_PATH = File.expand_path('../../config/application',  __FILE__)

--- a/railties/lib/rails/generators/rails/app/templates/test/performance/browsing_test.rb
+++ b/railties/lib/rails/generators/rails/app/templates/test/performance/browsing_test.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'test_helper'
 require 'rails/performance_test_help'
 

--- a/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb
+++ b/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 ENV["RAILS_ENV"] = "test"
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'

--- a/railties/lib/rails/generators/rails/controller/templates/controller.rb
+++ b/railties/lib/rails/generators/rails/controller/templates/controller.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 <% module_namespacing do -%>
 class <%= class_name %>Controller < ApplicationController
 <% actions.each do |action| -%>

--- a/railties/lib/rails/generators/rails/generator/templates/%file_name%_generator.rb.tt
+++ b/railties/lib/rails/generators/rails/generator/templates/%file_name%_generator.rb.tt
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class <%= class_name %>Generator < Rails::Generators::NamedBase
   source_root File.expand_path('../templates', __FILE__)
 end

--- a/railties/lib/rails/generators/rails/helper/templates/helper.rb
+++ b/railties/lib/rails/generators/rails/helper/templates/helper.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 <% module_namespacing do -%>
 module <%= class_name %>Helper
 end

--- a/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
 
 # Maintain your gem's version:

--- a/railties/lib/rails/generators/rails/plugin_new/templates/Rakefile
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/Rakefile
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 #!/usr/bin/env rake
 begin
   require 'bundler/setup'

--- a/railties/lib/rails/generators/rails/plugin_new/templates/app/controllers/%name%/application_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/app/controllers/%name%/application_controller.rb.tt
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module <%= camelized %>
   class ApplicationController < ActionController::Base
   end

--- a/railties/lib/rails/generators/rails/plugin_new/templates/app/helpers/%name%/application_helper.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/app/helpers/%name%/application_helper.rb.tt
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module <%= camelized %>
   module ApplicationHelper
   end

--- a/railties/lib/rails/generators/rails/plugin_new/templates/config/routes.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/config/routes.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 <% if mountable? -%>
 <%= camelized %>::Engine.routes.draw do
 <% else -%>

--- a/railties/lib/rails/generators/rails/plugin_new/templates/lib/%name%.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/lib/%name%.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 <% if full? -%>
 require "<%= name %>/engine"
 

--- a/railties/lib/rails/generators/rails/plugin_new/templates/lib/%name%/engine.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/lib/%name%/engine.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module <%= camelized %>
   class Engine < ::Rails::Engine
 <% if mountable? -%>

--- a/railties/lib/rails/generators/rails/plugin_new/templates/lib/%name%/version.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/lib/%name%/version.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module <%= camelized %>
   VERSION = "0.0.1"
 end

--- a/railties/lib/rails/generators/rails/plugin_new/templates/lib/tasks/%name%_tasks.rake
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/lib/tasks/%name%_tasks.rake
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # desc "Explaining what the task does"
 # task :<%= name %> do
 #   # Task goes here

--- a/railties/lib/rails/generators/rails/plugin_new/templates/rails/application.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/rails/application.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require File.expand_path('../boot', __FILE__)
 
 <% if include_all_railties? -%>

--- a/railties/lib/rails/generators/rails/plugin_new/templates/rails/boot.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/rails/boot.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'rubygems'
 gemfile = File.expand_path('../../../../Gemfile', __FILE__)
 

--- a/railties/lib/rails/generators/rails/plugin_new/templates/rails/routes.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/rails/routes.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 Rails.application.routes.draw do
 
   mount <%= camelized %>::Engine => "/<%= name %>"

--- a/railties/lib/rails/generators/rails/plugin_new/templates/script/rails.tt
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/script/rails.tt
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
 
 ENGINE_ROOT = File.expand_path('../..', __FILE__)

--- a/railties/lib/rails/generators/rails/plugin_new/templates/test/%name%_test.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/test/%name%_test.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'test_helper'
 
 class <%= camelized %>Test < ActiveSupport::TestCase

--- a/railties/lib/rails/generators/rails/plugin_new/templates/test/integration/navigation_test.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/test/integration/navigation_test.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'test_helper'
 
 class NavigationTest < ActionDispatch::IntegrationTest

--- a/railties/lib/rails/generators/rails/plugin_new/templates/test/test_helper.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/test/test_helper.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 <% module_namespacing do -%>
 class <%= controller_class_name %>Controller < ApplicationController
   # GET <%= route_url %>

--- a/railties/lib/rails/generators/rails/task/templates/task.rb
+++ b/railties/lib/rails/generators/rails/task/templates/task.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 namespace :<%= file_name %> do
 <% actions.each do |action| -%>
   desc "TODO"

--- a/railties/lib/rails/generators/test_unit/controller/templates/functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/controller/templates/functional_test.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'test_helper'
 
 <% module_namespacing do -%>

--- a/railties/lib/rails/generators/test_unit/helper/templates/helper_test.rb
+++ b/railties/lib/rails/generators/test_unit/helper/templates/helper_test.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'test_helper'
 
 <% module_namespacing do -%>

--- a/railties/lib/rails/generators/test_unit/integration/templates/integration_test.rb
+++ b/railties/lib/rails/generators/test_unit/integration/templates/integration_test.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'test_helper'
 
 class <%= class_name %>Test < ActionDispatch::IntegrationTest

--- a/railties/lib/rails/generators/test_unit/mailer/templates/functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/mailer/templates/functional_test.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'test_helper'
 
 <% module_namespacing do -%>

--- a/railties/lib/rails/generators/test_unit/model/templates/unit_test.rb
+++ b/railties/lib/rails/generators/test_unit/model/templates/unit_test.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'test_helper'
 
 <% module_namespacing do -%>

--- a/railties/lib/rails/generators/test_unit/observer/templates/unit_test.rb
+++ b/railties/lib/rails/generators/test_unit/observer/templates/unit_test.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'test_helper'
 
 <% module_namespacing do -%>

--- a/railties/lib/rails/generators/test_unit/performance/templates/performance_test.rb
+++ b/railties/lib/rails/generators/test_unit/performance/templates/performance_test.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'test_helper'
 require 'rails/performance_test_help'
 

--- a/railties/lib/rails/generators/test_unit/plugin/templates/%file_name%_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/plugin/templates/%file_name%_test.rb.tt
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'test_helper'
 
 class <%= class_name %>Test < ActiveSupport::TestCase

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'test_helper'
 
 <% module_namespacing do -%>


### PR DESCRIPTION
Since Rails choose to use Ruby 1.9 by default. Geneators's template should also use utf-8 by default. Lots people forget to add magic comment in application cause broken, it's really annoying.
