### PR TITLE
Remove button_to_function and link_to_function helpers

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Remove `button_to_function` and `link_to_function` helpers. *Rafael Mendonça França*
+
 *   Make current object and counter (when it applies) variables accessible when
     rendering templates with :object / :collection. *Carlos Antonio da Silva*
 

--- a/actionpack/lib/action_view/helpers/asset_tag_helpers/asset_paths.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helpers/asset_paths.rb
@@ -1,5 +1,6 @@
 require 'thread'
 require 'active_support/core_ext/file'
+require 'active_support/core_ext/module/attribute_accessors'
 
 module ActionView
   module Helpers

--- a/actionpack/lib/action_view/helpers/javascript_helper.rb
+++ b/actionpack/lib/action_view/helpers/javascript_helper.rb
@@ -15,7 +15,6 @@ module ActionView
 
       JS_ESCAPE_MAP["\342\200\250".force_encoding('UTF-8').encode!] = '&#x2028;'
       JS_ESCAPE_MAP["\342\200\251".force_encoding('UTF-8').encode!] = '&#x2029;'
-      
 
       # Escapes carriage returns and single and double quotes for JavaScript segments.
       #
@@ -67,40 +66,6 @@ module ActionView
 
       def javascript_cdata_section(content) #:nodoc:
         "\n//#{cdata_section("\n#{content}\n//")}\n".html_safe
-      end
-
-      # Returns a button whose +onclick+ handler triggers the passed JavaScript.
-      #
-      # The helper receives a name, JavaScript code, and an optional hash of HTML options. The
-      # name is used as button label and the JavaScript code goes into its +onclick+ attribute.
-      # If +html_options+ has an <tt>:onclick</tt>, that one is put before +function+.
-      #
-      #   button_to_function "Greeting", "alert('Hello world!')", :class => "ok"
-      #   # => <input class="ok" onclick="alert('Hello world!');" type="button" value="Greeting" />
-      #
-      def button_to_function(name, function=nil, html_options={})
-        onclick = "#{"#{html_options[:onclick]}; " if html_options[:onclick]}#{function};"
-
-        tag(:input, html_options.merge(:type => 'button', :value => name, :onclick => onclick))
-      end
-
-      # Returns a link whose +onclick+ handler triggers the passed JavaScript.
-      #
-      # The helper receives a name, JavaScript code, and an optional hash of HTML options. The
-      # name is used as the link text and the JavaScript code goes into the +onclick+ attribute.
-      # If +html_options+ has an <tt>:onclick</tt>, that one is put before +function+. Once all
-      # the JavaScript is set, the helper appends "; return false;".
-      #
-      # The +href+ attribute of the tag is set to "#" unless +html_options+ has one.
-      #
-      #   link_to_function "Greeting", "alert('Hello world!')", :class => "nav_link"
-      #   # => <a class="nav_link" href="#" onclick="alert('Hello world!'); return false;">Greeting</a>
-      #
-      def link_to_function(name, function, html_options={})
-        onclick = "#{"#{html_options[:onclick]}; " if html_options[:onclick]}#{function}; return false;"
-        href = html_options[:href] || '#'
-
-        content_tag(:a, name, html_options.merge(:href => href, :onclick => onclick))
       end
     end
   end

--- a/actionpack/test/template/javascript_helper_test.rb
+++ b/actionpack/test/template/javascript_helper_test.rb
@@ -42,36 +42,6 @@ class JavaScriptHelperTest < ActionView::TestCase
     assert_instance_of ActiveSupport::SafeBuffer, escape_javascript(ActiveSupport::SafeBuffer.new(given))
   end
 
-  def test_button_to_function
-    assert_dom_equal %(<input type="button" onclick="alert('Hello world!');" value="Greeting" />),
-      button_to_function("Greeting", "alert('Hello world!')")
-  end
-
-  def test_button_to_function_with_onclick
-    assert_dom_equal "<input onclick=\"alert('Goodbye World :('); alert('Hello world!');\" type=\"button\" value=\"Greeting\" />",
-      button_to_function("Greeting", "alert('Hello world!')", :onclick => "alert('Goodbye World :(')")
-  end
-
-  def test_button_to_function_without_function
-    assert_dom_equal "<input onclick=\";\" type=\"button\" value=\"Greeting\" />",
-      button_to_function("Greeting")
-  end
-
-  def test_link_to_function
-    assert_dom_equal %(<a href="#" onclick="alert('Hello world!'); return false;">Greeting</a>),
-      link_to_function("Greeting", "alert('Hello world!')")
-  end
-
-  def test_link_to_function_with_existing_onclick
-    assert_dom_equal %(<a href="#" onclick="confirm('Sanity!'); alert('Hello world!'); return false;">Greeting</a>),
-      link_to_function("Greeting", "alert('Hello world!')", :onclick => "confirm('Sanity!')")
-  end
-
-  def test_function_with_href
-    assert_dom_equal %(<a href="http://example.com/" onclick="alert('Hello world!'); return false;">Greeting</a>),
-      link_to_function("Greeting", "alert('Hello world!')", :href => 'http://example.com/')
-  end
-
   def test_javascript_tag
     self.output_buffer = 'foo'
 


### PR DESCRIPTION
They was deprecated in Rails 3.2.4.

Related with #5922.
