### PR TITLE
Tidy up cookies.rb a bit

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -273,10 +273,6 @@ module ActionDispatch
         @parent_jar[key] = options
       end
 
-      def signed
-        @signed ||= SignedCookieJar.new(self, @secret)
-      end
-
       def method_missing(method, *arguments, &block)
         @parent_jar.send(method, *arguments, &block)
       end


### PR DESCRIPTION
PermanentCookieJar inherits from CookieJar which already defines the exact same method 'signed', so no need to redefine it.
