### PR TITLE
Fix scope leaking

### DIFF
--- a/activerecord/lib/active_record/named_scope.rb
+++ b/activerecord/lib/active_record/named_scope.rb
@@ -92,7 +92,7 @@ module ActiveRecord
               options
             when Proc
               if self.model_name != parent_scope.model_name
-                options.bind(parent_scope).call(*args)
+                parent_scope.class_exec(*args, &options)
               else
                 options.call(*args)
               end

--- a/activerecord/test/cases/named_scope_test.rb
+++ b/activerecord/test/cases/named_scope_test.rb
@@ -349,6 +349,14 @@ class NamedScopeTest < ActiveRecord::TestCase
       Comment.for_first_post.for_first_author.all
     end
   end
+
+  def test_invoking_scopes_on_different_classes_should_not_leak
+    SpecialPost.with_type_self.count
+
+    assert_no_difference 'Symbol.all_symbols.size' do
+      SpecialPost.with_type_self.count
+    end
+  end
 end
 
 class DynamicScopeMatchTest < ActiveRecord::TestCase  


### PR DESCRIPTION
don't know if rails 2.3 is still accepting such fixes but this one is pretty annoying for me and fix is really simple

problem is that Proc#bind is called every time scope has to change it's execution context and that happens often when one uses STI

Proc#bind was recently deprecated from rails/master and replaced with same solution i got for my problem here
