### PR TITLE
Require ActiveSupport::TestCase form ActiveSupport isolation tests

### DIFF
--- a/actionpack/test/ts_isolated.rb
+++ b/actionpack/test/ts_isolated.rb
@@ -1,3 +1,4 @@
+$:.unshift(File.dirname(__FILE__))
 $:.unshift(File.dirname(__FILE__) + '/../../activesupport/lib')
 
 require 'test/unit'

--- a/activesupport/test/ts_isolated.rb
+++ b/activesupport/test/ts_isolated.rb
@@ -1,6 +1,7 @@
 $:.unshift(File.dirname(__FILE__) + '/../../activesupport/lib')
 
 require 'test/unit'
+require 'active_support/test_case'
 require 'rbconfig'
 require 'active_support/core_ext/kernel/reporting'
 


### PR DESCRIPTION
Fix broken CI build
