### PR TITLE
Fix usage of psql in db:test:prepare

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -420,7 +420,7 @@ db_namespace = namespace :db do
         end
       when /postgresql/
         set_psql_env(abcs[env])
-        `psql -f "#{filename}" #{abcs[env]['database']} #{abcs[env]['template']}`
+        `psql -f "#{filename}" #{abcs[env]['database']}`
       when /sqlite/
         dbfile = abcs[env]['database']
         `sqlite3 #{dbfile} < "#{filename}"`


### PR DESCRIPTION
Re-submit of https://github.com/rails/rails/pull/4810

According to http://www.postgresql.org/docs/9.1/static/app-psql.html (which hasn't changed since at least version 7.0), the psql command line tool optionally takes a username as its last argument. However, the rake db:test:prepare task is mistakenly passing in the template database from database.yml.

This bug probably hasn't been discovered until now because it requires users to be using a sql schema dump (by using in application.rb: config.active_record.schema_format = :sql) AND to have specified a template in their database.yml.
