### PR TITLE
Remove assignment that causes session creation

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -215,7 +215,6 @@ module ActionDispatch
     # be included by the session middleware.
     def reset_session
       session.destroy if session && session.respond_to?(:destroy)
-      self.session = {}
       @env['action_dispatch.request.flash_hash'] = nil
     end
 


### PR DESCRIPTION
`ActionDispatch::Request#reset_session` contains the following line:

```
self.session = {}
```

which appears to pre-date when sessions were updated to be lazily created. When using the ActiveRecord session store, calls to `reset_session` will result in `ActionDispatch::AbstractStore#call` creating a session record that is persisted, even if there is no session data (because `{}` is not an `AbstractStore::SessionHash`).

`ActionDispatch::Session::SessionHash#destroy` is already being called on the previous line, which results in the session being cleared and destroyed (if it exists) - and does not result in a new session being created (unless the session is updated after the call to `reset_session`).

As a side note, it seems like the # TODO on `reset_session` has been fulfilled for a couple years now.
