### PR TITLE
Restoring ability to derive id/sequence from tables with nonstandard sequences for primary keys

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1071,7 +1071,6 @@ module ActiveRecord
           end_sql
         end
 
-        # [primary_key, sequence]
         [result.first, result.last]
       rescue
         nil

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1032,26 +1032,47 @@ module ActiveRecord
       def pk_and_sequence_for(table) #:nodoc:
         # First try looking for a sequence with a dependency on the
         # given table's primary key.
-        result = exec_query(<<-end_sql, 'SCHEMA').rows.first
-          SELECT attr.attname, ns.nspname, seq.relname
-          FROM pg_class seq
-          INNER JOIN pg_depend dep ON seq.oid = dep.objid
-          INNER JOIN pg_attribute attr ON attr.attrelid = dep.refobjid AND attr.attnum = dep.refobjsubid
-          INNER JOIN pg_constraint cons ON attr.attrelid = cons.conrelid AND attr.attnum = cons.conkey[1]
-          INNER JOIN pg_namespace ns ON seq.relnamespace = ns.oid
-          WHERE seq.relkind  = 'S'
-            AND cons.contype = 'p'
-            AND dep.refobjid = '#{quote_table_name(table)}'::regclass
+        result = query(<<-end_sql, 'PK and serial sequence')[0]
+          SELECT attr.attname, seq.relname
+          FROM pg_class      seq,
+               pg_attribute  attr,
+               pg_depend     dep,
+               pg_namespace  name,
+               pg_constraint cons
+          WHERE seq.oid           = dep.objid
+            AND seq.relkind       = 'S'
+            AND attr.attrelid     = dep.refobjid
+            AND attr.attnum       = dep.refobjsubid
+            AND attr.attrelid     = cons.conrelid
+            AND attr.attnum       = cons.conkey[1]
+            AND cons.contype      = 'p'
+            AND dep.refobjid      = '#{quote_table_name(table)}'::regclass
         end_sql
 
-        # [primary_key, sequence]
-        if result.second ==  'public' then
-          sequence = result.last
-        else
-          sequence = result.second+'.'+result.last
+        if result.nil? or result.empty?
+          # If that fails, try parsing the primary key's default value.
+          # Support the 7.x and 8.0 nextval('foo'::text) as well as
+          # the 8.1+ nextval('foo'::regclass).
+          result = query(<<-end_sql, 'PK and custom sequence')[0]
+            SELECT attr.attname,
+              CASE
+                WHEN split_part(def.adsrc, '''', 2) ~ '.' THEN
+                  substr(split_part(def.adsrc, '''', 2),
+                         strpos(split_part(def.adsrc, '''', 2), '.')+1)
+                ELSE split_part(def.adsrc, '''', 2)
+              END
+            FROM pg_class       t
+            JOIN pg_attribute   attr ON (t.oid = attrelid)
+            JOIN pg_attrdef     def  ON (adrelid = attrelid AND adnum = attnum)
+            JOIN pg_constraint  cons ON (conrelid = adrelid AND adnum = conkey[1])
+            WHERE t.oid = '#{quote_table_name(table)}'::regclass
+              AND cons.contype = 'p'
+              AND def.adsrc ~* 'nextval'
+          end_sql
         end
 
-        [result.first, sequence]
+        # [primary_key, sequence]
+        [result.first, result.last]
       rescue
         nil
       end


### PR DESCRIPTION
Addresses issue https://github.com/rails/rails/issues/5094

Removed apparent duplication in test, included test table with default value using nonstandard sequence for primary key as seen in my Postgres 9 environment

Tested using Postgresql 9.0.4/Ruby 1.9.3-p125/ps 0.13.1
