### PR TITLE
Rails new generator will now add therubyracer gem to the Gemfile on Linu...

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -195,7 +195,7 @@ module Rails
             group :assets do
               gem 'sass-rails',   :git => 'https://github.com/rails/sass-rails.git'
               gem 'coffee-rails', :git => 'https://github.com/rails/coffee-rails.git'
-              #{"gem 'therubyrhino'\n" if defined?(JRUBY_VERSION)}
+              #{required_javascript_runtime}
               gem 'uglifier', '>= 1.0.3'
             end
           GEMFILE
@@ -206,7 +206,7 @@ module Rails
             group :assets do
               gem 'sass-rails',   '~> 4.0.0.beta'
               gem 'coffee-rails', '~> 4.0.0.beta'
-              #{"gem 'therubyrhino'\n" if defined?(JRUBY_VERSION)}
+              #{required_javascript_runtime}
               gem 'uglifier', '>= 1.0.3'
             end
           GEMFILE
@@ -252,6 +252,26 @@ module Rails
       def key_value(key, value)
         "#{key}: #{value}"
       end
+    
+    private
+
+      def required_javascript_runtime
+        # The execjs gem requires a Javascript runtime to be present on the 
+        # system. This can either be a gem or a system executable. Windows and
+        # Mac will have one, Linux typically does not unless node.js is 
+        # installed.  Install therubyracer on Linux.  Jruby should always use
+        # therubyrhino so everything is through the JVM
+        if defined?(JRUBY_VERSION)
+          "gem 'therubyrhino'  # Javascript runtime, required by execjs gem when using JRuby"  
+        else
+          if RbConfig::CONFIG['host_os'].match(/mswin|mingw|windows|darwin|mac/i).nil? 
+            "gem 'therubyracer'  # Javascript runtime, required by execjs gem unless node.js is installed"
+          else 
+            ""
+          end
+        end
+      end
+
     end
   end
 end

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -264,7 +264,7 @@ module Rails
         if defined?(JRUBY_VERSION)
           "gem 'therubyrhino'  # Javascript runtime, required by execjs gem when using JRuby"  
         else
-          if RbConfig::CONFIG['host_os'].match(/mswin|mingw|windows|darwin|mac/i).nil? 
+          if !(RbConfig::CONFIG['host_os'] =~ /mswin|mingw|windows|darwin|mac/i) 
             "gem 'therubyracer'  # Javascript runtime, required by execjs gem unless node.js is installed"
           else 
             ""


### PR DESCRIPTION
...x, which is needed by execjs when the newly generated app is run

This pull request takes over for pull request #4405 (https://github.com/rails/rails/pull/4405/).  I took tenderlove's suggestion and removed the checks for Javascript runtime in the generator, and instead assume that the gem is needed in Linux.
