### PR TITLE
allow mass-assign version attribute in AR::SchemaMigration

### DIFF
--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -4,6 +4,8 @@ require 'active_record/base'
 
 module ActiveRecord
   class SchemaMigration < ActiveRecord::Base
+    attr_accessible :version
+
     def self.table_name
       Base.table_name_prefix + 'schema_migrations' + Base.table_name_suffix
     end


### PR DESCRIPTION
Issue #4897

`rake db:migrate` uses mass-assignment https://github.com/rails/rails/blob/master/activerecord/lib/active_record/migration.rb#L777 that causes error when `config.active_record.whitelist_attributes` is set to `true`
