### PR TITLE
Add a "silence" behavior to completely turn off deprecation warnings.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*    Add ActiveSupport::Deprecations.behavior = :slience to to completely ignore *twinturbo*
+
 *    Make Module#delegate stop using `send` - can no longer delegate to private methods. *dasch*
 
 *    AS::Callbacks: deprecate `:rescuable` option. *Bogdan Gusiev*

--- a/activesupport/lib/active_support/deprecation/behaviors.rb
+++ b/activesupport/lib/active_support/deprecation/behaviors.rb
@@ -41,8 +41,9 @@ module ActiveSupport
        },
        :notify => Proc.new { |message, callstack|
           ActiveSupport::Notifications.instrument("deprecation.rails",
-            :message => message, :callstack => callstack)
-       }
+          :message => message, :callstack => callstack)
+       },
+       :silence => Proc.new { |message, callstack| }
     }
   end
 end

--- a/activesupport/lib/active_support/deprecation/behaviors.rb
+++ b/activesupport/lib/active_support/deprecation/behaviors.rb
@@ -13,6 +13,13 @@ module ActiveSupport
 
       # Sets the behavior to the specified value. Can be a single value or an array.
       #
+      # Available behaviors: 
+      #
+      # [+:stderr+] Print deprecations to +$stderror+
+      # [+:log+] Send to +Rails.logger+
+      # [+:notify+] Instrument using +ActiveSupport::Notifications+
+      # [+:silence+] Do nothing
+      #
       # Examples
       #
       #   ActiveSupport::Deprecation.behavior = :stderr

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -93,6 +93,26 @@ class DeprecationTest < ActiveSupport::TestCase
     assert_match(/foo=nil/, @b)
   end
 
+  def test_default_stderr_behavior
+    ActiveSupport::Deprecation.behavior = :stderr
+    behavior = ActiveSupport::Deprecation.behavior.first
+
+    content = capture(:stderr) {
+      assert_nil behavior.call('Some error!', ['call stack!'])
+    }
+    assert_match(/Some error!/, content)
+    assert_match(/call stack!/, content)
+  end
+
+  def test_default_silence_behavior
+    ActiveSupport::Deprecation.behavior = :silence
+    behavior = ActiveSupport::Deprecation.behavior.first
+
+    assert_blank capture(:stderr) {
+      assert_nil behavior.call('Some error!', ['call stack!'])
+    }
+  end
+
   def test_deprecated_instance_variable_proxy
     assert_not_deprecated { @dtc.request.size }
 


### PR DESCRIPTION
Cherry-picking all commits from #5852, that Github for some reason is not showing. Should be ok to go now.

Closes #5852

/cc @jeremy @twinturbo
