### PR TITLE
Add unordered_list helper

### DIFF
--- a/actionpack/lib/action_view/helpers.rb
+++ b/actionpack/lib/action_view/helpers.rb
@@ -24,6 +24,7 @@ module ActionView #:nodoc:
     autoload :TagHelper
     autoload :TextHelper
     autoload :TranslationHelper
+    autoload :UnorderedListHelper
     autoload :UrlHelper
 
     extend ActiveSupport::Concern
@@ -54,6 +55,7 @@ module ActionView #:nodoc:
     include TagHelper
     include TextHelper
     include TranslationHelper
+    include UnorderedListHelper
     include UrlHelper
   end
 end

--- a/actionpack/lib/action_view/helpers/unordered_list_helper.rb
+++ b/actionpack/lib/action_view/helpers/unordered_list_helper.rb
@@ -1,0 +1,34 @@
+# encoding: utf-8
+
+module ActionView
+  # = Action View Helpers
+  module Helpers #:nodoc:
+
+    # Provides methods for generating markup from Enumerables
+    module UnorderedListHelper
+
+      def unordered_list(klass_or_enum, options = {}, &block)
+        klass = klass_or_enum
+        enum = []
+
+        if block_given?
+          klass = klass_or_enum.map(&:class).first.to_s.downcase
+          enum = klass_or_enum
+        else
+          klass = klass.to_s
+        end
+
+        content_tag :ul, { class: klass.pluralize }.merge(options) do
+          list_items = []
+          enum.each do |item|
+            li = content_tag(:li, class: klass) { yield item }
+            list_items << li
+          end
+
+          list_items.join.html_safe
+        end
+      end
+      alias_method :ul, :unordered_list
+    end
+  end
+end

--- a/actionpack/test/template/unordered_list_helper_test.rb
+++ b/actionpack/test/template/unordered_list_helper_test.rb
@@ -1,0 +1,31 @@
+require 'abstract_unit'
+require 'controller/fake_models'
+
+class UnorderedListHelperTest < ActionView::TestCase
+  def test_empty_unordered_list
+    assert_dom_equal('<ul class="posts"></ul>', unordered_list(:posts))
+  end
+  
+  def test_unordered_list_with_list_items
+    posts = []
+    posts << Post.new('First')
+    assert_dom_equal('<ul class="posts"><li class="post">First</li></ul>', unordered_list(posts) { |post| post.title })
+  end
+  
+  def test_unordered_list_with_data_attributes
+    assert_dom_equal('<ul class="posts" data-url="/posts"></ul>', unordered_list(:posts, data: { url: '/posts' }))
+  end
+  
+  def test_unordered_list_with_data_attributes_and_list_items
+    posts = []
+    posts << Post.new('First')
+
+    expected = '<ul class="posts" data-url="/posts"><li class="post">First</li></ul>'
+    actual = unordered_list(posts, data: { url: '/posts' }) { |post| post.title }
+    assert_dom_equal(expected, actual)
+  end
+  
+  def test_unordered_list_abbreviation
+    assert_dom_equal('<ul class="posts"></ul>', ul(:posts))
+  end
+end


### PR DESCRIPTION
In an effort to reduce some common boilerplate for templates, I present to you an `unordered_list` view helper that will allow us to reduce this:

``` html
<ul class="items">
  <% @items.each do |item| %>
    <li class="item"><%= link_to item.name, item %></li>
  <% end %>
</ul>
```

down to this:

``` html
<%= unordered_list(@items) { |item| link_to item.name, item } %>
```
