### PR TITLE
fix ArgumentError being raised in case of invalid byte sequences

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -39,6 +39,7 @@ module ActionDispatch
     end
 
     def escape_glob_chars(path)
+      path.force_encoding('binary') if path.respond_to? :force_encoding
       path.gsub(/[*?{}\[\]]/, "\\\\\\&")
     end
   end

--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -7,6 +7,10 @@ module StaticTests
     assert_equal "Hello, World!", get("/nofile").body
   end
 
+  def test_handles_urls_with_bad_encoding
+    assert_equal "Hello, World!", get("/doorkeeper%E3E4").body
+  end
+
   def test_sets_cache_control
     response = get("/index.html")
     assert_html "/index.html", response


### PR DESCRIPTION
this resolves an issue when a request with an invalid byte sequence comes in. In that case, the framework should not throw an ArgumentError as it does right now.
