### PR TITLE
AS::Callbacks: remove unused runner

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -210,7 +210,7 @@ module ActiveRecord
 
       @attributes = cloned_attributes
 
-      _run_initialize_callbacks if _initialize_callbacks.any?
+      run_callbacks(:initialize) if _initialize_callbacks.any?
 
       @changed_attributes = {}
       self.class.column_defaults.each do |attr, orig_value|

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -76,8 +76,8 @@ module ActiveSupport
     #     save
     #   end
     #
-    def run_callbacks(kind, *args, &block)
-      send("_run_#{kind}_callbacks", *args, &block)
+    def run_callbacks(kind, key = nil, &block)
+      self.class.__run_callbacks(key, kind, self, &block)
     end
 
     private
@@ -379,24 +379,12 @@ module ActiveSupport
     end
 
     module ClassMethods
-      # Generate the internal runner method called by +run_callbacks+.
-      def __define_runner(symbol) #:nodoc:
-        runner_method = "_run_#{symbol}_callbacks" 
-        unless private_method_defined?(runner_method)
-          class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
-            def #{runner_method}(key = nil, &blk)
-              self.class.__run_callback(key, :#{symbol}, self, &blk)
-            end
-            private :#{runner_method}
-          RUBY_EVAL
-        end
-      end
 
       # This method calls the callback method for the given key.
       # If this called first time it creates a new callback method for the key, 
       # calculating which callbacks can be omitted because of per_key conditions.
       #
-      def __run_callback(key, kind, object, &blk) #:nodoc:
+      def __run_callbacks(key, kind, object, &blk) #:nodoc:
         name = __callback_runner_name(key, kind)
         unless object.respond_to?(name)
           str = send("_#{kind}_callbacks").compile(key, object)
@@ -621,7 +609,6 @@ module ActiveSupport
         callbacks.each do |callback|
           class_attribute "_#{callback}_callbacks"
           send("_#{callback}_callbacks=", CallbackChain.new(callback, config))
-          __define_runner(callback)
         end
       end
     end

--- a/railties/guides/source/active_model_basics.textile
+++ b/railties/guides/source/active_model_basics.textile
@@ -56,7 +56,7 @@ class Person
   before_update :reset_me
 
   def update
-    _run_update_callbacks do
+    run_callbacks(:update) do
       # This will call when we are trying to call update on object.
     end
   end


### PR DESCRIPTION
Based on discussion under #4305 and benchmark: https://github.com/rails/rails/issues/4305#issuecomment-3395384

Reapply the "remove runner" commit with additional change for AR `after_initialize` callbacks and fix  Guides examle.
#4305 could be closed I believe.

cc @josevalim
