### PR TITLE
ActiveSupport::Notifications::Event#parent_of? is not reliable in environments with poor clock resolution.

### DIFF
--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -161,7 +161,7 @@ module Notifications
       assert_equal 2, instrument(:awesome) { |p| p[:result] = 1 + 1 }
       assert_equal 1, @events.size
       assert_equal :awesome, @events.first.name
-      assert_equal Hash[:result => 2], @events.first.payload
+      assert_equal 2, @events.first.payload[:result]
     end
 
     def test_instrumenter_exposes_its_id
@@ -176,12 +176,12 @@ module Notifications
 
         assert_equal 1, @events.size
         assert_equal :wot, @events.first.name
-        assert_equal Hash[:payload => "child"], @events.first.payload
+        assert_equal "child", @events.first.payload[:payload]
       end
 
       assert_equal 2, @events.size
       assert_equal :awesome, @events.last.name
-      assert_equal Hash[:payload => "notifications"], @events.last.payload
+      assert_equal "notifications", @events.last.payload[:payload]
     end
 
     def test_instrument_publishes_when_exception_is_raised
@@ -194,15 +194,43 @@ module Notifications
       end
 
       assert_equal 1, @events.size
-      assert_equal Hash[:payload => "notifications",
-        :exception => ["RuntimeError", "FAIL"]], @events.last.payload
+      assert_equal "notifications", @events.last.payload[:payload]
+      assert_equal ["RuntimeError", "FAIL"], @events.last.payload[:exception]
     end
 
     def test_event_is_pushed_even_without_block
       instrument(:awesome, :payload => "notifications")
       assert_equal 1, @events.size
       assert_equal :awesome, @events.last.name
-      assert_equal Hash[:payload => "notifications"], @events.last.payload
+      assert_equal "notifications", @events.last.payload[:payload]
+    end
+
+    def test_distinguish_between_siblings_and_children_with_low_clock_resolution
+      # In some virtualized non-realtime systems, clock resolution can
+      # degrade. We simulate this by returning the same time for the
+      # duration of the test.
+      Time.stubs(:now).returns(Time.utc(2009, 01, 01, 0, 0, 1))
+
+      instrument(:dad) do
+        instrument(:child) do
+          instrument(:grand_child) do
+          end
+        end
+        instrument(:sibling) do
+        end
+      end
+
+      assert_equal 4, @events.size
+      assert_equal([:grand_child, :child, :sibling, :dad],
+                   @events.map(&:name))
+      assert(@events[1].parent_of?(@events[0]),
+             "#{@events[1].name} should be parent of #{@events[0].name}")
+      assert(@events[3].parent_of?(@events[1]),
+             "#{@events[3].name} should be parent of #{@events[1].name}")
+      assert(!@events[1].parent_of?(@events[2]),
+             "#{@events[1].name} should not be parent of #{@events[2].name}")
+      assert(!@events.first.parent_of?(@events.last),
+             "#{@events[0].name} should not be parent of #{@events[3].name}")
     end
   end
 
@@ -218,15 +246,18 @@ module Notifications
 
     def test_events_consumes_information_given_as_payload
       event = event(:foo, Time.now, Time.now + 1, random_id, :payload => :bar)
-      assert_equal Hash[:payload => :bar], event.payload
+      assert_equal :bar, event.payload[:payload]
     end
 
-    def test_event_is_parent_based_on_time_frame
+    def test_event_is_parent_based_on_time_frame_and_entry_index
       time = Time.utc(2009, 01, 01, 0, 0, 1)
 
-      parent    = event(:foo, Time.utc(2009), Time.utc(2009) + 100, random_id, {})
-      child     = event(:foo, time, time + 10, random_id, {})
-      not_child = event(:foo, time, time + 100, random_id, {})
+      parent    = event(:foo, Time.utc(2009), Time.utc(2009) + 100, random_id,
+                        {:entry_index => 0, :exit_index => 2})
+      child     = event(:foo, time, time + 10, random_id,
+                        {:entry_index => 1, :exit_index => 0})
+      not_child = event(:foo, time, time + 100, random_id,
+                        {:entry_index => 2, :exit_index => 1})
 
       assert parent.parent_of?(child)
       assert !child.parent_of?(parent)


### PR DESCRIPTION
Hi,

Some system clocks, particularly on virtual non-realtime environments can as tick with very low clock resolution. In such an environment the Event#parent_of? method can erroneously conclude that multiple instrumentation events that take place within a single tick are all each other's parents.

To work around this I implemented entry and exit counters for instrumentation events. These counters should reset with each transaction.

I'm not married to this implementation, but I would love to work with you guys on the issue. It's one of the things that is holding us up from implementing the Notifications API in the New Relic Ruby agent.

Regards,
Jon Guymon
