### PR TITLE
Fixed regression - unable to use a range as choices for form.select.

### DIFF
--- a/actionpack/lib/action_view/helpers/tags/select.rb
+++ b/actionpack/lib/action_view/helpers/tags/select.rb
@@ -4,6 +4,7 @@ module ActionView
       class Select < Base #:nodoc:
         def initialize(object_name, method_name, template_object, choices, options, html_options)
           @choices = choices
+          @choices = @choices.to_a if @choices.is_a?(Range)
           @html_options = html_options
 
           super(object_name, method_name, template_object, options)

--- a/actionpack/test/template/form_options_helper_test.rb
+++ b/actionpack/test/template/form_options_helper_test.rb
@@ -144,6 +144,13 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_range_options_for_select
+    assert_dom_equal(
+      "<option value=\"1\">1</option>\n<option value=\"2\">2</option>\n<option value=\"3\">3</option>",
+      options_for_select(1..3)
+    )
+  end
+
   def test_array_options_for_string_include_in_other_string_bug_fix
       assert_dom_equal(
         "<option value=\"ruby\">ruby</option>\n<option value=\"rubyonrails\" selected=\"selected\">rubyonrails</option>",
@@ -668,6 +675,15 @@ class FormOptionsHelperTest < ActionView::TestCase
     assert_dom_equal(
       "<select id=\"post_category\" name=\"post[category]\"><option value=\"abe\" disabled=\"disabled\">abe</option>\n<option value=\"&lt;mus&gt;\" selected=\"selected\">&lt;mus&gt;</option>\n<option value=\"hest\" disabled=\"disabled\">hest</option></select>",
       select("post", "category", %w( abe <mus> hest ), :disabled => ['hest', 'abe'])
+    )
+  end
+
+  def test_select_with_range
+    @post = Post.new
+    @post.category = 0
+    assert_dom_equal(
+      "<select id=\"post_category\" name=\"post[category]\"><option value=\"1\">1</option>\n<option value=\"2\">2</option>\n<option value=\"3\">3</option></select>",
+      select("post", "category", 1..3)
     )
   end
 


### PR DESCRIPTION
As of 3.2, form.select(:foobar, 1..3) fails with:

```
NoMethodError: undefined method `empty?' for 1..3:Range
    actionpack/lib/action_view/helpers/tags/select.rb:21:in `render'
```

However, this still works fine with select_tag and options_for.

I've added tests for both cases and added a one-line fix to convert the range to an array for form.select.
