### PR TITLE
Block version of label should wrapped in field_with_errors in case of error

### DIFF
--- a/actionpack/lib/action_view/helpers/tags/label.rb
+++ b/actionpack/lib/action_view/helpers/tags/label.rb
@@ -34,7 +34,6 @@ module ActionView
 
           if block_given?
             content = @template_object.capture(&block)
-            label_tag(name_and_id["id"], content, options)
           else
             content = if @content.blank?
                         @object_name.gsub!(/\[(.*)_attributes\]\[\d\]/, '.\1')
@@ -56,9 +55,9 @@ module ActionView
                         end
 
             content ||= @method_name.humanize
-
-            label_tag(name_and_id["id"], content, options)
           end
+
+          label_tag(name_and_id["id"], content, options)
         end
       end
     end

--- a/actionpack/lib/action_view/helpers/tags/label.rb
+++ b/actionpack/lib/action_view/helpers/tags/label.rb
@@ -33,7 +33,8 @@ module ActionView
           options["for"] = name_and_id["id"] unless options.key?("for")
 
           if block_given?
-            @template_object.label_tag(name_and_id["id"], options, &block)
+            content = @template_object.capture(&block)
+            label_tag(name_and_id["id"], content, options)
           else
             content = if @content.blank?
                         @object_name.gsub!(/\[(.*)_attributes\]\[\d\]/, '.\1')

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -1080,6 +1080,20 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_form_for_label_error_wrapping_block_and_non_block_versions
+    form_for(@post) do |f|
+      concat f.label(:author_name, 'Name', :class => 'label')
+      concat f.label(:author_name, :class => 'label') { 'Name' }
+    end
+
+    expected = whole_form('/posts/123', 'edit_post_123' , 'edit_post', 'patch') do
+      "<div class='field_with_errors'><label for='post_author_name' class='label'>Name</label></div>" +
+      "<div class='field_with_errors'><label for='post_author_name' class='label'>Name</label></div>"
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_form_for_with_namespace
     form_for(@post, :namespace => 'namespace') do |f|
       concat f.text_field(:title)


### PR DESCRIPTION
Now `f.label(:method){'content'}` is not wrappend in `div.field_with_errors` if there are saving errors.

It happens because the block version uses `@template_object.label_tag` instead local `label_tag` ( [tags/label.rb#L36](https://github.com/rails/rails/blob/0244c0d8f339385a9b420a0565b17d327bf25b13/actionpack/lib/action_view/helpers/tags/label.rb#L36), [tags/label.rb#L59](https://github.com/rails/rails/blob/0244c0d8f339385a9b420a0565b17d327bf25b13/actionpack/lib/action_view/helpers/tags/label.rb#L59) )

We should use local version because it mixes `Helpers::ActiveModelInstanceTag` ( [tags/base.rb#L5](https://github.com/rails/rails/blob/0244c0d8f339385a9b420a0565b17d327bf25b13/actionpack/lib/action_view/helpers/tags/base.rb#L5), [active_model_helper.rb#L11](https://github.com/rails/rails/blob/0244c0d8f339385a9b420a0565b17d327bf25b13/actionpack/lib/action_view/helpers/active_model_helper.rb#L11) )
