### PR TITLE
Remove redundant instance variables (@colorize_logging)

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -112,11 +112,10 @@ module Rails
       end
 
       def colorize_logging
-        @colorize_logging
+        ActiveSupport::LogSubscriber.colorize_logging
       end
 
       def colorize_logging=(val)
-        @colorize_logging = val
         ActiveSupport::LogSubscriber.colorize_logging = val
         self.generators.colorize_logging = val
       end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -534,5 +534,10 @@ module ApplicationTests
       assert_equal      app.env_config['action_dispatch.logger'],            Rails.logger
       assert_equal      app.env_config['action_dispatch.backtrace_cleaner'], Rails.backtrace_cleaner
     end
+
+    test "config.colorize_logging defaul is true" do
+      make_basic_app
+      assert app.config.colorize_logging
+    end
   end
 end


### PR DESCRIPTION
The setting for colorize logging is present in two place.

```
config.colorize_logging
```

  and

```
ActiveSupport::LogSubscriber.colorize_logging
```

This duplication is a little difficult to understand.
Because config.colorize_logging is set to nil in default, but ActiveSupport::LogSubscriber.colorize_logging is set to true.

Please see https://github.com/rails/rails/issues/4708 .
