### PR TITLE
Fix GH #3743. We must specify an encoding in rdoc_option explicitly.

### DIFF
--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |s|
   s.files        = Dir['CHANGELOG.md', 'MIT-LICENSE', 'README.rdoc', 'lib/**/*']
   s.require_path = 'lib'
 
+  s.rdoc_options.concat ['--encoding',  'UTF-8']
+
   s.add_dependency('i18n',       '~> 0.6')
   s.add_dependency('multi_json', '~> 1.0')
 end


### PR DESCRIPTION
We should specify an encoding in `rdoc_option` explicitly.
The encoding is not specified in activesupport.gemspec.

Before:

```

~/rails(fix_3743)$ export LANG=en_US.ISO-8859-1 ★ specified no UTF-8 encoding.
~/rails(fix_3743)$ cd (path to rails)
~/rails(fix_3743)$ rake build
~/rails(fix_3743)$ cd pkg
~/rails/pkg(fix_3743)$ gem install activesupport-4.0.0.beta.gem
Successfully installed activesupport-4.0.0.beta
1 gem installed
Installing ri documentation for activesupport-4.0.0.beta...
Installing RDoc documentation for activesupport-4.0.0.beta...
ERROR:  While generating documentation for activesupport-4.0.0.beta
... MESSAGE:   error generating ActiveSupport/Inflector.html: incompatible encoding regexp match (UTF-8 regexp with ISO-8859-1 string) (Encoding::CompatibilityError)
... RDOC args: --op /home/kennyj/.rvm/gems/ruby-1.9.3-p0/doc/activesupport-4.0.0.beta/rdoc lib --title activesupport-4.0.0.beta Documentation --quiet
```

After:

```
~/rails/pkg(fix_3743)$ gem install activesupport-4.0.0.beta.gem
Successfully installed activesupport-4.0.0.beta
1 gem installed
Installing ri documentation for activesupport-4.0.0.beta...
Installing RDoc documentation for activesupport-4.0.0.beta...
~/rails/pkg(fix_3743)$
```

Please see also https://github.com/rails/rails/issues/3743.
