### PR TITLE
Hstore parser/generator fixes

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -98,7 +98,7 @@ module ActiveRecord
         when :date                 then klass.value_to_date(value)
         when :binary               then klass.binary_to_string(value)
         when :boolean              then klass.value_to_boolean(value)
-        when :hstore               then klass.cast_hstore(value)
+        when :hstore               then klass.string_to_hstore(value)
         else value
         end
       end
@@ -116,7 +116,7 @@ module ActiveRecord
         when :date                 then "#{klass}.value_to_date(#{var_name})"
         when :binary               then "#{klass}.binary_to_string(#{var_name})"
         when :boolean              then "#{klass}.value_to_boolean(#{var_name})"
-        when :hstore               then "#{klass}.cast_hstore(#{var_name})"
+        when :hstore               then "#{klass}.string_to_hstore(#{var_name})"
         else var_name
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -476,6 +476,11 @@ module ActiveRecord
         return super unless column
 
         case value
+        when Hash
+          case column.sql_type
+          when 'hstore' then super(PostgreSQLColumn.hstore_to_string(value), column)
+          else super
+          end
         when Float
           return super unless value.infinite? && column.type == :datetime
           "'#{value.to_s.downcase}'"

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -217,6 +217,9 @@ module ActiveRecord
             # Arrays
             when /\A'(.*)'::"?\D+"?\[\]\z/
               $1
+            # Hstore
+            when /\A'(.*)'::hstore\z/
+              $1
             # Object identifier types
             when /\A-?\d+\z/
               $1
@@ -284,7 +287,8 @@ module ActiveRecord
         :binary      => { :name => "bytea" },
         :boolean     => { :name => "boolean" },
         :xml         => { :name => "xml" },
-        :tsvector    => { :name => "tsvector" }
+        :tsvector    => { :name => "tsvector" },
+        :hstore      => { :name => "hstore" }
       }
 
       # Returns 'PostgreSQL' as adapter name for identification purposes.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -87,7 +87,7 @@ module ActiveRecord
             value.nil?         ? 'NULL'
           : value =~ /[=\s,>]/ ? '"%s"' % value.gsub(/(["\\])/, '\\\\\1')
           : value == ""        ? '""'
-          :                      value.gsub(/(["\\])/, '\\\\\1')
+          :                      value.to_s.gsub(/(["\\])/, '\\\\\1')
         end
       end
       # :startdoc:

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -12,7 +12,7 @@ class PostgresqlHstoreTest < ActiveRecord::TestCase
     begin
       @connection.transaction do
         @connection.create_table('hstores') do |t|
-          t.hstore 'tags'
+          t.hstore 'tags', :default => ''
         end
       end
     rescue ActiveRecord::StatementInvalid
@@ -33,7 +33,7 @@ class PostgresqlHstoreTest < ActiveRecord::TestCase
     assert @column
 
     data = "\"1\"=>\"2\""
-    hash = @column.class.cast_hstore data
+    hash = @column.class.string_to_hstore data
     assert_equal({'1' => '2'}, hash)
     assert_equal({'1' => '2'}, @column.type_cast(data))
 
@@ -43,19 +43,19 @@ class PostgresqlHstoreTest < ActiveRecord::TestCase
   end
 
   def test_gen1
-    assert_equal(%q(" "=>""), @column.type_cast({' '=>''}))
+    assert_equal(%q(" "=>""), @column.class.hstore_to_string({' '=>''}))
   end
 
   def test_gen2
-    assert_equal(%q(","=>""), @column.type_cast({','=>''}))
+    assert_equal(%q(","=>""), @column.class.hstore_to_string({','=>''}))
   end
 
   def test_gen3
-    assert_equal(%q("="=>""), @column.type_cast({'='=>''}))
+    assert_equal(%q("="=>""), @column.class.hstore_to_string({'='=>''}))
   end
 
   def test_gen4
-    assert_equal(%q(">"=>""), @column.type_cast({'>'=>''}))
+    assert_equal(%q(">"=>""), @column.class.hstore_to_string({'>'=>''}))
   end
 
   def test_parse1

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -86,6 +86,14 @@ class PostgresqlHstoreTest < ActiveRecord::TestCase
     assert_equal({"\"a"=>"q\"w"}, @column.type_cast('\"a=>q"w'))
   end
 
+  def test_rewrite
+    @connection.execute "insert into hstores (tags) VALUES ('1=>2')"
+    x = Hstore.find :first
+    x.tags = { '"a\'' => 'b' }
+    assert x.save!
+  end
+
+
   def test_select
     @connection.execute "insert into hstores (tags) VALUES ('1=>2')"
     x = Hstore.find :first

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -229,6 +229,13 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
     def test_schema_dump_includes_tsvector_shorthand_definition
       output = standard_dump
+      if %r{create_table "postgresql_hstores"} =~ output
+        assert_match %r{t.hstore "hash_store", default => ""}, output
+      end
+    end
+
+    def test_schema_dump_includes_tsvector_shorthand_definition
+      output = standard_dump
       if %r{create_table "postgresql_tsvectors"} =~ output
         assert_match %r{t.tsvector "text_vector"}, output
       end

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -1,6 +1,6 @@
 ActiveRecord::Schema.define do
 
-  %w(postgresql_tsvectors postgresql_arrays postgresql_moneys postgresql_numbers postgresql_times postgresql_network_addresses postgresql_bit_strings
+  %w(postgresql_tsvectors postgresql_hstores postgresql_arrays postgresql_moneys postgresql_numbers postgresql_times postgresql_network_addresses postgresql_bit_strings
       postgresql_oids postgresql_xml_data_type defaults geometrics postgresql_timestamp_with_zones).each do |table_name|
     execute "DROP TABLE  IF EXISTS #{quote_table_name table_name}"
   end
@@ -60,6 +60,13 @@ _SQL
   CREATE TABLE postgresql_tsvectors (
     id SERIAL PRIMARY KEY,
     text_vector tsvector
+  );
+_SQL
+
+  execute <<_SQL
+  CREATE TABLE postgresql_hstores (
+    id SERIAL PRIMARY KEY,
+    hash_store hstore default ''::hstore
   );
 _SQL
 

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -63,12 +63,14 @@ _SQL
   );
 _SQL
 
+  if 't' == select_value("select 'hstore'=ANY(select typname from pg_type)")
   execute <<_SQL
   CREATE TABLE postgresql_hstores (
     id SERIAL PRIMARY KEY,
     hash_store hstore default ''::hstore
   );
 _SQL
+  end
 
   execute <<_SQL
   CREATE TABLE postgresql_moneys (


### PR DESCRIPTION
Thanks for adding the hstore support, this is great. It's missing a couple of cases though and doesn't quite match the postgres docs, for example "Double-quote keys and values that include whitespace, commas, =s or >s" and "A value (but not a key) can be an SQL NULL."  Here are some additional tests (some examples copied from the hstore distribution tests) and code that I think is correct.  I previously contributed a version of it to https://github.com/softa/activerecord-postgres-hstore .
