### PR TITLE
[3-2-stable] Don't fork a process when assets:precompile:nondigest is invoked in assets:precompile:all.

### DIFF
--- a/actionpack/lib/sprockets/assets.rake
+++ b/actionpack/lib/sprockets/assets.rake
@@ -1,12 +1,12 @@
 require "fileutils"
 
 namespace :assets do
-  def ruby_rake_task(task)
+  def ruby_rake_task(task, fork = true)
     env    = ENV['RAILS_ENV'] || 'production'
     groups = ENV['RAILS_GROUPS'] || 'assets'
     args   = [$0, task,"RAILS_ENV=#{env}","RAILS_GROUPS=#{groups}"]
     args << "--trace" if Rake.application.options.trace
-    ruby(*args)
+    fork ? ruby(*args) : Kernel.exec(FileUtils::RUBY, *args)
   end
 
   # We are currently running with no explicit bundler group
@@ -59,7 +59,7 @@ namespace :assets do
       # required in order to compile digestless assets as the
       # environment has already cached the assets on the primary
       # run.
-      ruby_rake_task "assets:precompile:nondigest" if Rails.application.config.assets.digest
+      ruby_rake_task("assets:precompile:nondigest", false) if Rails.application.config.assets.digest
     end
 
     task :primary => ["assets:environment", "tmp:cache:clear"] do


### PR DESCRIPTION
@josevalim
Please merge this PR.

This PR is a improvement for GH #3694.
Memory consumption will be reduced if we execute `assets:precompile` .

Please see also...
https://github.com/rails/rails/issues/3694
https://github.com/rails/rails/pull/4350
