### PR TITLE
Fix Deprecation usage in ActiveSupport when requiring only parts of AS

### DIFF
--- a/activesupport/lib/active_support/base64.rb
+++ b/activesupport/lib/active_support/base64.rb
@@ -1,3 +1,5 @@
+require 'active_support/deprecation'
+
 begin
   require 'base64'
 rescue LoadError

--- a/activesupport/lib/active_support/concern.rb
+++ b/activesupport/lib/active_support/concern.rb
@@ -1,3 +1,5 @@
+require 'active_support/deprecation'
+
 module ActiveSupport
   # A typical module looks like this:
   #

--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -1,4 +1,5 @@
 require 'active_support/base64'
+require 'active_support/deprecation'
 require 'active_support/core_ext/object/blank'
 
 module ActiveSupport

--- a/activesupport/lib/active_support/whiny_nil.rb
+++ b/activesupport/lib/active_support/whiny_nil.rb
@@ -1,3 +1,5 @@
+require 'active_support/deprecation'
+
 # Extensions to +nil+ which allow for more helpful error messages for people who
 # are new to Rails.
 #


### PR DESCRIPTION
I have a gem that uses ActiveSupport::Concern (and only requires `active_support/concern`, not all of AS), which fails with ActiveSupport 3.2 because it uses ActiveSupport::Deprecation without requiring it. Upon investigation, it seems there are a few other places where this happens.

I'm not sure which pieces are supposed to be able to be used in isolation, so I've fixed everything in seperate commits to make it easy to selectively apply as you see fit.
