### PR TITLE
Don't type-cast unknown types to YAML.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -71,7 +71,7 @@ module ActiveRecord
         when Date, Time then quoted_date(value)
         when Symbol     then value.to_s
         else
-          YAML.dump(value)
+          raise TypeError, "can't cast #{value.class} to #{column.type}"
         end
       end
 

--- a/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
@@ -70,9 +70,9 @@ module ActiveRecord
           assert_equal bd.to_f, @conn.type_cast(bd, nil)
         end
 
-        def test_type_cast_unknown
+        def test_type_cast_unknown_should_raise_error
           obj = Class.new.new
-          assert_equal YAML.dump(obj), @conn.type_cast(obj, nil)
+          assert_raise(TypeError) { @conn.type_cast(obj, nil) }
         end
 
         def test_quoted_id

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -992,10 +992,9 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal "b", duped_topic.title
 
     # test if the attribute values have been duped
-    topic.title = {"a" => "b"}
     duped_topic = topic.dup
-    duped_topic.title["a"] = "c"
-    assert_equal "b", topic.title["a"]
+    duped_topic.title.replace "c"
+    assert_equal "a", topic.title
 
     # test if attributes set as part of after_initialize are duped correctly
     assert_equal topic.author_email_address, duped_topic.author_email_address
@@ -1006,8 +1005,7 @@ class BasicsTest < ActiveRecord::TestCase
     assert_not_equal duped_topic.id, topic.id
 
     duped_topic.reload
-    # FIXME: I think this is poor behavior, and will fix it with #5686
-    assert_equal({'a' => 'c'}.to_yaml, duped_topic.title)
+    assert_equal("c", duped_topic.title)
   end
 
   def test_dup_with_aggregate_of_same_name_as_attribute


### PR DESCRIPTION
Take the following model:

``` ruby
class User
  validates_length_of :login, maximum: 10
end
```

If I tamper with the form submission so that the param name is "user[login][]" instead of "user[login]", I can post a string that's far longer than 10 characters and the application will accept it and serialize it to YAML when type-cast. More application logic may cause the request to blow up, but nothing guarantees a 500 at all let alone before the data is committed to the database.

I did some searching and came across this:

https://rails.lighthouseapp.com/projects/8994/tickets/5686-activerecord-should-raise-an-exception-sometimes

The whole thing must have fallen off @tenderlove's radar, so here's a patch that will raise `TypeError` during type-cast if a bad type makes it through the controller layer (unless `ActiveRecord::Base.serialize` was declared).
