### PR TITLE
fixing assert_template bug when template matches expected, but not ends with

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -87,7 +87,9 @@ module ActionController
           case options
           when String
             rendered.any? do |t, num|
-              (options.split(File::SEPARATOR) - t.split(File::SEPARATOR)).empty?
+              options_splited = options.split(File::SEPARATOR)
+              t_splited = t.split(File::SEPARATOR)
+              t_splited.last(options_splited.size) == options_splited
             end
           when Regexp
             rendered.any? { |t,num| t.match(options) }

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -86,7 +86,9 @@ module ActionController
         assert_block(msg) do
           case options
           when String
-            rendered.any? { |t,num| t.end_with?(options) }
+            rendered.any? do |t, num|
+              (options.split(File::SEPARATOR) - t.split(File::SEPARATOR)).empty?
+            end
           when Regexp
             rendered.any? { |t,num| t.match(options) }
           when NilClass

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -77,16 +77,20 @@ module ActionController
       response.body
 
       case options
-      when NilClass, String, Symbol, Regexp
+      when NilClass, Regexp, String, Symbol
         options = options.to_s if Symbol === options
         rendered = @templates
         msg = message || sprintf("expecting <%s> but rendering with <%s>",
                 options.inspect, rendered.keys)
+
         assert_block(msg) do
-          if options
+          case options
+          when String
+            rendered.any? { |t,num| t.end_with?(options) }
+          when Regexp
             rendered.any? { |t,num| t.match(options) }
-          else
-            @templates.blank?
+          when NilClass
+            rendered.blank?
           end
         end
       when Hash

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -495,6 +495,13 @@ class AssertTemplateTest < ActionController::TestCase
     get :nothing
     assert_template nil
   end
+
+  def test_fails_with_partial_name_matching_string
+    get :hello_world
+    assert_raise(ActiveSupport::TestCase::Assertion) do
+      assert_template 'world'
+    end
+  end
 end
 
 class ActionPackHeaderTest < ActionController::TestCase

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -7,6 +7,7 @@ class ActionPackAssertionsController < ActionController::Base
   def nothing() head :ok end
 
   def hello_world() render :template => "test/hello_world"; end
+  def hello_repeating_in_path() render :template => "test/hello/hello"; end
 
   def hello_xml_world() render :template => "test/hello_xml_world"; end
 
@@ -459,6 +460,13 @@ class AssertTemplateTest < ActionController::TestCase
     get :hello_world
     assert_raise(ActiveSupport::TestCase::Assertion) do
       assert_template 'est/he'
+    end
+  end
+
+  def test_fails_with_repeated_name_in_path
+    get :hello_repeating_in_path
+    assert_raise(ActiveSupport::TestCase::Assertion) do
+      assert_template 'test/hello'
     end
   end
 

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -495,13 +495,6 @@ class AssertTemplateTest < ActionController::TestCase
     get :nothing
     assert_template nil
   end
-
-  def test_fails_with_partial_name_matching_string
-    get :hello_world
-    assert_raise(ActiveSupport::TestCase::Assertion) do
-      assert_template 'world'
-    end
-  end
 end
 
 class ActionPackHeaderTest < ActionController::TestCase

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -455,10 +455,24 @@ class AssertTemplateTest < ActionController::TestCase
     end
   end
 
+  def test_fails_with_incorrect_string_that_matches
+    get :hello_world
+    assert_raise(ActiveSupport::TestCase::Assertion) do
+      assert_template 'est/he'
+    end
+  end
+
   def test_fails_with_incorrect_symbol
     get :hello_world
     assert_raise(ActiveSupport::TestCase::Assertion) do
       assert_template :hello_planet
+    end
+  end
+
+  def test_fails_with_incorrect_symbol_that_matches
+    get :hello_world
+    assert_raise(ActiveSupport::TestCase::Assertion) do
+      assert_template :"est/he"
     end
   end
 

--- a/actionpack/test/fixtures/test/hello/hello.erb
+++ b/actionpack/test/fixtures/test/hello/hello.erb
@@ -1,0 +1,1 @@
+Hello world!


### PR DESCRIPTION
Hello guys, I discover that when we rendering "test/hello_world" and asserting with "test" or "st/he" or anything that matches, the assertion pass.
I think this isn't a good behavior, so I changed to pass when ends with expected, now will pass with "hello_world" or "world" for example.
What do you think about don't pass with half folder or file name? I thinking in when rendering "test/bla/hello_world", the only correct strings would be: "hello_world", "bla/hello_world" and "test/bla/hello_world"
If you guys like the idea I can implement.
