### PR TITLE
Fix #5563. Should reflect the most recent change to either of association / association_id.

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -132,7 +132,8 @@ module ActiveRecord
       # ActiveRecord::RecordNotFound is rescued within the method, and it is
       # not reraised. The proxy is \reset and +nil+ is the return value.
       def load_target
-        @target ||= find_target if find_target?
+        @target = find_target if (@stale_state && stale_target?) || find_target?
+
         loaded! unless loaded?
         target
       rescue ActiveRecord::RecordNotFound

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -77,7 +77,7 @@ module ActiveRecord
         end
 
         def stale_state
-          owner[reflection.foreign_key].to_s
+          owner[reflection.foreign_key] && owner[reflection.foreign_key].to_s
         end
     end
   end

--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -27,7 +27,8 @@ module ActiveRecord
         end
 
         def stale_state
-          [super, owner[reflection.foreign_type].to_s]
+          foreign_key = super
+          foreign_key && [foreign_key.to_s, owner[reflection.foreign_type].to_s]
         end
     end
   end

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -62,7 +62,7 @@ module ActiveRecord
         # properly support stale-checking for nested associations.
         def stale_state
           if through_reflection.macro == :belongs_to
-            owner[through_reflection.foreign_key].to_s
+            owner[through_reflection.foreign_key] && owner[through_reflection.foreign_key].to_s
           end
         end
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -705,4 +705,15 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
 
     assert_equal toy, sponsor.reload.sponsorable
   end
+
+  def test_reflect_the_most_recent_change
+    author1, author2 = Author.limit(2)
+    post = Post.new(:title => "foo", :body=> "bar")
+
+    post.author    = author1
+    post.author_id = author2.id
+
+    assert post.save
+    assert_equal post.author_id, author2.id
+  end
 end


### PR DESCRIPTION
I think that I fixed a problem that the most recent change to _association_id_ didn't reflrect _association_.
Please see https://github.com/rails/rails/issues/5563

cc/ @jonleighton @tenderlove

If necessary, I'll send a PR to 3-2-stable.
