### PR TITLE
Remove Rack::SSL in favour of ActionDispatch::SSL

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Added ActionDispatch::SSL middleware that when included force all the requests to be under HTTPS protocol. *Rafael Mendonça França*
+
 *   Add `include_hidden` option to select tag. With `:include_hidden => false` select with `multiple` attribute doesn't generate hidden input with blank value. *Vasiliy Ermolovich*
 
 *   Removed default `size` option from the `text_field`, `search_field`, `telephone_field`, `url_field`, `email_field` helpers. *Philip Arndt*
@@ -120,8 +122,8 @@
 
 *   `favicon_link_tag` helper will now use the favicon in app/assets by default. *Lucas Caton*
 
-*    `ActionView::Helpers::TextHelper#highlight` now defaults to the
-     HTML5 `mark` element. *Brian Cardarella*
+*   `ActionView::Helpers::TextHelper#highlight` now defaults to the
+    HTML5 `mark` element. *Brian Cardarella*
 
 
 ## Rails 3.2.3 (unreleased) ##

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -61,6 +61,7 @@ module ActionDispatch
     autoload :Reloader
     autoload :RemoteIp
     autoload :ShowExceptions
+    autoload :SSL
     autoload :Static
   end
 

--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -9,7 +9,7 @@ module ActionDispatch
   # of ShowExceptions. Everytime there is an exception, ShowExceptions will
   # store the exception in env["action_dispatch.exception"], rewrite the
   # PATH_INFO to the exception status code and call the rack app.
-  # 
+  #
   # If the application returns a "X-Cascade" pass response, this middleware
   # will send an empty response as result with the correct status code.
   # If any exception happens inside the exceptions app, this middleware

--- a/actionpack/lib/action_dispatch/middleware/ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/ssl.rb
@@ -1,0 +1,87 @@
+module ActionDispatch
+  class SSL
+    YEAR = 31536000
+
+    def self.default_hsts_options
+      { :expires => YEAR, :subdomains => false }
+    end
+
+    def initialize(app, options = {})
+      @app = app
+
+      @hsts = options[:hsts]
+      @hsts = {} if @hsts.nil? || @hsts == true
+      @hsts = self.class.default_hsts_options.merge(@hsts) if @hsts
+
+      @exclude = options[:exclude]
+      @host    = options[:host]
+      @port    = options[:port]
+    end
+
+    def call(env)
+      if @exclude && @exclude.call(env)
+        @app.call(env)
+      elsif scheme(env) == 'https'
+        status, headers, body = @app.call(env)
+        headers = hsts_headers.merge(headers)
+        flag_cookies_as_secure!(headers)
+        [status, headers, body]
+      else
+        redirect_to_https(env)
+      end
+    end
+
+    private
+      # Fixed in rack >= 1.3
+      def scheme(env)
+        if env['HTTPS'] == 'on'
+          'https'
+        elsif env['HTTP_X_FORWARDED_PROTO']
+          env['HTTP_X_FORWARDED_PROTO'].split(',')[0]
+        else
+          env['rack.url_scheme']
+        end
+      end
+
+      def redirect_to_https(env)
+        req        = Request.new(env)
+        url        = URI(req.url)
+        url.scheme = "https"
+        url.host   = @host if @host
+        url.port   = @port if @port
+        headers    = hsts_headers.merge('Content-Type' => 'text/html',
+                                        'Location'     => url.to_s)
+
+        [301, headers, []]
+      end
+
+      # http://tools.ietf.org/html/draft-hodges-strict-transport-sec-02
+      def hsts_headers
+        if @hsts
+          value = "max-age=#{@hsts[:expires]}"
+          value += "; includeSubDomains" if @hsts[:subdomains]
+          { 'Strict-Transport-Security' => value }
+        else
+          {}
+        end
+      end
+
+      def flag_cookies_as_secure!(headers)
+        if cookies = headers['Set-Cookie']
+          # Rack 1.1's set_cookie_header! will sometimes wrap
+          # Set-Cookie in an array
+          unless cookies.respond_to?(:to_ary)
+            cookies = cookies.split("\n")
+          end
+
+          headers['Set-Cookie'] = cookies.map { |cookie|
+            if cookie !~ /; secure(;|$)/
+              "#{cookie}; secure"
+            else
+              cookie
+            end
+          }.join("\n")
+        end
+      end
+  end
+end

--- a/actionpack/test/dispatch/ssl_test.rb
+++ b/actionpack/test/dispatch/ssl_test.rb
@@ -1,0 +1,149 @@
+require 'abstract_unit'
+
+class SSLTest < ActionDispatch::IntegrationTest
+  def default_app
+    lambda { |env|
+      headers = {'Content-Type' => "text/html"}
+      headers['Set-Cookie'] = "id=1; path=/\ntoken=abc; path=/; secure; HttpOnly"
+      [200, headers, ["OK"]]
+    }
+  end
+
+  def app
+    @app ||= ActionDispatch::SSL.new(default_app)
+  end
+  attr_writer :app
+
+  def test_allows_https_url
+    get "https://example.org/path?key=value"
+    assert_response :success
+  end
+
+  def test_allows_https_proxy_header_url
+    get "http://example.org/", {}, 'HTTP_X_FORWARDED_PROTO' => "https"
+    assert_response :success
+  end
+
+  def test_redirects_http_to_https
+    get "http://example.org/path?key=value"
+    assert_response :redirect
+    assert_equal "https://example.org/path?key=value",
+      response.headers['Location']
+  end
+
+  def test_exclude_from_redirect
+    self.app = ActionDispatch::SSL.new(default_app, :exclude => lambda { |env| true })
+    get "http://example.org/"
+    assert_response :success
+  end
+
+  def test_hsts_header_by_default
+    get "https://example.org/"
+    assert_equal "max-age=31536000",
+      response.headers['Strict-Transport-Security']
+  end
+
+  def test_hsts_header
+    self.app = ActionDispatch::SSL.new(default_app, :hsts => true)
+    get "https://example.org/"
+    assert_equal "max-age=31536000",
+      response.headers['Strict-Transport-Security']
+  end
+
+  def test_disable_hsts_header
+    self.app = ActionDispatch::SSL.new(default_app, :hsts => false)
+    get "https://example.org/"
+    refute response.headers['Strict-Transport-Security']
+  end
+
+  def test_hsts_expires
+    self.app = ActionDispatch::SSL.new(default_app, :hsts => { :expires => 500 })
+    get "https://example.org/"
+    assert_equal "max-age=500",
+      response.headers['Strict-Transport-Security']
+  end
+
+  def test_hsts_include_subdomains
+    self.app = ActionDispatch::SSL.new(default_app, :hsts => { :subdomains => true })
+    get "https://example.org/"
+    assert_equal "max-age=31536000; includeSubDomains",
+      response.headers['Strict-Transport-Security']
+  end
+
+  def test_flag_cookies_as_secure
+    get "https://example.org/"
+    assert_equal ["id=1; path=/; secure", "token=abc; path=/; secure; HttpOnly" ],
+      response.headers['Set-Cookie'].split("\n")
+  end
+
+  def test_flag_cookies_as_secure_at_end_of_line
+    self.app = ActionDispatch::SSL.new(lambda { |env|
+      headers = {
+        'Content-Type' => "text/html",
+        'Set-Cookie' => "problem=def; path=/; HttpOnly; secure"
+      }
+      [200, headers, ["OK"]]
+    })
+
+    get "https://example.org/"
+    assert_equal ["problem=def; path=/; HttpOnly; secure"],
+      response.headers['Set-Cookie'].split("\n")
+  end
+
+  def test_legacy_array_headers
+    self.app = ActionDispatch::SSL.new(lambda { |env|
+      headers = {
+        'Content-Type' => "text/html",
+        'Set-Cookie' => ["id=1; path=/", "token=abc; path=/; HttpOnly"]
+      }
+      [200, headers, ["OK"]]
+    })
+
+    get "https://example.org/"
+    assert_equal ["id=1; path=/; secure", "token=abc; path=/; HttpOnly; secure"],
+      response.headers['Set-Cookie'].split("\n")
+  end
+
+  def test_no_cookies
+    self.app = ActionDispatch::SSL.new(lambda { |env|
+      [200, {'Content-Type' => "text/html"}, ["OK"]]
+    })
+    get "https://example.org/"
+    assert !response.headers['Set-Cookie']
+  end
+
+  def test_redirect_to_host
+    self.app = ActionDispatch::SSL.new(default_app, :host => "ssl.example.org")
+    get "http://example.org/path?key=value"
+    assert_equal "https://ssl.example.org/path?key=value",
+      response.headers['Location']
+  end
+
+  def test_redirect_to_port
+    self.app = ActionDispatch::SSL.new(default_app, :port => 8443)
+    get "http://example.org/path?key=value"
+    assert_equal "https://example.org:8443/path?key=value",
+      response.headers['Location']
+  end
+
+  def test_redirect_to_host_and_port
+    self.app = ActionDispatch::SSL.new(default_app, :host => "ssl.example.org", :port => 8443)
+    get "http://example.org/path?key=value"
+    assert_equal "https://ssl.example.org:8443/path?key=value",
+      response.headers['Location']
+  end
+
+  def test_redirect_to_secure_host_when_on_subdomain
+    self.app = ActionDispatch::SSL.new(default_app, :host => "ssl.example.org")
+    get "http://ssl.example.org/path?key=value"
+    assert_equal "https://ssl.example.org/path?key=value",
+      response.headers['Location']
+  end
+
+  def test_redirect_to_secure_subdomain_when_on_deep_subdomain
+    self.app = ActionDispatch::SSL.new(default_app, :host => "example.co.uk")
+    get "http://double.rainbow.what.does.it.mean.example.co.uk/path?key=value"
+    assert_equal "https://example.co.uk/path?key=value",
+      response.headers['Location']
+  end
+end

--- a/actionpack/test/dispatch/ssl_test.rb
+++ b/actionpack/test/dispatch/ssl_test.rb
@@ -90,20 +90,6 @@ class SSLTest < ActionDispatch::IntegrationTest
       response.headers['Set-Cookie'].split("\n")
   end
 
-  def test_legacy_array_headers
-    self.app = ActionDispatch::SSL.new(lambda { |env|
-      headers = {
-        'Content-Type' => "text/html",
-        'Set-Cookie' => ["id=1; path=/", "token=abc; path=/; HttpOnly"]
-      }
-      [200, headers, ["OK"]]
-    })
-
-    get "https://example.org/"
-    assert_equal ["id=1; path=/; secure", "token=abc; path=/; HttpOnly; secure"],
-      response.headers['Set-Cookie'].split("\n")
-  end
-
   def test_no_cookies
     self.app = ActionDispatch::SSL.new(lambda { |env|
       [200, {'Content-Type' => "text/html"}, ["OK"]]

--- a/guides/source/configuring.textile
+++ b/guides/source/configuring.textile
@@ -88,7 +88,7 @@ NOTE. The +config.asset_path+ configuration is ignored if the asset pipeline is 
 
 * +config.filter_parameters+ used for filtering out the parameters that you don't want shown in the logs, such as passwords or credit card numbers.
 
-* +config.force_ssl+ forces all requests to be under HTTPS protocol by using +Rack::SSL+ middleware.
+* +config.force_ssl+ forces all requests to be under HTTPS protocol by using +ActionDispatch::SSL+ middleware.
 
 * +config.log_level+ defines the verbosity of the Rails logger. This option defaults to +:debug+ for all modes except production, where it defaults to +:info+.
 
@@ -197,7 +197,7 @@ h4. Configuring Middleware
 
 Every Rails application comes with a standard set of middleware which it uses in this order in the development environment:
 
-* +Rack::SSL+ forces every request to be under HTTPS protocol. Will be available if +config.force_ssl+ is set to +true+.  Options passed to this can be configured by using +config.ssl_options+.
+* +ActionDispatch::SSL+ forces every request to be under HTTPS protocol. Will be available if +config.force_ssl+ is set to +true+. Options passed to this can be configured by using +config.ssl_options+.
 * +ActionDispatch::Static+ is used to serve static assets. Disabled if +config.serve_static_assets+ is +true+.
 * +Rack::Lock+ wraps the app in mutex so it can only be called by a single thread at a time. Only enabled if +config.action_controller.allow_concurrency+ is set to +false+, which it is by default.
 * +ActiveSupport::Cache::Strategy::LocalCache+ serves as a basic memory backed cache. This cache is not thread safe and is intended only for serving as a temporary memory cache for a single thread.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Remove Rack::SSL in favour of ActionDispatch::SSL. *Rafael Mendonça França*
+
 *   Remove Active Resource from Rails framework. *Prem Sichangrist*
 
 *   Allow to set class that will be used to run as a console, other than IRB, with `Rails.application.config.console=`. It's best to add it to `console` block. *Piotr Sarnacki*

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -225,8 +225,7 @@ module Rails
         end
 
         if config.force_ssl
-          require "rack/ssl"
-          middleware.use ::Rack::SSL, config.ssl_options
+          middleware.use ::ActionDispatch::SSL, config.ssl_options
         end
 
         if config.action_dispatch.x_sendfile_header.present?

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency('rake',          '>= 0.8.7')
   s.add_dependency('thor',          '~> 0.14.6')
-  s.add_dependency('rack-ssl',      '~> 1.3.2')
   s.add_dependency('rdoc',          '~> 3.4')
   s.add_dependency('activesupport', version)
   s.add_dependency('actionpack',    version)

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -66,13 +66,13 @@ module ApplicationTests
       assert_equal "Rack::Cache", middleware.first
     end
 
-    test "Rack::SSL is present when force_ssl is set" do
+    test "ActionDispatch::SSL is present when force_ssl is set" do
       add_to_config "config.force_ssl = true"
       boot!
-      assert middleware.include?("Rack::SSL")
+      assert middleware.include?("ActionDispatch::SSL")
     end
 
-    test "Rack::SSL is configured with options when given" do
+    test "ActionDispatch::SSL is configured with options when given" do
       add_to_config "config.force_ssl = true"
       add_to_config "config.ssl_options = { :host => 'example.com' }"
       boot!


### PR DESCRIPTION
As rack-ssl is an one file gem I think that is fine move this behavior inside the Rails itself.
