### PR TITLE
Remove unused and duplicated code. We should use 'active_support/time.rb'.

### DIFF
--- a/activesupport/lib/active_support/time/autoload.rb
+++ b/activesupport/lib/active_support/time/autoload.rb
@@ -1,5 +1,0 @@
-module ActiveSupport
-  autoload :Duration, 'active_support/duration'
-  autoload :TimeWithZone, 'active_support/time_with_zone'
-  autoload :TimeZone, 'active_support/values/time_zone'
-end


### PR DESCRIPTION
I guess that this code isn't used and we should use active_support/time.rb.

sorry and close it, if I'm wrong.
