### PR TITLE
Revert "Remove 'needless boolean casting'."

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -200,7 +200,7 @@ module ActiveRecord
         relation = relation.where(table[primary_key].eq(id)) if id
       end
 
-      connection.select_value(relation, "#{name} Exists", relation.bind_values)
+      connection.select_value(relation, "#{name} Exists", relation.bind_values) ? true : false
     end
 
     protected


### PR DESCRIPTION
This reverts commit ef64c6ba8c06f89995b4328d3468df9914e3c6b6.

Related reading: https://github.com/rails/rails/pull/5582
