### PR TITLE
stop generating vendor/plugins with new Rails 3.2 applications

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -134,10 +134,6 @@ module Rails
     def vendor_stylesheets
       empty_directory_with_gitkeep "vendor/assets/stylesheets"
     end
-
-    def vendor_plugins
-      empty_directory_with_gitkeep "vendor/plugins"
-    end
   end
 
   module Generators


### PR DESCRIPTION
Given that use of vendor/plugins is deprecated, should we not stop generating vendor/plugins with new Rails applications?

I know that this lacks fixing any tests that assert that vendor/plugins exists but I thought I'd see if there was support for this idea before spending more time.

Thanks!
