### PR TITLE
Fix #5847 and #4045. Force load AR::Base before loading an application model.

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -121,5 +121,10 @@ module ActiveRecord
         end
       end
     end
+
+    config.after_initialize do
+      # We should load ActiveRecord::Base class before loading an application model.
+      require "active_record/base"
+    end
   end
 end

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -150,5 +150,28 @@ module ApplicationTests
       # expect only Invoke db:structure:dump (first_time)
       assert_no_match(/^\*\* Invoke db:structure:dump\s+$/, output)
     end
+
+    def test_load_activerecord_base_when_we_use_observers
+      Dir.chdir(app_path) do
+        `bundle exec rails g model user;
+         bundle exec rake db:migrate;
+         bundle exec rails g observer user;`
+
+        add_to_config "config.active_record.observers = :user_observer"
+
+        assert_equal "0", `bundle exec rails r "puts User.count"`.strip
+
+        app_file "lib/tasks/count_user.rake", <<-RUBY
+          namespace :user do
+            task :count => :environment do
+              puts User.count
+            end
+          end
+        RUBY
+
+        assert_equal "0", `bundle exec rake user:count`.strip
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This PR closes #5847 and #4045.
Please see these issues

I think these commits should be merged to 3-2-stable.
And the testcase only should be merged to master (already passed), because AR::Base is loaded initially. 
meybe by https://github.com/rails/rails/commit/d0bb43d621c471659d03504f48f0197c0ae3b57c
