### PR TITLE
Binary mode window bug

### DIFF
--- a/activesupport/lib/active_support/core_ext/file/atomic.rb
+++ b/activesupport/lib/active_support/core_ext/file/atomic.rb
@@ -16,7 +16,7 @@ class File
     require 'tempfile' unless defined?(Tempfile)
     require 'fileutils' unless defined?(FileUtils)
 
-    temp_file = Tempfile.new(basename(file_name), temp_dir)
+    temp_file = Tempfile.new(basename(file_name), temp_dir, :binmode => true)
     yield temp_file
     temp_file.close
 


### PR DESCRIPTION
In asset_tag_helper_test.rb there is an assert on the number of bytes in a
concatenated file.  This test failed because Windows converts \n to \r\n as
the default for "w".  This is different than in *nix systems where there is
no conversion done.

The test that failed was test_caching_stylesheet_link_tag_when_caching_on

Using bin mode fixes this behavior on windows and makes no change on the
*nix systems.
