### PR TITLE
Add total_record_limit option for find_in_batches

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -27,11 +27,22 @@ module ActiveRecord
     # option; the default is 1000.
     #
     # You can control the starting point for the batch processing by
-    # supplying the <tt>:start</tt> option. This is especially useful if you
+    # supplying the <tt>:start</tt> option. The id of the first element 
+    # in the first batch will equal this value if such a record exists
+    # (or the record with the next lowest id).
+    #
+    # You can limit the total number of records returned across all batches 
+    # by supplying the <tt>:max_records</tt> option. This used with 
+    # the start option above is especially useful if you
     # want multiple workers dealing with the same processing queue. You can
     # make worker 1 handle all the records between id 0 and 10,000 and
-    # worker 2 handle from 10,000 and beyond (by setting the <tt>:start</tt>
-    # option on that worker).
+    # worker 2 handle from 10,000 and beyond (by setting the 
+    # <tt>:max_records</tt> to 10,000 on each worker, and the 
+    # <tt>:start</tt> option for the second worker).
+    #
+    # Note: the <tt>:max_records</tt> limits the number of records 
+    # returned. So if you are trying to divide up your record space
+    # you will need to find the correct offsets.
     #
     # It's not possible to set the order. That is automatically set to
     # ascending on the primary key ("id ASC") to make the batch ordering
@@ -45,6 +56,20 @@ module ActiveRecord
     #     sleep(50) # Make sure it doesn't get too crowded in there!
     #     group.each { |person| person.party_all_night! }
     #   end
+    #
+    #   Person.where("age > 21").find_in_batches(:batch_size => 10) do |group| 
+    #     puts group.class # Array
+    #     puts group.size # 10
+    #   end 
+    #
+    #   puts Person.count # 10000
+    #   batch_count
+    #   Person.where("age > 21").find_in_batches(:max_records => 5000) do |group|
+    #     # default batch size 1000
+    #     batch_count += 1
+    #   end 
+    #   puts batch_count # 5
+    #
     def find_in_batches(options = {})
       relation = self
 
@@ -52,15 +77,17 @@ module ActiveRecord
         ActiveRecord::Base.logger.warn("Scoped order and limit are ignored, it's forced to be batch order and batch size")
       end
 
-      if (finder_options = options.except(:start, :batch_size)).present?
+      if (finder_options = options.except(:start, :batch_size, :max_records)).present?
         raise "You can't specify an order, it's forced to be #{batch_order}" if options[:order].present?
-        raise "You can't specify a limit, it's forced to be the batch_size"  if options[:limit].present?
+        raise "You can't specify a limit, it's forced to be the batch_size. See max_records"  if options[:limit].present?
 
         relation = apply_finder_options(finder_options)
       end
 
       start = options.delete(:start).to_i
       batch_size = options.delete(:batch_size) || 1000
+      remaining_record_limit = options.delete(:max_records) 
+      batch_size = [batch_size, remaining_record_limit].min if remaining_record_limit
 
       relation = relation.reorder(batch_order).limit(batch_size)
       records = relation.where(table[primary_key].gteq(start)).all
@@ -68,13 +95,18 @@ module ActiveRecord
       while records.any?
         records_size = records.size
         primary_key_offset = records.last.id
+        remaining_record_limit -= records_size if remaining_record_limit
 
         yield records
 
-        break if records_size < batch_size
+        break if records_size < batch_size || (remaining_record_limit && remaining_record_limit <= 0)
 
         if primary_key_offset
-          records = relation.where(table[primary_key].gt(primary_key_offset)).to_a
+          records = relation.where(table[primary_key].gt(primary_key_offset))
+          if remaining_record_limit && remaining_record_limit < batch_size
+            records = records.limit(remaining_record_limit)
+          end 
+          records = records.to_a
         else
           raise "Primary key not included in the custom select clause"
         end

--- a/guides/source/active_record_querying.textile
+++ b/guides/source/active_record_querying.textile
@@ -284,6 +284,18 @@ Another example would be if you wanted multiple workers handling the same proces
 
 NOTE: The +:include+ option allows you to name associations that should be loaded alongside with the models.
 
+*+:max_records+* 
+
+The +:max_records+ option allows you to limit the number of records returned across all batches. 
+
+For example, to return the first 10000 records in batches of 500:
+
+<ruby>
+User.find_each(:batch_size => 500, :max_records => 10000) do |user|
+  NewsLetter.weekly_deliver(user)
+end
+</ruby>
+
 h5. +find_in_batches+
 
 The +find_in_batches+ method is similar to +find_each+, since both retrieve batches of records. The difference is that +find_in_batches+ yields _batches_ to the block as an array of models, instead of individually. The following example will yield to the supplied block an array of up to 1000 invoices at a time, with the final block containing any remaining invoices:


### PR DESCRIPTION
Discussion from: https://github.com/rails/rails/issues/5502

This change will actually make it possible to divide up your record space across workers.
