### PR TITLE
Remove not used requires from csrf helper file and test

### DIFF
--- a/actionpack/lib/action_view/helpers/csrf_helper.rb
+++ b/actionpack/lib/action_view/helpers/csrf_helper.rb
@@ -1,5 +1,3 @@
-require 'active_support/core_ext/string/strip'
-
 module ActionView
   # = Action View CSRF Helper
   module Helpers

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -1,6 +1,5 @@
 require 'abstract_unit'
 require 'digest/sha1'
-require 'active_support/core_ext/string/strip'
 require "active_support/log_subscriber/test_helper"
 
 # common controller actions
@@ -72,9 +71,7 @@ class CustomAuthenticityParamController < RequestForgeryProtectionController
   end
 end
 
-
 # common test methods
-
 module RequestForgeryProtectionTests
   def setup
     @token      = "cf50faa3fe97702ca1ae"
@@ -245,10 +242,6 @@ class FreeCookieControllerTest < ActionController::TestCase
     assert_blank @response.body
   end
 end
-
-
-
-
 
 class CustomAuthenticityParamControllerTest < ActionController::TestCase
   def setup


### PR DESCRIPTION
These requires were added in a87b92d and the implementation changed in 2cdc1f0, removing the need for them.
