### PR TITLE
Add missing dependency for active_record_deprecated_finders

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -137,12 +137,14 @@ module Rails
             gem 'rails',     :path => '#{Rails::Generators::RAILS_DEV_PATH}'
             gem 'journey',   :git => 'https://github.com/rails/journey.git'
             gem 'arel',      :git => 'https://github.com/rails/arel.git'
+            gem 'active_record_deprecated_finders', :git => 'git://github.com/rails/active_record_deprecated_finders.git'
           GEMFILE
         elsif options.edge?
           <<-GEMFILE.strip_heredoc
             gem 'rails',     :git => 'https://github.com/rails/rails.git'
             gem 'journey',   :git => 'https://github.com/rails/journey.git'
             gem 'arel',      :git => 'https://github.com/rails/arel.git'
+            gem 'active_record_deprecated_finders', :git => 'git://github.com/rails/active_record_deprecated_finders.git'
           GEMFILE
         else
           <<-GEMFILE.strip_heredoc


### PR DESCRIPTION
When running 
ruby railties/bin/rails new /tmp/myapp --dev
Bundle install fails because active_record_deprecated_finders gem is not released.
I added the gem dependency pointing to the git repo in the generated Gemfile.
