### PR TITLE
Revert to using 'for' loops when dealing with ranges.

### DIFF
--- a/actionpack/test/fixtures/developers.yml
+++ b/actionpack/test/fixtures/developers.yml
@@ -8,7 +8,7 @@ jamis:
   name: Jamis
   salary: 150000
 
-<% (3..10).each do |digit| %>
+<% for digit in 3..10 %>
 dev_<%= digit %>:
   id: <%= digit %>
   name: fixture_<%= digit %>

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1579,7 +1579,7 @@ class BasicsTest < ActiveRecord::TestCase
       Developer.find(:all)
     end
     assert developers.size >= 2
-    (1...developers.size).each do |i|
+    for i in 1...developers.size
       assert developers[i-1].salary >= developers[i].salary
     end
   end

--- a/activerecord/test/fixtures/developers.yml
+++ b/activerecord/test/fixtures/developers.yml
@@ -8,7 +8,7 @@ jamis:
   name: Jamis
   salary: 150000
 
-<% (3..10).each do |digit| %>
+<% for digit in 3..10 %>
 dev_<%= digit %>:
   id: <%= digit %>
   name: fixture_<%= digit %>

--- a/activesupport/lib/active_support/xml_mini/jdom.rb
+++ b/activesupport/lib/active_support/xml_mini/jdom.rb
@@ -71,7 +71,7 @@ module ActiveSupport
 
       child_nodes = element.child_nodes
       if child_nodes.length > 0
-        (0...child_nodes.length).each do |i|
+        for i in 0...child_nodes.length
           child = child_nodes.item(i)
           merge_element!(hash, child) unless child.node_type == Node.TEXT_NODE
         end
@@ -133,7 +133,7 @@ module ActiveSupport
     def get_attributes(element)
       attribute_hash = {}
       attributes = element.attributes
-      (0...attributes.length).each do |i|
+      for i in 0...attributes.length
          attribute_hash[CONTENT_KEY] ||= ''
          attribute_hash[attributes.item(i).name] =  attributes.item(i).value
        end
@@ -147,7 +147,7 @@ module ActiveSupport
     def texts(element)
       texts = []
       child_nodes = element.child_nodes
-      (0...child_nodes.length).each do |i|
+      for i in 0...child_nodes.length
         item = child_nodes.item(i)
         if item.node_type == Node.TEXT_NODE
           texts << item.get_data
@@ -163,7 +163,7 @@ module ActiveSupport
     def empty_content?(element)
       text = ''
       child_nodes = element.child_nodes
-      (0...child_nodes.length).each do |i|
+      for i in 0...child_nodes.length
         item = child_nodes.item(i)
         if item.node_type == Node.TEXT_NODE
           text << item.get_data.strip


### PR DESCRIPTION
The code is more readable, and the counter variable doesn't require an isolated scope.

(in response to https://github.com/rails/rails/pull/4744#issuecomment-3711000)
