### PR TITLE
Remove blank line from generated migration

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
@@ -5,7 +5,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration
     add_column :<%= table_name %>, :<%= attribute.name %>, :<%= attribute.type %><%= attribute.inject_options %>
     <%- if attribute.has_index? -%>
     add_index :<%= table_name %>, :<%= attribute.index_name %><%= attribute.inject_index_options %>
-    <%- end %>
+    <%- end -%>
 <%- end -%>
   end
 <%- else -%>

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -37,6 +37,7 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
       assert_method :change, content do |up|
         assert_match(/add_column :posts, :title, :string/, up)
         assert_match(/add_column :posts, :body, :text/, up)
+        assert_no_match(/\n\n/, up)
       end
     end
   end


### PR DESCRIPTION
When creating a migration with attributes the change method is being generated with an empty line.

```
script/rails g migration add_uid_to_users uid:integer
```

``` ruby
class AddUidToUsers < ActiveRecord::Migration
  def change
    add_column :users, :uid, :integer

  end
end
```

Cheers!
