### PR TITLE
Fix clear cache regression. tmp/cache directory includes sass.

### DIFF
--- a/actionpack/lib/sprockets/assets.rake
+++ b/actionpack/lib/sprockets/assets.rake
@@ -86,7 +86,16 @@ namespace :assets do
 
   namespace :cache do
     task :clean => ["assets:environment"] do
-      Rails.application.assets.cache.clear
+      cache = Rails.application.assets.cache
+      cache_path = cache.respond_to?(:cache_path) ? cache.cache_path : nil
+
+      # Sprockets cache clear
+      cache.clear
+
+      Rake::Task["tmp:cache:clear"].invoke
+    
+      # If Sprockets cache is ActiveSupport::Cache::FileStore, Rails cache path includes the assets cache path.
+      FileUtils.mkdir_p(cache_path) if cache_path
     end
   end
 

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -497,11 +497,13 @@ module ApplicationTests
       precompile!
 
       quietly do
+        FileUtils.mkdir_p(File.join(app_path, "tmp", "cache", "foo"))
         Dir.chdir(app_path){ `bundle exec rake assets:cache:clean` }
       end
 
       require "#{app_path}/config/environment"
       assert_equal 0, Dir.entries(Rails.application.assets.cache.cache_path).size - 2 # reject [".", ".."]
+      assert_equal 1, Dir.entries(Rails.cache.cache_path).size - 2
     end
 
     private


### PR DESCRIPTION
Fix clear assets cache regression. tmp/cache directory sometimes includes sass.

This PR is related to GH #4427.
I think that #4427 has one problem (sorry, it is my PR).

tmp/cache directory includes sass directory.
After all, it seems that we must delete tmp/cache/*.
