### PR TITLE
Return 204 No Content status when resource is blank

### DIFF
--- a/actionpack/lib/action_controller/metal/responder.rb
+++ b/actionpack/lib/action_controller/metal/responder.rb
@@ -198,8 +198,10 @@ module ActionController #:nodoc:
     def api_behavior(error)
       raise error unless resourceful?
 
-      if get?
+      if get? && resource.present?
         display resource
+      elsif get? && resource.blank?
+        display resource, :status => :no_content
       elsif post?
         display resource, :status => :created, :location => api_location
       else

--- a/actionpack/test/controller/mime_responds_test.rb
+++ b/actionpack/test/controller/mime_responds_test.rb
@@ -531,6 +531,10 @@ class RespondWithController < ActionController::Base
     respond_with([resource, Customer.new("jamis", 9)])
   end
 
+  def using_resource_with_blank_collection
+    respond_with([])
+  end
+
   def using_resource_with_parent
     respond_with(Quiz::Store.new("developer?", 11), Customer.new("david", 13))
   end
@@ -956,6 +960,13 @@ class RespondWithControllerTest < ActionController::TestCase
     assert_equal 200, @response.status
     assert_match(/<name>david<\/name>/, @response.body)
     assert_match(/<name>jamis<\/name>/, @response.body)
+  end
+
+  def test_using_resource_with_blank_collection
+    @request.accept = "application/xml"
+    get :using_resource_with_blank_collection
+    assert_equal "application/xml", @response.content_type
+    assert_equal 204, @response.status
   end
 
   def test_using_resource_with_action


### PR DESCRIPTION
I know it's maybe naive implementation and tests are not perfect. Please advise if it makes sense and/or how to improve this.

I don't know if it would be better to inline the condition (I wanted this to be more readable):

``` ruby
if get?
  display resource, status => (resource.present? ? :ok : :no_content)
end
```
