### PR TITLE
Fixed issue #1859: ArgumentError for to_xs after instruct! is called

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/xchar.rb
+++ b/activesupport/lib/active_support/core_ext/string/xchar.rb
@@ -13,6 +13,13 @@ else
 
   class String
     alias_method :original_xs, :to_xs if method_defined?(:to_xs)
-    alias_method :to_xs, :fast_xs
+
+    # to_xs expects 0 args from Builder < 3 but not >= 3, although fast_xs is 0 args
+    if instance_method(:to_xs).arity == 0
+      alias_method :to_xs, :fast_xs
+    else
+      def fast_xs_absorb_args(*args); fast_xs; end
+      alias_method :to_xs, :fast_xs_absorb_args
+    end
   end
 end

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -3,11 +3,13 @@ require 'date'
 require 'abstract_unit'
 require 'inflector_test_cases'
 require 'constantize_test_cases'
+require 'builder'
 
 require 'active_support/inflector'
 require 'active_support/core_ext/string'
 require 'active_support/time'
 require 'active_support/core_ext/string/strip'
+require 'active_support/core_ext/string/xchar'
 require 'active_support/core_ext/string/output_safety'
 
 module Ace
@@ -514,5 +516,16 @@ class StringExcludeTest < ActiveSupport::TestCase
   test 'inverse of #include' do
     assert_equal false, 'foo'.exclude?('o')
     assert_equal true, 'foo'.exclude?('p')
+  end
+end
+
+class StringBuilderFastXSTest < Test::Unit::TestCase
+  def test_build_xml_instruct_to_escaped_string
+    xml = Builder::XmlMarkup.new
+
+    assert_nothing_raised do
+    	xml.instruct!
+      assert_equal '<?xml version="1.0" encoding="UTF-8"?>', xml
+    end
   end
 end


### PR DESCRIPTION
Also mentioned in pull request #2076 (for the 3.1 branch), this one is for the 3.2 branch.
