### PR TITLE
Always treat the object passed to content_tag_for as an array.

### DIFF
--- a/actionpack/lib/action_view/helpers/record_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/record_tag_helper.rb
@@ -82,7 +82,7 @@ module ActionView
       #
       def content_tag_for(tag_name, single_or_multiple_records, prefix = nil, options = nil, &block)
         Array.wrap(single_or_multiple_records).map do |single_record|
-          capture { content_tag_for_single_record(tag_name, single_record, prefix, options, &block) }
+          content_tag_for_single_record tag_name, single_record, prefix, options, &block
         end.join("\n").html_safe
       end
 

--- a/actionpack/lib/action_view/helpers/record_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/record_tag_helper.rb
@@ -81,13 +81,9 @@ module ActionView
       #    <li id="person_123" class="person bar">...
       #
       def content_tag_for(tag_name, single_or_multiple_records, prefix = nil, options = nil, &block)
-        if single_or_multiple_records.respond_to?(:to_ary)
-          single_or_multiple_records.to_ary.map do |single_record|
-            capture { content_tag_for_single_record(tag_name, single_record, prefix, options, &block) }
-          end.join("\n").html_safe
-        else
-          content_tag_for_single_record(tag_name, single_or_multiple_records, prefix, options, &block)
-        end
+        Array.wrap(single_or_multiple_records).map do |single_record|
+          capture { content_tag_for_single_record(tag_name, single_record, prefix, options, &block) }
+        end.join("\n").html_safe
       end
 
       private


### PR DESCRIPTION
Currently `content_tag_for` checks if the object responds to `to_ary` to decide what to do with it. This patch eliminates the need to check by wrapping non-array like objects in an array and always iterating over the collection.
