### PR TITLE
none query method

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -8,7 +8,7 @@ module ActiveRecord
     delegate :find_each, :find_in_batches, :to => :scoped
     delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins,
              :where, :preload, :eager_load, :includes, :from, :lock, :readonly,
-             :having, :create_with, :uniq, :references, :to => :scoped
+             :having, :create_with, :uniq, :references, :none, :to => :scoped
     delegate :count, :average, :minimum, :maximum, :sum, :calculate, :pluck, :to => :scoped
 
     # Executes a custom SQL query against your database and returns all the results. The results will

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -8,7 +8,7 @@ module ActiveRecord
     JoinOperation = Struct.new(:relation, :join_class, :on)
     ASSOCIATION_METHODS = [:includes, :eager_load, :preload]
     MULTI_VALUE_METHODS = [:select, :group, :order, :joins, :where, :having, :bind, :references]
-    SINGLE_VALUE_METHODS = [:limit, :offset, :lock, :readonly, :from, :reordering, :reverse_order, :uniq]
+    SINGLE_VALUE_METHODS = [:limit, :offset, :lock, :readonly, :from, :reordering, :reverse_order, :uniq, :none]
 
     include FinderMethods, Calculations, SpawnMethods, QueryMethods, Batches, Explain, Delegation
 
@@ -166,7 +166,9 @@ module ActiveRecord
 
       default_scoped = with_default_scope
 
-      if default_scoped.equal?(self)
+      if @none_value
+        @records = []
+      elsif default_scoped.equal?(self)
         @records = if @readonly_value.nil? && !@klass.locking_enabled?
           eager_loading? ? find_with_associations : @klass.find_by_sql(arel, @bind_values)
         else

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -10,7 +10,7 @@ module ActiveRecord
                   :where_values, :having_values, :bind_values,
                   :limit_value, :offset_value, :lock_value, :readonly_value, :create_with_value,
                   :from_value, :reordering_value, :reverse_order_value,
-                  :uniq_value, :references_values
+                  :uniq_value, :references_values, :none_value
 
     def includes(*args)
       args.reject! {|a| a.blank? }
@@ -193,6 +193,17 @@ module ActiveRecord
         relation.lock_value = false
       end
 
+      relation
+    end
+
+    # Returns a chainable empty relation with zero records. It prevents the
+    # execution of the query.
+    #
+    # Any subsequent condition chained to the relation will continue
+    # generating an empty relation and will not fire any query to the database.
+    def none
+      relation = clone
+      relation.none_value = true
       relation
     end
 

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -20,7 +20,7 @@ module ActiveRecord
     end
 
     def test_single_values
-      assert_equal [:limit, :offset, :lock, :readonly, :from, :reordering, :reverse_order, :uniq].map(&:to_s).sort,
+      assert_equal [:limit, :offset, :lock, :readonly, :from, :reordering, :reverse_order, :uniq, :none].map(&:to_s).sort,
         Relation::SINGLE_VALUE_METHODS.map(&:to_s).sort
     end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -210,6 +210,19 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal 4, developers.map(&:salary).uniq.size
   end
 
+  def test_none
+    assert_no_queries do
+      assert_equal [], Developer.none
+      assert_equal [], Developer.scoped.none
+    end
+  end
+
+  def test_none_chainable
+    assert_no_queries do
+      assert_equal [], Developer.none.where(:name => 'David')
+    end
+  end
+
   def test_select_with_block
     even_ids = Developer.scoped.select {|d| d.id % 2 == 0 }.map(&:id)
     assert_equal [2, 4, 6, 8, 10], even_ids.sort


### PR DESCRIPTION
Here is a `none` method to return an empty relation from a AR model (i.e Post.none), as previously discussed here: https://github.com/rails/rails/pull/4548 

It prevents the query hitting the database, is chainable and makes any subsequent relation empty, so Post.none.where(:author_id => 1) is also empty.
