### PR TITLE
when validating a record, if a validation context is used, use the same context when validating related records 

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -295,7 +295,7 @@ module ActiveRecord
     def association_valid?(reflection, record)
       return true if record.destroyed? || record.marked_for_destruction?
 
-      unless valid = record.valid?
+      unless valid = record.valid?(validation_context)
         if reflection.options[:autosave]
           record.errors.each do |attribute, message|
             attribute = "#{reflection.name}.#{attribute}"

--- a/activerecord/lib/active_record/validations/associated.rb
+++ b/activerecord/lib/active_record/validations/associated.rb
@@ -2,7 +2,7 @@ module ActiveRecord
   module Validations
     class AssociatedValidator < ActiveModel::EachValidator
       def validate_each(record, attribute, value)
-        if Array.wrap(value).reject {|r| r.marked_for_destruction? || r.valid?}.any?
+        if Array.wrap(value).reject {|r| r.marked_for_destruction? || r.valid?(record.validation_context) }.any?
           record.errors.add(attribute, :invalid, options.merge(:value => value))
         end
       end

--- a/activerecord/test/cases/validations/association_validation_test.rb
+++ b/activerecord/test/cases/validations/association_validation_test.rb
@@ -118,4 +118,21 @@ class AssociationValidationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_validates_associated_models_in_the_same_context
+    Topic.validates_presence_of :title, :on => :custom_context
+    Topic.validates_associated :replies
+    Reply.validates_presence_of :title, :on => :custom_context
+
+    t = Topic.new('title' => '')
+    r = t.replies.new('title' => '')
+
+    assert t.valid?
+    assert !t.valid?(:custom_context)
+
+    t.title = "Longer"
+    assert !t.valid?(:custom_context), "Should NOT be valid if the associated object is not valid in the same context."
+
+    r.title = "Longer"
+    assert t.valid?(:custom_context), "Should be valid if the associated object is not valid in the same context."
+  end
 end


### PR DESCRIPTION
E.G.:

``` ruby
class Parent < ActiveRecord::Base
  has_one :child
  validates_presence_of :name, :on => "custom_context"
  validates_associated :child
end

class Child < ActiveRecord::Base
  belongs_to :parent
  validates_presence_of :name, :on => "custom_context"
end

p = Parent.new(:name => "Montoto", :child => Child.new)
p.valid?(:custom_context) # => Returns true, even though the child is not valid under the same context.
```
