### PR TITLE
show stats for app/mailers

### DIFF
--- a/railties/lib/rails/tasks/statistics.rake
+++ b/railties/lib/rails/tasks/statistics.rake
@@ -2,6 +2,7 @@ STATS_DIRECTORIES = [
   %w(Controllers        app/controllers),
   %w(Helpers            app/helpers),
   %w(Models             app/models),
+  %w(Mailers            app/mailers),
   %w(Libraries          lib/),
   %w(APIs               app/apis),
   %w(Integration\ tests test/integration),


### PR DESCRIPTION
I found `app/mailers` directory is not included in `rake stats` result.
Here's a fix.
