### PR TITLE
Downcase sanitized css properties

### DIFF
--- a/actionpack/lib/action_controller/vendor/html-scanner/html/sanitizer.rb
+++ b/actionpack/lib/action_controller/vendor/html-scanner/html/sanitizer.rb
@@ -129,13 +129,13 @@ module HTML
       clean = []
       style.scan(/([-\w]+)\s*:\s*([^:;]*)/) do |prop,val|
         if allowed_css_properties.include?(prop.downcase)
-          clean <<  prop + ': ' + val + ';'
+          clean <<  prop.downcase + ': ' + val + ';'
         elsif shorthand_css_properties.include?(prop.split('-')[0].downcase)
           unless val.split().any? do |keyword|
             !allowed_css_keywords.include?(keyword) &&
               keyword !~ /^(#[0-9a-f]+|rgb\(\d+%?,\d*%?,?\d*%?\)?|\d{0,2}\.?\d{0,2}(cm|em|ex|in|mm|pc|pt|px|%|,|\))?)$/
           end
-            clean << prop + ': ' + val + ';'
+            clean << prop.downcase + ': ' + val + ';'
           end
         end
       end

--- a/actionpack/test/template/html-scanner/sanitizer_test.rb
+++ b/actionpack/test/template/html-scanner/sanitizer_test.rb
@@ -242,6 +242,12 @@ class SanitizerTest < ActionController::TestCase
     assert_equal expected, sanitize_css(raw)
   end
 
+  def test_should_downcase_css_properties
+    raw      = %(cOlOr: red;bOrDer-LEFt: 1px solid black)
+    expected = %(color: red; border-left: 1px solid black;)
+    assert_equal expected, sanitize_css(raw)
+  end
+
   def test_should_sanitize_with_trailing_space
     raw = "display:block; "
     expected = "display: block;"


### PR DESCRIPTION
I suggest small improvement in satinize_css method (`sanitize text, attributes: %w[style ...]`).
Let downcase style properties keys to make output cleaner.
