### PR TITLE
warning removed: `&' interpreted as argument prefix

### DIFF
--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -160,7 +160,7 @@ module Rails
       end
 
       def each(&block)
-        @paths.each &block
+        @paths.each(&block)
       end
 
       def <<(path)


### PR DESCRIPTION
I HATE WARNINGS :bomb:
