### PR TITLE
Ensure ActiveResource serialization obeys ActiveResource::Base.include_root_in_json

### DIFF
--- a/activeresource/lib/active_resource/base.rb
+++ b/activeresource/lib/active_resource/base.rb
@@ -1337,7 +1337,9 @@ module ActiveResource
     end
 
     def to_json(options={})
-      super({ :root => self.class.element_name }.merge(options))
+      options = { :root => self.class.element_name }.merge(options) if self.class.include_root_in_json
+
+      super(options)
     end
 
     def to_xml(options={})

--- a/activeresource/test/cases/base_test.rb
+++ b/activeresource/test/cases/base_test.rb
@@ -1032,6 +1032,22 @@ class BaseTest < Test::Unit::TestCase
     assert_match %r{\}\}$}, json
   end
 
+  def test_to_json_without_root
+    Person.include_root_in_json = false
+    joe = Person.find(6)
+    encode = joe.encode
+    json = joe.to_json
+
+    assert_equal encode, json
+    assert_no_match %r{^\{"person":\{}, json
+    assert_match %r{"id":6}, json
+    assert_match %r{"name":"Joe"}, json
+    assert_no_match %r{\}\}$}, json
+    assert_match %r{\}$}, json
+  ensure
+    Person.include_root_in_json = true
+  end
+
   def test_to_json_with_element_name
     old_elem_name = Person.element_name
     Person.include_root_in_json = true


### PR DESCRIPTION
The root element in JSON serialization in Rails 3.2.1 is always present, regardless of the setting of `ActiveResource::Base.include_root_in_json`. This fix makes `ActiveResource::Base#to_json` obey the setting, and includes a test to make sure the setting works.
