### PR TITLE
Assert template layout improve

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -20,7 +20,9 @@ module ActionController
 
       ActiveSupport::Notifications.subscribe("render_template.action_view") do |name, start, finish, id, payload|
         path = payload[:layout]
-        @layouts[path] += 1
+        if path
+          @layouts[path] += 1
+        end
       end
 
       ActiveSupport::Notifications.subscribe("!render_template.action_view") do |name, start, finish, id, payload|
@@ -90,7 +92,8 @@ module ActionController
           end
         end
       when Hash
-        if expected_layout = options[:layout]
+        if options.key?(:layout)
+          expected_layout = options[:layout]
           msg = message || sprintf("expecting layout <%s> but action rendered <%s>",
                   expected_layout, @layouts.keys)
 

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -120,7 +120,7 @@ module ActionController
                     options[:partial], @partials.keys)
             assert_includes @partials, expected_partial, msg
           end
-        else
+        elsif options.key?(:partial)
           assert @partials.empty?,
             "Expected no partials to be rendered"
         end

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -22,6 +22,9 @@ module ActionController
         path = payload[:layout]
         if path
           @layouts[path] += 1
+          if path =~ /^layouts\/(.*)/
+            @layouts[$1] += 1
+          end
         end
       end
 
@@ -61,6 +64,15 @@ module ActionController
     #   # assert that the exact template "admin/posts/new" was rendered
     #   assert_template %r{\Aadmin/posts/new\Z}
     #
+    #   # assert that the layout 'admin' was rendered
+    #   assert_template :layout => 'admin'
+    #   assert_template :layout => 'layouts/admin'
+    #   assert_template :layout => :admin
+    #
+    #   # assert that no layout was rendered
+    #   assert_template :layout => nil
+    #   assert_template :layout => false
+    #
     #   # assert that the "_customer" partial was rendered twice
     #   assert_template :partial => '_customer', :count => 2
     #
@@ -98,11 +110,11 @@ module ActionController
                   expected_layout, @layouts.keys)
 
           case expected_layout
-          when String
-            assert_includes @layouts.keys, expected_layout, msg
+          when String, Symbol
+            assert_includes @layouts.keys, expected_layout.to_s, msg
           when Regexp
             assert(@layouts.keys.any? {|l| l =~ expected_layout }, msg)
-          when nil
+          when nil, false
             assert(@layouts.empty?, msg)
           end
         end

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -478,6 +478,13 @@ class AssertTemplateTest < ActionController::TestCase
     end
   end
 
+  def test_fails_expecting_no_layout
+    get :render_with_layout
+    assert_raise(ActiveSupport::TestCase::Assertion) do
+      assert_template :layout => nil
+    end
+  end
+
   def test_passes_with_correct_layout
     get :render_with_layout
     assert_template :layout => "layouts/standard"
@@ -486,6 +493,11 @@ class AssertTemplateTest < ActionController::TestCase
   def test_passes_with_layout_and_partial
     get :render_with_layout_and_partial
     assert_template :layout => "layouts/standard"
+  end
+
+  def test_passed_with_no_layout
+    get :hello_world
+    assert_template :layout => nil
   end
 
   def test_assert_template_reset_between_requests

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -500,6 +500,21 @@ class AssertTemplateTest < ActionController::TestCase
     assert_template :layout => nil
   end
 
+  def test_passed_with_no_layout_false
+    get :hello_world
+    assert_template :layout => false
+  end
+
+  def test_passes_with_correct_layout_without_layouts_prefix
+    get :render_with_layout
+    assert_template :layout => "standard"
+  end
+
+  def test_passes_with_correct_layout_symbol
+    get :render_with_layout
+    assert_template :layout => :standard
+  end
+
   def test_assert_template_reset_between_requests
     get :hello_world
     assert_template 'test/hello_world'

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -76,6 +76,11 @@ class ActionPackAssertionsController < ActionController::Base
     render "test/hello_world", :layout => "layouts/standard"
   end
 
+  def render_with_layout_and_partial
+    @variable_for_layout = nil
+    render "test/hello_world_with_partial", :layout => "layouts/standard"
+  end
+
   def session_stuffing
     session['xmas'] = 'turkey'
     render :text => "ho ho ho"
@@ -475,6 +480,11 @@ class AssertTemplateTest < ActionController::TestCase
 
   def test_passes_with_correct_layout
     get :render_with_layout
+    assert_template :layout => "layouts/standard"
+  end
+
+  def test_passes_with_layout_and_partial
+    get :render_with_layout_and_partial
     assert_template :layout => "layouts/standard"
   end
 

--- a/actionpack/test/fixtures/test/hello_world_with_partial.html.erb
+++ b/actionpack/test/fixtures/test/hello_world_with_partial.html.erb
@@ -1,0 +1,2 @@
+Hello world!
+<%= render '/test/partial' %>


### PR DESCRIPTION
There are fixes for 2 defects:

`assert_template :layout => 'some'` worked wrong if we rendered any partial

`assert_template :layout => nil` did nothing

And in the last commit I suggest to make `assert_template :layout => 'something'` a little bit better. Now we can set `layout :admin` in controller, but can't check `assert_template :layout => :admin` or  `assert_template :layout => 'admin'`. I think we should.
