### PR TITLE
Duping log handler on buffered logger silencer.

### DIFF
--- a/activesupport/lib/active_support/buffered_logger.rb
+++ b/activesupport/lib/active_support/buffered_logger.rb
@@ -30,7 +30,7 @@ module ActiveSupport
     def silence(temporary_level = ERROR)
       if silencer
         begin
-          logger = self.class.new @log_dest, temporary_level
+          logger = self.class.new @log_dest.dup, temporary_level
           yield logger
         ensure
           logger.close


### PR DESCRIPTION
This fixes #4668.

Relevant trace:

``` ruby
Loading development environment (Rails 3.2.0)
/Users/lunks/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/logger.rb:581:in `block in close'
/Users/lunks/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
/Users/lunks/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/logger.rb:580:in `close'
/Users/lunks/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/logger.rb:478:in `close'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activesupport/lib/active_support/buffered_logger.rb:117:in `close'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activesupport/lib/active_support/buffered_logger.rb:36:in `silence'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activesupport/lib/active_support/deprecation/method_wrappers.rb:22:in `silence_with_deprecation'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activesupport/lib/active_support/tagged_logging.rb:31:in `silence'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activesupport/lib/active_support/deprecation/method_wrappers.rb:22:in `silence_with_deprecation'
(eval):2:in `column_definitions_with_silencer'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:845:in `columns'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/connection_adapters/schema_cache.rb:12:in `block in initialize'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/model_schema.rb:228:in `yield'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/model_schema.rb:228:in `default'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/model_schema.rb:228:in `columns'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/gems/schema_plus-0.2.1/lib/schema_plus/active_record/base.rb:23:in `columns_with_schema_plus'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/model_schema.rb:237:in `columns_hash'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/locking/optimistic.rb:129:in `locking_enabled?'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/relation.rb:169:in `exec_queries'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/relation.rb:159:in `block in to_a'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/explain.rb:38:in `logging_query_plan'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/relation.rb:158:in `to_a'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/relation/finder_methods.rb:377:in `find_first'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/relation/finder_methods.rb:122:in `first'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/querying.rb:5:in `first'
/Users/lunks/Code/tarifador/.pryrc:1:in `<top (required)>'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activesupport/lib/active_support/dependencies.rb:245:in `load'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activesupport/lib/active_support/dependencies.rb:245:in `block in load'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activesupport/lib/active_support/dependencies.rb:236:in `load_dependency'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activesupport/lib/active_support/dependencies.rb:245:in `load'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/gems/pry-0.9.8/lib/pry/pry_class.rb:62:in `block in load_rc'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/gems/pry-0.9.8/lib/pry/pry_class.rb:60:in `each'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/gems/pry-0.9.8/lib/pry/pry_class.rb:60:in `load_rc'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/gems/pry-0.9.8/lib/pry/pry_class.rb:91:in `initial_session_setup'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/gems/pry-0.9.8/lib/pry/pry_class.rb:110:in `start'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/railties/lib/rails/commands/console.rb:47:in `start'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/railties/lib/rails/commands/console.rb:8:in `start'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/railties/lib/rails/commands.rb:41:in `<top (required)>'
script/rails:6:in `require'
script/rails:6:in `<main>'
##########################################################################################
log writing failed. closed stream
log writing failed. closed stream
##########################################################################################
/Users/lunks/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/logger.rb:581:in `block in close'
/Users/lunks/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
/Users/lunks/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/logger.rb:580:in `close'
/Users/lunks/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/logger.rb:478:in `close'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activesupport/lib/active_support/buffered_logger.rb:117:in `close'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activesupport/lib/active_support/buffered_logger.rb:36:in `silence'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activesupport/lib/active_support/deprecation/method_wrappers.rb:22:in `silence_with_deprecation'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activesupport/lib/active_support/tagged_logging.rb:31:in `silence'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activesupport/lib/active_support/deprecation/method_wrappers.rb:22:in `silence_with_deprecation'
(eval):2:in `table_exists_with_silencer?'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/connection_adapters/schema_cache.rb:30:in `table_exists?'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/model_schema.rb:223:in `table_exists?'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/attribute_methods/primary_key.rb:75:in `get_primary_key'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/attribute_methods/primary_key.rb:60:in `reset_primary_key'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/attribute_methods/primary_key.rb:49:in `primary_key'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/model_schema.rb:230:in `block in columns'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/model_schema.rb:228:in `map'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/model_schema.rb:228:in `columns'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/gems/schema_plus-0.2.1/lib/schema_plus/active_record/base.rb:23:in `columns_with_schema_plus'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/model_schema.rb:237:in `columns_hash'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/locking/optimistic.rb:129:in `locking_enabled?'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/relation.rb:169:in `exec_queries'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/relation.rb:159:in `block in to_a'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/explain.rb:38:in `logging_query_plan'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/relation.rb:158:in `to_a'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/relation/finder_methods.rb:377:in `find_first'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/relation/finder_methods.rb:122:in `first'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activerecord/lib/active_record/querying.rb:5:in `first'
/Users/lunks/Code/tarifador/.pryrc:1:in `<top (required)>'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activesupport/lib/active_support/dependencies.rb:245:in `load'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activesupport/lib/active_support/dependencies.rb:245:in `block in load'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activesupport/lib/active_support/dependencies.rb:236:in `load_dependency'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/activesupport/lib/active_support/dependencies.rb:245:in `load'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/gems/pry-0.9.8/lib/pry/pry_class.rb:62:in `block in load_rc'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/gems/pry-0.9.8/lib/pry/pry_class.rb:60:in `each'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/gems/pry-0.9.8/lib/pry/pry_class.rb:60:in `load_rc'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/gems/pry-0.9.8/lib/pry/pry_class.rb:91:in `initial_session_setup'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/gems/pry-0.9.8/lib/pry/pry_class.rb:110:in `start'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/railties/lib/rails/commands/console.rb:47:in `start'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/railties/lib/rails/commands/console.rb:8:in `start'
/Users/lunks/.rvm/gems/ruby-1.9.3-p0@tarifador/bundler/gems/rails-9e9e17a62e4d/railties/lib/rails/commands.rb:41:in `<top (required)>'
script/rails:6:in `require'
script/rails:6:in `<main>'
```

Tests to come!
