### PR TITLE
Disable logging for a mysql adapter (v3.0.3)

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -198,7 +198,7 @@ module ActiveRecord
           end
         rescue Exception => e
           message = "#{e.class.name}: #{e.message}: #{sql}"
-          @logger.debug message if @logger
+          @logger.debug message if (@logger &&(@logger.class != Proc))
           raise translate_exception(e, message)
         end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -283,11 +283,7 @@ module ActiveRecord
       # Executes an SQL query and returns a MySQL::Result object. Note that you have to free
       # the Result object after you're done using it.
       def execute(sql, name = nil) #:nodoc:
-        if name == :skip_logging
-          @connection.query(sql)
-        else
-          log(sql, name) { @connection.query(sql) }
-        end
+        @connection.query(sql)
       rescue ActiveRecord::StatementInvalid => exception
         if exception.message.split(":").first =~ /Packets out of order/
           raise ActiveRecord::StatementInvalid, "'Packets out of order' error was received from the database. Please update your mysql bindings (gem install mysql) and read http://dev.mysql.com/doc/mysql/en/password-hashing.html for more information.  If you're on Windows, use the Instant Rails installer to get the updated mysql bindings."


### PR DESCRIPTION
First commit solves that:
`NoMethodError: undefined method 'debug' for #<Proc:xxxxxxxxx>`

And second solving this one (may only appears in development mode):
`ArgumentError: wrong number of arguments (1 for 0): SHOW TABLES`
