### PR TITLE
Fix eagerly loading associations without primary keys

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency/join_part.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_part.rb
@@ -54,7 +54,7 @@ module ActiveRecord
           unless @column_names_with_alias
             @column_names_with_alias = []
 
-            ([primary_key] + (column_names - [primary_key])).each_with_index do |column_name, i|
+            ([primary_key] + (column_names - [primary_key])).compact.each_with_index do |column_name, i|
               @column_names_with_alias << [column_name, "#{aliased_prefix}_r#{i}"]
             end
           end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -39,6 +39,19 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_nil member.favourite_club
   end
 
+  def test_loading_with_one_association_without_primary_key
+    Comment.primary_key = nil
+    begin
+      assert_nothing_raised do
+        Post.includes(:comments).references(:comments).all
+      end
+    rescue
+      raise $!
+    ensure
+      Comment.primary_key = 'id'
+    end
+  end
+
   def test_loading_with_one_association
     posts = Post.find(:all, :include => :comments)
     post = posts.find { |p| p.id == 1 }

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -39,19 +39,6 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_nil member.favourite_club
   end
 
-  def test_loading_with_one_association_without_primary_key
-    Comment.primary_key = nil
-    begin
-      assert_nothing_raised do
-        Post.includes(:comments).references(:comments).all
-      end
-    rescue
-      raise $!
-    ensure
-      Comment.primary_key = 'id'
-    end
-  end
-
   def test_loading_with_one_association
     posts = Post.find(:all, :include => :comments)
     post = posts.find { |p| p.id == 1 }

--- a/activerecord/test/cases/associations/join_dependency_test.rb
+++ b/activerecord/test/cases/associations/join_dependency_test.rb
@@ -1,0 +1,8 @@
+require "cases/helper"
+require 'models/edge'
+
+class JoinDependencyTest < ActiveRecord::TestCase
+  def test_column_names_with_alias_handles_nil_primary_key
+    assert_equal Edge.column_names, ActiveRecord::Associations::JoinDependency::JoinBase.new(Edge).column_names_with_alias.map(&:first)
+  end
+end


### PR DESCRIPTION
column_names_with_alias allowed a nil through when used with associations without primary keys which breaks eager loading in some circumstances.
