### PR TITLE
Improved ActiveSupport::Autoload Performance

### DIFF
--- a/activesupport/lib/active_support/dependencies/autoload.rb
+++ b/activesupport/lib/active_support/dependencies/autoload.rb
@@ -9,13 +9,16 @@ module ActiveSupport
     @@eager_autoload = false
 
     def autoload(const_name, path = @@at_path)
-      full = [self.name, @@under_path, const_name.to_s, path].compact.join("::")
-      location = path || Inflector.underscore(full)
+      unless path
+        full = [name, @@under_path, const_name.to_s, path].compact.join("::")
+        path = Inflector.underscore(full)
+      end
 
       if @@eager_autoload
-        @@autoloads[const_name] = location
+        @@autoloads[const_name] = path
       end
-      super const_name, location
+
+      super const_name, path
     end
 
     def autoload_under(path)


### PR DESCRIPTION
`ActiveSupport::Autoload#autoload` performance is improved in the default case where a path is present. Since the full path name is not generated, it isn't necessary to determine the full constant name either. This results in a 3x performance gain and reduces the number of Ruby objects generated. For a full benchmark check [this gist](https://gist.github.com/2020228).
