### PR TITLE
Typecast 'id' attribute in read_attribute when using custom pks

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -67,7 +67,10 @@ module ActiveRecord
         @attributes_cache.fetch(attr_name.to_s) { |name|
           column = @columns_hash.fetch(name) {
             return @attributes.fetch(name) {
-              @attributes[self.class.primary_key] if name == 'id'
+              if name == 'id'
+                primary_key = self.class.primary_key
+                @columns_hash[primary_key].type_cast(@attributes[primary_key])
+              end
             }
           }
 

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -1,4 +1,5 @@
 require 'set'
+require 'active_support/deprecation'
 
 module ActiveRecord
   # :stopdoc:
@@ -107,6 +108,9 @@ module ActiveRecord
       end
 
       def type_cast_code(var_name)
+        ActiveSupport::Deprecation.warn("Column#type_cast_code is deprecated in favor of" \
+          "using Column#type_cast only, and it is going to be removed in future Rails versions.")
+
         klass = self.class.name
 
         case type

--- a/activerecord/test/cases/attribute_methods/read_test.rb
+++ b/activerecord/test/cases/attribute_methods/read_test.rb
@@ -6,10 +6,6 @@ module ActiveRecord
   module AttributeMethods
     class ReadTest < ActiveRecord::TestCase
       class FakeColumn < Struct.new(:name)
-        def type_cast_code(var)
-          var
-        end
-
         def type; :integer; end
       end
 


### PR DESCRIPTION
Related to [this awesome cleanup](https://github.com/rails/rails/commit/6cff09038d5d78e6a4a12d0a27c6b1b87f0a5147) :heart:.

When using custom primary keys, the `id` attribute works as an alias to the pk. But in case of read_attribute, when reading the `id` [it was not being typecasted after the change](http://travis-ci.org/#!/rails/rails/jobs/978068/L111).

Also added a deprecation message to `type_cast_code` according to the conversation in the same commit.

Thanks!
