### PR TITLE
ActionController caching small String#split optimization

### DIFF
--- a/actionpack/lib/action_controller/caching/actions.rb
+++ b/actionpack/lib/action_controller/caching/actions.rb
@@ -170,14 +170,14 @@ module ActionController #:nodoc:
             options.reverse_merge!(:format => @extension) if options.is_a?(Hash)
           end
 
-          path = controller.url_for(options).split(%r{://}).last
+          path = controller.url_for(options).split('://', 2).last
           @path = normalize!(path)
         end
 
       private
         def normalize!(path)
           path << 'index' if path[-1] == ?/
-          path << ".#{extension}" if extension and !path.split('?').first.ends_with?(".#{extension}")
+          path << ".#{extension}" if extension and !path.split('?', 2).first.ends_with?(".#{extension}")
           URI.parser.unescape(path)
         end
       end


### PR DESCRIPTION
It's a little bit better to split on 2 parts.

``` ruby
require 'benchmark'

n = 50000
Benchmark.bm(7) do |x|
  x.report("rails:") { n.times {"http://rubyonrails.org/documentation".split(%r{://}).last } }
  x.report("my:") { n.times { "http://rubyonrails.org/documentation".split(%r{://}, 2).last } }
end
```

on my laptop:

```
              user     system      total        real
rails:    0.170000   0.000000   0.170000 (  0.171520)
my:       0.090000   0.000000   0.090000 (  0.096497)
```
