### PR TITLE
Create a new errors reference in dup

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -223,6 +223,11 @@ module ActiveModel
     def to_hash
       messages.dup
     end
+    
+    #Return true if the instance other is the same of base
+    def has_base?(other)
+      @base.equal? other
+    end
 
     # Adds +message+ to the error messages on +attribute+. More than one error can be added to the same
     # +attribute+.

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -167,7 +167,7 @@ module ActiveModel
 
     # Returns the +Errors+ object that holds all information about attribute error messages.
     def errors
-      @errors ||= Errors.new(self)
+      @errors = (defined? @errors) && @errors.has_base?(self) ? @errors : Errors.new(self)
     end
 
     # Runs all the specified validations and returns true if no errors were added

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -53,7 +53,15 @@ class ErrorsTest < ActiveModel::TestCase
     errors_dup[:bar] = 'omg'
     assert_not_same errors_dup.messages, errors.messages
   end
-
+  
+  def test_has_base?
+    person = Person.new
+    errors = ActiveModel::Errors.new(person)
+    duped = person.dup
+    assert errors.has_base?(person)
+    assert !errors.has_base?(duped)
+  end
+  
   test "should return true if no errors" do
     person = Person.new
     person.errors[:foo]

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -297,7 +297,23 @@ class ValidationsTest < ActiveModel::TestCase
 
     assert auto.valid?
   end
-
+  
+  def test_dup_validity_is_independent
+    Topic.validates_presence_of :title
+    topic = Topic.new("title" => "Litterature")
+    topic.valid?
+    duped = topic.dup
+    duped.title = nil
+    
+    assert duped.invalid?
+    
+    topic.title = nil
+    duped.title = 'Mathematics'
+    
+    assert topic.invalid?
+    assert duped.valid?
+  end
+ 
   def test_strict_validation_in_validates
     Topic.validates :title, :strict => true, :presence => true
     assert_raises ActiveModel::StrictValidationFailed do
@@ -338,5 +354,5 @@ class ValidationsTest < ActiveModel::TestCase
       Topic.new.valid?
     end
     assert_equal "Title can't be blank", exception.message
-  end
+  end  
 end


### PR DESCRIPTION
If an ActiveRecord instance is cloned, this keeps track of errors of this 'parent', because both errors instances point to the same ActiveModel::Errors instance. This happen when before to call dup, save or valid? is called
