### PR TITLE
get rid of using instance_variable_names method from AS

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -332,7 +332,7 @@ module ActionMailer #:nodoc:
     include AbstractController::Translation
     include AbstractController::AssetPaths
 
-    self.protected_instance_variables = %w(@_action_has_layout)
+    self.protected_instance_variables = [:@_action_has_layout]
 
     helper  ActionMailer::MailHelper
 

--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -1,6 +1,5 @@
 require "abstract_controller/base"
 require "action_view"
-require "active_support/core_ext/object/instance_variables"
 
 module AbstractController
   class DoubleRenderError < Error
@@ -109,17 +108,17 @@ module AbstractController
       view_renderer.render(view_context, options)
     end
 
-    DEFAULT_PROTECTED_INSTANCE_VARIABLES = %w(
-      @_action_name @_response_body @_formats @_prefixes @_config
-      @_view_context_class @_view_renderer @_lookup_context
-    )
+    DEFAULT_PROTECTED_INSTANCE_VARIABLES = [
+      :@_action_name, :@_response_body, :@_formats, :@_prefixes, :@_config,
+      :@_view_context_class, :@_view_renderer, :@_lookup_context
+    ]
 
     # This method should return a hash with assigns.
     # You can overwrite this configuration per controller.
     # :api: public
     def view_assigns
       hash = {}
-      variables  = instance_variable_names
+      variables  = instance_variables
       variables -= protected_instance_variables
       variables -= DEFAULT_PROTECTED_INSTANCE_VARIABLES
       variables.each { |name| hash[name.to_s[1, name.length]] = instance_variable_get(name) }

--- a/actionpack/lib/action_controller/metal/compatibility.rb
+++ b/actionpack/lib/action_controller/metal/compatibility.rb
@@ -18,10 +18,10 @@ module ActionController
         delegate :default_charset=, :to => "ActionDispatch::Response"
       end
 
-      self.protected_instance_variables = %w(
-        @_status @_headers @_params @_env @_response @_request
-        @_view_runtime @_stream @_url_options @_action_has_layout
-      )
+      self.protected_instance_variables = [
+        :@_status, :@_headers, :@_params, :@_env, :@_response, :@_request,
+        :@_view_runtime, :@_stream, :@_url_options, :@_action_has_layout
+      ]
 
       def rescue_action(env)
         raise env["action_dispatch.rescue.exception"]

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -506,8 +506,8 @@ module ActionController
       def check_required_ivars
         # Sanity check for required instance variables so we can give an
         # understandable error message.
-        %w(@routes @controller @request @response).each do |iv_name|
-          if !(instance_variable_names.include?(iv_name) || instance_variable_names.include?(iv_name.to_sym)) || instance_variable_get(iv_name).nil?
+        [:@routes, :@controller, :@request, :@response].each do |iv_name|
+          if !instance_variable_defined?(iv_name) || instance_variable_get(iv_name).nil?
             raise "#{iv_name} is nil: make sure you set it in your test's setup method."
           end
         end

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -16,7 +16,7 @@ class ActionController::Base
 
   def assigns(key = nil)
     assigns = {}
-    instance_variable_names.each do |ivar|
+    instance_variables.each do |ivar|
       next if ActionController::Base.protected_instance_variables.include?(ivar)
       assigns[ivar[1..-1]] = instance_variable_get(ivar)
     end

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -67,7 +67,7 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
   def test_find_with_implicit_inner_joins_does_not_set_associations
     authors = Author.joins(:posts).select('authors.*')
     assert !authors.empty?, "expected authors to be non-empty"
-    assert authors.all? {|a| !a.send(:instance_variable_names).include?("@posts")}, "expected no authors to have the @posts association loaded"
+    assert authors.all? { |a| !a.instance_variable_defined?(:@posts) }, "expected no authors to have the @posts association loaded"
   end
 
   def test_count_honors_implicit_inner_joins


### PR DESCRIPTION
- instance_variables return symbols in 1.9
- there is instance_variable_defined? method
