### PR TITLE
Stricter @regex matcher

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -325,7 +325,7 @@ module ActiveModel
             end
 
             @prefix, @suffix = options[:prefix] || '', options[:suffix] || ''
-            @regex = /^(?:#{Regexp.escape(@prefix)})(.*)(?:#{Regexp.escape(@suffix)})$/
+            @regex = /^(?:#{Regexp.escape(@prefix)})(.+)(?:#{Regexp.escape(@suffix)})$/
             @method_missing_target = "#{@prefix}attribute#{@suffix}"
             @method_name = "#{prefix}%s#{suffix}"
           end


### PR DESCRIPTION
The purpose of this regex is to match prefix + method + suffix. By using + instead of \* we ensure that we only match strings where method is not blank.
