### PR TITLE
Rendering a partial with objects or collections using :as and a layout breaks

### DIFF
--- a/actionpack/lib/action_view/renderer/partial_renderer.rb
+++ b/actionpack/lib/action_view/renderer/partial_renderer.rb
@@ -167,11 +167,11 @@ module ActionView
   #   <%# app/views/users/index.html.erb %>
   #   <%# This does not use layouts %>
   #   <ul>
-  #     <% users.each do |user| %>
+  #     <% users.each do |user| -%>
   #       <li>
   #         <%= render :partial => "user", :locals => { :user => user } %>
   #       </li>
-  #     <% end %>
+  #     <% end -%>
   #   </ul>
   #
   #   <%# app/views/users/_li_layout.html.erb %>
@@ -238,11 +238,11 @@ module ActionView
   #
   #   <%# app/views/users/index.html.erb &>
   #   <%= render :layout => @users do |user, section| %>
-  #     <%- case section when :header %>
+  #     <%- case section when :header -%>
   #       Title: <%= user.title %>
-  #     <%- when :footer %>
+  #     <%- when :footer -%>
   #       Deadline: <%= user.deadline %>
-  #     <%- end %>
+  #     <%- end -%>
   #   <% end %>
   class PartialRenderer < AbstractRenderer
     PREFIXED_PARTIAL_NAMES = Hash.new { |h,k| h[k] = {} }

--- a/actionpack/lib/action_view/renderer/partial_renderer.rb
+++ b/actionpack/lib/action_view/renderer/partial_renderer.rb
@@ -167,11 +167,11 @@ module ActionView
   #   <%# app/views/users/index.html.erb %>
   #   <%# This does not use layouts %>
   #   <ul>
-  #     <% users.each do |user| -%>
+  #     <% users.each do |user| %>
   #       <li>
   #         <%= render :partial => "user", :locals => { :user => user } %>
   #       </li>
-  #     <% end -%>
+  #     <% end %>
   #   </ul>
   #
   #   <%# app/views/users/_li_layout.html.erb %>
@@ -238,11 +238,11 @@ module ActionView
   #
   #   <%# app/views/users/index.html.erb &>
   #   <%= render :layout => @users do |user, section| %>
-  #     <%- case section when :header -%>
+  #     <%- case section when :header %>
   #       Title: <%= user.title %>
-  #     <%- when :footer -%>
+  #     <%- when :footer %>
   #       Deadline: <%= user.deadline %>
-  #     <%- end -%>
+  #     <%- end %>
   #   <% end %>
   class PartialRenderer < AbstractRenderer
     PREFIXED_PARTIAL_NAMES = Hash.new { |h,k| h[k] = {} }
@@ -282,14 +282,14 @@ module ActionView
         spacer = find_template(@options[:spacer_template]).render(@view, @locals)
       end
 
+      result = @template ? collection_with_template : collection_without_template
+
       if layout = @options[:layout]
         layout = find_template(layout)
       end
 
-      result = @template ? collection_with_template : collection_without_template
-      
       result.map!{|content| layout.render(@view, @locals) { content } } if layout
-      
+
       result.join(spacer).html_safe
     end
 
@@ -297,12 +297,12 @@ module ActionView
       locals, view, block = @locals, @view, @block
       object, as = @object, @variable
 
+      object ||= locals[as]
+      locals[as] = object
+
       if !block && (layout = @options[:layout])
         layout = find_template(layout)
       end
-
-      object ||= locals[as]
-      locals[as] = object
 
       content = @template.render(view, locals) do |*name|
         view._layout_for(*name, &block)
@@ -391,10 +391,10 @@ module ActionView
         locals[as] = object
         segments << template.render(@view, locals)
       end
-      
+
       segments
     end
-    
+
 
     def collection_without_template
       segments, locals, collection_data = [], @locals, @collection_data

--- a/actionpack/test/fixtures/test/_reverse_object_inspector_layout.erb
+++ b/actionpack/test/fixtures/test/_reverse_object_inspector_layout.erb
@@ -1,0 +1,2 @@
+<%= object_inspector.reverse.inspect %>
+<%= yield %>

--- a/actionpack/test/template/render_test.rb
+++ b/actionpack/test/template/render_test.rb
@@ -204,6 +204,18 @@ module RenderTestCases
     assert_equal "Hello: david", @view.render(:partial => "test/customer", :object => Customer.new("david"))
   end
 
+  def test_render_partial_object_with_template_and_as
+    assert_equal "[3, 2, 1]\n[1, 2, 3]\n",
+      @view.render(:partial => "test/object_inspector", :object => [1, 2, 3],
+                   :as => :object_inspector, :layout => "test/reverse_object_inspector_layout")
+  end
+
+  def test_render_partial_collection_with_template_and_as
+    assert_equal "[4, 3]\n[1, 2]\n[4, 3]\n[3, 4]\n",
+      @view.render(:partial => "test/object_inspector", :collection => [[1,2], [3,4]],
+                   :as => :object_inspector, :layout => "test/reverse_object_inspector_layout")
+  end
+
   def test_render_object_with_array
     assert_equal "[1, 2, 3]", @view.render(:partial => "test/object_inspector", :object => [1, 2, 3])
   end
@@ -238,7 +250,7 @@ module RenderTestCases
   def test_render_partial_with_nil_values_in_collection
     assert_equal "Hello: davidHello: Anonymous", @view.render(:partial => "test/customer", :collection => [ Customer.new("david"), nil ])
   end
-  
+
   def test_render_partial_with_layout_using_collection_and_template
     assert_equal "<b>Hello: Amazon</b><b>Hello: Yahoo</b>", @view.render(:partial => "test/customer", :layout => 'test/b_layout_for_partial', :collection => [ Customer.new("Amazon"), Customer.new("Yahoo") ])
   end
@@ -315,7 +327,7 @@ module RenderTestCases
     ActionView::Template.register_template_handler :foo, CustomHandler
     assert_equal 'source: "Hello, <%= name %>!"', @view.render(:inline => "Hello, <%= name %>!", :locals => { :name => "Josh" }, :type => :foo)
   end
-  
+
   def test_render_knows_about_types_registered_when_extensions_are_checked_earlier_in_initialization
     ActionView::Template::Handlers.extensions
     ActionView::Template.register_template_handler :foo, CustomHandler


### PR DESCRIPTION
Currently,

`<%= render :partial => "user", :layout => "layouts/user", :object => user, :as => :user %>`

In _user.erb.html

`<%= user.first_name %>`

In layouts/_user.erb.html

`<div id="<%= dom_id(user) %>"><%= yield %></div>`

would throw an exception in the layout not having access to the `user` local variable.

This pull fixes that.
