### PR TITLE
switch rack-test in Gemfile to using git protocol

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ else
   gem 'arel'
 end
 
-gem 'rack-test', :git => "https://github.com/brynary/rack-test.git"
+gem 'rack-test', :git => "git://github.com/brynary/rack-test.git"
 gem 'bcrypt-ruby', '~> 3.0.0'
 gem 'jquery-rails'
 


### PR DESCRIPTION
can't run tests if git not compiled with libcurl

I'm wondering if there's a good reason to use https, but git blame didn't point to a commit with an explanation of why this is so. Sorry if there's already been discussion about this, I tried to find it though.
