### PR TITLE
Fix nil logger on 3.2

### DIFF
--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -191,7 +191,7 @@ module ActiveRecord
       protected
 
         def valid_scope_name?(name)
-          if respond_to?(name, true)
+          if logger && respond_to?(name, true)
             logger.warn "Creating scope :#{name}. " \
                         "Overwriting existing method #{self.name}.#{name}."
           end


### PR DESCRIPTION
The logger can sometimes be `nil` when AR records are used outside of Rails, this adds a check.

This patch is not necessary on 3-1-stable or master.
