### PR TITLE
Don't hardcode assets route skipped in route inspector

### DIFF
--- a/railties/lib/rails/application/route_inspector.rb
+++ b/railties/lib/rails/application/route_inspector.rb
@@ -51,7 +51,7 @@ module Rails
       end
 
       def internal?
-        path =~ %r{/rails/info/properties|^/assets}
+        path =~ %r{/rails/info/properties|^#{Rails.application.config.assets.prefix}}
       end
 
       def engine?

--- a/railties/test/application/route_inspect_test.rb
+++ b/railties/test/application/route_inspect_test.rb
@@ -8,6 +8,11 @@ module ApplicationTests
     def setup
       @set = ActionDispatch::Routing::RouteSet.new
       @inspector = Rails::Application::RouteInspector.new
+      app = ActiveSupport::OrderedOptions.new
+      app.config = ActiveSupport::OrderedOptions.new
+      app.config.assets = ActiveSupport::OrderedOptions.new
+      app.config.assets.prefix = '/sprockets'
+      Rails.stubs(:application).returns(app)
     end
 
     def test_displaying_routes_for_engines
@@ -143,6 +148,15 @@ module ApplicationTests
 
       output = @inspector.format @set.routes
       assert_equal ["  /foo #{RackApp.name} {:constraint=>( my custom constraint )}"], output
+    end
+
+    def test_rake_routes_dont_show_app_mounted_in_assets_prefix
+      @set.draw do
+        match '/sprockets' => RackApp
+      end
+      output = @inspector.format @set.routes
+      assert_no_match(/RackApp/, output.first)
+      assert_no_match(/\/sprockets/, output.first)
     end
   end
 end


### PR DESCRIPTION
Right now generating a resource named asset with scaffold and setting `config.assets.prefix = '/sprockets'` (to avoid conflicting with generated resources) the output of `rake routes` is:

```
/tmp/foo % rake routes
  /sprockets #<Sprockets::Environment:0x3fea8846578c root="/private/tmp/foo", paths=["/private/tmp/foo/app/assets/images", "/private/tmp/foo/app/assets/javascripts", "/private/tmp/foo/app/assets/stylesheets", "/private/tmp/foo/vendor/assets/javascripts", "/private/tmp/foo/vendor/assets/stylesheets", "/Users/guille/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/jquery-rails-2.0.0/vendor/assets/javascripts", "/Users/guille/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/bundler/gems/coffee-rails-6b4034abbf7d/lib/assets/javascripts"], digest="aa7d0db7619379e13b08335dee027df2">
```

This have two issues, the first one is that any of the routes prefixed with /assets is shown and the second one is that the /sprockets one shouldn't be shown.

After of apply this patch, the output `rake routes` is the expected:

```
/tmp/foo % rake routes
    assets GET    /assets(.:format)          assets#index
           POST   /assets(.:format)          assets#create
 new_asset GET    /assets/new(.:format)      assets#new
edit_asset GET    /assets/:id/edit(.:format) assets#edit
     asset GET    /assets/:id(.:format)      assets#show
           PUT    /assets/:id(.:format)      assets#update
           DELETE /assets/:id(.:format)      assets#destroy
```
