### PR TITLE
[Proposal] We should deprecate the RAILS_CACHE constant.

### DIFF
--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -14,7 +14,7 @@ module ActionController
     end
 
     initializer "action_controller.initialize_framework_caches" do
-      ActiveSupport.on_load(:action_controller) { self.cache_store ||= RAILS_CACHE }
+      ActiveSupport.on_load(:action_controller) { self.cache_store ||= Rails.cache }
     end
 
     initializer "action_controller.assets_config", :group => :all do |app|

--- a/actionpack/lib/action_dispatch/http/rack_cache.rb
+++ b/actionpack/lib/action_dispatch/http/rack_cache.rb
@@ -8,8 +8,7 @@ module ActionDispatch
       new
     end
 
-    # TODO: Finally deal with the RAILS_CACHE global
-    def initialize(store = RAILS_CACHE)
+    def initialize(store = Rails.cache)
       @store = store
     end
 
@@ -33,7 +32,7 @@ module ActionDispatch
       new
     end
 
-    def initialize(store = RAILS_CACHE)
+    def initialize(store = Rails.cache)
       @store = store
     end
 

--- a/railties/guides/source/configuring.textile
+++ b/railties/guides/source/configuring.textile
@@ -533,7 +533,7 @@ Serves as a placeholder so that +:load_environment_config+ can be defined to run
 
 *+initialize_logger+* Initializes the logger (an +ActiveSupport::BufferedLogger+ object) for the application and makes it accessible at +Rails.logger+, provided that no initializer inserted before this point has defined +Rails.logger+.
 
-*+initialize_cache+* If +RAILS_CACHE+ isn't set yet, initializes the cache by referencing the value in +config.cache_store+ and stores the outcome as +RAILS_CACHE+. If this object responds to the +middleware+ method, its middleware is inserted before +Rack::Runtime+ in the middleware stack.
+*+initialize_cache+* If +Rails.cache+ isn't set yet, initializes the cache by referencing the value in +config.cache_store+ and stores the outcome as +Rails.cache+. If this object responds to the +middleware+ method, its middleware is inserted before +Rack::Runtime+ in the middleware stack.
 
 *+set_clear_dependencies_hook+* Provides a hook for +active_record.set_dispatch_hooks+ to use, which will run before this initializer. This initializer -- which runs only if +cache_classes+ is set to +false+ -- uses +ActionDispatch::Callbacks.after+ to remove the constants which have been referenced during the request from the object space so that they will be reloaded during the following request.
 
@@ -571,7 +571,7 @@ The error occurred while evaluating nil.each
 
 *+action_controller.logger+* Sets +ActionController::Base.logger+ -- if it's not already set -- to +Rails.logger+.
 
-*+action_controller.initialize_framework_caches+* Sets +ActionController::Base.cache_store+ -- if it's not already set -- to +RAILS_CACHE+.
+*+action_controller.initialize_framework_caches+* Sets +ActionController::Base.cache_store+ -- if it's not already set -- to +Rails.cache+.
 
 *+action_controller.set_configs+* Sets up Action Controller by using the settings in +config.action_controller+ by +send+'ing the method names as setters to +ActionController::Base+ and passing the values through.
 

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -8,6 +8,7 @@ require 'active_support/core_ext/array/extract_options'
 
 require 'rails/application'
 require 'rails/version'
+require 'rails/deprecation'
 
 require 'active_support/railtie'
 require 'action_dispatch/railtie'
@@ -77,7 +78,11 @@ module Rails
     end
 
     def cache
-      RAILS_CACHE
+      @@cache ||= nil
+    end
+
+    def cache=(cache)
+      @@cache = cache
     end
 
     # Returns all rails groups for loading based on:

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -50,11 +50,11 @@ module Rails
 
       # Initialize cache early in the stack so railties can make use of it.
       initializer :initialize_cache, :group => :all do
-        unless defined?(RAILS_CACHE)
-          silence_warnings { Object.const_set "RAILS_CACHE", ActiveSupport::Cache.lookup_store(config.cache_store) }
+        unless Rails.cache
+          Rails.cache = ActiveSupport::Cache.lookup_store(config.cache_store)
 
-          if RAILS_CACHE.respond_to?(:middleware)
-            config.middleware.insert_before("Rack::Runtime", RAILS_CACHE.middleware)
+          if Rails.cache.respond_to?(:middleware)
+            config.middleware.insert_before("Rack::Runtime", Rails.cache.middleware)
           end
         end
       end

--- a/railties/lib/rails/deprecation.rb
+++ b/railties/lib/rails/deprecation.rb
@@ -1,0 +1,39 @@
+require "active_support/string_inquirer"
+require "active_support/basic_object"
+
+module Rails
+  module Initializer
+    def self.run(&block)
+      klass = Class.new(Rails::Application)
+      klass.instance_exec(klass.config, &block)
+      klass.initialize!
+    end
+  end
+
+  class DeprecatedConstant < ActiveSupport::BasicObject
+    def self.deprecate(old, new)
+      constant = self.new(old, new)
+      eval "::#{old} = constant"
+    end
+
+    def initialize(old, new)
+      @old, @new = old, new
+      @target = ::Kernel.eval "proc { #{@new} }"
+      @warned = false
+    end
+
+    def method_missing(meth, *args, &block)
+      ::ActiveSupport::Deprecation.warn("#{@old} is deprecated. Please use #{@new}") unless @warned
+      @warned = true
+
+      target = @target.call
+      if target.respond_to?(meth)
+        target.send(meth, *args, &block)
+      else
+        super
+      end
+    end
+  end
+
+  DeprecatedConstant.deprecate("RAILS_CACHE", "::Rails.cache")
+end

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -132,13 +132,13 @@ module ApplicationTests
       assert_equal "Rack::Config", middleware.second
     end
 
-    test "RAILS_CACHE does not respond to middleware" do
+    test "Rails.cache does not respond to middleware" do
       add_to_config "config.cache_store = :memory_store"
       boot!
       assert_equal "Rack::Runtime", middleware.third
     end
 
-    test "RAILS_CACHE does respond to middleware" do
+    test "Rails.cache does respond to middleware" do
       boot!
       assert_equal "Rack::Runtime", middleware.fourth
     end


### PR DESCRIPTION
I think it should be deprecated for the following reasons.

1) RAILS_ENV, RAILS_DEFAULT_LOGGER, RAILS_ROOT were removed.
2) I think that we should not use Global scope constant.
