### PR TITLE
fix activerecord query_method regression with offset into Fixnum

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -329,7 +329,7 @@ module ActiveRecord
       arel.having(*@having_values.uniq.reject{|h| h.blank?}) unless @having_values.empty?
 
       arel.take(connection.sanitize_limit(@limit_value)) if @limit_value
-      arel.skip(@offset_value) if @offset_value
+      arel.skip(@offset_value.to_i) if @offset_value
 
       arel.group(*@group_values.uniq.reject{|g| g.blank?}) unless @group_values.empty?
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1185,6 +1185,10 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
+  def test_finder_with_offset_string
+    assert_nothing_raised(ActiveRecord::StatementInvalid) { Topic.find(:all, :offset => "3") }
+  end
+
   protected
     def bind(statement, *vars)
       if vars.first.is_a?(Hash)


### PR DESCRIPTION
add test to show offset query_methods on mysql & mysql2

change test to cover public API

See PR #4410
