### PR TITLE
ordinal() helper function can be dropped if ordinalize() uses <<

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -250,29 +250,6 @@ module ActiveSupport
       end
     end
 
-    # Returns the suffix that should be added to a number to denote the position
-    # in an ordered sequence such as 1st, 2nd, 3rd, 4th.
-    #
-    # Examples:
-    #   ordinal(1)     # => "st"
-    #   ordinal(2)     # => "nd"
-    #   ordinal(1002)  # => "nd"
-    #   ordinal(1003)  # => "rd"
-    #   ordinal(-11)   # => "th"
-    #   ordinal(-1021) # => "st"
-    def ordinal(number)
-      if (11..13).include?(number.to_i.abs % 100)
-        "th"
-      else
-        case number.to_i.abs % 10
-          when 1; "st"
-          when 2; "nd"
-          when 3; "rd"
-          else    "th"
-        end
-      end
-    end
-
     # Turns a number into an ordinal string used to denote the position in an
     # ordered sequence such as 1st, 2nd, 3rd, 4th.
     #
@@ -284,7 +261,17 @@ module ActiveSupport
     #   ordinalize(-11)   # => "-11th"
     #   ordinalize(-1021) # => "-1021st"
     def ordinalize(number)
-      "#{number}#{ordinal(number)}"
+      "#{number}" <<
+      if (11..13).include?(number.to_i.abs % 100)
+        "th"
+      else
+        case number.to_i.abs % 10
+          when 1; "st"
+          when 2; "nd"
+          when 3; "rd"
+          else    "th"
+        end
+      end
     end
 
     private


### PR DESCRIPTION
This patch keeps the DRYed up ordinalize(), but removes the ordinal() helper in favor or concatenating within the ordinalize() method itself.
