### PR TITLE
Don't use ENV['DATABASE_URL'] in Rails proper

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -68,7 +68,9 @@ module ActiveRecord
     # and then establishes the connection.
     initializer "active_record.initialize_database" do |app|
       ActiveSupport.on_load(:active_record) do
-        self.configurations = app.config.database_configuration
+        unless ENV['DATABASE_URL']
+          self.configurations = app.config.database_configuration
+        end
         establish_connection
       end
     end


### PR DESCRIPTION
So I recently found out 4605b5639db4fa15f8b6627245c74b899241f38a the hard way. I think using `DATABASE_URL` is a good idea, but the way it currently interacts with `database.yml` is pretty unintuitive. If `database.yml` is missing and `DATABASE_URL` is present, Rails blows up (no surprise there). But if both are present, `DATABASE_URL` silently wins.

It was really, really hard to figure out what was going on here, so I figured I'd spare future developers some pain. I've changed the Railtie to always use `database.yml`, but left `establish_connection` alone.
