### PR TITLE
Support more directories for rake notes.

### DIFF
--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -47,7 +47,7 @@ class SourceAnnotationExtractor
 
   # Returns a hash that maps filenames under +dirs+ (recursively) to arrays
   # with their annotations.
-  def find(dirs=%w(app config lib script test))
+  def find(dirs=%w(app config lib script test db spec))
     dirs.inject({}) { |h, dir| h.update(find_in(dir)) }
   end
 

--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -18,6 +18,9 @@ module ApplicationTests
         app_file "app/views/home/index.html.haml", "-# TODO: note in haml"
         app_file "app/views/home/index.html.slim", "/ TODO: note in slim"
         app_file "app/controllers/application_controller.rb", 1000.times.map { "" }.join("\n") << "# TODO: note in ruby"
+        app_file "test/test_helper.rb", "# TODO: note in test"
+        app_file "db/seeds.rb", "# TODO: note in seeds"
+        app_file "spec/spec_helper.rb", "# TODO: note in spec"
 
         boot_rails
         require 'rake'
@@ -34,12 +37,18 @@ module ApplicationTests
           assert_match /note in haml/, output
           assert_match /note in slim/, output
           assert_match /note in ruby/, output
+          assert_match /note in test/, output
+          assert_match /note in seeds/, output
+          assert_match /note in spec/,  output
 
-          assert_equal 4, lines.size
+          assert_equal 7, lines.size
           assert_equal 4, lines[0].size
           assert_equal 4, lines[1].size
           assert_equal 4, lines[2].size
           assert_equal 4, lines[3].size
+          assert_equal 4, lines[4].size
+          assert_equal 4, lines[5].size
+          assert_equal 4, lines[6].size
         end
       
       end


### PR DESCRIPTION
While I was tackling the GH #4536, I found the problem first.
I should add some directories for the `rake notes` task.

I also added `spec` directory too.
