### PR TITLE
warning fix : mismatched indentations at 'end' with 'case'

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -458,7 +458,7 @@ db_namespace = namespace :db do
           db_namespace["test:load_schema"].invoke
         when :sql
           db_namespace["test:load_structure"].invoke
-        end
+      end
     end
 
     # desc "Recreate the test database from an existent structure.sql file"


### PR DESCRIPTION
mismatched indentations at 'end' with 'case'
