### PR TITLE
Remove reference to config.action_view.logger from Rails configuration guide

### DIFF
--- a/railties/guides/source/configuring.textile
+++ b/railties/guides/source/configuring.textile
@@ -337,7 +337,7 @@ h4. Configuring Action Dispatch
 
 h4. Configuring Action View
 
-There are only a few configuration options for Action View, starting with four on +ActionView::Base+:
+There are only a few configuration options for Action View, starting with three on +ActionView::Base+:
 
 * +config.action_view.field_error_proc+ provides an HTML generator for displaying errors that come from Active Record. The default is
 
@@ -346,8 +346,6 @@ Proc.new { |html_tag, instance| %Q(<div class="field_with_errors">#{html_tag}</d
 </ruby>
 
 * +config.action_view.default_form_builder+ tells Rails which form builder to use by default. The default is +ActionView::Helpers::FormBuilder+.
-
-* +config.action_view.logger+ accepts a logger conforming to the interface of Log4r or the default Ruby Logger class, which is then used to log information from Action Mailer. Set to +nil+ to disable logging.
 
 * +config.action_view.erb_trim_mode+ gives the trim mode to be used by ERB. It defaults to +'-'+. See the "ERB documentation":http://www.ruby-doc.org/stdlib/libdoc/erb/rdoc/ for more information.
 


### PR DESCRIPTION
This is a doc patch, but I'm sending a full pull request because I'm not 100% sure of it.

I tried using this configuration setting in my application, and got

```
actionpack-3.2.1/lib/action_view/railtie.rb:34:in `block (3 levels) in <class:Railtie>': undefined method `logger=' for ActionView::Base:Class (NoMethodError)
```

I looked in rails/action_pack/lib/action_view/base.rb and it seems that logger is delegated to ActionController::Base (line 151). Last but not least, ActionView::LogSubscriber.logger uses ActionController::Base.logger directly, with a TODO saying that ActionView needs a logger.

Last but not least, this pull is for 3-2-stable, just in case you might like to add the logger option in Rails 4. I'll be happy to send another pull request for master, if it's desired.
