### PR TITLE
Update ActiveRecord::AttributeMethods#attribute_present? to return false for empty strings

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -189,7 +189,7 @@ module ActiveRecord
     # nil nor empty? (the latter only applies to objects that respond to empty?, most notably Strings).
     def attribute_present?(attribute)
       value = read_attribute(attribute)
-      !value.nil? || (value.respond_to?(:empty?) && !value.empty?)
+      !value.nil? && !(value.respond_to?(:empty?) && value.empty?)
     end
 
     # Returns the column object for the named attribute.

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -30,9 +30,12 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     t = Topic.new
     t.title = "hello there!"
     t.written_on = Time.now
+    t.author_name = ""
     assert t.attribute_present?("title")
     assert t.attribute_present?("written_on")
     assert !t.attribute_present?("content")
+    assert !t.attribute_present?("author_name")
+    
   end
 
   def test_attribute_present_with_booleans


### PR DESCRIPTION
Right now, attribute_present? returns true on empty strings, when the documentation says that it should return false:

"Returns true if the specified +attribute+ has been set by the user or by a database load and is neither
nil nor empty? (the latter only applies to objects that respond to empty?, most notably Strings)."

This change fixes the function to correctly return false for empty strings.  Test is included.

Fixes #5314
