### PR TITLE
Activerecord cache key as timestamp

### DIFF
--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -33,14 +33,13 @@ module ActiveRecord
     #
     #   Product.new.cache_key     # => "products/new"
     #   Product.find(5).cache_key # => "products/5" (updated_at not available)
-    #   Person.find(5).cache_key  # => "people/5-20071224150000" (updated_at available)
+    #   Person.find(5).cache_key  # => "people/5-1334398193.832774" (updated_at available)
     def cache_key
       case
       when new_record?
         "#{self.class.model_name.cache_key}/new"
       when timestamp = self[:updated_at]
-        timestamp = timestamp.utc.to_s(:number)
-        "#{self.class.model_name.cache_key}/#{id}-#{timestamp}"
+        "#{self.class.model_name.cache_key}/#{id}-#{timestamp.utc.to_f}"
       else
         "#{self.class.model_name.cache_key}/#{id}"
       end

--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -39,7 +39,8 @@ module ActiveRecord
       when new_record?
         "#{self.class.model_name.cache_key}/new"
       when timestamp = self[:updated_at]
-        "#{self.class.model_name.cache_key}/#{id}-#{timestamp.utc.to_f}"
+        timestamp = timestamp.to_f.to_s.gsub('.','-')
+        "#{self.class.model_name.cache_key}/#{id}-#{timestamp}"
       else
         "#{self.class.model_name.cache_key}/#{id}"
       end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -2113,7 +2113,7 @@ class BasicsTest < ActiveRecord::TestCase
 
   def test_cache_key_format_for_existing_record_with_updated_at
     dev = Developer.first
-    assert_equal "developers/#{dev.id}-#{dev.updated_at.utc.to_s(:number)}", dev.cache_key
+    assert_equal "developers/#{dev.id}-#{dev.updated_at.utc.to_f}", dev.cache_key
   end
 
   def test_cache_key_format_for_existing_record_with_nil_updated_at

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -2113,7 +2113,7 @@ class BasicsTest < ActiveRecord::TestCase
 
   def test_cache_key_format_for_existing_record_with_updated_at
     dev = Developer.first
-    assert_equal "developers/#{dev.id}-#{dev.updated_at.utc.to_f}", dev.cache_key
+    assert_equal "developers/#{dev.id}-#{dev.updated_at.to_f.to_s.gsub('.','-')}", dev.cache_key
   end
 
   def test_cache_key_format_for_existing_record_with_nil_updated_at


### PR DESCRIPTION
Cache key for ActiveRecord model is calculated using `to_s(:number)` method on `updated_at` timestamp.

This approach rounds the `cache_key` to whole number of seconds. If record is changed twice within a second, later change wont change the `cache_key`, which leads to inconsistent state. 

Common example would be user accidentally clicking twice on an ajaxified link with some kind of toggle behavior. Even though it will toggle it twice, cache will change only once.

I changed the `cache_key` to include float timestamp rather than :number representation of time.
