### PR TITLE
[3-2-stable] migrate(:down) method with table_name_prefix

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -346,11 +346,23 @@ module ActiveRecord
       @name       = self.class.name
       @version    = nil
       @connection = nil
+      @reverting  = false
     end
 
     # instantiate the delegate object after initialize is defined
     self.verbose  = true
     self.delegate = new
+
+    def revert
+      @reverting = true
+      yield
+    ensure
+      @reverting = false
+    end
+
+    def reverting?
+      @reverting
+    end
 
     def up
       self.class.delegate = self
@@ -385,9 +397,11 @@ module ActiveRecord
             end
             @connection = conn
             time = Benchmark.measure {
-              recorder.inverse.each do |cmd, args|
-                send(cmd, *args)
-              end
+              self.revert {
+                recorder.inverse.each do |cmd, args|
+                  send(cmd, *args)
+                end
+              }
             }
           else
             time = Benchmark.measure { change }
@@ -442,9 +456,11 @@ module ActiveRecord
       arg_list = arguments.map{ |a| a.inspect } * ', '
 
       say_with_time "#{method}(#{arg_list})" do
-        unless arguments.empty? || method == :execute
-          arguments[0] = Migrator.proper_table_name(arguments.first)
-          arguments[1] = Migrator.proper_table_name(arguments.second) if method == :rename_table
+        unless reverting?
+          unless arguments.empty? || method == :execute
+            arguments[0] = Migrator.proper_table_name(arguments.first)
+            arguments[1] = Migrator.proper_table_name(arguments.second) if method == :rename_table
+          end
         end
         return super unless connection.respond_to?(method)
         connection.send(method, *arguments, &block)

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -88,5 +88,17 @@ module ActiveRecord
       LegacyMigration.down
       assert !ActiveRecord::Base.connection.table_exists?("horses"), "horses should not exist"
     end
+
+    def test_migrate_down_with_table_name_prefix
+      ActiveRecord::Base.table_name_prefix = 'p_'
+      ActiveRecord::Base.table_name_suffix = '_s'
+      migration = InvertibleMigration.new
+      migration.migrate(:up)
+      assert_nothing_raised { migration.migrate(:down) }
+      assert !ActiveRecord::Base.connection.table_exists?("p_horses_s"), "p_horses_s should not exist"
+    ensure
+      ActiveRecord::Base.table_name_prefix = ActiveRecord::Base.table_name_suffix = ''
+    end
+
   end
 end


### PR DESCRIPTION
This PR is backporting #4399 to 3-2-stable.
I think this fix isn't merged yet.

Please see https://github.com/rails/rails/pull/4399.

/cc @tenderlove
