### PR TITLE
When force redirecting to SSL, make sure that the session is kept

### DIFF
--- a/actionpack/lib/action_controller/metal/force_ssl.rb
+++ b/actionpack/lib/action_controller/metal/force_ssl.rb
@@ -29,6 +29,7 @@ module ActionController
           if !request.ssl? && !Rails.env.development?
             redirect_options = {:protocol => 'https://', :status => :moved_permanently}
             redirect_options.merge!(:host => host) if host
+            flash.keep
             redirect_to redirect_options
           end
         end

--- a/actionpack/test/controller/force_ssl_test.rb
+++ b/actionpack/test/controller/force_ssl_test.rb
@@ -26,6 +26,23 @@ class ForceSSLExceptAction < ForceSSLController
   force_ssl :except => :banana
 end
 
+class ForceSSLFlash < ForceSSLController
+  force_ssl :except => [:banana, :set_flash, :use_flash]
+
+  def set_flash
+    flash["that"] = "hello"
+    redirect_to '/force_ssl_flash/cheeseburger'
+  end
+
+  def use_flash
+    @flash_copy = {}.update flash
+    @flashy = flash["that"]
+    render :inline => "hello"
+  end
+
+end
+
+
 class ForceSSLControllerLevelTest < ActionController::TestCase
   tests ForceSSLControllerLevel
 
@@ -50,7 +67,7 @@ class ForceSSLCustomDomainTest < ActionController::TestCase
     assert_response 301
     assert_equal "https://secure.test.host/force_ssl_custom_domain/banana", redirect_to_url
   end
-  
+
   def test_cheeseburger_redirects_to_https_with_custom_host
     get :cheeseburger
     assert_response 301
@@ -100,4 +117,23 @@ class ForceSSLExcludeDevelopmentTest < ActionController::TestCase
     get :banana
     assert_response 200
   end
+end
+
+class ForceSSLFlashTest < ActionController::TestCase
+  tests ForceSSLFlash
+
+  def test_cheeseburger_redirects_to_https
+    get :set_flash
+    assert_response 302
+    assert_equal "http://test.host/force_ssl_flash/cheeseburger", redirect_to_url
+
+    get :cheeseburger
+    assert_response 301
+    assert_equal "https://test.host/force_ssl_flash/cheeseburger", redirect_to_url
+
+    get :use_flash
+    assert_equal "hello", assigns["flash_copy"]["that"]
+    assert_equal "hello", assigns["flashy"]
+  end
+
 end


### PR DESCRIPTION
This implements the fix submitted in issue #1923.

The logic behind is that we're redirecting from a non-secure environment to a secure environment, so the session cookie must be available in both. 

However if the app is running in force_ssl mode, this change makes no difference, so it's beneficial if you work in a split environment.
