### PR TITLE
Fix GH #4749. Remove branch options, because edge is not 3-2-stable.

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -200,8 +200,8 @@ module Rails
             # Gems used only for assets and not required
             # in production environments by default.
             group :assets do
-              gem 'sass-rails',   :git => 'git://github.com/rails/sass-rails.git',   :branch => '3-2-stable'
-              gem 'coffee-rails', :git => 'git://github.com/rails/coffee-rails.git', :branch => '3-2-stable'
+              gem 'sass-rails',   :git => 'git://github.com/rails/sass-rails.git'
+              gem 'coffee-rails', :git => 'git://github.com/rails/coffee-rails.git'
 
               # See https://github.com/sstephenson/execjs#readme for more supported runtimes
               #{javascript_runtime_gemfile_entry}

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -126,6 +126,11 @@ module SharedGeneratorTests
     generator([destination_root], :edge => true).expects(:bundle_command).with('install').once
     quietly { generator.invoke_all }
     assert_file 'Gemfile', %r{^gem\s+["']rails["'],\s+:git\s+=>\s+["']#{Regexp.escape("git://github.com/rails/rails.git")}["']$}
+    assert_file 'Gemfile', %r{^gem\s+["']journey["'],\s+:git\s+=>\s+["']#{Regexp.escape("git://github.com/rails/journey.git")}["']$}
+    assert_file 'Gemfile', %r{^gem\s+["']arel["'],\s+:git\s+=>\s+["']#{Regexp.escape("git://github.com/rails/arel.git")}["']$}
+    
+    assert_file 'Gemfile', %r{^\s+gem\s+["']sass-rails["'],\s+:git\s+=>\s+["']#{Regexp.escape("git://github.com/rails/sass-rails.git")}["']$}
+    assert_file 'Gemfile', %r{^\s+gem\s+["']coffee-rails["'],\s+:git\s+=>\s+["']#{Regexp.escape("git://github.com/rails/coffee-rails.git")}["']$}
   end
 
   def test_skip_gemfile


### PR DESCRIPTION
In 3-2-stable, when we run `rails new app --edge`, we see the following lines in Gemfile.

```
  gem 'sass-rails',   :git => 'git://github.com/rails/sass-rails.git', :branch => '3-2-stable'
  gem 'coffee-rails', :git => 'git://github.com/rails/coffee-rails.git', :branch => '3-2-stable'
```

 I think that this is a problem.

```
Bundler could not find compatible versions for gem "railties":
  In Gemfile:
    sass-rails (>= 0) ruby depends on
      railties (~> 3.2.0) ruby

    rails (>= 0) ruby depends on
      railties (4.0.0.beta)
```

Please see https://github.com/rails/rails/issues/4749
Please see also https://github.com/kennyj/rails/commit/8bf3c6d8165fa6442b3ae2f86a955c82d0abf99b (before rebasing)
