### PR TITLE
Remove sort on attributes.keys

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -68,7 +68,7 @@ module ActiveModel
     def serializable_hash(options = nil)
       options ||= {}
 
-      attribute_names = attributes.keys.sort
+      attribute_names = attributes.keys
       if only = options[:only]
         attribute_names &= Array(only).map(&:to_s)
       elsif except = options[:except]


### PR DESCRIPTION
Couldn't find a reason the keys are sorted and my preference would be for the hash to be remain in whatever order the attributes hash is.
