### PR TITLE
prevent the cache sweeper ignores NoMethodError

### DIFF
--- a/actionpack/lib/action_controller/caching/sweeping.rb
+++ b/actionpack/lib/action_controller/caching/sweeping.rb
@@ -93,7 +93,7 @@ module ActionController #:nodoc:
           end
 
           def method_missing(method, *arguments, &block)
-            super unless @controller
+            return super unless @controller
             @controller.__send__(method, *arguments, &block)
           end
       end

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -510,6 +510,13 @@ class FilterTest < ActionController::TestCase
     end
   end
 
+  def test_sweeper_should_not_ignore_no_method_error
+    sweeper = ActionController::Caching::Sweeper.send(:new)
+    assert_raise NoMethodError do
+      sweeper.send_not_defined
+    end
+  end
+
   def test_sweeper_should_not_block_rendering
     response = test_process(SweeperTestController)
     assert_equal 'hello world', response.body


### PR DESCRIPTION
i wasted so much time trying to figure out why there is no error but the sweeper didn't run, only to find out that there is a typo in method call. The typo did not raise any "no method error" when the cache sweeper is run.
