### PR TITLE
A scope for "none" which pulls no records from the database.

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -8,7 +8,7 @@ module ActiveRecord
     delegate :find_each, :find_in_batches, :to => :scoped
     delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins,
              :where, :preload, :eager_load, :includes, :from, :lock, :readonly,
-             :having, :create_with, :uniq, :references, :to => :scoped
+             :having, :create_with, :uniq, :references, :none, :to => :scoped
     delegate :count, :average, :minimum, :maximum, :sum, :calculate, :pluck, :to => :scoped
 
     # Executes a custom SQL query against your database and returns all the results. The results will

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -166,7 +166,10 @@ module ActiveRecord
 
       default_scoped = with_default_scope
 
-      if default_scoped.equal?(self)
+      if where_values.include?(false)
+        @records = []
+        
+      elsif default_scoped.equal?(self)
         @records = if @readonly_value.nil? && !@klass.locking_enabled?
           eager_loading? ? find_with_associations : @klass.find_by_sql(arel, @bind_values)
         else

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -153,6 +153,12 @@ module ActiveRecord
       relation
     end
 
+    def none
+      relation = clone
+      relation.where_values += build_where(false)
+      relation
+    end
+
     def where(opts, *rest)
       return self if opts.blank?
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -483,6 +483,18 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal 1, authors.all.length
   end
 
+  def test_none_with_ar_object
+    author = Author.first
+    authors = Author.scoped.none
+    assert_equal 0, authors.all.length
+  end
+
+  def test_chained_none_with_ar_object
+    author = Author.first
+    authors = Author.scoped.none.where(:id => author)
+    assert_equal 0, authors.all.length
+  end
+
   def test_find_with_list_of_ar
     author = Author.first
     authors = Author.find([author])

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -484,9 +484,7 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_none_with_ar_object
-    author = Author.first
-    authors = Author.scoped.none
-    assert_equal 0, authors.all.length
+    assert_equal 0, Author.scoped.none.length
   end
 
   def test_chained_none_with_ar_object


### PR DESCRIPTION
A scoped method for none that pulls no records from the database.

Initially proposed by @xuanxu and discussed at https://github.com/rails/rails/pull/4548
