### PR TITLE
[Backport][3-1-stable] Fix GH #4754. Remove double-quote characters around PK when using sql_mode=ANSI_QUOTES

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -576,7 +576,7 @@ module ActiveRecord
         create_table = result.first[1]
 
         if create_table.to_s =~ /PRIMARY KEY\s+\((.+)\)/
-          keys = $1.split(",").map { |key| key.gsub(/`/, "") }
+          keys = $1.split(",").map { |key| key.gsub(/[`"]/, "") }
           keys.length == 1 ? [keys.first, nil] : nil
         else
           nil

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -760,7 +760,7 @@ module ActiveRecord
         result.free
 
         if create_table.to_s =~ /PRIMARY KEY\s+\((.+)\)/
-          keys = $1.split(",").map { |key| key.gsub(/`/, "") }
+          keys = $1.split(",").map { |key| key.gsub(/[`"]/, "") }
           keys.length == 1 ? [keys.first, nil] : nil
         else
           nil

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -171,4 +171,15 @@ class PrimaryKeysTest < ActiveRecord::TestCase
 
     assert_equal 'foo', model.primary_key
   end
+
+  if current_adapter?(:MysqlAdapter) or current_adapter?(:Mysql2Adapter)
+    def test_primaery_key_method_with_ansi_quotes
+      con = ActiveRecord::Base.connection
+      con.execute("SET SESSION sql_mode='ANSI_QUOTES'")
+      assert_equal "id", con.primary_key("topics")
+    ensure
+      con.reconnect!
+    end
+  end
+
 end


### PR DESCRIPTION
This PR is GH #4754 fixing for 3-1-stable .

Please see https://github.com/rails/rails/issues/4754 and https://github.com/rails/rails/pull/4763 .

cc/ @jonleighton
