### PR TITLE
Sugar sintaxe: :not_nil on finders to query with IS NOT NULL

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -66,6 +66,8 @@ module ActiveRecord
         when Class
           # FIXME: I think we need to deprecate this behavior
           attribute.eq(value.name)
+        when :not_nil
+          attribute.not_eq(nil)
         else
           attribute.eq(value)
         end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -162,7 +162,7 @@ class FinderTest < ActiveRecord::TestCase
   end
   
   def test_find_first_not_nil
-    first = Topic.find(:first, :conditions => {:title => :not_nil})
+    first = Topic.where(:title => :not_nil).first
     assert_equal(topics(:first).title, first.title)
   end
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -160,6 +160,11 @@ class FinderTest < ActiveRecord::TestCase
       assert_equal topics(:second), Topic.where("title = 'The Second Topic of the day'").take!
     end
   end
+  
+  def test_find_first_not_nil
+    first = Topic.find(:first, :conditions => {:title => :not_nil})
+    assert_equal(topics(:first).title, first.title)
+  end
 
   def test_take_bang_missing
     assert_raises ActiveRecord::RecordNotFound do
@@ -173,6 +178,10 @@ class FinderTest < ActiveRecord::TestCase
 
   def test_first_failing
     assert_nil Topic.where("title = 'The Second Topic of the day!'").first
+  end
+  
+  def test_first_not_nil
+    assert_equal topics(:first).title, Topic.where(:title => :not_nil).first.title
   end
 
   def test_first_bang_present


### PR DESCRIPTION
Model.where(:field => :not_nil) will make a sql query like "...WHERE field IS NOT NULL..."
