### PR TITLE
allow zero-arity proc for AbstrController::layout

### DIFF
--- a/actionpack/lib/abstract_controller/layouts.rb
+++ b/actionpack/lib/abstract_controller/layouts.rb
@@ -89,7 +89,7 @@ module AbstractController
   #   class TillController < BankController
   #     layout false
   #
-  # In these examples, we have three implicit lookup scenrios:
+  # In these examples, we have three implicit lookup scenarios:
   # * The BankController uses the "bank" layout.
   # * The ExchangeController uses the "exchange" layout.
   # * The CurrencyController inherits the layout from BankController.
@@ -128,7 +128,14 @@ module AbstractController
   # If you want to use an inline method, such as a proc, do something like this:
   #
   #   class WeblogController < ActionController::Base
-  #     layout proc{ |controller| controller.logged_in? ? "writer_layout" : "reader_layout" }
+  #     layout proc { |controller| controller.logged_in? ? "writer_layout" : "reader_layout" }
+  #   end
+  #
+  # If an argument isn't given to the proc, it's evaluated in the context of
+  # the current controller anyway.
+  #
+  #   class WeblogController < ActionController::Base
+  #     layout proc { logged_in? ? "writer_layout" : "reader_layout" }
   #   end
   #
   # Of course, the most common way of specifying a layout is still just as a plain template name:
@@ -299,8 +306,8 @@ module AbstractController
               end
             RUBY
           when Proc
-            define_method :_layout_from_proc, &_layout
-            "_layout_from_proc(self)"
+              define_method :_layout_from_proc, &_layout
+              _layout.arity == 0 ? "_layout_from_proc" : "_layout_from_proc(self)"
           when false
             nil
           when true

--- a/actionpack/test/abstract/layouts_test.rb
+++ b/actionpack/test/abstract/layouts_test.rb
@@ -72,6 +72,27 @@ module AbstractControllerTests
       end
     end
 
+    class WithZeroArityProc < Base
+      layout proc { "overwrite" }
+
+      def index
+        render :template => ActionView::Template::Text.new("Hello zero arity proc!")
+      end
+    end
+
+    class WithProcInContextOfInstance < Base
+      def an_instance_method; end
+
+      layout proc {
+        break unless respond_to? :an_instance_method
+        "overwrite"
+      }
+
+      def index
+        render :template => ActionView::Template::Text.new("Hello again zero arity proc!")
+      end
+    end
+
     class WithSymbol < Base
       layout :hello
 
@@ -219,6 +240,18 @@ module AbstractControllerTests
         controller = WithProc.new
         controller.process(:index)
         assert_equal "Overwrite Hello proc!", controller.response_body
+      end
+
+      test "when layout is specified as a proc without parameters it works just the same" do
+        controller = WithZeroArityProc.new
+        controller.process(:index)
+        assert_equal "Overwrite Hello zero arity proc!", controller.response_body
+      end
+
+      test "when layout is specified as a proc without parameters the block is evaluated in the context of an instance" do
+        controller = WithProcInContextOfInstance.new
+        controller.process(:index)
+        assert_equal "Overwrite Hello again zero arity proc!", controller.response_body
       end
 
       test "when layout is specified as a symbol, call the requested method and use the layout returned" do


### PR DESCRIPTION
proc without parameters can now be given to
AbstractController::layout

See pull-request 5444 for full discussion.
