### PR TITLE
Removed ActiveSupport#load_all!

### DIFF
--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -22,20 +22,6 @@
 #++
 
 require 'securerandom'
-
-module ActiveSupport
-  class << self
-    attr_accessor :load_all_hooks
-    def on_load_all(&hook) load_all_hooks << hook end
-    def load_all!; load_all_hooks.each { |hook| hook.call } end
-  end
-  self.load_all_hooks = []
-
-  on_load_all do
-    [Dependencies, Deprecation, Gzip, MessageVerifier, Multibyte]
-  end
-end
-
 require "active_support/dependencies/autoload"
 require "active_support/version"
 require "active_support/logger"
@@ -44,6 +30,7 @@ module ActiveSupport
   extend ActiveSupport::Autoload
 
   autoload :Concern
+  autoload :Dependencies
   autoload :DescendantsTracker
   autoload :FileUpdateChecker
   autoload :LogSubscriber

--- a/activesupport/lib/active_support/time.rb
+++ b/activesupport/lib/active_support/time.rb
@@ -4,10 +4,6 @@ module ActiveSupport
   autoload :Duration, 'active_support/duration'
   autoload :TimeWithZone, 'active_support/time_with_zone'
   autoload :TimeZone, 'active_support/values/time_zone'
-
-  on_load_all do
-    [Duration, TimeWithZone, TimeZone]
-  end
 end
 
 require 'date'


### PR DESCRIPTION
This is no longer used, has no test coverage, and actually raises an error when trying to load `ActiveSupport::Dependencies`. I removed the related code and added the `Dependencies` module to the autoload list.
