### PR TITLE
Refactor ActionDispatch::UploadedFile

### DIFF
--- a/actionpack/lib/action_dispatch/http/upload.rb
+++ b/actionpack/lib/action_dispatch/http/upload.rb
@@ -4,11 +4,12 @@ module ActionDispatch
       attr_accessor :original_filename, :content_type, :tempfile, :headers
 
       def initialize(hash)
+        @tempfile          = hash[:tempfile]
+        raise(ArgumentError, ':tempfile is required') unless @tempfile
+
         @original_filename = encode_filename(hash[:filename])
         @content_type      = hash[:type]
         @headers           = hash[:head]
-        @tempfile          = hash[:tempfile]
-        raise(ArgumentError, ':tempfile is required') unless @tempfile
       end
 
       def read(*args)
@@ -19,15 +20,12 @@ module ActionDispatch
       [:open, :path, :rewind, :size].each do |method|
         class_eval "def #{method}; @tempfile.#{method}; end"
       end
-      
+
       private
+
       def encode_filename(filename)
         # Encode the filename in the utf8 encoding, unless it is nil
-        if filename
-          filename.force_encoding("UTF-8").encode!
-        else
-          filename
-        end
+        filename.force_encoding("UTF-8").encode! if filename
       end
     end
 

--- a/actionpack/test/dispatch/uploaded_file_test.rb
+++ b/actionpack/test/dispatch/uploaded_file_test.rb
@@ -12,7 +12,7 @@ module ActionDispatch
       uf = Http::UploadedFile.new(:filename => 'foo', :tempfile => Object.new)
       assert_equal 'foo', uf.original_filename
     end
-    
+
     def test_filename_should_be_in_utf_8
       uf = Http::UploadedFile.new(:filename => 'foo', :tempfile => Object.new)
       assert_equal "UTF-8", uf.original_filename.encoding.to_s


### PR DESCRIPTION
Cleanup encode_filename method, and raise ArgumentError sooner if
tempfile is not present - no need to try encoding and grabbing other
attributes if it raises an exception right after that.
