### PR TITLE
Fix bug where nested deletes could invalidate parent object

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -210,7 +210,7 @@ module ActiveRecord
       # attributes assignment. For example, setting the IDs of a child collection.
       with_transaction_returning_status do
         assign_attributes(attributes, options)
-        save
+        save && valid?
       end
     end
 

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -276,6 +276,27 @@ class TestNestedAttributesOnAHasOneAssociation < ActiveRecord::TestCase
     end
   end
 
+  def test_should_return_false_if_record_not_deleted
+    @ornithologist_pirate = OrnithologistPirate.create!({
+      :catchphrase => 'Chirp!',
+      :birds_attributes => [{:name => 'Tweetie'}]
+    })
+
+    bird = @ornithologist_pirate.birds.first
+    assert !@ornithologist_pirate.update_attributes({:birds_attributes => [{:id => bird.id, :_destroy => '1'}]})
+  end
+
+  def test_should_not_delete_records_to_make_object_invalid
+    @ornithologist_pirate = OrnithologistPirate.create!({
+      :catchphrase => 'Chirp!',
+      :birds_attributes => [{:name => 'Tweetie'}]
+    })
+
+    bird = @ornithologist_pirate.birds.first
+    @ornithologist_pirate.update_attributes({:birds_attributes => [{:id => bird.id, :_destroy => '1'}]})
+    assert_equal 1, @ornithologist_pirate.reload.birds.count
+  end
+
   def test_should_not_destroy_an_existing_record_if_allow_destroy_is_false
     Pirate.accepts_nested_attributes_for :ship, :allow_destroy => false, :reject_if => proc { |attributes| attributes.empty? }
 

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -84,3 +84,9 @@ end
 class DestructivePirate < Pirate
   has_one :dependent_ship, :class_name => 'Ship', :foreign_key => :pirate_id, :dependent => :destroy
 end
+
+class OrnithologistPirate < Pirate
+  has_many :birds, :foreign_key => :pirate_id
+
+  validates_presence_of :birds
+end


### PR DESCRIPTION
ActiveRecord allowed nested models to be deleted in update_attributes using the _destroy parameter even when this makes the parent invalid. This commit adds tests for the correct behavior, and fixes the problem by checking if the parent is valid before commiting the transaction.

Thanks to @itsmeduncan for pair programming on this bug fix.
