### PR TITLE
Fixes #4837 - value_before_type_cast returns value 

### DIFF
--- a/actionpack/lib/action_view/helpers/tags/base.rb
+++ b/actionpack/lib/action_view/helpers/tags/base.rb
@@ -34,9 +34,11 @@ module ActionView
           unless object.nil?
             method_before_type_cast = @method_name + "_before_type_cast"
 
-            object.respond_to?(method_before_type_cast) ?
-              object.send(method_before_type_cast) :
+            if object.respond_to?(method_before_type_cast)
+              object.send(method_before_type_cast).serialized_value
+            else
               object.send(@method_name)
+            end
           end
         end
 


### PR DESCRIPTION
Fixes #4837 - value_before_type_cast returns value not ActiveRecord::AttributeMethods::Serialization::Attribute

Hello. I found a solution how to fix #4837. If you will agree with this patch, I need to help with test. I tried to use

``` ruby
@topic = Topic.new

assert_dom_equal(
  '<input id="topic_content" name="topic[content]" size="30" type="text" />', text_field(:topic, :content)
)
```

but because of Topic is not real AR model, it throws `undefined method serialized_value for nil`. Should I fake behavior to that model in test ?

Also new "custom serializer option" feature is not mentioned in docs. So if you will be happy with this PR, I can improve some docs also.
