### PR TITLE
Removed unused assigns from ActionView::Template::Error

### DIFF
--- a/actionpack/lib/action_view/template.rb
+++ b/actionpack/lib/action_view/template.rb
@@ -288,7 +288,7 @@ module ActionView
             logger.debug "Backtrace: #{e.backtrace.join("\n")}"
           end
 
-          raise ActionView::Template::Error.new(self, {}, e)
+          raise ActionView::Template::Error.new(self, e)
         end
       end
 
@@ -297,13 +297,12 @@ module ActionView
           e.sub_template_of(self)
           raise e
         else
-          assigns  = view.respond_to?(:assigns) ? view.assigns : {}
           template = self
           unless template.source
             template = refresh(view)
             template.encode!
           end
-          raise Template::Error.new(template, assigns, e)
+          raise Template::Error.new(template, e)
         end
       end
 

--- a/actionpack/lib/action_view/template/error.rb
+++ b/actionpack/lib/action_view/template/error.rb
@@ -55,9 +55,9 @@ module ActionView
 
       attr_reader :original_exception, :backtrace
 
-      def initialize(template, assigns, original_exception)
+      def initialize(template, original_exception)
         super(original_exception.message)
-        @template, @assigns, @original_exception = template, assigns.dup, original_exception
+        @template, @original_exception = template, original_exception
         @sub_templates = nil
         @backtrace = original_exception.backtrace
       end

--- a/actionpack/test/controller/rescue_test.rb
+++ b/actionpack/test/controller/rescue_test.rb
@@ -137,11 +137,11 @@ class RescueController < ActionController::Base
   end
 
   def io_error_in_view
-    raise ActionView::TemplateError.new(nil, {}, IOError.new('this is io error'))
+    raise ActionView::TemplateError.new(nil, IOError.new('this is io error'))
   end
 
   def zero_division_error_in_view
-    raise ActionView::TemplateError.new(nil, {}, ZeroDivisionError.new('this is zero division error'))
+    raise ActionView::TemplateError.new(nil, ZeroDivisionError.new('this is zero division error'))
   end
 
   protected

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -34,7 +34,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
       when "/unprocessable_entity"
         raise ActionController::InvalidAuthenticityToken
       when "/not_found_original_exception"
-        raise ActionView::Template::Error.new('template', {}, AbstractController::ActionNotFound.new)
+        raise ActionView::Template::Error.new('template', AbstractController::ActionNotFound.new)
       else
         raise "puke!"
       end

--- a/actionpack/test/dispatch/show_exceptions_test.rb
+++ b/actionpack/test/dispatch/show_exceptions_test.rb
@@ -11,7 +11,7 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
       when "/method_not_allowed"
         raise ActionController::MethodNotAllowed
       when "/not_found_original_exception"
-        raise ActionView::Template::Error.new('template', {}, AbstractController::ActionNotFound.new)
+        raise ActionView::Template::Error.new('template', AbstractController::ActionNotFound.new)
       else
         raise "puke!"
       end

--- a/actionpack/test/template/template_error_test.rb
+++ b/actionpack/test/template/template_error_test.rb
@@ -2,12 +2,12 @@ require "abstract_unit"
 
 class TemplateErrorTest < ActiveSupport::TestCase
   def test_provides_original_message
-    error = ActionView::Template::Error.new("test", {}, Exception.new("original"))
+    error = ActionView::Template::Error.new("test", Exception.new("original"))
     assert_equal "original", error.message
   end
 
   def test_provides_useful_inspect
-    error = ActionView::Template::Error.new("test", {}, Exception.new("original"))
+    error = ActionView::Template::Error.new("test", Exception.new("original"))
     assert_equal "#<ActionView::Template::Error: original>", error.inspect
   end
 end


### PR DESCRIPTION
They existed since initial rails commit by DHH but lost use a long time
ago
