### PR TITLE
replace ruby-debug19 with debugger on Rails 3-2 stable

### DIFF
--- a/railties/guides/code/getting_started/Gemfile
+++ b/railties/guides/code/getting_started/Gemfile
@@ -35,4 +35,4 @@ gem 'jquery-rails'
 # gem 'capistrano'
 
 # To use debugger
-# gem 'ruby-debug19', :require => 'ruby-debug'
+# gem 'debugger'

--- a/railties/guides/source/debugging_rails_applications.textile
+++ b/railties/guides/source/debugging_rails_applications.textile
@@ -205,7 +205,7 @@ The debugger used by Rails, +ruby-debug+, comes as a gem. To install it, just ru
 $ sudo gem install ruby-debug
 </shell>
 
-TIP: If you are using Ruby 1.9, you can install a compatible version of +ruby-debug+ by running +sudo gem install ruby-debug19+
+TIP: If you are using Ruby 1.9, you can install a compatible version of +debugger+ by running +sudo gem install debugger+
 
 In case you want to download a particular version or get the source code, refer to the "project's page on rubyforge":http://rubyforge.org/projects/ruby-debug/.
 

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -188,7 +188,7 @@ module Rails
         if RUBY_VERSION < "1.9"
           "gem 'ruby-debug'"
         else
-          "gem 'ruby-debug19', :require => 'ruby-debug'"
+          "gem 'debugger'"
         end
       end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -308,10 +308,10 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_inclusion_of_ruby_debug19_if_ruby19
+  def test_inclusion_of_debugger_if_ruby19
     run_generator
     assert_file "Gemfile" do |contents|
-      assert_match(/gem 'ruby-debug19', :require => 'ruby-debug'/, contents) unless RUBY_VERSION < '1.9'
+      assert_match(/gem 'debugger'/, contents) unless RUBY_VERSION < '1.9'
     end
   end
 


### PR DESCRIPTION
In continuance of #5835 , an appropriate patch to weed out ruby-debug19 from Rails-3-2 master as well. It is likely a large number of people are going to generate new Rails 3.2 apps on ruby1.9.3 for sometime in the future. The guidance should be to use the debugger gem on that platform.
