### PR TITLE
Use http://rubygems.org source in default Gemfile (3-2-stable)

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Rails 3.2.2 (unreleased) ##
+
+*   The Gemfile generated in new apps has as source http://rubygems.org
+    instead of https://rubygems.org. This allow to JRuby users to
+    generate working apps without install jruby-openssl before of run
+    `rails new` *Guillermo Iguaran*
+
 ## Rails 3.2.1 (January 26, 2012) ##
 
 *   Documentation fixes.

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source 'http://rubygems.org'
 
 <%= rails_gemfile_entry -%>
 


### PR DESCRIPTION
This allow to JRuby users to create new Rails app without install jruby-openssl before. 
Additionally there are some MRI users that have problems with openssl.
