### PR TITLE
Fix #5847 and #4045. Load AR::Base before loading an application model.

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -128,5 +128,10 @@ module ActiveRecord
       end
 
     end
+
+    config.after_initialize do
+      # We should load ActiveRecord::Base class before loading an application model.
+      require "active_record/base"
+    end
   end
 end

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -167,5 +167,27 @@ module ApplicationTests
       end
       assert !File.exists?(File.join(app_path, 'db', 'schema_cache.dump'))
     end
+
+    def test_load_activerecord_base_when_we_use_observers
+      Dir.chdir(app_path) do
+        `bundle exec rails g model user;
+         bundle exec rake db:migrate;
+         bundle exec rails g observer user;`
+
+        add_to_config "config.active_record.observers = :user_observer"
+
+        assert_equal "0", `bundle exec rails r "puts User.count"`.strip
+
+        app_file "lib/tasks/count_user.rake", <<-RUBY
+          namespace :user do
+            task :count => :environment do
+              puts User.count
+            end
+          end
+        RUBY
+
+        assert_equal "0", `bundle exec rake user:count`.strip
+      end
+    end
   end
 end


### PR DESCRIPTION
I'm submitting this PR to master.
The original PR was https://github.com/rails/rails/pull/5879.
We should load active_record/base before loading some application models.

/cc @jonleighton
