### PR TITLE
AM::Errors: allow :full_messages parameter for #to_json

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,5 @@
+*   `AM::Errors#to_json`: support `:full_messages` parameter *Bogdan Gusiev*
+
 *   Trim down Active Model API by removing `valid?` and `errors.full_messages` *José Valim*
 
 ## Rails 3.2.0 (January 20, 2012) ##

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -206,12 +206,23 @@ module ActiveModel
     end
 
     # Returns an Hash that can be used as the JSON representation for this object.
+    # Options:
+    # * <tt>:full_messages</tt> - determines if json object should contain 
+    #   full messages or not. Default: <tt>false</tt>.
     def as_json(options=nil)
-      to_hash
+      to_hash(options && options[:full_messages])
     end
 
-    def to_hash
-      messages.dup
+    def to_hash(full_messages = false)
+      if full_messages
+        messages = {}
+        self.messages.each do |attribute, array|
+          messages[attribute] = array.map{|message| full_message(attribute, message) }
+        end
+        messages
+      else
+        self.messages.dup
+      end
     end
 
     # Adds +message+ to the error messages on +attribute+. More than one error can be added to the same

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -184,6 +184,16 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal ["is invalid"], hash[:email]
   end
 
+  test 'should return a JSON hash representation of the errors with full messages' do
+    person = Person.new
+    person.errors.add(:name, "can not be blank")
+    person.errors.add(:name, "can not be nil")
+    person.errors.add(:email, "is invalid")
+    hash = person.errors.as_json(:full_messages => true)
+    assert_equal ["name can not be blank", "name can not be nil"], hash[:name]
+    assert_equal ["email is invalid"], hash[:email]
+  end
+
   test "generate_message should work without i18n_scope" do
     person = Person.new
     assert !Person.respond_to?(:i18n_scope)


### PR DESCRIPTION
Some applications uses full messages in frontend. 

In order to support that
Added full messages parameter to `#to_json` method:

``` ruby
@user.error.to_json(:full_messages => true) 
  # => "{email: \"Email is invalid\", password: \"Password is too short\"}"
```
