### PR TITLE
Stamp out ruby-debug with debugger every where else in the code base

### DIFF
--- a/activesupport/lib/active_support/core_ext/kernel/debugger.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/debugger.rb
@@ -1,8 +1,8 @@
 module Kernel
   unless respond_to?(:debugger)
-    # Starts a debugging session if ruby-debug has been loaded (call rails server --debugger to do load it).
+    # Starts a debugging session if debugger has been loaded (call rails server --debugger to do load it).
     def debugger
-      message = "\n***** Debugger requested, but was not available (ensure ruby-debug19 is listed in Gemfile/installed as gem): Start server with --debugger to enable *****\n"
+      message = "\n***** Debugger requested, but was not available (ensure debugger is listed in Gemfile/installed as gem): Start server with --debugger to enable *****\n"
       defined?(Rails) ? Rails.logger.info(message) : $stderr.puts(message)
     end
     alias breakpoint debugger unless respond_to?(:breakpoint)

--- a/activesupport/lib/active_support/core_ext/kernel/debugger.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/debugger.rb
@@ -1,8 +1,8 @@
 module Kernel
   unless respond_to?(:debugger)
-    # Starts a debugging session if a debugger has been loaded (call rails server --debugger to do load it).
+    # Starts a debugging session if the +debugger+ gem has been loaded (call rails server --debugger to do load it).
     def debugger
-      message = "\n***** Debugger requested, but was not available (ensure debugger is listed in Gemfile/installed as gem): Start server with --debugger to enable *****\n"
+      message = "\n***** Debugger requested, but was not available (ensure the debugger gem is listed in Gemfile/installed as gem): Start server with --debugger to enable *****\n"
       defined?(Rails) ? Rails.logger.info(message) : $stderr.puts(message)
     end
     alias breakpoint debugger unless respond_to?(:breakpoint)

--- a/activesupport/lib/active_support/core_ext/kernel/debugger.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/debugger.rb
@@ -1,6 +1,6 @@
 module Kernel
   unless respond_to?(:debugger)
-    # Starts a debugging session if debugger has been loaded (call rails server --debugger to do load it).
+    # Starts a debugging session if +debugger+ gem has been loaded (call rails server --debugger to do load it).
     def debugger
       message = "\n***** Debugger requested, but was not available (ensure debugger is listed in Gemfile/installed as gem): Start server with --debugger to enable *****\n"
       defined?(Rails) ? Rails.logger.info(message) : $stderr.puts(message)

--- a/activesupport/lib/active_support/core_ext/kernel/debugger.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/debugger.rb
@@ -1,6 +1,6 @@
 module Kernel
   unless respond_to?(:debugger)
-    # Starts a debugging session if +debugger+ gem has been loaded (call rails server --debugger to do load it).
+    # Starts a debugging session if a debugger has been loaded (call rails server --debugger to do load it).
     def debugger
       message = "\n***** Debugger requested, but was not available (ensure debugger is listed in Gemfile/installed as gem): Start server with --debugger to enable *****\n"
       defined?(Rails) ? Rails.logger.info(message) : $stderr.puts(message)

--- a/guides/code/getting_started/Gemfile
+++ b/guides/code/getting_started/Gemfile
@@ -35,4 +35,4 @@ gem 'jquery-rails'
 # gem 'capistrano'
 
 # To use debugger
-# gem 'ruby-debug19', :require => 'ruby-debug'
+# gem 'debugger'

--- a/guides/code/getting_started/README.rdoc
+++ b/guides/code/getting_started/README.rdoc
@@ -86,7 +86,7 @@ programming in general.
 Debugger support is available through the debugger command when you start your
 Mongrel or WEBrick server with --debugger. This means that you can break out of
 execution at any point in the code, investigate and change the model, and then,
-resume execution! You need to install debugger to run the server in debugging
+resume execution! You need to install a debugger to run the server in debugging
 mode. With gems, use <tt>gem install debugger</tt>. Example:
 
   class WeblogController < ActionController::Base

--- a/guides/code/getting_started/README.rdoc
+++ b/guides/code/getting_started/README.rdoc
@@ -87,7 +87,7 @@ Debugger support is available through the debugger command when you start your
 Mongrel or WEBrick server with --debugger. This means that you can break out of
 execution at any point in the code, investigate and change the model, and then,
 resume execution! You need to install debugger to run the server in debugging
-mode. With gems, use <tt>sudo gem install debugger</tt>. Example:
+mode. With gems, use <tt>gem install debugger</tt>. Example:
 
   class WeblogController < ActionController::Base
     def index

--- a/guides/code/getting_started/README.rdoc
+++ b/guides/code/getting_started/README.rdoc
@@ -86,8 +86,8 @@ programming in general.
 Debugger support is available through the debugger command when you start your
 Mongrel or WEBrick server with --debugger. This means that you can break out of
 execution at any point in the code, investigate and change the model, and then,
-resume execution! You need to install ruby-debug19 to run the server in debugging
-mode. With gems, use <tt>sudo gem install ruby-debug19</tt>. Example:
+resume execution! You need to install debugger to run the server in debugging
+mode. With gems, use <tt>sudo gem install debugger</tt>. Example:
 
   class WeblogController < ActionController::Base
     def index

--- a/guides/code/getting_started/README.rdoc
+++ b/guides/code/getting_started/README.rdoc
@@ -86,8 +86,8 @@ programming in general.
 Debugger support is available through the debugger command when you start your
 Mongrel or WEBrick server with --debugger. This means that you can break out of
 execution at any point in the code, investigate and change the model, and then,
-resume execution! You need to install a debugger to run the server in debugging
-mode. With gems, use <tt>gem install debugger</tt>. Example:
+resume execution! You need to install the 'debugger' gem to run the server in debugging
+mode. Add gem 'debugger' to your Gemfile and run <tt>bundle</tt> to install it. Example:
 
   class WeblogController < ActionController::Base
     def index

--- a/guides/source/debugging_rails_applications.textile
+++ b/guides/source/debugging_rails_applications.textile
@@ -191,7 +191,7 @@ Completed in 0.01224 (81 reqs/sec) | DB: 0.00044 (3%) | 302 Found [http://localh
 
 Adding extra logging like this makes it easy to search for unexpected or unusual behavior in your logs. If you add extra logging, be sure to make sensible use of log levels, to avoid filling your production logs with useless trivia.
 
-h3. Debugging with +ruby-debug+
+h3. Debugging with +debugger+
 
 When your code is behaving in unexpected ways, you can try printing to logs or the console to diagnose the problem. Unfortunately, there are times when this sort of error tracking is not effective in finding the root cause of a problem. When you actually need to journey into your running source code, the debugger is your best companion.
 
@@ -199,17 +199,19 @@ The debugger can also help you if you want to learn about the Rails source code 
 
 h4. Setup
 
-The debugger used by Rails, +ruby-debug+, comes as a gem. To install it, just run:
+The debugger used by Rails, +debugger+, comes as a gem. To install it, just run:
 
 <shell>
-$ sudo gem install ruby-debug
+$ sudo gem install debugger
 </shell>
 
-TIP: If you are using Ruby 1.9, you can install a compatible version of +ruby-debug+ by running +sudo gem install ruby-debug19+
+TIP: If you are using Ruby 1.9, you can install a compatible version of +ruby-debug+ by running +sudo gem install debugger+
 
 In case you want to download a particular version or get the source code, refer to the "project's page on rubyforge":http://rubyforge.org/projects/ruby-debug/.
 
 Rails has had built-in support for ruby-debug since Rails 2.0. Inside any Rails application you can invoke the debugger by calling the +debugger+ method.
+
+ruby-debug19 has had a number of compatibility issues with ruby 1.9.3+ and as such the ball has been picked to maintain the ruby debugging gem in the newer "debugger" gem.
 
 Here's an example:
 
@@ -238,11 +240,11 @@ $ rails server --debugger
 ...
 </shell>
 
-TIP: In development mode, you can dynamically +require \'ruby-debug\'+ instead of restarting the server, if it was started without +--debugger+.
+TIP: In development mode, you can dynamically +require \'debugger\'+ instead of restarting the server, if it was started without +--debugger+.
 
 h4. The Shell
 
-As soon as your application calls the +debugger+ method, the debugger will be started in a debugger shell inside the terminal window where you launched your application server, and you will be placed at ruby-debug's prompt +(rdb:n)+. The _n_ is the thread number. The prompt will also show you the next line of code that is waiting to run.
+As soon as your application calls the +debugger+ method, the debugger will be started in a debugger shell inside the terminal window where you launched your application server, and you will be placed at debugger's prompt +(rdb:n)+. The _n_ is the thread number. The prompt will also show you the next line of code that is waiting to run.
 
 If you got there by a browser request, the browser tab containing the request will be hung until the debugger has finished and the trace has finished processing the entire request.
 
@@ -270,7 +272,7 @@ continue   edit     frame   method  putl  set      tmate   where
 
 TIP: To view the help menu for any command use +help &lt;command-name&gt;+ in active debug mode. For example: _+help var+_
 
-The next command to learn is one of the most useful: +list+. You can also abbreviate ruby-debug commands by supplying just enough letters to distinguish them from other commands, so you can also use +l+ for the +list+ command.
+The next command to learn is one of the most useful: +list+. You can also abbreviate debugger commands by supplying just enough letters to distinguish them from other commands, so you can also use +l+ for the +list+ command.
 
 This command shows you where you are in the code by printing 10 lines centered around the current line; the current line in this particular case is line 6 and is marked by +=>+.
 
@@ -347,7 +349,7 @@ h4. The Context
 
 When you start debugging your application, you will be placed in different contexts as you go through the different parts of the stack.
 
-ruby-debug creates a context when a stopping point or an event is reached. The context has information about the suspended program which enables a debugger to inspect the frame stack, evaluate variables from the perspective of the debugged program, and contains information about the place where the debugged program is stopped.
+debugger creates a context when a stopping point or an event is reached. The context has information about the suspended program which enables a debugger to inspect the frame stack, evaluate variables from the perspective of the debugged program, and contains information about the place where the debugged program is stopped.
 
 At any time you can call the +backtrace+ command (or its alias +where+) to print the backtrace of the application. This can be very helpful to know how you got where you are. If you ever wondered about how you got somewhere in your code, then +backtrace+ will supply the answer.
 
@@ -463,7 +465,7 @@ h4. Step by Step
 
 Now you should know where you are in the running trace and be able to print the available variables. But lets continue and move on with the application execution.
 
-Use +step+ (abbreviated +s+) to continue running your program until the next logical stopping point and return control to ruby-debug.
+Use +step+ (abbreviated +s+) to continue running your program until the next logical stopping point and return control to debugger.
 
 TIP: You can also use <tt>step<plus> n</tt> and <tt>step- n</tt> to move forward or backward +n+ steps respectively.
 
@@ -485,12 +487,12 @@ class Author < ActiveRecord::Base
 end
 </ruby>
 
-TIP: You can use ruby-debug while using +rails console+. Just remember to +require "ruby-debug"+ before calling the +debugger+ method.
+TIP: You can use debugger while using +rails console+. Just remember to +require "debugger"+ before calling the +debugger+ method.
 
 <shell>
 $ rails console
 Loading development environment (Rails 3.1.0)
->> require "ruby-debug"
+>> require "debugger"
 => []
 >> author = Author.first
 => #<Author id: 1, first_name: "Bob", last_name: "Smith", created_at: "2008-07-31 12:46:10", updated_at: "2008-07-31 12:46:10">
@@ -603,7 +605,7 @@ A simple quit tries to terminate all threads in effect. Therefore your server wi
 
 h4. Settings
 
-There are some settings that can be configured in ruby-debug to make it easier to debug your code. Here are a few of the available options:
+There are some settings that can be configured in debugger to make it easier to debug your code. Here are a few of the available options:
 
 * +set reload+: Reload source code when changed.
 * +set autolist+: Execute +list+ command on every breakpoint.
@@ -612,7 +614,7 @@ There are some settings that can be configured in ruby-debug to make it easier t
 
 You can see the full list by using +help set+. Use +help set _subcommand_+ to learn about a particular +set+ command.
 
-TIP: You can include any number of these configuration lines inside a +.rdebugrc+ file in your HOME directory. ruby-debug will read this file every time it is loaded and configure itself accordingly.
+TIP: You can include any number of these configuration lines inside a +.rdebugrc+ file in your HOME directory. debugger will read this file every time it is loaded and configure itself accordingly.
 
 Here's a good start for an +.rdebugrc+:
 
@@ -703,11 +705,13 @@ There are some Rails plugins to help you to find errors and debug your applicati
 h3. References
 
 * "ruby-debug Homepage":http://www.datanoise.com/ruby-debug
+* "debugger Homepage":http://github.com/cldwalker/debugger
 * "Article: Debugging a Rails application with ruby-debug":http://www.sitepoint.com/article/debug-rails-app-ruby-debug/
 * "ruby-debug Basics screencast":http://brian.maybeyoureinsane.net/blog/2007/05/07/ruby-debug-basics-screencast/
-* "Ryan Bate's ruby-debug screencast":http://railscasts.com/episodes/54-debugging-with-ruby-debug
-* "Ryan Bate's stack trace screencast":http://railscasts.com/episodes/24-the-stack-trace
-* "Ryan Bate's logger screencast":http://railscasts.com/episodes/56-the-logger
+* "Ryan Bates' ruby-debug screencast":http://railscasts.com/episodes/54-debugging-with-ruby-debug
+* "Ryan Bates' debugging ruby (revised) screencast":http://railscasts.com/episodes/54-debugging-ruby-revised
+* "Ryan Bates' stack trace screencast":http://railscasts.com/episodes/24-the-stack-trace
+* "Ryan Bates' logger screencast":http://railscasts.com/episodes/56-the-logger
 * "Debugging with ruby-debug":http://bashdb.sourceforge.net/ruby-debug.html
 * "ruby-debug cheat sheet":http://cheat.errtheblog.com/s/rdebug/
 * "Ruby on Rails Wiki: How to Configure Logging":http://wiki.rubyonrails.org/rails/pages/HowtoConfigureLogging

--- a/guides/source/debugging_rails_applications.textile
+++ b/guides/source/debugging_rails_applications.textile
@@ -191,7 +191,7 @@ Completed in 0.01224 (81 reqs/sec) | DB: 0.00044 (3%) | 302 Found [http://localh
 
 Adding extra logging like this makes it easy to search for unexpected or unusual behavior in your logs. If you add extra logging, be sure to make sensible use of log levels, to avoid filling your production logs with useless trivia.
 
-h3. Debugging with +debugger+ gem
+h3. Debugging with the +debugger+ gem
 
 When your code is behaving in unexpected ways, you can try printing to logs or the console to diagnose the problem. Unfortunately, there are times when this sort of error tracking is not effective in finding the root cause of a problem. When you actually need to journey into your running source code, the debugger is your best companion.
 
@@ -199,19 +199,13 @@ The debugger can also help you if you want to learn about the Rails source code 
 
 h4. Setup
 
-The debugger used by Rails, +debugger+, comes as a gem. To install it, just run:
+Rails uses the +debugger+ gem to set breakpoints and step through live code. To install it, just run:
 
 <shell>
 $ gem install debugger
 </shell>
 
-TIP: If you are using Ruby 1.9, you can install a compatible version of +ruby-debug+ by running +gem install debugger+
-
-In case you want to download a particular version or get the source code, refer to the "project's page on rubyforge":http://rubyforge.org/projects/ruby-debug/.
-
-Rails has had built-in support for ruby-debug since Rails 2.0. Inside any Rails application you can invoke the debugger by calling the +debugger+ method.
-
-+ruby-debug19+ gem has been replaced by the +debugger+ gem due to multiple issues on Ruby 1.9.3.
+Rails has had built-in support for debugging since Rails 2.0. Inside any Rails application you can invoke the debugger by calling the +debugger+ method.
 
 Here's an example:
 
@@ -272,7 +266,7 @@ continue   edit     frame   method  putl  set      tmate   where
 
 TIP: To view the help menu for any command use +help &lt;command-name&gt;+ in active debug mode. For example: _+help var+_
 
-The next command to learn is one of the most useful: +list+. You can also abbreviate the debugging commands by supplying just enough letters to distinguish them from other commands, so you can also use +l+ for the +list+ command.
+The next command to learn is one of the most useful: +list+. You can abbreviate any debugging command by supplying just enough letters to distinguish them from other commands, so you can also use +l+ for the +list+ command.
 
 This command shows you where you are in the code by printing 10 lines centered around the current line; the current line in this particular case is line 6 and is marked by +=>+.
 
@@ -487,7 +481,7 @@ class Author < ActiveRecord::Base
 end
 </ruby>
 
-TIP: You can use a debugger while using +rails console+. Just remember to +require "debugger"+ before calling the +debugger+ method.
+TIP: You can use the debugger while using +rails console+. Just remember to +require "debugger"+ before calling the +debugger+ method.
 
 <shell>
 $ rails console
@@ -605,7 +599,7 @@ A simple quit tries to terminate all threads in effect. Therefore your server wi
 
 h4. Settings
 
-There are some settings that can be configured in the +debugger+ gem to make it easier to debug your code. Here are a few of the available options:
+The +debugger+ gem can automatically show the code you're stepping through and reload it when you change it in an editor. Here are a few of the available options:
 
 * +set reload+: Reload source code when changed.
 * +set autolist+: Execute +list+ command on every breakpoint.
@@ -614,7 +608,7 @@ There are some settings that can be configured in the +debugger+ gem to make it 
 
 You can see the full list by using +help set+. Use +help set _subcommand_+ to learn about a particular +set+ command.
 
-TIP: You can include any number of these configuration lines inside a +.rdebugrc+ file in your HOME directory. +debugger+ gem will read this file every time it is loaded and configure itself accordingly.
+TIP: You can save these settings in an +.rdebugrc+ file in your home directory. The debugger reads these global settings when it starts.
 
 Here's a good start for an +.rdebugrc+:
 
@@ -708,7 +702,6 @@ h3. References
 * "debugger Homepage":http://github.com/cldwalker/debugger
 * "Article: Debugging a Rails application with ruby-debug":http://www.sitepoint.com/article/debug-rails-app-ruby-debug/
 * "ruby-debug Basics screencast":http://brian.maybeyoureinsane.net/blog/2007/05/07/ruby-debug-basics-screencast/
-* "Ryan Bates' ruby-debug screencast":http://railscasts.com/episodes/54-debugging-with-ruby-debug
 * "Ryan Bates' debugging ruby (revised) screencast":http://railscasts.com/episodes/54-debugging-ruby-revised
 * "Ryan Bates' stack trace screencast":http://railscasts.com/episodes/24-the-stack-trace
 * "Ryan Bates' logger screencast":http://railscasts.com/episodes/56-the-logger

--- a/guides/source/debugging_rails_applications.textile
+++ b/guides/source/debugging_rails_applications.textile
@@ -191,7 +191,7 @@ Completed in 0.01224 (81 reqs/sec) | DB: 0.00044 (3%) | 302 Found [http://localh
 
 Adding extra logging like this makes it easy to search for unexpected or unusual behavior in your logs. If you add extra logging, be sure to make sensible use of log levels, to avoid filling your production logs with useless trivia.
 
-h3. Debugging with +debugger+
+h3. Debugging with +debugger+ gem
 
 When your code is behaving in unexpected ways, you can try printing to logs or the console to diagnose the problem. Unfortunately, there are times when this sort of error tracking is not effective in finding the root cause of a problem. When you actually need to journey into your running source code, the debugger is your best companion.
 
@@ -244,7 +244,7 @@ TIP: In development mode, you can dynamically +require \'debugger\'+ instead of 
 
 h4. The Shell
 
-As soon as your application calls the +debugger+ method, the debugger will be started in a debugger shell inside the terminal window where you launched your application server, and you will be placed at debugger's prompt +(rdb:n)+. The _n_ is the thread number. The prompt will also show you the next line of code that is waiting to run.
+As soon as your application calls the +debugger+ method, the debugger will be started in a debugger shell inside the terminal window where you launched your application server, and you will be placed at the debugger's prompt +(rdb:n)+. The _n_ is the thread number. The prompt will also show you the next line of code that is waiting to run.
 
 If you got there by a browser request, the browser tab containing the request will be hung until the debugger has finished and the trace has finished processing the entire request.
 
@@ -272,7 +272,7 @@ continue   edit     frame   method  putl  set      tmate   where
 
 TIP: To view the help menu for any command use +help &lt;command-name&gt;+ in active debug mode. For example: _+help var+_
 
-The next command to learn is one of the most useful: +list+. You can also abbreviate debugger commands by supplying just enough letters to distinguish them from other commands, so you can also use +l+ for the +list+ command.
+The next command to learn is one of the most useful: +list+. You can also abbreviate the debugging commands by supplying just enough letters to distinguish them from other commands, so you can also use +l+ for the +list+ command.
 
 This command shows you where you are in the code by printing 10 lines centered around the current line; the current line in this particular case is line 6 and is marked by +=>+.
 
@@ -349,7 +349,7 @@ h4. The Context
 
 When you start debugging your application, you will be placed in different contexts as you go through the different parts of the stack.
 
-debugger creates a context when a stopping point or an event is reached. The context has information about the suspended program which enables a debugger to inspect the frame stack, evaluate variables from the perspective of the debugged program, and contains information about the place where the debugged program is stopped.
+The debugger creates a context when a stopping point or an event is reached. The context has information about the suspended program which enables a debugger to inspect the frame stack, evaluate variables from the perspective of the debugged program, and contains information about the place where the debugged program is stopped.
 
 At any time you can call the +backtrace+ command (or its alias +where+) to print the backtrace of the application. This can be very helpful to know how you got where you are. If you ever wondered about how you got somewhere in your code, then +backtrace+ will supply the answer.
 
@@ -465,7 +465,7 @@ h4. Step by Step
 
 Now you should know where you are in the running trace and be able to print the available variables. But lets continue and move on with the application execution.
 
-Use +step+ (abbreviated +s+) to continue running your program until the next logical stopping point and return control to debugger.
+Use +step+ (abbreviated +s+) to continue running your program until the next logical stopping point and return control to the debugger.
 
 TIP: You can also use <tt>step<plus> n</tt> and <tt>step- n</tt> to move forward or backward +n+ steps respectively.
 
@@ -487,7 +487,7 @@ class Author < ActiveRecord::Base
 end
 </ruby>
 
-TIP: You can use debugger while using +rails console+. Just remember to +require "debugger"+ before calling the +debugger+ method.
+TIP: You can use a debugger while using +rails console+. Just remember to +require "debugger"+ before calling the +debugger+ method.
 
 <shell>
 $ rails console
@@ -605,7 +605,7 @@ A simple quit tries to terminate all threads in effect. Therefore your server wi
 
 h4. Settings
 
-There are some settings that can be configured in debugger to make it easier to debug your code. Here are a few of the available options:
+There are some settings that can be configured in the +debugger+ gem to make it easier to debug your code. Here are a few of the available options:
 
 * +set reload+: Reload source code when changed.
 * +set autolist+: Execute +list+ command on every breakpoint.
@@ -614,7 +614,7 @@ There are some settings that can be configured in debugger to make it easier to 
 
 You can see the full list by using +help set+. Use +help set _subcommand_+ to learn about a particular +set+ command.
 
-TIP: You can include any number of these configuration lines inside a +.rdebugrc+ file in your HOME directory. debugger will read this file every time it is loaded and configure itself accordingly.
+TIP: You can include any number of these configuration lines inside a +.rdebugrc+ file in your HOME directory. +debugger+ gem will read this file every time it is loaded and configure itself accordingly.
 
 Here's a good start for an +.rdebugrc+:
 

--- a/guides/source/debugging_rails_applications.textile
+++ b/guides/source/debugging_rails_applications.textile
@@ -202,16 +202,16 @@ h4. Setup
 The debugger used by Rails, +debugger+, comes as a gem. To install it, just run:
 
 <shell>
-$ sudo gem install debugger
+$ gem install debugger
 </shell>
 
-TIP: If you are using Ruby 1.9, you can install a compatible version of +ruby-debug+ by running +sudo gem install debugger+
+TIP: If you are using Ruby 1.9, you can install a compatible version of +ruby-debug+ by running +gem install debugger+
 
 In case you want to download a particular version or get the source code, refer to the "project's page on rubyforge":http://rubyforge.org/projects/ruby-debug/.
 
 Rails has had built-in support for ruby-debug since Rails 2.0. Inside any Rails application you can invoke the debugger by calling the +debugger+ method.
 
-ruby-debug19 has had a number of compatibility issues with ruby 1.9.3+ and as such the ball has been picked to maintain the ruby debugging gem in the newer "debugger" gem.
++ruby-debug19+ gem has been replaced by the +debugger+ gem due to multiple issues on Ruby 1.9.3.
 
 Here's an example:
 
@@ -639,7 +639,7 @@ If a Ruby object does not go out of scope, the Ruby Garbage Collector won't swee
 To install it run:
 
 <shell>
-$ sudo gem install bleak_house
+$ gem install bleak_house
 </shell>
 
 Then setup your application for profiling. Then add the following at the bottom of config/environment.rb:

--- a/railties/lib/rails/commands/console.rb
+++ b/railties/lib/rails/commands/console.rb
@@ -27,7 +27,7 @@ module Rails
           opt.on("-e", "--environment=name", String,
                   "Specifies the environment to run this console under (test/development/production).",
                   "Default: development") { |v| options[:environment] = v.strip }
-          opt.on("--debugger", 'Enable ruby debugging for the console.') { |v| options[:debugger] = v }
+          opt.on("--debugger", 'Enable the debugger.') { |v| options[:debugger] = v }
           opt.parse!(arguments)
         end
 
@@ -76,7 +76,7 @@ module Rails
         require 'debugger'
         puts "=> Debugger enabled"
       rescue Exception
-        puts "You need to install a debugger to run the console in debugging mode. With gems, use 'gem install debugger'"
+        puts "You're missing the 'debugger' gem. Add it to your Gemfile, bundle, and try again."
         exit
       end
     end

--- a/railties/lib/rails/commands/console.rb
+++ b/railties/lib/rails/commands/console.rb
@@ -76,7 +76,7 @@ module Rails
         require 'debugger'
         puts "=> Debugger enabled"
       rescue Exception
-        puts "You need to install debugger to run the console in debugging mode. With gems, use 'gem install debugger'"
+        puts "You need to install a debugger to run the console in debugging mode. With gems, use 'gem install debugger'"
         exit
       end
     end

--- a/railties/lib/rails/commands/console.rb
+++ b/railties/lib/rails/commands/console.rb
@@ -27,7 +27,7 @@ module Rails
           opt.on("-e", "--environment=name", String,
                   "Specifies the environment to run this console under (test/development/production).",
                   "Default: development") { |v| options[:environment] = v.strip }
-          opt.on("--debugger", 'Enable ruby-debugging for the console.') { |v| options[:debugger] = v }
+          opt.on("--debugger", 'Enable ruby debugging for the console.') { |v| options[:debugger] = v }
           opt.parse!(arguments)
         end
 
@@ -73,10 +73,10 @@ module Rails
 
     def require_debugger
       begin
-        require 'ruby-debug'
+        require 'debugger'
         puts "=> Debugger enabled"
       rescue Exception
-        puts "You need to install ruby-debug19 to run the console in debugging mode. With gems, use 'gem install ruby-debug19'"
+        puts "You need to install debugger to run the console in debugging mode. With gems, use 'gem install debugger'"
         exit
       end
     end

--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -17,7 +17,7 @@ module Rails
           opts.on("-c", "--config=file", String,
                   "Use custom rackup configuration file") { |v| options[:config] = v }
           opts.on("-d", "--daemon", "Make server run as a Daemon.") { options[:daemonize] = true }
-          opts.on("-u", "--debugger", "Enable ruby-debugging for the server.") { options[:debugger] = true }
+          opts.on("-u", "--debugger", "Enable ruby debugging for the server.") { options[:debugger] = true }
           opts.on("-e", "--environment=name", String,
                   "Specifies the environment to run this server under (test/development/production).",
                   "Default: development") { |v| options[:environment] = v }

--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -17,7 +17,7 @@ module Rails
           opts.on("-c", "--config=file", String,
                   "Use custom rackup configuration file") { |v| options[:config] = v }
           opts.on("-d", "--daemon", "Make server run as a Daemon.") { options[:daemonize] = true }
-          opts.on("-u", "--debugger", "Enable ruby debugging for the server.") { options[:debugger] = true }
+          opts.on("-u", "--debugger", "Enable the debugger") { options[:debugger] = true }
           opts.on("-e", "--environment=name", String,
                   "Specifies the environment to run this server under (test/development/production).",
                   "Default: development") { |v| options[:environment] = v }

--- a/railties/lib/rails/generators/rails/app/templates/README
+++ b/railties/lib/rails/generators/rails/app/templates/README
@@ -86,8 +86,8 @@ programming in general.
 Debugger support is available through the debugger command when you start your
 Mongrel or WEBrick server with --debugger. This means that you can break out of
 execution at any point in the code, investigate and change the model, and then,
-resume execution! You need to install debugger to run the server in debugging
-mode. With gems, use <tt>sudo gem install debugger</tt>. Example:
+resume execution! You need to install a debugger to run the server in debugging
+mode. With gems, use <tt>gem install debugger</tt>. Example:
 
   class WeblogController < ActionController::Base
     def index

--- a/railties/lib/rails/generators/rails/app/templates/README
+++ b/railties/lib/rails/generators/rails/app/templates/README
@@ -86,8 +86,8 @@ programming in general.
 Debugger support is available through the debugger command when you start your
 Mongrel or WEBrick server with --debugger. This means that you can break out of
 execution at any point in the code, investigate and change the model, and then,
-resume execution! You need to install ruby-debug19 to run the server in debugging
-mode. With gems, use <tt>sudo gem install ruby-debug19</tt>. Example:
+resume execution! You need to install debugger to run the server in debugging
+mode. With gems, use <tt>sudo gem install debugger</tt>. Example:
 
   class WeblogController < ActionController::Base
     def index

--- a/railties/lib/rails/generators/rails/app/templates/README
+++ b/railties/lib/rails/generators/rails/app/templates/README
@@ -86,8 +86,8 @@ programming in general.
 Debugger support is available through the debugger command when you start your
 Mongrel or WEBrick server with --debugger. This means that you can break out of
 execution at any point in the code, investigate and change the model, and then,
-resume execution! You need to install a debugger to run the server in debugging
-mode. With gems, use <tt>gem install debugger</tt>. Example:
+resume execution! You need to install the 'debugger' gem to run the server in debugging
+mode. Add gem 'debugger' to your Gemfile and run <tt>bundle</tt> to install it. Example:
 
   class WeblogController < ActionController::Base
     def index

--- a/railties/lib/rails/generators/rails/plugin_new/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/Gemfile
@@ -20,4 +20,4 @@ gem "jquery-rails"
 
 <% end -%>
 # To use debugger
-# gem 'ruby-debug19', :require => 'ruby-debug'
+# gem 'debugger'

--- a/railties/lib/rails/rack/debugger.rb
+++ b/railties/lib/rails/rack/debugger.rb
@@ -6,13 +6,13 @@ module Rails
 
         ARGV.clear # clear ARGV so that rails server options aren't passed to IRB
 
-        require 'ruby-debug'
+        require 'debugger'
 
         ::Debugger.start
         ::Debugger.settings[:autoeval] = true if ::Debugger.respond_to?(:settings)
         puts "=> Debugger enabled"
       rescue LoadError
-        puts "You need to install ruby-debug19 to run the server in debugging mode. With gems, use 'gem install ruby-debug19'"
+        puts "You need to install debugger to run the server in debugging mode. With gems, use 'gem install debugger'"
         exit
       end
 

--- a/railties/lib/rails/rack/debugger.rb
+++ b/railties/lib/rails/rack/debugger.rb
@@ -12,7 +12,7 @@ module Rails
         ::Debugger.settings[:autoeval] = true if ::Debugger.respond_to?(:settings)
         puts "=> Debugger enabled"
       rescue LoadError
-        puts "You need to install a debugger to run the server in debugging mode. With gems, use 'gem install debugger'"
+        puts "You're missing the 'debugger' gem. Add it to your Gemfile, bundle, and try again."
         exit
       end
 

--- a/railties/lib/rails/rack/debugger.rb
+++ b/railties/lib/rails/rack/debugger.rb
@@ -12,7 +12,7 @@ module Rails
         ::Debugger.settings[:autoeval] = true if ::Debugger.respond_to?(:settings)
         puts "=> Debugger enabled"
       rescue LoadError
-        puts "You need to install debugger to run the server in debugging mode. With gems, use 'gem install debugger'"
+        puts "You need to install a debugger to run the server in debugging mode. With gems, use 'gem install debugger'"
         exit
       end
 


### PR DESCRIPTION
Just re-opening #5875 with a cleaner patch.
