### PR TITLE
Fix build for branch 3-2-stable - return the same session hash object

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
@@ -59,7 +59,7 @@ module ActionDispatch
       end
 
       def set_session(env, sid, session_data, options)
-        session_data.merge("session_id" => sid)
+        session_data.merge!("session_id" => sid)
       end
 
       def set_cookie(env, session_id, cookie)


### PR DESCRIPTION
This is an attempt to fix the build for branch 3-2-stable. It's currently green on travis by chance, due to randomly errors happening on Ruby 1.8.7 p538.

[Branch 3-1 on travis actually showed up the error related to cookie store tests](http://travis-ci.org/#!/rails/rails/jobs/932944).

The idea behind this is to ensure the session hash that will be used to set the cookie value by rack shouldn't change, whereas right now it returns a new hash object every time `set_session` is called. With the random hash change in Ruby 1.8.7, it was causing the failures when testing against the generated `Set-Cookie` header.

Given this is applied and 3-2 tests pass, I'll send to 3-1 as well - and I think the same patch could be applied later to master as it makes sense to not return a different object.

/cc @josevalim @spastorino
