### PR TITLE
Test for unicode path support

### DIFF
--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'erb'
 require 'abstract_unit'
 require 'controller/fake_controllers'
@@ -2540,5 +2541,24 @@ class TestUriPathEscaping < ActionDispatch::IntegrationTest
   test 'unescapes recognized path splat' do
     get '/a%20b/c+d'
     assert_equal 'a b/c+d', @response.body
+  end
+end
+
+class TestUnicodePaths < ActionDispatch::IntegrationTest
+  Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
+    app.draw do
+      match "/#{Rack::Utils.escape("ほげ")}" => lambda { |env|
+        path_params = env['action_dispatch.request.path_parameters']
+        [200, { 'Content-Type' => 'text/plain' }, []]
+      }, :as => :unicode_path
+    end
+  end
+
+  include Routes.url_helpers
+  def app; Routes end
+
+  test 'recognizes unicode path' do
+    get "/#{Rack::Utils.escape("ほげ")}"
+    assert_equal "200", @response.code
   end
 end


### PR DESCRIPTION
This is a test for a regression from 3.1. This is currently broken due to a bug in journey. I've submitted a pull request to fix it in Journey: (https://github.com/rails/journey/pull/14), but as there was no testing in Rails of this functionality, I'm submitting this request as well.
