### PR TITLE
Rename notify_observers argument *arg to *args to make it more clear

### DIFF
--- a/activemodel/lib/active_model/observing.rb
+++ b/activemodel/lib/active_model/observing.rb
@@ -69,8 +69,8 @@ module ActiveModel
       end
 
       # Notify list of observers of a change.
-      def notify_observers(*arg)
-        observer_instances.each { |observer| observer.update(*arg) }
+      def notify_observers(*args)
+        observer_instances.each { |observer| observer.update(*args) }
       end
 
       # Total number of observers.


### PR DESCRIPTION
Rename notify_observers argument *arg to *args to make it more clear that the method accepts multiple arguments (follows arguments naming convention)
