### PR TITLE
Fix deleting from a HABTM join table upon destroying an object of a model with optimistic locking enabled.

### DIFF
--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -104,6 +104,8 @@ module ActiveRecord
         def destroy #:nodoc:
           return super unless locking_enabled?
 
+          destroy_associations
+
           if persisted?
             table = self.class.arel_table
             lock_col = self.class.locking_column

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -22,7 +22,7 @@ class ReadonlyFirstNamePerson < Person
 end
 
 class OptimisticLockingTest < ActiveRecord::TestCase
-  fixtures :people, :legacy_things, :references, :string_key_objects
+  fixtures :people, :legacy_things, :references, :string_key_objects, :peoples_treasures
 
   def test_non_integer_lock_existing
     s1 = StringKeyObject.find("record1")
@@ -239,6 +239,16 @@ class OptimisticLockingTest < ActiveRecord::TestCase
     end
     assert car.destroyed?
   end
+  
+  def test_removing_has_and_belongs_to_many_associations_upon_destroy
+    p = RichPerson.create!
+    p.treasures.create!
+    assert !p.treasures.empty?
+    p.destroy
+    assert p.treasures.empty?
+    assert RichPerson.connection.select_all("SELECT * FROM peoples_treasures WHERE rich_person_id = 1").empty?
+  end
+  
 end
 
 class OptimisticLockingWithSchemaChangeTest < ActiveRecord::TestCase

--- a/activerecord/test/fixtures/peoples_treasures.yml
+++ b/activerecord/test/fixtures/peoples_treasures.yml
@@ -1,0 +1,3 @@
+michael_diamond:
+  rich_person_id: <%= ActiveRecord::Fixtures.identify(:michael) %>
+  treasure_id: <%= ActiveRecord::Fixtures.identify(:diamond) %>

--- a/activerecord/test/models/person.rb
+++ b/activerecord/test/models/person.rb
@@ -83,3 +83,9 @@ class TightPerson < ActiveRecord::Base
 end
 
 class TightDescendant < TightPerson; end
+
+class RichPerson < ActiveRecord::Base
+  self.table_name = 'people'
+  
+  has_and_belongs_to_many :treasures, :join_table => 'peoples_treasures'
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -467,6 +467,11 @@ ActiveRecord::Schema.define do
     t.references :best_friend_of
     t.timestamps
   end
+  
+  create_table :peoples_treasures, :id => false, :force => true do |t|
+    t.column :rich_person_id, :integer
+    t.column :treasure_id, :integer
+  end
 
   create_table :pets, :primary_key => :pet_id ,:force => true do |t|
     t.string :name


### PR DESCRIPTION
 Issue #5332.
