### PR TITLE
Stop SafeBuffer#clone_empty from issuing warnings

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -131,9 +131,7 @@ module ActiveSupport #:nodoc:
     end
 
     def clone_empty
-      new_safe_buffer = self[0, 0]
-      new_safe_buffer.instance_variable_set(:@dirty, @dirty)
-      new_safe_buffer
+      self[0, 0]
     end
 
     def concat(value)


### PR DESCRIPTION
Logic in clone_empty method was dealing with old @dirty variable, which has changed by @html_safe in this commit: https://github.com/rails/rails/commit/139963c99a955520db6373343662e55f4d16dcd1

This was issuing a "not initialized variable" warning - related to: #5237

The logic applied by this method is already handled by the [] override, so there is no need to reset the variable here.

/cc @tenderlove @drogus
