### PR TITLE
AS::Callbacks#run_callbacks: deprecated second argument

### DIFF
--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -14,7 +14,7 @@ module AbstractController
     # Override AbstractController::Base's process_action to run the
     # process_action callbacks around the normal behavior.
     def process_action(*args)
-      run_callbacks(:process_action, action_name) do
+      run_callbacks(:process_action) do
         super
       end
     end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,10 +1,12 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*    AS::Callbacks: deprecated second argument of `run_callbacks`. *Bogdan Gusiev*
+
 *    Adds Integer#ordinal to get the ordinal suffix string of an integer. *Tim Gildea*
 
-*    AS::Callbacks: `:per_key` option is no longer supported
+*    AS::Callbacks: `:per_key` option is no longer supported. *Bogdan Gusiev*
 
-*    `AS::Callbacks#define_callbacks`: add `:skip_after_callbacks_if_terminated` option.
+*    `AS::Callbacks#define_callbacks`: add `:skip_after_callbacks_if_terminated` option. *Bogdan Gusiev*
 
 *    Add html_escape_once to ERB::Util, and delegate escape_once tag helper to it. *Carlos Antonio da Silva*
 

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -75,7 +75,9 @@ module ActiveSupport
     #   end
     #
     def run_callbacks(kind, key = nil, &block)
-      #TODO: deprecate key argument
+      if key
+        raise NotImplementedError, "#run_callbacks second argument is no longer supported"
+      end
       self.class.__run_callbacks(kind, self, &block)
     end
 

--- a/activesupport/lib/active_support/testing/performance.rb
+++ b/activesupport/lib/active_support/testing/performance.rb
@@ -61,7 +61,7 @@ module ActiveSupport
         ensure
           begin
             teardown
-            run_callbacks :teardown, :enumerator => :reverse_each
+            run_callbacks :teardown
           rescue Exception => e
             result = @runner.puke(self.class, method_name, e)
           end

--- a/activesupport/test/callback_inheritance_test.rb
+++ b/activesupport/test/callback_inheritance_test.rb
@@ -29,7 +29,7 @@ class GrandParent
   end
 
   def dispatch
-    run_callbacks(:dispatch, action_name) do
+    run_callbacks(:dispatch) do
       @log << action_name
     end
     self

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -112,7 +112,7 @@ module CallbacksTest
     end
 
     def dispatch
-      run_callbacks :dispatch, action_name do
+      run_callbacks :dispatch do
         @logger << "Done"
       end
       self
@@ -153,7 +153,7 @@ module CallbacksTest
     end
 
     def save
-      run_callbacks :save, :action
+      run_callbacks :save
     end
   end
 
@@ -338,7 +338,7 @@ module CallbacksTest
     end
 
     def save
-      run_callbacks :save, "hyphen-ated" do
+      run_callbacks :save do
         @stuff
       end
     end
@@ -701,7 +701,7 @@ module CallbacksTest
     end
   end
 
-  class PerKeyOptionDeprecationTest < ActiveSupport::TestCase
+  class DeprecationsTest < ActiveSupport::TestCase
 
     def test_per_key_option_deprecaton
       assert_raise NotImplementedError do
@@ -713,6 +713,12 @@ module CallbacksTest
         Phone.class_eval do
           skip_callback :save, :before, :before_save1, :per_key => {:if => "true"}
         end
+      end
+    end
+
+    def test_run_callbacks_second_argument_deprecation
+      assert_raise NotImplementedError do
+        Phone.new.run_callbacks(:save, :action)
       end
     end
   end


### PR DESCRIPTION
`run_callbacks` has two arguments. But second one is not used any more.
