### PR TITLE
3 0 stable

### DIFF
--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -296,7 +296,10 @@ class IntegrationProcessTest < ActionController::IntegrationTest
       self.cookies['cookie_1'] = "sugar"
       self.cookies['cookie_2'] = "oatmeal"
       get '/cookie_monster'
-      assert_equal "cookie_1=; path=/\ncookie_3=chocolate; path=/", headers["Set-Cookie"]
+      assert headers["Set-Cookie"].include?("cookie_1=")
+      assert headers["Set-Cookie"].include?("cookie_3=chocolate")
+      assert_match(/path=\/([\n]|$)/, headers["Set-Cookie"])
+      assert headers["Set-Cookie"].include?("path=/\n")
       assert_equal({"cookie_1"=>"", "cookie_2"=>"oatmeal", "cookie_3"=>"chocolate"}, cookies.to_hash)
     end
   end

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -613,10 +613,9 @@ module NestedAttributesOnACollectionAssociationTests
     }
 
     assert @pirate.send(@association_name).first.new_record?
-    assert_equal 'Grace OMalley', @pirate.send(@association_name).first.name
-
     assert @pirate.send(@association_name).last.new_record?
-    assert_equal 'Privateers Greed', @pirate.send(@association_name).last.name
+
+    assert_equal ['Grace OMalley', 'Privateers Greed'].to_set, [@pirate.send(@association_name).first.name, @pirate.send(@association_name).last.name].to_set
   end
 
   def test_should_not_assign_destroy_key_to_a_record


### PR DESCRIPTION
These commits fix some of the tests failures mentioned in #4292. The last failing test (test_rendering_a_partial_in_an_RJS_template_should_pick_the_JS_template_over_the_HTML_one) is probably a flaw in the application logic itself and as I'm not familiar with actionpack that much, someone else should take a look at that.
