### PR TITLE
ConnectionPool#with_connection properly releases connection when needed. Re #5330

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -101,6 +101,13 @@ module ActiveRecord
         active_connections.any?
       end
 
+      # Check to see if there is an active connection for
+      # current_connection_id, that is by default the current
+      # thread.
+      def current_connection?
+        @reserved_connections.has_key?(current_connection_id)
+      end
+
       # Signal that the thread is finished with the current connection.
       # #release_connection releases the connection-thread association
       # and returns the connection to the pool.
@@ -114,7 +121,7 @@ module ActiveRecord
       # connection when finished.
       def with_connection
         connection_id = current_connection_id
-        fresh_connection = true unless active_connection?
+        fresh_connection = true unless current_connection?
         yield connection
       ensure
         release_connection(connection_id) if fresh_connection

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -58,6 +58,31 @@ module ActiveRecord
 
       end
 
+      def test_threaded_with_connection
+        # Neccesary to have a checked out connection in thread
+        # other than one we will test, in order to trigger bug
+        # we are testing fix for.
+        main_thread_conn = ActiveRecord::Base.connection_pool.checkout
+
+        aThread = Thread.new do
+          ActiveRecord::Base.connection_pool.with_connection do
+            ActiveRecord::Base.connection # need to do something AR to trigger the checkout
+
+            reserved_thread_ids = ActiveRecord::Base.connection_pool.instance_variable_get(:@reserved_connections)
+
+            assert reserved_thread_ids.has_key?( Thread.current.object_id ), "thread should be in reserved connections"
+          end
+          reserved_thread_ids = ActiveRecord::Base.connection_pool.instance_variable_get(:@reserved_connections)
+          assert !reserved_thread_ids.has_key?( Thread.current.object_id ), "thread should not be in reserved connections"
+        end
+        aThread.join
+
+        ActiveRecord::Base.connection_pool.checkin main_thread_conn
+
+        reserved_thread_ids = ActiveRecord::Base.connection_pool.instance_variable_get(:@reserved_connections)
+        assert !reserved_thread_ids.has_key?( aThread.object_id ), "thread should not be in reserved connections"
+      end
+
       def test_automatic_reconnect=
         pool = ConnectionPool.new ActiveRecord::Base.connection_pool.spec
         assert pool.automatic_reconnect


### PR DESCRIPTION
@tenderlove, appreciate any feedback. re #5330

If I've done the pull request wrong somehow, let me know (i had an epic battle with git to try and get this right). 

This pull request to 3-2-stable branch, hopefully that's right. I didn't want to deal with figuring out if things had changed in master yet regarding connection pools, it took me long enough to understand what was going on in 3.2. 

If you have anything you would like changed in the code or test, let me know and I'll do it if I can. 

The test isn't as non-fragile and clean as I'd like, but it's as clean as I could figure out to make it based on existing ConnectionPool API -- there are other existing tests that call instance_variable_get(:@reserved_connections) like this too. 

The code is the smallest change I could make, without actually refactoring or changing semantics of any existing methods. I was scared to do that. It is true that the term "active connection" is used in two incompatible ways in existing code base (does it mean "the connection for current thread" or does it mean "any currently checked-out connection"? method/variable names/comments are not consistent. )  But I don't have the courage to try to refactor this stuff more -- it's fairly untested code, and concurrency is always confusing, and who knows what existing third party downstream dependencies may rely on public methods staying as they are.  So I changed as little as possible to fix the problem. 

Included test runs failing where expected before included change (and with expected deprecation warnings printed out about 'close your own connection'), and runs passing after included change (without any deprecation warnings). 

thanks for your help/attention! 
