### PR TITLE
Remove trailing newline from strip_heredoc output.

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/strip.rb
+++ b/activesupport/lib/active_support/core_ext/string/strip.rb
@@ -21,6 +21,6 @@ class String
   # that amount of leading whitespace.
   def strip_heredoc
     indent = scan(/^[ \t]*(?=\S)/).min.try(:size) || 0
-    gsub(/^[ \t]{#{indent}}/, '')
+    gsub(/^[ \t]{#{indent}}/, '').chomp
   end
 end

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -36,7 +36,7 @@ class StringInflectionsTest < ActiveSupport::TestCase
   end
 
   def test_strip_heredoc_on_a_regular_indented_heredoc
-    assert_equal "foo\n  bar\nbaz\n", <<-EOS.strip_heredoc
+    assert_equal "foo\n  bar\nbaz", <<-EOS.strip_heredoc
       foo
         bar
       baz
@@ -44,7 +44,7 @@ class StringInflectionsTest < ActiveSupport::TestCase
   end
 
   def test_strip_heredoc_on_a_regular_indented_heredoc_with_blank_lines
-    assert_equal "foo\n  bar\n\nbaz\n", <<-EOS.strip_heredoc
+    assert_equal "foo\n  bar\n\nbaz", <<-EOS.strip_heredoc
       foo
         bar
 


### PR DESCRIPTION
Almost everytime I use strip_heredoc I end up manually removing the trailing newline at the end, which seems a bit redundant. This change adds a .chomp to the end to remove the trailing newline, but will preserve and whitespace the user intentionally adds.

I asked @tenderlove about this and his response was [a resounding 'meh'(https://twitter.com/#!/tenderlove/status/180044228418740224).
