### PR TITLE
Always passing a respond block from to responder

### DIFF
--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -235,16 +235,8 @@ module ActionController #:nodoc:
 
       if collector = retrieve_collector_from_mimes(&block)
         options = resources.size == 1 ? {} : resources.extract_options!
-
-        if defined_response = collector.response
-          if action = options.delete(:action)
-            render :action => action
-          else
-            defined_response.call
-          end
-        else
-          (options.delete(:responder) || self.class.responder).call(self, resources, options)
-        end
+        options[:default_response] = collector.response
+        (options.delete(:responder) || self.class.responder).call(self, resources, options)
       end
     end
 

--- a/actionpack/lib/action_controller/metal/responder.rb
+++ b/actionpack/lib/action_controller/metal/responder.rb
@@ -130,6 +130,7 @@ module ActionController #:nodoc:
       @resources = resources
       @options = options
       @action = options.delete(:action)
+      @default_response = options.delete(:default_response)
     end
 
     delegate :head, :render, :redirect_to,   :to => :controller
@@ -172,7 +173,7 @@ module ActionController #:nodoc:
     # responds to :to_format and display it.
     #
     def to_format
-      if get? || !has_errors?
+      if get? || !has_errors? || response_overridden?
         default_render
       else
         display_errors
@@ -226,7 +227,11 @@ module ActionController #:nodoc:
     # controller.
     #
     def default_render
-      controller.default_render(options)
+      if @default_response
+        @default_response.call(options)
+      else
+        controller.default_render(options)
+      end
     end
 
     # Display is just a shortcut to render a resource with the current format.
@@ -273,6 +278,10 @@ module ActionController #:nodoc:
 
     def json_resource_errors
       {:errors => resource.errors}
+    end
+
+    def response_overridden?
+      @default_response.present?
     end
   end
 end

--- a/actionpack/test/controller/mime_responds_test.rb
+++ b/actionpack/test/controller/mime_responds_test.rb
@@ -1183,3 +1183,39 @@ class MimeControllerLayoutsTest < ActionController::TestCase
     assert_equal '<html><div id="super_iphone">Super iPhone</div></html>', @response.body
   end
 end
+
+class FlashResponder < ActionController::Responder
+  def initialize(controller, resources, options={})
+    super
+  end
+
+  def to_html
+    controller.flash[:notice] = 'Success'
+    super
+  end
+end
+
+class FlashResponderController < ActionController::Base
+  self.responder = FlashResponder
+  respond_to :html
+
+  def index
+    respond_with Object.new do |format|
+      format.html { render :text => 'HTML' }
+    end
+  end
+end
+
+class FlashResponderControllerTest < ActionController::TestCase
+  tests FlashResponderController
+
+  def test_respond_with_block_executed
+    get :index
+    assert_equal 'HTML', @response.body
+  end
+
+  def test_flash_responder_executed
+    get :index
+    assert_equal 'Success', flash[:notice]
+  end
+end


### PR DESCRIPTION
We should let the responder to decide what to do with the given overridden response block, and not short circuit it.

Fixes #5280

This is for `master`, assigning to @josevalim
