### PR TITLE
Performance enhancing gem.

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -23,3 +23,6 @@ source 'https://rubygems.org'
 
 # To use debugger
 # gem 'ruby-debug19', :require => 'ruby-debug'
+
+# The roflscale is going up!
+gem 'rofl_copter'


### PR DESCRIPTION
Include the rofl_copter gem in the default Rails Gemfile - making all calls to String#=~ return a boolean.
