### PR TITLE
3.2 safe_constantize should handle wrong constant name NameErrors Fixes #4710

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -243,7 +243,7 @@ module ActiveSupport
       begin
         constantize(camel_cased_word)
       rescue NameError => e
-        raise unless e.message =~ /uninitialized constant #{const_regexp(camel_cased_word)}$/ ||
+        raise unless e.message =~ /(uninitialized constant|wrong constant name) #{const_regexp(camel_cased_word)}$/ ||
           e.name.to_s == camel_cased_word.to_s
       rescue ArgumentError => e
         raise unless e.message =~ /not missing constant #{const_regexp(camel_cased_word)}\!$/

--- a/activesupport/test/constantize_test_cases.rb
+++ b/activesupport/test/constantize_test_cases.rb
@@ -19,7 +19,7 @@ module ConstantizeTestCases
     assert_raise(NameError) { yield("Ace::ConstantizeTestCases") }
     assert_raise(NameError) { yield("Ace::Base::ConstantizeTestCases") }
   end
-  
+
   def run_safe_constantize_tests_on
     assert_nothing_raised { assert_equal Ace::Base::Case, yield("Ace::Base::Case") }
     assert_nothing_raised { assert_equal Ace::Base::Case, yield("::Ace::Base::Case") }
@@ -33,5 +33,6 @@ module ConstantizeTestCases
     assert_nothing_raised { assert_equal nil, yield("blargle") }
     assert_nothing_raised { assert_equal nil, yield("Ace::ConstantizeTestCases") }
     assert_nothing_raised { assert_equal nil, yield("Ace::Base::ConstantizeTestCases") }
+    assert_nothing_raised { assert_equal nil, yield("#<Class:0x7b8b718b>::Nested_1") }
   end
 end


### PR DESCRIPTION
See issue #4710 for details.
