### PR TITLE
Add an --editor option to ActiveRecord migration generator

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -3,11 +3,16 @@ require 'rails/generators/active_record'
 module ActiveRecord
   module Generators
     class MigrationGenerator < Base
+      class_option :editor, :type => :string, :lazy_default => ENV['EDITOR'], :required => false, :banner => "/path/to/your/editor", :desc => "Open migration using specified editor (defaults to EDITOR)"
       argument :attributes, :type => :array, :default => [], :banner => "field[:type][:index] field[:type][:index]"
 
       def create_migration_file
         set_local_assigns!
-        migration_template "migration.rb", "db/migrate/#{file_name}.rb"
+        path = migration_template "migration.rb", "db/migrate/#{file_name}.rb"
+
+        if options[:editor].present?
+          run("#{options[:editor]} #{path}")
+        end
       end
 
       protected


### PR DESCRIPTION
the first thing Rails devs do after running a migration is usually open that file in an editor. I added an --editor option here that does this for you automatically. I didn't see an easy way to test this (do the generators have their own tests?) but if there's a place where that should go, I'll gladly add them to this patch.
