### PR TITLE
Strip null bytes from Location header

### DIFF
--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -93,7 +93,7 @@ module ActionController
           _compute_redirect_to_location options.call
         else
           url_for(options)
-        end.gsub(/[\r\n]/, '')
+        end.gsub(/[\0\r\n]/, '')
       end
   end
 end

--- a/actionpack/lib/action_dispatch/testing/assertions/response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/response.rb
@@ -83,7 +83,7 @@ module ActionDispatch
             refer
           else
             @controller.url_for(fragment)
-          end.gsub(/[\r\n]/, '')
+          end.gsub(/[\0\r\n]/, '')
         end
     end
   end

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -103,6 +103,14 @@ class RedirectController < ActionController::Base
     redirect_to proc { {:action => "hello_world"} }
   end
 
+  def redirect_with_header_break
+    redirect_to "/lol\r\nwat"
+  end
+
+  def redirect_with_null_bytes
+    redirect_to "\000/lol\r\nwat"
+  end
+
   def rescue_errors(e) raise e end
 
   protected
@@ -118,6 +126,18 @@ class RedirectTest < ActionController::TestCase
     get :simple_redirect
     assert_response :redirect
     assert_equal "http://test.host/redirect/hello_world", redirect_to_url
+  end
+
+  def test_redirect_with_header_break
+    get :redirect_with_header_break
+    assert_response :redirect
+    assert_equal "http://test.host/lolwat", redirect_to_url
+  end
+
+  def test_redirect_with_null_bytes
+    get :redirect_with_header_break
+    assert_response :redirect
+    assert_equal "http://test.host/lolwat", redirect_to_url
   end
 
   def test_redirect_with_no_status


### PR DESCRIPTION
This strips null bytes off of the `Location` header in addition to `\r\n` which are already being stripped.

This is in response to a recent _nasty_ security [vulnerability in nginx](http://mailman.nginx.org/pipermail/nginx-announce/2012/000076.html). I figure it's probably easier for people to get this patch in their Rails applications than it is for them to get nginx upgraded in their infrastructure - which may or may not even be managed by them.

I'd like to get this into all supported Rails versions, not sure if this patch will apply cleanly to 3.1 or 3.0 - let me know if not and I'll send some others.
