### PR TITLE
Enable use of ActiveSupport::StringInquirer as an ActiveRecord::Serialization coder

### DIFF
--- a/activesupport/lib/active_support/string_inquirer.rb
+++ b/activesupport/lib/active_support/string_inquirer.rb
@@ -10,6 +10,14 @@ module ActiveSupport
   #   Rails.env.production?
   #
   class StringInquirer < String
+    def self.dump(value)
+      value.presence.try(:parameterize, "_")
+    end
+
+    def self.load(value)
+      value.present? ? new(dump(value)) : nil
+    end
+
     def method_missing(method_name, *arguments)
       if method_name[-1, 1] == "?"
         self == method_name[0..-2]

--- a/activesupport/test/string_inquirer_test.rb
+++ b/activesupport/test/string_inquirer_test.rb
@@ -12,4 +12,27 @@ class StringInquirerTest < ActiveSupport::TestCase
   def test_missing_question_mark
     assert_raise(NoMethodError) { ActiveSupport::StringInquirer.new("production").production }
   end
+
+  def test_dump_for_serialize
+    inquirer = ActiveSupport::StringInquirer.new("Gun Metal")
+    dumped = ActiveSupport::StringInquirer.dump(inquirer)
+    assert_instance_of String, dumped
+    assert_equal "gun_metal", dumped
+  end
+
+  def test_nil_dump_for_serialize
+    assert_nil ActiveSupport::StringInquirer.dump(nil)
+    assert_nil ActiveSupport::StringInquirer.dump("")
+  end
+
+  def test_load_for_serialize
+    loaded = ActiveSupport::StringInquirer.load("gun_metal")
+    assert_instance_of ActiveSupport::StringInquirer, loaded
+    assert loaded.gun_metal?
+  end
+
+  def test_nil_load_for_serialize
+    assert_nil ActiveSupport::StringInquirer.load(nil)
+    assert_nil ActiveSupport::StringInquirer.load("")
+  end
 end


### PR DESCRIPTION
The purpose of this is to allow `ActiveSupport::StringInquirer` to be used alongside ActiveRecord's `serialize` method, like so:

``` ruby
class Car < ActiveRecord::Base
  serialize :color, ActiveSupport::StringInquirer
end

car = Car.create(color: "red")
car.color.red? # => true
```

Because this straddles the line between ActiveSupport and ActiveRecord, I wasn't exactly sure of the proper place for this, so I'm certainly willing to move it around if need be.
