### PR TITLE
Fix GH #4344. Callback defined in a module is not triggered when the module extends an object under Rails 3.2rc2

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -359,7 +359,7 @@ module ActiveSupport
       def __run_callbacks(key, kind, object, &blk) #:nodoc:
         name = __callback_runner_name(kind)
         unless object.respond_to?(name)
-          str = send("_#{kind}_callbacks").compile(key, object)
+          str = object.send("_#{kind}_callbacks").compile(key, object)
           class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
             def #{name}() #{str} end
             protected :#{name}


### PR DESCRIPTION
It seems that this issue is introduced 66a587cf5590d37483d8aba64da5022df08ecf07.
Callbacks is compiled at different timing and context.

In 3.2.0.rc1
callbacks often is compiled in __define_runner method.

In 3.2.0.rc2
callbacks always is compiled in __run_callback method.

Please see also https://github.com/rails/rails/issues/4344

/cc @bogdan
