### PR TITLE
Fix adding/removing field's index when generating migration

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
@@ -24,6 +24,9 @@ class <%= migration_class_name %> < ActiveRecord::Migration
 <% attributes.reverse.each do |attribute| -%>
   <%- if migration_action -%>
     <%= migration_action == 'add' ? 'remove' : 'add' %>_column :<%= table_name %>, :<%= attribute.name %><% if migration_action == 'remove' %>, :<%= attribute.type %><%= attribute.inject_options %><% end %>
+    <%- if attribute.has_index? && migration_action == 'remove' -%>
+    add_index :<%= table_name %>, :<%= attribute.index_name %><%= attribute.inject_index_options %>
+    <%- end %>
   <%- end -%>
 <%- end -%>
   end

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -41,6 +41,24 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_remove_migration_with_indexed_attribute
+    migration = "remove_title_body_from_posts"
+    run_generator [migration, "title:string:index", "body:text"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :up, content do |up|
+        assert_match(/remove_column :posts, :title/, up)
+        assert_match(/remove_column :posts, :body/, up)
+      end
+
+      assert_method :down, content do |down|
+        assert_match(/add_column :posts, :title, :string/, down)
+        assert_match(/add_column :posts, :body, :text/, down)
+        assert_match(/add_index :posts, :title/, down)
+      end
+    end
+  end
+
   def test_remove_migration_with_attributes
     migration = "remove_title_body_from_posts"
     run_generator [migration, "title:string", "body:text"]


### PR DESCRIPTION
When trying to generate a migration that removes a field with an index,
the up migration will remove both the field and the index, and the down
will re-add both the field and the index.

Also improved the indentation formatting of the generated migration.

I believe the existing functionality is not tested, so I'll add tests too.

Thanks,

Travis
