### PR TITLE
Fix GH #4744. Don't run bundle install when executing `rails new app` with --pretend option

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -248,7 +248,7 @@ module Rails
       end
 
       def run_bundle
-        bundle_command('install') unless options[:skip_gemfile] || options[:skip_bundle]
+        bundle_command('install') unless options[:skip_gemfile] || options[:skip_bundle] || options[:pretend]
       end
 
       def empty_directory_with_gitkeep(destination, config = {})

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -355,6 +355,11 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "config/application.rb", /config\.active_record\.dependent_restrict_raises = false/
   end
 
+  def test_pretend_option
+    output = run_generator [File.join(destination_root, "myapp"), "--pretend"]
+    assert_no_match(/run  bundle install/, output)
+  end
+
 protected
 
   def action(*args, &block)


### PR DESCRIPTION
If rails new command is passed --pretend option, don't run bundle install.

Please see https://github.com/rails/rails/issues/4774.
