### PR TITLE
assigns(:foo) should not convert @foo's keys to strings if it happens to be a hash

### DIFF
--- a/actionpack/lib/action_dispatch/testing/test_process.rb
+++ b/actionpack/lib/action_dispatch/testing/test_process.rb
@@ -5,7 +5,8 @@ require 'active_support/core_ext/hash/indifferent_access'
 module ActionDispatch
   module TestProcess
     def assigns(key = nil)
-      assigns = @controller.view_assigns.with_indifferent_access
+      assigns = {}.with_indifferent_access
+      @controller.view_assigns.each {|k, v| assigns.regular_writer(k, v)}
       key.nil? ? assigns : assigns[key]
     end
 

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -119,6 +119,7 @@ XML
 
     def test_assigns
       @foo = "foo"
+      @foo_hash = {:foo => :bar}
       render :nothing => true
     end
 
@@ -292,6 +293,10 @@ XML
     assert_equal "foo", assigns("foo")
     assert_equal "foo", assigns[:foo]
     assert_equal "foo", assigns["foo"]
+
+    # but the assigned variable should not have its own keys stringified
+    expected_hash = { :foo => :bar }
+    assert_equal expected_hash, assigns(:foo_hash)
   end
 
   def test_view_assigns


### PR DESCRIPTION
This is an unintended side effect of the code to make assigns(:foo) work the same way as assigns('foo').

This pull request is relative to master, but the same bug and fix apply to all 3.x versions -
3.2: https://github.com/willbryant/rails/tree/assigns_should_not_stringify_values_3-2-stable
3.1: https://github.com/willbryant/rails/tree/assigns_should_not_stringify_values_3-1-stable
3.0: https://github.com/willbryant/rails/tree/assigns_should_not_stringify_values
