### PR TITLE
Fix collection helpers

### DIFF
--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -578,9 +578,9 @@ module ActionView
       #     b.label(:class => "radio_button") { b.radio_button(:class => "radio_button") }
       #   end
       #
-      # There are also two special methods available: <tt>text</tt> and
-      # <tt>value</tt>, which are the current text and value methods for the
-      # item being rendered, respectively. You can use them like this:
+      # There are also three special methods available: <tt>object</tt>, <tt>text</tt> and
+      # <tt>value</tt>, which are the current item being rendered, its text and value methods,
+      # respectively. You can use them like this:
       #   collection_radio_buttons(:post, :author_id, Author.all, :id, :name_with_initial) do |b|
       #      b.label(:"data-value" => b.value) { b.radio_button + b.text }
       #   end
@@ -641,9 +641,9 @@ module ActionView
       #     b.label(:class => "check_box") { b.check_box(:class => "check_box") }
       #   end
       #
-      # There are also two special methods available: <tt>text</tt> and
-      # <tt>value</tt>, which are the current text and value methods for the
-      # item being rendered, respectively. You can use them like this:
+      # There are also three special methods available: <tt>object</tt>, <tt>text</tt> and
+      # <tt>value</tt>, which are the current item being rendered, its text and value methods,
+      # respectively. You can use them like this:
       #   collection_check_boxes(:post, :author_ids, Author.all, :id, :name_with_initial) do |b|
       #      b.label(:"data-value" => b.value) { b.check_box + b.text }
       #   end

--- a/actionpack/lib/action_view/helpers/tags/collection_helpers.rb
+++ b/actionpack/lib/action_view/helpers/tags/collection_helpers.rb
@@ -59,6 +59,7 @@ module ActionView
             end
           end
 
+          html_options[:object] = @object
           html_options
         end
 

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -771,6 +771,44 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_form_for_with_collection_radio_buttons
+    post = Post.new
+    def post.active; false; end
+    form_for(post) do |f|
+      concat f.collection_radio_buttons(:active, [true, false], :to_s, :to_s)
+    end
+
+    expected = whole_form("/posts", "new_post" , "new_post") do
+      "<input id='post_active_true' name='post[active]' type='radio' value='true' />" +
+      "<label for='post_active_true'>true</label>" +
+      "<input checked='checked' id='post_active_false' name='post[active]' type='radio' value='false' />" +
+      "<label for='post_active_false'>false</label>"
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_form_for_with_collection_check_boxes
+    post = Post.new
+    def post.tag_ids; [1, 3]; end
+    collection = (1..3).map{|i| [i, "Tag #{i}"] }
+    form_for(post) do |f|
+      concat f.collection_check_boxes(:tag_ids, collection, :first, :last)
+    end
+
+    expected = whole_form("/posts", "new_post" , "new_post") do
+      "<input checked='checked' id='post_tag_ids_1' name='post[tag_ids][]' type='checkbox' value='1' />" +
+      "<label for='post_tag_ids_1'>Tag 1</label>" +
+      "<input id='post_tag_ids_2' name='post[tag_ids][]' type='checkbox' value='2' />" +
+      "<label for='post_tag_ids_2'>Tag 2</label>" +
+      "<input checked='checked' id='post_tag_ids_3' name='post[tag_ids][]' type='checkbox' value='3' />" +
+      "<label for='post_tag_ids_3'>Tag 3</label>" +
+      "<input name='post[tag_ids][]' type='hidden' value='' />"
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_form_for_with_file_field_generate_multipart
     Post.send :attr_accessor, :file
 

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -1999,37 +1999,6 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
-  def hidden_fields(method = nil)
-    txt =  %{<div style="margin:0;padding:0;display:inline">}
-    txt << %{<input name="utf8" type="hidden" value="&#x2713;" />}
-    if method && !method.to_s.in?(['get', 'post'])
-      txt << %{<input name="_method" type="hidden" value="#{method}" />}
-    end
-    txt << %{</div>}
-  end
-
-  def form_text(action = "/", id = nil, html_class = nil, remote = nil, multipart = nil, method = nil)
-    txt =  %{<form accept-charset="UTF-8" action="#{action}"}
-    txt << %{ enctype="multipart/form-data"} if multipart
-    txt << %{ data-remote="true"} if remote
-    txt << %{ class="#{html_class}"} if html_class
-    txt << %{ id="#{id}"} if id
-    method = method.to_s == "get" ? "get" : "post"
-    txt << %{ method="#{method}">}
-  end
-
-  def whole_form(action = "/", id = nil, html_class = nil, options = nil)
-    contents = block_given? ? yield : ""
-
-    if options.is_a?(Hash)
-      method, remote, multipart = options.values_at(:method, :remote, :multipart)
-    else
-      method = options
-    end
-
-    form_text(action, id, html_class, remote, multipart, method) + hidden_fields(method) + contents + "</form>"
-  end
-
   def test_default_form_builder
     old_default_form_builder, ActionView::Base.default_form_builder =
       ActionView::Base.default_form_builder, LabelledFormBuilder
@@ -2212,6 +2181,37 @@ class FormHelperTest < ActionView::TestCase
   end
 
   protected
+
+  def hidden_fields(method = nil)
+    txt =  %{<div style="margin:0;padding:0;display:inline">}
+    txt << %{<input name="utf8" type="hidden" value="&#x2713;" />}
+    if method && !method.to_s.in?(['get', 'post'])
+      txt << %{<input name="_method" type="hidden" value="#{method}" />}
+    end
+    txt << %{</div>}
+  end
+
+  def form_text(action = "/", id = nil, html_class = nil, remote = nil, multipart = nil, method = nil)
+    txt =  %{<form accept-charset="UTF-8" action="#{action}"}
+    txt << %{ enctype="multipart/form-data"} if multipart
+    txt << %{ data-remote="true"} if remote
+    txt << %{ class="#{html_class}"} if html_class
+    txt << %{ id="#{id}"} if id
+    method = method.to_s == "get" ? "get" : "post"
+    txt << %{ method="#{method}">}
+  end
+
+  def whole_form(action = "/", id = nil, html_class = nil, options = nil)
+    contents = block_given? ? yield : ""
+
+    if options.is_a?(Hash)
+      method, remote, multipart = options.values_at(:method, :remote, :multipart)
+    else
+      method = options
+    end
+
+    form_text(action, id, html_class, remote, multipart, method) + hidden_fields(method) + contents + "</form>"
+  end
 
   def protect_against_forgery?
     false


### PR DESCRIPTION
When `collection_check_boxes` and `collection_radio_buttons` are used in forms that use local variables they don't work as desired because they are not passing the object to your internal builder.

This pull request fixes this issue and also add documentation to `object` method of the `CollectionHelper::Builder`.

@carlosantoniodasilva, @josevalim, @jeremy please review this one.
