### PR TITLE
Add update_or_create family of methods to ActiveRecord

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -3,7 +3,8 @@ require 'active_support/core_ext/module/delegation'
 module ActiveRecord
   module Querying
     delegate :find, :first, :first!, :last, :last!, :all, :exists?, :any?, :many?, :to => :scoped
-    delegate :first_or_create, :first_or_create!, :first_or_initialize, :to => :scoped
+    delegate :first_or_create, :first_or_create!, :first_or_initialize,
+             :update_or_create, :update_or_create!, :to => :scoped
     delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, :to => :scoped
     delegate :find_each, :find_in_batches, :to => :scoped
     delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins,

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -126,6 +126,60 @@ module ActiveRecord
       first || create!(attributes, options, &block)
     end
 
+    # Tries to load the first record; if it succeeds then it calls
+    # <tt>update_attributes</tt>, else it will call <tt>create</tt> with
+    # the same arguments to the method
+    #
+    # Expects arguments in the same format as <tt>Base.update_attributes</tt>
+    # but accepts a block in the format of <tt>Base.create</tt>.
+    #
+    # ==== Examples
+    #   # Find the first user named Penélope or create a new one.
+    #   User.where(:first_name => 'Penélope').update_or_create
+    #   # => <User id: 1, first_name: 'Penélope', last_name: nil>
+    #
+    #   # Find the first user named Penélope or create a new one.
+    #   # We already have one so the existing record will be returned.
+    #   User.where(:first_name => 'Penélope').update_or_create
+    #   # => <User id: 1, first_name: 'Penélope', last_name: nil>
+    #
+    #   # Find the first user named Scarlett and update last name to 'Johansson'
+    #   # or create a new one with a particular last name.
+    #   User.where(:first_name => 'Scarlett').update_or_create(:last_name => 'Johansson')
+    #   # => <User id: 2, first_name: 'Scarlett', last_name: 'Johansson'>
+    #
+    #   # Find the first user named Scarlett and update to a different last name
+    #   # or create a new one with a different last name.
+    #   # We already have one so the existing record will be returned.
+    #   User.where(:first_name => 'Scarlett').first_or_create do |user|
+    #     user.last_name = "O'Hara"
+    #   end
+    #   # => <User id: 2, first_name: "Scarlett", last_name: "O'Hara">
+    def update_or_create(attributes = nil, options = {}, &block)
+      if record = first
+        record.tap(&block) if block_given?
+        record.update_attributes(attributes, options)
+        record
+      else
+        create(attributes, options, &block)
+      end
+    end
+
+    # Like <tt>update_or_create</tt> but calls <tt>create!</tt> and
+    # <tt>update_attributes</tt> so an exception is raised if the created or
+    # updated record is invalid.
+    #
+    # Expects arguments in the same format as <tt>Base.update_attributes!</tt>.
+    def update_or_create!(attributes = nil, options = {}, &block)
+      if record = first
+        record.tap(&block) if block_given?
+        record.update_attributes!(attributes, options)
+        record
+      else
+        create!(attributes, options, &block)
+      end
+    end
+
     # Like <tt>first_or_create</tt> but calls <tt>new</tt> instead of <tt>create</tt>.
     #
     # Expects arguments in the same format as <tt>Base.new</tt>.

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -306,6 +306,46 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal parrot, the_same_parrot
   end
 
+  def test_update_or_create
+    # base case
+    parrot = Bird.update_or_create(:color => 'green', :name => 'parrot')
+    assert parrot.persisted?
+    assert parrot.color, 'green'
+
+    # test create will use conditions and options for attributes
+    other_parrot = Bird.where(:color => 'red').
+      update_or_create(:name => 'macaw')
+    assert_equal other_parrot.name, 'macaw'
+    assert_equal other_parrot.color, 'red'
+    assert_not_equal parrot, other_parrot
+
+    # find other_parrot and update the name
+    other_parrot_again = Bird.where(:color => 'red').
+      update_or_create(:name => 'parrot')
+    assert_equal other_parrot, other_parrot_again
+    assert_equal other_parrot_again.name, 'parrot'
+  end
+
+  def test_update_or_create_bang
+    # base case
+    parrot = Bird.update_or_create!(:color => 'green', :name => 'parrot')
+    assert parrot.persisted?
+    assert parrot.color, 'green'
+
+    # test create will use conditions and options for attributes
+    other_parrot = Bird.where(:color => 'red').
+      update_or_create!(:name => 'macaw')
+    assert_equal other_parrot.name, 'macaw'
+    assert_equal other_parrot.color, 'red'
+    assert_not_equal parrot, other_parrot
+
+    # find other_parrot and update the name
+    other_parrot_again = Bird.where(:color => 'red').
+      update_or_create!(:name => 'parrot')
+    assert_equal other_parrot, other_parrot_again
+    assert_equal other_parrot_again.name, 'parrot'
+  end
+
   def test_first_or_create_bang
     assert_raises(ActiveRecord::RecordInvalid) { Bird.first_or_create! }
     parrot = Bird.first_or_create!(:color => 'green', :name => 'parrot')

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -968,6 +968,77 @@ class RelationTest < ActiveRecord::TestCase
     assert_raises(ActiveRecord::RecordInvalid) { Bird.where(:color => 'green').first_or_create!([ {:name => 'parrot'}, {:pirate_id => 1} ]) }
   end
 
+  def test_update_or_create
+    parrot = Bird.where(:color => 'green').update_or_create(:name => 'parrot')
+    assert_kind_of Bird, parrot
+    assert parrot.persisted?
+    assert_equal 'parrot', parrot.name
+    assert_equal 'green', parrot.color
+
+    same_parrot = Bird.where(:color => 'green').update_or_create(:name => 'parakeet')
+    assert_kind_of Bird, same_parrot
+    assert same_parrot.persisted?
+    assert_equal parrot, same_parrot
+  end
+
+  def test_update_or_create_with_no_parameters
+    parrot = Bird.where(:color => 'green').update_or_create
+    assert_kind_of Bird, parrot
+    assert !parrot.persisted?
+    assert_equal 'green', parrot.color
+  end
+
+  def test_update_or_create_with_block
+    parrot = Bird.where(:color => 'green').update_or_create { |bird| bird.name = 'parrot' }
+    assert_kind_of Bird, parrot
+    assert parrot.persisted?
+    assert_equal 'green', parrot.color
+    assert_equal 'parrot', parrot.name
+
+    same_parrot = Bird.where(:color => 'green').update_or_create { |bird| bird.name = 'parakeet' }
+    assert_equal parrot, same_parrot
+    # this test differentiates update_or_create from first_or_create
+    assert_equal 'parakeet', same_parrot.name
+  end
+
+  def test_update_or_create_bang_with_valid_options
+    parrot = Bird.where(:color => 'green').update_or_create!(:name => 'parrot')
+    assert_kind_of Bird, parrot
+    assert parrot.persisted?
+    assert_equal 'parrot', parrot.name
+    assert_equal 'green', parrot.color
+
+    same_parrot = Bird.where(:color => 'green').update_or_create!(:name => 'parakeet')
+    assert_kind_of Bird, same_parrot
+    assert same_parrot.persisted?
+    assert_equal parrot, same_parrot
+  end
+
+  def test_update_or_create_bang_with_invalid_options
+    assert_raises(ActiveRecord::RecordInvalid) { Bird.where(:color => 'green').update_or_create!(:pirate_id => 1) }
+  end
+
+  def test_update_or_create_bang_with_no_parameters
+    assert_raises(ActiveRecord::RecordInvalid) { Bird.where(:color => 'green').update_or_create! }
+  end
+
+  def test_update_or_create_bang_with_valid_block
+    parrot = Bird.where(:color => 'green').update_or_create! { |bird| bird.name = 'parrot' }
+    assert_kind_of Bird, parrot
+    assert parrot.persisted?
+    assert_equal 'green', parrot.color
+    assert_equal 'parrot', parrot.name
+
+    same_parrot = Bird.where(:color => 'green').update_or_create! { |bird| bird.name = 'parakeet' }
+    assert_equal parrot, same_parrot
+  end
+
+  def test_update_or_create_bang_with_invalid_block
+    assert_raise(ActiveRecord::RecordInvalid) do
+      Bird.where(:color => 'green').update_or_create! { |bird| bird.pirate_id = 1 }
+    end
+  end
+
   def test_first_or_initialize
     parrot = Bird.where(:color => 'green').first_or_initialize(:name => 'parrot')
     assert_kind_of Bird, parrot


### PR DESCRIPTION
Related: #2757
Previously: #5645

``` ruby
# from tests added via test/cases/relations_test.rb
parrot = Bird.where(:color => 'green').update_or_create { |bird| bird.name = 'parrot' }
assert_kind_of Bird, parrot
assert parrot.persisted?
assert_equal 'green', parrot.color
assert_equal 'parrot', parrot.name

same_parrot = Bird.where(:color => 'green').update_or_create { |bird| bird.name = 'parakeet' }
assert_equal parrot, same_parrot
# this test differentiates update_or_create from first_or_create
assert_equal 'parakeet', same_parrot.name
```

I've had to mimic this pattern in my app several times, and the pattern here seems to be consistent with other Relation additions to 3.2.

The only inconsistency is that it cannot take an array when creating. Whether it would be more useful to use this as an "update_all" is a topic for discussion or to be called `update_or_create_all`.

Also, I do use `Object#tap` here such that protected attributes can be updated alongside or separately from update_attributes.

Hope this is helpful!

/cc @jonleighton
