### PR TITLE
Add to_s("strftime-format") support for Time, Date, DateTime

### DIFF
--- a/activesupport/lib/active_support/core_ext/date/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date/conversions.rb
@@ -33,6 +33,7 @@ class Date
   #   date.to_formatted_s(:long)          # => "November 10, 2007"
   #   date.to_formatted_s(:long_ordinal)  # => "November 10th, 2007"
   #   date.to_formatted_s(:rfc822)        # => "10 Nov 2007"
+  #   date.to_formatted_s("%Y")           # => "2007"
   #
   # == Adding your own time formats to to_formatted_s
   # You can add your own formats to the Date::DATE_FORMATS hash.
@@ -44,11 +45,9 @@ class Date
   #   Date::DATE_FORMATS[:short_ordinal] = lambda { |date| date.strftime("%B #{date.day.ordinalize}") }
   def to_formatted_s(format = :default)
     if formatter = DATE_FORMATS[format]
-      if formatter.respond_to?(:call)
-        formatter.call(self).to_s
-      else
-        strftime(formatter)
-      end
+      formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
+    elsif format.is_a?(String)
+      strftime(format)
     else
       to_default_s
     end

--- a/activesupport/lib/active_support/core_ext/date_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/conversions.rb
@@ -22,6 +22,7 @@ class DateTime
   #   datetime.to_formatted_s(:long)          # => "December 04, 2007 00:00"
   #   datetime.to_formatted_s(:long_ordinal)  # => "December 4th, 2007 00:00"
   #   datetime.to_formatted_s(:rfc822)        # => "Tue, 04 Dec 2007 00:00:00 +0000"
+  #   datetime.to_formatted_s("%Y")           # => "2007"
   #
   # == Adding your own datetime formats to to_formatted_s
   # DateTime formats are shared with Time. You can add your own to the
@@ -35,6 +36,8 @@ class DateTime
   def to_formatted_s(format = :default)
     if formatter = ::Time::DATE_FORMATS[format]
       formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
+    elsif format.is_a?(String)
+      strftime(format)
     else
       to_default_s
     end

--- a/activesupport/lib/active_support/core_ext/time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/time/conversions.rb
@@ -27,6 +27,7 @@ class Time
   #   time.to_formatted_s(:long)          # => "January 18, 2007 06:10"
   #   time.to_formatted_s(:long_ordinal)  # => "January 18th, 2007 06:10"
   #   time.to_formatted_s(:rfc822)        # => "Thu, 18 Jan 2007 06:10:17 -0600"
+  #   time.to_formatted_s("%Y")           # => "2007"
   #
   # == Adding your own time formats to +to_formatted_s+
   # You can add your own formats to the Time::DATE_FORMATS hash.
@@ -39,6 +40,8 @@ class Time
   def to_formatted_s(format = :default)
     if formatter = DATE_FORMATS[format]
       formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
+    elsif format.is_a?(String)
+      strftime(format)
     else
       to_default_s
     end

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -10,6 +10,7 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
     assert_equal "February 21st, 2005", date.to_s(:long_ordinal)
     assert_equal "2005-02-21",          date.to_s(:db)
     assert_equal "21 Feb 2005",         date.to_s(:rfc822)
+    assert_equal "2005",                date.to_s("%Y")
   end
 
   def test_readable_inspect

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -11,6 +11,7 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal "Mon, 21 Feb 2005 14:30:00 +0000",   datetime.to_s(:rfc822)
     assert_equal "February 21st, 2005 14:30",         datetime.to_s(:long_ordinal)
     assert_match(/^2005-02-21T14:30:00(Z|\+00:00)$/,  datetime.to_s)
+    assert_equal "2005",                              datetime.to_s("%Y")
   end
 
   def test_readable_inspect

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -572,6 +572,10 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     Time::DATE_FORMATS.delete(:custom)
   end
 
+  def test_direct_format
+    assert_equal "2012", Time.local(2012, 4, 3, 11, 42, 0).to_s("%Y")
+  end
+
   def test_to_date
     assert_equal Date.new(2005, 2, 21), Time.local(2005, 2, 21, 17, 44, 30).to_date
   end


### PR DESCRIPTION
I suggest to add `#to_s("%Y-%m...")` support for all time types. Often I need to add date with specific format in one place. There are 3 variants:

``` ruby
Time.now.strftime("%Y-%m") # `strftime`, hm, I just can't remember this name :)
Time.now.to_s(:custom)     # add config/initializers/time_format.rb - it's boring and overhead for one time usage
I18n.l(Time.now, format: "%Y-%m") # overhead, especially for single language applications

Time.now.to_s("%Y-%m") # seems pretty good
```
