### PR TITLE
Cookie store session hash

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
@@ -59,7 +59,8 @@ module ActionDispatch
       end
 
       def set_session(env, sid, session_data, options)
-        session_data.merge("session_id" => sid)
+        session_data["session_id"] = sid
+        session_data
       end
 
       def set_cookie(env, session_id, cookie)

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -2238,7 +2238,7 @@ class FormHelperTest < ActionView::TestCase
       end
     end
 
-    assert_deprecated /Giving a block to FormBuilder is deprecated and has no effect anymore/ do
+    assert_deprecated(/Giving a block to FormBuilder is deprecated and has no effect anymore/) do
       builder_class.new(:foo, nil, nil, {}, proc {})
     end
   end


### PR DESCRIPTION
The same patch idea was applied to both 3-2 and 3-1 branches, #5597 and #5599 respectively, so this just brings it to master.

It also fixes a warning added by my own commit in form tests 7a0cf2f5294e8bcef547642435636b394340a3e4.
