### PR TITLE
Add separator argument to grouped_options_for_select

### DIFF
--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -474,13 +474,23 @@ module ActionView
       #
       # <b>Note:</b> Only the <tt><optgroup></tt> and <tt><option></tt> tags are returned, so you still have to
       # wrap the output in an appropriate <tt><select></tt> tag.
-      def grouped_options_for_select(grouped_options, selected_key = nil, prompt = nil)
+      def grouped_options_for_select(*args)
+        grouped_options = args.shift
+        options = args.extract_options!
+        selected_key, prompt = args
+        divider = options[:divider]
+
         body = "".html_safe
         body.safe_concat content_tag(:option, prompt, :value => "") if prompt
 
         grouped_options = grouped_options.sort if grouped_options.is_a?(Hash)
 
-        grouped_options.each do |label, container|
+        grouped_options.each do |container|
+          if divider
+            label, container = divider, container
+          else
+            label, container = container
+          end
           body.safe_concat content_tag(:optgroup, options_for_select(container, selected_key), :label => label)
         end
 

--- a/actionpack/test/template/form_options_helper_test.rb
+++ b/actionpack/test/template/form_options_helper_test.rb
@@ -296,6 +296,14 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_grouped_options_for_select_with_optional_divider
+    assert_dom_equal(
+      "<optgroup label=\"----------\"><option value=\"US\">US</option>\n<option value=\"Canada\">Canada</option></optgroup><optgroup label=\"----------\"><option value=\"GB\">GB</option>\n<option value=\"Germany\">Germany</option></optgroup>",
+
+      grouped_options_for_select([['US',"Canada"] , ["GB", "Germany"]], divider:"----------")
+    )
+  end
+
   def test_grouped_options_for_select_with_selected_and_prompt
     assert_dom_equal(
         "<option value=\"\">Choose a product...</option><optgroup label=\"Hats\"><option value=\"Baseball Cap\">Baseball Cap</option>\n<option selected=\"selected\" value=\"Cowboy Hat\">Cowboy Hat</option></optgroup>",


### PR DESCRIPTION
Added a separator argument to the method grouped_options_for_select if provided.

This is a common use case that people are often using optgroups for –– As a way of dividing options in a select.
