### PR TITLE
Lock mocha to older version 3 2 stable from mocha.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ end
 gem 'uglifier', '>= 1.0.3', :require => false
 
 gem 'rake', '>= 0.8.7'
-gem 'mocha', '>= 0.9.8'
+gem 'mocha', '0.10.5'
 
 group :doc do
   # The current sdoc cannot generate GitHub links due


### PR DESCRIPTION
See #5907 and
https://github.com/floehopper/mocha/pull/77
