### PR TITLE
Replacing Ordered Hash to Ruby Hash

### DIFF
--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency('actionpack',  version)
-  s.add_dependency('mail',        '~> 2.4.0')
+  s.add_dependency('mail',        '~> 2.4.1')
 end

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add `:format` option to number_to_percentage *Rodrigo Flores*
+
 *   Add `config.action_view.logger` to configure logger for ActionView. *Rafael França*
 
 *   Deprecated ActionController::Integration in favour of ActionDispatch::Integration

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Rails 4.0.0 (unreleased) ##
+
 *   Add `config.action_view.logger` to configure logger for ActionView. *Rafael França*
 
 *   Deprecated ActionController::Integration in favour of ActionDispatch::Integration
@@ -32,8 +33,6 @@
 *   Deprecate ActionController::DoubleRenderError in favour of AbstractController::DoubleRenderError. *Carlos Antonio da Silva*
 
 *   Deprecate method_missing handling for not found actions, use action_missing instead. *Carlos Antonio da Silva*
-
-*   Deprecate ActionController#performed?, check for response_body presence instead. *Carlos Antonio da Silva*
 
 *   Deprecate ActionController#rescue_action, ActionController#initialize_template_class, and ActionController#assign_shortcuts.
     These methods were not being used internally anymore and are going to be removed in Rails 4. *Carlos Antonio da Silva*

--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -181,13 +181,13 @@ module ActionController
       @_status = Rack::Utils.status_code(status)
     end
 
-    def response_body=(val)
-      body = (val.nil? || val.respond_to?(:each)) ? val : [val]
-      super body
+    def response_body=(body)
+      body = [body] unless body.nil? || body.respond_to?(:each)
+      super
     end
 
     def performed?
-      response_body
+      !!response_body
     end
 
     def dispatch(name, request) #:nodoc:

--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -186,6 +186,10 @@ module ActionController
       super body
     end
 
+    def performed?
+      response_body
+    end
+
     def dispatch(name, request) #:nodoc:
       @_request = request
       @_env = request.env

--- a/actionpack/lib/action_controller/metal/implicit_render.rb
+++ b/actionpack/lib/action_controller/metal/implicit_render.rb
@@ -2,7 +2,7 @@ module ActionController
   module ImplicitRender
     def send_action(method, *args)
       ret = super
-      default_render unless response_body
+      default_render unless performed?
       ret
     end
 

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -579,7 +579,8 @@ module ActionDispatch
               params[key] = URI.parser.unescape(value)
             end
           end
-
+          old_params = env[::ActionDispatch::Routing::RouteSet::PARAMETERS_KEY]
+          env[::ActionDispatch::Routing::RouteSet::PARAMETERS_KEY] = (old_params || {}).merge(params)
           dispatcher = route.app
           while dispatcher.is_a?(Mapper::Constraints) && dispatcher.matches?(env) do
             dispatcher = dispatcher.app

--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -627,7 +627,7 @@ module ActionView
               token_tag(authenticity_token)
             else
               html_options["method"] = "post"
-              tag(:input, :type => "hidden", :name => "_method", :value => method) + token_tag(authenticity_token)
+              method_tag(method) + token_tag(authenticity_token)
           end
 
           tags = utf8_enforcer_tag << method_tag

--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -646,15 +646,6 @@ module ActionView
           output.safe_concat("</form>")
         end
 
-        def token_tag(token)
-          if token == false || !protect_against_forgery?
-            ''
-          else
-            token ||= form_authenticity_token
-            tag(:input, :type => "hidden", :name => request_forgery_protection_token.to_s, :value => token)
-          end
-        end
-
         # see http://www.w3.org/TR/html4/types.html#type-name
         def sanitize_to_id(name)
           name.to_s.gsub(']','').gsub(/[^-a-zA-Z0-9:.]/, "_")

--- a/actionpack/lib/action_view/helpers/number_helper.rb
+++ b/actionpack/lib/action_view/helpers/number_helper.rb
@@ -205,8 +205,7 @@ module ActionView
           if options[:raise]
             raise
           else
-            formatted_number = e.number.to_s.html_safe? ? format.gsub(/%n/, e.number).html_safe : format.gsub(/%n/, e.number)
-            formatted_number.html_safe? ? formatted_number.html_safe : formatted_number
+            e.number.to_s.html_safe? ? format.gsub(/%n/, e.number).html_safe : format.gsub(/%n/, e.number)
           end
         end
       end

--- a/actionpack/lib/action_view/helpers/number_helper.rb
+++ b/actionpack/lib/action_view/helpers/number_helper.rb
@@ -169,6 +169,8 @@ module ActionView
       # * <tt>:delimiter</tt>                   - Sets the thousands delimiter (defaults to "").
       # * <tt>:strip_insignificant_zeros</tt>   - If +true+ removes insignificant zeros after the decimal separator
       #                                           (defaults to +false+).
+      # * <tt>:format</tt>                      - Specifies the format of the percentage string
+      #                                           The number field is <tt>%n</tt> (defaults to "%n%").
       # * <tt>:raise</tt>                       - If true, raises +InvalidNumberError+ when the argument is invalid.
       #
       # ==== Examples
@@ -180,6 +182,7 @@ module ActionView
       #  number_to_percentage(302.24398923423, :precision => 5)           # => 302.24399%
       #  number_to_percentage(1000, :locale => :fr)                       # => 1 000,000%
       #  number_to_percentage("98a")                                      # => 98a%
+      #  number_to_percentage(100, :format => "%n  %")                    # => 100  %
       #
       #  number_to_percentage("98a", :raise => true)                      # => InvalidNumberError
       def number_to_percentage(number, options = {})
@@ -193,13 +196,17 @@ module ActionView
 
         options = options.reverse_merge(defaults)
 
+        format = options[:format] || "%n%"
+
         begin
-          "#{number_with_precision(number, options.merge(:raise => true))}%".html_safe
+          value = number_with_precision(number, options.merge(:raise => true))
+          format.gsub(/%n/, value).html_safe
         rescue InvalidNumberError => e
           if options[:raise]
             raise
           else
-            e.number.to_s.html_safe? ? "#{e.number}%".html_safe : "#{e.number}%"
+            formatted_number = e.number.to_s.html_safe? ? format.gsub(/%n/, e.number).html_safe : format.gsub(/%n/, e.number)
+            formatted_number.html_safe? ? formatted_number.html_safe : formatted_number
           end
         end
       end

--- a/actionpack/lib/action_view/helpers/number_helper.rb
+++ b/actionpack/lib/action_view/helpers/number_helper.rb
@@ -237,14 +237,8 @@ module ActionView
       def number_with_delimiter(number, options = {})
         options.symbolize_keys!
 
-        begin
-          Float(number)
-        rescue ArgumentError, TypeError
-          if options[:raise]
-            raise InvalidNumberError, number
-          else
-            return number
-          end
+        parse_float_number(number, options[:raise]) do
+          return number
         end
 
         defaults = I18n.translate(:'number.format', :locale => options[:locale], :default => {})
@@ -253,7 +247,6 @@ module ActionView
         parts = number.to_s.to_str.split('.')
         parts[0].gsub!(/(\d)(?=(\d\d\d)+(?!\d))/, "\\1#{options[:delimiter]}")
         parts.join(options[:separator]).html_safe
-
       end
 
       # Formats a +number+ with the specified level of <tt>:precision</tt> (e.g., 112.32 has a precision
@@ -291,14 +284,8 @@ module ActionView
       def number_with_precision(number, options = {})
         options.symbolize_keys!
 
-        number = begin
-          Float(number)
-        rescue ArgumentError, TypeError
-          if options[:raise]
-            raise InvalidNumberError, number
-          else
-            return number
-          end
+        number = parse_float_number(number, options[:raise]) do
+          return number
         end
 
         defaults           = I18n.translate(:'number.format', :locale => options[:locale], :default => {})
@@ -330,7 +317,6 @@ module ActionView
         else
           formatted_number
         end
-
       end
 
       STORAGE_UNITS = [:byte, :kb, :mb, :gb, :tb].freeze
@@ -369,14 +355,8 @@ module ActionView
       def number_to_human_size(number, options = {})
         options.symbolize_keys!
 
-        number = begin
-          Float(number)
-        rescue ArgumentError, TypeError
-          if options[:raise]
-            raise InvalidNumberError, number
-          else
-            return number
-          end
+        number = parse_float_number(number, options[:raise]) do
+          return number
         end
 
         defaults = I18n.translate(:'number.format', :locale => options[:locale], :default => {})
@@ -489,14 +469,8 @@ module ActionView
       def number_to_human(number, options = {})
         options.symbolize_keys!
 
-        number = begin
-          Float(number)
-        rescue ArgumentError, TypeError
-          if options[:raise]
-            raise InvalidNumberError, number
-          else
-            return number
-          end
+        number = parse_float_number(number, options[:raise]) do
+          return number
         end
 
         defaults = I18n.translate(:'number.format', :locale => options[:locale], :default => {})
@@ -539,6 +513,17 @@ module ActionView
         decimal_format.gsub(/%n/, formatted_number).gsub(/%u/, unit).strip.html_safe
       end
 
+      private
+
+      def parse_float_number(number, raise_error)
+        Float(number)
+      rescue ArgumentError, TypeError
+        if raise_error
+          raise InvalidNumberError, number
+        else
+          yield
+        end
+      end
     end
   end
 end

--- a/actionpack/lib/action_view/helpers/number_helper.rb
+++ b/actionpack/lib/action_view/helpers/number_helper.rb
@@ -125,11 +125,10 @@ module ActionView
 
         options.symbolize_keys!
 
-        defaults  = I18n.translate(:'number.format', :locale => options[:locale], :default => {})
-        currency  = I18n.translate(:'number.currency.format', :locale => options[:locale], :default => {})
+        currency = translations_for('currency', options[:locale])
         currency[:negative_format] ||= "-" + currency[:format] if currency[:format]
 
-        defaults  = DEFAULT_CURRENCY_VALUES.merge(defaults).merge!(currency)
+        defaults  = DEFAULT_CURRENCY_VALUES.merge(defaults_translations(options[:locale])).merge!(currency)
         defaults[:negative_format] = "-" + options[:format] if options[:format]
         options   = defaults.merge!(options)
 
@@ -152,7 +151,6 @@ module ActionView
             e.number.to_s.html_safe? ? formatted_number.html_safe : formatted_number
           end
         end
-
       end
 
       # Formats a +number+ as a percentage string (e.g., 65%). You can customize the format in the +options+ hash.
@@ -190,9 +188,7 @@ module ActionView
 
         options.symbolize_keys!
 
-        defaults   = I18n.translate(:'number.format', :locale => options[:locale], :default => {})
-        percentage = I18n.translate(:'number.percentage.format', :locale => options[:locale], :default => {})
-        defaults  = defaults.merge(percentage)
+        defaults = defaults_translations(options[:locale]).merge(translations_for('percentage', options[:locale]))
 
         options = options.reverse_merge(defaults)
 
@@ -241,8 +237,7 @@ module ActionView
           return number
         end
 
-        defaults = I18n.translate(:'number.format', :locale => options[:locale], :default => {})
-        options = options.reverse_merge(defaults)
+        options = options.reverse_merge(defaults_translations(options[:locale]))
 
         parts = number.to_s.to_str.split('.')
         parts[0].gsub!(/(\d)(?=(\d\d\d)+(?!\d))/, "\\1#{options[:delimiter]}")
@@ -288,9 +283,7 @@ module ActionView
           return number
         end
 
-        defaults           = I18n.translate(:'number.format', :locale => options[:locale], :default => {})
-        precision_defaults = I18n.translate(:'number.precision.format', :locale => options[:locale], :default => {})
-        defaults           = defaults.merge(precision_defaults)
+        defaults = defaults_translations(options[:locale]).merge(translations_for('precision', options[:locale]))
 
         options = options.reverse_merge(defaults)  # Allow the user to unset default values: Eg.: :significant => false
         precision = options.delete :precision
@@ -359,9 +352,7 @@ module ActionView
           return number
         end
 
-        defaults = I18n.translate(:'number.format', :locale => options[:locale], :default => {})
-        human    = I18n.translate(:'number.human.format', :locale => options[:locale], :default => {})
-        defaults = defaults.merge(human)
+        defaults = defaults_translations(options[:locale]).merge(translations_for('human', options[:locale]))
 
         options = options.reverse_merge(defaults)
         #for backwards compatibility with those that didn't add strip_insignificant_zeros to their locale files
@@ -473,9 +464,7 @@ module ActionView
           return number
         end
 
-        defaults = I18n.translate(:'number.format', :locale => options[:locale], :default => {})
-        human    = I18n.translate(:'number.human.format', :locale => options[:locale], :default => {})
-        defaults = defaults.merge(human)
+        defaults = defaults_translations(options[:locale]).merge(translations_for('human', options[:locale]))
 
         options = options.reverse_merge(defaults)
         #for backwards compatibility with those that didn't add strip_insignificant_zeros to their locale files
@@ -514,6 +503,14 @@ module ActionView
       end
 
       private
+
+      def defaults_translations(locale)
+        I18n.translate(:'number.format', :locale => locale, :default => {})
+      end
+
+      def translations_for(namespace, locale)
+        I18n.translate(:"number.#{namespace}.format", :locale => locale, :default => {})
+      end
 
       def parse_float_number(number, raise_error)
         Float(number)

--- a/actionpack/lib/action_view/helpers/number_helper.rb
+++ b/actionpack/lib/action_view/helpers/number_helper.rb
@@ -271,6 +271,7 @@ module ActionView
       # * <tt>:delimiter</tt>                  - Sets the thousands delimiter (defaults to "").
       # * <tt>:strip_insignificant_zeros</tt>  - If +true+ removes insignificant zeros after the decimal separator
       #                                          (defaults to +false+).
+      # * <tt>:raise</tt>                      - If true, raises +InvalidNumberError+ when the argument is invalid.
       #
       # ==== Examples
       #  number_with_precision(111.2345)                                            # => 111.235
@@ -350,6 +351,7 @@ module ActionView
       # * <tt>:delimiter</tt>  - Sets the thousands delimiter (defaults to "").
       # * <tt>:strip_insignificant_zeros</tt>  - If +true+ removes insignificant zeros after the decimal separator (defaults to +true+)
       # * <tt>:prefix</tt>  - If +:si+ formats the number using the SI prefix (defaults to :binary)
+      # * <tt>:raise</tt>         - If true, raises +InvalidNumberError+ when the argument is invalid.
       # ==== Examples
       #  number_to_human_size(123)                                          # => 123 Bytes
       #  number_to_human_size(1234)                                         # => 1.21 KB
@@ -431,6 +433,7 @@ module ActionView
       #   * *integers*: <tt>:unit</tt>, <tt>:ten</tt>, <tt>:hundred</tt>, <tt>:thousand</tt>,  <tt>:million</tt>,  <tt>:billion</tt>, <tt>:trillion</tt>, <tt>:quadrillion</tt>
       #   * *fractionals*: <tt>:deci</tt>, <tt>:centi</tt>, <tt>:mili</tt>, <tt>:micro</tt>, <tt>:nano</tt>, <tt>:pico</tt>, <tt>:femto</tt>
       # * <tt>:format</tt> - Sets the format of the output string (defaults to "%n %u"). The field types are:
+      # * <tt>:raise</tt>         - If true, raises +InvalidNumberError+ when the argument is invalid.
       #
       #     %u  The quantifier (ex.: 'thousand')
       #     %n  The number

--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -476,7 +476,7 @@ module ActionView
       #   string given as the value.
       # * <tt>:subject</tt> - Preset the subject line of the email.
       # * <tt>:body</tt> - Preset the body of the email.
-      # * <tt>:cc</tt> - Carbon Copy addition recipients on the email.
+      # * <tt>:cc</tt> - Carbon Copy additional recipients on the email.
       # * <tt>:bcc</tt> - Blind Carbon Copy additional recipients on the email.
       #
       # ==== Examples

--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -327,7 +327,7 @@ module ActionView
 
         method_tag = ''
         if (method = html_options.delete('method')) && %w{put delete}.include?(method.to_s)
-          method_tag = tag('input', :type => 'hidden', :name => '_method', :value => method.to_s)
+          method_tag = method_tag(method)
         end
 
         form_method = method.to_s == 'get' ? 'get' : 'post'
@@ -675,6 +675,10 @@ module ActionView
             token ||= form_authenticity_token
             tag(:input, :type => "hidden", :name => request_forgery_protection_token.to_s, :value => token)
           end
+        end
+
+        def method_tag(method)
+          tag('input', :type => 'hidden', :name => '_method', :value => method.to_s)
         end
     end
   end

--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -336,10 +336,7 @@ module ActionView
 
         remote = html_options.delete('remote')
 
-        request_token_tag = ''
-        if form_method == 'post' && protect_against_forgery?
-          request_token_tag = tag(:input, :type => "hidden", :name => request_forgery_protection_token.to_s, :value => form_authenticity_token)
-        end
+        request_token_tag = form_method == 'post' ? token_tag : ''
 
         url = options.is_a?(String) ? options : self.url_for(options)
         name ||= url
@@ -669,6 +666,15 @@ module ActionView
         def convert_boolean_attributes!(html_options, bool_attrs)
           bool_attrs.each { |x| html_options[x] = x if html_options.delete(x) }
           html_options
+        end
+
+        def token_tag(token=nil)
+          if token == false || !protect_against_forgery?
+            ''
+          else
+            token ||= form_authenticity_token
+            tag(:input, :type => "hidden", :name => request_forgery_protection_token.to_s, :value => token)
+          end
         end
     end
   end

--- a/actionpack/lib/action_view/locale/en.yml
+++ b/actionpack/lib/action_view/locale/en.yml
@@ -37,6 +37,7 @@
         # precision:
         # significant: false
         # strip_insignificant_zeros: false
+        format: "%n%"
 
     # Used in number_to_precision()
     precision:

--- a/actionpack/lib/action_view/template.rb
+++ b/actionpack/lib/action_view/template.rb
@@ -288,7 +288,7 @@ module ActionView
             logger.debug "Backtrace: #{e.backtrace.join("\n")}"
           end
 
-          raise ActionView::Template::Error.new(self, {}, e)
+          raise ActionView::Template::Error.new(self, e)
         end
       end
 
@@ -297,13 +297,12 @@ module ActionView
           e.sub_template_of(self)
           raise e
         else
-          assigns  = view.respond_to?(:assigns) ? view.assigns : {}
           template = self
           unless template.source
             template = refresh(view)
             template.encode!
           end
-          raise Template::Error.new(template, assigns, e)
+          raise Template::Error.new(template, e)
         end
       end
 

--- a/actionpack/lib/action_view/template/error.rb
+++ b/actionpack/lib/action_view/template/error.rb
@@ -55,9 +55,9 @@ module ActionView
 
       attr_reader :original_exception, :backtrace
 
-      def initialize(template, assigns, original_exception)
+      def initialize(template, original_exception)
         super(original_exception.message)
-        @template, @assigns, @original_exception = template, assigns.dup, original_exception
+        @template, @original_exception = template, original_exception
         @sub_templates = nil
         @backtrace = original_exception.backtrace
       end

--- a/actionpack/test/controller/addresses_render_test.rb
+++ b/actionpack/test/controller/addresses_render_test.rb
@@ -3,16 +3,18 @@ require 'active_support/logger'
 require 'controller/fake_controllers'
 
 class Address
-  def Address.count(conditions = nil, join = nil)
-    nil
-  end
+  class << self
+    def count(conditions = nil, join = nil)
+      nil
+    end
 
-  def Address.find_all(arg1, arg2, arg3, arg4)
-    []
-  end
+    def find_all(arg1, arg2, arg3, arg4)
+      []
+    end
 
-  def self.find(*args)
-    []
+    def find(*args)
+      []
+    end
   end
 end
 

--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -93,6 +93,12 @@ class ControllerInstanceTests < ActiveSupport::TestCase
                               Submodule::ContainedNonEmptyController.new]
   end
 
+  def test_performed?
+    assert !@empty.performed?
+    @empty.response_body = ["sweet"]
+    assert @empty.performed?
+  end
+
   def test_action_methods
     @empty_controllers.each do |c|
       assert_equal Set.new, c.class.action_methods, "#{c.controller_path} should be empty!"

--- a/actionpack/test/controller/force_ssl_test.rb
+++ b/actionpack/test/controller/force_ssl_test.rb
@@ -39,9 +39,7 @@ class ForceSSLFlash < ForceSSLController
     @flashy = flash["that"]
     render :inline => "hello"
   end
-
 end
-
 
 class ForceSSLControllerLevelTest < ActionController::TestCase
   tests ForceSSLControllerLevel
@@ -135,5 +133,4 @@ class ForceSSLFlashTest < ActionController::TestCase
     assert_equal "hello", assigns["flash_copy"]["that"]
     assert_equal "hello", assigns["flashy"]
   end
-
 end

--- a/actionpack/test/controller/rescue_test.rb
+++ b/actionpack/test/controller/rescue_test.rb
@@ -137,11 +137,11 @@ class RescueController < ActionController::Base
   end
 
   def io_error_in_view
-    raise ActionView::TemplateError.new(nil, {}, IOError.new('this is io error'))
+    raise ActionView::TemplateError.new(nil, IOError.new('this is io error'))
   end
 
   def zero_division_error_in_view
-    raise ActionView::TemplateError.new(nil, {}, ZeroDivisionError.new('this is zero division error'))
+    raise ActionView::TemplateError.new(nil, ZeroDivisionError.new('this is zero division error'))
   end
 
   protected

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -1327,7 +1327,20 @@ class RouteSetTest < ActiveSupport::TestCase
       end
     end
   end
-
+  
+  def test_route_with_subdomain_and_constraints_must_receive_params
+    name_param = nil
+    set.draw do
+      match 'page/:name' => 'pages#show', :constraints => lambda {|request|
+        name_param = request.params[:name]
+        return true
+      }
+    end
+    assert_equal({:controller => 'pages', :action => 'show', :name => 'mypage'},
+      set.recognize_path('http://subdomain.example.org/page/mypage'))
+    assert_equal(name_param, 'mypage')
+  end
+  
   def test_route_requirement_recognize_with_ignore_case
     set.draw do
       match 'page/:name' => 'pages#show',

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -34,7 +34,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
       when "/unprocessable_entity"
         raise ActionController::InvalidAuthenticityToken
       when "/not_found_original_exception"
-        raise ActionView::Template::Error.new('template', {}, AbstractController::ActionNotFound.new)
+        raise ActionView::Template::Error.new('template', AbstractController::ActionNotFound.new)
       else
         raise "puke!"
       end

--- a/actionpack/test/dispatch/show_exceptions_test.rb
+++ b/actionpack/test/dispatch/show_exceptions_test.rb
@@ -11,7 +11,7 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
       when "/method_not_allowed"
         raise ActionController::MethodNotAllowed
       when "/not_found_original_exception"
-        raise ActionView::Template::Error.new('template', {}, AbstractController::ActionNotFound.new)
+        raise ActionView::Template::Error.new('template', AbstractController::ActionNotFound.new)
       else
         raise "puke!"
       end

--- a/actionpack/test/template/html-scanner/sanitizer_test.rb
+++ b/actionpack/test/template/html-scanner/sanitizer_test.rb
@@ -56,7 +56,6 @@ class SanitizerTest < ActionController::TestCase
     assert_sanitized "a b c<script language=\"Javascript\">blah blah blah</script>d e f", "a b cd e f"
   end
 
-  # TODO: Clean up
   def test_sanitize_js_handlers
     raw = %{onthis="do that" <a href="#" onclick="hello" name="foo" onbogus="remove me">hello</a>}
     assert_sanitized raw, %{onthis="do that" <a name="foo" href="#">hello</a>}
@@ -215,7 +214,6 @@ class SanitizerTest < ActionController::TestCase
     assert_sanitized img_hack, "<img>"
   end
 
-  # TODO: Clean up
   def test_should_sanitize_attributes
     assert_sanitized %(<SPAN title="'><script>alert()</script>">blah</SPAN>), %(<span title="'&gt;&lt;script&gt;alert()&lt;/script&gt;">blah</span>)
   end

--- a/actionpack/test/template/number_helper_test.rb
+++ b/actionpack/test/template/number_helper_test.rb
@@ -57,6 +57,7 @@ class NumberHelperTest < ActionView::TestCase
     assert_equal("1000.000%", number_to_percentage("1000"))
     assert_equal("123.4%", number_to_percentage(123.400, :precision => 3, :strip_insignificant_zeros => true))
     assert_equal("1.000,000%", number_to_percentage(1000, :delimiter => '.', :separator => ','))
+    assert_equal("1000.000  %", number_to_percentage(1000, :format => "%n  %"))
   end
 
   def test_number_with_delimiter

--- a/actionpack/test/template/template_error_test.rb
+++ b/actionpack/test/template/template_error_test.rb
@@ -2,12 +2,12 @@ require "abstract_unit"
 
 class TemplateErrorTest < ActiveSupport::TestCase
   def test_provides_original_message
-    error = ActionView::Template::Error.new("test", {}, Exception.new("original"))
+    error = ActionView::Template::Error.new("test", Exception.new("original"))
     assert_equal "original", error.message
   end
 
   def test_provides_useful_inspect
-    error = ActionView::Template::Error.new("test", {}, Exception.new("original"))
+    error = ActionView::Template::Error.new("test", Exception.new("original"))
     assert_equal "#<ActionView::Template::Error: original>", error.inspect
   end
 end

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -325,14 +325,14 @@ module ActiveModel
             end
 
             @prefix, @suffix = options[:prefix] || '', options[:suffix] || ''
-            @regex = /^(#{Regexp.escape(@prefix)})(.+?)(#{Regexp.escape(@suffix)})$/
+            @regex = /^(?:#{Regexp.escape(@prefix)})(.*)(?:#{Regexp.escape(@suffix)})$/
             @method_missing_target = "#{@prefix}attribute#{@suffix}"
             @method_name = "#{prefix}%s#{suffix}"
           end
 
           def match(method_name)
             if @regex =~ method_name
-              AttributeMethodMatch.new(method_missing_target, $2, method_name)
+              AttributeMethodMatch.new(method_missing_target, $1, method_name)
             else
               nil
             end

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -4,12 +4,11 @@ require 'active_support/core_ext/array/conversions'
 require 'active_support/core_ext/string/inflections'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/hash/reverse_merge'
-require 'active_support/ordered_hash'
 
 module ActiveModel
   # == Active Model Errors
   #
-  # Provides a modified +OrderedHash+ that you can include in your object
+  # Provides a modified +Hash+ that you can include in your object
   # for handling error messages and interacting with Action Pack helpers.
   #
   # A minimal implementation could be:
@@ -75,7 +74,7 @@ module ActiveModel
     #   end
     def initialize(base)
       @base     = base
-      @messages = ActiveSupport::OrderedHash.new
+      @messages = {}
     end
 
     def initialize_dup(other)
@@ -206,7 +205,7 @@ module ActiveModel
       to_a.to_xml options.reverse_merge(:root => "errors", :skip_types => true)
     end
 
-    # Returns an ActiveSupport::OrderedHash that can be used as the JSON representation for this object.
+    # Returns an Hash that can be used as the JSON representation for this object.
     def as_json(options=nil)
       to_hash
     end

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -33,7 +33,7 @@ module ActiveModel
   #   person.first_name = 'zoolander'
   #   person.valid?                   # => false
   #   person.invalid?                 # => true
-  #   person.errors                   # => #<OrderedHash {:first_name=>["starts with z."]}>
+  #   person.errors                   # => #<Hash {:first_name=>["starts with z."]}>
   #
   # Note that <tt>ActiveModel::Validations</tt> automatically adds an +errors+ method
   # to your instances initialized with a new <tt>ActiveModel::Errors</tt> object, so

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -154,7 +154,7 @@ class ErrorsTest < ActiveModel::TestCase
   test 'to_hash should return an ordered hash' do
     person = Person.new
     person.errors.add(:name, "can not be blank")
-    assert_instance_of ActiveSupport::OrderedHash, person.errors.to_hash
+    assert_instance_of ::Hash, person.errors.to_hash
   end
 
   test 'full_messages should return an array of error messages, with the attribute name included' do

--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -130,13 +130,13 @@ class JsonSerializationTest < ActiveModel::TestCase
     assert_match %r{"favorite_quote":"Constraints are liberating"}, methods_json
   end
 
-  test "should return OrderedHash for errors" do
+  test "should return Hash for errors" do
     contact = Contact.new
     contact.errors.add :name, "can't be blank"
     contact.errors.add :name, "is too short (minimum is 2 characters)"
     contact.errors.add :age, "must be 16 or over"
 
-    hash = ActiveSupport::OrderedHash.new
+    hash = {}
     hash[:name] = ["can't be blank", "is too short (minimum is 2 characters)"]
     hash[:age]  = ["must be 16 or over"]
     assert_equal hash.to_json, contact.errors.to_json

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -181,7 +181,7 @@ class ValidationsTest < ActiveModel::TestCase
     assert_match %r{<error>Title can't be blank</error>}, xml
     assert_match %r{<error>Content can't be blank</error>}, xml
 
-    hash = ActiveSupport::OrderedHash.new
+    hash = {}
     hash[:title] = ["can't be blank"]
     hash[:content] = ["can't be blank"]
     assert_equal t.errors.to_json, hash.to_json

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -72,6 +72,33 @@
 
 ## Rails 3.2.0 (unreleased) ##
 
+*   Added a `with_lock` method to ActiveRecord objects, which starts
+    a transaction, locks the object (pessimistically) and yields to the block.
+    The method takes one (optional) parameter and passes it to `lock!`.
+
+    Before:
+
+        class Order < ActiveRecord::Base
+          def cancel!
+            transaction do
+              lock!
+              # ... cancelling logic
+            end
+          end
+        end
+
+    After:
+
+        class Order < ActiveRecord::Base
+          def cancel!
+            with_lock do
+              # ... cancelling logic
+            end
+          end
+        end
+
+    *Olek Janiszewski*
+
 *   'on' and 'ON' boolean columns values are type casted to true
     *Santiago Pastorino*
 
@@ -82,7 +109,7 @@
     Example:
       rake db:migrate SCOPE=blog
 
-   *Piotr Sarnacki*
+    *Piotr Sarnacki*
 
 *   Migrations copied from engines are now scoped with engine's name,
     for example 01_create_posts.blog.rb. *Piotr Sarnacki*

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -1,6 +1,5 @@
 require 'active_support/core_ext/enumerable'
 require 'active_support/deprecation'
-require 'thread'
 
 module ActiveRecord
   # = Active Record Attribute Methods
@@ -38,8 +37,6 @@ module ActiveRecord
       def define_attribute_methods
         # Use a mutex; we don't want two thread simaltaneously trying to define
         # attribute methods.
-        @attribute_methods_mutex ||= Mutex.new
-
         @attribute_methods_mutex.synchronize do
           return if attribute_methods_generated?
           superclass.define_attribute_methods unless self == base_class

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -126,10 +126,7 @@ module ActiveRecord
         self.class.type_cast_attribute(attr_name, @attributes, @attributes_cache)
       end
 
-      private
-        def attribute(attribute_name)
-          read_attribute(attribute_name)
-        end
+      alias :attribute :read_attribute
     end
   end
 end

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -126,7 +126,10 @@ module ActiveRecord
         self.class.type_cast_attribute(attr_name, @attributes, @attributes_cache)
       end
 
-      alias :attribute :read_attribute
+      private
+        def attribute(attribute_name)
+          read_attribute(attribute_name)
+        end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -71,7 +71,7 @@ module ActiveRecord
         when Date, Time then quoted_date(value)
         when Symbol     then value.to_s
         else
-          YAML.dump(value)
+          raise TypeError, "can't cast #{value.class} to #{column.type}"
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -171,15 +171,15 @@ module ActiveRecord
 
         # Extracts the value from a PostgreSQL column default definition.
         def self.extract_value_from_default(default)
+          # This is a performance optimization for Ruby 1.9.2 in development.
+          # If the value is nil, we return nil straight away without checking
+          # the regular expressions. If we check each regular expression,
+          # Regexp#=== will call NilClass#to_str, which will trigger
+          # method_missing (defined by whiny nil in ActiveSupport) which
+          # makes this method very very slow.
+          return default unless default
+
           case default
-            # This is a performance optimization for Ruby 1.9.2 in development.
-            # If the value is nil, we return nil straight away without checking
-            # the regular expressions. If we check each regular expression,
-            # Regexp#=== will call NilClass#to_str, which will trigger
-            # method_missing (defined by whiny nil in ActiveSupport) which
-            # makes this method very very slow.
-            when NilClass
-              nil
             # Numeric types
             when /\A\(?(-?\d+(\.\d*)?\)?)\z/
               $1

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -152,16 +152,8 @@ module ActiveRecord
     #   User.new({ :first_name => 'Jamie', :is_admin => true }, :without_protection => true)
     def initialize(attributes = nil, options = {})
       @attributes = self.class.initialize_attributes(self.class.column_defaults.dup)
-      @association_cache = {}
-      @aggregation_cache = {}
-      @attributes_cache = {}
-      @new_record = true
-      @readonly = false
-      @destroyed = false
-      @marked_for_destruction = false
-      @previously_changed = {}
-      @changed_attributes = {}
-      @relation = nil
+
+      init_internals
 
       ensure_proper_type
 
@@ -185,13 +177,11 @@ module ActiveRecord
     #   post.title # => 'hello world'
     def init_with(coder)
       @attributes = self.class.initialize_attributes(coder['attributes'])
-      @relation = nil
 
-      @attributes_cache, @previously_changed, @changed_attributes = {}, {}, {}
-      @association_cache = {}
-      @aggregation_cache = {}
-      @readonly = @destroyed = @marked_for_destruction = false
+      init_internals
+
       @new_record = false
+
       run_callbacks :find
       run_callbacks :initialize
 
@@ -219,7 +209,8 @@ module ActiveRecord
 
       @aggregation_cache = {}
       @association_cache = {}
-      @attributes_cache = {}
+      @attributes_cache  = {}
+
       @new_record  = true
 
       ensure_proper_type
@@ -329,6 +320,19 @@ module ActiveRecord
     # See also http://tenderlovemaking.com/2011/06/28/til-its-ok-to-return-nil-from-to_ary/
     def to_ary # :nodoc:
       nil
+    end
+
+    def init_internals
+      @relation               = nil
+      @aggregation_cache      = {}
+      @association_cache      = {}
+      @attributes_cache       = {}
+      @previously_changed     = {}
+      @changed_attributes     = {}
+      @readonly               = false
+      @destroyed              = false
+      @marked_for_destruction = false
+      @new_record             = true
     end
   end
 end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -1,4 +1,5 @@
 require 'active_support/concern'
+require 'thread'
 
 module ActiveRecord
   module Core
@@ -80,6 +81,8 @@ module ActiveRecord
       end
 
       def initialize_generated_modules
+        @attribute_methods_mutex = Mutex.new
+
         # force attribute methods to be higher in inheritance hierarchy than other generated methods
         generated_attribute_methods
         generated_feature_methods

--- a/activerecord/lib/active_record/locking/pessimistic.rb
+++ b/activerecord/lib/active_record/locking/pessimistic.rb
@@ -38,6 +38,18 @@ module ActiveRecord
     #     account2.save!
     #   end
     #
+    # You can start a transaction and acquire the lock in one go by calling
+    # <tt>with_lock</tt> with a block. The block is called from within
+    # a transaction, the object is already locked. Example:
+    #
+    #   account = Account.first
+    #   account.with_lock do
+    #     # This block is called within a transaction,
+    #     # account is already locked.
+    #     account.balance -= 100
+    #     account.save!
+    #   end
+    #
     # Database-specific information on row locking:
     #   MySQL: http://dev.mysql.com/doc/refman/5.1/en/innodb-locking-reads.html
     #   PostgreSQL: http://www.postgresql.org/docs/current/interactive/sql-select.html#SQL-FOR-UPDATE-SHARE
@@ -49,6 +61,16 @@ module ActiveRecord
       def lock!(lock = true)
         reload(:lock => lock) if persisted?
         self
+      end
+
+      # Wraps the passed block in a transaction, locking the object
+      # before yielding. You pass can the SQL locking clause
+      # as argument (see <tt>lock!</tt>).
+      def with_lock(lock = true)
+        transaction do
+          lock!(lock)
+          yield
+        end
       end
     end
   end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -75,16 +75,16 @@ module ActiveRecord
     # array, it actually returns a relation object and can have other query
     # methods appended to it, such as the other methods in ActiveRecord::QueryMethods.
     #
-    # This method will also take multiple parameters:
+    # The argument to the method can also be an array of fields.
     #
-    #   >> Model.select(:field, :other_field, :and_one_more)
+    #   >> Model.select([:field, :other_field, :and_one_more])
     #   => [#<Model field: "value", other_field: "value", and_one_more: "value">]
     #
-    # Any attributes that do not have fields retrieved by a select
-    # will return `nil` when the getter method for that attribute is used:
+    # Accessing attributes of an object that do not have fields retrieved by a select
+    # will throw <tt>ActiveModel::MissingAttributeError</tt>:
     #
     #   >> Model.select(:field).first.other_field
-    #   => nil
+    #   => ActiveModel::MissingAttributeError: missing attribute: other_field
     def select(value = Proc.new)
       if block_given?
         to_a.select {|*block_args| value.call(*block_args) }

--- a/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
@@ -70,9 +70,9 @@ module ActiveRecord
           assert_equal bd.to_f, @conn.type_cast(bd, nil)
         end
 
-        def test_type_cast_unknown
+        def test_type_cast_unknown_should_raise_error
           obj = Class.new.new
-          assert_equal YAML.dump(obj), @conn.type_cast(obj, nil)
+          assert_raise(TypeError) { @conn.type_cast(obj, nil) }
         end
 
         def test_quoted_id

--- a/activerecord/test/cases/attribute_methods/read_test.rb
+++ b/activerecord/test/cases/attribute_methods/read_test.rb
@@ -1,5 +1,6 @@
 require "cases/helper"
 require 'active_support/core_ext/object/inclusion'
+require 'thread'
 
 module ActiveRecord
   module AttributeMethods
@@ -19,6 +20,13 @@ module ActiveRecord
           def self.base_class; self; end
 
           include ActiveRecord::AttributeMethods
+
+          def self.define_attribute_methods
+            # Created in the inherited/included hook for "proper" ARs
+            @attribute_methods_mutex ||= Mutex.new
+
+            super
+          end
 
           def self.column_names
             %w{ one two three }

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -992,10 +992,9 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal "b", duped_topic.title
 
     # test if the attribute values have been duped
-    topic.title = {"a" => "b"}
     duped_topic = topic.dup
-    duped_topic.title["a"] = "c"
-    assert_equal "b", topic.title["a"]
+    duped_topic.title.replace "c"
+    assert_equal "a", topic.title
 
     # test if attributes set as part of after_initialize are duped correctly
     assert_equal topic.author_email_address, duped_topic.author_email_address
@@ -1006,8 +1005,7 @@ class BasicsTest < ActiveRecord::TestCase
     assert_not_equal duped_topic.id, topic.id
 
     duped_topic.reload
-    # FIXME: I think this is poor behavior, and will fix it with #5686
-    assert_equal({'a' => 'c'}.to_yaml, duped_topic.title)
+    assert_equal("c", duped_topic.title)
   end
 
   def test_dup_with_aggregate_of_same_name_as_attribute

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -187,6 +187,31 @@ class BasicsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_previously_changed
+    topic = Topic.find :first
+    topic.title = '<3<3<3'
+    assert_equal({}, topic.previous_changes)
+
+    topic.save!
+    expected = ["The First Topic", "<3<3<3"]
+    assert_equal(expected, topic.previous_changes['title'])
+  end
+
+  def test_previously_changed_dup
+    topic = Topic.find :first
+    topic.title = '<3<3<3'
+    topic.save!
+
+    t2 = topic.dup
+
+    assert_equal(topic.previous_changes, t2.previous_changes)
+
+    topic.title = "lolwut"
+    topic.save!
+
+    assert_not_equal(topic.previous_changes, t2.previous_changes)
+  end
+
   def test_preserving_time_objects
     assert_kind_of(
       Time, Topic.find(1).bonus_time,

--- a/activeresource/lib/active_resource/base.rb
+++ b/activeresource/lib/active_resource/base.rb
@@ -939,12 +939,12 @@ module ActiveResource
 
         # Accepts a URI and creates the site URI from that.
         def create_site_uri_from(site)
-          site.is_a?(URI) ? site.dup : URI.parser.parse(site)
+          site.is_a?(URI) ? site.dup : URI.parse(site)
         end
 
         # Accepts a URI and creates the proxy URI from that.
         def create_proxy_uri_from(proxy)
-          proxy.is_a?(URI) ? proxy.dup : URI.parser.parse(proxy)
+          proxy.is_a?(URI) ? proxy.dup : URI.parse(proxy)
         end
 
         # contains a set of the current prefix parameters.

--- a/activeresource/lib/active_resource/connection.rb
+++ b/activeresource/lib/active_resource/connection.rb
@@ -39,14 +39,14 @@ module ActiveResource
 
     # Set URI for remote service.
     def site=(site)
-      @site = site.is_a?(URI) ? site : URI.parser.parse(site)
+      @site = site.is_a?(URI) ? site : URI.parse(site)
       @user = URI.parser.unescape(@site.user) if @site.user
       @password = URI.parser.unescape(@site.password) if @site.password
     end
 
     # Set the proxy for remote service.
     def proxy=(proxy)
-      @proxy = proxy.is_a?(URI) ? proxy : URI.parser.parse(proxy)
+      @proxy = proxy.is_a?(URI) ? proxy : URI.parse(proxy)
     end
 
     # Sets the user for remote service.

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -2,7 +2,7 @@ class DateTime
   class << self
     # DateTimes aren't aware of DST rules, so use a consistent non-DST offset when creating a DateTime with an offset in the local zone
     def local_offset
-      ::Time.local(2007).utc_offset.to_r / 86400
+      ::Time.local(2012).utc_offset.to_r / 86400
     end
 
     # Returns <tt>Time.zone.now.to_datetime</tt> when <tt>Time.zone</tt> or <tt>config.time_zone</tt> are set, otherwise returns <tt>Time.now.to_datetime</tt>.

--- a/activesupport/lib/active_support/core_ext/date_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/conversions.rb
@@ -58,31 +58,16 @@ class DateTime
   alias_method :default_inspect, :inspect
   alias_method :inspect, :readable_inspect
 
-  # Converts self to a Ruby Date object; time portion is discarded.
-  def to_date
-    ::Date.new(year, month, day)
-  end unless instance_methods(false).include?(:to_date)
-
   # Attempts to convert self to a Ruby Time object; returns self if out of range of Ruby Time class.
   # If self has an offset other than 0, self will just be returned unaltered, since there's no clean way to map it to a Time.
   def to_time
     self.offset == 0 ? ::Time.utc_time(year, month, day, hour, min, sec, sec_fraction * 1000000) : self
   end
 
-  # To be able to keep Times, Dates and DateTimes interchangeable on conversions.
-  def to_datetime
-    self
-  end unless instance_methods(false).include?(:to_datetime)
-
   def self.civil_from_format(utc_or_local, year, month=1, day=1, hour=0, min=0, sec=0)
     offset = utc_or_local.to_sym == :local ? local_offset : 0
     civil(year, month, day, hour, min, sec, offset)
   end
-
-  # Converts datetime to an appropriate format for use in XML.
-  def xmlschema
-    strftime("%Y-%m-%dT%H:%M:%S%Z")
-  end unless instance_methods(false).include?(:xmlschema)
 
   # Converts self to a floating-point number of seconds since the Unix epoch.
   def to_f

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -81,25 +81,25 @@ class Module
   # no matter whether +nil+ responds to the delegated method. You can get a
   # +nil+ instead with the +:allow_nil+ option.
   #
-  #  class Foo
-  #    attr_accessor :bar
-  #    def initialize(bar = nil)
-  #      @bar = bar
-  #    end
-  #    delegate :zoo, :to => :bar
-  #  end
+  #   class Foo
+  #     attr_accessor :bar
+  #     def initialize(bar = nil)
+  #       @bar = bar
+  #     end
+  #     delegate :zoo, :to => :bar
+  #   end
   #
-  #  Foo.new.zoo   # raises NoMethodError exception (you called nil.zoo)
+  #   Foo.new.zoo   # raises NoMethodError exception (you called nil.zoo)
   #
-  #  class Foo
-  #    attr_accessor :bar
-  #    def initialize(bar = nil)
-  #      @bar = bar
-  #    end
-  #    delegate :zoo, :to => :bar, :allow_nil => true
-  #  end
+  #   class Foo
+  #     attr_accessor :bar
+  #     def initialize(bar = nil)
+  #       @bar = bar
+  #     end
+  #     delegate :zoo, :to => :bar, :allow_nil => true
+  #   end
   #
-  #  Foo.new.zoo   # returns nil
+  #   Foo.new.zoo   # returns nil
   #
   def delegate(*methods)
     options = methods.pop

--- a/activesupport/lib/active_support/core_ext/uri.rb
+++ b/activesupport/lib/active_support/core_ext/uri.rb
@@ -20,7 +20,7 @@ end
 module URI
   class << self
     def parser
-      @parser ||= URI.const_defined?(:Parser) ? URI::Parser.new : URI
+      @parser ||= URI::Parser.new
     end
   end
 end

--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/object/blank'
 require 'logger'
+require 'active_support/logger'
 
 module ActiveSupport
   # Wraps any standard Logger class to provide tagging capabilities. Examples:
@@ -11,52 +12,47 @@ module ActiveSupport
   #
   # This is used by the default Rails.logger as configured by Railties to make it easy to stamp log lines
   # with subdomains, request ids, and anything else to aid debugging of multi-user production applications.
-  class TaggedLogging
-    def initialize(logger)
-      @logger = logger
+  module TaggedLogging
+    class Formatter < ActiveSupport::Logger::SimpleFormatter # :nodoc:
+      # This method is invoked when a log event occurs
+      def call(severity, timestamp, progname, msg)
+        super(severity, timestamp, progname, "#{tags_text}#{msg}")
+      end
+
+      def clear!
+        current_tags.clear
+      end
+
+      def current_tags
+        Thread.current[:activesupport_tagged_logging_tags] ||= []
+      end
+
+      private
+      def tags_text
+        tags = current_tags
+        if tags.any?
+          tags.collect { |tag| "[#{tag}] " }.join
+        end
+      end
+    end
+
+    def self.new(logger)
+      logger.formatter = Formatter.new
+      logger.extend(self)
     end
 
     def tagged(*new_tags)
-      tags     = current_tags
-      new_tags = Array(new_tags).flatten.reject(&:blank?)
+      tags     = formatter.current_tags
+      new_tags = new_tags.flatten.reject(&:blank?)
       tags.concat new_tags
       yield
     ensure
       tags.pop(new_tags.size)
     end
 
-    def add(severity, message = nil, progname = nil, &block)
-      @logger.add(severity, "#{tags_text}#{message}", progname, &block)
-    end
-
-    %w( fatal error warn info debug unknown ).each do |severity|
-      eval <<-EOM, nil, __FILE__, __LINE__ + 1
-        def #{severity}(progname = nil, &block)              # def warn(progname = nil, &block)
-          add(Logger::#{severity.upcase}, progname, &block)  #   add(Logger::WARN, progname, &block)
-        end                                                  # end
-      EOM
-    end
-
     def flush
-      current_tags.clear
-      @logger.flush if @logger.respond_to?(:flush)
-    end
-
-    def method_missing(method, *args)
-      @logger.send(method, *args)
-    end
-
-    protected
-
-    def tags_text
-      tags = current_tags
-      if tags.any?
-        tags.collect { |tag| "[#{tag}] " }.join
-      end
-    end
-
-    def current_tags
-      Thread.current[:activesupport_tagged_logging_tags] ||= []
+      formatter.clear!
+      super if defined?(super)
     end
   end
 end

--- a/activesupport/test/core_ext/uri_ext_test.rb
+++ b/activesupport/test/core_ext/uri_ext_test.rb
@@ -7,11 +7,7 @@ class URIExtTest < ActiveSupport::TestCase
   def test_uri_decode_handle_multibyte
     str = "\xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E" # Ni-ho-nn-go in UTF-8, means Japanese.
 
-    if URI.const_defined?(:Parser)
-      parser = URI::Parser.new
-      assert_equal str, parser.unescape(parser.escape(str))
-    else
-      assert_equal str, URI.unescape(URI.escape(str))
-    end
+    parser = URI::Parser.new
+    assert_equal str, parser.unescape(parser.escape(str))
   end
 end

--- a/railties/guides/code/getting_started/Gemfile
+++ b/railties/guides/code/getting_started/Gemfile
@@ -1,8 +1,9 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
-gem 'rails', '3.1.0'
+gem 'rails', '3.2.0'
+
 # Bundle edge Rails instead:
-# gem 'rails',     :git => 'git://github.com/rails/rails.git'
+# gem 'rails', :git => 'git://github.com/rails/rails.git'
 
 gem 'sqlite3'
 
@@ -10,12 +11,22 @@ gem 'sqlite3'
 # Gems used only for assets and not required
 # in production environments by default.
 group :assets do
-  gem 'sass-rails', "  ~> 3.1.0"
-  gem 'coffee-rails', "~> 3.1.0"
-  gem 'uglifier'
+  gem 'sass-rails',   '~> 3.2.3'
+  gem 'coffee-rails', '~> 3.2.1'
+
+  # See https://github.com/sstephenson/execjs#readme for more supported runtimes
+  # gem 'therubyracer'
+
+  gem 'uglifier', '>= 1.0.3'
 end
 
 gem 'jquery-rails'
+
+# To use ActiveModel has_secure_password
+# gem 'bcrypt-ruby', '~> 3.0.0'
+
+# To use Jbuilder templates for JSON
+# gem 'jbuilder'
 
 # Use unicorn as the web server
 # gem 'unicorn'

--- a/railties/guides/code/getting_started/app/assets/javascripts/application.js
+++ b/railties/guides/code/getting_started/app/assets/javascripts/application.js
@@ -1,8 +1,14 @@
-// This is a manifest file that'll be compiled into including all the files listed below.
-// Add new JavaScript/Coffee code in separate files in this directory and they'll automatically
-// be included in the compiled file accessible from http://example.com/assets/application.js
+// This is a manifest file that'll be compiled into application.js, which will include all the files
+// listed below.
+//
+// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
+// or vendor/assets/javascripts of plugins, if any, can be referenced here using a relative path.
+//
 // It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
 // the compiled file.
+//
+// WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
+// GO AFTER THE REQUIRES BELOW.
 //
 //= require jquery
 //= require jquery_ujs

--- a/railties/guides/code/getting_started/app/assets/stylesheets/application.css
+++ b/railties/guides/code/getting_started/app/assets/stylesheets/application.css
@@ -1,7 +1,13 @@
 /*
- * This is a manifest file that'll automatically include all the stylesheets available in this directory
- * and any sub-directories. You're free to add application-wide styles to this file and they'll appear at
- * the top of the compiled file, but it's generally better to create a new file per style scope.
+ * This is a manifest file that'll be compiled into application.css, which will include all the files
+ * listed below.
+ *
+ * Any CSS and SCSS file within this directory, lib/assets/stylesheets, vendor/assets/stylesheets,
+ * or vendor/assets/stylesheets of plugins, if any, can be referenced here using a relative path.
+ *
+ * You're free to add application-wide styles to this file and they'll appear at the top of the
+ * compiled file, but it's generally better to create a new file per style scope.
+ *
  *= require_self
- *= require_tree . 
+ *= require_tree .
 */

--- a/railties/guides/code/getting_started/app/views/layouts/application.html.erb
+++ b/railties/guides/code/getting_started/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
 </head>
-<body style="background: #EEEEEE;">
+<body>
 
 <%= yield %>
 

--- a/railties/guides/code/getting_started/config/application.rb
+++ b/railties/guides/code/getting_started/config/application.rb
@@ -4,7 +4,7 @@ require 'rails/all'
 
 if defined?(Bundler)
   # If you precompile assets before deploying to production, use this line
-  Bundler.require *Rails.groups(:assets => %w(development test))
+  Bundler.require(*Rails.groups(:assets => %w(development test)))
   # If you want your assets lazily compiled in production, use this line
   # Bundler.require(:default, :assets, Rails.env)
 end
@@ -39,6 +39,12 @@ module Blog
     # This is necessary if your schema can't be completely dumped by the schema dumper,
     # like if you have constraints or database-specific column types
     # config.active_record.schema_format = :sql
+
+    # Enforce whitelist mode for mass assignment.
+    # This will create an empty whitelist of attributes available for mass-assignment for all models
+    # in your app. As such, your models will need to explicitly whitelist or blacklist accessible
+    # parameters by using an attr_accessible or attr_protected declaration.
+    # config.active_record.whitelist_attributes = true
 
     # Enable the asset pipeline
     config.assets.enabled = true

--- a/railties/guides/code/getting_started/config/environments/test.rb
+++ b/railties/guides/code/getting_started/config/environments/test.rb
@@ -26,9 +26,9 @@ Blog::Application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # Raise exception on mass assignment protection for Active Record models
+  config.active_record.mass_assignment_sanitizer = :strict
+
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
-
-  # Allow pass debug_assets=true as a query parameter to load pages with unpackaged assets
-  config.assets.allow_debugging = true
 end

--- a/railties/guides/code/getting_started/config/initializers/inflections.rb
+++ b/railties/guides/code/getting_started/config/initializers/inflections.rb
@@ -8,3 +8,8 @@
 #   inflect.irregular 'person', 'people'
 #   inflect.uncountable %w( fish sheep )
 # end
+#
+# These inflection rules are supported but not enabled by default:
+# ActiveSupport::Inflector.inflections do |inflect|
+#   inflect.acronym 'RESTful'
+# end

--- a/railties/guides/code/getting_started/config/routes.rb
+++ b/railties/guides/code/getting_started/config/routes.rb
@@ -1,7 +1,7 @@
 Blog::Application.routes.draw do
-	resources :posts do
-		resources :comments
-	end
+  resources :posts do
+    resources :comments
+  end
 
   get "home/index"
 
@@ -60,5 +60,5 @@ Blog::Application.routes.draw do
 
   # This is a legacy wild controller route that's not recommended for RESTful applications.
   # Note: This route will make all actions in every controller accessible via GET requests.
-  # match ':controller(/:action(/:id(.:format)))'
+  # match ':controller(/:action(/:id))(.:format)'
 end

--- a/railties/guides/code/getting_started/public/500.html
+++ b/railties/guides/code/getting_started/public/500.html
@@ -20,7 +20,6 @@
   <!-- This file lives in public/500.html -->
   <div class="dialog">
     <h1>We're sorry, but something went wrong.</h1>
-    <p>We've been notified about this issue and we'll take a look at it shortly.</p>
   </div>
 </body>
 </html>

--- a/railties/guides/source/3_2_release_notes.textile
+++ b/railties/guides/source/3_2_release_notes.textile
@@ -138,7 +138,7 @@ will create indexes for +title+ and +author+ with the latter being an unique ind
 
 * Remove old <tt>config.paths.app.controller</tt> API in favor of <tt>config.paths["app/controller"]</tt>.
 
-h4. Deprecations
+h4(#railties_deprecations). Deprecations
 
 * +Rails::Plugin+ is deprecated and will be removed in Rails 4.0. Instead of adding plugins to +vendor/plugins+ use gems or bundler with path or git dependencies.
 
@@ -204,7 +204,7 @@ We now no longer write out HTTP_COOKIE and the cookie jar is persistent between 
 
 * Assets should use the request protocol by default or default to relative if no request is available.
 
-h5. Deprecations
+h5(#actioncontroller_deprecations). Deprecations
 
 * Deprecated implied layout lookup in controllers whose parent had a explicit layout set:
 
@@ -239,7 +239,7 @@ h4. Action Dispatch
 
 * Allow rescue responses to be configured through a railtie as in <tt>config.action_dispatch.rescue_responses</tt>.
 
-h5. Deprecations
+h5(#actiondispatch_deprecations). Deprecations
 
 * Deprecated the ability to set a default charset at the controller level, use the new <tt>config.action_dispatch.default_charset</tt> instead.
 
@@ -286,7 +286,7 @@ end
 
 * Added +font_path+ helper method that computes the path to a font asset in <tt>public/fonts</tt>.
 
-h5. Deprecations
+h5(#actionview_deprecations). Deprecations
 
 * Passing formats or handlers to render :template and friends like <tt>render :template => "foo.html.erb"</tt> is deprecated. Instead, you can provide :handlers and :formats directly as an options: <tt> render :template => "foo", :formats => [:html, :js], :handlers => :erb</tt>.
 
@@ -400,7 +400,7 @@ class Order < ActiveRecord::Base
 end
 </ruby>
 
-h4. Deprecations
+h4(#activerecord_deprecations). Deprecations
 
 * Automatic closure of connections in threads is deprecated. For example the following code is deprecated:
 
@@ -448,7 +448,7 @@ h3. Active Model
 
 * Provide mass_assignment_sanitizer as an easy API to replace the sanitizer behavior. Also support both :logger (default) and :strict sanitizer behavior.
 
-h4. Deprecations
+h4(#activemodel_deprecations). Deprecations
 
 * Deprecated <tt>define_attr_method</tt> in <tt>ActiveModel::AttributeMethods</tt> because this only existed to support methods like +set_table_name+ in Active Record, which are themselves being deprecated.
 
@@ -508,7 +508,7 @@ Event.where(:created_at => Time.now.all_day)
 
 * Removed <tt>ActiveSupport::SecureRandom</tt> in favor of <tt>SecureRandom</tt> from the standard library.
 
-h4. Deprecations
+h4(#activesupport_deprecations). Deprecations
 
 * +ActiveSupport::Base64+ is deprecated in favor of <tt>::Base64</tt>.
 

--- a/railties/guides/source/3_2_release_notes.textile
+++ b/railties/guides/source/3_2_release_notes.textile
@@ -27,6 +27,7 @@ h4. What to update in your apps
 ** <tt>rails = 3.2.0</tt>
 ** <tt>sass-rails ~> 3.2.3</tt>
 ** <tt>coffee-rails ~> 3.2.1</tt>
+** <tt>uglifier >= 1.0.3</tt>
 
 * Rails 3.2 deprecates <tt>vendor/plugins</tt> and Rails 4.0 will remove them completely. You can start replacing these plugins by extracting them as gems and adding them in your Gemfile. If you choose not to make them gems, you can move them into, say, <tt>lib/my_plugin/*</tt> and add an appropriate initializer in <tt>config/initializers/my_plugin.rb</tt>.
 

--- a/railties/guides/source/3_2_release_notes.textile
+++ b/railties/guides/source/3_2_release_notes.textile
@@ -226,8 +226,6 @@ In the example above, Posts controller will no longer automatically look up for 
 
 * Deprecated <tt>method_missing</tt> in favour of +action_missing+ for missing actions.
 
-* Deprecated <tt>ActionController#performed?</tt> in favour of checking for the presence of <tt>response_body</tt>.
-
 * Deprecated <tt>ActionController#rescue_action</tt>, <tt>ActionController#initialize_template_class</tt> and <tt>ActionController#assign_shortcuts</tt>.
 
 h4. Action Dispatch

--- a/railties/guides/source/3_2_release_notes.textile
+++ b/railties/guides/source/3_2_release_notes.textile
@@ -373,6 +373,33 @@ has_many :clients, :class_name => :Client # Note that the symbol need to be capi
 User.where(:first_name => "Scarlett").first_or_create!(:last_name => "Johansson")
 </ruby>
 
+* Added a <tt>with_lock</tt> method to Active Record objects, which starts a transaction, locks the object (pessimistically) and yields to the block. The method takes one (optional) parameter and passes it to +lock!+.
+
+This makes it possible to write the following:
+
+<ruby>
+class Order < ActiveRecord::Base
+  def cancel!
+    transaction do
+      lock!
+      # ... cancelling logic
+    end
+  end
+end
+</ruby>
+
+as:
+
+<ruby>
+class Order < ActiveRecord::Base
+  def cancel!
+    with_lock do
+      # ... cancelling logic
+    end
+  end
+end
+</ruby>
+
 h4. Deprecations
 
 * Automatic closure of connections in threads is deprecated. For example the following code is deprecated:

--- a/railties/guides/source/3_2_release_notes.textile
+++ b/railties/guides/source/3_2_release_notes.textile
@@ -298,6 +298,8 @@ h3. Active Record
 
 * Boolean columns with 'on' and 'ON' values are type casted to true.
 
+* When the +timestamps+ method creates the +created_at+ and +updated_at+ columns, it makes them non-nullable by default.
+
 * Implemented <tt>ActiveRecord::Relation#explain</tt>.
 
 * Implements <tt>AR::Base.silence_auto_explain</tt> which allows the user to selectively disable automatic EXPLAINs within a block.
@@ -370,8 +372,6 @@ has_many :clients, :class_name => :Client # Note that the symbol need to be capi
 <ruby>
 User.where(:first_name => "Scarlett").first_or_create!(:last_name => "Johansson")
 </ruby>
-
-* +timestamps+ will add non-null constraint as default.
 
 h4. Deprecations
 

--- a/railties/guides/source/3_2_release_notes.textile
+++ b/railties/guides/source/3_2_release_notes.textile
@@ -284,7 +284,7 @@ h5. Deprecations
 
 * Passing formats or handlers to render :template and friends like <tt>render :template => "foo.html.erb"</tt> is deprecated. Instead, you can provide :handlers and :formats directly as an options: <tt> render :template => "foo", :formats => [:html, :js], :handlers => :erb</tt>.
 
-h3. Sprockets
+h4. Sprockets
 
 * Adds a configuration option <tt>config.assets.logger</tt> to control Sprockets logging. Set it to +false+ to turn off logging and to +nil+ to default to +Rails.logger+.
 

--- a/railties/guides/source/3_2_release_notes.textile
+++ b/railties/guides/source/3_2_release_notes.textile
@@ -371,6 +371,8 @@ has_many :clients, :class_name => :Client # Note that the symbol need to be capi
 User.where(:first_name => "Scarlett").first_or_create!(:last_name => "Johansson")
 </ruby>
 
+* +timestamps+ will add non-null constraint as default.
+
 h4. Deprecations
 
 * Automatic closure of connections in threads is deprecated. For example the following code is deprecated:

--- a/railties/guides/source/3_2_release_notes.textile
+++ b/railties/guides/source/3_2_release_notes.textile
@@ -144,9 +144,9 @@ h4. Deprecations
 
 h3. Action Mailer
 
-* Upgraded mail version to 2.4.0
+* Upgraded <tt>mail</tt> version to 2.4.0.
 
-* Removed Old Action Mailer API. The Old API was deprecated since Rails 3.0 release.
+* Removed the old Action Mailer API which was deprecated since Rails 3.0.
 
 h3. Action Pack
 

--- a/railties/guides/source/3_2_release_notes.textile
+++ b/railties/guides/source/3_2_release_notes.textile
@@ -142,6 +142,12 @@ h4. Deprecations
 
 * +Rails::Plugin+ is deprecated and will be removed in Rails 4.0. Instead of adding plugins to +vendor/plugins+ use gems or bundler with path or git dependencies.
 
+h3. Action Mailer
+
+* Upgraded mail version to 2.4.0
+
+* Removed Old Action Mailer API. The Old API was deprecated since Rails 3.0 release.
+
 h3. Action Pack
 
 h4. Action Controller

--- a/railties/guides/source/active_record_querying.textile
+++ b/railties/guides/source/active_record_querying.textile
@@ -692,6 +692,17 @@ Item.transaction do
 end
 </ruby>
 
+If you already have an instance of your model, you can start a transaction and acquire the lock in one go using the following code:
+
+<ruby>
+item = Item.first
+item.with_lock do
+  # This block is called within a transaction,
+  # item is already locked.
+  item.increment!(:views)
+end
+</ruby>
+
 h3. Joining Tables
 
 Active Record provides a finder method called +joins+ for specifying +JOIN+ clauses on the resulting SQL. There are multiple ways to use the +joins+ method.

--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -89,6 +89,7 @@ module Rails
     def default_options
       super.merge({
         :Port        => 3000,
+        :DoNotReverseLookup => true,
         :environment => (ENV['RAILS_ENV'] || "development").dup,
         :daemonize   => false,
         :debugger    => false,

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -228,7 +228,7 @@ module Rails
   #     resources :articles
   #   end
   #
-  # The routes above will automatically point to <tt>MyEngine::ApplicationController</tt>. Furthermore, you don't
+  # The routes above will automatically point to <tt>MyEngine::ArticlesController</tt>. Furthermore, you don't
   # need to use longer url helpers like <tt>my_engine_articles_path</tt>. Instead, you should simply use
   # <tt>articles_path</tt> as you would do with your application.
   #

--- a/railties/lib/rails/rack/log_tailer.rb
+++ b/railties/lib/rails/rack/log_tailer.rb
@@ -4,10 +4,13 @@ module Rails
       def initialize(app, log = nil)
         @app = app
 
-        path = Pathname.new(log || "#{File.expand_path(Rails.root)}/log/#{Rails.env}.log").cleanpath
-        @cursor = ::File.size(path)
+        path = Pathname.new(log || "#{::File.expand_path(Rails.root)}/log/#{Rails.env}.log").cleanpath
 
-        @file = ::File.open(path, 'r')
+        @cursor = @file = nil
+        if ::File.exists?(path)
+          @cursor = ::File.size(path)
+          @file = ::File.open(path, 'r')
+        end
       end
 
       def call(env)
@@ -17,6 +20,7 @@ module Rails
       end
 
       def tail!
+        return unless @cursor
         @file.seek @cursor
 
         unless @file.eof?


### PR DESCRIPTION
Since Ruby 1.9 + defaults Hash works as Ordered Hash and rails 4 has minimum requirement of ruby 1.9 ++ we can replace the ActiveSupport Ordered hash to ruby hash. 
