### PR TITLE
DRYed database config YAML templates

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/databases/frontbase.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/frontbase.yml
@@ -5,27 +5,34 @@
 #
 # Configure Using Gemfile
 # gem 'ruby-frontbase'
-#
-development:
+# 
+# These default settings are applied for each environment.
+# You can override each setting as required by adding the
+# required changes below the +<<*: defaults+ block
+# e.g., 
+#   development:
+#     <<: *defaults
+#     username: myUsername
+#     password: myPassword
+
+defaults: &defaults
   adapter: frontbase
   host: localhost
-  database: <%= app_name %>_development
   username: <%= app_name %>
   password: ''
+  
+development:
+  <<: *defaults
+  database: <%= app_name %>_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: frontbase
-  host: localhost
+  <<: *defaults  
   database: <%= app_name %>_test
-  username: <%= app_name %>
-  password: ''
 
 production:
-  adapter: frontbase
-  host: localhost
+  <<: *defaults  
   database: <%= app_name %>_production
-  username: <%= app_name %>
-  password: ''
+  

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/frontbase.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/frontbase.yml
@@ -5,16 +5,15 @@
 #
 # Configure Using Gemfile
 # gem 'ruby-frontbase'
-# 
+
 # These default settings are applied for each environment.
 # You can override each setting as required by adding the
-# required changes below the +<<*: defaults+ block
+# required changes below <tt><<*: defaults</tt>
 # e.g., 
 #   development:
 #     <<: *defaults
 #     username: myUsername
 #     password: myPassword
-
 defaults: &defaults
   adapter: frontbase
   host: localhost

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/ibm_db.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/ibm_db.yml
@@ -33,10 +33,10 @@
 #
 # For more details on the installation and the connection parameters below,
 # please refer to the latest documents at http://rubyforge.org/docman/?group_id=2361
-# 
+
 # These default settings are applied for each environment.
 # You can override each setting as required by adding the
-# required changes below the +<<*: defaults+ block
+# required changes below <tt><<*: defaults</tt>
 # e.g., 
 #   development:
 #     <<: *defaults

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/ibm_db.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/ibm_db.yml
@@ -33,12 +33,19 @@
 #
 # For more details on the installation and the connection parameters below,
 # please refer to the latest documents at http://rubyforge.org/docman/?group_id=2361
-
-development:
+# 
+# These default settings are applied for each environment.
+# You can override each setting as required by adding the
+# required changes below the +<<*: defaults+ block
+# e.g., 
+#   development:
+#     <<: *defaults
+#     username: myUsername
+#     password: myPassword
+defaults: &defaults
   adapter: ibm_db
   username: db2inst1
   password:
-  database: <%= app_name[0,4] %>_dev
   #schema: db2inst1
   #host: localhost
   #port: 50000
@@ -50,37 +57,15 @@ development:
   #timeout: 10
   #authentication: SERVER
   #parameterized: false
+  
+development:
+  <<: *defaults
+  database: <%= app_name[0,4] %>_dev
 
 test:
-  adapter: ibm_db
-  username: db2inst1
-  password:
+  <<: *defaults  
   database: <%= app_name[0,4] %>_tst
-  #schema: db2inst1
-  #host: localhost
-  #port: 50000
-  #account: my_account
-  #app_user: my_app_user
-  #application: my_application
-  #workstation: my_workstation
-  #security: SSL
-  #timeout: 10
-  #authentication: SERVER
-  #parameterized: false
 
 production:
-  adapter: ibm_db
-  username: db2inst1
-  password:
+  <<: *defaults  
   database: <%= app_name[0,8] %>
-  #schema: db2inst1
-  #host: localhost
-  #port: 50000
-  #account: my_account
-  #app_user: my_app_user
-  #application: my_application
-  #workstation: my_workstation
-  #security: SSL
-  #timeout: 10
-  #authentication: SERVER
-  #parameterized: false

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml
@@ -38,7 +38,7 @@
 
 # These default settings are applied for each environment.
 # You can override each setting as required by adding the
-# required changes below the +<<*: defaults+ block
+# required changes below <tt><<*: defaults</tt>
 # e.g., 
 #   development:
 #     <<: *defaults

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml
@@ -36,11 +36,22 @@
 # file). See your driver documentation for the apropriate driver class and
 # connection string:
 
-development:
+# These default settings are applied for each environment.
+# You can override each setting as required by adding the
+# required changes below the +<<*: defaults+ block
+# e.g., 
+#   development:
+#     <<: *defaults
+#     username: myUsername
+#     password: myPassword
+defaults: &defaults
   adapter: jdbc
   username: <%= app_name %>
   password:
   driver:
+
+development:
+  <<: *defaults
   url: jdbc:db://localhost/<%= app_name %>_development
 
 # Warning: The database defined as "test" will be erased and
@@ -48,15 +59,9 @@ development:
 # Do not set this db to the same as development or production.
 
 test:
-  adapter: jdbc
-  username: <%= app_name %>
-  password:
-  driver:
+  <<: *defaults
   url: jdbc:db://localhost/<%= app_name %>_test
 
 production:
-  adapter: jdbc
-  username: <%= app_name %>
-  password:
-  driver:
+  <<: *defaults
   url: jdbc:db://localhost/<%= app_name %>_production

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml
@@ -8,26 +8,32 @@
 #
 # And be sure to use new-style password hashing:
 #   http://dev.mysql.com/doc/refman/5.0/en/old-client.html
-development:
+#
+# These default settings are applied for each environment.
+# You can override each setting as required by adding the
+# required changes below the +<<*: defaults+ block
+# e.g., 
+#   development:
+#     <<: *defaults
+#     username: myUsername
+#     password: myPassword
+defaults: &defaults
   adapter: mysql
-  database: <%= app_name %>_development
   username: root
   password:
   host: localhost
+
+development:
+  <<: *defaults
+  database: <%= app_name %>_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: mysql
+  <<: *defaults
   database: <%= app_name %>_test
-  username: root
-  password:
-  host: localhost
-
+  
 production:
-  adapter: mysql
+  <<: *defaults
   database: <%= app_name %>_production
-  username: root
-  password:
-  host: localhost

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml
@@ -8,10 +8,10 @@
 #
 # And be sure to use new-style password hashing:
 #   http://dev.mysql.com/doc/refman/5.0/en/old-client.html
-#
+
 # These default settings are applied for each environment.
 # You can override each setting as required by adding the
-# required changes below the +<<*: defaults+ block
+# required changes below <tt><<*: defaults</tt>
 # e.g., 
 #   development:
 #     <<: *defaults

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
@@ -5,7 +5,7 @@
 
 # These default settings are applied for each environment.
 # You can override each setting as required by adding the
-# required changes below the +<<*: defaults+ block
+# required changes below <tt><<*: defaults</tt>
 # e.g., 
 #   development:
 #     <<: *defaults

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
@@ -3,12 +3,23 @@
 # Configure Using Gemfile
 # gem 'activerecord-jdbcpostgresql-adapter'
 
-development:
+# These default settings are applied for each environment.
+# You can override each setting as required by adding the
+# required changes below the +<<*: defaults+ block
+# e.g., 
+#   development:
+#     <<: *defaults
+#     username: myUsername
+#     password: myPassword
+defaults: &defaults
   adapter: postgresql
   encoding: unicode
-  database: <%= app_name %>_development
   username: <%= app_name %>
   password:
+  
+development:
+  <<: *defaults
+  database: <%= app_name %>_development
 
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have
@@ -29,15 +40,9 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: postgresql
-  encoding: unicode
+  <<: *defaults  
   database: <%= app_name %>_test
-  username: <%= app_name %>
-  password:
 
 production:
-  adapter: postgresql
-  encoding: unicode
+  <<: *defaults  
   database: <%= app_name %>_production
-  username: <%= app_name %>
-  password:

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml
@@ -7,7 +7,7 @@
 
 # These default settings are applied for each environment.
 # You can override each setting as required by adding the
-# required changes below the +<<*: defaults+ block
+# required changes below <tt><<*: defaults</tt>
 # e.g., 
 #   development:
 #     <<: *defaults

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml
@@ -4,17 +4,28 @@
 # Configure Using Gemfile
 # gem 'activerecord-jdbcsqlite3-adapter'
 #
-development:
+
+# These default settings are applied for each environment.
+# You can override each setting as required by adding the
+# required changes below the +<<*: defaults+ block
+# e.g., 
+#   development:
+#     <<: *defaults
+#     timeout: myUsername
+defaults: &defaults
   adapter: sqlite3
+  
+development:
+  <<: *defaults
   database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: sqlite3
+  <<: *defaults
   database: db/test.sqlite3
 
 production:
-  adapter: sqlite3
+  <<: *defaults
   database: db/production.sqlite3

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml
@@ -8,16 +8,15 @@
 #
 # And be sure to use new-style password hashing:
 #   http://dev.mysql.com/doc/refman/5.0/en/old-client.html
-# 
+
 # These default settings are applied for each environment.
 # You can override each setting as required by adding the
-# required changes below the +<<*: defaults+ block
+# required changes below <tt><<*: defaults</tt>
 # e.g., 
 #   development:
 #     <<: *defaults
 #     username: myUsername
 #     password: myPassword
-
 defaults: &defaults
   adapter: mysql2
   encoding: utf8

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml
@@ -8,10 +8,19 @@
 #
 # And be sure to use new-style password hashing:
 #   http://dev.mysql.com/doc/refman/5.0/en/old-client.html
-development:
+# 
+# These default settings are applied for each environment.
+# You can override each setting as required by adding the
+# required changes below the +<<*: defaults+ block
+# e.g., 
+#   development:
+#     <<: *defaults
+#     username: myUsername
+#     password: myPassword
+
+defaults: &default
   adapter: mysql2
   encoding: utf8
-  database: <%= app_name %>_development
   pool: 5
   username: root
   password:
@@ -21,31 +30,17 @@ development:
   host: localhost
 <% end -%>
 
+development:
+  <<: *defaults
+  database: <%= app_name %>_development
+  
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: mysql2
-  encoding: utf8
+  <<: *defaults
   database: <%= app_name %>_test
-  pool: 5
-  username: root
-  password:
-<% if mysql_socket -%>
-  socket: <%= mysql_socket %>
-<% else -%>
-  host: localhost
-<% end -%>
 
 production:
-  adapter: mysql2
-  encoding: utf8
+  <<: *defaults
   database: <%= app_name %>_production
-  pool: 5
-  username: root
-  password:
-<% if mysql_socket -%>
-  socket: <%= mysql_socket %>
-<% else -%>
-  host: localhost
-<% end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml
@@ -18,7 +18,7 @@
 #     username: myUsername
 #     password: myPassword
 
-defaults: &default
+defaults: &defaults
   adapter: mysql2
   encoding: utf8
   pool: 5

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml
@@ -15,16 +15,15 @@
 #
 #  prefetch_rows: 100
 #  cursor_sharing: similar
-# 
+ 
 # These default settings are applied for each environment.
 # You can override each setting as required by adding the
-# required changes below the +<<*: defaults+ block
+# required changes below <tt><<*: defaults</tt>
 # e.g., 
 #   development:
 #     <<: *defaults
 #     username: myUsername
 #     password: myPassword
-
 defaults: &defaults
   adapter: oracle
   username: <%= app_name %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml
@@ -15,25 +15,32 @@
 #
 #  prefetch_rows: 100
 #  cursor_sharing: similar
-#
+# 
+# These default settings are applied for each environment.
+# You can override each setting as required by adding the
+# required changes below the +<<*: defaults+ block
+# e.g., 
+#   development:
+#     <<: *defaults
+#     username: myUsername
+#     password: myPassword
 
-development:
+defaults: &defaults
   adapter: oracle
-  database: <%= app_name %>_development
   username: <%= app_name %>
   password:
+
+development:
+  <<: *defaults
+  database: <%= app_name %>_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: oracle
+  <<: *defaults  
   database: <%= app_name %>_test
-  username: <%= app_name %>
-  password:
 
 production:
-  adapter: oracle
+  <<: *defaults
   database: <%= app_name %>_production
-  username: <%= app_name %>
-  password:

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml
@@ -11,14 +11,25 @@
 #
 # Configure Using Gemfile
 # gem 'pg'
-#
-development:
+
+# These default settings are applied for each environment.
+# You can override each setting as required by adding the
+# required changes below the +<<*: defaults+ block
+# e.g., 
+#   development:
+#     <<: *defaults
+#     username: myUsername
+#     password: myPassword
+defaults: &defaults
   adapter: postgresql
   encoding: unicode
-  database: <%= app_name %>_development
   pool: 5
   username: <%= app_name %>
   password:
+  
+development:
+  <<: *defaults
+  database: <%= app_name %>_development
 
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have
@@ -39,17 +50,9 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: postgresql
-  encoding: unicode
+  <<: *defaults
   database: <%= app_name %>_test
-  pool: 5
-  username: <%= app_name %>
-  password:
 
 production:
-  adapter: postgresql
-  encoding: unicode
+  <<: *defaults  
   database: <%= app_name %>_production
-  pool: 5
-  username: <%= app_name %>
-  password:

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml
@@ -14,7 +14,7 @@
 
 # These default settings are applied for each environment.
 # You can override each setting as required by adding the
-# required changes below the +<<*: defaults+ block
+# required changes below <tt><<*: defaults</tt>
 # e.g., 
 #   development:
 #     <<: *defaults

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml
@@ -3,15 +3,14 @@
 #
 #   Ensure the SQLite 3 gem is defined in your Gemfile
 #   gem 'sqlite3'
-# 
+
 # These default settings are applied for each environment.
 # You can override each setting as required by adding the
-# required changes below the +<<*: defaults+ block
+# required changes below <tt><<*: defaults</tt>
 # e.g., 
 #   development:
 #     <<: *defaults
 #     timeout: 1000
-
 defaults: &defaults
   adapter: sqlite3
   pool: 5

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml
@@ -3,23 +3,31 @@
 #
 #   Ensure the SQLite 3 gem is defined in your Gemfile
 #   gem 'sqlite3'
-development:
+# 
+# These default settings are applied for each environment.
+# You can override each setting as required by adding the
+# required changes below the +<<*: defaults+ block
+# e.g., 
+#   development:
+#     <<: *defaults
+#     timeout: 1000
+
+defaults: &defaults
   adapter: sqlite3
-  database: db/development.sqlite3
   pool: 5
   timeout: 5000
+  
+development:
+  <<: *defaults
+  database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: sqlite3
+  <<: *defaults
   database: db/test.sqlite3
-  pool: 5
-  timeout: 5000
 
 production:
-  adapter: sqlite3
+  <<: *defaults
   database: db/production.sqlite3
-  pool: 5
-  timeout: 5000


### PR DESCRIPTION
I've taken each of the database YAML config files and rewritten them.

The default values are all the same as before, I've just moved the duplication into a defaults block and then included this in each environment's settings.

I know quite a few developers who re-write their database files like this so I thought I'd save us all the effort in future.
## Before

``` yaml
development:
  adapter: mysql2
  encoding: utf8
  database: my_app_development
  pool: 5
  username: myAppUser
  password: myAppPassword
  host: localhost

test:
  adapter: mysql2
  encoding: utf8
  database: my_app_test
  pool: 5
  username: myAppUser
  password: myAppPassword
  host: localhost

production:
  adapter: mysql2
  encoding: utf8
  database: my_app_production
  pool: 5
  username: myLiveAppUser
  password: myLivePassword
  host: localhost
```
## After

``` yaml
defaults: &defaults
  adapter: mysql2
  encoding: utf8
  pool: 5
  username: myAppUser
  password: myAppPassword
  host: localhost

development:
  <<: *defaults
  database: my_app_development

test:
  <<: *defaults
  database: my_app_test

production:
  <<: *defaults
  database: my_app_production
  username: myLiveAppUser
  password: myLivePassword
```
