### PR TITLE
Refactor dynamic match

### DIFF
--- a/activerecord/lib/active_record/dynamic_finder_match.rb
+++ b/activerecord/lib/active_record/dynamic_finder_match.rb
@@ -10,7 +10,7 @@ module ActiveRecord
       klass = [FindBy, FindByBang, FindOrInitializeCreateBy].find do |klass|
         klass.matches?(method)
       end
-      klass.try(:new, method)
+      klass.new(method) if klass
     end
 
     def self.matches?(method)

--- a/activerecord/lib/active_record/dynamic_finder_match.rb
+++ b/activerecord/lib/active_record/dynamic_finder_match.rb
@@ -36,6 +36,10 @@ module ActiveRecord
     def bang?
       false
     end
+
+    def valid_arguments?(arguments)
+      arguments.size >= @attribute_names.size
+    end
   end
 
   class FindBy < DynamicFinderMatch
@@ -64,6 +68,10 @@ module ActiveRecord
       if method =~ /^find_or_(initialize|create)_by_([_a-zA-Z]\w*)$/
         new(:first, $2, $1 == 'initialize' ? :new : :create)
       end
+    end
+
+    def valid_arguments?(arguments)
+      arguments.size == 1 && arguments.first.is_a?(Hash) || super
     end
   end
 end

--- a/activerecord/lib/active_record/dynamic_matchers.rb
+++ b/activerecord/lib/active_record/dynamic_matchers.rb
@@ -25,7 +25,7 @@ module ActiveRecord
       if match = (DynamicFinderMatch.match(method_id) || DynamicScopeMatch.match(method_id))
         attribute_names = match.attribute_names
         super unless all_attributes_exists?(attribute_names)
-        if !(match.is_a?(DynamicFinderMatch) && match.instantiator? && arguments.first.is_a?(Hash)) && arguments.size < attribute_names.size
+        unless match.valid_arguments?(arguments)
           method_trace = "#{__FILE__}:#{__LINE__}:in `#{method_id}'"
           backtrace = [method_trace] + caller
           raise ArgumentError, "wrong number of arguments (#{arguments.size} for #{attribute_names.size})", backtrace

--- a/activerecord/lib/active_record/dynamic_scope_match.rb
+++ b/activerecord/lib/active_record/dynamic_scope_match.rb
@@ -19,5 +19,9 @@ module ActiveRecord
 
     attr_reader :scope, :attribute_names
     alias :scope? :scope
+
+    def valid_arguments?(arguments)
+      arguments.size >= @attribute_names.size
+    end
   end
 end


### PR DESCRIPTION
@jonleighton In #4715, I fixed a regression in a really hacky way. This pull request splits the DynamicFinderMatch into several classes, and moves argument validation into the match classes. By moving more logic into the match itself, it should be easier to handle edge cases in a cleaner manner.
