### PR TITLE
Remove deprecation from AS::Deprecation behavior, some minor cleanups

### DIFF
--- a/activesupport/lib/active_support/basic_object.rb
+++ b/activesupport/lib/active_support/basic_object.rb
@@ -10,5 +10,4 @@ module ActiveSupport
       ::Object.send(:raise, *args)
     end
   end
-
 end

--- a/activesupport/lib/active_support/file_update_checker.rb
+++ b/activesupport/lib/active_support/file_update_checker.rb
@@ -1,5 +1,3 @@
-require "active_support/core_ext/array/extract_options"
-
 module ActiveSupport
   # \FileUpdateChecker specifies the API used by Rails to watch files
   # and control reloading. The API depends on four methods:
@@ -93,10 +91,10 @@ module ActiveSupport
 
     def updated_at #:nodoc:
       @updated_at || begin
-        all = []
-        all.concat @files.select { |f| File.exists?(f) }
+        all = @files.select { |f| File.exists?(f) }
         all.concat Dir[@glob] if @glob
-        all.map { |path| File.mtime(path) }.max || Time.at(0)
+        all.map! { |path| File.mtime(path) }
+        all.max || Time.at(0)
       end
     end
 
@@ -104,9 +102,8 @@ module ActiveSupport
       hash.freeze # Freeze so changes aren't accidently pushed
       return if hash.empty?
 
-      globs = []
-      hash.each do |key, value|
-        globs << "#{escape(key)}/**/*#{compile_ext(value)}"
+      globs = hash.map do |key, value|
+        "#{escape(key)}/**/*#{compile_ext(value)}"
       end
       "{#{globs.join(",")}}"
     end

--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -3,7 +3,7 @@ require 'active_support/core_ext/class/attribute'
 
 module ActiveSupport
   # ActiveSupport::LogSubscriber is an object set to consume ActiveSupport::Notifications
-  # with the sole purpose of logging them. The log subscriber dispatches notifications to 
+  # with the sole purpose of logging them. The log subscriber dispatches notifications to
   # a registered object based on its given namespace.
   #
   # An example would be Active Record log subscriber responsible for logging queries:
@@ -75,7 +75,8 @@ module ActiveSupport
         @@flushable_loggers ||= begin
           loggers = log_subscribers.map(&:logger)
           loggers.uniq!
-          loggers.select { |l| l.respond_to?(:flush) }
+          loggers.select! { |l| l.respond_to?(:flush) }
+          loggers
         end
       end
 
@@ -101,8 +102,7 @@ module ActiveSupport
     %w(info debug warn error fatal unknown).each do |level|
       class_eval <<-METHOD, __FILE__, __LINE__ + 1
         def #{level}(progname = nil, &block)
-          return unless logger
-          logger.#{level}(progname, &block)
+          logger.#{level}(progname, &block) if logger
         end
       METHOD
     end

--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -9,15 +9,14 @@ module ActiveSupport
       end
 
       def subscribe(pattern = nil, block = Proc.new)
-        subscriber = Subscriber.new(pattern, block).tap do |s|
-          @subscribers << s
-        end
+        subscriber = Subscriber.new(pattern, block)
+        @subscribers << subscriber
         @listeners_for.clear
         subscriber
       end
 
       def unsubscribe(subscriber)
-        @subscribers.reject! {|s| s.matches?(subscriber)}
+        @subscribers.reject! { |s| s.matches?(subscriber) }
         @listeners_for.clear
       end
 

--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -1,5 +1,3 @@
-require 'active_support/core_ext/module/delegation'
-
 module ActiveSupport
   module Notifications
     class Instrumenter

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -8,30 +8,6 @@ module ActiveSupport
     initializer "active_support.deprecation_behavior" do |app|
       if deprecation = app.config.active_support.deprecation
         ActiveSupport::Deprecation.behavior = deprecation
-      else
-        defaults = {"development" => :log,
-                    "production"  => :notify,
-                    "test"        => :stderr}
-
-        env = Rails.env
-
-        if defaults.key?(env)
-          msg = "You did not specify how you would like Rails to report " \
-                "deprecation notices for your #{env} environment, please " \
-                "set config.active_support.deprecation to :#{defaults[env]} " \
-                "at config/environments/#{env}.rb"
-
-          warn msg
-          ActiveSupport::Deprecation.behavior = defaults[env]
-        else
-          msg = "You did not specify how you would like Rails to report " \
-                "deprecation notices for your #{env} environment, please " \
-                "set config.active_support.deprecation to :log, :notify or " \
-                ":stderr at config/environments/#{env}.rb"
-
-          warn msg
-          ActiveSupport::Deprecation.behavior = :stderr
-        end
       end
     end
 
@@ -42,8 +18,7 @@ module ActiveSupport
       zone_default = Time.find_zone!(app.config.time_zone)
 
       unless zone_default
-        raise \
-          'Value assigned to config.time_zone not recognized.' +
+        raise 'Value assigned to config.time_zone not recognized. ' \
           'Run "rake -D time" for a list of tasks for finding appropriate time zone names.'
       end
 

--- a/activesupport/test/file_update_checker_test.rb
+++ b/activesupport/test/file_update_checker_test.rb
@@ -83,10 +83,10 @@ class FileUpdateCheckerWithEnumerableTest < ActiveSupport::TestCase
 
   def test_should_not_block_if_a_strange_filename_used
     FileUtils.mkdir_p("tmp_watcher/valid,yetstrange,path,")
-    FileUtils.touch(FILES.map { |file_name| "tmp_watcher/valid,yetstrange,path,/#{file_name}" } )
+    FileUtils.touch(FILES.map { |file_name| "tmp_watcher/valid,yetstrange,path,/#{file_name}" })
 
     test = Thread.new do
-      ActiveSupport::FileUpdateChecker.new([],"tmp_watcher/valid,yetstrange,path," => :txt){ i += 1 }
+      ActiveSupport::FileUpdateChecker.new([],"tmp_watcher/valid,yetstrange,path," => :txt) { i += 1 }
       Thread.exit
     end
     test.priority = -1


### PR DESCRIPTION
- Refactor log subscriber, use select! to avoid a new object
- Remove deprecation messages related to AS::Deprecation behavior.
  This was added about 2 years ago for Rails 3:
  https://github.com/rails/rails/commit/d4c7d3fd94e5a885a6366eaeb3b908bb58ffd4db
- Remove some not used requires
- Refactor delegate to avoid string conversions and if statements inside each block
