### PR TITLE
Keep orignal exception

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -301,7 +301,7 @@ module ActiveRecord
 
       def translate_exception(e, message)
         # override in derived class
-        ActiveRecord::StatementInvalid.new(message)
+        ActiveRecord::WrappedDatabaseException.new(message,e)
       end
     end
   end


### PR DESCRIPTION
This change would enable better error handling of failures do to complex constraints and triggers.

There is a lot of useful information in the original error.
