### PR TITLE
Replicate :form html5 attribute to hidden field for check_box

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   check_box with `:form` html5 attribute will now replicate the `:form`
+    attribute to the hidden field as well. *Carlos Antonio da Silva*
+
 *   `label` form helper accepts :for => nil to not generate the attribute. *Carlos Antonio da Silva*
 
 *   Add `:format` option to number_to_percentage *Rodrigo Flores*

--- a/actionpack/lib/action_view/helpers/tags/check_box.rb
+++ b/actionpack/lib/action_view/helpers/tags/check_box.rb
@@ -25,7 +25,7 @@ module ActionView
             add_default_name_and_id(options)
           end
 
-          hidden = @unchecked_value ? tag("input", "name" => options["name"], "type" => "hidden", "value" => @unchecked_value, "disabled" => options["disabled"]) : "".html_safe
+          hidden   = hidden_field_for_checkbox(options)
           checkbox = tag("input", options)
           hidden + checkbox
         end
@@ -47,6 +47,10 @@ module ActionView
           else
             value.to_i != 0
           end
+        end
+
+        def hidden_field_for_checkbox(options)
+          @unchecked_value ? tag("input", options.slice("name", "disabled", "form").merge!("type" => "hidden", "value" => @unchecked_value)) : "".html_safe
         end
       end
     end

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -421,6 +421,13 @@ class FormHelperTest < ActionView::TestCase
     )
   end
 
+  def test_checkbox_form_html5_attribute
+    assert_dom_equal(
+      '<input form="new_form" name="post[secret]" type="hidden" value="0" /><input checked="checked" form="new_form" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      check_box("post", "secret", :form => "new_form")
+    )
+  end
+
   def test_radio_button
     assert_dom_equal('<input checked="checked" id="post_title_hello_world" name="post[title]" type="radio" value="Hello World" />',
       radio_button("post", "title", "Hello World")
@@ -2168,8 +2175,8 @@ class FormHelperTest < ActionView::TestCase
   end
 
   protected
-    def protect_against_forgery?
-      false
-    end
 
+  def protect_against_forgery?
+    false
+  end
 end


### PR DESCRIPTION
When the new html5 attribute :form is given to the check_box helper, it should be replicated to the hidden field as well. 

Closes #4848
