### PR TITLE
added :callbacks => false functionality for create, save, update_attribute(s), and destroy

### DIFF
--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -101,7 +101,7 @@ module ActiveRecord
           end
         end
 
-        def destroy #:nodoc:
+        def destroy(*) #:nodoc:
           return super unless locking_enabled?
 
           if persisted?

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -15,12 +15,18 @@ module ActiveRecord
       # +create+ respects mass-assignment security and accepts either +:as+ or +:without_protection+ options
       # in the +options+ parameter.
       #
+      # A newly created object will trigger the callbacks <tt>before_save</tt> <tt>before_create</tt> 
+      # <tt>after_save</tt> and <tt>after_create</tt>.  To skip these callbacks, pass in :callbacks => false
+      #
       # ==== Examples
       #   # Create a single new object
       #   User.create(:first_name => 'Jamie')
       #
       #   # Create a single new object using the :admin mass-assignment security role
       #   User.create({ :first_name => 'Jamie', :is_admin => true }, :as => :admin)
+      #
+      #   # Create a single new object and skip callbacks
+      #   User.create({ :first_name => 'Jamie'}, :callbacks => false)
       #
       #   # Create a single new object bypassing mass-assignment security
       #   User.create({ :first_name => 'Jamie', :is_admin => true }, :without_protection => true)
@@ -42,7 +48,7 @@ module ActiveRecord
           attributes.collect { |attr| create(attr, options, &block) }
         else
           object = new(attributes, options, &block)
-          object.save
+          object.save(:callbacks => options[:callbacks])
           object
         end
       end
@@ -77,8 +83,8 @@ module ActiveRecord
     #
     # There's a series of callbacks associated with +save+. If any of the
     # <tt>before_*</tt> callbacks return +false+ the action is cancelled and
-    # +save+ returns +false+. See ActiveRecord::Callbacks for further
-    # details.
+    # +save+ returns +false+. To skip callbacks, pass in :callbacks => false
+    # See ActiveRecord::Callbacks for further details.
     def save(*)
       begin
         create_or_update
@@ -97,9 +103,9 @@ module ActiveRecord
     # for more information.
     #
     # There's a series of callbacks associated with <tt>save!</tt>. If any of
-    # the <tt>before_*</tt> callbacks return +false+ the action is cancelled
-    # and <tt>save!</tt> raises ActiveRecord::RecordNotSaved. See
-    # ActiveRecord::Callbacks for further details.
+    # the <tt>before_*</tt> callbacks return +false+ the action is cancelled and 
+    # <tt>save!</tt> raises ActiveRecord::RecordNotSaved. To skip callbacks, pass
+    # in :callbacks => false. See ActiveRecord::Callbacks for further details.
     def save!(*)
       create_or_update || raise(RecordNotSaved)
     end
@@ -125,7 +131,10 @@ module ActiveRecord
 
     # Deletes the record in the database and freezes this instance to reflect
     # that no changes should be made (since they can't be persisted).
-    def destroy
+    # Destroying a record executes the <tt>before_destroy</tt> and
+    # <tt>after_destroy</tt> callbacks.  Pass in :callbacks => false to skip
+    # them.
+    def destroy(*) 
       destroy_associations
 
       if persisted?
@@ -170,15 +179,15 @@ module ActiveRecord
     # This is especially useful for boolean flags on existing records. Also note that
     #
     # * Validation is skipped.
-    # * Callbacks are invoked.
+    # * Callbacks are invoked unless <tt>:callbacks => false</tt> is supplied.
     # * updated_at/updated_on column is updated if that column is available.
     # * Updates all the attributes that are dirty in this object.
     #
-    def update_attribute(name, value)
+    def update_attribute(name, value, options = {})
       name = name.to_s
       raise ActiveRecordError, "#{name} is marked as readonly" if self.class.readonly_attributes.include?(name)
       send("#{name}=", value)
-      save(:validate => false)
+      save(:validate => false, :callbacks => options[:callbacks])
     end
 
     # Updates a single attribute of an object, without calling save.
@@ -205,12 +214,14 @@ module ActiveRecord
     # If no +:as+ option is supplied then the +:default+ role will be used.
     # If you want to bypass the protection given by +attr_protected+ and
     # +attr_accessible+ then you can do so using the +:without_protection+ option.
+    # You can also skip the <tt>before_save</tt> </tt>after_save</tt> <tt>before_update</tt> 
+    # <tt>after_update</tt> callbacks by passing in :callbacks => false
     def update_attributes(attributes, options = {})
       # The following transaction covers any possible database side-effects of the
       # attributes assignment. For example, setting the IDs of a child collection.
       with_transaction_returning_status do
         assign_attributes(attributes, options)
-        save
+        save(:callbacks => options[:callbacks])
       end
     end
 
@@ -221,7 +232,7 @@ module ActiveRecord
       # attributes assignment. For example, setting the IDs of a child collection.
       with_transaction_returning_status do
         assign_attributes(attributes, options)
-        save!
+        save!(:callbacks => options[:callbacks])
       end
     end
 

--- a/activerecord/lib/active_record/session_store.rb
+++ b/activerecord/lib/active_record/session_store.rb
@@ -281,7 +281,7 @@ module ActiveRecord
         end
       end
 
-      def destroy
+      def destroy(*)
         return if @new_record
 
         connect = connection

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -232,18 +232,24 @@ module ActiveRecord
       self.class.transaction(options, &block)
     end
 
-    def destroy #:nodoc:
-      with_transaction_returning_status { super }
+    def destroy(*) #:nodoc:
+      with_transaction_returning_status do
+        super
+      end
     end
 
     def save(*) #:nodoc:
       rollback_active_record_state! do
-        with_transaction_returning_status { super }
+        with_transaction_returning_status do
+          super
+        end
       end
     end
 
     def save!(*) #:nodoc:
-      with_transaction_returning_status { super }
+      with_transaction_returning_status do
+        super
+      end
     end
 
     # Reset id and @new_record if the transaction rolls back.

--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -38,7 +38,7 @@ module ActiveRecord
         else
           object = new(attributes, options)
           yield(object) if block_given?
-          object.save!
+          object.save!(:callbacks => options[:callbacks])
           object
         end
       end

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -274,6 +274,89 @@ class CallbacksTest < ActiveRecord::TestCase
     ], david.history
   end
 
+  def test_create!
+    david = CallbackDeveloper.create!('name' => 'David', 'salary' => 1000000)
+    assert_equal [
+      [ :after_initialize,            :method ],
+      [ :after_initialize,            :string ],
+      [ :after_initialize,            :proc   ],
+      [ :after_initialize,            :object ],
+      [ :after_initialize,            :block  ],
+      [ :before_validation,           :method ],
+      [ :before_validation,           :string ],
+      [ :before_validation,           :proc   ],
+      [ :before_validation,           :object ],
+      [ :before_validation,           :block  ],
+      [ :after_validation,            :method ],
+      [ :after_validation,            :string ],
+      [ :after_validation,            :proc   ],
+      [ :after_validation,            :object ],
+      [ :after_validation,            :block  ],
+      [ :before_save,                 :method ],
+      [ :before_save,                 :string ],
+      [ :before_save,                 :proc   ],
+      [ :before_save,                 :object ],
+      [ :before_save,                 :block  ],
+      [ :before_create,               :method ],
+      [ :before_create,               :string ],
+      [ :before_create,               :proc   ],
+      [ :before_create,               :object ],
+      [ :before_create,               :block  ],
+      [ :after_create,                :method ],
+      [ :after_create,                :string ],
+      [ :after_create,                :proc   ],
+      [ :after_create,                :object ],
+      [ :after_create,                :block  ],
+      [ :after_save,                  :method ],
+      [ :after_save,                  :string ],
+      [ :after_save,                  :proc   ],
+      [ :after_save,                  :object ],
+      [ :after_save,                  :block  ]
+    ], david.history
+  end
+
+  def test_create_without_callbacks
+    david = CallbackDeveloper.create({ 'name' => 'David', 'salary' => 1000000 }, :callbacks => false)
+    assert_equal [
+      [ :after_initialize,            :method ],
+      [ :after_initialize,            :string ],
+      [ :after_initialize,            :proc   ],
+      [ :after_initialize,            :object ],
+      [ :after_initialize,            :block  ],
+      [ :before_validation,           :method ],
+      [ :before_validation,           :string ],
+      [ :before_validation,           :proc   ],
+      [ :before_validation,           :object ],
+      [ :before_validation,           :block  ],
+      [ :after_validation,            :method ],
+      [ :after_validation,            :string ],
+      [ :after_validation,            :proc   ],
+      [ :after_validation,            :object ],
+      [ :after_validation,            :block  ]
+    ], david.history
+  end
+
+  def test_create_bang_without_callbacks
+    david = CallbackDeveloper.create!({ 'name' => 'David', 'salary' => 1000000 }, :callbacks => false)
+    assert_equal [
+      [ :after_initialize,            :method ],
+      [ :after_initialize,            :string ],
+      [ :after_initialize,            :proc   ],
+      [ :after_initialize,            :object ],
+      [ :after_initialize,            :block  ],
+      [ :before_validation,           :method ],
+      [ :before_validation,           :string ],
+      [ :before_validation,           :proc   ],
+      [ :before_validation,           :object ],
+      [ :before_validation,           :block  ],
+      [ :after_validation,            :method ],
+      [ :after_validation,            :string ],
+      [ :after_validation,            :proc   ],
+      [ :after_validation,            :object ],
+      [ :after_validation,            :block  ]
+    ], david.history
+  end
+
   def test_validate_on_create
     david = OnCallbacksDeveloper.create('name' => 'David', 'salary' => 1000000)
     assert_equal [
@@ -282,6 +365,161 @@ class CallbacksTest < ActiveRecord::TestCase
       :validate,
       :after_validation,
       :after_validation_on_create
+    ], david.history
+  end
+
+  def test_update_attribute
+    david = CallbackDeveloper.find(1)
+    david.update_attribute(:salary, 2000000)
+    assert_equal [
+      [ :after_find,            :method ],
+      [ :after_find,            :string ],
+      [ :after_find,            :proc   ],
+      [ :after_find,            :object ],
+      [ :after_find,            :block  ],
+      [ :after_initialize,            :method ],
+      [ :after_initialize,            :string ],
+      [ :after_initialize,            :proc   ],
+      [ :after_initialize,            :object ],
+      [ :after_initialize,            :block  ],
+      [ :before_save,                 :method ],
+      [ :before_save,                 :string ],
+      [ :before_save,                 :proc   ],
+      [ :before_save,                 :object ],
+      [ :before_save,                 :block  ],
+      [ :before_update,               :method ],
+      [ :before_update,               :string ],
+      [ :before_update,               :proc   ],
+      [ :before_update,               :object ],
+      [ :before_update,               :block  ],
+      [ :after_update,                :method ],
+      [ :after_update,                :string ],
+      [ :after_update,                :proc   ],
+      [ :after_update,                :object ],
+      [ :after_update,                :block  ],
+      [ :after_save,                  :method ],
+      [ :after_save,                  :string ],
+      [ :after_save,                  :proc   ],
+      [ :after_save,                  :object ],
+      [ :after_save,                  :block  ]
+    ], david.history
+  end
+
+  def test_update_attribute_without_callbacks
+    david = CallbackDeveloper.find(1)
+    david.update_attribute(:salary, 2000000, :callbacks => false)
+    assert_equal [
+      [ :after_find,            :method ],
+      [ :after_find,            :string ],
+      [ :after_find,            :proc   ],
+      [ :after_find,            :object ],
+      [ :after_find,            :block  ],
+      [ :after_initialize,            :method ],
+      [ :after_initialize,            :string ],
+      [ :after_initialize,            :proc   ],
+      [ :after_initialize,            :object ],
+      [ :after_initialize,            :block  ]
+    ], david.history
+  end
+
+  def test_update_attributes
+    david = CallbackDeveloper.find(1)
+    david.update_attributes(:salary => 2000000)
+    assert_equal [
+      [ :after_find,            :method ],
+      [ :after_find,            :string ],
+      [ :after_find,            :proc   ],
+      [ :after_find,            :object ],
+      [ :after_find,            :block  ],
+      [ :after_initialize,            :method ],
+      [ :after_initialize,            :string ],
+      [ :after_initialize,            :proc   ],
+      [ :after_initialize,            :object ],
+      [ :after_initialize,            :block  ],
+      [ :before_validation,           :method ],
+      [ :before_validation,           :string ],
+      [ :before_validation,           :proc   ],
+      [ :before_validation,           :object ],
+      [ :before_validation,           :block  ],
+      [ :after_validation,            :method ],
+      [ :after_validation,            :string ],
+      [ :after_validation,            :proc   ],
+      [ :after_validation,            :object ],
+      [ :after_validation,            :block  ],
+      [ :before_save,                 :method ],
+      [ :before_save,                 :string ],
+      [ :before_save,                 :proc   ],
+      [ :before_save,                 :object ],
+      [ :before_save,                 :block  ],
+      [ :before_update,               :method ],
+      [ :before_update,               :string ],
+      [ :before_update,               :proc   ],
+      [ :before_update,               :object ],
+      [ :before_update,               :block  ],
+      [ :after_update,                :method ],
+      [ :after_update,                :string ],
+      [ :after_update,                :proc   ],
+      [ :after_update,                :object ],
+      [ :after_update,                :block  ],
+      [ :after_save,                  :method ],
+      [ :after_save,                  :string ],
+      [ :after_save,                  :proc   ],
+      [ :after_save,                  :object ],
+      [ :after_save,                  :block  ]
+    ], david.history
+  end
+
+  def test_update_attributes_without_callbacks
+    david = CallbackDeveloper.find(1)
+    david.update_attributes({ :salary => 2000000 }, :callbacks => false)
+    assert_equal [
+      [ :after_find,            :method ],
+      [ :after_find,            :string ],
+      [ :after_find,            :proc   ],
+      [ :after_find,            :object ],
+      [ :after_find,            :block  ],
+      [ :after_initialize,            :method ],
+      [ :after_initialize,            :string ],
+      [ :after_initialize,            :proc   ],
+      [ :after_initialize,            :object ],
+      [ :after_initialize,            :block  ],
+      [ :before_validation,           :method ],
+      [ :before_validation,           :string ],
+      [ :before_validation,           :proc   ],
+      [ :before_validation,           :object ],
+      [ :before_validation,           :block  ],
+      [ :after_validation,            :method ],
+      [ :after_validation,            :string ],
+      [ :after_validation,            :proc   ],
+      [ :after_validation,            :object ],
+      [ :after_validation,            :block  ]
+    ], david.history
+  end
+  
+  def test_update_attributes_bang_without_callbacks
+    david = CallbackDeveloper.find(1)
+    david.update_attributes!({ :salary => 2000000 }, :callbacks => false)
+    assert_equal [
+      [ :after_find,            :method ],
+      [ :after_find,            :string ],
+      [ :after_find,            :proc   ],
+      [ :after_find,            :object ],
+      [ :after_find,            :block  ],
+      [ :after_initialize,            :method ],
+      [ :after_initialize,            :string ],
+      [ :after_initialize,            :proc   ],
+      [ :after_initialize,            :object ],
+      [ :after_initialize,            :block  ],
+      [ :before_validation,           :method ],
+      [ :before_validation,           :string ],
+      [ :before_validation,           :proc   ],
+      [ :before_validation,           :object ],
+      [ :before_validation,           :block  ],
+      [ :after_validation,            :method ],
+      [ :after_validation,            :string ],
+      [ :after_validation,            :proc   ],
+      [ :after_validation,            :object ],
+      [ :after_validation,            :block  ]
     ], david.history
   end
 
@@ -332,6 +570,33 @@ class CallbacksTest < ActiveRecord::TestCase
     ], david.history
   end
 
+  def test_update_without_callbacks
+    david = CallbackDeveloper.find(1)
+    david.save(:callbacks => false)
+    assert_equal [
+      [ :after_find,            :method ],
+      [ :after_find,            :string ],
+      [ :after_find,            :proc   ],
+      [ :after_find,            :object ],
+      [ :after_find,            :block  ],
+      [ :after_initialize,            :method ],
+      [ :after_initialize,            :string ],
+      [ :after_initialize,            :proc   ],
+      [ :after_initialize,            :object ],
+      [ :after_initialize,            :block  ],
+      [ :before_validation,           :method ],
+      [ :before_validation,           :string ],
+      [ :before_validation,           :proc   ],
+      [ :before_validation,           :object ],
+      [ :before_validation,           :block  ],
+      [ :after_validation,            :method ],
+      [ :after_validation,            :string ],
+      [ :after_validation,            :proc   ],
+      [ :after_validation,            :object ],
+      [ :after_validation,            :block  ]
+    ], david.history
+  end
+
   def test_validate_on_update
     david = OnCallbacksDeveloper.find(1)
     david.save
@@ -371,6 +636,23 @@ class CallbacksTest < ActiveRecord::TestCase
     ], david.history
   end
 
+  def test_destroy_without_callbacks
+    david = CallbackDeveloper.find(1)
+    david.destroy(:callbacks => false)
+    assert_equal [
+      [ :after_find,            :method ],
+      [ :after_find,            :string ],
+      [ :after_find,            :proc   ],
+      [ :after_find,            :object ],
+      [ :after_find,            :block  ],
+      [ :after_initialize,            :method ],
+      [ :after_initialize,            :string ],
+      [ :after_initialize,            :proc   ],
+      [ :after_initialize,            :object ],
+      [ :after_initialize,            :block  ]
+    ], david.history
+  end
+
   def test_delete
     david = CallbackDeveloper.find(1)
     CallbackDeveloper.delete(david.id)
@@ -387,7 +669,7 @@ class CallbacksTest < ActiveRecord::TestCase
       [ :after_initialize,            :block  ],
     ], david.history
   end
-
+  
   def test_before_save_returning_false
     david = ImmutableDeveloper.find(1)
     assert david.valid?

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -178,6 +178,16 @@ class PersistencesTest < ActiveRecord::TestCase
     assert_equal("null", topic.author_name)
   end
 
+  def test_save_without_callbacks!
+    topic = Topic.new(:title => "New Topic")
+    assert topic.save!
+    assert !topic.send(:_skip_callbacks?)
+
+    reply = WrongReply.new
+    assert_raise(ActiveRecord::RecordInvalid) { reply.save!(:callbacks => false) }
+    assert !reply.send(:_skip_callbacks?)
+  end
+
   def test_save_nil_string_attributes
     topic = Topic.find(1)
     topic.title = nil


### PR DESCRIPTION
Added the option of :callbacks => false to create, create!, save, save!, update_attribute, update_attributes, and destroy.

This will allow anyone to easily disable the before/after create/save/update/destroy callbacks.
