### PR TITLE
Use `:rubygems` shortcut as standard Gemfile's `source` instead of explicit URL

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source :rubygems
 
 <%= rails_gemfile_entry -%>
 


### PR DESCRIPTION
Theoretically this would future-proof Gemfiles against possible (albeit unlikely) change in the rubygems URL.

[Documentation](http://gembundler.com/gemfile.html)
