### PR TITLE
Automatically add the lock_version hidden field to forms

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Automatically add the `lock_version` hidden field to forms. *Damien Mathieu*
+
 *   Add `index` method to FormBuilder class. *Jorge Bejar*
 
 *   Remove the leading \n added by textarea on assert_select. *Santiago Pastorino*

--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -416,6 +416,7 @@ module ActionView
         options[:html][:remote] = options.delete(:remote) if options.has_key?(:remote)
         options[:html][:method] = options.delete(:method) if options.has_key?(:method)
         options[:html][:authenticity_token] = options.delete(:authenticity_token)
+        options[:hidden_lock_version] = record.respond_to?(:lock_version) unless options.has_key?(:hidden_lock_version)
 
         builder = options[:parent_builder] = instantiate_builder(object_name, object, options)
         fields_for = fields_for(object_name, object, options, &proc)
@@ -690,6 +691,7 @@ module ActionView
         builder = instantiate_builder(record_name, record_object, options)
         output = capture(builder, &block)
         output.concat builder.hidden_field(:id) if output && options[:hidden_field_id] && !builder.emitted_hidden_id?
+        output.concat builder.hidden_field(:lock_version) if output && options[:hidden_lock_version] && !builder.emitted_lock_version?
         output
       end
 
@@ -1147,6 +1149,7 @@ module ActionView
 
       def hidden_field(method, options = {})
         @emitted_hidden_id = true if method == :id
+        @emitted_lock_version = true if method == :lock_version
         @template.hidden_field(@object_name, method, objectify_options(options))
       end
 
@@ -1223,6 +1226,10 @@ module ActionView
 
       def emitted_hidden_id?
         @emitted_hidden_id ||= nil
+      end
+
+      def emitted_lock_version?
+        @emitted_lock_version ||= nil
       end
 
       private

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -1159,6 +1159,33 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected_2, output_buffer
   end
 
+  def test_form_for_with_lock_version
+    def @post.lock_version; 42; end
+    form_for(@post) do |f|
+      concat f.text_field(:title)
+    end
+
+    expected = whole_form("/posts/123", "edit_post_123" , "edit_post", :method => 'patch') do
+      '<input id="post_title" name="post[title]" type="text" value="Hello World" />' +
+      '<input id="post_lock_version" name="post[lock_version]" type="hidden" value="42" />'
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_form_for_with_lock_version_not_displayed
+    def @post.lock_version; 42; end
+    form_for(@post, :hidden_lock_version => false) do |f|
+      concat f.text_field(:title)
+    end
+
+    expected = whole_form("/posts/123", "edit_post_123" , "edit_post", :method => 'patch') do
+      '<input id="post_title" name="post[title]" type="text" value="Hello World" />'
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_fields_for_with_namespace
     @comment.body = 'Hello World'
     form_for(@post, :namespace => 'namespace') do |f|


### PR DESCRIPTION
This automatically adds the `lock_version` field to all forms when the model has optimistic locking.
