### PR TITLE
Define array methods in ActiveRecord::Associations::CollectionProxy

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -126,6 +126,19 @@ module ActiveRecord
         proxy_association.reload
         self
       end
+
+      # Define array public methods because we know it should be invoked over
+      # the target, so we can have a performance improvement using those methods
+      # in association collections
+      Array.public_instance_methods.each do |m|
+        unless method_defined?(m)
+          class_eval <<-RUBY, __FILE__, __LINE__ + 1
+            def #{m}(*args, &block)
+              target.public_send(:#{m}, *args, &block) if load_target
+            end
+          RUBY
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Define array methods in ActiveRecord::Associations::CollectionProxy if they are not defined or delegated.
In this way, we have a performance boost invoking some array methods which are not defined in CollectionAssociation.
