### PR TITLE
ActiveRecord::Relation - maintain context of joined associations on merges

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -109,7 +109,7 @@ module ActiveRecord
         case associations
         when Symbol, String
           reflection = parent.reflections[associations.to_s.intern] or
-          raise ConfigurationError, "Association named '#{ associations }' was not found; perhaps you misspelled it?"
+          raise ConfigurationError, "Association named '#{ associations }' was not found on #{parent.active_record.name}; perhaps you misspelled it?"
           unless join_association = find_join_association(reflection, parent)
             @reflections << reflection
             join_association = build_join_association(reflection, parent)

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -55,7 +55,12 @@ module ActiveRecord
 
         def find_parent_in(other_join_dependency)
           other_join_dependency.join_parts.detect do |join_part|
-            parent == join_part
+            case parent
+            when JoinBase
+              parent.active_record == join_part.active_record
+            else
+              parent == join_part
+            end
           end
         end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -6,6 +6,7 @@ require 'models/topic'
 require 'models/comment'
 require 'models/author'
 require 'models/comment'
+require 'models/rating'
 require 'models/entrant'
 require 'models/developer'
 require 'models/reply'
@@ -19,7 +20,7 @@ require 'models/minivan'
 
 class RelationTest < ActiveRecord::TestCase
   fixtures :authors, :topics, :entrants, :developers, :companies, :developers_projects, :accounts, :categories, :categorizations, :posts, :comments,
-    :tags, :taggings, :cars, :minivans
+    :ratings, :tags, :taggings, :cars, :minivans
 
   def test_do_not_double_quote_string_id
     van = Minivan.last
@@ -729,6 +730,12 @@ class RelationTest < ActiveRecord::TestCase
   def test_relation_merging_with_joins
     comments = Comment.joins(:post).where(:body => 'Thank you for the welcome').merge(Post.where(:body => 'Such a lovely day'))
     assert_equal 1, comments.count
+  end
+
+  def test_relation_merging_with_merged_joins
+    special_comments_with_ratings = SpecialComment.joins(:ratings)
+    posts_with_special_comments_with_ratings = Post.group("posts.id").joins(:special_comments).merge(special_comments_with_ratings)
+    assert_equal 1, authors(:david).posts.merge(posts_with_special_comments_with_ratings).to_a.length
   end
 
   def test_count


### PR DESCRIPTION
Adds functionality that allows scopes such as: `Author.joins(:posts).merge(Post.joins(:comments)).group("authors.id")`, which would presently raise an error because there is no association `:comments` on `Author`.

---

ActiveRecord::Relation merges presently don't maintain the context of joined associations. That is, merging a Relation/scope that references joined associations into another with a different base ActiveRecord model will fail because the join associations are resolved from the base model at the time of query generation.

For example, consider the following ActiveRecord models:

``` ruby
class Author
  has_many :posts
end

class Post
  belongs_to :author
  has_many :comments
end

class Comment
  belongs_to :post
end
```

One might want to query all Comments on Posts by a specific Author. One way to write such a query could be:

``` ruby
Comment.joins(:post).merge(Post.joins(:author).merge(Author.where(:name => "Joe Blogs"))).all
```

Unfortunately, as the association joins are resolved at the time of query generation from the model of the new base `Relation`(as they are merged in as the original values passed to `joins` on the merged `Relation`), this query will fail as there is no association `:author` on `Comment`.

---

My proposed solution is to ensure that the source ActiveRecord model for association joins is persisted through Relation merges.

There is already logic for applying explicit association joins within `JoinDependency`: `JoinDependency#graft`. `Relation::SpawnMethods#build_joins` already treats any `JoinDependency::JoinAssociation` object within the `joins_values` in this way, so my proposed solution is to, whenever a `Relation` is merged into another, instead convert any `Relation#joins` arguments which would be treated as association joins into `JoinAssociation` objects (which encapsulate the parent model and source association) _at the time of merge_, thus maintaining the original intended context of the association to join. 

At query time, `JoinDependency#graft` then can resolve the stashed associations joins from the new base ActiveRecord model _and_ its [chain of] joined associations.
