### PR TITLE
Update I18n defaults for activerecord.errors.messages.record_invalid

### DIFF
--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -14,7 +14,7 @@ module ActiveRecord
     def initialize(record)
       @record = record
       errors = @record.errors.full_messages.join(", ")
-      super(I18n.t("activerecord.errors.messages.record_invalid", :errors => errors))
+      super(I18n.t(:"#{@record.class.i18n_scope}.errors.messages.record_invalid", :errors => errors, :default => :"errors.messages.record_invalid"))
     end
   end
 

--- a/activerecord/test/cases/validations/i18n_generate_message_validation_test.rb
+++ b/activerecord/test/cases/validations/i18n_generate_message_validation_test.rb
@@ -8,11 +8,12 @@ class I18nGenerateMessageValidationTest < ActiveRecord::TestCase
     I18n.backend = I18n::Backend::Simple.new
   end
 
-  def reset_i18n_load_path(&block)
+  def reset_i18n_load_path
     @old_load_path, @old_backend = I18n.load_path.dup, I18n.backend
     I18n.load_path.clear
     I18n.backend = I18n::Backend::Simple.new
     yield
+  ensure 
     I18n.load_path.replace @old_load_path
     I18n.backend = @old_backend
   end


### PR DESCRIPTION
Allows translations of activerecord.errors.messages.record_invalid to in errors.messages.record_invalid
