### PR TITLE
Backport PR #4153 and #4224 to 3-1-stable 

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -490,8 +490,8 @@ module ActiveRecord
 
             # Cap primary key sequences to max(pk).
             if connection.respond_to?(:reset_pk_sequence!)
-              table_names.each do |table_name|
-                connection.reset_pk_sequence!(table_name.tr('/', '_'))
+              fixture_files.each do |ff|
+                connection.reset_pk_sequence!(ff.table_name)
               end
             end
           end

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -398,6 +398,11 @@ module ActiveRecord
         fixture_name.camelize
     end
 
+    def self.default_fixture_table_name(fixture_name) # :nodoc:
+       "#{ActiveRecord::Base.table_name_prefix}"\
+         "#{fixture_name.tr('/', '_')}#{ActiveRecord::Base.table_name_suffix}".to_sym
+    end
+
     def self.reset_cache
       @@all_cached_fixtures.clear
     end
@@ -458,12 +463,11 @@ module ActiveRecord
           fixtures_map = {}
 
           fixture_files = files_to_read.map do |path|
-            table_name = path.tr '/', '_'
             fixture_name = path
 
             fixtures_map[fixture_name] = new( # ActiveRecord::Fixtures.new
               connection,
-              table_name,
+              fixture_name,
               class_names[fixture_name] || default_fixture_model_name(fixture_name),
               File.join(fixtures_directory, path))
           end
@@ -508,24 +512,27 @@ module ActiveRecord
 
     attr_reader :table_name, :name, :fixtures, :model_class
 
-    def initialize(connection, table_name, class_name, fixture_path)
-      @connection   = connection
-      @table_name   = table_name
-      @fixture_path = fixture_path
-      @name         = table_name # preserve fixture base name
-      @class_name   = class_name
-
+    def initialize(connection, fixture_name, class_name, fixture_path)
       @fixtures     = ActiveSupport::OrderedHash.new
-      @table_name   = "#{ActiveRecord::Base.table_name_prefix}#{@table_name}#{ActiveRecord::Base.table_name_suffix}"
+      @name         = fixture_name.tr('/', '_') # preserve fixture base name
+                                                # TODO: see how it is used and if the substitution can be avoided
+      @fixture_path = fixture_path
+
+      @class_name   = class_name # TODO: this variable is not used, should it be removed?
 
       # Should be an AR::Base type class
       if class_name.is_a?(Class)
-        @table_name   = class_name.table_name
-        @connection   = class_name.connection
-        @model_class  = class_name
+        @model_class = class_name
       else
-        @model_class  = class_name.constantize rescue nil
+        @model_class = class_name.constantize rescue nil
       end
+
+      @connection  = ( model_class.respond_to?(:connection) ?
+                       model_class.connection : connection )
+
+      @table_name = ( model_class.respond_to?(:table_name) ?
+                      model_class.table_name :
+                      self.class.default_fixture_table_name(fixture_name) )
 
       read_fixture_files
     end

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -514,8 +514,7 @@ module ActiveRecord
 
     def initialize(connection, fixture_name, class_name, fixture_path)
       @fixtures     = ActiveSupport::OrderedHash.new
-      @name         = fixture_name.tr('/', '_') # preserve fixture base name
-                                                # TODO: see how it is used and if the substitution can be avoided
+      @name         = fixture_name
       @fixture_path = fixture_path
 
       @class_name   = class_name # TODO: this variable is not used, should it be removed?
@@ -849,9 +848,9 @@ module ActiveRecord
         fixture_names = Array.wrap(fixture_names || fixture_table_names)
         methods = Module.new do
           fixture_names.each do |fixture_name|
-            fixture_name = fixture_name.to_s.tr('./', '_') # TODO: use fixture_name variable for only one form of fixture names ("admin/users" for example)
+            accessor_name = fixture_name.tr('/', '_').to_sym
 
-            define_method(fixture_name) do |*fixtures|
+            define_method(accessor_name) do |*fixtures|
               force_reload = fixtures.pop if fixtures.last == true || fixtures.last == :reload
 
               @fixture_cache[fixture_name] ||= {}
@@ -864,13 +863,13 @@ module ActiveRecord
                     @fixture_cache[fixture_name][fixture] ||= @loaded_fixtures[fixture_name][fixture.to_s].find
                   end
                 else
-                  raise StandardError, "No fixture with name '#{fixture}' found for table '#{fixture_name}'"
+                  raise StandardError, "No entry named '#{fixture}' found for fixture collection '#{fixture_name}'"
                 end
               end
 
               instances.size == 1 ? instances.first : instances
             end
-            private fixture_name
+            private accessor_name
           end
         end
         include methods

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1,6 +1,7 @@
 require 'cases/helper'
 require 'models/admin'
 require 'models/admin/account'
+require 'models/admin/randomly_named_c1'
 require 'models/admin/user'
 require 'models/binary'
 require 'models/book'
@@ -14,6 +15,7 @@ require 'models/matey'
 require 'models/parrot'
 require 'models/pirate'
 require 'models/post'
+require 'models/randomly_named_c1'
 require 'models/reply'
 require 'models/ship'
 require 'models/task'
@@ -727,5 +729,31 @@ class FixtureLoadingTest < ActiveRecord::TestCase
     ActiveRecord::TestCase.expects(:require_dependency).with(:works_out_fine)
     ActiveRecord::Base.logger.expects(:warn).never
     ActiveRecord::TestCase.try_to_load_dependency(:works_out_fine)
+  end
+end
+
+class CustomNameForFixtureOrModelTest < ActiveRecord::TestCase
+  ActiveRecord::Fixtures.reset_cache
+
+  set_fixture_class :randomly_named_a9         =>
+                        ClassNameThatDoesNotFollowCONVENTIONS,
+                    :'admin/randomly_named_a9' =>
+                        Admin::ClassNameThatDoesNotFollowCONVENTIONS,
+                    'admin/randomly_named_b0'  =>
+                        Admin::ClassNameThatDoesNotFollowCONVENTIONS
+
+  fixtures :randomly_named_a9, 'admin/randomly_named_a9',
+           :'admin/randomly_named_b0'
+
+  def test_named_accessor_for_randomly_named_fixture_and_class
+    assert_kind_of ClassNameThatDoesNotFollowCONVENTIONS,
+                   randomly_named_a9(:first_instance)
+  end
+
+  def test_named_accessor_for_randomly_named_namespaced_fixture_and_class
+    assert_kind_of Admin::ClassNameThatDoesNotFollowCONVENTIONS,
+                   admin_randomly_named_a9(:first_instance)
+    assert_kind_of Admin::ClassNameThatDoesNotFollowCONVENTIONS,
+                   admin_randomly_named_b0(:second_instance)
   end
 end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -756,4 +756,9 @@ class CustomNameForFixtureOrModelTest < ActiveRecord::TestCase
     assert_kind_of Admin::ClassNameThatDoesNotFollowCONVENTIONS,
                    admin_randomly_named_b0(:second_instance)
   end
+
+  def test_table_name_is_defined_in_the_model
+    assert_equal 'randomly_named_table', ActiveRecord::Fixtures::all_loaded_fixtures['admin/randomly_named_a9'].table_name.to_s
+    assert_equal 'randomly_named_table', Admin::ClassNameThatDoesNotFollowCONVENTIONS.table_name.to_s
+  end
 end

--- a/activerecord/test/fixtures/admin/randomly_named_a9.yml
+++ b/activerecord/test/fixtures/admin/randomly_named_a9.yml
@@ -1,0 +1,7 @@
+first_instance:
+  some_attribute: AAA
+  another_attribute: 000
+
+second_instance:
+  some_attribute: BBB
+  another_attribute: 999

--- a/activerecord/test/fixtures/admin/randomly_named_b0.yml
+++ b/activerecord/test/fixtures/admin/randomly_named_b0.yml
@@ -1,0 +1,7 @@
+first_instance:
+  some_attribute: AAA
+  another_attribute: 000
+
+second_instance:
+  some_attribute: BBB
+  another_attribute: 999

--- a/activerecord/test/fixtures/other_topics.yml
+++ b/activerecord/test/fixtures/other_topics.yml
@@ -1,0 +1,42 @@
+first:
+  id: 1
+  title: The First Topic
+  author_name: David
+  author_email_address: david@loudthinking.com
+  written_on: 2003-07-16t15:28:11.2233+01:00
+  last_read: 2004-04-15
+  bonus_time: 2005-01-30t15:28:00.00+01:00
+  content: Have a nice day
+  approved: false
+  replies_count: 1
+
+second:
+  id: 2
+  title: The Second Topic of the day
+  author_name: Mary
+  written_on: 2004-07-15t15:28:00.0099+01:00
+  content: Have a nice day
+  approved: true
+  replies_count: 0
+  parent_id: 1
+  type: Reply
+
+third:
+  id: 3
+  title: The Third Topic of the day
+  author_name: Carl
+  written_on: 2005-07-15t15:28:00.0099+01:00
+  content: I'm a troll
+  approved: true
+  replies_count: 1
+
+fourth:
+  id: 4
+  title: The Fourth Topic of the day
+  author_name: Carl
+  written_on: 2006-07-15t15:28:00.0099+01:00
+  content: Why not?
+  approved: true
+  type: Reply
+  parent_id: 3
+

--- a/activerecord/test/fixtures/randomly_named_a9.yml
+++ b/activerecord/test/fixtures/randomly_named_a9.yml
@@ -1,0 +1,7 @@
+first_instance:
+  some_attribute: AAA
+  another_attribute: 000
+
+second_instance:
+  some_attribute: BBB
+  another_attribute: 999

--- a/activerecord/test/models/admin/randomly_named_c1.rb
+++ b/activerecord/test/models/admin/randomly_named_c1.rb
@@ -1,0 +1,3 @@
+class Admin::ClassNameThatDoesNotFollowCONVENTIONS < ActiveRecord::Base
+  self.table_name = :randomly_named_table
+end

--- a/activerecord/test/models/randomly_named_c1.rb
+++ b/activerecord/test/models/randomly_named_c1.rb
@@ -1,0 +1,3 @@
+class ClassNameThatDoesNotFollowCONVENTIONS < ActiveRecord::Base
+  self.table_name = :randomly_named_table
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -499,6 +499,11 @@ ActiveRecord::Schema.define do
     t.string :type
   end
 
+  create_table :randomly_named_table, :force => true do |t|
+    t.string  :some_attribute
+    t.integer :another_attribute
+  end
+
   create_table :ratings, :force => true do |t|
     t.integer :comment_id
     t.integer :value


### PR DESCRIPTION
This is a rebase of commits from PR #4153 and #4224 to `3-1-stable`, with minor changes in a couple of commits.

This fixes issue #2572 with `set_fixture_class` and makes fixture table name be defined in the associated model.
