### PR TITLE
Wrong behavior of ActiveModel::Errors#dup is causing regressions on Rails master

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -78,6 +78,11 @@ module ActiveModel
       @messages = ActiveSupport::OrderedHash.new
     end
 
+    def initialize_dup(other)
+      @messages = other.messages.dup
+      super
+    end
+
     # Clear the messages
     def clear
       messages.clear

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -123,7 +123,7 @@ module ActiveModel
     #   p.errors[:name] = "must be set"
     #   p.errors[:name] # => ['must be set']
     def []=(attribute, error)
-      self[attribute.to_sym] << error
+      self[attribute] << error
     end
 
     # Iterates through each error key, value pair in the error messages hash.

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -40,6 +40,14 @@ class ErrorsTest < ActiveModel::TestCase
     assert errors.include?(:foo), 'errors should include :foo'
   end
 
+  def test_dup
+    errors = ActiveModel::Errors.new(self)
+    errors[:foo] = 'bar'
+    errors_dup = errors.dup
+    errors_dup[:bar] = 'omg'
+    assert_not_same errors_dup.messages, errors.messages
+  end
+
   def test_has_key?
     errors = ActiveModel::Errors.new(self)
     errors[:foo] = 'omg'


### PR DESCRIPTION
Since ActiveModel::Errors instance keeps all error messages as hash
we should duplicate this object as well.

Previously ActiveModel::Errors was a subclass of ActiveSupport::OrderedHash,
which results in different behavior on `dup`, this may result in regression for
people relying on it.

I'm attaching also small cleanup of redundant code.
