### PR TITLE
Missed commits from 3-2-stable

### DIFF
--- a/actionpack/lib/abstract_controller/layouts.rb
+++ b/actionpack/lib/abstract_controller/layouts.rb
@@ -249,6 +249,7 @@ module AbstractController
       # Symbol:: call the method specified by the symbol, which will return the template name
       # false::  There is no layout
       # true::   raise an ArgumentError
+      # nil::    Force default layout behavior with inheritance
       #
       # ==== Parameters
       # * <tt>layout</tt> - The layout to use.

--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -795,7 +795,7 @@ module ActionView
       private
         %w( sec min hour day month year ).each do |method|
           define_method(method) do
-            @datetime.kind_of?(Fixnum) ? @datetime : @datetime.send(method) if @datetime
+            @datetime.kind_of?(Numeric) ? @datetime : @datetime.send(method) if @datetime
           end
         end
 

--- a/actionpack/test/abstract/layouts_test.rb
+++ b/actionpack/test/abstract/layouts_test.rb
@@ -14,7 +14,10 @@ module AbstractControllerTests
         "layouts/overwrite.erb"         => "Overwrite <%= yield %>",
         "layouts/with_false_layout.erb" => "False Layout <%= yield %>",
         "abstract_controller_tests/layouts/with_string_implied_child.erb" =>
-                                           "With Implied <%= yield %>"
+                                           "With Implied <%= yield %>",
+        "abstract_controller_tests/layouts/with_grand_child_of_implied.erb" =>
+                                           "With Grand Child <%= yield %>"
+
       )]
     end
 
@@ -62,6 +65,10 @@ module AbstractControllerTests
     end
 
     class WithChildOfImplied < WithStringImpliedChild
+    end
+
+    class WithGrandChildOfImplied < WithStringImpliedChild
+      layout nil
     end
 
     class WithProc < Base
@@ -297,6 +304,13 @@ module AbstractControllerTests
           controller = WithChildOfImplied.new
           controller.process(:index)
           assert_equal "With Implied Hello string!", controller.response_body
+      end
+
+      test "when a grandchild has nil layout specified, the child has an implied layout, and the " \
+        "parent has specified a layout, use the child controller layout" do
+          controller = WithGrandChildOfImplied.new
+          controller.process(:index)
+          assert_equal "With Grand Child Hello string!", controller.response_body
       end
 
       test "raises an exception when specifying layout true" do

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -2132,6 +2132,18 @@ class DateHelperTest < ActionView::TestCase
     assert_dom_equal expected, datetime_select("post", "updated_at", { :date_separator => " / ", :datetime_separator => " , ", :time_separator => " - ", :include_seconds => true })
   end
 
+  def test_datetime_select_with_integer
+    @post = Post.new
+    @post.updated_at = 3
+    datetime_select("post", "updated_at")
+  end
+
+  def test_datetime_select_with_infinity # Float
+    @post = Post.new
+    @post.updated_at = (-1.0/0)
+    datetime_select("post", "updated_at")
+  end
+
   def test_datetime_select_with_default_prompt
     @post = Post.new
     @post.updated_at = nil

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -15,7 +15,7 @@ source 'https://rubygems.org'
 # To use Jbuilder templates for JSON
 # gem 'jbuilder'
 
-# Use unicorn as the web server
+# Use unicorn as the app server
 # gem 'unicorn'
 
 # Deploy with Capistrano


### PR DESCRIPTION
By accident I found that commit f29b4a02fddb71d15fe1ee5f58096699caf61916 (Add a test case for layout nil) exists only in 3-2-stable branch. I wrote simple script and compare commits between master & 3-2-stable.
It likes that at least these 4 changes are committed only in 3.2 but missed in master.
@josevalim, @carlosantoniodasilva, @bsodmike, they are really missed, aren't they?
