### PR TITLE
sync __run_callbacks with ruby-trunk

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -356,7 +356,7 @@ module ActiveSupport
       #
       def __run_callbacks(kind, object, &blk) #:nodoc:
         name = __callback_runner_name(kind)
-        unless object.respond_to?(name)
+        unless object.respond_to?(name, true)
           str = object.send("_#{kind}_callbacks").compile
           class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
             def #{name}() #{str} end


### PR DESCRIPTION
https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/34580
In this revision behavior of respond_to? had changed: now to ask about
protected method one should pass second argument `true`
