### PR TITLE
distance_of_time_in_words inconsistency between code and documentation

### DIFF
--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -67,7 +67,8 @@ module ActionView
       def distance_of_time_in_words(from_time, to_time = 0, include_seconds = false, options = {})
         from_time = from_time.to_time if from_time.respond_to?(:to_time)
         to_time = to_time.to_time if to_time.respond_to?(:to_time)
-        distance_in_minutes = (((to_time - from_time).abs)/60).round
+        from_time, to_time = to_time, from_time if from_time > to_time
+        distance_in_minutes = (((to_time - from_time).abs)/60.0).round
         distance_in_seconds = ((to_time - from_time).abs).round
 
         I18n.with_options :locale => options[:locale], :scope => :'datetime.distance_in_words' do |locale|

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -128,10 +128,27 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_distance_in_words_with_integers
-    assert_equal "less than a minute", distance_of_time_in_words(59)
+    assert_equal "1 minute", distance_of_time_in_words(59)
     assert_equal "about 1 hour", distance_of_time_in_words(60*60)
-    assert_equal "less than a minute", distance_of_time_in_words(0, 59)
+    assert_equal "1 minute", distance_of_time_in_words(0, 59)
     assert_equal "about 1 hour", distance_of_time_in_words(60*60, 0)
+  end
+
+  def test_distance_in_words_with_times
+    assert_equal "1 minute", distance_of_time_in_words(30.seconds)
+    assert_equal "1 minute", distance_of_time_in_words(59.seconds)
+    assert_equal "2 minutes", distance_of_time_in_words(119.seconds)
+    assert_equal "2 minutes", distance_of_time_in_words(1.minute + 59.seconds)
+    assert_equal "3 minutes", distance_of_time_in_words(2.minute + 30.seconds)
+    assert_equal "44 minutes", distance_of_time_in_words(44.minutes + 29.seconds)
+    assert_equal "about 1 hour", distance_of_time_in_words(44.minutes + 30.seconds)
+    assert_equal "about 1 hour", distance_of_time_in_words(60.minutes)
+
+    # include seconds
+    assert_equal "half a minute", distance_of_time_in_words(39.seconds, 0, true)
+    assert_equal "less than a minute", distance_of_time_in_words(40.seconds, 0, true)
+    assert_equal "less than a minute", distance_of_time_in_words(59.seconds, 0, true)
+    assert_equal "1 minute", distance_of_time_in_words(60.seconds, 0, true)
   end
 
   def test_time_ago_in_words


### PR DESCRIPTION
`distance_of_time_in_words` documentation isn't consistent on what the method does.

`distance_of_time_in_words(1.minute + 59.seconds)`
should return 
`"2 minutes"`
but is returning
`"1 minute"`

So, either the method documentation or the code itself are wrong.
I've pull-requested a solution assuming that the error is in the code rather than in the documentation.

Any suggestions?
