### PR TITLE
correctly handle order calls after a reorder

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -8,7 +8,7 @@ module ActiveRecord
     JoinOperation = Struct.new(:relation, :join_class, :on)
     ASSOCIATION_METHODS = [:includes, :eager_load, :preload]
     MULTI_VALUE_METHODS = [:select, :group, :order, :joins, :where, :having, :bind]
-    SINGLE_VALUE_METHODS = [:limit, :offset, :lock, :readonly, :from, :reorder, :reverse_order, :uniq]
+    SINGLE_VALUE_METHODS = [:limit, :offset, :lock, :readonly, :from, :reordering, :reverse_order, :uniq]
 
     include FinderMethods, Calculations, SpawnMethods, QueryMethods, Batches, Explain, Delegation
 

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -134,7 +134,7 @@ module ActiveRecord
     def last(*args)
       if args.any?
         if args.first.kind_of?(Integer) || (loaded? && !args.first.kind_of?(Hash))
-          if order_values.empty? && reorder_value.nil?
+          if order_values.empty?
             order("#{primary_key} DESC").limit(*args).reverse
           else
             to_a.last(*args)
@@ -249,7 +249,7 @@ module ActiveRecord
     end
 
     def construct_limited_ids_condition(relation)
-      orders = (relation.reorder_value || relation.order_values).map { |val| val.presence }.compact
+      orders = relation.order_values.map { |val| val.presence }.compact
       values = @klass.connection.distinct("#{@klass.connection.quote_table_name table_name}.#{primary_key}", orders)
 
       relation = relation.dup

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -9,7 +9,7 @@ module ActiveRecord
                   :select_values, :group_values, :order_values, :joins_values,
                   :where_values, :having_values, :bind_values,
                   :limit_value, :offset_value, :lock_value, :readonly_value, :create_with_value,
-                  :from_value, :reorder_value, :reverse_order_value,
+                  :from_value, :reordering_value, :reverse_order_value,
                   :uniq_value
 
     def includes(*args)
@@ -97,7 +97,8 @@ module ActiveRecord
       return self if args.blank?
 
       relation = clone
-      relation.reorder_value = args.flatten
+      relation.reordering_value = true
+      relation.order_values = args.flatten
       relation
     end
 
@@ -263,7 +264,7 @@ module ActiveRecord
 
       arel.group(*@group_values.uniq.reject{|g| g.blank?}) unless @group_values.empty?
 
-      order = @reorder_value ? @reorder_value : @order_values
+      order = @order_values
       order = reverse_sql_order(order) if @reverse_order_value
       arel.order(*order.uniq.reject{|o| o.blank?}) unless order.empty?
 

--- a/activerecord/test/cases/relation_scoping_test.rb
+++ b/activerecord/test/cases/relation_scoping_test.rb
@@ -421,6 +421,12 @@ class DefaultScopingTest < ActiveRecord::TestCase
     assert_equal expected, received
   end
 
+  def test_order_after_reorder_combines_orders
+    expected = Developer.order('name DESC, id DESC').collect { |dev| [dev.name, dev.id] }
+    received = Developer.order('name ASC').reorder('name DESC').order('id DESC').collect { |dev| [dev.name, dev.id] }
+    assert_equal expected, received
+  end
+
   def test_nested_exclusive_scope
     expected = Developer.find(:all, :limit => 100).collect { |dev| dev.salary }
     received = DeveloperOrderedBySalary.send(:with_exclusive_scope, :find => { :limit => 100 }) do

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -20,7 +20,7 @@ module ActiveRecord
     end
 
     def test_single_values
-      assert_equal [:limit, :offset, :lock, :readonly, :from, :reorder, :reverse_order, :uniq].map(&:to_s).sort,
+      assert_equal [:limit, :offset, :lock, :readonly, :from, :reordering, :reverse_order, :uniq].map(&:to_s).sort,
         Relation::SINGLE_VALUE_METHODS.map(&:to_s).sort
     end
 


### PR DESCRIPTION
Calling `reorder` on a relation currently makes the order passed the _final_ order, regardless of any subsequent calls to `order`. For instance:

```
SomeModel.reorder('name ASC').order('created_at DESC').to_a
```

will execute:

```
SELECT * FROM some_models ORDER BY name ASC
```

(ignoring the `order` clause) rather than:

```
SELECT * FROM some_models ORDER BY name ASC, created_at DESC
```

as might reasonably be expected.

The included commit corrects this behavior. Calling `reorder` on a relation can now be described as 'start the ordering over again with this clause'. Subsequent calls to `order` will be appended rather than ignored.

This commit also unwinds the change (but not the test) in https://github.com/rails/rails/pull/4216 - that code is no longer needed, as `order_values` is now the authoritative source for a relation's order clauses.

Tested on master, but this should be applied to 3.2 as well.
