### PR TITLE
ActiveRecord support for where_not

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -38,7 +38,7 @@ module ActiveRecord
 
       instance_methods.each { |m| undef_method m unless m.to_s =~ /^(?:nil\?|send|object_id|to_a)$|^__|^respond_to|proxy_/ }
 
-      delegate :group, :order, :limit, :joins, :where, :preload, :eager_load, :includes, :from,
+      delegate :group, :order, :limit, :joins, :where, :where_not, :preload, :eager_load, :includes, :from,
                :lock, :readonly, :having, :pluck, :to => :scoped
 
       delegate :target, :load_target, :loaded?, :to => :@association

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -9,7 +9,7 @@ module ActiveRecord
     delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, :to => :scoped
     delegate :find_each, :find_in_batches, :to => :scoped
     delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins,
-             :where, :preload, :eager_load, :includes, :from, :lock, :readonly,
+             :where, :where_not, :preload, :eager_load, :includes, :from, :lock, :readonly,
              :having, :create_with, :uniq, :references, :none, :to => :scoped
     delegate :count, :average, :minimum, :maximum, :sum, :calculate, :pluck, :to => :scoped
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -194,6 +194,17 @@ module ActiveRecord
       self
     end
 
+    def where_not(opts, *rest)
+      opts.blank? ? self : clone.where_not!(opts, *rest)
+    end
+
+    def where_not!(opts, *rest)
+      references!(PredicateBuilder.references(opts)) if Hash === opts
+
+      self.where_values += build_where(opts, rest, :not)
+      self
+    end
+
     def where(opts, *rest)
       opts.blank? ? self : clone.where!(opts, *rest)
     end
@@ -452,13 +463,13 @@ module ActiveRecord
       end
     end
 
-    def build_where(opts, other = [])
+    def build_where(opts, other = [], operator = nil)
       case opts
       when String, Array
         [@klass.send(:sanitize_sql, other.empty? ? opts : ([opts] + other))]
       when Hash
         attributes = @klass.send(:expand_hash_conditions_for_aggregates, opts)
-        PredicateBuilder.build_from_hash(table.engine, attributes, table)
+        PredicateBuilder.build_from_hash(table.engine, attributes, table, operator)
       else
         [opts]
       end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -229,6 +229,11 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
+  def test_where_not
+    assert_equal [authors(:david)], Author.where_not(organization_id: nil).all
+    assert_equal [authors(:bob)], Author.where_not(name: ["David", "Mary"]).all
+  end
+
   def test_model_class_responds_to_first_bang
     assert Topic.first!
     Topic.delete_all


### PR DESCRIPTION
It's incredibly annoying to negate things in Active Record! I can do:

```
Person.where(:name => "Jacob")
```

but to negate it, I'd have to use a SQL fragment like this:

```
Person.where("name <> ? ", "Jacob")
```

I want support:

```
Person.where(:name.not => "Jacob")
```

(see: https://github.com/rails/rails/pull/5948)

But barring that, let's support:

```
Person.where_not(:name => "Jacob")
```
