### PR TITLE
Display annotations from .coffee files in `rake notes`

### DIFF
--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -53,7 +53,7 @@ class SourceAnnotationExtractor
 
   # Returns a hash that maps filenames under +dir+ (recursively) to arrays
   # with their annotations. Only files with annotations are included, and only
-  # those with extension +.builder+, +.rb+, +.erb+, +.haml+ and +.slim+
+  # those with extension +.builder+, +.rb+, +.erb+, +.haml+, +.slim+ and +.coffee+
   # are taken into account.
   def find_in(dir)
     results = {}
@@ -63,7 +63,7 @@ class SourceAnnotationExtractor
 
       if File.directory?(item)
         results.update(find_in(item))
-      elsif item =~ /\.(builder|rb)$/
+      elsif item =~ /\.(builder|rb|coffee)$/
         results.update(extract_annotations_from(item, /#\s*(#{tag}):?\s*(.*)$/))
       elsif item =~ /\.erb$/
         results.update(extract_annotations_from(item, /<%\s*#\s*(#{tag}):?\s*(.*?)\s*%>/))

--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -7,7 +7,7 @@ module ApplicationTests
         build_app
         require "rails/all"
       end
-    
+
       def teardown
         teardown_app
       end
@@ -17,6 +17,7 @@ module ApplicationTests
         app_file "app/views/home/index.html.erb", "<% # TODO: note in erb %>"
         app_file "app/views/home/index.html.haml", "-# TODO: note in haml"
         app_file "app/views/home/index.html.slim", "/ TODO: note in slim"
+        app_file "app/assets/javascripts/application.js.coffee", "# TODO: note in coffee"
         app_file "app/controllers/application_controller.rb", 1000.times.map { "" }.join("\n") << "# TODO: note in ruby"
 
         boot_rails
@@ -25,25 +26,26 @@ module ApplicationTests
         require 'rake/testtask'
 
         Rails.application.load_tasks
-   
+
         Dir.chdir(app_path) do
           output = `bundle exec rake notes`
           lines = output.scan(/\[([0-9\s]+)\]/).flatten
-        
+
           assert_match /note in erb/, output
           assert_match /note in haml/, output
           assert_match /note in slim/, output
           assert_match /note in ruby/, output
+          assert_match /note in coffee/, output
 
-          assert_equal 4, lines.size
-          assert_equal 4, lines[0].size
-          assert_equal 4, lines[1].size
-          assert_equal 4, lines[2].size
-          assert_equal 4, lines[3].size
+          assert_equal 5, lines.size
+
+          lines.each do |line_number|
+            assert_equal 4, line_number.size
+          end
         end
-      
+
       end
-    
+
       private
       def boot_rails
         super


### PR DESCRIPTION
Rake task "notes" doesn't displays annotations from .coffee files.
