### PR TITLE
Remove obsolete code

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -140,9 +140,6 @@ module ActionController
 
     class Result < ::Array #:nodoc:
       def to_s() join '/' end
-      def self.new_escaped(strings)
-        new strings.collect {|str| uri_parser.unescape str}
-      end
     end
 
     def assign_parameters(routes, controller_path, action, parameters = {})


### PR DESCRIPTION
Method #new_escaped was introduced at 2005 :  5727dc2f42874e32f8cac3c176a085de07b24dd9
and become useless after refactoring a1df2590744ed126981dfd5b5709ff6fd5dc6476

Method Result#to_s is really used in 2 tests. I suggest to keep it.
