### PR TITLE
AS::Callbacks: rip out per_key option.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*    AS::Callbacks: `:per_key` option is no longer supported
+
 *    `AS::Callbacks#define_callbacks`: add `:skip_after_callbacks_if_terminated` option.
 
 *    Add html_escape_once to ERB::Util, and delegate escape_once tag helper to it. *Carlos Antonio da Silva*

--- a/activesupport/test/callback_inheritance_test.rb
+++ b/activesupport/test/callback_inheritance_test.rb
@@ -9,8 +9,8 @@ class GrandParent
   end
 
   define_callbacks :dispatch
-  set_callback :dispatch, :before, :before1, :before2, :per_key => {:if => proc {|c| c.action_name == "index" || c.action_name == "update" }}
-  set_callback :dispatch, :after, :after1, :after2, :per_key => {:if => proc {|c| c.action_name == "update" || c.action_name == "delete" }}
+  set_callback :dispatch, :before, :before1, :before2, :if => proc {|c| c.action_name == "index" || c.action_name == "update" }
+  set_callback :dispatch, :after, :after1, :after2, :if => proc {|c| c.action_name == "update" || c.action_name == "delete" }
 
   def before1
     @log << "before1"
@@ -37,12 +37,12 @@ class GrandParent
 end
 
 class Parent < GrandParent
-  skip_callback :dispatch, :before, :before2, :per_key => {:unless => proc {|c| c.action_name == "update" }}
-  skip_callback :dispatch, :after, :after2, :per_key => {:unless => proc {|c| c.action_name == "delete" }}
+  skip_callback :dispatch, :before, :before2, :unless => proc {|c| c.action_name == "update" }
+  skip_callback :dispatch, :after, :after2, :unless => proc {|c| c.action_name == "delete" }
 end
 
 class Child < GrandParent
-  skip_callback :dispatch, :before, :before2, :per_key => {:unless => proc {|c| c.action_name == "update" }}, :if => :state_open?
+  skip_callback :dispatch, :before, :before2, :unless => proc {|c| c.action_name == "update" }, :if => :state_open?
 
   def state_open?
     @state == :open
@@ -112,15 +112,15 @@ class BasicCallbacksTest < ActiveSupport::TestCase
     @unknown  = GrandParent.new("unknown").dispatch
   end
 
-  def test_basic_per_key1
+  def test_basic_conditional_callback1
     assert_equal %w(before1 before2 index), @index.log
   end
 
-  def test_basic_per_key2
+  def test_basic_conditional_callback2
     assert_equal %w(before1 before2 update after2 after1), @update.log
   end
 
-  def test_basic_per_key3
+  def test_basic_conditional_callback3
     assert_equal %w(delete after2 after1), @delete.log
   end
 end

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -95,7 +95,7 @@ module CallbacksTest
 
     define_callbacks :dispatch
 
-    set_callback :dispatch, :before, :log, :per_key => {:unless => proc {|c| c.action_name == :index || c.action_name == :show }}
+    set_callback :dispatch, :before, :log, :unless => proc {|c| c.action_name == :index || c.action_name == :show }
     set_callback :dispatch, :after, :log2
 
     attr_reader :action_name, :logger
@@ -120,7 +120,7 @@ module CallbacksTest
   end
 
   class Child < ParentController
-    skip_callback :dispatch, :before, :log, :per_key => {:if => proc {|c| c.action_name == :update} }
+    skip_callback :dispatch, :before, :log, :if => proc {|c| c.action_name == :update} 
     skip_callback :dispatch, :after, :log2
   end
 
@@ -131,10 +131,10 @@ module CallbacksTest
       super
     end
 
-    before_save Proc.new {|r| r.history << [:before_save, :starts_true, :if] }, :per_key => {:if => :starts_true}
-    before_save Proc.new {|r| r.history << [:before_save, :starts_false, :if] }, :per_key => {:if => :starts_false}
-    before_save Proc.new {|r| r.history << [:before_save, :starts_true, :unless] }, :per_key => {:unless => :starts_true}
-    before_save Proc.new {|r| r.history << [:before_save, :starts_false, :unless] }, :per_key => {:unless => :starts_false}
+    before_save Proc.new {|r| r.history << [:before_save, :starts_true, :if] }, :if => :starts_true
+    before_save Proc.new {|r| r.history << [:before_save, :starts_false, :if] }, :if => :starts_false
+    before_save Proc.new {|r| r.history << [:before_save, :starts_true, :unless] }, :unless => :starts_true
+    before_save Proc.new {|r| r.history << [:before_save, :starts_false, :unless] }, :unless => :starts_false
 
     def starts_true
       if @@starts_true
@@ -329,7 +329,7 @@ module CallbacksTest
     define_callbacks :save
     attr_reader :stuff
 
-    set_callback :save, :before, :action, :per_key => {:if => :yes}
+    set_callback :save, :before, :action, :if => :yes
 
     def yes() true end
 
@@ -698,6 +698,22 @@ module CallbacksTest
       model = ExtendCallbacks.new.extend ExtendModule
       model.save
       assert_equal [1, 2, 3], model.recorder
+    end
+  end
+
+  class PerKeyOptionDeprecationTest < ActiveSupport::TestCase
+
+    def test_per_key_option_deprecaton
+      assert_raise NotImplementedError do
+        Phone.class_eval do
+          set_callback :save, :before, :before_save1, :per_key => {:if => "true"}
+        end
+      end
+      assert_raise NotImplementedError do
+        Phone.class_eval do
+          skip_callback :save, :before, :before_save1, :per_key => {:if => "true"}
+        end
+      end
     end
   end
  


### PR DESCRIPTION
This commit drops the support of `:per_key` option as it's "for perfomance" role is no longer makes sense.

All tests with `:per_key` option was converted into general `:if` and `:unless` to make sure we migrate smoothly.
If someone is using `:per_key` option outside of rails - he will receive this message:

``` ruby
raise NotImplementedError, ":per_key option is no longer supported. Use generic :if and :unless options instead."
```
