### PR TITLE
Fix regression from Rails 3.1

### DIFF
--- a/activerecord/lib/active_record/dynamic_matchers.rb
+++ b/activerecord/lib/active_record/dynamic_matchers.rb
@@ -25,7 +25,7 @@ module ActiveRecord
       if match = (DynamicFinderMatch.match(method_id) || DynamicScopeMatch.match(method_id))
         attribute_names = match.attribute_names
         super unless all_attributes_exists?(attribute_names)
-        if arguments.size < attribute_names.size
+        if !(match.is_a?(DynamicFinderMatch) && match.instantiator? && arguments.first.is_a?(Hash)) && arguments.size < attribute_names.size
           method_trace = "#{__FILE__}:#{__LINE__}:in `#{method_id}'"
           backtrace = [method_trace] + caller
           raise ArgumentError, "wrong number of arguments (#{arguments.size} for #{attribute_names.size})", backtrace

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -881,6 +881,17 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal 23, sig38.client_of
   end
 
+  def test_find_or_create_from_two_attributes_and_hash
+    number_of_companies = Company.count
+    sig38 = Company.find_or_create_by_name_and_firm_id({:name => "38signals", :firm_id => 17, :client_of => 23})
+    assert_equal number_of_companies + 1, Company.count
+    assert_equal sig38, Company.find_or_create_by_name_and_firm_id({:name => "38signals", :firm_id => 17, :client_of => 23})
+    assert sig38.persisted?
+    assert_equal "38signals", sig38.name
+    assert_equal 17, sig38.firm_id
+    assert_equal 23, sig38.client_of
+  end
+
   def test_find_or_create_from_one_aggregate_attribute
     number_of_customers = Customer.count
     created_customer = Customer.find_or_create_by_balance(Money.new(123))


### PR DESCRIPTION
Under Rails 3.1, you were allowed to pass a hash to a find_or_create
method with multiple attribute names, but this was broken as the
arguments were being improperly validated.

@jonleighton As per #4660, `match.is_a?(DynamicFinderMatch)` is required as it is only `find_or_(create|initialize)_by` that accepts a hash. `scoped_by` requires arguments to be passed individually.
