### PR TITLE
Add release date of Rails 3.2.0 to documentation

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -24,7 +24,7 @@
     This is a behavior change, previously the hidden tag had a value of the disabled checkbox.
     *Tadas Tamosauskas*
 
-## Rails 3.2.0 (unreleased) ##
+## Rails 3.2.0 (January 20, 2012) ##
 
 *   Add `config.action_dispatch.default_charset` to configure default charset for ActionDispatch::Response. *Carlos Antonio da Silva*
 

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Rails 3.2.0 (unreleased) ##
+## Rails 3.2.0 (January 20, 2012) ##
 
 *   Deprecated `define_attr_method` in `ActiveModel::AttributeMethods`, because this only existed to
     support methods like `set_table_name` in Active Record, which are themselves being deprecated.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -73,7 +73,7 @@
 
 *   PostgreSQL hstore types are automatically deserialized from the database.
 
-## Rails 3.2.0 (unreleased) ##
+## Rails 3.2.0 (January 20, 2012) ##
 
 *   Added a `with_lock` method to ActiveRecord objects, which starts
     a transaction, locks the object (pessimistically) and yields to the block.

--- a/activeresource/CHANGELOG.md
+++ b/activeresource/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Rails 3.2.0 (unreleased) ##
+## Rails 3.2.0 (January 20, 2012) ##
 
 *   Redirect responses: 303 See Other and 307 Temporary Redirect now behave like
     301 Moved Permanently and 302 Found.  GH #3302.

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -14,7 +14,7 @@
 *    BufferedLogger is deprecated.  Use ActiveSupport::Logger, or the logger
      from Ruby stdlib.
 
-## Rails 3.2.0 (unreleased) ##
+## Rails 3.2.0 (January 20, 2012) ##
 
 *   Add ActiveSupport::Cache::NullStore for use in development and testing. *Brian Durand*
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 *   Rails::Plugin has gone. Instead of adding plugins to vendor/plugins use gems or bundler with path or git dependencies. *Santiago Pastorino*
 
-## Rails 3.2.0 (unreleased) ##
+## Rails 3.2.0 (January 20, 2012) ##
 
 *   Turn gem has been removed from default Gemfile. We still looking for a best presentation for tests output. *Guillermo Iguaran*
 


### PR DESCRIPTION
This commit replaces in multiple CHANGELOG.md any occurrence of

```
## Rails 3.2.0 (unreleased) ##
```

with

```
## Rails 3.2.0 (January 20, 2012) ##
```
