### PR TITLE
Nice logic for deep_dup in rails

### DIFF
--- a/activesupport/lib/active_support/core_ext/array.rb
+++ b/activesupport/lib/active_support/core_ext/array.rb
@@ -1,6 +1,7 @@
 require 'active_support/core_ext/array/wrap'
 require 'active_support/core_ext/array/access'
 require 'active_support/core_ext/array/uniq_by'
+require 'active_support/core_ext/array/deep_dup'
 require 'active_support/core_ext/array/conversions'
 require 'active_support/core_ext/array/extract_options'
 require 'active_support/core_ext/array/grouping'

--- a/activesupport/lib/active_support/core_ext/array/deep_dup.rb
+++ b/activesupport/lib/active_support/core_ext/array/deep_dup.rb
@@ -1,0 +1,6 @@
+class Array
+  # Returns a deep copy of array.
+  def deep_dup
+    map { |it| it.deep_dup }
+  end
+end

--- a/activesupport/lib/active_support/core_ext/hash/deep_dup.rb
+++ b/activesupport/lib/active_support/core_ext/hash/deep_dup.rb
@@ -1,10 +1,8 @@
 class Hash
   # Returns a deep copy of hash.
   def deep_dup
-    duplicate = self.dup
-    duplicate.each_pair do |k,v|
-      duplicate[k] = v.is_a?(Hash) ? v.deep_dup : v
+    each_with_object(dup) do |(key, value), hash|
+      hash[key.deep_dup] = value.deep_dup
     end
-    duplicate
   end
 end

--- a/activesupport/lib/active_support/core_ext/object.rb
+++ b/activesupport/lib/active_support/core_ext/object.rb
@@ -1,6 +1,7 @@
 require 'active_support/core_ext/object/acts_like'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/object/duplicable'
+require 'active_support/core_ext/object/deep_dup'
 require 'active_support/core_ext/object/try'
 require 'active_support/core_ext/object/inclusion'
 

--- a/activesupport/lib/active_support/core_ext/object/deep_dup.rb
+++ b/activesupport/lib/active_support/core_ext/object/deep_dup.rb
@@ -1,0 +1,6 @@
+class Object
+  # Returns a deep copy of object if it's duplicable.
+  def deep_dup
+    duplicable? ? dup : self
+  end
+end

--- a/activesupport/test/core_ext/deep_dup_test.rb
+++ b/activesupport/test/core_ext/deep_dup_test.rb
@@ -1,0 +1,54 @@
+require 'active_support/core_ext/object'
+require 'active_support/core_ext/array'
+require 'active_support/core_ext/hash'
+
+class DeepDupTest < ActiveSupport::TestCase
+
+  def test_array_deep_dup
+    array = [1, [2, 3]]
+    dup = array.deep_dup
+    dup[1][2] = 4
+    assert_equal nil, array[1][2]
+    assert_equal 4, dup[1][2]
+  end
+
+  def test_hash_deep_dup
+    hash = { :a => { :b => 'b' } }
+    dup = hash.deep_dup
+    dup[:a][:c] = 'c'
+    assert_equal nil, hash[:a][:c]
+    assert_equal 'c', dup[:a][:c]
+  end
+
+  def test_array_deep_dup_with_hash_inside
+    array = [1, { :a => 2, :b => 3 } ]
+    dup = array.deep_dup
+    dup[1][:c] = 4
+    assert_equal nil, array[1][:c]
+    assert_equal 4, dup[1][:c]
+  end
+
+  def test_hash_deep_dup_with_array_inside
+    hash = { :a => [1, 2] }
+    dup = hash.deep_dup
+    dup[:a][2] = 'c'
+    assert_equal nil, hash[:a][2]
+    assert_equal 'c', dup[:a][2]
+  end
+
+  def test_deep_dup_initialize
+    zero_hash = Hash.new 0
+    hash = { :a => zero_hash }
+    dup = hash.deep_dup
+    assert_equal 0, dup[:a][44]
+  end
+
+  def test_object_deep_dup
+    object = Object.new
+    dup = object.deep_dup
+    dup.instance_variable_set(:@a, 1)
+    assert !object.instance_variable_defined?(:@a)
+    assert dup.instance_variable_defined?(:@a)
+  end
+
+end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -363,21 +363,6 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal expected, hash_1
   end
 
-  def test_deep_dup
-    hash = { :a => { :b => 'b' } }
-    dup = hash.deep_dup
-    dup[:a][:c] = 'c'
-    assert_equal nil, hash[:a][:c]
-    assert_equal 'c', dup[:a][:c]
-  end
-
-  def test_deep_dup_initialize
-    zero_hash = Hash.new 0
-    hash = { :a => zero_hash }
-    dup = hash.deep_dup
-    assert_equal 0, dup[:a][44]
-  end
-
   def test_store_on_indifferent_access
     hash = HashWithIndifferentAccess.new
     hash.store(:test1, 1)

--- a/guides/source/active_support_core_extensions.textile
+++ b/guides/source/active_support_core_extensions.textile
@@ -154,6 +154,40 @@ WARNING. Any class can disallow duplication removing +dup+ and +clone+ or raisin
 
 NOTE: Defined in +active_support/core_ext/object/duplicable.rb+.
 
+h4. +deep_dup+
+
+When data is very big and have many layers we need some recursive method to duplicate it right. For example, if we want to duplicate Array with some string inside and then work with this string as with part of duplicated object.
+
+<ruby>
+array = ['string']
+dup = array.dup
+dup[0] << '?'
+array.object_id == dup.object_id   # => false
+array[0] == dup[0]                 # => true
+</ruby>
+
+Active Support provides +deep_dup+ to dup all objects recursively inside deep dupilicated Array or Hash:
+
+If object can be duplicable - then it is just an alias for dup.
+
+<ruby>
+string = 'abc'
+dup = string.deep_dup
+string.object_id == dup.object_id   # => false
+</ruby>
+
+If not - this method will return original object.
+
+<ruby>
+number = 1
+dup = number.deep_dup
+number.object_id == dup.object_id   # => true
+</ruby>
+
+WARNING. The same as in +duplicable?+ because +deep_dup+ uses that method.
+
+NOTE: Defined in +active_support/core_ext/object/deep_dup.rb+.
+
 h4. +try+
 
 Sometimes you want to call a method provided the receiver object is not +nil+, which is something you usually check first. +try+ is like +Object#send+ except that it returns +nil+ if sent to +nil+.
@@ -2217,6 +2251,19 @@ Thus, in this case the behavior is different for +nil+, and the differences with
 
 NOTE: Defined in +active_support/core_ext/array/wrap.rb+.
 
+h4. Duplicating
+
+The method +Array.deep_dup+ duplicates itself and all objects inside recursively with ActiveSupport method +Object#deep_dup+. It works like +Array#map+ with sending +deep_dup+ method to each object inside.
+
+<ruby>
+array = [1, [2, 3]]
+dup = array.deep_dup
+dup[1][2] = 4
+array[1][2] == nil   # => true
+</ruby>
+
+NOTE: Defined in +active_support/core_ext/array/deep_dup.rb+.
+
 h4. Grouping
 
 h5. +in_groups_of(number, fill_with = nil)+
@@ -2422,6 +2469,23 @@ Active Support defines +Hash#deep_merge+. In a deep merge, if a key is found in 
 The method +deep_merge!+ performs a deep merge in place.
 
 NOTE: Defined in +active_support/core_ext/hash/deep_merge.rb+.
+
+h4. Deep duplicating
+
+The method +Hash.deep_dup+ duplicates itself and all keys and values inside recursively with ActiveSupport method +Object#deep_dup+. It works like +Enumerator#each_with_object+ with sending +deep_dup+ method to each pair inside.
+
+<ruby>
+hash = { :a => 1, :b => { :c => 2, :d => [3, 4] } }
+
+dup = hash.deep_dup
+dup[:b][:e] = 5
+dup[:b][:d] << 5
+
+hash[:b][:e] == nil      # => true
+hash[:b][:d] == [3, 4]   # => true
+</ruby>
+
+NOTE: Defined in +active_support/core_ext/hash/deep_dup.rb+.
 
 h4. Diffing
 

--- a/railties/lib/rails/configuration.rb
+++ b/railties/lib/rails/configuration.rb
@@ -1,6 +1,8 @@
 require 'active_support/deprecation'
 require 'active_support/ordered_options'
+require 'active_support/core_ext/object'
 require 'active_support/core_ext/hash/deep_dup'
+require 'active_support/core_ext/array/deep_dup'
 require 'rails/paths'
 require 'rails/rack'
 


### PR DESCRIPTION
I had several problems with deep_dup in rails and here is my proposition to improve logic of Hash#deep_dup and expand it from hash to all objects.
For example, the following cases will be affected:

``` ruby
{ :a => 1, { :b => [1, 2] } }.deep_dup
[1, [3, 4]].deep_dup
[1, { :a => 2 } ].deep_dup
```

and more complicated with combination of all listed above.

P.s. thanks to @brainopia for consultation and refactoring
