### PR TITLE
Add missing require

### DIFF
--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -1,4 +1,5 @@
 require 'abstract_unit'
+require 'active_support/ordered_options'
 
 class OrderedOptionsTest < ActiveSupport::TestCase
   def test_usage


### PR DESCRIPTION
When I executed `ruby -Ilib:test test/ordered_options_test.rb --name=test_inheritable_options_inheritable_copy`, I had NameError.
