### PR TITLE
Re-launch assets:precompile task using original $0 if $0 is batch file so it works on Windows

### DIFF
--- a/actionpack/lib/sprockets/assets.rake
+++ b/actionpack/lib/sprockets/assets.rake
@@ -6,7 +6,11 @@ namespace :assets do
     groups = ENV['RAILS_GROUPS'] || 'assets'
     args   = [$0, task,"RAILS_ENV=#{env}","RAILS_GROUPS=#{groups}"]
     args << "--trace" if Rake.application.options.trace
-    fork ? ruby(*args) : Kernel.exec(FileUtils::RUBY, *args)
+    if $0 =~ /rake\.bat\Z/i
+      Kernel.exec $0, *args
+    else  
+      fork ? ruby(*args) : Kernel.exec(FileUtils::RUBY, *args)
+    end    
   end
 
   # We are currently running with no explicit bundler group


### PR DESCRIPTION
MSWin32 version of ruby provides Windows batch file that converted from original script files.
The batch file is not plain ruby script, so the patch provided by https://github.com/rails/rails/pull/3121#issuecomment-3702853 causes error on Windows.

ex)
C:\tmp\webtest>rake assets:precompile
c:/Users/arton/bin/ruby.exe c:/Users/arton/rake.bat assets:precompile:all RAILS_ENV=production RAILS_GROUPS=assets
c:/Users/arton/bin/rake.bat:1: syntax error, unexpected tIDENTIFIER, expecting $end
rake aborted!
Command failed with status (1): [c:/Users/arton/bin/ruby.exe c:/U... (omitted by the poster)

Tasks: TOP => assets:precompile
(See full trace by running task with --trace)

So, this patch checks $0 is batch file or not. And if $0 is batch file, then run it with Kernel.exec (means Win32 API) instead of ruby.

Thanks.
