### PR TITLE
Add attribute_was?(value) to model

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -52,32 +52,32 @@ module ActiveModel
   #
   # A newly instantiated object is unchanged:
   #   person = Person.find_by_name('Uncle Bob')
-  #   person.changed?       # => false
+  #   person.changed?             # => false
   #
   # Change the name:
   #   person.name = 'Bob'
-  #   person.changed?       # => true
-  #   person.name_changed?  # => true
-  #   person.name_was       # => 'Uncle Bob'
+  #   person.changed?             # => true
+  #   person.name_changed?        # => true
+  #   person.name_was             # => 'Uncle Bob'
   #   person.name_was? 'UncleBob' # => true
-  #   person.name_change    # => ['Uncle Bob', 'Bob']
+  #   person.name_change          # => ['Uncle Bob', 'Bob']
   #   person.name = 'Bill'
-  #   person.name_change    # => ['Uncle Bob', 'Bill']
+  #   person.name_change          # => ['Uncle Bob', 'Bill']
   #
   # Save the changes:
   #   person.save
-  #   person.changed?       # => false
-  #   person.name_changed?  # => false
+  #   person.changed?             # => false
+  #   person.name_changed?        # => false
   #
   # Assigning the same value leaves the attribute unchanged:
   #   person.name = 'Bill'
-  #   person.name_changed?  # => false
-  #   person.name_change    # => nil
+  #   person.name_changed?        # => false
+  #   person.name_change          # => nil
   #
   # Which attributes have changed?
   #   person.name = 'Bob'
-  #   person.changed        # => ['name']
-  #   person.changes        # => { 'name' => ['Bill', 'Bob'] }
+  #   person.changed              # => ['name']
+  #   person.changes              # => { 'name' => ['Bill', 'Bob'] }
   #
   # If an attribute is modified in-place then make use of <tt>[attribute_name]_will_change!</tt>
   # to mark that the attribute is changing. Otherwise ActiveModel can't track changes to

--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -59,6 +59,7 @@ module ActiveModel
   #   person.changed?       # => true
   #   person.name_changed?  # => true
   #   person.name_was       # => 'Uncle Bob'
+  #   person.name_was? 'UncleBob' # => true
   #   person.name_change    # => ['Uncle Bob', 'Bob']
   #   person.name = 'Bill'
   #   person.name_change    # => ['Uncle Bob', 'Bill']
@@ -90,7 +91,7 @@ module ActiveModel
     include ActiveModel::AttributeMethods
 
     included do
-      attribute_method_suffix '_changed?', '_change', '_will_change!', '_was'
+      attribute_method_suffix '_changed?', '_change', '_will_change!', '_was', '_was?'
       attribute_method_affix :prefix => 'reset_', :suffix => '!'
     end
 
@@ -147,6 +148,11 @@ module ActiveModel
       # Handle <tt>*_was</tt> for +method_missing+.
       def attribute_was(attr)
         attribute_changed?(attr) ? changed_attributes[attr] : __send__(attr)
+      end
+
+      # Handle <tt>*_was?</tt> for +method_missing+.
+      def attribute_was?(attr, old_value)
+        old_value == attribute_was(attr)
       end
 
       # Handle <tt>*_will_change!</tt> for +method_missing+.

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -41,6 +41,7 @@ class DirtyTest < ActiveRecord::TestCase
     pirate.catchphrase = 'arrr'
     assert pirate.catchphrase_changed?
     assert_nil pirate.catchphrase_was
+    assert pirate.catchphrase_was? nil
     assert_equal [nil, 'arrr'], pirate.catchphrase_change
 
     # Saved - no changes.
@@ -50,6 +51,7 @@ class DirtyTest < ActiveRecord::TestCase
 
     # Same value - no changes.
     pirate.catchphrase = 'arrr'
+    assert pirate.catchphrase_was? 'arrr'
     assert !pirate.catchphrase_changed?
     assert_nil pirate.catchphrase_change
   end


### PR DESCRIPTION
I'd prefer to read

``` ruby
  report_change if notifications_enabled? && model.panel_was? 'backlog'
```

to

``` ruby
  report_change if notifications_enabled? && model.panel_was == 'backlog'
```
