### PR TITLE
use read_attribute to allow scoping by an aggregation's attribute value

### DIFF
--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -26,7 +26,7 @@ module ActiveRecord
         relation = relation.and(table[finder_class.primary_key.to_sym].not_eq(record.send(:id))) if record.persisted?
 
         Array(options[:scope]).each do |scope_item|
-          scope_value = record.send(scope_item)
+          scope_value = record.read_attribute(scope_item)
           reflection = record.class.reflect_on_association(scope_item)
           if reflection
             scope_value = record.send(reflection.foreign_key)

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -25,7 +25,7 @@ end
 class UniquenessValidationTest < ActiveRecord::TestCase
   fixtures :topics, 'warehouse-things', :developers
 
-  repair_validations(Topic, Reply)
+  repair_validations(Topic, Reply, DeveloperWithAggregate)
 
   def test_validate_uniqueness
     Topic.validates_uniqueness_of(:title)
@@ -129,6 +129,19 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     # UniqueReply and its subclasses
     r3 = t.replies.create "title" => "r2", "content" => "a barrel of fun"
     assert r3.valid?, "Saving r3"
+  end
+
+  def test_validate_uniqueness_scoped_to_aggregation
+    DeveloperWithAggregate.validates_uniqueness_of(:name, :scope => :salary)
+
+    existing  = developers(:jamis)
+    duplicate = DeveloperWithAggregate.new :name => existing.name, :salary => DeveloperSalary.new(existing.salary)
+
+    assert duplicate.invalid?
+
+    duplicate.salary = DeveloperSalary.new(existing.salary + 1)
+
+    assert duplicate.valid?
   end
 
   def test_validate_uniqueness_with_scope_array


### PR DESCRIPTION
The following error is produced in `Arel` when an aggregation is provided as the `:scope` parameter to `validates_uniqueness_of`:

```
TypeError: Cannot visit CustomClassWithoutRecognizedAncestors
    from /usr/local/Cellar/ruby/1.9.3-p125/lib/ruby/gems/1.9.1/gems/arel-3.0.2/lib/arel/visitors/visitor.rb:25:in `rescue in visit'
    from /usr/local/Cellar/ruby/1.9.3-p125/lib/ruby/gems/1.9.1/gems/arel-3.0.2/lib/arel/visitors/visitor.rb:19:in `visit'
    ...
```

`ActiveRecord` uses the aggregation's value object as the scope value instead of its actual attribute value.

The attached code resolves this issue by using the attribute value after type cast but before conversion.
