### PR TITLE
Update Gemfile to use 'debugger' instead of unmaintained 'ruby-debug19'

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -22,4 +22,4 @@ source 'https://rubygems.org'
 # gem 'capistrano', :group => :development
 
 # To use debugger
-# gem 'ruby-debug19', :require => 'ruby-debug'
+# gem 'debugger'


### PR DESCRIPTION
...by-debug19 and move to debugger. Whats the consensus here? If we want better adoption on ruby1.9, please lets just use this fork.
