### PR TITLE
ensure u2029 is escaped in escape_javascript helper

### DIFF
--- a/actionpack/lib/action_view/helpers/javascript_helper.rb
+++ b/actionpack/lib/action_view/helpers/javascript_helper.rb
@@ -14,6 +14,8 @@ module ActionView
       }
 
       JS_ESCAPE_MAP["\342\200\250".force_encoding('UTF-8').encode!] = '&#x2028;'
+      JS_ESCAPE_MAP["\342\200\251".force_encoding('UTF-8').encode!] = '&#x2029;'
+      
 
       # Escapes carriage returns and single and double quotes for JavaScript segments.
       #
@@ -22,7 +24,7 @@ module ActionView
       #   $('some_element').replaceWith('<%=j render 'some/element_template' %>');
       def escape_javascript(javascript)
         if javascript
-          result = javascript.gsub(/(\\|<\/|\r\n|\342\200\250|[\n\r"'])/u) {|match| JS_ESCAPE_MAP[match] }
+          result = javascript.gsub(/(\\|<\/|\r\n|\342\200\250|\342\200\251|[\n\r"'])/u) {|match| JS_ESCAPE_MAP[match] }
           javascript.html_safe? ? result.html_safe : result
         else
           ''

--- a/actionpack/test/template/javascript_helper_test.rb
+++ b/actionpack/test/template/javascript_helper_test.rb
@@ -28,6 +28,8 @@ class JavaScriptHelperTest < ActionView::TestCase
     assert_equal %(backslash\\\\test), escape_javascript( %(backslash\\test) )
     assert_equal %(dont <\\/close> tags), escape_javascript(%(dont </close> tags))
     assert_equal %(unicode &#x2028; newline), escape_javascript(%(unicode \342\200\250 newline).force_encoding('UTF-8').encode!)
+    assert_equal %(unicode &#x2029; newline), escape_javascript(%(unicode \342\200\251 newline).force_encoding('UTF-8').encode!)
+
     assert_equal %(dont <\\/close> tags), j(%(dont </close> tags))
   end
 


### PR DESCRIPTION
similar to issue #2587

http://www.fileformat.info/info/unicode/char/2029/index.htm
http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf (section 7.3)

```
The ECMAScript line terminator characters are listed in Table 3.
Table 3 — Line Terminator Characters
Code Unit Value Name Formal Name
\u000A Line Feed <LF>
\u000D Carriage Return  <CR>
\u2028 Line separator <LS>
\u2029 Paragraph separator <PS>
```
