### PR TITLE
Remove not used button translation from av locale

### DIFF
--- a/actionpack/lib/action_view/locale/en.yml
+++ b/actionpack/lib/action_view/locale/en.yml
@@ -147,15 +147,8 @@
       # Default value for :prompt => true in FormOptionsHelper
       prompt: "Please select"
 
-    # Default translation keys for submit FormHelper
+    # Default translation keys for submit and button FormHelper
     submit:
       create: 'Create %{model}'
       update: 'Update %{model}'
       submit: 'Save %{model}'
-
-    # Default translation keys for button FormHelper
-    button:
-      create: 'Create %{model}'
-      update: 'Update %{model}'
-      submit: 'Save %{model}'
-


### PR DESCRIPTION
These translations were not used as the button helper does i18n lookup
for labels using the using the 'submit' key.
