### PR TITLE
Correctly print names of non-timestamped migrations with db:migrate:status

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -207,11 +207,12 @@ db_namespace = namespace :db do
         next  # means "return" for rake task
       end
       db_list = ActiveRecord::Base.connection.select_values("SELECT version FROM #{ActiveRecord::Migrator.schema_migrations_table_name}")
+      db_list.map! { |version| "%.3d" % version }
       file_list = []
       ActiveRecord::Migrator.migrations_paths.each do |path|
         Dir.foreach(path) do |file|
-          # only files matching "20091231235959_some_name.rb" pattern
-          if match_data = /^(\d{14})_(.+)\.rb$/.match(file)
+          # match "20091231235959_some_name.rb" and "001_some_name.rb" pattern
+          if match_data = /^(\d{3,})_(.+)\.rb$/.match(file)
             status = db_list.delete(match_data[1]) ? 'up' : 'down'
             file_list << [status, match_data[1], match_data[2].humanize]
           end

--- a/railties/test/application/rake/migrations_test.rb
+++ b/railties/test/application/rake/migrations_test.rb
@@ -67,7 +67,7 @@ module ApplicationTests
           `rails generate migration add_email_to_users email:string`
         end
 
-        Dir.chdir(app_path) { `rake db:migrate`}
+        Dir.chdir(app_path) { `rake db:migrate` }
         output = Dir.chdir(app_path) { `rake db:migrate:status` }
 
         assert_match(/up\s+\d{14}\s+Create users/, output)
@@ -78,6 +78,27 @@ module ApplicationTests
 
         assert_match(/up\s+\d{14}\s+Create users/, output)
         assert_match(/down\s+\d{14}\s+Add email to users/, output)
+      end
+
+      test 'migration status without timestamps' do
+        add_to_config('config.active_record.timestamped_migrations = false')
+
+        Dir.chdir(app_path) do
+          `rails generate model user username:string password:string`
+          `rails generate migration add_email_to_users email:string`
+        end
+
+        Dir.chdir(app_path) { `rake db:migrate` }
+        output = Dir.chdir(app_path) { `rake db:migrate:status` }
+
+        assert_match(/up\s+\d{3,}\s+Create users/, output)
+        assert_match(/up\s+\d{3,}\s+Add email to users/, output)
+
+        Dir.chdir(app_path) { `rake db:rollback STEP=1` }
+        output = Dir.chdir(app_path) { `rake db:migrate:status` }
+
+        assert_match(/up\s+\d{3,}\s+Create users/, output)
+        assert_match(/down\s+\d{3,}\s+Add email to users/, output)
       end
 
       test 'test migration status after rollback and redo' do
@@ -103,6 +124,33 @@ module ApplicationTests
 
         assert_match(/up\s+\d{14}\s+Create users/, output)
         assert_match(/up\s+\d{14}\s+Add email to users/, output)
+      end
+
+      test 'migration status after rollback and redo without timestamps' do
+        add_to_config('config.active_record.timestamped_migrations = false')
+
+        Dir.chdir(app_path) do
+          `rails generate model user username:string password:string`
+          `rails generate migration add_email_to_users email:string`
+        end
+
+        Dir.chdir(app_path) { `rake db:migrate` }
+        output = Dir.chdir(app_path) { `rake db:migrate:status` }
+
+        assert_match(/up\s+\d{3,}\s+Create users/, output)
+        assert_match(/up\s+\d{3,}\s+Add email to users/, output)
+
+        Dir.chdir(app_path) { `rake db:rollback STEP=2` }
+        output = Dir.chdir(app_path) { `rake db:migrate:status` }
+
+        assert_match(/down\s+\d{3,}\s+Create users/, output)
+        assert_match(/down\s+\d{3,}\s+Add email to users/, output)
+
+        Dir.chdir(app_path) { `rake db:migrate:redo` }
+        output = Dir.chdir(app_path) { `rake db:migrate:status` }
+
+        assert_match(/up\s+\d{3,}\s+Create users/, output)
+        assert_match(/up\s+\d{3,}\s+Add email to users/, output)
       end
     end
   end


### PR DESCRIPTION
The `db:migrate:status` rake task currently does not print the names of non-timestamped migrations (ie. older migrations and migrations generated with `config.active_record.timestamped_migrations` set to false).
