### PR TITLE
Fix routing test and remove deprecated method

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -33,8 +33,8 @@ module ActionDispatch
 
     class GetIp
       def initialize(env, middleware)
-        @env          = env
-        @middleware   = middleware
+        @env           = env
+        @middleware    = middleware
         @calculated_ip = false
       end
 

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -338,7 +338,7 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
   end
 
   def test_render_based_on_parameters
-    process :render_based_on_parameters, "name" => "David"
+    process :render_based_on_parameters, "GET", "name" => "David"
     assert_equal "Mr. David", @response.body
   end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1443,10 +1443,10 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
   def test_nested_optional_path_shorthand
     with_test_routes do
       get '/registrations/new'
-      assert @request.params[:locale].nil?
+      assert_nil @request.params[:locale]
 
       get '/en/registrations/new'
-      assert 'en', @request.params[:locale]
+      assert_equal 'en', @request.params[:locale]
     end
   end
 


### PR DESCRIPTION
Some fixes for ActionPack
- Fix routing test to use `assert_equal` instead of `assert`, and to use `assert_nil`
- Remove deprecated method from AC::TestCase to handle old process api

Thanks!
