### PR TITLE
Do not generate label for attribute when giving nil

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `label` form helper accepts :for => nil to not generate the attribute. *Carlos Antonio da Silva*
+
 *   Add `:format` option to number_to_percentage *Rodrigo Flores*
 
 *   Add `config.action_view.logger` to configure logger for ActionView. *Rafael França*

--- a/actionpack/lib/action_view/helpers/tags/label.rb
+++ b/actionpack/lib/action_view/helpers/tags/label.rb
@@ -30,7 +30,7 @@ module ActionView
           add_default_name_and_id_for_value(tag_value, name_and_id)
           options.delete("index")
           options.delete("namespace")
-          options["for"] ||= name_and_id["id"]
+          options["for"] = name_and_id["id"] unless options.key?("for")
 
           if block_given?
             @template_object.label_tag(name_and_id["id"], options, &block)

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -215,6 +215,10 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal('<label for="my_for">Title</label>', label(:post, :title, nil, "for" => "my_for"))
   end
 
+  def test_label_does_not_generate_for_attribute_when_given_nil
+    assert_dom_equal('<label>Title</label>', label(:post, :title, :for => nil))
+  end
+
   def test_label_with_id_attribute_as_symbol
     assert_dom_equal('<label for="post_title" id="my_id">Title</label>', label(:post, :title, nil, :id => "my_id"))
   end


### PR DESCRIPTION
We've found this a while ago while fixing an issue in SimpleForm for a specific case. We had to fallback to use `label_tag` instead, because `label` was not handling this case.
