### PR TITLE
Added deep_map! instance method for Hash

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash.rb
+++ b/activesupport/lib/active_support/core_ext/hash.rb
@@ -1,6 +1,7 @@
 require 'active_support/core_ext/hash/conversions'
 require 'active_support/core_ext/hash/deep_merge'
 require 'active_support/core_ext/hash/deep_dup'
+require 'active_support/core_ext/hash/deep_map'
 require 'active_support/core_ext/hash/diff'
 require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/hash/indifferent_access'

--- a/activesupport/lib/active_support/core_ext/hash/deep_map.rb
+++ b/activesupport/lib/active_support/core_ext/hash/deep_map.rb
@@ -1,0 +1,18 @@
+class Hash
+  # Invokes the block once for each pair of self recursively,
+  # replacing the pair's value with the value returned by block.
+  #
+  # Examples:
+  #
+  #   {:a => 2}.deep_map! { |k,v| v * 2 }                     # => {:a => 4}
+  #   {:a => {:b => 3}}.deep_map! { |k,v| v + 2 }             # => {:a => {:b => 5}}
+  #   {1 => {2 => "a"}}.deep_map! { |k,v| v + "!" }           # => {1 => {2 => "a!"}}
+  #   {1 => {2 => ["a"]}, 3=>1 }.deep_map! { |k,v| v * 2  }   # => {1 => {2 => ["a", "a"]}, 3 => 2}
+  def deep_map!( &block )
+    self.each_pair do |k,v|
+      tv = self[k]
+      self[k] = tv.is_a?(Hash) && v.is_a?(Hash) ? tv.deep_map!(&block) : block.call( [k, v] )
+    end
+    self
+  end
+end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -378,6 +378,14 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal 0, dup[:a][44]
   end
 
+  def test_deep_map!
+    hash = { :a => { :b => 1, :c => "c" }, :a2 => 3 }
+    hash.deep_map! { |k,v| v * 3 }
+    assert_equal 3, hash[:a][:b]
+    assert_equal 'ccc', hash[:a][:c]
+    assert_equal 9, hash[:a2]
+  end
+
   def test_store_on_indifferent_access
     hash = HashWithIndifferentAccess.new
     hash.store(:test1, 1)


### PR DESCRIPTION
This method invoke a block and replace each elements with a block result, like Array#map! method. 
