### PR TITLE
Make AC::LogSubscriber#send_file like #send_data

### DIFF
--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -33,9 +33,7 @@ module ActionController
     end
 
     def send_file(event)
-      message = "Sent file %s"
-      message << " (%.1fms)"
-      info(message % [event.payload[:path], event.duration])
+      info("Sent file %s (%.1fms)" % [event.payload[:path], event.duration])
     end
 
     def redirect_to(event)


### PR DESCRIPTION
AC::LogSubsriber #send_data and #send_file makes the same things now [action_controller/log_subscriber.rb#L35](https://github.com/rails/rails/blob/0560ce0b2928afce0c1ca9507b706ede8fd45138/actionpack/lib/action_controller/log_subscriber.rb#L35)

I suggest to make them the same.

PS. The difference is because historical reasons. For example [5e2bd08#L1L22](https://github.com/rails/rails/commit/5e2bd08023344f3fd4675e80203a10967ffe9000#L1L22) one step of LogSubbscriber#send_file evolution.
