### PR TITLE
Provide access to logger instance within TaggedLogging blocks

### DIFF
--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -45,7 +45,7 @@ module ActiveSupport
       tags     = formatter.current_tags
       new_tags = new_tags.flatten.reject(&:blank?)
       tags.concat new_tags
-      yield
+      yield self
     ensure
       tags.pop(new_tags.size)
     end

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -18,7 +18,7 @@ class TaggedLoggingTest < ActiveSupport::TestCase
     @logger.tagged("BCX") { @logger.info "Funky time" }
     assert_equal "[BCX] Funky time\n", @output.string
   end
-  
+
   test "tagged twice" do
     @logger.tagged("BCX") { @logger.tagged("Jason") { @logger.info "Funky time" } }
     assert_equal "[BCX] [Jason] Funky time\n", @output.string
@@ -27,6 +27,11 @@ class TaggedLoggingTest < ActiveSupport::TestCase
   test "tagged thrice at once" do
     @logger.tagged("BCX", "Jason", "New") { @logger.info "Funky time" }
     assert_equal "[BCX] [Jason] [New] Funky time\n", @output.string
+  end
+
+  test "provides access to the logger instance" do
+    @logger.tagged("BCX") { |logger| logger.info "Funky time" }
+    assert_equal "[BCX] Funky time\n", @output.string
   end
 
   test "tagged once with blank and nil" do


### PR DESCRIPTION
this improves encapsulation, simplifying occurrences like the following:

```
Rails.logger.tagged("DEBUG") { Rails.logger.debug(msg) }
```

... by removing the need to rely on (i.e. repeat) outer variables:

```
Rails.logger.tagged("DEBUG") { |logger| logger.debug(msg) }
```
