### PR TITLE
fix issue temp_file is removed by GC

### DIFF
--- a/activesupport/lib/active_support/core_ext/file/atomic.rb
+++ b/activesupport/lib/active_support/core_ext/file/atomic.rb
@@ -15,6 +15,8 @@ class File
   def self.atomic_write(file_name, temp_dir = Dir.tmpdir)
     require 'tempfile' unless defined?(Tempfile)
     require 'fileutils' unless defined?(FileUtils)
+    
+    GC.disable
 
     temp_file = Tempfile.new(basename(file_name), temp_dir)
     yield temp_file
@@ -33,6 +35,8 @@ class File
 
     # Overwrite original file with temp file
     FileUtils.mv(temp_file.path, file_name)
+    
+    GC.enable
 
     # Set correct permissions on new file
     chown(old_stat.uid, old_stat.gid, file_name)


### PR DESCRIPTION
In rare cases, temp_file is removed by GC after temp_file.close.
So we should be disable GC when writing the file.
