### PR TITLE
Array.wrap is an overhead as there is already check for class

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -382,7 +382,7 @@ module ActiveRecord
       if attributes_collection.is_a? Hash
         keys = attributes_collection.keys
         attributes_collection = if keys.include?('id') || keys.include?(:id)
-          Array.wrap(attributes_collection)
+          [attributes_collection]
         else
           attributes_collection.values
         end


### PR DESCRIPTION
```
irb(main):008:0> attributes_collection = {a: 1}
=> {:a=>1}
irb(main):009:0> Array.wrap attributes_collection
=> [{:a=>1}]
irb(main):010:0> [attributes_collection]
=> [{:a=>1}]
```
