### PR TITLE
Sanity check for `String#to_date`

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/string/conversions.rb
@@ -12,7 +12,14 @@ class String
 
   def to_date
     return nil if self.blank?
-    ::Date.new(*::Date._parse(self, false).values_at(:year, :mon, :mday))
+    
+    tokens = ::Date._parse(self, false).values_at(:year, :mon, :mday)
+    
+    if tokens.compact.length == 3
+      ::Date.new(*tokens)
+    else
+      nil 
+    end
   end
 
   def to_datetime

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -182,6 +182,8 @@ class StringInflectionsTest < ActiveSupport::TestCase
   def test_string_to_date
     assert_equal Date.new(2005, 2, 27), "2005-02-27".to_date
     assert_nil "".to_date
+    assert_nil "zemba".to_date
+    assert_nil "2005-02-NaN".to_date
   end
 
   def test_access


### PR DESCRIPTION
"".to_date returns nil but what if you do "fleiba".to_date? It crashes.
