### PR TITLE
Possibly clearer way of getting rid of ` and "

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -505,7 +505,7 @@ module ActiveRecord
         execute_and_free("SHOW CREATE TABLE #{quote_table_name(table)}", 'SCHEMA') do |result|
           create_table = each_hash(result).first[:"Create Table"]
           if create_table.to_s =~ /PRIMARY KEY\s+\((.+)\)/
-            keys = $1.split(",").map { |key| key.tr('`"', "") }
+            keys = $1.split(",").map { |key| key.delete('`"') }
             keys.length == 1 ? [keys.first, nil] : nil
           else
             nil

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -505,7 +505,7 @@ module ActiveRecord
         execute_and_free("SHOW CREATE TABLE #{quote_table_name(table)}", 'SCHEMA') do |result|
           create_table = each_hash(result).first[:"Create Table"]
           if create_table.to_s =~ /PRIMARY KEY\s+\((.+)\)/
-            keys = $1.split(",").map { |key| key.gsub(/[`"]/, "") }
+            keys = $1.split(",").map { |key| key.tr('`"', "") }
             keys.length == 1 ? [keys.first, nil] : nil
           else
             nil


### PR DESCRIPTION
hi,

You may find String#tr clearer than String#gsub in this case (YMMV)

Incidentally it's also faster...
    >> a = 'hello "id`world'; Benchmark.realtime { 500_000.times { a.tr('`"', "") } }
    => 0.7388770580291748 
    >> a = 'hello "id`world'; Benchmark.realtime { 500_000.times { a.gsub(/[`"]/, "") } }
    => 1.7843739986419678 

Best,
Seamus
