### PR TITLE
Fix associations with per-class/multiple database connections

### DIFF
--- a/activerecord/lib/active_record/associations/alias_tracker.rb
+++ b/activerecord/lib/active_record/associations/alias_tracker.rb
@@ -5,12 +5,13 @@ module ActiveRecord
     # Keeps track of table aliases for ActiveRecord::Associations::ClassMethods::JoinDependency and
     # ActiveRecord::Associations::ThroughAssociationScope
     class AliasTracker # :nodoc:
-      attr_reader :aliases, :table_joins
+      attr_reader :aliases, :table_joins, :connection
 
       # table_joins is an array of arel joins which might conflict with the aliases we assign here
-      def initialize(table_joins = [])
+      def initialize(connection = ActiveRecord::Model.connection, table_joins = [])
         @aliases     = Hash.new { |h,k| h[k] = initial_count_for(k) }
         @table_joins = table_joins
+        @connection  = connection
       end
 
       def aliased_table_for(table_name, aliased_name = nil)
@@ -69,10 +70,6 @@ module ActiveRecord
 
         def truncate(name)
           name.slice(0, connection.table_alias_length - 2)
-        end
-
-        def connection
-          ActiveRecord::Base.connection
         end
     end
   end

--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -10,7 +10,7 @@ module ActiveRecord
 
       def initialize(association)
         @association   = association
-        @alias_tracker = AliasTracker.new
+        @alias_tracker = AliasTracker.new klass.connection
       end
 
       def scope

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -13,7 +13,7 @@ module ActiveRecord
         @join_parts    = [JoinBase.new(base)]
         @associations  = {}
         @reflections   = []
-        @alias_tracker = AliasTracker.new(joins)
+        @alias_tracker = AliasTracker.new(base.connection, joins)
         @alias_tracker.aliased_name_for(base.table_name) # Updates the count for base.table_name to 1
         build(associations)
       end

--- a/activerecord/test/cases/multiple_db_test.rb
+++ b/activerecord/test/cases/multiple_db_test.rb
@@ -10,6 +10,7 @@ class MultipleDbTest < ActiveRecord::TestCase
 
   def setup
     @courses  = create_fixtures("courses") { Course.retrieve_connection }
+    @colleges = create_fixtures("colleges") { College.retrieve_connection }
     @entrants = create_fixtures("entrants")
   end
 
@@ -86,5 +87,16 @@ class MultipleDbTest < ActiveRecord::TestCase
 
   def test_arel_table_engines
     assert_equal Entrant.arel_engine, Bird.arel_engine
+  end
+
+  def test_associations_should_work_when_model_has_no_connection
+    begin
+      ActiveRecord::Model.remove_connection
+      assert_nothing_raised ActiveRecord::ConnectionNotEstablished do
+        College.first.courses.first
+      end
+    ensure
+      ActiveRecord::Model.establish_connection 'arunit'
+    end
   end
 end

--- a/activerecord/test/fixtures/colleges.yml
+++ b/activerecord/test/fixtures/colleges.yml
@@ -1,0 +1,3 @@
+FIU:
+  id: 1
+  name: Florida International University

--- a/activerecord/test/fixtures/courses.yml
+++ b/activerecord/test/fixtures/courses.yml
@@ -1,6 +1,7 @@
 ruby:
   id: 1
   name: Ruby Development
+  college: FIU
 
 java:
   id: 2

--- a/activerecord/test/models/arunit2_model.rb
+++ b/activerecord/test/models/arunit2_model.rb
@@ -1,0 +1,3 @@
+class ARUnit2Model < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/activerecord/test/models/college.rb
+++ b/activerecord/test/models/college.rb
@@ -1,0 +1,5 @@
+require_dependency 'models/arunit2_model'
+
+class College < ARUnit2Model
+  has_many :courses
+end

--- a/activerecord/test/models/course.rb
+++ b/activerecord/test/models/course.rb
@@ -1,3 +1,6 @@
-class Course < ActiveRecord::Base
+require_dependency 'models/arunit2_model'
+
+class Course < ARUnit2Model
+  belongs_to :college
   has_many :entrants
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -760,4 +760,9 @@ end
 
 Course.connection.create_table :courses, :force => true do |t|
   t.column :name, :string, :null => false
+  t.column :college_id, :integer
+end
+
+College.connection.create_table :colleges, :force => true do |t|
+  t.column :name, :string, :null => false
 end

--- a/activerecord/test/support/connection.rb
+++ b/activerecord/test/support/connection.rb
@@ -1,4 +1,5 @@
 require 'active_support/logger'
+require_dependency 'models/college'
 require_dependency 'models/course'
 
 module ARTest
@@ -15,6 +16,6 @@ module ARTest
     ActiveRecord::Model.logger = ActiveSupport::Logger.new("debug.log")
     ActiveRecord::Model.configurations = connection_config
     ActiveRecord::Model.establish_connection 'arunit'
-    Course.establish_connection 'arunit2'
+    ARUnit2Model.establish_connection 'arunit2'
   end
 end


### PR DESCRIPTION
Originally reported by @larskanis, associations break when using per-model database connections. This is due to always referencing ActiveRecord::Base's connection instead of asking for a specific connection to work with.

This pull request is the issue/fix described in #3732 but confirmed with tests and built on Rails 3.2. Hopefully this will ensure speedy integration this time around.

This is #4953, but built for master instead of 3-2-stable
