### PR TITLE
Fix comments about to_partial_path

### DIFF
--- a/activemodel/lib/active_model/conversion.rb
+++ b/activemodel/lib/active_model/conversion.rb
@@ -21,7 +21,7 @@ module ActiveModel
   #   cm.to_model == self # => true
   #   cm.to_key           # => nil
   #   cm.to_param         # => nil
-  #   cm.to_path          # => "contact_messages/contact_message"
+  #   cm.to_partial_path  # => "contact_messages/contact_message"
   #
   module Conversion
     extend ActiveSupport::Concern
@@ -57,7 +57,7 @@ module ActiveModel
     end
 
     module ClassMethods #:nodoc:
-      # Provide a class level cache for the to_path. This is an
+      # Provide a class level cache for #to_partial_path. This is an
       # internal method and should not be accessed directly.
       def _to_partial_path #:nodoc:
         @_to_partial_path ||= begin

--- a/activemodel/test/cases/conversion_test.rb
+++ b/activemodel/test/cases/conversion_test.rb
@@ -24,7 +24,7 @@ class ConversionTest < ActiveModel::TestCase
     assert_equal "1", Contact.new(:id => 1).to_param
   end
 
-  test "to_path default implementation returns a string giving a relative path" do
+  test "to_partial_path default implementation returns a string giving a relative path" do
     assert_equal "contacts/contact", Contact.new.to_partial_path
     assert_equal "helicopters/helicopter", Helicopter.new.to_partial_path,
       "ActiveModel::Conversion#to_partial_path caching should be class-specific"


### PR DESCRIPTION
These comments still mention the "to_path" method name which ended up as "to_partial_path" instead.
