### PR TITLE
Add instance_accessor option to class_attribute

### DIFF
--- a/actionpack/lib/abstract_controller/layouts.rb
+++ b/actionpack/lib/abstract_controller/layouts.rb
@@ -203,8 +203,7 @@ module AbstractController
     include Rendering
 
     included do
-      class_attribute :_layout, :_layout_conditions,
-        :instance_reader => false, :instance_writer => false
+      class_attribute :_layout, :_layout_conditions, :instance_accessor => false
       self._layout = nil
       self._layout_conditions = {}
       _write_layout_method

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add `:instance_accessor` option for `class_attribute`. *Alexey Vakhov*
+
 *   `constantize` now looks in the ancestor chain. *Marc-Andre Lafortune & Andrew White*
 
 *   `Object#try` can't call private methods. *Vasiliy Ermolovich*

--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -65,10 +65,12 @@ class Class
   # To opt out of the instance writer method, pass :instance_writer => false.
   #
   #   object.setting = false  # => NoMethodError
+  #
+  # To opt out of both instance methods, pass :instance_accessor => false.
   def class_attribute(*attrs)
     options = attrs.extract_options!
-    instance_reader = options.fetch(:instance_reader, true)
-    instance_writer = options.fetch(:instance_writer, true)
+    instance_reader = options.fetch(:instance_accessor, true) && options.fetch(:instance_reader, true)
+    instance_writer = options.fetch(:instance_accessor, true) && options.fetch(:instance_writer, true)
 
     attrs.each do |name|
       class_eval <<-RUBY, __FILE__, __LINE__ + 1

--- a/activesupport/test/core_ext/class/attribute_test.rb
+++ b/activesupport/test/core_ext/class/attribute_test.rb
@@ -66,6 +66,13 @@ class ClassAttributeTest < ActiveSupport::TestCase
     assert_raise(NoMethodError) { object.setting? }
   end
 
+  test 'disabling both instance writer and reader' do
+    object = Class.new { class_attribute :setting, :instance_accessor => false }.new
+    assert_raise(NoMethodError) { object.setting }
+    assert_raise(NoMethodError) { object.setting? }
+    assert_raise(NoMethodError) { object.setting = 'boom' }
+  end
+
   test 'works well with singleton classes' do
     object = @klass.new
     object.singleton_class.setting = 'foo'


### PR DESCRIPTION
option for cattr_accessor was added at Jun 2011 - b12c2e4ebb85170467ac250219557d631c842d8d,
for mattr_accessor at the same time: bf526c2dbeb73bf11553004e43889a804b72866d

I suggest to add this option to class_attribute also.
