### PR TITLE
Fix match docs

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1250,7 +1250,7 @@ module ActionDispatch
         end
 
         # match 'path' => 'controller#action'
-        # match 'path', as: 'controller#action'
+        # match 'path', to: 'controller#action'
         # match 'path', 'otherpath', on: :member, via: :get
         def match(path, *rest)
           if rest.empty? && Hash === path


### PR DESCRIPTION
I fixed the match docs added in this commit: 007c41100b06db53630ce60048eaa625a9e955ee

I opened this pull request because the docrails repository is not updated
