### PR TITLE
Replaced all 'for' loops with Enumerable#each

### DIFF
--- a/actionpack/Rakefile
+++ b/actionpack/Rakefile
@@ -57,13 +57,13 @@ task :lines do
 
   FileList["lib/**/*.rb"].each do |file_name|
     next if file_name =~ /vendor/
-    f = File.open(file_name)
-
-    while line = f.gets
-      lines += 1
-      next if line =~ /^\s*$/
-      next if line =~ /^\s*#/
-      codelines += 1
+    File.open(file_name, 'r') do |f|
+      while line = f.gets
+        lines += 1
+        next if line =~ /^\s*$/
+        next if line =~ /^\s*#/
+        codelines += 1
+      end
     end
     puts "L: #{sprintf("%4d", lines)}, LOC #{sprintf("%4d", codelines)} | #{file_name}"
 

--- a/actionpack/Rakefile
+++ b/actionpack/Rakefile
@@ -55,7 +55,7 @@ end
 task :lines do
   lines, codelines, total_lines, total_codelines = 0, 0, 0, 0
 
-  for file_name in FileList["lib/**/*.rb"]
+  FileList["lib/**/*.rb"].each do |file_name|
     next if file_name =~ /vendor/
     f = File.open(file_name)
 

--- a/actionpack/lib/action_dispatch/testing/assertions/selector.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/selector.rb
@@ -417,8 +417,8 @@ module ActionDispatch
         deliveries = ActionMailer::Base.deliveries
         assert !deliveries.empty?, "No e-mail in delivery list"
 
-        for delivery in deliveries
-          for part in (delivery.parts.empty? ? [delivery] : delivery.parts)
+        deliveries.each do |delivery|
+          (delivery.parts.empty? ? [delivery] : delivery.parts).each do |part|
             if part["Content-Type"].to_s =~ /^text\/html\W/
               root = HTML::Document.new(part.body.to_s).root
               assert_select root, ":root", &block

--- a/actionpack/test/fixtures/developers.yml
+++ b/actionpack/test/fixtures/developers.yml
@@ -8,7 +8,7 @@ jamis:
   name: Jamis
   salary: 150000
 
-<% for digit in 3..10 %>
+<% (3..10).each do |digit| %>
 dev_<%= digit %>:
   id: <%= digit %>
   name: fixture_<%= digit %>

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -187,7 +187,7 @@ end
 task :lines do
   lines, codelines, total_lines, total_codelines = 0, 0, 0, 0
 
-  for file_name in FileList["lib/active_record/**/*.rb"]
+  FileList["lib/active_record/**/*.rb"].each do |file_name|
     next if file_name =~ /vendor/
     f = File.open(file_name)
 

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -189,13 +189,13 @@ task :lines do
 
   FileList["lib/active_record/**/*.rb"].each do |file_name|
     next if file_name =~ /vendor/
-    f = File.open(file_name)
-
-    while line = f.gets
-      lines += 1
-      next if line =~ /^\s*$/
-      next if line =~ /^\s*#/
-      codelines += 1
+    File.open(file_name, 'r') do |f|
+      while line = f.gets
+        lines += 1
+        next if line =~ /^\s*$/
+        next if line =~ /^\s*#/
+        codelines += 1
+      end
     end
     puts "L: #{sprintf("%4d", lines)}, LOC #{sprintf("%4d", codelines)} | #{file_name}"
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1579,7 +1579,7 @@ class BasicsTest < ActiveRecord::TestCase
       Developer.find(:all)
     end
     assert developers.size >= 2
-    for i in 1...developers.size
+    (1...developers.size).each do |i|
       assert developers[i-1].salary >= developers[i].salary
     end
   end

--- a/activerecord/test/cases/serialization_test.rb
+++ b/activerecord/test/cases/serialization_test.rb
@@ -25,7 +25,7 @@ class SerializationTest < ActiveRecord::TestCase
   end
 
   def test_serialize_should_be_reversible
-    for format in FORMATS
+    FORMATS.each do |format|
       @serialized = Contact.new.send("to_#{format}")
       contact = Contact.new.send("from_#{format}", @serialized)
 
@@ -34,7 +34,7 @@ class SerializationTest < ActiveRecord::TestCase
   end
 
   def test_serialize_should_allow_attribute_only_filtering
-    for format in FORMATS
+    FORMATS.each do |format|
       @serialized = Contact.new(@contact_attributes).send("to_#{format}", :only => [ :age, :name ])
       contact = Contact.new.send("from_#{format}", @serialized)
       assert_equal @contact_attributes[:name], contact.name, "For #{format}"
@@ -43,7 +43,7 @@ class SerializationTest < ActiveRecord::TestCase
   end
 
   def test_serialize_should_allow_attribute_except_filtering
-    for format in FORMATS
+    FORMATS.each do |format|
       @serialized = Contact.new(@contact_attributes).send("to_#{format}", :except => [ :age, :name ])
       contact = Contact.new.send("from_#{format}", @serialized)
       assert_nil contact.name, "For #{format}"

--- a/activerecord/test/fixtures/developers.yml
+++ b/activerecord/test/fixtures/developers.yml
@@ -8,7 +8,7 @@ jamis:
   name: Jamis
   salary: 150000
 
-<% for digit in 3..10 %>
+<% (3..10).each do |digit| %>
 dev_<%= digit %>:
   id: <%= digit %>
   name: fixture_<%= digit %>

--- a/activeresource/Rakefile
+++ b/activeresource/Rakefile
@@ -33,7 +33,7 @@ end
 task :lines do
   lines, codelines, total_lines, total_codelines = 0, 0, 0, 0
 
-  for file_name in FileList["lib/active_resource/**/*.rb"]
+  FileList["lib/active_resource/**/*.rb"].each do |file_name|
     next if file_name =~ /vendor/
     f = File.open(file_name)
 

--- a/activeresource/test/cases/format_test.rb
+++ b/activeresource/test/cases/format_test.rb
@@ -19,7 +19,7 @@ class FormatTest < ActiveSupport::TestCase
   end
 
   def test_formats_on_single_element
-    for format in [ :json, :xml ]
+    [ :json, :xml ].each do |format|
       using_format(Person, format) do
         ActiveResource::HttpMock.respond_to.get "/people/1.#{format}", {'Accept' => ActiveResource::Formats[format].mime_type}, ActiveResource::Formats[format].encode(@david)
         assert_equal @david[:name], Person.find(1).name
@@ -28,7 +28,7 @@ class FormatTest < ActiveSupport::TestCase
   end
 
   def test_formats_on_collection
-    for format in [ :json, :xml ]
+    [ :json, :xml ].each do |format|
       using_format(Person, format) do
         ActiveResource::HttpMock.respond_to.get "/people.#{format}", {'Accept' => ActiveResource::Formats[format].mime_type}, ActiveResource::Formats[format].encode(@programmers)
         remote_programmers = Person.find(:all)
@@ -39,7 +39,7 @@ class FormatTest < ActiveSupport::TestCase
   end
 
   def test_formats_on_custom_collection_method
-    for format in [ :json, :xml ]
+    [ :json, :xml ].each do |format|
       using_format(Person, format) do
         ActiveResource::HttpMock.respond_to.get "/people/retrieve.#{format}?name=David", {'Accept' => ActiveResource::Formats[format].mime_type}, ActiveResource::Formats[format].encode([@david])
         remote_programmers = Person.get(:retrieve, :name => 'David')

--- a/activesupport/lib/active_support/xml_mini/jdom.rb
+++ b/activesupport/lib/active_support/xml_mini/jdom.rb
@@ -71,7 +71,7 @@ module ActiveSupport
 
       child_nodes = element.child_nodes
       if child_nodes.length > 0
-        for i in 0...child_nodes.length
+        (0...child_nodes.length).each do |i|
           child = child_nodes.item(i)
           merge_element!(hash, child) unless child.node_type == Node.TEXT_NODE
         end
@@ -133,7 +133,7 @@ module ActiveSupport
     def get_attributes(element)
       attribute_hash = {}
       attributes = element.attributes
-      for i in 0...attributes.length
+      (0...attributes.length).each do |i|
          attribute_hash[CONTENT_KEY] ||= ''
          attribute_hash[attributes.item(i).name] =  attributes.item(i).value
        end
@@ -147,7 +147,7 @@ module ActiveSupport
     def texts(element)
       texts = []
       child_nodes = element.child_nodes
-      for i in 0...child_nodes.length
+      (0...child_nodes.length).each do |i|
         item = child_nodes.item(i)
         if item.node_type == Node.TEXT_NODE
           texts << item.get_data
@@ -163,7 +163,7 @@ module ActiveSupport
     def empty_content?(element)
       text = ''
       child_nodes = element.child_nodes
-      for i in 0...child_nodes.length
+      (0...child_nodes.length).each do |i|
         item = child_nodes.item(i)
         if item.node_type == Node.TEXT_NODE
           text << item.get_data.strip

--- a/railties/lib/rails/rubyprof_ext.rb
+++ b/railties/lib/rails/rubyprof_ext.rb
@@ -12,7 +12,7 @@ module Prof #:nodoc:
     io.puts " time   seconds   seconds    calls  ms/call  ms/call  name"
 
     sum = 0.0
-    for r in results
+    results.each do |r|
       sum += r.self_time
 
       name =  if r.method_class.nil?


### PR DESCRIPTION
Was reading a [small discussion on r/ruby](http://www.reddit.com/r/ruby/comments/p1l8k/why_is_there_forstatement_in_ruby/) about `for` loops vs. `Enumerable#each`.

`foo.each do |bar|` is definitely the most common and preferred style, so I grepped the Rails codebase and replaced the 27 `for` loops that I found.
