### PR TITLE
Add ActionView own logger

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Rails 4.0.0 (unreleased) ##
+*   Add `config.action_view.logger` to configure logger for ActionView. *Rafael França*
+
 *   Deprecated ActionController::Integration in favour of ActionDispatch::Integration
 
 *   Deprecated ActionController::IntegrationTest in favour of ActionDispatch::IntegrationTest

--- a/actionpack/lib/action_view/base.rb
+++ b/actionpack/lib/action_view/base.rb
@@ -143,6 +143,7 @@ module ActionView #:nodoc:
 
     class_attribute :helpers
     class_attribute :_routes
+    class_attribute :logger
 
     class << self
       delegate :erb_trim_mode=, :to => 'ActionView::Template::Handlers::ERB'

--- a/actionpack/lib/action_view/log_subscriber.rb
+++ b/actionpack/lib/action_view/log_subscriber.rb
@@ -12,9 +12,8 @@ module ActionView
     alias :render_partial :render_template
     alias :render_collection :render_template
 
-    # TODO: Ideally, ActionView should have its own logger so it does not depend on AC.logger
     def logger
-      ActionController::Base.logger if defined?(ActionController::Base)
+      ActionView::Base.logger
     end
 
   protected

--- a/actionpack/lib/action_view/railtie.rb
+++ b/actionpack/lib/action_view/railtie.rb
@@ -8,6 +8,10 @@ module ActionView
     config.action_view.stylesheet_expansions = {}
     config.action_view.javascript_expansions = { :defaults => %w(jquery jquery_ujs) }
 
+    initializer "action_view.logger" do
+      ActiveSupport.on_load(:action_view) { self.logger ||= Rails.logger }
+    end
+
     initializer "action_view.cache_asset_ids" do |app|
       unless app.config.cache_classes
         ActiveSupport.on_load(:action_view) do

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -692,7 +692,8 @@ class RenderTest < ActionController::TestCase
     # enable a logger so that (e.g.) the benchmarking stuff runs, so we can get
     # a more accurate simulation of what happens in "real life".
     super
-    @controller.logger = ActiveSupport::Logger.new(nil)
+    @controller.logger      = ActiveSupport::Logger.new(nil)
+    ActionView::Base.logger = ActiveSupport::Logger.new(nil)
 
     @request.host = "www.nextangle.com"
   end

--- a/actionpack/test/template/log_subscriber_test.rb
+++ b/actionpack/test/template/log_subscriber_test.rb
@@ -8,7 +8,6 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
 
   def setup
     super
-    @old_logger = ActionController::Base.logger
     @controller = Object.new
     @controller.stubs(:_prefixes).returns(%w(test))
     @view = ActionView::Base.new(ActionController::Base.view_paths, {}, @controller)
@@ -19,11 +18,10 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
   def teardown
     super
     ActiveSupport::LogSubscriber.log_subscribers.clear
-    ActionController::Base.logger = @old_logger
   end
 
   def set_logger(logger)
-    ActionController::Base.logger = logger
+    ActionView::Base.logger = logger
   end
 
   def test_render_file_template

--- a/railties/guides/source/configuring.textile
+++ b/railties/guides/source/configuring.textile
@@ -342,7 +342,7 @@ Proc.new { |html_tag, instance| %Q(<div class="field_with_errors">#{html_tag}</d
 
 * +config.action_view.default_form_builder+ tells Rails which form builder to use by default. The default is +ActionView::Helpers::FormBuilder+.
 
-* +config.action_view.logger+ accepts a logger conforming to the interface of Log4r or the default Ruby Logger class, which is then used to log information from Action Mailer. Set to +nil+ to disable logging.
+* +config.action_view.logger+ accepts a logger conforming to the interface of Log4r or the default Ruby Logger class, which is then used to log information from Action View. Set to +nil+ to disable logging.
 
 * +config.action_view.erb_trim_mode+ gives the trim mode to be used by ERB. It defaults to +'-'+. See the "ERB documentation":http://www.ruby-doc.org/stdlib/libdoc/erb/rdoc/ for more information.
 


### PR DESCRIPTION
This pull request add `ActionView::Base.logger` and remove the check if `ActionController` is defined
at `ActionView::LogSubscriber`
