### PR TITLE
Update time zone offset information

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -2,7 +2,7 @@ class DateTime
   class << self
     # DateTimes aren't aware of DST rules, so use a consistent non-DST offset when creating a DateTime with an offset in the local zone
     def local_offset
-      ::Time.local(2007).utc_offset.to_r / 86400
+      ::Time.local(2012).utc_offset.to_r / 86400
     end
 
     # Returns <tt>Time.zone.now.to_datetime</tt> when <tt>Time.zone</tt> or <tt>config.time_zone</tt> are set, otherwise returns <tt>Time.now.to_datetime</tt>.


### PR DESCRIPTION
To demonstrate an issue run following:

```
$ export TZ='Europe/Moscow'
$ rake test TEST=activesupport/test/core_ext/time_ext_test.rb
```

You'll get following:

```
  1) Failure:
test_local_time(TimeExtCalculationsTest) [/Users/brainopia/code/sources/rails/activesupport/test/core_ext/time_ext_test.rb:650]:
--- expected
+++ actual
@@ -1 +1 @@
-2039-02-21 17:44:30 +0400
+Mon, 21 Feb 2039 17:44:30 +0300


  2) Failure:
test_time_with_datetime_fallback(TimeExtCalculationsTest) [/Users/brainopia/code/sources/rails/activesupport/test/core_ext/time_ext_test.rb:621]:
--- expected
+++ actual
@@ -1 +1 @@
-2039-02-21 17:44:30 +0400
+Mon, 21 Feb 2039 17:44:30 +0300
```

The reason is that rails uses time zone offets for 2007 year. And since then there were changes, for example Russia abolished daylight savings.

```
> ENV['TZ'] = 'Europe/Moscow'
"Europe/Moscow" 
> Time.new(2007).utc_offset
10800 
> Time.new(2012).utc_offset
14400
```
