### PR TITLE
Move config.autoflush_log to correct template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -35,7 +35,4 @@
   # Expands the lines which load the assets.
   config.assets.debug = true
   <%- end -%>
-
-  # Disable automatic flushing of the log to improve performance.
-  #config.autoflush_log = false
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -70,4 +70,7 @@
   # with SQLite, MySQL, and PostgreSQL).
   # config.active_record.auto_explain_threshold_in_seconds = 0.5
   <%- end -%>
+
+  # Disable automatic flushing of the log to improve performance.
+  #config.autoflush_log = false
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -72,5 +72,5 @@
   <%- end -%>
 
   # Disable automatic flushing of the log to improve performance.
-  #config.autoflush_log = false
+  # config.autoflush_log = false
 end


### PR DESCRIPTION
This accidentally ended up in the development template
instead of the production template, where it makes
most sense.
