### PR TITLE
prevent returning a negative zero from number_with_precision

### DIFF
--- a/actionpack/lib/action_view/helpers/number_helper.rb
+++ b/actionpack/lib/action_view/helpers/number_helper.rb
@@ -292,6 +292,7 @@ module ActionView
           precision = precision > 0 ? precision : 0  #don't let it be negative
         else
           rounded_number = BigDecimal.new(number.to_s).round(precision).to_f
+          rounded_number = rounded_number.zero? ? rounded_number.abs : rounded_number #prevent showing negative zeros
         end
         formatted_number = number_with_delimiter("%01.#{precision}f" % rounded_number, options)
         if strip_insignificant_zeros

--- a/actionpack/test/template/number_helper_test.rb
+++ b/actionpack/test/template/number_helper_test.rb
@@ -96,6 +96,7 @@ class NumberHelperTest < ActionView::TestCase
     assert_equal("0.001", number_with_precision(0.00111, :precision => 3))
     assert_equal("10.00", number_with_precision(9.995, :precision => 2))
     assert_equal("11.00", number_with_precision(10.995, :precision => 2))
+    assert_equal("0.00", number_with_precision(-0.001, :precision => 2))
   end
 
   def test_number_with_precision_with_custom_delimiter_and_separator


### PR DESCRIPTION
For most applications, showing a negative zero is probably not the desired outcome.

If this patch is unsuitable, how about an option to pass to number_with_precision?  Something like `:allow_negative_zero => true`?
