### PR TITLE
Implement #swapcase and #swapcase! for multibyte strings

### DIFF
--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -118,6 +118,14 @@ module ActiveSupport #:nodoc:
         chars Unicode.downcase(@wrapped_string)
       end
 
+      # Converts characters in the string to the opposite case.
+      #
+      # Example:
+      #    'El Cañón".mb_chars.swapcase.to_s # => "eL cAÑÓN"
+      def swapcase
+        chars Unicode.swapcase(@wrapped_string)
+      end
+
       # Converts the first character to uppercase and the remainder to lowercase.
       #
       # Example:

--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -93,7 +93,7 @@ module ActiveSupport #:nodoc:
         chars(Unicode.unpack_graphemes(@wrapped_string).reverse.flatten.pack('U*'))
       end
 
-      # Limit the byte size of the string to a number of bytes without breaking characters. Usable
+      # Limits the byte size of the string to a number of bytes without breaking characters. Usable
       # when the storage for a string is limited for some reason.
       #
       # Example:
@@ -102,7 +102,7 @@ module ActiveSupport #:nodoc:
         slice(0...translate_offset(limit))
       end
 
-      # Convert characters in the string to uppercase.
+      # Converts characters in the string to uppercase.
       #
       # Example:
       #   'Laurent, où sont les tests ?'.mb_chars.upcase.to_s # => "LAURENT, OÙ SONT LES TESTS ?"
@@ -110,7 +110,7 @@ module ActiveSupport #:nodoc:
         chars Unicode.upcase(@wrapped_string)
       end
 
-      # Convert characters in the string to lowercase.
+      # Converts characters in the string to lowercase.
       #
       # Example:
       #   'VĚDA A VÝZKUM'.mb_chars.downcase.to_s # => "věda a výzkum"

--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -293,9 +293,17 @@ module ActiveSupport
         apply_mapping string, :uppercase_mapping
       end
 
+      def swapcase(string)
+        apply_mapping string, :swapcase_mapping
+      end
+
       # Holds data about a codepoint in the Unicode database
       class Codepoint
         attr_accessor :code, :combining_class, :decomp_type, :decomp_mapping, :uppercase_mapping, :lowercase_mapping
+
+        def swapcase_mapping
+          uppercase_mapping > 0 ? uppercase_mapping : lowercase_mapping
+        end
       end
 
       # Holds static data from the Unicode database

--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -106,7 +106,7 @@ class MultibyteCharsUTF8BehaviourTest < ActiveSupport::TestCase
     end
   end
 
-  %w{capitalize downcase lstrip reverse rstrip upcase}.each do |method|
+  %w{capitalize downcase lstrip reverse rstrip swapcase upcase}.each do |method|
     class_eval(<<-EOTESTS)
       def test_#{method}_bang_should_return_self_when_modifying_wrapped_string
         chars = ' él piDió Un bUen café '
@@ -161,6 +161,7 @@ class MultibyteCharsUTF8BehaviourTest < ActiveSupport::TestCase
     assert chars('').decompose.kind_of?(ActiveSupport::Multibyte.proxy_class)
     assert chars('').compose.kind_of?(ActiveSupport::Multibyte.proxy_class)
     assert chars('').tidy_bytes.kind_of?(ActiveSupport::Multibyte.proxy_class)
+    assert chars('').swapcase.kind_of?(ActiveSupport::Multibyte.proxy_class)
   end
 
   def test_should_be_equal_to_the_wrapped_string
@@ -432,6 +433,11 @@ class MultibyteCharsUTF8BehaviourTest < ActiveSupport::TestCase
     assert_equal 'abc', 'aBc'.mb_chars.downcase
   end
 
+  def test_swapcase_should_swap_ascii_characters
+    assert_equal '', ''.mb_chars.swapcase
+    assert_equal 'AbC', 'aBc'.mb_chars.swapcase
+  end
+
   def test_capitalize_should_work_on_ascii_characters
     assert_equal '', ''.mb_chars.capitalize
     assert_equal 'Abc', 'abc'.mb_chars.capitalize
@@ -466,8 +472,13 @@ class MultibyteCharsExtrasTest < ActiveSupport::TestCase
   end
 
   def test_downcase_should_be_unicode_aware
-    assert_equal "абвгд\0f", chars("аБвгд\0f").downcase
+    assert_equal "абвгд\0f", chars("аБвгд\0F").downcase
     assert_equal 'こにちわ', chars('こにちわ').downcase
+  end
+
+  def test_swapcase_should_be_unicode_aware
+    assert_equal "аaéÜ\0f", chars("АAÉü\0F").swapcase
+    assert_equal 'こにちわ', chars('こにちわ').swapcase
   end
 
   def test_capitalize_should_be_unicode_aware


### PR DESCRIPTION
Ruby's String class has these two methods, but they were missing from AS::Multibyte::Chars.
