### PR TITLE
Fix side effect on strings in url_for

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -521,11 +521,11 @@ module ActionDispatch
 
           if options[:controller]
             options[:action]     ||= 'index'
-            options[:controller]   = options[:controller].to_s
+            options[:controller]   = options[:controller].to_s.dup
           end
 
           if options[:action]
-            options[:action] = options[:action].to_s
+            options[:action] = options[:action].to_s.dup
           end
         end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -802,6 +802,15 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal original_options, options
   end
 
+  # checks that url_for doesn't change controller and action
+  def test_url_for_with_no_side_effects_on_strings
+    # freeze controller and action to be sure they are not changed
+    # we'll get RuntimeError if somebody tries to modify them
+    options = {:controller => '/projects'.freeze, :action => 'status'.freeze}
+
+    url_for options
+  end
+
   # tests the arguments modification free version of define_hash_access
   def test_named_route_with_no_side_effects
     original_options = { :host => 'test.host' }


### PR DESCRIPTION
`url_for` method changes controller that passed to the method. Example:  

``` ruby
controller = '/projects'
url_for {:controller => controller, :action => 'status'}
puts 'Side effect!' if controller == 'projects'
```

I suppose `url_for` shouldn't change any arguments it takes.  
Controller is changed [here](https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/routing/route_set.rb#L490)
