### PR TITLE
Fix GH #5430. A Payload name for schema_search_path should be SCHEMA.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1006,7 +1006,7 @@ module ActiveRecord
       # This should be not be called manually but set in database.yml.
       def schema_search_path=(schema_csv)
         if schema_csv
-          execute "SET search_path TO #{schema_csv}"
+          execute("SET search_path TO #{schema_csv}", 'SCHEMA')
           @schema_search_path = schema_csv
         end
       end

--- a/activerecord/test/cases/adapters/postgresql/explain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/explain_test.rb
@@ -22,6 +22,13 @@ module ActiveRecord
           assert_match %(EXPLAIN for: SELECT "audit_logs".* FROM "audit_logs"  WHERE "audit_logs"."developer_id" IN (1)), explain
           assert_match %(Seq Scan on audit_logs), explain
         end
+
+        def test_dont_explain_for_set_search_path
+          queries = Thread.current[:available_queries_for_explain] = []
+          ActiveRecord::Base.connection.schema_search_path = "public"
+          assert queries.empty?
+        end
+
       end
     end
   end


### PR DESCRIPTION
The original issue for this PR is #5430 .
I think a payload name for schema_search_path should be SCHEMA.

The original issue found on 3-2-stable.

_Updated:_ The original issue also was solved by this PR.
