### PR TITLE
Solve an error using 'rake db:create:all'

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -28,7 +28,7 @@ db_namespace = namespace :db do
         #  development:
         #    database: blog_development
         #    *defaults
-        next unless config['database']
+        next unless config && config['database']
         # Only connect to local databases
         local_database?(config) { create_database(config) }
       end


### PR DESCRIPTION
I tried: rake --trace db:create:all ==>
undefined method `[]' for nil:NilClass
/home/akt/.rvm/gems/ruby-1.9.3-p125/gems/activerecord-3.2.1/lib/active_record/railties/databases.rake:31:in`block (4 levels) in <top (required)>'

Adding this patch, the error removed an the action worked.
