### PR TITLE
Fixes support for database alias on database.yml 

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_specification.rb
@@ -17,7 +17,7 @@ module ActiveRecord
         end
 
         def spec
-          case config
+					case config
           when nil
             raise AdapterNotSpecified unless defined?(Rails.env)
             resolve_string_connection Rails.env
@@ -36,7 +36,7 @@ module ActiveRecord
 
           raise(AdapterNotSpecified, "#{spec} database is not configured") unless hash
 
-          resolve_hash_connection hash
+          hash.is_a?(Hash) ? resolve_hash_connection(hash) : resolve_string_connection(hash)
         end
 
         def resolve_hash_connection(spec) # :nodoc:

--- a/activerecord/test/cases/connection_specification/resolver_test.rb
+++ b/activerecord/test/cases/connection_specification/resolver_test.rb
@@ -4,11 +4,18 @@ module ActiveRecord
   class Base
     class ConnectionSpecification
       class ResolverTest < ActiveRecord::TestCase
-        def resolve(spec)
-          Resolver.new(spec, {}).spec.config
+				
+				def resolve(spec)
+					@configurations = ActiveRecord::Base.configurations.merge({'arunit_alias' => 'arunit'})
+          Resolver.new(spec, @configurations).spec.config
         end
 
-        def test_url_host_no_db
+				def test_alias_host
+          spec = resolve 'arunit_alias'
+          assert_equal(@configurations['arunit'].symbolize_keys, spec)
+				end
+
+				def test_url_host_no_db
           spec = resolve 'mysql://foo?encoding=utf8'
           assert_equal({
             :adapter  => "mysql",


### PR DESCRIPTION
Until Rails 3.1 we could use a string to copythe same config from another database config:

``` yml
development:
  adapter: postgresql
  encoding: utf8
  database: test_development
  host: localhost

production:
  development
```

This stopped working when @tenderlove used his refactoring sword to slice the `establish_connection` logic on commit 2a9a8ad4dfb2609a2275c1a3540ad2768562a026

I don't know if this is the right approach to fix this issue or even if it's a issue, if you guys accept it I need to apply this patch on master as well.
