### PR TITLE
Test for circular reference while saving has_many relationship

### DIFF
--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1,4 +1,5 @@
 require 'cases/helper'
+require 'models/article'
 require 'models/bird'
 require 'models/company'
 require 'models/customer'
@@ -11,6 +12,7 @@ require 'models/person'
 require 'models/pirate'
 require 'models/post'
 require 'models/reader'
+require 'models/section'
 require 'models/ship'
 require 'models/ship_part'
 require 'models/tag'
@@ -1297,6 +1299,16 @@ class TestAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCase
   end
 
   include AutosaveAssociationOnACollectionAssociationTests
+end
+
+class TestAutosaveInverseAssociationOnAHasManyAssociation < ActiveRecord::TestCase
+
+  self.use_transactional_fixtures = false
+
+  def test_should_save_the_inverse_association_model
+    Article.create(:sections_attributes => [{:name => 'First'}, {:name => 'Last'}])
+  end
+
 end
 
 class TestAutosaveAssociationOnAHasAndBelongsToManyAssociation < ActiveRecord::TestCase

--- a/activerecord/test/models/article.rb
+++ b/activerecord/test/models/article.rb
@@ -1,0 +1,4 @@
+class Article < ActiveRecord::Base
+  has_many :sections, :inverse_of => :article
+  accepts_nested_attributes_for :sections
+end

--- a/activerecord/test/models/section.rb
+++ b/activerecord/test/models/section.rb
@@ -1,0 +1,4 @@
+class Section < ActiveRecord::Base
+  belongs_to :article
+  accepts_nested_attributes_for :article
+end 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -46,6 +46,10 @@ ActiveRecord::Schema.define do
     t.string :name
   end
 
+  create_table :articles, :force => true do |t|
+    t.string :name
+  end
+
   create_table :audit_logs, :force => true do |t|
     t.column :message, :string, :null=>false
     t.column :developer_id, :integer, :null=>false
@@ -546,6 +550,11 @@ ActiveRecord::Schema.define do
     t.integer :job_id
     t.boolean :favourite
     t.integer :lock_version, :default => 0
+  end
+
+  create_table :sections, :force => true do |t|
+    t.string :name
+    t.integer :article_id
   end
 
   create_table :shape_expressions, :force => true do |t|


### PR DESCRIPTION
Test for #5774 :inverse_of + accepts_nested_attributes_for causes stack overflow on save

There is a cyclic autosave for belongs_to/has_many when using accepts_nested_attributes for both models. It causes stack overflow.
