### PR TITLE
Fix GH #4259. When we execute schema dumper, we must remove table_name_prefix and table_name_suffix.

### DIFF
--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -70,8 +70,8 @@ HEADER
         @connection.tables.sort.each do |tbl|
           next if ['schema_migrations', ignore_tables].flatten.any? do |ignored|
             case ignored
-            when String; tbl == ignored
-            when Regexp; tbl =~ ignored
+            when String; remove_prefix_and_suffix(tbl) == ignored
+            when Regexp; remove_prefix_and_suffix(tbl) =~ ignored
             else
               raise StandardError, 'ActiveRecord::SchemaDumper.ignore_tables accepts an array of String and / or Regexp values.'
             end
@@ -92,7 +92,7 @@ HEADER
             pk = @connection.primary_key(table)
           end
 
-          tbl.print "  create_table #{table.inspect}"
+          tbl.print "  create_table #{remove_prefix_and_suffix(table).inspect}"
           if columns.detect { |c| c.name == pk }
             if pk != 'id'
               tbl.print %Q(, :primary_key => "#{pk}")
@@ -185,7 +185,7 @@ HEADER
         if (indexes = @connection.indexes(table)).any?
           add_index_statements = indexes.map do |index|
             statement_parts = [
-              ('add_index ' + index.table.inspect),
+              ('add_index ' + remove_prefix_and_suffix(index.table).inspect),
               index.columns.inspect,
               (':name => ' + index.name.inspect),
             ]
@@ -203,6 +203,10 @@ HEADER
           stream.puts add_index_statements.sort.join("\n")
           stream.puts
         end
+      end
+
+      def remove_prefix_and_suffix(table)
+        table.gsub(/^(#{ActiveRecord::Base.table_name_prefix})(.+)(#{ActiveRecord::Base.table_name_suffix})$/,  "\\2")
       end
   end
 end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -242,4 +242,36 @@ class SchemaDumperTest < ActiveRecord::TestCase
     output = standard_dump
     assert_match %r{create_table "subscribers", :id => false}, output
   end
+
+  class CreateDogMigration < ActiveRecord::Migration
+    def up
+      create_table("dogs") do |t|
+        t.column :name, :string
+      end
+      add_index "dogs", [:name]
+    end
+    def down
+      drop_table("dogs")
+    end
+  end
+
+  def test_schema_dump_with_table_name_prefix_and_suffix
+    original, $stdout = $stdout, StringIO.new
+    ActiveRecord::Base.table_name_prefix = 'foo_'
+    ActiveRecord::Base.table_name_suffix = '_bar'
+
+    migration = CreateDogMigration.new
+    migration.migrate(:up)
+
+    output = standard_dump
+    assert_no_match %r{create_table "foo_.+_bar"}, output
+    assert_no_match %r{create_index "foo_.+_bar"}, output
+    assert_no_match %r{create_table "schema_migrations"}, output
+  ensure
+    migration.migrate(:down)
+
+    ActiveRecord::Base.table_name_suffix = ActiveRecord::Base.table_name_prefix = ''
+    $stdout = original
+  end
+
 end


### PR DESCRIPTION
Please see #4259
and https://rails.lighthouseapp.com/projects/8994/tickets/1210-table_name_prefix-with-dbschemaload-causes-double-prefixes
