### PR TITLE
Don't reset inheritance_column when setting explicitly.

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -160,6 +160,7 @@ module ActiveRecord
       # Sets the value of inheritance_column
       def inheritance_column=(value)
         @inheritance_column = value.to_s
+        @explicit_inheritance_column = true
       end
 
       def sequence_name
@@ -303,7 +304,7 @@ module ActiveRecord
         @column_types         = nil
         @content_columns      = nil
         @dynamic_methods_hash = nil
-        @inheritance_column   = nil
+        @inheritance_column   = nil unless defined?(@explicit_inheritance_column) && @explicit_inheritance_column
         @relation             = nil
       end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1503,6 +1503,16 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal before_seq, after_seq unless before_seq.blank? && after_seq.blank?
   end
 
+  def test_dont_clear_inheritnce_column_when_setting_explicitly
+    Joke.inheritance_column = "my_type"
+    before_inherit = Joke.inheritance_column
+
+    Joke.reset_column_information
+    after_inherit = Joke.inheritance_column
+
+    assert_equal before_inherit, after_inherit unless before_inherit.blank? && after_inherit.blank?
+  end
+
   def test_set_table_name_symbol_converted_to_string
     Joke.table_name = :cold_jokes
     assert_equal 'cold_jokes', Joke.table_name


### PR DESCRIPTION
In https://github.com/rails/rails/pull/5267, we don't reset _sequence_name_, when setting explicitly.
But in the current implementation, we rest _inheritance_column_ when setting explicitly.

I think we also don't reset it.

/cc @jonleighton
