### PR TITLE
ids_reader method fixed, test added to has_many association (for PostgreSQL)

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -58,7 +58,7 @@ module ActiveRecord
             end
           end
 
-          relation.uniq.pluck(column)
+          relation.pluck(column)
         end
       end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1253,6 +1253,10 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert company.clients_using_sql.loaded?
   end
 
+  def test_get_ids_for_ordered_association
+    assert_equal [companies(:second_client).id, companies(:first_client).id], companies(:first_firm).clients_ordered_by_rating_ids
+  end
+
   def test_assign_ids_ignoring_blanks
     firm = Firm.create!(:name => 'Apple')
     firm.client_ids = [companies(:first_client).id, nil, companies(:second_client).id, '']

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -45,6 +45,7 @@ class Firm < Company
   has_many :unsorted_clients_with_symbol, :class_name => :Client
   has_many :clients_sorted_desc, :class_name => "Client", :order => "id DESC"
   has_many :clients_of_firm, :foreign_key => "client_of", :class_name => "Client", :order => "id"
+  has_many :clients_ordered_by_rating, :order => "rating", :class_name => "Client"
   has_many :unvalidated_clients_of_firm, :foreign_key => "client_of", :class_name => "Client", :validate => false
   has_many :dependent_clients_of_firm, :foreign_key => "client_of", :class_name => "Client", :order => "id", :dependent => :destroy
   has_many :exclusively_dependent_clients_of_firm, :foreign_key => "client_of", :class_name => "Client", :order => "id", :dependent => :delete_all


### PR DESCRIPTION
See this issue #4758, and this PR #4738 to follow the discussion.
`uniq` was added to `ids_reader` in 109db5a, but, due to SELECT DISTINCT limitation on PostgreSQL, this cause an error.
I've added a test that was failing on PostgreSQL and fixed `ids_reader` by removing `uniq`.
