### PR TITLE
Missing active_model/naming.rb dependency.

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -2,6 +2,7 @@ require 'active_support/inflector'
 require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/module/introspection'
 require 'active_support/core_ext/module/deprecation'
+require 'active_support/core_ext/object/blank'
 
 module ActiveModel
   class Name < String


### PR DESCRIPTION
ActiveModel::Name constructor expects to be able to call #blank? on a String but the core Object#blank? extension is never required.
