### PR TITLE
Add missing require to Array#wrap in generators action methods

### DIFF
--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -1,5 +1,6 @@
 require 'open-uri'
 require 'rbconfig'
+require 'active_support/core_ext/array/wrap'
 
 module Rails
   module Generators


### PR DESCRIPTION
I've got this error while adding an `environment` call inside a template file, when building a new rails application.

```
rails new test_drive -m my_template_with_enviroment.rb

.../railties-3.2.0/lib/rails/generators/actions.rb:128:in `block in environment': undefined method `wrap' for Array:Class (NoMethodError)
```

Rails master already changed from `Array.wrap` to `Array()`.
