### PR TITLE
Remove obsolete reader from AC::MethodNotAllowed exception class

### DIFF
--- a/actionpack/lib/action_controller/metal/exceptions.rb
+++ b/actionpack/lib/action_controller/metal/exceptions.rb
@@ -14,8 +14,6 @@ module ActionController
   end
 
   class MethodNotAllowed < ActionControllerError #:nodoc:
-    attr_reader :allowed_methods
-
     def initialize(*allowed_methods)
       super("Only #{allowed_methods.to_sentence(:locale => :en)} requests are allowed.")
     end


### PR DESCRIPTION
The MethodNotAllowed exception class was designed with member `@allowed_methods` 
[01a4bc8#L0R18](https://github.com/rails/rails/commit/01a4bc84b8787df74d54147a0cf564df75e87970#L0R18) (3 years ago)

and refactored at
[588225f#L0L18](https://github.com/rails/rails/commit/588225f8852c4b60bfba38f16d8797a41e175400#L0L18) (2 years ago)

`attr_reader :allowed_methods` is not used now.
