### PR TITLE
5559 fix dst jump bug

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -269,6 +269,11 @@ module ActiveSupport
       date_parts = Date._parse(str)
       return if date_parts.blank?
       time = Time.parse(str, now) rescue DateTime.parse(str)
+
+      if date_parts[:hour] && time.hour != date_parts[:hour]
+        time = DateTime.parse(str)
+      end
+
       if date_parts[:offset].nil?
         ActiveSupport::TimeWithZone.new(nil, self, time)
       else


### PR DESCRIPTION
The system timezone DST jump hour should not be blacked out by Time.zone.parse if current Time.zone does not do the jump at that time.

Tested on 1.8.7-p358, ree-1.8.7-2012.01 and ruby-1.9.3-p125.

Fixes #5559.
