### PR TITLE
ordered_options will work if inherited from Hash, remove OrderedHash usage

### DIFF
--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -1,5 +1,3 @@
-require 'active_support/ordered_hash'
-
 # Usually key value pairs are handled something like this:
 #
 #   h = {}
@@ -17,7 +15,7 @@ require 'active_support/ordered_hash'
 #   h.girl # => 'Mary'
 #
 module ActiveSupport #:nodoc:
-  class OrderedOptions < OrderedHash
+  class OrderedOptions < Hash
     alias_method :_get, :[] # preserve the original #[] method
     protected :_get # make it protected
 


### PR DESCRIPTION
ordered_options will work if inherited from Hash, remove OrderedHash usage
