### PR TITLE
#[] and #[]= are no longer interchangeable with #read_attribute and #write_attribute (3-1-stable)

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -2173,13 +2173,15 @@ MSG
     # Returns the value of the attribute identified by <tt>attr_name</tt> after it has been typecast (for example,
     # "2004-12-12" in a data column is cast to a date object, like Date.new(2004, 12, 12)).
     # (Alias for the protected read_attribute method).
-    alias [] read_attribute
+    def [](attr_name)
+      read_attribute(attr_name)
+    end
 
     # Updates the attribute identified by <tt>attr_name</tt> with the specified +value+.
     # (Alias for the protected write_attribute method).
-    alias []= write_attribute
-
-    public :[], :[]=
+    def []=(attr_name, value)
+      write_attribute(attr_name, value)
+    end
   end
 end
 

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -234,8 +234,14 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     topic.send(:write_attribute, :title, "Still another topic")
     assert_equal "Still another topic", topic.title
 
-    topic.send(:write_attribute, "title", "Still another topic: part 2")
+    topic[:title] = "Still another topic: part 2"
     assert_equal "Still another topic: part 2", topic.title
+
+    topic.send(:write_attribute, "title", "Still another topic: part 3")
+    assert_equal "Still another topic: part 3", topic.title
+
+    topic["title"] = "Still another topic: part 4"
+    assert_equal "Still another topic: part 4", topic.title
   end
 
   def test_read_attribute

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -294,6 +294,39 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     # puts ""
   end
 
+  def test_overridden_write_attribute
+    topic = Topic.new
+    def topic.write_attribute(attr_name, value)
+      super(attr_name, value.downcase)
+    end
+
+    topic.send(:write_attribute, :title, "Yet another topic")
+    assert_equal "yet another topic", topic.title
+
+    topic[:title] = "Yet another topic: part 2"
+    assert_equal "yet another topic: part 2", topic.title
+
+    topic.send(:write_attribute, "title", "Yet another topic: part 3")
+    assert_equal "yet another topic: part 3", topic.title
+
+    topic["title"] = "Yet another topic: part 4"
+    assert_equal "yet another topic: part 4", topic.title
+  end
+
+  def test_overridden_read_attribute
+    topic = Topic.new
+    topic.title = "Stop changing the topic"
+    def topic.read_attribute(attr_name)
+      super(attr_name).upcase
+    end
+
+    assert_equal "STOP CHANGING THE TOPIC", topic.send(:read_attribute, "title")
+    assert_equal "STOP CHANGING THE TOPIC", topic["title"]
+
+    assert_equal "STOP CHANGING THE TOPIC", topic.send(:read_attribute, :title)
+    assert_equal "STOP CHANGING THE TOPIC", topic[:title]
+  end
+
   def test_read_overridden_attribute
     topic = Topic.new(:title => 'a')
     def topic.title() 'b' end


### PR DESCRIPTION
As requested by @spastorino, this is a backport of #4408 to 3-1-stable.
