### PR TITLE
Decoupling ActiveSupport from ActionView

### DIFF
--- a/actionpack/lib/action_dispatch/testing/performance_test.rb
+++ b/actionpack/lib/action_dispatch/testing/performance_test.rb
@@ -1,4 +1,15 @@
 require 'active_support/testing/performance'
+require 'action_view/helpers/number_helper'
+
+ActiveSupport::Testing::Performance::Metrics::Amount.formatter = Proc.new() do |measurement| 
+  include ActionView::Helpers::NumberHelper
+  number_with_delimiter(measurement.floor)
+end
+
+ActiveSupport::Testing::Performance::Metrics::DigitalInformationUnit.formatter = Proc.new() do |measurement| 
+  include ActionView::Helpers::NumberHelper
+  number_to_human_size(measurement, :precision => 2)
+end
 
 module ActionDispatch
   # An integration test that runs a code profiler on your test methods.

--- a/activesupport/lib/active_support/testing/performance.rb
+++ b/activesupport/lib/active_support/testing/performance.rb
@@ -3,6 +3,7 @@ require 'rails/version'
 require 'active_support/concern'
 require 'active_support/core_ext/class/delegating_attributes'
 require 'active_support/core_ext/string/inflections'
+require 'active_support/core_ext/class/attribute'
 
 module ActiveSupport
   module Testing

--- a/activesupport/lib/active_support/testing/performance.rb
+++ b/activesupport/lib/active_support/testing/performance.rb
@@ -3,7 +3,6 @@ require 'rails/version'
 require 'active_support/concern'
 require 'active_support/core_ext/class/delegating_attributes'
 require 'active_support/core_ext/string/inflections'
-require 'action_view/helpers/number_helper'
 
 module ActiveSupport
   module Testing
@@ -246,9 +245,8 @@ module ActiveSupport
         end
 
         class Base
-          include ActionView::Helpers::NumberHelper
-
           attr_reader :total
+          class_attribute :formatter
 
           def initialize
             @total = 0
@@ -290,13 +288,21 @@ module ActiveSupport
 
         class Amount < Base
           def format(measurement)
-            number_with_delimiter(measurement.floor)
+            if self.class.formatter.present?
+              self.class.formatter.call(measurement.floor)
+            else
+              measurement.floor
+            end
           end
         end
 
         class DigitalInformationUnit < Base
           def format(measurement)
-            number_to_human_size(measurement, :precision => 2)
+            if self.class.formatter.present?
+              self.class.formatter.call(measurement)
+            else
+              "#{measurement} Bytes"
+            end
           end
         end
 


### PR DESCRIPTION
I'm interested in using the ActiveSupport::Testing::Performance module and was surprised to see that it requires and calls code from ActionView.  Is this intentional?

I'd like to use this module in a context without ActionView, so I'm submitting a pull request that decouples ActiveSupport from ActionView.
