### PR TITLE
Catch nil.to_sym errors in partial_renderer, and raise ArgumentError instead

### DIFF
--- a/actionpack/lib/action_view/renderer/partial_renderer.rb
+++ b/actionpack/lib/action_view/renderer/partial_renderer.rb
@@ -407,7 +407,7 @@ module ActionView
     end
 
     def retrieve_variable(path)
-      variable = @options[:as].try(:to_sym) || path[%r'_?(\w+)(\.\w+)*$', 1].to_sym
+      variable = @options[:as].try(:to_sym) || path[%r'_?(\w+)(\.\w+)*$', 1].try(:to_sym)
       variable_counter = :"#{variable}_counter" if @collection
       [variable, variable_counter]
     end

--- a/actionpack/lib/action_view/renderer/partial_renderer.rb
+++ b/actionpack/lib/action_view/renderer/partial_renderer.rb
@@ -407,7 +407,7 @@ module ActionView
     end
 
     def retrieve_variable(path)
-      variable = @options[:as].try(:to_sym) || path[%r'_?(\w+)(\.\w+)*$', 1].try(:to_sym)
+      variable = @options.fetch(:as) { path[%r'_?(\w+)(\.\w+)*$', 1] }.try(:to_sym)
       variable_counter = :"#{variable}_counter" if @collection
       [variable, variable_counter]
     end

--- a/actionpack/test/template/render_test.rb
+++ b/actionpack/test/template/render_test.rb
@@ -161,6 +161,15 @@ module RenderTestCases
                                 "and is followed by any combinations of letters, numbers, or underscores.", e.message
   end
 
+  def test_render_partial_with_missing_filename
+    @view.render(:partial => "test/")
+    flunk "Render did not raise ArgumentError"
+  rescue ArgumentError => e
+    assert_equal "The partial name (test/) is not a valid Ruby identifier; " +
+                                "make sure your partial name starts with a letter or underscore, " +
+                                "and is followed by any combinations of letters, numbers, or underscores.", e.message
+  end
+
   def test_render_partial_with_incompatible_object
     @view.render(:partial => nil)
     flunk "Render did not raise ArgumentError"

--- a/actionpack/test/template/render_test.rb
+++ b/actionpack/test/template/render_test.rb
@@ -21,9 +21,7 @@ module RenderTestCases
   end
 
   def test_render_without_options
-    @view.render()
-    flunk "Render did not raise ArgumentError"
-  rescue ArgumentError => e
+    e = assert_raises(ArgumentError) { @view.render() }
     assert_match "You invoked render but did not give any of :partial, :template, :inline, :file or :text option.", e.message
   end
 
@@ -153,34 +151,26 @@ module RenderTestCases
   end
 
   def test_render_partial_with_invalid_name
-    @view.render(:partial => "test/200")
-    flunk "Render did not raise ArgumentError"
-  rescue ArgumentError => e
+    e = assert_raises(ArgumentError) { @view.render(:partial => "test/200") }
     assert_equal "The partial name (test/200) is not a valid Ruby identifier; " +
-                                "make sure your partial name starts with a letter or underscore, " +
-                                "and is followed by any combinations of letters, numbers, or underscores.", e.message
+      "make sure your partial name starts with a letter or underscore, " +
+      "and is followed by any combinations of letters, numbers, or underscores.", e.message
   end
 
   def test_render_partial_with_missing_filename
-    @view.render(:partial => "test/")
-    flunk "Render did not raise ArgumentError"
-  rescue ArgumentError => e
+    e = assert_raises(ArgumentError) { @view.render(:partial => "test/") }
     assert_equal "The partial name (test/) is not a valid Ruby identifier; " +
-                                "make sure your partial name starts with a letter or underscore, " +
-                                "and is followed by any combinations of letters, numbers, or underscores.", e.message
+      "make sure your partial name starts with a letter or underscore, " +
+      "and is followed by any combinations of letters, numbers, or underscores.", e.message
   end
 
   def test_render_partial_with_incompatible_object
-    @view.render(:partial => nil)
-    flunk "Render did not raise ArgumentError"
-  rescue ArgumentError => e
-    assert_equal "'#{nil.inspect}' is not an ActiveModel-compatible object that returns a valid partial path.", e.message
+    e = assert_raises(ArgumentError) { @view.render(:partial => nil) }
+    assert_equal "'#{nil.inspect}' is not an ActiveModel-compatible object. It must implement :to_partial_path.", e.message
   end
 
   def test_render_partial_with_errors
-    @view.render(:partial => "test/raise")
-    flunk "Render did not raise Template::Error"
-  rescue ActionView::Template::Error => e
+    e = assert_raises(ActionView::Template::Error) { @view.render(:partial => "test/raise") }
     assert_match %r!method.*doesnt_exist!, e.message
     assert_equal "", e.sub_template_message
     assert_equal "1", e.line_number
@@ -189,9 +179,7 @@ module RenderTestCases
   end
 
   def test_render_sub_template_with_errors
-    @view.render(:template => "test/sub_template_raise")
-    flunk "Render did not raise Template::Error"
-  rescue ActionView::Template::Error => e
+    e = assert_raises(ActionView::Template::Error) { @view.render(:template => "test/sub_template_raise") }
     assert_match %r!method.*doesnt_exist!, e.message
     assert_equal "Trace of template inclusion: #{File.expand_path("#{FIXTURE_LOAD_PATH}/test/sub_template_raise.html.erb")}", e.sub_template_message
     assert_equal "1", e.line_number
@@ -199,9 +187,7 @@ module RenderTestCases
   end
 
   def test_render_file_with_errors
-    @view.render(:file => File.expand_path("test/_raise", FIXTURE_LOAD_PATH))
-    flunk "Render did not raise Template::Error"
-  rescue ActionView::Template::Error => e
+    e = assert_raises(ActionView::Template::Error) { @view.render(:file => File.expand_path("test/_raise", FIXTURE_LOAD_PATH)) }
     assert_match %r!method.*doesnt_exist!, e.message
     assert_equal "", e.sub_template_message
     assert_equal "1", e.line_number
@@ -309,7 +295,7 @@ module RenderTestCases
   # TODO: The reason for this test is unclear, improve documentation
   def test_render_missing_xml_partial_and_raise_missing_template
     @view.formats = [:xml]
-    assert_raise(ActionView::MissingTemplate) { @view.render(:partial => "test/layout_for_partial") }
+    assert_raises(ActionView::MissingTemplate) { @view.render(:partial => "test/layout_for_partial") }
   ensure
     @view.formats = nil
   end
@@ -360,7 +346,7 @@ module RenderTestCases
   def test_render_ignores_templates_with_malformed_template_handlers
     ActiveSupport::Deprecation.silence do
       %w(malformed malformed.erb malformed.html.erb malformed.en.html.erb).each do |name|
-        assert_raise(ActionView::MissingTemplate) { @view.render(:file => "test/malformed/#{name}") }
+        assert_raises(ActionView::MissingTemplate) { @view.render(:file => "test/malformed/#{name}") }
       end
     end
   end
@@ -484,26 +470,16 @@ class LazyViewRenderTest < ActiveSupport::TestCase
       end
     end
 
-    def test_render_utf8_template_with_incompatible_external_encoding
-      with_external_encoding Encoding::SHIFT_JIS do
-        begin
-          @view.render(:file => "test/utf8", :formats => [:html], :layouts => "layouts/yield")
-          flunk 'Should have raised incompatible encoding error'
-        rescue ActionView::Template::Error => error
-          assert_match 'Your template was not saved as valid Shift_JIS', error.original_exception.message
-        end
-      end
+  def test_render_utf8_template_with_incompatible_external_encoding
+    with_external_encoding Encoding::SHIFT_JIS do
+      e = assert_raises(ActionView::Template::Error) { @view.render(:file => "test/utf8", :formats => [:html], :layouts => "layouts/yield") }
+      assert_match 'Your template was not saved as valid Shift_JIS', e.original_exception.message
     end
 
-    def test_render_utf8_template_with_partial_with_incompatible_encoding
-      with_external_encoding Encoding::SHIFT_JIS do
-        begin
-          @view.render(:file => "test/utf8_magic_with_bare_partial", :formats => [:html], :layouts => "layouts/yield")
-          flunk 'Should have raised incompatible encoding error'
-        rescue ActionView::Template::Error => error
-          assert_match 'Your template was not saved as valid Shift_JIS', error.original_exception.message
-        end
-      end
+  def test_render_utf8_template_with_partial_with_incompatible_encoding
+    with_external_encoding Encoding::SHIFT_JIS do
+      e = assert_raises(ActionView::Template::Error) { @view.render(:file => "test/utf8_magic_with_bare_partial", :formats => [:html], :layouts => "layouts/yield") }
+      assert_match 'Your template was not saved as valid Shift_JIS', e.original_exception.message
     end
 
     def with_external_encoding(encoding)


### PR DESCRIPTION
Rendering a partial with a path, but missing filename like this...

`render :partial => "templates/subdir/"`

raises this error:

`undefined method `to_sym' for nil:NilClass`

from `ActionView::PartialRenderer#retrieve_variable` because it doesn't match the template name regexp. I think instead that method should return `variable` as `nil` instead, raising the `ArgumentError` further on instead.

(there's a corresponding pull request for master too: https://github.com/rails/rails/pull/5865) 
