### PR TITLE
Fixes Tests of pull request 4746

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -394,5 +394,12 @@ module ActiveRecord
     def using_limitable_reflections?(reflections)
       reflections.none? { |r| r.collection? }
     end
+
+    def contains_only_subclass_constraint?(where_values)
+      equalities = where_values.grep(Arel::Nodes::In)
+      equalities.respond_to?('length') && equalities.length == 1 &&
+      !equalities[0].left.nil? && equalities[0].left.relation.name == table_name &&
+      !equalities[0].right.nil? && equalities[0].right.length == 1 && equalities[0].right[0] == @klass.name
+    end
   end
 end

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -397,9 +397,10 @@ module ActiveRecord
     end
     
     def contains_only_subclass_constraint?(where_values)
-      where_values.length == 1 &&
-      !where_values[0].left.nil? && where_values[0].left.relation.name == table_name &&
-      !where_values[0].right.nil? && where_values[0].right.length == 1 && where_values[0].right[0] == @klass.name
+      equalities = where_values.grep(Arel::Nodes::In)
+      equalities.respond_to?('length') && equalities.length == 1 && 
+      !equalities[0].left.nil? && equalities[0].left.relation.name == table_name &&
+      !equalities[0].right.nil? && equalities[0].right.length == 1 && equalities[0].right[0] == @klass.name
     end
   end
 end


### PR DESCRIPTION
@tenderlove

There seems to be a problem how or when identity map stores its records.

With using the identity map the test test_instantiation_doesnt_try_to_require_corresponding_file (inheritance_test.rb) fails because the line

foo = Firm.find(:first).clone

stores foo in the identiy map before the type is set to FirmOnTheFly. So querying for Firm.find hits the identity map cache and returns foo. So I used IdentityMap.without in the test.

One way would be to check the type attribute of the returned record what do you think?
