### PR TITLE
added namespace option for activerecord store

### DIFF
--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -24,24 +24,52 @@ module ActiveRecord
   #   class SuperUser < User
   #     store_accessor :settings, :privileges, :servants
   #   end
+  #
+  # To prevent method name conflicts, you can pass in a <tt>namespace</tt> option containing
+  # either custom text or true to simply use the database column as the namespace.
+  #
+  #   class User < ActiveRecord::Base
+  #     store :settings, accessors: [ :color ], namespace: true
+  #     store :preferences, accessors: [ :color ], namespace: 'config'
+  #
+  #     store_accessor :settings, :homepage, namespace: true
+  #     store_accessor :preferences, :homepage, namespace: 'config'
+  #   end
+  #
+  #   u = User.new(settings_color: 'black',
+  #                settings_homepage: '37signals.com',
+  #                config_color: 'blue',
+  #                config_homepage: 'example.com')
+  #
   module Store
     extend ActiveSupport::Concern
 
     module ClassMethods
       def store(store_attribute, options = {})
         serialize store_attribute, Hash
-        store_accessor(store_attribute, options[:accessors]) if options.has_key? :accessors
+        store_accessor(store_attribute, options[:accessors], :namespace => options[:namespace]) if options.has_key? :accessors
       end
 
-      def store_accessor(store_attribute, *keys)
-        keys.flatten.each do |key|
-          define_method("#{key}=") do |value|
+      def store_accessor(store_attribute, *args)
+        options = args.extract_options!
+
+        args.flatten.each do |key|
+          method_name = \
+            if options[:namespace]
+              options[:namespace].is_a?(TrueClass) ? "#{store_attribute}_#{key}" : "#{options[:namespace]}_#{key}"
+            else
+              key
+            end
+
+          method_name = key unless method_name
+
+          define_method("#{method_name}=") do |value|
             send("#{store_attribute}=", {}) unless send(store_attribute).is_a?(Hash)
             send(store_attribute)[key] = value
             send("#{store_attribute}_will_change!")
           end
 
-          define_method(key) do
+          define_method(method_name) do
             send("#{store_attribute}=", {}) unless send(store_attribute).is_a?(Hash)
             send(store_attribute)[key]
           end

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -25,15 +25,15 @@ module ActiveRecord
   #     store_accessor :settings, :privileges, :servants
   #   end
   #
-  # To prevent method name conflicts, you can pass in a <tt>namespace</tt> option containing
-  # either custom text or true to simply use the database column as the namespace.
+  # To prevent method name conflicts, you can pass in a <tt>prefix</tt> option containing
+  # either custom text or true to simply use the database column as the prefix.
   #
   #   class User < ActiveRecord::Base
-  #     store :settings, accessors: [ :color ], namespace: true
-  #     store :preferences, accessors: [ :color ], namespace: 'config'
+  #     store :settings, accessors: [ :color ], prefix: true
+  #     store :preferences, accessors: [ :color ], prefix: 'config'
   #
-  #     store_accessor :settings, :homepage, namespace: true
-  #     store_accessor :preferences, :homepage, namespace: 'config'
+  #     store_accessor :settings, :homepage, prefix: true
+  #     store_accessor :preferences, :homepage, prefix: 'config'
   #   end
   #
   #   u = User.new(settings_color: 'black',
@@ -47,7 +47,7 @@ module ActiveRecord
     module ClassMethods
       def store(store_attribute, options = {})
         serialize store_attribute, Hash
-        store_accessor(store_attribute, options[:accessors], :namespace => options[:namespace]) if options.has_key? :accessors
+        store_accessor(store_attribute, options[:accessors], prefix: options[:prefix]) if options.has_key? :accessors
       end
 
       def store_accessor(store_attribute, *args)
@@ -55,8 +55,8 @@ module ActiveRecord
 
         args.flatten.each do |key|
           method_name = \
-            if options[:namespace]
-              options[:namespace].is_a?(TrueClass) ? "#{store_attribute}_#{key}" : "#{options[:namespace]}_#{key}"
+            if options[:prefix]
+              options[:prefix].is_a?(TrueClass) ? "#{store_attribute}_#{key}" : "#{options[:prefix]}_#{key}"
             else
               key
             end

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -20,24 +20,24 @@ class StoreTest < ActiveRecord::TestCase
     assert_equal '37signals.com', @john.homepage
   end
 
-  test "custom namespacing" do
+  test "custom namespacing via prefix option" do
     @john.book_title = 'Picture of Dorian Gray'
     @john.save
 
     @john.reload
     assert_equal 'Picture of Dorian Gray', @john.book_title
-    assert_equal 'Picture of Dorian Gray', @john.novel[:title]
-    assert_equal nil, @john.novel[:book_title]
+    assert_equal 'Picture of Dorian Gray', @john.novels[:title]
+    assert_equal nil, @john.novels[:book_title]
   end
 
-  test "namespace 'true' uses serialized database column as namespace" do
-    @john.magazine_cover = 'awesome'
+  test "prefix 'true' uses serialized database column as namespace" do
+    @john.magazines_cover = 'Cat Fancy'
     @john.save
 
     @john.reload
-    assert_equal 'awesome', @john.magazine_cover
-    assert_equal 'awesome', @john.magazine[:cover]
-    assert_equal nil, @john.magazine[:magazine_cover]
+    assert_equal 'Cat Fancy', @john.magazines_cover
+    assert_equal 'Cat Fancy', @john.magazines[:cover]
+    assert_equal nil, @john.magazines[:magazine_cover]
   end
 
   test "accessing attributes not exposed by accessors" do

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -20,6 +20,26 @@ class StoreTest < ActiveRecord::TestCase
     assert_equal '37signals.com', @john.homepage
   end
 
+  test "custom namespacing" do
+    @john.book_title = 'Picture of Dorian Gray'
+    @john.save
+
+    @john.reload
+    assert_equal 'Picture of Dorian Gray', @john.book_title
+    assert_equal 'Picture of Dorian Gray', @john.novel[:title]
+    assert_equal nil, @john.novel[:book_title]
+  end
+
+  test "namespace 'true' uses serialized database column as namespace" do
+    @john.magazine_cover = 'awesome'
+    @john.save
+
+    @john.reload
+    assert_equal 'awesome', @john.magazine_cover
+    assert_equal 'awesome', @john.magazine[:cover]
+    assert_equal nil, @john.magazine[:magazine_cover]
+  end
+
   test "accessing attributes not exposed by accessors" do
     @john.settings[:icecream] = 'graeters'
     @john.save

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -2,4 +2,6 @@ class Admin::User < ActiveRecord::Base
   belongs_to :account
   store :settings, :accessors => [ :color, :homepage ]
   store :preferences, :accessors => [ :remember_login ]
+  store :novel, :accessors => [ :title ], :namespace => :book
+  store :magazine, :accessors => [ :cover ], :namespace => true
 end

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -2,6 +2,6 @@ class Admin::User < ActiveRecord::Base
   belongs_to :account
   store :settings, :accessors => [ :color, :homepage ]
   store :preferences, :accessors => [ :remember_login ]
-  store :novel, :accessors => [ :title ], :namespace => :book
-  store :magazine, :accessors => [ :cover ], :namespace => true
+  store :novels, :accessors => [ :title ], :prefix => :book
+  store :magazines, :accessors => [ :cover ], :prefix => true
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -39,8 +39,8 @@ ActiveRecord::Schema.define do
     t.string :name
     t.text :settings, :null => true
     t.text :preferences, :null => false, :default => ""
-    t.text :novel, :null => false, :default => ""
-    t.text :magazine, :null => false, :default => ""
+    t.text :novels
+    t.text :magazines
     t.references :account
   end
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -39,6 +39,8 @@ ActiveRecord::Schema.define do
     t.string :name
     t.text :settings, :null => true
     t.text :preferences, :null => false, :default => ""
+    t.text :novel, :null => false, :default => ""
+    t.text :magazine, :null => false, :default => ""
     t.references :account
   end
 


### PR DESCRIPTION
To prevent method name conflicts, I have added namespacing to the ActiveRecord store.  The way it works is you can now pass in some custom text to prefix the accessor/writer method names.  Passing in a value of _true_ will namespace it with the database column name.

```
class Stuff < ActiveRecord::Base
  store :item, accessors: [ :color ], namespace: true
  store :thing, accessors: [ :color ], namespace: "article"
end

s = Stuff.new(item_color: "blue", article_color: "purple")

s.item_color
#=> "blue"
s.article_color
#=> "purple"
```

This also can be done via the store_accessor method:

```
store_accessor :item, :size, namespace: true
store_accessor :thing, :size, namespace: 'article'
```

-patrick
