### PR TITLE
AS::Callbacks#run_callbacks optimized to reduce backtrace

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -76,7 +76,8 @@ module ActiveSupport
     #
     def run_callbacks(kind, key = nil, &block)
       #TODO: deprecate key argument
-      self.class.__run_callbacks(kind, self, &block)
+      runner_name = self.class.__define_callbacks(kind, self)
+      send(runner_name, &block)
     end
 
     private
@@ -323,18 +324,17 @@ module ActiveSupport
         method << callbacks
 
         method << "halted ? false : (block_given? ? value : true)"
-        method.flatten.compact.join("\n")
+        method.join("\n")
       end
 
     end
 
     module ClassMethods
 
-      # This method runs callback chain for the given kind.
-      # If this called first time it creates a new callback method for the kind.
+      # This method defines callback chain method for the given kind
+      # if it was not yet defined.
       # This generated method plays caching role.
-      #
-      def __run_callbacks(kind, object, &blk) #:nodoc:
+      def __define_callbacks(kind, object) #:nodoc:
         name = __callback_runner_name(kind)
         unless object.respond_to?(name, true)
           str = object.send("_#{kind}_callbacks").compile
@@ -343,7 +343,7 @@ module ActiveSupport
             protected :#{name}
           RUBY_EVAL
         end
-        object.send(name, &blk)
+        name
       end
 
       def __reset_runner(symbol)


### PR DESCRIPTION
I remember @tenderlove was saying once that reduce backtrace size is a good idea.
And maybe it is especially good for Callbacks because they might appear several times per action call and also they are so ugly.

So, this patch reduce it by one

``` diff
  activerecord (3.2.3) lib/active_record/connection_adapters/abstract/connection_pool.rb:467:in `call'
  actionpack (3.2.3) lib/action_dispatch/middleware/callbacks.rb:28:in `block in call'
  activesupport (3.2.3) lib/active_support/callbacks.rb:405:in `_run__3245509492598542750__call__654369043753597113__callbacks'
-  activesupport (3.2.3) lib/active_support/callbacks.rb:405:in `__run_callback'
  activesupport (3.2.3) lib/active_support/callbacks.rb:81:in `run_callbacks'
  actionpack (3.2.3) lib/action_dispatch/middleware/callbacks.rb:27:in `call'
  actionpack (3.2.3) lib/action_dispatch/middleware/reloader.rb:65:in `call'
```
