### PR TITLE
Don't echo the user's root database password.

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -85,7 +85,11 @@ db_namespace = namespace :db do
         rescue error_class => sqlerr
           if sqlerr.errno == access_denied_error
             print "#{sqlerr.error}. \nPlease provide the root password for your mysql installation\n>"
+            
+            system "stty -echo"
             root_password = $stdin.gets.strip
+            system "stty echo"
+            
             grant_statement = "GRANT ALL PRIVILEGES ON #{config['database']}.* " \
               "TO '#{config['username']}'@'localhost' " \
               "IDENTIFIED BY '#{config['password']}' WITH GRANT OPTION;"


### PR DESCRIPTION
If a script needs my root database password, it should not display it. I've used the poor-man's solution of sending "stty -echo" to avoid dependencies on more full-featured libs. I can't imagine a situation where it wouldn't work.
