### PR TITLE
Fixed small typo in ActveRecord/CHANGELOG.md

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -208,7 +208,7 @@
 
         Client.select(:name).uniq
 
-    This also allows you to revert the unqueness in a relation:
+    This also allows you to revert the uniqueness in a relation:
 
         Client.select(:name).uniq.uniq(false)
 


### PR DESCRIPTION
`uniqueness` was spelled `unqueness`
