### PR TITLE
Fix for query bind nil bug

### DIFF
--- a/activerecord/lib/active_record/explain.rb
+++ b/activerecord/lib/active_record/explain.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/class/attribute'
+require 'active_support/core_ext/object/blank'
 
 module ActiveRecord
   module Explain
@@ -58,7 +59,7 @@ module ActiveRecord
       queries && queries.map do |sql, bind|
         [].tap do |msg|
           msg << "EXPLAIN for: #{sql}"
-          unless bind.empty?
+          unless bind.blank?
             bind_msg = bind.map {|col, val| [col.name, val]}.inspect
             msg.last << " #{bind_msg}"
           end

--- a/activerecord/test/cases/explain_test.rb
+++ b/activerecord/test/cases/explain_test.rb
@@ -68,7 +68,7 @@ if ActiveRecord::Base.connection.supports_explain?
 
     def test_exec_explain_with_no_binds
       sqls    = %w(foo bar)
-      binds   = [[], []]
+      binds   = [[], nil]
       queries = sqls.zip(binds)
 
       connection.stubs(:explain).returns('query plan foo', 'query plan bar')


### PR DESCRIPTION
In cases where the query bind is `nil`, `exec_explain` raises the following error:

```
NoMethodError: undefined method `empty?' for nil:NilClass
```

This patch changes `unless bind.empty?` to `unless bind.blank?` and adds a test case for a `nil` bind.
