### PR TITLE
reset on an association should behave like reload: actually cause an unload of the target association

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -41,7 +41,7 @@ module ActiveRecord
       delegate :group, :order, :limit, :joins, :where, :preload, :eager_load, :includes, :from,
                :lock, :readonly, :having, :pluck, :to => :scoped
 
-      delegate :target, :load_target, :loaded?, :to => :@association
+      delegate :reset, :target, :load_target, :loaded?, :to => :@association
 
       delegate :select, :find, :first, :last,
                :build, :create, :create!,

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -209,6 +209,15 @@ class AssociationProxyTest < ActiveRecord::TestCase
     david = developers(:david)
     assert_equal david.association(:projects), david.projects.proxy_association
   end
+
+  def test_proxy_association_reset_unloads
+    david = developers(:david)
+    assert !david.projects.loaded?
+    david.projects.reload
+    assert david.projects.loaded?
+    david.projects.reset
+    assert !david.projects.loaded?
+  end
 end
 
 class OverridingAssociationsTest < ActiveRecord::TestCase


### PR DESCRIPTION
The result: reset causes an unloaded association
