### PR TITLE
Build fix when running isolated test

### DIFF
--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require 'active_support/json'
 require 'active_support/core_ext/string/access'
 require 'active_support/core_ext/string/behavior'
 require 'active_support/core_ext/module/delegation'


### PR DESCRIPTION
fixed 

``` ruby
  1) Error:
807test_should_return_string_as_json(MultibyteCharsTest):
808NoMethodError: undefined method `as_json' for "こにちわ":String
809    /home/vagrant/builds/rails/rails/activesupport/lib/active_support/multibyte/chars.rb:192:in `as_json'
810    /home/vagrant/builds/rails/rails/activesupport/test/multibyte_chars_test.rb:92:in `test_should_return_string_as_json'
811    /home/vagrant/builds/rails/rails/vendor/bundle/ruby/1.9.1/gems/mocha-0.10.3/lib/mocha/integration/mini_test/version_230_to_262.rb:28:in `run'
812    /home/vagrant/builds/rails/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:29:in `block in run'
813    /home/vagrant/builds/rails/rails/activesupport/lib/active_support/callbacks.rb:366:in `_run__36564177__setup__callbacks'
814    /home/vagrant/builds/rails/rails/activesupport/lib/active_support/callbacks.rb:368:in `__run_callbacks'
815    /home/vagrant/builds/rails/rails/activesupport/lib/active_support/callbacks.rb:80:in `run_callbacks'
816    /home/vagrant/builds/rails/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:28:in `run'

```
