### PR TITLE
Fix broken test from the earlier merge conflict

### DIFF
--- a/actionpack/test/template/render_test.rb
+++ b/actionpack/test/template/render_test.rb
@@ -166,7 +166,7 @@ module RenderTestCases
 
   def test_render_partial_with_incompatible_object
     e = assert_raises(ArgumentError) { @view.render(:partial => nil) }
-    assert_equal "'#{nil.inspect}' is not an ActiveModel-compatible object. It must implement :to_partial_path.", e.message
+    assert_equal "'#{nil.inspect}' is not an ActiveModel-compatible object that returns a valid partial path.", e.message
   end
 
   def test_render_partial_with_errors
@@ -470,16 +470,18 @@ class LazyViewRenderTest < ActiveSupport::TestCase
       end
     end
 
-  def test_render_utf8_template_with_incompatible_external_encoding
-    with_external_encoding Encoding::SHIFT_JIS do
-      e = assert_raises(ActionView::Template::Error) { @view.render(:file => "test/utf8", :formats => [:html], :layouts => "layouts/yield") }
-      assert_match 'Your template was not saved as valid Shift_JIS', e.original_exception.message
+    def test_render_utf8_template_with_incompatible_external_encoding
+      with_external_encoding Encoding::SHIFT_JIS do
+        e = assert_raises(ActionView::Template::Error) { @view.render(:file => "test/utf8", :formats => [:html], :layouts => "layouts/yield") }
+        assert_match 'Your template was not saved as valid Shift_JIS', e.original_exception.message
+      end
     end
 
-  def test_render_utf8_template_with_partial_with_incompatible_encoding
-    with_external_encoding Encoding::SHIFT_JIS do
-      e = assert_raises(ActionView::Template::Error) { @view.render(:file => "test/utf8_magic_with_bare_partial", :formats => [:html], :layouts => "layouts/yield") }
-      assert_match 'Your template was not saved as valid Shift_JIS', e.original_exception.message
+    def test_render_utf8_template_with_partial_with_incompatible_encoding
+      with_external_encoding Encoding::SHIFT_JIS do
+        e = assert_raises(ActionView::Template::Error) { @view.render(:file => "test/utf8_magic_with_bare_partial", :formats => [:html], :layouts => "layouts/yield") }
+        assert_match 'Your template was not saved as valid Shift_JIS', e.original_exception.message
+      end
     end
 
     def with_external_encoding(encoding)


### PR DESCRIPTION
The test for actionpack actually failed to run.

```
[~/Projects/rails/actionpack] rake
/Users/sikachu/.rvm/rubies/ruby-1.9.3-p125-perf/bin/ruby -w -I"lib:test" -I"/Users/sikachu/.rvm/gems/ruby-1.9.3-p125-perf/gems/rake-0.9.3.beta.1/lib" "/Users/sikachu/.rvm/gems/ruby-1.9.3-p125-perf/gems/rake-0.9.3.beta.1/lib/rake/rake_test_loader.rb" "test/abstract/abstract_controller_test.rb" "test/abstract/callbacks_test.rb" "test/abstract/collector_test.rb" "test/abstract/helper_test.rb" "test/abstract/layouts_test.rb" "test/abstract/render_test.rb" "test/abstract/translation_test.rb" "test/controller/action_pack_assertions_test.rb" "test/controller/addresses_render_test.rb" "test/controller/assert_select_test.rb" "test/controller/base_test.rb" "test/controller/caching_test.rb" "test/controller/capture_test.rb" "test/controller/content_type_test.rb" "test/controller/default_url_options_with_filter_test.rb" "test/controller/filters_test.rb" "test/controller/flash_hash_test.rb" "test/controller/flash_test.rb" "test/controller/force_ssl_test.rb" "test/controller/helper_test.rb" "test/controller/http_basic_authentication_test.rb" "test/controller/http_digest_authentication_test.rb" "test/controller/http_token_authentication_test.rb" "test/controller/integration_test.rb" "test/controller/layout_test.rb" "test/controller/localized_templates_test.rb" "test/controller/log_subscriber_test.rb" "test/controller/mime_responds_test.rb" "test/controller/new_base/bare_metal_test.rb" "test/controller/new_base/base_test.rb" "test/controller/new_base/content_negotiation_test.rb" "test/controller/new_base/content_type_test.rb" "test/controller/new_base/metal_test.rb" "test/controller/new_base/middleware_test.rb" "test/controller/new_base/render_action_test.rb" "test/controller/new_base/render_context_test.rb" "test/controller/new_base/render_file_test.rb" "test/controller/new_base/render_implicit_action_test.rb" "test/controller/new_base/render_layout_test.rb" "test/controller/new_base/render_partial_test.rb" "test/controller/new_base/render_streaming_test.rb" "test/controller/new_base/render_template_test.rb" "test/controller/new_base/render_test.rb" "test/controller/new_base/render_text_test.rb" "test/controller/new_base/render_xml_test.rb" "test/controller/output_escaping_test.rb" "test/controller/params_wrapper_test.rb" "test/controller/record_identifier_test.rb" "test/controller/redirect_test.rb" "test/controller/render_js_test.rb" "test/controller/render_json_test.rb" "test/controller/render_other_test.rb" "test/controller/render_test.rb" "test/controller/render_xml_test.rb" "test/controller/request/test_request_test.rb" "test/controller/request_forgery_protection_test.rb" "test/controller/rescue_test.rb" "test/controller/resources_test.rb" "test/controller/routing_test.rb" "test/controller/runner_test.rb" "test/controller/selector_test.rb" "test/controller/send_file_test.rb" "test/controller/show_exceptions_test.rb" "test/controller/test_test.rb" "test/controller/url_for_integration_test.rb" "test/controller/url_for_test.rb" "test/controller/url_rewriter_test.rb" "test/controller/view_paths_test.rb" "test/controller/webservice_test.rb" "test/dispatch/callbacks_test.rb" "test/dispatch/cookies_test.rb" "test/dispatch/debug_exceptions_test.rb" "test/dispatch/header_test.rb" "test/dispatch/mapper_test.rb" "test/dispatch/middleware_stack/middleware_test.rb" "test/dispatch/middleware_stack_test.rb" "test/dispatch/mime_type_test.rb" "test/dispatch/mount_test.rb" "test/dispatch/prefix_generation_test.rb" "test/dispatch/rack_cache_test.rb" "test/dispatch/rack_test.rb" "test/dispatch/reloader_test.rb" "test/dispatch/request/json_params_parsing_test.rb" "test/dispatch/request/multipart_params_parsing_test.rb" "test/dispatch/request/query_string_parsing_test.rb" "test/dispatch/request/url_encoded_params_parsing_test.rb" "test/dispatch/request/xml_params_parsing_test.rb" "test/dispatch/request_id_test.rb" "test/dispatch/request_test.rb" "test/dispatch/response_test.rb" "test/dispatch/routing_assertions_test.rb" "test/dispatch/routing_test.rb" "test/dispatch/session/cache_store_test.rb" "test/dispatch/session/cookie_store_test.rb" "test/dispatch/session/mem_cache_store_test.rb" "test/dispatch/session/test_session_test.rb" "test/dispatch/show_exceptions_test.rb" "test/dispatch/static_test.rb" "test/dispatch/test_request_test.rb" "test/dispatch/test_response_test.rb" "test/dispatch/uploaded_file_test.rb" "test/dispatch/url_generation_test.rb" "test/template/active_model_helper_test.rb" "test/template/asset_tag_helper_test.rb" "test/template/atom_feed_helper_test.rb" "test/template/capture_helper_test.rb" "test/template/compiled_templates_test.rb" "test/template/compressors_test.rb" "test/template/date_helper_i18n_test.rb" "test/template/date_helper_test.rb" "test/template/erb/form_for_test.rb" "test/template/erb/tag_helper_test.rb" "test/template/erb_util_test.rb" "test/template/form_helper_test.rb" "test/template/form_options_helper_i18n_test.rb" "test/template/form_options_helper_test.rb" "test/template/form_tag_helper_test.rb" "test/template/html-scanner/cdata_node_test.rb" "test/template/html-scanner/document_test.rb" "test/template/html-scanner/node_test.rb" "test/template/html-scanner/sanitizer_test.rb" "test/template/html-scanner/tag_node_test.rb" "test/template/html-scanner/text_node_test.rb" "test/template/html-scanner/tokenizer_test.rb" "test/template/javascript_helper_test.rb" "test/template/log_subscriber_test.rb" "test/template/lookup_context_test.rb" "test/template/number_helper_i18n_test.rb" "test/template/number_helper_test.rb" "test/template/output_buffer_test.rb" "test/template/output_safety_helper_test.rb" "test/template/record_tag_helper_test.rb" "test/template/render_test.rb" "test/template/resolver_patterns_test.rb" "test/template/sanitize_helper_test.rb" "test/template/sprockets_helper_test.rb" "test/template/sprockets_helper_with_routes_test.rb" "test/template/streaming_render_test.rb" "test/template/tag_helper_test.rb" "test/template/template_error_test.rb" "test/template/template_test.rb" "test/template/test_case_test.rb" "test/template/test_test.rb" "test/template/testing/fixture_resolver_test.rb" "test/template/testing/null_resolver_test.rb" "test/template/text_helper_test.rb" "test/template/translation_helper_test.rb" "test/template/url_helper_test.rb" 
/Users/sikachu/Projects/rails/activesupport/lib/active_support/core_ext/time/calculations.rb:2: warning: loading in progress, circular require considered harmful - /Users/sikachu/Projects/rails/activesupport/lib/active_support/core_ext/time/zones.rb
    from /Users/sikachu/.rvm/gems/ruby-1.9.3-p125-perf/gems/rake-0.9.3.beta.1/lib/rake/rake_test_loader.rb:4:in `<main>'
    from /Users/sikachu/.rvm/gems/ruby-1.9.3-p125-perf/gems/rake-0.9.3.beta.1/lib/rake/rake_test_loader.rb:4:in `select'
    from /Users/sikachu/.rvm/gems/ruby-1.9.3-p125-perf/gems/rake-0.9.3.beta.1/lib/rake/rake_test_loader.rb:15:in `block in <main>'
    from /Users/sikachu/.rvm/rubies/ruby-1.9.3-p125-perf/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/sikachu/.rvm/rubies/ruby-1.9.3-p125-perf/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/sikachu/Projects/rails/actionpack/test/abstract/abstract_controller_test.rb:1:in `<top (required)>'
    from /Users/sikachu/.rvm/rubies/ruby-1.9.3-p125-perf/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/sikachu/.rvm/rubies/ruby-1.9.3-p125-perf/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/sikachu/Projects/rails/actionpack/test/abstract_unit.rb:28:in `<top (required)>'
    from /Users/sikachu/Projects/rails/actionpack/test/abstract_unit.rb:28:in `require'
    from /Users/sikachu/Projects/rails/actionpack/lib/abstract_controller.rb:6:in `<top (required)>'
    from /Users/sikachu/Projects/rails/actionpack/lib/abstract_controller.rb:6:in `require'
    from /Users/sikachu/Projects/rails/activesupport/lib/active_support/ruby/shim.rb:12:in `<top (required)>'
    from /Users/sikachu/Projects/rails/activesupport/lib/active_support/ruby/shim.rb:12:in `require'
    from /Users/sikachu/Projects/rails/activesupport/lib/active_support/core_ext/date/calculations.rb:4:in `<top (required)>'
    from /Users/sikachu/Projects/rails/activesupport/lib/active_support/core_ext/date/calculations.rb:4:in `require'
    from /Users/sikachu/Projects/rails/activesupport/lib/active_support/core_ext/date/zones.rb:2:in `<top (required)>'
    from /Users/sikachu/Projects/rails/activesupport/lib/active_support/core_ext/date/zones.rb:2:in `require'
    from /Users/sikachu/Projects/rails/activesupport/lib/active_support/core_ext/time/zones.rb:1:in `<top (required)>'
    from /Users/sikachu/Projects/rails/activesupport/lib/active_support/core_ext/time/zones.rb:1:in `require'
    from /Users/sikachu/Projects/rails/activesupport/lib/active_support/core_ext/time/calculations.rb:2:in `<top (required)>'
    from /Users/sikachu/Projects/rails/activesupport/lib/active_support/core_ext/time/calculations.rb:2:in `require'
/Users/sikachu/Projects/rails/activesupport/lib/active_support/core_ext/hash/slice.rb:15: warning: method redefined; discarding old slice
/Users/sikachu/.rvm/gems/ruby-1.9.3-p125-perf/gems/i18n-0.6.0/lib/i18n/core_ext/hash.rb:2: warning: previous definition of slice was here
/Users/sikachu/Projects/rails/activesupport/lib/active_support/core_ext/hash/deep_merge.rb:9: warning: method redefined; discarding old deep_merge!
/Users/sikachu/.rvm/gems/ruby-1.9.3-p125-perf/gems/i18n-0.6.0/lib/i18n/core_ext/hash.rb:25: warning: previous definition of deep_merge! was here
/Users/sikachu/Projects/rails/activesupport/lib/active_support/core_ext/hash/except.rb:14: warning: method redefined; discarding old except
/Users/sikachu/.rvm/gems/ruby-1.9.3-p125-perf/gems/i18n-0.6.0/lib/i18n/core_ext/hash.rb:8: warning: previous definition of except was here
/Users/sikachu/Projects/rails/actionpack/lib/abstract_controller/layouts.rb:312: warning: instance variable @_layout not initialized
/Users/sikachu/Projects/rails/actionpack/lib/abstract_controller/layouts.rb:312: warning: instance variable @_layout not initialized
/Users/sikachu/Projects/rails/actionpack/lib/abstract_controller/layouts.rb:312: warning: instance variable @_layout not initialized
/Users/sikachu/.rvm/gems/ruby-1.9.3-p125-perf/gems/mail-2.4.4/lib/mail/core_extensions/nil.rb:6: warning: method redefined; discarding old blank?
/Users/sikachu/Projects/rails/activesupport/lib/active_support/core_ext/object/blank.rb:48: warning: previous definition of blank? was here
/Users/sikachu/.rvm/gems/ruby-1.9.3-p125-perf/gems/mail-2.4.4/lib/mail/core_extensions/object.rb:6: warning: method redefined; discarding old blank?
/Users/sikachu/Projects/rails/activesupport/lib/active_support/core_ext/object/blank.rb:15: warning: previous definition of blank? was here
/Users/sikachu/.rvm/gems/ruby-1.9.3-p125-perf/gems/mail-2.4.4/lib/mail/core_extensions/shell_escape.rb:33: warning: character class has duplicated range: /([^A-Za-z0-9_\s\+\-.,:\/@\n])/
/Users/sikachu/.rvm/gems/ruby-1.9.3-p125-perf/gems/mail-2.4.4/lib/mail/patterns.rb:11: warning: assigned but unused variable - lwsp
/Users/sikachu/Projects/rails/actionpack/lib/abstract_controller/layouts.rb:312: warning: instance variable @_layout not initialized
/Users/sikachu/.rvm/gems/ruby-1.9.3-p125-perf/gems/memcache-client-1.8.5/lib/memcache.rb:303: warning: assigned but unused variable - key_count
/Users/sikachu/.rvm/gems/ruby-1.9.3-p125-perf/gems/memcache-client-1.8.5/lib/memcache.rb:812: warning: assigned but unused variable - key
/Users/sikachu/.rvm/gems/ruby-1.9.3-p125-perf/gems/memcache-client-1.8.5/lib/memcache.rb:24: warning: assigned but unused variable - e
/Users/sikachu/.rvm/gems/ruby-1.9.3-p125-perf/gems/memcache-client-1.8.5/lib/continuum_native.rb:38: warning: assigned but unused variable - e
/Users/sikachu/Projects/rails/actionpack/test/template/render_test.rb:493: warning: mismatched indentations at 'end' with 'def' at 473
/Users/sikachu/Projects/rails/activesupport/lib/active_support/dependencies.rb:251:in `require': /Users/sikachu/Projects/rails/actionpack/test/template/render_test.rb:493: syntax error, unexpected $end, expecting keyword_end (SyntaxError)
    from /Users/sikachu/Projects/rails/activesupport/lib/active_support/dependencies.rb:251:in `block in require'
    from /Users/sikachu/Projects/rails/activesupport/lib/active_support/dependencies.rb:236:in `load_dependency'
    from /Users/sikachu/Projects/rails/activesupport/lib/active_support/dependencies.rb:251:in `require'
    from /Users/sikachu/.rvm/gems/ruby-1.9.3-p125-perf/gems/rake-0.9.3.beta.1/lib/rake/rake_test_loader.rb:15:in `block in <main>'
    from /Users/sikachu/.rvm/gems/ruby-1.9.3-p125-perf/gems/rake-0.9.3.beta.1/lib/rake/rake_test_loader.rb:4:in `select'
    from /Users/sikachu/.rvm/gems/ruby-1.9.3-p125-perf/gems/rake-0.9.3.beta.1/lib/rake/rake_test_loader.rb:4:in `<main>'
rake aborted!
Command failed with status (1): [/Users/sikachu/.rvm/rubies/ruby-1.9.3-p125...]
Tasks: TOP => default => test => test_action_pack
(See full trace by running task with --trace)
[~/Projects/rails/actionpack] 
```
