### PR TITLE
When Active Record has already loaded a unique association `.size` returns the wrong number.

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -248,8 +248,12 @@ module ActiveRecord
       # This method is abstract in the sense that it relies on
       # +count_records+, which is a method descendants have to provide.
       def size
-        if !find_target? || (loaded? && !options[:uniq])
-          target.size
+        if !find_target? || loaded?
+          if options[:uniq]
+            target.uniq.size
+          else
+            target.size
+          end
         elsif !loaded? && options[:group]
           load_target.size
         elsif !loaded? && !options[:uniq] && target.is_a?(Array)

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -338,6 +338,12 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 3, project.developers.size
   end
 
+  def test_uniq_when_association_already_loaded
+    project = projects(:active_record)
+    project.developers << [ developers(:jamis), developers(:david), developers(:jamis), developers(:david) ]
+    assert_equal 3, Project.includes(:developers).find(project.id).developers.size
+  end
+
   def test_deleting
     david = Developer.find(1)
     active_record = Project.find(1)


### PR DESCRIPTION
When ActiveRecord has already eager loaded an association a call to that association returns the wrong number, count still returns correctly because it executes a fresh query. This may be undesirable. This patch respects the `:uniq` flag on the association and filters the already loaded array accordingly before calling `.size`.

Tested against SQLite, Mysql and Postgres (even though this modified no sql).

Fixes #4982 (symptoms shown below)

<pre>
User.where(id:5).first.followers.size
  User Load (0.8ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 5 LIMIT 1
  User Load (0.3ms)  SELECT DISTINCT `users`.* FROM `users` INNER JOIN `followers_users` ON `users`.`id` = `followers_users`.`user_id` WHERE `followers_users`.`follower_id` = 5
</pre>


<pre>
User.where(id:5).includes(:followers).first.followers.size
  User Load (0.6ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 5 LIMIT 1
  SQL (0.8ms)  SELECT `users`.*, `t0`.`follower_id` AS ar_association_key_name FROM `users` INNER JOIN `followers_users` `t0` ON `users`.`id` = `t0`.`user_id` WHERE `t0`.`follower_id` IN (5)
 => 18
</pre>


See https://gist.github.com/2044768 for files needed to replicate
