### PR TITLE
current MySQL driver fails to fetch PK name when the PK has USING option

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -516,7 +516,7 @@ module ActiveRecord
       def pk_and_sequence_for(table)
         execute_and_free("SHOW CREATE TABLE #{quote_table_name(table)}", 'SCHEMA') do |result|
           create_table = each_hash(result).first[:"Create Table"]
-          if create_table.to_s =~ /PRIMARY KEY\s+\((.+)\)/
+          if create_table.to_s =~ /PRIMARY KEY\s+(?:USING\s+\w+\s+)?\((.+)\)/
             keys = $1.split(",").map { |key| key.delete('`"') }
             keys.length == 1 ? [keys.first, nil] : nil
           else

--- a/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
@@ -56,6 +56,36 @@ module ActiveRecord
         end
       end
 
+      def test_pk_and_sequence_for
+        pk, seq = @conn.pk_and_sequence_for('ex')
+        assert_equal 'id', pk
+        assert_equal @conn.default_sequence_name('ex', 'id'), seq
+      end
+
+      def test_pk_and_sequence_for_with_non_standard_primary_key
+        @conn.exec_query('drop table if exists ex_with_non_standard_pk')
+        @conn.exec_query(<<-eosql)
+          CREATE TABLE `ex_with_non_standard_pk` (
+            `code` INT(11) DEFAULT NULL auto_increment,
+             PRIMARY KEY  (`code`))
+        eosql
+        pk, seq = @conn.pk_and_sequence_for('ex_with_non_standard_pk')
+        assert_equal 'code', pk
+        assert_equal @conn.default_sequence_name('ex_with_non_standard_pk', 'code'), seq
+      end
+
+      def test_pk_and_sequence_for_with_custom_index_type_pk
+        @conn.exec_query('drop table if exists ex_with_custom_index_type_pk')
+        @conn.exec_query(<<-eosql)
+          CREATE TABLE `ex_with_custom_index_type_pk` (
+            `id` INT(11) DEFAULT NULL auto_increment,
+             PRIMARY KEY  USING BTREE (`id`))
+        eosql
+        pk, seq = @conn.pk_and_sequence_for('ex_with_custom_index_type_pk')
+        assert_equal 'id', pk
+        assert_equal @conn.default_sequence_name('ex_with_custom_index_type_pk', 'id'), seq
+      end
+
       private
       def insert(ctx, data)
         binds   = data.map { |name, value|


### PR DESCRIPTION
Given the following MySQL table (you know we sometimes should unfortunately work on some legacy DB or non-Rails DB like this):

``` SQL```
CREATE TABLE `btree_pk_tables` (
  `id` int(11) NOT NULL auto_increment,
  PRIMARY KEY  USING BTREE (`id`)
)
```

`BtreePkTable.primary_key` becomes `nil` because of Regexp bug.
Attached a patch with test cases. Tested on MySQL 5.1, Ruby 1.9.3.

Because this bug happens on current stable version of AR, I hope this to be backported to 3-2-stable branch. I confirmed that the Regexp works either on Ruby 1.9 and Ruby 1.8.7, so it should work.
