### PR TITLE
Missing js runtime fix 3 1 stable

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -212,7 +212,7 @@ module Rails
           group :assets do
             gem 'sass-rails', #{options.dev? || options.edge? ? "  :git => 'git://github.com/rails/sass-rails.git', :branch => '3-1-stable'" : "  '~> 3.1.5'"}
             gem 'coffee-rails', #{options.dev? || options.edge? ? ":git => 'git://github.com/rails/coffee-rails.git', :branch => '3-1-stable'" : "'~> 3.1.1'"}
-            #{"gem 'therubyrhino'\n" if defined?(JRUBY_VERSION)}
+            #{required_javascript_runtime}
             gem 'uglifier', '>= 1.0.3'
           end
         GEMFILE
@@ -256,6 +256,26 @@ module Rails
           "#{key}: #{value}"
         end
       end
+
+    private
+
+      def required_javascript_runtime
+        # The execjs gem requires a Javascript runtime to be present on the 
+        # system. This can either be a gem or a system executable. Windows and
+        # Mac will have one, Linux typically does not unless node.js is 
+        # installed.  Install therubyracer on Linux.  Jruby should always use
+        # therubyrhino so everything is through the JVM
+        if defined?(JRUBY_VERSION)
+          "gem 'therubyrhino'  # Javascript runtime, required by execjs gem when using JRuby"  
+        else
+          if RbConfig::CONFIG['host_os'].match(/mswin|mingw|windows|darwin|mac/i).nil? 
+            "gem 'therubyracer'  # Javascript runtime, required by execjs gem unless node.js is installed"
+          else 
+            ""
+          end
+        end
+      end
+
     end
   end
 end

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -268,7 +268,7 @@ module Rails
         if defined?(JRUBY_VERSION)
           "gem 'therubyrhino'  # Javascript runtime, required by execjs gem when using JRuby"  
         else
-          if RbConfig::CONFIG['host_os'].match(/mswin|mingw|windows|darwin|mac/i).nil? 
+          if !(RbConfig::CONFIG['host_os'] =~ /mswin|mingw|windows|darwin|mac/i)
             "gem 'therubyracer'  # Javascript runtime, required by execjs gem unless node.js is installed"
           else 
             ""


### PR DESCRIPTION
...x, which is needed by execjs when the newly generated app is run

This pull request takes over for pull request #4407 (https://github.com/rails/rails/pull/4407/).  I took tenderlove's suggestion and removed the checks for Javascript runtime in the generator, and instead assume that the gem is needed in Linux.
