### PR TITLE
Fixed Issue #2884 ActiveModel::SecurePassword code / rdoc conflict

### DIFF
--- a/activemodel/lib/active_model/locale/en.yml
+++ b/activemodel/lib/active_model/locale/en.yml
@@ -1,4 +1,8 @@
 en:
+  attributes:
+    # Prevent confusion in form errors due to 'has_secure_password'
+    password_digest: "Password"
+
   errors:
     # The default format to use in full error messages.
     format: "%{attribute} %{message}"

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -10,6 +10,19 @@ module ActiveModel
       # a "password_confirmation" attribute) are automatically added.
       # You can add more validations by hand if need be.
       #
+      # Note: the implementation of <tt>has_secure_password</tt> enforces presence validation
+      # on the <tt>:password_digest</tt> attribute rather than on <tt>:password</tt>, which is
+      # in fact a virtual reader attribute.  However, <tt>validates_confirmation_of</tt> ensures
+      # an indirect means of presence validation of <tt>:password</tt> if the
+      # <tt>:password_confirmation</tt> attribute is not nil.
+      #
+      # You may want to add presence validation on <tt>:password</tt> for the benefit of your forms
+      #
+      #   class User < ActiveRecord::Base
+      #     has_secure_password
+      #     validates :password, :presence => { :on => :create }
+      #   end
+      #
       # You need to add bcrypt-ruby (~> 3.0.0) to Gemfile to use has_secure_password:
       #
       #   gem 'bcrypt-ruby', '~> 3.0.0'


### PR DESCRIPTION
A elucidated explanation has been provided and ActiveModel en-locale updated to present a less confusing attribute name for `:password_digest` in form errors due to `has_secure_password`.  This is in reference to [Issue #2884](https://github.com/rails/rails/issues/2884).

**Note**: Opened as a PR on rails/rails as per [this note](https://github.com/lifo/docrails/commit/ddbea9474e20a40e80110944c1e3493ba0efe572#commitcomment-1079463) from @vijaydev

@vijaydev &mdash; I just cherry-picked my fix across, rdoc and YAML change so they may be reviewed with the correct context.  Thanks! =)
@rurounijones and @rohit, please see.
