### PR TITLE
params on force_ssl 

### DIFF
--- a/actionpack/lib/action_controller/metal/force_ssl.rb
+++ b/actionpack/lib/action_controller/metal/force_ssl.rb
@@ -26,7 +26,9 @@ module ActionController
       def force_ssl(options = {})
         before_filter(options) do
           if !request.ssl? && !Rails.env.development?
-            redirect_to :protocol => 'https://', :status => :moved_permanently
+            redirect_options = { :protocol => 'https://', :status => :moved_permanently }
+            redirect_options.merge!(:params => request.query_parameters)
+            redirect_to redirect_options
           end
         end
       end

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -519,6 +519,8 @@ module ActionDispatch
         path_addition, params = generate(path_options, path_segments || {})
         path << path_addition
 
+        params.merge!(options[:params] || {})
+
         ActionDispatch::Http::URL.url_for(options.merge({
           :path => path,
           :params => params,

--- a/actionpack/test/controller/force_ssl_test.rb
+++ b/actionpack/test/controller/force_ssl_test.rb
@@ -31,6 +31,11 @@ class ForceSSLControllerLevelTest < ActionController::TestCase
     assert_equal "https://test.host/force_ssl_controller_level/banana", redirect_to_url
   end
 
+  def test_banana_with_params_redirects_to_https_with_params
+    get :banana, :id => "12345"
+    assert_equal "https://test.host/force_ssl_controller_level/banana?id=12345", redirect_to_url
+  end
+
   def test_cheeseburger_redirects_to_https
     get :cheeseburger
     assert_response 301


### PR DESCRIPTION
This commit fixes a small bug on 3-1-stable when using force_ssl in a controller. 

When hitting a url like: 

http://host.com/people/1

it would redirect to the secure url, but without the param "1". 

https://host.com/people/

This commit fixes it by redirecting to the https equivalent using the params: 

https://host.com/people?id=1
