### PR TITLE
Fix for #2781

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -594,6 +594,7 @@ module ActionDispatch
       def recognize_path(path, environment = {})
         method = (environment[:method] || "GET").to_s.upcase
         path = Journey::Router::Utils.normalize_path(path) unless path =~ %r{://}
+        extras = environment[:extras] || {}
 
         begin
           env = Rack::MockRequest.env_for(path, {:method => method})
@@ -603,6 +604,7 @@ module ActionDispatch
 
         req = @request_class.new(env)
         @router.recognize(req) do |route, matches, params|
+          params.merge!(extras)
           params.each do |key, value|
             if value.is_a?(String)
               value = value.dup.force_encoding(Encoding::BINARY)

--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -39,10 +39,9 @@ module ActionDispatch
       #   # Test a custom route
       #   assert_recognizes({:controller => 'items', :action => 'show', :id => '1'}, 'view/item1')
       def assert_recognizes(expected_options, path, extras={}, message=nil)
-        request = recognized_request_for(path)
+        request = recognized_request_for(path, extras)
 
         expected_options = expected_options.clone
-        extras.each_key { |key| expected_options.delete key } unless extras.nil?
 
         expected_options.stringify_keys!
 
@@ -181,7 +180,7 @@ module ActionDispatch
 
       private
         # Recognizes the route for a given path.
-        def recognized_request_for(path)
+        def recognized_request_for(path, extras = {})
           if path.is_a?(Hash)
             method = path[:method]
             path   = path[:path]
@@ -209,7 +208,7 @@ module ActionDispatch
 
           request.request_method = method if method
 
-          params = @routes.recognize_path(path, { :method => method })
+          params = @routes.recognize_path(path, { :method => method, :extras => extras })
           request.path_parameters = params.with_indifferent_access
 
           request

--- a/actionpack/test/dispatch/routing_assertions_test.rb
+++ b/actionpack/test/dispatch/routing_assertions_test.rb
@@ -3,6 +3,7 @@ require 'controller/fake_controllers'
 
 class SecureArticlesController < ArticlesController; end
 class BlockArticlesController < ArticlesController; end
+class QueryArticlesController < ArticlesController; end
 
 class RoutingAssertionsTest < ActionController::TestCase
 
@@ -17,6 +18,10 @@ class RoutingAssertionsTest < ActionController::TestCase
 
       scope 'block', :constraints => lambda { |r| r.ssl? } do
         resources :articles, :controller => 'block_articles'
+      end
+
+      scope 'query', :constraints => lambda { |r| r.params[:use_query] == 'true' } do
+        resources :articles, :controller => 'query_articles'
       end
     end
   end
@@ -60,6 +65,13 @@ class RoutingAssertionsTest < ActionController::TestCase
       assert_recognizes({ :controller => 'block_articles', :action => 'index' }, 'http://test.host/block/articles')
     end
     assert_recognizes({ :controller => 'block_articles', :action => 'index' }, 'https://test.host/block/articles')
+  end
+
+  def test_assert_recognizes_with_query_constraint
+    assert_raise(ActionController::RoutingError) do
+      assert_recognizes({ :controller => 'query_articles', :action => 'index', :use_query => 'false' }, '/query/articles', { :use_query => 'false' })
+    end
+    assert_recognizes({ :controller => 'query_articles', :action => 'index', :use_query => 'true' }, '/query/articles', { :use_query => 'true' })
   end
 
   def test_assert_routing


### PR DESCRIPTION
Fix the assert_recognizes test method so that it works when there are constraints on the querystring. 

Issue #2781
