### PR TITLE
Always include requires for built-in frameworks, for customization

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -1,7 +1,15 @@
 require File.expand_path('../boot', __FILE__)
 
 <% if include_all_railties? -%>
+# Load all built-in Rails frameworks.
 require 'rails/all'
+
+# Or pick the frameworks you want:
+# require "active_record/railtie"
+# require "action_controller/railtie"
+# require "action_mailer/railtie"
+# require "sprockets/rails/railtie"
+# require "rails/test_unit/railtie"
 <% else -%>
 # Pick the frameworks you want:
 <%= comment_if :skip_active_record %>require "active_record/railtie"


### PR DESCRIPTION
Rails is a modular framework, which means customization is likely in many (most?) cases. To make this easier, always generate in application.rb a commented-out list of built-in framework require statements, so it's trivially easy to strip an app down.

I always forget what's included in "rails/all". This would mean I never have to poke around for it again.

This could/should be backported into a 3.x update as well.
