### PR TITLE
Fix type_to_sql with text and limit on mysql/mysql2. Fix GH #3931 (Try again).

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -484,15 +484,26 @@ module ActiveRecord
 
       # Maps logical Rails types to MySQL-specific data types.
       def type_to_sql(type, limit = nil, precision = nil, scale = nil)
-        return super unless type.to_s == 'integer'
-
-        case limit
-        when 1; 'tinyint'
-        when 2; 'smallint'
-        when 3; 'mediumint'
-        when nil, 4, 11; 'int(11)'  # compatibility with MySQL default
-        when 5..8; 'bigint'
-        else raise(ActiveRecordError, "No integer type has byte size #{limit}")
+        case type.to_s
+        when 'integer'
+          case limit
+          when 1; 'tinyint'
+          when 2; 'smallint'
+          when 3; 'mediumint'
+          when nil, 4, 11; 'int(11)'  # compatibility with MySQL default
+          when 5..8; 'bigint'
+          else raise(ActiveRecordError, "No integer type has byte size #{limit}")
+          end
+        when 'text'
+          case limit
+          when 0..0xff;               'tinytext'
+          when nil, 0x100..0xffff;    'text'
+          when 0x10000..0xffffff;     'mediumtext'
+          when 0x1000000..0xffffffff; 'longtext'
+          else raise(ActiveRecordError, "No text type has character length #{limit}")
+          end
+        else
+          super
         end
       end
 

--- a/activerecord/test/schema/mysql2_specific_schema.rb
+++ b/activerecord/test/schema/mysql2_specific_schema.rb
@@ -1,5 +1,5 @@
 ActiveRecord::Schema.define do
-  create_table :binary_fields, :force => true, :options => 'CHARACTER SET latin1' do |t|
+  create_table :binary_fields, :force => true do |t|
     t.binary :tiny_blob,   :limit => 255
     t.binary :normal_blob, :limit => 65535
     t.binary :medium_blob, :limit => 16777215

--- a/activerecord/test/schema/mysql_specific_schema.rb
+++ b/activerecord/test/schema/mysql_specific_schema.rb
@@ -1,5 +1,5 @@
 ActiveRecord::Schema.define do
-  create_table :binary_fields, :force => true, :options => 'CHARACTER SET latin1' do |t|
+  create_table :binary_fields, :force => true do |t|
     t.binary :tiny_blob,   :limit => 255
     t.binary :normal_blob, :limit => 65535
     t.binary :medium_blob, :limit => 16777215


### PR DESCRIPTION
The original issue is #3931.

First, add the following line.

```
t.text :example, :limit => 0x555555 (5592405) # means `mediumtext`
```

Second, migrate and be generated schema.rb. I'll see

```
t.text "example", :limit => 16777215 # `longtext` !
```

I think that the cause of problem is mysql behavior difference by character encoding.

If we use latin1 encoding, the limit is 16777215.
But if we use utf-8 encoding, the limit is 16777215 / 3 = 5592405.

Thus, I should fix `binary_fields` test, because I guess that we usually use utf-8 encoding.

Please see also #3931 and #4382.

Closes #3931.
