### PR TITLE
assert_template matches against Regexp

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -56,6 +56,9 @@ module ActionController
     #   # assert that the "new" view template was rendered
     #   assert_template "new"
     #
+    #   # assert that the exact template "admin/posts/new" was rendered
+    #   assert_template %r{\Aadmin/posts/new\Z}
+    #
     #   # assert that the "_customer" partial was rendered twice
     #   assert_template :partial => '_customer', :count => 2
     #
@@ -74,11 +77,11 @@ module ActionController
       response.body
 
       case options
-      when NilClass, String, Symbol
+      when NilClass, String, Symbol, Regexp
         options = options.to_s if Symbol === options
         rendered = @templates
         msg = message || sprintf("expecting <%s> but rendering with <%s>",
-                options, rendered.keys)
+                options.inspect, rendered.keys)
         assert_block(msg) do
           if options
             rendered.any? { |t,num| t.match(options) }
@@ -121,6 +124,8 @@ module ActionController
           assert @partials.empty?,
             "Expected no partials to be rendered"
         end
+      else
+        raise ArgumentError, "assert_template only accepts a String, Symbol, Hash, Regexp, or nil"
       end
     end
   end

--- a/actionpack/test/template/test_case_test.rb
+++ b/actionpack/test/template/test_case_test.rb
@@ -277,6 +277,12 @@ module ActionView
   end
 
   class RenderTemplateTest < ActionView::TestCase
+    test "supports specifying templates with a Regexp" do
+      controller.controller_path = "fun"
+      render(:template => "fun/games/hello_world")
+      assert_template %r{\Afun/games/hello_world\Z}
+    end
+
     test "supports specifying partials" do
       controller.controller_path = "test"
       render(:template => "test/calling_partial_with_layout")


### PR DESCRIPTION
This allows for more strict template assertions, while maintaining backward compatibility.

For example, if you use `assert_template("foo/bar")` and "foo/bar/baz" was rendered, the test passes.

But if you use `assert_template(%r{\Afoo/bar\Z})`, you will catch that a different template was rendered.

Also, if you passed an unsupported argument to `assert_template()` in the past, it would silently succeed. Now it raises an ArgumentError.
