### PR TITLE
In AR depths use &:to_i before :uniq to process mixed arrays likes ["1", 1] correct

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -544,7 +544,7 @@ module ActiveRecord
         # If using a custom finder_sql, #find scans the entire collection.
         def find_by_scan(*args)
           expects_array = args.first.kind_of?(Array)
-          ids           = args.flatten.compact.uniq.map { |arg| arg.to_i }
+          ids           = args.flatten.compact.map{ |arg| arg.to_i }.uniq
 
           if ids.size == 1
             id = ids.first

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -378,6 +378,13 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 1, Firm.find(:first, :order => "id").clients_using_sql.size
   end
 
+  def test_finding_using_sql_take_into_account_only_uniq_ids
+    firm = Firm.find(:first, :order => "id")
+    client = firm.clients_using_sql.first
+    assert_equal client, firm.clients_using_sql.find(client.id, client.id)
+    assert_equal client, firm.clients_using_sql.find(client.id, client.id.to_s)
+  end
+
   def test_counting_using_sql
     assert_equal 1, Firm.find(:first, :order => "id").clients_using_counter_sql.size
     assert Firm.find(:first, :order => "id").clients_using_counter_sql.any?


### PR DESCRIPTION
Without fix my new test failed:

```
  1) Failure:
test_finding_using_sql_take_into_account_only_uniq_ids(HasManyAssociationsTest) [test/cases/associations/has_many_associations_test.rb:385]:
--- expected
+++ actual
@@ -1 +1 @@
-#<Client id: 3, type: "Client", ruby_type: "Client", firm_id: 1, firm_name: nil, name: "Microsoft", client_of: 1, rating: 1, account_id: nil>
+[#<Client id: 3, type: "Client", ruby_type: "Client", firm_id: 1, firm_name: nil, name: "Microsoft", client_of: 1, rating: 1, account_id: nil>]
```

This only one case then logic in condition [collection_association.rb#L549-555](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/collection_association.rb#L549-555) works not good. In other cases the method returned right results:

``` ruby
firm.clients_using_sql.find(1, "1", 2) # => [Client1, Client2] # <- that's correct
```
