### PR TITLE
refactor AS::Multibyte::Chars

### DIFF
--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -506,7 +506,7 @@ class MultibyteCharsExtrasTest < Test::Unit::TestCase
 
   def test_limit_should_work_on_a_multibyte_string
     example = chars(UNICODE_STRING)
-    bytesize = UNICODE_STRING.respond_to?(:bytesize) ? UNICODE_STRING.bytesize : UNICODE_STRING.size
+    bytesize = UNICODE_STRING.bytesize
 
     assert_equal UNICODE_STRING, example.limit(bytesize)
     assert_equal '', example.limit(0)


### PR DESCRIPTION
Don't need that all under ruby 1.9
