### PR TITLE
Fix typo in TimeWithZone documentation for consistency.

### DIFF
--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -15,7 +15,7 @@ module ActiveSupport
   #   Time.zone.parse('2007-02-10 15:30:45')          # => Sat, 10 Feb 2007 15:30:45 EST -05:00
   #   Time.zone.at(1170361845)                        # => Sat, 10 Feb 2007 15:30:45 EST -05:00
   #   Time.zone.now                                   # => Sun, 18 May 2008 13:07:55 EDT -04:00
-  #   Time.utc(2007, 2, 10, 20, 30, 45).in_time_zone  # => Sat, 10 Feb 2007 15:30:45 EST -05:00
+  #   Time.utc(2007, 2, 10, 15, 30, 45).in_time_zone  # => Sat, 10 Feb 2007 15:30:45 EST -05:00
   #
   # See Time and TimeZone for further documentation of these methods.
   #


### PR DESCRIPTION
Fixed a tiny typo in the example code for ActiveSupport::TimeWithZone.
