### PR TITLE
Fix build for branch 3-2-stable

### DIFF
--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -912,7 +912,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_clearing_updates_counter_cache
-    topic = Topic.first
+    topic = Topic.order(:id).first
 
     assert_difference 'topic.reload.replies_count', -1 do
       topic.replies.clear
@@ -1001,14 +1001,14 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_delete_all_association_with_primary_key_deletes_correct_records
-    firm = Firm.find(:first)
+    firm = Firm.order(:id).first
     # break the vanilla firm_id foreign key
     assert_equal 2, firm.clients.count
     firm.clients.first.update_column(:firm_id, nil)
     assert_equal 1, firm.clients(true).count
     assert_equal 1, firm.clients_using_primary_key_with_delete_all.count
     old_record = firm.clients_using_primary_key_with_delete_all.first
-    firm = Firm.find(:first)
+    firm = Firm.order(:id).first
     firm.destroy
     assert_nil Client.find_by_id(old_record.id)
   end
@@ -1168,12 +1168,11 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     core = companies(:rails_core)
     assert_equal accounts(:rails_core_account), core.account
-    assert_equal companies(:leetsoft, :jadedpixel), core.companies
+    assert_equal companies(:leetsoft, :jadedpixel), core.companies.order(:id)
     core.destroy
     assert_nil accounts(:rails_core_account).reload.firm_id
     assert_nil companies(:leetsoft).reload.client_of
     assert_nil companies(:jadedpixel).reload.client_of
-
 
     assert_equal num_accounts, Account.count
   end

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -403,7 +403,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_polymorphic_has_one
-    assert_equal Tagging.find(1,2).sort_by { |t| t.id }, authors(:david).tagging
+    assert_equal Tagging.find(1,2).sort_by { |t| t.id }, authors(:david).tagging.order(:id)
   end
 
   def test_has_many_through_polymorphic_has_many
@@ -452,7 +452,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_uses_conditions_specified_on_the_has_many_association
-    author = Author.find(:first)
+    author = Author.order(:id).first
     assert_present author.comments
     assert_blank author.nonexistant_comments
   end
@@ -649,7 +649,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
   end
 
   def test_preload_polymorph_many_types
-    taggings = Tagging.find :all, :include => :taggable, :conditions => ['taggable_type != ?', 'FakeModel']
+    taggings = Tagging.find :all, :include => :taggable, :conditions => ['taggable_type != ?', 'FakeModel'], :order => 'id'
     assert_no_queries do
       taggings.first.taggable.id
       taggings[1].taggable.id

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -55,7 +55,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_has_many_with_has_many_through_source_reflection_preload
-    authors = assert_queries(5) { Author.includes(:tags).to_a }
+    authors = assert_queries(5) { Author.includes(:tags).order(:id).to_a }
     general = tags(:general)
 
     assert_no_queries do
@@ -84,7 +84,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_has_many_through_has_many_through_with_has_many_source_reflection_preload
     luke, david = subscribers(:first), subscribers(:second)
-    authors = assert_queries(4) { Author.includes(:subscribers).to_a }
+    authors = assert_queries(4) { Author.includes(:subscribers).order(:id).to_a }
     assert_no_queries do
       assert_equal [luke, david, david], authors.first.subscribers.sort_by(&:nick)
     end
@@ -106,10 +106,10 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_has_one_with_has_one_through_source_reflection_preload
-    members = assert_queries(4) { Member.includes(:nested_member_types).to_a }
+    members = assert_queries(4) { Member.includes(:nested_member_types).order(:id).to_a }
     founding = member_types(:founding)
     assert_no_queries do
-      assert_equal [founding], members.first.nested_member_types
+      assert_equal [founding], members.first.nested_member_types.to_a
     end
   end
 
@@ -128,10 +128,10 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_has_one_through_with_has_one_source_reflection_preload
-    members = assert_queries(4) { Member.includes(:nested_sponsors).to_a }
+    members = assert_queries(4) { Member.includes(:nested_sponsors).order(:id).to_a }
     mustache = sponsors(:moustache_club_sponsor_for_groucho)
     assert_no_queries do
-      assert_equal [mustache], members.first.nested_sponsors
+      assert_equal [mustache], members.first.nested_sponsors.to_a
     end
   end
 
@@ -163,7 +163,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_has_many_through_has_one_with_has_many_through_source_reflection_preload_via_joins
     assert_includes_and_joins_equal(
-      Member.where('member_details.id' => member_details(:groucho).id).order('member_details.id'),
+      Member.where('member_details.id' => member_details(:groucho).id).order('members.id'),
       [members(:groucho), members(:some_other_guy)], :organization_member_details
     )
 
@@ -193,7 +193,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_has_many_through_has_one_through_with_has_many_source_reflection_preload_via_joins
     assert_includes_and_joins_equal(
-      Member.where('member_details.id' => member_details(:groucho).id).order('member_details.id'),
+      Member.where('member_details.id' => member_details(:groucho).id).order('members.id'),
       [members(:groucho), members(:some_other_guy)], :organization_member_details_2
     )
 
@@ -285,7 +285,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_has_many_through_with_belongs_to_source_reflection_preload
-    authors = assert_queries(5) { Author.includes(:tagging_tags).to_a }
+    authors = assert_queries(5) { Author.includes(:tagging_tags).order(:id).to_a }
     general = tags(:general)
 
     assert_no_queries do

--- a/activerecord/test/cases/clone_test.rb
+++ b/activerecord/test/cases/clone_test.rb
@@ -6,7 +6,7 @@ module ActiveRecord
     fixtures :topics
 
     def test_persisted
-      topic = Topic.first
+      topic = Topic.order(:id).first
       cloned = topic.clone
       assert topic.persisted?, 'topic persisted'
       assert cloned.persisted?, 'topic persisted'
@@ -14,7 +14,7 @@ module ActiveRecord
     end
 
     def test_stays_frozen
-      topic = Topic.first
+      topic = Topic.order(:id).first
       topic.freeze
 
       cloned = topic.clone
@@ -24,7 +24,7 @@ module ActiveRecord
     end
 
     def test_shallow
-      topic = Topic.first
+      topic = Topic.order(:id).first
       cloned = topic.clone
       topic.author_name = 'Aaron'
       assert_equal 'Aaron', cloned.author_name

--- a/activerecord/test/cases/dup_test.rb
+++ b/activerecord/test/cases/dup_test.rb
@@ -10,14 +10,14 @@ module ActiveRecord
     end
 
     def test_not_readonly
-      topic = Topic.first
+      topic = Topic.order(:id).first
 
       duped = topic.dup
       assert !duped.readonly?, 'should not be readonly'
     end
 
     def test_is_readonly
-      topic = Topic.first
+      topic = Topic.order(:id).first
       topic.readonly!
 
       duped = topic.dup
@@ -25,7 +25,7 @@ module ActiveRecord
     end
 
     def test_dup_not_persisted
-      topic = Topic.first
+      topic = Topic.order(:id).first
       duped = topic.dup
 
       assert !duped.persisted?, 'topic not persisted'
@@ -33,20 +33,20 @@ module ActiveRecord
     end
 
     def test_dup_has_no_id
-      topic = Topic.first
+      topic = Topic.order(:id).first
       duped = topic.dup
       assert_nil duped.id
     end
 
     def test_dup_with_modified_attributes
-      topic = Topic.first
+      topic = Topic.order(:id).first
       topic.author_name = 'Aaron'
       duped = topic.dup
       assert_equal 'Aaron', duped.author_name
     end
 
     def test_dup_with_changes
-      dbtopic = Topic.first
+      dbtopic = Topic.order(:id).first
       topic = Topic.new
 
       topic.attributes = dbtopic.attributes
@@ -61,7 +61,7 @@ module ActiveRecord
     end
 
     def test_dup_topics_are_independent
-      topic = Topic.first
+      topic = Topic.order(:id).first
       topic.author_name = 'Aaron'
       duped = topic.dup
 
@@ -71,7 +71,7 @@ module ActiveRecord
     end
 
     def test_dup_attributes_are_independent
-      topic = Topic.first
+      topic = Topic.order(:id).first
       duped = topic.dup
 
       duped.author_name = 'meow'
@@ -82,7 +82,7 @@ module ActiveRecord
     end
 
     def test_dup_timestamps_are_cleared
-      topic = Topic.first
+      topic = Topic.order(:id).first
       assert_not_nil topic.updated_at
       assert_not_nil topic.created_at
 
@@ -98,6 +98,5 @@ module ActiveRecord
       assert_not_nil new_topic.updated_at
       assert_not_nil new_topic.created_at
     end
-
   end
 end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -53,8 +53,8 @@ class FinderTest < ActiveRecord::TestCase
   def test_exists_with_nil_arg
     assert !Topic.exists?(nil)
     assert Topic.exists?
-    assert !Topic.first.replies.exists?(nil)
-    assert Topic.first.replies.exists?
+    assert !Topic.order(:id).first.replies.exists?(nil)
+    assert Topic.order(:id).first.replies.exists?
   end
 
   # ensures +exists?+ runs valid SQL by excluding order value

--- a/activerecord/test/cases/json_serialization_test.rb
+++ b/activerecord/test/cases/json_serialization_test.rb
@@ -211,7 +211,7 @@ class DatabaseConnectedJsonEncodingTest < ActiveRecord::TestCase
     ['"name":"David"', '"posts":[', '{"id":1}', '{"id":2}', '{"id":4}',
      '{"id":5}', '{"id":6}', '"name":"Mary"', '"posts":[', '{"id":7}', '{"id":9}'].each do |fragment|
       assert json.include?(fragment), json
-     end
+    end
   end
 
   def test_should_allow_options_for_hash_of_authors
@@ -223,7 +223,7 @@ class DatabaseConnectedJsonEncodingTest < ActiveRecord::TestCase
   end
 
   def test_should_be_able_to_encode_relation
-    authors_relation = Author.where(:id => [@david.id, @mary.id])
+    authors_relation = Author.where(:id => [@david.id, @mary.id]).order(:id)
 
     json = ActiveSupport::JSON.encode authors_relation, :only => :name
     assert_equal '[{"author":{"name":"David"}},{"author":{"name":"Mary"}}]', json

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -876,7 +876,7 @@ class TestNestedAttributesWithNonStandardPrimaryKeys < ActiveRecord::TestCase
 
   def test_should_update_existing_records_with_non_standard_primary_key
     @owner.update_attributes(@params)
-    assert_equal ['Foo', 'Bar'], @owner.pets.map(&:name)
+    assert_equal %w(Bar Foo), @owner.pets.map(&:name).sort
   end
 
   def test_attr_accessor_of_child_should_be_value_provided_during_update_attributes

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -17,15 +17,16 @@ require 'rexml/document'
 require 'active_support/core_ext/exception'
 
 class PersistencesTest < ActiveRecord::TestCase
+  fixtures :topics, :companies, :developers, :projects, :computers, :accounts, :minimalistics,
+    'warehouse-things', :authors, :categorizations, :categories, :posts, :minivans
 
-  fixtures :topics, :companies, :developers, :projects, :computers, :accounts, :minimalistics, 'warehouse-things', :authors, :categorizations, :categories, :posts, :minivans
-
-  # Oracle UPDATE does not support ORDER BY
-  unless current_adapter?(:OracleAdapter)
+  # Skip databases that don't support UPDATE + ORDER BY
+  unless current_adapter?(:OracleAdapter, :PostgreSQLAdapter)
     def test_update_all_ignores_order_without_limit_from_association
       author = authors(:david)
       assert_nothing_raised do
-        assert_equal author.posts_with_comments_and_categories.length, author.posts_with_comments_and_categories.update_all([ "body = ?", "bulk update!" ])
+        assert_equal author.posts_with_comments_and_categories.length,
+          author.posts_with_comments_and_categories.update_all([ "body = ?", "bulk update!" ])
       end
     end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -674,7 +674,7 @@ class RelationTest < ActiveRecord::TestCase
   def test_relation_merging_with_preload
     ActiveRecord::IdentityMap.without do
       [Post.scoped.merge(Post.preload(:author)), Post.preload(:author).merge(Post.scoped)].each do |posts|
-        assert_queries(2) { assert posts.first.author }
+        assert_queries(2) { assert posts.order(:id).first.author }
       end
     end
   end

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -10,7 +10,7 @@ class TimestampTest < ActiveRecord::TestCase
   fixtures :developers, :owners, :pets, :toys, :cars, :tasks
 
   def setup
-    @developer = Developer.first
+    @developer = Developer.order(:id).first
     @developer.update_attribute(:updated_at, Time.now.prev_month)
     @previously_updated_at = @developer.updated_at
   end

--- a/activerecord/test/cases/yaml_serialization_test.rb
+++ b/activerecord/test/cases/yaml_serialization_test.rb
@@ -12,7 +12,7 @@ class YamlSerializationTest < ActiveRecord::TestCase
   end
 
   def test_roundtrip
-    topic = Topic.first
+    topic = Topic.order(:id).first
     assert topic
     t = YAML.load YAML.dump topic
     assert_equal topic, t
@@ -24,7 +24,7 @@ class YamlSerializationTest < ActiveRecord::TestCase
   end
 
   def test_encode_with_coder
-    topic = Topic.first
+    topic = Topic.order(:id).first
     coder = {}
     topic.encode_with coder
     assert_equal({'attributes' => topic.attributes}, coder)
@@ -34,7 +34,7 @@ class YamlSerializationTest < ActiveRecord::TestCase
     require 'psych'
 
     def test_psych_roundtrip
-      topic = Topic.first
+      topic = Topic.order(:id).first
       assert topic
       t = Psych.load Psych.dump topic
       assert_equal topic, t

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -104,7 +104,7 @@ class Firm < Company
 end
 
 class DependentFirm < Company
-  has_one :account, :foreign_key => "firm_id", :dependent => :nullify
+  has_one :account, :foreign_key => "firm_id", :dependent => :nullify, :order => "accounts.id"
   has_many :companies, :foreign_key => 'client_of', :dependent => :nullify
 end
 


### PR DESCRIPTION
These changes should fix the build for 3-2-stable branch.

The failures are happening due to the change from 1.8.7-p352 to 1.8.7-p358. It includes a change on Hash implementation, making fixtures to be loaded randomly, thus making tests without explicit ordering fail.

After talking to @tenderlove, we decided to skip persistence tests related to UPDATE + ORDER BY for PostgreSQL (there are three). PG does not support updates with order by, and a test is failing randomly depending on the fixture loading order now without a proper way to fix (a possibility would be to force all fixtures to use omap, but the test doesn't make that much sense to run under pg anyway - more ideas are welcome).

I've run both `test_postgresql` and `isolated_test_postgresql` rake tasks several times locally to make sure no other test was failing randomly, however I can't ensure some test won't fail in a near future that my runs didn't catch.

I have also fixes for 3-1 and 3-0 branches, just want to discuss this PR and if applied, make sure it runs green on travis before sending the others.

Let me know if something should be improved.

/cc @nzkoz @spastorino
