### PR TITLE
Provided fix for calling rake tasks within mountable engines

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -603,7 +603,12 @@ module Rails
           desc "Copy migrations from #{railtie_name} to application"
           task :migrations do
             ENV["FROM"] = railtie_name
-            Rake::Task["railties:install:migrations"].invoke
+            if Rake::Task.task_defined?("railties:install:migrations")
+              Rake::Task["railties:install:migrations"].invoke
+            else
+              Rake::Task["app:railties:install:migrations"].invoke
+            end
+
           end
         end
       end


### PR DESCRIPTION
Following issue: Lets look at creating mountable Engine (Also discussed here: #2594)

```
rails plugin new foobar --mountable
cd foobar
rails g model foo bar:string
rake app:foobar:install:migrations
```

The last command will fail with: `Don't know how to build task 'railties:install:migrations'`

So I might provide a possible fix here.
There might be cooler solutions here, but I'm not familiar with the `Rails::Engine`.
I'm also not that familiar with this TestFramework, so please have a look.
