### PR TITLE
ConnectionPooll#clear_active_connections! rdoc inaccuracy since 3.2.0

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -345,9 +345,7 @@ connection.  For example: ActiveRecord::Base.connection.close
         connection_pools.values.any? { |pool| pool.active_connection? }
       end
 
-      # Returns any connections in use by the current thread back to the pool,
-      # and also returns connections to the pool cached by threads that are no
-      # longer alive.
+      # Returns any connections in use by the current thread back to the pool.
       def clear_active_connections!
         @connection_pools.each_value {|pool| pool.release_connection }
       end


### PR DESCRIPTION
@tenderlove, believe clear_active_connections! stopped checking for connections checked out to dead threads in 3.2.0, but it's inline comment rdoc still says it does. Needs to be fixed to be accurate and not mislead developers trying to figure out what's up. 

This needs to be committed to master too, I think, but only pull requesting for 3-2-stable. Let me know what preferred practices are for sending a pull request that needs to go to a release branch and to master both. 

thanks!
