### PR TITLE
Move javascript to bottom of the page

### DIFF
--- a/actionpack/lib/action_view/helpers/number_helper.rb
+++ b/actionpack/lib/action_view/helpers/number_helper.rb
@@ -74,11 +74,11 @@ module ActionView
           number.slice!(0, 1) if number.start_with?(delimiter) && !delimiter.blank?
         end
 
-        str = []
+        str = ''
         str << "+#{country_code}#{delimiter}" unless country_code.blank?
         str << number
         str << " x #{extension}" unless extension.blank?
-        ERB::Util.html_escape(str.join)
+        ERB::Util.html_escape(str)
       end
 
       # Formats a +number+ into a currency string (e.g., $13.65). You can customize the format

--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -9,6 +9,7 @@
 <body>
 
 <%%= yield %>
-
+<!-- Move JavaScript at the bottom for fast page loading. For more info see: http://developer.yahoo.com/performance/rules.html#js_bottom
+Notice: This may break inline javascript. -->
 </body>
 </html>


### PR DESCRIPTION
with rails templates, we promote "Best practices" in web development. Hence, we should move all JavaScripts at bottom of the page which is also one of the "Best Practices". It improves performance.

Further, if anyone does not want to follow best practices & move javascript block in head. it can be simply moved back. Its just a template which people would customize to their own needs. 

More info on why it is important can be found here: http://developer.yahoo.com/performance/rules.html#js_bottom
