### PR TITLE
Support string substitution in the order clause

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -143,7 +143,13 @@ module ActiveRecord
     end
 
     def order!(*args)
-      args       = args.flatten
+      if args.size == 1 && ::Array === args.first &&
+          !args.first.find{ |arg| ::String === arg && arg =~ /\?/ }
+        args = args.first
+      elsif ::String === args.first && args.first =~ /\?/
+        args = [args]
+      end
+      args.map!{ |arg| ::Array === arg ? @klass.send(:sanitize_sql, arg) : arg }
 
       references = args.reject { |arg| Arel::Node === arg }
                        .map { |arg| arg =~ /^([a-zA-Z]\w*)\.(\w+)/ && $1 }

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -144,9 +144,9 @@ module ActiveRecord
 
     def order!(*args)
       if args.size == 1 && ::Array === args.first &&
-          !args.first.find{ |arg| ::String === arg && arg =~ /\?/ }
+          !args.first.find{ |arg| ::String === arg && arg =~ /\?|:\w/ }
         args = args.first
-      elsif ::String === args.first && args.first =~ /\?/
+      elsif ::String === args.first && args.first =~ /\?|:\w/
         args = [args]
       end
       args.map!{ |arg| ::Array === arg ? @klass.send(:sanitize_sql, arg) : arg }

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -145,6 +145,12 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal topics(:first).title, topics.first.title
   end
 
+  def test_finding_with_order_with_substitution
+    topics = Topic.order(['(id + ?)', 1])
+    assert_equal 4, topics.to_a.size
+    assert_equal topics(:first).title, topics.first.title
+  end
+
 
   def test_finding_with_arel_order
     topics = Topic.order(Topic.arel_table[:id].asc)


### PR DESCRIPTION
Support string substitutions in the order clause in ActiveRecord.

This helps cases when you want to order on an expression. For example:

``` ruby
value = 10
MyModel.order(['(id % ?)', value])
```

Note that it uses a heuristic to distinguish between ordering by a list of values, and a single value that happens to be a string substitution (an sql sanitization). If the first item in an array is a string that contains a question mark, it is assumed that the intent is for that array to be a string substitution. I'm of course open to suggestions on this heuristic.

This is also very useful in geospatial queries where the order clause sometimes contains function calls, as in:

``` ruby
loc = get_location
max_dist = get_max_dist
MyLocation.order(['st_distance("latlon", ?) < ?', loc, max_dist])
```
