### PR TITLE
Fixing Identity Map when using find select

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -954,15 +954,7 @@ module ActiveRecord #:nodoc:
         record_id = sti_class.primary_key && record[sti_class.primary_key]
 
         if ActiveRecord::IdentityMap.enabled? && record_id
-          if (column = sti_class.columns_hash[sti_class.primary_key]) && column.number?
-            record_id = record_id.to_i
-          end
-          if instance = IdentityMap.get(sti_class, record_id)
-            instance.reinit_with('attributes' => record)
-          else
-            instance = sti_class.allocate.init_with('attributes' => record)
-            IdentityMap.add(instance)
-          end
+          instance = use_identity_map(sti_class, record_id, record)
         else
           instance = sti_class.allocate.init_with('attributes' => record)
         end
@@ -971,6 +963,21 @@ module ActiveRecord #:nodoc:
       end
 
       private
+
+        def use_identity_map(sti_class, record_id, record)
+          if (column = sti_class.columns_hash[sti_class.primary_key]) && column.number?
+            record_id = record_id.to_i
+          end
+
+          if instance = IdentityMap.get(sti_class, record_id)
+            instance.reinit_with('attributes' => record)
+          else
+            instance = sti_class.allocate.init_with('attributes' => record)
+            IdentityMap.add(instance)
+          end
+
+          instance
+        end
 
         def relation #:nodoc:
           @relation ||= Relation.new(self, arel_table)

--- a/activerecord/lib/active_record/identity_map.rb
+++ b/activerecord/lib/active_record/identity_map.rb
@@ -90,7 +90,7 @@ module ActiveRecord
       end
 
       def add(record)
-        repository[record.class.symbolized_sti_name][record.id] = record if record.class.column_names - record.attribute_names == []
+        repository[record.class.symbolized_sti_name][record.id] = record if contain_all_columns(record)
       end
 
       def remove(record)
@@ -104,6 +104,12 @@ module ActiveRecord
       def clear
         repository.clear
       end
+
+      private
+
+        def contain_all_columns(record)
+          (record.class.column_names - record.attribute_names) == []
+        end
     end
 
     # Reinitialize an Identity Map model object from +coder+.

--- a/activerecord/lib/active_record/identity_map.rb
+++ b/activerecord/lib/active_record/identity_map.rb
@@ -90,7 +90,7 @@ module ActiveRecord
       end
 
       def add(record)
-        repository[record.class.symbolized_sti_name][record.id] = record
+        repository[record.class.symbolized_sti_name][record.id] = record if record.class.column_names - record.attribute_names == []
       end
 
       def remove(record)

--- a/activerecord/lib/active_record/identity_map.rb
+++ b/activerecord/lib/active_record/identity_map.rb
@@ -90,7 +90,7 @@ module ActiveRecord
       end
 
       def add(record)
-        repository[record.class.symbolized_sti_name][record.id] = record if contain_all_columns(record)
+        repository[record.class.symbolized_sti_name][record.id] = record if contain_all_columns?(record)
       end
 
       def remove(record)
@@ -107,8 +107,8 @@ module ActiveRecord
 
       private
 
-        def contain_all_columns(record)
-          (record.class.column_names - record.attribute_names) == []
+        def contain_all_columns?(record)
+          (record.class.column_names - record.attribute_names).empty?
         end
     end
 

--- a/activerecord/test/cases/identity_map_test.rb
+++ b/activerecord/test/cases/identity_map_test.rb
@@ -404,11 +404,12 @@ class IdentityMapTest < ActiveRecord::TestCase
     assert comment.save
   end
 
-  def test_do_not_add_to_identity_map_if_record_do_not_contain_all_columns
-    post = Post.select(:id).first
-    comment = post.comments[0]
+  def test_do_not_add_to_repository_if_record_does_not_contain_all_columns
+    author = Author.select(:id).first
+    post = author.posts.first
+
     assert_nothing_raised do
-      assert_not_nil comment.post.title
+      assert_not_nil post.author.name
     end
   end
 

--- a/activerecord/test/cases/identity_map_test.rb
+++ b/activerecord/test/cases/identity_map_test.rb
@@ -404,18 +404,12 @@ class IdentityMapTest < ActiveRecord::TestCase
     assert comment.save
   end
 
-  def test_find_using_select_and_identity_map
-    author_id, author = Author.select('id').order(:id).first, Author.order(:id).first
-
-    assert_equal author_id, author
-    assert_same author_id, author
-    assert_not_nil author.name
-
-    post, post_id = Post.order(:id).first, Post.select('id').order(:id).first
-
-    assert_equal post_id, post
-    assert_same post_id, post
-    assert_not_nil post.title
+  def test_do_not_add_to_identity_map_if_record_do_not_contain_all_columns
+    post = Post.select(:id).first
+    comment = post.comments[0]
+    assert_nothing_raised do
+      assert_not_nil comment.post.title
+    end
   end
 
 # Currently AR is not allowing changing primary key (see Persistence#update)


### PR DESCRIPTION
## Issue:

When loading an object that doesn't contains all the columns (using 'select' for example), IdentityMap stores this partial object. If this object is used later, but in this case we want all the attributes (or at least one that wasn't loaded at the beginning), then we will get a 'MissingAttributeError'. The following code will fail, for example

``` ruby
ActiveRecord::IdentityMap.use do
  author = Author.select(:id).first
  post = author.posts.first

  name = post.author.name
end
```

However, this code will load the author's name from the db:

``` ruby
author = Author.select(:id).first
post = author.posts.first

name = post.author.name
```
## Fix:

If the object being loaded doesn't contain all values for all its columns, then we don't save it in the repository of IdentityMap.

I also did some refactoring in base.rb

PS: Sorry for the number of commits, I will try to make fewer commits in a pull request next time. I can apply the cherry picks to the other branches if you accept this pull request.
