### PR TITLE
No need for if_params at the end of the initializer as an initializer

### DIFF
--- a/activemodel/lib/active_model/model.rb
+++ b/activemodel/lib/active_model/model.rb
@@ -66,7 +66,7 @@ module ActiveModel
     def initialize(params={})
       params.each do |attr, value|
         self.public_send("#{attr}=", value)
-      end if params
+      end
     end
 
     def persisted?

--- a/activemodel/lib/active_model/model.rb
+++ b/activemodel/lib/active_model/model.rb
@@ -66,7 +66,7 @@ module ActiveModel
     def initialize(params={})
       params.each do |attr, value|
         self.public_send("#{attr}=", value)
-      end
+      end if params
     end
 
     def persisted?

--- a/activemodel/test/cases/model_test.rb
+++ b/activemodel/test/cases/model_test.rb
@@ -21,6 +21,7 @@ class ModelTest < ActiveModel::TestCase
     assert_nothing_raised do
       BasicModel.new()
       BasicModel.new({})
+      BasicModel.new(nil)
     end
   end
 end


### PR DESCRIPTION
always returns the object instance
