### PR TITLE
Removes caching from ActiveRecord::Core::ClassMethods#relation

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -137,12 +137,12 @@ module ActiveRecord
       private
 
       def relation #:nodoc:
-        @relation ||= Relation.new(self, arel_table)
+        relation = Relation.new(self, arel_table)
 
         if finder_needs_type_condition?
-          @relation.where(type_condition).create_with(inheritance_column.to_sym => sti_name)
+          relation.where(type_condition).create_with(inheritance_column.to_sym => sti_name)
         else
-          @relation
+          relation
         end
       end
     end
@@ -351,7 +351,6 @@ module ActiveRecord
 
       @attributes[pk] = nil unless @attributes.key?(pk)
 
-      @relation               = nil
       @aggregation_cache      = {}
       @association_cache      = {}
       @attributes_cache       = {}

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -35,7 +35,7 @@ module ActiveRecord
             if current_scope
               current_scope.clone
             else
-              scope = relation.clone
+              scope = relation
               scope.default_scoped = true
               scope
             end
@@ -49,7 +49,7 @@ module ActiveRecord
           if current_scope
             current_scope.scope_for_create
           else
-            scope = relation.clone
+            scope = relation
             scope.default_scoped = true
             scope.scope_for_create
           end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1174,6 +1174,12 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal Comment.find(1), Comment.preload(:post => :comments).scoping { Comment.find(1) }
   end
 
+  test "circular preload does not modify unscoped" do
+    expected = FirstPost.unscoped.find(2)
+    FirstPost.preload(:comments => :first_post).find(1)
+    assert_equal expected, FirstPost.unscoped.find(2)
+  end
+
   test "preload ignores the scoping" do
     assert_equal(
       Comment.find(1).post,

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1099,6 +1099,10 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal 'honda', FastCar.unscoped { FastCar.order_using_old_style.limit(1).first.name}
   end
 
+  def test_unscoped_relation_clones
+    assert_not_equal CoolCar.unscoped.object_id, CoolCar.unscoped.object_id
+  end
+
   def test_intersection_with_array
     relation = Author.where(:name => "David")
     rails_author = relation.first

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1099,10 +1099,6 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal 'honda', FastCar.unscoped { FastCar.order_using_old_style.limit(1).first.name}
   end
 
-  def test_unscoped_relation_clones
-    assert_not_equal CoolCar.unscoped.object_id, CoolCar.unscoped.object_id
-  end
-
   def test_intersection_with_array
     relation = Author.where(:name => "David")
     rails_author = relation.first

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -9,6 +9,8 @@ class Comment < ActiveRecord::Base
   belongs_to :post, :counter_cache => true
   has_many :ratings
 
+  belongs_to :first_post, :foreign_key => :post_id
+
   has_many :children, :class_name => 'Comment', :foreign_key => :parent_id
   belongs_to :parent, :class_name => 'Comment', :counter_cache => :children_count
 


### PR DESCRIPTION
The `#relation` method gets called in four places and the return value was instantly cloned in three of them. The only place that did not clone was `ActiveRecord::Scoping::Default::ClassMethods#unscoped`. This introduced a bug described in #5667 and should really clone the relation, too. This means all four places would clone the relation, so it doesn't make a lot of sense caching it in the first place.

The four places with calls to relations are:

```
activerecord/lib/active_record/scoping/default.rb:110:in `block in build_default_scope'"
activerecord/lib/active_record/scoping/default.rb:42:in `unscoped'"
activerecord/lib/active_record/scoping/named.rb:38:in `scoped'"
activerecord/lib/active_record/scoping/named.rb:52:in `scope_attributes'"
```
