### PR TITLE
Don't ignore non Enumerable values passed to sanitize (closes #5585)

### DIFF
--- a/actionpack/lib/action_controller/vendor/html-scanner/html/sanitizer.rb
+++ b/actionpack/lib/action_controller/vendor/html-scanner/html/sanitizer.rb
@@ -5,6 +5,7 @@ require 'active_support/core_ext/class/attribute'
 module HTML
   class Sanitizer
     def sanitize(text, options = {})
+      validate_options(options)
       return text unless sanitizeable?(text)
       tokenize(text, options).join
     end
@@ -26,6 +27,16 @@ module HTML
 
     def process_node(node, result, options)
       result << node.to_s
+    end
+
+    def validate_options(options)
+      if options[:tags] && !options[:tags].is_a?(Enumerable)
+        raise ArgumentError, "You should pass :tags as an Enumerable"
+      end
+
+      if options[:attributes] && !options[:attributes].is_a?(Enumerable)
+        raise ArgumentError, "You should pass :attributes as an Enumerable"
+      end
     end
   end
 

--- a/actionpack/test/template/html-scanner/sanitizer_test.rb
+++ b/actionpack/test/template/html-scanner/sanitizer_test.rb
@@ -125,6 +125,20 @@ class SanitizerTest < ActionController::TestCase
     assert_equal(text, sanitizer.sanitize(text, :attributes => ['foo']))
   end
 
+  def test_should_raise_argument_error_if_tags_is_not_enumerable
+    sanitizer = HTML::WhiteListSanitizer.new
+    assert_raise(ArgumentError, "You should pass :tags as an Enumerable") do
+      sanitizer.sanitize('', :tags => 'foo')
+    end
+  end
+
+  def test_should_raise_argument_error_if_attributes_is_not_enumerable
+    sanitizer = HTML::WhiteListSanitizer.new
+    assert_raise(ArgumentError, "You should pass :attributes as an Enumerable") do
+      sanitizer.sanitize('', :attributes => 'foo')
+    end
+  end
+
   [%w(img src), %w(a href)].each do |(tag, attr)|
     define_method "test_should_strip_#{attr}_attribute_in_#{tag}_with_bad_protocols" do
       assert_sanitized %(<#{tag} #{attr}="javascript:bang" title="1">boo</#{tag}>), %(<#{tag} title="1">boo</#{tag}>)


### PR DESCRIPTION
When someone accidentally passes a string to sanitize like:

sanitize("<span>foo</span>", :tags => "b")

there is no indication that it's the wrong way and span
will not be removed.
