### PR TITLE
Made `first` finder consistent among database engines by adding a default order

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Added default order to `first` to assure consistent results among
+    diferent database engines. Introduced `take` as a replacement to
+    the old behavior of `first`.
+
+    *Marcelo Silveira*
+
 *   Added an :index option to automatically create indexes for references
     and belongs_to statements in migrations.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1233,7 +1233,10 @@ module ActiveRecord
 
         # Construct a clean list of column names from the ORDER BY clause, removing
         # any ASC/DESC modifiers
-        order_columns = orders.collect { |s| s.gsub(/\s+(ASC|DESC)\s*(NULLS\s+(FIRST|LAST)\s*)?/i, '') }
+        order_columns = orders.collect do |s|
+          s = s.to_sql unless s.is_a?(String)
+          s.gsub(/\s+(ASC|DESC)\s*(NULLS\s+(FIRST|LAST)\s*)?/i, '')
+        end
         order_columns.delete_if { |c| c.blank? }
         order_columns = order_columns.zip((0...order_columns.size).to_a).map { |s,i| "#{s} AS alias_#{i}" }
 

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -3,7 +3,7 @@ require 'active_support/deprecation'
 
 module ActiveRecord
   module Querying
-    delegate :find, :first, :first!, :last, :last!, :all, :exists?, :any?, :many?, :to => :scoped
+    delegate :find, :take, :take!, :first, :first!, :last, :last!, :all, :exists?, :any?, :many?, :to => :scoped
     delegate :first_or_create, :first_or_create!, :first_or_initialize, :to => :scoped
     delegate :find_by, :find_by!, :to => :scoped
     delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, :to => :scoped

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -87,6 +87,9 @@ module ActiveRecord
       first or raise RecordNotFound
     end
 
+    # Find the last record (or last N records if a parameter is supplied).
+    # If no order is defined it will order by primary key.
+    #
     # Examples:
     #
     #   Person.last # returns the last object fetched by SELECT * FROM people
@@ -94,8 +97,8 @@ module ActiveRecord
     #   Person.order("created_on DESC").offset(5).last
     def last(limit = nil)
       if limit
-        if order_values.empty?
-          order("#{primary_key} DESC").limit(limit).reverse
+        if order_values.empty? && primary_key
+          order("#{quoted_table_name}.#{quoted_primary_key} DESC").limit(limit).reverse
         else
           to_a.last(limit)
         end

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -91,7 +91,7 @@ module ActiveRecord
     def first(limit = nil)
       if limit
         if order_values.empty? && primary_key
-          order("#{quoted_table_name}.#{quoted_primary_key} ASC").limit(limit).to_a
+          order(arel_table[primary_key].asc).limit(limit).to_a
         else
           limit(limit).to_a
         end
@@ -117,7 +117,7 @@ module ActiveRecord
     def last(limit = nil)
       if limit
         if order_values.empty? && primary_key
-          order("#{quoted_table_name}.#{quoted_primary_key} DESC").limit(limit).reverse
+          order(arel_table[primary_key].desc).limit(limit).reverse
         else
           to_a.last(limit)
         end
@@ -362,7 +362,7 @@ module ActiveRecord
       else
         @first ||=
           if order_values.empty? && primary_key
-            order("#{quoted_table_name}.#{quoted_primary_key} ASC").limit(1).to_a.first
+            order(arel_table[primary_key].asc).limit(1).to_a.first
           else
             limit(1).to_a.first
           end

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -350,9 +350,9 @@ module ActiveRecord
 
     def find_take
       if loaded?
-        @records.take(1)[0]
+        @records.take(1).first
       else
-        @take ||= limit(1).to_a[0]
+        @take ||= limit(1).to_a.first
       end
     end
 
@@ -362,9 +362,9 @@ module ActiveRecord
       else
         @first ||=
           if order_values.empty? && primary_key
-            order("#{quoted_table_name}.#{quoted_primary_key} ASC").limit(1).to_a[0]
+            order("#{quoted_table_name}.#{quoted_primary_key} ASC").limit(1).to_a.first
           else
-            limit(1).to_a[0]
+            limit(1).to_a.first
           end
       end
     end
@@ -377,7 +377,7 @@ module ActiveRecord
           if offset_value || limit_value
             to_a.last
           else
-            reverse_order.limit(1).to_a[0]
+            reverse_order.limit(1).to_a.first
           end
       end
     end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -163,6 +163,12 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
+  def test_first_have_primary_key_order_by_default
+    expected = topics(:first)
+    expected.touch # PostgreSQL changes the default order if no order clause is used
+    assert_equal expected, Topic.first
+  end
+
   def test_model_class_responds_to_first_bang
     assert Topic.first!
     Topic.delete_all

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -143,6 +143,26 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal [Account], accounts.collect(&:class).uniq
   end
 
+  def test_take
+    assert_equal topics(:first), Topic.take
+  end
+
+  def test_take_failing
+    assert_nil Topic.where("title = 'This title does not exist'").take
+  end
+
+  def test_take_bang_present
+    assert_nothing_raised do
+      assert_equal topics(:second), Topic.where("title = 'The Second Topic of the day'").take!
+    end
+  end
+
+  def test_take_bang_missing
+    assert_raises ActiveRecord::RecordNotFound do
+      Topic.where("title = 'This title does not exist'").take!
+    end
+  end
+
   def test_first
     assert_equal topics(:second).title, Topic.where("title = 'The Second Topic of the day'").first.title
   end
@@ -197,7 +217,8 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
-  def test_first_and_last_with_integer_should_use_sql_limit
+  def test_take_and_first_and_last_with_integer_should_use_sql_limit
+    assert_sql(/LIMIT 3|ROWNUM <= 3/) { Topic.take(3).entries }
     assert_sql(/LIMIT 2|ROWNUM <= 2/) { Topic.first(2).entries }
     assert_sql(/LIMIT 5|ROWNUM <= 5/) { Topic.last(5).entries }
   end
@@ -218,7 +239,8 @@ class FinderTest < ActiveRecord::TestCase
     assert_no_match(/LIMIT/, query.first)
   end
 
-  def test_first_and_last_with_integer_should_return_an_array
+  def test_take_and_first_and_last_with_integer_should_return_an_array
+    assert_kind_of Array, Topic.take(5)
     assert_kind_of Array, Topic.first(5)
     assert_kind_of Array, Topic.last(5)
   end


### PR DESCRIPTION
Hi,

When you do a call to `first` the generated SQL is this:

``` ruby
> User.first
  User Load (35.2ms)  SELECT "users".* FROM "users" LIMIT 1
```

However, PostgreSQL changes the 'default order' of the records when you perform an update as you can observe in this example:

``` sql
# CREATE TABLE users (id serial, name varchar(40));
# INSERT INTO users (name) VALUES ('John');
# INSERT INTO users (name) VALUES ('Michael');
# SELECT * FROM users;
 id |     name      
----+---------------
  1 | John
  2 | Michael

# SELECT "users".* FROM "users" LIMIT 1;
 id | name 
----+------
  1 | John

# UPDATE users SET name = 'Modified John' WHERE id = 1;
# SELECT * FROM users;
 id |     name      
----+---------------
  2 | Michael
  1 | Modified John

# SELECT "users".* FROM "users" LIMIT 1;
 id |  name   
----+---------
  2 | Michael
```

So I made a change so that all `first` calls gains a default order clause:

``` ruby
> User.first
  User Load (3.1ms)  SELECT "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT 1
```

If an order clause is already chained, nothing is added:

``` ruby
> User.order(:name).first
  User Load (75.1ms)  SELECT "users".* FROM "users" ORDER BY name LIMIT 1
```

I'm not particularly confortable changing the global behavior for a PostgreSQL specific fix but I think an adapter check wouldn't make sense in this area of the code. What do you think?

If accepted I'd be happy to backport the fix to previous versions.

Cheers!
