### PR TITLE
Trying to fix mocha upgrade failures

### DIFF
--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -435,6 +435,13 @@ class RequestTest < ActiveSupport::TestCase
 
   test "parameters" do
     request = stub_request
+
+    request.instance_eval do
+      def method(method)
+        self.superclass.method(method)
+      end
+    end
+
     request.stubs(:request_parameters).returns({ "foo" => 1 })
     request.stubs(:query_parameters).returns({ "bar" => 2 })
 


### PR DESCRIPTION
So Mocha got an update to new version and our actionpack started failing after that

``` ruby

 1) Error:
test_parameters(RequestTest):
ArgumentError: wrong number of arguments (1 for 0)
    /Users/arunagw/checkouts/rails/actionpack/lib/action_dispatch/http/request.rb:79:in `method'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/mocha-0.11.0/lib/mocha/class_method.rb:39:in `hide_original_method'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/mocha-0.11.0/lib/mocha/class_method.rb:15:in `stub'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/mocha-0.11.0/lib/mocha/central.rb:13:in `stub'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/mocha-0.11.0/lib/mocha/object.rb:121:in `block in stubs'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/mocha-0.11.0/lib/mocha/argument_iterator.rb:15:in `call'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/mocha-0.11.0/lib/mocha/argument_iterator.rb:15:in `each'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/mocha-0.11.0/lib/mocha/object.rb:117:in `stubs'
    /Users/arunagw/checkouts/rails/actionpack/test/dispatch/request_test.rb:438:in `block in <class:RequestTest>'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/mocha-0.11.0/lib/mocha/integration/mini_test/version_230_to_262.rb:28:in `run'

3507 tests, 15952 assertions, 0 failures, 1 errors, 0 skips

```

So after research i found that mocha internally doing some stuff with <pre> method </pre>

We have one function <pre>method</pre> in our request model which is not having any argument. 

This is why we are getting above error that mocha is giving 1 argument for stubbee

here you can found that call https://github.com/floehopper/mocha/compare/24314c2e77...master#L68R39

I tried to fix this in test itself as we don't want to change much things.

Please let me know your suggestions. I will make changes according to that.
