### PR TITLE
Add ActiveModel::Model, a mixin to make plain Ruby objects work with AP out of box

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,5 @@
+*   Added ActiveModel::Model, a mixin to make Ruby objects work with AP out of box *Guillermo Iguaran*
+
 *   `AM::Errors#to_json`: support `:full_messages` parameter *Bogdan Gusiev*
 
 *   Trim down Active Model API by removing `valid?` and `errors.full_messages` *José Valim*

--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -39,6 +39,7 @@ module ActiveModel
   autoload :Errors
   autoload :Lint
   autoload :MassAssignmentSecurity
+  autoload :Model
   autoload :Name, 'active_model/naming'
   autoload :Naming
   autoload :Observer, 'active_model/observing'

--- a/activemodel/lib/active_model/model.rb
+++ b/activemodel/lib/active_model/model.rb
@@ -1,0 +1,22 @@
+module ActiveModel
+  module Model
+    def self.included(base)
+      base.class_eval do
+        extend  ActiveModel::Naming
+        extend  ActiveModel::Translation
+        include ActiveModel::Validations
+        include ActiveModel::Conversion
+      end
+    end
+
+    def initialize(params={})
+      params.each do |attr, value|
+        self.send(:"#{attr}=", value)
+      end if params
+    end
+
+    def persisted?
+      false
+    end
+  end
+end

--- a/activemodel/test/cases/model_test.rb
+++ b/activemodel/test/cases/model_test.rb
@@ -1,0 +1,19 @@
+require 'cases/helper'
+
+class ModelTest < ActiveModel::TestCase
+  include ActiveModel::Lint::Tests
+
+  class BasicModel
+    include ActiveModel::Model
+    attr_accessor :attr
+  end
+
+  def setup
+    @model = BasicModel.new
+  end
+
+  def test_initialize_with_params
+    object = BasicModel.new(:attr => "value")
+    assert_equal object.attr, "value"
+  end
+end


### PR DESCRIPTION
Usage example:

``` ruby
class Person
  include ActiveModel::Model
end
```
