### PR TITLE
Fix GH #4285. Remove options when we record calling create_table

### DIFF
--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -59,7 +59,7 @@ module ActiveRecord
       private
 
       def invert_create_table(args)
-        [:drop_table, args]
+        [:drop_table, [args.first]]
       end
 
       def invert_rename_table(args)

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -67,6 +67,12 @@ module ActiveRecord
         assert_equal [:drop_table, [:system_settings]], drop_table
       end
 
+      def test_invert_create_table_with_options
+        @recorder.record :create_table, [:people_reminders, {:id => false}]
+        drop_table = @recorder.inverse.first
+        assert_equal [:drop_table, [:people_reminders]], drop_table
+      end
+
       def test_invert_rename_table
         @recorder.record :rename_table, [:old, :new]
         rename = @recorder.inverse.first


### PR DESCRIPTION
`drop_table` method can't be passed option arguments.
