### PR TITLE
Add :conditions option to uniqueness validator

### DIFF
--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -35,7 +35,13 @@ module ActiveRecord
           relation = relation.and(table[scope_item].eq(scope_value))
         end
 
-        if finder_class.unscoped.where(relation).where(options[:conditions]).exists?
+        relation = finder_class.unscoped.where(relation)
+
+        if options[:conditions]
+          relation = relation.merge(options[:conditions])
+        end
+
+        if relation.exists?
           record.errors.add(attribute, :taken, options.except(:case_sensitive, :scope, :conditions).merge(:value => value))
         end
       end
@@ -107,7 +113,7 @@ module ActiveRecord
       # of the title attribute:
       #
       #   class Article < ActiveRecord::Base
-      #     validates_uniqueness_of :title, :conditions => ['status != ?', 'archived']
+      #     validates_uniqueness_of :title, :conditions => where('status != ?', 'archived')
       #   end
       #
       # When the record is created, a check is performed to make sure that no record exists in the database
@@ -118,7 +124,7 @@ module ActiveRecord
       # * <tt>:message</tt> - Specifies a custom error message (default is: "has already been taken").
       # * <tt>:scope</tt> - One or more columns by which to limit the scope of the uniqueness constraint.
       # * <tt>:conditions</tt> - Specify the conditions to be included as a <tt>WHERE</tt> SQL fragment to limit
-      #   the uniqueness constraint lookup. (e.g. <tt>:conditions => {:status => 'active'}</tt>)
+      #   the uniqueness constraint lookup. (e.g. <tt>:conditions => where('status = ?', 'active')</tt>)
       # * <tt>:case_sensitive</tt> - Looks for an exact match. Ignored by non-text columns (+true+ by default).
       # * <tt>:allow_nil</tt> - If set to true, skips this validation if the attribute is +nil+ (default is +false+).
       # * <tt>:allow_blank</tt> - If set to true, skips this validation if the attribute is blank (default is +false+).

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -109,7 +109,7 @@ module ActiveRecord
       #   end
       #
       # It is also possible to limit the uniqueness constraint to a set of records matching certain conditions.
-      # In this example archived articles with are not being taken into consideration when validating uniqueness
+      # In this example archived articles are not being taken into consideration when validating uniqueness
       # of the title attribute:
       #
       #   class Article < ActiveRecord::Base

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -35,8 +35,8 @@ module ActiveRecord
           relation = relation.and(table[scope_item].eq(scope_value))
         end
 
-        if finder_class.unscoped.where(relation).exists?
-          record.errors.add(attribute, :taken, options.except(:case_sensitive, :scope).merge(:value => value))
+        if finder_class.unscoped.where(relation).where(options[:conditions]).exists?
+          record.errors.add(attribute, :taken, options.except(:case_sensitive, :scope, :conditions).merge(:value => value))
         end
       end
 
@@ -102,6 +102,14 @@ module ActiveRecord
       #     validates_uniqueness_of :teacher_id, :scope => [:semester_id, :class_id]
       #   end
       #
+      # It is also possible to limit the uniqueness constraint to a set of records matching certain conditions.
+      # In this example archived articles with are not being taken into consideration when validating uniqueness
+      # of the title attribute:
+      #
+      #   class Article < ActiveRecord::Base
+      #     validates_uniqueness_of :title, :conditions => ['status != ?', 'archived']
+      #   end
+      #
       # When the record is created, a check is performed to make sure that no record exists in the database
       # with the given value for the specified attribute (that maps to a column). When the record is updated,
       # the same check is made but disregarding the record itself.
@@ -109,6 +117,8 @@ module ActiveRecord
       # Configuration options:
       # * <tt>:message</tt> - Specifies a custom error message (default is: "has already been taken").
       # * <tt>:scope</tt> - One or more columns by which to limit the scope of the uniqueness constraint.
+      # * <tt>:conditions</tt> - Specify the conditions to be included as a <tt>WHERE</tt> SQL fragment to limit
+      #   the uniqueness constraint lookup. (e.g. <tt>:conditions => {:status => 'active'}</tt>)
       # * <tt>:case_sensitive</tt> - Looks for an exact match. Ignored by non-text columns (+true+ by default).
       # * <tt>:allow_nil</tt> - If set to true, skips this validation if the attribute is +nil+ (default is +false+).
       # * <tt>:allow_blank</tt> - If set to true, skips this validation if the attribute is blank (default is +false+).

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -325,4 +325,16 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     assert w6.errors[:city].any?, "Should have errors for city"
     assert_equal ["has already been taken"], w6.errors[:city], "Should have uniqueness message for city"
   end
+  
+  def test_validate_uniqueness_with_conditions
+    Topic.validates_uniqueness_of(:title, :conditions => ["approved = ?", true])
+    t1 = Topic.create("title" => "I'm a topic", "approved" => true)
+    t2 = Topic.create("title" => "I'm an unapproved topic", "approved" => false)
+    
+    t3 = Topic.new("title" => "I'm a topic", "approved" => true)
+    assert !t3.valid?, "t3 shouldn't be valid"
+    
+    t4 = Topic.new("title" => "I'm an unapproved topic", "approved" => false)
+    assert t4.valid?, "t4 should be valid"
+  end
 end

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -327,7 +327,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
   end
   
   def test_validate_uniqueness_with_conditions
-    Topic.validates_uniqueness_of(:title, :conditions => ["approved = ?", true])
+    Topic.validates_uniqueness_of(:title, :conditions => Topic.where('approved = ?', true))
     t1 = Topic.create("title" => "I'm a topic", "approved" => true)
     t2 = Topic.create("title" => "I'm an unapproved topic", "approved" => false)
     


### PR DESCRIPTION
This commit adds a `:conditions` option to the uniqueness validator. The `:conditions` is added to the lookup used for determining the uniqueness of the attribute.

_Example use-case:_
An article with a `title` and a `status`. Status can be either `draft`, `published` or `archived`. We want to have unique titles - but only for non-archived articles. This cannot be accomplished using `:scope => :status`, since a draft article and a published article with identical titles both would be valid. This can now be accomplished with:

``` ruby
class Article < AR::Base
  validates :title, :uniqueness => {:conditions => ['status != ?', 'archived']}
end
```

In this case a draft article can have the same title as an archived article, but not the same name as a published article.

What do you think? Let me know if anything is missing - this is my first pull request to Rails.
