### PR TITLE
Fix GH #4737. Missing helper file (LoadError) in mountable plugin.

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -285,7 +285,9 @@ task :default => :test
       end
 
       def valid_const?
-        if camelized =~ /^\d/
+        if original_name =~ /[^0-9a-zA-Z_]+/
+          raise Error, "Invalid plugin name #{original_name}. Please give a name which use only alphabetic or numeric or \"_\" characters."
+        elsif camelized =~ /^\d/
           raise Error, "Invalid plugin name #{original_name}. Please give a name which does not start with numbers."
         elsif RESERVED_NAMES.include?(name)
           raise Error, "Invalid plugin name #{original_name}. Please give a name which does not match one of the reserved rails words."

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -27,13 +27,14 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
   include SharedGeneratorTests
 
   def test_invalid_plugin_name_raises_an_error
-    content = capture(:stderr){ run_generator [File.join(destination_root, "43-things")] }
-    assert_equal "Invalid plugin name 43-things. Please give a name which does not start with numbers.\n", content
-  end
+    content = capture(:stderr){ run_generator [File.join(destination_root, "things-43")] }
+    assert_equal "Invalid plugin name things-43. Please give a name which use only alphabetic or numeric or \"_\" characters.\n", content
 
-  def test_invalid_plugin_name_is_fixed
-    run_generator [File.join(destination_root, "things-43")]
-    assert_file "things-43/lib/things-43.rb", /module Things43/
+    content = capture(:stderr){ run_generator [File.join(destination_root, "things4.3")] }
+    assert_equal "Invalid plugin name things4.3. Please give a name which use only alphabetic or numeric or \"_\" characters.\n", content
+ 
+    content = capture(:stderr){ run_generator [File.join(destination_root, "43things")] }
+    assert_equal "Invalid plugin name 43things. Please give a name which does not start with numbers.\n", content
   end
 
   def test_camelcase_plugin_name_underscores_filenames


### PR DESCRIPTION
I think that the cause of the problem is difference of concept for underscore and camelize in helpers.rb (actionpack) and plugins_new_generator.rb (railties)

I modified plugins new generator's acceptable characters for constants name. because I prevent this issue.
"-" is not acceptable characters anymore :)

Please see https://github.com/rails/rails/issues/4737.

/cc @josevalim @drogus
