### PR TITLE
Fix typo in asset pipeline guide

### DIFF
--- a/railties/guides/source/asset_pipeline.textile
+++ b/railties/guides/source/asset_pipeline.textile
@@ -128,7 +128,7 @@ For example, these files:
 <plain>
 app/assets/javascripts/home.js
 lib/assets/javascripts/moovinator.js
-vendor/assets/javascript/slider.js
+vendor/assets/javascripts/slider.js
 </plain>
 
 would be referenced in a manifest like this:


### PR DESCRIPTION
The Rails Guide on the asset pipeline referenced a javascript file in vendor/ with an incorrect path, this commit fixes that reference.
