### PR TITLE
Dependent restrict should add error 3 2 stable

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1098,8 +1098,7 @@ module ActiveRecord
       #   alongside this object by calling their +destroy+ method. If set to <tt>:delete_all</tt> all associated
       #   objects are deleted *without* calling their +destroy+ method. If set to <tt>:nullify</tt> all associated
       #   objects' foreign keys are set to +NULL+ *without* calling their +save+ callbacks. If set to
-      #   <tt>:restrict</tt> this object raises an <tt>ActiveRecord::DeleteRestrictionError</tt> exception and
-      #   cannot be deleted if it has any associated objects.
+      #   <tt>:restrict</tt> this object cannot be deleted if it has any associated objects.
       #
       #   If using with the <tt>:through</tt> option, the association on the join model must be
       #   a +belongs_to+, and the records which get deleted are the join records, rather than
@@ -1252,8 +1251,7 @@ module ActiveRecord
       #   If set to <tt>:destroy</tt>, the associated object is destroyed when this object is. If set to
       #   <tt>:delete</tt>, the associated object is deleted *without* calling its destroy method.
       #   If set to <tt>:nullify</tt>, the associated object's foreign key is set to +NULL+.
-      #   Also, association is assigned. If set to <tt>:restrict</tt> this object raises an
-      #   <tt>ActiveRecord::DeleteRestrictionError</tt> exception and cannot be deleted if it has any associated object.
+      #   If set to <tt>:restrict</tt>, this object cannot be deleted if it has any associated object.
       # [:foreign_key]
       #   Specify the foreign key used for the association. By default this is guessed to be the name
       #   of this class in lower-case and "_id" suffixed. So a Person class that makes a +has_one+ association

--- a/activerecord/lib/active_record/associations/builder/has_one.rb
+++ b/activerecord/lib/active_record/associations/builder/has_one.rb
@@ -55,7 +55,21 @@ module ActiveRecord::Associations::Builder
       def define_restrict_dependency_method
         name = self.name
         mixin.redefine_method(dependency_method_name) do
-          raise ActiveRecord::DeleteRestrictionError.new(name) unless send(name).nil?
+          unless send(name).nil?
+            msg = "has_one association :dependent => :restrict option, no longer raises an " \
+                  "ActiveRecord::DeleteRestrictionError and is going to be deprecated in the " \
+                  "next version. In order for the exception be raised, please set " \
+                  "ActiveRecord::Base.dependent_restrict_raises = true."
+
+            ActiveSupport::Deprecation.warn msg
+
+            if dependent_restrict_raises == true
+              raise ActiveRecord::DeleteRestrictionError.new(name)
+            else
+              self.errors.add(:base, "Cannot delete record because dependent #{name} exists")
+              return false
+            end
+          end
         end
       end
   end

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -389,6 +389,15 @@ module ActiveRecord #:nodoc:
     cattr_accessor :timestamped_migrations , :instance_writer => false
     @@timestamped_migrations = true
 
+    ##
+    # Specifies wether or not has_many or has_one association option
+    # :dependent => :restrict raises an exception. If set to true, then
+    # ActiveRecord::DeleteRestrictionError exception would be raised
+    # alongwith a DEPRECATION WARNING. If set to false, then no exception
+    # would be raised but a DEPRECATION WARNING would be displayed.
+    cattr_accessor :dependent_restrict_raises, :instance_writer => false
+    @@dependent_restrict_raises = false
+
     class << self # Class methods
       def inherited(child_class) #:nodoc:
         child_class.initialize_generated_modules


### PR DESCRIPTION
has_many/has_one, :dependent => :restrict, now adds an error with a Deprecation Warning, instead of raising DeleteRestrictionError exception. [3-2-stable]

Tests included and passing.

fixes #2502
