### PR TITLE
3 2 stable

### DIFF
--- a/railties/lib/rails/commands.rb
+++ b/railties/lib/rails/commands.rb
@@ -13,6 +13,7 @@ aliases = {
 
 command = ARGV.shift
 command = aliases[command] || command
+RAILS_COMMAND = command
 
 case command
 when 'generate', 'destroy', 'plugin'


### PR DESCRIPTION
Adding RAILS_COMMAND constant on initialization process, so with that a gem can access which rails command is being executed:

On rails initializer hook you can't know which rails command is running. with that I can use is on a hook like this:

```
config.after_initialize do
  puts RAILS_COMMAND
end
```
