### PR TITLE
ActiveModel::Name does not inherit from string

### DIFF
--- a/activemodel/lib/active_model/lint.rb
+++ b/activemodel/lib/active_model/lint.rb
@@ -78,7 +78,7 @@ module ActiveModel
       def test_model_naming
         assert model.class.respond_to?(:model_name), "The model should respond to model_name"
         model_name = model.class.model_name
-        assert_kind_of String, model_name
+        assert_kind_of ActiveModel::Name, model_name
         assert_kind_of String, model_name.human
         assert_kind_of String, model_name.singular
         assert_kind_of String, model_name.plural


### PR DESCRIPTION
Like in ActiveModel::Errors we should favor composition over inheritance
