### PR TITLE
ruby 1.9 related refactoring

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -121,7 +121,7 @@ module AbstractController
       variables  = instance_variables
       variables -= protected_instance_variables
       variables -= DEFAULT_PROTECTED_INSTANCE_VARIABLES
-      variables.each { |name| hash[name.to_s[1, name.length]] = instance_variable_get(name) }
+      variables.each { |name| hash[name[1..-1]] = instance_variable_get(name) }
       hash
     end
 

--- a/actionpack/lib/action_view/test_case.rb
+++ b/actionpack/lib/action_view/test_case.rb
@@ -183,32 +183,32 @@ module ActionView
 
       alias_method :_view, :view
 
-      INTERNAL_IVARS = %w{
-        @__name__
-        @__io__
-        @_assertion_wrapped
-        @_assertions
-        @_result
-        @_routes
-        @controller
-        @layouts
-        @locals
-        @method_name
-        @output_buffer
-        @partials
-        @passed
-        @rendered
-        @request
-        @routes
-        @templates
-        @options
-        @test_passed
-        @view
-        @view_context_class
-      }
+      INTERNAL_IVARS = [
+        :@__name__,
+        :@__io__,
+        :@_assertion_wrapped,
+        :@_assertions,
+        :@_result,
+        :@_routes,
+        :@controller,
+        :@layouts,
+        :@locals,
+        :@method_name,
+        :@output_buffer,
+        :@partials,
+        :@passed,
+        :@rendered,
+        :@request,
+        :@routes,
+        :@templates,
+        :@options,
+        :@test_passed,
+        :@view,
+        :@view_context_class
+      ]
 
       def _user_defined_ivars
-        instance_variables.map(&:to_s) - INTERNAL_IVARS
+        instance_variables - INTERNAL_IVARS
       end
 
       # Returns a Hash of instance variables and their values, as defined by
@@ -216,8 +216,8 @@ module ActionView
       # rendered. This is generally intended for internal use and extension
       # frameworks.
       def view_assigns
-        Hash[_user_defined_ivars.map do |var|
-          [var[1, var.length].to_sym, instance_variable_get(var)]
+        Hash[_user_defined_ivars.map do |ivar|
+          [ivar[1..-1].to_sym, instance_variable_get(ivar)]
         end]
       end
 

--- a/actionpack/test/template/test_case_test.rb
+++ b/actionpack/test/template/test_case_test.rb
@@ -155,7 +155,7 @@ module ActionView
     test "view_assigns excludes internal ivars" do
       INTERNAL_IVARS.each do |ivar|
         assert defined?(ivar), "expected #{ivar} to be defined"
-        assert !view_assigns.keys.include?(ivar.sub('@','').to_sym), "expected #{ivar} to be excluded from view_assigns"
+        assert !view_assigns.keys.include?(ivar.to_s.sub('@', '').to_sym), "expected #{ivar} to be excluded from view_assigns"
       end
     end
   end

--- a/activesupport/lib/active_support/core_ext/object/instance_variables.rb
+++ b/activesupport/lib/active_support/core_ext/object/instance_variables.rb
@@ -10,7 +10,7 @@ class Object
   #
   #   C.new(0, 1).instance_values # => {"x" => 0, "y" => 1}
   def instance_values #:nodoc:
-    Hash[instance_variables.map { |name| [name.to_s[1..-1], instance_variable_get(name)] }]
+    Hash[instance_variables.map { |name| [name[1..-1], instance_variable_get(name)] }]
   end
 
   # Returns an array of instance variable names including "@". They are strings

--- a/activesupport/lib/active_support/string_inquirer.rb
+++ b/activesupport/lib/active_support/string_inquirer.rb
@@ -11,8 +11,8 @@ module ActiveSupport
   #
   class StringInquirer < String
     def method_missing(method_name, *arguments)
-      if method_name.to_s[-1,1] == "?"
-        self == method_name.to_s[0..-2]
+      if method_name[-1, 1] == "?"
+        self == method_name[0..-2]
       else
         super
       end


### PR DESCRIPTION
- instance_variables method returns symbols in 1.9 ruby
- Symbol#[] method presents in Ruby 1.9
