### PR TITLE
Ask Connection to quote symbolic column names when building ORDER BY

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -113,6 +113,7 @@ module ActiveRecord
 
       relation = clone
       relation = relation.references(references) if references.any?
+      args = args.map { |arg| Symbol === arg ? connection.quote_column_name(arg) : arg }
       relation.order_values += args
       relation
     end


### PR DESCRIPTION
In some databases (e.g, mysql) column names referenced in ORDER BY clauses
should be quoted in case they are reserved words. This corrects an issue that
occurs when using the `Model.order(:symbol)` method if `:symbol` happens to be a reserved word (e.g., "key").

Most AR methods already handle this correctly, so calling `Model.where(:key)` does NOT fail
but `Model.order(:key)` does. This change impacts columns specified as symbols only.

This problem was originally reported as issue #2601. Tests pass.

Note to @tenderlove: it seems that this is something that could ultimately live within AREL, but based on what I saw the symbols are already strings and " ASC/DESC" is already attached to the column names before we get there. To be honest, after a few hours in the code I'm not completely clear as to where AR's intended responsibilities end and AREL's begin so if I'm missing something obvious pls inform.

PS - First Rails pull request so go easy on me... :)
