### PR TITLE
refactor response_body= method

### DIFF
--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -182,13 +182,7 @@ module ActionController
     end
 
     def response_body=(val)
-      body = if val.is_a?(String)
-        [val]
-      elsif val.nil? || val.respond_to?(:each)
-        val
-      else
-        [val]
-      end
+      body = (val.nil? || val.respond_to?(:each)) ? val : [val]
       super body
     end
 


### PR DESCRIPTION
response_to?(:each) returns false for strings in ruby 1.9, so there is no need for these checks
