### PR TITLE
Added as_json method for multibyte strings

### DIFF
--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -188,6 +188,10 @@ module ActiveSupport #:nodoc:
         chars(Unicode.tidy_bytes(@wrapped_string, force))
       end
 
+      def as_json(options = nil) #:nodoc:
+        to_s.as_json(options)
+      end
+
       %w(capitalize downcase reverse tidy_bytes upcase).each do |method|
         define_method("#{method}!") do |*args|
           @wrapped_string = send(method, *args).to_s

--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -88,6 +88,9 @@ class MultibyteCharsTest < ActiveSupport::TestCase
     assert(('a'.mb_chars << 'b'.mb_chars).kind_of?(@proxy_class))
   end
 
+  def test_should_return_string_as_json
+    assert_equal UNICODE_STRING, @chars.as_json
+  end
 end
 
 class MultibyteCharsUTF8BehaviourTest < ActiveSupport::TestCase


### PR DESCRIPTION
For multibyte strings we need as_json method. Multibyte strings are object and if we are calling "text".mb_chars.as_json then result will be {"wrapped_string"=>"text"} although I've expected a string. 
