### PR TITLE
removed unnecessary block when using fetch

### DIFF
--- a/actionpack/lib/action_view/helpers/atom_feed_helper.rb
+++ b/actionpack/lib/action_view/helpers/atom_feed_helper.rb
@@ -189,7 +189,7 @@ module ActionView
               @xml.updated((options[:updated] || record.updated_at).xmlschema)
             end
 
-            type = options.fetch(:type) { 'text/html' }
+            type = options.fetch(:type, 'text/html')
 
             @xml.link(:rel => 'alternate', :type => type, :href => options[:url] || @view.polymorphic_url(record))
 


### PR DESCRIPTION
Default value can be passed as second argument:
http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-fetch
