### PR TITLE
Reset memoized hash keys when new ActionView::Template handler is registered

### DIFF
--- a/actionpack/lib/action_view/template/handlers.rb
+++ b/actionpack/lib/action_view/template/handlers.rb
@@ -26,6 +26,7 @@ module ActionView #:nodoc:
       # return the rendered template as a string.
       def register_template_handler(extension, klass)
         @@template_handlers[extension.to_sym] = klass
+        @@template_extensions = nil
       end
 
       def template_handler_extensions

--- a/actionpack/test/template/render_test.rb
+++ b/actionpack/test/template/render_test.rb
@@ -329,6 +329,12 @@ module RenderTestCases
     ActionView::Template.register_template_handler :foo, CustomHandler
     assert_equal 'source: "Hello, <%= name %>!"', @view.render(:inline => "Hello, <%= name %>!", :locals => { :name => "Josh" }, :type => :foo)
   end
+  
+  def test_render_knows_about_types_registered_when_extensions_are_checked_earlier_in_initialization
+    ActionView::Template::Handlers.extensions
+    ActionView::Template.register_template_handler :foo, CustomHandler
+    assert ActionView::Template::Handlers.extensions.include?(:foo)
+  end
 
   def test_render_ignores_templates_with_malformed_template_handlers
     ActiveSupport::Deprecation.silence do


### PR DESCRIPTION
When any code in an initializer or gem load accesses the list of view handlers (ActionView::Template::Handlers.extensions), this gets memoized which prevents new handlers (in my case, adding in Mustache via an initializer using ActionView::Template.register_template_handler) from being made available for use.

This patch resets the memoization so that the next time '.extensions' is called, it includes all extensions that have been registered.
