### PR TITLE
specify a role for identifying accessible attributes when wrapping params

### DIFF
--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -167,8 +167,9 @@ module ActionController
 
         unless options[:include] || options[:exclude]
           model ||= _default_wrap_model
-          if model.respond_to?(:accessible_attributes) && model.accessible_attributes.present?
-            options[:include] = model.accessible_attributes.to_a
+          role = options.has_key?(:as) ? options[:as] : :default
+          if model.respond_to?(:accessible_attributes) && model.accessible_attributes(role).present?
+            options[:include] = model.accessible_attributes(role).to_a
           elsif model.respond_to?(:attribute_names) && model.attribute_names.present?
             options[:include] = model.attribute_names
           end

--- a/actionpack/test/controller/params_wrapper_test.rb
+++ b/actionpack/test/controller/params_wrapper_test.rb
@@ -174,7 +174,7 @@ class ParamsWrapperTest < ActionController::TestCase
   
   def test_accessible_wrapped_keys_from_matching_model
     User.expects(:respond_to?).with(:accessible_attributes).returns(true)
-    User.expects(:accessible_attributes).twice.returns(["username"])
+    User.expects(:accessible_attributes).with(:default).twice.returns(["username"])
     
     with_default_wrapper_options do
       @request.env['CONTENT_TYPE'] = 'application/json'
@@ -186,9 +186,22 @@ class ParamsWrapperTest < ActionController::TestCase
   def test_accessible_wrapped_keys_from_specified_model
     with_default_wrapper_options do
       Person.expects(:respond_to?).with(:accessible_attributes).returns(true)
-      Person.expects(:accessible_attributes).twice.returns(["username"])
+      Person.expects(:accessible_attributes).with(:default).twice.returns(["username"])
 
       UsersController.wrap_parameters Person
+
+      @request.env['CONTENT_TYPE'] = 'application/json'
+      post :parse, { 'username' => 'sikachu', 'title' => 'Developer' }
+      assert_parameters({ 'username' => 'sikachu', 'title' => 'Developer', 'person' => { 'username' => 'sikachu' }})
+    end
+  end
+  
+  def test_accessible_wrapped_keys_with_role_from_specified_model
+    with_default_wrapper_options do
+      Person.expects(:respond_to?).with(:accessible_attributes).returns(true)
+      Person.expects(:accessible_attributes).with(:admin).twice.returns(["username"])
+
+      UsersController.wrap_parameters Person, :as => :admin
 
       @request.env['CONTENT_TYPE'] = 'application/json'
       post :parse, { 'username' => 'sikachu', 'title' => 'Developer' }


### PR DESCRIPTION
This is an addition to https://github.com/rails/rails/pull/3900

In addition to using `attr_accessible` to identify which params to wrap, this also allows you to specify a role using an :as option on `wrap_parameters`. Then the wrapped params will only be those accessible to that role.
