### PR TITLE
Fix GH #5399. connection_pools's keys are ActiveRecord::Base::ConnectionSpecification objects.

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -130,7 +130,7 @@ module ActiveRecord
       end
 
       def arel_engine
-        @arel_engine ||= connection_handler.connection_pools[name] ? self : active_record_super.arel_engine
+        @arel_engine ||= connection_handler.retrieve_connection_pool(self) ? self : active_record_super.arel_engine
       end
 
       private

--- a/activerecord/test/cases/multiple_db_test.rb
+++ b/activerecord/test/cases/multiple_db_test.rb
@@ -86,7 +86,13 @@ class MultipleDbTest < ActiveRecord::TestCase
   end
 
   def test_arel_table_engines
-    assert_equal Entrant.arel_engine, Bird.arel_engine
+    assert_not_equal Entrant.arel_engine, Bird.arel_engine
+    assert_not_equal Entrant.arel_engine, Course.arel_engine
+  end
+
+  def test_connection
+    assert_equal Entrant.arel_engine.connection, Bird.arel_engine.connection
+    assert_not_equal Entrant.arel_engine.connection, Course.arel_engine.connection
   end
 
   unless in_memory_db?


### PR DESCRIPTION
Please see https://github.com/rails/rails/issues/5399

I'm going to send this PR to 3-2-stable.
