### PR TITLE
ActiveRecord::Core#initialize: improve performance

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -176,7 +176,7 @@ module ActiveRecord
       assign_attributes(attributes, options) if attributes
 
       yield self if block_given?
-      run_callbacks :initialize
+      run_callbacks :initialize if _initialize_callbacks.any?
     end
 
     # Initialize an empty model object from +coder+. +coder+ must contain


### PR DESCRIPTION
According to this article:
http://merbist.com/2012/02/23/quick-dive-into-ruby-orm-object-initialization/

AR initialization callbacks are slow even if we don't use them.
I didn't find a way to improve performance in `AS::Callbacks` level.

So, Here is what we can do to avoid going into `run_callbacks` if we don't use them.

Benchmark file: https://gist.github.com/2043384
Super funny benchmark tool: [diffbench](https://github.com/bogdan/diffbench)

```
Running benchmark with current working tree
Checkout HEAD^
Running benchmark with HEAD^
Checkout to previous HEAD again

----------simple initialize----------
After patch:   0.160000   0.000000   0.160000 (  0.159779)
Before patch:   0.210000   0.010000   0.220000 (  0.216816)

----------initialize with attributes----------
After patch:   0.610000   0.000000   0.610000 (  0.623824)
Before patch:   0.660000   0.000000   0.660000 (  0.663776)
```
