### PR TITLE
Fix GH #5411. When precompiling, params method is undefined.

### DIFF
--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -81,7 +81,7 @@ module Sprockets
     private
       def debug_assets?
         compile_assets? && (Rails.application.config.assets.debug || params[:debug_assets])
-      rescue NoMethodError
+      rescue NameError
         false
       end
 

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -492,6 +492,18 @@ module ApplicationTests
       assert_match 'src="/sub/uri/assets/rails.png"', File.read("#{app_path}/public/assets/app.js")
     end
 
+    test "html assets are compiled when executing precompile" do
+      app_file "app/assets/pages/page.html.erb", "<%= javascript_include_tag :application %>"
+      ENV["RAILS_ENV"]   = "production"
+      ENV["RAILS_GROUP"] = "assets"
+
+      quietly do
+        Dir.chdir(app_path){ `bundle exec rake assets:precompile` }
+      end
+
+      assert File.exists?("#{app_path}/public/assets/page.html")
+    end
+
     private
 
     def app_with_assets_in_view


### PR DESCRIPTION
If we execute assets:precompile, params method is undefined.
But ruby can't judge that _params_ is method (or localvariable). Thus we should rescue NameError.

Please see https://github.com/rails/rails/issues/5411

BTW: NoMethodError's superclass is NameError.
