### PR TITLE
Add role inheritance to attr_accessible

### DIFF
--- a/activemodel/lib/active_model/mass_assignment_security.rb
+++ b/activemodel/lib/active_model/mass_assignment_security.rb
@@ -182,11 +182,8 @@ module ActiveModel
         self._accessible_attributes = accessible_attributes_configs.dup
 
         Array(role).each do |name|
-          if inherited_role
-            self._accessible_attributes[name] = self.accessible_attributes(inherited_role) + args
-          else
-            self._accessible_attributes[name] = self.accessible_attributes(name) + args
-          end
+          role = inherited_role || name # Use name role if inherited_role doesn't exist
+          self._accessible_attributes[name] = self.accessible_attributes(role) + args
         end
 
         self._active_authorizer = self._accessible_attributes

--- a/activemodel/lib/active_model/mass_assignment_security.rb
+++ b/activemodel/lib/active_model/mass_assignment_security.rb
@@ -144,7 +144,8 @@ module ActiveModel
       #     attr_accessor :name, :credit_rating
       #
       #     attr_accessible :name
-      #     attr_accessible :name, :credit_rating, :as => :admin
+      #     # Admin role inherits attributes fron :default so all :defaults attributes are available to :admin
+      #     attr_accessible :credit_rating, :as => :admin, :inherits => :default
       #
       #     def assign_attributes(values, options = {})
       #       sanitize_for_mass_assignment(values, options[:as]).each do |k, v|
@@ -176,11 +177,16 @@ module ActiveModel
       def attr_accessible(*args)
         options = args.extract_options!
         role = options[:as] || :default
+        inherited_role = options[:inherits]
 
         self._accessible_attributes = accessible_attributes_configs.dup
 
         Array(role).each do |name|
-          self._accessible_attributes[name] = self.accessible_attributes(name) + args
+          if inherited_role
+            self._accessible_attributes[name] = self.accessible_attributes(inherited_role) + args
+          else
+            self._accessible_attributes[name] = self.accessible_attributes(name) + args
+          end
         end
 
         self._active_authorizer = self._accessible_attributes

--- a/activemodel/test/cases/mass_assignment_security_test.rb
+++ b/activemodel/test/cases/mass_assignment_security_test.rb
@@ -50,6 +50,13 @@ class MassAssignmentSecurityTest < ActiveModel::TestCase
     assert_equal expected, sanitized
   end
 
+  def test_role_inheritance_on_attr_accessible
+    user = InheritedUser.new
+    expected = { "name" => "John Smith", "email" => "john@smith.com", "admin" => true }
+    sanitized = user.sanitize_for_mass_assignment(expected, :admin)
+    assert_equal expected, sanitized
+  end
+
   def test_attributes_accessible_with_roles_given_as_array
     user = Account.new
     expected = { "name" => "John Smith", "email" => "john@smith.com" }

--- a/activemodel/test/models/mass_assignment_specific.rb
+++ b/activemodel/test/models/mass_assignment_specific.rb
@@ -20,6 +20,14 @@ class Person
   public :sanitize_for_mass_assignment
 end
 
+class InheritedUser
+  include ActiveModel::MassAssignmentSecurity
+  attr_accessible :name, :email
+  attr_accessible :admin, :as => :admin, :inherits => :default
+
+  public :sanitize_for_mass_assignment
+end
+
 class Account
   include ActiveModel::MassAssignmentSecurity
   attr_accessible :name, :email, :as => [:default, :admin]


### PR DESCRIPTION
I noticed when making pretty complex applications with a lot of attributes and roles, that the attr_accessible list gets copied a lot, and just isn't very DRY. Adding an inheritance option to attr_accessible enables developers to clearly see the attributes being inherited to the role.
