### PR TITLE
Added aliases for prev_year, prev_month, and prev_week in Time and Date calculations

### DIFF
--- a/activesupport/lib/active_support/core_ext/date/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date/calculations.rb
@@ -182,6 +182,13 @@ class Date
     result = (self - 7).beginning_of_week + DAYS_INTO_WEEK[day]
     self.acts_like?(:time) ? result.change(:hour => 0) : result
   end
+  alias :last_week :prev_week
+
+  # Alias of prev_month
+  alias :last_month :prev_month
+
+  # Alias of prev_year
+  alias :last_year :prev_year
 
   # Returns a new Date/DateTime representing the start of the given day in next week (default is :monday).
   def next_week(day = :monday)

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -145,6 +145,7 @@ class Time
   def prev_year
     years_ago(1)
   end
+  alias_method :last_year, :prev_year
 
   # Short-hand for years_since(1)
   def next_year
@@ -155,6 +156,7 @@ class Time
   def prev_month
     months_ago(1)
   end
+  alias_method :last_month, :prev_month
 
   # Short-hand for months_since(1)
   def next_month
@@ -199,6 +201,7 @@ class Time
   def prev_week(day = :monday)
     ago(1.week).beginning_of_week.since(DAYS_INTO_WEEK[day].day).change(:hour => 0)
   end
+  alias_method :last_week, :prev_week
 
   # Returns a new Time representing the start of the given day in next week (default is :monday).
   def next_week(day = :monday)

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -175,6 +175,18 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
     assert_equal Date.new(1582,10,4), Date.new(1583,10,14).prev_year
   end
 
+  def test_last_year
+    assert_equal Date.new(2004,6,5),  Date.new(2005,6,5).last_year
+  end
+
+  def test_last_year_in_leap_years
+    assert_equal Date.new(1999,2,28), Date.new(2000,2,29).last_year
+  end
+
+  def test_last_year_in_calendar_reform
+    assert_equal Date.new(1582,10,4), Date.new(1583,10,14).last_year
+  end
+
   def test_next_year
     assert_equal Date.new(2006,6,5), Date.new(2005,6,5).next_year
   end
@@ -245,6 +257,14 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
     assert_equal Date.new(2010,2,27), Date.new(2010,3,4).prev_week(:saturday)
   end
 
+  def test_last_week
+    assert_equal Date.new(2005,5,9), Date.new(2005,5,17).last_week
+    assert_equal Date.new(2006,12,25), Date.new(2007,1,7).last_week
+    assert_equal Date.new(2010,2,12), Date.new(2010,2,19).last_week(:friday)
+    assert_equal Date.new(2010,2,13), Date.new(2010,2,19).last_week(:saturday)
+    assert_equal Date.new(2010,2,27), Date.new(2010,3,4).last_week(:saturday)
+  end
+
   def test_next_week
     assert_equal Date.new(2005,2,28), Date.new(2005,2,22).next_week
     assert_equal Date.new(2005,3,4), Date.new(2005,2,22).next_week(:friday)
@@ -263,6 +283,10 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
 
   def test_prev_month_on_31st
     assert_equal Date.new(2004, 2, 29), Date.new(2004, 3, 31).prev_month
+  end
+
+  def test_last_month_on_31st
+    assert_equal Date.new(2004, 2, 29), Date.new(2004, 3, 31).last_month
   end
 
   def test_yesterday_constructor

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -159,6 +159,10 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal DateTime.civil(2004,6,5,10),  DateTime.civil(2005,6,5,10,0,0).prev_year
   end
 
+  def test_last_year
+    assert_equal DateTime.civil(2004,6,5,10),  DateTime.civil(2005,6,5,10,0,0).last_year
+  end
+
   def test_next_year
     assert_equal DateTime.civil(2006,6,5,10), DateTime.civil(2005,6,5,10,0,0).next_year
   end
@@ -232,6 +236,14 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal DateTime.civil(2006,11,15), DateTime.civil(2006,11,23,0,0,0).prev_week(:wednesday)
   end
 
+  def test_last_week
+    assert_equal DateTime.civil(2005,2,21), DateTime.civil(2005,3,1,15,15,10).last_week
+    assert_equal DateTime.civil(2005,2,22), DateTime.civil(2005,3,1,15,15,10).last_week(:tuesday)
+    assert_equal DateTime.civil(2005,2,25), DateTime.civil(2005,3,1,15,15,10).last_week(:friday)
+    assert_equal DateTime.civil(2006,10,30), DateTime.civil(2006,11,6,0,0,0).last_week
+    assert_equal DateTime.civil(2006,11,15), DateTime.civil(2006,11,23,0,0,0).last_week(:wednesday)
+  end
+
   def test_next_week
     assert_equal DateTime.civil(2005,2,28), DateTime.civil(2005,2,22,15,15,10).next_week
     assert_equal DateTime.civil(2005,3,4), DateTime.civil(2005,2,22,15,15,10).next_week(:friday)
@@ -245,6 +257,10 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
 
   def test_prev_month_on_31st
     assert_equal DateTime.civil(2004, 2, 29), DateTime.civil(2004, 3, 31).prev_month
+  end
+
+  def test_last_month_on_31st
+    assert_equal DateTime.civil(2004, 2, 29), DateTime.civil(2004, 3, 31).last_month
   end
 
   def test_xmlschema

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -198,6 +198,10 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal Time.local(2004,6,5,10),  Time.local(2005,6,5,10,0,0).prev_year
   end
 
+  def test_last_year
+    assert_equal Time.local(2004,6,5,10),  Time.local(2005,6,5,10,0,0).last_year
+  end
+
   def test_next_year
     assert_equal Time.local(2006,6,5,10), Time.local(2005,6,5,10,0,0).next_year
   end
@@ -505,6 +509,16 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
       assert_equal Time.local(2006,11,15), Time.local(2006,11,23,0,0,0).prev_week(:wednesday)
     end
   end
+  
+  def test_last_week
+    with_env_tz 'US/Eastern' do
+      assert_equal Time.local(2005,2,21), Time.local(2005,3,1,15,15,10).last_week
+      assert_equal Time.local(2005,2,22), Time.local(2005,3,1,15,15,10).last_week(:tuesday)
+      assert_equal Time.local(2005,2,25), Time.local(2005,3,1,15,15,10).last_week(:friday)
+      assert_equal Time.local(2006,10,30), Time.local(2006,11,6,0,0,0).last_week
+      assert_equal Time.local(2006,11,15), Time.local(2006,11,23,0,0,0).last_week(:wednesday)
+    end
+  end
 
   def test_next_week
     with_env_tz 'US/Eastern' do
@@ -660,6 +674,10 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
 
   def test_prev_month_on_31st
     assert_equal Time.local(2004, 2, 29), Time.local(2004, 3, 31).prev_month
+  end
+
+  def test_last_month_on_31st
+    assert_equal Time.local(2004, 2, 29), Time.local(2004, 3, 31).last_month
   end
 
   def test_xmlschema_is_available

--- a/railties/guides/source/active_support_core_extensions.textile
+++ b/railties/guides/source/active_support_core_extensions.textile
@@ -2858,6 +2858,8 @@ d.next_year               # => Wed, 28 Feb 2001
 
 Active Support defines these methods as well for Ruby 1.8.
 
++prev_year+ is aliased to +last_year+.
+
 h6. +prev_month+, +next_month+
 
 In Ruby 1.9 +prev_month+ and +next_month+ return the date with the same day in the last or next month:
@@ -2878,6 +2880,8 @@ Date.new(2000, 1, 31).next_month # => Tue, 29 Feb 2000
 </ruby>
 
 Active Support defines these methods as well for Ruby 1.8.
+
++prev_month+ is aliased to +last_month+.
 
 h6. +beginning_of_week+, +end_of_week+
 
@@ -2923,6 +2927,8 @@ d.prev_week              # => Mon, 26 Apr 2010
 d.prev_week(:saturday)   # => Sat, 01 May 2010
 d.prev_week(:friday)     # => Fri, 30 Apr 2010
 </ruby>
+
++prev_week+ is aliased to +last_week+.
 
 h6. +beginning_of_month+, +end_of_month+
 
@@ -3134,13 +3140,13 @@ end_of_week (at_end_of_week)
 monday
 sunday
 weeks_ago
-prev_week
+prev_week (last_week)
 next_week
 months_ago
 months_since
 beginning_of_month (at_beginning_of_month)
 end_of_month (at_end_of_month)
-prev_month
+prev_month (last_month)
 next_month
 beginning_of_quarter (at_beginning_of_quarter)
 end_of_quarter (at_end_of_quarter)
@@ -3148,7 +3154,7 @@ beginning_of_year (at_beginning_of_year)
 end_of_year (at_end_of_year)
 years_ago
 years_since
-prev_year
+prev_year (last_year)
 next_year
 </ruby>
 
@@ -3310,13 +3316,13 @@ end_of_week (at_end_of_week)
 monday
 sunday
 weeks_ago
-prev_week
+prev_week (last_week)
 next_week
 months_ago
 months_since
 beginning_of_month (at_beginning_of_month)
 end_of_month (at_end_of_month)
-prev_month
+prev_month (last_month)
 next_month
 beginning_of_quarter (at_beginning_of_quarter)
 end_of_quarter (at_end_of_quarter)
@@ -3324,7 +3330,7 @@ beginning_of_year (at_beginning_of_year)
 end_of_year (at_end_of_year)
 years_ago
 years_since
-prev_year
+prev_year (last_year)
 next_year
 </ruby>
 


### PR DESCRIPTION
As I was working with some time methods, I noticed that using the word `last` made more sense as it is generally how it is thought of. I have added aliases for these three methods last_year, last_month, and last_week.
