### PR TITLE
check_box with nil as unchecked value should be HTML safe

### DIFF
--- a/actionpack/lib/action_view/helpers/tags/check_box.rb
+++ b/actionpack/lib/action_view/helpers/tags/check_box.rb
@@ -25,7 +25,7 @@ module ActionView
             add_default_name_and_id(options)
           end
 
-          hidden = @unchecked_value ? tag("input", "name" => options["name"], "type" => "hidden", "value" => @unchecked_value, "disabled" => options["disabled"]) : ""
+          hidden = @unchecked_value ? tag("input", "name" => options["name"], "type" => "hidden", "value" => @unchecked_value, "disabled" => options["disabled"]) : "".html_safe
           checkbox = tag("input", options)
           hidden + checkbox
         end

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -398,6 +398,10 @@ class FormHelperTest < ActionView::TestCase
     )
   end
 
+  def test_check_box_with_nil_unchecked_value_is_html_safe
+    assert check_box("post", "secret", {}, "on", nil).html_safe?
+  end
+
   def test_check_box_with_multiple_behavior
     @post.comment_ids = [2,3]
     assert_dom_equal(


### PR DESCRIPTION
This will fix a bug that generates a html unsafe string when the unchecked value is `nil`
