### PR TITLE
Incorporating Pacific Island zone changes circa Dec 31 2011

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -28,7 +28,7 @@ module ActiveSupport
     MAPPING = {
       "International Date Line West" => "Pacific/Midway",
       "Midway Island"                => "Pacific/Midway",
-      "Samoa"                        => "Pacific/Pago_Pago",
+      "American Samoa"               => "Pacific/Pago_Pago",
       "Hawaii"                       => "Pacific/Honolulu",
       "Alaska"                       => "America/Juneau",
       "Pacific Time (US & Canada)"   => "America/Los_Angeles",
@@ -167,7 +167,9 @@ module ActiveSupport
       "Marshall Is."                 => "Pacific/Majuro",
       "Auckland"                     => "Pacific/Auckland",
       "Wellington"                   => "Pacific/Auckland",
-      "Nuku'alofa"                   => "Pacific/Tongatapu"
+      "Nuku'alofa"                   => "Pacific/Tongatapu",
+      "Tokelau Is."                  => "Pacific/Fakaofo",
+      "Samoa"                        => "Pacific/Apia"
     }
 
     UTC_OFFSET_WITH_COLON = '%s%02d:%02d'


### PR DESCRIPTION
Correcting some confusion. The Pacific/Pago_Pago zone should have been labeled "American Samoa" not "Samoa". They're 75 miles apart but different.

It's especially important because at the end of 2011 Samoa (and also Tokelau) jumped across the international dateline to be on the same day as New Zealand and Australia. They switched to UTC+13 and left American Samoa at UTC-11.

Documentation about the dateline change is at IANA in the file 'austalasia'.

Pacific/Fakaofo and Pacific/Apia are in TZInfo and present in ruby 1.9.3. Perhaps this is a Rails 4.0 tweak.
