### PR TITLE
remove unused require from AS/core_ext/class/delegating_att.rb 

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/delegating_attributes.rb
+++ b/activesupport/lib/active_support/core_ext/class/delegating_attributes.rb
@@ -1,5 +1,3 @@
-require 'active_support/core_ext/object/blank'
-require 'active_support/core_ext/array/extract_options'
 require 'active_support/core_ext/kernel/singleton_class'
 require 'active_support/core_ext/module/remove_method'
 


### PR DESCRIPTION
remove unused require. nolonger useful. with AS/core_ext/class/delegating_att.rb, now we are not using blank? and extract_options! in Class extension
