### PR TITLE
Fix for #5440

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -106,6 +106,7 @@ module AbstractController
     # Find and renders a template based on the options given.
     # :api: private
     def _render_template(options) #:nodoc:
+      lookup_context.rendered_format = nil if options[:formats]
       view_renderer.render(view_context, options)
     end
 

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -560,6 +560,12 @@ class TestController < ActionController::Base
     render :template => "test/with_partial", :formats => [:text]
   end
 
+  def render_template_within_a_template_with_other_format
+    render  :template => "test/with_xml_template",
+            :formats  => [:html],
+            :layout   => "with_html_partial"
+  end
+
   def partial_with_counter
     render :partial => "counter", :locals => { :counter_counter => 5 }
   end
@@ -1287,6 +1293,13 @@ class RenderTest < ActionController::TestCase
     assert_equal "<strong>only partial</strong>\n", assigns(:html)
     assert_equal "**only partial**\n", @response.body
     assert_equal "text/plain", @response.content_type
+  end
+
+  def test_render_template_within_a_template_with_other_format
+    get :render_template_within_a_template_with_other_format
+    expected = "only html partial<p>This is grand!</p>"
+    assert_equal expected, @response.body.strip
+    assert_equal "text/html", @response.content_type
   end
 
   def test_partial_with_counter

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -549,6 +549,17 @@ class TestController < ActionController::Base
     render :template => "test/hello_world"
   end
 
+  def render_to_string_with_template_and_html_partial
+    @text = render_to_string :template => "test/with_partial", :formats => [:text]
+    @html = render_to_string :template => "test/with_partial", :formats => [:html]
+    render :template => "test/with_html_partial"
+  end
+
+  def render_to_string_and_render_with_different_formats
+    @html = render_to_string :template => "test/with_partial", :formats => [:html]
+    render :template => "test/with_partial", :formats => [:text]
+  end
+
   def partial_with_counter
     render :partial => "counter", :locals => { :counter_counter => 5 }
   end
@@ -1261,6 +1272,21 @@ class RenderTest < ActionController::TestCase
     assert_equal "only partial", assigns(:partial_only)
     assert_equal "Hello: david", assigns(:partial_with_locals)
     assert_equal "text/html", @response.content_type
+  end
+
+  def test_render_to_string_with_template_and_html_partial
+    get :render_to_string_with_template_and_html_partial
+    assert_equal "**only partial**\n", assigns(:text)
+    assert_equal "<strong>only partial</strong>\n", assigns(:html)
+    assert_equal "<strong>only html partial</strong>\n", @response.body
+    assert_equal "text/html", @response.content_type
+  end
+
+  def test_render_to_string_and_render_with_different_formats
+    get :render_to_string_and_render_with_different_formats
+    assert_equal "<strong>only partial</strong>\n", assigns(:html)
+    assert_equal "**only partial**\n", @response.body
+    assert_equal "text/plain", @response.content_type
   end
 
   def test_partial_with_counter

--- a/actionpack/test/fixtures/layouts/with_html_partial.html.erb
+++ b/actionpack/test/fixtures/layouts/with_html_partial.html.erb
@@ -1,0 +1,1 @@
+<%= render :partial => "partial_only_html" %><%= yield %>

--- a/actionpack/test/fixtures/test/_partial_only_html.html
+++ b/actionpack/test/fixtures/test/_partial_only_html.html
@@ -1,0 +1,1 @@
+only html partial

--- a/actionpack/test/fixtures/test/with_html_partial.html.erb
+++ b/actionpack/test/fixtures/test/with_html_partial.html.erb
@@ -1,0 +1,1 @@
+<strong><%= render :partial => "partial_only_html" %></strong>

--- a/actionpack/test/fixtures/test/with_partial.html.erb
+++ b/actionpack/test/fixtures/test/with_partial.html.erb
@@ -1,0 +1,1 @@
+<strong><%= render :partial => "partial_only" %></strong>

--- a/actionpack/test/fixtures/test/with_partial.text.erb
+++ b/actionpack/test/fixtures/test/with_partial.text.erb
@@ -1,0 +1,1 @@
+**<%= render :partial => "partial_only" %>**

--- a/actionpack/test/fixtures/test/with_xml_template.html.erb
+++ b/actionpack/test/fixtures/test/with_xml_template.html.erb
@@ -1,0 +1,1 @@
+<%= render :template => "test/greeting", :formats => :xml %>


### PR DESCRIPTION
This fixes situation where rendering template to string sets `rendered_format` to the format rendered there. This is ok to have consistent formats rendered in partials, but it breaks on next renders if format is explicitly set or on last render where default format does not necessarily need to be the format of first rendered template.

cc @josevalim
