### PR TITLE
Fix plugin_new test failure from c8c84397

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -133,6 +133,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_edge_gemfile_option
+    generator([destination_root], :edge => true).expects(:bundle_command).with('install').once
+    quietly { generator.invoke_all }
+    assert_file 'Gemfile', %r{^\s+gem\s+["']sass-rails["'],\s+:git\s+=>\s+["']#{Regexp.escape("git://github.com/rails/sass-rails.git")}["']$}
+    assert_file 'Gemfile', %r{^\s+gem\s+["']coffee-rails["'],\s+:git\s+=>\s+["']#{Regexp.escape("git://github.com/rails/coffee-rails.git")}["']$}
+  end
+
   def test_config_database_is_added_by_default
     run_generator
     assert_file "config/database.yml", /sqlite3/

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -128,9 +128,6 @@ module SharedGeneratorTests
     assert_file 'Gemfile', %r{^gem\s+["']rails["'],\s+:git\s+=>\s+["']#{Regexp.escape("git://github.com/rails/rails.git")}["']$}
     assert_file 'Gemfile', %r{^gem\s+["']journey["'],\s+:git\s+=>\s+["']#{Regexp.escape("git://github.com/rails/journey.git")}["']$}
     assert_file 'Gemfile', %r{^gem\s+["']arel["'],\s+:git\s+=>\s+["']#{Regexp.escape("git://github.com/rails/arel.git")}["']$}
-    
-    assert_file 'Gemfile', %r{^\s+gem\s+["']sass-rails["'],\s+:git\s+=>\s+["']#{Regexp.escape("git://github.com/rails/sass-rails.git")}["']$}
-    assert_file 'Gemfile', %r{^\s+gem\s+["']coffee-rails["'],\s+:git\s+=>\s+["']#{Regexp.escape("git://github.com/rails/coffee-rails.git")}["']$}
   end
 
   def test_skip_gemfile


### PR DESCRIPTION
`plugin_new` generator doesn't generate `sass-rails` in the Gemfile, so
you can't check for that.
