### PR TITLE
Fix GH #3931. A text type column with limit is returned incorrect data type on mysql.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -474,15 +474,27 @@ module ActiveRecord
 
       # Maps logical Rails types to MySQL-specific data types.
       def type_to_sql(type, limit = nil, precision = nil, scale = nil)
-        return super unless type.to_s == 'integer'
-
-        case limit
-        when 1; 'tinyint'
-        when 2; 'smallint'
-        when 3; 'mediumint'
-        when nil, 4, 11; 'int(11)'  # compatibility with MySQL default
-        when 5..8; 'bigint'
-        else raise(ActiveRecordError, "No integer type has byte size #{limit}")
+        case type.to_s
+        when 'integer'
+          case limit
+          when 1; 'tinyint'
+          when 2; 'smallint'
+          when 3; 'mediumint'
+          when nil, 4, 11; 'int(11)'  # compatibility with MySQL default
+          when 5..8; 'bigint'
+          else raise(ActiveRecordError, "No integer type has byte size #{limit}")
+          end
+        when 'text'
+          case limit
+          when nil; 'text'
+          when 0..0xff; 'tinytext'
+          when 0x100..0xffff; 'text'
+          when 0x10000..0xffffff; 'mediumtext'
+          when 0x1000000..0xffffffff; 'longtext'
+          else raise(ActiveRecordError, "No text type has character length #{limit}")
+          end
+        else
+          super
         end
       end
 


### PR DESCRIPTION
This PR fixed GH #3931.

If you execute the following migration, foo column becomes _mediumtext_, and bar column becomes _longtext_.

```
  t.column :foo, :limit => 0x555555 (5592405)
  t.column :bar, :limit => 0x555556 (5592406)
```

But mediumtext's limit on mysql is 0xffffff (16777215).

Please see http://dev.mysql.com/doc/refman/5.5/en/storage-requirements.html

Please see also https://github.com/rails/rails/issues/3931.
