### PR TITLE
[3-2-stable] Fix GH #4760. A Block was not evaluated.

### DIFF
--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -33,13 +33,14 @@ module ActiveSupport
     deprecate :silence
 
     def add(severity, message = nil, progname = nil, &block)
-      @logger.add(severity, "#{tags_text}#{message}", progname, &block)
+      message = (block_given? ? block.call : progname) if message.nil?
+      @logger.add(severity, "#{tags_text}#{message}", progname)
     end
 
     %w( fatal error warn info debug unknown ).each do |severity|
       eval <<-EOM, nil, __FILE__, __LINE__ + 1
         def #{severity}(progname = nil, &block)
-          add(Logger::#{severity.upcase}, progname, &block)
+          add(Logger::#{severity.upcase}, nil, progname, &block)
         end
       EOM
     end

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -70,4 +70,12 @@ class TaggedLoggingTest < ActiveSupport::TestCase
       assert_nothing_raised { @logger.silence {} }
     end
   end
+
+  test "calls block" do
+    @logger.tagged("BCX") do
+      @logger.info { "Funky town" }
+    end
+    assert_equal "[BCX] Funky town\n", @output.string
+  end
+
 end


### PR DESCRIPTION
It seems that 3-2-stable's TaggedLogging#debug (info, and so on) don't evaluate block, because the 2nd argument of Logger#add is not never nil.

Please see also https://github.com/rails/rails/issues/4760

This issue is found in only 3-2-stable.
