### PR TITLE
Distance of time in words should work correct if from time > to_time

### DIFF
--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -67,8 +67,9 @@ module ActionView
       def distance_of_time_in_words(from_time, to_time = 0, include_seconds = false, options = {})
         from_time = from_time.to_time if from_time.respond_to?(:to_time)
         to_time = to_time.to_time if to_time.respond_to?(:to_time)
-        distance_in_minutes = (((to_time - from_time).abs)/60).round
-        distance_in_seconds = ((to_time - from_time).abs).round
+        from_time, to_time = to_time, from_time if from_time > to_time
+        distance_in_minutes = ((to_time - from_time)/60).round
+        distance_in_seconds = (to_time - from_time).round
 
         I18n.with_options :locale => options[:locale], :scope => :'datetime.distance_in_words' do |locale|
           case distance_in_minutes

--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -68,7 +68,7 @@ module ActionView
         from_time = from_time.to_time if from_time.respond_to?(:to_time)
         to_time = to_time.to_time if to_time.respond_to?(:to_time)
         from_time, to_time = to_time, from_time if from_time > to_time
-        distance_in_minutes = ((to_time - from_time)/60).round
+        distance_in_minutes = ((to_time - from_time)/60.0).round
         distance_in_seconds = (to_time - from_time).round
 
         I18n.with_options :locale => options[:locale], :scope => :'datetime.distance_in_words' do |locale|

--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -95,18 +95,22 @@ module ActionView
             when 43200..86399    then locale.t :about_x_months, :count => 1
             when 86400..525599   then locale.t :x_months,       :count => (distance_in_minutes.to_f / 43200.0).round
             else
-              fyear = from_time.year
-              fyear += 1 if from_time.month >= 3
-              tyear = to_time.year
-              tyear -= 1 if to_time.month < 3
-              leap_years = (fyear > tyear) ? 0 : (fyear..tyear).count{|x| Date.leap?(x)}
-              minute_offset_for_leap_year = leap_years * 1440
-              # Discount the leap year days when calculating year distance.
-              # e.g. if there are 20 leap year days between 2 dates having the same day
-              # and month then the based on 365 days calculation
-              # the distance in years will come out to over 80 years when in written
-              # english it would read better as about 80 years.
-              minutes_with_offset         = distance_in_minutes - minute_offset_for_leap_year
+              if from_time.acts_like?(:time) && to_time.acts_like?(:time)
+                fyear = from_time.year
+                fyear += 1 if from_time.month >= 3
+                tyear = to_time.year
+                tyear -= 1 if to_time.month < 3
+                leap_years = (fyear > tyear) ? 0 : (fyear..tyear).count{|x| Date.leap?(x)}
+                minute_offset_for_leap_year = leap_years * 1440
+                # Discount the leap year days when calculating year distance.
+                # e.g. if there are 20 leap year days between 2 dates having the same day
+                # and month then the based on 365 days calculation
+                # the distance in years will come out to over 80 years when in written
+                # english it would read better as about 80 years.
+                minutes_with_offset = distance_in_minutes - minute_offset_for_leap_year
+              else
+                minutes_with_offset = distance_in_minutes
+              end
               remainder                   = (minutes_with_offset % 525600)
               distance_in_years           = (minutes_with_offset / 525600)
               if remainder < 131400

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -125,6 +125,7 @@ class DateHelperTest < ActionView::TestCase
     start_date = Date.new 1982, 12, 3
     end_date = Date.new 2010, 11, 30
     assert_equal("almost 28 years", distance_of_time_in_words(start_date, end_date))
+    assert_equal("almost 28 years", distance_of_time_in_words(end_date, start_date))
   end
 
   def test_distance_in_words_with_integers

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -129,10 +129,27 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_distance_in_words_with_integers
-    assert_equal "less than a minute", distance_of_time_in_words(59)
+    assert_equal "1 minute", distance_of_time_in_words(59)
     assert_equal "about 1 hour", distance_of_time_in_words(60*60)
-    assert_equal "less than a minute", distance_of_time_in_words(0, 59)
+    assert_equal "1 minute", distance_of_time_in_words(0, 59)
     assert_equal "about 1 hour", distance_of_time_in_words(60*60, 0)
+  end
+
+  def test_distance_in_words_with_times
+    assert_equal "1 minute", distance_of_time_in_words(30.seconds)
+    assert_equal "1 minute", distance_of_time_in_words(59.seconds)
+    assert_equal "2 minutes", distance_of_time_in_words(119.seconds)
+    assert_equal "2 minutes", distance_of_time_in_words(1.minute + 59.seconds)
+    assert_equal "3 minutes", distance_of_time_in_words(2.minute + 30.seconds)
+    assert_equal "44 minutes", distance_of_time_in_words(44.minutes + 29.seconds)
+    assert_equal "about 1 hour", distance_of_time_in_words(44.minutes + 30.seconds)
+    assert_equal "about 1 hour", distance_of_time_in_words(60.minutes)
+
+    # include seconds
+    assert_equal "half a minute", distance_of_time_in_words(39.seconds, 0, true)
+    assert_equal "less than a minute", distance_of_time_in_words(40.seconds, 0, true)
+    assert_equal "less than a minute", distance_of_time_in_words(59.seconds, 0, true)
+    assert_equal "1 minute", distance_of_time_in_words(60.seconds, 0, true)
   end
 
   def test_time_ago_in_words

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -133,6 +133,8 @@ class DateHelperTest < ActionView::TestCase
     assert_equal "about 1 hour", distance_of_time_in_words(60*60)
     assert_equal "1 minute", distance_of_time_in_words(0, 59)
     assert_equal "about 1 hour", distance_of_time_in_words(60*60, 0)
+    assert_equal "about 3 years", distance_of_time_in_words(10**8)
+    assert_equal "about 3 years", distance_of_time_in_words(0, 10**8)
   end
 
   def test_distance_in_words_with_times


### PR DESCRIPTION
In accordance with documentation https://github.com/rails/rails/blob/master/actionpack/lib/action_view/helpers/date_helper.rb#L63-64 `distance_of_time_in_words` should have the same result independent of args order.

Because of leap years trick https://github.com/rails/rails/blob/master/actionpack/lib/action_view/helpers/date_helper.rb#L97-102 result for long time distances can differ.

In the test case which I added result was 'about 28 years' instead of 'almost 28 years`
