### PR TITLE
Using Array directly instead of Array.wrap

### DIFF
--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -84,7 +84,7 @@ module ActiveRecord
       # only one level deep in the +associations+ argument, i.e. it's not passed
       # to the child associations when +associations+ is a Hash.
       def initialize(records, associations, options = {})
-        @records      = Array.wrap(records).compact.uniq
+        @records      = Array(records).compact.uniq
         @associations = Array.wrap(associations)
         @options      = options
       end


### PR DESCRIPTION
1.9.3-p0 :004 > Array([[1,2],[3,4]])  
 => [[1, 2], [3, 4]]

1.9.3-p0 :001 > Array([1,2]) 
 => [1, 2] 
