### PR TITLE
Assert with no deprecation warnings activesupport tests.

### DIFF
--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -66,6 +66,8 @@ class TaggedLoggingTest < ActiveSupport::TestCase
   end
 
   test "silence" do
-    assert_nothing_raised { @logger.silence {} }
+    assert_deprecated do
+      assert_nothing_raised { @logger.silence {} }
+    end
   end
 end


### PR DESCRIPTION
This removes deprecation warnings in test console output introduced in #4582
