### PR TITLE
Address the dump file format for hstore

### DIFF
--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -239,7 +239,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     def test_schema_dump_includes_hstores_shorthand_definition
       output = standard_dump
       if %r{create_table "postgresql_hstores"} =~ output
-        assert_match %r{t.hstore "hash_store", default => ""}, output
+        assert_match %r[t.hstore "hash_store", :default => {}], output
       end
     end
 


### PR DESCRIPTION
When ActiveRecord unit tests are tested with PostgreSQL v9.1.2(hstore installed), 
Always got a failure as follows. 

``` ruby
$ ARCONN=postgresql ruby -Itest test/cases/schema_dumper_test.rb -n 'test_schema_dump_includes_hstores_shorthand_definition'
Using postgresql
Run options: -n test_schema_dump_includes_hstores_shorthand_definition --seed 31050

# Running tests:

F

Finished tests in 1.178730s, 0.8484 tests/s, 1.6967 assertions/s.

  1) Failure:
test_schema_dump_includes_hstores_shorthand_definition(SchemaDumperTest) [test/cases/schema_dumper_test.rb:242]:
Expected /t.hstore "hash_store", default => ""/ to match "# ... snip ...
```

The dump file output is slightly different from current test code.
You can see the whole (very long) output via https://gist.github.com/1b0444910e7d6ad5b404
