### PR TITLE
Remove redundant variable from core_ext/hash/deep_dup.rb

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/deep_dup.rb
+++ b/activesupport/lib/active_support/core_ext/hash/deep_dup.rb
@@ -3,8 +3,7 @@ class Hash
   def deep_dup
     duplicate = self.dup
     duplicate.each_pair do |k,v|
-      tv = duplicate[k]
-      duplicate[k] = tv.is_a?(Hash) && v.is_a?(Hash) ? tv.deep_dup : v
+      duplicate[k] = v.is_a?(Hash) ? v.deep_dup : v
     end
     duplicate
   end


### PR DESCRIPTION
All tests are passed.

If this variable is necessary, please let me know, I'd like to write additional tests.

Thanks
