### PR TITLE
SSL should not be disabled by default in any environment.

### DIFF
--- a/actionpack/lib/action_controller/metal/force_ssl.rb
+++ b/actionpack/lib/action_controller/metal/force_ssl.rb
@@ -26,7 +26,7 @@ module ActionController
       def force_ssl(options = {})
         host = options.delete(:host)
         before_filter(options) do
-          if !request.ssl? && !Rails.env.development?
+          unless request.ssl?
             redirect_options = {:protocol => 'https://', :status => :moved_permanently}
             redirect_options.merge!(:host => host) if host
             redirect_options.merge!(:params => request.query_parameters)

--- a/actionpack/test/controller/force_ssl_test.rb
+++ b/actionpack/test/controller/force_ssl_test.rb
@@ -109,20 +109,6 @@ class ForceSSLExceptActionTest < ActionController::TestCase
   end
 end
 
-class ForceSSLExcludeDevelopmentTest < ActionController::TestCase
-  tests ForceSSLControllerLevel
-
-  def setup
-    Rails.env.stubs(:development?).returns(false)
-  end
-
-  def test_development_environment_not_redirects_to_https
-    Rails.env.stubs(:development?).returns(true)
-    get :banana
-    assert_response 200
-  end
-end
-
 class ForceSSLFlashTest < ActionController::TestCase
   tests ForceSSLFlash
 


### PR DESCRIPTION
Disabling SSL in any environment should be a decision made by each individual developer/team - really not keen on Rails forcing this. Also, I think it's far better to have a consistent environment as much as possible across all environments. So, this patch removes the `Rails.env.development?` check in `force_ssl`.

As a related aside, I've just been working on a gem that makes it far easier to use SSL in development and (Capybara-driven) test environments. It's built with bartt's version of ssl_requirement in mind, but I'm keen to have it work with `force_ssl` as well (I didn't realise it existed until just now).
https://github.com/freelancing-god/thin-glazed
