### PR TITLE
Revert table_name= needs connection now, so just stub table_name

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -118,7 +118,7 @@ module ActiveRecord
 
         if defined?(@table_name)
           return if value == @table_name
-          reset_column_information
+          reset_column_information if connected?
         end
 
         @table_name        = value

--- a/railties/test/generators/session_migration_generator_test.rb
+++ b/railties/test/generators/session_migration_generator_test.rb
@@ -15,7 +15,7 @@ class SessionMigrationGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_session_migration_with_custom_table_name
-    ActiveRecord::SessionStore::Session.stubs(:table_name => "custom_table_name")
+    ActiveRecord::SessionStore::Session.table_name = "custom_table_name"
     run_generator
     assert_migration "db/migrate/add_sessions_table.rb" do |migration|
       assert_match(/class AddSessionsTable < ActiveRecord::Migration/, migration)


### PR DESCRIPTION
This PR is revert c8f6025fd37c7b5c8922b11eb5ceba22e4650b59.

My commit (2fdb5219fb70a6368602c9d6073be8fa70b720fa) broke build, because table_name= method need a connection.

Please see c8f6025fd37c7b5c8922b11eb5ceba22e4650b59

cc @jonleighton @drogus
