### PR TITLE
Tiny refactoring in NumberHelper and RecordTagHelper

### DIFF
--- a/actionpack/lib/action_view/helpers/number_helper.rb
+++ b/actionpack/lib/action_view/helpers/number_helper.rb
@@ -233,7 +233,7 @@ module ActionView
 
         parts = number.to_s.to_str.split('.')
         parts[0].gsub!(/(\d)(?=(\d\d\d)+(?!\d))/, "\\1#{options[:delimiter]}")
-        parts.join(options[:separator]).html_safe
+        safe_join(parts, options[:separator])
       end
 
       # Formats a +number+ with the specified level of <tt>:precision</tt> (e.g., 112.32 has a precision

--- a/actionpack/lib/action_view/helpers/record_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/record_tag_helper.rb
@@ -94,10 +94,10 @@ module ActionView
         # for each record.
         def content_tag_for_single_record(tag_name, record, prefix, options, &block)
           options = options ? options.dup : {}
-          options.merge!(:class => "#{dom_class(record, prefix)} #{options[:class]}".rstrip, :id => dom_id(record, prefix))
+          options[:class] = "#{dom_class(record, prefix)} #{options[:class]}".rstrip
+          options[:id]    = dom_id(record, prefix)
 
-          content = block.arity == 0 ? capture(&block) : capture(record, &block)
-          content_tag(tag_name, content, options)
+          content_tag(tag_name, capture(record, &block), options)
         end
     end
   end


### PR DESCRIPTION
- use safe_join in number helper
- refactor content_tag_for helper:
  - do not use merge! just for 2 values
  - there is no need to check block arity
