### PR TITLE
Don't break Haml with textarea newline fix. (master)

### DIFF
--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -17,6 +17,10 @@ module ActionView
                            autofocus novalidate formnovalidate open pubdate).to_set
       BOOLEAN_ATTRIBUTES.merge(BOOLEAN_ATTRIBUTES.map {|attribute| attribute.to_sym })
 
+      PRE_CONTENT_STRINGS = {
+        :textarea => "\n"
+      }
+
       # Returns an empty HTML tag of type +name+ which by default is XHTML
       # compliant. Set +open+ to true to create an open tag compatible
       # with HTML 4.0 and below. Add HTML attributes by passing an attributes
@@ -126,7 +130,7 @@ module ActionView
         def content_tag_string(name, content, options, escape = true)
           tag_options = tag_options(options, escape) if options
           content     = ERB::Util.h(content) if escape
-          "<#{name}#{tag_options}>#{content}</#{name}>".html_safe
+          "<#{name}#{tag_options}>#{PRE_CONTENT_STRINGS[name.to_sym]}#{content}</#{name}>".html_safe
         end
 
         def tag_options(options, escape = true)

--- a/actionpack/lib/action_view/helpers/tags/text_area.rb
+++ b/actionpack/lib/action_view/helpers/tags/text_area.rb
@@ -10,7 +10,7 @@ module ActionView
             options["cols"], options["rows"] = size.split("x") if size.respond_to?(:split)
           end
 
-          content_tag("textarea", "\n#{options.delete('value') || value_before_type_cast(object)}", options)
+          content_tag("textarea", options.delete('value') || value_before_type_cast(object), options)
         end
       end
     end

--- a/actionpack/test/template/form_tag_helper_test.rb
+++ b/actionpack/test/template/form_tag_helper_test.rb
@@ -222,19 +222,19 @@ class FormTagHelperTest < ActionView::TestCase
 
   def test_text_area_tag_size_string
     actual = text_area_tag "body", "hello world", "size" => "20x40"
-    expected = %(<textarea cols="20" id="body" name="body" rows="40">hello world</textarea>)
+    expected = %(<textarea cols="20" id="body" name="body" rows="40">\nhello world</textarea>)
     assert_dom_equal expected, actual
   end
 
   def test_text_area_tag_size_symbol
     actual = text_area_tag "body", "hello world", :size => "20x40"
-    expected = %(<textarea cols="20" id="body" name="body" rows="40">hello world</textarea>)
+    expected = %(<textarea cols="20" id="body" name="body" rows="40">\nhello world</textarea>)
     assert_dom_equal expected, actual
   end
 
   def test_text_area_tag_should_disregard_size_if_its_given_as_an_integer
     actual = text_area_tag "body", "hello world", :size => 20
-    expected = %(<textarea id="body" name="body">hello world</textarea>)
+    expected = %(<textarea id="body" name="body">\nhello world</textarea>)
     assert_dom_equal expected, actual
   end
 
@@ -245,19 +245,19 @@ class FormTagHelperTest < ActionView::TestCase
 
   def test_text_area_tag_escape_content
     actual = text_area_tag "body", "<b>hello world</b>", :size => "20x40"
-    expected = %(<textarea cols="20" id="body" name="body" rows="40">&lt;b&gt;hello world&lt;/b&gt;</textarea>)
+    expected = %(<textarea cols="20" id="body" name="body" rows="40">\n&lt;b&gt;hello world&lt;/b&gt;</textarea>)
     assert_dom_equal expected, actual
   end
 
   def test_text_area_tag_unescaped_content
     actual = text_area_tag "body", "<b>hello world</b>", :size => "20x40", :escape => false
-    expected = %(<textarea cols="20" id="body" name="body" rows="40"><b>hello world</b></textarea>)
+    expected = %(<textarea cols="20" id="body" name="body" rows="40">\n<b>hello world</b></textarea>)
     assert_dom_equal expected, actual
   end
 
   def test_text_area_tag_unescaped_nil_content
     actual = text_area_tag "body", nil, :escape => false
-    expected = %(<textarea id="body" name="body"></textarea>)
+    expected = %(<textarea id="body" name="body">\n</textarea>)
     assert_dom_equal expected, actual
   end
 


### PR DESCRIPTION
See issue #393, issue #4000, issue #5190, and issue #5191. Adds a newline after the textarea opening tag based on @codykrieger's original patch so that we don't cause regressions in Haml-using apps. The regression caused textarea tags to add newlines to the field unintentionally (each update/save added an extra newline.)
