### PR TITLE
Unnecessary Rubygems dependency check has been removed at BacktraceClean...

### DIFF
--- a/railties/lib/rails/backtrace_cleaner.rb
+++ b/railties/lib/rails/backtrace_cleaner.rb
@@ -17,10 +17,7 @@ module Rails
 
     private
       def add_gem_filters
-        return unless defined?(Gem)
-
         gems_paths = (Gem.path | [Gem.default_dir]).map { |p| Regexp.escape(p) }
-        return if gems_paths.empty?
 
         gems_regexp = %r{(#{gems_paths.join('|')})/gems/([^/]+)-([\w.]+)/(.*)}
         add_filter { |line| line.sub(gems_regexp, '\2 (\3) \4') }

--- a/railties/test/backtrace_cleaner_test.rb
+++ b/railties/test/backtrace_cleaner_test.rb
@@ -1,26 +1,24 @@
 require 'abstract_unit'
 require 'rails/backtrace_cleaner'
 
-if defined? Gem
-  class BacktraceCleanerVendorGemTest < ActiveSupport::TestCase
-    def setup
-      @cleaner = Rails::BacktraceCleaner.new
-    end
+class BacktraceCleanerVendorGemTest < ActiveSupport::TestCase
+  def setup
+    @cleaner = Rails::BacktraceCleaner.new
+  end
 
-    test "should format installed gems correctly" do
-      @backtrace = [ "#{Gem.path[0]}/gems/nosuchgem-1.2.3/lib/foo.rb" ]
+  test "should format installed gems correctly" do
+    @backtrace = [ "#{Gem.path[0]}/gems/nosuchgem-1.2.3/lib/foo.rb" ]
+    @result = @cleaner.clean(@backtrace, :all)
+    assert_equal "nosuchgem (1.2.3) lib/foo.rb", @result[0]
+  end
+
+  test "should format installed gems not in Gem.default_dir correctly" do
+    @target_dir = Gem.path.detect { |p| p != Gem.default_dir }
+    # skip this test if default_dir is the only directory on Gem.path
+    if @target_dir
+      @backtrace = [ "#{@target_dir}/gems/nosuchgem-1.2.3/lib/foo.rb" ]
       @result = @cleaner.clean(@backtrace, :all)
       assert_equal "nosuchgem (1.2.3) lib/foo.rb", @result[0]
-    end
-
-    test "should format installed gems not in Gem.default_dir correctly" do
-      @target_dir = Gem.path.detect { |p| p != Gem.default_dir }
-      # skip this test if default_dir is the only directory on Gem.path
-      if @target_dir
-        @backtrace = [ "#{@target_dir}/gems/nosuchgem-1.2.3/lib/foo.rb" ]
-        @result = @cleaner.clean(@backtrace, :all)
-        assert_equal "nosuchgem (1.2.3) lib/foo.rb", @result[0]
-      end
     end
   end
 end


### PR DESCRIPTION
...er#add_gem_filters

Rails permanently depends from Rubygems. Gem module presence check needless.
Gem.path can't be empty. 
