### PR TITLE
Stub ip method of alternative request class in router tests

### DIFF
--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -524,6 +524,10 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
         "GET"
       end
 
+      def ip
+        "127.0.0.1"
+      end
+
       def x_header
         @env["HTTP_X_HEADER"] || ""
       end


### PR DESCRIPTION
This patch stubs the `ip` method of the request class for the alternate request class router tests, so that rails/journey#11 can be applied without breaking ActionPack tests.
