### PR TITLE
Fix assert_template assertion with :layout option

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -120,7 +120,7 @@ module ActionController
                     options[:partial], @partials.keys)
             assert_includes @partials, expected_partial, msg
           end
-        else
+        elsif options.key?(:partial)
           assert @partials.empty?,
             "Expected no partials to be rendered"
         end

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -76,6 +76,11 @@ class ActionPackAssertionsController < ActionController::Base
     render "test/hello_world", :layout => "layouts/standard"
   end
 
+  def render_with_layout_and_partial
+    @variable_for_layout = nil
+    render "test/hello_world_with_partial", :layout => "layouts/standard"
+  end
+
   def session_stuffing
     session['xmas'] = 'turkey'
     render :text => "ho ho ho"
@@ -471,6 +476,11 @@ class AssertTemplateTest < ActionController::TestCase
 
   def test_passes_with_correct_layout
     get :render_with_layout
+    assert_template :layout => "layouts/standard"
+  end
+
+  def test_passes_with_layout_and_partial
+    get :render_with_layout_and_partial
     assert_template :layout => "layouts/standard"
   end
 

--- a/actionpack/test/fixtures/test/hello_world_with_partial.html.erb
+++ b/actionpack/test/fixtures/test/hello_world_with_partial.html.erb
@@ -1,0 +1,2 @@
+Hello world!
+<%= render '/test/partial' %>


### PR DESCRIPTION
Without my fix `assert_tempate :layout => 'layouts/application'` works incorrect if there are any partials.

Like this:

```
  1) Failure:
test_passes_with_layout_and_partial(AssertTemplateTest)
   [test/controller/action_pack_assertions_test.rb:484]:
Expected no partials to be rendered
```
