### PR TITLE
Added clarification stating the counter_cache attribute needs to be created on the associate class via a migration

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1382,9 +1382,10 @@ module ActiveRecord
       #   and +decrement_counter+. The counter cache is incremented when an object of this
       #   class is created and decremented when it's destroyed. This requires that a column
       #   named <tt>#{table_name}_count</tt> (such as +comments_count+ for a belonging Comment class)
-      #   is used on the associate class (such as a Post class). You can also specify a custom counter
-      #   cache column by providing a column name instead of a +true+/+false+ value to this
-      #   option (e.g., <tt>:counter_cache => :my_custom_counter</tt>.)
+      #   is used on the associate class (such as a Post class) - that is the migration for <tt>#{table_name}_count</tt>
+      #   is created on the associate class (such that Post.comments_count will return the count cached, see note below).
+      #   You can also specify a custom counter cache column by providing a column name instead of a +true+/+false+
+      #   value to this option (e.g., <tt>:counter_cache => :my_custom_counter</tt>.)
       #   Note: Specifying a counter cache will add it to that model's list of readonly attributes
       #   using +attr_readonly+.
       # [:include]


### PR DESCRIPTION
Hi all,

I only updated the comment for `:counter_cache`.  Hopefully this should provide an elucidation to newcomers (to Rails and the `:counter_cache` option itself)

Thanks, M.
