### PR TITLE
Fix sanitize_for_mass_assigment when role is nil

### DIFF
--- a/activemodel/lib/active_model/mass_assignment_security.rb
+++ b/activemodel/lib/active_model/mass_assignment_security.rb
@@ -226,12 +226,12 @@ module ActiveModel
 
   protected
 
-    def sanitize_for_mass_assignment(attributes, role = :default)
+    def sanitize_for_mass_assignment(attributes, role = nil)
       _mass_assignment_sanitizer.sanitize(attributes, mass_assignment_authorizer(role))
     end
 
-    def mass_assignment_authorizer(role = :default)
-      self.class.active_authorizer[role]
+    def mass_assignment_authorizer(role)
+      self.class.active_authorizer[role || :default]
     end
   end
 end

--- a/activemodel/test/cases/mass_assignment_security_test.rb
+++ b/activemodel/test/cases/mass_assignment_security_test.rb
@@ -19,6 +19,13 @@ class MassAssignmentSecurityTest < ActiveModel::TestCase
     assert_equal expected, sanitized
   end
 
+  def test_attribute_protection_when_role_is_nil
+    user = User.new
+    expected = { "name" => "John Smith", "email" => "john@smith.com" }
+    sanitized = user.sanitize_for_mass_assignment(expected.merge("admin" => true), nil)
+    assert_equal expected, sanitized
+  end
+
   def test_only_moderator_role_attribute_accessible
     user = SpecialUser.new
     expected = { "name" => "John Smith", "email" => "john@smith.com" }


### PR DESCRIPTION
There is an example in Rails documentation that suggests implementing
assign_attributes method for ActiveModel interface, that by default
sends option role with nil. Since mass_assignment_authorizer never
is called without args, we can move the default value internally.

This should be backported to Rails 3.2
