### PR TITLE
engine knows the path where it is mounted

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -414,6 +414,14 @@ module Rails
           File.expand_path(engine.root.to_s) == expanded_path
         }
       end
+
+      def mounted_path
+        my_route = Rails.application.routes.routes.detect do |route|
+          route.app == self
+        end
+        raise "#{self} is not yet mounted." unless my_route
+        my_route.path.spec.to_s
+      end
     end
 
     delegate :middleware, :root, :paths, :to => :config

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -793,6 +793,27 @@ module RailtiesTest
       assert_equal "Bukkit's foo partial", last_response.body.strip
     end
 
+    test "engine knows at which path it was mounted" do
+      @plugin.write "lib/bukkits.rb", <<-RUBY
+        module Bukkits
+          class Engine < ::Rails::Engine
+          end
+        end
+      RUBY
+
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          mount(Bukkits::Engine => "/foo-bar")
+        end
+      RUBY
+
+      boot_rails
+      require "#{rails_root}/config/environment"
+
+      assert_raise(RuntimeError) { ::Rails::Engine.mounted_path }
+      assert_equal ::Bukkits::Engine.mounted_path, "/foo-bar"
+    end
+
   private
     def app
       Rails.application


### PR DESCRIPTION
In some cases, an engine might want to know the path where it is mounted by the main app. Here is an example when using the paperclip gem inside an engine:

```
module MyEngine
  class MyAttachment < ActiveRecord::Base
    has_attached_file :document, :styles => { :thumb => "100x100>" },
        :url => "/document/:id/:style.:extension"   # where did the main_app mount me?
  end
end
```

See also https://github.com/rails/rails/issues/4940
