### PR TITLE
fix has_one, has_many restrict error message

### DIFF
--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -74,7 +74,8 @@ module ActiveRecord::Associations::Builder
             if dependent_restrict_raises?
               raise ActiveRecord::DeleteRestrictionError.new(name)
             else
-              errors.add(:base, :restrict_dependent_destroy, :model => name.to_s.singularize)
+              key  = association(name).reflection.macro == :has_one ? "one" : "many"
+              errors.add(:base, :"restrict_dependent_destroy.#{key}", :record => name)
               return false
             end
           end

--- a/activerecord/lib/active_record/locale/en.yml
+++ b/activerecord/lib/active_record/locale/en.yml
@@ -10,7 +10,9 @@ en:
       messages:
         taken: "has already been taken"
         record_invalid: "Validation failed: %{errors}"
-        restrict_dependent_destroy: "Cannot delete record because dependent %{model} exists"
+        restrict_dependent_destroy:
+          one: "Cannot delete record because a dependent %{record} exists"
+          many: "Cannot delete record because dependent %{record} exist"
         # Append your own errors here or at the model/attributes scope.
 
       # You can define own errors for models or model attributes.

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1171,7 +1171,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert !firm.errors.empty?
 
-    assert_equal "Cannot delete record because dependent company exists", firm.errors[:base].first
+    assert_equal "Cannot delete record because dependent companies exist", firm.errors[:base].first
     assert RestrictedFirm.exists?(:name => 'restrict')
     assert firm.companies.exists?(:name => 'child')
   ensure

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -184,7 +184,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     firm.destroy
 
     assert !firm.errors.empty?
-    assert_equal "Cannot delete record because dependent account exists", firm.errors[:base].first
+    assert_equal "Cannot delete record because a dependent account exists", firm.errors[:base].first
     assert RestrictedFirm.exists?(:name => 'restrict')
     assert firm.account.present?
   ensure


### PR DESCRIPTION
@josevalim as per the comments in

https://github.com/rails/rails/commit/23074c81a5e0b1e08e2e6555053678e8d656f484#commitcomment-922035

I have modified the messages for has_one and has_many :dependent => :restrict method.

Is this good enough or should I only change the model to human name ?
please comment. Thanks. :)
