### PR TITLE
Allow manual rollbacks in after_save to reset object correctly

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -290,7 +290,15 @@ module ActiveRecord
       status = nil
       self.class.transaction do
         add_to_transaction
-        status = yield
+        begin
+          status = yield
+        rescue ActiveRecord::Rollback
+          if defined?(@_start_transaction_state) 
+            @_start_transaction_state[:level] = (@_start_transaction_state[:level] || 0) - 1
+          end
+          status = nil
+        end
+        
         raise ActiveRecord::Rollback unless status
       end
       status


### PR DESCRIPTION
Started digging into #5527 and was at least able to confirm the case was happening in the given situation, find what was causing it, and write some tests to further confirm it and the fix.

Now...I don't really pretend to know if actually fixing this is a good idea or not. The example raises `ActiveRecord::Rollback` in an `after_save` hook. I can't find any examples that this is actually a good idea in the first place.

I'm also not keen on where I added the tests or the actual solution....so all around an iffy PR. But all the tests pass...so that's something.

It's my first dive into AR::Transactions, so if this is a bad idea, close the PR and no love lost. If it just needs some cleanup, let me know where to start.
