### PR TITLE
Add create_join_table migration helper to create HABTM join tables

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,7 +1,18 @@
 ## Rails 4.0.0 (unreleased) ##
 
-* The primary key is always initialized in the @attributes hash to nil (unless
-  another value has been specified).
+*   Added `create_join_table` migration helper to create HABTM join tables
+
+        create_join_table :products, :categories
+        # =>
+        # create_table :categories_products, :id => false do |td|
+        #   td.integer :product_id, :null => false
+        #   td.integer :category_id, :null => false
+        # end
+
+    *Rafael Mendonça França*
+
+*   The primary key is always initialized in the @attributes hash to nil (unless
+    another value has been specified).
 
 *   In previous releases, the following would generate a single query with
     an `OUTER JOIN comments`, rather than two separate queries:

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -8,11 +8,14 @@ module ActiveRecord
     # * add_index
     # * add_timestamps
     # * create_table
+    # * create_join_table
     # * remove_timestamps
     # * rename_column
     # * rename_index
     # * rename_table
     class CommandRecorder
+      include JoinTable
+
       attr_accessor :commands, :delegate
 
       def initialize(delegate = nil)
@@ -48,7 +51,7 @@ module ActiveRecord
         super || delegate.respond_to?(*args)
       end
 
-      [:create_table, :change_table, :rename_table, :add_column, :remove_column, :rename_index, :rename_column, :add_index, :remove_index, :add_timestamps, :remove_timestamps, :change_column, :change_column_default].each do |method|
+      [:create_table, :create_join_table, :change_table, :rename_table, :add_column, :remove_column, :rename_index, :rename_column, :add_index, :remove_index, :add_timestamps, :remove_timestamps, :change_column, :change_column_default].each do |method|
         class_eval <<-EOV, __FILE__, __LINE__ + 1
           def #{method}(*args)          # def create_table(*args)
             record(:"#{method}", args)  #   record(:create_table, args)
@@ -60,6 +63,12 @@ module ActiveRecord
 
       def invert_create_table(args)
         [:drop_table, [args.first]]
+      end
+
+      def invert_create_join_table(args)
+        table_name = find_join_table_name(*args)
+
+        [:drop_table, [table_name]]
       end
 
       def invert_rename_table(args)
@@ -99,7 +108,6 @@ module ActiveRecord
       rescue NoMethodError => e
         raise e, e.message.sub(/ for #<.*$/, " via proxy for #{@delegate}")
       end
-
     end
   end
 end

--- a/activerecord/lib/active_record/migration/join_table.rb
+++ b/activerecord/lib/active_record/migration/join_table.rb
@@ -1,0 +1,17 @@
+module ActiveRecord
+  class Migration
+    module JoinTable #:nodoc:
+      private
+
+      def find_join_table_name(table_1, table_2, options = {})
+        options.delete(:table_name) { join_table_name(table_1, table_2) }
+      end
+
+      def join_table_name(table_1, table_2)
+        tables_names = [table_1, table_2].map(&:to_s).sort
+
+        tables_names.join("_").to_sym
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -173,7 +173,6 @@ module ActiveRecord
           skip "not supported on #{connection.class}"
         end
 
-
         connection.create_table :testings do |t|
           t.column :foo, :string
         end

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -73,6 +73,18 @@ module ActiveRecord
         assert_equal [:drop_table, [:people_reminders]], drop_table
       end
 
+      def test_invert_create_join_table
+        @recorder.record :create_join_table, [:musics, :artists]
+        drop_table = @recorder.inverse.first
+        assert_equal [:drop_table, [:artists_musics]], drop_table
+      end
+
+      def test_invert_create_join_table_with_table_name
+        @recorder.record :create_join_table, [:musics, :artists, {:table_name => :catalog}]
+        drop_table = @recorder.inverse.first
+        assert_equal [:drop_table, [:catalog]], drop_table
+      end
+
       def test_invert_rename_table
         @recorder.record :rename_table, [:old, :new]
         rename = @recorder.inverse.first

--- a/activerecord/test/cases/migration/create_join_table_test.rb
+++ b/activerecord/test/cases/migration/create_join_table_test.rb
@@ -1,0 +1,70 @@
+require 'cases/helper'
+
+module ActiveRecord
+  class Migration
+    class CreateJoinTableTest < ActiveRecord::TestCase
+      attr_reader :connection
+
+      def setup
+        super
+        @connection = ActiveRecord::Base.connection
+      end
+
+      def test_create_join_table
+        connection.create_join_table :artists, :musics
+
+        assert_equal %w(artist_id music_id), connection.columns(:artists_musics).map(&:name).sort
+      ensure
+        connection.drop_table :artists_musics
+      end
+
+      def test_create_join_table_set_not_null_by_default
+        connection.create_join_table :artists, :musics
+
+        assert_equal [false, false], connection.columns(:artists_musics).map(&:null)
+      ensure
+        connection.drop_table :artists_musics
+      end
+
+      def test_create_join_table_with_strings
+        connection.create_join_table 'artists', 'musics'
+
+        assert_equal %w(artist_id music_id), connection.columns(:artists_musics).map(&:name).sort
+      ensure
+        connection.drop_table :artists_musics
+      end
+
+      def test_create_join_table_with_the_proper_order
+        connection.create_join_table :videos, :musics
+
+        assert_equal %w(music_id video_id), connection.columns(:musics_videos).map(&:name).sort
+      ensure
+        connection.drop_table :musics_videos
+      end
+
+      def test_create_join_table_with_the_table_name
+        connection.create_join_table :artists, :musics, :table_name => :catalog
+
+        assert_equal %w(artist_id music_id), connection.columns(:catalog).map(&:name).sort
+      ensure
+        connection.drop_table :catalog
+      end
+
+      def test_create_join_table_with_the_table_name_as_string
+        connection.create_join_table :artists, :musics, :table_name => 'catalog'
+
+        assert_equal %w(artist_id music_id), connection.columns(:catalog).map(&:name).sort
+      ensure
+        connection.drop_table :catalog
+      end
+
+      def test_create_join_table_with_column_options
+        connection.create_join_table :artists, :musics, :column_options => {:null => true}
+
+        assert_equal [true, true], connection.columns(:artists_musics).map(&:null)
+      ensure
+        connection.drop_table :artists_musics
+      end
+    end
+  end
+end

--- a/railties/guides/source/migrations.textile
+++ b/railties/guides/source/migrations.textile
@@ -114,6 +114,7 @@ database independent way (you'll read about them in detail later):
 * +change_column+
 * +change_table+
 * +create_table+
+* +create_join_table+
 * +drop_table+
 * +remove_column+
 * +remove_index+
@@ -383,6 +384,35 @@ end
 
 will append +ENGINE=BLACKHOLE+ to the SQL statement used to create the table
 (when using MySQL, the default is +ENGINE=InnoDB+).
+
+h4. Creating a Join Table
+
+Migration method +create_join_table+ creates a HABTM join table. A typical use
+would be
+
+<ruby>
+create_join_table :products, :categories
+</ruby>
+
+which creates a +categories_products+ table with two columns called +category_id+ and +product_id+.
+These columns have the option +:null+ set to +false+ by default.
+
+You can pass the option +:table_name+ with you want to customize the table name. For example,
+
+<ruby>
+create_join_table :products, :categories, :table_name => :categorization
+</ruby>
+
+will create a +categorization+ table.
+
+By default, +create_join_table+ will create two columns with no options, but you can specify these
+options using the +:column_options+ option. For example,
+
+<ruby>
+create_join_table :products, :categories, :column_options => {:null => true}
+</ruby>
+
+will create the +product_id+ and +category_id+ with the +:null+ option as +true+.
 
 h4. Changing Tables
 


### PR DESCRIPTION
This helper was created as described [here](https://github.com/rails/rails/issues/4653#issuecomment-3676623).

It can help to avoid issues like this #4653.
- Docs and CHANGELOG line included
