### PR TITLE
Remove not used env[] call in routing_test.

### DIFF
--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -2550,7 +2550,6 @@ class TestUnicodePaths < ActionDispatch::IntegrationTest
   Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
     app.draw do
       match "/#{Rack::Utils.escape("ほげ")}" => lambda { |env|
-        env['action_dispatch.request.path_parameters']
         [200, { 'Content-Type' => 'text/plain' }, []]
       }, :as => :unicode_path
     end


### PR DESCRIPTION
The commit 4c321c6d42b6e35f9ead12eb1dccdead03c5abf4 removes the path_params variable assignment, actually seems the entire line is not used at all.
