### PR TITLE
Validation guides update 3 2

### DIFF
--- a/activeresource/lib/active_resource/validations.rb
+++ b/activeresource/lib/active_resource/validations.rb
@@ -41,7 +41,7 @@ module ActiveResource
   # Module to support validation and errors with Active Resource objects. The module overrides
   # Base#save to rescue ActiveResource::ResourceInvalid exceptions and parse the errors returned
   # in the web service response. The module also adds an +errors+ collection that mimics the interface
-  # of the errors provided by ActiveRecord::Errors.
+  # of the errors provided by ActiveModel::Errors.
   #
   # ==== Example
   #

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -100,8 +100,8 @@ class String
   #
   # +underscore+ will also change '::' to '/' to convert namespaces to paths.
   #
-  #   "ActiveRecord".underscore         # => "active_record"
-  #   "ActiveRecord::Errors".underscore # => active_record/errors
+  #   "ActiveModel".underscore         # => "active_model"
+  #   "ActiveModel::Errors".underscore # => "active_model/errors"
   def underscore
     ActiveSupport::Inflector.underscore(self)
   end

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -42,10 +42,10 @@ module ActiveSupport
     # +camelize+ will also convert '/' to '::' which is useful for converting paths to namespaces.
     #
     # Examples:
-    #   "active_record".camelize                # => "ActiveRecord"
-    #   "active_record".camelize(:lower)        # => "activeRecord"
-    #   "active_record/errors".camelize         # => "ActiveRecord::Errors"
-    #   "active_record/errors".camelize(:lower) # => "activeRecord::Errors"
+    #   "active_model".camelize                # => "ActiveModel"
+    #   "active_model".camelize(:lower)        # => "activeModel"
+    #   "active_model/errors".camelize         # => "ActiveModel::Errors"
+    #   "active_model/errors".camelize(:lower) # => "activeModel::Errors"
     #
     # As a rule of thumb you can think of +camelize+ as the inverse of +underscore+,
     # though there are cases where that does not hold:
@@ -66,8 +66,8 @@ module ActiveSupport
     # Changes '::' to '/' to convert namespaces to paths.
     #
     # Examples:
-    #   "ActiveRecord".underscore         # => "active_record"
-    #   "ActiveRecord::Errors".underscore # => active_record/errors
+    #   "ActiveModel".underscore         # => "active_model"
+    #   "ActiveModel::Errors".underscore # => "active_model/errors"
     #
     # As a rule of thumb you can think of +underscore+ as the inverse of +camelize+,
     # though there are cases where that does not hold:

--- a/railties/guides/source/active_record_validations_callbacks.textile
+++ b/railties/guides/source/active_record_validations_callbacks.textile
@@ -671,7 +671,7 @@ h3. Working with Validation Errors
 
 In addition to the +valid?+ and +invalid?+ methods covered earlier, Rails provides a number of methods for working with the +errors+ collection and inquiring about the validity of objects.
 
-The following is a list of the most commonly used methods. Please refer to the +ActiveRecord::Errors+ documentation for a list of all the available methods.
+The following is a list of the most commonly used methods. Please refer to the +ActiveModel::Errors+ documentation for a list of all the available methods.
 
 h4(#working_with_validation_errors-errors). +errors+
 

--- a/railties/guides/source/active_record_validations_callbacks.textile
+++ b/railties/guides/source/active_record_validations_callbacks.textile
@@ -956,6 +956,7 @@ h4. Creating an Object
 * +before_validation+
 * +after_validation+
 * +before_save+
+* +around_save+
 * +before_create+
 * +around_create+
 * +after_create+
@@ -966,6 +967,7 @@ h4. Updating an Object
 * +before_validation+
 * +after_validation+
 * +before_save+
+* +around_save+
 * +before_update+
 * +around_update+
 * +after_update+
@@ -974,8 +976,8 @@ h4. Updating an Object
 h4. Destroying an Object
 
 * +before_destroy+
-* +after_destroy+
 * +around_destroy+
+* +after_destroy+
 
 WARNING. +after_save+ runs both on create and update, but always _after_ the more specific callbacks +after_create+ and +after_update+, no matter the order in which the macro calls were executed.
 
@@ -1020,7 +1022,7 @@ The following methods trigger callbacks:
 * +increment!+
 * +save+
 * +save!+
-* +save(false)+
+* +save(:validate => false)+
 * +toggle!+
 * +update+
 * +update_attribute+

--- a/railties/guides/source/active_record_validations_callbacks.textile
+++ b/railties/guides/source/active_record_validations_callbacks.textile
@@ -901,13 +901,8 @@ Below is a simple example where we change the Rails behavior to always display t
 
 <ruby>
 ActionView::Base.field_error_proc = Proc.new do |html_tag, instance|
-  if instance.error_message.kind_of?(Array)
-    %(#{html_tag}<span class="validation-error">&nbsp;
-      #{instance.error_message.join(',')}</span>).html_safe
-  else
-    %(#{html_tag}<span class="validation-error">&nbsp;
-      #{instance.error_message}</span>).html_safe
-  end
+  errors = Array(instance.error_message).join(',')
+  %(#{html_tag}<span class="validation-error">&nbsp;#{errors}</span>).html_safe
 end
 </ruby>
 

--- a/railties/guides/source/active_record_validations_callbacks.textile
+++ b/railties/guides/source/active_record_validations_callbacks.textile
@@ -614,7 +614,7 @@ As shown in the example, you can also combine standard validations with your own
 
 h4. Custom Methods
 
-You can also create methods that verify the state of your models and add messages to the +errors+ collection when they are invalid. You must then register these methods by using one or more of the +validate+, +validate_on_create+ or +validate_on_update+ class methods, passing in the symbols for the validation methods' names.
+You can also create methods that verify the state of your models and add messages to the +errors+ collection when they are invalid. You must then register these methods by using the +validate+ class method, passing in the symbols for the validation methods' names.
 
 You can pass more than one symbol for each class method and the respective validations will be run in the same order as they were registered.
 
@@ -637,12 +637,24 @@ class Invoice < ActiveRecord::Base
 end
 </ruby>
 
+By default such validations will run every time you call +valid?+. It is also possible to control when to run these custom validations by giving an +:on+ option to the +validate+ method, with either: +:create+ or +:update+.
+
+<ruby>
+class Invoice < ActiveRecord::Base
+  validate :active_customer, :on => :create
+
+  def active_customer
+    errors.add(:customer_id, "is not active") unless customer.active?
+  end
+end
+</ruby>
+
 You can even create your own validation helpers and reuse them in several different models. For example, an application that manages surveys may find it useful to express that a certain field corresponds to a set of choices:
 
 <ruby>
 ActiveRecord::Base.class_eval do
   def self.validates_as_choice(attr_name, n, options={})
-    validates attr_name, :inclusion => { {:in => 1..n}.merge(options) }
+    validates attr_name, :inclusion => { { :in => 1..n }.merge!(options) }
   end
 end
 </ruby>

--- a/railties/guides/source/active_resource_basics.textile
+++ b/railties/guides/source/active_resource_basics.textile
@@ -71,7 +71,7 @@ person.destroy
 
 h3. Validations
 
-Module to support validation and errors with Active Resource objects. The module overrides Base#save to rescue ActiveResource::ResourceInvalid exceptions and parse the errors returned in the web service response. The module also adds an errors collection that mimics the interface of the errors provided by ActiveRecord::Errors.
+Module to support validation and errors with Active Resource objects. The module overrides Base#save to rescue ActiveResource::ResourceInvalid exceptions and parse the errors returned in the web service response. The module also adds an errors collection that mimics the interface of the errors provided by ActiveModel::Errors.
 
 h4. Validating client side resources by overriding validation methods in base class
 

--- a/railties/guides/source/i18n.textile
+++ b/railties/guides/source/i18n.textile
@@ -819,13 +819,13 @@ h5. Action View Helper Methods
 
 * The +number_to_currency+, +number_with_precision+, +number_to_percentage+, +number_with_delimiter+, and +number_to_human_size+ helpers use the number format settings located in the "number":https://github.com/rails/rails/blob/master/actionpack/lib/action_view/locale/en.yml#L2 scope.
 
-h5. Active Record Methods
+h5. Active Model Methods
 
 * +model_name.human+ and +human_attribute_name+ use translations for model names and attribute names if available in the "activerecord.models":https://github.com/rails/rails/blob/master/activerecord/lib/active_record/locale/en.yml#L29 scope. They also support translations for inherited class names (e.g. for use with STI) as explained above in "Error message scopes".
 
-* +ActiveRecord::Errors#generate_message+ (which is used by Active Record validations but may also be used manually) uses +model_name.human+ and +human_attribute_name+ (see above). It also translates the error message and supports translations for inherited class names as explained above in "Error message scopes".
+* +ActiveModel::Errors#generate_message+ (which is used by Active Model validations but may also be used manually) uses +model_name.human+ and +human_attribute_name+ (see above). It also translates the error message and supports translations for inherited class names as explained above in "Error message scopes".
 
-* +ActiveRecord::Errors#full_messages+ prepends the attribute name to the error message using a separator that will be looked up from "activerecord.errors.format.separator":https://github.com/rails/rails/blob/master/actionpack/lib/action_view/locale/en.yml#L91 (and which defaults to +'&nbsp;'+).
+* +ActiveModel::Errors#full_messages+ prepends the attribute name to the error message using a separator that will be looked up from "errors.format":https://github.com/rails/rails/blob/master/activemodel/lib/active_model/locale/en.yml#L4 (and which defaults to +"%{attribute} %{message}"+).
 
 h5. Active Support Methods
 


### PR DESCRIPTION
I've cherry-picked the same commits I've done in docrails (master) related to updates in ActiveRecord validation and callbacks guide. I do believe they contain important fixes that should be available in 3-2 branch as well, mainly related to `validate_on_create` and `validate_on_update` methods that are not available anymore, besides some other small fixes.

Please let me know if something should be changed before merging. Thanks.

/cc @vijaydev @fxn @rafaelfranca
