### PR TITLE
migrate(:down) method with table_name_prefix

### DIFF
--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -88,5 +88,17 @@ module ActiveRecord
       LegacyMigration.down
       assert !ActiveRecord::Base.connection.table_exists?("horses"), "horses should not exist"
     end
+
+    def test_migrate_down_with_table_name_prefix
+      ActiveRecord::Base.table_name_prefix = 'p_'
+      ActiveRecord::Base.table_name_suffix = '_s'
+      migration = InvertibleMigration.new
+      migration.migrate(:up)
+      assert_nothing_raised { migration.migrate(:down) }
+      assert !ActiveRecord::Base.connection.table_exists?("p_horses_s"), "p_horses_s should not exist"
+    ensure
+      ActiveRecord::Base.table_name_prefix = ActiveRecord::Base.table_name_suffix = ''
+    end
+
   end
 end


### PR DESCRIPTION
I found the following issues, while a survey of GH #4259.

If we execute migrate(:down) method with table_name_prefix, an exception (table isn't exists) is raised.
When we call change method (down direction), It seems that Migrator.proper_table_name method is called twice.

For example,

```
1) ActiveRecord::Base.table_name_prefix = "foo_"
2) def change
     create_table "horses" do |t|
       ...
     end
   end

3) migrate(:up)

=> executed: create table foo_horses ...

4) migrate(:down)

=> executed: drop table foo_foo_horses ...
```
