### PR TITLE
escape_javascript helper corrupts strings

### DIFF
--- a/actionpack/lib/action_view/helpers/javascript_helper.rb
+++ b/actionpack/lib/action_view/helpers/javascript_helper.rb
@@ -28,6 +28,8 @@ module ActionView
       }
 
       JS_ESCAPE_MAP["\342\200\250".force_encoding('UTF-8').encode!] = '&#x2028;'
+      JS_ESCAPE_MAP["\342\200\251".force_encoding('UTF-8').encode!] = '&#x2029;'
+      
 
       # Escapes carriage returns and single and double quotes for JavaScript segments.
       #
@@ -36,7 +38,7 @@ module ActionView
       #   $('some_element').replaceWith('<%=j render 'some/element_template' %>');
       def escape_javascript(javascript)
         if javascript
-          result = javascript.gsub(/(\\|<\/|\r\n|\342\200\250|[\n\r"'])/u) {|match| JS_ESCAPE_MAP[match] }
+          result = javascript.gsub(/(\\|<\/|\r\n|\342\200\250|\342\200\251|[\n\r"'])/u) {|match| JS_ESCAPE_MAP[match] }
           javascript.html_safe? ? result.html_safe : result
         else
           ''

--- a/actionpack/lib/action_view/helpers/javascript_helper.rb
+++ b/actionpack/lib/action_view/helpers/javascript_helper.rb
@@ -3,6 +3,19 @@ require 'action_view/helpers/tag_helper'
 module ActionView
   module Helpers
     module JavaScriptHelper
+
+      JS_STRING_ESCAPE_MAP = {
+        '\\'    => '\\\\',
+        "\r"    => '\r',
+        "\n"    => '\n',
+        '"'     => '\u0022',
+        "'"     => "\\'",
+        "<"     => '\u003C',
+        ">"     => '\u003E',
+        "&"     => '\u0026',
+        "\342\200\250".force_encoding('UTF-8').encode! => '\u2028'
+      }
+
       JS_ESCAPE_MAP = {
         '\\'    => '\\\\',
         '</'    => '<\/',
@@ -23,6 +36,17 @@ module ActionView
       def escape_javascript(javascript)
         if javascript
           result = javascript.gsub(/(\\|<\/|\r\n|\342\200\250|[\n\r"'])/u) {|match| JS_ESCAPE_MAP[match] }
+          javascript.html_safe? ? result.html_safe : result
+        else
+          ''
+        end
+      end
+
+      # Escapes a string so that it can be used as a javascript string literal. It also escapes
+      # html characters so the string can be correctly embedded in a <script> tag.
+      def escape_javascript_string(javascript)
+        if javascript
+          result = javascript.gsub(/(\\|\342\200\250|[<>&\n\r"'])/u) {|match| JS_STRING_ESCAPE_MAP[match] }
           javascript.html_safe? ? result.html_safe : result
         else
           ''

--- a/actionpack/lib/action_view/helpers/javascript_helper.rb
+++ b/actionpack/lib/action_view/helpers/javascript_helper.rb
@@ -13,7 +13,8 @@ module ActionView
         "<"     => '\u003C',
         ">"     => '\u003E',
         "&"     => '\u0026',
-        "\342\200\250".force_encoding('UTF-8').encode! => '\u2028'
+        "\342\200\250".force_encoding('UTF-8').encode! => '\u2028',
+        "\342\200\251".force_encoding('UTF-8').encode! => '\u2029'
       }
 
       JS_ESCAPE_MAP = {
@@ -46,7 +47,7 @@ module ActionView
       # html characters so the string can be correctly embedded in a <script> tag.
       def escape_javascript_string(javascript)
         if javascript
-          result = javascript.gsub(/(\\|\342\200\250|[<>&\n\r"'])/u) {|match| JS_STRING_ESCAPE_MAP[match] }
+          result = javascript.gsub(/(\\|\342\200\250|\342\200\251|[<>&\n\r"'])/u) {|match| JS_STRING_ESCAPE_MAP[match] }
           javascript.html_safe? ? result.html_safe : result
         else
           ''

--- a/actionpack/test/template/javascript_helper_test.rb
+++ b/actionpack/test/template/javascript_helper_test.rb
@@ -28,7 +28,7 @@ class JavaScriptHelperTest < ActionView::TestCase
     assert_equal %(This \\u0022thing\\u0022 is really\\n netos\\'), escape_javascript_string(%(This "thing" is really\n netos'))
     assert_equal %(backslash\\\\test), escape_javascript_string( %(backslash\\test) )
     assert_equal %(dont \\u003C/close\\u003E tags), escape_javascript_string(%(dont </close> tags))
-    assert_equal %(unicode \\u2028 newline), escape_javascript_string(%(unicode \342\200\250 newline).force_encoding('UTF-8').encode!)
+    assert_equal %(unicode \\u2028 \\u2029 newline), escape_javascript_string(%(unicode \342\200\250 \342\200\251 newline).force_encoding('UTF-8').encode!)
 
     assert_equal %(\\u0026 should not be html encoded), escape_javascript_string(%(& should not be html encoded))
     assert_equal %(\\r should be preserved), escape_javascript_string(%(\r should be preserved))

--- a/actionpack/test/template/javascript_helper_test.rb
+++ b/actionpack/test/template/javascript_helper_test.rb
@@ -41,6 +41,8 @@ class JavaScriptHelperTest < ActionView::TestCase
     assert_equal %(backslash\\\\test), escape_javascript( %(backslash\\test) )
     assert_equal %(dont <\\/close> tags), escape_javascript(%(dont </close> tags))
     assert_equal %(unicode &#x2028; newline), escape_javascript(%(unicode \342\200\250 newline).force_encoding('UTF-8').encode!)
+    assert_equal %(unicode &#x2029; newline), escape_javascript(%(unicode \342\200\251 newline).force_encoding('UTF-8').encode!)
+
     assert_equal %(dont <\\/close> tags), j(%(dont </close> tags))
   end
 

--- a/actionpack/test/template/javascript_helper_test.rb
+++ b/actionpack/test/template/javascript_helper_test.rb
@@ -22,6 +22,19 @@ class JavaScriptHelperTest < ActionView::TestCase
     ActiveSupport.escape_html_entities_in_json  = false
   end
 
+  def test_escape_javascript_string
+    assert_equal '', escape_javascript_string(nil)
+
+    assert_equal %(This \\u0022thing\\u0022 is really\\n netos\\'), escape_javascript_string(%(This "thing" is really\n netos'))
+    assert_equal %(backslash\\\\test), escape_javascript_string( %(backslash\\test) )
+    assert_equal %(dont \\u003C/close\\u003E tags), escape_javascript_string(%(dont </close> tags))
+    assert_equal %(unicode \\u2028 newline), escape_javascript_string(%(unicode \342\200\250 newline).force_encoding('UTF-8').encode!)
+
+    assert_equal %(\\u0026 should not be html encoded), escape_javascript_string(%(& should not be html encoded))
+    assert_equal %(\\r should be preserved), escape_javascript_string(%(\r should be preserved))
+    assert_equal %(\\r\\n should be preserved), escape_javascript_string(%(\r\n should be preserved))
+  end
+
   def test_escape_javascript
     assert_equal '', escape_javascript(nil)
     assert_equal %(This \\"thing\\" is really\\n netos\\'), escape_javascript(%(This "thing" is really\n netos'))


### PR DESCRIPTION
```
  <%= javascript_tag do %>

     window.myvar = '<%= j "\u2028\\\r\n\"'<>&" %>';
         alert(JSON.stringify(window.myvar));
  <% end %>
```

this produces the following output: 

```
"&amp;#x2028;\\\n&quot;'&lt;&gt;&amp;"
```

this happens because the content of a script tag is not interpreted as html except for certain sequences which look like a closing </script> tag to the browser. but rails escapes &,>,<," which means the values end up getting escaped too many times.

I think this is quite unexpected behaviour but may be a feature because it stops xss attacks caused by the user doing something like:

```
my_element.innerHtml = window.myvar;
```

i've added a new method to the helper called escape_javascript_string that doesn't cause the value of the string to be modified. it does this by changing html characters to unicode javascript escapes. example:

```
  <%= javascript_tag do %>

     window.myvar2 = '<%= escape_javascript_string "\u2028\\\r\n\"'<>&" %>';

     alert(JSON.stringify(window.myvar2));
  <% end %>
```

which produces the following output (chrome JSON.stringify doesn't escape unicode new line):

```
" 
\\\r\n\"'<>&"
```
