### PR TITLE
Fixes #5324 by removing default size options from input:text and default cols and rows options from textarea.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Removed default `size` option from the `text_field`, `search_field`, `telephone_field`, `url_field`, `email_field` helpers. *Philip Arndt*
+
+*   Removed default `cols` and `rows` options from the `text_area` helper. *Philip Arndt*
+
 *   Adds support for layouts when rendering a partial with a given collection. *serabe*
 
 *   Allows the route helper `root` to take a string argument. For example, `root 'pages#main'`. *bcardarella*

--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -757,7 +757,7 @@ module ActionView
       #   #    </textarea>
       #
       #   text_area(:application, :notes, :cols => 40, :rows => 15, :class => 'app_input')
-      #   # => <textarea rows="15" id="application_notes" name="application[notes]" class="app_input">
+      #   # => <textarea cols="40" rows="15" id="application_notes" name="application[notes]" class="app_input">
       #   #      #{@application.notes}
       #   #    </textarea>
       #

--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -45,10 +45,10 @@ module ActionView
     #       <input name="authenticity_token" type="hidden" value="NrOp5bsjoLRuK8IW5+dQEYjKGUJDe7TQoZVvq95Wteg=" />
     #     </div>
     #     <label for="person_first_name">First name</label>:
-    #     <input id="person_first_name" name="person[first_name]" size="30" type="text" /><br />
+    #     <input id="person_first_name" name="person[first_name]" type="text" /><br />
     #
     #     <label for="person_last_name">Last name</label>:
-    #     <input id="person_last_name" name="person[last_name]" size="30" type="text" /><br />
+    #     <input id="person_last_name" name="person[last_name]" type="text" /><br />
     #
     #     <input name="commit" type="submit" value="Create Person" />
     #   </form>
@@ -76,10 +76,10 @@ module ActionView
     #       <input name="authenticity_token" type="hidden" value="NrOp5bsjoLRuK8IW5+dQEYjKGUJDe7TQoZVvq95Wteg=" />
     #     </div>
     #     <label for="person_first_name">First name</label>:
-    #     <input id="person_first_name" name="person[first_name]" size="30" type="text" value="John" /><br />
+    #     <input id="person_first_name" name="person[first_name]" type="text" value="John" /><br />
     #
     #     <label for="person_last_name">Last name</label>:
-    #     <input id="person_last_name" name="person[last_name]" size="30" type="text" value="Smith" /><br />
+    #     <input id="person_last_name" name="person[last_name]" type="text" value="Smith" /><br />
     #
     #     <input name="commit" type="submit" value="Update Person" />
     #   </form>
@@ -757,7 +757,7 @@ module ActionView
       #   #    </textarea>
       #
       #   text_area(:application, :notes, :cols => 40, :rows => 15, :class => 'app_input')
-      #   # => <textarea cols="40" rows="15" id="application_notes" name="application[notes]" class="app_input">
+      #   # => <textarea rows="15" id="application_notes" name="application[notes]" class="app_input">
       #   #      #{@application.notes}
       #   #    </textarea>
       #
@@ -860,20 +860,20 @@ module ActionView
       # ==== Examples
       #
       #   search_field(:user, :name)
-      #   # => <input id="user_name" name="user[name]" size="30" type="search" />
+      #   # => <input id="user_name" name="user[name]" type="search" />
       #   search_field(:user, :name, :autosave => false)
-      #   # => <input autosave="false" id="user_name" name="user[name]" size="30" type="search" />
+      #   # => <input autosave="false" id="user_name" name="user[name]" type="search" />
       #   search_field(:user, :name, :results => 3)
-      #   # => <input id="user_name" name="user[name]" results="3" size="30" type="search" />
+      #   # => <input id="user_name" name="user[name]" results="3" type="search" />
       #   #  Assume request.host returns "www.example.com"
       #   search_field(:user, :name, :autosave => true)
-      #   # => <input autosave="com.example.www" id="user_name" name="user[name]" results="10" size="30" type="search" />
+      #   # => <input autosave="com.example.www" id="user_name" name="user[name]" results="10" type="search" />
       #   search_field(:user, :name, :onsearch => true)
-      #   # => <input id="user_name" incremental="true" name="user[name]" onsearch="true" size="30" type="search" />
+      #   # => <input id="user_name" incremental="true" name="user[name]" onsearch="true" type="search" />
       #   search_field(:user, :name, :autosave => false, :onsearch => true)
-      #   # => <input autosave="false" id="user_name" incremental="true" name="user[name]" onsearch="true" size="30" type="search" />
+      #   # => <input autosave="false" id="user_name" incremental="true" name="user[name]" onsearch="true" type="search" />
       #   search_field(:user, :name, :autosave => true, :onsearch => true)
-      #   # => <input autosave="com.example.www" id="user_name" incremental="true" name="user[name]" onsearch="true" results="10" size="30" type="search" />
+      #   # => <input autosave="com.example.www" id="user_name" incremental="true" name="user[name]" onsearch="true" results="10" type="search" />
       #
       def search_field(object_name, method, options = {})
         Tags::SearchField.new(object_name, method, self, options).render
@@ -882,7 +882,7 @@ module ActionView
       # Returns a text_field of type "tel".
       #
       #   telephone_field("user", "phone")
-      #   # => <input id="user_phone" name="user[phone]" size="30" type="tel" />
+      #   # => <input id="user_phone" name="user[phone]" type="tel" />
       #
       def telephone_field(object_name, method, options = {})
         Tags::TelField.new(object_name, method, self, options).render
@@ -910,7 +910,7 @@ module ActionView
       # Returns a text_field of type "url".
       #
       #   url_field("user", "homepage")
-      #   # => <input id="user_homepage" size="30" name="user[homepage]" type="url" />
+      #   # => <input id="user_homepage" name="user[homepage]" type="url" />
       #
       def url_field(object_name, method, options = {})
         Tags::UrlField.new(object_name, method, self, options).render
@@ -919,7 +919,7 @@ module ActionView
       # Returns a text_field of type "email".
       #
       #   email_field("user", "address")
-      #   # => <input id="user_address" size="30" name="user[address]" type="email" />
+      #   # => <input id="user_address" name="user[address]" type="email" />
       #
       def email_field(object_name, method, options = {})
         Tags::EmailField.new(object_name, method, self, options).render

--- a/actionpack/lib/action_view/helpers/tags/base.rb
+++ b/actionpack/lib/action_view/helpers/tags/base.rb
@@ -5,8 +5,6 @@ module ActionView
         include Helpers::ActiveModelInstanceTag, Helpers::TagHelper, Helpers::FormTagHelper
         include FormOptionsHelper
 
-        DEFAULT_FIELD_OPTIONS = { "size" => 30 }
-
         attr_reader :object
 
         def initialize(object_name, method_name, template_object, options = {})

--- a/actionpack/lib/action_view/helpers/tags/text_area.rb
+++ b/actionpack/lib/action_view/helpers/tags/text_area.rb
@@ -2,10 +2,8 @@ module ActionView
   module Helpers
     module Tags
       class TextArea < Base #:nodoc:
-        DEFAULT_TEXT_AREA_OPTIONS = { "cols" => 40, "rows" => 20 }
-
         def render
-          options = DEFAULT_TEXT_AREA_OPTIONS.merge(@options.stringify_keys)
+          options = @options.stringify_keys
           add_default_name_and_id(options)
 
           if size = options.delete("size")

--- a/actionpack/lib/action_view/helpers/tags/text_field.rb
+++ b/actionpack/lib/action_view/helpers/tags/text_field.rb
@@ -4,8 +4,7 @@ module ActionView
       class TextField < Base #:nodoc:
         def render
           options = @options.stringify_keys
-          options["size"] = options["maxlength"] || DEFAULT_FIELD_OPTIONS["size"] unless options.key?("size")
-          options = DEFAULT_FIELD_OPTIONS.merge(options)
+          options["size"] = options["maxlength"] unless options.key?("size")
           options["type"]  ||= field_type
           options["value"] = options.fetch("value"){ value_before_type_cast(object) } unless field_type == "file"
           options["value"] &&= ERB::Util.html_escape(options["value"])

--- a/actionpack/test/template/active_model_helper_test.rb
+++ b/actionpack/test/template/active_model_helper_test.rb
@@ -29,14 +29,14 @@ class ActiveModelHelperTest < ActionView::TestCase
 
   def test_text_area_with_errors
     assert_dom_equal(
-      %(<div class="field_with_errors"><textarea cols="40" id="post_body" name="post[body]" rows="20">\nBack to the hill and over it again!</textarea></div>),
+      %(<div class="field_with_errors"><textarea id="post_body" name="post[body]">\nBack to the hill and over it again!</textarea></div>),
       text_area("post", "body")
     )
   end
 
   def test_text_field_with_errors
     assert_dom_equal(
-      %(<div class="field_with_errors"><input id="post_author_name" name="post[author_name]" size="30" type="text" value="" /></div>),
+      %(<div class="field_with_errors"><input id="post_author_name" name="post[author_name]" type="text" value="" /></div>),
       text_field("post", "author_name")
     )
   end
@@ -76,7 +76,7 @@ class ActiveModelHelperTest < ActionView::TestCase
     end
 
     assert_dom_equal(
-      %(<div class="field_with_errors"><input id="post_author_name" name="post[author_name]" size="30" type="text" value="" /> <span class="error">can't be empty</span></div>),
+      %(<div class="field_with_errors"><input id="post_author_name" name="post[author_name]" type="text" value="" /> <span class="error">can't be empty</span></div>),
       text_field("post", "author_name")
     )
   ensure

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -249,35 +249,35 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_label_with_block_in_erb
-    assert_equal "<label for=\"post_message\">\n  Message\n  <input id=\"post_message\" name=\"post[message]\" size=\"30\" type=\"text\" />\n</label>", view.render("test/label_with_block")
+    assert_equal "<label for=\"post_message\">\n  Message\n  <input id=\"post_message\" name=\"post[message]\" type=\"text\" />\n</label>", view.render("test/label_with_block")
   end
 
   def test_text_field
     assert_dom_equal(
-      '<input id="post_title" name="post[title]" size="30" type="text" value="Hello World" />', text_field("post", "title")
+      '<input id="post_title" name="post[title]" type="text" value="Hello World" />', text_field("post", "title")
     )
     assert_dom_equal(
-      '<input id="post_title" name="post[title]" size="30" type="password" />', password_field("post", "title")
+      '<input id="post_title" name="post[title]" type="password" />', password_field("post", "title")
     )
     assert_dom_equal(
-      '<input id="post_title" name="post[title]" size="30" type="password" value="Hello World" />', password_field("post", "title", :value => @post.title)
+      '<input id="post_title" name="post[title]" type="password" value="Hello World" />', password_field("post", "title", :value => @post.title)
     )
     assert_dom_equal(
-      '<input id="person_name" name="person[name]" size="30" type="password" />', password_field("person", "name")
+      '<input id="person_name" name="person[name]" type="password" />', password_field("person", "name")
     )
   end
 
   def test_text_field_with_escapes
     @post.title = "<b>Hello World</b>"
     assert_dom_equal(
-      '<input id="post_title" name="post[title]" size="30" type="text" value="&lt;b&gt;Hello World&lt;/b&gt;" />', text_field("post", "title")
+      '<input id="post_title" name="post[title]" type="text" value="&lt;b&gt;Hello World&lt;/b&gt;" />', text_field("post", "title")
     )
   end
 
   def test_text_field_with_html_entities
     @post.title = "The HTML Entity for & is &amp;"
     assert_dom_equal(
-      '<input id="post_title" name="post[title]" size="30" type="text" value="The HTML Entity for &amp; is &amp;amp;" />',
+      '<input id="post_title" name="post[title]" type="text" value="The HTML Entity for &amp; is &amp;amp;" />',
       text_field("post", "title")
     )
   end
@@ -301,18 +301,18 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_text_field_with_nil_value
-    expected = '<input id="post_title" name="post[title]" size="30" type="text" />'
+    expected = '<input id="post_title" name="post[title]" type="text" />'
     assert_dom_equal expected, text_field("post", "title", :value => nil)
   end
 
   def test_text_field_with_nil_name
-    expected = '<input id="post_title" size="30" type="text" value="Hello World" />'
+    expected = '<input id="post_title" type="text" value="Hello World" />'
     assert_dom_equal expected, text_field("post", "title", :name => nil)
   end
 
   def test_text_field_doesnt_change_param_values
     object_name = 'post[]'
-    expected = '<input id="post_123_title" name="post[123][title]" size="30" type="text" value="Hello World" />'
+    expected = '<input id="post_123_title" name="post[123][title]" type="text" value="Hello World" />'
     assert_equal expected, text_field(object_name, "title")
     assert_equal object_name, "post[]"
   end
@@ -346,7 +346,7 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_text_field_with_custom_type
-    assert_dom_equal '<input id="user_email" size="30" name="user[email]" type="email" />',
+    assert_dom_equal '<input id="user_email" name="user[email]" type="email" />',
       text_field("user", "email", :type => "email")
   end
 
@@ -474,7 +474,7 @@ class FormHelperTest < ActionView::TestCase
 
   def test_text_area
     assert_dom_equal(
-      %{<textarea cols="40" id="post_body" name="post[body]" rows="20">\nBack to the hill and over it again!</textarea>},
+      %{<textarea id="post_body" name="post[body]">\nBack to the hill and over it again!</textarea>},
       text_area("post", "body")
     )
   end
@@ -482,14 +482,14 @@ class FormHelperTest < ActionView::TestCase
   def test_text_area_with_escapes
     @post.body        = "Back to <i>the</i> hill and over it again!"
     assert_dom_equal(
-      %{<textarea cols="40" id="post_body" name="post[body]" rows="20">\nBack to &lt;i&gt;the&lt;/i&gt; hill and over it again!</textarea>},
+      %{<textarea id="post_body" name="post[body]">\nBack to &lt;i&gt;the&lt;/i&gt; hill and over it again!</textarea>},
       text_area("post", "body")
     )
   end
 
   def test_text_area_with_alternate_value
     assert_dom_equal(
-      %{<textarea cols="40" id="post_body" name="post[body]" rows="20">\nTesting alternate values.</textarea>},
+      %{<textarea id="post_body" name="post[body]">\nTesting alternate values.</textarea>},
       text_area("post", "body", :value => 'Testing alternate values.')
     )
   end
@@ -497,7 +497,7 @@ class FormHelperTest < ActionView::TestCase
   def test_text_area_with_html_entities
     @post.body        = "The HTML Entity for & is &amp;"
     assert_dom_equal(
-      %{<textarea cols="40" id="post_body" name="post[body]" rows="20">\nThe HTML Entity for &amp; is &amp;amp;</textarea>},
+      %{<textarea id="post_body" name="post[body]">\nThe HTML Entity for &amp; is &amp;amp;</textarea>},
       text_area("post", "body")
     )
   end
@@ -510,12 +510,12 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_search_field
-    expected = %{<input id="contact_notes_query" size="30" name="contact[notes_query]" type="search" />}
+    expected = %{<input id="contact_notes_query" name="contact[notes_query]" type="search" />}
     assert_dom_equal(expected, search_field("contact", "notes_query"))
   end
 
   def test_telephone_field
-    expected = %{<input id="user_cell" size="30" name="user[cell]" type="tel" />}
+    expected = %{<input id="user_cell" name="user[cell]" type="tel" />}
     assert_dom_equal(expected, telephone_field("user", "cell"))
   end
 
@@ -546,12 +546,12 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_url_field
-    expected = %{<input id="user_homepage" size="30" name="user[homepage]" type="url" />}
+    expected = %{<input id="user_homepage" name="user[homepage]" type="url" />}
     assert_dom_equal(expected, url_field("user", "homepage"))
   end
 
   def test_email_field
-    expected = %{<input id="user_address" size="30" name="user[address]" type="email" />}
+    expected = %{<input id="user_address" name="user[address]" type="email" />}
     assert_dom_equal(expected, email_field("user", "address"))
   end
 
@@ -571,10 +571,10 @@ class FormHelperTest < ActionView::TestCase
 
   def test_explicit_name
     assert_dom_equal(
-      '<input id="post_title" name="dont guess" size="30" type="text" value="Hello World" />', text_field("post", "title", "name" => "dont guess")
+      '<input id="post_title" name="dont guess" type="text" value="Hello World" />', text_field("post", "title", "name" => "dont guess")
     )
     assert_dom_equal(
-      %{<textarea cols="40" id="post_body" name="really!" rows="20">\nBack to the hill and over it again!</textarea>},
+      %{<textarea id="post_body" name="really!">\nBack to the hill and over it again!</textarea>},
       text_area("post", "body", "name" => "really!")
     )
     assert_dom_equal(
@@ -591,10 +591,10 @@ class FormHelperTest < ActionView::TestCase
 
   def test_explicit_id
     assert_dom_equal(
-      '<input id="dont guess" name="post[title]" size="30" type="text" value="Hello World" />', text_field("post", "title", "id" => "dont guess")
+      '<input id="dont guess" name="post[title]" type="text" value="Hello World" />', text_field("post", "title", "id" => "dont guess")
     )
     assert_dom_equal(
-      %{<textarea cols="40" id="really!" name="post[body]" rows="20">\nBack to the hill and over it again!</textarea>},
+      %{<textarea id="really!" name="post[body]">\nBack to the hill and over it again!</textarea>},
       text_area("post", "body", "id" => "really!")
     )
     assert_dom_equal(
@@ -611,10 +611,10 @@ class FormHelperTest < ActionView::TestCase
 
   def test_nil_id
     assert_dom_equal(
-      '<input name="post[title]" size="30" type="text" value="Hello World" />', text_field("post", "title", "id" => nil)
+      '<input name="post[title]" type="text" value="Hello World" />', text_field("post", "title", "id" => nil)
     )
     assert_dom_equal(
-      %{<textarea cols="40" name="post[body]" rows="20">\nBack to the hill and over it again!</textarea>},
+      %{<textarea name="post[body]">\nBack to the hill and over it again!</textarea>},
       text_area("post", "body", "id" => nil)
     )
     assert_dom_equal(
@@ -641,11 +641,11 @@ class FormHelperTest < ActionView::TestCase
 
   def test_index
     assert_dom_equal(
-      '<input name="post[5][title]" size="30" id="post_5_title" type="text" value="Hello World" />',
+      '<input name="post[5][title]" id="post_5_title" type="text" value="Hello World" />',
       text_field("post", "title", "index" => 5)
     )
     assert_dom_equal(
-      %{<textarea cols="40" name="post[5][body]" id="post_5_body" rows="20">\nBack to the hill and over it again!</textarea>},
+      %{<textarea name="post[5][body]" id="post_5_body">\nBack to the hill and over it again!</textarea>},
       text_area("post", "body", "index" => 5)
     )
     assert_dom_equal(
@@ -668,11 +668,11 @@ class FormHelperTest < ActionView::TestCase
 
   def test_index_with_nil_id
     assert_dom_equal(
-      '<input name="post[5][title]" size="30" type="text" value="Hello World" />',
+      '<input name="post[5][title]" type="text" value="Hello World" />',
       text_field("post", "title", "index" => 5, 'id' => nil)
     )
     assert_dom_equal(
-      %{<textarea cols="40" name="post[5][body]" rows="20">\nBack to the hill and over it again!</textarea>},
+      %{<textarea name="post[5][body]">\nBack to the hill and over it again!</textarea>},
       text_area("post", "body", "index" => 5, 'id' => nil)
     )
     assert_dom_equal(
@@ -700,10 +700,10 @@ class FormHelperTest < ActionView::TestCase
       label("post[]", "title")
     )
     assert_dom_equal(
-      "<input id=\"post_#{pid}_title\" name=\"post[#{pid}][title]\" size=\"30\" type=\"text\" value=\"Hello World\" />", text_field("post[]","title")
+      "<input id=\"post_#{pid}_title\" name=\"post[#{pid}][title]\" type=\"text\" value=\"Hello World\" />", text_field("post[]","title")
     )
     assert_dom_equal(
-      "<textarea cols=\"40\" id=\"post_#{pid}_body\" name=\"post[#{pid}][body]\" rows=\"20\">\nBack to the hill and over it again!</textarea>",
+      "<textarea id=\"post_#{pid}_body\" name=\"post[#{pid}][body]\">\nBack to the hill and over it again!</textarea>",
       text_area("post[]", "body")
     )
     assert_dom_equal(
@@ -722,11 +722,11 @@ class FormHelperTest < ActionView::TestCase
   def test_auto_index_with_nil_id
     pid = 123
     assert_dom_equal(
-      "<input name=\"post[#{pid}][title]\" size=\"30\" type=\"text\" value=\"Hello World\" />",
+      "<input name=\"post[#{pid}][title]\" type=\"text\" value=\"Hello World\" />",
       text_field("post[]","title", :id => nil)
     )
     assert_dom_equal(
-      "<textarea cols=\"40\" name=\"post[#{pid}][body]\" rows=\"20\">\nBack to the hill and over it again!</textarea>",
+      "<textarea name=\"post[#{pid}][body]\">\nBack to the hill and over it again!</textarea>",
       text_area("post[]", "body", :id => nil)
     )
     assert_dom_equal(
@@ -760,8 +760,8 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form("/posts/123", "create-post" , "edit_post", :method => 'patch') do
       "<label for='post_title'>The Title</label>" +
-      "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
+      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" +
+      "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />" +
       "<input name='commit' type='submit' value='Create post' />" +
@@ -859,7 +859,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/44", "edit_post_44" , "edit_post", :method => 'patch') do
-      "<input name='post[title]' size='30' type='text' id='post_title' value='And his name will be forty and four.' />" +
+      "<input name='post[title]' type='text' id='post_title' value='And his name will be forty and four.' />" +
       "<input name='commit' type='submit' value='Edit post' />"
     end
 
@@ -877,8 +877,8 @@ class FormHelperTest < ActionView::TestCase
 
     expected =  whole_form("/posts/123", "create-post", "edit_other_name", :method => 'patch') do
       "<label for='other_name_title' class='post_title'>Title</label>" +
-      "<input name='other_name[title]' size='30' id='other_name_title' value='Hello World' type='text' />" +
-      "<textarea name='other_name[body]' id='other_name_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
+      "<input name='other_name[title]' id='other_name_title' value='Hello World' type='text' />" +
+      "<textarea name='other_name[body]' id='other_name_body'>\nBack to the hill and over it again!</textarea>" +
       "<input name='other_name[secret]' value='0' type='hidden' />" +
       "<input name='other_name[secret]' checked='checked' id='other_name_secret' value='1' type='checkbox' />" +
       "<input name='commit' value='Create post' type='submit' />"
@@ -895,8 +895,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected =  whole_form("/", "create-post", "edit_post", "delete") do
-      "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
+      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" +
+      "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
@@ -912,8 +912,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected =  whole_form("/", "create-post", "edit_post", "delete") do
-      "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
+      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" +
+      "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
@@ -929,7 +929,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected =  whole_form("/search", "search-post", "new_post", "get") do
-      "<input name='post[title]' size='30' type='search' id='post_title' />"
+      "<input name='post[title]' type='search' id='post_title' />"
     end
 
     assert_dom_equal expected, output_buffer
@@ -943,8 +943,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected =  whole_form("/", "create-post", "edit_post", :method => 'patch', :remote => true) do
-      "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
+      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" +
+      "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
@@ -960,8 +960,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected =  whole_form("/", "create-post", "edit_post", :method => 'patch', :remote => true) do
-      "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
+      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" +
+      "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
@@ -979,8 +979,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected =  whole_form("/posts", 'new_post', 'new_post', :remote => true) do
-      "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
+      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" +
+      "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
@@ -996,8 +996,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/", "create-post") do
-      "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
+      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" +
+      "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
@@ -1015,8 +1015,8 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form('/posts/123', 'edit_post[]', 'edit_post[]', 'patch') do
       "<label for='post_123_title'>Title</label>" +
-      "<input name='post[123][title]' size='30' type='text' id='post_123_title' value='Hello World' />" +
-      "<textarea name='post[123][body]' id='post_123_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
+      "<input name='post[123][title]' type='text' id='post_123_title' value='Hello World' />" +
+      "<textarea name='post[123][body]' id='post_123_body'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[123][secret]' type='hidden' value='0' />" +
       "<input name='post[123][secret]' checked='checked' type='checkbox' id='post_123_secret' value='1' />"
     end
@@ -1032,8 +1032,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post[]', 'edit_post[]', 'patch') do
-      "<input name='post[][title]' size='30' type='text' id='post__title' value='Hello World' />" +
-      "<textarea name='post[][body]' id='post__body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
+      "<input name='post[][title]' type='text' id='post__title' value='Hello World' />" +
+      "<textarea name='post[][body]' id='post__body'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[][secret]' type='hidden' value='0' />" +
       "<input name='post[][secret]' checked='checked' type='checkbox' id='post__secret' value='1' />"
     end
@@ -1049,8 +1049,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'namespace_edit_post_123', 'edit_post', 'patch') do
-      "<input name='post[title]' size='30' type='text' id='namespace_post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='namespace_post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
+      "<input name='post[title]' type='text' id='namespace_post_title' value='Hello World' />" +
+      "<textarea name='post[body]' id='namespace_post_body'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='namespace_post_secret' value='1' />"
     end
@@ -1066,7 +1066,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form('/posts/123', 'namespace_edit_post_123', 'edit_post', 'patch') do
       "<label for='namespace_post_title'>Title</label>" +
-      "<input name='post[title]' size='30' type='text' id='namespace_post_title' value='Hello World' />"
+      "<input name='post[title]' type='text' id='namespace_post_title' value='Hello World' />"
     end
 
     assert_dom_equal expected, output_buffer
@@ -1080,7 +1080,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected_1 = whole_form('/posts/123', 'namespace_1_edit_post_123', 'edit_post', 'patch') do
       "<label for='namespace_1_post_title'>Title</label>" +
-      "<input name='post[title]' size='30' type='text' id='namespace_1_post_title' value='Hello World' />"
+      "<input name='post[title]' type='text' id='namespace_1_post_title' value='Hello World' />"
     end
 
     assert_dom_equal expected_1, output_buffer
@@ -1092,7 +1092,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected_2 = whole_form('/posts/123', 'namespace_2_edit_post_123', 'edit_post', 'patch') do
       "<label for='namespace_2_post_title'>Title</label>" +
-      "<input name='post[title]' size='30' type='text' id='namespace_2_post_title' value='Hello World' />"
+      "<input name='post[title]' type='text' id='namespace_2_post_title' value='Hello World' />"
     end
 
     assert_dom_equal expected_2, output_buffer
@@ -1109,9 +1109,9 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'namespace_edit_post_123', 'edit_post', 'patch') do
-      "<input name='post[title]' size='30' type='text' id='namespace_post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='namespace_post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
-      "<input name='post[comment][body]' size='30' type='text' id='namespace_post_comment_body' value='Hello World' />"
+      "<input name='post[title]' type='text' id='namespace_post_title' value='Hello World' />" +
+      "<textarea name='post[body]' id='namespace_post_body'>\nBack to the hill and over it again!</textarea>" +
+      "<input name='post[comment][body]' type='text' id='namespace_post_comment_body' value='Hello World' />"
     end
 
     assert_dom_equal expected, output_buffer
@@ -1192,7 +1192,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      "<input name='post[comment][body]' size='30' type='text' id='post_comment_body' value='Hello World' />"
+      "<input name='post[comment][body]' type='text' id='post_comment_body' value='Hello World' />"
     end
 
     assert_dom_equal expected, output_buffer
@@ -1207,8 +1207,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post[]', 'edit_post[]', 'patch') do
-      "<input name='post[123][title]' size='30' type='text' id='post_123_title' value='Hello World' />" +
-      "<input name='post[123][comment][][name]' size='30' type='text' id='post_123_comment__name' value='new comment' />"
+      "<input name='post[123][title]' type='text' id='post_123_title' value='Hello World' />" +
+      "<input name='post[123][comment][][name]' type='text' id='post_123_comment__name' value='new comment' />"
     end
 
     assert_dom_equal expected, output_buffer
@@ -1223,8 +1223,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', 'patch') do
-      "<input name='post[1][title]' size='30' type='text' id='post_1_title' value='Hello World' />" +
-      "<input name='post[1][comment][1][name]' size='30' type='text' id='post_1_comment_1_name' value='new comment' />"
+      "<input name='post[1][title]' type='text' id='post_1_title' value='Hello World' />" +
+      "<input name='post[1][comment][1][name]' type='text' id='post_1_comment_1_name' value='new comment' />"
     end
 
     assert_dom_equal expected, output_buffer
@@ -1238,7 +1238,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', 'patch') do
-      "<input name='post[1][comment][title]' size='30' type='text' id='post_1_comment_title' value='Hello World' />"
+      "<input name='post[1][comment][title]' type='text' id='post_1_comment_title' value='Hello World' />"
     end
 
     assert_dom_equal expected, output_buffer
@@ -1252,7 +1252,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', 'patch') do
-      "<input name='post[1][comment][5][title]' size='30' type='text' id='post_1_comment_5_title' value='Hello World' />"
+      "<input name='post[1][comment][5][title]' type='text' id='post_1_comment_5_title' value='Hello World' />"
     end
 
     assert_dom_equal expected, output_buffer
@@ -1266,7 +1266,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post[]', 'edit_post[]', 'patch') do
-      "<input name='post[123][comment][title]' size='30' type='text' id='post_123_comment_title' value='Hello World' />"
+      "<input name='post[123][comment][title]' type='text' id='post_123_comment_title' value='Hello World' />"
     end
 
     assert_dom_equal expected, output_buffer
@@ -1294,7 +1294,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post[]', 'edit_post[]', 'patch') do
-      "<input name='post[123][comment][123][title]' size='30' type='text' id='post_123_comment_123_title' value='Hello World' />"
+      "<input name='post[123][comment][123][title]' type='text' id='post_123_comment_123_title' value='Hello World' />"
     end
 
     assert_dom_equal expected, output_buffer
@@ -1314,9 +1314,9 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post[]', 'edit_post[]', 'patch') do
-      "<input name='post[123][comment][5][title]' size='30' type='text' id='post_123_comment_5_title' value='Hello World' />"
+      "<input name='post[123][comment][5][title]' type='text' id='post_123_comment_5_title' value='Hello World' />"
     end + whole_form('/posts/123', 'edit_post', 'edit_post', 'patch') do
-      "<input name='post[1][comment][123][title]' size='30' type='text' id='post_1_comment_123_title' value='Hello World' />"
+      "<input name='post[1][comment][123][title]' type='text' id='post_1_comment_123_title' value='Hello World' />"
     end
 
     assert_dom_equal expected, output_buffer
@@ -1333,8 +1333,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
-        '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="new author" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' +
+        '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="new author" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1360,8 +1360,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-     '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
-     '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="author #321" />' +
+     '<input name="post[title]" type="text" id="post_title" value="Hello World" />' +
+     '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />' +
      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" />'
    end
 
@@ -1379,8 +1379,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
-      '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="author #321" />' +
+      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' +
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />' +
       '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" />'
     end
 
@@ -1398,8 +1398,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
-      '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="author #321" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' +
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1416,8 +1416,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
-      '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="author #321" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' +
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1434,8 +1434,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
-      '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="author #321" />' +
+      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' +
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />' +
       '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" />'
     end
 
@@ -1454,9 +1454,9 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
+      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' +
       '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" />' +
-      '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="author #321" />'
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1475,10 +1475,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #1" />' +
+      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' +
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' +
       '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" />' +
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" size="30" type="text" value="comment #2" />' +
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />' +
       '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" />'
     end
 
@@ -1502,11 +1502,11 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
-      '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="author #321" />' +
+      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' +
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />' +
       '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" />' +
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #1" />' +
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" size="30" type="text" value="comment #2" />'
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' +
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1529,10 +1529,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
-      '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="author #321" />' +
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #1" />' +
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" size="30" type="text" value="comment #2" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' +
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />' +
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' +
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1555,11 +1555,11 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
-      '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="author #321" />' +
+      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' +
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />' +
       '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" />' +
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #1" />' +
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" size="30" type="text" value="comment #2" />'
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' +
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1578,10 +1578,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #1" />' +
+      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' +
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' +
       '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" />' +
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" size="30" type="text" value="comment #2" />' +
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />' +
       '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" />'
     end
 
@@ -1602,11 +1602,11 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
+      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' +
       '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" />' +
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #1" />' +
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' +
       '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" />' +
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" size="30" type="text" value="comment #2" />'
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1625,9 +1625,9 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="new comment" />' +
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" size="30" type="text" value="new comment" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' +
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="new comment" />' +
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="new comment" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1646,10 +1646,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #321" />' +
+      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' +
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #321" />' +
       '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="321" />' +
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" size="30" type="text" value="new comment" />'
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="new comment" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1664,7 +1664,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1681,10 +1681,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #1" />' +
+      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' +
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' +
       '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" />' +
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" size="30" type="text" value="comment #2" />' +
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />' +
       '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" />'
     end
 
@@ -1702,10 +1702,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #1" />' +
+      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' +
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' +
       '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" />' +
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" size="30" type="text" value="comment #2" />' +
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />' +
       '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" />'
     end
 
@@ -1724,10 +1724,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #1" />' +
+      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' +
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' +
       '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" />' +
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" size="30" type="text" value="comment #2" />' +
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />' +
       '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" />'
     end
 
@@ -1747,10 +1747,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      '<input name="post[title]" size="30" type="text" id="post_title" value="Hello World" />' +
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #321" />' +
+      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' +
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #321" />' +
       '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="321" />' +
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" size="30" type="text" value="new comment" />'
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="new comment" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1767,7 +1767,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      '<input id="post_comments_attributes_abc_name" name="post[comments_attributes][abc][name]" size="30" type="text" value="comment #321" />' +
+      '<input id="post_comments_attributes_abc_name" name="post[comments_attributes][abc][name]" type="text" value="comment #321" />' +
       '<input id="post_comments_attributes_abc_id" name="post[comments_attributes][abc][id]" type="hidden" value="321" />'
     end
 
@@ -1803,16 +1803,16 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" size="30" type="text" value="comment #321" />' +
-      '<input id="post_comments_attributes_0_relevances_attributes_0_value" name="post[comments_attributes][0][relevances_attributes][0][value]" size="30" type="text" value="commentrelevance #314" />' +
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #321" />' +
+      '<input id="post_comments_attributes_0_relevances_attributes_0_value" name="post[comments_attributes][0][relevances_attributes][0][value]" type="text" value="commentrelevance #314" />' +
       '<input id="post_comments_attributes_0_relevances_attributes_0_id" name="post[comments_attributes][0][relevances_attributes][0][id]" type="hidden" value="314" />' +
       '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="321" />' +
-      '<input id="post_tags_attributes_0_value" name="post[tags_attributes][0][value]" size="30" type="text" value="tag #123" />' +
-      '<input id="post_tags_attributes_0_relevances_attributes_0_value" name="post[tags_attributes][0][relevances_attributes][0][value]" size="30" type="text" value="tagrelevance #3141" />' +
+      '<input id="post_tags_attributes_0_value" name="post[tags_attributes][0][value]" type="text" value="tag #123" />' +
+      '<input id="post_tags_attributes_0_relevances_attributes_0_value" name="post[tags_attributes][0][relevances_attributes][0][value]" type="text" value="tagrelevance #3141" />' +
       '<input id="post_tags_attributes_0_relevances_attributes_0_id" name="post[tags_attributes][0][relevances_attributes][0][id]" type="hidden" value="3141" />' +
       '<input id="post_tags_attributes_0_id" name="post[tags_attributes][0][id]" type="hidden" value="123" />' +
-      '<input id="post_tags_attributes_1_value" name="post[tags_attributes][1][value]" size="30" type="text" value="tag #456" />' +
-      '<input id="post_tags_attributes_1_relevances_attributes_0_value" name="post[tags_attributes][1][relevances_attributes][0][value]" size="30" type="text" value="tagrelevance #31415" />' +
+      '<input id="post_tags_attributes_1_value" name="post[tags_attributes][1][value]" type="text" value="tag #456" />' +
+      '<input id="post_tags_attributes_1_relevances_attributes_0_value" name="post[tags_attributes][1][relevances_attributes][0][value]" type="text" value="tagrelevance #31415" />' +
       '<input id="post_tags_attributes_1_relevances_attributes_0_id" name="post[tags_attributes][1][relevances_attributes][0][id]" type="hidden" value="31415" />' +
       '<input id="post_tags_attributes_1_id" name="post[tags_attributes][1][id]" type="hidden" value="456" />'
     end
@@ -1830,7 +1830,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      '<input id="post_author_attributes_name" name="post[author_attributes][name]" size="30" type="text" value="hash backed author" />'
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="hash backed author" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1844,8 +1844,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected =
-      "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
+      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" +
+      "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
 
@@ -1860,8 +1860,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected =
-      "<input name='post[123][title]' size='30' type='text' id='post_123_title' value='Hello World' />" +
-      "<textarea name='post[123][body]' id='post_123_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
+      "<input name='post[123][title]' type='text' id='post_123_title' value='Hello World' />" +
+      "<textarea name='post[123][body]' id='post_123_body'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[123][secret]' type='hidden' value='0' />" +
       "<input name='post[123][secret]' checked='checked' type='checkbox' id='post_123_secret' value='1' />"
 
@@ -1876,8 +1876,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected =
-      "<input name='post[][title]' size='30' type='text' id='post__title' value='Hello World' />" +
-      "<textarea name='post[][body]' id='post__body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
+      "<input name='post[][title]' type='text' id='post__title' value='Hello World' />" +
+      "<textarea name='post[][body]' id='post__body'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[][secret]' type='hidden' value='0' />" +
       "<input name='post[][secret]' checked='checked' type='checkbox' id='post__secret' value='1' />"
 
@@ -1892,8 +1892,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected =
-      "<input name='post[abc][title]' size='30' type='text' id='post_abc_title' value='Hello World' />" +
-      "<textarea name='post[abc][body]' id='post_abc_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
+      "<input name='post[abc][title]' type='text' id='post_abc_title' value='Hello World' />" +
+      "<textarea name='post[abc][body]' id='post_abc_body'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[abc][secret]' type='hidden' value='0' />" +
       "<input name='post[abc][secret]' checked='checked' type='checkbox' id='post_abc_secret' value='1' />"
 
@@ -1908,8 +1908,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected =
-      "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
+      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" +
+      "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
 
@@ -1924,8 +1924,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected =
-      "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
+      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" +
+      "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" +
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
 
@@ -1939,7 +1939,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     assert_dom_equal "<label for=\"author_post_title\">Title</label>" +
-    "<input name='author[post][title]' size='30' type='text' id='author_post_title' value='Hello World' />",
+    "<input name='author[post][title]' type='text' id='author_post_title' value='Hello World' />",
       output_buffer
   end
 
@@ -1950,7 +1950,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     assert_dom_equal "<label for=\"author_post_1_title\">Title</label>" +
-      "<input name='author[post][1][title]' size='30' type='text' id='author_post_1_title' value='Hello World' />",
+      "<input name='author[post][1][title]' type='text' id='author_post_1_title' value='Hello World' />",
       output_buffer
   end
 
@@ -1969,8 +1969,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'create-post', 'edit_post', :method => 'patch') do
-      "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
+      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" +
+      "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" +
       "<input name='parent_post[secret]' type='hidden' value='0' />" +
       "<input name='parent_post[secret]' checked='checked' type='checkbox' id='parent_post_secret' value='1' />"
     end
@@ -1989,9 +1989,9 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'create-post', 'edit_post', :method => 'patch') do
-      "<input name='post[title]' size='30' type='text' id='post_title' value='Hello World' />" +
-      "<textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea>" +
-      "<input name='post[comment][name]' type='text' id='post_comment_name' value='new comment' size='30' />"
+      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" +
+      "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" +
+      "<input name='post[comment][name]' type='text' id='post_comment_name' value='new comment' />"
     end
 
     assert_dom_equal expected, output_buffer
@@ -2005,7 +2005,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', 'patch') do
-      "<input name='post[category][name]' type='text' size='30' id='post_category_name' />"
+      "<input name='post[category][name]' type='text' id='post_category_name' />"
     end
 
     assert_dom_equal expected, output_buffer
@@ -2029,8 +2029,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      "<label for='title'>Title:</label> <input name='post[title]' size='30' type='text' id='post_title' value='Hello World' /><br/>" +
-      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea><br/>" +
+      "<label for='title'>Title:</label> <input name='post[title]' type='text' id='post_title' value='Hello World' /><br/>" +
+      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea><br/>" +
       "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' /><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' /><br/>"
     end
 
@@ -2048,8 +2048,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', :method => 'patch') do
-      "<label for='title'>Title:</label> <input name='post[title]' size='30' type='text' id='post_title' value='Hello World' /><br/>" +
-      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea><br/>" +
+      "<label for='title'>Title:</label> <input name='post[title]' type='text' id='post_title' value='Hello World' /><br/>" +
+      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea><br/>" +
       "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' /><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' /><br/>"
     end
 
@@ -2066,8 +2066,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected =
-      "<label for='title'>Title:</label> <input name='post[title]' size='30' type='text' id='post_title' value='Hello World' /><br/>" +
-      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body' rows='20' cols='40'>\nBack to the hill and over it again!</textarea><br/>" +
+      "<label for='title'>Title:</label> <input name='post[title]' type='text' id='post_title' value='Hello World' /><br/>" +
+      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea><br/>" +
       "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' /><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' /><br/>"
 
     assert_dom_equal expected, output_buffer

--- a/railties/guides/source/action_view_overview.textile
+++ b/railties/guides/source/action_view_overview.textile
@@ -431,11 +431,11 @@ form("post")
 <form action='/posts/create' method='post'>
   <p>
     <label for="post_title">Title</label><br />
-    <input id="post_title" name="post[title]" size="30" type="text" value="Hello World" />
+    <input id="post_title" name="post[title]" type="text" value="Hello World" />
   </p>
   <p>
     <label for="post_body">Body</label><br />
-    <textarea cols="40" id="post_body" name="post[body]" rows="20"></textarea>
+    <textarea id="post_body" name="post[body]"></textarea>
   </p>
   <input name="commit" type="submit" value="Create" />
 </form>
@@ -451,7 +451,7 @@ For example, if +@post+ has an attribute +title+ mapped to a +String+ column tha
 
 <ruby>
 input("post", "title") # =>
-  <input id="post_title" name="post[title]" size="30" type="text" value="Hello World" />
+  <input id="post_title" name="post[title]" type="text" value="Hello World" />
 </ruby>
 
 h4. RecordTagHelper
@@ -987,8 +987,8 @@ The HTML generated for this would be:
 
 <html>
 <form action="/persons/create" method="post">
-  <input id="person_first_name" name="person[first_name]" size="30" type="text" />
-  <input id="person_last_name" name="person[last_name]" size="30" type="text" />
+  <input id="person_first_name" name="person[first_name]" type="text" />
+  <input id="person_last_name" name="person[last_name]" type="text" />
   <input name="commit" type="submit" value="Create" />
 </form>
 </html>

--- a/railties/guides/source/form_helpers.textile
+++ b/railties/guides/source/form_helpers.textile
@@ -169,11 +169,11 @@ Output:
 <textarea id="message" name="message" cols="24" rows="6">Hi, nice site</textarea>
 <input id="password" name="password" type="password" />
 <input id="parent_id" name="parent_id" type="hidden" value="5" />
-<input id="user_name" name="user[name]" size="30" type="search" />
-<input id="user_phone" name="user[phone]" size="30" type="tel" />
+<input id="user_name" name="user[name]" type="search" />
+<input id="user_phone" name="user[phone]" type="tel" />
 <input id="user_born_on" name="user[born_on]" type="date" />
-<input id="user_homepage" size="30" name="user[homepage]" type="url" />
-<input id="user_address" size="30" name="user[address]" type="email" />
+<input id="user_homepage" name="user[homepage]" type="url" />
+<input id="user_address" name="user[address]" type="email" />
 </html>
 
 Hidden inputs are not shown to the user but instead hold data like any textual input. Values inside them can be changed with JavaScript.
@@ -239,7 +239,7 @@ The resulting HTML is:
 
 <html>
 <form accept-charset="UTF-8" action="/articles/create" method="post" class="nifty_form">
-  <input id="article_title" name="article[title]" size="30" type="text" />
+  <input id="article_title" name="article[title]" type="text" />
   <textarea id="article_body" name="article[body]" cols="60" rows="12"></textarea>
   <input name="commit" type="submit" value="Create" />
 </form>
@@ -264,8 +264,8 @@ which produces the following output:
 
 <html>
 <form accept-charset="UTF-8" action="/people/create" class="new_person" id="new_person" method="post">
-  <input id="person_name" name="person[name]" size="30" type="text" />
-  <input id="contact_detail_phone_number" name="contact_detail[phone_number]" size="30" type="text" />
+  <input id="person_name" name="person[name]" type="text" />
+  <input id="contact_detail_phone_number" name="contact_detail[phone_number]" type="text" />
 </form>
 </html>
 
@@ -714,9 +714,9 @@ Assuming the person had two addresses, with ids 23 and 45 this would create outp
 
 <html>
 <form accept-charset="UTF-8" action="/people/1" class="edit_person" id="edit_person_1" method="post">
-  <input id="person_name" name="person[name]" size="30" type="text" />
-  <input id="person_address_23_city" name="person[address][23][city]" size="30" type="text" />
-  <input id="person_address_45_city" name="person[address][45][city]" size="30" type="text" />
+  <input id="person_name" name="person[name]" type="text" />
+  <input id="person_address_23_city" name="person[address][23][city]" type="text" />
+  <input id="person_address_45_city" name="person[address][45][city]" type="text" />
 </form>
 </html>
 
@@ -739,7 +739,7 @@ To create more intricate nestings, you can specify the first part of the input n
 will create inputs like
 
 <html>
-<input id="person_address_primary_1_city" name="person[address][primary][1][city]" size="30" type="text" value="bologna" />
+<input id="person_address_primary_1_city" name="person[address][primary][1][city]" type="text" value="bologna" />
 </html>
 
 As a general rule the final input name is the concatenation of the name given to +fields_for+/+form_for+, the index value and the name of the attribute. You can also pass an +:index+ option directly to helpers such as +text_field+, but it is usually less repetitive to specify this at the form builder level rather than on individual input controls.

--- a/railties/guides/source/nested_model_forms.textile
+++ b/railties/guides/source/nested_model_forms.textile
@@ -131,7 +131,7 @@ This will generate the following html:
 
 <html>
 <form action="/people" class="new_person" id="new_person" method="post">
-  <input id="person_name" name="person[name]" size="30" type="text" />
+  <input id="person_name" name="person[name]" type="text" />
 </form>
 </html>
 
@@ -153,9 +153,9 @@ This generates:
 
 <html>
 <form action="/people" class="new_person" id="new_person" method="post">
-  <input id="person_name" name="person[name]" size="30" type="text" />
+  <input id="person_name" name="person[name]" type="text" />
 
-  <input id="person_address_attributes_street" name="person[address_attributes][street]" size="30" type="text" />
+  <input id="person_address_attributes_street" name="person[address_attributes][street]" type="text" />
 </form>
 </html>
 
@@ -194,10 +194,10 @@ Which generates:
 
 <html>
 <form action="/people" class="new_person" id="new_person" method="post">
-  <input id="person_name" name="person[name]" size="30" type="text" />
+  <input id="person_name" name="person[name]" type="text" />
 
-  <input id="person_projects_attributes_0_name" name="person[projects_attributes][0][name]" size="30" type="text" />
-  <input id="person_projects_attributes_1_name" name="person[projects_attributes][1][name]" size="30" type="text" />
+  <input id="person_projects_attributes_0_name" name="person[projects_attributes][0][name]" type="text" />
+  <input id="person_projects_attributes_1_name" name="person[projects_attributes][1][name]" type="text" />
 </form>
 </html>
 


### PR DESCRIPTION
I'm sure this will be a controversial change :-)

But this reduces hardcoded HTML and makes default HTML easier to add CSS to (in my opinion) and has the added benefit of reducing the amount of HTML that is sent to the browser.

See issue #5324 for more reasoning.

Thanks!
