### PR TITLE
Compute asset paths from the request if RAILS_RELATIVE_URL_ROOT not set

### DIFF
--- a/actionpack/lib/action_view/asset_paths.rb
+++ b/actionpack/lib/action_view/asset_paths.rb
@@ -117,7 +117,7 @@ module ActionView
     end
 
     def relative_url_root
-      config.relative_url_root
+      config.relative_url_root || current_request.try(:script_name)
     end
 
     def asset_host_config

--- a/actionpack/test/template/sprockets_helper_test.rb
+++ b/actionpack/test/template/sprockets_helper_test.rb
@@ -12,6 +12,7 @@ class SprocketsHelperTest < ActionView::TestCase
     def protocol() 'http://' end
     def ssl?() false end
     def host_with_port() 'localhost' end
+    def script_name() nil end
   end
 
   def setup


### PR DESCRIPTION
This fixes https://github.com/rails/rails/issues/910 ("Rails is not a Rack Application (SCRIPT_NAME vs. relative_url_root ?)"), which was marked closed during the Lighthouse -> GitHub bugtracker migration for some reason.
