### PR TITLE
Added support for conditional fragment caching using :if and :unless options.

### DIFF
--- a/actionpack/lib/action_view/helpers/cache_helper.rb
+++ b/actionpack/lib/action_view/helpers/cache_helper.rb
@@ -104,7 +104,7 @@ module ActionView
       #
       # Now all you'll have to do is change that timestamp when the helper method changes.
       def cache(name = {}, options = nil, &block)
-        if controller.perform_caching && options_pass_conditions(options)
+        if controller.perform_caching && options_pass_conditions?(options)
           safe_concat(fragment_for(fragment_name_with_digest(name), options, &block))
         else
           yield
@@ -143,12 +143,8 @@ module ActionView
         end
       end
 
-      def options_pass_conditions(options)
-        if options && ((options.has_key?(:if) && !options[:if]) || (options.has_key?(:unless) && options[:unless]))
-          false
-        else
-          true
-        end
+      def options_pass_conditions?(options)
+        !( options && ((options.has_key?(:if) && !options[:if]) || (options.has_key?(:unless) && options[:unless])) )
       end
     end
   end

--- a/actionpack/lib/action_view/helpers/cache_helper.rb
+++ b/actionpack/lib/action_view/helpers/cache_helper.rb
@@ -144,7 +144,7 @@ module ActionView
       end
 
       def options_pass_conditions?(options)
-        !( options && ((options.has_key?(:if) && !options[:if]) || (options.has_key?(:unless) && options[:unless])) )
+        !(options && (!options.fetch(:if, true) || options.fetch(:unless, false)))
       end
     end
   end

--- a/actionpack/lib/action_view/helpers/cache_helper.rb
+++ b/actionpack/lib/action_view/helpers/cache_helper.rb
@@ -104,7 +104,7 @@ module ActionView
       #
       # Now all you'll have to do is change that timestamp when the helper method changes.
       def cache(name = {}, options = nil, &block)
-        if controller.perform_caching
+        if controller.perform_caching && options_pass_conditions(options)
           safe_concat(fragment_for(fragment_name_with_digest(name), options, &block))
         else
           yield
@@ -140,6 +140,14 @@ module ActionView
             self.output_buffer = output_buffer.class.new(output_buffer)
           end
           controller.write_fragment(name, fragment, options)
+        end
+      end
+
+      def options_pass_conditions(options)
+        if options && ((options.has_key?(:if) && !options[:if]) || (options.has_key?(:unless) && options[:unless]))
+          false
+        else
+          true
         end
       end
     end

--- a/actionpack/lib/action_view/helpers/cache_helper.rb
+++ b/actionpack/lib/action_view/helpers/cache_helper.rb
@@ -143,7 +143,7 @@ module ActionView
         end
       end
 
-      def options_pass_conditions?(options)
+      def options_pass_conditions?(options) #:nodoc:
         !(options && (!options.fetch(:if, true) || options.fetch(:unless, false)))
       end
     end

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -146,6 +146,23 @@ class FragmentCachingTest < ActionController::TestCase
     assert_equal content, html_safe
     assert html_safe.html_safe?
   end
+
+  def test_options_pass_conditions
+    view_context = @controller.view_context
+
+    passing_options = [ nil, { if: true }, { unless: false }, { if: true, unless: false } ]
+    failing_options = [ { if: false }, { unless: true }, { if: false, unless: true }, { if: true,  unless: true }, { if: false, unless: false } ]
+
+    for options in passing_options
+      options_pass_conditions = view_context.send(:options_pass_conditions?, options)
+      assert options_pass_conditions
+    end
+
+    for options in failing_options
+      options_pass_conditions = view_context.send(:options_pass_conditions?, options)
+      assert !options_pass_conditions
+    end
+  end
 end
 
 class FunctionalCachingController < CachingController

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -147,21 +147,18 @@ class FragmentCachingTest < ActionController::TestCase
     assert html_safe.html_safe?
   end
 
-  def test_options_pass_conditions
+  def test_conditional_fragment_caching
+    @controller.write_fragment('name', 'fragment content')
+    if_fragment_computed     = false
+    unless_fragment_computed = false
+
     view_context = @controller.view_context
 
-    passing_options = [ nil, { if: true }, { unless: false }, { if: true, unless: false } ]
-    failing_options = [ { if: false }, { unless: true }, { if: false, unless: true }, { if: true,  unless: true }, { if: false, unless: false } ]
+    view_context.send(:cache, 'name', { if: false })    { if_fragment_computed = true }
+    view_context.send(:cache, 'name', { unless: true }) { unless_fragment_computed = true }
 
-    for options in passing_options
-      options_pass_conditions = view_context.send(:options_pass_conditions?, options)
-      assert options_pass_conditions
-    end
-
-    for options in failing_options
-      options_pass_conditions = view_context.send(:options_pass_conditions?, options)
-      assert !options_pass_conditions
-    end
+    assert if_fragment_computed
+    assert unless_fragment_computed
   end
 end
 


### PR DESCRIPTION
This allows fragment caching to be used conditionally by passing `if/unless` to the `cache` helper method. This comes in especially handy when caching forms that may contain changed values/errors.

Usage:

``` erb
<% cache [ @user, 'form' ], :unless => @user.changed? do %>
  <%= render partial: 'shared/error_messages', locals: {instance: @user} %>
  <%= form_for @user do |f| %>
    <div class="field">
      <div><%= f.label :name %></div>
      <div><%= f.text_field :name %></div>
    </div>
    <div class="actions">
      <%= f.submit %>
    </div>
  <% end %>
<% end %>
```
