### PR TITLE
Always quote hstore keys and values

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -88,9 +88,8 @@ module ActiveRecord
 
         def escape_hstore(value)
             value.nil?         ? 'NULL'
-          : value =~ /[=\s,>]/ ? '"%s"' % value.gsub(/(["\\])/, '\\\\\1')
           : value == ""        ? '""'
-          :                      value.to_s.gsub(/(["\\])/, '\\\\\1')
+          :                      '"%s"' % value.gsub(/(["\\])/, '\\\\\1')
         end
       end
       # :startdoc:

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -89,7 +89,7 @@ module ActiveRecord
         def escape_hstore(value)
             value.nil?         ? 'NULL'
           : value == ""        ? '""'
-          :                      '"%s"' % value.gsub(/(["\\])/, '\\\\\1')
+          :                      '"%s"' % value.to_s.gsub(/(["\\])/, '\\\\\1')
         end
       end
       # :startdoc:

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require "cases/helper"
 require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
@@ -134,13 +136,19 @@ class PostgresqlHstoreTest < ActiveRecord::TestCase
     assert_cycle('a=>b' => 'bar', '1"foo' => '2')
   end
 
+  def test_quoting_special_characters
+    assert_cycle('ca' => 'cà', 'ac' => 'àc')
+  end
+
   private
   def assert_cycle hash
+    # test creation
     x = Hstore.create!(:tags => hash)
     x.reload
     assert_equal(hash, x.tags)
 
-    # make sure updates work
+    # test updating
+    x = Hstore.create!(:tags => {})
     x.tags = hash
     x.save!
     x.reload


### PR DESCRIPTION
`escape_hstore` uses quotation marks around keys and values only if it seems necessary. However, it currently breaks in the presence of some non-ASCII characters. Instead of trying to guess which characters are safe, it seems better to always use quotes.
