### PR TITLE
Make log_level explicit in production.rb template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -32,8 +32,8 @@
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # See everything in the log (default is :info).
-  # config.log_level = :debug
+  # Set to :debug to see everything in the log.
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]


### PR DESCRIPTION
The 'production' environment name is currently checked for setting up
the default log_level to 'info' but that won't work if the environment
is copied to staging.rb, for instance. Better to have it explicitly set.

Please, take a look at the whole discussion in this thread:

https://groups.google.com/forum/?fromgroups#!topic/rubyonrails-core/sLG7EpAWQfg
