### PR TITLE
Add *_url helpers to get the full assets URL

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Adds `image_url`, `javascript_url`, `stylesheet_url`, `audio_url`, `video_url`, and `font_url`
+    to assets tag helper. These URL helpers will return the full path to your assets. This is useful
+    when you are going to reference this asset from external host. *Prem Sichanugrist*
+
 *   Default responder will now always use your overridden block in `respond_with` to render your response. *Prem Sichanugrist*
 
 *   Allow `value_method` and `text_method` arguments from `collection_select` and

--- a/actionpack/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helper.rb
@@ -278,6 +278,13 @@ module ActionView
       end
       alias_method :path_to_image, :image_path # aliased to avoid conflicts with an image_path named route
 
+      # Computes the full URL to an image asset in the public images directory.
+      # This will use +image_path+ internally, so most of their behaviors will be the same.
+      def image_url(source)
+        URI.join(current_host, path_to_image(source)).to_s
+      end
+      alias_method :url_to_image, :image_url # aliased to avoid conflicts with an image_url named route
+
       # Computes the path to a video asset in the public videos directory.
       # Full paths from the document root will be passed through.
       # Used internally by +video_tag+ to build the video path.
@@ -292,6 +299,13 @@ module ActionView
         asset_paths.compute_public_path(source, 'videos')
       end
       alias_method :path_to_video, :video_path # aliased to avoid conflicts with a video_path named route
+
+      # Computes the full URL to a video asset in the public videos directory.
+      # This will use +video_path+ internally, so most of their behaviors will be the same.
+      def video_url(source)
+        URI.join(current_host, path_to_video(source)).to_s
+      end
+      alias_method :url_to_video, :video_url # aliased to avoid conflicts with an video_url named route
 
       # Computes the path to an audio asset in the public audios directory.
       # Full paths from the document root will be passed through.
@@ -308,6 +322,13 @@ module ActionView
       end
       alias_method :path_to_audio, :audio_path # aliased to avoid conflicts with an audio_path named route
 
+      # Computes the full URL to a audio asset in the public audios directory.
+      # This will use +audio_path+ internally, so most of their behaviors will be the same.
+      def audio_url(source)
+        URI.join(current_host, path_to_audio(source)).to_s
+      end
+      alias_method :url_to_audio, :audio_url # aliased to avoid conflicts with an audio_url named route
+
       # Computes the path to a font asset in the public fonts directory.
       # Full paths from the document root will be passed through.
       #
@@ -321,6 +342,13 @@ module ActionView
         asset_paths.compute_public_path(source, 'fonts')
       end
       alias_method :path_to_font, :font_path # aliased to avoid conflicts with an font_path named route
+
+      # Computes the full URL to a font asset in the public fonts directory.
+      # This will use +font_path+ internally, so most of their behaviors will be the same.
+      def font_url(source)
+        URI.join(current_host, path_to_font(source)).to_s
+      end
+      alias_method :url_to_font, :font_url # aliased to avoid conflicts with an font_url named route
 
       # Returns an html image tag for the +source+. The +source+ can be a full
       # path or a file that exists in your public images directory.
@@ -462,6 +490,10 @@ module ActionView
             options[:src] = send("path_to_#{type}", sources.first)
             tag(type, options)
           end
+        end
+
+        def current_host
+          url_for(:only_path => false)
         end
     end
   end

--- a/actionpack/lib/action_view/helpers/asset_tag_helpers/javascript_tag_helpers.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helpers/javascript_tag_helpers.rb
@@ -87,6 +87,13 @@ module ActionView
         end
         alias_method :path_to_javascript, :javascript_path # aliased to avoid conflicts with a javascript_path named route
 
+        # Computes the full URL to a javascript asset in the public javascripts directory.
+        # This will use +javascript_path+ internally, so most of their behaviors will be the same.
+        def javascript_url(source)
+          URI.join(current_host, path_to_javascript(source)).to_s
+        end
+        alias_method :url_to_javascript, :javascript_url # aliased to avoid conflicts with a javascript_url named route
+
         # Returns an HTML script tag for each of the +sources+ provided.
         #
         # Sources may be paths to JavaScript files. Relative paths are assumed to be relative

--- a/actionpack/lib/action_view/helpers/asset_tag_helpers/stylesheet_tag_helpers.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helpers/stylesheet_tag_helpers.rb
@@ -65,6 +65,13 @@ module ActionView
         end
         alias_method :path_to_stylesheet, :stylesheet_path # aliased to avoid conflicts with a stylesheet_path named route
 
+        # Computes the full URL to a stylesheet asset in the public stylesheets directory.
+        # This will use +stylesheet_path+ internally, so most of their behaviors will be the same.
+        def stylesheet_url(source)
+          URI.join(current_host, path_to_stylesheet(source)).to_s
+        end
+        alias_method :url_to_stylesheet, :stylesheet_url # aliased to avoid conflicts with a stylesheet_url named route
+
         # Returns a stylesheet link tag for the sources specified as arguments. If
         # you don't specify an extension, <tt>.css</tt> will be appended automatically.
         # You can modify the link attributes by passing a hash as the last argument.

--- a/actionpack/test/template/asset_tag_helper_test.rb
+++ b/actionpack/test/template/asset_tag_helper_test.rb
@@ -88,6 +88,18 @@ class AssetTagHelperTest < ActionView::TestCase
     %(path_to_javascript("/super/xmlhr.js")) => %(/super/xmlhr.js)
   }
 
+  JavascriptUrlToTag = {
+    %(javascript_url("xmlhr")) => %(http://www.example.com/javascripts/xmlhr.js),
+    %(javascript_url("super/xmlhr")) => %(http://www.example.com/javascripts/super/xmlhr.js),
+    %(javascript_url("/super/xmlhr.js")) => %(http://www.example.com/super/xmlhr.js)
+  }
+
+  UrlToJavascriptToTag = {
+    %(url_to_javascript("xmlhr")) => %(http://www.example.com/javascripts/xmlhr.js),
+    %(url_to_javascript("super/xmlhr")) => %(http://www.example.com/javascripts/super/xmlhr.js),
+    %(url_to_javascript("/super/xmlhr.js")) => %(http://www.example.com/super/xmlhr.js)
+  }
+
   JavascriptIncludeToTag = {
     %(javascript_include_tag("bank")) => %(<script src="/javascripts/bank.js" type="text/javascript"></script>),
     %(javascript_include_tag("bank.js")) => %(<script src="/javascripts/bank.js" type="text/javascript"></script>),
@@ -119,6 +131,20 @@ class AssetTagHelperTest < ActionView::TestCase
     %(path_to_stylesheet('/dir/file.rcss')) => %(/dir/file.rcss)
   }
 
+  StyleUrlToTag = {
+    %(stylesheet_url("bank")) => %(http://www.example.com/stylesheets/bank.css),
+    %(stylesheet_url("bank.css")) => %(http://www.example.com/stylesheets/bank.css),
+    %(stylesheet_url('subdir/subdir')) => %(http://www.example.com/stylesheets/subdir/subdir.css),
+    %(stylesheet_url('/subdir/subdir.css')) => %(http://www.example.com/subdir/subdir.css)
+  }
+
+  UrlToStyleToTag = {
+    %(url_to_stylesheet("style")) => %(http://www.example.com/stylesheets/style.css),
+    %(url_to_stylesheet("style.css")) => %(http://www.example.com/stylesheets/style.css),
+    %(url_to_stylesheet('dir/file')) => %(http://www.example.com/stylesheets/dir/file.css),
+    %(url_to_stylesheet('/dir/file.rcss')) => %(http://www.example.com/dir/file.rcss)
+  }
+
   StyleLinkToTag = {
     %(stylesheet_link_tag("bank")) => %(<link href="/stylesheets/bank.css" media="screen" rel="stylesheet" type="text/css" />),
     %(stylesheet_link_tag("bank.css")) => %(<link href="/stylesheets/bank.css" media="screen" rel="stylesheet" type="text/css" />),
@@ -147,6 +173,20 @@ class AssetTagHelperTest < ActionView::TestCase
     %(path_to_image("xml.png"))      => %(/images/xml.png),
     %(path_to_image("dir/xml.png"))  => %(/images/dir/xml.png),
     %(path_to_image("/dir/xml.png")) => %(/dir/xml.png)
+  }
+
+  ImageUrlToTag = {
+    %(image_url("xml"))          => %(http://www.example.com/images/xml),
+    %(image_url("xml.png"))      => %(http://www.example.com/images/xml.png),
+    %(image_url("dir/xml.png"))  => %(http://www.example.com/images/dir/xml.png),
+    %(image_url("/dir/xml.png")) => %(http://www.example.com/dir/xml.png)
+  }
+
+  UrlToImageToTag = {
+    %(url_to_image("xml"))          => %(http://www.example.com/images/xml),
+    %(url_to_image("xml.png"))      => %(http://www.example.com/images/xml.png),
+    %(url_to_image("dir/xml.png"))  => %(http://www.example.com/images/dir/xml.png),
+    %(url_to_image("/dir/xml.png")) => %(http://www.example.com/dir/xml.png)
   }
 
   ImageLinkToTag = {
@@ -189,6 +229,20 @@ class AssetTagHelperTest < ActionView::TestCase
     %(path_to_video("/dir/xml.ogg")) => %(/dir/xml.ogg)
   }
 
+  VideoUrlToTag = {
+    %(video_url("xml"))          => %(http://www.example.com/videos/xml),
+    %(video_url("xml.ogg"))      => %(http://www.example.com/videos/xml.ogg),
+    %(video_url("dir/xml.ogg"))  => %(http://www.example.com/videos/dir/xml.ogg),
+    %(video_url("/dir/xml.ogg")) => %(http://www.example.com/dir/xml.ogg)
+  }
+
+  UrlToVideoToTag = {
+    %(url_to_video("xml"))          => %(http://www.example.com/videos/xml),
+    %(url_to_video("xml.ogg"))      => %(http://www.example.com/videos/xml.ogg),
+    %(url_to_video("dir/xml.ogg"))  => %(http://www.example.com/videos/dir/xml.ogg),
+    %(url_to_video("/dir/xml.ogg")) => %(http://www.example.com/dir/xml.ogg)
+  }
+
   VideoLinkToTag = {
     %(video_tag("xml.ogg")) => %(<video src="/videos/xml.ogg" />),
     %(video_tag("rss.m4v", :autoplay => true, :controls => true)) => %(<video autoplay="autoplay" controls="controls" src="/videos/rss.m4v" />),
@@ -206,7 +260,7 @@ class AssetTagHelperTest < ActionView::TestCase
     %(video_tag(["multiple.ogg", "multiple.avi"], :size => "160x120", :controls => true)) => %(<video controls="controls" height="120" width="160"><source src="/videos/multiple.ogg" /><source src="/videos/multiple.avi" /></video>)
   }
 
- AudioPathToTag = {
+  AudioPathToTag = {
     %(audio_path("xml"))          => %(/audios/xml),
     %(audio_path("xml.wav"))      => %(/audios/xml.wav),
     %(audio_path("dir/xml.wav"))  => %(/audios/dir/xml.wav),
@@ -218,6 +272,20 @@ class AssetTagHelperTest < ActionView::TestCase
     %(path_to_audio("xml.wav"))      => %(/audios/xml.wav),
     %(path_to_audio("dir/xml.wav"))  => %(/audios/dir/xml.wav),
     %(path_to_audio("/dir/xml.wav")) => %(/dir/xml.wav)
+  }
+
+  AudioUrlToTag = {
+    %(audio_url("xml"))          => %(http://www.example.com/audios/xml),
+    %(audio_url("xml.wav"))      => %(http://www.example.com/audios/xml.wav),
+    %(audio_url("dir/xml.wav"))  => %(http://www.example.com/audios/dir/xml.wav),
+    %(audio_url("/dir/xml.wav")) => %(http://www.example.com/dir/xml.wav)
+  }
+
+  UrlToAudioToTag = {
+    %(url_to_audio("xml"))          => %(http://www.example.com/audios/xml),
+    %(url_to_audio("xml.wav"))      => %(http://www.example.com/audios/xml.wav),
+    %(url_to_audio("dir/xml.wav"))  => %(http://www.example.com/audios/dir/xml.wav),
+    %(url_to_audio("/dir/xml.wav")) => %(http://www.example.com/dir/xml.wav)
   }
 
   AudioLinkToTag = {
@@ -240,6 +308,14 @@ class AssetTagHelperTest < ActionView::TestCase
 
   def test_path_to_javascript_alias_for_javascript_path
     PathToJavascriptToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
+  end
+
+  def test_javascript_url
+    JavascriptUrlToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
+  end
+
+  def test_url_to_javascript_alias_for_javascript_url
+    UrlToJavascriptToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
   end
 
   def test_javascript_include_tag_with_blank_asset_id
@@ -349,6 +425,15 @@ class AssetTagHelperTest < ActionView::TestCase
     PathToStyleToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
   end
 
+  def test_stylesheet_url
+    ENV["RAILS_ASSET_ID"] = ""
+    StyleUrlToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
+  end
+
+  def test_url_to_stylesheet_alias_for_stylesheet_url
+    UrlToStyleToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
+  end
+
   def test_stylesheet_link_tag
     ENV["RAILS_ASSET_ID"] = ""
     StyleLinkToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
@@ -433,6 +518,14 @@ class AssetTagHelperTest < ActionView::TestCase
     PathToImageToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
   end
 
+  def test_image_url
+    ImageUrlToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
+  end
+
+  def test_url_to_image_alias_for_image_url
+    UrlToImageToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
+  end
+
   def test_image_alt
     [nil, '/', '/foo/bar/', 'foo/bar/'].each do |prefix|
       assert_equal 'Rails', image_alt("#{prefix}rails.png")
@@ -478,6 +571,14 @@ class AssetTagHelperTest < ActionView::TestCase
     PathToVideoToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
   end
 
+  def test_video_url
+    VideoUrlToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
+  end
+
+  def test_url_to_video_alias_for_video_url
+    UrlToVideoToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
+  end
+
   def test_video_tag
     VideoLinkToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
   end
@@ -488,6 +589,14 @@ class AssetTagHelperTest < ActionView::TestCase
 
   def test_path_to_audio_alias_for_audio_path
     PathToAudioToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
+  end
+
+  def test_audio_url
+    AudioUrlToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
+  end
+
+  def test_url_to_audio_alias_for_audio_url
+    UrlToAudioToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
   end
 
   def test_audio_tag
@@ -572,7 +681,6 @@ class AssetTagHelperTest < ActionView::TestCase
         "#{request.protocol}assets#{source.length}.example.com"
       end
     end
-
 
     @controller.request.stubs(:ssl?).returns(false)
     assert_equal "http://assets15.example.com/images/xml.png", image_path("xml.png")
@@ -1141,6 +1249,22 @@ class AssetTagHelperNonVhostTest < ActionView::TestCase
     assert_dom_equal(%(<img alt="Mouse2" onmouseover="this.src='gopher://assets.example.com/collaboration/hieraki/images/mouse_over2.png'" onmouseout="this.src='gopher://assets.example.com/collaboration/hieraki/images/mouse2.png'" src="gopher://assets.example.com/collaboration/hieraki/images/mouse2.png" />), image_tag("mouse2.png", :mouseover => image_path("mouse_over2.png")))
   end
 
+  def test_should_compute_proper_url_with_asset_host
+    @controller.config.asset_host = "assets.example.com"
+    assert_dom_equal(%(<link href="http://www.example.com/collaboration/hieraki" rel="alternate" title="RSS" type="application/rss+xml" />), auto_discovery_link_tag)
+    assert_dom_equal(%(gopher://assets.example.com/collaboration/hieraki/javascripts/xmlhr.js), javascript_url("xmlhr"))
+    assert_dom_equal(%(gopher://assets.example.com/collaboration/hieraki/stylesheets/style.css), stylesheet_url("style"))
+    assert_dom_equal(%(gopher://assets.example.com/collaboration/hieraki/images/xml.png), image_url("xml.png"))
+  end
+
+  def test_should_compute_proper_url_with_asset_host_and_default_protocol
+    @controller.config.asset_host = "assets.example.com"
+    @controller.config.default_asset_host_protocol = :request
+    assert_dom_equal(%(gopher://assets.example.com/collaboration/hieraki/javascripts/xmlhr.js), javascript_url("xmlhr"))
+    assert_dom_equal(%(gopher://assets.example.com/collaboration/hieraki/stylesheets/style.css), stylesheet_url("style"))
+    assert_dom_equal(%(gopher://assets.example.com/collaboration/hieraki/images/xml.png), image_url("xml.png"))
+  end
+
   def test_should_ignore_asset_host_on_complete_url
     @controller.config.asset_host = "http://assets.example.com"
     assert_dom_equal(%(<link href="http://bar.example.com/stylesheets/style.css" media="screen" rel="stylesheet" type="text/css" />), stylesheet_link_tag("http://bar.example.com/stylesheets/style.css"))
@@ -1154,16 +1278,19 @@ class AssetTagHelperNonVhostTest < ActionView::TestCase
   def test_should_wildcard_asset_host_between_zero_and_four
     @controller.config.asset_host = 'http://a%d.example.com'
     assert_match(%r(http://a[0123].example.com/collaboration/hieraki/images/xml.png), image_path('xml.png'))
+    assert_match(%r(http://a[0123].example.com/collaboration/hieraki/images/xml.png), image_url('xml.png'))
   end
 
   def test_asset_host_without_protocol_should_be_protocol_relative
     @controller.config.asset_host = 'a.example.com'
     assert_equal 'gopher://a.example.com/collaboration/hieraki/images/xml.png', image_path('xml.png')
+    assert_equal 'gopher://a.example.com/collaboration/hieraki/images/xml.png', image_url('xml.png')
   end
 
   def test_asset_host_without_protocol_should_be_protocol_relative_even_if_path_present
     @controller.config.asset_host = 'a.example.com/files/go/here'
     assert_equal 'gopher://a.example.com/files/go/here/collaboration/hieraki/images/xml.png', image_path('xml.png')
+    assert_equal 'gopher://a.example.com/files/go/here/collaboration/hieraki/images/xml.png', image_url('xml.png')
   end
 
   def test_assert_css_and_js_of_the_same_name_return_correct_extension

--- a/railties/guides/source/action_view_overview.textile
+++ b/railties/guides/source/action_view_overview.textile
@@ -585,6 +585,14 @@ Computes the path to an image asset in the +public/images+ directory. Full paths
 image_path("edit.png") # => /images/edit.png
 </ruby>
 
+h5. image_url
+
+Computes the url to an image asset in the +public/images+ directory. This will call +image_path+ internally and merge with your current host or your asset host.
+
+<ruby>
+image_url("edit.png") # => http://www.example.com/images/edit.png
+</ruby>
+
 h5. image_tag
 
 Returns an html image tag for the source. The source can be a full path or a file that exists in your +public/images+ directory.
@@ -629,6 +637,14 @@ Computes the path to a JavaScript asset in the +public/javascripts+ directory. I
 javascript_path "common" # => /javascripts/common.js
 </ruby>
 
+h5. javascript_url
+
+Computes the url to a JavaScript asset in the +public/javascripts+ directory. This will call +javascript_path+ internally and merge with your current host or your asset host.
+
+<ruby>
+javascript_url "common" # => http://www.example.com/javascripts/common.js
+</ruby>
+
 h5. stylesheet_link_tag
 
 Returns a stylesheet link tag for the sources specified as arguments. If you don't specify an extension, +.css+ will be appended automatically.
@@ -657,6 +673,14 @@ Computes the path to a stylesheet asset in the +public/stylesheets+ directory. I
 
 <ruby>
 stylesheet_path "application" # => /stylesheets/application.css
+</ruby>
+
+h5. stylesheet_url
+
+Computes the url to a stylesheet asset in the +public/stylesheets+ directory. This will call +stylesheet_path+ internally and merge with your current host or your asset host.
+
+<ruby>
+stylesheet_url "application" # => http://www.example.com/stylesheets/application.css
 </ruby>
 
 h4. AtomFeedHelper


### PR DESCRIPTION
Adds `image_url`, `javascript_url`, `stylesheet_url`, `audio_url`, `video_url`, and `font_url` to assets tag helper. These URL helpers will return the full path to your assets. This is useful when you are going to reference this asset from external host.
