### PR TITLE
ActionView content_tag_for refactoring and improvements

### DIFF
--- a/actionpack/lib/action_view/helpers/record_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/record_tag_helper.rb
@@ -81,6 +81,8 @@ module ActionView
       #    <li id="person_123" class="person bar">...
       #
       def content_tag_for(tag_name, single_or_multiple_records, prefix = nil, options = nil, &block)
+        options, prefix = prefix, nil if prefix.is_a?(Hash)
+
         Array.wrap(single_or_multiple_records).map do |single_record|
           content_tag_for_single_record tag_name, single_record, prefix, options, &block
         end.join("\n").html_safe
@@ -91,14 +93,11 @@ module ActionView
         # Called by <tt>content_tag_for</tt> internally to render a content tag
         # for each record.
         def content_tag_for_single_record(tag_name, record, prefix, options, &block)
-          options, prefix = prefix, nil if prefix.is_a?(Hash)
           options = options ? options.dup : {}
-          options.merge!(:class => "#{dom_class(record, prefix)} #{options[:class]}".strip, :id => dom_id(record, prefix))
-          if block.arity == 0
-            content_tag(tag_name, capture(&block), options)
-          else
-            content_tag(tag_name, capture(record, &block), options)
-          end
+          options.merge!(:class => "#{dom_class(record, prefix)} #{options[:class]}".rstrip, :id => dom_id(record, prefix))
+
+          content = block.arity == 0 ? capture(&block) : capture(record, &block)
+          content_tag(tag_name, content, options)
         end
     end
   end

--- a/actionpack/lib/action_view/helpers/record_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/record_tag_helper.rb
@@ -82,7 +82,7 @@ module ActionView
       #
       def content_tag_for(tag_name, single_or_multiple_records, prefix = nil, options = nil, &block)
         Array.wrap(single_or_multiple_records).map do |single_record|
-          capture { content_tag_for_single_record(tag_name, single_record, prefix, options, &block) }
+          content_tag_for_single_record tag_name, single_record, prefix, options, &block
         end.join("\n").html_safe
       end
 

--- a/actionpack/lib/action_view/helpers/record_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/record_tag_helper.rb
@@ -83,8 +83,8 @@ module ActionView
       def content_tag_for(tag_name, single_or_multiple_records, prefix = nil, options = nil, &block)
         options, prefix = prefix, nil if prefix.is_a?(Hash)
 
-        Array.wrap(single_or_multiple_records).map do |single_record|
-          content_tag_for_single_record tag_name, single_record, prefix, options, &block
+        Array(single_or_multiple_records).map do |single_record|
+          content_tag_for_single_record(tag_name, single_record, prefix, options, &block)
         end.join("\n").html_safe
       end
 

--- a/actionpack/lib/action_view/helpers/record_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/record_tag_helper.rb
@@ -81,13 +81,9 @@ module ActionView
       #    <li id="person_123" class="person bar">...
       #
       def content_tag_for(tag_name, single_or_multiple_records, prefix = nil, options = nil, &block)
-        if single_or_multiple_records.respond_to?(:to_ary)
-          single_or_multiple_records.to_ary.map do |single_record|
-            capture { content_tag_for_single_record(tag_name, single_record, prefix, options, &block) }
-          end.join("\n").html_safe
-        else
-          content_tag_for_single_record(tag_name, single_or_multiple_records, prefix, options, &block)
-        end
+        Array.wrap(single_or_multiple_records).map do |single_record|
+          capture { content_tag_for_single_record(tag_name, single_record, prefix, options, &block) }
+        end.join("\n").html_safe
       end
 
       private

--- a/actionpack/lib/action_view/helpers/record_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/record_tag_helper.rb
@@ -92,8 +92,8 @@ module ActionView
         # for each record.
         def content_tag_for_single_record(tag_name, record, prefix, options, &block)
           options, prefix = prefix, nil if prefix.is_a?(Hash)
-          options ||= {}
-          options.merge!({ :class => "#{dom_class(record, prefix)} #{options[:class]}".strip, :id => dom_id(record, prefix) })
+          options = options ? options.dup : {}
+          options.merge!(:class => "#{dom_class(record, prefix)} #{options[:class]}".strip, :id => dom_id(record, prefix))
           if block.arity == 0
             content_tag(tag_name, capture(&block), options)
           else

--- a/actionpack/test/template/record_tag_helper_test.rb
+++ b/actionpack/test/template/record_tag_helper_test.rb
@@ -33,8 +33,8 @@ class RecordTagHelperTest < ActionView::TestCase
   end
 
   def test_content_tag_for
-    expected = %(<li class="post bar" id="post_45"></li>)
-    actual = content_tag_for(:li, @post, :class => 'bar') { }
+    expected = %(<li class="post" id="post_45"></li>)
+    actual = content_tag_for(:li, @post) { }
     assert_dom_equal expected, actual
   end
 
@@ -44,9 +44,15 @@ class RecordTagHelperTest < ActionView::TestCase
     assert_dom_equal expected, actual
   end
 
-  def test_content_tag_for_with_extra_html_tags
+  def test_content_tag_for_with_extra_html_options
     expected = %(<tr class="post bar" id="post_45" style='background-color: #f0f0f0'></tr>)
-    actual = content_tag_for(:tr, @post, {:class => "bar", :style => "background-color: #f0f0f0"}) { }
+    actual = content_tag_for(:tr, @post, :class => "bar", :style => "background-color: #f0f0f0") { }
+    assert_dom_equal expected, actual
+  end
+
+  def test_content_tag_for_with_prefix_and_extra_html_options
+    expected = %(<tr class="archived_post bar" id="archived_post_45" style='background-color: #f0f0f0'></tr>)
+    actual = content_tag_for(:tr, @post, :archived, :class => "bar", :style => "background-color: #f0f0f0") { }
     assert_dom_equal expected, actual
   end
 

--- a/actionpack/test/template/record_tag_helper_test.rb
+++ b/actionpack/test/template/record_tag_helper_test.rb
@@ -80,7 +80,7 @@ class RecordTagHelperTest < ActionView::TestCase
     post_1 = Post.new.tap { |post| post.id = 101; post.body = "Hello!"; post.persisted = true }
     post_2 = Post.new.tap { |post| post.id = 102; post.body = "World!"; post.persisted = true }
     expected = %(<li class="post" id="post_101">Hello!</li>\n<li class="post" id="post_102">World!</li>)
-    actual = content_tag_for(:li, [post_1, post_2]) { |post| concat post.body }
+    actual = content_tag_for(:li, [post_1, post_2]) { |post| post.body }
     assert_dom_equal expected, actual
   end
 
@@ -88,19 +88,19 @@ class RecordTagHelperTest < ActionView::TestCase
     post_1 = Post.new.tap { |post| post.id = 101; post.body = "Hello!"; post.persisted = true }
     post_2 = Post.new.tap { |post| post.id = 102; post.body = "World!"; post.persisted = true }
     expected = %(<div class="post" id="post_101">Hello!</div>\n<div class="post" id="post_102">World!</div>)
-    actual = div_for([post_1, post_2]) { |post| concat post.body }
+    actual = div_for([post_1, post_2]) { |post| post.body }
     assert_dom_equal expected, actual
   end
 
   def test_content_tag_for_single_record_is_html_safe
-    result = div_for(@post, :class => "bar") { concat @post.body }
+    result = div_for(@post, :class => "bar") { @post.body }
     assert result.html_safe?
   end
 
   def test_content_tag_for_collection_is_html_safe
     post_1 = Post.new.tap { |post| post.id = 101; post.body = "Hello!"; post.persisted = true }
     post_2 = Post.new.tap { |post| post.id = 102; post.body = "World!"; post.persisted = true }
-    result = content_tag_for(:li, [post_1, post_2]) { |post| concat post.body }
+    result = content_tag_for(:li, [post_1, post_2]) { |post| post.body }
     assert result.html_safe?
   end
 end

--- a/actionpack/test/template/record_tag_helper_test.rb
+++ b/actionpack/test/template/record_tag_helper_test.rb
@@ -1,6 +1,6 @@
 require 'abstract_unit'
 
-class Post
+class RecordTagPost
   extend ActiveModel::Naming
   include ActiveModel::Conversion
   attr_accessor :id, :body
@@ -20,77 +20,77 @@ class RecordTagHelperTest < ActionView::TestCase
 
   def setup
     super
-    @post = Post.new
+    @post = RecordTagPost.new
   end
 
   def test_content_tag_for
-    expected = %(<li class="post" id="post_45"></li>)
+    expected = %(<li class="record_tag_post" id="record_tag_post_45"></li>)
     actual = content_tag_for(:li, @post) { }
     assert_dom_equal expected, actual
   end
 
   def test_content_tag_for_prefix
-    expected = %(<ul class="archived_post" id="archived_post_45"></ul>)
+    expected = %(<ul class="archived_record_tag_post" id="archived_record_tag_post_45"></ul>)
     actual = content_tag_for(:ul, @post, :archived) { }
     assert_dom_equal expected, actual
   end
 
   def test_content_tag_for_with_extra_html_options
-    expected = %(<tr class="post bar" id="post_45" style='background-color: #f0f0f0'></tr>)
-    actual = content_tag_for(:tr, @post, :class => "bar", :style => "background-color: #f0f0f0") { }
+    expected = %(<tr class="record_tag_post special" id="record_tag_post_45" style='background-color: #f0f0f0'></tr>)
+    actual = content_tag_for(:tr, @post, :class => "special", :style => "background-color: #f0f0f0") { }
     assert_dom_equal expected, actual
   end
 
   def test_content_tag_for_with_prefix_and_extra_html_options
-    expected = %(<tr class="archived_post bar" id="archived_post_45" style='background-color: #f0f0f0'></tr>)
-    actual = content_tag_for(:tr, @post, :archived, :class => "bar", :style => "background-color: #f0f0f0") { }
+    expected = %(<tr class="archived_record_tag_post special" id="archived_record_tag_post_45" style='background-color: #f0f0f0'></tr>)
+    actual = content_tag_for(:tr, @post, :archived, :class => "special", :style => "background-color: #f0f0f0") { }
     assert_dom_equal expected, actual
   end
 
   def test_block_not_in_erb_multiple_calls
-    expected = %(<div class="post bar" id="post_45">What a wonderful world!</div>)
-    actual = div_for(@post, :class => "bar") { @post.body }
+    expected = %(<div class="record_tag_post special" id="record_tag_post_45">What a wonderful world!</div>)
+    actual = div_for(@post, :class => "special") { @post.body }
     assert_dom_equal expected, actual
-    actual = div_for(@post, :class => "bar") { @post.body }
+    actual = div_for(@post, :class => "special") { @post.body }
     assert_dom_equal expected, actual
   end
 
   def test_block_works_with_content_tag_for_in_erb
-    expected = %(<tr class="post" id="post_45">What a wonderful world!</tr>)
+    expected = %(<tr class="record_tag_post" id="record_tag_post_45">What a wonderful world!</tr>)
     actual = render_erb("<%= content_tag_for(:tr, @post) do %><%= @post.body %><% end %>")
     assert_dom_equal expected, actual
   end
 
   def test_div_for_in_erb
-    expected = %(<div class="post bar" id="post_45">What a wonderful world!</div>)
-    actual = render_erb("<%= div_for(@post, :class => 'bar') do %><%= @post.body %><% end %>")
+    expected = %(<div class="record_tag_post special" id="record_tag_post_45">What a wonderful world!</div>)
+    actual = render_erb("<%= div_for(@post, :class => 'special') do %><%= @post.body %><% end %>")
     assert_dom_equal expected, actual
   end
 
   def test_content_tag_for_collection
-    post_1 = Post.new { |post| post.id = 101; post.body = "Hello!" }
-    post_2 = Post.new { |post| post.id = 102; post.body = "World!" }
-    expected = %(<li class="post" id="post_101">Hello!</li>\n<li class="post" id="post_102">World!</li>)
+    post_1 = RecordTagPost.new { |post| post.id = 101; post.body = "Hello!" }
+    post_2 = RecordTagPost.new { |post| post.id = 102; post.body = "World!" }
+    expected = %(<li class="record_tag_post" id="record_tag_post_101">Hello!</li>\n<li class="record_tag_post" id="record_tag_post_102">World!</li>)
     actual = content_tag_for(:li, [post_1, post_2]) { |post| post.body }
     assert_dom_equal expected, actual
   end
 
   def test_div_for_collection
-    post_1 = Post.new { |post| post.id = 101; post.body = "Hello!" }
-    post_2 = Post.new { |post| post.id = 102; post.body = "World!" }
-    expected = %(<div class="post" id="post_101">Hello!</div>\n<div class="post" id="post_102">World!</div>)
+    post_1 = RecordTagPost.new { |post| post.id = 101; post.body = "Hello!" }
+    post_2 = RecordTagPost.new { |post| post.id = 102; post.body = "World!" }
+    expected = %(<div class="record_tag_post" id="record_tag_post_101">Hello!</div>\n<div class="record_tag_post" id="record_tag_post_102">World!</div>)
     actual = div_for([post_1, post_2]) { |post| post.body }
     assert_dom_equal expected, actual
   end
 
   def test_content_tag_for_single_record_is_html_safe
-    result = div_for(@post, :class => "bar") { @post.body }
+    result = div_for(@post, :class => "special") { @post.body }
     assert result.html_safe?
   end
 
   def test_content_tag_for_collection_is_html_safe
-    post_1 = Post.new { |post| post.id = 101; post.body = "Hello!" }
-    post_2 = Post.new { |post| post.id = 102; post.body = "World!" }
+    post_1 = RecordTagPost.new { |post| post.id = 101; post.body = "Hello!" }
+    post_2 = RecordTagPost.new { |post| post.id = 102; post.body = "World!" }
     result = content_tag_for(:li, [post_1, post_2]) { |post| post.body }
     assert result.html_safe?
   end

--- a/actionpack/test/template/record_tag_helper_test.rb
+++ b/actionpack/test/template/record_tag_helper_test.rb
@@ -1,26 +1,15 @@
 require 'abstract_unit'
-require 'controller/fake_models'
 
 class Post
   extend ActiveModel::Naming
   include ActiveModel::Conversion
-  attr_writer :id, :body
+  attr_accessor :id, :body
 
   def initialize
-    @id = nil
-    @body = nil
-    super
+    @id   = 45
+    @body = "What a wonderful world!"
 
-    @persisted = true
     yield self if block_given?
-  end
-
-  def id
-     @id || 45
-  end
-
-  def body
-    super || @body || "What a wonderful world!"
   end
 end
 
@@ -59,7 +48,7 @@ class RecordTagHelperTest < ActionView::TestCase
   end
 
   def test_block_not_in_erb_multiple_calls
-    expected = %(<div class="post bar" id="post_45">#{@post.body}</div>)
+    expected = %(<div class="post bar" id="post_45">What a wonderful world!</div>)
     actual = div_for(@post, :class => "bar") { @post.body }
     assert_dom_equal expected, actual
     actual = div_for(@post, :class => "bar") { @post.body }
@@ -67,13 +56,13 @@ class RecordTagHelperTest < ActionView::TestCase
   end
 
   def test_block_works_with_content_tag_for_in_erb
-    expected = %(<tr class="post" id="post_45">#{@post.body}</tr>)
+    expected = %(<tr class="post" id="post_45">What a wonderful world!</tr>)
     actual = render_erb("<%= content_tag_for(:tr, @post) do %><%= @post.body %><% end %>")
     assert_dom_equal expected, actual
   end
 
   def test_div_for_in_erb
-    expected = %(<div class="post bar" id="post_45">#{@post.body}</div>)
+    expected = %(<div class="post bar" id="post_45">What a wonderful world!</div>)
     actual = render_erb("<%= div_for(@post, :class => 'bar') do %><%= @post.body %><% end %>")
     assert_dom_equal expected, actual
   end

--- a/actionpack/test/template/record_tag_helper_test.rb
+++ b/actionpack/test/template/record_tag_helper_test.rb
@@ -105,4 +105,10 @@ class RecordTagHelperTest < ActionView::TestCase
     result = content_tag_for(:li, [post_1, post_2]) { |post| post.body }
     assert result.html_safe?
   end
+
+  def test_content_tag_for_does_not_change_options_hash
+    options = { :class => "important" }
+    result  = content_tag_for(:li, @post, options) { }
+    assert_equal({ :class => "important" }, options)
+  end
 end

--- a/actionpack/test/template/record_tag_helper_test.rb
+++ b/actionpack/test/template/record_tag_helper_test.rb
@@ -11,6 +11,7 @@ class Post
     @body = nil
     super
 
+    @persisted = true
     yield self if block_given?
   end
 
@@ -31,7 +32,6 @@ class RecordTagHelperTest < ActionView::TestCase
   def setup
     super
     @post = Post.new
-    @post.persisted = true
   end
 
   def test_content_tag_for
@@ -79,16 +79,16 @@ class RecordTagHelperTest < ActionView::TestCase
   end
 
   def test_content_tag_for_collection
-    post_1 = Post.new { |post| post.id = 101; post.body = "Hello!"; post.persisted = true }
-    post_2 = Post.new { |post| post.id = 102; post.body = "World!"; post.persisted = true }
+    post_1 = Post.new { |post| post.id = 101; post.body = "Hello!" }
+    post_2 = Post.new { |post| post.id = 102; post.body = "World!" }
     expected = %(<li class="post" id="post_101">Hello!</li>\n<li class="post" id="post_102">World!</li>)
     actual = content_tag_for(:li, [post_1, post_2]) { |post| post.body }
     assert_dom_equal expected, actual
   end
 
   def test_div_for_collection
-    post_1 = Post.new { |post| post.id = 101; post.body = "Hello!"; post.persisted = true }
-    post_2 = Post.new { |post| post.id = 102; post.body = "World!"; post.persisted = true }
+    post_1 = Post.new { |post| post.id = 101; post.body = "Hello!" }
+    post_2 = Post.new { |post| post.id = 102; post.body = "World!" }
     expected = %(<div class="post" id="post_101">Hello!</div>\n<div class="post" id="post_102">World!</div>)
     actual = div_for([post_1, post_2]) { |post| post.body }
     assert_dom_equal expected, actual
@@ -100,8 +100,8 @@ class RecordTagHelperTest < ActionView::TestCase
   end
 
   def test_content_tag_for_collection_is_html_safe
-    post_1 = Post.new { |post| post.id = 101; post.body = "Hello!"; post.persisted = true }
-    post_2 = Post.new { |post| post.id = 102; post.body = "World!"; post.persisted = true }
+    post_1 = Post.new { |post| post.id = 101; post.body = "Hello!" }
+    post_2 = Post.new { |post| post.id = 102; post.body = "World!" }
     result = content_tag_for(:li, [post_1, post_2]) { |post| post.body }
     assert result.html_safe?
   end

--- a/actionpack/test/template/record_tag_helper_test.rb
+++ b/actionpack/test/template/record_tag_helper_test.rb
@@ -10,6 +10,8 @@ class Post
     @id = nil
     @body = nil
     super
+
+    yield self if block_given?
   end
 
   def id
@@ -77,16 +79,16 @@ class RecordTagHelperTest < ActionView::TestCase
   end
 
   def test_content_tag_for_collection
-    post_1 = Post.new.tap { |post| post.id = 101; post.body = "Hello!"; post.persisted = true }
-    post_2 = Post.new.tap { |post| post.id = 102; post.body = "World!"; post.persisted = true }
+    post_1 = Post.new { |post| post.id = 101; post.body = "Hello!"; post.persisted = true }
+    post_2 = Post.new { |post| post.id = 102; post.body = "World!"; post.persisted = true }
     expected = %(<li class="post" id="post_101">Hello!</li>\n<li class="post" id="post_102">World!</li>)
     actual = content_tag_for(:li, [post_1, post_2]) { |post| post.body }
     assert_dom_equal expected, actual
   end
 
   def test_div_for_collection
-    post_1 = Post.new.tap { |post| post.id = 101; post.body = "Hello!"; post.persisted = true }
-    post_2 = Post.new.tap { |post| post.id = 102; post.body = "World!"; post.persisted = true }
+    post_1 = Post.new { |post| post.id = 101; post.body = "Hello!"; post.persisted = true }
+    post_2 = Post.new { |post| post.id = 102; post.body = "World!"; post.persisted = true }
     expected = %(<div class="post" id="post_101">Hello!</div>\n<div class="post" id="post_102">World!</div>)
     actual = div_for([post_1, post_2]) { |post| post.body }
     assert_dom_equal expected, actual
@@ -98,8 +100,8 @@ class RecordTagHelperTest < ActionView::TestCase
   end
 
   def test_content_tag_for_collection_is_html_safe
-    post_1 = Post.new.tap { |post| post.id = 101; post.body = "Hello!"; post.persisted = true }
-    post_2 = Post.new.tap { |post| post.id = 102; post.body = "World!"; post.persisted = true }
+    post_1 = Post.new { |post| post.id = 101; post.body = "Hello!"; post.persisted = true }
+    post_2 = Post.new { |post| post.id = 102; post.body = "World!"; post.persisted = true }
     result = content_tag_for(:li, [post_1, post_2]) { |post| post.body }
     assert result.html_safe?
   end


### PR DESCRIPTION
- Make sure `content_tag_for` does not mutate the options hash.
- Cleanup `content_tag_for` helper by removing call to capture and using `Array()` instead of checking for `to_ary`.

This pull is partially related to #4341, which I just found out after finishing doing the changes here. I ended up cherry picking @coop's commits and rebasing into my changes to have him as author. The issue he was having with `Array()` was due to the `Post` class being used everywhere inside the test suite. Changes to this class coming from some other place were interfering on these tests, making them fail hard. I've fixed that by renaming the class to `RecordTagPost` - all AP tests are green.

Let me know if something should be improved.
Thanks.
