### PR TITLE
Add convenience method to hide a generator from the available ones

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add convenience `hide!` method to Rails generators to hide current generator
+    namespace from showing when running `rails generate`. *Carlos Antonio da Silva*
+
 *   Scaffold now uses `content_tag_for` in index.html.erb *José Valim*
 
 *   Rails::Plugin has gone. Instead of adding plugins to vendor/plugins use gems or bundler with path or git dependencies. *Santiago Pastorino*

--- a/railties/lib/rails/generators/base.rb
+++ b/railties/lib/rails/generators/base.rb
@@ -48,6 +48,12 @@ module Rails
         @namespace ||= super.sub(/_generator$/, '').sub(/:generators:/, ':')
       end
 
+      # Convenience method to hide this generator from the available ones when
+      # running rails generator command.
+      def self.hide!
+        Rails::Generators.hide_namespace self.namespace
+      end
+
       # Invoke a generator based on the value supplied by the user to the
       # given option named "name". A class option is created when this method
       # is invoked and you can set a hash to customize it.

--- a/railties/test/generators/named_base_test.rb
+++ b/railties/test/generators/named_base_test.rb
@@ -108,6 +108,15 @@ class NamedBaseTest < Rails::Generators::TestCase
     assert_name g, 'sheep_index', :index_helper
   end
 
+  def test_hide_namespace
+    g = generator ['Hidden']
+    g.class.stubs(:namespace).returns('hidden')
+
+    assert !Rails::Generators.hidden_namespaces.include?('hidden')
+    g.class.hide!
+    assert Rails::Generators.hidden_namespaces.include?('hidden')
+  end
+
   protected
 
     def assert_name(generator, value, method)

--- a/railties/test/generators_test.rb
+++ b/railties/test/generators_test.rb
@@ -201,10 +201,16 @@ class GeneratorsTest < Rails::Generators::TestCase
     mspec = Rails::Generators.find_by_namespace :fixjour
     assert mspec.source_paths.include?(File.join(Rails.root, "lib", "templates", "fixjour"))
   end
-  
+
   def test_usage_with_embedded_ruby
     require File.expand_path("fixtures/lib/generators/usage_template/usage_template_generator", File.dirname(__FILE__))
     output = capture(:stdout) { Rails::Generators.invoke :usage_template, ['--help'] }
     assert_match /:: 2 ::/, output
+  end
+
+  def test_hide_namespace
+    assert !Rails::Generators.hidden_namespaces.include?("special:namespace")
+    Rails::Generators.hide_namespace("special:namespace")
+    assert Rails::Generators.hidden_namespaces.include?("special:namespace")
   end
 end


### PR DESCRIPTION
It is usually useful to be able to hide a generator when running `rails generate` command. Such generators might be used only to dry up generators code and shouldn't be available to end users.
