### PR TITLE
Infinity should be a valid validates_length_of maximum

### DIFF
--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -29,8 +29,8 @@ module ActiveModel
         keys.each do |key|
           value = options[key]
 
-          unless value.is_a?(Integer) && value >= 0
-            raise ArgumentError, ":#{key} must be a nonnegative Integer"
+          unless value.is_a?(Integer) && value >= 0 or value == Float::INFINITY
+            raise ArgumentError, ":#{key} must be a nonnegative Integer or Infinity"
           end
         end
       end

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -357,4 +357,22 @@ class LengthValidationTest < ActiveModel::TestCase
   ensure
     Person.reset_callbacks(:validate)
   end
+
+  def test_validates_length_of_for_infinite_maxima
+    Topic.validates_length_of(:title, :within => 5..Float::INFINITY)
+
+    t = Topic.new("title" => "1234")
+    assert t.invalid?
+    assert t.errors[:title].any?
+
+    t.title = "12345"
+    assert t.valid?
+
+    Topic.validates_length_of(:author_name, :maximum => Float::INFINITY)
+
+    assert t.valid?
+
+    t.author_name = "A very long author name that should still be valid." * 100
+    assert t.valid?
+  end
 end


### PR DESCRIPTION
Allow infinite values for validates_length_of. Particularly useful
for prettily defining an open ended range such as

validates_length_of :human_stupidity, :within => 0..Float::INFINITY
