### PR TITLE
Fix ActiveRecord warning in tests with Marshal

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -28,6 +28,7 @@ module ActiveRecord
         @target = nil
         @owner, @reflection = owner, reflection
         @updated = false
+        @stale_state = nil
 
         reset
         reset_scope

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -193,7 +193,6 @@ module ActiveRecord
       @attributes = self.class.initialize_attributes(coder['attributes'])
       @columns_hash = self.class.column_types.merge(coder['column_types'] || {})
 
-
       init_internals
 
       @new_record = false

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1920,6 +1920,20 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal 1, post.comments.length
   end
 
+  def test_marshalling_new_record_round_trip_with_associations
+    if ENV['TRAVIS'] && RUBY_VERSION == "1.8.7"
+      return skip("Marshalling tests disabled for Ruby 1.8.7 on Travis CI due to what appears " \
+                  "to be a Ruby bug.")
+    end
+
+    post = Post.new
+    post.comments.build
+
+    post = Marshal.load(Marshal.dump(post))
+
+    assert post.new_record?, "should be a new record"
+  end
+
   def test_attribute_names
     assert_equal ["id", "type", "ruby_type", "firm_id", "firm_name", "name", "client_of", "rating", "account_id"],
                  Company.attribute_names

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1921,11 +1921,6 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_marshalling_new_record_round_trip_with_associations
-    if ENV['TRAVIS'] && RUBY_VERSION == "1.8.7"
-      return skip("Marshalling tests disabled for Ruby 1.8.7 on Travis CI due to what appears " \
-                  "to be a Ruby bug.")
-    end
-
     post = Post.new
     post.comments.build
 


### PR DESCRIPTION
Initializing `@stale_state` apparently fix the warning related to `@new_record` variable not being initialized in AR's test suit, when an association is built and the object is marshaled/loaded. 

I couldn't completely figure out the relation between these though, but not initializing it gives us the warning and the loaded object doesn't have the `@new_record` instance variable, while it has `@stale_state` when it shouldn't.

See these tests in AR's base_test.rb:

test_marshalling_with_associations
test_marshalling_new_record_round_trip_with_associations

Related to #3720 /cc @kennyj @lest.
