### PR TITLE
Added a generator option to skip the public/index.html file

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -49,6 +49,9 @@ module Rails
         class_option :skip_javascript,    :type => :boolean, :aliases => "-J", :default => false,
                                           :desc => "Skip JavaScript files"
 
+        class_option :skip_index_html,    :type => :boolean, :aliases => "-I", :default => false,
+                                          :desc => "Skip public/index.html and app/assets/images/rails.png files"
+
         class_option :dev,                :type => :boolean, :default => false,
                                           :desc => "Setup the #{name} with Gemfile pointing to your Rails checkout"
 

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -97,6 +97,11 @@ module Rails
 
     def public_directory
       directory "public", "public", :recursive => false
+      if options[:skip_index_html]
+        remove_file "public/index.html"
+        remove_file 'app/assets/images/rails.png'
+        git_keep 'app/assets/images'
+      end
     end
 
     def script

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -240,6 +240,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_generator_if_skip_index_html_is_given
+    run_generator [destination_root, "--skip-index-html"]
+    assert_no_file "public/index.html"
+    assert_no_file "app/assets/images/rails.png"
+    assert_file "app/assets/images/.gitkeep"
+  end
+
   def test_creation_of_a_test_directory
     run_generator
     assert_file 'test'


### PR DESCRIPTION
Squashed the branch from @ivanvanderbyl as requested in rails/rails#2649 and rebased on master.

Branch is largely as per the previous pull request except for fixing the broken test that the commit from @parndt introduced on that branch (`assert no_file` -> `assert_no_file`).
