### PR TITLE
:if and :unless procs of callback filters are called, even when callback chain is terminated.

### DIFF
--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -452,7 +452,7 @@ module CallbacksTest
     set_callback :save, :before, :first
     set_callback :save, :before, :second
     set_callback :save, :around, :around_it
-    set_callback :save, :before, :third
+    set_callback :save, :before, :third, :if => :third_if
     set_callback :save, :after, :first
     set_callback :save, :around, :around_it
     set_callback :save, :after, :second
@@ -482,6 +482,10 @@ module CallbacksTest
 
     def third
       @history << "third"
+    end
+
+    def third_if
+      @history << "third_if"
     end
 
     def save


### PR DESCRIPTION
``` ruby
before_filter :first
before_filter :second, :if => :second_condition
```

In this example, if :first terminates the callback chain, then the `second` method is not called (= correct), but the `second_condition` method _is_ called.

The commit shows a failing test case for this.
