### PR TITLE
Maximum wait_timeout on Windows is 2147483

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -260,7 +260,7 @@ module ActiveRecord
 
         # increase timeout so mysql server doesn't disconnect us
         wait_timeout = @config[:wait_timeout]
-        wait_timeout = 2592000 unless wait_timeout.is_a?(Fixnum)
+        wait_timeout = 2147483 unless wait_timeout.is_a?(Fixnum)
         variable_assignments << "@@wait_timeout = #{wait_timeout}"
 
         execute("SET #{variable_assignments.join(', ')}", :skip_logging)


### PR DESCRIPTION
As documented on MySQL's site [1] this is the maximum value for Windows. We should use the least common denominator. Also done in the old branch (0.2.x) of mysql2 gem [2] and [3].

[1] http://dev.mysql.com/doc/refman/5.0/en/server-system-variables.html#sysvar_wait_timeout
[2] https://github.com/brianmario/mysql2/blob/0.2.x/lib/active_record/connection_adapters/mysql2_adapter.rb#L577
[3] https://github.com/brianmario/mysql2/commit/4f4909f4d654ac01c93b55a109cc12a6047c6726
