### PR TITLE
Fix #5797. Error calling dup method on AR model with serialized field

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -72,12 +72,13 @@ module ActiveRecord
           self.serialized_attributes = serialized_attributes.merge(attr_name.to_s => coder)
         end
 
-        def initialize_attributes(attributes) #:nodoc:
-          super
+        def initialize_attributes(attributes, options = {}) #:nodoc:
+          serialized = (options.delete(:serialized) { true }) ? :serialized : :unserialized
+          super(attributes, options)
 
           serialized_attributes.each do |key, coder|
             if attributes.key?(key)
-              attributes[key] = Attribute.new(coder, attributes[key], :serialized)
+              attributes[key] = Attribute.new(coder, attributes[key], serialized)
             end
           end
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -241,7 +241,7 @@ module ActiveRecord
     ##
     def initialize_dup(other) # :nodoc:
       cloned_attributes = other.clone_attributes(:read_attribute_before_type_cast)
-      self.class.initialize_attributes(cloned_attributes)
+      self.class.initialize_attributes(cloned_attributes, :serialized => false)
 
       cloned_attributes.delete(self.class.primary_key)
 

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -168,7 +168,7 @@ module ActiveRecord
         # start the lock version at zero. Note we can't use
         # <tt>locking_enabled?</tt> at this point as
         # <tt>@attributes</tt> may not have been initialized yet.
-        def initialize_attributes(attributes) #:nodoc:
+        def initialize_attributes(attributes, options = {}) #:nodoc:
           if attributes.key?(locking_column) && lock_optimistically
             attributes[locking_column] ||= 0
           end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1309,6 +1309,15 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal({ :foo => :bar }, t.content_before_type_cast)
   end
 
+  def test_serialized_attribute_calling_dup_method
+    klass = Class.new(ActiveRecord::Base)
+    klass.table_name = "topics"
+    klass.serialize :content, JSON
+
+    t = klass.new(:content => { :foo => :bar }).dup
+    assert_equal({ :foo => :bar }, t.content_before_type_cast)
+  end
+
   def test_serialized_attribute_declared_in_subclass
     hash = { 'important1' => 'value1', 'important2' => 'value2' }
     important_topic = ImportantTopic.create("important" => hash)


### PR DESCRIPTION
When we call the initialize_attributes method in serialization.rb, sometimes it is serialized, sometimes it is not serialized.

And for consistency I also changed the initialize_attributes's signiture in optimistic.rb. 

Closes #5797
