### PR TITLE
already defined in quoting

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -163,11 +163,6 @@ module ActiveRecord
 
       # QUOTING ==================================================
 
-      # Override to return the quoted table name. Defaults to column quoting.
-      def quote_table_name(name)
-        quote_column_name(name)
-      end
-
       # Returns a bind substitution value given a +column+ and list of current
       # +binds+
       def substitute_at(column, index)


### PR DESCRIPTION
This method already defined in https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb#L90 and included here https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L51
