### PR TITLE
Support postgresql partitioning by making INSERT RETURNING optional

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -59,7 +59,7 @@ module ActiveRecord
       # Executes insert +sql+ statement in the context of this connection using
       # +binds+ as the bind substitutes. +name+ is the logged along with
       # the executed +sql+ statement.
-      def exec_insert(sql, name, binds)
+      def exec_insert(sql, name, binds, pk = nil, sequence_name = nil)
         exec_query(sql, name, binds)
       end
 
@@ -87,7 +87,7 @@ module ActiveRecord
       # passed in as +id_value+.
       def insert(arel, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [])
         sql, binds = sql_for_insert(to_sql(arel, binds), pk, id_value, sequence_name, binds)
-        value      = exec_insert(sql, name, binds)
+        value      = exec_insert(sql, name, binds, pk, sequence_name)
         id_value || last_inserted_id(value)
       end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -226,7 +226,7 @@ module ActiveRecord
       end
       alias :create :insert_sql
 
-      def exec_insert(sql, name, binds)
+      def exec_insert(sql, name, binds, pk = nil, sequence_name = nil)
         execute to_sql(sql, binds), name
       end
 

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -50,38 +50,30 @@ module ActiveRecord
       end
 
       def test_insert_sql_with_returning_disabled
-        @connection.disable_insert_returning!
-        id = @connection.insert_sql("insert into postgresql_partitioned_table_parent (number) VALUES (1)")
-        expect = @connection.query('select max(id) from postgresql_partitioned_table_parent').first.first
+        connection = connection_without_insert_returning
+        id = connection.insert_sql("insert into postgresql_partitioned_table_parent (number) VALUES (1)")
+        expect = connection.query('select max(id) from postgresql_partitioned_table_parent').first.first
         assert_equal expect, id
-      ensure
-        @connection.enable_insert_returning!
       end
 
       def test_exec_insert_with_returning_disabled
-        @connection.disable_insert_returning!
-        result = @connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], 'id', 'postgresql_partitioned_table_parent_id_seq')
-        expect = @connection.query('select max(id) from postgresql_partitioned_table_parent').first.first
+        connection = connection_without_insert_returning
+        result = connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], 'id', 'postgresql_partitioned_table_parent_id_seq')
+        expect = connection.query('select max(id) from postgresql_partitioned_table_parent').first.first
         assert_equal expect, result.rows.first.first
-      ensure
-        @connection.enable_insert_returning!
       end
 
       def test_exec_insert_with_returning_disabled_and_no_sequence_name_given
-        @connection.disable_insert_returning!
-        result = @connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], 'id')
-        expect = @connection.query('select max(id) from postgresql_partitioned_table_parent').first.first
+        connection = connection_without_insert_returning
+        result = connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], 'id')
+        expect = connection.query('select max(id) from postgresql_partitioned_table_parent').first.first
         assert_equal expect, result.rows.first.first
-      ensure
-        @connection.enable_insert_returning!
       end
 
       def test_sql_for_insert_with_returning_disabled
-        @connection.disable_insert_returning!
-        result = @connection.sql_for_insert('sql', nil, nil, nil, 'binds')
+        connection = connection_without_insert_returning
+        result = connection.sql_for_insert('sql', nil, nil, nil, 'binds')
         assert_equal ['sql', 'binds'], result
-      ensure
-        @connection.enable_insert_returning!
       end
 
       def test_serial_sequence
@@ -238,6 +230,10 @@ module ActiveRecord
                VALUES (#{bind_subs.join(', ')})"
 
         ctx.exec_insert(sql, 'SQL', binds)
+      end
+
+      def connection_without_insert_returning
+        ActiveRecord::Base.postgresql_connection(ActiveRecord::Base.configurations['arunit'].merge(:insert_returning => false))
       end
     end
   end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -50,38 +50,38 @@ module ActiveRecord
       end
 
       def test_insert_sql_with_returning_disabled
-        @connection.use_returning = false
+        @connection.disable_insert_returning!
         id = @connection.insert_sql("insert into postgresql_partitioned_table_parent (number) VALUES (1)")
         expect = @connection.query('select max(id) from postgresql_partitioned_table_parent').first.first
         assert_equal expect, id
       ensure
-        @connection.use_returning = true
+        @connection.enable_insert_returning!
       end
 
       def test_exec_insert_with_returning_disabled
-        @connection.use_returning = false
+        @connection.disable_insert_returning!
         result = @connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], 'id', 'postgresql_partitioned_table_parent_id_seq')
         expect = @connection.query('select max(id) from postgresql_partitioned_table_parent').first.first
         assert_equal expect, result.rows.first.first
       ensure
-        @connection.use_returning = true
+        @connection.enable_insert_returning!
       end
 
       def test_exec_insert_with_returning_disabled_and_no_sequence_name_given
-        @connection.use_returning = false
+        @connection.disable_insert_returning!
         result = @connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], 'id')
         expect = @connection.query('select max(id) from postgresql_partitioned_table_parent').first.first
         assert_equal expect, result.rows.first.first
       ensure
-        @connection.use_returning = true
+        @connection.enable_insert_returning!
       end
 
       def test_sql_for_insert_with_returning_disabled
-        @connection.use_returning = false
+        @connection.disable_insert_returning!
         result = @connection.sql_for_insert('sql', nil, nil, nil, 'binds')
         assert_equal ['sql', 'binds'], result
       ensure
-        @connection.use_returning = true
+        @connection.enable_insert_returning!
       end
 
       def test_serial_sequence

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -58,6 +58,32 @@ module ActiveRecord
         @connection.use_returning = true
       end
 
+      def test_exec_insert_with_returning_disabled
+        @connection.use_returning = false
+        result = @connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], 'id', 'postgresql_partitioned_table_parent_id_seq')
+        expect = @connection.query('select max(id) from postgresql_partitioned_table_parent').first.first
+        assert_equal expect, result.rows.first.first
+      ensure
+        @connection.use_returning = true
+      end
+
+      def test_exec_insert_with_returning_disabled_and_no_sequence_name_given
+        @connection.use_returning = false
+        result = @connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], 'id')
+        expect = @connection.query('select max(id) from postgresql_partitioned_table_parent').first.first
+        assert_equal expect, result.rows.first.first
+      ensure
+        @connection.use_returning = true
+      end
+
+      def test_sql_for_insert_with_returning_disabled
+        @connection.use_returning = false
+        result = @connection.sql_for_insert('sql', nil, nil, nil, 'binds')
+        assert_equal ['sql', 'binds'], result
+      ensure
+        @connection.use_returning = true
+      end
+
       def test_serial_sequence
         assert_equal 'public.accounts_id_seq',
           @connection.serial_sequence('accounts', 'id')

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -49,6 +49,15 @@ module ActiveRecord
         assert_equal expect, id
       end
 
+      def test_insert_sql_with_returning_disabled
+        @connection.use_returning = false
+        id = @connection.insert_sql("insert into postgresql_partitioned_table_parent (number) VALUES (1)")
+        expect = @connection.query('select max(id) from postgresql_partitioned_table_parent').first.first
+        assert_equal expect, id
+      ensure
+        @connection.use_returning = true
+      end
+
       def test_serial_sequence
         assert_equal 'public.accounts_id_seq',
           @connection.serial_sequence('accounts', 'id')

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -1,14 +1,16 @@
 ActiveRecord::Schema.define do
 
   %w(postgresql_tsvectors postgresql_hstores postgresql_arrays postgresql_moneys postgresql_numbers postgresql_times postgresql_network_addresses postgresql_bit_strings
-      postgresql_oids postgresql_xml_data_type defaults geometrics postgresql_timestamp_with_zones).each do |table_name|
-    execute "DROP TABLE  IF EXISTS #{quote_table_name table_name}"
+      postgresql_oids postgresql_xml_data_type defaults geometrics postgresql_timestamp_with_zones postgresql_partitioned_table postgresql_partitioned_table_parent).each do |table_name|
+    execute "DROP TABLE IF EXISTS #{quote_table_name table_name}"
   end
 
   execute 'DROP SEQUENCE IF EXISTS companies_nonstd_seq CASCADE'
   execute 'CREATE SEQUENCE companies_nonstd_seq START 101 OWNED BY companies.id'
   execute "ALTER TABLE companies ALTER COLUMN id SET DEFAULT nextval('companies_nonstd_seq')"
   execute 'DROP SEQUENCE IF EXISTS companies_id_seq'
+
+  execute 'DROP FUNCTION IF EXISTS partitioned_insert_trigger()'
 
   %w(accounts_id_seq developers_id_seq projects_id_seq topics_id_seq customers_id_seq orders_id_seq).each do |seq_name|
     execute "SELECT setval('#{seq_name}', 100)"
@@ -124,6 +126,29 @@ _SQL
     time TIMESTAMP WITH TIME ZONE
   );
 _SQL
+
+  execute <<_SQL
+  CREATE TABLE postgresql_partitioned_table_parent (
+    id SERIAL PRIMARY KEY,
+    number integer
+  );
+  CREATE TABLE postgresql_partitioned_table ( )
+    INHERITS (postgresql_partitioned_table_parent);
+
+  CREATE OR REPLACE FUNCTION partitioned_insert_trigger()
+  RETURNS TRIGGER AS $$
+  BEGIN
+    INSERT INTO postgresql_partitioned_table VALUES (NEW.*);
+    RETURN NULL;
+  END;
+  $$
+  LANGUAGE plpgsql;
+
+  CREATE TRIGGER insert_partitioning_trigger
+    BEFORE INSERT ON postgresql_partitioned_table_parent
+    FOR EACH ROW EXECUTE PROCEDURE partitioned_insert_trigger();
+_SQL
+
 
   begin
     execute <<_SQL


### PR DESCRIPTION
Currently the Postgresql adapters use of INSERT RETURNING for insert statements makes using trigger based partitioning of tables impossible (See http://www.postgresql.org/docs/9.1/static/ddl-partitioning.html for more info). This patch adds a per connection option to disable INSERT RETURNING and use a simpler INSERT; SELECT currval() which works with trigger based inserts. Fixes #4955
