### PR TITLE
Pluck fails when ordering by column that is not included in the SELECT DISTINCT query (PostgreSQL)

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -177,7 +177,10 @@ module ActiveRecord
     #   Person.where(:confirmed => true).limit(5).pluck(:id)
     #
     def pluck(column_name)
-      klass.connection.select_all(select(column_name).arel).map! do |attributes|
+      column_name = column_name.to_s
+      select_manager = select(column_name).arel
+      select_manager.orders.delete_if { |key| key != column_name }
+      klass.connection.select_all(select_manager).map! do |attributes|
         klass.type_cast_attribute(attributes.keys.first, klass.initialize_attributes(attributes))
       end
     end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -478,4 +478,8 @@ class CalculationsTest < ActiveRecord::TestCase
   def test_pluck_with_qualified_column_name
     assert_equal [1,2,3,4], Topic.order(:id).pluck("topics.id")
   end
+
+  def test_pluck_with_incorrect_order
+    Topic.uniq.order(:written_on).pluck("topics.id")
+  end
 end


### PR DESCRIPTION
Don't know if it's correct behavior or not but here it goes:
PostgreSQL SELECT DISTINCT query fails if result is ordered by a column that is not included in the select list.

For example, this code:

`````` User.order(:first_name).uniq.pluck(:id)```
troughs this error (when using postresql): 
```SELECT DISTINCT id FROM "users" ORDER BY first_name
ActiveRecord::StatementInvalid: PGError: ERROR:  for SELECT DISTINCT, 
ORDER BY expressions must appear in select list
LINE 1: SELECT DISTINCT id FROM "users"  ORDER BY first_name```

See first commit with test that fails on PostgreSQL.

That can be fixed by cleaning ```Arel::SelectManager#orders``` list just before 'plucking' (see the second commit).
To make MySQL users happy (MySQL allows to order by a column that is not in the select list) we can clean orders list only when PostgreSQL is used (I'm not sure about that, so it's not included in the PR):

```ruby
if select_manager.engine.connection.adapter_name ~= /postgresql/i
  select_manager.orders.delete_if { |key| key != column_name }
end
``````

That's a typical situation - having conditions like `uniq: true` on an association, along with the `default_scope` ordering by some column. Then 'plucking' on that association can lead to this error easily.

Let me know if it's desired behavior or we can make awesome `pluck` method even more user friendly.

Thanks!

P.S. `Arel::SelectManager` got no `orders=` method, but we can somehow replace orders via `@ast` instance variable. Unfortunately direct assignment via `orders=` doesn't work for unknown reason. That's why I've used delete_if.
