### PR TITLE
Fixes #4764 - remove generated new line in routes.rb on scaffold generation

### DIFF
--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -246,7 +246,7 @@ module Rails
         sentinel = /\.routes\.draw do\s*$/
 
         in_root do
-          inject_into_file 'config/routes.rb', "\n  #{routing_code}\n", { :after => sentinel, :verbose => false }
+          inject_into_file 'config/routes.rb', "\n  #{routing_code}", { :after => sentinel, :verbose => false }
         end
       end
 


### PR DESCRIPTION
As explained in #4764, when destroying a scaffold, routes.rb loses a new line. This seems to happen because a new line is added while generating the route and the destroy generator removes it. However, this causes a problem if the routes file is manually edited to remove such new lines. 

This commit just removes that extra new line from added in the first place.
