### PR TITLE
No need of html_safe here

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -1093,7 +1093,7 @@ module ActionView
         end
         hidden = tag("input", "name" => options["name"], "type" => "hidden", "value" => options['disabled'] && checked ? checked_value : unchecked_value)
         checkbox = tag("input", options)
-        (hidden + checkbox).html_safe
+        hidden + checkbox
       end
 
       def to_boolean_select_tag(options = {})

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -330,6 +330,7 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_check_box
+    assert check_box("post", "secret").html_safe?
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
       check_box("post", "secret")

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -96,6 +96,13 @@ class SafeBufferTest < ActiveSupport::TestCase
     assert !@buffer.dup.html_safe?
   end
 
+  test "Should return safe buffer when added with another safe buffer" do
+    clean = "<script>".html_safe
+    result_buffer = @buffer + clean
+    assert result_buffer.html_safe?
+    assert_equal "<script>", result_buffer
+  end
+
   test "Should raise an error when safe_concat is called on dirty buffers" do
     @buffer.gsub!('', '<>')
     assert_raise ActiveSupport::SafeBuffer::SafeConcatError do

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -109,7 +109,7 @@ class SafeBufferTest < ActiveSupport::TestCase
       @buffer.safe_concat "BUSTED"
     end
   end
-  
+
   test "should not fail if the returned object is not a string" do
     assert_kind_of NilClass, @buffer.slice("chipchop")
   end


### PR DESCRIPTION
tag helper always return a html safe string and concat two html safe strings always return a html safe string

``` ruby
>> a = "a".html_safe
=> "a"
>> b = "b".html_safe
=> "b"
>> a.html_safe?
=> true
>> b.html_safe?
=> true
>> ab = a+b
=> "ab"
>> ab.html_safe?
=> true
```
