### PR TITLE
make Range#overlaps? accept Range of Time

### DIFF
--- a/activesupport/lib/active_support/core_ext/range/overlaps.rb
+++ b/activesupport/lib/active_support/core_ext/range/overlaps.rb
@@ -3,6 +3,6 @@ class Range
   #  (1..5).overlaps?(4..6) # => true
   #  (1..5).overlaps?(7..9) # => false
   def overlaps?(other)
-    include?(other.first) || other.include?(first)
+    cover?(other.first) || other.cover?(first)
   end
 end

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -71,4 +71,16 @@ class RangeTest < ActiveSupport::TestCase
     range = (1..3)
     assert range.method(:include?) != range.method(:cover?)
   end
+
+  def test_overlaps_on_time
+    time_range_1 = Time.utc(2005, 12, 10, 15, 30)..Time.utc(2005, 12, 10, 17, 30)
+    time_range_2 = Time.utc(2005, 12, 10, 17, 00)..Time.utc(2005, 12, 10, 18, 00)
+    assert time_range_1.overlaps?(time_range_2)
+  end
+
+  def test_no_overlaps_on_time
+    time_range_1 = Time.utc(2005, 12, 10, 15, 30)..Time.utc(2005, 12, 10, 17, 30)
+    time_range_2 = Time.utc(2005, 12, 10, 17, 31)..Time.utc(2005, 12, 10, 18, 00)
+    assert !time_range_1.overlaps?(time_range_2)
+  end
 end


### PR DESCRIPTION
Current Range#overlaps? use Range#include? to check the coverage of range of Time.

Use overlaps? on Time like this:

```
time_range_1 = Time.utc(2005, 12, 10, 15, 30)..Time.utc(2005, 12, 10, 17, 30)
time_range_2 = Time.utc(2005, 12, 10, 17, 00)..Time.utc(2005, 12, 10, 18, 00)
assert time_range_1.overlaps?(time_range_2)
```

cause:

```
TypeError: can't iterate from Time
```

use cover? instead of include? makes Time range happy, as noted in [ruby-trunk Bug#3623](http://bugs.ruby-lang.org/issues/3623)
