### PR TITLE
Fix contributing guide to reflect preferred position on indentation

### DIFF
--- a/railties/guides/source/contributing_to_ruby_on_rails.textile
+++ b/railties/guides/source/contributing_to_ruby_on_rails.textile
@@ -309,7 +309,7 @@ Rails follows a simple set of coding style conventions.
 
 * Two spaces, no tabs.
 * No trailing whitespace. Blank lines should not have any space.
-* Indent after private/protected.
+* Do not indent after private/protected. Private/protected should have the same indentation as the methods around.
 * Prefer +&amp;&amp;+/+||+ over +and+/+or+.
 * Prefer class << self block over self.method for class methods.
 * +MyClass.my_method(my_arg)+ not +my_method( my_arg )+ or +my_method my_arg+.


### PR DESCRIPTION
Change incorrect recommendation from indenting after private/protected to not.
Based on opinions of rails core team members - @spastorino, @jonleighton, @tenderlove:

https://github.com/rails/rails/pull/1838#issuecomment-1440281
https://en.twitter.com/#!/spastorino/status/142054749351575552
https://en.twitter.com/#!/tenderlove/status/142014046445641728
https://en.twitter.com/#!/jonleighton/status/142021813415841794
