### PR TITLE
[3-2-stable] Fix GH #5435. db:structure:dump should be re-enable.

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -407,6 +407,7 @@ db_namespace = namespace :db do
       if ActiveRecord::Base.connection.supports_migrations?
         File.open(filename, "a") { |f| f << ActiveRecord::Base.connection.dump_schema_information }
       end
+      db_namespace['structure:dump'].reenable
     end
 
     # desc "Recreate the databases from the structure.sql file"

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -138,5 +138,17 @@ module ApplicationTests
       end
       assert File.exists?(File.join(app_path, 'db', 'my_structure.sql'))
     end
+
+    def test_rake_dump_structure_should_be_called_twice_when_migrate_redo
+      add_to_config "config.active_record.schema_format = :sql"
+
+      output = Dir.chdir(app_path) do
+        `rails g model post title:string;
+         bundle exec rake db:migrate:redo 2>&1 --trace;`
+      end
+
+      # expect only Invoke db:structure:dump (first_time)
+      assert_no_match(/^\*\* Invoke db:structure:dump\s+$/, output)
+    end
   end
 end


### PR DESCRIPTION
Backport to 3-2-stable.

/cc @tenderlove

Please see
https://github.com/rails/rails/pull/5486 and https://github.com/rails/rails/issues/5435
