### PR TITLE
validate attribute names in alias_attribute

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/aliasing.rb
+++ b/activesupport/lib/active_support/core_ext/module/aliasing.rb
@@ -61,6 +61,10 @@ class Module
   #   e.subject = "Megastars"
   #   e.title    # => "Megastars"
   def alias_attribute(new_name, old_name)
+    [new_name, old_name].each do |attribute|
+      raise NameError.new("invalid attribute name") unless attribute =~ /^[_A-Za-z]\w*$/
+    end
+
     module_eval <<-STR, __FILE__, __LINE__ + 1
       def #{new_name}; self.#{old_name}; end          # def subject; self.title; end
       def #{new_name}?; self.#{old_name}?; end        # def subject?; self.title?; end

--- a/activesupport/test/core_ext/module/attribute_aliasing_test.rb
+++ b/activesupport/test/core_ext/module/attribute_aliasing_test.rb
@@ -56,4 +56,18 @@ class AttributeAliasingTest < ActiveSupport::TestCase
     assert_equal "Uppercased methods are teh suck", e.body
     assert e.body?
   end
+
+  def test_should_raise_name_error_if_attribute_name_is_invalid
+    assert_raises NameError do
+      Class.new do
+        alias_attribute "invalid attribute name", "valid_name"
+      end
+    end
+
+    assert_raises NameError do
+      Class.new do
+        alias_attribute "valid_name", "invalid attribute name"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Here a ruby code injection issue:

```class A
  alias_attribute "test;end;`echo 1 > ~/1`; def test2", "test3"
end

```
```
