### PR TITLE
date_select doesn't work correctly with include_blank and discard_day

### DIFF
--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -734,7 +734,7 @@ module ActionView
 
       def select_day
         if @options[:use_hidden] || @options[:discard_day]
-          build_hidden(:day, day)
+          build_hidden(:day, day || 1)
         else
           build_options_and_select(:day, day, :start => 1, :end => 31, :leading_zeros => false, :use_two_digit_numbers => @options[:use_two_digit_numbers])
         end

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -1396,22 +1396,6 @@ class DateHelperTest < ActionView::TestCase
     assert_dom_equal expected, date_select("post", "written_on", :order => [ :month, :year ])
   end
 
-  def test_date_select_without_day_and_include_blank_option_when_written_on_is_nil
-    @post = Post.new
-
-    expected = "<input type=\"hidden\" id=\"post_written_on_3i\" name=\"post[written_on(3i)]\" value=\"1\" />\n"
-
-    expected <<  %{<select id="post_written_on_2i" name="post[written_on(2i)]">\n}
-    expected << %{<option value=""></option>\n<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7">July</option>\n<option value="8">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n}
-    expected << "</select>\n"
-
-    expected <<  %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}
-    expected << %{<option value=""></option>\n<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
-    expected << "</select>\n"
-
-    assert_dom_equal expected, date_select("post", "written_on", :start_year => 1999, :end_year => 2009, :order => [ :month, :year ], :discard_day => true, :include_blank => true)
-  end
-
   def test_date_select_without_day_with_separator
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
@@ -1603,7 +1587,7 @@ class DateHelperTest < ActionView::TestCase
     start_year = Time.now.year-5
     end_year   = Time.now.year+5
 
-    expected = '<input name="post[written_on(3i)]" type="hidden" id="post_written_on_3i"/>' + "\n"
+    expected = '<input name="post[written_on(3i)]" type="hidden" id="post_written_on_3i" value="1"/>' + "\n"
     expected <<   %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}
     expected << "<option value=\"\"></option>\n"
     start_year.upto(end_year) { |i| expected << %(<option value="#{i}">#{i}</option>\n) }

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -1396,6 +1396,22 @@ class DateHelperTest < ActionView::TestCase
     assert_dom_equal expected, date_select("post", "written_on", :order => [ :month, :year ])
   end
 
+  def test_date_select_without_day_and_include_blank_option_when_written_on_is_nil
+    @post = Post.new
+
+    expected = "<input type=\"hidden\" id=\"post_written_on_3i\" name=\"post[written_on(3i)]\" value=\"1\" />\n"
+
+    expected <<  %{<select id="post_written_on_2i" name="post[written_on(2i)]">\n}
+    expected << %{<option value=""></option>\n<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7">July</option>\n<option value="8">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n}
+    expected << "</select>\n"
+
+    expected <<  %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}
+    expected << %{<option value=""></option>\n<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
+    expected << "</select>\n"
+
+    assert_dom_equal expected, date_select("post", "written_on", :start_year => 1999, :end_year => 2009, :order => [ :month, :year ], :discard_day => true, :include_blank => true)
+  end
+
   def test_date_select_without_day_with_separator
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)


### PR DESCRIPTION
date_select does not work when day is discarded, include blank option is
enabled and struct date itself is nil.

e.g

```
job = Job.new
job.date_from #=> nil
form_for job do |f|
  f.date_select :date_from, :discard_day => true, :include_blank => true
```

This generates

```
<input id="job_date_from_3i" type="hidden" name="job[date_from(3i)]">
```

As you can see, value="1" is not generated and the record can't be saved correctly in the AR.

This problem also exists in 3-2-stable.
