### PR TITLE
Adding comma to commented code.

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/test/performance/browsing_test.rb
+++ b/railties/lib/rails/generators/rails/app/templates/test/performance/browsing_test.rb
@@ -3,7 +3,7 @@ require 'rails/performance_test_help'
 
 class BrowsingTest < ActionDispatch::PerformanceTest
   # Refer to the documentation for all available options
-  # self.profile_options = { :runs => 5, :metrics => [:wall_time, :memory]
+  # self.profile_options = { :runs => 5, :metrics => [:wall_time, :memory],
   #                          :output => 'tmp/performance', :formats => [:flat] }
 
   def test_homepage


### PR DESCRIPTION
- Comment contains a syntax error that will fail if user attempts to use it in their own code.
