### PR TITLE
Test and fix for issue 4718

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -318,7 +318,8 @@ module ActiveRecord
     def find_one(id)
       id = id.id if ActiveRecord::Base === id
 
-      if IdentityMap.enabled? && where_values.blank? &&
+      if IdentityMap.enabled? &&
+        (where_values.blank? || contains_only_subclass_constraint?(where_values)) &&
         limit_value.blank? && order_values.blank? &&
         includes_values.blank? && preload_values.blank? &&
         readonly_value.nil? && joins_values.blank? &&
@@ -393,6 +394,12 @@ module ActiveRecord
 
     def using_limitable_reflections?(reflections)
       reflections.none? { |r| r.collection? }
+    end
+    
+    def contains_only_subclass_constraint?(where_values)
+      where_values.length == 1 &&
+      !where_values[0].left.nil? && where_values[0].left.relation.name == table_name &&
+      !where_values[0].right.nil? && where_values[0].right.length == 1 && where_values[0].right[0] == @klass.name
     end
   end
 end

--- a/activerecord/test/cases/identity_map_test.rb
+++ b/activerecord/test/cases/identity_map_test.rb
@@ -162,6 +162,14 @@ class IdentityMapTest < ActiveRecord::TestCase
     c2 = Comment.find(c.id)
     assert_same(c1, c2)
   end
+  
+  def test_queries_are_not_executed_when_finding_inherited_class_by_id
+    c = comments(:sub_special_comment)
+    SubSpecialComment.find(c.id)
+    assert_no_queries do
+      SubSpecialComment.find(c.id)
+    end
+  end
 
   ##############################################################################
   # Tests checking dirty attribute behavior with IM                            #


### PR DESCRIPTION
A test case and a fix for issue 4718 (https://github.com/rails/rails/issues/4718).
The problem lied in line 321 of activerecord/lib/relation/finder_methods.rb:
where_values are not blank in case of subclasses but contained the subclass restriction.
Checking for it should resolve the issue.
