### PR TITLE
Fix Issue #4819

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -426,7 +426,7 @@ module ActiveRecord
           si_table = Base.table_name_prefix + 'schema_info' + Base.table_name_suffix
 
           if table_exists?(si_table)
-            ActiveRecord::Deprecation.warn "Usage of the schema table `#{si_table}` is deprecated. Please switch to using `schema_migrations` table"
+            ActiveSupport::Deprecation.warn "Usage of the schema table `#{si_table}` is deprecated. Please switch to using `schema_migrations` table"
 
             old_version = select_value("SELECT version FROM #{quote_table_name(si_table)}").to_i
             assume_migrated_upto_version(old_version)


### PR DESCRIPTION
'uninitialized constant ActiveRecord::Deprecation in Rails3.2.1'

Just a typo of 'ActiveSupport::...'
