### PR TITLE
Convert URI.parser.parse to URI.parse, and remove ruby 1.8.x code.

### DIFF
--- a/activeresource/lib/active_resource/base.rb
+++ b/activeresource/lib/active_resource/base.rb
@@ -939,12 +939,12 @@ module ActiveResource
 
         # Accepts a URI and creates the site URI from that.
         def create_site_uri_from(site)
-          site.is_a?(URI) ? site.dup : URI.parser.parse(site)
+          site.is_a?(URI) ? site.dup : URI.parse(site)
         end
 
         # Accepts a URI and creates the proxy URI from that.
         def create_proxy_uri_from(proxy)
-          proxy.is_a?(URI) ? proxy.dup : URI.parser.parse(proxy)
+          proxy.is_a?(URI) ? proxy.dup : URI.parse(proxy)
         end
 
         # contains a set of the current prefix parameters.

--- a/activeresource/lib/active_resource/connection.rb
+++ b/activeresource/lib/active_resource/connection.rb
@@ -39,14 +39,14 @@ module ActiveResource
 
     # Set URI for remote service.
     def site=(site)
-      @site = site.is_a?(URI) ? site : URI.parser.parse(site)
+      @site = site.is_a?(URI) ? site : URI.parse(site)
       @user = URI.parser.unescape(@site.user) if @site.user
       @password = URI.parser.unescape(@site.password) if @site.password
     end
 
     # Set the proxy for remote service.
     def proxy=(proxy)
-      @proxy = proxy.is_a?(URI) ? proxy : URI.parser.parse(proxy)
+      @proxy = proxy.is_a?(URI) ? proxy : URI.parse(proxy)
     end
 
     # Sets the user for remote service.

--- a/activesupport/lib/active_support/core_ext/uri.rb
+++ b/activesupport/lib/active_support/core_ext/uri.rb
@@ -20,7 +20,7 @@ end
 module URI
   class << self
     def parser
-      @parser ||= URI.const_defined?(:Parser) ? URI::Parser.new : URI
+      @parser ||= URI::Parser.new
     end
   end
 end

--- a/activesupport/test/core_ext/uri_ext_test.rb
+++ b/activesupport/test/core_ext/uri_ext_test.rb
@@ -7,11 +7,7 @@ class URIExtTest < ActiveSupport::TestCase
   def test_uri_decode_handle_multibyte
     str = "\xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E" # Ni-ho-nn-go in UTF-8, means Japanese.
 
-    if URI.const_defined?(:Parser)
-      parser = URI::Parser.new
-      assert_equal str, parser.unescape(parser.escape(str))
-    else
-      assert_equal str, URI.unescape(URI.escape(str))
-    end
+    parser = URI::Parser.new
+    assert_equal str, parser.unescape(parser.escape(str))
   end
 end


### PR DESCRIPTION
I had mistaken related to GH #4521.

URI.unescape and URI.escape are deprecated since 1.9.2.

Therefore it seems that we use URI.parser method to use URI.parser.unescape,
and I think that we shouldn't remove URI.parser method (core_ext).

And I seen the below line in railties/guides/source/3_0_release_notes.textile.

```
Ruby 1.9.2: <tt>URI.parse</tt> and <tt>.decode</tt> are deprecated and are no longer used in the library.
```

But I think that the above one has an incorrect fact (URI.parse is not deprecated).
Therefore I converted URI.parser.parse to URI.parse for consistency.

/cc @josevalim
