### PR TITLE
Fix GH #4873. Allow swapping same class middleware.

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -93,8 +93,9 @@ module ActionDispatch
     end
 
     def swap(target, *args, &block)
-      insert_before(target, *args, &block)
-      delete(target)
+      index = assert_index(target, :before)
+      insert(index, *args, &block)
+      middlewares.delete_at(index + 1)
     end
 
     def delete(target)

--- a/actionpack/test/dispatch/middleware_stack_test.rb
+++ b/actionpack/test/dispatch/middleware_stack_test.rb
@@ -81,6 +81,12 @@ class MiddlewareStackTest < ActiveSupport::TestCase
     assert_equal BazMiddleware, @stack[0].klass
   end
 
+  test "swaps one middleware out for same middleware class" do
+    assert_equal FooMiddleware, @stack[0].klass
+    @stack.swap(FooMiddleware, FooMiddleware, Proc.new { |env| [500, {}, ['error!']] })
+    assert_equal FooMiddleware, @stack[0].klass
+  end
+
   test "raise an error on invalid index" do
     assert_raise RuntimeError do
       @stack.insert("HiyaMiddleware", BazMiddleware)


### PR DESCRIPTION
I don't allow swapping same class middleware in current implementation.

``` ruby
config.middleware.swap ActionDispatch::ShowExceptions,
  ActionDispatch::ShowExceptions,
  lambda { |env| [ 500, {}, ['error!'] ] }
```

Please see https://github.com/rails/rails/issues/4873

This issuei is also existed on 3-2-stable..
