### PR TITLE
Get a properly aliased_table_name, when we use a polymorphic association.

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -39,7 +39,7 @@ module ActiveRecord
       #   post.comments.aliased_table_name # => "comments"
       #
       def aliased_table_name
-        reflection.klass.table_name
+        klass.table_name
       end
 
       # Resets the \loaded flag to +false+ and sets the \target to +nil+.

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -168,6 +168,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
 
     sponsor.sponsorable = Member.new :name => "Bert"
     assert_equal Member, sponsor.association(:sponsorable).send(:klass)
+    assert_equal "members", sponsor.association(:sponsorable).aliased_table_name
   end
 
   def test_with_polymorphic_and_condition


### PR DESCRIPTION
According to ActiveRecord::Associations::BelongsToPolymorphicAssociation, we override _klass_ method.
We get a properly aliased_table_name, when we use a polymorphic association and this method.
