### PR TITLE
Refactor and cleanup in some ActiveRecord modules

### DIFF
--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -71,7 +71,7 @@ module ActiveRecord
 
       IdentityMap.remove_by_id(symbolized_base_class, id) if IdentityMap.enabled?
 
-      update_all(updates.join(', '), primary_key => id )
+      update_all(updates.join(', '), primary_key => id)
     end
 
     # Increment a number field by one, usually representing a count.

--- a/activerecord/lib/active_record/dynamic_matchers.rb
+++ b/activerecord/lib/active_record/dynamic_matchers.rb
@@ -1,13 +1,10 @@
 module ActiveRecord
   module DynamicMatchers
     def respond_to?(method_id, include_private = false)
-      if match = DynamicFinderMatch.match(method_id)
-        return true if all_attributes_exists?(match.attribute_names)
-      elsif match = DynamicScopeMatch.match(method_id)
-        return true if all_attributes_exists?(match.attribute_names)
-      end
+      match       = find_dynamic_match(method_id)
+      valid_match = match && all_attributes_exists?(match.attribute_names)
 
-      super
+      valid_match || super
     end
 
     private
@@ -22,22 +19,18 @@ module ActiveRecord
     # Each dynamic finder using <tt>scoped_by_*</tt> is also defined in the class after it
     # is first invoked, so that future attempts to use it do not run through method_missing.
     def method_missing(method_id, *arguments, &block)
-      if match = (DynamicFinderMatch.match(method_id) || DynamicScopeMatch.match(method_id))
+      if match = find_dynamic_match(method_id)
         attribute_names = match.attribute_names
         super unless all_attributes_exists?(attribute_names)
+
         unless match.valid_arguments?(arguments)
           method_trace = "#{__FILE__}:#{__LINE__}:in `#{method_id}'"
           backtrace = [method_trace] + caller
           raise ArgumentError, "wrong number of arguments (#{arguments.size} for #{attribute_names.size})", backtrace
         end
+
         if match.respond_to?(:scope?) && match.scope?
-          self.class_eval <<-METHOD, __FILE__, __LINE__ + 1
-            def self.#{method_id}(*args)                                    # def self.scoped_by_user_name_and_password(*args)
-              attributes = Hash[[:#{attribute_names.join(',:')}].zip(args)] #   attributes = Hash[[:user_name, :password].zip(args)]
-                                                                            #
-              scoped(:conditions => attributes)                             #   scoped(:conditions => attributes)
-            end                                                             # end
-          METHOD
+          define_scope_method(method_id, attribute_names)
           send(method_id, *arguments)
         elsif match.finder?
           options = arguments.extract_options!
@@ -51,17 +44,30 @@ module ActiveRecord
       end
     end
 
+    def define_scope_method(method_id, attribute_names) #:nodoc
+      self.class_eval <<-METHOD, __FILE__, __LINE__ + 1
+        def self.#{method_id}(*args)                                    # def self.scoped_by_user_name_and_password(*args)
+          conditions = Hash[[:#{attribute_names.join(',:')}].zip(args)] #   conditions = Hash[[:user_name, :password].zip(args)]
+          where(conditions)                                             #   where(conditions)
+        end                                                             # end
+      METHOD
+    end
+
+    def find_dynamic_match(method_id) #:nodoc:
+      DynamicFinderMatch.match(method_id) || DynamicScopeMatch.match(method_id)
+    end
+
     # Similar in purpose to +expand_hash_conditions_for_aggregates+.
     def expand_attribute_names_for_aggregates(attribute_names)
-      attribute_names.map { |attribute_name|
-        unless (aggregation = reflect_on_aggregation(attribute_name.to_sym)).nil?
+      attribute_names.map do |attribute_name|
+        if aggregation = reflect_on_aggregation(attribute_name.to_sym)
           aggregate_mapping(aggregation).map do |field_attr, _|
             field_attr.to_sym
           end
         else
           attribute_name.to_sym
         end
-      }.flatten
+      end.flatten
     end
 
     def all_attributes_exists?(attribute_names)
@@ -73,7 +79,5 @@ module ActiveRecord
       mapping = reflection.options[:mapping] || [reflection.name, reflection.name]
       mapping.first.is_a?(Array) ? mapping : [mapping]
     end
-
-
   end
 end

--- a/activerecord/lib/active_record/dynamic_scope_match.rb
+++ b/activerecord/lib/active_record/dynamic_scope_match.rb
@@ -7,9 +7,12 @@ module ActiveRecord
   # chain more <tt>scoped_by_* </tt> methods after the other. It acts like a named
   # scope except that it's dynamic.
   class DynamicScopeMatch
+    METHOD_PATTERN = /^scoped_by_([_a-zA-Z]\w*)$/
+
     def self.match(method)
-      return unless method.to_s =~ /^scoped_by_([_a-zA-Z]\w*)$/
-      new(true, $1 && $1.split('_and_'))
+      if method.to_s =~ METHOD_PATTERN
+        new(true, $1 && $1.split('_and_'))
+      end
     end
 
     def initialize(scope, attribute_names)

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -23,11 +23,11 @@ module ActiveRecord
     module ClassMethods
       def create_reflection(macro, name, options, active_record)
         case macro
-          when :has_many, :belongs_to, :has_one, :has_and_belongs_to_many
-            klass = options[:through] ? ThroughReflection : AssociationReflection
-            reflection = klass.new(macro, name, options, active_record)
-          when :composed_of
-            reflection = AggregateReflection.new(macro, name, options, active_record)
+        when :has_many, :belongs_to, :has_one, :has_and_belongs_to_many
+          klass = options[:through] ? ThroughReflection : AssociationReflection
+          reflection = klass.new(macro, name, options, active_record)
+        when :composed_of
+          reflection = AggregateReflection.new(macro, name, options, active_record)
         end
 
         self.reflections = self.reflections.merge(name => reflection)
@@ -44,7 +44,8 @@ module ActiveRecord
       #   Account.reflect_on_aggregation(:balance) # => the balance AggregateReflection
       #
       def reflect_on_aggregation(aggregation)
-        reflections[aggregation].is_a?(AggregateReflection) ? reflections[aggregation] : nil
+        reflection = reflections[aggregation]
+        reflection if reflection.is_a?(AggregateReflection)
       end
 
       # Returns an array of AssociationReflection objects for all the
@@ -68,7 +69,8 @@ module ActiveRecord
       #   Invoice.reflect_on_association(:line_items).macro  # returns :has_many
       #
       def reflect_on_association(association)
-        reflections[association].is_a?(AssociationReflection) ? reflections[association] : nil
+        reflection = reflections[association]
+        reflection if reflection.is_a?(AssociationReflection)
       end
 
       # Returns an array of AssociationReflection objects for all associations which have <tt>:autosave</tt> enabled.
@@ -76,7 +78,6 @@ module ActiveRecord
         reflections.values.select { |reflection| reflection.options[:autosave] }
       end
     end
-
 
     # Abstract base class for AggregateReflection and AssociationReflection. Objects of
     # AggregateReflection and AssociationReflection are returned by the Reflection::ClassMethods.
@@ -452,7 +453,6 @@ module ActiveRecord
           # Recursively fill out the rest of the array from the through reflection
           conditions += through_conditions
 
-          # And return
           conditions
         end
       end

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -37,9 +37,9 @@ module ActiveRecord
       #   { :name => nil, :group_id => 4 }  returns "name = NULL , group_id='4'"
       def sanitize_sql_for_assignment(assignments)
         case assignments
-          when Array; sanitize_sql_array(assignments)
-          when Hash;  sanitize_sql_hash_for_assignment(assignments)
-          else        assignments
+        when Array; sanitize_sql_array(assignments)
+        when Hash;  sanitize_sql_hash_for_assignment(assignments)
+        else        assignments
         end
       end
 
@@ -57,7 +57,7 @@ module ActiveRecord
       def expand_hash_conditions_for_aggregates(attrs)
         expanded_attrs = {}
         attrs.each do |attr, value|
-          unless (aggregation = reflect_on_aggregation(attr.to_sym)).nil?
+          if aggregation = reflect_on_aggregation(attr.to_sym)
             mapping = aggregate_mapping(aggregation)
             mapping.each do |field_attr, aggregate_attr|
               if mapping.size == 1 && !value.respond_to?(aggregate_attr)


### PR DESCRIPTION
A bunch of commits squashed:
- Avoid double hash lookups in AR::Reflection when reflecting associations/aggregations
- Minor cleanups: use elsif, do..end, if..else instead of unless..else
- Simplify DynamicMatchers#respond_to?
- Use "where" instead of scoped with conditions hash
- Extract `scoped_by` method pattern regexp to constant
- Extract noisy class_eval from method_missing in dynamic matchers
- Extract readonly check, avoid calling column#to_s twice in persistence
- Refactor predicate builder, remove some variables
