### PR TITLE
Override AR::Relation methods in NullRelation.

### DIFF
--- a/activerecord/lib/active_record/null_relation.rb
+++ b/activerecord/lib/active_record/null_relation.rb
@@ -6,5 +6,58 @@ module ActiveRecord
     def exec_queries
       @records = []
     end
+
+    def pluck(column_name)
+      []
+    end
+
+    def delete_all(conditions = nil)
+      0
+    end
+
+    def update_all(updates, conditions = nil, options = {})
+      0
+    end
+
+    def delete(id_or_array)
+      0
+    end
+
+    def size
+      0
+    end
+
+    def empty?
+      true
+    end
+
+    def any?
+      false
+    end
+
+    def many?
+      false
+    end
+
+    def to_sql
+      @to_sql ||= ""
+    end
+
+    def where_values_hash
+      {}
+    end
+
+    def count
+      0
+    end
+
+    def calculate(operation, column_name, options = {})
+      nil
+    end
+
+    def exists?(id = false)
+      false
+    end
+
   end
 end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -219,6 +219,7 @@ class RelationTest < ActiveRecord::TestCase
     assert_no_queries do
       assert_equal [], Developer.none
       assert_equal [], Developer.scoped.none
+      assert           Developer.none.is_a?(ActiveRecord::NullRelation)
     end
   end
 
@@ -226,6 +227,38 @@ class RelationTest < ActiveRecord::TestCase
     assert_no_queries do
       assert_equal [], Developer.none.where(:name => 'David')
     end
+  end
+
+  def test_none_chained_to_methods_firing_queries_straight_to_db
+    assert_no_queries do
+      assert_equal [],    Developer.none.pluck(:id) # => uses select_all
+      assert_equal 0,     Developer.none.delete_all
+      assert_equal 0,     Developer.none.update_all(:name => 'David')
+      assert_equal 0,     Developer.none.delete(1)
+      assert_equal false, Developer.none.exists?(1)
+    end
+  end
+
+  def test_null_relation_content_size_methods
+    assert_no_queries do
+      assert_equal 0,     Developer.none.size
+      assert_equal 0,     Developer.none.count
+      assert_equal true,  Developer.none.empty?
+      assert_equal false, Developer.none.any?
+      assert_equal false, Developer.none.many?
+    end
+  end
+
+  def test_null_relation_calculations_methods
+    assert_no_queries do
+      assert_equal 0,     Developer.none.count
+      assert_equal nil,   Developer.none.calculate(:average, 'salary')
+    end
+  end
+  
+  def test_null_relation_metadata_methods
+    assert_equal "", Developer.none.to_sql
+    assert_equal({}, Developer.none.where_values_hash)
   end
 
   def test_joins_with_nil_argument


### PR DESCRIPTION
So a NullRelation (Relation#none) is chainable with database methods, as discussed with @josevalim and @jonleighton here: rails/rails#5590
