### PR TITLE
Fix environment support for rails server, and match interface of rails console

### DIFF
--- a/railties/lib/rails/commands/console.rb
+++ b/railties/lib/rails/commands/console.rb
@@ -24,6 +24,9 @@ module Rails
         OptionParser.new do |opt|
           opt.banner = "Usage: console [environment] [options]"
           opt.on('-s', '--sandbox', 'Rollback database modifications on exit.') { |v| options[:sandbox] = v }
+          opt.on("-e", "--environment=name", String,
+                  "Specifies the environment to run this console under (test/development/production).",
+                  "Default: development") { |v| options[:environment] = v.strip }
           opt.on("--debugger", 'Enable ruby-debugging for the console.') { |v| options[:debugger] = v }
           opt.parse!(arguments)
         end
@@ -36,6 +39,14 @@ module Rails
       options[:sandbox]
     end
 
+    def environment?
+      options[:environment]
+    end
+
+    def set_environment!
+      Rails.env = options[:environment]
+    end
+
     def debugger?
       options[:debugger]
     end
@@ -44,6 +55,8 @@ module Rails
       app.sandbox = sandbox?
 
       require_debugger if debugger?
+
+      set_environment! if environment?
 
       if sandbox?
         puts "Loading #{Rails.env} environment in sandbox (Rails #{Rails.version})"

--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -32,6 +32,11 @@ module Rails
 
         opt_parser.parse! args
 
+        # Handle's environment like RAILS_ENV=production passed in directly
+        if index = args.index {|arg| arg.include?("RAILS_ENV")}
+          options[:environment] ||= args.delete_at(index).split('=').last
+        end
+
         options[:server] = args.shift
         options
       end

--- a/railties/test/commands/console_test.rb
+++ b/railties/test/commands/console_test.rb
@@ -55,6 +55,25 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
     assert_match /Loading \w+ environment in sandbox \(Rails/, output
   end
 
+  def test_console_with_environment
+    app.expects(:sandbox=).with(nil)
+    FakeConsole.expects(:start)
+
+    start ["-e production"]
+
+    assert_match /production/, output
+  end
+
+  def test_console_with_rails_environment
+    app.expects(:sandbox=).with(nil)
+    FakeConsole.expects(:start)
+
+    start ["RAILS_ENV=production"]
+
+    assert_match /production/, output
+  end
+
+
   def test_console_defaults_to_IRB
     config = mock("config", :console => nil)
     app = mock("app", :config => config)

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -1,0 +1,26 @@
+require 'abstract_unit'
+require 'rails/commands/server'
+
+class Rails::ServerTest < ActiveSupport::TestCase
+
+  def test_environment_with_server_option
+    args    = ["thin", "RAILS_ENV=production"]
+    options = Rails::Server::Options.new.parse!(args)
+    assert_equal 'production', options[:environment]
+    assert_equal 'thin', options[:server]
+  end
+
+  def test_environment_without_server_option
+    args    = ["RAILS_ENV=production"]
+    options = Rails::Server::Options.new.parse!(args)
+    assert_equal 'production', options[:environment]
+    assert_nil options[:server]
+  end
+
+  def test_server_option_without_environment
+    args    = ["thin"]
+    options = Rails::Server::Options.new.parse!(args)
+    assert_nil options[:environment]
+    assert_equal 'thin', options[:server]
+  end
+end


### PR DESCRIPTION
Right now when a user migrates a database and they need to specify an environment they must do it by specifying `RAILS_ENV=environment`, this also works if you are running console i.e. `rails console RAILS_ENV=production` works. However if you try to use the same syntax with `rails server` you get an error. The first commit in this pull request fixes that problem. 

`rails server` also takes a `-e` option for setting environment, while `rails console` does not. The second commit in this pull request adds a `-e` option to `rails console` so anyone will be able to set environment across server and console the same way. 

Added tests covering setting the environment in server and console by both `-e` and `RAILS_ENV`. 
