### PR TITLE
Commas in directory names causes hang in ActiveSupport::FileUpdateChecker

### DIFF
--- a/activesupport/lib/active_support/file_update_checker.rb
+++ b/activesupport/lib/active_support/file_update_checker.rb
@@ -107,9 +107,13 @@ module ActiveSupport
 
       globs = []
       hash.each do |key, value|
-        globs << "#{key}/**/*#{compile_ext(value)}"
+        globs << "#{escape(key)}/**/*#{compile_ext(value)}"
       end
       "{#{globs.join(",")}}"
+    end
+
+    def escape(key)
+      key.gsub(',','\,')
     end
 
     def compile_ext(array) #:nodoc:


### PR DESCRIPTION
Having commas in directory names passed through to ActiveSupport::FileUpdateChecker causes an infinite hang whilst Dir[@glob] tries and fails to list files in these directories. This wasn't an issue before ~> 3.2 but on 3.2 upwards it prevents Rails from booting in development mode and prevents test suites running (rspec, cucumber at least).

Commas are perfectly valid parts of directory names (on OS X at least) and escaping them when compiling the glob solves this issue.

This issue can be triggered by adding such directories to the autoload component of rails config see: https://github.com/JonRowe/rails-broken-dir-example for an example broken application.
