### PR TITLE
Fix broken test introduced from #4814

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/Gemfile
@@ -20,4 +20,4 @@ gem "jquery-rails"
 
 <% end -%>
 # To use debugger
-# <%= ruby_debugger_gemfile_entry %>
+# gem 'ruby-debug19', :require => 'ruby-debug'


### PR DESCRIPTION
`ruby_debugger_gemfile_entry` was removed from the generator in #4814.
