### PR TITLE
Fix build

### DIFF
--- a/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
@@ -13,12 +13,14 @@ module ActiveRecord
             :timeout => 100
         end
 
-        def test_type_cast_binary_encoding_without_logger
-          @conn.extend(Module.new { def logger; end })
-          column = Struct.new(:type, :name).new(:string, "foo")
-          binary = SecureRandom.hex
-          expected = binary.dup.encode!('utf-8')
-          assert_equal expected, @conn.type_cast(binary, column)
+        if "<3".encoding_aware?
+          def test_type_cast_binary_encoding_without_logger
+            @conn.extend(Module.new { def logger; end })
+            column = Struct.new(:type, :name).new(:string, "foo")
+            binary = SecureRandom.hex
+            expected = binary.dup.encode!('utf-8')
+            assert_equal expected, @conn.type_cast(binary, column)
+          end
         end
 
         def test_type_cast_symbol


### PR DESCRIPTION
Related to the commits below, that end up failing in Ruby 1.8 due to the `encode!` method.

3-2: af022918716e894608d655cdb52ec3164fee597a

3-1: b1358c8fa1d875bdeb0639baab1dc91ed39ac175

/cc @tenderlove
