### PR TITLE
A little constantize update

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -351,7 +351,7 @@ module ActionController
         def tests(controller_class)
           case controller_class
           when String, Symbol
-            self.controller_class = "#{controller_class.to_s.underscore}_controller".camelize.constantize
+            self.controller_class = "#{controller_class.to_s.camelize}Controller".constantize
           when Class
             self.controller_class = controller_class
           else

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -212,7 +212,7 @@ module ActiveSupport
 
       constant = Object
       names.each do |name|
-        constant = constant.const_defined?(name, false) ? constant.const_get(name) : constant.const_missing(name)
+        constant = constant.const_get(name, false)
       end
       constant
     end


### PR DESCRIPTION
I was also able to reduce safe_constantize to the following without breaking any tests and I don't really understand what is the point in the deleted lines. Maybe someone could provide some tests explaining and covering them?

``` ruby
def safe_constantize(camel_cased_word)
  begin
    constantize(camel_cased_word)
  rescue NameError => e
  end
end
```
