### PR TITLE
sqlite supports explain too

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -155,7 +155,7 @@ module ActiveRecord
         false
       end
 
-      # Does this adapter support explain? As of this writing sqlite3,
+      # Does this adapter support explain? As of this writing sqlite, sqlite3,
       # mysql2, and postgresql are the only ones that do.
       def supports_explain?
         false

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -155,7 +155,7 @@ module ActiveRecord
         false
       end
 
-      # Does this adapter support explain? As of this writing sqlite, sqlite3,
+      # Does this adapter support explain? As of this writing sqlite3,
       # mysql2, and postgresql are the only ones that do.
       def supports_explain?
         false

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -50,6 +50,33 @@ module ActiveRecord
         @connection.encoding.to_s
       end
 
+      # Returns true.
+      def supports_explain?
+        true
+      end
+
+      # DATABASE STATEMENTS ======================================
+
+      def explain(arel, binds = [])
+        sql = "EXPLAIN QUERY PLAN #{to_sql(arel, binds)}"
+        ExplainPrettyPrinter.new.pp(exec_query(sql, 'EXPLAIN', binds))
+      end
+
+      class ExplainPrettyPrinter
+        # Pretty prints the result of a EXPLAIN QUERY PLAN in a way that resembles
+        # the output of the SQLite shell:
+        #
+        #   0|0|0|SEARCH TABLE users USING INTEGER PRIMARY KEY (rowid=?) (~1 rows)
+        #   0|1|1|SCAN TABLE posts (~100000 rows)
+        #
+        def pp(result) # :nodoc:
+          result.rows.map do |row|
+            row.join('|')
+          end.join("\n") + "\n"
+        end
+      end
+
+
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
@@ -116,11 +116,6 @@ module ActiveRecord
         true
       end
 
-      # Returns true.
-      def supports_explain?
-        true
-      end
-
       def requires_reloading?
         true
       end
@@ -209,25 +204,6 @@ module ActiveRecord
       end
 
       # DATABASE STATEMENTS ======================================
-
-      def explain(arel, binds = [])
-        sql = "EXPLAIN QUERY PLAN #{to_sql(arel, binds)}"
-        ExplainPrettyPrinter.new.pp(exec_query(sql, 'EXPLAIN', binds))
-      end
-
-      class ExplainPrettyPrinter
-        # Pretty prints the result of a EXPLAIN QUERY PLAN in a way that resembles
-        # the output of the SQLite shell:
-        #
-        #   0|0|0|SEARCH TABLE users USING INTEGER PRIMARY KEY (rowid=?) (~1 rows)
-        #   0|1|1|SCAN TABLE posts (~100000 rows)
-        #
-        def pp(result) # :nodoc:
-          result.rows.map do |row|
-            row.join('|')
-          end.join("\n") + "\n"
-        end
-      end
 
       def exec_query(sql, name = nil, binds = [])
         log(sql, name, binds) do


### PR DESCRIPTION
Sqlite3 adapter is inherited from sqlite and it supports explain. And based on https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb#L121 we may say that sqlite adapter supports explain too.
