### PR TITLE
Remove Gem.source_index warning

### DIFF
--- a/railties/lib/rails/gem_dependency.rb
+++ b/railties/lib/rails/gem_dependency.rb
@@ -18,7 +18,8 @@ module Rails
 
     def self.add_frozen_gem_path
       @@paths_loaded ||= begin
-        source_index = Rails::VendorGemSourceIndex.new(Gem.source_index)
+        original_source_index = Gem::Specification.respond_to?(:dirs) ? Gem::SourceIndex.new(Gem::Specification.dirs) : Gem.source_index
+        source_index = Rails::VendorGemSourceIndex.new(original_source_index)
         Gem.clear_paths
         Gem.source_index = source_index
         # loaded before us - we can't change them, so mark them


### PR DESCRIPTION
Conditionally removes the Gem.source_index for the `2-3-stable` branch.

Probably complements #536

**NOTE** _(2 feb 2012):_ I wasn't able to setup the rails `2-3-stable` development environment, if anyone can point me to some working  instruction/tutorial I'll happily do my homework :)
