### PR TITLE
rm unnecessary &blk args in abstract/rendering

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -82,16 +82,16 @@ module AbstractController
 
     # Normalize arguments, options and then delegates render_to_body and
     # sticks the result in self.response_body.
-    def render(*args, &block)
-      options = _normalize_render(*args, &block)
+    def render(*args)
+      options = _normalize_render(*args)
       self.response_body = render_to_body(options)
     end
 
     # Raw rendering of a template to a string. Just convert the results of
     # render_response into a String.
     # :api: plugin
-    def render_to_string(*args, &block)
-      options = _normalize_render(*args, &block)
+    def render_to_string(*args)
+      options = _normalize_render(*args)
       render_to_body(options)
     end
 
@@ -130,8 +130,8 @@ module AbstractController
 
     # Normalize args and options.
     # :api: private
-    def _normalize_render(*args, &block)
-      options = _normalize_args(*args, &block)
+    def _normalize_render(*args)
+      options = _normalize_args(*args)
       _normalize_options(options)
       options
     end

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -11,8 +11,8 @@ module ActionController
     end
 
     # Check for double render errors and set the content_type after rendering.
-    def render(*args) #:nodoc:
-      raise ::AbstractController::DoubleRenderError if response_body
+    def render(*) #:nodoc:
+      raise AbstractController::DoubleRenderError if response_body
       super
       self.content_type ||= Mime[lookup_context.rendered_format].to_s
       response_body
@@ -37,7 +37,7 @@ module ActionController
 
     # Normalize arguments by catching blocks and setting them on :update.
     def _normalize_args(action=nil, options={}, &blk) #:nodoc:
-      options = super
+      options = super(action, options)
       options[:update] = blk if block_given?
       options
     end


### PR DESCRIPTION
Also, clean up args and methods in action_controller/rendering,
getting rid of useless arguments to super.

Small change, just a cleanup.
