### PR TITLE
Made @secret a SHA512 digest

### DIFF
--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -24,7 +24,7 @@ module ActiveSupport
     OpenSSLCipherError = OpenSSL::Cipher.const_defined?(:CipherError) ? OpenSSL::Cipher::CipherError : OpenSSL::CipherError
 
     def initialize(secret, options = {})
-      @secret = secret
+      @secret = OpenSSL::Digest::SHA512.new(secret).digest
       @cipher = options[:cipher] || 'aes-256-cbc'
       @verifier = MessageVerifier.new(@secret, :serializer => NullSerializer)
       @serializer = options[:serializer] || Marshal


### PR DESCRIPTION
I'm no cryptographer, but isn't this a good idea to prevent an `OpenSSL::Cipher::CipherError: key length too short` exception? Or does this encourage people to use bad keys?
