### PR TITLE
Hello! I faced problem with adapters at RAILS_ENV=some_env rake test.

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -488,6 +488,51 @@ db_namespace = namespace :db do
         db_namespace["structure:load"].invoke
       ensure
         ENV['RAILS_ENV'] = old_env
+        #here problem rise! I have environment lite(for tests on sqlite)
+        #when I invoke RAILS_ENV=lite rake test I purge test database
+        #but my lite database for tests untouched=( and I get connection error.
+        #could we add something like 
+        #if %w(production development).include? Rails.env
+        #  ENV['RAILS_ENV'] = 'test'
+        #end
+        #or add to adapters parameter like testable(dropable,purgable,etc):
+        #production:
+        #  adapter: sqlserver
+        #  dataserver: development
+        #  database: development
+        #  username: development
+        #  password: development
+        #  pool: 5
+        #  timeout: 5000
+
+        #staging:
+        #  adapter: sqlserver
+        #  host: staging
+        #  port: staging
+        #  database: staging
+        #  username: staging
+        #  password: staging
+        #  pool: 5
+        #  timeout: 5000
+        #  testable(dropable,purgable,etc): false
+      
+        #lite:
+        #  adapter: sqlite3
+        #  database: db/test.sqlite3   
+        #  pool: 5
+        #  timeout: 5000
+        #  testable: true
+        
+        #test:
+        #  adapter: sqlserver
+        #  host: test
+        #  port: test
+        #  database: test
+        #  username: test
+        #  password: test
+        #  pool: 5
+        #  timeout: 5000
+        #  testable(dropable,purgable,etc): test
       end
     end
 


### PR DESCRIPTION
Scenario:
I run tests on couple environments:
test, lite, etc.
But I get purge only on my "test" database when I invoke tests with RAILS_ENV=lite because of

```
task :purge => :environment do
  abcs = ActiveRecord::Base.configurations
  case abcs['test']['adapter']
```

It is wrong behavior and it breaks tests with connection error if adapters for test and lite differs.

Makes me very sad about that. I had to monkeypatch my Rake file like so:

```
Add your own tasks in files placed in lib/tasks ending in .rake,
for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.



require File.expand_path('../config/application', __FILE__)
require 'rake'

SomeApp::Application.load_tasks

if %w(test lite).include? Rails.env

tasks = Rake.application.instance_variable_get '@tasks'
tasks.delete 'db:test:load'
tasks.delete 'db:test:purge'

db_namespace = namespace :db do
namespace :test do
task :load => 'db:test:purge' do
ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations[Rails.env])
ActiveRecord::Schema.verbose = false
db_namespace['schema:load'].invoke
end
task :purge => :environment do
abcs = ActiveRecord::Base.configurations
case abcs[Rails.env]['adapter']
when /mysql/
ActiveRecord::Base.establish_connection(:test)
ActiveRecord::Base.connection.recreate_database(abcs['test']['database'], mysql_creation_options(abcs['test']))
when /postgresql/
 ActiveRecord::Base.clear_active_connections!
   drop_database(abcs['test'])
    create_database(abcs['test'])
    when /sqlite/
   dbfile = abcs['test']['database'] || abcs['test']['dbfile']
   File.delete(dbfile) if File.exist?(dbfile)
    when 'sqlserver'
    test = abcs.deep_dup['test']
    test_database = test['database']
   test['database'] = 'master'
   ActiveRecord::Base.establish_connection(test)
     ActiveRecord::Base.connection.recreate_database!(test_database)
    when "oci", "oracle"
     ActiveRecord::Base.establish_connection(:test)
      ActiveRecord::Base.connection.structure_drop.split(";\n\n").each do |ddl|
      ActiveRecord::Base.connection.execute(ddl)
       end
      when 'firebird'
      ActiveRecord::Base.establish_connection(:test)
      ActiveRecord::Base.connection.recreate_database!
      else
     raise "Task not supported by '#{abcs['test']['adapter']}'"
     end
    end
  end
end

end
```

Sorry for broken mardown. Didn`t find out how to properly use ruby

Similar:
http://stackoverflow.com/questions/991038/why-do-testunits-and-testfunctionals-insist-on-running-in-development-environm
http://stackoverflow.com/questions/1090176/how-do-i-force-rails-env-in-a-rake-task

Hope to hear Your opinion! It works for me but it surely not expected behavior for RAILS_ENV=some_not_named_test_environment_for_tests rake test.
Thanks,
Alexander at alexandr.kostrikov@gmail.com
