### PR TITLE
Fix for issue #3560

### DIFF
--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -29,7 +29,8 @@ module ActionView
       #   89 mins, 30 secs <-> 23 hrs, 59 mins, 29 secs                             # => about [2..24] hours
       #   23 hrs, 59 mins, 30 secs <-> 41 hrs, 59 mins, 29 secs                     # => 1 day
       #   41 hrs, 59 mins, 30 secs  <-> 29 days, 23 hrs, 59 mins, 29 secs           # => [2..29] days
-      #   29 days, 23 hrs, 59 mins, 30 secs <-> 59 days, 23 hrs, 59 mins, 29 secs   # => about 1 month
+      #   29 days, 23 hrs, 59 mins, 30 secs <-> 44 days, 23 hrs, 59 mins, 29 secs   # => about 1 month
+      #   44 days, 23 hrs, 59 mins, 30 secs <-> 59 days, 23 hrs, 59 mins, 29 secs   # => about 2 months
       #   59 days, 23 hrs, 59 mins, 30 secs <-> 1 yr minus 1 sec                    # => [2..12] months
       #   1 yr <-> 1 yr, 3 months                                                   # => about 1 year
       #   1 yr, 3 months <-> 1 yr, 9 months                                         # => over 1 year
@@ -100,7 +101,7 @@ module ActionView
             when 90..1439        then locale.t :about_x_hours,  :count => (distance_in_minutes.to_f / 60.0).round
             when 1440..2519      then locale.t :x_days,         :count => 1
             when 2520..43199     then locale.t :x_days,         :count => (distance_in_minutes.to_f / 1440.0).round
-            when 43200..86399    then locale.t :about_x_months, :count => 1
+            when 43200..86399    then locale.t :about_x_months, :count => (distance_in_minutes.to_f / 43200.0).round
             when 86400..525599   then locale.t :x_months,       :count => (distance_in_minutes.to_f / 43200.0).round
             else
               if from_time.acts_like?(:time) && to_time.acts_like?(:time)

--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -96,13 +96,18 @@ module ActionView
                 else             locale.t :x_minutes,           :count => 1
               end
 
-            when 2..44           then locale.t :x_minutes,      :count => distance_in_minutes
-            when 45..89          then locale.t :about_x_hours,  :count => 1
-            when 90..1439        then locale.t :about_x_hours,  :count => (distance_in_minutes.to_f / 60.0).round
-            when 1440..2519      then locale.t :x_days,         :count => 1
-            when 2520..43199     then locale.t :x_days,         :count => (distance_in_minutes.to_f / 1440.0).round
-            when 43200..86399    then locale.t :about_x_months, :count => (distance_in_minutes.to_f / 43200.0).round
-            when 86400..525599   then locale.t :x_months,       :count => (distance_in_minutes.to_f / 43200.0).round
+            when 2...45           then locale.t :x_minutes,      :count => distance_in_minutes
+            when 45...90          then locale.t :about_x_hours,  :count => 1
+            # 90 mins up to 24 hours
+            when 90...1440        then locale.t :about_x_hours,  :count => (distance_in_minutes.to_f / 60.0).round
+            # 24 hours up to 42 hours
+            when 1440...2520      then locale.t :x_days,         :count => 1
+            # 42 hours up to 30 days
+            when 2520...43200     then locale.t :x_days,         :count => (distance_in_minutes.to_f / 1440.0).round
+            # 30 days up to 60 days
+            when 43200...86400    then locale.t :about_x_months, :count => (distance_in_minutes.to_f / 43200.0).round
+            # 60 days up to 365 days
+            when 86400...525600   then locale.t :x_months,       :count => (distance_in_minutes.to_f / 43200.0).round
             else
               if from_time.acts_like?(:time) && to_time.acts_like?(:time)
                 fyear = from_time.year

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -77,7 +77,9 @@ class DateHelperTest < ActionView::TestCase
 
     # 43200..86399
     assert_equal "about 1 month", distance_of_time_in_words(from, to + 29.days + 23.hours + 59.minutes + 30.seconds)
-    assert_equal "about 1 month", distance_of_time_in_words(from, to + 59.days + 23.hours + 59.minutes + 29.seconds)
+    assert_equal "about 1 month", distance_of_time_in_words(from, to + 44.days + 23.hours + 59.minutes + 29.seconds)
+    assert_equal "about 2 months", distance_of_time_in_words(from, to + 44.days + 23.hours + 59.minutes + 30.seconds)
+    assert_equal "about 2 months", distance_of_time_in_words(from, to + 59.days + 23.hours + 59.minutes + 29.seconds)
 
     # 86400..525599
     assert_equal "2 months", distance_of_time_in_words(from, to + 59.days + 23.hours + 59.minutes + 30.seconds)

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -21,7 +21,7 @@ class DateHelperTest < ActionView::TestCase
   def assert_distance_of_time_in_words(from, to=nil)
     to ||= from
 
-    # 0..1 with :include_seconds => true
+    # 0..1 minute with :include_seconds => true
     assert_equal "less than 5 seconds", distance_of_time_in_words(from, to + 0.seconds, :include_seconds => true)
     assert_equal "less than 5 seconds", distance_of_time_in_words(from, to + 4.seconds, :include_seconds => true)
     assert_equal "less than 10 seconds", distance_of_time_in_words(from, to + 5.seconds, :include_seconds => true)
@@ -35,7 +35,7 @@ class DateHelperTest < ActionView::TestCase
     assert_equal "1 minute", distance_of_time_in_words(from, to + 60.seconds, :include_seconds => true)
     assert_equal "1 minute", distance_of_time_in_words(from, to + 89.seconds, :include_seconds => true)
 
-    # 0..1 with :include_seconds => false
+    # 0..1 minute with :include_seconds => false
     assert_equal "less than a minute", distance_of_time_in_words(from, to + 0.seconds, :include_seconds => false)
     assert_equal "less than a minute", distance_of_time_in_words(from, to + 4.seconds, :include_seconds => false)
     assert_equal "less than a minute", distance_of_time_in_words(from, to + 5.seconds, :include_seconds => false)
@@ -48,44 +48,53 @@ class DateHelperTest < ActionView::TestCase
     assert_equal "1 minute", distance_of_time_in_words(from, to + 59.seconds, :include_seconds => false)
     assert_equal "1 minute", distance_of_time_in_words(from, to + 60.seconds, :include_seconds => false)
     assert_equal "1 minute", distance_of_time_in_words(from, to + 89.seconds, :include_seconds => false)
-    # First case 0..1
+
+    # Note that we are including a 30-second boundary around the interval we
+    # want to test. For instance, "1 minute" is actually 30s to 1m29s. The
+    # reason for doing this is simple -- in `distance_of_time_to_words`, when we
+    # take the distance between our two Time objects in seconds and convert it
+    # to minutes, we round the number. So 29s gets rounded down to 0m, 30s gets
+    # rounded up to 1m, and 1m29s gets rounded down to 1m. A similar thing
+    # happens with the other cases.
+
+    # First case 0..1 minute
     assert_equal "less than a minute", distance_of_time_in_words(from, to + 0.seconds)
     assert_equal "less than a minute", distance_of_time_in_words(from, to + 29.seconds)
     assert_equal "1 minute", distance_of_time_in_words(from, to + 30.seconds)
     assert_equal "1 minute", distance_of_time_in_words(from, to + 1.minutes + 29.seconds)
 
-    # 2..44
+    # 2 minutes up to 45 minutes
     assert_equal "2 minutes", distance_of_time_in_words(from, to + 1.minutes + 30.seconds)
     assert_equal "44 minutes", distance_of_time_in_words(from, to + 44.minutes + 29.seconds)
 
-    # 45..89
+    # 45 minutes up to 90 minutes
     assert_equal "about 1 hour", distance_of_time_in_words(from, to + 44.minutes + 30.seconds)
     assert_equal "about 1 hour", distance_of_time_in_words(from, to + 89.minutes + 29.seconds)
 
-    # 90..1439
+    # 90 minutes up to 24 hours
     assert_equal "about 2 hours", distance_of_time_in_words(from, to + 89.minutes + 30.seconds)
     assert_equal "about 24 hours", distance_of_time_in_words(from, to + 23.hours + 59.minutes + 29.seconds)
 
-    # 1440..2519
+    # 24 hours up to 42 hours
     assert_equal "1 day", distance_of_time_in_words(from, to + 23.hours + 59.minutes + 30.seconds)
     assert_equal "1 day", distance_of_time_in_words(from, to + 41.hours + 59.minutes + 29.seconds)
 
-    # 2520..43199
+    # 42 hours up to 30 days
     assert_equal "2 days", distance_of_time_in_words(from, to + 41.hours + 59.minutes + 30.seconds)
     assert_equal "3 days", distance_of_time_in_words(from, to + 2.days + 12.hours)
     assert_equal "30 days", distance_of_time_in_words(from, to + 29.days + 23.hours + 59.minutes + 29.seconds)
 
-    # 43200..86399
+    # 30 days up to 60 days
     assert_equal "about 1 month", distance_of_time_in_words(from, to + 29.days + 23.hours + 59.minutes + 30.seconds)
     assert_equal "about 1 month", distance_of_time_in_words(from, to + 44.days + 23.hours + 59.minutes + 29.seconds)
     assert_equal "about 2 months", distance_of_time_in_words(from, to + 44.days + 23.hours + 59.minutes + 30.seconds)
     assert_equal "about 2 months", distance_of_time_in_words(from, to + 59.days + 23.hours + 59.minutes + 29.seconds)
 
-    # 86400..525599
+    # 60 days up to 365 days
     assert_equal "2 months", distance_of_time_in_words(from, to + 59.days + 23.hours + 59.minutes + 30.seconds)
     assert_equal "12 months", distance_of_time_in_words(from, to + 1.years - 31.seconds)
 
-    # > 525599
+    # >= 365 days
     assert_equal "about 1 year",    distance_of_time_in_words(from, to + 1.years - 30.seconds)
     assert_equal "about 1 year",    distance_of_time_in_words(from, to + 1.years + 3.months - 1.day)
     assert_equal "over 1 year",     distance_of_time_in_words(from, to + 1.years + 6.months)


### PR DESCRIPTION
The problem here was that converting days 45..60 would be converted to "about 1 month ago" instead of "2 months ago". This is because distance_of_time_in_words doesn't round the days to the nearest month (it does do this for > 60 days, but not before).
