### PR TITLE
use Hash#delete on styelsheet_link_tag

### DIFF
--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -36,9 +36,9 @@ module Sprockets
 
       def stylesheet_link_tag(*sources)
         options = sources.extract_options!
-        debug   = options.key?(:debug) ? options.delete(:debug) : debug_assets?
-        body    = options.key?(:body)  ? options.delete(:body)  : false
-        digest  = options.key?(:digest)  ? options.delete(:digest)  : digest_assets?
+        debug   = options.delete(:debug)  { debug_assets? }
+        body    = options.delete(:body)   { false }
+        digest  = options.delete(:digest) { digest_assets? }
 
         sources.collect do |source|
           if debug && asset = asset_paths.asset_for(source, 'css')


### PR DESCRIPTION
Following the path of https://github.com/rails/rails/commit/563df87f19d21eb491f1c24dab0f59682fe0a737 I've refactored the stylesheet_link_tag too, using exactly the same principle.

Tests are all passing.
