### PR TITLE
Infer currency negative format from positive one. (3-2-stable)

### DIFF
--- a/actionpack/lib/action_view/helpers/number_helper.rb
+++ b/actionpack/lib/action_view/helpers/number_helper.rb
@@ -128,6 +128,7 @@ module ActionView
 
         defaults  = I18n.translate(:'number.format', :locale => options[:locale], :default => {})
         currency  = I18n.translate(:'number.currency.format', :locale => options[:locale], :default => {})
+        currency[:negative_format] ||= "-" + currency[:format] if currency[:format]
 
         defaults  = DEFAULT_CURRENCY_VALUES.merge(defaults).merge!(currency)
         defaults[:negative_format] = "-" + options[:format] if options[:format]

--- a/actionpack/test/template/number_helper_i18n_test.rb
+++ b/actionpack/test/template/number_helper_i18n_test.rb
@@ -53,6 +53,13 @@ class NumberHelperTest < ActionView::TestCase
       assert_equal("-$10.00", number_to_currency(-10))
     end
   end
+  
+  def test_number_to_currency_without_currency_negative_format
+    clean_i18n do
+      I18n.backend.store_translations 'ts', :number => { :currency => { :format => { :unit => '@', :format => '%n %u' } } }
+      assert_equal("-10.00 @", number_to_currency(-10, :locale => 'ts'))
+    end
+  end
 
   def test_number_with_i18n_precision
     #Delimiter was set to ""


### PR DESCRIPTION
When a locale file sets the format of the positive
currency value as '%n %u', the default negative
currency format should be '-%n %u'.

Cherry-picked from master (6724c8c8)
