### PR TITLE
check_box helper with :disabled => true generates disabled hidden field. fixes #1953 (3-2-stable)

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 3.2.0 (unreleased) ##
 
+*   check_box helper with :disabled => true will generate a disabled hidden field to conform with the HTML convention where disabled fields are not submitted with the form.
+    This is a behavior change, previously the hidden tag had a value of the disabled checkbox.
+    *Tadas Tamosauskas*
+
 *   Add font_path helper method *Santiago Pastorino*
 
 *   Depends on rack ~> 1.4.0 *Santiago Pastorino*

--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -1092,7 +1092,7 @@ module ActionView
         else
           add_default_name_and_id(options)
         end
-        hidden = tag("input", "name" => options["name"], "type" => "hidden", "value" => options['disabled'] && checked ? checked_value : unchecked_value)
+        hidden = tag("input", "name" => options["name"], "type" => "hidden", "value" => unchecked_value, "disabled" => options["disabled"])
         checkbox = tag("input", options)
         (hidden + checkbox).html_safe
       end

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -385,11 +385,10 @@ class FormHelperTest < ActionView::TestCase
     )
   end
 
-
-  def test_checkbox_disabled_still_submits_checked_value
+  def test_checkbox_disabled_disables_hidden_field
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="1" /><input checked="checked" disabled="disabled" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
-      check_box("post", "secret", { :disabled => :true })
+      '<input name="post[secret]" type="hidden" value="0" disabled="disabled"/><input checked="checked" disabled="disabled" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      check_box("post", "secret", { :disabled => true })
     )
   end
 


### PR DESCRIPTION
This is a rebased version of https://github.com/rails/rails/pull/3698, fixes #1953 for rails v3.2, if it is not too late for changes like this :)
