### PR TITLE
Pass a symbol instead of a block in Enumerable#sum

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -59,7 +59,7 @@ module Enumerable
     if block_given?
       map(&block).sum(identity)
     else
-      inject { |sum, element| sum + element } || identity
+      inject(:+) || identity
     end
   end
 


### PR DESCRIPTION
This is faster and more concise. At least Ruby 1.8.7 is required which is ok since 3.2.

Benchmark:

``` ruby
require "benchmark"

enum = 1..10_000
N = 100
Benchmark.bm do |x|
  x.report "inject block" do
    N.times do
      enum.inject { |sum, n| sum + n }
    end
  end

  x.report "inject symbol" do
    N.times do
      enum.inject(:+)
    end
  end
end
```

Result:

```
       user     system      total        real
inject block   0.160000   0.000000   0.160000 (  0.179723)
inject symbol  0.090000   0.000000   0.090000 (  0.095667)
```
