### PR TITLE
don't add the source JS asset when in debug mode

### DIFF
--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -26,7 +26,9 @@ module Sprockets
         sources.collect do |source|
           if debug && asset = asset_paths.asset_for(source, 'js')
             asset.to_a.map { |dep|
-              super(dep.pathname.to_s, { :src => path_to_asset(dep, :ext => 'js', :body => true, :digest => digest) }.merge!(options))
+              unless File.basename(dep.pathname, '.js') == source
+                super(dep.pathname.to_s, { :src => path_to_asset(dep, :ext => 'js', :body => true, :digest => digest) }.merge!(options))
+              end
             }
           else
             super(source.to_s, { :src => path_to_asset(source, :ext => 'js', :body => body, :digest => digest) }.merge!(options))


### PR DESCRIPTION
This fixes issue #5145 by not adding the source Javascript asset in the Sprockets Rails helper when config.assets.debug is true.

I wanted to find a way to treat the source asset as a Sprockets::Asset and use the #eql? method to compare them, but I didn't see an obvious way to do that. If anyone has any pointers there, please let me know.

That said, this does fix the issue of not including application.js along with the other .js files when config.assets.debug is true.
