### PR TITLE
Return routing redirect :path interpolation

### DIFF
--- a/actionpack/lib/action_dispatch/routing/redirection.rb
+++ b/actionpack/lib/action_dispatch/routing/redirection.rb
@@ -40,11 +40,14 @@ module ActionDispatch
       alias :options :block
 
       def path(params, request)
+        path = options.delete(:path){ request.path }
+        path = (!params.empty? && String === path && path.match(/%\{\w*\}/)) ? (path % params) : path
+
         url_options = {
           :protocol => request.protocol,
           :host     => request.host,
           :port     => request.optional_port,
-          :path     => request.path,
+          :path     => path,
           :params   => request.query_parameters
         }.merge options
 


### PR DESCRIPTION
This feature was implemented at 0bda6f1ec664fcfd1b312492a6419e3d76d5baa7, documented by 1e26bda0959c313ce5c1816bf4958b542050e5e2 and removed at 0809c675ef5831852b7c1aa8497402b2beff5185.

But the description is still here: https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/routing/redirection.rb#L75-79

I suggest to reimplement it (it's simple only 3 lines of code in this PR) or remove it from the documentation.

@joshk, @tenderlove what do yout think about it?
