### PR TITLE
Remove ActiveModel::Naming#partial_path

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -6,12 +6,10 @@ require 'active_support/core_ext/object/blank'
 
 module ActiveModel
   class Name < String
-    attr_reader :singular, :plural, :element, :collection, :partial_path,
+    attr_reader :singular, :plural, :element, :collection,
       :singular_route_key, :route_key, :param_key, :i18n_key
 
     alias_method :cache_key, :collection
-
-    deprecate :partial_path => "ActiveModel::Name#partial_path is deprecated. Call #to_partial_path on model instances directly instead."
 
     def initialize(klass, namespace = nil, name = nil)
       name ||= klass.name
@@ -27,7 +25,6 @@ module ActiveModel
       @element      = ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.demodulize(self)).freeze
       @human        = ActiveSupport::Inflector.humanize(@element).freeze
       @collection   = ActiveSupport::Inflector.tableize(self).freeze
-      @partial_path = "#{@collection}/#{@element}".freeze
       @param_key    = (namespace ? _singularize(@unnamespaced) : @singular).freeze
       @i18n_key     = self.underscore.to_sym
 

--- a/activemodel/test/cases/naming_test.rb
+++ b/activemodel/test/cases/naming_test.rb
@@ -25,12 +25,6 @@ class NamingTest < ActiveModel::TestCase
     assert_equal 'post/track_backs', @model_name.collection
   end
 
-  def test_partial_path
-    assert_deprecated(/#partial_path.*#to_partial_path/) do
-      assert_equal 'post/track_backs/track_back', @model_name.partial_path
-    end
-  end
-
   def test_human
     assert_equal 'Track back', @model_name.human
   end
@@ -59,12 +53,6 @@ class NamingWithNamespacedModelInIsolatedNamespaceTest < ActiveModel::TestCase
 
   def test_collection
     assert_equal 'blog/posts', @model_name.collection
-  end
-
-  def test_partial_path
-    assert_deprecated(/#partial_path.*#to_partial_path/) do
-      assert_equal 'blog/posts/post', @model_name.partial_path
-    end
   end
 
   def test_human
@@ -105,12 +93,6 @@ class NamingWithNamespacedModelInSharedNamespaceTest < ActiveModel::TestCase
     assert_equal 'blog/posts', @model_name.collection
   end
 
-  def test_partial_path
-    assert_deprecated(/#partial_path.*#to_partial_path/) do
-      assert_equal 'blog/posts/post', @model_name.partial_path
-    end
-  end
-
   def test_human
     assert_equal 'Post', @model_name.human
   end
@@ -147,12 +129,6 @@ class NamingWithSuppliedModelNameTest < ActiveModel::TestCase
 
   def test_collection
     assert_equal 'articles', @model_name.collection
-  end
-
-  def test_partial_path
-    assert_deprecated(/#partial_path.*#to_partial_path/) do
-      assert_equal 'articles/article', @model_name.partial_path
-    end
   end
 
   def test_human


### PR DESCRIPTION
It was deprecated in 3.2
