### PR TITLE
Rename ActiveRecord::TestFixtures public methods

### DIFF
--- a/actionpack/lib/action_dispatch/testing/test_process.rb
+++ b/actionpack/lib/action_dispatch/testing/test_process.rb
@@ -35,8 +35,8 @@ module ActionDispatch
     #
     #   post :change_avatar, avatar: fixture_file_upload('files/spongebob.png', 'image/png', :binary)
     def fixture_file_upload(path, mime_type = nil, binary = false)
-      if self.class.respond_to?(:fixture_path) && self.class.fixture_path
-        path = File.join(self.class.fixture_path, path)
+      if self.class.respond_to?(:fixture_directory_path) && self.class.fixture_directory_path
+        path = File.join(self.class.fixture_directory_path, path)
       end
       Rack::Test::UploadedFile.new(path, mime_type, binary)
     end

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -190,7 +190,7 @@ end
 class IntegrationTestTest < ActiveSupport::TestCase
   def setup
     @test = ::ActionDispatch::IntegrationTest.new(:app)
-    @test.class.stubs(:fixture_table_names).returns([])
+    @test.class.stubs(:fixture_set_names).returns([])
     @session = @test.open_session
   end
 
@@ -225,7 +225,7 @@ end
 # Tests that integration tests don't call Controller test methods for processing.
 # Integration tests have their own setup and teardown.
 class IntegrationTestUsesCorrectClass < ActionDispatch::IntegrationTest
-  def self.fixture_table_names
+  def self.fixture_set_names
     []
   end
 

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -793,7 +793,7 @@ XML
   end
 
   def test_fixture_path_is_accessed_from_self_instead_of_active_support_test_case
-    TestCaseTest.stubs(:fixture_path).returns(FILES_DIR)
+    TestCaseTest.stubs(:fixture_directory_path).returns(FILES_DIR)
 
     uploaded_file = fixture_file_upload('/mona_lisa.jpg', 'image/png')
     assert_equal File.open("#{FILES_DIR}/mona_lisa.jpg", READ_PLAIN).read, uploaded_file.read

--- a/actionview/test/active_record_unit.rb
+++ b/actionview/test/active_record_unit.rb
@@ -75,7 +75,7 @@ class ActiveRecordTestCase < ActionController::TestCase
 
   # Set our fixture path
   if ActiveRecordTestConnector.able_to_connect
-    self.fixture_path = [FIXTURE_LOAD_PATH]
+    self.fixture_directory_path = [FIXTURE_LOAD_PATH]
     self.use_transactional_fixtures = false
   end
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Rename public class methods in the module `ActiveRecord::TestFixtures`:
+
+        `fixture_path`        -> `fixture_directory_path`
+        `fixture_table_names` -> `fixture_set_names`
+        `fixture_class_names` -> `fixture_model_names`
+        `set_fixture_class`   -> `set_fixture_model`
+
+    `fixture_table_names` can be used for something different in the future,
+    something better corresponding to its name (maybe some hash with
+    database table names as values?).
+
+    *Alexey Muranov*
+
 *   Don't allow `quote_value` to be called without a column.
 
     Some adapters require column information to do their job properly.

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -380,7 +380,7 @@ class MultipleFixturesTest < ActiveRecord::TestCase
   fixtures :developers, :accounts
 
   def test_fixture_table_names
-    assert_equal %w(topics developers accounts), fixture_table_names
+    assert_equal %w(topics developers accounts), fixture_set_names
   end
 end
 
@@ -413,7 +413,7 @@ class OverlappingFixturesTest < ActiveRecord::TestCase
   fixtures :developers, :accounts
 
   def test_fixture_table_names
-    assert_equal %w(topics developers accounts), fixture_table_names
+    assert_equal %w(topics developers accounts), fixture_set_names
   end
 end
 
@@ -449,10 +449,10 @@ class OverRideFixtureMethodTest < ActiveRecord::TestCase
 end
 
 class CheckSetTableNameFixturesTest < ActiveRecord::TestCase
-  set_fixture_class :funny_jokes => 'Joke'
+  set_fixture_model :funny_jokes => 'Joke'
   fixtures :funny_jokes
   # Set to false to blow away fixtures cache and ensure our fixtures are loaded
-  # and thus takes into account our set_fixture_class
+  # and thus takes into account our set_fixture_model
   self.use_transactional_fixtures = false
 
   def test_table_method
@@ -461,10 +461,10 @@ class CheckSetTableNameFixturesTest < ActiveRecord::TestCase
 end
 
 class FixtureNameIsNotTableNameFixturesTest < ActiveRecord::TestCase
-  set_fixture_class :items => Book
+  set_fixture_model :items => Book
   fixtures :items
   # Set to false to blow away fixtures cache and ensure our fixtures are loaded
-  # and thus takes into account our set_fixture_class
+  # and thus takes into account our set_fixture_model
   self.use_transactional_fixtures = false
 
   def test_named_accessor
@@ -473,10 +473,10 @@ class FixtureNameIsNotTableNameFixturesTest < ActiveRecord::TestCase
 end
 
 class FixtureNameIsNotTableNameMultipleFixturesTest < ActiveRecord::TestCase
-  set_fixture_class :items => Book, :funny_jokes => Joke
+  set_fixture_model :items => Book, :funny_jokes => Joke
   fixtures :items, :funny_jokes
   # Set to false to blow away fixtures cache and ensure our fixtures are loaded
-  # and thus takes into account our set_fixture_class
+  # and thus takes into account our set_fixture_model
   self.use_transactional_fixtures = false
 
   def test_named_accessor_of_differently_named_fixture
@@ -489,7 +489,7 @@ class FixtureNameIsNotTableNameMultipleFixturesTest < ActiveRecord::TestCase
 end
 
 class CustomConnectionFixturesTest < ActiveRecord::TestCase
-  set_fixture_class :courses => Course
+  set_fixture_model :courses => Course
   fixtures :courses
   self.use_transactional_fixtures = false
 
@@ -504,7 +504,7 @@ class CustomConnectionFixturesTest < ActiveRecord::TestCase
 end
 
 class TransactionalFixturesOnCustomConnectionTest < ActiveRecord::TestCase
-  set_fixture_class :courses => Course
+  set_fixture_model :courses => Course
   fixtures :courses
   self.use_transactional_fixtures = true
 
@@ -521,7 +521,7 @@ end
 class InvalidTableNameFixturesTest < ActiveRecord::TestCase
   fixtures :funny_jokes
   # Set to false to blow away fixtures cache and ensure our fixtures are loaded
-  # and thus takes into account our lack of set_fixture_class
+  # and thus takes into account our lack of set_fixture_model
   self.use_transactional_fixtures = false
 
   def test_raises_error
@@ -532,10 +532,10 @@ class InvalidTableNameFixturesTest < ActiveRecord::TestCase
 end
 
 class CheckEscapedYamlFixturesTest < ActiveRecord::TestCase
-  set_fixture_class :funny_jokes => 'Joke'
+  set_fixture_model :funny_jokes => 'Joke'
   fixtures :funny_jokes
   # Set to false to blow away fixtures cache and ensure our fixtures are loaded
-  # and thus takes into account our set_fixture_class
+  # and thus takes into account our set_fixture_model
   self.use_transactional_fixtures = false
 
   def test_proper_escaped_fixture
@@ -580,11 +580,11 @@ class FixturesBrokenRollbackTest < ActiveRecord::TestCase
 end
 
 class LoadAllFixturesTest < ActiveRecord::TestCase
-  self.fixture_path = FIXTURES_ROOT + "/all"
+  self.fixture_directory_path = FIXTURES_ROOT + "/all"
   fixtures :all
 
   def test_all_there
-    assert_equal %w(developers people tasks), fixture_table_names.sort
+    assert_equal %w(developers people tasks), fixture_set_names.sort
   end
 end
 
@@ -779,7 +779,7 @@ end
 class CustomNameForFixtureOrModelTest < ActiveRecord::TestCase
   ActiveRecord::FixtureSet.reset_cache
 
-  set_fixture_class :randomly_named_a9         =>
+  set_fixture_model :randomly_named_a9         =>
                         ClassNameThatDoesNotFollowCONVENTIONS,
                     :'admin/randomly_named_a9' =>
                         Admin::ClassNameThatDoesNotFollowCONVENTIONS,

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -74,12 +74,12 @@ class ActiveSupport::TestCase
   include ActiveRecord::TestFixtures
   include ActiveRecord::ValidationsRepairHelper
 
-  self.fixture_path = FIXTURES_ROOT
+  self.fixture_directory_path = FIXTURES_ROOT
   self.use_instantiated_fixtures  = false
   self.use_transactional_fixtures = true
 
   def create_fixtures(*fixture_set_names, &block)
-    ActiveRecord::FixtureSet.create_fixtures(ActiveSupport::TestCase.fixture_path, fixture_set_names, fixture_class_names, &block)
+    ActiveRecord::FixtureSet.create_fixtures(self.class.fixture_directory_path, fixture_set_names, fixture_model_names, &block)
   end
 end
 

--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -175,13 +175,13 @@ class Product < ActiveRecord::Base
 end
 ```
 
-If you do so, you will have to define manually the class name that is hosting
-the fixtures (class_name.yml) using the `set_fixture_class` method in your test
+If you do so, you will have to define manually the model name that is hosting 
+the fixtures (model_name.yml) using the `set_fixture_model` method in your test
 definition:
 
 ```ruby
 class FunnyJoke < ActiveSupport::TestCase
-  set_fixture_class funny_jokes: 'Joke'
+  set_fixture_model funny_jokes: 'Joke'
   fixtures :funny_jokes
   ...
 end

--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -15,13 +15,13 @@ MiniTest.backtrace_filter = Rails.backtrace_cleaner
 if defined?(ActiveRecord::Base)
   class ActiveSupport::TestCase
     include ActiveRecord::TestFixtures
-    self.fixture_path = "#{Rails.root}/test/fixtures/"
+    self.fixture_directory_path = "#{Rails.root}/test/fixtures/"
   end
 
-  ActionDispatch::IntegrationTest.fixture_path = ActiveSupport::TestCase.fixture_path
+  ActionDispatch::IntegrationTest.fixture_directory_path = ActiveSupport::TestCase.fixture_directory_path
 
   def create_fixtures(*fixture_set_names, &block)
-    FixtureSet.create_fixtures(ActiveSupport::TestCase.fixture_path, fixture_set_names, {}, &block)
+    FixtureSet.create_fixtures(ActiveSupport::TestCase.fixture_directory_path, fixture_set_names, {}, &block)
   end
 end
 


### PR DESCRIPTION
I would like to know what you think about this.  I propose to rename public methods of  `ActiveRecord::TestFixtures` module as follows:

```
fixture_path        -> fixture_directory_path
fixture_table_names -> fixture_set_names
# fixture_table_names  be reserved to return a hash of the form { "fixture_set/name" => "fixture_table_name", ... }
fixture_class_names -> fixture_model_names
set_fixture_class   -> set_fixture_model
```

This extends PR #4254, where i only tried to give consistent and descriptive names to local variables.

I've posted about this on the mailing list, but there were no comments:
http://groups.google.com/group/rubyonrails-core/browse_thread/thread/22491c3963433854

My motivation was to be consistent in how `directory`, `path`, `table_name` etc. are used.  Also to me `fixture_model` is more flexible and descriptive than `fixture_class`.

Please let me know what you think: if you are happy with existing names, or you have better suggestions, or you like some of the proposed changes but not the other.
