### PR TITLE
Improve signed cookies documentation

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -29,6 +29,7 @@ module ActionDispatch
   #   # Sets a signed cookie, which prevents a user from tampering with its value.
   #   # The cookie is signed by your app's <tt>config.secret_token</tt> value.
   #   # Rails generates this value by default when you create a new Rails app.
+  #   # Signed cookies must read with the signed method <tt>cookies.signed[:key]</tt>
   #   cookies.signed[:user_id] = current_user.id
   #
   #   # Sets a "permanent" cookie (which expires in 20 years from now).
@@ -39,9 +40,10 @@ module ActionDispatch
   #
   # Examples for reading:
   #
-  #   cookies[:user_name] # => "david"
-  #   cookies.size        # => 2
-  #   cookies[:lat_lon]   # => [47.68, -122.37]
+  #   cookies[:user_name]    # => "david"
+  #   cookies.size           # => 2
+  #   cookies[:lat_lon]      # => [47.68, -122.37]
+  #   cookies.signed[:login] # => "XJ-122"
   #
   # Example for deleting:
   #


### PR DESCRIPTION
note that signed cookies must also be read with the signed method `cookies.signed[:key]` 
