### PR TITLE
Remove circular require from AS Deprecation, and fix warnings

### DIFF
--- a/activesupport/lib/active_support/deprecation/method_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/method_wrappers.rb
@@ -1,4 +1,3 @@
-require 'active_support/core_ext/module/deprecation'
 require 'active_support/core_ext/module/aliasing'
 require 'active_support/core_ext/array/extract_options'
 

--- a/activesupport/lib/active_support/file_update_checker.rb
+++ b/activesupport/lib/active_support/file_update_checker.rb
@@ -54,6 +54,9 @@ module ActiveSupport
       @glob  = compile_glob(dirs)
       @block = block
 
+      @watched    = nil
+      @updated_at = nil
+
       @last_watched   = watched
       @last_update_at = updated_at(@last_watched)
     end


### PR DESCRIPTION
Fix in commit acae4fd4eda2209008527f2e554720f5cb874ac7 showed an unused require that ended up with a circular reference.

Also fix warnings in file check updater by initializing variables with `nil`.
