### PR TITLE
Added to_range method in integer class, and made extract_options! a one-liner

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/extract_options.rb
+++ b/activesupport/lib/active_support/core_ext/array/extract_options.rb
@@ -20,10 +20,6 @@ class Array
   #   options(1, 2)           # => {}
   #   options(1, 2, :a => :b) # => {:a=>:b}
   def extract_options!
-    if last.is_a?(Hash) && last.extractable_options?
-      pop
-    else
-      {}
-    end
+    last.is_a?(Hash) && last.extractable_options? ? pop : {}
   end
 end

--- a/activesupport/lib/active_support/core_ext/integer.rb
+++ b/activesupport/lib/active_support/core_ext/integer.rb
@@ -1,3 +1,4 @@
 require 'active_support/core_ext/integer/multiple'
 require 'active_support/core_ext/integer/inflections'
 require 'active_support/core_ext/integer/time'
+require 'active_support/core_ext/integer/conversions'

--- a/activesupport/lib/active_support/core_ext/integer/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/integer/conversions.rb
@@ -1,0 +1,13 @@
+class Integer
+  # Converts a integer into an array by default to_range includes the integer
+  #
+  # 5.to_range                    # => 0..5
+  # 5.to_range(:exclude => true)  # => 0...5
+  #
+  def to_range(*args)
+    options = args.extract_options!
+    exclude_num = options[:exclude] || false
+
+    exclude_num ? (0...self) : (0..self)
+  end
+end

--- a/activesupport/test/core_ext/integer_ext_test.rb
+++ b/activesupport/test/core_ext/integer_ext_test.rb
@@ -4,6 +4,11 @@ require 'active_support/core_ext/integer'
 class IntegerExtTest < ActiveSupport::TestCase
   PRIME = 22953686867719691230002707821868552601124472329079
 
+  def test_to_range
+    assert_equal 0..5, 5.to_range
+    assert_equal 0...5, 5.to_range(:exclude => true)
+  end
+
   def test_multiple_of
     [ -7, 0, 7, 14 ].each { |i| assert i.multiple_of?(7) }
     [ -7, 7, 14 ].each { |i| assert ! i.multiple_of?(6) }

--- a/guides/source/active_support_core_extensions.textile
+++ b/guides/source/active_support_core_extensions.textile
@@ -1823,6 +1823,17 @@ The method +multiple_of?+ tests whether an integer is multiple of the argument:
 
 NOTE: Defined in +active_support/core_ext/integer/multiple.rb+.
 
+h4. +to_range+
+
+The method +to_range+ converts an integer into a range with or without the integer included:
+
+<ruby>
+5.to_range # => 0..5
+5.to_range(:exclude => true) # => 0...5
+</ruby>
+
+NOTE: Defined in +active_support/core_ext/integer/conversions.rb+.
+
 h4. +ordinal+
 
 The method +ordinal+ returns the ordinal suffix string corresponding to the receiver integer:


### PR DESCRIPTION
I thought it would be a good idea to include a to_range method, since there are so many already like to_s, to_a, etc. Also it includes an exclude option so that the integer doesn't get included into the range. 

Finally I changed `extract_options!` so that the if..else is a ternary operator now, to maybe increase some speed in methods using it.
