### PR TITLE
Stamping out ruby-debug19 and its cohorts with extreme prejudice

### DIFF
--- a/actionpack/lib/action_controller/vendor/html-scanner/html/sanitizer.rb
+++ b/actionpack/lib/action_controller/vendor/html-scanner/html/sanitizer.rb
@@ -99,7 +99,7 @@ module HTML
     self.allowed_protocols      = Set.new(%w(ed2k ftp http https irc mailto news gopher nntp telnet webcal xmpp callto
       feed svn urn aim rsync tag ssh sftp rtsp afs))
 
-    # Specifies the default Set of acceptable css keywords that #sanitize and #sanitize_css will accept.
+    # Specifies the default Set of acceptable css properties that #sanitize and #sanitize_css will accept.
     self.allowed_css_properties = Set.new(%w(azimuth background-color border-bottom-color border-collapse
       border-color border-left-color border-right-color border-top-color clear color cursor direction display
       elevation float font font-family font-size font-style font-variant font-weight height letter-spacing line-height

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -29,7 +29,7 @@ module ActionDispatch # :nodoc:
   #  class DemoControllerTest < ActionDispatch::IntegrationTest
   #    def test_print_root_path_to_console
   #      get('/')
-  #      puts @response.body
+  #      puts response.body
   #    end
   #  end
   class Response

--- a/actionpack/lib/action_dispatch/middleware/flash.rb
+++ b/actionpack/lib/action_dispatch/middleware/flash.rb
@@ -17,7 +17,7 @@ module ActionDispatch
   #     def create
   #       # save post
   #       flash[:notice] = "Post successfully created"
-  #       redirect_to posts_path(@post)
+  #       redirect_to @post
   #     end
   #
   #     def show

--- a/actionpack/lib/action_dispatch/routing/redirection.rb
+++ b/actionpack/lib/action_dispatch/routing/redirection.rb
@@ -67,10 +67,10 @@ module ActionDispatch
       # params, depending of how many arguments your block accepts. A string is required as a
       # return value.
       #
-      #   match 'jokes/:number', :to => redirect do |params, request|
+      #   match 'jokes/:number', :to => redirect { |params, request|
       #     path = (params[:number].to_i.even? ? "/wheres-the-beef" : "/i-love-lamp")
-      #     "http://#{request.host_with_port}/#{path}"
-      #   end
+      #     "http://#{request.host_with_port}#{path}"
+      #   }
       #
       # The options version of redirect allows you to supply only the parts of the url which need
       # to change, it also supports interpolation of the path similar to the first example.

--- a/actionpack/lib/action_dispatch/routing/redirection.rb
+++ b/actionpack/lib/action_dispatch/routing/redirection.rb
@@ -68,8 +68,8 @@ module ActionDispatch
       # return value.
       #
       #   match 'jokes/:number', :to => redirect { |params, request|
-      #     path = (params[:number].to_i.even? ? "/wheres-the-beef" : "/i-love-lamp")
-      #     "http://#{request.host_with_port}#{path}"
+      #     path = (params[:number].to_i.even? ? "wheres-the-beef" : "i-love-lamp")
+      #     "http://#{request.host_with_port}/#{path}"
       #   }
       #
       # Note that the `do end` syntax for the redirect block wouldn't work, as Ruby would pass

--- a/actionpack/lib/action_dispatch/routing/redirection.rb
+++ b/actionpack/lib/action_dispatch/routing/redirection.rb
@@ -72,6 +72,9 @@ module ActionDispatch
       #     "http://#{request.host_with_port}#{path}"
       #   }
       #
+      # Note that the `do end` syntax for the redirect block wouldn't work, as Ruby would pass
+      # the block to `match` instead of `redirect`. Use `{ ... }` instead.
+      #
       # The options version of redirect allows you to supply only the parts of the url which need
       # to change, it also supports interpolation of the path similar to the first example.
       #

--- a/actionpack/test/controller/rescue_test.rb
+++ b/actionpack/test/controller/rescue_test.rb
@@ -60,11 +60,6 @@ class RescueController < ActionController::Base
     render :text => exception.message
   end
 
-  # This is a Dispatcher exception and should be in ApplicationController.
-  rescue_from ActionController::RoutingError do
-    render :text => 'no way'
-  end
-
   rescue_from ActionView::TemplateError do
     render :text => 'action_view templater error'
   end

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -130,12 +130,12 @@ module ActiveModel
     # has more than one error message, yields once for each error message.
     #
     #   p.errors.add(:name, "can't be blank")
-    #   p.errors.each do |attribute, errors_array|
+    #   p.errors.each do |attribute, error|
     #     # Will yield :name and "can't be blank"
     #   end
     #
     #   p.errors.add(:name, "must be specified")
-    #   p.errors.each do |attribute, errors_array|
+    #   p.errors.each do |attribute, error|
     #     # Will yield :name and "can't be blank"
     #     # then yield :name and "must be specified"
     #   end

--- a/activemodel/lib/active_model/model.rb
+++ b/activemodel/lib/active_model/model.rb
@@ -42,7 +42,7 @@ module ActiveModel
   #     include ActiveModel::Model
   #     attr_accessor :id, :name, :omg
   #
-  #     def initialize(attributes)
+  #     def initialize(attributes={})
   #       super
   #       @omg ||= true
   #     end

--- a/activemodel/lib/active_model/model.rb
+++ b/activemodel/lib/active_model/model.rb
@@ -2,11 +2,11 @@ module ActiveModel
 
   # == Active Model Basic Model
   #
-  # Includes the required interface for an object to interact with +ActionPack+,
-  # using different +ActiveModel+ modules. It includes model name introspections,
+  # Includes the required interface for an object to interact with <tt>ActionPack</tt>,
+  # using different <tt>ActiveModel</tt> modules. It includes model name introspections,
   # conversions, translations and validations. Besides that, it allows you to
   # initialize the object with a hash of attributes, pretty much like
-  # +ActiveRecord+ does.
+  # <tt>ActiveRecord</tt> does.
   #
   # A minimal implementation could be:
   #
@@ -19,8 +19,8 @@ module ActiveModel
   #   person.name # => 'bob'
   #   person.age # => 18
   #
-  # Note that, by default, +ActiveModel::Model+ implements +persisted?+ to
-  # return +false+, which is the most common case. You may want to override it
+  # Note that, by default, <tt>ActiveModel::Model</tt> implements <tt>persisted?</tt> to
+  # return <tt>false</tt>, which is the most common case. You may want to override it
   # in your class to simulate a different scenario:
   #
   #   class Person
@@ -35,7 +35,7 @@ module ActiveModel
   #   person = Person.new(:id => 1, :name => 'bob')
   #   person.persisted? # => true
   #
-  # Also, if for some reason you need to run code on +initialize+, make sure you
+  # Also, if for some reason you need to run code on <tt>initialize</tt>, make sure you
   # call super if you want the attributes hash initialization to happen.
   #
   #   class Person
@@ -52,7 +52,7 @@ module ActiveModel
   #   person.omg # => true
   #
   # For more detailed information on other functionalities available, please refer
-  # to the specific modules included in +ActiveModel::Model+ (see below).
+  # to the specific modules included in <tt>ActiveModel::Model</tt> (see below).
   module Model
     def self.included(base)
       base.class_eval do

--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -8,7 +8,8 @@ module ActiveModel
       # Provides an interface for any class to have <tt>before_validation</tt> and
       # <tt>after_validation</tt> callbacks.
       #
-      # First, extend ActiveModel::Callbacks from the class you are creating:
+      # First, include ActiveModel::Validations::Callbacks from the class you are
+      # creating:
       #
       #   class MyModel
       #     include ActiveModel::Validations::Callbacks

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1097,15 +1097,12 @@ module ActiveRecord
       #   alongside this object by calling their +destroy+ method. If set to <tt>:delete_all</tt> all associated
       #   objects are deleted *without* calling their +destroy+ method. If set to <tt>:nullify</tt> all associated
       #   objects' foreign keys are set to +NULL+ *without* calling their +save+ callbacks. If set to
-      #   <tt>:restrict</tt> an error will be added to the object, preventing its deletion, if any associated
+      #   <tt>:restrict</tt> an error will be added to the object, preventing its deletion, if any associated 
       #   objects are present.
       #
       #   If using with the <tt>:through</tt> option, the association on the join model must be
       #   a +belongs_to+, and the records which get deleted are the join records, rather than
       #   the associated records.
-      #
-      #   If you don't set any values, all associated objects remain untouched and with an invalid
-      #   foreign key.
       #
       # [:finder_sql]
       #   Specify a complete SQL statement to fetch the association. This is a good way to go for complex
@@ -1385,7 +1382,7 @@ module ActiveRecord
       #   and +decrement_counter+. The counter cache is incremented when an object of this
       #   class is created and decremented when it's destroyed. This requires that a column
       #   named <tt>#{table_name}_count</tt> (such as +comments_count+ for a belonging Comment class)
-      #   is used on the associate class (such as a Post class) - that is the migration for
+      #   is used on the associate class (such as a Post class) - that is the migration for 
       #   <tt>#{table_name}_count</tt> is created on the associate class (such that Post.comments_count will
       #   return the count cached, see note below). You can also specify a custom counter
       #   cache column by providing a column name instead of a +true+/+false+ value to this

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1097,12 +1097,15 @@ module ActiveRecord
       #   alongside this object by calling their +destroy+ method. If set to <tt>:delete_all</tt> all associated
       #   objects are deleted *without* calling their +destroy+ method. If set to <tt>:nullify</tt> all associated
       #   objects' foreign keys are set to +NULL+ *without* calling their +save+ callbacks. If set to
-      #   <tt>:restrict</tt> an error will be added to the object, preventing its deletion, if any associated 
+      #   <tt>:restrict</tt> an error will be added to the object, preventing its deletion, if any associated
       #   objects are present.
       #
       #   If using with the <tt>:through</tt> option, the association on the join model must be
       #   a +belongs_to+, and the records which get deleted are the join records, rather than
       #   the associated records.
+      #
+      #   If you don't set any values, all associated objects remain untouched and with an invalid
+      #   foreign key.
       #
       # [:finder_sql]
       #   Specify a complete SQL statement to fetch the association. This is a good way to go for complex
@@ -1382,7 +1385,7 @@ module ActiveRecord
       #   and +decrement_counter+. The counter cache is incremented when an object of this
       #   class is created and decremented when it's destroyed. This requires that a column
       #   named <tt>#{table_name}_count</tt> (such as +comments_count+ for a belonging Comment class)
-      #   is used on the associate class (such as a Post class) - that is the migration for 
+      #   is used on the associate class (such as a Post class) - that is the migration for
       #   <tt>#{table_name}_count</tt> is created on the associate class (such that Post.comments_count will
       #   return the count cached, see note below). You can also specify a custom counter
       #   cache column by providing a column name instead of a +true+/+false+ value to this

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -376,7 +376,7 @@ module ActiveRecord
       # Note: SQLite doesn't support index length
       #
       # ====== Creating an index with a sort order (desc or asc, asc is the default)
-      #  add_index(:accounts, [:branch_id, :party_id, :surname], :order => {:branch_id => :desc, :part_id => :asc})
+      #  add_index(:accounts, [:branch_id, :party_id, :surname], :order => {:branch_id => :desc, :party_id => :asc})
       # generates
       #  CREATE INDEX by_branch_desc_party ON accounts(branch_id DESC, party_id ASC, surname)
       #

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -65,6 +65,7 @@ module ActiveSupport
     autoload :MessageVerifier
     autoload :Multibyte
     autoload :OptionMerger
+    autoload :OrderedHash
     autoload :OrderedOptions
     autoload :Rescuable
     autoload :StringInquirer

--- a/activesupport/lib/active_support/core_ext/kernel/debugger.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/debugger.rb
@@ -1,8 +1,8 @@
 module Kernel
   unless respond_to?(:debugger)
-    # Starts a debugging session if ruby-debug has been loaded (call rails server --debugger to do load it).
+    # Starts a debugging session if debugger has been loaded (call rails server --debugger to do load it).
     def debugger
-      message = "\n***** Debugger requested, but was not available (ensure ruby-debug19 is listed in Gemfile/installed as gem): Start server with --debugger to enable *****\n"
+      message = "\n***** Debugger requested, but was not available (ensure debugger is listed in Gemfile/installed as gem): Start server with --debugger to enable *****\n"
       defined?(Rails) ? Rails.logger.info(message) : $stderr.puts(message)
     end
     alias breakpoint debugger unless respond_to?(:breakpoint)

--- a/activesupport/lib/active_support/core_ext/kernel/debugger.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/debugger.rb
@@ -1,6 +1,6 @@
 module Kernel
   unless respond_to?(:debugger)
-    # Starts a debugging session if debugger has been loaded (call rails server --debugger to do load it).
+    # Starts a debugging session if +debugger+ gem has been loaded (call rails server --debugger to do load it).
     def debugger
       message = "\n***** Debugger requested, but was not available (ensure debugger is listed in Gemfile/installed as gem): Start server with --debugger to enable *****\n"
       defined?(Rails) ? Rails.logger.info(message) : $stderr.puts(message)

--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -44,16 +44,16 @@ module ActiveSupport
   #   event.duration  # => 10 (in milliseconds)
   #   event.payload   # => { :extra => :information }
   #
-  # The block in the +subscribe+ call gets the name of the event, start
+  # The block in the <tt>subscribe</tt> call gets the name of the event, start
   # timestamp, end timestamp, a string with a unique identifier for that event
   # (something like "535801666f04d0298cd6"), and a hash with the payload, in
   # that order.
   #
   # If an exception happens during that particular instrumentation the payload will
-  # have a key +:exception+ with an array of two elements as value: a string with
+  # have a key <tt>:exception</tt> with an array of two elements as value: a string with
   # the name of the exception class, and the exception message.
   #
-  # As the previous example depicts, the class +ActiveSupport::Notifications::Event+
+  # As the previous example depicts, the class <tt>ActiveSupport::Notifications::Event</tt>
   # is able to take the arguments as they come and provide an object-oriented
   # interface to that data.
   #
@@ -63,7 +63,7 @@ module ActiveSupport
   #     ...
   #   end
   #
-  # and even pass no argument to +subscribe+, in which case you are subscribing
+  # and even pass no argument to <tt>subscribe</tt>, in which case you are subscribing
   # to all events.
   #
   # == Temporary Subscriptions

--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -57,6 +57,33 @@ module ActiveSupport
   # is able to take the arguments as they come and provide an object-oriented
   # interface to that data.
   #
+  # It is also possible to pass an object as the second parameter passed to the
+  # <tt>subscribe</tt> method instead of a block:
+  #
+  #   module ActionController
+  #     class PageRequest
+  #       def call(name, started, finished, unique_id, payload)
+  #         Rails.logger.debug ["notification:", name, started, finished, unique_id, payload].join(" ")
+  #       end
+  #     end
+  #   end
+  #
+  #   ActiveSupport::Notifications.subscribe('process_action.action_controller', ActionController::PageRequest.new)
+  #
+  # resulting in the following output within the logs including a hash with the payload:
+  #
+  #   notification: process_action.action_controller 2012-04-13 01:08:35 +0300 2012-04-13 01:08:35 +0300 af358ed7fab884532ec7 {
+  #      :controller=>"Devise::SessionsController",
+  #      :action=>"new",
+  #      :params=>{"action"=>"new", "controller"=>"devise/sessions"},
+  #      :format=>:html,
+  #      :method=>"GET",
+  #      :path=>"/login/sign_in",
+  #      :status=>200,
+  #      :view_runtime=>279.3080806732178,
+  #      :db_runtime=>40.053
+  #    }
+  #
   # You can also subscribe to all events whose name matches a certain regexp:
   #
   #   ActiveSupport::Notifications.subscribe(/render/) do |*args|

--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -4,7 +4,7 @@ require 'active_support/notifications/fanout'
 module ActiveSupport
   # = Notifications
   #
-  # +ActiveSupport::Notifications+ provides an instrumentation API for Ruby.
+  # <tt>ActiveSupport::Notifications</tt> provides an instrumentation API for Ruby.
   #
   # == Instrumenters
   #

--- a/guides/code/getting_started/Gemfile
+++ b/guides/code/getting_started/Gemfile
@@ -35,4 +35,4 @@ gem 'jquery-rails'
 # gem 'capistrano'
 
 # To use debugger
-# gem 'ruby-debug19', :require => 'ruby-debug'
+# gem 'debugger'

--- a/guides/code/getting_started/README.rdoc
+++ b/guides/code/getting_started/README.rdoc
@@ -87,7 +87,7 @@ Debugger support is available through the debugger command when you start your
 Mongrel or WEBrick server with --debugger. This means that you can break out of
 execution at any point in the code, investigate and change the model, and then,
 resume execution! You need to install debugger to run the server in debugging
-mode. With gems, use <tt>sudo gem install debugger</tt>. Example:
+mode. With gems, use <tt>gem install debugger</tt>. Example:
 
   class WeblogController < ActionController::Base
     def index

--- a/guides/code/getting_started/README.rdoc
+++ b/guides/code/getting_started/README.rdoc
@@ -86,8 +86,8 @@ programming in general.
 Debugger support is available through the debugger command when you start your
 Mongrel or WEBrick server with --debugger. This means that you can break out of
 execution at any point in the code, investigate and change the model, and then,
-resume execution! You need to install ruby-debug19 to run the server in debugging
-mode. With gems, use <tt>sudo gem install ruby-debug19</tt>. Example:
+resume execution! You need to install debugger to run the server in debugging
+mode. With gems, use <tt>sudo gem install debugger</tt>. Example:
 
   class WeblogController < ActionController::Base
     def index

--- a/guides/source/active_record_querying.textile
+++ b/guides/source/active_record_querying.textile
@@ -539,7 +539,9 @@ And this will give you a single +Order+ object for each date where there are ord
 The SQL that would be executed would be something like this:
 
 <sql>
-SELECT date(created_at) as ordered_date, sum(price) as total_price FROM orders GROUP BY date(created_at)
+SELECT date(created_at) as ordered_date, sum(price) as total_price 
+FROM orders 
+GROUP BY date(created_at)
 </sql>
 
 h3. Having
@@ -555,7 +557,10 @@ Order.select("date(created_at) as ordered_date, sum(price) as total_price").grou
 The SQL that would be executed would be something like this:
 
 <sql>
-SELECT date(created_at) as ordered_date, sum(price) as total_price FROM orders GROUP BY date(created_at) HAVING sum(price) > 100
+SELECT date(created_at) as ordered_date, sum(price) as total_price 
+FROM orders 
+GROUP BY date(created_at) 
+HAVING sum(price) > 100
 </sql>
 
 This will return single order objects for each day, but only those that are ordered more than $100 in a day.

--- a/guides/source/active_record_querying.textile
+++ b/guides/source/active_record_querying.textile
@@ -834,7 +834,7 @@ SELECT categories.* FROM categories
   INNER JOIN posts ON posts.category_id = categories.id
 </sql>
 
-Or, in English: "return a Category object for all categories with posts". Note that you will see duplicate categories if more than one post has the same category. If you want unique categories, you can use Category.joins(:post).select("distinct(categories.id)").
+Or, in English: "return a Category object for all categories with posts". Note that you will see duplicate categories if more than one post has the same category. If you want unique categories, you can use Category.joins(:posts).select("distinct(categories.id)").
 
 h5. Joining Multiple Associations
 

--- a/guides/source/debugging_rails_applications.textile
+++ b/guides/source/debugging_rails_applications.textile
@@ -191,7 +191,7 @@ Completed in 0.01224 (81 reqs/sec) | DB: 0.00044 (3%) | 302 Found [http://localh
 
 Adding extra logging like this makes it easy to search for unexpected or unusual behavior in your logs. If you add extra logging, be sure to make sensible use of log levels, to avoid filling your production logs with useless trivia.
 
-h3. Debugging with +ruby-debug+
+h3. Debugging with +debugger+
 
 When your code is behaving in unexpected ways, you can try printing to logs or the console to diagnose the problem. Unfortunately, there are times when this sort of error tracking is not effective in finding the root cause of a problem. When you actually need to journey into your running source code, the debugger is your best companion.
 
@@ -199,17 +199,19 @@ The debugger can also help you if you want to learn about the Rails source code 
 
 h4. Setup
 
-The debugger used by Rails, +ruby-debug+, comes as a gem. To install it, just run:
+The debugger used by Rails, +debugger+, comes as a gem. To install it, just run:
 
 <shell>
-$ sudo gem install ruby-debug
+$ sudo gem install debugger
 </shell>
 
-TIP: If you are using Ruby 1.9, you can install a compatible version of +ruby-debug+ by running +sudo gem install ruby-debug19+
+TIP: If you are using Ruby 1.9, you can install a compatible version of +ruby-debug+ by running +sudo gem install debugger+
 
 In case you want to download a particular version or get the source code, refer to the "project's page on rubyforge":http://rubyforge.org/projects/ruby-debug/.
 
 Rails has had built-in support for ruby-debug since Rails 2.0. Inside any Rails application you can invoke the debugger by calling the +debugger+ method.
+
+ruby-debug19 has had a number of compatibility issues with ruby 1.9.3+ and as such the ball has been picked to maintain the ruby debugging gem in the newer "debugger" gem.
 
 Here's an example:
 
@@ -238,11 +240,11 @@ $ rails server --debugger
 ...
 </shell>
 
-TIP: In development mode, you can dynamically +require \'ruby-debug\'+ instead of restarting the server, if it was started without +--debugger+.
+TIP: In development mode, you can dynamically +require \'debugger\'+ instead of restarting the server, if it was started without +--debugger+.
 
 h4. The Shell
 
-As soon as your application calls the +debugger+ method, the debugger will be started in a debugger shell inside the terminal window where you launched your application server, and you will be placed at ruby-debug's prompt +(rdb:n)+. The _n_ is the thread number. The prompt will also show you the next line of code that is waiting to run.
+As soon as your application calls the +debugger+ method, the debugger will be started in a debugger shell inside the terminal window where you launched your application server, and you will be placed at debugger's prompt +(rdb:n)+. The _n_ is the thread number. The prompt will also show you the next line of code that is waiting to run.
 
 If you got there by a browser request, the browser tab containing the request will be hung until the debugger has finished and the trace has finished processing the entire request.
 
@@ -270,7 +272,7 @@ continue   edit     frame   method  putl  set      tmate   where
 
 TIP: To view the help menu for any command use +help &lt;command-name&gt;+ in active debug mode. For example: _+help var+_
 
-The next command to learn is one of the most useful: +list+. You can also abbreviate ruby-debug commands by supplying just enough letters to distinguish them from other commands, so you can also use +l+ for the +list+ command.
+The next command to learn is one of the most useful: +list+. You can also abbreviate debugger commands by supplying just enough letters to distinguish them from other commands, so you can also use +l+ for the +list+ command.
 
 This command shows you where you are in the code by printing 10 lines centered around the current line; the current line in this particular case is line 6 and is marked by +=>+.
 
@@ -347,7 +349,7 @@ h4. The Context
 
 When you start debugging your application, you will be placed in different contexts as you go through the different parts of the stack.
 
-ruby-debug creates a context when a stopping point or an event is reached. The context has information about the suspended program which enables a debugger to inspect the frame stack, evaluate variables from the perspective of the debugged program, and contains information about the place where the debugged program is stopped.
+debugger creates a context when a stopping point or an event is reached. The context has information about the suspended program which enables a debugger to inspect the frame stack, evaluate variables from the perspective of the debugged program, and contains information about the place where the debugged program is stopped.
 
 At any time you can call the +backtrace+ command (or its alias +where+) to print the backtrace of the application. This can be very helpful to know how you got where you are. If you ever wondered about how you got somewhere in your code, then +backtrace+ will supply the answer.
 
@@ -463,7 +465,7 @@ h4. Step by Step
 
 Now you should know where you are in the running trace and be able to print the available variables. But lets continue and move on with the application execution.
 
-Use +step+ (abbreviated +s+) to continue running your program until the next logical stopping point and return control to ruby-debug.
+Use +step+ (abbreviated +s+) to continue running your program until the next logical stopping point and return control to debugger.
 
 TIP: You can also use <tt>step<plus> n</tt> and <tt>step- n</tt> to move forward or backward +n+ steps respectively.
 
@@ -485,12 +487,12 @@ class Author < ActiveRecord::Base
 end
 </ruby>
 
-TIP: You can use ruby-debug while using +rails console+. Just remember to +require "ruby-debug"+ before calling the +debugger+ method.
+TIP: You can use debugger while using +rails console+. Just remember to +require "debugger"+ before calling the +debugger+ method.
 
 <shell>
 $ rails console
 Loading development environment (Rails 3.1.0)
->> require "ruby-debug"
+>> require "debugger"
 => []
 >> author = Author.first
 => #<Author id: 1, first_name: "Bob", last_name: "Smith", created_at: "2008-07-31 12:46:10", updated_at: "2008-07-31 12:46:10">
@@ -603,7 +605,7 @@ A simple quit tries to terminate all threads in effect. Therefore your server wi
 
 h4. Settings
 
-There are some settings that can be configured in ruby-debug to make it easier to debug your code. Here are a few of the available options:
+There are some settings that can be configured in debugger to make it easier to debug your code. Here are a few of the available options:
 
 * +set reload+: Reload source code when changed.
 * +set autolist+: Execute +list+ command on every breakpoint.
@@ -612,7 +614,7 @@ There are some settings that can be configured in ruby-debug to make it easier t
 
 You can see the full list by using +help set+. Use +help set _subcommand_+ to learn about a particular +set+ command.
 
-TIP: You can include any number of these configuration lines inside a +.rdebugrc+ file in your HOME directory. ruby-debug will read this file every time it is loaded and configure itself accordingly.
+TIP: You can include any number of these configuration lines inside a +.rdebugrc+ file in your HOME directory. debugger will read this file every time it is loaded and configure itself accordingly.
 
 Here's a good start for an +.rdebugrc+:
 
@@ -703,11 +705,13 @@ There are some Rails plugins to help you to find errors and debug your applicati
 h3. References
 
 * "ruby-debug Homepage":http://www.datanoise.com/ruby-debug
+* "debugger Homepage":http://github.com/cldwalker/debugger
 * "Article: Debugging a Rails application with ruby-debug":http://www.sitepoint.com/article/debug-rails-app-ruby-debug/
 * "ruby-debug Basics screencast":http://brian.maybeyoureinsane.net/blog/2007/05/07/ruby-debug-basics-screencast/
-* "Ryan Bate's ruby-debug screencast":http://railscasts.com/episodes/54-debugging-with-ruby-debug
-* "Ryan Bate's stack trace screencast":http://railscasts.com/episodes/24-the-stack-trace
-* "Ryan Bate's logger screencast":http://railscasts.com/episodes/56-the-logger
+* "Ryan Bates' ruby-debug screencast":http://railscasts.com/episodes/54-debugging-with-ruby-debug
+* "Ryan Bates' debugging ruby (revised) screencast":http://railscasts.com/episodes/54-debugging-ruby-revised
+* "Ryan Bates' stack trace screencast":http://railscasts.com/episodes/24-the-stack-trace
+* "Ryan Bates' logger screencast":http://railscasts.com/episodes/56-the-logger
 * "Debugging with ruby-debug":http://bashdb.sourceforge.net/ruby-debug.html
 * "ruby-debug cheat sheet":http://cheat.errtheblog.com/s/rdebug/
 * "Ruby on Rails Wiki: How to Configure Logging":http://wiki.rubyonrails.org/rails/pages/HowtoConfigureLogging

--- a/guides/source/debugging_rails_applications.textile
+++ b/guides/source/debugging_rails_applications.textile
@@ -202,16 +202,16 @@ h4. Setup
 The debugger used by Rails, +debugger+, comes as a gem. To install it, just run:
 
 <shell>
-$ sudo gem install debugger
+$ gem install debugger
 </shell>
 
-TIP: If you are using Ruby 1.9, you can install a compatible version of +ruby-debug+ by running +sudo gem install debugger+
+TIP: If you are using Ruby 1.9, you can install a compatible version of +ruby-debug+ by running +gem install debugger+
 
 In case you want to download a particular version or get the source code, refer to the "project's page on rubyforge":http://rubyforge.org/projects/ruby-debug/.
 
 Rails has had built-in support for ruby-debug since Rails 2.0. Inside any Rails application you can invoke the debugger by calling the +debugger+ method.
 
-ruby-debug19 has had a number of compatibility issues with ruby 1.9.3+ and as such the ball has been picked to maintain the ruby debugging gem in the newer "debugger" gem.
++ruby-debug19+ gem has been replaced by the +debugger+ gem due to multiple issues on Ruby 1.9.3.
 
 Here's an example:
 
@@ -639,7 +639,7 @@ If a Ruby object does not go out of scope, the Ruby Garbage Collector won't swee
 To install it run:
 
 <shell>
-$ sudo gem install bleak_house
+$ gem install bleak_house
 </shell>
 
 Then setup your application for profiling. Then add the following at the bottom of config/environment.rb:

--- a/guides/source/migrations.textile
+++ b/guides/source/migrations.textile
@@ -779,7 +779,7 @@ Both migrations work for Alice.
 
 Bob comes back from vacation and:
 
-# Updates the source - which contains both migrations and the latests version of
+# Updates the source - which contains both migrations and the latest version of
 the Product model.
 # Runs outstanding migrations with +rake db:migrate+, which
 includes the one that updates the +Product+ model.

--- a/railties/lib/rails/commands/console.rb
+++ b/railties/lib/rails/commands/console.rb
@@ -27,7 +27,7 @@ module Rails
           opt.on("-e", "--environment=name", String,
                   "Specifies the environment to run this console under (test/development/production).",
                   "Default: development") { |v| options[:environment] = v.strip }
-          opt.on("--debugger", 'Enable ruby-debugging for the console.') { |v| options[:debugger] = v }
+          opt.on("--debugger", 'Enable ruby debugging for the console.') { |v| options[:debugger] = v }
           opt.parse!(arguments)
         end
 
@@ -73,10 +73,10 @@ module Rails
 
     def require_debugger
       begin
-        require 'ruby-debug'
+        require 'debugger'
         puts "=> Debugger enabled"
       rescue Exception
-        puts "You need to install ruby-debug19 to run the console in debugging mode. With gems, use 'gem install ruby-debug19'"
+        puts "You need to install debugger to run the console in debugging mode. With gems, use 'gem install debugger'"
         exit
       end
     end

--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -17,7 +17,7 @@ module Rails
           opts.on("-c", "--config=file", String,
                   "Use custom rackup configuration file") { |v| options[:config] = v }
           opts.on("-d", "--daemon", "Make server run as a Daemon.") { options[:daemonize] = true }
-          opts.on("-u", "--debugger", "Enable ruby-debugging for the server.") { options[:debugger] = true }
+          opts.on("-u", "--debugger", "Enable ruby debugging for the server.") { options[:debugger] = true }
           opts.on("-e", "--environment=name", String,
                   "Specifies the environment to run this server under (test/development/production).",
                   "Default: development") { |v| options[:environment] = v }

--- a/railties/lib/rails/generators/rails/app/templates/README
+++ b/railties/lib/rails/generators/rails/app/templates/README
@@ -86,8 +86,8 @@ programming in general.
 Debugger support is available through the debugger command when you start your
 Mongrel or WEBrick server with --debugger. This means that you can break out of
 execution at any point in the code, investigate and change the model, and then,
-resume execution! You need to install ruby-debug19 to run the server in debugging
-mode. With gems, use <tt>sudo gem install ruby-debug19</tt>. Example:
+resume execution! You need to install debugger to run the server in debugging
+mode. With gems, use <tt>sudo gem install debugger</tt>. Example:
 
   class WeblogController < ActionController::Base
     def index

--- a/railties/lib/rails/generators/rails/plugin_new/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/Gemfile
@@ -20,4 +20,4 @@ gem "jquery-rails"
 
 <% end -%>
 # To use debugger
-# gem 'ruby-debug19', :require => 'ruby-debug'
+# gem 'debugger'

--- a/railties/lib/rails/rack/debugger.rb
+++ b/railties/lib/rails/rack/debugger.rb
@@ -6,13 +6,13 @@ module Rails
 
         ARGV.clear # clear ARGV so that rails server options aren't passed to IRB
 
-        require 'ruby-debug'
+        require 'debugger'
 
         ::Debugger.start
         ::Debugger.settings[:autoeval] = true if ::Debugger.respond_to?(:settings)
         puts "=> Debugger enabled"
       rescue LoadError
-        puts "You need to install ruby-debug19 to run the server in debugging mode. With gems, use 'gem install ruby-debug19'"
+        puts "You need to install debugger to run the server in debugging mode. With gems, use 'gem install debugger'"
         exit
       end
 


### PR DESCRIPTION
Thank you `ruby-debug19` you served us well. Time for NKOTB.

Previous commit #5835 only removed the most obvious and visible +ruby-debug19+ presence (in a new Rails app's Gemfile), this pull request one goes postal on ruby-debug\* within guides and other generated messages.

/cc @vijaydev Feel free to further edit/improve the guides.
