### PR TITLE
Remove unnecessary in HTML 5 type attribute with default value

### DIFF
--- a/actionpack/lib/action_controller/metal/streaming.rb
+++ b/actionpack/lib/action_controller/metal/streaming.rb
@@ -162,7 +162,7 @@ module ActionController #:nodoc:
   # Currently, when an exception happens in development or production, Rails
   # will automatically stream to the client:
   #
-  #   "><script type="text/javascript">window.location = "/500.html"</script></html>
+  #   "><script>window.location = "/500.html"</script></html>
   #
   # The first two characters (">) are required in case the exception happens
   # while rendering attributes for a given tag. You can check the real cause

--- a/actionpack/lib/action_view/base.rb
+++ b/actionpack/lib/action_view/base.rb
@@ -139,7 +139,7 @@ module ActionView #:nodoc:
     # How to complete the streaming when an exception occurs.
     # This is our best guess: first try to close the attribute, then the tag.
     cattr_accessor :streaming_completion_on_exception
-    @@streaming_completion_on_exception = %("><script type="text/javascript">window.location = "/500.html"</script></html>)
+    @@streaming_completion_on_exception = %("><script>window.location = "/500.html"</script></html>)
 
     # Specify whether rendering within namespaced controllers should prefix
     # the partial paths for ActiveModel objects with the namespace.

--- a/actionpack/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helper.rb
@@ -15,7 +15,7 @@ module ActionView
     #   image_tag("rails.png")
     #   # => <img alt="Rails" src="/images/rails.png?1230601161" />
     #   stylesheet_link_tag("application")
-    #   # => <link href="/stylesheets/application.css?1232285206" media="screen" rel="stylesheet" type="text/css" />
+    #   # => <link href="/stylesheets/application.css?1232285206" media="screen" rel="stylesheet" />
     #
     # === Using asset hosts
     #
@@ -34,7 +34,7 @@ module ActionView
     #   image_tag("rails.png")
     #   # => <img alt="Rails" src="http://assets.example.com/images/rails.png?1230601161" />
     #   stylesheet_link_tag("application")
-    #   # => <link href="http://assets.example.com/stylesheets/application.css?1232285206" media="screen" rel="stylesheet" type="text/css" />
+    #   # => <link href="http://assets.example.com/stylesheets/application.css?1232285206" media="screen" rel="stylesheet" />
     #
     # Browsers typically open at most two simultaneous connections to a single
     # host, which means your assets often have to wait for other assets to finish
@@ -47,7 +47,7 @@ module ActionView
     #   image_tag("rails.png")
     #   # => <img alt="Rails" src="http://assets0.example.com/images/rails.png?1230601161" />
     #   stylesheet_link_tag("application")
-    #   # => <link href="http://assets2.example.com/stylesheets/application.css?1232285206" media="screen" rel="stylesheet" type="text/css" />
+    #   # => <link href="http://assets2.example.com/stylesheets/application.css?1232285206" media="screen" rel="stylesheet" />
     #
     # To do this, you can either setup four actual hosts, or you can use wildcard
     # DNS to CNAME the wildcard to a single asset host. You can read more about
@@ -66,7 +66,7 @@ module ActionView
     #   image_tag("rails.png")
     #   # => <img alt="Rails" src="http://assets1.example.com/images/rails.png?1230601161" />
     #   stylesheet_link_tag("application")
-    #   # => <link href="http://assets2.example.com/stylesheets/application.css?1232285206" media="screen" rel="stylesheet" type="text/css" />
+    #   # => <link href="http://assets2.example.com/stylesheets/application.css?1232285206" media="screen" rel="stylesheet" />
     #
     # The example above generates "http://assets1.example.com" and
     # "http://assets2.example.com". This option is useful for example if
@@ -86,7 +86,7 @@ module ActionView
     #   image_tag("rails.png")
     #   # => <img alt="Rails" src="http://images.example.com/images/rails.png?1230601161" />
     #   stylesheet_link_tag("application")
-    #   # => <link href="http://assets.example.com/stylesheets/application.css?1232285206" media="screen" rel="stylesheet" type="text/css" />
+    #   # => <link href="http://assets.example.com/stylesheets/application.css?1232285206" media="screen" rel="stylesheet" />
     #
     # Alternatively you may ask for a second parameter +request+. That one is
     # particularly useful for serving assets from an SSL-protected page. The
@@ -163,7 +163,7 @@ module ActionView
     #   image_tag("rails.png")
     #   # => <img alt="Rails" src="/release-12345/images/rails.png" />
     #   stylesheet_link_tag("application")
-    #   # => <link href="/release-12345/stylesheets/application.css?1232285206" media="screen" rel="stylesheet" type="text/css" />
+    #   # => <link href="/release-12345/stylesheets/application.css?1232285206" media="screen" rel="stylesheet" />
     #
     # Changing the asset_path does require that your web servers have
     # knowledge of the asset template paths that you rewrite to so it's not

--- a/actionpack/lib/action_view/helpers/asset_tag_helpers/javascript_tag_helpers.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helpers/javascript_tag_helpers.rb
@@ -16,7 +16,7 @@ module ActionView
         end
 
         def asset_tag(source, options)
-          content_tag("script", "", { "type" => Mime::JS, "src" => path_to_asset(source) }.merge(options))
+          content_tag("script", "", { "src" => path_to_asset(source) }.merge(options))
         end
 
         def custom_dir
@@ -60,9 +60,9 @@ module ActionView
           #   ActionView::Helpers::AssetTagHelper.register_javascript_expansion :monkey => ["head", "body", "tail"]
           #
           #   javascript_include_tag :monkey # =>
-          #     <script type="text/javascript" src="/javascripts/head.js"></script>
-          #     <script type="text/javascript" src="/javascripts/body.js"></script>
-          #     <script type="text/javascript" src="/javascripts/tail.js"></script>
+          #     <script src="/javascripts/head.js"></script>
+          #     <script src="/javascripts/body.js"></script>
+          #     <script src="/javascripts/tail.js"></script>
           def register_javascript_expansion(expansions)
             js_expansions = JavascriptIncludeTag.expansions
             expansions.each do |key, values|
@@ -116,36 +116,36 @@ module ActionView
         #
         # ==== Examples
         #   javascript_include_tag "xmlhr"
-        #   # => <script type="text/javascript" src="/javascripts/xmlhr.js?1284139606"></script>
+        #   # => <script src="/javascripts/xmlhr.js?1284139606"></script>
         #
         #   javascript_include_tag "xmlhr.js"
-        #   # => <script type="text/javascript" src="/javascripts/xmlhr.js?1284139606"></script>
+        #   # => <script src="/javascripts/xmlhr.js?1284139606"></script>
         #
         #   javascript_include_tag "common.javascript", "/elsewhere/cools"
-        #   # => <script type="text/javascript" src="/javascripts/common.javascript?1284139606"></script>
-        #   #    <script type="text/javascript" src="/elsewhere/cools.js?1423139606"></script>
+        #   # => <script src="/javascripts/common.javascript?1284139606"></script>
+        #   #    <script src="/elsewhere/cools.js?1423139606"></script>
         #
         #   javascript_include_tag "http://www.example.com/xmlhr"
-        #   # => <script type="text/javascript" src="http://www.example.com/xmlhr"></script>
+        #   # => <script src="http://www.example.com/xmlhr"></script>
         #
         #   javascript_include_tag "http://www.example.com/xmlhr.js"
-        #   # => <script type="text/javascript" src="http://www.example.com/xmlhr.js"></script>
+        #   # => <script src="http://www.example.com/xmlhr.js"></script>
         #
         #   javascript_include_tag :defaults
-        #   # => <script type="text/javascript" src="/javascripts/jquery.js?1284139606"></script>
-        #   #    <script type="text/javascript" src="/javascripts/rails.js?1284139606"></script>
-        #   #    <script type="text/javascript" src="/javascripts/application.js?1284139606"></script>
+        #   # => <script src="/javascripts/jquery.js?1284139606"></script>
+        #   #    <script src="/javascripts/rails.js?1284139606"></script>
+        #   #    <script src="/javascripts/application.js?1284139606"></script>
         #
         # * = The application.js file is only referenced if it exists
         #
         # You can also include all JavaScripts in the +javascripts+ directory using <tt>:all</tt> as the source:
         #
         #   javascript_include_tag :all
-        #   # => <script type="text/javascript" src="/javascripts/jquery.js?1284139606"></script>
-        #   #    <script type="text/javascript" src="/javascripts/rails.js?1284139606"></script>
-        #   #    <script type="text/javascript" src="/javascripts/application.js?1284139606"></script>
-        #   #    <script type="text/javascript" src="/javascripts/shop.js?1284139606"></script>
-        #   #    <script type="text/javascript" src="/javascripts/checkout.js?1284139606"></script>
+        #   # => <script src="/javascripts/jquery.js?1284139606"></script>
+        #   #    <script src="/javascripts/rails.js?1284139606"></script>
+        #   #    <script src="/javascripts/application.js?1284139606"></script>
+        #   #    <script src="/javascripts/shop.js?1284139606"></script>
+        #   #    <script src="/javascripts/checkout.js?1284139606"></script>
         #
         # Note that your defaults of choice will be included first, so they will be available to all subsequently
         # included files.
@@ -166,25 +166,25 @@ module ActionView
         #
         #   # assuming config.perform_caching is false
         #   javascript_include_tag :all, :cache => true
-        #   # => <script type="text/javascript" src="/javascripts/jquery.js?1284139606"></script>
-        #   #    <script type="text/javascript" src="/javascripts/rails.js?1284139606"></script>
-        #   #    <script type="text/javascript" src="/javascripts/application.js?1284139606"></script>
-        #   #    <script type="text/javascript" src="/javascripts/shop.js?1284139606"></script>
-        #   #    <script type="text/javascript" src="/javascripts/checkout.js?1284139606"></script>
+        #   # => <script src="/javascripts/jquery.js?1284139606"></script>
+        #   #    <script src="/javascripts/rails.js?1284139606"></script>
+        #   #    <script src="/javascripts/application.js?1284139606"></script>
+        #   #    <script src="/javascripts/shop.js?1284139606"></script>
+        #   #    <script src="/javascripts/checkout.js?1284139606"></script>
         #
         #   # assuming config.perform_caching is true
         #   javascript_include_tag :all, :cache => true
-        #   # => <script type="text/javascript" src="/javascripts/all.js?1344139789"></script>
+        #   # => <script src="/javascripts/all.js?1344139789"></script>
         #
         #   # assuming config.perform_caching is false
         #   javascript_include_tag "jquery", "cart", "checkout", :cache => "shop"
-        #   # => <script type="text/javascript" src="/javascripts/jquery.js?1284139606"></script>
-        #   #    <script type="text/javascript" src="/javascripts/cart.js?1289139157"></script>
-        #   #    <script type="text/javascript" src="/javascripts/checkout.js?1299139816"></script>
+        #   # => <script src="/javascripts/jquery.js?1284139606"></script>
+        #   #    <script src="/javascripts/cart.js?1289139157"></script>
+        #   #    <script src="/javascripts/checkout.js?1299139816"></script>
         #
         #   # assuming config.perform_caching is true
         #   javascript_include_tag "jquery", "cart", "checkout", :cache => "shop"
-        #   # => <script type="text/javascript" src="/javascripts/shop.js?1299139816"></script>
+        #   # => <script src="/javascripts/shop.js?1299139816"></script>
         #
         # The <tt>:recursive</tt> option is also available for caching:
         #

--- a/actionpack/lib/action_view/helpers/asset_tag_helpers/stylesheet_tag_helpers.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helpers/stylesheet_tag_helpers.rb
@@ -17,7 +17,7 @@ module ActionView
 
         def asset_tag(source, options)
           # We force the :request protocol here to avoid a double-download bug in IE7 and IE8
-          tag("link", { "rel" => "stylesheet", "type" => Mime::CSS, "media" => "screen", "href" => path_to_asset(source, :protocol => :request) }.merge(options))
+          tag("link", { "rel" => "stylesheet", "media" => "screen", "href" => path_to_asset(source, :protocol => :request) }.merge(options))
         end
 
         def custom_dir
@@ -38,9 +38,9 @@ module ActionView
           #   ActionView::Helpers::AssetTagHelper.register_stylesheet_expansion :monkey => ["head", "body", "tail"]
           #
           #   stylesheet_link_tag :monkey # =>
-          #     <link href="/stylesheets/head.css"  media="screen" rel="stylesheet" type="text/css" />
-          #     <link href="/stylesheets/body.css"  media="screen" rel="stylesheet" type="text/css" />
-          #     <link href="/stylesheets/tail.css"  media="screen" rel="stylesheet" type="text/css" />
+          #     <link href="/stylesheets/head.css"  media="screen" rel="stylesheet" />
+          #     <link href="/stylesheets/body.css"  media="screen" rel="stylesheet" />
+          #     <link href="/stylesheets/tail.css"  media="screen" rel="stylesheet" />
           def register_stylesheet_expansion(expansions)
             style_expansions = StylesheetIncludeTag.expansions
             expansions.each do |key, values|
@@ -81,30 +81,30 @@ module ActionView
         #
         # ==== Examples
         #   stylesheet_link_tag "style" # =>
-        #     <link href="/stylesheets/style.css" media="screen" rel="stylesheet" type="text/css" />
+        #     <link href="/stylesheets/style.css" media="screen" rel="stylesheet" />
         #
         #   stylesheet_link_tag "style.css" # =>
-        #     <link href="/stylesheets/style.css" media="screen" rel="stylesheet" type="text/css" />
+        #     <link href="/stylesheets/style.css" media="screen" rel="stylesheet" />
         #
         #   stylesheet_link_tag "http://www.example.com/style.css" # =>
-        #     <link href="http://www.example.com/style.css" media="screen" rel="stylesheet" type="text/css" />
+        #     <link href="http://www.example.com/style.css" media="screen" rel="stylesheet" />
         #
         #   stylesheet_link_tag "style", :media => "all" # =>
-        #     <link href="/stylesheets/style.css" media="all" rel="stylesheet" type="text/css" />
+        #     <link href="/stylesheets/style.css" media="all" rel="stylesheet" />
         #
         #   stylesheet_link_tag "style", :media => "print" # =>
-        #     <link href="/stylesheets/style.css" media="print" rel="stylesheet" type="text/css" />
+        #     <link href="/stylesheets/style.css" media="print" rel="stylesheet" />
         #
         #   stylesheet_link_tag "random.styles", "/css/stylish" # =>
-        #     <link href="/stylesheets/random.styles" media="screen" rel="stylesheet" type="text/css" />
-        #     <link href="/css/stylish.css" media="screen" rel="stylesheet" type="text/css" />
+        #     <link href="/stylesheets/random.styles" media="screen" rel="stylesheet" />
+        #     <link href="/css/stylish.css" media="screen" rel="stylesheet" />
         #
         # You can also include all styles in the stylesheets directory using <tt>:all</tt> as the source:
         #
         #   stylesheet_link_tag :all # =>
-        #     <link href="/stylesheets/style1.css"  media="screen" rel="stylesheet" type="text/css" />
-        #     <link href="/stylesheets/styleB.css"  media="screen" rel="stylesheet" type="text/css" />
-        #     <link href="/stylesheets/styleX2.css" media="screen" rel="stylesheet" type="text/css" />
+        #     <link href="/stylesheets/style1.css"  media="screen" rel="stylesheet" />
+        #     <link href="/stylesheets/styleB.css"  media="screen" rel="stylesheet" />
+        #     <link href="/stylesheets/styleX2.css" media="screen" rel="stylesheet" />
         #
         # If you want Rails to search in all the subdirectories under stylesheets, you should explicitly set <tt>:recursive</tt>:
         #
@@ -119,20 +119,20 @@ module ActionView
         #
         # ==== Examples
         #   stylesheet_link_tag :all, :cache => true # when config.perform_caching is false =>
-        #     <link href="/stylesheets/style1.css"  media="screen" rel="stylesheet" type="text/css" />
-        #     <link href="/stylesheets/styleB.css"  media="screen" rel="stylesheet" type="text/css" />
-        #     <link href="/stylesheets/styleX2.css" media="screen" rel="stylesheet" type="text/css" />
+        #     <link href="/stylesheets/style1.css"  media="screen" rel="stylesheet" />
+        #     <link href="/stylesheets/styleB.css"  media="screen" rel="stylesheet" />
+        #     <link href="/stylesheets/styleX2.css" media="screen" rel="stylesheet" />
         #
         #   stylesheet_link_tag :all, :cache => true # when config.perform_caching is true =>
-        #     <link href="/stylesheets/all.css"  media="screen" rel="stylesheet" type="text/css" />
+        #     <link href="/stylesheets/all.css"  media="screen" rel="stylesheet" />
         #
         #   stylesheet_link_tag "shop", "cart", "checkout", :cache => "payment" # when config.perform_caching is false =>
-        #     <link href="/stylesheets/shop.css"  media="screen" rel="stylesheet" type="text/css" />
-        #     <link href="/stylesheets/cart.css"  media="screen" rel="stylesheet" type="text/css" />
-        #     <link href="/stylesheets/checkout.css" media="screen" rel="stylesheet" type="text/css" />
+        #     <link href="/stylesheets/shop.css"  media="screen" rel="stylesheet" />
+        #     <link href="/stylesheets/cart.css"  media="screen" rel="stylesheet" />
+        #     <link href="/stylesheets/checkout.css" media="screen" rel="stylesheet" />
         #
         #   stylesheet_link_tag "shop", "cart", "checkout", :cache => "payment" # when config.perform_caching is true =>
-        #     <link href="/stylesheets/payment.css"  media="screen" rel="stylesheet" type="text/css" />
+        #     <link href="/stylesheets/payment.css"  media="screen" rel="stylesheet" />
         #
         # The <tt>:recursive</tt> option is also available for caching:
         #

--- a/actionpack/lib/action_view/helpers/capture_helper.rb
+++ b/actionpack/lib/action_view/helpers/capture_helper.rb
@@ -96,7 +96,7 @@ module ActionView
       #   Please login!
       #
       #   <% content_for :script do %>
-      #     <script type="text/javascript">alert('You are not authorized to view this page!')</script>
+      #     <script>alert('You are not authorized to view this page!')</script>
       #   <% end %>
       #
       # Then, in another view, you could to do something like this:

--- a/actionpack/lib/action_view/helpers/javascript_helper.rb
+++ b/actionpack/lib/action_view/helpers/javascript_helper.rb
@@ -37,7 +37,7 @@ module ActionView
       #   javascript_tag "alert('All is good')"
       #
       # Returns:
-      #   <script type="text/javascript">
+      #   <script>
       #   //<![CDATA[
       #   alert('All is good')
       #   //]]>
@@ -46,7 +46,7 @@ module ActionView
       # +html_options+ may be a hash of attributes for the <tt>\<script></tt>
       # tag. Example:
       #   javascript_tag "alert('All is good')", :defer => 'defer'
-      #   # => <script defer="defer" type="text/javascript">alert('All is good')</script>
+      #   # => <script defer="defer">alert('All is good')</script>
       #
       # Instead of passing the content as an argument, you can also use a block
       # in which case, you pass your +html_options+ as the first parameter.
@@ -62,7 +62,7 @@ module ActionView
             content_or_options_with_block
           end
 
-        content_tag(:script, javascript_cdata_section(content), html_options.merge(:type => Mime::JS))
+        content_tag(:script, javascript_cdata_section(content), html_options)
       end
 
       def javascript_cdata_section(content) #:nodoc:

--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -481,7 +481,7 @@ module ActionView
       #   # => <a href="mailto:me@domain.com">me@domain.com</a>
       #
       #   mail_to "me@domain.com", "My email", :encode => "javascript"
-      #   # => <script type="text/javascript">eval(decodeURIComponent('%64%6f%63...%27%29%3b'))</script>
+      #   # => <script>eval(decodeURIComponent('%64%6f%63...%27%29%3b'))</script>
       #
       #   mail_to "me@domain.com", "My email", :encode => "hex"
       #   # => <a href="mailto:%6d%65@%64%6f%6d%61%69%6e.%63%6f%6d">My email</a>
@@ -515,7 +515,7 @@ module ActionView
           "document.write('#{html}');".each_byte do |c|
             string << sprintf("%%%x", c)
           end
-          "<script type=\"#{Mime::JS}\">eval(decodeURIComponent('#{string}'))</script>".html_safe
+          "<script>eval(decodeURIComponent('#{string}'))</script>".html_safe
         when "hex"
           email_address_encoded = email_address_obfuscated.unpack('C*').map {|c|
             sprintf("&#%d;", c)

--- a/actionpack/test/controller/new_base/render_streaming_test.rb
+++ b/actionpack/test/controller/new_base/render_streaming_test.rb
@@ -73,13 +73,13 @@ module RenderStreaming
 
     test "rendering with layout exception" do
       get "/render_streaming/basic/layout_exception"
-      assert_body "d\r\n<body class=\"\r\n4e\r\n\"><script type=\"text/javascript\">window.location = \"/500.html\"</script></html>\r\n0\r\n\r\n"
+      assert_body "d\r\n<body class=\"\r\n37\r\n\"><script>window.location = \"/500.html\"</script></html>\r\n0\r\n\r\n"
       assert_streaming!
     end
 
     test "rendering with template exception" do
       get "/render_streaming/basic/template_exception"
-      assert_body "4e\r\n\"><script type=\"text/javascript\">window.location = \"/500.html\"</script></html>\r\n0\r\n\r\n"
+      assert_body "37\r\n\"><script>window.location = \"/500.html\"</script></html>\r\n0\r\n\r\n"
       assert_streaming!
     end
 

--- a/actionpack/test/template/asset_tag_helper_test.rb
+++ b/actionpack/test/template/asset_tag_helper_test.rb
@@ -102,20 +102,20 @@ class AssetTagHelperTest < ActionView::TestCase
   }
 
   JavascriptIncludeToTag = {
-    %(javascript_include_tag("bank")) => %(<script src="/javascripts/bank.js" type="text/javascript"></script>),
-    %(javascript_include_tag("bank.js")) => %(<script src="/javascripts/bank.js" type="text/javascript"></script>),
-    %(javascript_include_tag("bank", :lang => "vbscript")) => %(<script lang="vbscript" src="/javascripts/bank.js" type="text/javascript"></script>),
-    %(javascript_include_tag("common.javascript", "/elsewhere/cools")) => %(<script src="/javascripts/common.javascript" type="text/javascript"></script>\n<script src="/elsewhere/cools.js" type="text/javascript"></script>),
-    %(javascript_include_tag(:defaults)) => %(<script src="/javascripts/prototype.js" type="text/javascript"></script>\n<script src="/javascripts/effects.js" type="text/javascript"></script>\n<script src="/javascripts/dragdrop.js" type="text/javascript"></script>\n<script src="/javascripts/controls.js" type="text/javascript"></script>\n<script src="/javascripts/rails.js" type="text/javascript"></script>\n<script src="/javascripts/application.js" type="text/javascript"></script>),
-    %(javascript_include_tag(:all)) => %(<script src="/javascripts/prototype.js" type="text/javascript"></script>\n<script src="/javascripts/effects.js" type="text/javascript"></script>\n<script src="/javascripts/dragdrop.js" type="text/javascript"></script>\n<script src="/javascripts/controls.js" type="text/javascript"></script>\n<script src="/javascripts/bank.js" type="text/javascript"></script>\n<script src="/javascripts/robber.js" type="text/javascript"></script>\n<script src="/javascripts/version.1.0.js" type="text/javascript"></script>\n<script src="/javascripts/application.js" type="text/javascript"></script>),
-    %(javascript_include_tag(:all, :recursive => true)) => %(<script src="/javascripts/prototype.js" type="text/javascript"></script>\n<script src="/javascripts/effects.js" type="text/javascript"></script>\n<script src="/javascripts/dragdrop.js" type="text/javascript"></script>\n<script src="/javascripts/controls.js" type="text/javascript"></script>\n<script src="/javascripts/bank.js" type="text/javascript"></script>\n<script src="/javascripts/robber.js" type="text/javascript"></script>\n<script src="/javascripts/subdir/subdir.js" type="text/javascript"></script>\n<script src="/javascripts/version.1.0.js" type="text/javascript"></script>\n<script src="/javascripts/application.js" type="text/javascript"></script>),
-    %(javascript_include_tag(:defaults, "bank")) => %(<script src="/javascripts/prototype.js" type="text/javascript"></script>\n<script src="/javascripts/effects.js" type="text/javascript"></script>\n<script src="/javascripts/dragdrop.js" type="text/javascript"></script>\n<script src="/javascripts/controls.js" type="text/javascript"></script>\n<script src="/javascripts/rails.js" type="text/javascript"></script>\n<script src="/javascripts/bank.js" type="text/javascript"></script>\n<script src="/javascripts/application.js" type="text/javascript"></script>),
-    %(javascript_include_tag(:defaults, "application")) => %(<script src="/javascripts/prototype.js" type="text/javascript"></script>\n<script src="/javascripts/effects.js" type="text/javascript"></script>\n<script src="/javascripts/dragdrop.js" type="text/javascript"></script>\n<script src="/javascripts/controls.js" type="text/javascript"></script>\n<script src="/javascripts/rails.js" type="text/javascript"></script>\n<script src="/javascripts/application.js" type="text/javascript"></script>),
-    %(javascript_include_tag("bank", :defaults)) => %(<script src="/javascripts/bank.js" type="text/javascript"></script>\n<script src="/javascripts/prototype.js" type="text/javascript"></script>\n<script src="/javascripts/effects.js" type="text/javascript"></script>\n<script src="/javascripts/dragdrop.js" type="text/javascript"></script>\n<script src="/javascripts/controls.js" type="text/javascript"></script>\n<script src="/javascripts/rails.js" type="text/javascript"></script>\n<script src="/javascripts/application.js" type="text/javascript"></script>),
+    %(javascript_include_tag("bank")) => %(<script src="/javascripts/bank.js" ></script>),
+    %(javascript_include_tag("bank.js")) => %(<script src="/javascripts/bank.js" ></script>),
+    %(javascript_include_tag("bank", :lang => "vbscript")) => %(<script lang="vbscript" src="/javascripts/bank.js" ></script>),
+    %(javascript_include_tag("common.javascript", "/elsewhere/cools")) => %(<script src="/javascripts/common.javascript" ></script>\n<script src="/elsewhere/cools.js" ></script>),
+    %(javascript_include_tag(:defaults)) => %(<script src="/javascripts/prototype.js" ></script>\n<script src="/javascripts/effects.js"></script>\n<script src="/javascripts/dragdrop.js"></script>\n<script src="/javascripts/controls.js"></script>\n<script src="/javascripts/rails.js"></script>\n<script src="/javascripts/application.js"></script>),
+    %(javascript_include_tag(:all)) => %(<script src="/javascripts/prototype.js"></script>\n<script src="/javascripts/effects.js"></script>\n<script src="/javascripts/dragdrop.js"></script>\n<script src="/javascripts/controls.js"></script>\n<script src="/javascripts/bank.js"></script>\n<script src="/javascripts/robber.js"></script>\n<script src="/javascripts/version.1.0.js"></script>\n<script src="/javascripts/application.js"></script>),
+    %(javascript_include_tag(:all, :recursive => true)) => %(<script src="/javascripts/prototype.js"></script>\n<script src="/javascripts/effects.js"></script>\n<script src="/javascripts/dragdrop.js"></script>\n<script src="/javascripts/controls.js"></script>\n<script src="/javascripts/bank.js"></script>\n<script src="/javascripts/robber.js"></script>\n<script src="/javascripts/subdir/subdir.js"></script>\n<script src="/javascripts/version.1.0.js"></script>\n<script src="/javascripts/application.js"></script>),
+    %(javascript_include_tag(:defaults, "bank")) => %(<script src="/javascripts/prototype.js"></script>\n<script src="/javascripts/effects.js"></script>\n<script src="/javascripts/dragdrop.js"></script>\n<script src="/javascripts/controls.js"></script>\n<script src="/javascripts/rails.js"></script>\n<script src="/javascripts/bank.js"></script>\n<script src="/javascripts/application.js"></script>),
+    %(javascript_include_tag(:defaults, "application")) => %(<script src="/javascripts/prototype.js"></script>\n<script src="/javascripts/effects.js"></script>\n<script src="/javascripts/dragdrop.js"></script>\n<script src="/javascripts/controls.js"></script>\n<script src="/javascripts/rails.js"></script>\n<script src="/javascripts/application.js"></script>),
+    %(javascript_include_tag("bank", :defaults)) => %(<script src="/javascripts/bank.js"></script>\n<script src="/javascripts/prototype.js"></script>\n<script src="/javascripts/effects.js"></script>\n<script src="/javascripts/dragdrop.js"></script>\n<script src="/javascripts/controls.js"></script>\n<script src="/javascripts/rails.js"></script>\n<script src="/javascripts/application.js"></script>),
 
-    %(javascript_include_tag("http://example.com/all")) => %(<script src="http://example.com/all" type="text/javascript"></script>),
-    %(javascript_include_tag("http://example.com/all.js")) => %(<script src="http://example.com/all.js" type="text/javascript"></script>),
-    %(javascript_include_tag("//example.com/all.js")) => %(<script src="//example.com/all.js" type="text/javascript"></script>),
+    %(javascript_include_tag("http://example.com/all")) => %(<script src="http://example.com/all"></script>),
+    %(javascript_include_tag("http://example.com/all.js")) => %(<script src="http://example.com/all.js"></script>),
+    %(javascript_include_tag("//example.com/all.js")) => %(<script src="//example.com/all.js"></script>),
   }
 
   StylePathToTag = {
@@ -147,19 +147,19 @@ class AssetTagHelperTest < ActionView::TestCase
   }
 
   StyleLinkToTag = {
-    %(stylesheet_link_tag("bank")) => %(<link href="/stylesheets/bank.css" media="screen" rel="stylesheet" type="text/css" />),
-    %(stylesheet_link_tag("bank.css")) => %(<link href="/stylesheets/bank.css" media="screen" rel="stylesheet" type="text/css" />),
-    %(stylesheet_link_tag("/elsewhere/file")) => %(<link href="/elsewhere/file.css" media="screen" rel="stylesheet" type="text/css" />),
-    %(stylesheet_link_tag("subdir/subdir")) => %(<link href="/stylesheets/subdir/subdir.css" media="screen" rel="stylesheet" type="text/css" />),
-    %(stylesheet_link_tag("bank", :media => "all")) => %(<link href="/stylesheets/bank.css" media="all" rel="stylesheet" type="text/css" />),
-    %(stylesheet_link_tag(:all)) => %(<link href="/stylesheets/bank.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/robber.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/version.1.0.css" media="screen" rel="stylesheet" type="text/css" />),
-    %(stylesheet_link_tag(:all, :recursive => true)) => %(<link href="/stylesheets/bank.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/robber.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/subdir/subdir.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/version.1.0.css" media="screen" rel="stylesheet" type="text/css" />),
-    %(stylesheet_link_tag(:all, :media => "all")) => %(<link href="/stylesheets/bank.css" media="all" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/robber.css" media="all" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/version.1.0.css" media="all" rel="stylesheet" type="text/css" />),
-    %(stylesheet_link_tag("random.styles", "/elsewhere/file")) => %(<link href="/stylesheets/random.styles" media="screen" rel="stylesheet" type="text/css" />\n<link href="/elsewhere/file.css" media="screen" rel="stylesheet" type="text/css" />),
+    %(stylesheet_link_tag("bank")) => %(<link href="/stylesheets/bank.css" media="screen" rel="stylesheet" />),
+    %(stylesheet_link_tag("bank.css")) => %(<link href="/stylesheets/bank.css" media="screen" rel="stylesheet" />),
+    %(stylesheet_link_tag("/elsewhere/file")) => %(<link href="/elsewhere/file.css" media="screen" rel="stylesheet" />),
+    %(stylesheet_link_tag("subdir/subdir")) => %(<link href="/stylesheets/subdir/subdir.css" media="screen" rel="stylesheet" />),
+    %(stylesheet_link_tag("bank", :media => "all")) => %(<link href="/stylesheets/bank.css" media="all" rel="stylesheet" />),
+    %(stylesheet_link_tag(:all)) => %(<link href="/stylesheets/bank.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/robber.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/version.1.0.css" media="screen" rel="stylesheet" />),
+    %(stylesheet_link_tag(:all, :recursive => true)) => %(<link href="/stylesheets/bank.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/robber.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/subdir/subdir.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/version.1.0.css" media="screen" rel="stylesheet" />),
+    %(stylesheet_link_tag(:all, :media => "all")) => %(<link href="/stylesheets/bank.css" media="all" rel="stylesheet" />\n<link href="/stylesheets/robber.css" media="all" rel="stylesheet" />\n<link href="/stylesheets/version.1.0.css" media="all" rel="stylesheet" />),
+    %(stylesheet_link_tag("random.styles", "/elsewhere/file")) => %(<link href="/stylesheets/random.styles" media="screen" rel="stylesheet" />\n<link href="/elsewhere/file.css" media="screen" rel="stylesheet" />),
 
-    %(stylesheet_link_tag("http://www.example.com/styles/style")) => %(<link href="http://www.example.com/styles/style" media="screen" rel="stylesheet" type="text/css" />),
-    %(stylesheet_link_tag("http://www.example.com/styles/style.css")) => %(<link href="http://www.example.com/styles/style.css" media="screen" rel="stylesheet" type="text/css" />),
-    %(stylesheet_link_tag("//www.example.com/styles/style.css")) => %(<link href="//www.example.com/styles/style.css" media="screen" rel="stylesheet" type="text/css" />),
+    %(stylesheet_link_tag("http://www.example.com/styles/style")) => %(<link href="http://www.example.com/styles/style" media="screen" rel="stylesheet" />),
+    %(stylesheet_link_tag("http://www.example.com/styles/style.css")) => %(<link href="http://www.example.com/styles/style.css" media="screen" rel="stylesheet" />),
+    %(stylesheet_link_tag("//www.example.com/styles/style.css")) => %(<link href="//www.example.com/styles/style.css" media="screen" rel="stylesheet" />),
   }
 
   ImagePathToTag = {
@@ -340,7 +340,7 @@ class AssetTagHelperTest < ActionView::TestCase
 
   def test_javascript_include_tag_with_given_asset_id
     ENV["RAILS_ASSET_ID"] = "1"
-    assert_dom_equal(%(<script src="/javascripts/prototype.js?1" type="text/javascript"></script>\n<script src="/javascripts/effects.js?1" type="text/javascript"></script>\n<script src="/javascripts/dragdrop.js?1" type="text/javascript"></script>\n<script src="/javascripts/controls.js?1" type="text/javascript"></script>\n<script src="/javascripts/rails.js?1" type="text/javascript"></script>\n<script src="/javascripts/application.js?1" type="text/javascript"></script>), javascript_include_tag(:defaults))
+    assert_dom_equal(%(<script src="/javascripts/prototype.js?1"></script>\n<script src="/javascripts/effects.js?1"></script>\n<script src="/javascripts/dragdrop.js?1"></script>\n<script src="/javascripts/controls.js?1"></script>\n<script src="/javascripts/rails.js?1"></script>\n<script src="/javascripts/application.js?1"></script>), javascript_include_tag(:defaults))
   end
 
   def test_javascript_include_tag_is_html_safe
@@ -351,35 +351,35 @@ class AssetTagHelperTest < ActionView::TestCase
   def test_custom_javascript_expansions
     ENV["RAILS_ASSET_ID"] = ""
     ActionView::Helpers::AssetTagHelper::register_javascript_expansion :robbery => ["bank", "robber"]
-    assert_dom_equal  %(<script src="/javascripts/controls.js" type="text/javascript"></script>\n<script src="/javascripts/bank.js" type="text/javascript"></script>\n<script src="/javascripts/robber.js" type="text/javascript"></script>\n<script src="/javascripts/effects.js" type="text/javascript"></script>), javascript_include_tag('controls', :robbery, 'effects')
+    assert_dom_equal  %(<script src="/javascripts/controls.js"></script>\n<script src="/javascripts/bank.js"></script>\n<script src="/javascripts/robber.js"></script>\n<script src="/javascripts/effects.js"></script>), javascript_include_tag('controls', :robbery, 'effects')
   end
 
   def test_custom_javascript_expansions_return_unique_set
     ENV["RAILS_ASSET_ID"] = ""
     ActionView::Helpers::AssetTagHelper::register_javascript_expansion :defaults => %w(prototype effects dragdrop controls rails application)
-    assert_dom_equal  %(<script src="/javascripts/prototype.js" type="text/javascript"></script>\n<script src="/javascripts/effects.js" type="text/javascript"></script>\n<script src="/javascripts/dragdrop.js" type="text/javascript"></script>\n<script src="/javascripts/controls.js" type="text/javascript"></script>\n<script src="/javascripts/rails.js" type="text/javascript"></script>\n<script src="/javascripts/application.js" type="text/javascript"></script>), javascript_include_tag(:defaults)
+    assert_dom_equal  %(<script src="/javascripts/prototype.js"></script>\n<script src="/javascripts/effects.js"></script>\n<script src="/javascripts/dragdrop.js"></script>\n<script src="/javascripts/controls.js"></script>\n<script src="/javascripts/rails.js"></script>\n<script src="/javascripts/application.js"></script>), javascript_include_tag(:defaults)
   end
 
   def test_custom_javascript_expansions_and_defaults_puts_application_js_at_the_end
     ENV["RAILS_ASSET_ID"] = ""
     ActionView::Helpers::AssetTagHelper::register_javascript_expansion :robbery => ["bank", "robber"]
-    assert_dom_equal  %(<script src="/javascripts/controls.js" type="text/javascript"></script>\n<script src="/javascripts/prototype.js" type="text/javascript"></script>\n<script src="/javascripts/dragdrop.js" type="text/javascript"></script>\n<script src="/javascripts/rails.js" type="text/javascript"></script>\n<script src="/javascripts/bank.js" type="text/javascript"></script>\n<script src="/javascripts/robber.js" type="text/javascript"></script>\n<script src="/javascripts/effects.js" type="text/javascript"></script>\n<script src="/javascripts/application.js" type="text/javascript"></script>), javascript_include_tag('controls',:defaults, :robbery, 'effects')
+    assert_dom_equal  %(<script src="/javascripts/controls.js"></script>\n<script src="/javascripts/prototype.js"></script>\n<script src="/javascripts/dragdrop.js"></script>\n<script src="/javascripts/rails.js"></script>\n<script src="/javascripts/bank.js"></script>\n<script src="/javascripts/robber.js"></script>\n<script src="/javascripts/effects.js"></script>\n<script src="/javascripts/application.js"></script>), javascript_include_tag('controls',:defaults, :robbery, 'effects')
   end
 
   def test_javascript_include_tag_should_not_output_the_same_asset_twice
     ENV["RAILS_ASSET_ID"] = ""
-    assert_dom_equal  %(<script src="/javascripts/prototype.js" type="text/javascript"></script>\n<script src="/javascripts/effects.js" type="text/javascript"></script>\n<script src="/javascripts/dragdrop.js" type="text/javascript"></script>\n<script src="/javascripts/controls.js" type="text/javascript"></script>\n<script src="/javascripts/rails.js" type="text/javascript"></script>\n<script src="/javascripts/application.js" type="text/javascript"></script>), javascript_include_tag('prototype', 'effects', :defaults)
+    assert_dom_equal  %(<script src="/javascripts/prototype.js"></script>\n<script src="/javascripts/effects.js"></script>\n<script src="/javascripts/dragdrop.js"></script>\n<script src="/javascripts/controls.js"></script>\n<script src="/javascripts/rails.js"></script>\n<script src="/javascripts/application.js"></script>), javascript_include_tag('prototype', 'effects', :defaults)
   end
 
   def test_javascript_include_tag_should_not_output_the_same_expansion_twice
     ENV["RAILS_ASSET_ID"] = ""
-    assert_dom_equal  %(<script src="/javascripts/prototype.js" type="text/javascript"></script>\n<script src="/javascripts/effects.js" type="text/javascript"></script>\n<script src="/javascripts/dragdrop.js" type="text/javascript"></script>\n<script src="/javascripts/controls.js" type="text/javascript"></script>\n<script src="/javascripts/rails.js" type="text/javascript"></script>\n<script src="/javascripts/application.js" type="text/javascript"></script>), javascript_include_tag(:defaults, :defaults)
+    assert_dom_equal  %(<script src="/javascripts/prototype.js"></script>\n<script src="/javascripts/effects.js"></script>\n<script src="/javascripts/dragdrop.js"></script>\n<script src="/javascripts/controls.js"></script>\n<script src="/javascripts/rails.js"></script>\n<script src="/javascripts/application.js"></script>), javascript_include_tag(:defaults, :defaults)
   end
 
   def test_single_javascript_asset_keys_should_take_precedence_over_expansions
     ENV["RAILS_ASSET_ID"] = ""
-    assert_dom_equal  %(<script src="/javascripts/controls.js" type="text/javascript"></script>\n<script src="/javascripts/prototype.js" type="text/javascript"></script>\n<script src="/javascripts/dragdrop.js" type="text/javascript"></script>\n<script src="/javascripts/rails.js" type="text/javascript"></script>\n<script src="/javascripts/effects.js" type="text/javascript"></script>\n<script src="/javascripts/application.js" type="text/javascript"></script>), javascript_include_tag('controls', :defaults, 'effects')
-    assert_dom_equal  %(<script src="/javascripts/controls.js" type="text/javascript"></script>\n<script src="/javascripts/effects.js" type="text/javascript"></script>\n<script src="/javascripts/prototype.js" type="text/javascript"></script>\n<script src="/javascripts/dragdrop.js" type="text/javascript"></script>\n<script src="/javascripts/rails.js" type="text/javascript"></script>\n<script src="/javascripts/application.js" type="text/javascript"></script>), javascript_include_tag('controls', 'effects', :defaults)
+    assert_dom_equal  %(<script src="/javascripts/controls.js"></script>\n<script src="/javascripts/prototype.js"></script>\n<script src="/javascripts/dragdrop.js"></script>\n<script src="/javascripts/rails.js"></script>\n<script src="/javascripts/effects.js"></script>\n<script src="/javascripts/application.js"></script>), javascript_include_tag('controls', :defaults, 'effects')
+    assert_dom_equal  %(<script src="/javascripts/controls.js"></script>\n<script src="/javascripts/effects.js"></script>\n<script src="/javascripts/prototype.js"></script>\n<script src="/javascripts/dragdrop.js"></script>\n<script src="/javascripts/rails.js"></script>\n<script src="/javascripts/application.js"></script>), javascript_include_tag('controls', 'effects', :defaults)
   end
 
   def test_registering_javascript_expansions_merges_with_existing_expansions
@@ -387,7 +387,7 @@ class AssetTagHelperTest < ActionView::TestCase
     ActionView::Helpers::AssetTagHelper::register_javascript_expansion :can_merge => ['bank']
     ActionView::Helpers::AssetTagHelper::register_javascript_expansion :can_merge => ['robber']
     ActionView::Helpers::AssetTagHelper::register_javascript_expansion :can_merge => ['bank']
-    assert_dom_equal  %(<script src="/javascripts/bank.js" type="text/javascript"></script>\n<script src="/javascripts/robber.js" type="text/javascript"></script>), javascript_include_tag(:can_merge)
+    assert_dom_equal  %(<script src="/javascripts/bank.js"></script>\n<script src="/javascripts/robber.js"></script>), javascript_include_tag(:can_merge)
   end
 
   def test_custom_javascript_expansions_with_undefined_symbol
@@ -396,20 +396,20 @@ class AssetTagHelperTest < ActionView::TestCase
 
   def test_custom_javascript_expansions_with_nil_value
     ActionView::Helpers::AssetTagHelper::register_javascript_expansion :monkey => nil
-    assert_dom_equal  %(<script src="/javascripts/first.js" type="text/javascript"></script>\n<script src="/javascripts/last.js" type="text/javascript"></script>), javascript_include_tag('first', :monkey, 'last')
+    assert_dom_equal  %(<script src="/javascripts/first.js"></script>\n<script src="/javascripts/last.js"></script>), javascript_include_tag('first', :monkey, 'last')
   end
 
   def test_custom_javascript_expansions_with_empty_array_value
     ActionView::Helpers::AssetTagHelper::register_javascript_expansion :monkey => []
-    assert_dom_equal  %(<script src="/javascripts/first.js" type="text/javascript"></script>\n<script src="/javascripts/last.js" type="text/javascript"></script>), javascript_include_tag('first', :monkey, 'last')
+    assert_dom_equal  %(<script src="/javascripts/first.js"></script>\n<script src="/javascripts/last.js"></script>), javascript_include_tag('first', :monkey, 'last')
   end
 
   def test_custom_javascript_and_stylesheet_expansion_with_same_name
     ENV["RAILS_ASSET_ID"] = ""
     ActionView::Helpers::AssetTagHelper::register_javascript_expansion :robbery => ["bank", "robber"]
     ActionView::Helpers::AssetTagHelper::register_stylesheet_expansion :robbery => ["money", "security"]
-    assert_dom_equal  %(<script src="/javascripts/controls.js" type="text/javascript"></script>\n<script src="/javascripts/bank.js" type="text/javascript"></script>\n<script src="/javascripts/robber.js" type="text/javascript"></script>\n<script src="/javascripts/effects.js" type="text/javascript"></script>), javascript_include_tag('controls', :robbery, 'effects')
-    assert_dom_equal  %(<link href="/stylesheets/style.css" rel="stylesheet" type="text/css" media="screen" />\n<link href="/stylesheets/money.css" rel="stylesheet" type="text/css" media="screen" />\n<link href="/stylesheets/security.css" rel="stylesheet" type="text/css" media="screen" />\n<link href="/stylesheets/print.css" rel="stylesheet" type="text/css" media="screen" />), stylesheet_link_tag('style', :robbery, 'print')
+    assert_dom_equal  %(<script src="/javascripts/controls.js"></script>\n<script src="/javascripts/bank.js"></script>\n<script src="/javascripts/robber.js"></script>\n<script src="/javascripts/effects.js"></script>), javascript_include_tag('controls', :robbery, 'effects')
+    assert_dom_equal  %(<link href="/stylesheets/style.css" rel="stylesheet" media="screen" />\n<link href="/stylesheets/money.css" rel="stylesheet" media="screen" />\n<link href="/stylesheets/security.css" rel="stylesheet" media="screen" />\n<link href="/stylesheets/print.css" rel="stylesheet" media="screen" />), stylesheet_link_tag('style', :robbery, 'print')
   end
 
   def test_reset_javascript_expansions
@@ -457,36 +457,36 @@ class AssetTagHelperTest < ActionView::TestCase
   end
 
   def test_stylesheet_link_tag_escapes_options
-    assert_dom_equal %(<link href="/file.css" media="&lt;script&gt;" rel="stylesheet" type="text/css" />), stylesheet_link_tag('/file', :media => '<script>')
+    assert_dom_equal %(<link href="/file.css" media="&lt;script&gt;" rel="stylesheet" />), stylesheet_link_tag('/file', :media => '<script>')
   end
 
   def test_custom_stylesheet_expansions
     ENV["RAILS_ASSET_ID"] = ''
     ActionView::Helpers::AssetTagHelper::register_stylesheet_expansion :robbery => ["bank", "robber"]
-    assert_dom_equal  %(<link href="/stylesheets/version.1.0.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/bank.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/robber.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/subdir/subdir.css" media="screen" rel="stylesheet" type="text/css" />), stylesheet_link_tag('version.1.0', :robbery, 'subdir/subdir')
+    assert_dom_equal  %(<link href="/stylesheets/version.1.0.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/bank.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/robber.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/subdir/subdir.css" media="screen" rel="stylesheet" />), stylesheet_link_tag('version.1.0', :robbery, 'subdir/subdir')
   end
 
   def test_custom_stylesheet_expansions_return_unique_set
     ENV["RAILS_ASSET_ID"] = ""
     ActionView::Helpers::AssetTagHelper::register_stylesheet_expansion :cities => %w(wellington amsterdam london)
-    assert_dom_equal  %(<link href="/stylesheets/wellington.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/amsterdam.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/london.css" media="screen" rel="stylesheet" type="text/css" />), stylesheet_link_tag(:cities)
+    assert_dom_equal  %(<link href="/stylesheets/wellington.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/amsterdam.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/london.css" media="screen" rel="stylesheet" />), stylesheet_link_tag(:cities)
   end
 
   def test_stylesheet_link_tag_should_not_output_the_same_asset_twice
     ENV["RAILS_ASSET_ID"] = ""
-    assert_dom_equal  %(<link href="/stylesheets/wellington.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/amsterdam.css" media="screen" rel="stylesheet" type="text/css" />), stylesheet_link_tag('wellington', 'wellington', 'amsterdam')
+    assert_dom_equal  %(<link href="/stylesheets/wellington.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/amsterdam.css" media="screen" rel="stylesheet" />), stylesheet_link_tag('wellington', 'wellington', 'amsterdam')
   end
 
   def test_stylesheet_link_tag_should_not_output_the_same_expansion_twice
     ENV["RAILS_ASSET_ID"] = ""
     ActionView::Helpers::AssetTagHelper::register_stylesheet_expansion :cities => %w(wellington amsterdam london)
-    assert_dom_equal  %(<link href="/stylesheets/wellington.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/amsterdam.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/london.css" media="screen" rel="stylesheet" type="text/css" />), stylesheet_link_tag(:cities, :cities)
+    assert_dom_equal  %(<link href="/stylesheets/wellington.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/amsterdam.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/london.css" media="screen" rel="stylesheet" />), stylesheet_link_tag(:cities, :cities)
   end
 
   def test_single_stylesheet_asset_keys_should_take_precedence_over_expansions
     ENV["RAILS_ASSET_ID"] = ""
     ActionView::Helpers::AssetTagHelper::register_stylesheet_expansion :cities => %w(wellington amsterdam london)
-    assert_dom_equal  %(<link href="/stylesheets/london.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/wellington.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/amsterdam.css" media="screen" rel="stylesheet" type="text/css" />), stylesheet_link_tag('london', :cities)
+    assert_dom_equal  %(<link href="/stylesheets/london.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/wellington.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/amsterdam.css" media="screen" rel="stylesheet" />), stylesheet_link_tag('london', :cities)
   end
 
   def test_custom_stylesheet_expansions_with_unknown_symbol
@@ -495,12 +495,12 @@ class AssetTagHelperTest < ActionView::TestCase
 
   def test_custom_stylesheet_expansions_with_nil_value
     ActionView::Helpers::AssetTagHelper::register_stylesheet_expansion :monkey => nil
-    assert_dom_equal  %(<link href="/stylesheets/first.css" rel="stylesheet" type="text/css" media="screen" />\n<link href="/stylesheets/last.css" rel="stylesheet" type="text/css" media="screen" />), stylesheet_link_tag('first', :monkey, 'last')
+    assert_dom_equal  %(<link href="/stylesheets/first.css" rel="stylesheet" media="screen" />\n<link href="/stylesheets/last.css" rel="stylesheet" media="screen" />), stylesheet_link_tag('first', :monkey, 'last')
   end
 
   def test_custom_stylesheet_expansions_with_empty_array_value
     ActionView::Helpers::AssetTagHelper::register_stylesheet_expansion :monkey => []
-    assert_dom_equal  %(<link href="/stylesheets/first.css" rel="stylesheet" type="text/css" media="screen" />\n<link href="/stylesheets/last.css" rel="stylesheet" type="text/css" media="screen" />), stylesheet_link_tag('first', :monkey, 'last')
+    assert_dom_equal  %(<link href="/stylesheets/first.css" rel="stylesheet" media="screen" />\n<link href="/stylesheets/last.css" rel="stylesheet" media="screen" />), stylesheet_link_tag('first', :monkey, 'last')
   end
 
   def test_registering_stylesheet_expansions_merges_with_existing_expansions
@@ -508,7 +508,7 @@ class AssetTagHelperTest < ActionView::TestCase
     ActionView::Helpers::AssetTagHelper::register_stylesheet_expansion :can_merge => ['bank']
     ActionView::Helpers::AssetTagHelper::register_stylesheet_expansion :can_merge => ['robber']
     ActionView::Helpers::AssetTagHelper::register_stylesheet_expansion :can_merge => ['bank']
-    assert_dom_equal  %(<link href="/stylesheets/bank.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/robber.css" media="screen" rel="stylesheet" type="text/css" />), stylesheet_link_tag(:can_merge)
+    assert_dom_equal  %(<link href="/stylesheets/bank.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/robber.css" media="screen" rel="stylesheet" />), stylesheet_link_tag(:can_merge)
   end
 
   def test_image_path
@@ -703,21 +703,21 @@ class AssetTagHelperTest < ActionView::TestCase
     config.perform_caching = true
 
     assert_dom_equal(
-      %(<script src="http://a0.example.com/javascripts/all.js" type="text/javascript"></script>),
+      %(<script src="http://a0.example.com/javascripts/all.js"></script>),
       javascript_include_tag(:all, :cache => true)
     )
 
     assert File.exist?(File.join(ActionView::Helpers::AssetTagHelper::JAVASCRIPTS_DIR, 'all.js'))
 
     assert_dom_equal(
-      %(<script src="http://a0.example.com/javascripts/money.js" type="text/javascript"></script>),
+      %(<script src="http://a0.example.com/javascripts/money.js"></script>),
       javascript_include_tag(:all, :cache => "money")
     )
 
     assert File.exist?(File.join(ActionView::Helpers::AssetTagHelper::JAVASCRIPTS_DIR, 'money.js'))
 
     assert_dom_equal(
-      %(<script src="http://a0.example.com/absolute/test.js" type="text/javascript"></script>),
+      %(<script src="http://a0.example.com/absolute/test.js"></script>),
       javascript_include_tag(:all, :cache => "/absolute/test")
     )
 
@@ -736,7 +736,7 @@ class AssetTagHelperTest < ActionView::TestCase
 
     assert_equal '/javascripts/scripts.js'.length, 23
     assert_dom_equal(
-      %(<script src="http://a23.example.com/javascripts/scripts.js" type="text/javascript"></script>),
+      %(<script src="http://a23.example.com/javascripts/scripts.js"></script>),
       javascript_include_tag(:all, :cache => 'scripts')
     )
 
@@ -759,7 +759,7 @@ class AssetTagHelperTest < ActionView::TestCase
 
     assert_equal '/javascripts/vanilla.js'.length, 23
     assert_dom_equal(
-      %(<script src="http://assets23.example.com/javascripts/vanilla.js" type="text/javascript"></script>),
+      %(<script src="http://assets23.example.com/javascripts/vanilla.js"></script>),
       javascript_include_tag(:all, :cache => 'vanilla')
     )
 
@@ -772,7 +772,7 @@ class AssetTagHelperTest < ActionView::TestCase
 
     assert_equal '/javascripts/secure.js'.length, 22
     assert_dom_equal(
-      %(<script src="https://localhost/javascripts/secure.js" type="text/javascript"></script>),
+      %(<script src="https://localhost/javascripts/secure.js"></script>),
       javascript_include_tag(:all, :cache => 'secure')
     )
 
@@ -799,7 +799,7 @@ class AssetTagHelperTest < ActionView::TestCase
 
     assert_equal '/javascripts/vanilla.js'.length, 23
     assert_dom_equal(
-      %(<script src="http://assets23.example.com/javascripts/vanilla.js" type="text/javascript"></script>),
+      %(<script src="http://assets23.example.com/javascripts/vanilla.js"></script>),
       javascript_include_tag(:all, :cache => 'vanilla')
     )
 
@@ -812,7 +812,7 @@ class AssetTagHelperTest < ActionView::TestCase
 
     assert_equal '/javascripts/secure.js'.length, 22
     assert_dom_equal(
-      %(<script src="https://localhost/javascripts/secure.js" type="text/javascript"></script>),
+      %(<script src="https://localhost/javascripts/secure.js"></script>),
       javascript_include_tag(:all, :cache => 'secure')
     )
 
@@ -830,7 +830,7 @@ class AssetTagHelperTest < ActionView::TestCase
 
     number = Zlib.crc32('/javascripts/cache/money.js') % 4
     assert_dom_equal(
-      %(<script src="http://a#{number}.example.com/javascripts/cache/money.js" type="text/javascript"></script>),
+      %(<script src="http://a#{number}.example.com/javascripts/cache/money.js"></script>),
       javascript_include_tag(:all, :cache => "cache/money")
     )
 
@@ -845,7 +845,7 @@ class AssetTagHelperTest < ActionView::TestCase
     config.perform_caching = true
 
     assert_dom_equal(
-      %(<script src="http://a0.example.com/javascripts/combined.js" type="text/javascript"></script>),
+      %(<script src="http://a0.example.com/javascripts/combined.js"></script>),
       javascript_include_tag(:all, :cache => "combined", :recursive => true)
     )
 
@@ -866,7 +866,7 @@ class AssetTagHelperTest < ActionView::TestCase
     config.perform_caching = true
 
     assert_dom_equal(
-      %(<script src="http://a0.example.com/javascripts/combined.js" type="text/javascript"></script>),
+      %(<script src="http://a0.example.com/javascripts/combined.js"></script>),
       javascript_include_tag(:all, :cache => "combined")
     )
 
@@ -887,14 +887,14 @@ class AssetTagHelperTest < ActionView::TestCase
     config.perform_caching = true
 
     assert_dom_equal(
-      %(<script src="/collaboration/hieraki/javascripts/all.js" type="text/javascript"></script>),
+      %(<script src="/collaboration/hieraki/javascripts/all.js"></script>),
       javascript_include_tag(:all, :cache => true)
     )
 
     assert File.exist?(File.join(ActionView::Helpers::AssetTagHelper::JAVASCRIPTS_DIR, 'all.js'))
 
     assert_dom_equal(
-      %(<script src="/collaboration/hieraki/javascripts/money.js" type="text/javascript"></script>),
+      %(<script src="/collaboration/hieraki/javascripts/money.js"></script>),
       javascript_include_tag(:all, :cache => "money")
     )
 
@@ -912,14 +912,14 @@ class AssetTagHelperTest < ActionView::TestCase
     config.perform_caching = true
 
     assert_dom_equal(
-      %(<script src="/collaboration/hieraki/javascripts/all.js" type="text/javascript"></script>),
+      %(<script src="/collaboration/hieraki/javascripts/all.js"></script>),
       javascript_include_tag(:all, :cache => true)
     )
 
     assert File.exist?(File.join(ActionView::Helpers::AssetTagHelper::JAVASCRIPTS_DIR, 'all.js'))
 
     assert_dom_equal(
-      %(<script src="/collaboration/hieraki/javascripts/money.js" type="text/javascript"></script>),
+      %(<script src="/collaboration/hieraki/javascripts/money.js"></script>),
       javascript_include_tag(:all, :cache => "money")
     )
 
@@ -936,14 +936,14 @@ class AssetTagHelperTest < ActionView::TestCase
     config.perform_caching = false
 
     assert_dom_equal(
-      %(<script src="/collaboration/hieraki/javascripts/robber.js" type="text/javascript"></script>),
+      %(<script src="/collaboration/hieraki/javascripts/robber.js"></script>),
       javascript_include_tag('robber', :cache => true)
     )
 
     assert !File.exist?(File.join(ActionView::Helpers::AssetTagHelper::JAVASCRIPTS_DIR, 'all.js'))
 
     assert_dom_equal(
-      %(<script src="/collaboration/hieraki/javascripts/robber.js" type="text/javascript"></script>),
+      %(<script src="/collaboration/hieraki/javascripts/robber.js"></script>),
       javascript_include_tag('robber', :cache => "money", :recursive => true)
     )
 
@@ -957,14 +957,14 @@ class AssetTagHelperTest < ActionView::TestCase
     config.perform_caching = false
 
     assert_dom_equal(
-      %(<script src="/collaboration/hieraki/javascripts/robber.js" type="text/javascript"></script>),
+      %(<script src="/collaboration/hieraki/javascripts/robber.js"></script>),
       javascript_include_tag('robber', :cache => true)
     )
 
     assert !File.exist?(File.join(ActionView::Helpers::AssetTagHelper::JAVASCRIPTS_DIR, 'all.js'))
 
     assert_dom_equal(
-      %(<script src="/collaboration/hieraki/javascripts/robber.js" type="text/javascript"></script>),
+      %(<script src="/collaboration/hieraki/javascripts/robber.js"></script>),
       javascript_include_tag('robber', :cache => "money", :recursive => true)
     )
 
@@ -976,24 +976,24 @@ class AssetTagHelperTest < ActionView::TestCase
     config.perform_caching = false
 
     assert_dom_equal(
-      %(<script src="/javascripts/prototype.js" type="text/javascript"></script>\n<script src="/javascripts/effects.js" type="text/javascript"></script>\n<script src="/javascripts/dragdrop.js" type="text/javascript"></script>\n<script src="/javascripts/controls.js" type="text/javascript"></script>\n<script src="/javascripts/bank.js" type="text/javascript"></script>\n<script src="/javascripts/robber.js" type="text/javascript"></script>\n<script src="/javascripts/version.1.0.js" type="text/javascript"></script>\n<script src="/javascripts/application.js" type="text/javascript"></script>),
+      %(<script src="/javascripts/prototype.js"></script>\n<script src="/javascripts/effects.js"></script>\n<script src="/javascripts/dragdrop.js"></script>\n<script src="/javascripts/controls.js"></script>\n<script src="/javascripts/bank.js"></script>\n<script src="/javascripts/robber.js"></script>\n<script src="/javascripts/version.1.0.js"></script>\n<script src="/javascripts/application.js"></script>),
       javascript_include_tag(:all, :cache => true)
     )
 
     assert_dom_equal(
-      %(<script src="/javascripts/prototype.js" type="text/javascript"></script>\n<script src="/javascripts/effects.js" type="text/javascript"></script>\n<script src="/javascripts/dragdrop.js" type="text/javascript"></script>\n<script src="/javascripts/controls.js" type="text/javascript"></script>\n<script src="/javascripts/bank.js" type="text/javascript"></script>\n<script src="/javascripts/robber.js" type="text/javascript"></script>\n<script src="/javascripts/subdir/subdir.js" type="text/javascript"></script>\n<script src="/javascripts/version.1.0.js" type="text/javascript"></script>\n<script src="/javascripts/application.js" type="text/javascript"></script>),
+      %(<script src="/javascripts/prototype.js"></script>\n<script src="/javascripts/effects.js"></script>\n<script src="/javascripts/dragdrop.js"></script>\n<script src="/javascripts/controls.js"></script>\n<script src="/javascripts/bank.js"></script>\n<script src="/javascripts/robber.js"></script>\n<script src="/javascripts/subdir/subdir.js"></script>\n<script src="/javascripts/version.1.0.js"></script>\n<script src="/javascripts/application.js"></script>),
       javascript_include_tag(:all, :cache => true, :recursive => true)
     )
 
     assert !File.exist?(File.join(ActionView::Helpers::AssetTagHelper::JAVASCRIPTS_DIR, 'all.js'))
 
     assert_dom_equal(
-      %(<script src="/javascripts/prototype.js" type="text/javascript"></script>\n<script src="/javascripts/effects.js" type="text/javascript"></script>\n<script src="/javascripts/dragdrop.js" type="text/javascript"></script>\n<script src="/javascripts/controls.js" type="text/javascript"></script>\n<script src="/javascripts/bank.js" type="text/javascript"></script>\n<script src="/javascripts/robber.js" type="text/javascript"></script>\n<script src="/javascripts/version.1.0.js" type="text/javascript"></script>\n<script src="/javascripts/application.js" type="text/javascript"></script>),
+      %(<script src="/javascripts/prototype.js"></script>\n<script src="/javascripts/effects.js"></script>\n<script src="/javascripts/dragdrop.js"></script>\n<script src="/javascripts/controls.js"></script>\n<script src="/javascripts/bank.js"></script>\n<script src="/javascripts/robber.js"></script>\n<script src="/javascripts/version.1.0.js"></script>\n<script src="/javascripts/application.js"></script>),
       javascript_include_tag(:all, :cache => "money")
     )
 
     assert_dom_equal(
-      %(<script src="/javascripts/prototype.js" type="text/javascript"></script>\n<script src="/javascripts/effects.js" type="text/javascript"></script>\n<script src="/javascripts/dragdrop.js" type="text/javascript"></script>\n<script src="/javascripts/controls.js" type="text/javascript"></script>\n<script src="/javascripts/bank.js" type="text/javascript"></script>\n<script src="/javascripts/robber.js" type="text/javascript"></script>\n<script src="/javascripts/subdir/subdir.js" type="text/javascript"></script>\n<script src="/javascripts/version.1.0.js" type="text/javascript"></script>\n<script src="/javascripts/application.js" type="text/javascript"></script>),
+      %(<script src="/javascripts/prototype.js"></script>\n<script src="/javascripts/effects.js"></script>\n<script src="/javascripts/dragdrop.js"></script>\n<script src="/javascripts/controls.js"></script>\n<script src="/javascripts/bank.js"></script>\n<script src="/javascripts/robber.js"></script>\n<script src="/javascripts/subdir/subdir.js"></script>\n<script src="/javascripts/version.1.0.js"></script>\n<script src="/javascripts/application.js"></script>),
       javascript_include_tag(:all, :cache => "money", :recursive => true)
     )
 
@@ -1051,7 +1051,7 @@ class AssetTagHelperTest < ActionView::TestCase
     config.perform_caching = true
 
     assert_dom_equal(
-      %(<link href="http://a0.example.com/stylesheets/all.css" media="screen" rel="stylesheet" type="text/css" />),
+      %(<link href="http://a0.example.com/stylesheets/all.css" media="screen" rel="stylesheet" />),
       stylesheet_link_tag(:all, :cache => true)
     )
 
@@ -1065,14 +1065,14 @@ class AssetTagHelperTest < ActionView::TestCase
     assert_equal expected_size, File.size(File.join(ActionView::Helpers::AssetTagHelper::STYLESHEETS_DIR, 'all.css'))
 
     assert_dom_equal(
-      %(<link href="http://a0.example.com/stylesheets/money.css" media="screen" rel="stylesheet" type="text/css" />),
+      %(<link href="http://a0.example.com/stylesheets/money.css" media="screen" rel="stylesheet" />),
       stylesheet_link_tag(:all, :cache => "money")
     )
 
     assert File.exist?(File.join(ActionView::Helpers::AssetTagHelper::STYLESHEETS_DIR, 'money.css'))
 
     assert_dom_equal(
-      %(<link href="http://a0.example.com/absolute/test.css" media="screen" rel="stylesheet" type="text/css" />),
+      %(<link href="http://a0.example.com/absolute/test.css" media="screen" rel="stylesheet" />),
       stylesheet_link_tag(:all, :cache => "/absolute/test")
     )
 
@@ -1087,7 +1087,7 @@ class AssetTagHelperTest < ActionView::TestCase
     ENV["RAILS_ASSET_ID"] = ""
 
     assert_dom_equal(
-      %(<link href="/stylesheets/all.css" media="screen" rel="stylesheet" type="text/css" />),
+      %(<link href="/stylesheets/all.css" media="screen" rel="stylesheet" />),
       stylesheet_link_tag(:all, :concat => true)
     )
 
@@ -1095,14 +1095,14 @@ class AssetTagHelperTest < ActionView::TestCase
     assert_equal expected, File.mtime(File.join(ActionView::Helpers::AssetTagHelper::STYLESHEETS_DIR, 'all.css'))
 
     assert_dom_equal(
-      %(<link href="/stylesheets/money.css" media="screen" rel="stylesheet" type="text/css" />),
+      %(<link href="/stylesheets/money.css" media="screen" rel="stylesheet" />),
       stylesheet_link_tag(:all, :concat => "money")
     )
 
     assert File.exist?(File.join(ActionView::Helpers::AssetTagHelper::STYLESHEETS_DIR, 'money.css'))
 
     assert_dom_equal(
-      %(<link href="/absolute/test.css" media="screen" rel="stylesheet" type="text/css" />),
+      %(<link href="/absolute/test.css" media="screen" rel="stylesheet" />),
       stylesheet_link_tag(:all, :concat => "/absolute/test")
     )
 
@@ -1162,7 +1162,7 @@ class AssetTagHelperTest < ActionView::TestCase
 
     assert_equal '/stylesheets/styles.css'.length, 23
     assert_dom_equal(
-      %(<link href="http://a23.example.com/stylesheets/styles.css" media="screen" rel="stylesheet" type="text/css" />),
+      %(<link href="http://a23.example.com/stylesheets/styles.css" media="screen" rel="stylesheet" />),
       stylesheet_link_tag(:all, :cache => 'styles')
     )
 
@@ -1178,7 +1178,7 @@ class AssetTagHelperTest < ActionView::TestCase
     config.perform_caching = true
 
     assert_dom_equal(
-      %(<link href="/collaboration/hieraki/stylesheets/all.css" media="screen" rel="stylesheet" type="text/css" />),
+      %(<link href="/collaboration/hieraki/stylesheets/all.css" media="screen" rel="stylesheet" />),
       stylesheet_link_tag(:all, :cache => true)
     )
 
@@ -1188,7 +1188,7 @@ class AssetTagHelperTest < ActionView::TestCase
     assert_equal expected_mtime, File.mtime(File.join(ActionView::Helpers::AssetTagHelper::STYLESHEETS_DIR, 'all.css'))
 
     assert_dom_equal(
-      %(<link href="/collaboration/hieraki/stylesheets/money.css" media="screen" rel="stylesheet" type="text/css" />),
+      %(<link href="/collaboration/hieraki/stylesheets/money.css" media="screen" rel="stylesheet" />),
       stylesheet_link_tag(:all, :cache => "money")
     )
 
@@ -1205,7 +1205,7 @@ class AssetTagHelperTest < ActionView::TestCase
     config.perform_caching = true
 
     assert_dom_equal(
-      %(<link href="/collaboration/hieraki/stylesheets/all.css" media="screen" rel="stylesheet" type="text/css" />),
+      %(<link href="/collaboration/hieraki/stylesheets/all.css" media="screen" rel="stylesheet" />),
       stylesheet_link_tag(:all, :cache => true)
     )
 
@@ -1215,7 +1215,7 @@ class AssetTagHelperTest < ActionView::TestCase
     assert_equal expected_mtime, File.mtime(File.join(ActionView::Helpers::AssetTagHelper::STYLESHEETS_DIR, 'all.css'))
 
     assert_dom_equal(
-      %(<link href="/collaboration/hieraki/stylesheets/money.css" media="screen" rel="stylesheet" type="text/css" />),
+      %(<link href="/collaboration/hieraki/stylesheets/money.css" media="screen" rel="stylesheet" />),
       stylesheet_link_tag(:all, :cache => "money")
     )
 
@@ -1232,14 +1232,14 @@ class AssetTagHelperTest < ActionView::TestCase
     config.perform_caching = false
 
     assert_dom_equal(
-      %(<link href="/collaboration/hieraki/stylesheets/robber.css" media="screen" rel="stylesheet" type="text/css" />),
+      %(<link href="/collaboration/hieraki/stylesheets/robber.css" media="screen" rel="stylesheet" />),
       stylesheet_link_tag('robber', :cache => true)
     )
 
     assert !File.exist?(File.join(ActionView::Helpers::AssetTagHelper::STYLESHEETS_DIR, 'all.css'))
 
     assert_dom_equal(
-      %(<link href="/collaboration/hieraki/stylesheets/robber.css" media="screen" rel="stylesheet" type="text/css" />),
+      %(<link href="/collaboration/hieraki/stylesheets/robber.css" media="screen" rel="stylesheet" />),
       stylesheet_link_tag('robber', :cache => "money")
     )
 
@@ -1253,14 +1253,14 @@ class AssetTagHelperTest < ActionView::TestCase
     config.perform_caching = false
 
     assert_dom_equal(
-      %(<link href="/collaboration/hieraki/stylesheets/robber.css" media="screen" rel="stylesheet" type="text/css" />),
+      %(<link href="/collaboration/hieraki/stylesheets/robber.css" media="screen" rel="stylesheet" />),
       stylesheet_link_tag('robber', :cache => true)
     )
 
     assert !File.exist?(File.join(ActionView::Helpers::AssetTagHelper::STYLESHEETS_DIR, 'all.css'))
 
     assert_dom_equal(
-      %(<link href="/collaboration/hieraki/stylesheets/robber.css" media="screen" rel="stylesheet" type="text/css" />),
+      %(<link href="/collaboration/hieraki/stylesheets/robber.css" media="screen" rel="stylesheet" />),
       stylesheet_link_tag('robber', :cache => "money")
     )
 
@@ -1275,24 +1275,24 @@ class AssetTagHelperTest < ActionView::TestCase
     config.perform_caching = false
 
     assert_dom_equal(
-      %(<link href="/stylesheets/bank.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/robber.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/version.1.0.css" media="screen" rel="stylesheet" type="text/css" />),
+      %(<link href="/stylesheets/bank.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/robber.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/version.1.0.css" media="screen" rel="stylesheet" />),
       stylesheet_link_tag(:all, :cache => true)
     )
 
     assert_dom_equal(
-      %(<link href="/stylesheets/bank.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/robber.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/subdir/subdir.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/version.1.0.css" media="screen" rel="stylesheet" type="text/css" />),
+      %(<link href="/stylesheets/bank.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/robber.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/subdir/subdir.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/version.1.0.css" media="screen" rel="stylesheet" />),
       stylesheet_link_tag(:all, :cache => true, :recursive => true)
     )
 
     assert !File.exist?(File.join(ActionView::Helpers::AssetTagHelper::STYLESHEETS_DIR, 'all.css'))
 
     assert_dom_equal(
-      %(<link href="/stylesheets/bank.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/robber.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/version.1.0.css" media="screen" rel="stylesheet" type="text/css" />),
+      %(<link href="/stylesheets/bank.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/robber.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/version.1.0.css" media="screen" rel="stylesheet" />),
       stylesheet_link_tag(:all, :cache => "money")
     )
 
     assert_dom_equal(
-      %(<link href="/stylesheets/bank.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/robber.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/subdir/subdir.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/stylesheets/version.1.0.css" media="screen" rel="stylesheet" type="text/css" />),
+      %(<link href="/stylesheets/bank.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/robber.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/subdir/subdir.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/version.1.0.css" media="screen" rel="stylesheet" />),
       stylesheet_link_tag(:all, :cache => "money", :recursive => true)
     )
 
@@ -1369,12 +1369,12 @@ class AssetTagHelperNonVhostTest < ActionView::TestCase
 
   def test_should_ignore_asset_host_on_complete_url
     @controller.config.asset_host = "http://assets.example.com"
-    assert_dom_equal(%(<link href="http://bar.example.com/stylesheets/style.css" media="screen" rel="stylesheet" type="text/css" />), stylesheet_link_tag("http://bar.example.com/stylesheets/style.css"))
+    assert_dom_equal(%(<link href="http://bar.example.com/stylesheets/style.css" media="screen" rel="stylesheet" />), stylesheet_link_tag("http://bar.example.com/stylesheets/style.css"))
   end
 
   def test_should_ignore_asset_host_on_scheme_relative_url
     @controller.config.asset_host = "http://assets.example.com"
-    assert_dom_equal(%(<link href="//bar.example.com/stylesheets/style.css" media="screen" rel="stylesheet" type="text/css" />), stylesheet_link_tag("//bar.example.com/stylesheets/style.css"))
+    assert_dom_equal(%(<link href="//bar.example.com/stylesheets/style.css" media="screen" rel="stylesheet" />), stylesheet_link_tag("//bar.example.com/stylesheets/style.css"))
   end
 
   def test_should_wildcard_asset_host_between_zero_and_four

--- a/actionpack/test/template/erb/tag_helper_test.rb
+++ b/actionpack/test/template/erb/tag_helper_test.rb
@@ -11,12 +11,12 @@ module ERBTest
     end
 
     test "percent equals works for javascript_tag" do
-      expected_output = "<script type=\"text/javascript\">\n//<![CDATA[\nalert('Hello')\n//]]>\n</script>"
+      expected_output = "<script>\n//<![CDATA[\nalert('Hello')\n//]]>\n</script>"
       assert_equal expected_output, render_content("javascript_tag", "alert('Hello')")
     end
 
     test "percent equals works for javascript_tag with options" do
-      expected_output = "<script id=\"the_js_tag\" type=\"text/javascript\">\n//<![CDATA[\nalert('Hello')\n//]]>\n</script>"
+      expected_output = "<script id=\"the_js_tag\">\n//<![CDATA[\nalert('Hello')\n//]]>\n</script>"
       assert_equal expected_output, render_content("javascript_tag(:id => 'the_js_tag')", "alert('Hello')")
     end
 

--- a/actionpack/test/template/javascript_helper_test.rb
+++ b/actionpack/test/template/javascript_helper_test.rb
@@ -75,14 +75,14 @@ class JavaScriptHelperTest < ActionView::TestCase
   def test_javascript_tag
     self.output_buffer = 'foo'
 
-    assert_dom_equal "<script type=\"text/javascript\">\n//<![CDATA[\nalert('hello')\n//]]>\n</script>",
+    assert_dom_equal "<script>\n//<![CDATA[\nalert('hello')\n//]]>\n</script>",
       javascript_tag("alert('hello')")
 
     assert_equal 'foo', output_buffer, 'javascript_tag without a block should not concat to output_buffer'
   end
 
   def test_javascript_tag_with_options
-    assert_dom_equal "<script id=\"the_js_tag\" type=\"text/javascript\">\n//<![CDATA[\nalert('hello')\n//]]>\n</script>",
+    assert_dom_equal "<script id=\"the_js_tag\">\n//<![CDATA[\nalert('hello')\n//]]>\n</script>",
       javascript_tag("alert('hello')", :id => "the_js_tag")
   end
 

--- a/actionpack/test/template/url_helper_test.rb
+++ b/actionpack/test/template/url_helper_test.rb
@@ -408,12 +408,12 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   def test_mail_to_with_javascript
     snippet = mail_to("me@domain.com", "My email", :encode => "javascript")
-    assert_dom_equal "<script type=\"text/javascript\">eval(decodeURIComponent('%64%6f%63%75%6d%65%6e%74%2e%77%72%69%74%65%28%27%3c%61%20%68%72%65%66%3d%5c%22%6d%61%69%6c%74%6f%3a%6d%65%40%64%6f%6d%61%69%6e%2e%63%6f%6d%5c%22%3e%4d%79%20%65%6d%61%69%6c%3c%5c%2f%61%3e%27%29%3b'))</script>", snippet
+    assert_dom_equal "<script>eval(decodeURIComponent('%64%6f%63%75%6d%65%6e%74%2e%77%72%69%74%65%28%27%3c%61%20%68%72%65%66%3d%5c%22%6d%61%69%6c%74%6f%3a%6d%65%40%64%6f%6d%61%69%6e%2e%63%6f%6d%5c%22%3e%4d%79%20%65%6d%61%69%6c%3c%5c%2f%61%3e%27%29%3b'))</script>", snippet
   end
 
   def test_mail_to_with_javascript_unicode
     snippet = mail_to("unicode@example.com", "únicode", :encode => "javascript")
-    assert_dom_equal "<script type=\"text/javascript\">eval(decodeURIComponent('%64%6f%63%75%6d%65%6e%74%2e%77%72%69%74%65%28%27%3c%61%20%68%72%65%66%3d%5c%22%6d%61%69%6c%74%6f%3a%75%6e%69%63%6f%64%65%40%65%78%61%6d%70%6c%65%2e%63%6f%6d%5c%22%3e%c3%ba%6e%69%63%6f%64%65%3c%5c%2f%61%3e%27%29%3b'))</script>", snippet
+    assert_dom_equal "<script>eval(decodeURIComponent('%64%6f%63%75%6d%65%6e%74%2e%77%72%69%74%65%28%27%3c%61%20%68%72%65%66%3d%5c%22%6d%61%69%6c%74%6f%3a%75%6e%69%63%6f%64%65%40%65%78%61%6d%70%6c%65%2e%63%6f%6d%5c%22%3e%c3%ba%6e%69%63%6f%64%65%3c%5c%2f%61%3e%27%29%3b'))</script>", snippet
   end
 
   def test_mail_with_options
@@ -438,8 +438,8 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert_dom_equal "<a href=\"&#109;&#97;&#105;&#108;&#116;&#111;&#58;%6d%65@%64%6f%6d%61%69%6e.%63%6f%6d\">&#109;&#101;&#40;&#97;&#116;&#41;&#100;&#111;&#109;&#97;&#105;&#110;&#46;&#99;&#111;&#109;</a>", mail_to("me@domain.com", nil, :encode => "hex", :replace_at => "(at)")
     assert_dom_equal "<a href=\"&#109;&#97;&#105;&#108;&#116;&#111;&#58;%6d%65@%64%6f%6d%61%69%6e.%63%6f%6d\">My email</a>", mail_to("me@domain.com", "My email", :encode => "hex", :replace_at => "(at)")
     assert_dom_equal "<a href=\"&#109;&#97;&#105;&#108;&#116;&#111;&#58;%6d%65@%64%6f%6d%61%69%6e.%63%6f%6d\">&#109;&#101;&#40;&#97;&#116;&#41;&#100;&#111;&#109;&#97;&#105;&#110;&#40;&#100;&#111;&#116;&#41;&#99;&#111;&#109;</a>", mail_to("me@domain.com", nil, :encode => "hex", :replace_at => "(at)", :replace_dot => "(dot)")
-    assert_dom_equal "<script type=\"text/javascript\">eval(decodeURIComponent('%64%6f%63%75%6d%65%6e%74%2e%77%72%69%74%65%28%27%3c%61%20%68%72%65%66%3d%5c%22%6d%61%69%6c%74%6f%3a%6d%65%40%64%6f%6d%61%69%6e%2e%63%6f%6d%5c%22%3e%4d%79%20%65%6d%61%69%6c%3c%5c%2f%61%3e%27%29%3b'))</script>", mail_to("me@domain.com", "My email", :encode => "javascript", :replace_at => "(at)", :replace_dot => "(dot)")
-    assert_dom_equal "<script type=\"text/javascript\">eval(decodeURIComponent('%64%6f%63%75%6d%65%6e%74%2e%77%72%69%74%65%28%27%3c%61%20%68%72%65%66%3d%5c%22%6d%61%69%6c%74%6f%3a%6d%65%40%64%6f%6d%61%69%6e%2e%63%6f%6d%5c%22%3e%6d%65%28%61%74%29%64%6f%6d%61%69%6e%28%64%6f%74%29%63%6f%6d%3c%5c%2f%61%3e%27%29%3b'))</script>", mail_to("me@domain.com", nil, :encode => "javascript", :replace_at => "(at)", :replace_dot => "(dot)")
+    assert_dom_equal "<script>eval(decodeURIComponent('%64%6f%63%75%6d%65%6e%74%2e%77%72%69%74%65%28%27%3c%61%20%68%72%65%66%3d%5c%22%6d%61%69%6c%74%6f%3a%6d%65%40%64%6f%6d%61%69%6e%2e%63%6f%6d%5c%22%3e%4d%79%20%65%6d%61%69%6c%3c%5c%2f%61%3e%27%29%3b'))</script>", mail_to("me@domain.com", "My email", :encode => "javascript", :replace_at => "(at)", :replace_dot => "(dot)")
+    assert_dom_equal "<script>eval(decodeURIComponent('%64%6f%63%75%6d%65%6e%74%2e%77%72%69%74%65%28%27%3c%61%20%68%72%65%66%3d%5c%22%6d%61%69%6c%74%6f%3a%6d%65%40%64%6f%6d%61%69%6e%2e%63%6f%6d%5c%22%3e%6d%65%28%61%74%29%64%6f%6d%61%69%6e%28%64%6f%74%29%63%6f%6d%3c%5c%2f%61%3e%27%29%3b'))</script>", mail_to("me@domain.com", nil, :encode => "javascript", :replace_at => "(at)", :replace_dot => "(dot)")
   end
 
   def test_mail_to_returns_html_safe_string

--- a/guides/source/action_view_overview.textile
+++ b/guides/source/action_view_overview.textile
@@ -550,9 +550,9 @@ Register one or more JavaScript files to be included when symbol is passed to ja
 ActionView::Helpers::AssetTagHelper.register_javascript_expansion :monkey => ["head", "body", "tail"]
 
 javascript_include_tag :monkey # =>
-  <script type="text/javascript" src="/javascripts/head.js"></script>
-  <script type="text/javascript" src="/javascripts/body.js"></script>
-  <script type="text/javascript" src="/javascripts/tail.js"></script>
+  <script src="/javascripts/head.js"></script>
+  <script src="/javascripts/body.js"></script>
+  <script src="/javascripts/tail.js"></script>
 </ruby>
 
 h5. register_stylesheet_expansion
@@ -563,9 +563,9 @@ Register one or more stylesheet files to be included when symbol is passed to +s
 ActionView::Helpers::AssetTagHelper.register_stylesheet_expansion :monkey => ["head", "body", "tail"]
 
 stylesheet_link_tag :monkey # =>
-  <link href="/stylesheets/head.css" media="screen" rel="stylesheet" type="text/css" />
-  <link href="/stylesheets/body.css" media="screen" rel="stylesheet" type="text/css" />
-  <link href="/stylesheets/tail.css" media="screen" rel="stylesheet" type="text/css" />
+  <link href="/stylesheets/head.css" media="screen" rel="stylesheet" />
+  <link href="/stylesheets/body.css" media="screen" rel="stylesheet" />
+  <link href="/stylesheets/tail.css" media="screen" rel="stylesheet" />
 </ruby>
 
 h5. auto_discovery_link_tag
@@ -607,7 +607,7 @@ Returns an html script tag for each of the sources provided. You can pass in the
 
 <ruby>
 javascript_include_tag "common" # =>
-  <script type="text/javascript" src="/javascripts/common.js"></script>
+  <script src="/javascripts/common.js"></script>
 </ruby>
 
 If the application does not use the asset pipeline, to include the jQuery JavaScript library in your application, pass +:defaults+ as the source. When using +:defaults+, if an +application.js+ file exists in your +public/javascripts+ directory, it will be included as well.
@@ -626,7 +626,7 @@ You can also cache multiple JavaScript files into one file, which requires less 
 
 <ruby>
 javascript_include_tag :all, :cache => true # =>
-  <script type="text/javascript" src="/javascripts/all.js"></script>
+  <script src="/javascripts/all.js"></script>
 </ruby>
 
 h5. javascript_path
@@ -651,7 +651,7 @@ Returns a stylesheet link tag for the sources specified as arguments. If you don
 
 <ruby>
 stylesheet_link_tag "application" # =>
-  <link href="/stylesheets/application.css" media="screen" rel="stylesheet" type="text/css" />
+  <link href="/stylesheets/application.css" media="screen" rel="stylesheet" />
 </ruby>
 
 You can also include all styles in the stylesheet directory using :all as the source:
@@ -664,7 +664,7 @@ You can also cache multiple stylesheets into one file, which requires less HTTP 
 
 <ruby>
 stylesheet_link_tag :all, :cache => true
-  <link href="/stylesheets/all.css"  media="screen" rel="stylesheet" type="text/css" />
+  <link href="/stylesheets/all.css"  media="screen" rel="stylesheet" />
 </ruby>
 
 h5. stylesheet_path
@@ -805,7 +805,7 @@ For example, let's say we have a standard application layout, but also a special
 <p>This is a special page.</p>
 
 <% content_for :special_script do %>
-  <script type="text/javascript">alert('Hello!')</script>
+  <script>alert('Hello!')</script>
 <% end %>
 </ruby>
 
@@ -1501,7 +1501,7 @@ javascript_tag "alert('All is good')"
 </ruby>
 
 <html>
-<script type="text/javascript">
+<script>
 //<![CDATA[
 alert('All is good')
 //]]>

--- a/guides/source/asset_pipeline.textile
+++ b/guides/source/asset_pipeline.textile
@@ -328,9 +328,9 @@ This manifest +app/assets/javascripts/application.js+:
 would generate this HTML:
 
 <html>
-<script src="/assets/core.js?body=1" type="text/javascript"></script>
-<script src="/assets/projects.js?body=1" type="text/javascript"></script>
-<script src="/assets/tickets.js?body=1" type="text/javascript"></script>
+<script src="/assets/core.js?body=1"></script>
+<script src="/assets/projects.js?body=1"></script>
+<script src="/assets/tickets.js?body=1"></script>
 </html>
 
 The +body+ param is required by Sprockets.
@@ -346,7 +346,7 @@ config.assets.debug = false
 When debug mode is off, Sprockets concatenates and runs the necessary preprocessors on all files. With debug mode turned off the manifest above would generate instead:
 
 <html>
-<script src="/assets/application.js" type="text/javascript"></script>
+<script src="/assets/application.js"></script>
 </html>
 
 Assets are compiled and cached on the first request after the server is started. Sprockets sets a +must-revalidate+ Cache-Control HTTP header to reduce request overhead on subsequent requests -- on these the browser gets a 304 (Not Modified) response.
@@ -380,8 +380,8 @@ For example this:
 generates something like this:
 
 <html>
-<script src="/assets/application-908e25f4bf641868d8683022a5b62f54.js" type="text/javascript"></script>
-<link href="/assets/application-4dd5b109ee3439da54f5bdfd78a80473.css" media="screen" rel="stylesheet" type="text/css" />
+<script src="/assets/application-908e25f4bf641868d8683022a5b62f54.js"></script>
+<link href="/assets/application-4dd5b109ee3439da54f5bdfd78a80473.css" media="screen" rel="stylesheet" />
 </html>
 
 The fingerprinting behavior is controlled by the setting of +config.assets.digest+ setting in Rails (which defaults to +true+ for production and +false+ for everything else).

--- a/guides/source/layouts_and_rendering.textile
+++ b/guides/source/layouts_and_rendering.textile
@@ -686,7 +686,7 @@ You can specify a full path relative to the document root, or a URL, if you pref
 Rails will then output a +script+ tag such as this:
 
 <html>
-<script src='/assets/main.js' type="text/javascript"></script>
+<script src='/assets/main.js'></script>
 </html>
 
 The request to this asset is then served by the Sprockets gem.
@@ -718,8 +718,8 @@ If the application does not use the asset pipeline, the +:defaults+ option loads
 Outputting +script+ tags such as this:
 
 <html>
-<script src="/javascripts/jquery.js" type="text/javascript"></script>
-<script src="/javascripts/jquery_ujs.js" type="text/javascript"></script>
+<script src="/javascripts/jquery.js"></script>
+<script src="/javascripts/jquery_ujs.js"></script>
 </html>
 
 These two files for jQuery, +jquery.js+ and +jquery_ujs.js+ must be placed inside +public/javascripts+ if the application doesn't use the asset pipeline. These files can be downloaded from the "jquery-rails repository on GitHub":https://github.com/indirect/jquery-rails/tree/master/vendor/assets/javascripts
@@ -805,7 +805,7 @@ To include +http://example.com/main.css+:
 <%= stylesheet_link_tag "http://example.com/main.css" %>
 </erb>
 
-By default, the +stylesheet_link_tag+ creates links with +media="screen" rel="stylesheet" type="text/css"+. You can override any of these defaults by specifying an appropriate option (+:media+, +:rel+, or +:type+):
+By default, the +stylesheet_link_tag+ creates links with +media="screen" rel="stylesheet"+. You can override any of these defaults by specifying an appropriate option (+:media+, +:rel+):
 
 <erb>
 <%= stylesheet_link_tag "main_print", :media => "print" %>
@@ -1206,7 +1206,7 @@ Suppose you have the following +ApplicationController+ layout:
 <head>
   <title><%= @page_title or 'Page Title' %></title>
   <%= stylesheet_link_tag 'layout' %>
-  <style type="text/css"><%= yield :stylesheets %></style>
+  <style><%= yield :stylesheets %></style>
 </head>
 <body>
   <div id="top_menu">Top menu items here</div>

--- a/railties/lib/rails/generators/rails/app/templates/public/404.html
+++ b/railties/lib/rails/generators/rails/app/templates/public/404.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>The page you were looking for doesn't exist (404)</title>
-  <style type="text/css">
+  <style>
     body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
     div.dialog {
       width: 25em;

--- a/railties/lib/rails/generators/rails/app/templates/public/422.html
+++ b/railties/lib/rails/generators/rails/app/templates/public/422.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>The change you wanted was rejected (422)</title>
-  <style type="text/css">
+  <style>
     body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
     div.dialog {
       width: 25em;

--- a/railties/lib/rails/generators/rails/app/templates/public/500.html
+++ b/railties/lib/rails/generators/rails/app/templates/public/500.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>We're sorry, but something went wrong (500)</title>
-  <style type="text/css">
+  <style>
     body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
     div.dialog {
       width: 25em;

--- a/railties/lib/rails/generators/rails/app/templates/public/index.html
+++ b/railties/lib/rails/generators/rails/app/templates/public/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Ruby on Rails: Welcome aboard</title>
-    <style type="text/css" media="screen">
+    <style media="screen">
       body {
         margin: 0;
         margin-bottom: 25px;
@@ -171,7 +171,7 @@
         font-style: italic;
       }
     </style>
-    <script type="text/javascript">
+    <script>
       function about() {
         info = document.getElementById('about-content');
         if (window.XMLHttpRequest)


### PR DESCRIPTION
In HTML 5 `type` attribute in `<style>`, `<script>` and `<link rel="stylesheet">` have default value (`text/javascript` or `text/css`), so it’s unnecessary now.

By default, `app/views/layout/application.html.erb` have HTML 5 doctype, so we can miss `type` attribute.

Without it code will become cleaner and shorter.

If someone use HTML 4, browser will understand tags without `type`. Also HTML 4 users can just set type by `:type` params in `javascript_include_tag`, etc.
