### PR TITLE
Fixed missing space bug introduces in rails/rails@9299bfd

### DIFF
--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -22,7 +22,7 @@ class SourceAnnotationExtractor
     # If +options+ has a flag <tt>:tag</tt> the tag is shown as in the example above.
     # Otherwise the string contains just line and text.
     def to_s(options={})
-      s = "[#{line.to_s.rjust(options[:indent])}]"
+      s = "[#{line.to_s.rjust(options[:indent])}] "
       s << "[#{tag}] " if options[:tag]
       s << text
     end

--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -28,7 +28,7 @@ module ApplicationTests
 
         Dir.chdir(app_path) do
           output = `bundle exec rake notes`
-          lines = output.scan(/\[([0-9\s]+)\]/).flatten
+          lines = output.scan(/\[([0-9\s]+)\](\s)/)
 
           assert_match /note in erb/, output
           assert_match /note in haml/, output
@@ -38,8 +38,9 @@ module ApplicationTests
 
           assert_equal 5, lines.size
 
-          lines.each do |line_number|
-            assert_equal 4, line_number.size
+          lines.each do |line|
+            assert_equal 4, line[0].size
+            assert_equal ' ', line[1]
           end
         end
 


### PR DESCRIPTION
A bug got introduced in commit rails/rails@9299bfd by me. See comments from @martinrehfeld for further reference.

Deeply sorry for the inconvenience!
