### PR TITLE
Fix GH #3163. Should quote database on mysql/mysql2.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -375,7 +375,7 @@ module ActiveRecord
 
       def tables(name = nil, database = nil, like = nil) #:nodoc:
         sql = "SHOW TABLES "
-        sql << "IN #{database} " if database
+        sql << "IN #{quote_table_name(database)} " if database
         sql << "LIKE #{quote(like)}" if like
 
         execute_and_free(sql, 'SCHEMA') do |result|

--- a/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
@@ -46,6 +46,16 @@ module ActiveRecord
         assert_equal str, value
       end
 
+      def test_tables_quoting
+        begin
+          @conn.tables(nil, "foo-bar", nil)
+          flunk
+        rescue => e
+          # assertion for *quoted* database properly
+          assert_match(/Access denied for user/, e.inspect)
+        end
+      end
+
       private
       def insert(ctx, data)
         binds   = data.map { |name, value|

--- a/activerecord/test/cases/adapters/mysql2/schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_test.rb
@@ -35,6 +35,17 @@ module ActiveRecord
       def test_table_exists_wrong_schema
         assert(!@connection.table_exists?("#{@db_name}.zomg"), "table should not exist")
       end
+
+      def test_tables_quoting
+        begin
+          @connection.tables(nil, "foo-bar", nil)
+          flunk
+        rescue => e
+          # assertion for *quoted* database properly
+          assert_match(/Access denied for user/, e.inspect)
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
_database_ argument pass to _tables_ method isn't escaped.
Please see https://github.com/rails/rails/issues/3163
