### PR TITLE
Remove ruby_debugger_gemfile_entry from app_base

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -181,10 +181,6 @@ module Rails
         end
       end
 
-      def ruby_debugger_gemfile_entry
-        "gem 'ruby-debug19', :require => 'ruby-debug'"
-      end
-
       def assets_gemfile_entry
         return if options[:skip_sprockets]
 

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -22,4 +22,4 @@ source :rubygems
 # gem 'capistrano', :group => :development
 
 # To use debugger
-# <%= ruby_debugger_gemfile_entry %>
+# gem 'ruby-debug19', :require => 'ruby-debug'


### PR DESCRIPTION
We can just put ruby-debug19 commented directly in Gemfile
