### PR TITLE
Handle case when `caches_action layout: false` and `layout false`

### DIFF
--- a/actionpack/lib/action_controller/caching/actions.rb
+++ b/actionpack/lib/action_controller/caching/actions.rb
@@ -149,7 +149,7 @@ module ActionController #:nodoc:
             controller.action_has_layout = true
             body = controller._save_fragment(cache_path.path, @store_options)
           end
-          has_layout = !controller.send(:_layout).nil?
+          has_layout = controller.send(:_layout)
           body = controller.render_to_string(:text => body, :layout => has_layout) unless @cache_layout
 
           controller.response_body = body

--- a/actionpack/lib/action_controller/caching/actions.rb
+++ b/actionpack/lib/action_controller/caching/actions.rb
@@ -142,15 +142,15 @@ module ActionController #:nodoc:
           cache_path = ActionCachePath.new(controller, path_options || {})
 
           body = controller.read_fragment(cache_path.path, @store_options)
-
+          
           unless body
             controller.action_has_layout = false unless @cache_layout
             yield
             controller.action_has_layout = true
             body = controller._save_fragment(cache_path.path, @store_options)
           end
-
-          body = controller.render_to_string(:text => body, :layout => true) unless @cache_layout
+          has_layout = !controller.send(:_layout).nil?
+          body = controller.render_to_string(:text => body, :layout => has_layout) unless @cache_layout
 
           controller.response_body = body
           controller.content_type = Mime[cache_path.extension || :html]


### PR DESCRIPTION
When a controller looks like this:

```
class IndexController < ApplicationController
  layout false
  caches_action :show, :layout => false
  def show
  end
end
```

This would throw an Exception. This commit fixes this issue.

I found about this problem when using pjax which conditionally sets layout to false. See [this StackOverflow question](http://stackoverflow.com/q/9551759/333786) for details.
