### PR TITLE
Allow a defining custom member field on resources

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -880,17 +880,18 @@ module ActionDispatch
         # CANONICAL_ACTIONS holds all actions that does not need a prefix or
         # a path appended since they fit properly in their scope level.
         VALID_ON_OPTIONS  = [:new, :collection, :member]
-        RESOURCE_OPTIONS  = [:as, :controller, :path, :only, :except]
+        RESOURCE_OPTIONS  = [:as, :controller, :path, :only, :except, :param]
         CANONICAL_ACTIONS = %w(index create new show update destroy)
 
         class Resource #:nodoc:
-          attr_reader :controller, :path, :options
+          attr_reader :controller, :path, :options, :param
 
           def initialize(entities, options = {})
             @name       = entities.to_s
             @path       = (options[:path] || @name).to_s
             @controller = (options[:controller] || @name).to_s
             @as         = options[:as]
+            @param      = options[:param] || :id
             @options    = options
           end
 
@@ -935,7 +936,7 @@ module ActionDispatch
           alias :collection_scope :path
 
           def member_scope
-            "#{path}/:id"
+            "#{path}/:#{param}"
           end
 
           def new_scope(new_path)
@@ -943,7 +944,7 @@ module ActionDispatch
           end
 
           def nested_scope
-            "#{path}/:#{singular}_id"
+            "#{path}/:#{singular}_#{param}"
           end
 
         end

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -475,6 +475,11 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
         get :preview, :on => :member
       end
 
+      resources :profiles, :param => :username do
+        get :details, :on => :member
+        resources :messages
+      end
+
       scope :as => "routes" do
         get "/c/:id", :as => :collision, :to => "collision#show"
         get "/collision", :to => "collision#show"
@@ -2181,6 +2186,19 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     get "/posts/1/admin"
     assert_equal "admin/index#index", @response.body
     assert_equal "/posts/1/admin", post_admin_root_path(:post_id => '1')
+  end
+
+  def test_custom_param
+    get '/profiles/bob'
+    assert_equal 'profiles#show', @response.body
+    assert_equal 'bob', @request.params[:username]
+
+    get '/profiles/bob/details'
+    assert_equal 'bob', @request.params[:username]
+
+    get '/profiles/bob/messages/34'
+    assert_equal 'bob', @request.params[:profile_username]
+    assert_equal '34', @request.params[:id]
   end
 
 private


### PR DESCRIPTION
By default, resources routes are created with :resource/:id. A model
defining to_param can make prettier urls by using something more
readable than an integer ID when generating URLs, but since the route picks it up as :id you
wind up with awkward User.find_by_username(params[:id]) calls.

By overriding the key to be used in @request.params you can be more
obvious in your intent.

This override is basically as simple as it needs to be, just an extra :param
option on the resource(s) definition on the route. There's no work done to force
the url generators to use that field when passed a model, but since to_param
is already overridable I don't think it's necessary.

Patch includes tests for a plain resource as well as a nested resource
(generating user_login for the above example).
