### PR TITLE
confirmation validation error attribute

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 *   Trim down Active Model API by removing `valid?` and `errors.full_messages` *José Valim*
 
+*   `ConfirmationValidator` error messages will attach to `:#{attribute}_confirmation` instead of `attribute` *Brian Cardarella*
+
 
 ## Rails 3.2.2 (March 1, 2012) ##
 

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,12 +1,12 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `ConfirmationValidator` error messages will attach to `:#{attribute}_confirmation` instead of `attribute` *Brian Cardarella*
+
 *   Added ActiveModel::Model, a mixin to make Ruby objects work with AP out of box *Guillermo Iguaran*
 
 *   `AM::Errors#to_json`: support `:full_messages` parameter *Bogdan Gusiev*
 
 *   Trim down Active Model API by removing `valid?` and `errors.full_messages` *José Valim*
-
-*   `ConfirmationValidator` error messages will attach to `:#{attribute}_confirmation` instead of `attribute` *Brian Cardarella*
 
 
 ## Rails 3.2.2 (March 1, 2012) ##

--- a/activemodel/lib/active_model/locale/en.yml
+++ b/activemodel/lib/active_model/locale/en.yml
@@ -9,7 +9,7 @@ en:
       inclusion: "is not included in the list"
       exclusion: "is reserved"
       invalid: "is invalid"
-      confirmation: "doesn't match confirmation"
+      confirmation: "doesn't match %{attribute}"
       accepted: "must be accepted"
       empty: "can't be empty"
       blank: "can't be blank"

--- a/activemodel/lib/active_model/validations/confirmation.rb
+++ b/activemodel/lib/active_model/validations/confirmation.rb
@@ -5,7 +5,8 @@ module ActiveModel
     class ConfirmationValidator < EachValidator
       def validate_each(record, attribute, value)
         if (confirmed = record.send("#{attribute}_confirmation")) && (value != confirmed)
-          record.errors.add(:"#{attribute}_confirmation", :confirmation, options.merge(:attribute => attribute))
+          human_attribute_name = record.class.human_attribute_name(attribute)
+          record.errors.add(:"#{attribute}_confirmation", :confirmation, options.merge(:attribute => human_attribute_name))
         end
       end
 

--- a/activemodel/lib/active_model/validations/confirmation.rb
+++ b/activemodel/lib/active_model/validations/confirmation.rb
@@ -5,7 +5,7 @@ module ActiveModel
     class ConfirmationValidator < EachValidator
       def validate_each(record, attribute, value)
         if (confirmed = record.send("#{attribute}_confirmation")) && (value != confirmed)
-          record.errors.add(attribute, :confirmation, options)
+          record.errors.add(:"#{attribute}_confirmation", :confirmation, options.merge(:attribute => attribute))
         end
       end
 

--- a/activemodel/test/cases/validations/confirmation_validation_test.rb
+++ b/activemodel/test/cases/validations/confirmation_validation_test.rb
@@ -44,12 +44,31 @@ class ConfirmationValidationTest < ActiveModel::TestCase
     p.karma_confirmation = "None"
     assert p.invalid?
 
-    assert_equal ["doesn't match karma"], p.errors[:karma_confirmation]
+    assert_equal ["doesn't match Karma"], p.errors[:karma_confirmation]
 
     p.karma = "None"
     assert p.valid?
   ensure
     Person.reset_callbacks(:validate)
+  end
+
+  def test_title_confirmation_with_i18n_attribute
+    @old_load_path, @old_backend = I18n.load_path.dup, I18n.backend
+    I18n.load_path.clear
+    I18n.backend = I18n::Backend::Simple.new
+    I18n.backend.store_translations('en', {
+      :errors => {:messages => {:confirmation => "doesn't match %{attribute}"}},
+      :activemodel => {:attributes => {:topic => {:title => 'Test Title'}}}
+    })
+
+    Topic.validates_confirmation_of(:title)
+
+    t = Topic.new("title" => "We should be confirmed","title_confirmation" => "")
+    assert t.invalid?
+    assert_equal ["doesn't match Test Title"], t.errors[:title_confirmation]
+
+    I18n.load_path.replace @old_load_path
+    I18n.backend = @old_backend
   end
 
 end

--- a/activemodel/test/cases/validations/confirmation_validation_test.rb
+++ b/activemodel/test/cases/validations/confirmation_validation_test.rb
@@ -44,7 +44,7 @@ class ConfirmationValidationTest < ActiveModel::TestCase
     p.karma_confirmation = "None"
     assert p.invalid?
 
-    assert_equal ["doesn't match confirmation"], p.errors[:karma]
+    assert_equal ["doesn't match karma"], p.errors[:karma_confirmation]
 
     p.karma = "None"
     assert p.valid?

--- a/activemodel/test/cases/validations/i18n_generate_message_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_generate_message_validation_test.rb
@@ -37,7 +37,7 @@ class I18nGenerateMessageValidationTest < ActiveModel::TestCase
 
   # validates_confirmation_of: generate_message(attr_name, :confirmation, :message => custom_message)
   def test_generate_message_confirmation_with_default_message
-    assert_equal "doesn't match confirmation", @person.errors.generate_message(:title, :confirmation)
+    assert_equal "doesn't match Title", @person.errors.generate_message(:title, :confirmation)
   end
 
   def test_generate_message_confirmation_with_custom_message

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -81,7 +81,7 @@ class I18nValidationTest < ActiveModel::TestCase
     test "validates_confirmation_of on generated message #{name}" do
       Person.validates_confirmation_of :title, validation_options
       @person.title_confirmation = 'foo'
-      @person.errors.expects(:generate_message).with(:title, :confirmation, generate_message_options)
+      @person.errors.expects(:generate_message).with(:title_confirmation, :confirmation, generate_message_options.merge(:attribute => :title))
       @person.valid?
     end
   end
@@ -217,24 +217,29 @@ class I18nValidationTest < ActiveModel::TestCase
 
   # To make things DRY this macro is defined to define 3 tests for every validation case.
   def self.set_expectations_for_validation(validation, error_type, &block_that_sets_validation)
+    if error_type == :confirmation
+      attribute = :title_confirmation
+    else
+      attribute = :title
+    end
     # test "validates_confirmation_of finds custom model key translation when blank"
     test "#{validation} finds custom model key translation when #{error_type}" do
-      I18n.backend.store_translations 'en', :activemodel => {:errors => {:models => {:person => {:attributes => {:title => {error_type => 'custom message'}}}}}}
+      I18n.backend.store_translations 'en', :activemodel => {:errors => {:models => {:person => {:attributes => {attribute => {error_type => 'custom message'}}}}}}
       I18n.backend.store_translations 'en', :errors => {:messages => {error_type => 'global message'}}
 
       yield(@person, {})
       @person.valid?
-      assert_equal ['custom message'], @person.errors[:title]
+      assert_equal ['custom message'], @person.errors[attribute]
     end
 
     # test "validates_confirmation_of finds custom model key translation with interpolation when blank"
     test "#{validation} finds custom model key translation with interpolation when #{error_type}" do
-      I18n.backend.store_translations 'en', :activemodel => {:errors => {:models => {:person => {:attributes => {:title => {error_type => 'custom message with %{extra}'}}}}}}
+      I18n.backend.store_translations 'en', :activemodel => {:errors => {:models => {:person => {:attributes => {attribute => {error_type => 'custom message with %{extra}'}}}}}}
       I18n.backend.store_translations 'en', :errors => {:messages => {error_type => 'global message'}}
 
       yield(@person, {:extra => "extra information"})
       @person.valid?
-      assert_equal ['custom message with extra information'], @person.errors[:title]
+      assert_equal ['custom message with extra information'], @person.errors[attribute]
     end
 
     # test "validates_confirmation_of finds global default key translation when blank"
@@ -243,7 +248,7 @@ class I18nValidationTest < ActiveModel::TestCase
 
       yield(@person, {})
       @person.valid?
-      assert_equal ['global message'], @person.errors[:title]
+      assert_equal ['global message'], @person.errors[attribute]
     end
   end
 

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -81,7 +81,7 @@ class I18nValidationTest < ActiveModel::TestCase
     test "validates_confirmation_of on generated message #{name}" do
       Person.validates_confirmation_of :title, validation_options
       @person.title_confirmation = 'foo'
-      @person.errors.expects(:generate_message).with(:title_confirmation, :confirmation, generate_message_options.merge(:attribute => :title))
+      @person.errors.expects(:generate_message).with(:title_confirmation, :confirmation, generate_message_options.merge(:attribute => 'Title'))
       @person.valid?
     end
   end

--- a/activemodel/test/cases/validations/validates_test.rb
+++ b/activemodel/test/cases/validations/validates_test.rb
@@ -154,6 +154,6 @@ class ValidatesTest < ActiveModel::TestCase
     topic.title = "What's happening"
     topic.title_confirmation = "Not this"
     assert !topic.valid?
-    assert_equal ['Y U NO CONFIRM'], topic.errors[:title]
+    assert_equal ['Y U NO CONFIRM'], topic.errors[:title_confirmation]
   end
 end


### PR DESCRIPTION
This will render the error message on `:#{attribute}_confirmation` instead
of on `attribute` itself. When rendering confirmation errors inline on the
form with form builders such as `SimpleForm` and `Formtastic` it is
confusing to the end user to see the confirmation error message on the
attribute element. Instead it makes more sense to have this validation
error render on the confirmation field instead.

The i18n message has been updated for the confirmation validator error
message to include the original attribute name.
