### PR TITLE
remove use of Multibyte.clean as it's no-op in ruby 1.9

### DIFF
--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -118,7 +118,7 @@ module ActionView
       #   escape_once("&lt;&lt; Accept & Checkout")
       #   # => "&lt;&lt; Accept &amp; Checkout"
       def escape_once(html)
-        ActiveSupport::Multibyte.clean(html.to_s).gsub(/[\"><]|&(?!([a-zA-Z]+|(#\d+));)/) { |special| ERB::Util::HTML_ESCAPE[special] }
+        html.to_s.gsub(/[\"><]|&(?!([a-zA-Z]+|(#\d+));)/) { |special| ERB::Util::HTML_ESCAPE[special] }
       end
 
       private


### PR DESCRIPTION
It do nothing https://github.com/rails/rails/blob/39625d153781ffa07121c35dc4bba40410624c9c/activesupport/lib/active_support/multibyte/utils.rb#L20-25

And is going to be removed in https://github.com/rails/rails/pull/4332/files#diff-4
