### PR TITLE
Add :password_confirmation as a filtered param by default.

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -43,7 +43,7 @@ module <%= app_const_base %>
     config.encoding = "utf-8"
 
     # Configure sensitive parameters which will be filtered from the log file.
-    config.filter_parameters += [:password]
+    config.filter_parameters += [:password, :password_confirmation]
 
     # Use SQL instead of Active Record's schema dumper when creating the database.
     # This is necessary if your schema can't be completely dumped by the schema dumper,


### PR DESCRIPTION
Most authentication solutions like Devise and Authlogic use a password confirmation field.  I end up adding this to every rails app, and I'm sure plenty of other developers need to as well.  Forgetting this could inadvertently leave a password unfiltered during user registration so I think it's a sensible default.
