### PR TITLE
Use request.GET and request.POST instead of request.params in abstract_store

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
@@ -201,7 +201,7 @@ module ActionDispatch
           stale_session_check! do
             request = ActionDispatch::Request.new(env)
             sid = request.cookies[@key]
-            sid ||= request.params[@key] unless @cookie_only
+            sid ||= (request.GET[@key] || request.POST[@key]) unless @cookie_only
             sid
           end
         end


### PR DESCRIPTION
To avoid caching of parsed request params before appropriate and fix #5670.

(Second pull request. First one I didn't push properly.)
