### PR TITLE
Remove "needless boolean casting"

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -200,7 +200,7 @@ module ActiveRecord
         relation = relation.where(table[primary_key].eq(id)) if id
       end
 
-      connection.select_value(relation, "#{name} Exists", relation.bind_values) ? true : false
+      connection.select_value(relation, "#{name} Exists", relation.bind_values)
     end
 
     protected


### PR DESCRIPTION
"Predicates in Rails rely on standard Ruby semantics for boolean values
and guarantee no singletons whatsoever." - @fxn
