### PR TITLE
Fix message assertions for quoting database name in "show tables" for mysql

### DIFF
--- a/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
@@ -52,7 +52,7 @@ module ActiveRecord
           flunk
         rescue => e
           # assertion for *quoted* database properly
-          assert_match(/Access denied for user/, e.inspect)
+          assert_match(/Unknown database 'foo-bar': SHOW TABLES IN `foo-bar`/, e.inspect)
         end
       end
 

--- a/activerecord/test/cases/adapters/mysql2/schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_test.rb
@@ -42,7 +42,7 @@ module ActiveRecord
           flunk
         rescue => e
           # assertion for *quoted* database properly
-          assert_match(/Access denied for user/, e.inspect)
+          assert_match(/Unknown database 'foo-bar': SHOW TABLES IN `foo-bar`/, e.inspect)
         end
       end
 


### PR DESCRIPTION
This should fix the master build, related to mysql and mysql2 tests.
