### PR TITLE
Set the timezone correctly for a test in activerecord/../base_test.rb

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1104,7 +1104,10 @@ class BasicsTest < ActiveRecord::TestCase
   # TODO: extend defaults tests to other databases!
   if current_adapter?(:PostgreSQLAdapter)
     def test_default
+      tz = Default.default_timezone
+      Default.default_timezone = :local
       default = Default.new
+      Default.default_timezone = tz
 
       # fixed dates / times
       assert_equal Date.new(2004, 1, 1), default.fixed_date


### PR DESCRIPTION
Rails version d5ddc6c triggered a failing test when running `bundle exec rake test_postgresql`
on my system (Ubuntu 10.04 Postgesql 8.4). Running the same test (base_test.rb) individually,
did not trigger the failing test.

This is BEFORE the current pull request.

``` bash
peterv@ASUS:~/b/github/petervandenabeele/rails/activerecord$ /home/peterv/.rvm/rubies/ruby-1.9.3-p0/bin/ruby -w -I"lib:test" -I"/home/peterv/.rvm/gems/ruby-1.9.3-p0@global/gems/rake-0.9.2.2/lib" "/home/peterv/.rvm/gems/ruby-1.9.3-p0@global/gems/rake-0.9.2.2/lib/rake/rake_test_loader.rb" "test/cases/base_test.rb"
Using sqlite3 with Identity Map off
Run options: --seed 33655

  # Running tests:

.......................................................................................
/home/peterv/data/backed_up/github/petervandenabeele/rails/activerecord/lib/active_record/persistence.rb:54: warning: instance variable @new_record not initialized
..........................................................S........................................

Finished tests in 1.841152s, 101.0237 tests/s, 237.3514 assertions/s.

186 tests, 437 assertions, 0 failures, 0 errors, 1 skips

peterv@ASUS:~/b/github/petervandenabeele/rails/activerecord$ bundle exec rake test_postgresql
/home/peterv/.rvm/rubies/ruby-1.9.3-p0/bin/ruby -w -I"lib:test" -I"/home/peterv/.rvm/gems/ruby-1.9.3-p0@global/gems/rake-0.9.2.2/lib" "/home/peterv/.rvm/gems/ruby-1.9.3-p0@global/gems/rake-0.9.2.2/lib/rake/rake_test_loader.rb" "test/cases/adapter_test.rb" "test/cases/adapters/postgresql/active_schema_test.rb" "test/cases/adapters/postgresql/connection_test.rb" "test/cases/adapters/postgresql/datatype_test.rb" "test/cases/adapters/postgresql/explain_test.rb" "test/cases/adapters/postgresql/hstore_test.rb" "test/cases/adapters/postgresql/postgresql_adapter_test.rb" "test/cases/adapters/postgresql/quoting_test.rb" "test/cases/adapters/postgresql/schema_authorization_test.rb" "test/cases/adapters/postgresql/schema_test.rb" "test/cases/adapters/postgresql/statement_pool_test.rb" "test/cases/adapters/postgresql/timestamp_test.rb" "test/cases/adapters/postgresql/utils_test.rb" "test/cases/adapters/postgresql/view_test.rb" "test/cases/aggregations_test.rb" "test/cases/ar_schema_test.rb" "test/cases/associations/belongs_to_associations_test.rb" "test/cases/associations/callbacks_test.rb" "test/cases/associations/cascaded_eager_loading_test.rb" "test/cases/associations/eager_load_includes_full_sti_class_test.rb" "test/cases/associations/eager_load_nested_include_test.rb" "test/cases/associations/eager_singularization_test.rb" "test/cases/associations/eager_test.rb" "test/cases/associations/extension_test.rb" "test/cases/associations/habtm_join_table_test.rb" "test/cases/associations/has_and_belongs_to_many_associations_test.rb" "test/cases/associations/has_many_associations_test.rb" "test/cases/associations/has_many_through_associations_test.rb" "test/cases/associations/has_one_associations_test.rb" "test/cases/associations/has_one_through_associations_test.rb" "test/cases/associations/identity_map_test.rb" "test/cases/associations/inner_join_association_test.rb" "test/cases/associations/inverse_associations_test.rb" "test/cases/associations/join_model_test.rb" "test/cases/associations/nested_through_associations_test.rb" "test/cases/associations_test.rb" "test/cases/attribute_methods/read_test.rb" "test/cases/attribute_methods_test.rb" "test/cases/autosave_association_test.rb" "test/cases/base_test.rb" "test/cases/batches_test.rb" "test/cases/binary_test.rb" "test/cases/bind_parameter_test.rb" "test/cases/calculations_test.rb" "test/cases/callbacks_test.rb" "test/cases/clone_test.rb" "test/cases/coders/yaml_column_test.rb" "test/cases/column_alias_test.rb" "test/cases/column_definition_test.rb" "test/cases/column_test.rb" "test/cases/connection_adapters/abstract_adapter_test.rb" "test/cases/connection_adapters/connection_handler_test.rb" "test/cases/connection_adapters/connection_specification_test.rb" "test/cases/connection_adapters/schema_cache_test.rb" "test/cases/connection_management_test.rb" "test/cases/connection_pool_test.rb" "test/cases/connection_specification/resolver_test.rb" "test/cases/counter_cache_test.rb" "test/cases/custom_locking_test.rb" "test/cases/database_statements_test.rb" "test/cases/date_time_test.rb" "test/cases/defaults_test.rb" "test/cases/deprecated_finder_test.rb" "test/cases/dirty_test.rb" "test/cases/dup_test.rb" "test/cases/dynamic_finder_match_test.rb" "test/cases/explain_test.rb" "test/cases/finder_respond_to_test.rb" "test/cases/finder_test.rb" "test/cases/fixtures/file_test.rb" "test/cases/fixtures_test.rb" "test/cases/habtm_destroy_order_test.rb" "test/cases/i18n_test.rb" "test/cases/identity_map/middleware_test.rb" "test/cases/identity_map_test.rb" "test/cases/inclusion_test.rb" "test/cases/inheritance_test.rb" "test/cases/invalid_date_test.rb" "test/cases/invertible_migration_test.rb" "test/cases/json_serialization_test.rb" "test/cases/lifecycle_test.rb" "test/cases/locking_test.rb" "test/cases/log_subscriber_test.rb" "test/cases/mass_assignment_security_test.rb" "test/cases/method_scoping_test.rb" "test/cases/migration/change_schema_test.rb" "test/cases/migration/column_attributes_test.rb" "test/cases/migration/column_positioning_test.rb" "test/cases/migration/command_recorder_test.rb" "test/caMses/migration/create_join_table_test.rb" "test/cases/migration/index_test.rb" "test/cases/migration/logger_test.rb" "test/cases/migration/rename_column_test.rb" "test/cases/migration/rename_table_test.rb" "test/cases/migration/table_and_index_test.rb" "test/cases/migration_test.rb" "test/cases/migrator_test.rb" "test/cases/mixin_test.rb" "test/cases/modules_test.rb" "test/cases/multiple_db_test.rb" "test/cases/named_scope_test.rb" "test/cases/nested_attributes_test.rb" "test/cases/persistence_test.rb" "test/cases/pooled_connections_test.rb" "test/cases/primary_keys_test.rb" "test/cases/query_cache_test.rb" "test/cases/quoting_test.rb" "test/cases/readonly_test.rb" "test/cases/reaper_test.rb" "test/cases/reflection_test.rb" "test/cases/relation_scoping_test.rb" "test/cases/relation_test.rb" "test/cases/relations_test.rb" "test/cases/reload_models_test.rb" "test/cases/sanitize_test.rb" "test/cases/schema_dumper_test.rb" "test/cases/serialization_test.rb" "test/cases/session_store/session_test.rb" "test/cases/store_test.rb" "test/cases/timestamp_test.rb" "test/cases/transaction_callbacks_test.rb" "test/cases/transactions_test.rb" "test/cases/unconnected_test.rb" "test/cases/validations/association_validation_test.rb" "test/cases/validations/i18n_generate_message_validation_test.rb" "test/cases/validations/i18n_validation_test.rb" "test/cases/validations/uniqueness_validation_test.rb" "test/cases/validations_test.rb" "test/cases/xml_serialization_test.rb" "test/cases/yaml_serialization_test.rb" 
Using postgresql with Identity Map off
Run options: --seed 44987

# Running tests:

.............................................................................................................................................................................................................S..SSSSSS.....................................................................................................................................................................................................................................................................................................................................................................................................................................F............................................/home/peterv/data/backed_up/github/petervandenabeele/rails/activerecord/lib/active_record/persistence.rb:54: warning: instance variable @new_record not initialized
..................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................S...............................................................................................................................................................................................................................................................................................................................SSSSSSSSSS...........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished tests in 118.787079s, 28.5469 tests/s, 87.6695 assertions/s.

  1) Failure:
test_default(BasicsTest) [/home/peterv/data/backed_up/github/petervandenabeele/rails/activerecord/test/cases/base_test.rb:1111]:
Expected: 2004-01-01 00:00:00 +0100
  Actual: 2004-01-01 00:00:00 UTC

3391 tests, 10414 assertions, 1 failures, 0 errors, 18 skips
rake aborted!
Command failed with status (1): [/home/peterv/.rvm/rubies/ruby-1.9.3-p0/bin...]

Tasks: TOP => test_postgresql
(See full trace by running task with --trace)
```

I presume this is caused by the setting of the default default_timezone that is swapped from
:local to :utc a few times in the test file and the assert in that test comparing against Time.local.

``` bash
peterv@ASUS:~/b/github/petervandenabeele/rails/activerecord/test/cases$ grep ActiveRecord::Base.default_timezone base_test.rb 
    ActiveRecord::Base.default_timezone = :utc
    ActiveRecord::Base.default_timezone = :local
    ActiveRecord::Base.default_timezone = :utc
    ActiveRecord::Base.default_timezone = :local
    ActiveRecord::Base.default_timezone = :utc
    ActiveRecord::Base.default_timezone = :local
      ActiveRecord::Base.default_timezone = :utc
      ActiveRecord::Base.default_timezone = :local
```

The solution that I found that is most localized is supplied in this patch. After the patch, all tests in activerecord pass:

```
peterv@ASUS:~/b/github/petervandenabeele/rails/activerecord$ bundle exec rake
/home/peterv/.rvm/rubies/ruby-1.9.3-p0/bin/ruby -w -I"lib:test" -I"/home/peterv/.rvm/gems/ruby-1.9.3-p0@global/gems/rake-0.9.2.2/lib" "/home/peterv/.rvm/gems/ruby-1.9.3-p0@global/gems/rake-0.9.2.2/lib/rake/rake_test_loader.rb" "test/cases/adapter_test.rb" "test/cases/adapters/mysql/active_schema_test.rb" "test/cases/adapters/mysql/case_sensitivity_test.rb" 

...

Using mysql with Identity Map off
Run options: --seed 34600

...

Finished tests in 126.265658s, 26.1433 tests/s, 79.9267 assertions/s.

3301 tests, 10092 assertions, 0 failures, 0 errors, 4 skips

/home/peterv/.rvm/rubies/ruby-1.9.3-p0/bin/ruby -w -I"lib:test" -I"/home/peterv/.rvm/gems/ruby-1.9.3-p0@global/gems/rake-0.9.2.2/lib" "/home/peterv/.rvm/gems/ruby-1.9.3-p0@global/gems/rake-0.9.2.2/lib/rake/rake_test_loader.rb" "test/cases/adapter_test.rb" "test/cases/adapters/mysql2/active_schema_test.rb" 

...

Using mysql2 with Identity Map off
Run options: --seed 50839

...

Finished tests in 84.640289s, 38.9176 tests/s, 119.2104 assertions/s.

3294 tests, 10090 assertions, 0 failures, 0 errors, 4 skips

/home/peterv/.rvm/rubies/ruby-1.9.3-p0/bin/ruby -w -I"lib:test" -I"/home/peterv/.rvm/gems/ruby-1.9.3-p0@global/gems/rake-0.9.2.2/lib" "/home/peterv/.rvm/gems/ruby-1.9.3-p0@global/gems/rake-0.9.2.2/lib/rake/rake_test_loader.rb" "test/cases/adapter_test.rb" "test/cases/adapters/sqlite3/copy_table_test.rb" 

...

Using sqlite3 with Identity Map off
Run options: --seed 30505

...

Finished tests in 58.961055s, 55.9352 tests/s, 170.2989 assertions/s.

3298 tests, 10041 assertions, 0 failures, 0 errors, 9 skips

/home/peterv/.rvm/rubies/ruby-1.9.3-p0/bin/ruby -w -I"lib:test" -I"/home/peterv/.rvm/gems/ruby-1.9.3-p0@global/gems/rake-0.9.2.2/lib" "/home/peterv/.rvm/gems/ruby-1.9.3-p0@global/gems/rake-0.9.2.2/lib/rake/rake_test_loader.rb" "test/cases/adapter_test.rb" "test/cases/adapters/postgresql/active_schema_test.rb" 

...

"test/cases/base_test.rb"

...

Using postgresql with Identity Map off
Run options: --seed 46281

...

Finished tests in 121.389141s, 27.9350 tests/s, 85.8149 assertions/s.

3391 tests, 10417 assertions, 0 failures, 0 errors, 18 skips
```

Other solutions are possible.
- provide more explicit fixing of default_timezone for other tests that suffer from the same issue
- fix the default timezone in schema/postgresql_specific_schema.rb
  (that is currently dangerously specified:

``` sql
    fixed_time timestamp default '2004-01-01 00:00:00.000000-00',
```

Following http://www.postgresql.org/docs/8.4/static/datatype-datetime.html

The timestamp (without a notion of "with time zone" or "without time zone")
defaults to "without time zone" but the string terminates in "-00".

When I changed that line to

``` sql
  fixed_time timestamp with time zone default '2004-01-01 00:00:00.000000+00',
```

the test problem in the test also went away.
