### PR TITLE
fix assets test

### DIFF
--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -64,7 +64,7 @@ module ApplicationTests
       files << Dir["#{app_path}/public/assets/foo/application.js"].first
       files.each do |file|
         assert_not_nil file, "Expected application.js asset to be generated, but none found"
-        assert_equal "alert()", File.read(file)
+        assert_equal "alert();", File.read(file)
       end
     end
 


### PR DESCRIPTION
I have the same test failture as on travis

```
  1) Failure:
test_precompile_creates_the_file,_gives_it_the_original_asset's_content_and_run_in_production_as_default(ApplicationTests::AssetsTest) [test/application/assets_test.rb:67]:
Expected: "alert()"
  Actual: "alert();"
```
