### PR TITLE
symbolize_keys now works recursively in addition to being fully backward compatible.

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -14,15 +14,19 @@ class Hash
 
   # Return a new hash with all keys converted to symbols, as long as
   # they respond to +to_sym+.
-  def symbolize_keys
-    dup.symbolize_keys!
+  # If recursive is set to true, then keys at all levels will be symbolized.
+  def symbolize_keys(recursive = false)
+    dup.symbolize_keys!(recursive)
   end
 
   # Destructively convert all keys to symbols, as long as they respond
   # to +to_sym+.
-  def symbolize_keys!
+  # If recursive is set to true, then keys at all levels will be symbolized.
+  def symbolize_keys!(recursive = false)
     keys.each do |key|
-      self[(key.to_sym rescue key) || key] = delete(key)
+      value = delete(key)
+      key = key.respond_to?(:to_sym) ? key.to_sym : key
+      self[key] = (recursive && value.is_a?(Hash)) ? value.dup.symbolize_keys!(recursive) : value
     end
     self
   end

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -143,7 +143,12 @@ module ActiveSupport
     def stringify_keys!; self end
     def stringify_keys; dup end
     undef :symbolize_keys!
-    def symbolize_keys; to_hash.symbolize_keys end
+
+    # If recursive is set to true, keys at all levels will be symbolized
+    def symbolize_keys(recursive = false)
+      to_hash.symbolize_keys(recursive)
+    end
+
     def to_options!; self end
 
     # Convert to a Hash with String keys.

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -28,6 +28,9 @@ class HashExtTest < ActiveSupport::TestCase
     @mixed   = { :a  => 1, 'b' => 2 }
     @fixnums = {  0  => 1,  1  => 2 }
     @illegal_symbols = { [] => 3 }
+    @nested_hash = { 'a' => {'b' => 2} }
+    @nested_hash_first_level_symbolized = { :a => { 'b' => 2 } }
+    @nested_hash_all_keys_symbolized = { :a => { :b => 2 } }
   end
 
   def test_methods
@@ -44,12 +47,28 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal @symbols, @symbols.symbolize_keys
     assert_equal @symbols, @strings.symbolize_keys
     assert_equal @symbols, @mixed.symbolize_keys
+    assert_equal @nested_hash_first_level_symbolized, @nested_hash.symbolize_keys
+  end
+
+  def test_symbolize_keys_with_recursive_option
+    assert_equal @symbols, @symbols.symbolize_keys(true)
+    assert_equal @symbols, @strings.symbolize_keys(true)
+    assert_equal @symbols, @mixed.symbolize_keys(true)
+    assert_equal @nested_hash_all_keys_symbolized, @nested_hash.symbolize_keys(true)
   end
 
   def test_symbolize_keys!
     assert_equal @symbols, @symbols.dup.symbolize_keys!
     assert_equal @symbols, @strings.dup.symbolize_keys!
     assert_equal @symbols, @mixed.dup.symbolize_keys!
+    assert_equal @nested_hash_first_level_symbolized, @nested_hash.symbolize_keys!
+  end
+
+  def test_symbolize_keys_bang_with_recursive_option
+    assert_equal @symbols, @symbols.dup.symbolize_keys!(true)
+    assert_equal @symbols, @strings.dup.symbolize_keys!(true)
+    assert_equal @symbols, @mixed.dup.symbolize_keys!(true)
+    assert_equal @nested_hash_all_keys_symbolized, @nested_hash.symbolize_keys!(true)
   end
 
   def test_symbolize_keys_preserves_keys_that_cant_be_symbolized
@@ -57,9 +76,19 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal @illegal_symbols, @illegal_symbols.dup.symbolize_keys!
   end
 
+  def test_symbolize_keys_with_recursive_option_preserves_keys_that_cant_be_symbolized
+    assert_equal @illegal_symbols, @illegal_symbols.symbolize_keys(true)
+    assert_equal @illegal_symbols, @illegal_symbols.dup.symbolize_keys!(true)
+  end
+
   def test_symbolize_keys_preserves_fixnum_keys
     assert_equal @fixnums, @fixnums.symbolize_keys
     assert_equal @fixnums, @fixnums.dup.symbolize_keys!
+  end
+
+  def test_symbolize_keys_with_recursive_option_preserves_fixnum_keys
+    assert_equal @fixnums, @fixnums.symbolize_keys(true)
+    assert_equal @fixnums, @fixnums.dup.symbolize_keys!(true)
   end
 
   def test_stringify_keys
@@ -81,10 +110,26 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal @symbols, @mixed.with_indifferent_access.symbolize_keys
   end
 
+  def test_symbolize_keys_with_recursive_option_for_hash_with_indifferent_access
+    assert_instance_of Hash, @symbols.with_indifferent_access.symbolize_keys(true)
+    assert_equal @symbols, @symbols.with_indifferent_access.symbolize_keys(true)
+    assert_equal @symbols, @strings.with_indifferent_access.symbolize_keys(true)
+    assert_equal @symbols, @mixed.with_indifferent_access.symbolize_keys(true)
+    assert_equal @nested_hash_all_keys_symbolized, @nested_hash.symbolize_keys(true)
+  end
+
   def test_symbolize_keys_bang_for_hash_with_indifferent_access
     assert_raise(NoMethodError) { @symbols.with_indifferent_access.dup.symbolize_keys! }
     assert_raise(NoMethodError) { @strings.with_indifferent_access.dup.symbolize_keys! }
     assert_raise(NoMethodError) { @mixed.with_indifferent_access.dup.symbolize_keys! }
+    assert_raise(NoMethodError) { @nested_hash.with_indifferent_access.dup.symbolize_keys! }
+  end
+
+  def test_symbolize_keys_bang_with_recursive_option_for_hash_with_indifferent_access
+    assert_raise(NoMethodError) { @symbols.with_indifferent_access.dup.symbolize_keys!(true) }
+    assert_raise(NoMethodError) { @strings.with_indifferent_access.dup.symbolize_keys!(true)  }
+    assert_raise(NoMethodError) { @mixed.with_indifferent_access.dup.symbolize_keys!(true) }
+    assert_raise(NoMethodError) { @nested_hash.with_indifferent_access.dup.symbolize_keys!(true) }
   end
 
   def test_symbolize_keys_preserves_keys_that_cant_be_symbolized_for_hash_with_indifferent_access
@@ -92,9 +137,19 @@ class HashExtTest < ActiveSupport::TestCase
     assert_raise(NoMethodError) { @illegal_symbols.with_indifferent_access.dup.symbolize_keys! }
   end
 
+  def test_symbolize_keys_with_recursive_option_preserves_keys_that_cant_be_symbolized_for_hash_with_indifferent_access
+    assert_equal @illegal_symbols, @illegal_symbols.with_indifferent_access.symbolize_keys(true)
+    assert_raise(NoMethodError) { @illegal_symbols.with_indifferent_access.dup.symbolize_keys!(true) }
+  end
+
   def test_symbolize_keys_preserves_fixnum_keys_for_hash_with_indifferent_access
     assert_equal @fixnums, @fixnums.with_indifferent_access.symbolize_keys
     assert_raise(NoMethodError) { @fixnums.with_indifferent_access.dup.symbolize_keys! }
+  end
+
+  def test_symbolize_keys_with_recursive_option_preserves_fixnum_keys_for_hash_with_indifferent_access
+    assert_equal @fixnums, @fixnums.with_indifferent_access.symbolize_keys(true)
+    assert_raise(NoMethodError) { @fixnums.with_indifferent_access.dup.symbolize_keys!(true) }
   end
 
   def test_stringify_keys_for_hash_with_indifferent_access


### PR DESCRIPTION
1. Current behavior of symbolize_keys remains unaltered (recursive flag is set to false by default)
2. If the recursive flag is set to true and the value is a Hash, then the value's keys will also be symbolized recursively.
