### PR TITLE
Don't create log directories

### DIFF
--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -24,9 +24,6 @@ module Rails
       initializer :initialize_logger, :group => :all do
         Rails.logger ||= config.logger || begin
           path = config.paths["log"].first
-          unless File.exist? File.dirname path
-            FileUtils.mkdir_p File.dirname path
-          end
 
           f = File.open path, 'a'
           f.binmode


### PR DESCRIPTION
Without removing this code which creates the log directory, no error will be raised and the warning below will not be shown to the user
