### PR TITLE
Improve performance of xhr

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -154,7 +154,7 @@ module ActionDispatch
     # (case-insensitive). All major JavaScript libraries send this header with
     # every Ajax request.
     def xml_http_request?
-      @env['HTTP_X_REQUESTED_WITH'] =~ /XMLHttpRequest/i
+      /XMLHttpRequest/i === @env['HTTP_X_REQUESTED_WITH']
     end
     alias :xhr? :xml_http_request?
 


### PR DESCRIPTION
As mentioned in #5329 and 3756a3fdfe8d339a53bf347487342f93fd9e1edb

This change is needed to improve the performance of `xhr?` in rubinius and jruby.
