### PR TITLE
AS::Callbacks#define_callbacks: add :terminate_after_callbacks option

### DIFF
--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -8,7 +8,7 @@ module AbstractController
     include ActiveSupport::Callbacks
 
     included do
-      define_callbacks :process_action, :terminator => "response_body"
+      define_callbacks :process_action, :terminator => "response_body", :skip_after_callbacks_if_terminated => true
     end
 
     # Override AbstractController::Base's process_action to run the
@@ -167,7 +167,6 @@ module AbstractController
           # for details on the allowed parameters.
           def #{filter}_filter(*names, &blk)                                                 # def before_filter(*names, &blk)
             _insert_callbacks(names, blk) do |name, options|                                 #   _insert_callbacks(names, blk) do |name, options|
-              options[:if] = (Array(options[:if]) << "!halted") if #{filter == :after}       #     options[:if] = (Array(options[:if]) << "!halted") if false
               set_callback(:process_action, :#{filter}, name, options)                       #     set_callback(:process_action, :before, name, options)
             end                                                                              #   end
           end                                                                                # end
@@ -176,7 +175,6 @@ module AbstractController
           # for details on the allowed parameters.
           def prepend_#{filter}_filter(*names, &blk)                                            # def prepend_before_filter(*names, &blk)
             _insert_callbacks(names, blk) do |name, options|                                    #   _insert_callbacks(names, blk) do |name, options|
-              options[:if] = (Array(options[:if]) << "!halted") if #{filter == :after}          #     options[:if] = (Array(options[:if]) << "!halted") if false
               set_callback(:process_action, :#{filter}, name, options.merge(:prepend => true))  #     set_callback(:process_action, :before, name, options.merge(:prepend => true))
             end                                                                                 #   end
           end                                                                                   # end

--- a/activemodel/lib/active_model/callbacks.rb
+++ b/activemodel/lib/active_model/callbacks.rb
@@ -88,6 +88,7 @@ module ActiveModel
       options = callbacks.extract_options!
       options = {
          :terminator => "result == false",
+         :skip_after_callbacks_if_terminated => true,
          :scope => [:kind, :name],
          :only => [:before, :around, :after]
       }.merge(options)
@@ -124,7 +125,7 @@ module ActiveModel
         def self.after_#{callback}(*args, &block)
           options = args.extract_options!
           options[:prepend] = true
-          options[:if] = Array(options[:if]) << "!halted && value != false"
+          options[:if] = Array(options[:if]) << "value != false"
           set_callback(:#{callback}, :after, *(args << options), &block)
         end
       CALLBACK

--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -23,7 +23,7 @@ module ActiveModel
 
       included do
         include ActiveSupport::Callbacks
-        define_callbacks :validation, :terminator => "result == false", :scope => [:kind, :name]
+        define_callbacks :validation, :terminator => "result == false", :skip_after_callbacks_if_terminated => true, :scope => [:kind, :name]
       end
 
       module ClassMethods
@@ -40,7 +40,6 @@ module ActiveModel
           options = args.extract_options!
           options[:prepend] = true
           options[:if] = Array(options[:if])
-          options[:if] << "!halted"
           options[:if].unshift("self.validation_context == :#{options[:on]}") if options[:on]
           set_callback(:validation, :after, *(args << options), &block)
         end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*    `AS::Callbacks#define_callbacks`: add `:skip_after_callbacks_if_terminated` option.
+
 *    Add html_escape_once to ERB::Util, and delegate escape_once tag helper to it. *Carlos Antonio da Silva*
 
 *    Remove ActiveSupport::TestCase#pending method, use `skip` instead. *Carlos Antonio da Silva*

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -169,7 +169,7 @@ module ActiveSupport
         when :after
           <<-RUBY_EVAL
           #{code}
-          if #{@compiled_options}
+          if #{!chain.config[:skip_after_callbacks_if_terminated] || "!halted"} && #{@compiled_options}
             #{@filter}
           end
           RUBY_EVAL
@@ -527,6 +527,11 @@ module ActiveSupport
       #   In this example, if any before validate callbacks returns +false+,
       #   other callbacks are not executed. Defaults to "false", meaning no value
       #   halts the chain.
+      #
+      # * <tt>:skip_after_callbacks_if_terminated</tt> - Determines if after callbacks should be terminated
+      #   by the <tt>:terminator</tt> option. By default after callbacks executed no matter
+      #   if callback chain was terminated or not.
+      #   Option makes sence only when <tt>:terminator</tt> option is specified.
       #
       # * <tt>:rescuable</tt> - By default, after filters are not executed if
       #   the given block or a before filter raises an error. By setting this option


### PR DESCRIPTION
This commit remove a hacky usage of Callbacks when `"!halted"` is passed as to `:if` for after callbacks.
`halted` is an internal local variable and it should not be used from outside.

This commits adds `:terminate_after_callbacks` option instead:

```
# * <tt>:terminate_after_callbacks</tt> - Determines if after callbacks should be terminated
#   by the <tt>:terminator</tt> option. By default after callbacks executed no matter
#   if callback chain was terminated or not.
#   Option makes sence only when <tt>:terminator</tt> option is specified.
#
```
