### PR TITLE
Fix secure_password setter

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -64,8 +64,8 @@ module ActiveModel
 
       # Encrypts the password into the password_digest attribute.
       def password=(unencrypted_password)
-        @password = unencrypted_password
         unless unencrypted_password.blank?
+          @password = unencrypted_password
           self.password_digest = BCrypt::Password.create(unencrypted_password)
         end
       end

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -19,6 +19,12 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert !@user.valid?, 'user should be invalid'
   end
 
+  test "blank password doesn't override previous password" do
+    @user.password = 'test'
+    @user.password = ''
+    assert_equal @user.password, 'test'
+  end
+
   test "password must be present" do
     assert !@user.valid?
     assert_equal 1, @user.errors.size


### PR DESCRIPTION
I think the password attribute should not update if we don't generate a new password.
