### PR TITLE
Fix ORA-00972 error at test_rename_table_with_prefix_and_suffix

### DIFF
--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -36,7 +36,7 @@ class MigrationTest < ActiveRecord::TestCase
     ActiveRecord::Base.connection.initialize_schema_migrations_table
     ActiveRecord::Base.connection.execute "DELETE FROM #{ActiveRecord::Migrator.schema_migrations_table_name}"
 
-    %w(things awesome_things prefix_things_suffix prefix_awesome_things_suffix).each do |table|
+    %w(things awesome_things prefix_things_suffix p_awesome_things_s ).each do |table|
       Thing.connection.drop_table(table) rescue nil
     end
     Thing.reset_column_information
@@ -278,8 +278,8 @@ class MigrationTest < ActiveRecord::TestCase
 
   def test_rename_table_with_prefix_and_suffix
     assert !Thing.table_exists?
-    ActiveRecord::Base.table_name_prefix = 'prefix_'
-    ActiveRecord::Base.table_name_suffix = '_suffix'
+    ActiveRecord::Base.table_name_prefix = 'p_'
+    ActiveRecord::Base.table_name_suffix = '_s'
     Thing.reset_table_name
     Thing.reset_sequence_name
     WeNeedThings.up
@@ -288,7 +288,7 @@ class MigrationTest < ActiveRecord::TestCase
     assert_equal "hello world", Thing.find(:first).content
 
     RenameThings.up
-    Thing.table_name = "prefix_awesome_things_suffix"
+    Thing.table_name = "p_awesome_things_s"
 
     assert_equal "hello world", Thing.find(:first).content
   ensure


### PR DESCRIPTION
This pull request addresses the following ORA-00972 error because Oracle supports 30 byte maximum sequence name length.

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/migration_test.rb -n 'test_rename_table_with_prefix_and_suffix'
Using oracle
Run options: -n test_rename_table_with_prefix_and_suffix --seed 55032

# Running tests:

... snip ...
E

Finished tests in 0.979560s, 1.0209 tests/s, 3.0626 assertions/s.

  1) Error:
test_rename_table_with_prefix_and_suffix(MigrationTest):
ArgumentError: New sequence name 'prefix_awesome_things_suffix_seq' is too long; the limit is 30 characters
    /home/yahonda/Dropbox/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:105:in `rename_table'
    /home/yahonda/Dropbox/git/rails/activerecord/lib/active_record/migration.rb:467:in `block in method_missing'
    /home/yahonda/Dropbox/git/rails/activerecord/lib/active_record/migration.rb:439:in `block in say_with_time'

1 tests, 3 assertions, 0 failures, 1 errors, 0 skips
```

It was originally reported at #4190 and was closed because Oracle oracle enhanced adapter did not work with rails master branch for a while.

Recently, Oracle oracle enhanced adapter is working with the rails master branch and found this error still exists.

This pull request has been tested with postgresql, mysql, mysql2 and sqlite3 adapters.
