### PR TITLE
Update documentation for register_template_handler

### DIFF
--- a/actionpack/lib/action_view/template/handlers.rb
+++ b/actionpack/lib/action_view/template/handlers.rb
@@ -17,15 +17,12 @@ module ActionView #:nodoc:
         @@template_extensions ||= @@template_handlers.keys
       end
 
-      # Register a class that knows how to handle template files with the given
+      # Register an object that knows how to handle template files with the given
       # extension. This can be used to implement new template types.
-      # The constructor for the class must take the ActiveView::Base instance
-      # as a parameter, and the class must implement a +render+ method that
-      # takes the contents of the template to render as well as the Hash of
-      # local assigns available to the template. The +render+ method ought to
-      # return the rendered template as a string.
-      def register_template_handler(extension, klass)
-        @@template_handlers[extension.to_sym] = klass
+      # The handler must respond to `:call`, which will be passed the template
+      # and should return the rendered template as a String.
+      def register_template_handler(extension, handler)
+        @@template_handlers[extension.to_sym] = handler
       end
 
       def template_handler_extensions


### PR DESCRIPTION
The existing documentation was written in c1304098cca8a9247a9ad1461a1a343354650843, but has become outdated, most notably as of c7408a0e40545558872efb4129fe4bf097c9ce2f.
