### PR TITLE
Fix failing request test

### DIFF
--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -127,7 +127,7 @@ class RequestTest < ActiveSupport::TestCase
                            'HTTP_X_FORWARDED_FOR' => '3.4.5.6'
     assert_equal '3.4.5.6', request.remote_ip
 
-    request = stub_request 'HTTP_X_FORWARDED_FOR' => '9.9.9.9, 3.4.5.6, 10.0.0.1, 67.205.106.73'
+    request = stub_request 'HTTP_X_FORWARDED_FOR' => '67.205.106.73, 10.0.0.1, 9.9.9.9, 3.4.5.6'
     assert_equal '10.0.0.1', request.remote_ip
   end
 


### PR DESCRIPTION
Latest changes in remote ip handling conflicted with each other in
tests. Related:

dd09811fa6214a130fdc2de1d4c00b4337cb15f9
6a720226aad2adffcbd2422d40db772719579e2f
