### PR TITLE
Don't ignore call to undefined method in Sweeper

### DIFF
--- a/actionpack/lib/action_controller/caching/sweeping.rb
+++ b/actionpack/lib/action_controller/caching/sweeping.rb
@@ -88,7 +88,7 @@ module ActionController #:nodoc:
           end
 
           def method_missing(method, *arguments, &block)
-            return unless @controller
+            super unless @controller
             @controller.__send__(method, *arguments, &block)
           end
       end

--- a/actionpack/test/controller/sweeper_test.rb
+++ b/actionpack/test/controller/sweeper_test.rb
@@ -1,0 +1,16 @@
+require 'abstract_unit'
+
+
+class SweeperTest < ActionController::TestCase
+
+  class ::AppSweeper < ActionController::Caching::Sweeper; end
+
+  def test_sweeper_should_not_ignore_unknown_method_calls
+    sweeper = ActionController::Caching::Sweeper.send(:new)
+    assert_raise NameError do
+      sweeper.instance_eval do
+        some_method_that_doesnt_exist
+      end
+    end
+  end
+end


### PR DESCRIPTION
In any class that subclassed `ActionController::Caching::Sweeper` if you called any undefined method, it would just ignore it without any error. This patch fixes that.
