### PR TITLE
replaced active support ordered hash to ruby hash on active resource

### DIFF
--- a/activeresource/test/cases/base_test.rb
+++ b/activeresource/test/cases/base_test.rb
@@ -8,7 +8,6 @@ require "fixtures/proxy"
 require "fixtures/address"
 require "fixtures/subscription_plan"
 require 'active_support/json'
-require 'active_support/ordered_hash'
 require 'active_support/core_ext/hash/conversions'
 require 'mocha'
 
@@ -464,8 +463,7 @@ class BaseTest < ActiveSupport::TestCase
     assert Person.collection_path(:gender => 'male', :student => true).include?('student=true')
 
     assert_equal '/people.json?name%5B%5D=bob&name%5B%5D=your+uncle%2Bme&name%5B%5D=&name%5B%5D=false', Person.collection_path(:name => ['bob', 'your uncle+me', nil, false])
-
-    assert_equal '/people.json?struct%5Ba%5D%5B%5D=2&struct%5Ba%5D%5B%5D=1&struct%5Bb%5D=fred', Person.collection_path(:struct => ActiveSupport::OrderedHash[:a, [2,1], 'b', 'fred'])
+    assert_equal '/people.json?struct%5Ba%5D%5B%5D=2&struct%5Ba%5D%5B%5D=1&struct%5Bb%5D=fred', Person.collection_path(:struct => {:a => [2,1], 'b' => 'fred'})
   end
 
   def test_custom_element_path


### PR DESCRIPTION
Since Ruby 1.9 + defaults Hash works as Ordered Hash and rails 4 has minimum requirement of ruby 1.9 ++ we can replace the ActiveSupport Ordered hash to ruby hash. Checked the tests looks good.
