### PR TITLE
[MySQL] Fix GH #4754. Remove double-quote characters around PK when using sql_mode=ANSI_QUOTES

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -505,7 +505,7 @@ module ActiveRecord
         execute_and_free("SHOW CREATE TABLE #{quote_table_name(table)}", 'SCHEMA') do |result|
           create_table = each_hash(result).first[:"Create Table"]
           if create_table.to_s =~ /PRIMARY KEY\s+\((.+)\)/
-            keys = $1.split(",").map { |key| key.gsub(/`/, "") }
+            keys = $1.split(",").map { |key| key.gsub(/[`"]/, "") }
             keys.length == 1 ? [keys.first, nil] : nil
           else
             nil

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -200,3 +200,19 @@ class PrimaryKeyWithNoConnectionTest < ActiveRecord::TestCase
     assert_equal 'foo', model.primary_key
   end
 end
+
+if current_adapter?(:MysqlAdapter) or current_adapter?(:Mysql2Adapter)
+  class PrimaryKeyWithAnsiQuotesTest < ActiveRecord::TestCase
+    self.use_transactional_fixtures = false
+  
+    def test_primaery_key_method_with_ansi_quotes
+      con = ActiveRecord::Base.connection
+      con.execute("SET SESSION sql_mode='ANSI_QUOTES'")
+      assert_equal "id", con.primary_key("topics")
+    ensure
+      con.reconnect!
+    end
+  
+  end
+end
+


### PR DESCRIPTION
I think that I fixed GH #4754.
Please see https://github.com/rails/rails/issues/4754 .

It seems that this issue is in 3-1, 3-2, and master.
