### PR TITLE
Active Support Cache - race_condition_ttl should be an integer

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -280,7 +280,7 @@ module ActiveSupport
             end
           end
           if entry && entry.expired?
-            race_ttl = options[:race_condition_ttl].to_f
+            race_ttl = options[:race_condition_ttl].to_i
             if race_ttl and Time.now.to_f - entry.expires_at <= race_ttl
               entry.expires_at = Time.now + race_ttl
               write_entry(key, entry, :expires_in => race_ttl * 2)


### PR DESCRIPTION
Consistency with RFCs related to other common forms of caching:
HTTP - RFC2616
DNS  - RFC1912
