### PR TITLE
Remove extra attributes from HABTM join tables in AR tests

### DIFF
--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -712,8 +712,6 @@ ActiveRecord::Schema.define do
   create_table :countries_treaties, :force => true, :id => false do |t|
     t.string :country_id, :null => false
     t.string :treaty_id, :null => false
-    t.datetime :created_at
-    t.datetime :updated_at
   end
 
   create_table :liquid, :force => true do |t|


### PR DESCRIPTION
HABTM Join tables should not have extra attributes

When extra attributes is needed in HABTM join tables is better to use
`has_many :through` association.

Fix #4653
