### PR TITLE
Expose ActiveSupport::Autoload.autoloads

### DIFF
--- a/activesupport/lib/active_support/dependencies/autoload.rb
+++ b/activesupport/lib/active_support/dependencies/autoload.rb
@@ -46,7 +46,7 @@ module ActiveSupport
       @@autoloads.values.each { |file| require file }
     end
 
-    def autoloads
+    def self.autoloads
       @@autoloads
     end
   end


### PR DESCRIPTION
Preloading AR doesn't work when no `ActionDispatch` is available since `AR::SessionStore` inherits from `ActionDispatch::Something`.

So I needed `ActiveSupport::Autoload.autoloads` to remove `SessionStore` from preloading.
I discovered that `autoloads` is a instance method and is used nowhere, so I guess this was overlooked.
