### PR TITLE
Add a testcase for non english filename. Related to #2982.

### DIFF
--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'abstract_unit'
 
 module StaticTests
@@ -28,6 +29,10 @@ module StaticTests
     assert_html "/foo/index.html", get("/foo/index.html")
     assert_html "/foo/index.html", get("/foo/")
     assert_html "/foo/index.html", get("/foo")
+  end
+
+  def test_served_static_file_with_non_english_filename
+    assert_html "means hello in Japanese\n", get("/foo/#{Rack::Utils.escape("こんにちは.html")}")
   end
 
   private

--- a/actionpack/test/fixtures/public/foo/こんにちは.html
+++ b/actionpack/test/fixtures/public/foo/こんにちは.html
@@ -1,0 +1,1 @@
+means hello in Japanese


### PR DESCRIPTION
I could not find a testcase for non english filename (for action_dispatch/middleware/static.rb)

Please see also https://github.com/rails/rails/pull/2982.
