### PR TITLE
gemspec assumes that user kept all generated files

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = "TODO: Summary of <%= camelized %>."
   s.description = "TODO: Description of <%= camelized %>."
 
-  s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
+  s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 <% unless options.skip_test_unit? -%>
   s.test_files = Dir["test/**/*"]
 <% end -%>


### PR DESCRIPTION
This commit allows the user be lazy and not update
their gemspec's `files` directive after deleting
unwanted files from their generated Rails plugin.
