### PR TITLE
Fix dash disappearing for titleize method

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -81,7 +81,7 @@ module ActiveSupport
       word.gsub!(/(?:([A-Za-z\d])|^)(#{inflections.acronym_regex})(?=\b|[^a-z])/) { "#{$1}#{$1 && '_'}#{$2.downcase}" }
       word.gsub!(/([A-Z\d]+)([A-Z][a-z])/,'\1_\2')
       word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
-      word.tr!("-", "_")
+      word.tr!("-", "_") unless /in `titleize'/ =~ caller.first
       word.downcase!
       word
     end

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -227,6 +227,7 @@ module InflectorTestCases
     "¿por qué?"             => '¿Por Qué?',
     "Fred’s"                => "Fred’s",
     "Fred`s"                => "Fred`s"
+    "down-case - test"      => "Down-Case - Test"
   }
 
   OrdinalNumbers = {


### PR DESCRIPTION
There is a bug in `titleize` method. Here is example:

`"simple-test".titleize #=> "Simple Test"`

As you see dash disappeared but it should be presented in titled message
