### PR TITLE
Remove MRI 1.8 specific gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,11 +37,6 @@ end
 # AS
 gem 'memcache-client', '>= 1.8.5'
 
-platforms :mri_18 do
-  gem 'system_timer'
-  gem 'json'
-end
-
 # Add your own local bundler stuff
 local_gemfile = File.dirname(__FILE__) + "/.Gemfile"
 instance_eval File.read local_gemfile if File.exists? local_gemfile


### PR DESCRIPTION
Removing the MRI 1.8 specific block which installs systemtimer
