### PR TITLE
FormOptionsHelper refactor

### DIFF
--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -506,23 +506,24 @@ module ActionView
       # NOTE: Only the option tags are returned, you have to wrap this call in
       # a regular HTML select tag.
       def time_zone_options_for_select(selected = nil, priority_zones = nil, model = ::ActiveSupport::TimeZone)
-        zone_options = ""
+        zone_options = "".html_safe
 
         zones = model.all
         convert_zones = lambda { |list| list.map { |z| [ z.to_s, z.name ] } }
 
         if priority_zones
           if priority_zones.is_a?(Regexp)
-            priority_zones = model.all.find_all {|z| z =~ priority_zones}
+            priority_zones = zones.select { |z| z =~ priority_zones }
           end
-          zone_options += options_for_select(convert_zones[priority_zones], selected)
-          zone_options += "<option value=\"\" disabled=\"disabled\">-------------</option>\n"
 
-          zones = zones.reject { |z| priority_zones.include?( z ) }
+          zone_options.safe_concat options_for_select(convert_zones[priority_zones], selected)
+          zone_options.safe_concat content_tag(:option, '-------------', :value => '', :disabled => 'disabled')
+          zone_options.safe_concat "\n"
+
+          zones.reject! { |z| priority_zones.include?(z) }
         end
 
-        zone_options += options_for_select(convert_zones[zones], selected)
-        zone_options.html_safe
+        zone_options.safe_concat options_for_select(convert_zones[zones], selected)
       end
 
       # Returns radio button tags for the collection of existing return values

--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -660,11 +660,8 @@ module ActionView
 
         def option_text_and_value(option)
           # Options are [text, value] pairs or strings used for both.
-          case
-          when Array === option
-            option = option.reject { |e| Hash === e }
-            [option.first, option.last]
-          when !option.is_a?(String) && option.respond_to?(:first) && option.respond_to?(:last)
+          if !option.is_a?(String) && option.respond_to?(:first) && option.respond_to?(:last)
+            option = option.reject { |e| Hash === e } if Array === option
             [option.first, option.last]
           else
             [option, option]
@@ -672,11 +669,7 @@ module ActionView
         end
 
         def option_value_selected?(value, selected)
-          if selected.respond_to?(:include?) && !selected.is_a?(String)
-            selected.include? value
-          else
-            value == selected
-          end
+          Array(selected).include? value
         end
 
         def extract_selected_and_disabled(selected)


### PR DESCRIPTION
BTW, select works a little faster then find_all:

``` ruby
require 'benchmark'

n = [1]*100_000_000
Benchmark.bm do |x|
  x.report { n.select { |a| a > 1 } }
  x.report { n.find_all { |a| a > 1 } }
end
```

```
    user     system      total        real
7.590000   0.010000   7.600000 (  7.927171)
9.650000   0.010000   9.660000 (  9.634406)
```
