### PR TITLE
Raise exception when date.order includes invalid elements

### DIFF
--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -836,7 +836,15 @@ module ActionView
         end
 
         def translated_date_order
-          I18n.translate(:'date.order', :locale => @options[:locale]) || []
+          date_order = I18n.translate(:'date.order', :locale => @options[:locale]) || []
+
+          forbidden_elements = date_order - [:year, :month, :day]
+          if forbidden_elements.any?
+            raise StandardError,
+              "#{@options[:locale]}.date.order only accepts :year, :month and :day"
+          end
+
+          date_order
         end
 
         # Build full select tag from date type and options.

--- a/actionpack/test/template/date_helper_i18n_test.rb
+++ b/actionpack/test/template/date_helper_i18n_test.rb
@@ -118,4 +118,12 @@ class DateHelperSelectTagsI18nTests < ActiveSupport::TestCase
     I18n.expects(:translate).with(:'date.order', :locale => 'en').returns [:year, :month, :day]
     datetime_select('post', 'updated_at', :locale => 'en')
   end
+
+  def test_date_or_time_select_given_invalid_order
+    I18n.expects(:translate).with(:'date.order', :locale => 'en').returns [:invalid, :month, :day]
+
+    assert_raise StandardError do
+      datetime_select('post', 'updated_at', :locale => 'en')
+    end
+  end
 end


### PR DESCRIPTION
## Short background story:

Our locale files were translated to Russian, but the translator didn't know that :locale.date.order is not translatable. So the locale file looked like this:

```
order:
  - :день
  - :месяц
  - :год
```

In the view we had `f.date_select :starts_at` and this raised an exception:

```
undefined method `select_год' for #<ActionView::Helpers::DateTimeSelector:0x00000008036a08>
```

I debugged it and found out, that this comes from the locale file.
## About pull request

I feel that :order values from locales should not be evaluated directly. Actual line that evaluates it: https://github.com/indrekj/rails/blob/translated_date_order/actionpack/lib/action_view/helpers/date_helper.rb#L961

My patch adds code to check if the order includes only :year, :month and :day. If it doesn't then it raises an exception.

I'm not sure if my approach is correct. I wasn't sure which type of exception should be raised. Maybe there shouldn't be anything raised. Even if my patch is bad, I still feel that there should be more informative message than undefined method `select_год` exception.
