### PR TITLE
Fix build for branch 3-0-stable - failing in ruby 1.8.8-p358

### DIFF
--- a/actionpack/lib/action_view/testing/resolvers.rb
+++ b/actionpack/lib/action_view/testing/resolvers.rb
@@ -22,10 +22,11 @@ module ActionView #:nodoc:
       end
 
       templates = []
-      @hash.select { |k,v| k =~ /^#{query}$/ }.each do |path, source|
-        handler, format = extract_handler_and_format(path, formats)
-        templates << Template.new(source, path, handler,
-          :virtual_path => path, :format => format)
+      @hash.each do |_path, source|
+        next unless _path =~ /^#{query}$/
+        handler, format = extract_handler_and_format(_path, formats)
+        templates << Template.new(source, _path, handler,
+          :virtual_path => _path, :format => format)
       end
 
       templates.sort_by {|t| -t.identifier.match(/^#{query}$/).captures.reject(&:blank?).size }

--- a/actionpack/test/controller/new_base/render_rjs_test.rb
+++ b/actionpack/test/controller/new_base/render_rjs_test.rb
@@ -4,18 +4,18 @@ module RenderRjs
   class BasicController < ActionController::Base
     layout "application", :only => :index_respond_to
 
-    self.view_paths = [ActionView::FixtureResolver.new(
-      "layouts/application.html.erb"           => "",
-      "render_rjs/basic/index.js.rjs"          => "page[:customer].replace_html render(:partial => 'customer')",
-      "render_rjs/basic/index_html.js.rjs"     => "page[:customer].replace_html :partial => 'customer'",
-      "render_rjs/basic/index_no_js.js.erb"    => "<%= render(:partial => 'developer') %>",
-      "render_rjs/basic/_customer.js.erb"      => "JS Partial",
-      "render_rjs/basic/_customer.html.erb"    => "HTML Partial",
-      "render_rjs/basic/_developer.html.erb"   => "HTML Partial",
-      "render_rjs/basic/index_locale.js.rjs"   => "page[:customer].replace_html :partial => 'customer'",
-      "render_rjs/basic/_customer.da.html.erb" => "Danish HTML Partial",
-      "render_rjs/basic/_customer.da.js.erb"   => "Danish JS Partial"
-    )]
+    self.view_paths = [ActionView::FixtureResolver.new(ActiveSupport::OrderedHash[
+      "layouts/application.html.erb"           , "",
+      "render_rjs/basic/index.js.rjs"          , "page[:customer].replace_html render(:partial => 'customer')",
+      "render_rjs/basic/index_html.js.rjs"     , "page[:customer].replace_html :partial => 'customer'",
+      "render_rjs/basic/index_no_js.js.erb"    , "<%= render(:partial => 'developer') %>",
+      "render_rjs/basic/_customer.js.erb"      , "JS Partial",
+      "render_rjs/basic/_customer.html.erb"    , "HTML Partial",
+      "render_rjs/basic/_developer.html.erb"   , "HTML Partial",
+      "render_rjs/basic/index_locale.js.rjs"   , "page[:customer].replace_html :partial => 'customer'",
+      "render_rjs/basic/_customer.da.html.erb" , "Danish HTML Partial",
+      "render_rjs/basic/_customer.da.js.erb"   , "Danish JS Partial"
+    ])]
 
     def index
       render

--- a/actionpack/test/template/form_options_helper_test.rb
+++ b/actionpack/test/template/form_options_helper_test.rb
@@ -921,17 +921,15 @@ class FormOptionsHelperTest < ActionView::TestCase
   end
 
   def test_option_html_attributes_with_multiple_element_hash
-    assert_dom_equal(
-      " class=\"fancy\" onclick=\"alert('Hello World');\"",
-      option_html_attributes([ 'foo', 'bar', { :class => 'fancy', 'onclick' => "alert('Hello World');" } ])
-    )
+    output = option_html_attributes([ 'foo', 'bar', { :class => 'fancy', 'onclick' => "alert('Hello World');" } ])
+    assert output.include?(" class=\"fancy\"")
+    assert output.include?(" onclick=\"alert('Hello World');\"")
   end
 
   def test_option_html_attributes_with_multiple_hashes
-    assert_dom_equal(
-      " class=\"fancy\" onclick=\"alert('Hello World');\"",
-      option_html_attributes([ 'foo', 'bar', { :class => 'fancy' }, { 'onclick' => "alert('Hello World');" } ])
-    )
+    output = option_html_attributes([ 'foo', 'bar', { :class => 'fancy' }, { 'onclick' => "alert('Hello World');" } ])
+    assert output.include?(" class=\"fancy\"")
+    assert output.include?(" onclick=\"alert('Hello World');\"")
   end
 
   def test_option_html_attributes_with_special_characters


### PR DESCRIPTION
This fixes failing tests related to form options, and a random issue that happens with rjs tests, all related to Ruby 1.8.7-p358. I had to change a little bit the implementation of the FixtureResolver to avoid calling `hash.select {}.each` - it also is more similar to [the implementation in 3-1 forward](https://github.com/rails/rails/blob/3-1-stable/actionpack/lib/action_view/testing/resolvers.rb#L30-36).

These rjs tests [were completely removed in 3-1 together with `render :update`](https://github.com/rails/rails/commit/eea66892c80d51c1b959171c2e3feac67124aaba). And I didn't find any other test that uses FixtureResolver relying on ordering like this one.

Let me know if something needs improvement. Thanks.
