### PR TITLE
Update ActionDispatch::Request#xml_http_request? documentation to match its behavior regarding return values

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -150,9 +150,9 @@ module ActionDispatch
       super.to_i
     end
 
-    # Returns true if the "X-Requested-With" header contains "XMLHttpRequest"
-    # (case-insensitive). All major JavaScript libraries send this header with
-    # every Ajax request.
+    # Returns 0 if the "X-Requested-With" header contains "XMLHttpRequest"
+    # (case-insensitive), nil otherwise. All major JavaScript libraries
+    # send this header with every Ajax request.
     def xml_http_request?
       @env['HTTP_X_REQUESTED_WITH'] =~ /XMLHttpRequest/i
     end


### PR DESCRIPTION
The docs say this returns true on success, which it doesn't.

As noted in the debate about this method (see #5329), plenty of core library interrogative methods return values other then true and false, but from my checks they also consistently and correctly document what is returned.

E.g.:
http://ruby-doc.org/core-1.9.3/FileTest.html#method-i-world_writable-3F
http://ruby-doc.org/core-1.9.3/FileTest.html#method-i-world_readable-3F
http://ruby-doc.org/core-1.9.3/File.html#method-c-size-3F
http://ruby-doc.org/core-1.9.3/Encoding.html#method-c-compatible-3F
http://ruby-doc.org/core-1.9.3/Kernel.html#method-i-autoload-3F

Incidentally, in these other methods the returned values also all have additional informational content beyond "I am a truthy stand-in for true". But that is a separate discussion.
