### PR TITLE
CookieJar#deleted? predicate method

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -191,6 +191,15 @@ module ActionDispatch
         value
       end
 
+      # Whether the given cookie is to be deleted by this CookieJar.
+      # Like <tt>[]=</tt>, you can pass in an options hash to test if a
+      # deletion applies to a specific <tt>:path</tt>, <tt>:domain</tt> etc.
+      def deleted?(key, options = {})
+        options.symbolize_keys!
+        handle_options(options)
+        @delete_cookies[key.to_s] == options
+      end
+
       # Removes all cookies on the client machine by calling <tt>delete</tt> for each cookie
       def clear(options = {})
         @cookies.each_key{ |k| delete(k, options) }

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -245,6 +245,17 @@ class CookiesTest < ActionController::TestCase
     assert_cookie_header "user_name=; path=/beaten; expires=Thu, 01-Jan-1970 00:00:00 GMT"
   end
 
+  def test_deleted_cookie_predicate
+    cookies.delete("user_name")
+    assert cookies.deleted?("user_name")
+    assert_equal false, cookies.deleted?("another")
+  end
+
+  def test_deleted_cookie_predicate_with_mismatching_options
+    cookies.delete("user_name", :path => "/path")
+    assert_equal false, cookies.deleted?("user_name", :path => "/different")
+  end
+
   def test_cookies_persist_throughout_request
     response = get :authenticate
     assert response.headers["Set-Cookie"] =~ /user_name=david/


### PR DESCRIPTION
`ActionDispatch::Cookies::CookieJar` needs a way to query for deleted cookies.

Here's an example use case from a controller test:

``` ruby
get :destroy
assert cookies.deleted? "auth_token"
```

Cheers!
Paul
