### PR TITLE
Clear template extension memoize cache on register_template_handler

### DIFF
--- a/actionpack/lib/action_view/lookup_context.rb
+++ b/actionpack/lib/action_view/lookup_context.rb
@@ -133,7 +133,7 @@ module ActionView
       end
 
       def default_handlers #:nodoc:
-        @@default_handlers ||= Template::Handlers.extensions
+        Template::Handlers.extensions
       end
 
       def handlers_regexp #:nodoc:

--- a/actionpack/lib/action_view/template/handlers.rb
+++ b/actionpack/lib/action_view/template/handlers.rb
@@ -25,6 +25,8 @@ module ActionView #:nodoc:
       # local assigns available to the template. The +render+ method ought to
       # return the rendered template as a string.
       def register_template_handler(extension, klass)
+        # Clear cache of template extensions
+        @@template_extensions = nil
         @@template_handlers[extension.to_sym] = klass
       end
 

--- a/actionpack/test/template/render_test.rb
+++ b/actionpack/test/template/render_test.rb
@@ -242,6 +242,13 @@ module RenderTestCases
     assert_equal 'source: "Hello, <%= name %>!"', @view.render(:inline => "Hello, <%= name %>!", :locals => { :name => "Josh" }, :type => :foo)
   end
 
+  def test_register_template_handler_resets_extensions_list
+    ActionView::Template::Handlers.extensions
+
+    ActionView::Template.register_template_handler :new_handler, CustomHandler
+    assert ActionView::Template::Handlers.extensions.include?(:new_handler)
+  end
+
   def test_render_ignores_templates_with_malformed_template_handlers
     %w(malformed malformed.erb malformed.html.erb malformed.en.html.erb).each do |name|
       assert_raise(ActionView::MissingTemplate) { @view.render(:file => "test/malformed/#{name}") }


### PR DESCRIPTION
Some gems like to monkey around with ActionView in a railtie. The one that prompted this issue for a client of mine was [best_in_place](https://github.com/bernat/best_in_place/blob/0d8434246dc20713df3de076c49817fb3aaeb376/lib/best_in_place/railtie.rb#L4).

Currently, ActionView::Template::Handlers.extensions memoizes itself into a cvar the first time it's touched. So after it's called, register_template_handlers has no effect on the recognized set of extensions. In the application in question, the problematic gem loaded before prototype-rails could register its RJS handler, and so any RJS templates raised a MissingTemplate.

This commit fixes register_template_handlers to clear the memoization cache so that the extensions list is always accurate. Added a test differentiating my fix from 3-1-stable.

I also removed memoization from LookupContext#default_handlers, since it would exhibit the same problem. It just calls Template::Handlers.extensions, which is memoized anyway, so I don't think this incurs any appreciable slowdown.

If this is an acceptable fix, I can also port to 3-2-stable and master. Neither 3-2-stable nor master appear to have the LookupContext issue, as that code has been refactored since 3.1. But the Template::Handlers.extensions issue exists from 3.1 through today on master.

Thanks!
