### PR TITLE
Fix for #5200

### DIFF
--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -3,6 +3,7 @@ module ActiveRecord
   module CounterCache
     extend ActiveSupport::Concern
 
+<<<<<<< HEAD
     module ClassMethods
       # Resets one or more counter caches to their correct value using an SQL
       # count query. This is useful when adding new counter caches, or if the
@@ -25,7 +26,7 @@ module ActiveRecord
           foreign_key  = has_many_association.foreign_key.to_s
           child_class  = has_many_association.klass
           belongs_to   = child_class.reflect_on_all_associations(:belongs_to)
-          reflection   = belongs_to.find { |e| e.foreign_key.to_s == foreign_key }
+          reflection   = belongs_to.find { |e| e.foreign_key.to_s == foreign_key && e.options[:counter_cache].present? }
           counter_name = reflection.counter_cache_column
 
           stmt = unscoped.where(arel_table[primary_key].eq(object.id)).arel.compile_update({

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -3,7 +3,6 @@ module ActiveRecord
   module CounterCache
     extend ActiveSupport::Concern
 
-<<<<<<< HEAD
     module ClassMethods
       # Resets one or more counter caches to their correct value using an SQL
       # count query. This is useful when adding new counter caches, or if the

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -8,9 +8,11 @@ require 'models/category'
 require 'models/categorization'
 require 'models/dog'
 require 'models/dog_lover'
+require 'models/person'
+require 'models/friendship'
 
 class CounterCacheTest < ActiveRecord::TestCase
-  fixtures :topics, :categories, :categorizations, :cars, :dogs, :dog_lovers
+  fixtures :topics, :categories, :categorizations, :cars, :dogs, :dog_lovers, :people, :friendships
 
   class ::SpecialTopic < ::Topic
     has_many :special_replies, :foreign_key => 'parent_id'
@@ -107,6 +109,13 @@ class CounterCacheTest < ActiveRecord::TestCase
 
     assert_difference ['t1.reload.replies_count', 't2.reload.replies_count'], 2 do
       Topic.update_counters([t1.id, t2.id], :replies_count => 2)
+    end
+  end
+
+  test "reset the right counter if two have the same foreign key" do
+    michael = people(:michael)
+    assert_nothing_raised(ActiveRecord::StatementInvalid) do
+      Person.reset_counters(michael.id, :followers)
     end
   end
 end

--- a/activerecord/test/fixtures/friendships.yml
+++ b/activerecord/test/fixtures/friendships.yml
@@ -1,0 +1,4 @@
+Connection 1:
+  id: 1
+  person_id: 1
+  friend_id: 2

--- a/activerecord/test/fixtures/people.yml
+++ b/activerecord/test/fixtures/people.yml
@@ -4,15 +4,18 @@ michael:
   primary_contact_id: 2
   number1_fan_id: 3
   gender: M
+  followers_count: 1
 david:
   id: 2
   first_name: David
   primary_contact_id: 3
   number1_fan_id: 1
   gender: M
+  followers_count: 1
 susan:
   id: 3
   first_name: Susan
   primary_contact_id: 2
   number1_fan_id: 1
   gender: F
+  followers_count: 1

--- a/activerecord/test/models/friendship.rb
+++ b/activerecord/test/models/friendship.rb
@@ -1,0 +1,4 @@
+class Friendship < ActiveRecord::Base
+  belongs_to :friend, class_name: 'Person'
+  belongs_to :follower, foreign_key: 'friend_id', class_name: 'Person', counter_cache: :followers_count
+end

--- a/activerecord/test/models/person.rb
+++ b/activerecord/test/models/person.rb
@@ -8,6 +8,8 @@ class Person < ActiveRecord::Base
   has_many :posts_with_no_comments, -> { includes(:comments).where('comments.id is null').references(:comments) },
                                     :through => :readers, :source => :post
 
+  has_many :followers, foreign_key: 'friend_id', class_name: 'Friendship'
+
   has_many :references
   has_many :bad_references
   has_many :fixed_bad_references, -> { where :favourite => true }, :class_name => 'BadReference'

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -270,6 +270,11 @@ ActiveRecord::Schema.define do
     t.string :name
   end
 
+  create_table :friendships, :force => true do |t|
+    t.integer :friend_id
+    t.integer :person_id
+  end
+
   create_table :goofy_string_id, :force => true, :id => false do |t|
     t.string :id, :null => false
     t.string :info
@@ -476,6 +481,7 @@ ActiveRecord::Schema.define do
     t.references :number1_fan
     t.integer    :lock_version, :null => false, :default => 0
     t.string     :comments
+    t.integer    :followers_count, :default => 0
     t.references :best_friend
     t.references :best_friend_of
     t.timestamps


### PR DESCRIPTION
reset_counters() was crashing when there were multiple belongs_to associations with the same foreign key.. with only one of the belongs_to associations having a custom counter_cache.

reset_counters() made the false assumption that each belongs_to association has a counter_cache.
