### PR TITLE
Handle nil in add_index :length option in MySQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -541,7 +541,7 @@ module ActiveRecord
         if options.is_a?(Hash) && length = options[:length]
           case length
           when Hash
-            column_names.each {|name| option_strings[name] += "(#{length[name]})" if length.has_key?(name)}
+            column_names.each {|name| option_strings[name] += "(#{length[name]})" if length.has_key?(name) && length[name].present?}
           when Fixnum
             column_names.each {|name| option_strings[name] += "(#{length})"}
           end

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -55,7 +55,7 @@ module ActiveRecord
         assert_raise(ArgumentError) { connection.remove_index(table_name, "no_such_index") }
       end
 
-      def test_add_index_length_limit
+      def test_add_index_name_length_limit
         good_index_name = 'x' * connection.index_name_length
         too_long_index_name = good_index_name + 'x'
 
@@ -101,6 +101,12 @@ module ActiveRecord
         connection.add_index :testings, :foo, :name => "custom_index_name"
 
         assert connection.index_exists?(:testings, :foo, :name => "custom_index_name")
+      end
+
+      def test_add_index_attribute_length_limit
+        connection.add_index :testings, [:foo, :bar], :length => {:foo => 10, :bar => nil}
+
+        assert connection.index_exists?(:testings, [:foo, :bar])
       end
 
       def test_add_index


### PR DESCRIPTION
Our schema.rb is being generated with an `add_index` line similar to this:

```
add_index "foo", ["foo", "bar"], :name => "xxx", :length => {"foo"=>8, "bar=>nil}
```

This is the same as it was on Rails 3.1.3, however, now when that
schema.rb is evaluated, its generating bad SQL in MySQL:

```
Mysql::Error: You have an error in your SQL syntax; check the manual
that corresponds to your MySQL server version for the right syntax
to use near '))' at line 1: CREATE UNIQUE INDEX
`xxx` ON `foo` (`foo`(8), `bar`())
```

This commit adds a check for nil on the length attribute to prevent the
empty parens from being output.
