### PR TITLE
[#5559] Do not black out the system timezone DST jump hour if Time.zone ...

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -268,7 +268,12 @@ module ActiveSupport
       date_parts = Date._parse(str)
       return if date_parts.empty?
       time = Time.parse(str, now) rescue DateTime.parse(str)
+
       if date_parts[:offset].nil?
+        if date_parts[:hour] && time.hour != date_parts[:hour]
+          time = DateTime.parse(str)
+        end
+
         ActiveSupport::TimeWithZone.new(nil, self, time)
       else
         time.in_time_zone(self)


### PR DESCRIPTION
...differs from that.

The system timezone DST jump hour should not be blacked out by Time.zone.parse if current Time.zone does not do the jump at that time.

Fixes #5559.
