### PR TITLE
Render img tag with empty src if empty string is passed to image_tag.

### DIFF
--- a/actionpack/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helper.rb
@@ -274,7 +274,7 @@ module ActionView
       # The alias +path_to_image+ is provided to avoid that. Rails uses the alias internally, and
       # plugin authors are encouraged to do so.
       def image_path(source)
-        asset_paths.compute_public_path(source, 'images')
+        source.present? ? asset_paths.compute_public_path(source, 'images') : ""
       end
       alias_method :path_to_image, :image_path # aliased to avoid conflicts with an image_path named route
 
@@ -377,7 +377,7 @@ module ActionView
 
         src = options[:src] = path_to_image(source)
 
-        unless src =~ /^(?:cid|data):/
+        unless src =~ /^(?:cid|data):/ || src.blank?
           options[:alt] = options.fetch(:alt){ image_alt(src) }
         end
 

--- a/actionpack/test/template/asset_tag_helper_test.rb
+++ b/actionpack/test/template/asset_tag_helper_test.rb
@@ -205,6 +205,7 @@ class AssetTagHelperTest < ActionView::TestCase
     %(image_tag("//www.rubyonrails.com/images/rails.png")) => %(<img alt="Rails" src="//www.rubyonrails.com/images/rails.png" />),
     %(image_tag("mouse.png", :alt => nil)) => %(<img src="/images/mouse.png" />),
     %(image_tag("data:image/gif;base64,R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==", :alt => nil)) => %(<img src="data:image/gif;base64,R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" />),
+    %(image_tag("")) => %(<img src="" />)
   }
 
   FaviconLinkToTag = {


### PR DESCRIPTION
Fixes #3080, but I think it might be a good idea to move that check down to `AssetsPath#compute_public_path` so we have same behavior for other asset tags.
