### PR TITLE
Commas in directory names causes hang in ActiveSupport::FileUpdateChecker

### DIFF
--- a/activesupport/lib/active_support/file_update_checker.rb
+++ b/activesupport/lib/active_support/file_update_checker.rb
@@ -106,9 +106,13 @@ module ActiveSupport
 
       globs = []
       hash.each do |key, value|
-        globs << "#{key}/**/*#{compile_ext(value)}"
+        globs << "#{escape(key)}/**/*#{compile_ext(value)}"
       end
       "{#{globs.join(",")}}"
+    end
+
+    def escape(key)
+      key.gsub(',','\,')
     end
 
     def compile_ext(array) #:nodoc:

--- a/activesupport/test/file_update_checker_test.rb
+++ b/activesupport/test/file_update_checker_test.rb
@@ -1,5 +1,6 @@
 require 'abstract_unit'
 require 'fileutils'
+require 'thread'
 
 MTIME_FIXTURES_PATH = File.expand_path("../fixtures", __FILE__)
 
@@ -78,5 +79,19 @@ class FileUpdateCheckerWithEnumerableTest < ActiveSupport::TestCase
     end
     assert !checker.execute_if_updated
     assert_equal 0, i
+  end
+
+  def test_should_not_block_if_a_strange_filename_used
+    FileUtils.mkdir_p("tmp_watcher/valid,yetstrange,path,")
+    FileUtils.touch(FILES.map { |file_name| "tmp_watcher/valid,yetstrange,path,/#{file_name}" } )
+
+    test = Thread.new do
+      checker = ActiveSupport::FileUpdateChecker.new([],"tmp_watcher/valid,yetstrange,path," => :txt){ i += 1 }
+      Thread.exit
+    end
+    test.priority = -1
+    test.join(5)
+
+    assert !test.alive?
   end
 end


### PR DESCRIPTION
Having commas in directory names passed through to ActiveSupport::FileUpdateChecker causes an infinite hang whilst Dir[@glob] tries and fails to list files in these directories. This wasn't an issue before ~> 3.2 but on 3.2 upwards it prevents Rails from booting in development mode and prevents test suites running (rspec, cucumber at least).

Commas are perfectly valid parts of directory names (on OS X at least) and escaping them when compiling the glob solves this issue.

This issue can be triggered by adding such directories to the autoload component of rails config see: https://github.com/JonRowe/rails-broken-dir-example for an example broken application.

This is a duplicate of #5445 but, as requested, against master and without fork.

Be warned on OSX/MRI Ruby this causes an infinite hang on test failure... 
