### PR TITLE
Remove Arel::Relation constant from PredicateBuilder.

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -39,7 +39,7 @@ module ActiveRecord
           attribute.in(value.arel.ast)
         when Array, ActiveRecord::Associations::CollectionProxy
           values = value.to_a.map {|x| x.is_a?(ActiveRecord::Model) ? x.id : x}
-          ranges, values = values.partition {|v| v.is_a?(Range) || v.is_a?(Arel::Relation)}
+          ranges, values = values.partition {|v| v.is_a?(Range)}
 
           values_predicate = if values.include?(nil)
             values = values.compact
@@ -59,7 +59,7 @@ module ActiveRecord
           array_predicates = ranges.map { |range| attribute.in(range) }
           array_predicates << values_predicate
           array_predicates.inject { |composite, predicate| composite.or(predicate) }
-        when Range, Arel::Relation
+        when Range
           attribute.in(value)
         when ActiveRecord::Model
           attribute.eq(value.id)


### PR DESCRIPTION
Arel::Relation is not needed, and is deprecated in Arel.
