### PR TITLE
Fix GH #4674. Reset column information and sequence name when setting table_name.

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -114,10 +114,17 @@ module ActiveRecord
       # You can also just define your own <tt>self.table_name</tt> method; see
       # the documentation for ActiveRecord::Base#table_name.
       def table_name=(value)
-        @table_name        = value && value.to_s
-        @quoted_table_name = nil
-        @arel_table        = nil
-        @relation          = Relation.new(self, arel_table)
+        value = value && value.to_s
+        if defined?(@table_name)
+          return if value == @table_name
+
+          reset_column_information
+        end
+        @table_name          = value
+        @quoted_table_name   = nil
+        @arel_table          = nil
+        @sequence_name       = nil
+        @relation            = Relation.new(self, arel_table)
       end
 
       # Returns a quoted version of the table name, used to construct SQL statements.

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -123,7 +123,7 @@ module ActiveRecord
         @table_name          = value
         @quoted_table_name   = nil
         @arel_table          = nil
-        @sequence_name       = nil
+        @sequence_name       = nil unless defined?(@explicitly_sequence_name) && @explicitly_sequence_name
         @relation            = Relation.new(self, arel_table)
       end
 
@@ -170,7 +170,8 @@ module ActiveRecord
       end
 
       def reset_sequence_name #:nodoc:
-        self.sequence_name = connection.default_sequence_name(table_name, primary_key)
+        @sequence_name = connection.default_sequence_name(table_name, primary_key)
+        @explicitly_sequence_name = false
       end
 
       # Sets the name of the sequence to use when generating ids to the given
@@ -189,6 +190,7 @@ module ActiveRecord
       #   end
       def sequence_name=(value)
         @sequence_name = value.to_s
+        @explicitly_sequence_name = true
       end
 
       # Indicates whether the table associated with this class exists

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1479,6 +1479,19 @@ class BasicsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_clear_cash_when_setting_table_name
+    Joke.table_name = "cold_jokes"
+    before_columns = Joke.columns
+    before_seq     = Joke.sequence_name
+
+    Joke.table_name = "funny_jokes"
+    after_columns = Joke.columns
+    after_seq     = Joke.sequence_name
+
+    assert_not_equal before_columns, after_columns
+    assert_not_equal before_seq, after_seq unless before_seq.blank? && after_seq.blank?
+  end
+
   def test_set_table_name_symbol_converted_to_string
     Joke.table_name = :cold_jokes
     assert_equal 'cold_jokes', Joke.table_name

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1492,6 +1492,17 @@ class BasicsTest < ActiveRecord::TestCase
     assert_not_equal before_seq, after_seq unless before_seq.blank? && after_seq.blank?
   end
 
+  def test_dont_clear_sequence_name_when_setting_explicitly
+    Joke.sequence_name = "black_jokes_seq"
+    Joke.table_name    = "cold_jokes"
+    before_seq         = Joke.sequence_name
+
+    Joke.table_name    = "funny_jokes"
+    after_seq          = Joke.sequence_name
+
+    assert_equal before_seq, after_seq unless before_seq.blank? && after_seq.blank?
+  end
+
   def test_set_table_name_symbol_converted_to_string
     Joke.table_name = :cold_jokes
     assert_equal 'cold_jokes', Joke.table_name


### PR DESCRIPTION
In now implementation, when calling table_name=, we reset @quoted_table_name, @arel_table, but we don't reset column information and sequence name.

Please see #4674 .

BTW, the original issue was happen on 3-2-stable.
