### PR TITLE
Show class name in RecordInvalid error

### DIFF
--- a/activerecord/lib/active_record/locale/en.yml
+++ b/activerecord/lib/active_record/locale/en.yml
@@ -9,7 +9,7 @@ en:
     errors:
       messages:
         taken: "has already been taken"
-        record_invalid: "Validation failed: %{errors}"
+        record_invalid: "%{class_name} validation failed: %{errors}"
         restrict_dependent_destroy:
           one: "Cannot delete record because a dependent %{record} exists"
           many: "Cannot delete record because dependent %{record} exist"

--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -14,7 +14,7 @@ module ActiveRecord
     def initialize(record)
       @record = record
       errors = @record.errors.full_messages.join(", ")
-      super(I18n.t("activerecord.errors.messages.record_invalid", :errors => errors))
+      super(I18n.t("activerecord.errors.messages.record_invalid", :class_name => @record.class, :errors => errors))
     end
   end
 


### PR DESCRIPTION
My first pull request to Rails. :)

Patch to make RecordInvalid errors say the class name of the model where the validation failed. This would have saved me a lot of time yesterday when my tests were failing; I thought the problem was with an attribute of the same name on a different model.

I need help making sure this passes tests because I couldn't get the Rails test suite to run on my machine. I tried `rake` and got `no such file to load -- sdoc`. Thoughts?
