### PR TITLE
Adding itemscope to list of boolean attributes.

### DIFF
--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -14,7 +14,7 @@ module ActionView
       BOOLEAN_ATTRIBUTES = %w(disabled readonly multiple checked autobuffer
                            autoplay controls loop selected hidden scoped async
                            defer reversed ismap seemless muted required
-                           autofocus novalidate formnovalidate open pubdate).to_set
+                           autofocus novalidate formnovalidate open pubdate itemscope).to_set
       BOOLEAN_ATTRIBUTES.merge(BOOLEAN_ATTRIBUTES.map {|attribute| attribute.to_sym })
 
       PRE_CONTENT_STRINGS = {

--- a/actionpack/test/template/tag_helper_test.rb
+++ b/actionpack/test/template/tag_helper_test.rb
@@ -30,8 +30,8 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_tag_options_converts_boolean_option
-    assert_equal '<p disabled="disabled" multiple="multiple" readonly="readonly" />',
-      tag("p", :disabled => true, :multiple => true, :readonly => true)
+    assert_equal '<p disabled="disabled" itemscope="itemscope" multiple="multiple" readonly="readonly" />',
+      tag("p", :disabled => true, :itemscope => true, :multiple => true, :readonly => true)
   end
 
   def test_content_tag


### PR DESCRIPTION
'itemscope' is defined within HTML5 for use in microdata markup. See
http://www.whatwg.org/specs/web-apps/current-work/multipage/microdata.ht
ml#attr-itemscope
