### PR TITLE
added skip_callbacks functionality to ActiveRecord's save, create, destroy, update_attributes methods

### DIFF
--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -205,8 +205,6 @@ module ActiveRecord
   # The entire callback chain of a +save+, <tt>save!</tt>, or +destroy+ call runs
   # within a transaction. That includes <tt>after_*</tt> hooks. If everything
   # goes fine a COMMIT is executed once the chain has been completed.
-  #
-  # If a <tt>before_*</tt> callback cancels the action a ROLLBACK is issued. You
   # can also trigger a ROLLBACK raising an exception in any of the callbacks,
   # including <tt>after_*</tt> hooks. Note, however, that in that case the client
   # needs to be aware of it because an ordinary +save+ will raise such exception
@@ -276,7 +274,7 @@ module ActiveRecord
     end
 
     def destroy #:nodoc:
-      run_callbacks(:destroy) { super }
+      skip_callbacks? ? super : run_callbacks(:destroy) { super }
     end
 
     def touch(*) #:nodoc:
@@ -286,15 +284,19 @@ module ActiveRecord
   private
 
     def create_or_update #:nodoc:
-      run_callbacks(:save) { super }
+      skip_callbacks? ? super : run_callbacks(:save) { super }
     end
 
     def create #:nodoc:
-      run_callbacks(:create) { super }
+      skip_callbacks? ? super : run_callbacks(:create) { super }
     end
 
     def update(*) #:nodoc:
-      run_callbacks(:update) { super }
+      skip_callbacks? ? super : run_callbacks(:update) { super }
+    end
+
+    def skip_callbacks?
+      self.send(:_skip_callbacks?)
     end
   end
 end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -42,10 +42,51 @@ module ActiveRecord
           attributes.collect { |attr| create(attr, options, &block) }
         else
           object = new(attributes, options, &block)
-          object.save
+          _save_with_or_without_callbacks(object)
           object
         end
       end
+
+      # Creates an object without triggering the following callbacks:
+      #   * <tt>before_create</tt>
+      #   * <tt>after_create</tt>
+      def create_without_callbacks(*args, &block)
+        _create_without_callbacks(*args, &block)
+      end
+
+      private
+
+      # This method is shared with with ActiveRecord::Validations
+      # if a :bang option is passed it, it knows to call save! instead of save
+      def _save_with_or_without_callbacks(object, options = {})
+        save_method = _skip_callbacks? ? "save_without_callbacks" : "save"
+        save_method << "!" if options[:bang]
+        object.send(save_method)
+      end
+
+      # This method is shared with with ActiveRecord::Validations
+      # if a :bang option is passed it, it knows to call create! instead of create
+      def _create_without_callbacks(*args, options, &block)
+        bang = options[:bang] if options
+
+        begin
+          self._skip_callbacks = true
+          object = bang ? create!(*args, &block) : create(*args, &block) 
+        ensure
+          self._skip_callbacks = nil
+        end
+
+        object
+      end
+
+      def _skip_callbacks?
+        @@_skip_callbacks if defined?(@@_skip_callbacks)
+      end
+
+      def _skip_callbacks=(value)
+        @@_skip_callbacks = value
+      end
+
     end
 
     # Returns true if this object hasn't been saved yet -- that is, a record
@@ -87,6 +128,17 @@ module ActiveRecord
       end
     end
 
+    # Saves the model without triggering the following callbacks:
+    #   * <tt>before_save</tt>
+    #   * <tt>after_save</tt>
+    #   * <tt>before_update</tt>
+    #   * <tt>after_update</tt>
+    def save_without_callbacks(*args)
+      without_callbacks do
+        save(*args)
+      end
+    end
+    
     # Saves the model.
     #
     # If the model is new a record gets created in the database, otherwise
@@ -102,6 +154,13 @@ module ActiveRecord
     # ActiveRecord::Callbacks for further details.
     def save!(*)
       create_or_update || raise(RecordNotSaved)
+    end
+
+    # Same as <tt>save_without_callbacks</tt> except <tt>save!</tt> is called instead of <tt>save</tt>
+    def save_without_callbacks!(*args)
+      without_callbacks do
+        save!(*args)
+      end
     end
 
     # Deletes the record in the database and freezes this instance to
@@ -145,6 +204,15 @@ module ActiveRecord
       freeze
     end
 
+    # Deletes the record in the database without triggering the following callbacks:
+    #   * <tt>before_destroy</tt>
+    #   * <tt>after_destroy</tt>
+    def destroy_without_callbacks
+      without_callbacks do
+        destroy
+      end
+    end
+
     # Returns an instance of the specified +klass+ with the attributes of the
     # current record. This is mostly useful in relation to single-table
     # inheritance structures where you want a subclass to appear as the
@@ -181,6 +249,17 @@ module ActiveRecord
       save(:validate => false)
     end
 
+    # Updates a single attribute and saves the record without triggering the following callbacks:
+    #   * <tt>before_save</tt>
+    #   * <tt>after_save</tt>
+    #   * <tt>before_update</tt>
+    #   * <tt>after_update</tt>
+    def update_attribute_without_callbacks(*args)
+      without_callbacks do
+        update_attribute(*args)
+      end
+    end
+
     # Updates a single attribute of an object, without calling save.
     #
     # * Validation is skipped.
@@ -214,6 +293,17 @@ module ActiveRecord
       end
     end
 
+    # Updates the attributes and saves the record without triggering the following callbacks:
+    #   * <tt>before_save</tt>
+    #   * <tt>after_save</tt>
+    #   * <tt>before_update</tt>
+    #   * <tt>after_update</tt>
+    def update_attributes_without_callbacks(*args)
+      without_callbacks do
+        update_attributes(*args)
+      end
+    end
+
     # Updates its receiver just like +update_attributes+ but calls <tt>save!</tt> instead
     # of +save+, so an exception is raised if the record is invalid.
     def update_attributes!(attributes, options = {})
@@ -222,6 +312,17 @@ module ActiveRecord
       with_transaction_returning_status do
         assign_attributes(attributes, options)
         save!
+      end
+    end
+
+    # Does the same thing as +update_attributes!+ but does not trigger the following callbacks:
+    #   * <tt>before_save</tt>
+    #   * <tt>after_save</tt>
+    #   * <tt>before_update</tt>
+    #   * <tt>after_update</tt>
+    def update_attributes_without_callbacks!(*args)
+      without_callbacks do
+        update_attributes!(*args)
       end
     end
 
@@ -368,5 +469,28 @@ module ActiveRecord
       @new_record = false
       id
     end
+
+    # A wrapper method for +save(!)+, +destroy+, +update_attribute(s)(!)+, 
+    # which sets @_skip_callbacks to true so that ActiveRecord::Callbacks
+    # can know to not trigger the callbacks for a given action
+    def without_callbacks(&block)
+      begin
+        self._skip_callbacks = true
+        result = yield
+      ensure
+        self._skip_callbacks = nil
+      end
+
+      result
+    end
+
+    def _skip_callbacks?
+      @_skip_callbacks if defined?(@_skip_callbacks)
+    end
+
+    def _skip_callbacks=(value)
+      @_skip_callbacks = value
+    end
+
   end
 end

--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -38,10 +38,18 @@ module ActiveRecord
         else
           object = new(attributes, options)
           yield(object) if block_given?
-          object.save!
+          _save_with_or_without_callbacks(object, :bang => true)
           object
         end
       end
+
+      # Creates an object without triggering the following callbacks:
+      #   * <tt>before_create</tt>
+      #   * <tt>after_create</tt>
+      def create_without_callbacks!(*args, &block)
+        _create_without_callbacks(*args, { :bang => true }, &block)
+      end
+
     end
 
     # The validation process on save can be skipped by passing <tt>:validate => false</tt>. The regular Base#save method is
@@ -50,10 +58,28 @@ module ActiveRecord
       perform_validations(options) ? super : false
     end
 
+    # Saves the model without triggering the following callbacks:
+    #   * <tt>before_save</tt>
+    #   * <tt>after_save</tt>
+    #   * <tt>before_update</tt>
+    #   * <tt>after_update</tt>
+    def save_without_callbacks(*args)
+      without_callbacks do
+        save(*args)
+      end
+    end
+
     # Attempts to save the record just like Base#save but will raise a +RecordInvalid+ exception instead of returning false
     # if the record is not valid.
     def save!(options={})
       perform_validations(options) ? super : raise(RecordInvalid.new(self))
+    end
+
+    # Same as <tt>save_without_callbacks</tt> except <tt>save!</tt> is called instead of <tt>save</tt>
+    def save_without_callbacks!(*args)
+      without_callbacks do
+        save!(*args)
+      end
     end
 
     # Runs all the validations within the specified context. Returns true if no errors are found,

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -274,6 +274,89 @@ class CallbacksTest < ActiveRecord::TestCase
     ], david.history
   end
 
+  def test_create!
+    david = CallbackDeveloper.create!('name' => 'David', 'salary' => 1000000)
+    assert_equal [
+      [ :after_initialize,            :method ],
+      [ :after_initialize,            :string ],
+      [ :after_initialize,            :proc   ],
+      [ :after_initialize,            :object ],
+      [ :after_initialize,            :block  ],
+      [ :before_validation,           :method ],
+      [ :before_validation,           :string ],
+      [ :before_validation,           :proc   ],
+      [ :before_validation,           :object ],
+      [ :before_validation,           :block  ],
+      [ :after_validation,            :method ],
+      [ :after_validation,            :string ],
+      [ :after_validation,            :proc   ],
+      [ :after_validation,            :object ],
+      [ :after_validation,            :block  ],
+      [ :before_save,                 :method ],
+      [ :before_save,                 :string ],
+      [ :before_save,                 :proc   ],
+      [ :before_save,                 :object ],
+      [ :before_save,                 :block  ],
+      [ :before_create,               :method ],
+      [ :before_create,               :string ],
+      [ :before_create,               :proc   ],
+      [ :before_create,               :object ],
+      [ :before_create,               :block  ],
+      [ :after_create,                :method ],
+      [ :after_create,                :string ],
+      [ :after_create,                :proc   ],
+      [ :after_create,                :object ],
+      [ :after_create,                :block  ],
+      [ :after_save,                  :method ],
+      [ :after_save,                  :string ],
+      [ :after_save,                  :proc   ],
+      [ :after_save,                  :object ],
+      [ :after_save,                  :block  ]
+    ], david.history
+  end
+
+  def test_create_without_callbacks
+    david = CallbackDeveloper.create_without_callbacks('name' => 'David', 'salary' => 1000000)
+    assert_equal [
+      [ :after_initialize,            :method ],
+      [ :after_initialize,            :string ],
+      [ :after_initialize,            :proc   ],
+      [ :after_initialize,            :object ],
+      [ :after_initialize,            :block  ],
+      [ :before_validation,           :method ],
+      [ :before_validation,           :string ],
+      [ :before_validation,           :proc   ],
+      [ :before_validation,           :object ],
+      [ :before_validation,           :block  ],
+      [ :after_validation,            :method ],
+      [ :after_validation,            :string ],
+      [ :after_validation,            :proc   ],
+      [ :after_validation,            :object ],
+      [ :after_validation,            :block  ]
+    ], david.history
+  end
+
+  def test_create_without_callbacks!
+    david = CallbackDeveloper.create_without_callbacks!('name' => 'David', 'salary' => 1000000)
+    assert_equal [
+      [ :after_initialize,            :method ],
+      [ :after_initialize,            :string ],
+      [ :after_initialize,            :proc   ],
+      [ :after_initialize,            :object ],
+      [ :after_initialize,            :block  ],
+      [ :before_validation,           :method ],
+      [ :before_validation,           :string ],
+      [ :before_validation,           :proc   ],
+      [ :before_validation,           :object ],
+      [ :before_validation,           :block  ],
+      [ :after_validation,            :method ],
+      [ :after_validation,            :string ],
+      [ :after_validation,            :proc   ],
+      [ :after_validation,            :object ],
+      [ :after_validation,            :block  ]
+    ], david.history
+  end
+
   def test_validate_on_create
     david = OnCallbacksDeveloper.create('name' => 'David', 'salary' => 1000000)
     assert_equal [
@@ -285,6 +368,134 @@ class CallbacksTest < ActiveRecord::TestCase
     ], david.history
   end
 
+  def test_update_attribute
+    david = CallbackDeveloper.find(1)
+    david.update_attribute(:salary, 2000000)
+    assert_equal [
+      [ :after_find,            :method ],
+      [ :after_find,            :string ],
+      [ :after_find,            :proc   ],
+      [ :after_find,            :object ],
+      [ :after_find,            :block  ],
+      [ :after_initialize,            :method ],
+      [ :after_initialize,            :string ],
+      [ :after_initialize,            :proc   ],
+      [ :after_initialize,            :object ],
+      [ :after_initialize,            :block  ],
+      [ :before_save,                 :method ],
+      [ :before_save,                 :string ],
+      [ :before_save,                 :proc   ],
+      [ :before_save,                 :object ],
+      [ :before_save,                 :block  ],
+      [ :before_update,               :method ],
+      [ :before_update,               :string ],
+      [ :before_update,               :proc   ],
+      [ :before_update,               :object ],
+      [ :before_update,               :block  ],
+      [ :after_update,                :method ],
+      [ :after_update,                :string ],
+      [ :after_update,                :proc   ],
+      [ :after_update,                :object ],
+      [ :after_update,                :block  ],
+      [ :after_save,                  :method ],
+      [ :after_save,                  :string ],
+      [ :after_save,                  :proc   ],
+      [ :after_save,                  :object ],
+      [ :after_save,                  :block  ]
+    ], david.history
+  end
+
+  def test_update_attribute_without_callbacks
+    david = CallbackDeveloper.find(1)
+    david.update_attribute_without_callbacks(:salary, 2000000)
+    assert_equal [
+      [ :after_find,            :method ],
+      [ :after_find,            :string ],
+      [ :after_find,            :proc   ],
+      [ :after_find,            :object ],
+      [ :after_find,            :block  ],
+      [ :after_initialize,            :method ],
+      [ :after_initialize,            :string ],
+      [ :after_initialize,            :proc   ],
+      [ :after_initialize,            :object ],
+      [ :after_initialize,            :block  ]
+    ], david.history
+  end
+
+  def test_update_attributes
+    david = CallbackDeveloper.find(1)
+    david.update_attributes(:salary => 2000000)
+    assert_equal [
+      [ :after_find,            :method ],
+      [ :after_find,            :string ],
+      [ :after_find,            :proc   ],
+      [ :after_find,            :object ],
+      [ :after_find,            :block  ],
+      [ :after_initialize,            :method ],
+      [ :after_initialize,            :string ],
+      [ :after_initialize,            :proc   ],
+      [ :after_initialize,            :object ],
+      [ :after_initialize,            :block  ],
+      [ :before_validation,           :method ],
+      [ :before_validation,           :string ],
+      [ :before_validation,           :proc   ],
+      [ :before_validation,           :object ],
+      [ :before_validation,           :block  ],
+      [ :after_validation,            :method ],
+      [ :after_validation,            :string ],
+      [ :after_validation,            :proc   ],
+      [ :after_validation,            :object ],
+      [ :after_validation,            :block  ],
+      [ :before_save,                 :method ],
+      [ :before_save,                 :string ],
+      [ :before_save,                 :proc   ],
+      [ :before_save,                 :object ],
+      [ :before_save,                 :block  ],
+      [ :before_update,               :method ],
+      [ :before_update,               :string ],
+      [ :before_update,               :proc   ],
+      [ :before_update,               :object ],
+      [ :before_update,               :block  ],
+      [ :after_update,                :method ],
+      [ :after_update,                :string ],
+      [ :after_update,                :proc   ],
+      [ :after_update,                :object ],
+      [ :after_update,                :block  ],
+      [ :after_save,                  :method ],
+      [ :after_save,                  :string ],
+      [ :after_save,                  :proc   ],
+      [ :after_save,                  :object ],
+      [ :after_save,                  :block  ]
+    ], david.history
+  end
+
+  def test_update_attributes_without_callbacks
+    david = CallbackDeveloper.find(1)
+    david.update_attributes_without_callbacks(:salary => 2000000)
+    assert_equal [
+      [ :after_find,            :method ],
+      [ :after_find,            :string ],
+      [ :after_find,            :proc   ],
+      [ :after_find,            :object ],
+      [ :after_find,            :block  ],
+      [ :after_initialize,            :method ],
+      [ :after_initialize,            :string ],
+      [ :after_initialize,            :proc   ],
+      [ :after_initialize,            :object ],
+      [ :after_initialize,            :block  ],
+      [ :before_validation,           :method ],
+      [ :before_validation,           :string ],
+      [ :before_validation,           :proc   ],
+      [ :before_validation,           :object ],
+      [ :before_validation,           :block  ],
+      [ :after_validation,            :method ],
+      [ :after_validation,            :string ],
+      [ :after_validation,            :proc   ],
+      [ :after_validation,            :object ],
+      [ :after_validation,            :block  ]
+    ], david.history
+  end
+  
   def test_update
     david = CallbackDeveloper.find(1)
     david.save
@@ -332,6 +543,33 @@ class CallbacksTest < ActiveRecord::TestCase
     ], david.history
   end
 
+  def test_update_without_callbacks
+    david = CallbackDeveloper.find(1)
+    david.save_without_callbacks
+    assert_equal [
+      [ :after_find,            :method ],
+      [ :after_find,            :string ],
+      [ :after_find,            :proc   ],
+      [ :after_find,            :object ],
+      [ :after_find,            :block  ],
+      [ :after_initialize,            :method ],
+      [ :after_initialize,            :string ],
+      [ :after_initialize,            :proc   ],
+      [ :after_initialize,            :object ],
+      [ :after_initialize,            :block  ],
+      [ :before_validation,           :method ],
+      [ :before_validation,           :string ],
+      [ :before_validation,           :proc   ],
+      [ :before_validation,           :object ],
+      [ :before_validation,           :block  ],
+      [ :after_validation,            :method ],
+      [ :after_validation,            :string ],
+      [ :after_validation,            :proc   ],
+      [ :after_validation,            :object ],
+      [ :after_validation,            :block  ]
+    ], david.history
+  end
+
   def test_validate_on_update
     david = OnCallbacksDeveloper.find(1)
     david.save
@@ -371,6 +609,23 @@ class CallbacksTest < ActiveRecord::TestCase
     ], david.history
   end
 
+  def test_destroy_without_callbacks
+    david = CallbackDeveloper.find(1)
+    david.destroy_without_callbacks
+    assert_equal [
+      [ :after_find,            :method ],
+      [ :after_find,            :string ],
+      [ :after_find,            :proc   ],
+      [ :after_find,            :object ],
+      [ :after_find,            :block  ],
+      [ :after_initialize,            :method ],
+      [ :after_initialize,            :string ],
+      [ :after_initialize,            :proc   ],
+      [ :after_initialize,            :object ],
+      [ :after_initialize,            :block  ]
+    ], david.history
+  end
+
   def test_delete
     david = CallbackDeveloper.find(1)
     CallbackDeveloper.delete(david.id)
@@ -387,7 +642,7 @@ class CallbacksTest < ActiveRecord::TestCase
       [ :after_initialize,            :block  ],
     ], david.history
   end
-
+  
   def test_before_save_returning_false
     david = ImmutableDeveloper.find(1)
     assert david.valid?

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -161,6 +161,11 @@ class PersistencesTest < ActiveRecord::TestCase
     assert_equal("New Topic", topic_reloaded.title)
   end
 
+  def test_create_without_callbacks
+    assert_raise(ActiveRecord::RecordInvalid) { Topic.create_without_callbacks!(:title => "new topic", :validation_test => "invalid") }
+    assert !Topic.send(:_skip_callbacks?)
+  end
+
   def test_save!
     topic = Topic.new(:title => "New Topic")
     assert topic.save!
@@ -176,6 +181,16 @@ class PersistencesTest < ActiveRecord::TestCase
     topic.reload
     assert_equal("null", topic.title)
     assert_equal("null", topic.author_name)
+  end
+
+  def test_save_without_callbacks!
+    topic = Topic.new(:title => "New Topic")
+    assert topic.save!
+    assert !topic.send(:_skip_callbacks?)
+
+    reply = WrongReply.new
+    assert_raise(ActiveRecord::RecordInvalid) { reply.save_without_callbacks! }
+    assert !reply.send(:_skip_callbacks?)
   end
 
   def test_save_nil_string_attributes

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -81,6 +81,10 @@ class Topic < ActiveRecord::Base
   after_initialize :set_email_address
 
   class_attribute :after_initialize_called
+  attr_accessor :validation_test
+
+  validates :validation_test, :numericality => true, :unless => proc { validation_test.blank? }
+
   after_initialize do
     self.class.after_initialize_called = true
   end


### PR DESCRIPTION
I have recently been experiencing situations where I've wanted to create or save a record and not have the model's callbacks fire.  I have had to manually deal with this in my models by adding procs to the callback declarations, such as:

before_save :my_method, :unless => proc { should_skip_callback? }

...  Where a model has many callbacks, this can quickly become very tedious and result in noisy code.  So I have taken it upon myself to add this functionality within ActiveRecord, so you can now call:

Foo.create_without_callbacks
Foo.create_without_callbacks!
@foo.save_without_callbacks
@foo.save_without_callbacks!
@foo.update_attribute_without_callbacks(:bar, "bar")
@foo.update_attributes_without_callbacks(:bar => "bar")
@foo.update_attributes_without_callbacks!(:bar => "bar")
@foo.destroy_without_callbacks

I hope others will find this to be useful, I've seen quite a few posts on Stack Overflow where people are wanting to be able to do this:

http://stackoverflow.com/questions/4491728/rails3-disable-activerecord-callbacks
http://stackoverflow.com/questions/632742/how-can-i-avoid-running-activerecord-callbacks
http://stackoverflow.com/questions/1342761/how-to-skip-activerecord-callbacks

etc.

Thank you.
