### PR TITLE
Fix GH #3980. Support assets:cache:clean task.

### DIFF
--- a/actionpack/lib/sprockets/assets.rake
+++ b/actionpack/lib/sprockets/assets.rake
@@ -62,11 +62,11 @@ namespace :assets do
       ruby_rake_task("assets:precompile:nondigest", false) if Rails.application.config.assets.digest
     end
 
-    task :primary => ["assets:environment", "tmp:cache:clear"] do
+    task :primary => ["assets:cache:clean"] do
       internal_precompile
     end
 
-    task :nondigest => ["assets:environment", "tmp:cache:clear"] do
+    task :nondigest => ["assets:cache:clean"] do
       internal_precompile(false)
     end
   end
@@ -77,10 +77,16 @@ namespace :assets do
   end
 
   namespace :clean do
-    task :all => ["assets:environment", "tmp:cache:clear"] do
+    task :all => ["assets:cache:clean"] do
       config = Rails.application.config
       public_asset_path = File.join(Rails.public_path, config.assets.prefix)
       rm_rf public_asset_path, :secure => true
+    end
+  end
+
+  namespace :cache do
+    task :clean => ["assets:environment"] do
+      Rails.application.assets.cache.clear
     end
   end
 

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -314,7 +314,7 @@ module ApplicationTests
         Dir.chdir(app_path){ `bundle exec rake assets:clean` }
       end
 
-      files = Dir["#{app_path}/public/assets/**/*", "#{app_path}/tmp/cache/*"]
+      files = Dir["#{app_path}/public/assets/**/*", "#{app_path}/tmp/cache/assets/*"]
       assert_equal 0, files.length, "Expected no assets, but found #{files.join(', ')}"
     end
 
@@ -490,6 +490,18 @@ module ApplicationTests
       precompile!
 
       assert_match 'src="/sub/uri/assets/rails.png"', File.read("#{app_path}/public/assets/app.js")
+    end
+
+    test "assets:cache:clean should clean cache" do
+      ENV["RAILS_ENV"] = "production"
+      precompile!
+
+      quietly do
+        Dir.chdir(app_path){ `bundle exec rake assets:cache:clean` }
+      end
+
+      require "#{app_path}/config/environment"
+      assert_equal 0, Dir.entries(Rails.application.assets.cache.cache_path).size - 2 # reject [".", ".."]
     end
 
     private


### PR DESCRIPTION
We should support `assets:cache:clean` task to respect sprockets cache.

Please see also https://github.com/rails/rails/issues/3980 .

/cc @guilleiguaran
