### PR TITLE
Html escape once

### DIFF
--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -118,7 +118,7 @@ module ActionView
       #   escape_once("&lt;&lt; Accept & Checkout")
       #   # => "&lt;&lt; Accept &amp; Checkout"
       def escape_once(html)
-        html.to_s.gsub(/[\"><]|&(?!([a-zA-Z]+|(#\d+));)/) { |special| ERB::Util::HTML_ESCAPE[special] }
+        ERB::Util.html_escape_once(html)
       end
 
       private

--- a/actionpack/test/template/erb_util_test.rb
+++ b/actionpack/test/template/erb_util_test.rb
@@ -44,4 +44,18 @@ class ErbUtilTest < ActiveSupport::TestCase
       assert_equal chr, html_escape(chr)
     end
   end
+
+  def test_html_escape_once
+    assert_equal '1 &lt; 2 &amp; 3', html_escape_once('1 < 2 &amp; 3')
+  end
+
+  def test_html_escape_once_returns_unsafe_strings_when_passed_unsafe_strings
+    value = html_escape_once('1 < 2 &amp; 3')
+    assert !value.html_safe?
+  end
+
+  def test_html_escape_once_returns_safe_strings_when_passed_safe_strings
+    value = html_escape_once('1 < 2 &amp; 3'.html_safe)
+    assert value.html_safe?
+  end
 end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*    Add html_escape_once to ERB::Util, and delegate escape_once tag helper to it. *Carlos Antonio da Silva*
+
 *    Remove ActiveSupport::TestCase#pending method, use `skip` instead. *Carlos Antonio da Silva*
 
 *    Deprecates the compatibility method Module#local_constant_names,

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -5,6 +5,8 @@ class ERB
   module Util
     HTML_ESCAPE = { '&' => '&amp;',  '>' => '&gt;',   '<' => '&lt;', '"' => '&quot;' }
     JSON_ESCAPE = { '&' => '\u0026', '>' => '\u003E', '<' => '\u003C' }
+    HTML_ESCAPE_ONCE_REGEXP = /[\"><]|&(?!([a-zA-Z]+|(#\d+));)/
+    JSON_ESCAPE_REGEXP = /[&"><]/
 
     # A utility method for escaping HTML tag characters.
     # This method is also aliased as <tt>h</tt>.
@@ -42,7 +44,7 @@ class ERB
     #   html_escape_once("&lt;&lt; Accept & Checkout")
     #   # => "&lt;&lt; Accept &amp; Checkout"
     def html_escape_once(s)
-      result = s.to_s.gsub(/[\"><]|&(?!([a-zA-Z]+|(#\d+));)/) { |special| HTML_ESCAPE[special] }
+      result = s.to_s.gsub(HTML_ESCAPE_ONCE_REGEXP) { |special| HTML_ESCAPE[special] }
       s.html_safe? ? result.html_safe : result
     end
 
@@ -66,7 +68,7 @@ class ERB
     #   <%=j @person.to_json %>
     #
     def json_escape(s)
-      result = s.to_s.gsub(/[&"><]/) { |special| JSON_ESCAPE[special] }
+      result = s.to_s.gsub(JSON_ESCAPE_REGEXP) { |special| JSON_ESCAPE[special] }
       s.html_safe? ? result.html_safe : result
     end
 

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -33,6 +33,21 @@ class ERB
     singleton_class.send(:remove_method, :html_escape)
     module_function :html_escape
 
+    # Returns an escaped version of +html+ without affecting existing escaped entities.
+    #
+    # ==== Examples
+    #   html_escape_once("1 < 2 &amp; 3")
+    #   # => "1 &lt; 2 &amp; 3"
+    #
+    #   html_escape_once("&lt;&lt; Accept & Checkout")
+    #   # => "&lt;&lt; Accept &amp; Checkout"
+    def html_escape_once(s)
+      result = s.to_s.gsub(/[\"><]|&(?!([a-zA-Z]+|(#\d+));)/) { |special| HTML_ESCAPE[special] }
+      s.html_safe? ? result.html_safe : result
+    end
+
+    module_function :html_escape_once
+
     # A utility method for escaping HTML entities in JSON strings
     # using \uXXXX JavaScript escape sequences for string literals:
     #


### PR DESCRIPTION
All the logic is based on the HTML_ESCAPE constant available in ERB::Util, so it seems more logic to have the entire method there and just delegate the helper to use it.
