### PR TITLE
ActionMailer#default_i18n_subject i18n scope add 'actionmailer' prefix.

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -523,7 +523,7 @@ module ActionMailer #:nodoc:
     #
     # * <tt>:subject</tt> - The subject of the message, if this is omitted, Action Mailer will
     #   ask the Rails I18n class for a translated <tt>:subject</tt> in the scope of
-    #   <tt>[mailer_scope, action_name]</tt> or if this is missing, will translate the
+    #   <tt>[:actionmailer, mailer_scope, action_name]</tt> or if this is missing, will translate the
     #   humanized version of the <tt>action_name</tt>
     # * <tt>:to</tt> - Who the message is destined for, can be a string of addresses, or an array
     #   of addresses.
@@ -667,12 +667,12 @@ module ActionMailer #:nodoc:
       end
     end
 
-    # Translates the +subject+ using Rails I18n class under <tt>[mailer_scope, action_name]</tt> scope.
+    # Translates the +subject+ using Rails I18n class under <tt>[:actionmailer, mailer_scope, action_name]</tt> scope.
     # If it does not find a translation for the +subject+ under the specified scope it will default to a
     # humanized version of the <tt>action_name</tt>.
     def default_i18n_subject #:nodoc:
       mailer_scope = self.class.mailer_name.gsub('/', '.')
-      I18n.t(:subject, :scope => [mailer_scope, action_name], :default => action_name.humanize)
+      I18n.t(:subject, :scope => [:actionmailer, mailer_scope, action_name], :default => action_name.humanize)
     end
 
     def collect_responses_and_parts_order(headers) #:nodoc:

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -201,7 +201,7 @@ class BaseTest < ActiveSupport::TestCase
     email = BaseMailer.welcome(:subject => nil)
     assert_equal "Welcome", email.subject
 
-    I18n.backend.store_translations('en', :base_mailer => {:welcome => {:subject => "New Subject!"}})
+    I18n.backend.store_translations('en', :actionmailer => {:base_mailer => {:welcome => {:subject => "New Subject!"}}})
     email = BaseMailer.welcome(:subject => nil)
     assert_equal "New Subject!", email.subject
   end


### PR DESCRIPTION
I think subject i18n translation need 'actionmailer' prefix like ActiveRecord or ActiveModel.
