### PR TITLE
Fix url_for method's behavior. GH #3684.

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -482,7 +482,7 @@ module ActionDispatch
         # if the current controller is "foo/bar/baz" and :controller => "baz/bat"
         # is specified, the controller becomes "foo/baz/bat"
         def use_relative_controller!
-          if !named_route && different_controller?
+          if !named_route && different_controller? && !controller.start_with?("/")
             old_parts = current_controller.split('/')
             size = controller.count("/") + 1
             parts = old_parts[0...-size] << controller

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -2562,3 +2562,36 @@ class TestUnicodePaths < ActionDispatch::IntegrationTest
     assert_equal "200", @response.code
   end
 end
+
+class TestMultipleNestedController < ActionDispatch::IntegrationTest
+  module ::Foo
+    module Bar
+      class BazController < ActionController::Base
+        def index
+          render :inline => "<%= url_for :controller => '/pooh', :action => 'index' %>"
+        end
+      end
+    end
+  end
+
+  Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
+    app.draw do
+      namespace :foo do
+        namespace :bar do
+          match "baz" => "baz#index"
+        end
+      end
+      match "pooh" => "pooh#index"
+    end
+  end
+
+  include Routes.url_helpers
+  def app; Routes end
+
+  test "controller option which starts with '/' from multiple nested controller" do
+    get "/foo/bar/baz"
+    assert_equal "/pooh", @response.body
+  end
+
+end
+


### PR DESCRIPTION
Fix url_for method's behavior when it is passed with :controller option which starts with "/" in a multiple nested controller. Please see a testcase, and https://github.com/rails/rails/issues/3864

```
 1) Failure:
test_controller_option_which_starts_with_'/'_from_multiple_nested_controller(TestMultipleNestedController) [test/dispatch/routing_test.rb:2593]:
Expected: "/pooh"
  Actual: "/foo//pooh"
```

It seems that this problem is occured on 3-1-stable, 3-2-stable, and master.

Closes #3864
