### PR TITLE
therubyracer gem is now added to the Gemfile on systems that do not have...

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -195,7 +195,7 @@ module Rails
             group :assets do
               gem 'sass-rails',   :git => 'https://github.com/rails/sass-rails.git'
               gem 'coffee-rails', :git => 'https://github.com/rails/coffee-rails.git'
-              #{"gem 'therubyrhino'\n" if defined?(JRUBY_VERSION)}
+              #{required_javascript_runtime}
               gem 'uglifier', '>= 1.0.3'
             end
           GEMFILE
@@ -206,7 +206,7 @@ module Rails
             group :assets do
               gem 'sass-rails',   '~> 4.0.0.beta'
               gem 'coffee-rails', '~> 4.0.0.beta'
-              #{"gem 'therubyrhino'\n" if defined?(JRUBY_VERSION)}
+              #{required_javascript_runtime}
               gem 'uglifier', '>= 1.0.3'
             end
           GEMFILE
@@ -252,6 +252,45 @@ module Rails
       def key_value(key, value)
         "#{key}: #{value}"
       end
+    
+    private
+
+      def required_javascript_runtime
+        # The execjs gem requires a Javascript runtime to be present on the 
+        # system. This can either be a gem or a system executable. Windows and
+        # Mac will have one, Linux typically does not unless node.js is 
+        # installed.  This will add the required gem if a runtime is not on the
+        # system
+        if defined?(JRUBY_VERSION)
+          "gem 'therubyrhino'\n"  
+        else
+          runtime_executables = [
+            "nodejs", "node",  # NodeJS
+            "/System/Library/Frameworks/JavaScriptCore.framework/Versions/A/Resources/jsc", # Mac JavaScriptCore
+            "js", # Mozilla Spidermonkey
+            "cscript" # Windows scripting host
+          ] 
+
+          found = runtime_executables.find do |cmd|
+            if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|windows|cygwin/i && 
+               File.extname(cmd) == ""
+              cmd << ".exe"
+            end
+
+            if File.executable? cmd
+              true
+            else
+              path = ENV['PATH'].split(File::PATH_SEPARATOR).find { |p|
+                full_path = File.join(p, cmd)
+                File.executable?(full_path) && File.file?(full_path)
+              }
+              path && File.expand_path(cmd, path)
+            end
+          end
+          found.nil? ? "gem 'therubyracer'\n" : ""
+        end
+      end
+
     end
   end
 end

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -259,35 +259,16 @@ module Rails
         # The execjs gem requires a Javascript runtime to be present on the 
         # system. This can either be a gem or a system executable. Windows and
         # Mac will have one, Linux typically does not unless node.js is 
-        # installed.  This will add the required gem if a runtime is not on the
-        # system
+        # installed.  Install therubyracer on Linux.  Jruby should always use
+        # therubyrhino so everything is through the JVM
         if defined?(JRUBY_VERSION)
-          "gem 'therubyrhino'\n"  
+          "gem 'therubyrhino'  # Javascript runtime, required by execjs gem when using JRuby"  
         else
-          runtime_executables = [
-            "nodejs", "node",  # NodeJS
-            "/System/Library/Frameworks/JavaScriptCore.framework/Versions/A/Resources/jsc", # Mac JavaScriptCore
-            "js", # Mozilla Spidermonkey
-            "cscript" # Windows scripting host
-          ] 
-
-          found = runtime_executables.find do |cmd|
-            if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|windows|cygwin/i && 
-               File.extname(cmd) == ""
-              cmd << ".exe"
-            end
-
-            if File.executable? cmd
-              true
-            else
-              path = ENV['PATH'].split(File::PATH_SEPARATOR).find { |p|
-                full_path = File.join(p, cmd)
-                File.executable?(full_path) && File.file?(full_path)
-              }
-              path && File.expand_path(cmd, path)
-            end
+          if RbConfig::CONFIG['host_os'].match(/mswin|mingw|windows|darwin|mac/i).nil? 
+            "gem 'therubyracer'  # Javascript runtime, required by execjs gem on everything except Mac and Windows and when node.js is installed"
+          else 
+            ""
           end
-          found.nil? ? "gem 'therubyracer'\n" : ""
         end
       end
 


### PR DESCRIPTION
... a Javascript runtime (Linux without node js). Without this gem an error is reported by execjs

Issues #412 and #4020

I've tested this on Ubuntu with and without nodejs, and on Windows, and it works correctly, the Gemfile contains a line for therubyracer only on Ubuntu without nodejs
