### PR TITLE
Fixed after_initialize callbacks call on AR model #dup

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -210,7 +210,7 @@ module ActiveRecord
 
       @attributes = cloned_attributes
 
-      _run_after_initialize_callbacks if respond_to?(:_run_after_initialize_callbacks)
+      _run_initialize_callbacks if _initialize_callbacks.any?
 
       @changed_attributes = {}
       self.class.column_defaults.each do |attr, orig_value|

--- a/activerecord/test/cases/dup_test.rb
+++ b/activerecord/test/cases/dup_test.rb
@@ -99,5 +99,13 @@ module ActiveRecord
       assert_not_nil new_topic.created_at
     end
 
+    def test_dup_after_initialize_callbacks
+      topic = Topic.new
+      assert Topic.after_initialize_called
+      Topic.after_initialize_called = false
+      topic.dup
+      assert Topic.after_initialize_called
+    end
+
   end
 end

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -80,6 +80,11 @@ class Topic < ActiveRecord::Base
 
   after_initialize :set_email_address
 
+  class_attribute :after_initialize_called
+  after_initialize do
+    self.class.after_initialize_called = true
+  end
+
   def approved=(val)
     @custom_approved = val
     write_attribute(:approved, val)


### PR DESCRIPTION
Callbacks are defined through some method_missing schema.
That's why `respond_to?(...)` doesn't work and we need to check if some callbacks present manually.
