### PR TITLE
Replace regexp matching with a simple string manipulation.

### DIFF
--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -30,8 +30,9 @@ module ActiveSupport #:nodoc:
     end
 
     def method_missing(name, *args)
-      if name.to_s =~ /(.*)=$/
-        self[$1] = args.first
+      name_string = name.to_s
+      if name_string.chomp!('=')
+        self[name_string] = args.first
       else
         self[name]
       end


### PR DESCRIPTION
Using regexp looks like overkill here and is also 2x slower.

```
             user     system      total        real
string   0.020000   0.000000   0.020000 (  0.016256)
regexp   0.030000   0.000000   0.030000 (  0.035360)
```

``` ruby
require "benchmark"

names = ("a".."z").map { |c| c + "a" * rand(5..10) + "=" * rand(0..1) }.map(&:to_sym)
puts names

n = 1000
Benchmark.bmbm do |x|
  x.report "string" do
    n.times do
      names.each do |name|
        string_name = name.to_s
        string_name.chomp!('=')
        string_name
      end
    end
  end

  x.report "regexp" do
    n.times do
      names.each do |name|
        name.to_s =~ /(.*)=$/
        $1
      end
    end
  end
end
```
