### PR TITLE
optimize AR::Associations::Preloader#grouped_records

### DIFF
--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -131,11 +131,11 @@ module ActiveRecord
       end
 
       def grouped_records(association)
-        Hash[
-          records_by_reflection(association).map do |reflection, records|
-            [reflection, records.group_by { |record| association_klass(reflection, record) }]
+        {}.tap do |grouped|
+          records_by_reflection(association).each do |reflection, records|
+            grouped[reflection] = records.group_by { |record| association_klass(reflection, record) }
           end
-        ]
+        end
       end
 
       def records_by_reflection(association)


### PR DESCRIPTION
There is no need to create a temporary array object. [Benchmark](https://gist.github.com/52cf9b809efb07a4890b)
