### PR TITLE
Rake notes directories

### DIFF
--- a/guides/source/command_line.textile
+++ b/guides/source/command_line.textile
@@ -446,6 +446,19 @@ app/model/post.rb:
 
 NOTE. When using specific annotations and custom annotations, the annotation name (FIXME, BUG etc) is not displayed in the output lines.
 
+Be default, rake notes will look in the app, config, lib, script and test directories for notes. If you would like to search additional directories,
+simply provide the directories as a comma seperated list in an environment variable +SOURCE_ANNOTATION_DIRECTORIES+.
+
+<shell>
+$ export SOURCE_ANNOTATION_DIRECTORIES='rspec,vendor'
+$ rake notes
+(in /home/foobar/commandsapp)
+app/model/user.rb:
+  * [ 35] [FIXME] User should have a subscription at this point
+rspec/model/user_spec.rb:
+  * [122] [TODO] Verify the user that has a subscription works
+</shell>
+
 h4. +routes+
 
 +rake routes+ will list all of your defined routes, which is useful for tracking down routing problems in your app, or giving you a good overview of the URLs in an app you're trying to get familiar with.

--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -14,6 +14,9 @@
 # of the line (or closing ERB comment tag) is considered to be their text.
 class SourceAnnotationExtractor
   class Annotation < Struct.new(:line, :tag, :text)
+    def self.directories
+      @@directories ||= %w(app config lib script test) + (ENV['SOURCE_ANNOTATION_DIRECTORIES'] || '').split(',')
+    end
 
     # Returns a representation of the annotation that looks like this:
     #
@@ -48,7 +51,7 @@ class SourceAnnotationExtractor
 
   # Returns a hash that maps filenames under +dirs+ (recursively) to arrays
   # with their annotations.
-  def find(dirs=%w(app config lib script test))
+  def find(dirs=Annotation.directories)
     dirs.inject({}) { |h, dir| h.update(find_in(dir)) }
   end
 

--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -51,7 +51,7 @@ class SourceAnnotationExtractor
 
   # Returns a hash that maps filenames under +dirs+ (recursively) to arrays
   # with their annotations.
-  def find(dirs=Annotation.directories)
+  def find(dirs = Annotation.directories)
     dirs.inject({}) { |h, dir| h.update(find_in(dir)) }
   end
 

--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -49,7 +49,6 @@ module ApplicationTests
             assert_equal ' ', line[1]
           end
         end
-
       end
 
       test 'notes finds notes in default directories' do
@@ -86,11 +85,9 @@ module ApplicationTests
             assert_equal 4, line_number.size
           end
         end
-
       end
 
       test 'notes finds notes in custom directories' do
-
         app_file "app/controllers/some_controller.rb", "# TODO: note in app directory"
         app_file "config/initializers/some_initializer.rb", "# TODO: note in config directory"
         app_file "lib/some_file.rb", "# TODO: note in lib directory"
@@ -125,7 +122,6 @@ module ApplicationTests
             assert_equal 4, line_number.size
           end
         end
-
       end
 
       private

--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -13,7 +13,6 @@ module ApplicationTests
       end
 
       test 'notes finds notes for certain file_types' do
-
         app_file "app/views/home/index.html.erb", "<% # TODO: note in erb %>"
         app_file "app/views/home/index.html.haml", "-# TODO: note in haml"
         app_file "app/views/home/index.html.slim", "/ TODO: note in slim"
@@ -52,8 +51,8 @@ module ApplicationTests
         end
 
       end
-      test 'notes finds notes in default directories' do
 
+      test 'notes finds notes in default directories' do
         app_file "app/controllers/some_controller.rb", "# TODO: note in app directory"
         app_file "config/initializers/some_initializer.rb", "# TODO: note in config directory"
         app_file "lib/some_file.rb", "# TODO: note in lib directory"

--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -60,6 +60,8 @@ module ApplicationTests
         app_file "script/run_something.rb", "# TODO: note in script directory"
         app_file "test/some_test.rb", 1000.times.map { "" }.join("\n") << "# TODO: note in test directory"
 
+        app_file "some_other_dir/blah.rb", "# TODO: note in some_other directory"
+
         boot_rails
 
         require 'rake'
@@ -77,8 +79,48 @@ module ApplicationTests
           assert_match /note in lib directory/, output
           assert_match /note in script directory/, output
           assert_match /note in test directory/, output
+          assert_no_match /note in some_other directory/, output
 
           assert_equal 5, lines.size
+
+          lines.each do |line_number|
+            assert_equal 4, line_number.size
+          end
+        end
+
+      end
+
+      test 'notes finds notes in custom directories' do
+
+        app_file "app/controllers/some_controller.rb", "# TODO: note in app directory"
+        app_file "config/initializers/some_initializer.rb", "# TODO: note in config directory"
+        app_file "lib/some_file.rb", "# TODO: note in lib directory"
+        app_file "script/run_something.rb", "# TODO: note in script directory"
+        app_file "test/some_test.rb", 1000.times.map { "" }.join("\n") << "# TODO: note in test directory"
+
+        app_file "some_other_dir/blah.rb", "# TODO: note in some_other directory"
+
+        boot_rails
+
+        require 'rake'
+        require 'rdoc/task'
+        require 'rake/testtask'
+
+        Rails.application.load_tasks
+
+        Dir.chdir(app_path) do
+          output = `SOURCE_ANNOTATION_DIRECTORIES='some_other_dir' bundle exec rake notes`
+          lines = output.scan(/\[([0-9\s]+)\]/).flatten
+
+          assert_match /note in app directory/, output
+          assert_match /note in config directory/, output
+          assert_match /note in lib directory/, output
+          assert_match /note in script directory/, output
+          assert_match /note in test directory/, output
+
+          assert_match /note in some_other directory/, output
+
+          assert_equal 6, lines.size
 
           lines.each do |line_number|
             assert_equal 4, line_number.size


### PR DESCRIPTION
These commits do two things:

```
Verify that Annotations are found in all the default directories
      app config lib script test

If an environment variable SOURCE_ANNOTATION_DIRECTORIES exists, it searches there too
      SOURCE_ANNOTATION_DIRECTORIES='dir1,dir2' bundle exec rake notes
          searches:  app config lib script test dir1 dir2
```

References: #4536, #4540
