### PR TITLE
Add Array#rest, a convenience method to return all elements but the first

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/access.rb
+++ b/activesupport/lib/active_support/core_ext/array/access.rb
@@ -19,6 +19,13 @@ class Array
     self.first position + 1
   end
 
+  # Returns the all of the elements in the array but the first.
+  #
+  #   %w( a b c d ).rest # => %w( b c d )
+  def rest
+    self[1, length] || []
+  end
+
   # Equal to <tt>self[1]</tt>.
   def second
     self[1]

--- a/activesupport/test/core_ext/array_ext_test.rb
+++ b/activesupport/test/core_ext/array_ext_test.rb
@@ -19,6 +19,12 @@ class ArrayExtAccessTests < ActiveSupport::TestCase
     assert_equal %w( a b c d ), %w( a b c d ).to(10)
   end
 
+  def test_rest
+    assert_equal %w( b c d ), %w( a b c d ).rest
+    assert_equal %w(), %w( a ).rest
+    assert_equal %w(), %w().rest
+  end
+
   def test_second_through_tenth
     array = (1..42).to_a
 


### PR DESCRIPTION
Splitting a list into the first elements and the rest of the elements (head/teal, car/cdr) is a fairly common pattern in programming. We have .first already, so here's a convenience method for rest.
