### PR TITLE
Changed the config.assets.manifest to nil

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -21,7 +21,7 @@
   # Generate digests for assets URLs.
   config.assets.digest = true
 
-  # Defaults to Rails.root.join("public/assets").
+  # Defaults to nil and saved in location specified by config.assets.prefix
   # config.assets.manifest = YOUR_PATH
   <%- end -%>
 


### PR DESCRIPTION
config.assets.manifest's default was changed to nil as a fix for #2776. However, the app generators for production config wasn't updated to reflect the same. This also fixes #5482.
