### PR TITLE
Fix GH #4909. Dependency on TZInfo move from AR to AS.

### DIFF
--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -22,5 +22,4 @@ Gem::Specification.new do |s|
   s.add_dependency('activesupport', version)
   s.add_dependency('activemodel',   version)
   s.add_dependency('arel',          '~> 3.0.0')
-  s.add_dependency('tzinfo',        '~> 0.3.29')
 end

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency('i18n',       '~> 0.6')
   s.add_dependency('multi_json', '~> 1.0')
+  s.add_dependency('tzinfo',     '~> 0.3.29')
 end


### PR DESCRIPTION
I found reference to TZInfo in active_support, but I couldn't find reference to TZInfo in active_record.
I think that we should move dependency on tzinfo from active_record to active_support.

I found steps to reproduce for acitvesupport.

```
$ cd (path to rails)
$ git checkout master
$ rake build
$ ls -la pkg
...
-rw-rw-r--  1 kennyj kennyj  306688  1月 12 01:13 activesupport-4.0.0.beta.gem
...

$ gem install pkg/activesupport-4.0.0.beta.gem --no-ri --no-rdoc

$ cd (path to work)
$ vim Gemfile
source 'http://rubygems.org'
gem 'activesupport', '4.0.0.beta'
$ bundle install
$ bundle exec irb

■before
ruby-1.9.3-p0 :001 > require 'active_support/all'
 => true
ruby-1.9.3-p0 :002 > Time.find_zone!("Tokyo")
You don't have tzinfo installed in your application. Please add it to your Gemfile and run bundle install
NameError: uninitialized constant Class::TZInfo
        from /home/kennyj/.rvm/gems/ruby-1.9.3-p0/gems/activesupport-4.0.0.beta/lib/active_support/core_ext/time/zones.rb:60:in `rescue in find_zone!'
        from /home/kennyj/.rvm/gems/ruby-1.9.3-p0/gems/activesupport-4.0.0.beta/lib/active_support/core_ext/time/zones.rb:53:in `find_zone!'
        from (irb):2
        from /home/kennyj/.rvm/rubies/ruby-1.9.3-p0/bin/irb:16:in `<main>'

■after (with myfix)
ruby-1.9.3-p0 :001 > require 'active_support/all'
 => true
ruby-1.9.3-p0 :002 > Time.find_zone!("Tokyo")
 => (GMT+09:00) Tokyo
```

and for activerecord

```
~/rails(fix_4909)$ cd activerecord/
~/rails/activerecord(fix_4909)$ find . -name "*" -print | xargs grep "tzinfo"
./CHANGELOG.md:*   Removing unnecessary uses_tzinfo helper from tests, given that TZInfo is now bundled *Geoff Buesing*
~/rails/activerecord(fix_4909)$ find . -name "*" -print | xargs grep "TZInfo"
./CHANGELOG.md:*   Removing unnecessary uses_tzinfo helper from tests, given that TZInfo is now bundled *Geoff Buesing*
```
