### PR TITLE
Fix mocha compatibility in 3-2-stable

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -76,8 +76,15 @@ module ActionDispatch
     # Returns the original value of the environment's REQUEST_METHOD,
     # even if it was overridden by middleware. See #request_method for
     # more information.
-    def method
-      @method ||= check_method(env["rack.methodoverride.original_method"] || env['REQUEST_METHOD'])
+    #
+    # Note: Calling this method with an argument will pass your argument
+    # to Object#method. This is implemented to fix compatibility issue.
+    def method(superclass_argument = nil)
+      if superclass_argument
+        super
+      else
+        @method ||= check_method(env["rack.methodoverride.original_method"] || env['REQUEST_METHOD'])
+      end
     end
 
     # Returns a symbol form of the #method

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -320,6 +320,11 @@ class RequestTest < ActiveSupport::TestCase
     end
   end
 
+  test "Calling method method with an argument" do
+    request = stub_request
+    assert_kind_of Method, request.method(:method)
+  end
+
   test "Symbol forms of request methods via method_symbol" do
     [:get, :post, :put, :delete].each do |method|
       request = stub_request 'REQUEST_METHOD' => method.to_s.upcase

--- a/actionpack/test/template/render_test.rb
+++ b/actionpack/test/template/render_test.rb
@@ -166,7 +166,7 @@ module RenderTestCases
 
   def test_render_partial_with_incompatible_object
     e = assert_raises(ArgumentError) { @view.render(:partial => nil) }
-    assert_equal "'#{nil.inspect}' is not an ActiveModel-compatible object. It must implement :to_partial_path.", e.message
+    assert_equal "'#{nil.inspect}' is not an ActiveModel-compatible object that returns a valid partial path.", e.message
   end
 
   def test_render_partial_with_errors
@@ -470,16 +470,18 @@ class LazyViewRenderTest < ActiveSupport::TestCase
       end
     end
 
-  def test_render_utf8_template_with_incompatible_external_encoding
-    with_external_encoding Encoding::SHIFT_JIS do
-      e = assert_raises(ActionView::Template::Error) { @view.render(:file => "test/utf8", :formats => [:html], :layouts => "layouts/yield") }
-      assert_match 'Your template was not saved as valid Shift_JIS', e.original_exception.message
+    def test_render_utf8_template_with_incompatible_external_encoding
+      with_external_encoding Encoding::SHIFT_JIS do
+        e = assert_raises(ActionView::Template::Error) { @view.render(:file => "test/utf8", :formats => [:html], :layouts => "layouts/yield") }
+        assert_match 'Your template was not saved as valid Shift_JIS', e.original_exception.message
+      end
     end
 
-  def test_render_utf8_template_with_partial_with_incompatible_encoding
-    with_external_encoding Encoding::SHIFT_JIS do
-      e = assert_raises(ActionView::Template::Error) { @view.render(:file => "test/utf8_magic_with_bare_partial", :formats => [:html], :layouts => "layouts/yield") }
-      assert_match 'Your template was not saved as valid Shift_JIS', e.original_exception.message
+    def test_render_utf8_template_with_partial_with_incompatible_encoding
+      with_external_encoding Encoding::SHIFT_JIS do
+        e = assert_raises(ActionView::Template::Error) { @view.render(:file => "test/utf8_magic_with_bare_partial", :formats => [:html], :layouts => "layouts/yield") }
+        assert_match 'Your template was not saved as valid Shift_JIS', e.original_exception.message
+      end
     end
 
     def with_external_encoding(encoding)


### PR DESCRIPTION
Mocha is explicitly using Object#method when stubbing a method. So, I've made Request#method to acts like Object#method if there's an argument passed to it.

Also, there's a bad merge conflict that doesn't allow the test to even run. I've fixed that as well.
