### PR TITLE
Fixed sqlite_adapter to support SecureRandom.hex by adding US_ASCII encoding to type_cast.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
@@ -201,7 +201,7 @@ module ActiveRecord
         return super unless column && value
 
         value = super
-        if column.type == :string && value.encoding == Encoding::ASCII_8BIT
+        if column.type == :string && [Encoding::ASCII_8BIT, Encoding::US_ASCII].include?(value.encoding)
           @logger.error "Binary data inserted for `string` type on column `#{column.name}`"
           value.encode! 'utf-8'
         end


### PR DESCRIPTION
Setting a String column to SecureRandom.hex causes a no method error.

SecureRandom.hex returns a :string type, only without utf-8 or ASCII_8BIT encodings.

But this makes it all better.

I figured we should add this since SecureRandom is part of core ruby.
