### PR TITLE
Fixed force_ssl redirects to include original query params

### DIFF
--- a/actionpack/lib/action_controller/metal/force_ssl.rb
+++ b/actionpack/lib/action_controller/metal/force_ssl.rb
@@ -29,6 +29,7 @@ module ActionController
           if !request.ssl? && !Rails.env.development?
             redirect_options = {:protocol => 'https://', :status => :moved_permanently}
             redirect_options.merge!(:host => host) if host
+            redirect_options.merge!(:params => request.query_parameters)
             redirect_to redirect_options
           end
         end

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -575,6 +575,7 @@ module ActionDispatch
 
         path_addition, params = generate(path_options, path_segments || {})
         path << path_addition
+        params.merge!(options[:params] || {})
 
         ActionDispatch::Http::URL.url_for(options.merge!({
           :path => path,

--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -257,6 +257,22 @@ class UrlOptionsTest < ActionController::TestCase
     assert_equal '/special', rs.url_for(url_params)
   end
 
+  def test_url_for_query_params_included
+    rs = ActionDispatch::Routing::RouteSet.new
+    rs.draw do
+      match 'home' => 'pages#home'
+    end
+
+    options = {
+      :action     => "home",
+      :controller => "pages",
+      :only_path  => true,
+      :params     => { "token" => "secret" }
+    }
+
+    assert_equal '/home?token=secret', rs.url_for(options)
+  end
+
   def test_url_options_override
     with_routing do |set|
       set.draw do

--- a/actionpack/test/controller/force_ssl_test.rb
+++ b/actionpack/test/controller/force_ssl_test.rb
@@ -35,6 +35,12 @@ class ForceSSLControllerLevelTest < ActionController::TestCase
     assert_equal "https://test.host/force_ssl_controller_level/banana", redirect_to_url
   end
 
+  def test_banana_redirects_to_https_with_extra_params
+    get :banana, :token => "secret"
+    assert_response 301
+    assert_equal "https://test.host/force_ssl_controller_level/banana?token=secret", redirect_to_url
+  end
+
   def test_cheeseburger_redirects_to_https
     get :cheeseburger
     assert_response 301


### PR DESCRIPTION
`ActionController.force_ssl` redirects http URLs to their https equivalent; however, when a URL contains a query string, the resulting redirect lacked the original query string.

For example, this URL (with force_ssl):

```
http://example.com/widgets/new?name=foo
```

Only redirects to:

```
https://example.com/widgets/new
```
