### PR TITLE
Fix #camelize for terms with both underscore and camelcase

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -58,7 +58,7 @@ module ActiveSupport
       else
         string = string.sub(/^(?:#{inflections.acronym_regex}(?=\b|[A-Z_])|\w)/) { $&.downcase }
       end
-      string.gsub(/(?:_|(\/))([a-z\d]*)/i) { "#{$1}#{inflections.acronyms[$2] || $2.capitalize}" }.gsub('/', '::')
+      string.gsub(/(?:_|(\/))([a-z\d]*)/) { "#{$1}#{inflections.acronyms[$2] || $2.capitalize}" }.gsub('/', '::')
     end
 
     # Makes an underscored, lowercase form from the expression in the string.

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -98,6 +98,14 @@ class InflectorTest < ActiveSupport::TestCase
     assert_equal("CamelCase", ActiveSupport::Inflector.camelize('Camel_Case'))
   end
 
+  def test_camelize_with_camelcase
+    assert_equal("CamelCase", ActiveSupport::Inflector.camelize('CamelCase'))
+  end
+
+  def test_camelize_with_mixed
+    assert_equal("CamelCaseMixedWithUnderscore", ActiveSupport::Inflector.camelize('_CamelCase_mixedWith_Underscore'))
+  end
+
   def test_acronyms
     ActiveSupport::Inflector.inflections do |inflect|
       inflect.acronym("API")


### PR DESCRIPTION
Currently, `"mixed_underscoreCamel".camelize` returns `"MixedUnderscorecamel"`.

It should return `"MixedUnderscoreCamel"`.
