### PR TITLE
replacing the orderhash with hash for ruby-1.9

### DIFF
--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -1,6 +1,5 @@
 require 'abstract_unit'
 require 'controller/fake_controllers'
-require 'active_support/ordered_hash'
 
 class TestCaseTest < ActionController::TestCase
   class TestController < ActionController::Base
@@ -155,14 +154,14 @@ XML
   end
 
   def test_raw_post_handling
-    params = ActiveSupport::OrderedHash[:page, {:name => 'page name'}, 'some key', 123]
+    params = Hash[:page, {:name => 'page name'}, 'some key', 123]
     post :render_raw_post, params.dup
 
     assert_equal params.to_query, @response.body
   end
 
   def test_body_stream
-    params = ActiveSupport::OrderedHash[:page, { :name => 'page name' }, 'some key', 123]
+    params = Hash[:page, { :name => 'page name' }, 'some key', 123]
 
     post :render_body, params.dup
 


### PR DESCRIPTION
Changed the ordered hash with hash
