### PR TITLE
Replacing ordered hash to ruby hash on active model

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -4,12 +4,11 @@ require 'active_support/core_ext/array/conversions'
 require 'active_support/core_ext/string/inflections'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/hash/reverse_merge'
-require 'active_support/ordered_hash'
 
 module ActiveModel
   # == Active Model Errors
   #
-  # Provides a modified +OrderedHash+ that you can include in your object
+  # Provides a modified +Hash+ that you can include in your object
   # for handling error messages and interacting with Action Pack helpers.
   #
   # A minimal implementation could be:
@@ -75,7 +74,7 @@ module ActiveModel
     #   end
     def initialize(base)
       @base     = base
-      @messages = ActiveSupport::OrderedHash.new
+      @messages = {}
     end
 
     def initialize_dup(other)
@@ -206,7 +205,7 @@ module ActiveModel
       to_a.to_xml options.reverse_merge(:root => "errors", :skip_types => true)
     end
 
-    # Returns an ActiveSupport::OrderedHash that can be used as the JSON representation for this object.
+    # Returns an Hash that can be used as the JSON representation for this object.
     def as_json(options=nil)
       to_hash
     end

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -33,7 +33,7 @@ module ActiveModel
   #   person.first_name = 'zoolander'
   #   person.valid?                   # => false
   #   person.invalid?                 # => true
-  #   person.errors                   # => #<OrderedHash {:first_name=>["starts with z."]}>
+  #   person.errors                   # => #<Hash {:first_name=>["starts with z."]}>
   #
   # Note that <tt>ActiveModel::Validations</tt> automatically adds an +errors+ method
   # to your instances initialized with a new <tt>ActiveModel::Errors</tt> object, so

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -154,7 +154,7 @@ class ErrorsTest < ActiveModel::TestCase
   test 'to_hash should return an ordered hash' do
     person = Person.new
     person.errors.add(:name, "can not be blank")
-    assert_instance_of ActiveSupport::OrderedHash, person.errors.to_hash
+    assert_instance_of ::Hash, person.errors.to_hash
   end
 
   test 'full_messages should return an array of error messages, with the attribute name included' do

--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -130,13 +130,13 @@ class JsonSerializationTest < ActiveModel::TestCase
     assert_match %r{"favorite_quote":"Constraints are liberating"}, methods_json
   end
 
-  test "should return OrderedHash for errors" do
+  test "should return Hash for errors" do
     contact = Contact.new
     contact.errors.add :name, "can't be blank"
     contact.errors.add :name, "is too short (minimum is 2 characters)"
     contact.errors.add :age, "must be 16 or over"
 
-    hash = ActiveSupport::OrderedHash.new
+    hash = {}
     hash[:name] = ["can't be blank", "is too short (minimum is 2 characters)"]
     hash[:age]  = ["must be 16 or over"]
     assert_equal hash.to_json, contact.errors.to_json

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -180,7 +180,7 @@ class ValidationsTest < ActiveModel::TestCase
     assert_match %r{<error>Title can't be blank</error>}, xml
     assert_match %r{<error>Content can't be blank</error>}, xml
 
-    hash = ActiveSupport::OrderedHash.new
+    hash = {}
     hash[:title] = ["can't be blank"]
     hash[:content] = ["can't be blank"]
     assert_equal t.errors.to_json, hash.to_json


### PR DESCRIPTION
Since Ruby 1.9 + defaults Hash works as Ordered Hash and rails 4 has minimum requirement of ruby 1.9 ++ we can replace the ActiveSupport Ordered hash to ruby hash. Checked the tests looks good.
