### PR TITLE
Undefined Rake::DSL in railtie documentation

### DIFF
--- a/railties/lib/rails/tasks/documentation.rake
+++ b/railties/lib/rails/tasks/documentation.rake
@@ -8,7 +8,7 @@ end
 
 # Monkey-patch to remove redoc'ing and clobber descriptions to cut down on rake -T noise
 class RDocTaskWithoutDescriptions < RDoc::Task
-  include ::Rake::DSL
+  include ::Rake::DSL if defined? ::Rake::DSL
 
   def define
     task rdoc_task_name


### PR DESCRIPTION
The raised exception:

```
$ bundle exec rake db:seed --trace
(in /Users/threez/Development/demail-ident/frontend)
rake aborted!
uninitialized constant Rake::DSL
/Users/threez/.rvm/gems/jruby-1.6.5@project/gems/railties-3.2.0.rc2/lib/rails/tasks/documentation.rake:11:in `RDocTaskWithoutDescriptions'
/Users/threez/.rvm/gems/jruby-1.6.5@project/gems/railties-3.2.0.rc2/lib/rails/tasks/documentation.rake:10:in `(root)'
/Users/threez/.rvm/gems/jruby-1.6.5@project/gems/railties-3.2.0.rc2/lib/rails/tasks/documentation.rake:245:in `load'
/Users/threez/.rvm/gems/jruby-1.6.5@project/gems/railties-3.2.0.rc2/lib/rails/tasks/documentation.rake:245:in `load'
/Users/threez/.rvm/gems/jruby-1.6.5@project/gems/railties-3.2.0.rc2/lib/rails/tasks.rb:15:in `(root)'
/Users/threez/.rvm/gems/jruby-1.6.5@project/gems/railties-3.2.0.rc2/lib/rails/tasks.rb:5:in `each'
/Users/threez/.rvm/gems/jruby-1.6.5@project/gems/railties-3.2.0.rc2/lib/rails/tasks.rb:5:in `(root)'
/Users/threez/.rvm/gems/jruby-1.6.5@project/gems/railties-3.2.0.rc2/lib/rails/tasks.rb:6:in `(root)'
/Users/threez/Development/project/frontend/Rakefile:2383:in `load'
/Users/threez/Development/project/frontend/Rakefile:2383:in `raw_load_rakefile'
/Users/threez/.rvm/gems/jruby-1.6.5@project/gems/rake-0.8.7/lib/rake.rb:2017:in `load_rakefile'
/Users/threez/.rvm/gems/jruby-1.6.5@project/gems/rake-0.8.7/lib/rake.rb:2068:in `standard_exception_handling'
/Users/threez/.rvm/gems/jruby-1.6.5@project/gems/rake-0.8.7/lib/rake.rb:2016:in `load_rakefile'
/Users/threez/.rvm/gems/jruby-1.6.5@project/gems/rake-0.8.7/lib/rake.rb:2000:in `run'
/Users/threez/.rvm/gems/jruby-1.6.5@project/gems/rake-0.8.7/lib/rake.rb:2068:in `standard_exception_handling'
/Users/threez/.rvm/gems/jruby-1.6.5@project/gems/rake-0.8.7/lib/rake.rb:1998:in `run'
/Users/threez/.rvm/gems/jruby-1.6.5@project/gems/rake-0.8.7/bin/rake:31:in `(root)'
/Users/threez/.rvm/gems/jruby-1.6.5@project/bin/rake:19:in `load'
/Users/threez/.rvm/gems/jruby-1.6.5@project/bin/rake:19:in `(root)'
```
