### PR TITLE
Issue 4083

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 3.1.4 (unreleased) ##
 
+*   :subdomain can now be specified with a value of false in url_for, 
+    allowing for subdomain(s) removal from the host during link generation. GH #4083
+
+    *Arun Agrawal*
+
 *   Skip assets group in Gemfile and all assets configurations options
     when the application is generated with --skip-sprockets option.
 

--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -64,14 +64,16 @@ module ActionDispatch
         end
 
         def host_or_subdomain_and_domain(options)
-          return options[:host] unless (options[:subdomain] || options[:domain]) && named_host?(options[:host])
+          return options[:host] if !named_host?(options[:host]) || (options[:subdomain].nil? && options[:domain].nil?)
 
           tld_length = options[:tld_length] || @@tld_length
 
           host = ""
-          host << (options[:subdomain] || extract_subdomain(options[:host], tld_length))
-          host << "."
-          host << (options[:domain]    || extract_domain(options[:host], tld_length))
+          unless options[:subdomain] == false
+            host << (options[:subdomain] || extract_subdomain(options[:host], tld_length)).to_param
+            host << "."
+          end
+          host << (options[:domain] || extract_domain(options[:host], tld_length))
           host
         end
       end

--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -116,9 +116,10 @@ module ActionDispatch
       #   If <tt>:only_path</tt> is false, this option must be
       #   provided either explicitly, or via +default_url_options+.
       # * <tt>:subdomain</tt> - Specifies the subdomain of the link, using the +tld_length+
-      #   to split the domain from the host.
-      # * <tt>:domain</tt> - Specifies the domain of the link, using the +tld_length+
       #   to split the subdomain from the host.
+      #   If false, removes all subdomains from the host part of the link.
+      # * <tt>:domain</tt> - Specifies the domain of the link, using the +tld_length+
+      #   to split the domain from the host.
       # * <tt>:tld_length</tt> - Number of labels the TLD id composed of, only used if
       #   <tt>:subdomain</tt> or <tt>:domain</tt> are supplied. Defaults to
       #   <tt>ActionDispatch::Http::URL.tld_length</tt>, which in turn defaults to 1.

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -71,6 +71,20 @@ module AbstractController
         )
       end
 
+      def test_subdomain_may_be_removed
+        add_host!
+        assert_equal('http://basecamphq.com/c/a/i',
+          W.new.url_for(:subdomain => false, :controller => 'c', :action => 'a', :id => 'i')
+        )
+      end
+
+      def test_multiple_subdomains_may_be_removed
+        W.default_url_options[:host] = 'mobile.www.api.basecamphq.com'
+        assert_equal('http://basecamphq.com/c/a/i',
+          W.new.url_for(:subdomain => false, :controller => 'c', :action => 'a', :id => 'i')
+        )
+      end
+
       def test_subdomain_may_be_accepted_with_numeric_host
         add_numeric_host!
         assert_equal('http://127.0.0.1/c/a/i',

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -15,6 +15,7 @@ class RequestTest < ActiveSupport::TestCase
 
     assert_equal 'http://www.example.com',  url_for
     assert_equal 'http://api.example.com',  url_for(:subdomain => 'api')
+    assert_equal 'http://example.com',      url_for(:subdomain => false)
     assert_equal 'http://www.ror.com',      url_for(:domain => 'ror.com')
     assert_equal 'http://api.ror.co.uk',    url_for(:host => 'www.ror.co.uk', :subdomain => 'api', :tld_length => 2)
     assert_equal 'http://www.example.com:8080',   url_for(:port => 8080)


### PR DESCRIPTION
allowing for subdomain(s) removal from the host during link generation. 

Closes #4083

cherry-picked from 

de942e5534a26942e261a7699adc28597c5ad1bc
96aa3bd0eae0afa98a1a16d87f5e0b6fa0005dab
