### PR TITLE
Use the values side of the attributes hash by default for ActiveModel.

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -98,8 +98,8 @@ module ActiveModel
     private
 
       # Hook method defining how an attribute value should be retrieved for
-      # serialization. By default this is assumed to be an instance named after
-      # the attribute. Override this method in subclasses should you need to
+      # serialization. By default this is assumed to be the value of the key
+      # in attributes. Override this method in subclasses should you need to
       # retrieve the value for a given attribute differently:
       #
       #   class MyClass
@@ -114,7 +114,9 @@ module ActiveModel
       #     end
       #   end
       #
-      alias :read_attribute_for_serialization :send
+      def read_attribute_for_serialization(key)
+        attributes[key]
+      end
 
       # Add associations specified via the <tt>:include</tt> option.
       #

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -31,6 +31,22 @@ class SerializationTest < ActiveModel::TestCase
     end
   end
 
+  class BusinessCard
+    include ActiveModel::Serialization
+
+    def initialize(user)
+      @user = user
+    end
+
+    def attributes
+      {
+        :name => @user.name,
+        :email => @user.email,
+        :address => @user.address.serializable_hash
+      }
+    end
+  end
+
   setup do
     @user = User.new('David', 'david@example.com', 'male')
     @user.address = Address.new
@@ -41,7 +57,6 @@ class SerializationTest < ActiveModel::TestCase
     @user.friends = [User.new('Joe', 'joe@example.com', 'male'),
                      User.new('Sue', 'sue@example.com', 'female')]
   end
-
   def test_method_serializable_hash_should_work
     expected =  {"name"=>"David", "gender"=>"male", "email"=>"david@example.com"}
     assert_equal expected , @user.serializable_hash
@@ -70,6 +85,13 @@ class SerializationTest < ActiveModel::TestCase
   def test_method_serializable_hash_should_work_with_except_and_methods
     expected =  {"gender"=>"male", :foo=>"i_am_foo"}
     assert_equal expected , @user.serializable_hash(:except => [:name, :email], :methods => [:foo])
+  end
+
+  def test_method_serializable_hash_should_use_values_part_of_hash
+    expected =  {:name=>"David", :email=>"david@example.com",
+                 :address=>{"street"=>"123 Lane", "city"=>"Springfield", "state"=>"CA", "zip"=>11111}}
+    business_card = BusinessCard.new(@user)
+    assert_equal expected, business_card.serializable_hash
   end
 
   def test_should_not_call_methods_that_dont_respond


### PR DESCRIPTION
Methods can still be added via the options hash and/or by invoking the
method in the attributes method. You may still override the method in
order to provide custom behavior.

I'm attaching a pull request for issue #4659 to demonstrate a possible solution :)
