### PR TITLE
multipart POST - utf8 param name not encoded

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -273,7 +273,7 @@ module ActionDispatch
 
     # Override Rack's GET method to support indifferent access
     def GET
-      @env["action_dispatch.request.query_parameters"] ||= (normalize_parameters(super) || {})
+      @env["action_dispatch.request.query_parameters"] ||= (normalize_encode_params(super) || {})
     rescue TypeError => e
       raise ActionController::BadRequest.new(:query, e)
     end
@@ -281,7 +281,7 @@ module ActionDispatch
 
     # Override Rack's POST method to support indifferent access
     def POST
-      @env["action_dispatch.request.request_parameters"] ||= (normalize_parameters(super) || {})
+      @env["action_dispatch.request.request_parameters"] ||= (normalize_encode_params(super) || {})
     rescue TypeError => e
       raise ActionController::BadRequest.new(:request, e)
     end

--- a/actionpack/lib/action_dispatch/http/upload.rb
+++ b/actionpack/lib/action_dispatch/http/upload.rb
@@ -75,16 +75,16 @@ module ActionDispatch
     end
 
     module Upload # :nodoc:
-      # Convert nested Hash to ActiveSupport::HashWithIndifferentAccess and replace
-      # file upload hash with UploadedFile objects
-      def normalize_parameters(value)
+      # Replace file upload hash with UploadedFile objects
+      # when normalize and encode parameters.
+      def normalize_encode_params(value)
         if Hash === value && value.has_key?(:tempfile)
           UploadedFile.new(value)
         else
           super
         end
       end
-      private :normalize_parameters
+      private :normalize_encode_params
     end
   end
 end

--- a/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
@@ -1,13 +1,15 @@
+# encoding: utf-8
 require 'abstract_unit'
 
 class MultipartParamsParsingTest < ActionDispatch::IntegrationTest
   class TestController < ActionController::Base
     class << self
-      attr_accessor :last_request_parameters
+      attr_accessor :last_request_parameters, :last_parameters
     end
 
     def parse
       self.class.last_request_parameters = request.request_parameters
+      self.class.last_parameters = request.parameters
       head :ok
     end
 
@@ -28,6 +30,23 @@ class MultipartParamsParsingTest < ActionDispatch::IntegrationTest
 
   test "parses bracketed parameters" do
     assert_equal({ 'foo' => { 'baz' => 'bar'}}, parse_multipart('bracketed_param'))
+  end
+
+  test "parse single utf8 parameter" do
+    assert_equal({ 'Iñtërnâtiônàlizætiøn_name' => 'Iñtërnâtiônàlizætiøn_value'}, 
+                 parse_multipart('single_utf8_param'), "request.request_parameters")
+    assert_equal(
+      'Iñtërnâtiônàlizætiøn_value',
+      TestController.last_parameters['Iñtërnâtiônàlizætiøn_name'], "request.parameters")
+  end
+
+  test "parse bracketed utf8 parameter" do
+    assert_equal({ 'Iñtërnâtiônàlizætiøn_name' => { 
+      'Iñtërnâtiônàlizætiøn_nested_name' => 'Iñtërnâtiônàlizætiøn_value'} }, 
+      parse_multipart('bracketed_utf8_param'), "request.request_parameters")
+    assert_equal(
+      {'Iñtërnâtiônàlizætiøn_nested_name' => 'Iñtërnâtiônàlizætiøn_value'},
+      TestController.last_parameters['Iñtërnâtiônàlizætiøn_name'], "request.parameters")
   end
 
   test "parses text file" do

--- a/actionpack/test/fixtures/multipart/bracketed_utf8_param
+++ b/actionpack/test/fixtures/multipart/bracketed_utf8_param
@@ -1,0 +1,5 @@
+--AaB03x
+Content-Disposition: form-data; name="Iñtërnâtiônàlizætiøn_name[Iñtërnâtiônàlizætiøn_nested_name]"
+
+Iñtërnâtiônàlizætiøn_value
+--AaB03x--

--- a/actionpack/test/fixtures/multipart/single_utf8_param
+++ b/actionpack/test/fixtures/multipart/single_utf8_param
@@ -1,0 +1,5 @@
+--AaB03x
+Content-Disposition: form-data; name="Iñtërnâtiônàlizætiøn_name"
+
+Iñtërnâtiônàlizætiøn_value
+--AaB03x--


### PR DESCRIPTION
### Issue

When submit a multipart form that contains a unicode param name e.g.

``` html
<form method="post" enctype="multipart/form-data" action="..">
  <input name="Iñtërnâtiônàlizætiøn_name" value="Iñtërnâtiônàlizætiøn_value" />
</form>
```

Controller receives the param value as "Iñtërnâtiônàlizætiøn_value", as expected. But the **param name** becomes **"I\xC3\xB1t\xC3\xABrn\xC3\xA2ti\xC3\xB4n\xC3\xA0liz\xC3\xA6ti\xC3\xB8n_name"**.
### Failed Tests

2 failed tests are added in the pull request.

Test results:

``` bash
$ cd rails/actionpack
$ rake test TEST=test/dispatch/request/multipart_params_parsing_test.rb 

# Running tests:
.FF..........

Finished tests in 0.542967s, 23.9425 tests/s, 88.4032 assertions/s.

  1) Failure:
test_parse_bracketed_utf8_parameter(MultipartParamsParsingTest) [rails/actionpack/test/dispatch/request/multipart_params_parsing_test.rb:41]:
--- expected
+++ actual
@@ -1 +1 @@
-{"Iñtërnâtiônàlizætiøn_name"=>{"Iñtërnâtiônàlizætiøn_nested_name"=>"Iñtërnâtiônàlizætiøn_value"}}
+{"I\xC3\xB1t\xC3\xABrn\xC3\xA2ti\xC3\xB4n\xC3\xA0liz\xC3\xA6ti\xC3\xB8n_name"=>{"I\xC3\xB1t\xC3\xABrn\xC3\xA2ti\xC3\xB4n\xC3\xA0liz\xC3\xA6ti\xC3\xB8n_nested_name"=>"Iñtërnâtiônàlizætiøn_value"}}

  2) Failure:
test_parse_single_utf8_parameter(MultipartParamsParsingTest) [rails/actionpack/test/dispatch/request/multipart_params_parsing_test.rb:35]:
--- expected
+++ actual
@@ -1 +1 @@
-{"Iñtërnâtiônàlizætiøn_name"=>"Iñtërnâtiônàlizætiøn_value"}
+{"I\xC3\xB1t\xC3\xABrn\xC3\xA2ti\xC3\xB4n\xC3\xA0liz\xC3\xA6ti\xC3\xB8n_name"=>"Iñtërnâtiônàlizætiøn_value"}

```
### Cause

I spent some time troubleshoot the issue, and found that **ActionDispatch::Http::Parameters#encode_params** (in `actionpack/lib/action_dispatch/http/parameters.rb`) only encodes param values, but _not_ param keys. Is such behavior intended? 
