### PR TITLE
Added comment on how to enable gzip compression

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -1,5 +1,8 @@
 <%= app_const %>.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+  
+  # If you want to enable Enable gzip compression, uncomment this line.
+  # config.gzip_compression = true
 
   # Code is not reloaded between requests.
   config.cache_classes = true


### PR DESCRIPTION
Disabled by default but should be handy for people running rails without using any frontend proxy e.g Cedar stack on Heroku. Added in production environment on advice from @sikachu, as that's the place it going to be needed.  
