### PR TITLE
Changes b tag to strong

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/templates/show.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/show.html.erb
@@ -2,7 +2,7 @@
 
 <% attributes.each do |attribute| -%>
 <p>
-  <b><%= attribute.human_name %>:</b>
+  <strong><%= attribute.human_name %>:</strong>
   <%%= @<%= singular_table_name %>.<%= attribute.name %> %>
 </p>
 


### PR DESCRIPTION
The change is made due to importance of the attribute name (e.g. Name:) on the page (versus just stylistic / appearance sake tag).
