### PR TITLE
remove unnecessary memcache require in ActionDispatch CacheStore

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/session/cache_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cache_store.rb
@@ -1,5 +1,4 @@
 require 'action_dispatch/middleware/session/abstract_store'
-require 'rack/session/memcache'
 
 module ActionDispatch
   module Session


### PR DESCRIPTION
Leftover from copied code. This removes an unnecessary dependency on memcache.
