### PR TITLE
Bug: cache_key.size doesn't return length of filename but size of file

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -143,7 +143,7 @@ module ActiveSupport
 
         # Translate a file path into a key.
         def file_path_key(path)
-          fname = path[cache_path.size, path.size].split(File::SEPARATOR, 4).last
+          fname = path[cache_path.to_s.size..-1].split(File::SEPARATOR, 4).last
           Rack::Utils.unescape(fname)
         end
 


### PR DESCRIPTION
`cache_key.size` returns the file size if `cache_key` is an instance of Pathname.
But in this case it should be length of the filename.
