### PR TITLE
Update with new task names for building mysql and postgresql databases

### DIFF
--- a/activerecord/RUNNING_UNIT_TESTS
+++ b/activerecord/RUNNING_UNIT_TESTS
@@ -3,7 +3,7 @@
 Copy test/config.example.yml to test/config.yml and edit as needed. Or just run the tests for
 the first time, which will do the copy automatically and use the default (sqlite3).
 
-You can build postgres and mysql databases using the build_postgresql and build_mysql rake tasks.
+You can build postgres and mysql databases using the postgresql:build_databases and mysql:build_databases rake tasks.
 
 == Running the tests
 


### PR DESCRIPTION
Looks like the task names for creating databases have been namespaced.  This just updates RUNNING_UNIT_TESTS with the new task names.
