### PR TITLE
Remove initialize variable columnn, not needed

### DIFF
--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -57,8 +57,7 @@ module ActiveRecord
 
       def build_relation(klass, table, attribute, value) #:nodoc:
         reflection = klass.reflect_on_association(attribute)
-        column = nil
-        if(reflection)
+        if reflection
           column = klass.columns_hash[reflection.foreign_key]
           attribute = reflection.foreign_key
           value = value.attributes[reflection.primary_key_column.name]


### PR DESCRIPTION
I think is not needed to initialize the column variable to nil, is already initialized in each branch of the condition
