### PR TITLE
Remove unused global variable in controller filters test

### DIFF
--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -937,9 +937,7 @@ class ControllerWithAllTypesOfFilters < PostsController
 end
 
 class ControllerWithTwoLessFilters < ControllerWithAllTypesOfFilters
-  $vbf = true
   skip_filter :around_again
-  $vbf = false
   skip_filter :after
 end
 


### PR DESCRIPTION
It likes $vbf global variables used only for debug purporses (injected at 196f780e30fcece25e4d09c12f9b9f7374ebed29 3 years ago). I didn't find this in sources or in any ruby implementation.
