### PR TITLE
Add therubyracer gem commented in default Gemfile

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -195,7 +195,9 @@ module Rails
             group :assets do
               gem 'sass-rails',   :git => 'https://github.com/rails/sass-rails.git'
               gem 'coffee-rails', :git => 'https://github.com/rails/coffee-rails.git'
-              #{"gem 'therubyrhino'\n" if defined?(JRUBY_VERSION)}
+
+              # See https://github.com/sstephenson/execjs#readme for more supported runtimes
+              #{javascript_runtime_gemfile_entry}
               gem 'uglifier', '>= 1.0.3'
             end
           GEMFILE
@@ -206,7 +208,9 @@ module Rails
             group :assets do
               gem 'sass-rails',   '~> 4.0.0.beta'
               gem 'coffee-rails', '~> 4.0.0.beta'
-              #{"gem 'therubyrhino'\n" if defined?(JRUBY_VERSION)}
+
+              # See https://github.com/sstephenson/execjs#readme for more supported runtimes
+              #{javascript_runtime_gemfile_entry}
               gem 'uglifier', '>= 1.0.3'
             end
           GEMFILE
@@ -217,6 +221,14 @@ module Rails
 
       def javascript_gemfile_entry
         "gem '#{options[:javascript]}-rails'" unless options[:skip_javascript]
+      end
+
+      def javascript_runtime_gemfile_entry
+        if defined?(JRUBY_VERSION)
+          "gem 'therubyrhino'\n"
+        else
+          "# gem 'therubyracer'\n"
+        end
       end
 
       def bundle_command(command)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -229,14 +229,12 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "test/performance/browsing_test.rb"
   end
 
-  def test_inclusion_of_therubyrhino_under_jruby
+  def test_inclusion_of_javascript_runtime
     run_generator([destination_root])
     if defined?(JRUBY_VERSION)
       assert_file "Gemfile", /gem\s+["']therubyrhino["']$/
     else
-      assert_file "Gemfile" do |content|
-        assert_no_match(/gem\s+["']therubyrhino["']$/, content)
-      end
+      assert_file "Gemfile", /# gem\s+["']therubyracer["']$/
     end
   end
 


### PR DESCRIPTION
This add therubyracer to default Gemfile but commented since we want avoid the detection of existing JS runtimes on the system. (See #3619)

Also I plan to update Getting Started guide to tell new Rails users that they can uncomment this line when they don't have a JS runtime in their system.
