### PR TITLE
Use -e option instead of -c option (rake rdoc task).

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -94,7 +94,7 @@ RDoc::Task.new do |rdoc|
 
   rdoc.options << '-f' << 'sdoc'
   rdoc.options << '-T' << 'rails'
-  rdoc.options << '-c' << 'utf-8'
+  rdoc.options << '-e' << 'UTF-8'
   rdoc.options << '-g' # SDoc flag, link methods to GitHub
   rdoc.options << '-m' << RDOC_MAIN
 


### PR DESCRIPTION
If we set ISO-8859-1 (excepting utf-8) to LANG environment variable, rake rdoc task is not work fine.

```
$ export LANG=en_US.ISO-8859-1 ★
$ bundle exec rake rdoc
Parsing sources...
100% [644/644]  RDOC_MAIN.rdoc

Generating SDoc format into /home/kennyj/rails/doc/rdoc...
rake aborted!
incompatible encoding regexp match (UTF-8 regexp with ISO-8859-1 string)

Tasks: TOP => rdoc => doc/rdoc/index.html
(See full trace by running task with --trace)
```

It seems that "-c" option is not work fine.
With this pull request (instead of using -e (encoding) option).

```
$ bundle exec rake rdoc
Parsing sources...
100% [644/644]  RDOC_MAIN.rdoc

Generating SDoc format into /home/kennyj/rails/doc/rdoc...

Files:       644

Classes:     369 ( 214 undocumented)
Modules:     353 ( 236 undocumented)
Constants:   214 ( 193 undocumented)
Attributes:  329 ( 309 undocumented)
Methods:    3443 (1653 undocumented)

Total:      4708 (2605 undocumented)
 44.67% documented

Elapsed: 323.7s
```

I thinks that this issue is related to GH #3743 .
