### PR TITLE
Validate :on option on after_commit and after_rollback callbacks

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -22,6 +22,11 @@
 
     *Rafael Mendonça França*
 
+*   after_commit and after_rollback now validate the :on option and raise an ArgumentError if
+    it is not one of :create, :destroy or :update
+
+    *Pascal Friederich*
+
 *   Keep index names when using `alter_table` with sqlite3.
     Fix #3489.
 

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -244,6 +244,14 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
     assert_equal :rollback, @first.last_after_transaction_error
     assert_equal [:after_rollback], @second.history
   end
+
+  def test_after_rollback_callbacks_should_validate_on_condition
+    assert_raise(ArgumentError) { Topic.send(:after_rollback, :on => :save) }
+  end
+
+  def test_after_commit_callbacks_should_validate_on_condition
+    assert_raise(ArgumentError) { Topic.send(:after_commit, :on => :save) }
+  end
 end
 
 


### PR DESCRIPTION
the :on option on after_commit and after_rollback is just a shortcut for :if => "transaction_include_action?...", because of that the valid actions are very well known. unfortunately it doesn't do any validation on the :on condition. If, for example, somebody uses :on => :save, active record will happily setup a transaction_include_action?(:save) (or :whatever) which will never be true.

This patch adds a check if the on condition is one of Transactions::ACTIONS and raises a meaningful ArgumentError if the check fails.

In case you wonder, I've moved the check to a private module method to avoid pollution of the including classes namespaces.
