### PR TITLE
deprecated clear_stale_active_connections! can call #reap 

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -186,8 +186,9 @@ module ActiveRecord
       end
 
       def clear_stale_cached_connections! # :nodoc:
+        reap
       end
-      deprecate :clear_stale_cached_connections!
+      deprecate :clear_stale_cached_connections! => "Please use #reap instead"
 
       # Check-out a database connection from the pool, indicating that you want
       # to use it. You should call #checkin when you no longer need this.


### PR DESCRIPTION
Not sure about this, sending my question/suggestion in the form of a pull request. Only applies to master, so not an urgent matter, thanks @tenderlove. 

The new #reap method accomplishes the same thing as the deprecated #clear_stale_active_connections! , although it uses other means to do it.  At least #reap is documented to do the same thing -- remove connections associated with dead threads from the pool. 

If you want to deprecate the old method name, that may be reasonable.  But why not have it call the new #reap method instead of just no-op'ing?  And why not have the deprecation warning suggest the new #reap method?  Calling the #reap method instead of no-op'ing seems kinder to applications that are trying to use the deprecated behavior.  

Alternately, seems like it would be better to remove the clear_stale_active_connections! method entirely, instead of leaving it as a no-op deprecated method. but personally, I like having it there, deprecated, but calling out to #reap, seems kindest to upgrading clients. 
