### PR TITLE
Explicit deprecation require

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -1,7 +1,7 @@
 require 'active_support/inflector'
 require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/module/introspection'
-require 'active_support/core_ext/module/deprecation'
+require 'active_support/deprecation'
 
 module ActiveModel
   class Name < String


### PR DESCRIPTION
Requiring 'active_model/naming' will raise an uninitialized constant
ActiveSupport::Deprecation exception because the module core extension
doesn't require 'active_support/deprecation'. This require cannot be
added to the core extension because of circular dependency issues.
