### PR TITLE
Upgrade sprockets version to 2.2.0

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,4 +1,9 @@
-## Rails 3.2.3 (unreleased) ##
+## Rails 3.2.4 (unreleased) ##
+
+*  Upgrade sprockets dependency to 2.2.0, this version fixes encoding issues under Ruby 1.9. *Guillermo Iguaran*
+
+
+## Rails 3.2.3 (March 30, 2012) ##
 
 *   Fix #5632, render :inline set the proper rendered format. *Santiago Pastorino*
 

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency('rack',          '~> 1.4.0')
   s.add_dependency('rack-test',     '~> 0.6.1')
   s.add_dependency('journey',       '~> 1.0.1')
-  s.add_dependency('sprockets',     '~> 2.1.2')
+  s.add_dependency('sprockets',     '~> 2.2.0')
   s.add_dependency('erubis',        '~> 2.7.0')
 
   s.add_development_dependency('tzinfo', '~> 0.3.29')


### PR DESCRIPTION
This version fixes encoding issues under Ruby 1.9. 

I prefer do a conservative upgrade to 2.2.0 in 3-2-stable branch. In master I upgraded it to 2.4.0
