### PR TITLE
deprecate Proc#bind that can cause symbol memory leak

### DIFF
--- a/activesupport/lib/active_support/core_ext/proc.rb
+++ b/activesupport/lib/active_support/core_ext/proc.rb
@@ -1,7 +1,10 @@
 require "active_support/core_ext/kernel/singleton_class"
+require "active_support/deprecation"
 
 class Proc #:nodoc:
   def bind(object)
+    ActiveSupport::Deprecation.warn 'Proc#bind is deprecated and will be removed in future versions', caller
+
     block, time = self, Time.now
     object.class_eval do
       method_name = "__bind_#{time.to_i}_#{time.usec}"

--- a/activesupport/lib/active_support/rescuable.rb
+++ b/activesupport/lib/active_support/rescuable.rb
@@ -108,7 +108,7 @@ module ActiveSupport
       when Symbol
         method(rescuer)
       when Proc
-        rescuer.bind(self)
+        Proc.new { |*args| instance_exec(*args, &rescuer) }
       end
     end
   end

--- a/activesupport/test/core_ext/proc_test.rb
+++ b/activesupport/test/core_ext/proc_test.rb
@@ -3,10 +3,12 @@ require 'active_support/core_ext/proc'
 
 class ProcTests < ActiveSupport::TestCase
   def test_bind_returns_method_with_changed_self
-    block = Proc.new { self }
-    assert_equal self, block.call
-    bound_block = block.bind("hello")
-    assert_not_equal block, bound_block
-    assert_equal "hello", bound_block.call
+    assert_deprecated do
+      block = Proc.new { self }
+      assert_equal self, block.call
+      bound_block = block.bind("hello")
+      assert_not_equal block, bound_block
+      assert_equal "hello", bound_block.call
+    end
   end
 end


### PR DESCRIPTION
https://groups.google.com/forum/#!msg/rubyonrails-core/ucD1rQ2KbpU/mys8W5xHmsUJ

<blockquote>
if i run my application for long enough time i start getting errors like this:
<br /><br />
RuntimeError: symbol table overflow (symbol __bind_1328993330_18...)
<br /><br />
apparently it's because symbols are never GCed and rails generates one every time this proc extension is used because method names are implicitly converted to symbols
</blockquote>
