### PR TITLE
change AR default_timezone to :utc since it's the default for AR::Railtie

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -45,10 +45,10 @@ module ActiveRecord
 
       ##
       # :singleton-method:
-      # Determines whether to use Time.local (using :local) or Time.utc (using :utc) when pulling
-      # dates and times from the database. This is set to :local by default.
+      # Determines whether to use Time.utc (using :utc) or Time.local (using :local) when pulling
+      # dates and times from the database. This is set to :utc by default.
       config_attribute :default_timezone, :global => true
-      self.default_timezone = :local
+      self.default_timezone = :utc
 
       ##
       # :singleton-method:

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -689,7 +689,7 @@ class BasicsTest < ActiveRecord::TestCase
     }
     topic = Topic.find(1)
     topic.attributes = attributes
-    assert_equal Time.local(2004, 6, 24, 16, 24, 0), topic.written_on
+    assert_equal Time.utc(2004, 6, 24, 16, 24, 0), topic.written_on
   end
 
   def test_multiparameter_attributes_on_time_with_no_date
@@ -938,7 +938,7 @@ class BasicsTest < ActiveRecord::TestCase
     }
     topic = Topic.find(1)
     topic.attributes = attributes
-    assert_equal Time.local(2000, 1, 1, 5, 42, 0), topic.bonus_time
+    assert_equal Time.utc(2000, 1, 1, 5, 42, 0), topic.bonus_time
   end
 
   def test_boolean


### PR DESCRIPTION
This is an already known inconsistency reported here https://rails.lighthouseapp.com/projects/8994/tickets/5679-activerecordbasedefault_timezone

Since AR 3.0, `AR::Base.default_timezone` is set to `:utc` in Railtie https://github.com/rails/rails/blob/c05f3b0e4f/activerecord/lib/active_record/railtie.rb#L48
then overridden to `:local` at Base or Core
https://github.com/rails/rails/blob/c05f3b0e4f/activerecord/lib/active_record/core.rb#L51

Because of this, `AR::Base.default_timezone` value defers for a Rails app

```
% bundle e rails runner 'p ActiveRecord::Base.default_timezone'
:utc
```

and a Ruby script that doesn't load `AR::Railtie`

```
% ruby -e "require 'active_record'; p ActiveRecord::Base.default_timezone"
:local
```

The next major version up must be the best timing for fixing this inconsistency, so I propose this patch again for 4.0.
