### PR TITLE
Backporting #4918 with one added test for googlebot accept header as I saw it

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -82,6 +82,7 @@ module Mime
     class << self
 
       TRAILING_STAR_REGEXP = /(text|application)\/\*/
+      Q_SEPARATOR_REGEXP = /;\s*q=/
 
       def lookup(string)
         LOOKUP[string]
@@ -108,6 +109,7 @@ module Mime
 
       def parse(accept_header)
         if accept_header !~ /,/
+          accept_header = accept_header.split(Q_SEPARATOR_REGEXP).first
           if accept_header =~ TRAILING_STAR_REGEXP
             parse_data_with_trailing_star($1)
           else
@@ -117,7 +119,7 @@ module Mime
           # keep track of creation order to keep the subsequent sort stable
           list, index = [], 0
           accept_header.split(/,/).each do |header|
-            params, q = header.split(/;\s*q=/)
+            params, q = header.split(Q_SEPARATOR_REGEXP)
             if params.present?
               params.strip!
 

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -69,6 +69,18 @@ class MimeTypeTest < ActiveSupport::TestCase
     assert_equal expect, Mime::Type.parse(accept)
   end
 
+  test "parse single media range with q" do
+    accept = "text/html;q=0.9"
+    expect = [Mime::HTML]
+    assert_equal expect, Mime::Type.parse(accept)
+  end
+
+  test "parse any media range with q" do
+    accept = "*/*;q=0.9"
+    expect = [Mime::ALL]
+    assert_equal expect, Mime::Type.parse(accept)
+  end
+
   # Accept header send with user HTTP_USER_AGENT: Sunrise/0.42j (Windows XP)
   test "parse broken acceptlines" do
     accept = "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/*,,*/*;q=0.5"


### PR DESCRIPTION
It's probably important to backport #4918 to Rails 3.2 stable.

/cc @josevalim @scottwb
