### PR TITLE
Fix GH #5063. Support include_root_in_json for ActiveResource properly.

### DIFF
--- a/activeresource/lib/active_resource/base.rb
+++ b/activeresource/lib/active_resource/base.rb
@@ -1363,7 +1363,7 @@ module ActiveResource
     end
 
     def to_json(options={})
-      super({ :root => self.class.element_name }.merge(options))
+      super(include_root_in_json ? { :root => self.class.element_name }.merge(options) : options)
     end
 
     def to_xml(options={})

--- a/activeresource/test/cases/base_test.rb
+++ b/activeresource/test/cases/base_test.rb
@@ -1018,7 +1018,6 @@ class BaseTest < ActiveSupport::TestCase
   end
 
   def test_to_json
-    Person.include_root_in_json = true
     joe = Person.find(6)
     encode = joe.encode
     json = joe.to_json
@@ -1030,9 +1029,22 @@ class BaseTest < ActiveSupport::TestCase
     assert_match %r{\}\}$}, json
   end
 
+  def test_to_json_without_root
+    ActiveResource::Base.include_root_in_json = false
+    joe = Person.find(6)
+    encode = joe.encode
+    json = joe.to_json
+
+    assert_equal encode, json
+    assert_match %r{^\{"id":6}, json
+    assert_match %r{"name":"Joe"}, json
+    assert_match %r{"\}$}, json
+  ensure
+    ActiveResource::Base.include_root_in_json = true
+  end
+
   def test_to_json_with_element_name
     old_elem_name = Person.element_name
-    Person.include_root_in_json = true
     joe = Person.find(6)
     Person.element_name = 'ruby_creator'
     encode = joe.encode


### PR DESCRIPTION
I also removed redundant assigns. Because the default value of include_root_in_json is true.

Closes #5063.
