### PR TITLE
Fix scaffold controller template and ensure rake test for scaffold works

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
@@ -46,10 +46,10 @@ class <%= controller_class_name %>Controller < ApplicationController
     respond_to do |format|
       if @<%= orm_instance.save %>
         format.html { redirect_to @<%= singular_table_name %>, notice: <%= "'#{human_name} was successfully created.'" %> }
-        format.json { render json: <%= "@#{singular_table_name}" %>, :status: :created, location: <%= "@#{singular_table_name}" %> }
+        format.json { render json: <%= "@#{singular_table_name}" %>, status: :created, location: <%= "@#{singular_table_name}" %> }
       else
         format.html { render action: "new" }
-        format.json { render json: <%= "@#{orm_instance.errors}" %>, status: :unprocessable_entity %> }
+        format.json { render json: <%= "@#{orm_instance.errors}" %>, status: :unprocessable_entity }
       end
     end
   end

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -123,12 +123,33 @@ module ApplicationTests
     end
 
     def test_scaffold_tests_pass_by_default
-      content = Dir.chdir(app_path) do
+      output = Dir.chdir(app_path) do
         `rails generate scaffold user username:string password:string;
          bundle exec rake db:migrate db:test:clone test`
       end
 
-      assert_match(/\d+ tests, \d+ assertions, 0 failures, 0 errors/, content)
+      assert_match(/7 tests, 13 assertions, 0 failures, 0 errors/, output)
+      assert_no_match(/Errors running/, output)
+    end
+
+    def test_http_scaffold_tests_pass_by_default
+      add_to_config <<-RUBY
+        config.middleware.http_only!
+        config.generators.http_only!
+      RUBY
+
+      app_file "app/controllers/application_controller.rb", <<-RUBY
+        class ApplicationController < ActionController::HTTP
+        end
+      RUBY
+
+      output = Dir.chdir(app_path) do
+        `rails generate scaffold user username:string password:string;
+         bundle exec rake db:migrate db:test:clone test`
+      end
+
+      assert_match(/6 tests, 12 assertions, 0 failures, 0 errors/, output)
+      assert_no_match(/Errors running/, output)
     end
 
     def test_rake_dump_structure_should_respect_db_structure_env_variable

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -116,7 +116,12 @@ module TestHelpers
         end
       end
 
-      add_to_config 'config.secret_token = "3b7cd727ee24e8444053437c36cc66c4"; config.session_store :cookie_store, :key => "_myapp_session"; config.active_support.deprecation = :log'
+      add_to_config <<-RUBY
+        config.secret_token = "3b7cd727ee24e8444053437c36cc66c4"
+        config.session_store :cookie_store, :key => "_myapp_session"
+        config.active_support.deprecation = :log
+        config.action_controller.allow_forgery_protection = false
+      RUBY
     end
 
     def teardown_app


### PR DESCRIPTION
This fixes the test asserting that running `rake test` after creating
a scaffold passes successfully. The test was silently failing before,
due to the assertion that was matching against `unit` tests results
instead of the `functional` ones.

It also adds the same test to ensure running `rake test` works fine
after creating a scaffold when app is configured as http.
