### PR TITLE
Restore "%" ERb/Erubis Trim Mode

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Restored support for the "%" ERb/Erubis _trim mode_.  This can be activated with:
+
+        config.action_view.erb_trim_mode = "%"  # or "%-" whitespace trim
+
+    With that mode active, you can use a single percent sign at the beginning of a line to engage Ruby mode (without inserting results).  It allows for template code like this:
+
+        % if current_user.try(:admin?)
+          <%= render "edit_links" %>
+        % end
+
+    *James Edward Gray II*
+
 *   Add `index` method to FormBuilder class. *Jorge Bejar*
 
 *   Remove the leading \n added by textarea on assert_select. *Santiago Pastorino*

--- a/actionpack/lib/action_view/template/handlers/erb.rb
+++ b/actionpack/lib/action_view/template/handlers/erb.rb
@@ -38,6 +38,10 @@ module ActionView
         end
       end
 
+      class ErubisWithPercentLine < Erubis
+        include ::Erubis::PercentLineEnhancer
+      end
+
       class ERB
         # Specify trim mode for the ERB compiler. Defaults to '-'.
         # See ERB documentation for suitable values.
@@ -77,10 +81,12 @@ module ActionView
           # Always make sure we return a String in the default_internal
           erb.encode!
 
-          self.class.erb_implementation.new(
-            erb,
-            :trim => (self.class.erb_trim_mode == "-")
-          ).src
+          mode           = self.class.erb_trim_mode.to_s
+          implementation = self.class.erb_implementation
+          if mode.include? "%" and implementation == Erubis
+            implementation = ErubisWithPercentLine
+          end
+          implementation.new(erb, :trim => mode.include?("-")).src
         end
 
       private

--- a/actionpack/test/template/erb/handlers_test.rb
+++ b/actionpack/test/template/erb/handlers_test.rb
@@ -1,0 +1,54 @@
+require "abstract_unit"
+
+class HandlersTest < ActiveSupport::TestCase
+  HANDLER  = ActionView::Template::Handlers::ERB
+  Template = Struct.new(:source)
+  
+  extend ActiveSupport::Testing::Declarative
+
+  test "content is not trimmed without a trim mode" do
+    with_erb_trim_mode nil do
+      assert_equal("   \ntest", render(" <% 'IGNORED' %>  \ntest"))
+    end
+  end
+
+  test "content around tags is trimmed if the trim mode includes a dash" do
+    with_erb_trim_mode '-' do
+      assert_equal("test", render(" <% 'IGNORED' %>  \ntest"))
+    end
+  end
+
+  test "percent lines are normal content without a trim mode" do
+    with_erb_trim_mode nil do
+      assert_equal( "% if false\noops\n% end\n",
+                    render("% if false\noops\n% end\n") )
+    end
+  end
+
+  test "percent lines count as ruby if trim mode includes a percent" do
+    with_erb_trim_mode "%" do
+      assert_equal("", render("% if false\noops\n% end\n"))
+    end
+  end
+
+  test "both trim modes can be used at the same time" do
+    with_erb_trim_mode "%-" do
+      assert_equal( "test", render( "% if false\noops\n% end\n" +
+                                    " <% 'IGNORED' %>  \ntest" ) )
+    end
+  end
+
+  private
+
+  def with_erb_trim_mode(mode)
+    @old_erb_trim_mode    = HANDLER.erb_trim_mode
+    HANDLER.erb_trim_mode = mode
+    yield
+  ensure
+    HANDLER.erb_trim_mode = @old_erb_trim_mode
+  end
+
+  def render(template)
+    eval("output_buffer = nil; " + HANDLER.call(Template.new(template)))
+  end
+end


### PR DESCRIPTION
Restored support for the "%" ERb/Erubis _trim mode_.  This can be activated with:

```
config.action_view.erb_trim_mode = "%"  # or "%-" whitespace trim
```

With that mode active, you can use a single percent sign at the beginning of a line to engage Ruby mode (without inserting results).  It allows for template code like this:

```
% if current_user.try(:admin?)
  <%= render "edit_links" %>
% end
```
