### PR TITLE
Fix ActiveModel serializable hash to return string keys with :methods

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -82,7 +82,7 @@ module ActiveModel
       attribute_names.each { |n| hash[n] = read_attribute_for_serialization(n) }
 
       method_names = Array(options[:methods]).select { |n| respond_to?(n) }
-      method_names.each { |n| hash[n] = send(n) }
+      method_names.each { |n| hash[n.to_s] = send(n) }
 
       serializable_add_includes(options) do |association, records, opts|
         hash[association] = if records.is_a?(Enumerable)

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -43,38 +43,38 @@ class SerializationTest < ActiveModel::TestCase
   end
 
   def test_method_serializable_hash_should_work
-    expected =  {"name"=>"David", "gender"=>"male", "email"=>"david@example.com"}
-    assert_equal expected , @user.serializable_hash
+    expected = {"name"=>"David", "gender"=>"male", "email"=>"david@example.com"}
+    assert_equal expected, @user.serializable_hash
   end
 
   def test_method_serializable_hash_should_work_with_only_option
-    expected =  {"name"=>"David"}
-    assert_equal expected , @user.serializable_hash(:only => [:name])
+    expected = {"name"=>"David"}
+    assert_equal expected, @user.serializable_hash(:only => [:name])
   end
 
   def test_method_serializable_hash_should_work_with_except_option
-    expected =  {"gender"=>"male", "email"=>"david@example.com"}
-    assert_equal expected , @user.serializable_hash(:except => [:name])
+    expected = {"gender"=>"male", "email"=>"david@example.com"}
+    assert_equal expected, @user.serializable_hash(:except => [:name])
   end
 
   def test_method_serializable_hash_should_work_with_methods_option
-    expected =  {"name"=>"David", "gender"=>"male", :foo=>"i_am_foo", "email"=>"david@example.com"}
-    assert_equal expected , @user.serializable_hash(:methods => [:foo])
+    expected = {"name"=>"David", "gender"=>"male", :foo=>"i_am_foo", "email"=>"david@example.com"}
+    assert_equal expected, @user.serializable_hash(:methods => [:foo])
   end
 
   def test_method_serializable_hash_should_work_with_only_and_methods
-    expected =  {:foo=>"i_am_foo"}
-    assert_equal expected , @user.serializable_hash(:only => [], :methods => [:foo])
+    expected = {:foo=>"i_am_foo"}
+    assert_equal expected, @user.serializable_hash(:only => [], :methods => [:foo])
   end
 
   def test_method_serializable_hash_should_work_with_except_and_methods
-    expected =  {"gender"=>"male", :foo=>"i_am_foo"}
-    assert_equal expected , @user.serializable_hash(:except => [:name, :email], :methods => [:foo])
+    expected = {"gender"=>"male", :foo=>"i_am_foo"}
+    assert_equal expected, @user.serializable_hash(:except => [:name, :email], :methods => [:foo])
   end
 
   def test_should_not_call_methods_that_dont_respond
-    expected =  {"name"=>"David", "gender"=>"male", "email"=>"david@example.com"}
-    assert_equal expected , @user.serializable_hash(:methods => [:bar])
+    expected = {"name"=>"David", "gender"=>"male", "email"=>"david@example.com"}
+    assert_equal expected, @user.serializable_hash(:methods => [:bar])
   end
 
   def test_should_use_read_attribute_for_serialization
@@ -87,65 +87,64 @@ class SerializationTest < ActiveModel::TestCase
   end
 
   def test_include_option_with_singular_association
-    expected =  {"name"=>"David", "gender"=>"male", "email"=>"david@example.com",
-                 :address=>{"street"=>"123 Lane", "city"=>"Springfield", "state"=>"CA", "zip"=>11111}}
-    assert_equal expected , @user.serializable_hash(:include => :address)
+    expected = {"name"=>"David", "gender"=>"male", "email"=>"david@example.com",
+                :address=>{"street"=>"123 Lane", "city"=>"Springfield", "state"=>"CA", "zip"=>11111}}
+    assert_equal expected, @user.serializable_hash(:include => :address)
   end
 
   def test_include_option_with_plural_association
-    expected =  {"email"=>"david@example.com", "gender"=>"male", "name"=>"David",
-                 :friends=>[{"name"=>'Joe', "email"=>'joe@example.com', "gender"=>'male'},
-                            {"name"=>'Sue', "email"=>'sue@example.com', "gender"=>'female'}]}
-    assert_equal expected , @user.serializable_hash(:include => :friends)
+    expected = {"email"=>"david@example.com", "gender"=>"male", "name"=>"David",
+                :friends=>[{"name"=>'Joe', "email"=>'joe@example.com', "gender"=>'male'},
+                           {"name"=>'Sue', "email"=>'sue@example.com', "gender"=>'female'}]}
+    assert_equal expected, @user.serializable_hash(:include => :friends)
   end
 
   def test_include_option_with_empty_association
     @user.friends = []
-    expected =  {"email"=>"david@example.com", "gender"=>"male", "name"=>"David", :friends=>[]}
-    assert_equal expected , @user.serializable_hash(:include => :friends)
+    expected = {"email"=>"david@example.com", "gender"=>"male", "name"=>"David", :friends=>[]}
+    assert_equal expected, @user.serializable_hash(:include => :friends)
   end
 
   def test_multiple_includes
-    expected =  {"email"=>"david@example.com", "gender"=>"male", "name"=>"David",
-                 :address=>{"street"=>"123 Lane", "city"=>"Springfield", "state"=>"CA", "zip"=>11111},
-                 :friends=>[{"name"=>'Joe', "email"=>'joe@example.com', "gender"=>'male'},
-                            {"name"=>'Sue', "email"=>'sue@example.com', "gender"=>'female'}]}
-    assert_equal expected , @user.serializable_hash(:include => [:address, :friends])
+    expected = {"email"=>"david@example.com", "gender"=>"male", "name"=>"David",
+                :address=>{"street"=>"123 Lane", "city"=>"Springfield", "state"=>"CA", "zip"=>11111},
+                :friends=>[{"name"=>'Joe', "email"=>'joe@example.com', "gender"=>'male'},
+                           {"name"=>'Sue', "email"=>'sue@example.com', "gender"=>'female'}]}
+    assert_equal expected, @user.serializable_hash(:include => [:address, :friends])
   end
 
   def test_include_with_options
-    expected =  {"email"=>"david@example.com", "gender"=>"male", "name"=>"David",
-                 :address=>{"street"=>"123 Lane"}}
-    assert_equal expected , @user.serializable_hash(:include => {:address => {:only => "street"}})
+    expected = {"email"=>"david@example.com", "gender"=>"male", "name"=>"David",
+                :address=>{"street"=>"123 Lane"}}
+    assert_equal expected, @user.serializable_hash(:include => {:address => {:only => "street"}})
   end
 
   def test_nested_include
     @user.friends.first.friends = [@user]
-    expected =  {"email"=>"david@example.com", "gender"=>"male", "name"=>"David",
-                 :friends=>[{"name"=>'Joe', "email"=>'joe@example.com', "gender"=>'male',
-                             :friends => [{"email"=>"david@example.com", "gender"=>"male", "name"=>"David"}]},
+    expected = {"email"=>"david@example.com", "gender"=>"male", "name"=>"David",
+                :friends=>[{"name"=>'Joe', "email"=>'joe@example.com', "gender"=>'male',
+                            :friends => [{"email"=>"david@example.com", "gender"=>"male", "name"=>"David"}]},
                             {"name"=>'Sue', "email"=>'sue@example.com', "gender"=>'female', :friends => []}]}
-    assert_equal expected , @user.serializable_hash(:include => {:friends => {:include => :friends}})
+    assert_equal expected, @user.serializable_hash(:include => {:friends => {:include => :friends}})
   end
 
   def test_only_include
     expected = {"name"=>"David", :friends => [{"name" => "Joe"}, {"name" => "Sue"}]}
-    assert_equal expected , @user.serializable_hash(:only => :name, :include => {:friends => {:only => :name}})
+    assert_equal expected, @user.serializable_hash(:only => :name, :include => {:friends => {:only => :name}})
   end
 
   def test_except_include
     expected = {"name"=>"David", "email"=>"david@example.com",
-                                :friends => [{"name" => 'Joe', "email" => 'joe@example.com'},
-                                             {"name" => "Sue", "email" => 'sue@example.com'}]}
-    assert_equal expected , @user.serializable_hash(:except => :gender, :include => {:friends => {:except => :gender}})
+                :friends => [{"name" => 'Joe', "email" => 'joe@example.com'},
+                             {"name" => "Sue", "email" => 'sue@example.com'}]}
+    assert_equal expected, @user.serializable_hash(:except => :gender, :include => {:friends => {:except => :gender}})
   end
 
   def test_multiple_includes_with_options
-    expected =  {"email"=>"david@example.com", "gender"=>"male", "name"=>"David",
-                 :address=>{"street"=>"123 Lane"},
-                 :friends=>[{"name"=>'Joe', "email"=>'joe@example.com', "gender"=>'male'},
-                            {"name"=>'Sue', "email"=>'sue@example.com', "gender"=>'female'}]}
-    assert_equal expected , @user.serializable_hash(:include => [{:address => {:only => "street"}}, :friends])
+    expected = {"email"=>"david@example.com", "gender"=>"male", "name"=>"David",
+                :address=>{"street"=>"123 Lane"},
+                :friends=>[{"name"=>'Joe', "email"=>'joe@example.com', "gender"=>'male'},
+                           {"name"=>'Sue', "email"=>'sue@example.com', "gender"=>'female'}]}
+    assert_equal expected, @user.serializable_hash(:include => [{:address => {:only => "street"}}, :friends])
   end
-
 end

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -58,17 +58,17 @@ class SerializationTest < ActiveModel::TestCase
   end
 
   def test_method_serializable_hash_should_work_with_methods_option
-    expected = {"name"=>"David", "gender"=>"male", :foo=>"i_am_foo", "email"=>"david@example.com"}
+    expected = {"name"=>"David", "gender"=>"male", "foo"=>"i_am_foo", "email"=>"david@example.com"}
     assert_equal expected, @user.serializable_hash(:methods => [:foo])
   end
 
   def test_method_serializable_hash_should_work_with_only_and_methods
-    expected = {:foo=>"i_am_foo"}
+    expected = {"foo"=>"i_am_foo"}
     assert_equal expected, @user.serializable_hash(:only => [], :methods => [:foo])
   end
 
   def test_method_serializable_hash_should_work_with_except_and_methods
-    expected = {"gender"=>"male", :foo=>"i_am_foo"}
+    expected = {"gender"=>"male", "foo"=>"i_am_foo"}
     assert_equal expected, @user.serializable_hash(:except => [:name, :email], :methods => [:foo])
   end
 


### PR DESCRIPTION
Currently `serializable_hash` uses the `attributes` method which is supposed to return a hash containing string keys. It adds/removes other keys with `:only` and `:except` options, mapping them to strings. But when given the `:methods` option, it doesn't do any conversion, thus returning symbol keys.

This changes it to make the return of `serializable_hash` more consistent, returning string keys for `:methods`.
