### PR TITLE
Added parsing of arbitrary media type parameters.

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -82,7 +82,7 @@ module Mime
     class << self
 
       TRAILING_STAR_REGEXP = /(text|application)\/\*/
-      Q_SEPARATOR_REGEXP = /;\s*q=/
+      PARAMETER_SEPARATOR_REGEXP = /;\s*\w+="?\w+"?/
 
       def lookup(string)
         LOOKUP[string]
@@ -109,7 +109,7 @@ module Mime
 
       def parse(accept_header)
         if accept_header !~ /,/
-          accept_header = accept_header.split(Q_SEPARATOR_REGEXP).first
+          accept_header = accept_header.split(PARAMETER_SEPARATOR_REGEXP).first
           if accept_header =~ TRAILING_STAR_REGEXP
             parse_data_with_trailing_star($1)
           else
@@ -119,7 +119,7 @@ module Mime
           # keep track of creation order to keep the subsequent sort stable
           list, index = [], 0
           accept_header.split(/,/).each do |header|
-            params, q = header.split(Q_SEPARATOR_REGEXP)
+            params, q = header.split(PARAMETER_SEPARATOR_REGEXP)
             if params.present?
               params.strip!
 

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -75,6 +75,12 @@ class MimeTypeTest < ActiveSupport::TestCase
     assert_equal expect, Mime::Type.parse(accept)
   end
 
+  test "parse arbitarry media type parameters" do
+    accept = 'multipart/form-data; boundary="simple boundary"'
+    expect = [Mime::MULTIPART_FORM]
+    assert_equal expect, Mime::Type.parse(accept)
+  end
+
   # Accept header send with user HTTP_USER_AGENT: Sunrise/0.42j (Windows XP)
   test "parse broken acceptlines" do
     accept = "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/*,,*/*;q=0.5"


### PR DESCRIPTION
Mime types can accept arbitrary parameters. Right now, we only supported the q parameter, this extends them to arbitrary ones.

Here's the grammar: http://www.ietf.org/rfc/rfc2045.txt

This parsing is still not fantastic: the regexp might be made better, since it doesn't ensure that we have both actual quotes. Also, I'm not 100% \w matches up with '&lt;any (US-ASCII) CHAR except SPACE, CTLs, or tspecials&gt;'

Related: #4918 and #4127.
