### PR TITLE
Remove code duplication in InclusionValidator and ExclusionValidator.

### DIFF
--- a/activemodel/lib/active_model/validations/clusivity.rb
+++ b/activemodel/lib/active_model/validations/clusivity.rb
@@ -1,0 +1,31 @@
+require 'active_support/core_ext/range.rb'
+
+module ActiveModel
+  module Validations
+    module Clusivity
+      ERROR_MESSAGE = "An object with the method #include? or a proc or lambda is required, " <<
+                      "and must be supplied as the :in option of the configuration hash"
+
+      def check_validity!
+        unless [:include?, :call].any?{ |method| options[:in].respond_to?(method) }
+          raise ArgumentError, ERROR_MESSAGE
+        end
+      end
+
+    private
+
+      def include?(record, value)
+        delimiter = options[:in]
+        exclusions = delimiter.respond_to?(:call) ? delimiter.call(record) : delimiter
+        exclusions.send(inclusion_method(exclusions), value)
+      end
+
+      # In Ruby 1.9 <tt>Range#include?</tt> on non-numeric ranges checks all possible values in the
+      # range for equality, so it may be slow for large ranges. The new <tt>Range#cover?</tt>
+      # uses the previous logic of comparing a value with the range endpoints.
+      def inclusion_method(enumerable)
+        enumerable.is_a?(Range) ? :cover? : :include?
+      end
+    end
+  end
+end

--- a/activemodel/lib/active_model/validations/exclusion.rb
+++ b/activemodel/lib/active_model/validations/exclusion.rb
@@ -1,34 +1,16 @@
-require 'active_support/core_ext/range'
+require "active_model/validations/clusivity"
 
 module ActiveModel
 
   # == Active Model Exclusion Validator
   module Validations
     class ExclusionValidator < EachValidator
-      ERROR_MESSAGE = "An object with the method #include? or a proc or lambda is required, " <<
-                      "and must be supplied as the :in option of the configuration hash"
-
-      def check_validity!
-        unless [:include?, :call].any? { |method| options[:in].respond_to?(method) }
-          raise ArgumentError, ERROR_MESSAGE
-        end
-      end
+      include Clusivity
 
       def validate_each(record, attribute, value)
-        delimiter = options[:in]
-        exclusions = delimiter.respond_to?(:call) ? delimiter.call(record) : delimiter
-        if exclusions.send(inclusion_method(exclusions), value)
+        if include?(record, value)
           record.errors.add(attribute, :exclusion, options.except(:in).merge!(:value => value))
         end
-      end
-
-    private
-
-      # In Ruby 1.9 <tt>Range#include?</tt> on non-numeric ranges checks all possible values in the
-      # range for equality, so it may be slow for large ranges. The new <tt>Range#cover?</tt>
-      # uses the previous logic of comparing a value with the range endpoints.
-      def inclusion_method(enumerable)
-        enumerable.is_a?(Range) ? :cover? : :include?
       end
     end
 
@@ -59,7 +41,7 @@ module ActiveModel
       # * <tt>:unless</tt> - Specifies a method, proc or string to call to determine if the validation should
       #   not occur (e.g. <tt>:unless => :skip_validation</tt>, or <tt>:unless => Proc.new { |user| user.signup_step <= 2 }</tt>). The
       #   method, proc or string should return or evaluate to a true or false value.
-      # * <tt>:strict</tt> - Specifies whether validation should be strict. 
+      # * <tt>:strict</tt> - Specifies whether validation should be strict.
       #   See <tt>ActiveModel::Validation#validates!</tt> for more information
       def validates_exclusion_of(*attr_names)
         validates_with ExclusionValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/inclusion.rb
+++ b/activemodel/lib/active_model/validations/inclusion.rb
@@ -1,34 +1,16 @@
-require 'active_support/core_ext/range'
+require "active_model/validations/clusivity"
 
 module ActiveModel
 
   # == Active Model Inclusion Validator
   module Validations
     class InclusionValidator < EachValidator
-      ERROR_MESSAGE = "An object with the method #include? or a proc or lambda is required, " <<
-                      "and must be supplied as the :in option of the configuration hash"
-
-      def check_validity!
-        unless [:include?, :call].any?{ |method| options[:in].respond_to?(method) }
-          raise ArgumentError, ERROR_MESSAGE
-        end
-      end
+      include Clusivity
 
       def validate_each(record, attribute, value)
-        delimiter = options[:in]
-        exclusions = delimiter.respond_to?(:call) ? delimiter.call(record) : delimiter
-        unless exclusions.send(inclusion_method(exclusions), value)
+        unless include?(record, value)
           record.errors.add(attribute, :inclusion, options.except(:in).merge!(:value => value))
         end
-      end
-
-    private
-
-      # In Ruby 1.9 <tt>Range#include?</tt> on non-numeric ranges checks all possible values in the
-      # range for equality, so it may be slow for large ranges. The new <tt>Range#cover?</tt>
-      # uses the previous logic of comparing a value with the range endpoints.
-      def inclusion_method(enumerable)
-        enumerable.is_a?(Range) ? :cover? : :include?
       end
     end
 
@@ -59,7 +41,7 @@ module ActiveModel
       # * <tt>:unless</tt> - Specifies a method, proc or string to call to determine if the validation should
       #   not occur (e.g. <tt>:unless => :skip_validation</tt>, or <tt>:unless => Proc.new { |user| user.signup_step <= 2 }</tt>). The
       #   method, proc or string should return or evaluate to a true or false value.
-      # * <tt>:strict</tt> - Specifies whether validation should be strict. 
+      # * <tt>:strict</tt> - Specifies whether validation should be strict.
       #   See <tt>ActiveModel::Validation#validates!</tt> for more information
       def validates_inclusion_of(*attr_names)
         validates_with InclusionValidator, _merge_attributes(attr_names)


### PR DESCRIPTION
I got the implementation in #1352 by @jamescook and changed to use composition instead of inheritance.

I tried to cherry-pick the original commit to give credits to the original author but he deleted their fork, so I added it as co-author in the commit message.
