### PR TITLE
Add option to config_accessor to allow a default value.

### DIFF
--- a/activesupport/lib/active_support/configurable.rb
+++ b/activesupport/lib/active_support/configurable.rb
@@ -61,7 +61,7 @@ module ActiveSupport
           class_eval reader, __FILE__, line unless options[:instance_reader] == false
           class_eval writer, __FILE__, line unless options[:instance_writer] == false
 
-          config[name] = options[:default] if options[:default]
+          config[name] = options[:default] if options.key?(:default)
         end
       end
     end

--- a/activesupport/lib/active_support/configurable.rb
+++ b/activesupport/lib/active_support/configurable.rb
@@ -60,6 +60,8 @@ module ActiveSupport
           singleton_class.class_eval writer, __FILE__, line
           class_eval reader, __FILE__, line unless options[:instance_reader] == false
           class_eval writer, __FILE__, line unless options[:instance_writer] == false
+
+          config[name] = options[:default] if options[:default]
         end
       end
     end

--- a/activesupport/test/configurable_test.rb
+++ b/activesupport/test/configurable_test.rb
@@ -71,6 +71,16 @@ class ConfigurableActiveSupport < ActiveSupport::TestCase
     assert_method_defined child.new.config, :bar
   end
 
+  test "configuration can take defaults" do
+    parent = Class.new do
+      include ActiveSupport::Configurable
+      config_accessor :foo, :bar, :default => 'bar'
+    end
+
+    assert_equal parent.config.foo, 'bar'
+    assert_equal parent.config.bar, 'bar'
+  end
+
   def assert_method_defined(object, method)
     methods = object.public_methods.map(&:to_s)
     assert methods.include?(method.to_s), "Expected #{methods.inspect} to include #{method.to_s.inspect}"

--- a/activesupport/test/configurable_test.rb
+++ b/activesupport/test/configurable_test.rb
@@ -81,6 +81,15 @@ class ConfigurableActiveSupport < ActiveSupport::TestCase
     assert_equal parent.config.bar, 'bar'
   end
 
+  test "configuration can take a default of false" do
+    parent = Class.new do
+      include ActiveSupport::Configurable
+      config_accessor :foo, :default => false
+    end
+
+    assert_equal parent.config.foo, false
+  end
+
   def assert_method_defined(object, method)
     methods = object.public_methods.map(&:to_s)
     assert methods.include?(method.to_s), "Expected #{methods.inspect} to include #{method.to_s.inspect}"


### PR DESCRIPTION
This allows ActiveSupport::Configurable to allow default values.

```
class Configuration
  include ActiveSupport::Configurable
  config_accessor :foo, :bar, :default => 'bar'
end
```
