### PR TITLE
redirect_to now accepts flash options for controller actions without explicit syntax

### DIFF
--- a/actionpack/lib/action_controller/metal/flash.rb
+++ b/actionpack/lib/action_controller/metal/flash.rb
@@ -22,6 +22,20 @@ module ActionController #:nodoc:
           flash.update(other_flashes)
         end
 
+        if options.is_a?(Hash)
+          if options_alert = options.delete(:alert)
+            flash[:alert] = options_alert
+          end
+
+          if options_notice = options.delete(:notice)
+            flash[:notice] = options_notice
+          end
+
+          if options_other_flashes = options.delete(:flash)
+            flash.update(options_other_flashes)
+          end
+        end
+
         super(options, response_status_and_flash)
       end
   end

--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -52,7 +52,7 @@ module ActionController
     #   redirect_to post_url(@post), :alert => "Watch it, mister!"
     #   redirect_to post_url(@post), :status=> :found, :notice => "Pay attention to the road"
     #   redirect_to post_url(@post), :status => 301, :flash => { :updated_post_id => @post.id }
-    #   redirect_to { :action=>'atom' }, :alert => "Something serious happened"
+    #   redirect_to :action=>'atom', :alert => "Something serious happened"
     #
     # When using <tt>redirect_to :back</tt>, if there is no referrer, ActionController::RedirectBackError will be raised. You may specify some fallback
     # behavior for this case by rescuing ActionController::RedirectBackError.

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -77,6 +77,14 @@ class FlashTest < ActionController::TestCase
       redirect_to '/somewhere', :notice => "Good luck in the somewheres!"
     end
 
+    def redirect_to_action_with_alert
+      redirect_to :action => 'nowhere', :alert => "Beware the nowheres!"
+    end
+
+    def redirect_to_action_with_notice
+      redirect_to :action => 'somewhere', :notice => "Good luck in the somewheres!"
+    end
+
     def render_with_flash_now_alert
       flash.now.alert = "Beware the nowheres now!"
       render :inline => "hello"
@@ -89,6 +97,10 @@ class FlashTest < ActionController::TestCase
 
     def redirect_with_other_flashes
       redirect_to '/wonderland', :flash => { :joyride => "Horses!" }
+    end
+
+    def redirect_to_action_with_other_flashes
+      redirect_to :action => 'wonderland', :flash => { :joyride => "Horses!" }
     end
   end
 
@@ -189,6 +201,16 @@ class FlashTest < ActionController::TestCase
     assert_equal "Good luck in the somewheres!", @controller.send(:flash)[:notice]
   end
 
+  def test_redirect_to_action_with_alert
+    get :redirect_to_action_with_alert
+    assert_equal "Beware the nowheres!", @controller.send(:flash)[:alert]
+  end
+
+  def test_redirect_to_action_with_notice
+    get :redirect_to_action_with_notice
+    assert_equal "Good luck in the somewheres!", @controller.send(:flash)[:notice]
+  end
+
   def test_render_with_flash_now_alert
     get :render_with_flash_now_alert
     assert_equal "Beware the nowheres now!", @controller.send(:flash)[:alert]
@@ -201,6 +223,11 @@ class FlashTest < ActionController::TestCase
 
   def test_redirect_to_with_other_flashes
     get :redirect_with_other_flashes
+    assert_equal "Horses!", @controller.send(:flash)[:joyride]
+  end
+
+  def test_redirect_to_action_with_other_flashes
+    get :redirect_to_action_with_other_flashes
     assert_equal "Horses!", @controller.send(:flash)[:joyride]
   end
 end


### PR DESCRIPTION
This is a minor change, but the syntax for redirecting to controller actions with flash options is more cumbersome than for other redirect targets. Previously, `redirect_to` required explicit parentheses and braces:

```
# Redirect to url
redirect_to post_url(@post), status: 301
redirect_to post_url(@post), status: 302, notice: "We've temporarily moved!"

# Redirect to controller action
redirect_to action: 'atom', status: 301
redirect_to({action: 'atom'}, status: 302, notice: "We're temporarily moved!")
redirect_to({action: 'atom', status: 302}, notice: "We're temporarily moved!")
```

To avoid this, we could pull flash options from the action hash, as we currently do for the status option, leaving us with the syntax:

```
redirect_to action: 'atom', status: 302, notice: "We're temporarily moved!"
```

This change would be backwards compatible with the exception of anyone using `:notice', ':alert', or ':flash' as action hash keys to provide query string parameters or something. 
