### PR TITLE
retrieve_cache_key should work on objects that act like arrays.

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -91,6 +91,7 @@ module ActiveSupport
         case
         when key.respond_to?(:cache_key) then key.cache_key
         when key.is_a?(Array)            then key.map { |element| retrieve_cache_key(element) }.to_param
+        when key.respond_to?(:to_a)      then retrieve_cache_key(key.to_a)
         else                                  key.to_param
         end.to_s
       end

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -69,6 +69,10 @@ class CacheKeyTest < ActiveSupport::TestCase
   def test_expand_cache_key_of_true
     assert_equal 'true', ActiveSupport::Cache.expand_cache_key(true)
   end
+  
+  def test_expand_cache_key_of_array_like_object
+    assert_equal 'foo/bar/baz', ActiveSupport::Cache.expand_cache_key(%w{foo bar baz}.to_enum)
+  end
 end
 
 class CacheStoreSettingTest < ActiveSupport::TestCase


### PR DESCRIPTION
I don't have nearly the experience you guys have, so if this is idiotic, please be gentle.

If you have a ActiveRecord::Relation collection, the cache key that is generated is something like "#ActiveRecord::Relation:0x007fc4ef0b7c08".  This may be unexpected.
