### PR TITLE
Active model serialization :include returning string keys

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -1,6 +1,5 @@
 require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/hash/slice'
-require 'active_support/core_ext/array/wrap'
 
 module ActiveModel
   # == Active Model Serialization
@@ -128,7 +127,7 @@ module ActiveModel
         return unless include = options[:include]
 
         unless include.is_a?(Hash)
-          include = Hash[Array.wrap(include).map { |n| n.is_a?(Hash) ? n.to_a.first : [n, {}] }]
+          include = Hash[Array(include).map { |n| n.is_a?(Hash) ? n.to_a.first : [n, {}] }]
         end
 
         include.each do |association, opts|

--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -9,7 +9,6 @@ module ActiveModel
   # A minimal implementation could be:
   #
   #   class Person
-  #
   #     include ActiveModel::Serialization
   #
   #     attr_accessor :name
@@ -17,7 +16,6 @@ module ActiveModel
   #     def attributes
   #       {'name' => nil}
   #     end
-  #
   #   end
   #
   # Which would provide you with:
@@ -41,7 +39,6 @@ module ActiveModel
   # So a minimal implementation including XML and JSON would be:
   #
   #   class Person
-  #
   #     include ActiveModel::Serializers::JSON
   #     include ActiveModel::Serializers::Xml
   #
@@ -50,7 +47,6 @@ module ActiveModel
   #     def attributes
   #       {'name' => nil}
   #     end
-  #
   #   end
   #
   # Which would provide you with:
@@ -124,13 +120,13 @@ module ActiveModel
       #   +records+     - the association record(s) to be serialized
       #   +opts+        - options for the association records
       def serializable_add_includes(options = {}) #:nodoc:
-        return unless include = options[:include]
+        return unless includes = options[:include]
 
-        unless include.is_a?(Hash)
-          include = Hash[Array(include).map { |n| n.is_a?(Hash) ? n.to_a.first : [n, {}] }]
+        unless includes.is_a?(Hash)
+          includes = Hash[Array(includes).map { |n| n.is_a?(Hash) ? n.to_a.first : [n, {}] }]
         end
 
-        include.each do |association, opts|
+        includes.each do |association, opts|
           if records = send(association)
             yield association, records, opts
           end

--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -2,7 +2,6 @@ require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/hash/slice'
 require 'active_support/core_ext/array/wrap'
 
-
 module ActiveModel
   # == Active Model Serialization
   #
@@ -88,7 +87,7 @@ module ActiveModel
       method_names.each { |n| hash[n.to_s] = send(n) }
 
       serializable_add_includes(options) do |association, records, opts|
-        hash[association] = if records.is_a?(Enumerable)
+        hash[association.to_s] = if records.is_a?(Enumerable)
           records.map { |a| a.serializable_hash(opts) }
         else
           records.serializable_hash(opts)

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -88,62 +88,62 @@ class SerializationTest < ActiveModel::TestCase
 
   def test_include_option_with_singular_association
     expected = {"name"=>"David", "gender"=>"male", "email"=>"david@example.com",
-                :address=>{"street"=>"123 Lane", "city"=>"Springfield", "state"=>"CA", "zip"=>11111}}
+                "address"=>{"street"=>"123 Lane", "city"=>"Springfield", "state"=>"CA", "zip"=>11111}}
     assert_equal expected, @user.serializable_hash(:include => :address)
   end
 
   def test_include_option_with_plural_association
     expected = {"email"=>"david@example.com", "gender"=>"male", "name"=>"David",
-                :friends=>[{"name"=>'Joe', "email"=>'joe@example.com', "gender"=>'male'},
+                "friends"=>[{"name"=>'Joe', "email"=>'joe@example.com', "gender"=>'male'},
                            {"name"=>'Sue', "email"=>'sue@example.com', "gender"=>'female'}]}
     assert_equal expected, @user.serializable_hash(:include => :friends)
   end
 
   def test_include_option_with_empty_association
     @user.friends = []
-    expected = {"email"=>"david@example.com", "gender"=>"male", "name"=>"David", :friends=>[]}
+    expected = {"email"=>"david@example.com", "gender"=>"male", "name"=>"David", "friends"=>[]}
     assert_equal expected, @user.serializable_hash(:include => :friends)
   end
 
   def test_multiple_includes
     expected = {"email"=>"david@example.com", "gender"=>"male", "name"=>"David",
-                :address=>{"street"=>"123 Lane", "city"=>"Springfield", "state"=>"CA", "zip"=>11111},
-                :friends=>[{"name"=>'Joe', "email"=>'joe@example.com', "gender"=>'male'},
+                "address"=>{"street"=>"123 Lane", "city"=>"Springfield", "state"=>"CA", "zip"=>11111},
+                "friends"=>[{"name"=>'Joe', "email"=>'joe@example.com', "gender"=>'male'},
                            {"name"=>'Sue', "email"=>'sue@example.com', "gender"=>'female'}]}
     assert_equal expected, @user.serializable_hash(:include => [:address, :friends])
   end
 
   def test_include_with_options
     expected = {"email"=>"david@example.com", "gender"=>"male", "name"=>"David",
-                :address=>{"street"=>"123 Lane"}}
+                "address"=>{"street"=>"123 Lane"}}
     assert_equal expected, @user.serializable_hash(:include => {:address => {:only => "street"}})
   end
 
   def test_nested_include
     @user.friends.first.friends = [@user]
     expected = {"email"=>"david@example.com", "gender"=>"male", "name"=>"David",
-                :friends=>[{"name"=>'Joe', "email"=>'joe@example.com', "gender"=>'male',
-                            :friends => [{"email"=>"david@example.com", "gender"=>"male", "name"=>"David"}]},
-                            {"name"=>'Sue', "email"=>'sue@example.com', "gender"=>'female', :friends => []}]}
+                "friends"=>[{"name"=>'Joe', "email"=>'joe@example.com', "gender"=>'male',
+                            "friends"=> [{"email"=>"david@example.com", "gender"=>"male", "name"=>"David"}]},
+                            {"name"=>'Sue', "email"=>'sue@example.com', "gender"=>'female', "friends"=> []}]}
     assert_equal expected, @user.serializable_hash(:include => {:friends => {:include => :friends}})
   end
 
   def test_only_include
-    expected = {"name"=>"David", :friends => [{"name" => "Joe"}, {"name" => "Sue"}]}
+    expected = {"name"=>"David", "friends" => [{"name" => "Joe"}, {"name" => "Sue"}]}
     assert_equal expected, @user.serializable_hash(:only => :name, :include => {:friends => {:only => :name}})
   end
 
   def test_except_include
     expected = {"name"=>"David", "email"=>"david@example.com",
-                :friends => [{"name" => 'Joe', "email" => 'joe@example.com'},
+                "friends"=> [{"name" => 'Joe', "email" => 'joe@example.com'},
                              {"name" => "Sue", "email" => 'sue@example.com'}]}
     assert_equal expected, @user.serializable_hash(:except => :gender, :include => {:friends => {:except => :gender}})
   end
 
   def test_multiple_includes_with_options
     expected = {"email"=>"david@example.com", "gender"=>"male", "name"=>"David",
-                :address=>{"street"=>"123 Lane"},
-                :friends=>[{"name"=>'Joe', "email"=>'joe@example.com', "gender"=>'male'},
+                "address"=>{"street"=>"123 Lane"},
+                "friends"=>[{"name"=>'Joe', "email"=>'joe@example.com', "gender"=>'male'},
                            {"name"=>'Sue', "email"=>'sue@example.com', "gender"=>'female'}]}
     assert_equal expected, @user.serializable_hash(:include => [{:address => {:only => "street"}}, :friends])
   end


### PR DESCRIPTION
Some time ago [this was fixed related to the `:methods` option](https://github.com/rails/rails/commit/ad9f968c4a4639bdc5e0a6e71189a1756c959ca3), now I noticed the same issue with `:include`. To make the api more consistent, this changes it to return string keys as well.

It also removes the usage of `Array#wrap` in serialization module.
