### PR TITLE
Don't indent blank lines in named base generators

### DIFF
--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -40,7 +40,7 @@ module Rails
 
         def indent(content, multiplier = 2)
           spaces = " " * multiplier
-          content = content.each_line.map {|line| "#{spaces}#{line}" }.join
+          content = content.each_line.map {|line| line.blank? ? line : "#{spaces}#{line}" }.join
         end
 
         def wrap_with_namespace(content)

--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -61,6 +61,14 @@ class NamespacedControllerGeneratorTest < NamespacedGeneratorTestCase
     run_generator ["account"]
     assert_file "app/views/test_app/account"
   end
+
+  def test_namespaced_controller_dont_indent_blank_lines
+    run_generator
+    assert_file "app/controllers/test_app/account_controller.rb"
+    File.readlines(File.expand_path("app/controllers/test_app/account_controller.rb", destination_root)).each do |line|
+      assert_no_match line.chomp, /^\s+$/, "Don't indent blank lines"
+    end
+  end
 end
 
 class NamespacedModelGeneratorTest < NamespacedGeneratorTestCase


### PR DESCRIPTION
This method is not documented, but I use it in my generators.

``` ruby
code = <<-ROUTES.strip_heredoc
  get "admin/login"

  get "admin/logout"
ROUTES

route indent(code).strip
```

And this code also used for example here: https://github.com/rails/rails/blob/master/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb#L1
