### PR TITLE
Route root helper shortcut

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -254,10 +254,15 @@ module ActionDispatch
         #
         # For options, see +match+, as +root+ uses it internally.
         #
+        # You can also pass a string which will expand
+        #
+        #   root 'pages#main'
+        #
         # You should put the root route at the top of <tt>config/routes.rb</tt>,
         # because this means it will be matched first. As this is the most popular route
         # of most Rails applications, this is beneficial.
         def root(options = {})
+          options = { :to => options } if options.is_a?(String)
           match '/', { :as => :root }.merge(options)
         end
 

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -437,6 +437,15 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     assert_equal("/", routes.send(:root_path))
   end
 
+  def test_named_route_root_without_hash
+    rs.draw do
+      root "hello#index"
+    end
+    routes = setup_for_named_route
+    assert_equal("http://test.host/", routes.send(:root_url))
+    assert_equal("/", routes.send(:root_path))
+  end
+
   def test_named_route_with_regexps
     rs.draw do
       match 'page/:year/:month/:day/:title' => 'page#show', :as => 'article',


### PR DESCRIPTION
Allow the root route helper to accept just a string
