### PR TITLE
Refactored method SpawnMethods#apply_finder_options

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       attr_reader :association, :alias_tracker
 
       delegate :klass, :owner, :reflection, :interpolate, :to => :association
-      delegate :chain, :conditions, :options, :source_options, :active_record, :to => :reflection
+      delegate :chain, :conditions, :where, :options, :source_options, :active_record, :to => :reflection
 
       def initialize(association)
         @association   = association

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -147,17 +147,12 @@ module ActiveRecord
       end
 
       result = klass.connection.select_all(select(column_name).arel, nil, bind_values)
-      types  = result.column_types.merge klass.column_types
-      column = types[key]
+      column = klass.column_types[key] || result.column_types.values.first
 
       result.map do |attributes|
         raise ArgumentError, "Pluck expects to select just one attribute: #{attributes.inspect}" unless attributes.one?
-        value = klass.initialize_attributes(attributes).first[1]
-        if column
-          column.type_cast value
-        else
-          value
-        end
+        value = klass.initialize_attributes(attributes).values.first
+        column ? column.type_cast(value) : value
       end
     end
 

--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -128,26 +128,50 @@ module ActiveRecord
       result
     end
 
-    VALID_FIND_OPTIONS = [ :conditions, :include, :joins, :limit, :offset, :extend, :references,
-                           :order, :select, :readonly, :group, :having, :from, :lock ]
+    VALID_FIND_OPTIONS = [ :conditions, :where, :include, :includes, :joins,
+                           :limit, :offset, :extend, :extending, :references,
+                           :order, :select, :readonly, :group, :having, :from,
+                           :lock ]
 
     def apply_finder_options(options)
       relation = clone
       return relation unless options
 
-      options.assert_valid_keys(VALID_FIND_OPTIONS)
-      finders = options.dup
-      finders.delete_if { |key, value| value.nil? && key != :limit }
+      finders = sanitize_finder_options(options.dup)
 
-      ((VALID_FIND_OPTIONS - [:conditions, :include, :extend]) & finders.keys).each do |finder|
-        relation = relation.send(finder, finders[finder])
+      finders.keys.inject(relation) do |rel, finder|
+        rel.send(finder, finders[finder])
       end
+    end
 
-      relation = relation.where(finders[:conditions]) if options.has_key?(:conditions)
-      relation = relation.includes(finders[:include]) if options.has_key?(:include)
-      relation = relation.extending(finders[:extend]) if options.has_key?(:extend)
+    private
 
-      relation
+    def sanitize_finder_options(options)
+      filter_invalid options
+      filter_empty options
+      substitute_keys options
+    end
+
+    def filter_invalid(options)
+      options.assert_valid_keys(VALID_FIND_OPTIONS)
+    end
+
+    def filter_empty(options)
+      options.delete_if { |key, value| value.nil? && key != :limit }
+    end
+
+    # Substitutes keys for which Relation::QueryMethods has no method by ones
+    # for which there is a method.
+    def substitute_keys(options)
+      options.inject({}) do |finders, (key, value)|
+
+        key = :where     if key == :conditions
+        key = :includes  if key == :include
+        key = :extending if key == :extend
+
+        finders[key] = value
+        finders
+      end
     end
 
   end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -468,6 +468,9 @@ class CalculationsTest < ActiveRecord::TestCase
 
   def test_pluck_with_selection_clause
     assert_equal [50, 53, 55, 60], Account.pluck('DISTINCT credit_limit').sort
+    assert_equal [50, 53, 55, 60], Account.pluck('DISTINCT accounts.credit_limit').sort
+    assert_equal [50, 53, 55, 60], Account.pluck('DISTINCT(credit_limit)').sort
+    assert_equal [50 + 53 + 55 + 60], Account.pluck('SUM(DISTINCT(credit_limit))')
   end
 
   def test_pluck_expects_a_single_selection


### PR DESCRIPTION
I refactored the SpawnMethods#apply_finder_options a bit. Two things I have done:
- The options :conditions, :include, :extend cannot map directly on a method inRelation::QueryMethods. I made the subsitution explicit instead of filtering out the keys from the loop and performing the methods one by one after.
- Extracted the filtering of the invalid and empty options for readability.

All ActiveRecord and Rails tests pass.

**Deprecate?**
I'd like to deprecate the three finder-options: :conditions, :include, :extend. This would mean a lot of (fairly simple) changes in code, test and documentation. Let me know what you think of this - I could add it to the PR.
