### PR TITLE
Allow store to be a not null column.

### DIFF
--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -36,11 +36,13 @@ module ActiveRecord
       def store_accessor(store_attribute, *keys)
         Array(keys).flatten.each do |key|
           define_method("#{key}=") do |value|
+            send("#{store_attribute}=", {}) unless send(store_attribute).is_a?(Hash)
             send(store_attribute)[key] = value
             send("#{store_attribute}_will_change!")
           end
     
           define_method(key) do
+            send("#{store_attribute}=", {}) unless send(store_attribute).is_a?(Hash)
             send(store_attribute)[key]
           end
         end

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -4,14 +4,14 @@ require 'models/admin/user'
 
 class StoreTest < ActiveRecord::TestCase
   setup do
-    @john = Admin::User.create(:name => 'John Doe', :color => 'black')
+    @john = Admin::User.create(:name => 'John Doe', :color => 'black', :remember_login => true)
   end
 
   test "reading store attributes through accessors" do
     assert_equal 'black', @john.color
     assert_nil @john.homepage
   end
-
+  
   test "writing store attributes through accessors" do
     @john.color = 'red'
     @john.homepage = '37signals.com'
@@ -30,5 +30,14 @@ class StoreTest < ActiveRecord::TestCase
   test "updating the store will mark it as changed" do
     @john.color = 'red'
     assert @john.settings_changed?
+  end
+
+  test "object initialization with not nullable column" do
+    assert_equal true, @john.remember_login
+  end
+
+  test "writing with not nullable column" do
+    @john.remember_login = false
+    assert_equal false, @john.remember_login
   end
 end

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -1,4 +1,5 @@
 class Admin::User < ActiveRecord::Base
   belongs_to :account
   store :settings, :accessors => [ :color, :homepage ]
+  store :preferences, :accessors => [ :remember_login ]
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -37,7 +37,8 @@ ActiveRecord::Schema.define do
 
   create_table :admin_users, :force => true do |t|
     t.string :name
-    t.text :settings
+    t.text :settings, :null => true
+    t.text :preferences, :null => false, :default => ""
     t.references :account
   end
 


### PR DESCRIPTION
Pull request to fix issue #4840 (cc @tenderlove)

I don't really like the fact it's checking the variable every time the column is accessed, but unless we want to play around with the initialisation of the variable, it seems to be the most robust way.
