### PR TITLE
Add config option to turn off prefixing partial path with controller namespace

### DIFF
--- a/actionpack/lib/action_view/base.rb
+++ b/actionpack/lib/action_view/base.rb
@@ -141,6 +141,12 @@ module ActionView #:nodoc:
     cattr_accessor :streaming_completion_on_exception
     @@streaming_completion_on_exception = %("><script type="text/javascript">window.location = "/500.html"</script></html>)
 
+    # Specify whether rendering within namespaced controllers should prefix
+    # the partial paths for ActiveModel objects with the namespace.
+    # (e.g., an Admin::PostsController would render @post using /admin/posts/_post.erb)
+    cattr_accessor :prefix_partial_path_with_controller_namespace
+    @@prefix_partial_path_with_controller_namespace = true
+
     class_attribute :helpers
     class_attribute :_routes
     class_attribute :logger

--- a/actionpack/lib/action_view/renderer/partial_renderer.rb
+++ b/actionpack/lib/action_view/renderer/partial_renderer.rb
@@ -245,12 +245,11 @@ module ActionView
   #     <%- end -%>
   #   <% end %>
   class PartialRenderer < AbstractRenderer
-    PARTIAL_NAMES = Hash.new { |h,k| h[k] = {} }
+    PREFIXED_PARTIAL_NAMES = Hash.new { |h,k| h[k] = {} }
 
     def initialize(*)
       super
       @context_prefix = @lookup_context.prefixes.first
-      @partial_names = PARTIAL_NAMES[@context_prefix]
     end
 
     def render(context, options, block)
@@ -423,7 +422,15 @@ module ActionView
         raise ArgumentError.new("'#{object.inspect}' is not an ActiveModel-compatible object. It must implement :to_partial_path.")
       end
 
-      @partial_names[path] ||= merge_prefix_into_object_path(@context_prefix, path.dup)
+      if @view.prefix_partial_path_with_controller_namespace
+        prefixed_partial_names[path] ||= merge_prefix_into_object_path(@context_prefix, path.dup)
+      else
+        path
+      end
+    end
+
+    def prefixed_partial_names
+      @prefixed_partial_names ||= PREFIXED_PARTIAL_NAMES[@context_prefix]
     end
 
     def merge_prefix_into_object_path(prefix, object_path)

--- a/actionpack/test/activerecord/render_partial_with_record_identification_test.rb
+++ b/actionpack/test/activerecord/render_partial_with_record_identification_test.rb
@@ -130,13 +130,13 @@ class RenderPartialWithRecordIdentificationAndNestedControllersTest < ActiveReco
 
   def test_render_with_record_in_nested_controller
     get :render_with_record_in_nested_controller
-    assert_template 'fun/games/_game'
+    assert_template %r{\Afun/games/_game\Z}
     assert_equal 'Pong', @response.body
   end
 
   def test_render_with_record_collection_in_nested_controller
     get :render_with_record_collection_in_nested_controller
-    assert_template 'fun/games/_game'
+    assert_template %r{\Afun/games/_game\Z}
     assert_equal 'PongTank', @response.body
   end
 end
@@ -146,13 +146,13 @@ class RenderPartialWithRecordIdentificationAndNestedDeeperControllersTest < Acti
 
   def test_render_with_record_in_deeper_nested_controller
     get :render_with_record_in_deeper_nested_controller
-    assert_template 'fun/serious/games/_game'
+    assert_template %r{\Afun/serious/games/_game\Z}
     assert_equal 'Chess', @response.body
   end
 
   def test_render_with_record_collection_in_deeper_nested_controller
     get :render_with_record_collection_in_deeper_nested_controller
-    assert_template 'fun/serious/games/_game'
+    assert_template %r{\Afun/serious/games/_game\Z}
     assert_equal 'ChessSudokuSolitaire', @response.body
   end
 end

--- a/actionpack/test/activerecord/render_partial_with_record_identification_test.rb
+++ b/actionpack/test/activerecord/render_partial_with_record_identification_test.rb
@@ -131,13 +131,39 @@ class RenderPartialWithRecordIdentificationAndNestedControllersTest < ActiveReco
   def test_render_with_record_in_nested_controller
     get :render_with_record_in_nested_controller
     assert_template %r{\Afun/games/_game\Z}
-    assert_equal 'Pong', @response.body
+    assert_equal "Fun Pong\n", @response.body
   end
 
   def test_render_with_record_collection_in_nested_controller
     get :render_with_record_collection_in_nested_controller
     assert_template %r{\Afun/games/_game\Z}
-    assert_equal 'PongTank', @response.body
+    assert_equal "Fun Pong\nFun Tank\n", @response.body
+  end
+end
+
+class RenderPartialWithRecordIdentificationAndNestedControllersWithoutPrefixTest < ActiveRecordTestCase
+  tests Fun::NestedController
+
+  def test_render_with_record_in_nested_controller
+    old_config = ActionView::Base.prefix_partial_path_with_controller_namespace
+    ActionView::Base.prefix_partial_path_with_controller_namespace = false
+
+    get :render_with_record_in_nested_controller
+    assert_template %r{\Agames/_game\Z}
+    assert_equal "Just Pong\n", @response.body
+  ensure
+    ActionView::Base.prefix_partial_path_with_controller_namespace = old_config
+  end
+
+  def test_render_with_record_collection_in_nested_controller
+    old_config = ActionView::Base.prefix_partial_path_with_controller_namespace
+    ActionView::Base.prefix_partial_path_with_controller_namespace = false
+
+    get :render_with_record_collection_in_nested_controller
+    assert_template %r{\Agames/_game\Z}
+    assert_equal "Just Pong\nJust Tank\n", @response.body
+  ensure
+    ActionView::Base.prefix_partial_path_with_controller_namespace = old_config
   end
 end
 
@@ -147,12 +173,38 @@ class RenderPartialWithRecordIdentificationAndNestedDeeperControllersTest < Acti
   def test_render_with_record_in_deeper_nested_controller
     get :render_with_record_in_deeper_nested_controller
     assert_template %r{\Afun/serious/games/_game\Z}
-    assert_equal 'Chess', @response.body
+    assert_equal "Serious Chess\n", @response.body
   end
 
   def test_render_with_record_collection_in_deeper_nested_controller
     get :render_with_record_collection_in_deeper_nested_controller
     assert_template %r{\Afun/serious/games/_game\Z}
-    assert_equal 'ChessSudokuSolitaire', @response.body
+    assert_equal "Serious Chess\nSerious Sudoku\nSerious Solitaire\n", @response.body
+  end
+end
+
+class RenderPartialWithRecordIdentificationAndNestedDeeperControllersWithoutPrefixTest < ActiveRecordTestCase
+  tests Fun::Serious::NestedDeeperController
+
+  def test_render_with_record_in_deeper_nested_controller
+    old_config = ActionView::Base.prefix_partial_path_with_controller_namespace
+    ActionView::Base.prefix_partial_path_with_controller_namespace = false
+
+    get :render_with_record_in_deeper_nested_controller
+    assert_template %r{\Agames/_game\Z}
+    assert_equal "Just Chess\n", @response.body
+  ensure
+    ActionView::Base.prefix_partial_path_with_controller_namespace = old_config
+  end
+
+  def test_render_with_record_collection_in_deeper_nested_controller
+    old_config = ActionView::Base.prefix_partial_path_with_controller_namespace
+    ActionView::Base.prefix_partial_path_with_controller_namespace = false
+
+    get :render_with_record_collection_in_deeper_nested_controller
+    assert_template %r{\Agames/_game\Z}
+    assert_equal "Just Chess\nJust Sudoku\nJust Solitaire\n", @response.body
+  ensure
+    ActionView::Base.prefix_partial_path_with_controller_namespace = old_config
   end
 end

--- a/actionpack/test/fixtures/fun/games/_game.erb
+++ b/actionpack/test/fixtures/fun/games/_game.erb
@@ -1,1 +1,1 @@
-<%= game.name %>
+Fun <%= game.name %>

--- a/actionpack/test/fixtures/fun/serious/games/_game.erb
+++ b/actionpack/test/fixtures/fun/serious/games/_game.erb
@@ -1,1 +1,1 @@
-<%= game.name %>
+Serious <%= game.name %>

--- a/actionpack/test/fixtures/games/_game.erb
+++ b/actionpack/test/fixtures/games/_game.erb
@@ -1,0 +1,1 @@
+Just <%= game.name %>

--- a/guides/source/configuring.textile
+++ b/guides/source/configuring.textile
@@ -354,8 +354,7 @@ h4. Configuring Action Dispatch
 
 h4. Configuring Action View
 
-There are only a few configuration options for Action View, starting with six on +ActionView::Base+:
-
+<tt>config.action_view</tt> includes a small number of configuration settings:
 
 * +config.action_view.field_error_proc+ provides an HTML generator for displaying errors that come from Active Record. The default is
 
@@ -396,6 +395,14 @@ And can reference in the view with the following code:
 * +config.action_view.cache_asset_ids+ With the cache enabled, the asset tag helper methods will make fewer expensive file system calls (the default implementation checks the file system timestamp). However this prevents you from modifying any asset files while the server is running.
 
 * +config.action_view.embed_authenticity_token_in_remote_forms+ allows you to set the default behavior for +authenticity_token+ in forms with +:remote => true+. By default it's set to false, which means that remote forms will not include +authenticity_token+, which is helpful when you're fragment-caching the form. Remote forms get the authenticity from the +meta+ tag, so embedding is unnecessary unless you support browsers without JavaScript. In such case you can either pass +:authenticity_token => true+ as a form option or set this config setting to +true+
+
+* +config.action_view.prefix_partial_path_with_controller_namespace+ determines whether or not partials are looked up from a subdirectory in templates rendered from namespaced controllers. For example, consider a controller named +Admin::PostsController+ which renders this template:
+
+<erb>
+<%= render @post %>
+<erb>
+
+The default setting is +true+, which uses the partial at +/admin/posts/_post.erb+. Setting the value to +false+ would render +/posts/_post.erb+, which is the same behavior as rendering from a non-namespaced controller such as +PostsController+.
 
 h4. Configuring Action Mailer
 


### PR DESCRIPTION
It's annoying that if my controller happens to be namespaced, I am not allowed to render objects by using `<%= render @objects %>` unless I have a separate set of partials under the namespace.

See http://blog.obiefernandez.com/content/2012/01/rendering-collections-of-heterogeneous-objects-in-rails-32.html for more justification.

cc @josevalim
