### PR TITLE
Fix human attribute_name to handle deeply nested attributes

### DIFF
--- a/activemodel/lib/active_model/translation.rb
+++ b/activemodel/lib/active_model/translation.rb
@@ -42,9 +42,9 @@ module ActiveModel
     # Specify +options+ with additional translating options.
     def human_attribute_name(attribute, options = {})
       options   = { :count => 1 }.merge!(options)
-      parts     = attribute.to_s.split(".", 2)
+      parts     = attribute.to_s.split(".")
       attribute = parts.pop
-      namespace = parts.pop
+      namespace = parts.join("/") unless parts.empty?
       attributes_scope = "#{self.i18n_scope}.attributes"
 
       if namespace

--- a/activemodel/test/cases/translation_test.rb
+++ b/activemodel/test/cases/translation_test.rb
@@ -56,6 +56,11 @@ class ActiveModelI18nTests < ActiveModel::TestCase
     assert_equal 'person gender attribute', Person::Gender.human_attribute_name('attribute')
   end
 
+  def test_translated_deeply_nested_model_attributes
+    I18n.backend.store_translations 'en', :activemodel => {:attributes => {:"person/contacts/addresses" => {:street => 'Deeply Nested Address Street'}}}
+    assert_equal 'Deeply Nested Address Street', Person.human_attribute_name('contacts.addresses.street')
+  end
+
   def test_translated_nested_model_attributes
     I18n.backend.store_translations 'en', :activemodel => {:attributes => {:"person/addresses" => {:street => 'Person Address Street'}}}
     assert_equal 'Person Address Street', Person.human_attribute_name('addresses.street')


### PR DESCRIPTION
When a model nests another model that also nests yet another model
using accepts_nested_attributes_for method, its Errors object can
have an attribute name with "contacts.addresses.street" style.

In this case, the dots within the namespace should be substituted
with slashes so that we can provide the translation under the
"activemodel.attributes.person/contacts/addresses.street" key.

This commit is related to #3859.
