### PR TITLE
Use performed? instead of checking for response_body

### DIFF
--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -181,13 +181,13 @@ module ActionController
       @_status = Rack::Utils.status_code(status)
     end
 
-    def response_body=(val)
-      body = (val.nil? || val.respond_to?(:each)) ? val : [val]
-      super body
+    def response_body=(body)
+      body = [body] unless body.nil? || body.respond_to?(:each)
+      super
     end
 
     def performed?
-      response_body
+      !!response_body
     end
 
     def dispatch(name, request) #:nodoc:

--- a/actionpack/lib/action_controller/metal/implicit_render.rb
+++ b/actionpack/lib/action_controller/metal/implicit_render.rb
@@ -2,7 +2,7 @@ module ActionController
   module ImplicitRender
     def send_action(method, *args)
       ret = super
-      default_render unless response_body
+      default_render unless performed?
       ret
     end
 

--- a/actionpack/test/controller/force_ssl_test.rb
+++ b/actionpack/test/controller/force_ssl_test.rb
@@ -39,9 +39,7 @@ class ForceSSLFlash < ForceSSLController
     @flashy = flash["that"]
     render :inline => "hello"
   end
-
 end
-
 
 class ForceSSLControllerLevelTest < ActionController::TestCase
   tests ForceSSLControllerLevel
@@ -135,5 +133,4 @@ class ForceSSLFlashTest < ActionController::TestCase
     assert_equal "hello", assigns["flash_copy"]["that"]
     assert_equal "hello", assigns["flashy"]
   end
-
 end


### PR DESCRIPTION
`performed?` is back, so we can make use of it internally.
- Check for performed? instead of response_body
- Change performed? to return a boolean
- Refactor AC::Metal#response_body= to reuse variable
