### PR TITLE
#read_entry in ActiveSupport::Cache::FileStore should log details of the exception when an exception is thrown

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -81,7 +81,8 @@ module ActiveSupport
           if File.exist?(file_name)
             File.open(file_name) { |f| Marshal.load(f) }
           end
-        rescue
+        rescue => e
+          logger.error("FileStoreError (#{e}): #{e.message}") if logger
           nil
         end
 

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -549,6 +549,9 @@ class FileStoreTest < ActiveSupport::TestCase
     @cache = ActiveSupport::Cache.lookup_store(:file_store, cache_dir, :expires_in => 60)
     @peek = ActiveSupport::Cache.lookup_store(:file_store, cache_dir, :expires_in => 60)
     @cache_with_pathname = ActiveSupport::Cache.lookup_store(:file_store, Pathname.new(cache_dir), :expires_in => 60)
+
+    @buffer = StringIO.new
+    @cache.logger = ActiveSupport::Logger.new(@buffer)
   end
 
   def teardown
@@ -590,6 +593,12 @@ class FileStoreTest < ActiveSupport::TestCase
     assert_nothing_raised(Exception) do
       ActiveSupport::Cache::FileStore.new('/test/cache/directory').delete_matched(/does_not_exist/)
     end
+  end
+
+  def test_log_exception_when_cache_read_fails
+    File.expects(:exist?).raises(StandardError, "failed")
+    @cache.send(:read_entry, "winston", {})
+    assert_present @buffer.string
   end
 end
 


### PR DESCRIPTION
Currently, when an exception is thrown in the private method ActiveSupport::Cache::FileStore#read_entry, the exception is rescued and the method fails silently. 

Besides failing gracefully, we should also log the exception so that it's easily debuggable.

This follows the convention in ActiveSupport::Cache::MemCacheStore#read_entry which logs the exception when one is thrown.

Thanks!
