### PR TITLE
Fix CI test failing. It seems that pg(postgresql)'s behavior was changed since 0.13.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -4,7 +4,7 @@ require 'active_record/connection_adapters/statement_pool'
 require 'active_record/connection_adapters/postgresql/oid'
 
 # Make sure we're using pg high enough for PGResult#values
-gem 'pg', '~> 0.11'
+gem 'pg', '~> 0.13'
 require 'pg'
 
 module ActiveRecord

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -423,7 +423,7 @@ module ActiveRecord
       # method does nothing.
       def disconnect!
         clear_cache!
-        @connection.close rescue nil
+        @connection.close rescue nil unless @connection.finished?
       end
 
       def native_database_types #:nodoc:

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -402,7 +402,7 @@ module ActiveRecord
 
       # Is this connection alive and ready for queries?
       def active?
-        @connection.status == PGconn::CONNECTION_OK
+        !@connection.finished? && @connection.status == PGconn::CONNECTION_OK
       rescue PGError
         false
       end

--- a/activerecord/test/cases/unconnected_test.rb
+++ b/activerecord/test/cases/unconnected_test.rb
@@ -30,4 +30,9 @@ class TestUnconnectedAdapter < ActiveRecord::TestCase
   def test_underlying_adapter_no_longer_active
     assert !@underlying.active?, "Removed adapter should no longer be active"
   end
+
+  def test_underlying_adapter_disconnection
+    assert_nothing_raised { @underlying.disconnect! }
+  end
+
 end


### PR DESCRIPTION
This problem is occured at https://bitbucket.org/ged/ruby-pg/src/a9b8576bb35c/ext/pg_connection.c#cl-581
If a connection was closed already, exception is raised.

If necessary, I'll squash some commits.
