### PR TITLE
Allow extending ActiveResource connections by assigning custom ones

### DIFF
--- a/activeresource/lib/active_resource/base.rb
+++ b/activeresource/lib/active_resource/base.rb
@@ -421,6 +421,24 @@ module ActiveResource
         end
       end
 
+      # Gets the class used to establish connection.
+      def connection_class
+        if defined?(@connection_class) && @connection_class
+          @connection_class
+        elsif superclass != Object
+          superclass.connection_class
+        else
+          ActiveResource::Connection
+        end
+      end
+
+      # Sets the connection class for this model to the value in the +klass+ argument.
+      # The +klass+ should inherit from ActiveResource::Connection.
+      def connection_class=(klass)
+        @connection = nil
+        @connection_class = klass
+      end
+
       # Gets the \proxy variable if a proxy is required
       def proxy
         # Not using superclass_delegating_reader. See +site+ for explanation
@@ -547,7 +565,7 @@ module ActiveResource
       # or not (defaults to <tt>false</tt>).
       def connection(refresh = false)
         if defined?(@connection) || superclass == Object
-          @connection = Connection.new(site, format) if refresh || @connection.nil?
+          @connection = connection_class.new(site, format) if refresh || @connection.nil?
           @connection.proxy = proxy if proxy
           @connection.user = user if user
           @connection.password = password if password

--- a/activeresource/test/cases/base_test.rb
+++ b/activeresource/test/cases/base_test.rb
@@ -7,6 +7,7 @@ require "fixtures/beast"
 require "fixtures/proxy"
 require "fixtures/address"
 require "fixtures/subscription_plan"
+require "fixtures/hierarchy"
 require 'active_support/json'
 require 'active_support/ordered_hash'
 require 'active_support/core_ext/hash/conversions'
@@ -47,6 +48,21 @@ class BaseTest < Test::Unit::TestCase
     actor.site = 'http://localhost:31337'
     actor.site = nil
     assert_nil actor.site
+  end
+
+  def test_connection_class_assignable_and_inheritable
+    assert_same ActiveResource::Connection, RootResource.connection_class
+    assert_same ParentConnection, ParentResource.connection_class
+    assert_same ParentConnection, ChildResource.connection_class
+  end
+
+  def test_connection_class_changes_connection    
+    assert_not_same ParentResource.connection, RootResource.connection
+    assert_same ChildResource.connection, ParentResource.connection
+
+    assert_instance_of ActiveResource::Connection, RootResource.connection
+    assert_instance_of ParentConnection, ParentResource.connection
+    assert_instance_of ParentConnection, ChildResource.connection
   end
 
   def test_proxy_accessor_accepts_uri_or_string_argument

--- a/activeresource/test/fixtures/beast.rb
+++ b/activeresource/test/fixtures/beast.rb
@@ -12,3 +12,4 @@ end
 class Topic < BeastResource
   self.site += '/forums/:forum_id'
 end
+

--- a/activeresource/test/fixtures/hierarchy.rb
+++ b/activeresource/test/fixtures/hierarchy.rb
@@ -1,0 +1,13 @@
+class ParentConnection < ActiveResource::Connection
+end
+
+class RootResource < ActiveResource::Base
+  self.site = 'http://api.example.com'
+end
+
+class ParentResource < RootResource
+  self.connection_class = ParentConnection
+end
+
+class ChildResource < ParentResource
+end


### PR DESCRIPTION
...n classes.

APIs aren't always easy, sometimes they want you to do something very special, something there is no hook in ActiveResource::Connection for. Extending connections isn't very slick at the moment, it requires you to overload `ActiveResource::Base.connection` in your models or some dirty patching. 

The solution above allows users to assign a connection class in their models, allowing a new dimension of API customisations. I could also think of opportunities for new gems, with Connection classes that use other HTTP libraries, e.g. `activeresource-excon-connection`, etc. These would then be applicable on a model-by-model basis.

dim
