### PR TITLE
[3-2-stable] Fix GH #5399. connection_pools's keys are ActiveRecord::Base::ConnectionSpecification objects.

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -442,7 +442,7 @@ module ActiveRecord #:nodoc:
           if self == ActiveRecord::Base
             ActiveRecord::Base
           else
-            connection_handler.connection_pools[name] ? self : superclass.arel_engine
+            connection_handler.retrieve_connection_pool(self) ? self : superclass.arel_engine
           end
         end
       end

--- a/activerecord/test/cases/multiple_db_test.rb
+++ b/activerecord/test/cases/multiple_db_test.rb
@@ -85,6 +85,12 @@ class MultipleDbTest < ActiveRecord::TestCase
   end
 
   def test_arel_table_engines
-    assert_equal Entrant.arel_engine, Bird.arel_engine
+    assert_not_equal Entrant.arel_engine, Bird.arel_engine
+    assert_not_equal Entrant.arel_engine, Course.arel_engine
+  end
+
+  def test_connection
+    assert_equal Entrant.arel_engine.connection, Bird.arel_engine.connection
+    assert_not_equal Entrant.arel_engine.connection, Course.arel_engine.connection
   end
 end


### PR DESCRIPTION
Please see #5416 .

Closes #5399
