### PR TITLE
Fix for log tailer when the log file doesn't exist.

### DIFF
--- a/railties/lib/rails/rack/log_tailer.rb
+++ b/railties/lib/rails/rack/log_tailer.rb
@@ -4,10 +4,13 @@ module Rails
       def initialize(app, log = nil)
         @app = app
 
-        path = Pathname.new(log || "#{File.expand_path(Rails.root)}/log/#{Rails.env}.log").cleanpath
-        @cursor = ::File.size(path)
+        path = Pathname.new(log || "#{::File.expand_path(Rails.root)}/log/#{Rails.env}.log").cleanpath
 
-        @file = ::File.open(path, 'r')
+        @cursor = @file = nil
+        if ::File.exists?(path)
+          @cursor = ::File.size(path)
+          @file = ::File.open(path, 'r')
+        end
       end
 
       def call(env)
@@ -17,6 +20,7 @@ module Rails
       end
 
       def tail!
+        return unless @cursor
         @file.seek @cursor
 
         unless @file.eof?


### PR DESCRIPTION
If the log file doesn't exist, log tailer errors out and takes down the server with it. Currently this does not happen because even if the log directory doesn't exist, https://github.com/rails/rails/blob/master/railties/lib/rails/application/bootstrap.rb#L27 creates it and the log file will be created. 
