### PR TITLE
Update Rails 3.2.3 release date in changelogs as March 30, 2012

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Rails 3.2.3 (unreleased) ##
+## Rails 3.2.3 (March 30, 2012) ##
 
 *   Upgrade mail version to 2.4.3 *ML*
 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -135,7 +135,7 @@
     HTML5 `mark` element. *Brian Cardarella*
 
 
-## Rails 3.2.3 (unreleased) ##
+## Rails 3.2.3 (March 30, 2012) ##
 
 *   Add `config.action_view.embed_authenticity_token_in_remote_forms` (defaults to true) which allows to set if authenticity token will be included by default in remote forms. If you change it to false, you can still force authenticity token by passing `:authenticity_token => true` in form options *Piotr Sarnacki*
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -239,7 +239,7 @@
 *   PostgreSQL hstore types are automatically deserialized from the database.
 
 
-## Rails 3.2.3 (unreleased) ##
+## Rails 3.2.3 (March 30, 2012) ##
 
 *   Added find_or_create_by_{attribute}! dynamic method. *Andrew White*
 


### PR DESCRIPTION
The release date details have been taken from
http://weblog.rubyonrails.org/2012/3/30/ann-rails-3-2-3-has-been-released/ as well as [45d6cd94](https://github.com/rails/rails/commit/45d6cd94b3ef2ec77166def41f29188445b35608)

Cheers, M.
