### PR TITLE
Add check if value is frozen before attempting to mutate via encode!

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
@@ -203,7 +203,11 @@ module ActiveRecord
         value = super
         if column.type == :string && value.encoding == Encoding::ASCII_8BIT
           @logger.error "Binary data inserted for `string` type on column `#{column.name}`"
-          value.encode! 'utf-8'
+          if value.frozen?
+            value = value.dup.encode! 'utf-8'
+          elsif
+            value.encode! 'utf-8'
+          end
         end
         value
       end


### PR DESCRIPTION
This fixes the following error I was receiving (the "day" string, e.g., "Thursday" was frozen by rails, presumably because it's Encoding::ASCII_8BIT? Therefore, when it gets "encode!"-ed to utf-8, a RuntimeError occurs.). This is related to this stackoverflow question (http://stackoverflow.com/questions/9474730/rails-active-record-runtimeerror-cant-modify-frozen-string-somehow-related).

(0.1ms)  begin transaction
Binary data inserted for `string` type on column `day`
  SQL (0.5ms)  INSERT INTO "availabilities" ("coach_id", "created_at", "day", "hour", "updated_at") VALUES (?, ?, ?, ?, ?)  [["coach_id", 3], ["created_at", Tue, 28 Feb 2012 18:05:33 UTC +00:00], ["day", "Monday"], ["hour", 18], ["updated_at", Tue, 28 Feb 2012 18:05:33 UTC +00:00]]
RuntimeError: can't modify frozen String: INSERT INTO "availabilities" ("coach_id", "created_at", "day", "hour", "updated_at") VALUES (?, ?, ?, ?, ?)
   (0.1ms)  rollback transaction
Completed 500 Internal Server Error in 59ms
