### PR TITLE
Deprecate link_to_function and button_to_function

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Rails 3.2.3 (unreleased) ##
+## Rails 3.2.3 (March 30, 2012) ##
 
 *   Upgrade mail version to 2.4.3 *ML*
 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,4 +1,9 @@
-## Rails 3.2.3 (unreleased) ##
+## Rails 3.2.4 (unreleased) ##
+
+*   Deprecate `button_to_function` and `link_to_function` helpers. *Rafael Mendonça França*
+
+
+## Rails 3.2.3 (March 30, 2012) ##
 
 *   Allow to lazy load `default_form_builder` by passing a `String` instead of a constant. *Piotr Sarnacki*
 

--- a/actionpack/lib/action_view/helpers/asset_tag_helpers/asset_paths.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helpers/asset_paths.rb
@@ -1,5 +1,6 @@
 require 'thread'
 require 'active_support/core_ext/file'
+require 'active_support/core_ext/module/attribute_accessors'
 
 module ActionView
   module Helpers

--- a/actionpack/lib/action_view/helpers/javascript_helper.rb
+++ b/actionpack/lib/action_view/helpers/javascript_helper.rb
@@ -82,6 +82,8 @@ module ActionView
       #   # => <input class="ok" onclick="alert('Hello world!');" type="button" value="Greeting" />
       #
       def button_to_function(name, function=nil, html_options={})
+        ActiveSupport::Deprecation.warn("button_to_function is deprecated and will be removed from Rails 4.0")
+
         onclick = "#{"#{html_options[:onclick]}; " if html_options[:onclick]}#{function};"
 
         tag(:input, html_options.merge(:type => 'button', :value => name, :onclick => onclick))
@@ -100,6 +102,8 @@ module ActionView
       #   # => <a class="nav_link" href="#" onclick="alert('Hello world!'); return false;">Greeting</a>
       #
       def link_to_function(name, function, html_options={})
+        ActiveSupport::Deprecation.warn("link_to_function is deprecated and will be removed from Rails 4.0")
+
         onclick = "#{"#{html_options[:onclick]}; " if html_options[:onclick]}#{function}; return false;"
         href = html_options[:href] || '#'
 

--- a/actionpack/test/template/javascript_helper_test.rb
+++ b/actionpack/test/template/javascript_helper_test.rb
@@ -46,33 +46,45 @@ class JavaScriptHelperTest < ActionView::TestCase
   end
 
   def test_button_to_function
-    assert_dom_equal %(<input type="button" onclick="alert('Hello world!');" value="Greeting" />),
-      button_to_function("Greeting", "alert('Hello world!')")
+    assert_deprecated "button_to_function is deprecated and will be removed from Rails 4.0" do
+      assert_dom_equal %(<input type="button" onclick="alert('Hello world!');" value="Greeting" />),
+        button_to_function("Greeting", "alert('Hello world!')")
+    end
   end
 
   def test_button_to_function_with_onclick
-    assert_dom_equal "<input onclick=\"alert('Goodbye World :('); alert('Hello world!');\" type=\"button\" value=\"Greeting\" />",
-      button_to_function("Greeting", "alert('Hello world!')", :onclick => "alert('Goodbye World :(')")
+    assert_deprecated "button_to_function is deprecated and will be removed from Rails 4.0" do
+      assert_dom_equal "<input onclick=\"alert('Goodbye World :('); alert('Hello world!');\" type=\"button\" value=\"Greeting\" />",
+        button_to_function("Greeting", "alert('Hello world!')", :onclick => "alert('Goodbye World :(')")
+    end
   end
 
   def test_button_to_function_without_function
-    assert_dom_equal "<input onclick=\";\" type=\"button\" value=\"Greeting\" />",
-      button_to_function("Greeting")
+    assert_deprecated "button_to_function is deprecated and will be removed from Rails 4.0" do
+      assert_dom_equal "<input onclick=\";\" type=\"button\" value=\"Greeting\" />",
+        button_to_function("Greeting")
+    end
   end
 
   def test_link_to_function
-    assert_dom_equal %(<a href="#" onclick="alert('Hello world!'); return false;">Greeting</a>),
-      link_to_function("Greeting", "alert('Hello world!')")
+    assert_deprecated "link_to_function is deprecated and will be removed from Rails 4.0" do
+      assert_dom_equal %(<a href="#" onclick="alert('Hello world!'); return false;">Greeting</a>),
+        link_to_function("Greeting", "alert('Hello world!')")
+    end
   end
 
   def test_link_to_function_with_existing_onclick
-    assert_dom_equal %(<a href="#" onclick="confirm('Sanity!'); alert('Hello world!'); return false;">Greeting</a>),
-      link_to_function("Greeting", "alert('Hello world!')", :onclick => "confirm('Sanity!')")
+    assert_deprecated "link_to_function is deprecated and will be removed from Rails 4.0" do
+      assert_dom_equal %(<a href="#" onclick="confirm('Sanity!'); alert('Hello world!'); return false;">Greeting</a>),
+        link_to_function("Greeting", "alert('Hello world!')", :onclick => "confirm('Sanity!')")
+    end
   end
 
   def test_function_with_href
-    assert_dom_equal %(<a href="http://example.com/" onclick="alert('Hello world!'); return false;">Greeting</a>),
-      link_to_function("Greeting", "alert('Hello world!')", :href => 'http://example.com/')
+    assert_deprecated "link_to_function is deprecated and will be removed from Rails 4.0" do
+      assert_dom_equal %(<a href="http://example.com/" onclick="alert('Hello world!'); return false;">Greeting</a>),
+        link_to_function("Greeting", "alert('Hello world!')", :href => 'http://example.com/')
+    end
   end
 
   def test_javascript_tag

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Rails 3.2.3 (unreleased) ##
+## Rails 3.2.3 (March 30, 2012) ##
 
 *   No changes.
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -4,7 +4,7 @@
     This could cause infinite recursion and potentially other problems.
     See GH #5667. *Jon Leighton*
 
-## Rails 3.2.3 (unreleased) ##
+## Rails 3.2.3 (March 30, 2012) ##
 
 *   Added find_or_create_by_{attribute}! dynamic method. *Andrew White*
 

--- a/activeresource/CHANGELOG.md
+++ b/activeresource/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Rails 3.2.3 (unreleased) ##
+## Rails 3.2.3 (March 30, 2012) ##
 
 *   No changes.
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Rails 3.2.3 (unreleased) ##
+## Rails 3.2.3 (March 30, 2012) ##
 
 *   No changes.
 


### PR DESCRIPTION
Since the Rails community is getting the [unobtrusive javascript](http://en.wikipedia.org/wiki/Unobtrusive_JavaScript) as best practices we don't need these helper anymore.

Closes #5886 and #3093
