### PR TITLE
AR::Relation#pluck: improve to work with joins

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -177,6 +177,9 @@ module ActiveRecord
     #   Person.where(:confirmed => true).limit(5).pluck(:id)
     #
     def pluck(column_name)
+      if column_name.is_a?(Symbol) && column_names.include?(column_name.to_s)
+        column_name = "#{table_name}.#{column_name}"
+      end
       klass.connection.select_all(select(column_name).arel).map! do |attributes|
         klass.type_cast_attribute(attributes.keys.first, klass.initialize_attributes(attributes))
       end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -478,4 +478,15 @@ class CalculationsTest < ActiveRecord::TestCase
   def test_pluck_with_qualified_column_name
     assert_equal [1,2,3,4], Topic.order(:id).pluck("topics.id")
   end
+
+  def test_pluck_auto_table_name_prefix
+    c = Company.create!(:name => "test", :contracts => [Contract.new])
+    assert_equal [c.id], Company.joins(:contracts).pluck(:id)
+  end
+
+  def test_pluck_not_auto_table_name_prefix_if_column_joined
+    c = Company.create!(:name => "test", :contracts => [Contract.new(:developer_id => 7)])
+    # No chance for typecast here
+    assert_equal ["7"], Company.joins(:contracts).pluck(:developer_id)
+  end
 end


### PR DESCRIPTION
When Relation has some joined table, columns like `id` will become ambiguous. 
This patch automatically plucks column from main table if possible, like:

``` ruby
User.joins(:projects).pluck(:id) # select users.id from users join projects on ...
```
