### PR TITLE
Add --skip-action-mailer and change the generators to pick the wanted frameworks in the Gemfile

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -159,6 +159,14 @@ module Rails
 
             # Bundle edge Rails instead:
             # gem 'rails', :git => 'https://github.com/rails/rails.git'
+
+            # Or pick the frameworks you want:
+            # gem 'activesupport', '#{Rails::VERSION::STRING}'
+            # gem 'actionpack', '#{Rails::VERSION::STRING}'
+            # gem 'activerecord', '#{Rails::VERSION::STRING}'
+            # gem 'actionmailer', '#{Rails::VERSION::STRING}'
+            # gem 'railties', '#{Rails::VERSION::STRING}'
+            # gem 'sprockets-rails', '~> 1.0'
           GEMFILE
         else
           <<-GEMFILE.strip_heredoc

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -145,11 +145,26 @@ module Rails
             gem 'arel',      :git => 'https://github.com/rails/arel.git'
           GEMFILE
         else
+          railties_gemfile_entry
+        end
+      end
+
+      def railties_gemfile_entry
+        if include_all_railties?
           <<-GEMFILE.strip_heredoc
             gem 'rails', '#{Rails::VERSION::STRING}'
 
             # Bundle edge Rails instead:
             # gem 'rails', :git => 'https://github.com/rails/rails.git'
+          GEMFILE
+        else
+          <<-GEMFILE.strip_heredoc
+            gem 'activesupport', '#{Rails::VERSION::STRING}'
+            gem 'actionpack', '#{Rails::VERSION::STRING}'
+            #{comment_if :skip_active_record}gem 'activerecord', '#{Rails::VERSION::STRING}'
+            gem 'actionmailer', '#{Rails::VERSION::STRING}'
+            gem 'railties', '#{Rails::VERSION::STRING}'
+            #{comment_if :skip_sprockets}gem 'sprockets-rails', '~> 1.0'
           GEMFILE
         end
       end

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -37,6 +37,9 @@ module Rails
         class_option :skip_active_record, :type => :boolean, :aliases => "-O", :default => false,
                                           :desc => "Skip Active Record files"
 
+        class_option :skip_action_mailer, :type => :boolean, :aliases => "-M", :default => false,
+                                          :desc => "Skip Action Mailer files"
+
         class_option :skip_sprockets,     :type => :boolean, :aliases => "-S", :default => false,
                                           :desc => "Skip Sprockets files"
 
@@ -124,7 +127,7 @@ module Rails
       end
 
       def include_all_railties?
-        !options[:skip_active_record] && !options[:skip_test_unit] && !options[:skip_sprockets]
+        options.values_at(:skip_active_record, :skip_action_mailer, :skip_test_unit, :skip_sprockets).none?
       end
 
       def comment_if(value)
@@ -162,7 +165,7 @@ module Rails
             gem 'activesupport', '#{Rails::VERSION::STRING}'
             gem 'actionpack', '#{Rails::VERSION::STRING}'
             #{comment_if :skip_active_record}gem 'activerecord', '#{Rails::VERSION::STRING}'
-            gem 'actionmailer', '#{Rails::VERSION::STRING}'
+            #{comment_if :skip_action_mailer}gem 'actionmailer', '#{Rails::VERSION::STRING}'
             gem 'railties', '#{Rails::VERSION::STRING}'
             #{comment_if :skip_sprockets}gem 'sprockets-rails', '~> 1.0'
           GEMFILE

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -161,20 +161,16 @@ module Rails
             # gem 'rails', :git => 'https://github.com/rails/rails.git'
 
             # Or pick the frameworks you want:
-            # gem 'activesupport', '#{Rails::VERSION::STRING}'
-            # gem 'actionpack', '#{Rails::VERSION::STRING}'
+            # gem 'railties', '#{Rails::VERSION::STRING}'
             # gem 'activerecord', '#{Rails::VERSION::STRING}'
             # gem 'actionmailer', '#{Rails::VERSION::STRING}'
-            # gem 'railties', '#{Rails::VERSION::STRING}'
             # gem 'sprockets-rails', '~> 1.0'
           GEMFILE
         else
           <<-GEMFILE.strip_heredoc
-            gem 'activesupport', '#{Rails::VERSION::STRING}'
-            gem 'actionpack', '#{Rails::VERSION::STRING}'
+            gem 'railties', '#{Rails::VERSION::STRING}'
             #{comment_if :skip_active_record}gem 'activerecord', '#{Rails::VERSION::STRING}'
             #{comment_if :skip_action_mailer}gem 'actionmailer', '#{Rails::VERSION::STRING}'
-            gem 'railties', '#{Rails::VERSION::STRING}'
             #{comment_if :skip_sprockets}gem 'sprockets-rails', '~> 1.0'
           GEMFILE
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -1,6 +1,6 @@
 require File.expand_path('../boot', __FILE__)
 
-<% if include_all_railties? -%>
+<% unless options.skip_test_unit? -%>
 require 'rails/all'
 <% else -%>
 # Pick the frameworks you want:

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -6,7 +6,7 @@ require 'rails/all'
 # Pick the frameworks you want:
 <%= comment_if :skip_active_record %>require "active_record/railtie"
 require "action_controller/railtie"
-require "action_mailer/railtie"
+<%= comment_if :skip_action_mailer %>require "action_mailer/railtie"
 <%= comment_if :skip_sprockets %>require "sprockets/rails/railtie"
 <%= comment_if :skip_test_unit %>require "rails/test_unit/railtie"
 <% end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -10,8 +10,10 @@
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
+  <%- unless options.skip_action_mailer? -%>
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
+  <%- end -%>
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -52,8 +52,10 @@
   # config.assets.precompile += %w( search.js )
   <%- end -%>
 
+  <%- unless options.skip_action_mailer? -%>
   # Disable delivery errors, bad email addresses will be ignored.
   # config.action_mailer.raise_delivery_errors = false
+  <%- end -%>
 
   # Enable threaded mode.
   # config.threadsafe!

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -21,10 +21,12 @@
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
+  <%- unless options.skip_action_mailer? -%>
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  <%- end -%>
 
   <%- unless options.skip_active_record? -%>
   # Raise exception on mass assignment protection for Active Record models.

--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -69,7 +69,8 @@ task :default => :test
     end
 
     PASSTHROUGH_OPTIONS = [
-      :skip_active_record, :skip_javascript, :database, :javascript, :quiet, :pretend, :force, :skip
+      :skip_active_record, :skip_action_mailer, :skip_javascript, :database, :javascript, :quiet,
+      :pretend, :force, :skip
     ]
 
     def generate_test_dummy(force = false)

--- a/railties/lib/rails/generators/rails/plugin_new/templates/rails/application.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/rails/application.rb
@@ -6,7 +6,7 @@ require 'rails/all'
 # Pick the frameworks you want:
 <%= comment_if :skip_active_record %>require "active_record/railtie"
 require "action_controller/railtie"
-require "action_mailer/railtie"
+<%= comment_if :skip_action_mailer %>require "action_mailer/railtie"
 <%= comment_if :skip_sprockets %>require "sprockets/rails/railtie"
 <%= comment_if :skip_test_unit %>require "rails/test_unit/railtie"
 <% end -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -198,6 +198,19 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_gemfile_without_skips
+    run_generator
+    assert_file "Gemfile" do |gemfile_content|
+      assert_match(/^gem ["']rails["']/, gemfile_content)
+      assert_match(/# gem ["']activesupport["']/, gemfile_content)
+      assert_match(/# gem ["']actionpack["']/, gemfile_content)
+      assert_match(/# gem ["']activerecord["']/, gemfile_content)
+      assert_match(/# gem ["']actionmailer["']/, gemfile_content)
+      assert_match(/# gem ["']railties["']/, gemfile_content)
+      assert_match(/# gem ["']sprockets-rails["'], '~> 1\.0'/, gemfile_content)
+    end
+  end
+
   def test_generator_if_skip_active_record_is_given
     run_generator [destination_root, "--skip-active-record"]
     assert_no_file "config/database.yml"

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -202,11 +202,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_file "Gemfile" do |gemfile_content|
       assert_match(/^gem ["']rails["']/, gemfile_content)
-      assert_match(/# gem ["']activesupport["']/, gemfile_content)
-      assert_match(/# gem ["']actionpack["']/, gemfile_content)
+      assert_match(/# gem ["']railties["']/, gemfile_content)
       assert_match(/# gem ["']activerecord["']/, gemfile_content)
       assert_match(/# gem ["']actionmailer["']/, gemfile_content)
-      assert_match(/# gem ["']railties["']/, gemfile_content)
       assert_match(/# gem ["']sprockets-rails["'], '~> 1\.0'/, gemfile_content)
     end
   end
@@ -216,11 +214,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_file "config/database.yml"
     assert_file "Gemfile" do |gemfile_content|
       assert_no_match(/gem ["']rails["']/, gemfile_content)
-      assert_match(/gem ["']activesupport["']/, gemfile_content)
-      assert_match(/gem ["']actionpack["']/, gemfile_content)
+      assert_match(/gem ["']railties["']/, gemfile_content)
       assert_match(/# gem ["']activerecord["']/, gemfile_content)
       assert_match(/gem ["']actionmailer["']/, gemfile_content)
-      assert_match(/gem ["']railties["']/, gemfile_content)
       assert_match(/gem ["']sprockets-rails["'], '~> 1\.0'/, gemfile_content)
     end
     assert_file "config/application.rb", /#\s+require\s+["']active_record\/railtie["']/
@@ -236,11 +232,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator [destination_root, "--skip-action-mailer"]
     assert_file "Gemfile" do |gemfile_content|
       assert_no_match(/gem ["']rails["']/, gemfile_content)
-      assert_match(/gem ["']activesupport["']/, gemfile_content)
-      assert_match(/gem ["']actionpack["']/, gemfile_content)
+      assert_match(/gem ["']railties["']/, gemfile_content)
       assert_match(/gem ["']activerecord["']/, gemfile_content)
       assert_match(/# gem ["']actionmailer["']/, gemfile_content)
-      assert_match(/gem ["']railties["']/, gemfile_content)
       assert_match(/gem ["']sprockets-rails["'], '~> 1\.0'/, gemfile_content)
     end
     assert_file "config/application.rb", /#\s+require\s+["']action_mailer\/railtie["']/
@@ -259,8 +253,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator [destination_root, "--skip-sprockets"]
     assert_file "Gemfile" do |gemfile_content|
       assert_no_match(/gem ["']rails["']/, gemfile_content)
-      assert_match(/gem ["']activesupport["']/, gemfile_content)
-      assert_match(/gem ["']actionpack["']/, gemfile_content)
       assert_match(/gem ["']activerecord["']/, gemfile_content)
       assert_match(/gem ["']actionmailer["']/, gemfile_content)
       assert_match(/gem ["']railties["']/, gemfile_content)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -219,7 +219,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_match(/gem ["']actionmailer["']/, gemfile_content)
       assert_match(/gem ["']sprockets-rails["'], '~> 1\.0'/, gemfile_content)
     end
-    assert_file "config/application.rb", /#\s+require\s+["']active_record\/railtie["']/
+    assert_file "config/application.rb", /\s+require\s+["']rails\/all["']/
     assert_file "config/application.rb", /#\s+config\.active_record\.whitelist_attributes = true/
     assert_file "config/application.rb", /#\s+config\.active_record\.dependent_restrict_raises = false/
     assert_file "test/test_helper.rb" do |helper_content|
@@ -237,7 +237,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_match(/# gem ["']actionmailer["']/, gemfile_content)
       assert_match(/gem ["']sprockets-rails["'], '~> 1\.0'/, gemfile_content)
     end
-    assert_file "config/application.rb", /#\s+require\s+["']action_mailer\/railtie["']/
+    assert_file "config/application.rb", /\s+require\s+["']rails\/all["']/
     assert_file "config/environments/development.rb" do |content|
       assert_no_match(/config\.action_mailer\.raise_delivery_errors = false/, content)
     end
@@ -259,7 +259,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_match(/# gem ["']sprockets-rails["'], '~> 1\.0'/, gemfile_content)
     end
     assert_file "config/application.rb" do |content|
-      assert_match(/#\s+require\s+["']sprockets\/rails\/railtie["']/, content)
+      assert_match(/\s+require\s+["']rails\/all["']/, content)
       assert_no_match(/config\.assets\.enabled = true/, content)
     end
     assert_file "Gemfile" do |content|
@@ -370,6 +370,18 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator [destination_root, "--skip-test-unit", "--skip-active-record"]
     assert_file "config/application.rb", /#\s+require\s+["']rails\/test_unit\/railtie["']/
     assert_file "config/application.rb", /#\s+require\s+["']active_record\/railtie["']/
+  end
+
+  def test_no_action_mailer_or_test_unit_if_skips_given
+    run_generator [destination_root, "--skip-test-unit", "--skip-action-mailer"]
+    assert_file "config/application.rb", /#\s+require\s+["']rails\/test_unit\/railtie["']/
+    assert_file "config/application.rb", /#\s+require\s+["']action_mailer\/railtie["']/
+  end
+
+  def test_no_sprockets_or_test_unit_if_skips_given
+    run_generator [destination_root, "--skip-test-unit", "--skip-sprockets"]
+    assert_file "config/application.rb", /#\s+require\s+["']rails\/test_unit\/railtie["']/
+    assert_file "config/application.rb", /#\s+require\s+["']sprockets\/rails\/railtie["']/
   end
 
   def test_new_hash_style

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -219,6 +219,29 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "test/performance/browsing_test.rb"
   end
 
+  def test_generator_if_skip_action_mailer_is_given
+    run_generator [destination_root, "--skip-action-mailer"]
+    assert_file "Gemfile" do |gemfile_content|
+      assert_no_match(/gem ["']rails["']/, gemfile_content)
+      assert_match(/gem ["']activesupport["']/, gemfile_content)
+      assert_match(/gem ["']actionpack["']/, gemfile_content)
+      assert_match(/gem ["']activerecord["']/, gemfile_content)
+      assert_match(/# gem ["']actionmailer["']/, gemfile_content)
+      assert_match(/gem ["']railties["']/, gemfile_content)
+      assert_match(/gem ["']sprockets-rails["'], '~> 1\.0'/, gemfile_content)
+    end
+    assert_file "config/application.rb", /#\s+require\s+["']action_mailer\/railtie["']/
+    assert_file "config/environments/development.rb" do |content|
+      assert_no_match(/config\.action_mailer\.raise_delivery_errors = false/, content)
+    end
+    assert_file "config/environments/production.rb" do |content|
+      assert_no_match(/# config\.action_mailer\.raise_delivery_errors = false/, content)
+    end
+    assert_file "config/environments/test.rb" do |content|
+      assert_no_match(/config\.action_mailer\.delivery_method = :test/, content)
+    end
+  end
+
   def test_generator_if_skip_sprockets_is_given
     run_generator [destination_root, "--skip-sprockets"]
     assert_file "Gemfile" do |gemfile_content|

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -201,6 +201,15 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_generator_if_skip_active_record_is_given
     run_generator [destination_root, "--skip-active-record"]
     assert_no_file "config/database.yml"
+    assert_file "Gemfile" do |gemfile_content|
+      assert_no_match(/gem ["']rails["']/, gemfile_content)
+      assert_match(/gem ["']activesupport["']/, gemfile_content)
+      assert_match(/gem ["']actionpack["']/, gemfile_content)
+      assert_match(/# gem ["']activerecord["']/, gemfile_content)
+      assert_match(/gem ["']actionmailer["']/, gemfile_content)
+      assert_match(/gem ["']railties["']/, gemfile_content)
+      assert_match(/gem ["']sprockets-rails["'], '~> 1\.0'/, gemfile_content)
+    end
     assert_file "config/application.rb", /#\s+require\s+["']active_record\/railtie["']/
     assert_file "config/application.rb", /#\s+config\.active_record\.whitelist_attributes = true/
     assert_file "config/application.rb", /#\s+config\.active_record\.dependent_restrict_raises = false/
@@ -212,6 +221,15 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_generator_if_skip_sprockets_is_given
     run_generator [destination_root, "--skip-sprockets"]
+    assert_file "Gemfile" do |gemfile_content|
+      assert_no_match(/gem ["']rails["']/, gemfile_content)
+      assert_match(/gem ["']activesupport["']/, gemfile_content)
+      assert_match(/gem ["']actionpack["']/, gemfile_content)
+      assert_match(/gem ["']activerecord["']/, gemfile_content)
+      assert_match(/gem ["']actionmailer["']/, gemfile_content)
+      assert_match(/gem ["']railties["']/, gemfile_content)
+      assert_match(/# gem ["']sprockets-rails["'], '~> 1\.0'/, gemfile_content)
+    end
     assert_file "config/application.rb" do |content|
       assert_match(/#\s+require\s+["']sprockets\/rails\/railtie["']/, content)
       assert_no_match(/config\.assets\.enabled = true/, content)

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -32,7 +32,7 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
 
     content = capture(:stderr){ run_generator [File.join(destination_root, "things4.3")] }
     assert_equal "Invalid plugin name things4.3. Please give a name which use only alphabetic or numeric or \"_\" characters.\n", content
- 
+
     content = capture(:stderr){ run_generator [File.join(destination_root, "43things")] }
     assert_equal "Invalid plugin name 43things. Please give a name which does not start with numbers.\n", content
   end

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -93,6 +93,12 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
     assert_no_match(/ActiveRecord/, File.read(File.join(destination_root, "test/test_helper.rb")))
   end
 
+  def test_action_mailer_is_removed_from_frameworks_if_skip_action_mailer_is_given
+    run_generator [destination_root, "--skip-action-mailer"]
+    assert_file "test/dummy/config/application.rb", /#\s+require\s+["']action_mailer\/railtie["']/
+  end
+
+
   def test_ensure_that_database_option_is_passed_to_app_generator
     run_generator [destination_root, "--database", "postgresql"]
     assert_file "test/dummy/config/database.yml", /postgres/


### PR DESCRIPTION
This pull request change the application generator to pick the frameworks in the `Gemfile` instead of in the `application.rb`

This is related with #5652
