### PR TITLE
2.3 association collection's find_or_create_by doesn't accept hashes.

### DIFF
--- a/activerecord/lib/active_record/associations/association_collection.rb
+++ b/activerecord/lib/active_record/associations/association_collection.rb
@@ -384,7 +384,16 @@ module ActiveRecord
             return  send("find_by_#{rest}", *find_args) ||
                     method_missing("create_by_#{rest}", *args, &block)
           when /^create_by_(.*)$/
-            return create($1.split('_and_').zip(args).inject({}) { |h,kv| k,v=kv ; h[k] = v ; h }, &block)
+            attribute_names = $1.split('_and_')
+            if args[0].is_a? Hash
+              create_args = args[0]
+            else
+              create_args = Hash[ attribute_names.zip(args.first(attribute_names.length))]
+              if args.length > attribute_names.length && args[attribute_names.length].is_a?(Hash)
+                create_args.merge! args[attribute_names.length]
+              end
+            end
+            return create create_args, &block
           end
 
           if @target.respond_to?(method) || (!@reflection.klass.respond_to?(method) && Class.respond_to?(method))

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -71,7 +71,9 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_equal comment, post.comments.find_or_create_by_body('test comment body')
 
-    post.comments.find_or_create_by_body(:body => 'other test comment body', :type => 'test')
+    other_comment = post.comments.find_or_create_by_body(:body => 'other test comment body', :type => 'test')
+
+    assert_equal 'other test comment body', other_comment.body
     assert_equal 2, post.comments.count
     assert_equal 2, post.comments.length
     post.comments.find_or_create_by_body('other other test comment body', :type => 'test')


### PR DESCRIPTION
I was updating a 2.3.8 app to 2.3.14 and ran into an issue where association's find_or_create_by\* methods no longer accepted hashes. When passing a hash to a dynamic finder, this would happen:

``` ruby
joe = Person.friends.find_or_create_by_name :name => 'joe'
joe.name
#=> {:name => 'joe'}
```

This patch changes a test to check that a find_or_create_by created object has the expected attribute value & changes AssociationCollection#method_missing so that find_or_create_by\* will accept either a single hash as an argument, or a list of arguments corresponding to the find_or_create_by\* attributes followed by a hash.
- find_or_create_by_foo :foo => 'bar', :baz => 'qux'
- find_or_create_by_foo 'foo', :baz => 'qux'
