### PR TITLE
Postgresql custom types in ActiveRecord

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -49,6 +49,22 @@ module ActiveRecord
             super
           end
         end
+
+        def add_custom_type options
+          options.each do |name, type|
+            custom_types[name.to_s] = type
+          end
+        end
+
+        def custom_type_for field_type
+          custom_types[field_type.to_s]
+        end
+
+        private
+
+        def custom_types
+          Thread.current[:custom_types] ||= {}
+        end
       end
       # :startdoc:
 
@@ -125,7 +141,7 @@ module ActiveRecord
               :integer
             # Pass through all types that are not specific to PostgreSQL.
             else
-              super
+              self.class.custom_type_for(field_type) || super
           end
         end
 
@@ -834,7 +850,7 @@ module ActiveRecord
           # add info on sort order for columns (only desc order is explicitly specified, asc is the default)
           desc_order_columns = inddef.scan(/(\w+) DESC/).flatten
           orders = desc_order_columns.any? ? Hash[desc_order_columns.map {|order_column| [order_column, :desc]}] : {}
-      
+
           column_names.empty? ? nil : IndexDefinition.new(table_name, index_name, unique, column_names, [], orders)
         end.compact
       end

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -9,6 +9,13 @@ end
 class PostgresqlMoney < ActiveRecord::Base
 end
 
+class PostgresqlDomain < ActiveRecord::Base
+  ActiveRecord::ConnectionAdapters::PostgreSQLColumn.add_custom_type(
+    'custom_money'  => :decimal,
+    :email_address  => :text
+  )
+end
+
 class PostgresqlNumber < ActiveRecord::Base
 end
 
@@ -45,6 +52,9 @@ class PostgresqlDataTypeTest < ActiveRecord::TestCase
     @first_money = PostgresqlMoney.find(1)
     @second_money = PostgresqlMoney.find(2)
 
+    PostgresqlDomain.create! :amount => 3.333333333333, :email => 'joe@email.com'
+    @first_domain = PostgresqlDomain.first
+
     @connection.execute("INSERT INTO postgresql_numbers (single, double) VALUES (123.456, 123456.789)")
     @first_number = PostgresqlNumber.find(1)
 
@@ -61,6 +71,14 @@ class PostgresqlDataTypeTest < ActiveRecord::TestCase
     @first_oid = PostgresqlOid.find(1)
 
     @connection.execute("INSERT INTO postgresql_timestamp_with_zones (time) VALUES ('2010-01-01 10:00:00-1')")
+  end
+
+  def test_custom_domain
+    assert_equal :decimal, @first_domain.column_for_attribute(:amount).type
+    assert_equal BigDecimal.new('3.33'), @first_domain.amount
+
+    assert_equal :text, @first_domain.column_for_attribute(:email).type
+    assert_equal 'joe@email.com', @first_domain.email
   end
 
   def test_data_type_of_array_types

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -1,14 +1,19 @@
 ActiveRecord::Schema.define do
 
-  %w(postgresql_tsvectors postgresql_arrays postgresql_moneys postgresql_numbers postgresql_times postgresql_network_addresses postgresql_bit_strings
+  %w(postgresql_tsvectors postgresql_arrays postgresql_domains postgresql_moneys postgresql_numbers postgresql_times postgresql_network_addresses postgresql_bit_strings
       postgresql_oids postgresql_xml_data_type defaults geometrics postgresql_timestamp_with_zones).each do |table_name|
-    execute "DROP TABLE  IF EXISTS #{quote_table_name table_name}"
+    execute "DROP TABLE  IF EXISTS #{quote_table_name table_name} CASCADE"
   end
 
   execute 'DROP SEQUENCE IF EXISTS companies_nonstd_seq CASCADE'
   execute 'CREATE SEQUENCE companies_nonstd_seq START 101 OWNED BY companies.id'
   execute "ALTER TABLE companies ALTER COLUMN id SET DEFAULT nextval('companies_nonstd_seq')"
   execute 'DROP SEQUENCE IF EXISTS companies_id_seq'
+
+  execute 'DROP DOMAIN IF EXISTS custom_money CASCADE'
+  execute 'CREATE DOMAIN custom_money numeric(19, 2) CONSTRAINT not_negative CHECK (VALUE >= 0)'
+  execute 'DROP DOMAIN IF EXISTS email_address CASCADE'
+  execute "CREATE DOMAIN email_address TEXT CONSTRAINT valid_email_address_format CHECK (VALUE ~ '.com')"
 
   %w(accounts_id_seq developers_id_seq projects_id_seq topics_id_seq customers_id_seq orders_id_seq).each do |seq_name|
     execute "SELECT setval('#{seq_name}', 100)"
@@ -53,6 +58,14 @@ _SQL
     id SERIAL PRIMARY KEY,
     commission_by_quarter INTEGER[],
     nicknames TEXT[]
+  );
+_SQL
+
+  execute <<_SQL
+  CREATE TABLE postgresql_domains (
+    id SERIAL PRIMARY KEY,
+    amount custom_money,
+    email email_address
   );
 _SQL
 


### PR DESCRIPTION
I'd love to be able to tell ActiveRecord how to handle my custom postgresql domains (data types).

This commit lets me do that!

```
SQL:
create domain custom_money numeric(19, 2);
create domain email_address text constraint email_address_format check (value ~ '\w+@\w+.com');

Ruby:
ActiveRecord::ConnectionAdapters::PostgreSQLColumn.add_custom_type(
  :custom_money => :decimal, 
  :email_address => :string)
```

The method might not be thread safe... problem?
