### PR TITLE
get rid of warning when running tests

### DIFF
--- a/actionpack/lib/action_controller/caching/sweeping.rb
+++ b/actionpack/lib/action_controller/caching/sweeping.rb
@@ -88,8 +88,11 @@ module ActionController #:nodoc:
           end
 
           def method_missing(method, *arguments, &block)
-            super unless @controller
-            @controller.__send__(method, *arguments, &block)
+            if defined?(@controller) and @controller
+              @controller.__send__(method, *arguments, &block)
+            else
+              super
+            end
           end
       end
     end


### PR DESCRIPTION
get rid of annoying warning when running actionpack tests
