### PR TITLE
Fixed bug in ActiveRecord that caused classes to be quoted incorrectly

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -34,6 +34,7 @@ module ActiveRecord
         when Numeric    then value.to_s
         when Date, Time then "'#{quoted_date(value)}'"
         when Symbol     then "'#{quote_string(value.to_s)}'"
+        when Class      then "'#{value.to_s}'"
         else
           "'#{quote_string(YAML.dump(value))}'"
         end

--- a/activerecord/test/cases/connection_adapters/quoting_test.rb
+++ b/activerecord/test/cases/connection_adapters/quoting_test.rb
@@ -1,0 +1,11 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module Quoting
+      class QuotingTest < ActiveRecord::TestCase
+        def test_quoting_classes
+          assert_equal "'Object'", AbstractAdapter.new(nil).quote(Object)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I observed this behavior in rails 3.2.2 with ruby 1.9.3p125:

```
1.9.3p125 :001 > Challenge.where(:type => SpecialChallenge)
  Challenge Load (0.9ms)  SELECT "challenges".* FROM "challenges" WHERE "challenges"."type" = 'SpecialChallenge'
 => [] 
1.9.3p125 :002 > Challenge.where(:type => [SpecialChallenge])
  Challenge Load (0.4ms)  SELECT "challenges".* FROM "challenges" WHERE "challenges"."type" IN ('--- !ruby/class ''SpecialChallenge''
')
 => []
```

Clearly the second query is built incorrectly. I tracked it down to how classes are quoted when inside of arrays in AR. I believe this (previously unnoticed) behavior may be due to psych.

This pull request fixes the behavior so that the query is built correctly:

```
1.9.3p125 :001 > Challenge.where(:type => [SpecialChallenge])
  Challenge Load (1.7ms)  SELECT "challenges".* FROM "challenges" WHERE "challenges"."type" IN ('SpecialChallenge')
 => []
```
