### PR TITLE
Accept a block passed to pessimistic `lock!`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -72,6 +72,33 @@
 
 ## Rails 3.2.0 (unreleased) ##
 
+*   Accept a block passed to pessimistic `lock!`, which automatically
+    wraps the block in a transaction, locks the object and yields to
+    the block.
+
+    Before:
+
+        class Order < ActiveRecord::Base
+          def cancel!
+            transaction do
+              lock!
+              # ... cancelling logic
+            end
+          end
+        end
+
+    After:
+
+        class Order < ActiveRecord::Base
+          def cancel!
+            lock! do
+              # ... cancelling logic
+            end
+          end
+        end
+
+    *Olek Janiszewski*
+
 *   'on' and 'ON' boolean columns values are type casted to true
     *Santiago Pastorino*
 
@@ -82,7 +109,7 @@
     Example:
       rake db:migrate SCOPE=blog
 
-   *Piotr Sarnacki*
+    *Piotr Sarnacki*
 
 *   Migrations copied from engines are now scoped with engine's name,
     for example 01_create_posts.blog.rb. *Piotr Sarnacki*

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -388,6 +388,26 @@ unless current_adapter?(:SybaseAdapter, :OpenBaseAdapter) || in_memory_db?
       end
     end
 
+    def test_lock_with_block_commits_transaction
+      person = Person.find 1
+      person.lock! do
+        person.first_name = 'fooman'
+        person.save!
+      end
+      assert_equal 'fooman', person.reload.first_name
+    end
+
+    def test_lock_with_block_rolls_back_transaction
+      person = Person.find 1
+      old = person.first_name
+      person.lock! do
+        person.first_name = 'fooman'
+        person.save!
+        raise 'oops'
+      end rescue nil
+      assert_equal old, person.reload.first_name
+    end
+
     if current_adapter?(:PostgreSQLAdapter, :OracleAdapter)
       def test_no_locks_no_wait
         first, second = duel { Person.find 1 }

--- a/railties/guides/source/active_record_querying.textile
+++ b/railties/guides/source/active_record_querying.textile
@@ -692,6 +692,17 @@ Item.transaction do
 end
 </ruby>
 
+If you already have an instance of your model, you can start a transaction and acquire the lock in one go using the following code:
+
+<ruby>
+item = Item.first
+item.lock! do
+  # This block is called within a transaction,
+  # item is already locked.
+  item.increment!(:views)
+end
+</ruby>
+
 h3. Joining Tables
 
 Active Record provides a finder method called +joins+ for specifying +JOIN+ clauses on the resulting SQL. There are multiple ways to use the +joins+ method.


### PR DESCRIPTION
This allows to shorten a typical idiom of calling the `lock!`
method as first within a transaction:

``` ruby
class Order < ActiveRecord::Base
  def cancel!
    transaction do
      lock!
      # ... cancelling logic
    end
  end
end

# becomes:

class Order < ActiveRecord::Base
  def cancel!
    lock! do
      # ... cancelling logic
    end
  end
end
```

@tenderlove this is the port of #4479 you asked for. Please backport to 3-2-stable as well.
