### PR TITLE
Fix indenting in migration generator

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
@@ -13,9 +13,9 @@ class <%= migration_class_name %> < ActiveRecord::Migration
 <% attributes.each do |attribute| -%>
   <%- if migration_action -%>
     <%= migration_action %>_column :<%= table_name %>, :<%= attribute.name %><% if migration_action == 'add' %>, :<%= attribute.type %><%= attribute.inject_options %><% end %>
-    <% if attribute.has_index? && migration_action == 'add' %>
+    <%- if attribute.has_index? && migration_action == 'add' -%>
     add_index :<%= table_name %>, :<%= attribute.index_name %><%= attribute.inject_index_options %>
-    <% end -%>
+    <%- end -%>
   <%- end -%>
 <%- end -%>
   end


### PR DESCRIPTION
```
$ rails generate migration remove_foo_from_bars foo:string
```

This currently generates:

```
  def up
    remove_column :bars, :foo
      end
```

Fix it:

```
  def up
    remove_column :bars, :foo
  end
```
