### PR TITLE
Don't instantiate two objects in collection proxy / find_or_instantiate_by

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -82,9 +82,8 @@ module ActiveRecord
             proxy_association.send :add_to_target, r
             yield(r) if block_given?
           end
-        end
 
-        if target.respond_to?(method) || (!proxy_association.klass.respond_to?(method) && Class.respond_to?(method))
+        elsif target.respond_to?(method) || (!proxy_association.klass.respond_to?(method) && Class.respond_to?(method))
           if load_target
             if target.respond_to?(method)
               target.send(method, *args, &block)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -738,6 +738,18 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal number_of_clients + 1, companies(:first_firm).clients_of_firm.size
   end
 
+  def test_find_or_initialize_returns_the_instantiated_object
+    client = companies(:first_firm).clients_of_firm.find_or_initialize_by_name("name" => "Another Client")
+    assert_equal client, companies(:first_firm).clients_of_firm[-1]
+  end
+
+  def test_find_or_initialize_only_instantiates_a_single_object
+    number_of_clients = Client.count
+    companies(:first_firm).clients_of_firm.find_or_initialize_by_name("name" => "Another Client").save!
+    companies(:first_firm).save!
+    assert_equal number_of_clients+1, Client.count
+  end
+
   def test_find_or_create_with_hash
     post = authors(:david).posts.find_or_create_by_title(:title => 'Yet another post', :body => 'somebody')
     assert_equal post, authors(:david).posts.find_or_create_by_title(:title => 'Yet another post', :body => 'somebody')


### PR DESCRIPTION
Hi, I ran into what I believe is a bug in CollectionProxy's method_missing.  Given something like

``` ruby
class Company
  has_many :clients
end

company.clients.find_or_initialize_by_foo('bar')
```

the current code calls find_or_instantiator_by_attributes for the company.clients proxy, then discards the return value and calls find_or_initialize_by on the client scope.  The return value then looks rather similar to what you'd 
expect from the find_or_instantiator_by_attributes call, but the resulting object isn't in the company.clients collection.

I'm fairly sure that it's just missing an 'elsif', like in the attached commit, but if someone (@jonleighton?) could double-check I'm not missing something stupid that would be appreciated.  I believe the problem dates back to https://github.com/rails/rails/commit/86ea94e4d0c228c79b3709f0c667ba90b02e41cd.

I've only been able to try this against our app running 3-1-stable, but the commit applies cleanly to 3-2-stable and master.  Any preference which the pull request should be against?
