### PR TITLE
Allow ActiveResource subclasses to inherit headers from parent

### DIFF
--- a/activeresource/lib/active_resource/base.rb
+++ b/activeresource/lib/active_resource/base.rb
@@ -588,6 +588,12 @@ module ActiveResource
 
       def headers
         @headers ||= {}
+        
+        if superclass != Object && superclass.headers
+          @headers = superclass.headers.merge(@headers)
+        else
+          @headers
+        end
       end
 
       attr_writer :element_name

--- a/activeresource/test/cases/base_test.rb
+++ b/activeresource/test/cases/base_test.rb
@@ -437,6 +437,52 @@ class BaseTest < ActiveSupport::TestCase
     assert_not_equal(first_connection, second_connection, 'Connection should be re-created')
   end
 
+  def test_header_inheritance
+    fruit = Class.new(ActiveResource::Base)
+    apple = Class.new(fruit)
+    fruit.site = 'http://market'
+
+    fruit.headers['key'] = 'value'
+    assert_equal 'value', apple.headers['key']
+  end
+
+  def test_header_inheritance_set_at_multiple_points
+    fruit = Class.new(ActiveResource::Base)
+    apple = Class.new(fruit)
+    fruit.site = 'http://market'
+
+    fruit.headers['key'] = 'value'
+    assert_equal 'value', apple.headers['key']
+
+    apple.headers['key2'] = 'value2'
+    fruit.headers['key3'] = 'value3'
+
+    assert_equal 'value', apple.headers['key']
+    assert_equal 'value2', apple.headers['key2']
+    assert_equal 'value3', apple.headers['key3']
+  end
+
+  def test_header_inheritance_should_not_leak_upstream
+    fruit = Class.new(ActiveResource::Base)
+    apple = Class.new(fruit)
+    fruit.site = 'http://market'
+
+    fruit.headers['key'] = 'value'
+
+    apple.headers['key2'] = 'value2'
+    assert_equal nil, fruit.headers['key2']
+  end
+
+  def test_header_inheritance_should_not_leak_upstream
+    fruit = Class.new(ActiveResource::Base)
+    apple = Class.new(fruit)
+    fruit.site = 'http://market'
+
+    fruit.headers['key'] = 'value'
+
+    apple.headers['key2'] = 'value2'
+    assert_equal nil, fruit.headers['key2']
+  end
 
   ########################################################################
   # Tests for setting up remote URLs for a given model (including adding

--- a/activeresource/test/cases/base_test.rb
+++ b/activeresource/test/cases/base_test.rb
@@ -473,17 +473,6 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal nil, fruit.headers['key2']
   end
 
-  def test_header_inheritance_should_not_leak_upstream
-    fruit = Class.new(ActiveResource::Base)
-    apple = Class.new(fruit)
-    fruit.site = 'http://market'
-
-    fruit.headers['key'] = 'value'
-
-    apple.headers['key2'] = 'value2'
-    assert_equal nil, fruit.headers['key2']
-  end
-
   ########################################################################
   # Tests for setting up remote URLs for a given model (including adding
   # parameters appropriately)


### PR DESCRIPTION
I've been working more with ActiveResource lately, specifically with services that use an Api-Key header for authentication. Through this I've realized what others have before me, that headers don't inherit when subclassing a class that inherits from ActiveResource::Base.

This patch adds that ability without changing the underlying structure of @header. It allows for headers to be added at multiple points in parent's lifecycle and ensures those are available to the child. It also ensures that headers added to the child do NOT leak up to the parent.

There are probably other ways to accomplish this if you're willing to mess with @header and how headers are set, but this does what I think many expect with little impact.

Open to feedback and suggestions.

(Solution loosely based off an older "blog post by Brandon Keepers":http://opensoul.org/blog/archives/2010/02/16/active-resource-in-practice and the comments on that post also provide others expectations around inherited headers.)
