### PR TITLE
Action view refactor

### DIFF
--- a/actionpack/lib/action_view/asset_paths.rb
+++ b/actionpack/lib/action_view/asset_paths.rb
@@ -4,6 +4,8 @@ require 'action_controller/metal/exceptions'
 
 module ActionView
   class AssetPaths #:nodoc:
+    URI_REGEXP = %r{^[-a-z]+://|^cid:|^//}
+
     attr_reader :config, :controller
 
     def initialize(config, controller = nil)
@@ -37,7 +39,7 @@ module ActionView
     end
 
     def is_uri?(path)
-      path =~ %r{^[-a-z]+://|^cid:|^//}
+      path =~ URI_REGEXP
     end
 
   private

--- a/actionpack/lib/action_view/base.rb
+++ b/actionpack/lib/action_view/base.rb
@@ -156,12 +156,6 @@ module ActionView #:nodoc:
         ActionView::Resolver.caching = value
       end
 
-      def process_view_paths(value)
-        value.is_a?(PathSet) ?
-          value.dup : ActionView::PathSet.new(Array(value))
-      end
-      deprecate :process_view_paths
-
       def xss_safe? #:nodoc:
         true
       end

--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -125,7 +125,8 @@ module ActionView
 
         def content_tag_string(name, content, options, escape = true)
           tag_options = tag_options(options, escape) if options
-          "<#{name}#{tag_options}>#{escape ? ERB::Util.h(content) : content}</#{name}>".html_safe
+          content     = ERB::Util.h(content) if escape
+          "<#{name}#{tag_options}>#{content}</#{name}>".html_safe
         end
 
         def tag_options(options, escape = true)
@@ -147,10 +148,8 @@ module ActionView
         end
 
         def data_tag_option(k, v, escape)
-          if !v.is_a?(String) && !v.is_a?(Symbol)
-            v = v.to_json
-          end
-          v = ERB::Util.html_escape(v) if escape
+          v = v.to_json if !v.is_a?(String) && !v.is_a?(Symbol)
+          v = ERB::Util.h(v) if escape
           %(data-#{k.to_s.dasherize}="#{v}")
         end
 
@@ -159,9 +158,9 @@ module ActionView
         end
 
         def tag_option(key, value, escape)
-          final_value = value.is_a?(Array) ? value.join(" ") : value
-          final_value = ERB::Util.html_escape(final_value) if escape
-          %(#{key}="#{final_value}")
+          value = value.join(" ") if value.is_a?(Array)
+          value = ERB::Util.h(value) if escape
+          %(#{key}="#{value}")
         end
     end
   end

--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -138,7 +138,7 @@ module ActionView
                 attrs << data_tag_option(k, v, escape)
               end
             elsif BOOLEAN_ATTRIBUTES.include?(key)
-              attrs << boolean_tag_option(key, value) if value
+              attrs << boolean_tag_option(key) if value
             elsif !value.nil?
               attrs << tag_option(key, value, escape)
             end
@@ -152,7 +152,7 @@ module ActionView
           %(data-#{k.to_s.dasherize}="#{v}")
         end
 
-        def boolean_tag_option(key, value)
+        def boolean_tag_option(key)
           %(#{key}="#{key}")
         end
 

--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -134,22 +134,34 @@ module ActionView
             options.each_pair do |key, value|
               if key.to_s == 'data' && value.is_a?(Hash)
                 value.each do |k, v|
-                  if !v.is_a?(String) && !v.is_a?(Symbol)
-                    v = v.to_json
-                  end
-                  v = ERB::Util.html_escape(v) if escape
-                  attrs << %(data-#{k.to_s.dasherize}="#{v}")
+                  attrs << data_tag_option(k, v, escape)
                 end
               elsif BOOLEAN_ATTRIBUTES.include?(key)
-                attrs << %(#{key}="#{key}") if value
+                attrs << boolean_tag_option(key, value) if value
               elsif !value.nil?
-                final_value = value.is_a?(Array) ? value.join(" ") : value
-                final_value = ERB::Util.html_escape(final_value) if escape
-                attrs << %(#{key}="#{final_value}")
+                attrs << tag_option(key, value, escape)
               end
             end
             " #{attrs.sort * ' '}".html_safe unless attrs.empty?
           end
+        end
+
+        def data_tag_option(k, v, escape)
+          if !v.is_a?(String) && !v.is_a?(Symbol)
+            v = v.to_json
+          end
+          v = ERB::Util.html_escape(v) if escape
+          %(data-#{k.to_s.dasherize}="#{v}")
+        end
+
+        def boolean_tag_option(key, value)
+          %(#{key}="#{key}")
+        end
+
+        def tag_option(key, value, escape)
+          final_value = value.is_a?(Array) ? value.join(" ") : value
+          final_value = ERB::Util.html_escape(final_value) if escape
+          %(#{key}="#{final_value}")
         end
     end
   end

--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -134,7 +134,7 @@ module ActionView
           attrs = []
           options.each_pair do |key, value|
             if key.to_s == 'data' && value.is_a?(Hash)
-              value.each do |k, v|
+              value.each_pair do |k, v|
                 attrs << data_tag_option(k, v, escape)
               end
             elsif BOOLEAN_ATTRIBUTES.include?(key)
@@ -146,10 +146,11 @@ module ActionView
           " #{attrs.sort * ' '}".html_safe unless attrs.empty?
         end
 
-        def data_tag_option(k, v, escape)
-          v = v.to_json if !v.is_a?(String) && !v.is_a?(Symbol)
-          v = ERB::Util.h(v) if escape
-          %(data-#{k.to_s.dasherize}="#{v}")
+        def data_tag_option(key, value, escape)
+          key   = "data-#{key.to_s.dasherize}"
+          value = value.to_json if !value.is_a?(String) && !value.is_a?(Symbol)
+
+          tag_option(key, value, escape)
         end
 
         def boolean_tag_option(key)

--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -130,21 +130,20 @@ module ActionView
         end
 
         def tag_options(options, escape = true)
-          unless options.blank?
-            attrs = []
-            options.each_pair do |key, value|
-              if key.to_s == 'data' && value.is_a?(Hash)
-                value.each do |k, v|
-                  attrs << data_tag_option(k, v, escape)
-                end
-              elsif BOOLEAN_ATTRIBUTES.include?(key)
-                attrs << boolean_tag_option(key, value) if value
-              elsif !value.nil?
-                attrs << tag_option(key, value, escape)
+          return if options.blank?
+          attrs = []
+          options.each_pair do |key, value|
+            if key.to_s == 'data' && value.is_a?(Hash)
+              value.each do |k, v|
+                attrs << data_tag_option(k, v, escape)
               end
+            elsif BOOLEAN_ATTRIBUTES.include?(key)
+              attrs << boolean_tag_option(key, value) if value
+            elsif !value.nil?
+              attrs << tag_option(key, value, escape)
             end
-            " #{attrs.sort * ' '}".html_safe unless attrs.empty?
           end
+          " #{attrs.sort * ' '}".html_safe unless attrs.empty?
         end
 
         def data_tag_option(k, v, escape)

--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -97,12 +97,12 @@ module ActionView
       #   <%= url_for(:back) %>
       #   # if request.env["HTTP_REFERER"] is not set or is blank
       #   # => javascript:history.back()
-      def url_for(options = {})
-        options ||= {}
+      def url_for(options = nil)
         case options
         when String
           options
-        when Hash
+        when nil, Hash
+          options ||= {}
           options = options.symbolize_keys.reverse_merge!(:only_path => options[:host].nil?)
           super
         when :back
@@ -301,7 +301,7 @@ module ActionView
       #   #      <div><input value="Create" type="submit" /></div>
       #   #    </form>"
       #
-      #      
+      #
       #   <%= button_to "Delete Image", { :action => "delete", :id => @image.id },
       #             :confirm => "Are you sure?", :method => :delete %>
       #   # => "<form method="post" action="/images/delete/1" class="button_to">
@@ -333,9 +333,9 @@ module ActionView
         form_method = method.to_s == 'get' ? 'get' : 'post'
         form_options = html_options.delete('form') || {}
         form_options[:class] ||= html_options.delete('form_class') || 'button_to'
-        
+
         remote = html_options.delete('remote')
-        
+
         request_token_tag = ''
         if form_method == 'post' && protect_against_forgery?
           request_token_tag = tag(:input, :type => "hidden", :name => request_forgery_protection_token.to_s, :value => form_authenticity_token)
@@ -350,7 +350,7 @@ module ActionView
 
         form_options.merge!(:method => form_method, :action => url)
         form_options.merge!("data-remote" => "true") if remote
-        
+
         "#{tag(:form, form_options, true)}<div>#{method_tag}#{tag("input", html_options)}#{request_token_tag}</div></form>".html_safe
       end
 
@@ -624,7 +624,7 @@ module ActionView
 
             html_options["data-disable-with"] = disable_with if disable_with
             html_options["data-confirm"] = confirm if confirm
-            add_method_to_attributes!(html_options, method)   if method
+            add_method_to_attributes!(html_options, method) if method
 
             html_options
           else


### PR DESCRIPTION
Refactor `tag_options` and break it in smaller methods.

I've also removed the `process_views_paths` method from AV::Base, it was deprecated and there is no other mention of it in the entire source code - neither in master nor in 3-2-stable branch. Tests are all green.

Let me know if something should be changed. Thanks.
