### PR TITLE
Expose Arel predicates... somehow?

### DIFF
--- a/activerecord/lib/active_record/core_ext/symbol.rb
+++ b/activerecord/lib/active_record/core_ext/symbol.rb
@@ -1,0 +1,9 @@
+class Symbol
+  (Arel::Predications.instance_methods + [:not]).each do |sym|
+    class_eval <<-RUBY, __FILE__, __LINE__ + 1
+      def #{sym}
+        ActiveRecord::PredicateBuilder::Operator.new(self, #{sym.inspect})
+      end
+    RUBY
+  end
+end # class Symbol

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -1,5 +1,17 @@
+require 'active_record/core_ext/symbol'
+
 module ActiveRecord
   class PredicateBuilder # :nodoc:
+    class Operator
+      attr_reader :target, :operator
+      def initialize(target, operator)
+        @target, @operator = target, operator.to_sym
+      end
+      def to_sym
+        self
+      end
+    end
+
     def self.build_from_hash(engine, attributes, default_table)
       attributes.map do |column, value|
         table = default_table
@@ -8,14 +20,18 @@ module ActiveRecord
           table = Arel::Table.new(column, engine)
           build_from_hash(engine, value, table)
         else
-          column = column.to_s
+          if column.is_a?(Operator)
+            build(table[column.target], value, column.operator)
+          else
+            column = column.to_s
 
-          if column.include?('.')
-            table_name, column = column.split('.', 2)
-            table = Arel::Table.new(table_name, engine)
+            if column.include?('.')
+              table_name, column = column.split('.', 2)
+              table = Arel::Table.new(table_name, engine)
+            end
+
+            build(table[column.to_sym], value)
           end
-
-          build(table[column.to_sym], value)
         end
       end.flatten
     end
@@ -32,42 +48,50 @@ module ActiveRecord
     end
 
     private
-      def self.build(attribute, value)
-        case value
-        when ActiveRecord::Relation
-          value = value.select(value.klass.arel_table[value.klass.primary_key]) if value.select_values.empty?
-          attribute.in(value.arel.ast)
-        when Array, ActiveRecord::Associations::CollectionProxy
-          values = value.to_a.map {|x| x.is_a?(ActiveRecord::Model) ? x.id : x}
-          ranges, values = values.partition {|v| v.is_a?(Range)}
-
-          values_predicate = if values.include?(nil)
-            values = values.compact
-
-            case values.length
-            when 0
-              attribute.eq(nil)
-            when 1
-              attribute.eq(values.first).or(attribute.eq(nil))
-            else
-              attribute.in(values).or(attribute.eq(nil))
-            end
-          else
-            attribute.in(values)
-          end
-
-          array_predicates = ranges.map { |range| attribute.in(range) }
-          array_predicates << values_predicate
-          array_predicates.inject { |composite, predicate| composite.or(predicate) }
-        when Range
-          attribute.in(value)
-        when ActiveRecord::Model
-          attribute.eq(value.id)
-        when Class
-          # FIXME: I think we need to deprecate this behavior
-          attribute.eq(value.name)
+      def self.build(attribute, value, operator = nil)
+        if operator && !(operator == :not)
+          return attribute.send(operator, value)
         else
-          attribute.eq(value)
+          in_pred, eq_pred = :in, :eq
+          if operator == :not
+            in_pred, eq_pred = :not_in, :not_eq
+          end
+          case value
+          when ActiveRecord::Relation
+            value = value.select(value.klass.arel_table[value.klass.primary_key]) if value.select_values.empty?
+            attribute.send(in_pred, value.arel.ast)
+          when Array, ActiveRecord::Associations::CollectionProxy
+            values = value.to_a.map {|x| x.is_a?(ActiveRecord::Model) ? x.id : x}
+            ranges, values = values.partition {|v| v.is_a?(Range)}
+
+            values_predicate = if values.include?(nil)
+              values = values.compact
+
+              case values.length
+              when 0
+                attribute.send(eq_pred, nil)
+              when 1
+                attribute.send(eq_pred, values.first).or(attribute.send(eq_pred, nil))
+              else
+                attribute.send(in_pred, values).or(attribute.send(eq_pred, nil))
+              end
+            else
+              attribute.send(in_pred, values)
+            end
+
+            array_predicates = ranges.map { |range| attribute.in(range) }
+            array_predicates << values_predicate
+            array_predicates.inject { |composite, predicate| composite.or(predicate) }
+          when Range
+            attribute.send(in_pred, value)
+          when ActiveRecord::Model
+            attribute.send(eq_pred, value.id)
+          when Class
+            # FIXME: I think we need to deprecate this behavior
+            attribute.send(eq_pred, value.name)
+          else
+            attribute.send(eq_pred, value)
+          end
         end
       end
   end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -229,6 +229,22 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
+  def test_basic_arel_predicates
+    assert_equal [authors(:david)], Author.where(:name.matches => "%avid").all
+    assert_equal [authors(:bob)], Author.where(:name.not_eq => "Mary").where(:name.not_eq => "David").all
+    assert_equal [authors(:bob)], Author.where(:name.not_in => ["David", "Mary"]).all
+    assert_equal [authors(:mary)], Author.where(:name.in => ["Mary", "Sue"]).all
+    assert_equal [authors(:bob)], Author.where(:name.does_not_match => "%a%").all
+    assert_equal [authors(:david)], Author.where(:organization_id.not_eq => nil).all
+    assert_equal [authors(:david)], Author.where(:id.lt => 2).all
+    assert_equal [authors(:bob)], Author.where(:id.gt => 2).all
+  end
+
+  def test_smarter_arel_predicates
+    assert_equal [authors(:david)], Author.where(:organization_id.not => nil).all
+    assert_equal [authors(:bob)], Author.where(:name.not => ["David", "Mary"]).all
+  end
+
   def test_model_class_responds_to_first_bang
     assert Topic.first!
     Topic.delete_all


### PR DESCRIPTION
It's incredibly annoying to negate things in Active Record! I can do:

```
Person.where(:name => "Jacob")
```

but to negate it, I'd have to use a SQL fragment like this:

```
Person.where("name <> ? ", "Jacob")
```

I want support:

```
Person.where(:name.not => "Jacob")
```

This is inspired by the DataMapper way (http://datamapper.org/docs/find.html)

It turns out Arel actually has a LOT of predicates that are not exposed by Active Record.  So why not expose them all? (see: https://github.com/brynary/arel/blob/master/lib/arel/predications.rb)

Examples of using predicates directly defined by arel:

```
Person.where(:name.matches => "%opher")
Person.where(:age.gt => 10)
```

Examples of the special "not" predicate:

```
Person.where(:name.not => nil)
Person.where(:name.not => ["Jacob","Micah"])
```
