### PR TITLE
minor elsif/else typo fix

### DIFF
--- a/actionpack/lib/action_view/base.rb
+++ b/actionpack/lib/action_view/base.rb
@@ -200,7 +200,7 @@ module ActionView #:nodoc:
       # TODO Provide a new API for AV::Base and deprecate this one.
       if context.is_a?(ActionView::Renderer)
         @view_renderer = context
-      elsif
+      else
         lookup_context = context.is_a?(ActionView::LookupContext) ?
           context : ActionView::LookupContext.new(context)
         lookup_context.formats  = formats if formats


### PR DESCRIPTION
Just noticed this typo in ActionView::Base#initialize. Harmless now, but if someone added another "else" clause at the end it could run both of the last 2 clauses.
