### PR TITLE
let AR::Relation pretty_printed like an Array

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -496,6 +496,10 @@ module ActiveRecord
       to_a.inspect
     end
 
+    def pretty_print(q)
+      q.pp(self.to_a)
+    end
+
     def with_default_scope #:nodoc:
       if default_scoped? && default_scope = klass.send(:build_default_scope)
         default_scope = default_scope.merge(self)


### PR DESCRIPTION
While `pp [model1, model2]` looks like this

```
[#<Model id: 1, created_at: "2012-01-20 14:05:39", updated_at: "2012-01-20 14:05:39">,
 #<Model id: 2, created_at: "2012-01-20 14:05:42", updated_at: "2012-01-20 14:05:42">]
```

`pp Model.scoped` prints all AR instances in one line

```
[#<Model id: 1, created_at: "2012-01-20 14:05:39", updated_at: "2012-01-20 14:05:39">, #<Model id: 2, created_at: "2012-01-20 14:05:42", updated_at: "2012-01-20 14:05:42">]
```

Added `AR::Relation#pretty_print` to let `PP` regard a `Relation` as an `Array` of models.
