### PR TITLE
Remove AC::RenderError class second declaration

### DIFF
--- a/actionpack/lib/action_controller/metal/exceptions.rb
+++ b/actionpack/lib/action_controller/metal/exceptions.rb
@@ -30,9 +30,6 @@ module ActionController
   class MissingFile < ActionControllerError #:nodoc:
   end
 
-  class RenderError < ActionControllerError #:nodoc:
-  end
-
   class SessionOverflowError < ActionControllerError #:nodoc:
     DEFAULT_MESSAGE = 'Your session data is larger than the data column in which it is to be stored. You must increase the size of your data column if you intend to store large data.'
 


### PR DESCRIPTION
RenderError class declared twice:

[action_controller/metal/exceptions.rb#L5](https://github.com/rails/rails/blob/86aefdb4f2b957acc6d6c7eef557dff6a3888803/actionpack/lib/action_controller/metal/exceptions.rb#L5)
[action_controller/metal/exceptions.rb#L33](https://github.com/rails/rails/blob/86aefdb4f2b957acc6d6c7eef557dff6a3888803/actionpack/lib/action_controller/metal/exceptions.rb#L33)

Injected at: 01a4bc84b8787df74d54147a0cf564df75e87970
