### PR TITLE
remove extra new line from generated Gemfile

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -120,7 +120,7 @@ module Rails
       end
 
       def database_gemfile_entry
-        options[:skip_active_record] ? "" : "gem '#{gem_for_database}'\n"
+        options[:skip_active_record] ? "" : "gem '#{gem_for_database}'"
       end
 
       def include_all_railties?


### PR DESCRIPTION
because we have one newline in Gemfile template: https://github.com/rails/rails/blob/master/railties/lib/rails/generators/rails/app/templates/Gemfile#L6
