### PR TITLE
Fix counter cache column name if :inverse_of is specified on belongs_to

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -223,7 +223,11 @@ module ActiveRecord
 
       def counter_cache_column
         if options[:counter_cache] == true
-          "#{active_record.name.demodulize.underscore.pluralize}_count"
+          if options[:inverse_of]
+            "#{options[:inverse_of]}_count"
+          else
+            "#{active_record.name.demodulize.underscore.pluralize}_count"
+          end
         elsif options[:counter_cache]
           options[:counter_cache].to_s
         end

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -391,6 +391,20 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     reply[:replies_count] = 17
     assert_equal 17, reply.replies.size
   end
+  
+  def test_counter_cache_with_class_name
+    reply = Reply.create(:title => "re: zoom", :content => "speedy quick!")
+    assert_equal 0, reply[:other_replies_count]
+
+    inverse = InverseReply.create(:title => "gaga", :content => "boo-boo")
+    inverse.reply = reply
+
+    assert_equal 1, reply.reload[:other_replies_count]
+    assert_equal 1, reply.other_replies.size
+
+    reply[:other_replies_count] = 17
+    assert_equal 17, reply.other_replies.size
+  end
 
   def test_association_assignment_sticks
     post = Post.find(:first)

--- a/activerecord/test/models/reply.rb
+++ b/activerecord/test/models/reply.rb
@@ -6,6 +6,7 @@ class Reply < Topic
   belongs_to :topic, :foreign_key => "parent_id", :counter_cache => true
   belongs_to :topic_with_primary_key, :class_name => "Topic", :primary_key => "title", :foreign_key => "parent_title", :counter_cache => "replies_count"
   has_many :replies, :class_name => "SillyReply", :dependent => :destroy, :foreign_key => "parent_id"
+  has_many :other_replies, :class_name => "InverseReply", :dependent => :destroy, :foreign_key => "parent_id"
 
   attr_accessible :title, :author_name, :author_email_address, :written_on, :content, :last_read, :parent_title
 end
@@ -55,6 +56,10 @@ end
 
 class SillyReply < Reply
   belongs_to :reply, :foreign_key => "parent_id", :counter_cache => :replies_count
+end
+
+class InverseReply < Reply
+  belongs_to :reply, :foreign_key => "parent_id", :counter_cache => true, :inverse_of => :other_replies
 end
 
 module Web

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -636,6 +636,7 @@ ActiveRecord::Schema.define do
     end
     t.boolean  :approved, :default => true
     t.integer  :replies_count, :default => 0
+    t.integer  :other_replies_count, :default => 0
     t.integer  :parent_id
     t.string   :parent_title
     t.string   :type


### PR DESCRIPTION
This gist explains what problem I'm fixing: https://gist.github.com/1665503

This patch adds a test and a small amount of code to fix the issue.  Sorry for the stupid merging master commit.  I can't seem to figure out how to get it to behave and don't have time to wrestle with git to fix it. :)
