### PR TITLE
Cosmetic fixes in block_format AM helper method + test

### DIFF
--- a/actionmailer/lib/action_mailer/mail_helper.rb
+++ b/actionmailer/lib/action_mailer/mail_helper.rb
@@ -3,9 +3,9 @@ module ActionMailer
     # Uses Text::Format to take the text and format it, indented two spaces for
     # each line, and wrapped at 72 columns.
     def block_format(text)
-      formatted = text.split(/\n\r\n/).collect { |paragraph|
+      formatted = text.split(/\n\r?\n/).collect { |paragraph|
         format_paragraph(paragraph)
-      }.join("\n")
+      }.join("\n\n")
 
       # Make list points stand on their own line
       formatted.gsub!(/[ ]*([*]+) ([^*]*)/) { |s| "  #{$1} #{$2.strip}\n" }

--- a/actionmailer/test/mail_helper_test.rb
+++ b/actionmailer/test/mail_helper_test.rb
@@ -34,6 +34,23 @@ class HelperMailer < ActionMailer::Base
     end
   end
 
+  def use_block_format
+    @text = <<-TEXT
+This is the
+first     paragraph.
+
+The second
+   paragraph.
+
+* item1 * item2
+  * item3
+    TEXT
+
+    mail_with_defaults do |format|
+      format.html { render(:inline => "<%= block_format @text %>") }
+    end
+  end
+
   protected
 
   def mail_with_defaults(&block)
@@ -62,6 +79,20 @@ class MailerHelperTest < ActionMailer::TestCase
   def test_use_format_paragraph
     mail = HelperMailer.use_format_paragraph
     assert_match " But soft! What\r\n light through\r\n yonder window\r\n breaks?", mail.body.encoded
+  end
+
+  def test_use_block_format
+    mail = HelperMailer.use_block_format
+    expected = <<-TEXT
+  This is the first paragraph.
+
+  The second paragraph.
+
+  * item1
+  * item2
+  * item3
+    TEXT
+    assert_equal expected.gsub("\n", "\r\n"), mail.body.encoded
   end
 end
 


### PR DESCRIPTION
The block_format ActionMailer helper method was introduced at the end of 2009 - 63b124b043dec036403f9a88aeafdf99669064e0 and tested bd96614101262e0ad0cc176ed8e2d95a5c17936b.

I'm not sure that block_format is widely used but I think we can make it better.
I suggest to make small changes in paragraph splitting technique and increase test coverage.
