### PR TITLE
API change to Relation#first and Relation#last

### DIFF
--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -813,7 +813,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_deleting_updates_counter_cache
-    topic = Topic.first(:order => "id ASC")
+    topic = Topic.order('id asc').first
     assert_equal topic.replies.to_a.size, topic.replies_count
 
     topic.replies.delete(topic.replies.first)
@@ -1505,7 +1505,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_queries 2 do
       assert firm.clients.loaded?
-      firm.clients.first(:order => 'name')
+      firm.clients.order('name').first
       firm.clients.last(:order => 'name')
     end
   end

--- a/activerecord/test/cases/named_scope_test.rb
+++ b/activerecord/test/cases/named_scope_test.rb
@@ -165,7 +165,9 @@ class NamedScopeTest < ActiveRecord::TestCase
   end
 
   def test_first_and_last_should_support_find_options
-    assert_equal Topic.base.first(:order => 'title'), Topic.base.find(:first, :order => 'title')
+    assert_deprecated do
+      assert_equal Topic.base.first(:order => 'title'), Topic.base.find(:first, :order => 'title')
+    end
     assert_equal Topic.base.last(:order => 'title'), Topic.base.find(:last, :order => 'title')
   end
 
@@ -187,7 +189,7 @@ class NamedScopeTest < ActiveRecord::TestCase
     topics = Topic.base
     topics.reload # force load
     assert_queries(2) do
-      topics.first(:order => 'title')
+      topics.order('title').first
       topics.last(:order => 'title')
     end
   end

--- a/activerecord/test/cases/relation_scoping_test.rb
+++ b/activerecord/test/cases/relation_scoping_test.rb
@@ -53,8 +53,8 @@ class RelationScopingTest < ActiveRecord::TestCase
   end
 
   def test_scoped_find_last_preserves_scope
-    lowest_salary  = Developer.first :order => "salary ASC"
-    highest_salary = Developer.first :order => "salary DESC"
+    lowest_salary  = Developer.order('salary asc').first
+    highest_salary = Developer.order('salary desc').first
 
     Developer.order("salary").scoping do
       assert_equal highest_salary, Developer.last

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1256,4 +1256,22 @@ class RelationTest < ActiveRecord::TestCase
 
     assert topics.loaded?
   end
+
+  test "first with hash conditions returns the first matching record" do
+    assert_equal posts(:eager_other), Post.order(:id).first(author_id: 2)
+  end
+
+  test "first with non-hash conditions returns the first matching record" do
+    assert_equal posts(:eager_other), Post.order(:id).first("author_id = 2")
+  end
+
+  test "first with multi-arg conditions returns the first matching record" do
+    assert_equal posts(:eager_other), Post.order(:id).first('author_id = ?', 2)
+  end
+
+  test "first with deprecated finder options conditions returns the first record matching the condition" do
+    assert_deprecated do
+      assert_equal posts(:eager_other), Post.first(conditions: { author_id: 2 }, order: :id)
+    end
+  end
 end


### PR DESCRIPTION
Hi guys,

I want to deprecate dynamic finders etc:
- They are duplicating functionality we already have from `ActiveRecord::Relation`
- They are inflexible; changing the columns dynamically requires using `send`
- API bloat

The problem:

``` ruby
Post.find_by_title('lol')
```

is nicer than these:

``` ruby
Post.where(title: 'lol').first
Post.first(conditions: { title: 'lol' })
```

This would not be a problem if we could do this:

``` ruby
Post.first(title: 'lol')
```

But currently `#first` and `#last` take a hash of old-style finder conditions.

I want to:
- Deprecate `#first` and `#last` taking old-style finder conditions
- Enable `#first` and `#last` to take normal conditions, just like you'd pass to `#where`
- Deprecate dynamic finders

This code is _unfinished_ but contains a proof-of-concept for `#first` to show that this is possible and to demonstrate my proposed solution.
