### PR TITLE
use consistent explicit module inclusion

### DIFF
--- a/actionpack/test/abstract/abstract_controller_test.rb
+++ b/actionpack/test/abstract/abstract_controller_test.rb
@@ -29,7 +29,7 @@ module AbstractController
     # Test Render mixin
     # ====
     class RenderingController < AbstractController::Base
-      include ::AbstractController::Rendering
+      include AbstractController::Rendering
 
       def _prefixes
         []
@@ -153,7 +153,7 @@ module AbstractController
     # ====
     # self._layout is used when defined
     class WithLayouts < PrefixedViews
-      include Layouts
+      include AbstractController::Layouts
 
       private
       def self.layout(formats)

--- a/actionpack/test/abstract/collector_test.rb
+++ b/actionpack/test/abstract/collector_test.rb
@@ -3,7 +3,7 @@ require 'abstract_unit'
 module AbstractController
   module Testing
     class MyCollector
-      include Collector
+      include AbstractController::Collector
       attr_accessor :responses
 
       def initialize

--- a/actionpack/test/abstract/helper_test.rb
+++ b/actionpack/test/abstract/helper_test.rb
@@ -7,7 +7,7 @@ module AbstractController
 
     class ControllerWithHelpers < AbstractController::Base
       include AbstractController::Rendering
-      include Helpers
+      include AbstractController::Helpers
 
       def with_module
         render :inline => "Module <%= included_method %>"
@@ -44,7 +44,7 @@ module AbstractController
 
     class AbstractHelpersBlock < ControllerWithHelpers
       helper do
-        include ::AbstractController::Testing::HelperyTest
+        include AbstractController::Testing::HelperyTest
       end
     end
 


### PR DESCRIPTION
aid ease of understanding and readability for tests

I'm new to rails internals and going through the tests to get a good idea of how things work. Sometimes important modules that bring in lots of functionality are referenced by their absolute name and sometimes they aren't. I think they should be referenced using their full name.
