### PR TITLE
recent commits have reversed the symbolized hash in the name of speed but caused bugs

### DIFF
--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -144,32 +144,27 @@ module ActionDispatch
       #    # => 'http://somehost.org/tasks/testing?number=33'
       def url_for(options = nil)
         case options
+        when nil
+          _routes.url_for(url_options)
+        when Hash
+          symbolized = {}
+          options.keys.each do |k|
+            sym = k.to_sym
+            symbolized[sym] = options[k] unless symbolized.has_key?(sym)
+          end
+          url_options.keys.each do |k|
+            sym = k.to_sym
+            symbolized[sym] = url_options[k] unless symbolized.has_key?(sym)
+          end
+          _routes.url_for(symbolized)
         when String
           options
-        when nil, Hash
-          _routes.url_for(_merge_url_for_options(options, url_options))
         else
           polymorphic_url(options)
         end
       end
 
       protected
-
-      def _merge_url_for_options(h1, h2)
-        opts = {}
-
-        h1.keys.each do |k|
-          s = k.to_sym
-          opts[s] = h1[k] unless opts.has_key?(s)
-        end if h1
-
-        h2.keys.each do |k|
-          s = k.to_sym
-          opts[s] = h2[k] unless opts.has_key?(s)
-        end if h2
-
-        opts
-      end
 
       def optimize_routes_generation?
         return @_optimized_routes if defined?(@_optimized_routes)

--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -147,13 +147,29 @@ module ActionDispatch
         when String
           options
         when nil, Hash
-          _routes.url_for((options || {}).symbolize_keys.reverse_merge!(url_options))
+          _routes.url_for(_merge_url_for_options(options, url_options))
         else
           polymorphic_url(options)
         end
       end
 
       protected
+
+      def _merge_url_for_options(h1, h2)
+        opts = {}
+
+        h1.keys.each do |k|
+          s = k.to_sym
+          opts[s] = h1[k] unless opts.has_key?(s)
+        end if h1
+
+        h2.keys.each do |k|
+          s = k.to_sym
+          opts[s] = h2[k] unless opts.has_key?(s)
+        end if h2
+
+        opts
+      end
 
       def optimize_routes_generation?
         return @_optimized_routes if defined?(@_optimized_routes)

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -356,6 +356,15 @@ module AbstractController
         assert_equal("/c/a", W.new.url_for(HashWithIndifferentAccess.new('controller' => 'c', 'action' => 'a', 'only_path' => true)))
       end
 
+      def test_with_stringified_default_url_options
+        W.default_url_options['controller'] = 'd'
+        W.default_url_options['only_path']  = false
+        assert_equal("/c", W.new.url_for(:controller => 'c', :only_path => true))
+
+        W.default_url_options['action'] = 'b'
+        assert_equal("/c/a", W.new.url_for(:controller => 'c', :action => 'a', :only_path => true))
+      end
+
       def test_url_params_with_nil_to_param_are_not_in_url
         assert_equal("/c/a", W.new.url_for(:only_path => true, :controller => 'c', :action => 'a', :id => Struct.new(:to_param).new(nil)))
       end


### PR DESCRIPTION
  https://github.com/customink/central_logger/pull/28#issuecomment-4961975

  https://github.com/ahoward/rails_default_url_options/pull/1

this patch makes sure that the output hash is symbolized and reverse merged _regardless_ of what kind of hash-y objects are used (HashWithIndifferentAccess, string keys, symbol keys, etc) _and_ is very fast
