### PR TITLE
Accept heder parsing with single mimetype and quality param

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -111,7 +111,7 @@ module Mime
           if accept_header =~ TRAILING_STAR_REGEXP
             parse_data_with_trailing_star($1)
           else
-            [Mime::Type.lookup(accept_header)]
+            [Mime::Type.lookup(accept_header.split(/\s*;/).first)]
           end
         else
           # keep track of creation order to keep the subsequent sort stable

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -76,6 +76,12 @@ class MimeTypeTest < ActiveSupport::TestCase
     assert_equal expect, Mime::Type.parse(accept).collect { |c| c.to_s }
   end
 
+  test "parse single type with q" do
+    accept = "*/*;q=0.9"
+    expect = [Mime::ALL]
+    assert_equal expect, Mime::Type.parse(accept)
+  end
+
   # Accept header send with user HTTP_USER_AGENT: Mozilla/4.0
   #  (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322; InfoPath.1)
   test "parse other broken acceptlines" do


### PR DESCRIPTION
I had a problem on my production env when google bot comes it gets 500 with MissingTemplate exception. During the investigation I found that rails do not able to parse properly Accept mime type if it is only one in header AND contains quality parameter. Not sure if it is proper behaviour from the Google Bot side, but it behaves these way ( It sends Accept: */*;q=0.9). 
