### PR TITLE
Make NullRelation chainable with database methods.

### DIFF
--- a/activerecord/lib/active_record/null_relation.rb
+++ b/activerecord/lib/active_record/null_relation.rb
@@ -3,6 +3,11 @@
 module ActiveRecord
   # = Active Record Null Relation
   class NullRelation < Relation
+    def initialize(klass, table)
+      super
+      @where_values += ["33<3"]
+    end
+
     def exec_queries
       @records = []
     end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -228,6 +228,13 @@ class RelationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_none_chained_to_methods_firing_queries_straight_to_db
+    assert_equal [], Developer.none.pluck(:id) # => uses select_all
+    assert_equal 0,  Developer.none.delete_all
+    assert_equal 0,  Developer.none.update_all(:name => 'David')
+    assert_equal 0,  Developer.none.delete(Developer.first.id)
+  end
+
   def test_joins_with_nil_argument
     assert_nothing_raised { DependentFirm.joins(nil).first }
   end


### PR DESCRIPTION
Now `none` method doesn't work as expected if chained with methods that query the database directly, like pluck or delete_all, as stated by @josevalim here: 8270e4a8ce8337fca98030953922e5992b06a3dd 

This PR fixes it adding a false where condition.
