### PR TITLE
Make automatic log flushing configurable

### DIFF
--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -30,7 +30,7 @@ module Rails
 
           f = File.open path, 'a'
           f.binmode
-          f.sync = true # make sure every write flushes
+          f.sync = config.autoflush_log # if true make sure every write flushes
 
           logger = ActiveSupport::TaggedLogging.new(
             ActiveSupport::Logger.new(f)

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -41,7 +41,7 @@ module Rails
         @file_watcher                  = ActiveSupport::FileUpdateChecker
         @exceptions_app                = nil
         @default_method_for_update     = :put
-        @autoflush_log                 = !Rails.env.production?
+        @autoflush_log                 = true
 
         @assets = ActiveSupport::OrderedOptions.new
         @assets.enabled                  = false

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -5,7 +5,7 @@ require 'rails/engine/configuration'
 module Rails
   class Application
     class Configuration < ::Rails::Engine::Configuration
-      attr_accessor :allow_concurrency, :asset_host, :asset_path, :assets,
+      attr_accessor :allow_concurrency, :asset_host, :asset_path, :assets, :autoflush_log,
                     :cache_classes, :cache_store, :consider_all_requests_local, :console,
                     :dependency_loading, :exceptions_app, :file_watcher, :filter_parameters,
                     :force_ssl, :helpers_paths, :logger, :log_tags, :preload_frameworks,
@@ -41,6 +41,7 @@ module Rails
         @file_watcher                  = ActiveSupport::FileUpdateChecker
         @exceptions_app                = nil
         @default_method_for_update     = :put
+        @autoflush_log                 = !Rails.env.production?
 
         @assets = ActiveSupport::OrderedOptions.new
         @assets.enabled                  = false

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -37,5 +37,5 @@
   <%- end -%>
 
   # Disable automatic flushing of the log to improve performance.
-  config.autoflush_log = false
+  #config.autoflush_log = false
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -35,4 +35,7 @@
   # Expands the lines which load the assets.
   config.assets.debug = true
   <%- end -%>
+
+  # Disable automatic flushing of the log to improve performance.
+  config.autoflush_log = false
 end


### PR DESCRIPTION
As discussed in GH #4277 this allows to configure, wether the application log should always be flushed (for debugging) or only as the OS sees fit (for performance).

Currently it defauts to no autoflushing in production and enables it everywhere else.

This needs some minor editing to apply against HEAD because of commit 55cc16f.
