### PR TITLE
Use symbols in case statements for great justice

### DIFF
--- a/activesupport/lib/active_support/core_ext/symbol.rb
+++ b/activesupport/lib/active_support/core_ext/symbol.rb
@@ -1,0 +1,20 @@
+class Symbol
+
+  # Unary ~ provides syntactic sugar for case statements. Examples:
+  #
+  #   case user
+  #   when ~:admin?
+  #     # Do stuff
+  #   when ~:active?
+  #     # Do stuff
+  #   end
+  #
+  # Would be equivalent to:
+  #
+  #   if user.admin?
+  #     # Do stuff
+  #   elsif user.active?
+  #     # Do stuff
+  #   end
+  alias_method :~, :to_proc
+end

--- a/activesupport/test/core_ext/symbol_test.rb
+++ b/activesupport/test/core_ext/symbol_test.rb
@@ -16,12 +16,13 @@ class SymbolTests < ActiveSupport::TestCase
   def test_tilde_operator_in_case
     case ExamplePredicateClass.new
     when ~:not_true?
-      fail 'Reached not_true? clause'
+      clause = 'not-true'
     when ~:so_true?
-      pass
+      clause = 'so-true'
     else
-      fail 'Reached else clause'
+      clause = 'else'
     end
-  end
 
+    assert_equal 'so-true', clause
+  end
 end

--- a/activesupport/test/core_ext/symbol_test.rb
+++ b/activesupport/test/core_ext/symbol_test.rb
@@ -1,0 +1,27 @@
+require 'abstract_unit'
+require 'active_support/core_ext/symbol'
+
+class SymbolTests < ActiveSupport::TestCase
+
+  class ExamplePredicateClass
+    def so_true?
+      true
+    end
+
+    def not_true?
+      false
+    end
+  end
+
+  def test_tilde_operator_in_case
+    case ExamplePredicateClass.new
+    when ~:not_true?
+      fail 'Reached not_true? clause'
+    when ~:so_true?
+      pass
+    else
+      fail 'Reached else clause'
+    end
+  end
+
+end


### PR DESCRIPTION
This is syntactic sugar for case statements.

``` ruby

 case user
 when ~:admin?
   # Do stuff
 when ~:active?
   # Do stuff
 end
```

Would be equivalent to:

``` ruby
 if user.admin?
   # Do stuff
 elsif user.active?
   # Do stuff
 end

```

With the added benefit that if `user` is a method, it would only get called once, which, in certain cases, is significantly more efficient without adding complexity to the code.
## Rationale

The short answer is because it looks nice.

ActiveSupport does a great job of extending ruby with simple conveniences like `Symbol#to_proc` which has now been merged in to ruby core. I think this could be part of the sugar that makes Ruby sweeter.
## Why the `~`

I chose the unary method `~` because I don't see it having any other use for `Symbol`, but it could just as easily be `+` or `-`.

My original concept was to override `Symbol#===`, which allows case to be used like this:

``` ruby
case user
when :root?
  # Do stuff
when :active?
  # Do stuff
end
```

but I felt that overriding `Symbol#===` is too obtrusive and dangerous.

I wanted to use `&` as it is already accepted syntax for `Symbol#to_proc` but this is invalid ruby syntax:

``` ruby
case user
when &:active?
  # Do stuff
end
```
## Negation

In offering this support I also thought about supporting negation: https://github.com/amiel/rails/compare/rails:master...case_with_predicates_and_negative

That branch allows for syntax like this as well:

``` ruby
 case user
 when ! :admin?
   # Do stuff
 when ! :active?
   # Do stuff
 end
```

This pull request does not support negation in this way. I didn't want to override `Symbol#!`, and I think the # 2 under _Implementation Discussions_ below would be a better way to handle negation.
## Implementation discussion

I tried a few different implementation concepts for this. This one is by far the simplest (thanks @emmanuel for pointing me in that direction).

In ruby 1.9, procs respond to `===` for use in case (see http://www.aimred.com/news/developers/2008/08/14/unlocking_the_power_of_case_equality_proc/)

Here are a couple of other options:
1. My first concept was to override `Symbol#===`, which offered the nicest syntax, but I felt was too obtrusive.
2. In another version, `Symbol#~` returns an object that responds to `===`, this is also concise, but not as simple as the other two options. However, it offers the most complete support for negation. Here's an example implementation that also supports negation: https://github.com/amiel/rails/compare/rails:master...case_with_predicates_with_object
