### PR TITLE
prevents the database.yml template option from being passed to PGConn

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -14,7 +14,7 @@ module ActiveRecord
 
       # Forward any unused config params to PGconn.connect.
       [:statement_limit, :encoding, :min_messages, :schema_search_path,
-       :schema_order, :adapter, :pool, :wait_timeout,
+       :schema_order, :adapter, :pool, :wait_timeout, :template,
        :reaping_frequency].each do |key|
         conn_params.delete key
       end


### PR DESCRIPTION
Commit https://github.com/rails/rails/commit/8ee6406acc67aa721127d69486bf8e244ea6d576 introduces a bug when specifying a template in the database.yml file. PGConn dies if you try to pass this option to it. It must be filtered out.
