### PR TITLE
Fix implied layout detection for anonymous controllers

### DIFF
--- a/actionpack/lib/abstract_controller/layouts.rb
+++ b/actionpack/lib/abstract_controller/layouts.rb
@@ -275,7 +275,9 @@ module AbstractController
         remove_possible_method(:_layout)
 
         prefixes    = _implied_layout_name =~ /\blayouts/ ? [] : ["layouts"]
-        name_clause = if name
+        name_clause = if anonymous?
+          "super"
+        else
           <<-RUBY
             lookup_context.find_all("#{_implied_layout_name}", #{prefixes.inspect}).first || super
           RUBY
@@ -315,7 +317,7 @@ module AbstractController
 
           layout_definition = if parent.nil?
               name_clause
-            elsif name
+            elsif !anonymous?
               <<-RUBY
                 if template = lookup_context.find_all("#{_implied_layout_name}", #{prefixes.inspect}).first
                   ActiveSupport::Deprecation.warn 'Layout found at "#{_implied_layout_name}" for #{name} but parent controller ' \

--- a/actionpack/test/abstract/layouts_test.rb
+++ b/actionpack/test/abstract/layouts_test.rb
@@ -16,7 +16,9 @@ module AbstractControllerTests
         "abstract_controller_tests/layouts/with_string_implied_child.erb" =>
                                            "With Implied <%= yield %>",
         "abstract_controller_tests/layouts/with_grand_child_of_implied.erb" =>
-                                           "With Grand Child <%= yield %>"
+                                           "With Grand Child <%= yield %>",
+        "abstract_controller_tests/layouts/with_implied_layout.erb" =>
+                                           "With Implied Layout <%= yield %>"
 
       )]
     end
@@ -168,6 +170,15 @@ module AbstractControllerTests
       end
     end
 
+    class WithImpliedLayout < Base
+      def index
+        render :template => ActionView::Template::Text.new("Hello!")
+      end
+    end
+
+    class WithImpliedLayoutChild < WithImpliedLayout
+    end
+
     class TestBase < ActiveSupport::TestCase
       test "when no layout is specified, and no default is available, render without a layout" do
         controller = Blank.new
@@ -311,6 +322,25 @@ module AbstractControllerTests
         controller = WithExceptConditional.new
         controller.process(:index)
         assert_equal "Overwrite Hello index!", controller.response_body
+      end
+
+      test "when no layout is specified and an implied layout exists, use the implied layout" do
+        controller = WithImpliedLayout.new
+        controller.process(:index)
+        assert_equal "With Implied Layout Hello!", controller.response_body
+      end
+
+      test "when no layout is specified and the parent has an implied layout, use the parent's implied layout" do
+        controller = WithImpliedLayoutChild.new
+        controller.process(:index)
+        assert_equal "With Implied Layout Hello!", controller.response_body
+      end
+
+      test "when an anonymous child has no layout specified and the parent has an implied layout, use the parent's implied layout" do
+        klass = Class.new(WithImpliedLayout)
+        controller = klass.new
+        controller.process(:index)
+        assert_equal "With Implied Layout Hello!", controller.response_body
       end
     end
   end


### PR DESCRIPTION
When creating an anonymous subclass of a controller,
`_write_layout_method` wasn't able to find a layout path even if a
parent controller had one that could be used. Now, the method will call
`super` if the current controller has no name.

In a related issue, we switch to using `anonymous?` rather than checking
only for `name` in order to be compatible with Ruby < 1.9 where anonymous
class names are set to the empty string rather than `nil`.
