### PR TITLE
AC::Callbacks: remove usage of :per_key option from filters

### DIFF
--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -21,11 +21,9 @@ module AbstractController
 
     module ClassMethods
       # If :only or :except are used, convert the options into the
-      # primitive form (:per_key) used by ActiveSupport::Callbacks.
+      # :unless and :if options of ActiveSupport::Callbacks.
       # The basic idea is that :only => :index gets converted to
-      # :if => proc {|c| c.action_name == "index" }, but that the
-      # proc is only evaluated once per action for the lifetime of
-      # a Rails process.
+      # :if => proc {|c| c.action_name == "index" }.
       #
       # ==== Options
       # * <tt>only</tt>   - The callback should be run only for this action
@@ -33,11 +31,11 @@ module AbstractController
       def _normalize_callback_options(options)
         if only = options[:only]
           only = Array(only).map {|o| "action_name == '#{o}'"}.join(" || ")
-          options[:per_key] = {:if => only}
+          options[:if] = Array(options[:if]) << only
         end
         if except = options[:except]
           except = Array(except).map {|e| "action_name == '#{e}'"}.join(" || ")
-          options[:per_key] = {:unless => except}
+          options[:unless] = Array(options[:unless]) << except
         end
       end
 

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -136,8 +136,8 @@ module ActiveSupport
       end
 
       def _update_filter(filter_options, new_options)
-        filter_options[:if].push(new_options[:unless]) if new_options.key?(:unless)
-        filter_options[:unless].push(new_options[:if]) if new_options.key?(:if)
+        filter_options[:if].concat(Array(new_options[:unless])) if new_options.key?(:unless)
+        filter_options[:unless].concat(Array(new_options[:if])) if new_options.key?(:if)
       end
 
       def recompile!(_options, _per_key)


### PR DESCRIPTION
This commit removes the only one usage of `:per_key` option as it currently doesn't make sense. See #4493.

So, it's not used by Rails anymore.
Now we can deprecate and just remove it. This will safe additional performance and reduce lines of code.
I would say that we can remove it bypassing deprecation, because:
- I can't believe somebody is using it outside of rails 
- There is a clean way how it can be reworked with general `:unless` and `:if` option
- Next release will be major

What do you think guys?
