### PR TITLE
Remove unused variable since #4487.

### DIFF
--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -19,12 +19,6 @@ module ActiveRecord
       counters.each do |association|
         has_many_association = reflect_on_association(association.to_sym)
 
-        expected_name = if has_many_association.options[:as]
-          has_many_association.options[:as].to_s.classify
-        else
-          self.name
-        end
-
         foreign_key  = has_many_association.foreign_key.to_s
         child_class  = has_many_association.klass
         belongs_to   = child_class.reflect_on_all_associations(:belongs_to)


### PR DESCRIPTION
`expected_name` is not used anymore.
