### PR TITLE
Backport Bugfix: Stack Overflow (3-0-stable)

### DIFF
--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -3,8 +3,10 @@ require 'models/bird'
 require 'models/company'
 require 'models/customer'
 require 'models/developer'
+require 'models/face'
 require 'models/invoice'
 require 'models/line_item'
+require 'models/man'
 require 'models/order'
 require 'models/parrot'
 require 'models/person'
@@ -877,6 +879,16 @@ class TestAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
 
   def test_should_not_load_the_associated_model
     assert_queries(1) { @pirate.catchphrase = 'Arr'; @pirate.save! }
+  end
+end
+
+class TestAutosaveInverseAssociationOnAHasOneAssociation < ActiveRecord::TestCase
+  self.use_transactional_fixtures = false
+
+  def test_should_save_the_inverse_association_model
+    man = Man.new
+    man.build_face
+    man.face.save
   end
 end
 

--- a/activerecord/test/models/face.rb
+++ b/activerecord/test/models/face.rb
@@ -4,4 +4,6 @@ class Face < ActiveRecord::Base
   # These is a "broken" inverse_of for the purposes of testing
   belongs_to :horrible_man, :class_name => 'Man', :inverse_of => :horrible_face
   belongs_to :horrible_polymorphic_man, :polymorphic => true, :inverse_of => :horrible_polymorphic_face
+
+  accepts_nested_attributes_for :man
 end


### PR DESCRIPTION
Bugfix for #2525 belongs_to + :inverse_of + accepts_nested_attributes_for causes stack overflow on save

I run into the same issue. There is a cyclic autosave for belongs_to/has_one when using accepts_nested_attributes. It causes stack overflow.
