### PR TITLE
GH #4883. Optional start_day argument for Time#all_week

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -274,8 +274,8 @@ class Time
   end
 
   # Returns a Range representing the whole week of the current time.
-  def all_week
-    beginning_of_week..end_of_week
+  def all_week(start_day = :monday)
+    beginning_of_week(start_day)..end_of_week(start_day)
   end
 
   # Returns a Range representing the whole month of the current time.

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -802,6 +802,7 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
 
   def test_all_week
     assert_equal Time.local(2011,6,6,0,0,0)..Time.local(2011,6,12,23,59,59,999999.999), Time.local(2011,6,7,10,10,10).all_week
+    assert_equal Time.local(2011,6,5,0,0,0)..Time.local(2011,6,11,23,59,59,999999.999), Time.local(2011,6,7,10,10,10).all_week(:sunday)
   end
 
   def test_all_month


### PR DESCRIPTION
Supported start_day argument for Time#all_week.

Please see https://github.com/rails/rails/issues/4883

/cc @spastorino
