### PR TITLE
fix inflector bug where -ice gets singularized into -ouse

### DIFF
--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -16,8 +16,8 @@ module ActiveSupport
     inflect.plural(/([^aeiouy]|qu)y$/i, '\1ies')
     inflect.plural(/(x|ch|ss|sh)$/i, '\1es')
     inflect.plural(/(matr|vert|ind)(?:ix|ex)$/i, '\1ices')
-    inflect.plural(/(m|l)ouse$/i, '\1ice')
-    inflect.plural(/(m|l)ice$/i, '\1ice')
+    inflect.plural(/^(m|l)ouse$/i, '\1ice')
+    inflect.plural(/^(m|l)ice$/i, '\1ice')
     inflect.plural(/^(ox)$/i, '\1en')
     inflect.plural(/^(oxen)$/i, '\1')
     inflect.plural(/(quiz)$/i, '\1zes')
@@ -36,7 +36,7 @@ module ActiveSupport
     inflect.singular(/(s)eries$/i, '\1eries')
     inflect.singular(/(m)ovies$/i, '\1ovie')
     inflect.singular(/(x|ch|ss|sh)es$/i, '\1')
-    inflect.singular(/(m|l)ice$/i, '\1ouse')
+    inflect.singular(/^(m|l)ice$/i, '\1ouse')
     inflect.singular(/(bus)(es)?$/i, '\1')
     inflect.singular(/(o)es$/i, '\1')
     inflect.singular(/(shoe)s$/i, '\1')
@@ -58,6 +58,6 @@ module ActiveSupport
     inflect.irregular('cow', 'kine')
     inflect.irregular('zombie', 'zombies')
 
-    inflect.uncountable(%w(equipment information rice money species series fish sheep jeans))
+    inflect.uncountable(%w(equipment information rice money species series fish sheep jeans police))
   end
 end

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -109,7 +109,9 @@ module InflectorTestCases
 
     # regression tests against improper inflection regexes
     "|ice"        => "|ices",
-    "|ouse"       => "|ouses"
+    "|ouse"       => "|ouses",
+    "slice"       => "slices",
+    "police"      => "police"
   }
 
   CamelToUnderscore = {


### PR DESCRIPTION
This should happen for mouse or louse, but not slice or pumice.

I know the inflector is "frozen," but this is a pretty cut and dry bug with a very simple fix. It doesn't seem likely that there are many cases out there where this bug fix will break existing code.

Fixes issue #4374.
