### PR TITLE
Adding param to ActionController::Metal, param is a method that can handle with nested params hashes

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Added ActionController::Metal#param method that can handle with nested params hashes.
+    For instance, param("user.id") is the same as params[:user].is_a?(Hash) && params[:user][:id].
+
+    *Guillermo Iguaran*
+
 *   Remove the leading \n added by textarea on assert_select. *Santiago Pastorino*
 
 *   Changed default value for `config.action_view.embed_authenticity_token_in_remote_forms`

--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -148,6 +148,16 @@ module ActionController
       @_params = val
     end
 
+    # Method that can handle with nested params hashes.
+    # For instance, param("user.id") is the same as
+    # params[:user].is_a?(Hash) && params[:user][:id]
+    def param(key)
+      key.to_s.split('.').inject(params) do |param, key|
+        return unless param
+        param[key]
+      end
+    end
+
     # Basic implementations for content_type=, location=, and headers are
     # provided to reduce the dependency on the RackDelegation module
     # in Renderer and Redirector.

--- a/actionpack/test/controller/params_test.rb
+++ b/actionpack/test/controller/params_test.rb
@@ -32,6 +32,14 @@ class ParamsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_param
+    with_test_route_set do
+      post "/", {"user" => {"username" => "gorbachev"}}
+      assert_equal "gorbachev", @controller.param("user.username")
+      assert_nil @controller.param("user.baz")
+    end
+  end
+
   private
     def with_test_route_set
       with_routing do |set|

--- a/actionpack/test/controller/params_test.rb
+++ b/actionpack/test/controller/params_test.rb
@@ -1,0 +1,45 @@
+require "abstract_unit"
+
+class ParamsTest < ActionDispatch::IntegrationTest
+  class TestController < ActionController::Base
+    def params_test ; end
+  end
+
+  def setup
+    @controller = TestController.new
+  end
+
+  def test_post_params
+    with_test_route_set do
+      post "/", {"username" => "david"}
+      assert_equal "david", @controller.params[:username]
+      assert_nil @controller.params[:baz]
+    end
+  end
+
+  def test_route_params
+    with_test_route_set do
+      get "/bar"
+      assert_equal "bar", @controller.params[:foo]
+    end
+  end
+
+  def test_nested_params
+    with_test_route_set do
+      post "/", {"user" => {"username" => "guille"}}
+      assert_equal "guille", @controller.params[:user][:username]
+      assert_nil @controller.params[:user][:baz]
+    end
+  end
+
+  private
+    def with_test_route_set
+      with_routing do |set|
+        set.draw do
+          match '/', :to => 'params_test/test#params_test'
+          match '/:foo', :to => 'params_test/test#params_test'
+        end
+        yield
+      end
+    end
+end

--- a/guides/source/action_controller_overview.textile
+++ b/guides/source/action_controller_overview.textile
@@ -110,6 +110,8 @@ When this form is submitted, the value of +params[:client]+ will be <tt>{"name" 
 
 Note that the +params+ hash is actually an instance of +HashWithIndifferentAccess+ from Active Support, which acts like a hash that lets you use symbols and strings interchangeably as keys.
 
+For convenience the +params+ hash also can be accessed using with the +param+ method. For instance, param("client.name") is the same as params[:client][:name].
+
 h4. JSON/XML parameters
 
 If you're writing a web service application, you might find yourself more comfortable on accepting parameters in JSON or XML format. Rails will automatically convert your parameters into +params+ hash, which you'll be able to access like you would normally do with form data.


### PR DESCRIPTION
For instance, param("user.id") is the same as params[:user].is_a?(Hash) && params[:user][:id]

Made by @josevalim for [strobe-rails-ext](https://github.com/strobecorp/strobe-rails-ext)

cc @spastorino @wycats
