### PR TITLE
cleanliness in method parameters

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -299,7 +299,7 @@ module ActiveRecord
         raise exception
       end
 
-      def translate_exception(e, message)
+      def translate_exception(exception, message)
         # override in derived class
         ActiveRecord::StatementInvalid.new(message)
       end


### PR DESCRIPTION
For all connection adapters method `translate_exception` has 2 parameters `exception` and `message`. 

https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L588

https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L1245

https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb#L552

But in parent class this method has another parameters. Let's clean up this.
