### PR TITLE
Spring cleaning in Rails::Paths

### DIFF
--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -1,5 +1,3 @@
-require 'set'
-
 module Rails
   module Paths
     # This object is an extended hash that behaves as root of the <tt>Rails::Paths</tt> system.

--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -51,8 +51,7 @@ module Rails
       end
 
       def []=(path, value)
-        value = Path.new(self, path, [value].flatten) unless value.is_a?(Path)
-        @root[path] = value
+        add(path, :with => value)
       end
 
       def add(path, options={})

--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -45,7 +45,6 @@ module Rails
       attr_accessor :path
 
       def initialize(path)
-        raise "Argument should be a String of the physical root path" if path.is_a?(Array)
         @current = nil
         @path = path
         @root = {}

--- a/railties/test/paths_test.rb
+++ b/railties/test/paths_test.rb
@@ -91,10 +91,6 @@ class PathsTest < ActiveSupport::TestCase
     assert_equal ["/foo/bar/app2", "/foo/bar/app"], @root["app"].to_a
   end
 
-  test "the root can only have one physical path" do
-    assert_raise(RuntimeError) { Rails::Paths::Root.new(["/fiz", "/biz"]) }
-  end
-
   test "it is possible to add a path that should be autoloaded only once" do
     @root.add "app", :with => "/app"
     @root["app"].autoload_once!


### PR DESCRIPTION
Saw @tenderlove did some work in here, and noticed set is required unnecessarily, Path wasn't enforcing its own argument expectations, and a RuntimeError was raised where an ArgumentError would be more appropriate.

I'm assuming this is appropriate for 4.0.
