### PR TITLE
Bump rubygems required version to 1.8.11 (default version in 1.9.3-p0)

### DIFF
--- a/rails.gemspec
+++ b/rails.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.description = 'Ruby on Rails is a full-stack web framework optimized for programmer happiness and sustainable productivity. It encourages beautiful code by favoring convention over configuration.'
 
   s.required_ruby_version     = '>= 1.9.3'
-  s.required_rubygems_version = ">= 1.3.6"
+  s.required_rubygems_version = ">= 1.8.11"
 
   s.author            = 'David Heinemeier Hansson'
   s.email             = 'david@loudthinking.com'


### PR DESCRIPTION
See #4559
