### PR TITLE
Partial layout collection item

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Make current object and counter (when it applies) variables accessible when
+    rendering templates with :object / :collection. *Carlos Antonio da Silva*
+
 *   JSONP now uses mimetype application/javascript instead of application/json *omjokine*
 
 *   Allow to lazy load `default_form_builder` by passing a `String` instead of a constant. *Piotr Sarnacki*

--- a/actionpack/lib/action_view/renderer/partial_renderer.rb
+++ b/actionpack/lib/action_view/renderer/partial_renderer.rb
@@ -304,7 +304,7 @@ module ActionView
       object, as = @object, @variable
 
       if !block && (layout = @options[:layout])
-        layout = find_template(layout)
+        layout = find_template(layout, @locals.keys + [@variable])
       end
 
       object ||= locals[as]

--- a/actionpack/lib/action_view/renderer/partial_renderer.rb
+++ b/actionpack/lib/action_view/renderer/partial_renderer.rb
@@ -158,8 +158,8 @@ module ActionView
   #     Name: <%= user.name %>
   #   </div>
   #
-  # If a collection is given, the layout will be rendered once for each item in the collection. Just think
-  # these two snippets have the same output:
+  # If a collection is given, the layout will be rendered once for each item in
+  # the collection. Just think these two snippets have the same output:
   #
   #   <%# app/views/users/_user.html.erb %>
   #   Name: <%= user.name %>
@@ -184,7 +184,7 @@ module ActionView
   #     <%= render :partial => "user", :layout => "li_layout", :collection => users %>
   #   </ul>
   #
-  #   Given two users whose names are Alice and Bob, these snippets return:
+  # Given two users whose names are Alice and Bob, these snippets return:
   #
   #   <ul>
   #     <li>
@@ -194,6 +194,10 @@ module ActionView
   #       Name: Bob
   #     </li>
   #   </ul>
+  #
+  # The current object being rendered, as well as the object_counter, will be
+  # available as local variables inside the layout template under the same names
+  # as available in the partial.
   #
   # You can also apply a layout to a block within any template:
   #

--- a/actionpack/lib/action_view/renderer/partial_renderer.rb
+++ b/actionpack/lib/action_view/renderer/partial_renderer.rb
@@ -283,13 +283,19 @@ module ActionView
       end
 
       if layout = @options[:layout]
-        layout = find_template(layout)
+        layout = find_template(layout, @locals.keys + [@variable])
       end
 
       result = @template ? collection_with_template : collection_without_template
-      
-      result.map!{|content| layout.render(@view, @locals) { content } } if layout
-      
+
+      if layout
+        locals = @locals
+        result.map! do |content|
+          locals[@variable] = @collection[result.index(content)]
+          layout.render(@view, @locals) { content }
+        end
+      end
+
       result.join(spacer).html_safe
     end
 
@@ -391,10 +397,9 @@ module ActionView
         locals[as] = object
         segments << template.render(@view, locals)
       end
-      
+
       segments
     end
-    
 
     def collection_without_template
       segments, locals, collection_data = [], @locals, @collection_data

--- a/actionpack/lib/action_view/renderer/partial_renderer.rb
+++ b/actionpack/lib/action_view/renderer/partial_renderer.rb
@@ -283,7 +283,7 @@ module ActionView
       end
 
       if layout = @options[:layout]
-        layout = find_template(layout, @locals.keys + [@variable])
+        layout = find_template(layout, @locals.keys + [@variable, @variable_counter])
       end
 
       result = @template ? collection_with_template : collection_without_template
@@ -292,6 +292,7 @@ module ActionView
         locals = @locals
         result.map! do |content|
           locals[@variable] = @collection[result.index(content)]
+          locals[@variable_counter] = result.index(content)
           layout.render(@view, @locals) { content }
         end
       end

--- a/actionpack/test/fixtures/test/_b_layout_for_partial_with_object.html.erb
+++ b/actionpack/test/fixtures/test/_b_layout_for_partial_with_object.html.erb
@@ -1,0 +1,1 @@
+<b class="<%= customer.name.downcase %>"><%= yield %></b>

--- a/actionpack/test/fixtures/test/_b_layout_for_partial_with_object_counter.html.erb
+++ b/actionpack/test/fixtures/test/_b_layout_for_partial_with_object_counter.html.erb
@@ -1,0 +1,1 @@
+<b data-counter="<%= customer_counter %>"><%= yield %></b>

--- a/actionpack/test/template/render_test.rb
+++ b/actionpack/test/template/render_test.rb
@@ -233,9 +233,13 @@ module RenderTestCases
   def test_render_partial_with_nil_values_in_collection
     assert_equal "Hello: davidHello: Anonymous", @view.render(:partial => "test/customer", :collection => [ Customer.new("david"), nil ])
   end
-  
+
   def test_render_partial_with_layout_using_collection_and_template
     assert_equal "<b>Hello: Amazon</b><b>Hello: Yahoo</b>", @view.render(:partial => "test/customer", :layout => 'test/b_layout_for_partial', :collection => [ Customer.new("Amazon"), Customer.new("Yahoo") ])
+  end
+
+  def test_render_partial_with_layout_using_collection_and_template_makes_current_item_available_in_template
+    assert_equal '<b class="amazon">Hello: Amazon</b><b class="yahoo">Hello: Yahoo</b>', @view.render(:partial => "test/customer", :layout => 'test/b_layout_for_partial_with_object', :collection => [ Customer.new("Amazon"), Customer.new("Yahoo") ])
   end
 
   def test_render_partial_with_empty_array_should_return_nil
@@ -310,7 +314,7 @@ module RenderTestCases
     ActionView::Template.register_template_handler :foo, CustomHandler
     assert_equal 'source: "Hello, <%= name %>!"', @view.render(:inline => "Hello, <%= name %>!", :locals => { :name => "Josh" }, :type => :foo)
   end
-  
+
   def test_render_knows_about_types_registered_when_extensions_are_checked_earlier_in_initialization
     ActionView::Template::Handlers.extensions
     ActionView::Template.register_template_handler :foo, CustomHandler

--- a/actionpack/test/template/render_test.rb
+++ b/actionpack/test/template/render_test.rb
@@ -238,12 +238,19 @@ module RenderTestCases
     assert_equal "<b>Hello: Amazon</b><b>Hello: Yahoo</b>", @view.render(:partial => "test/customer", :layout => 'test/b_layout_for_partial', :collection => [ Customer.new("Amazon"), Customer.new("Yahoo") ])
   end
 
-  def test_render_partial_with_layout_using_collection_and_template_makes_current_item_available_in_template
-    assert_equal '<b class="amazon">Hello: Amazon</b><b class="yahoo">Hello: Yahoo</b>', @view.render(:partial => "test/customer", :layout => 'test/b_layout_for_partial_with_object', :collection => [ Customer.new("Amazon"), Customer.new("Yahoo") ])
+  def test_render_partial_with_layout_using_collection_and_template_makes_current_item_available_in_layout
+    assert_equal '<b class="amazon">Hello: Amazon</b><b class="yahoo">Hello: Yahoo</b>',
+      @view.render(:partial => "test/customer", :layout => 'test/b_layout_for_partial_with_object', :collection => [ Customer.new("Amazon"), Customer.new("Yahoo") ])
   end
 
-  def test_render_partial_with_layout_using_object_and_template_makes_object_available_in_template
-    assert_equal '<b class="amazon">Hello: Amazon</b>', @view.render(:partial => "test/customer", :layout => 'test/b_layout_for_partial_with_object', :object => Customer.new("Amazon"))
+  def test_render_partial_with_layout_using_collection_and_template_makes_current_item_counter_available_in_layout
+    assert_equal '<b data-counter="0">Hello: Amazon</b><b data-counter="1">Hello: Yahoo</b>',
+      @view.render(:partial => "test/customer", :layout => 'test/b_layout_for_partial_with_object_counter', :collection => [ Customer.new("Amazon"), Customer.new("Yahoo") ])
+  end
+
+  def test_render_partial_with_layout_using_object_and_template_makes_object_available_in_layout
+    assert_equal '<b class="amazon">Hello: Amazon</b>',
+      @view.render(:partial => "test/customer", :layout => 'test/b_layout_for_partial_with_object', :object => Customer.new("Amazon"))
   end
 
   def test_render_partial_with_empty_array_should_return_nil

--- a/actionpack/test/template/render_test.rb
+++ b/actionpack/test/template/render_test.rb
@@ -242,6 +242,10 @@ module RenderTestCases
     assert_equal '<b class="amazon">Hello: Amazon</b><b class="yahoo">Hello: Yahoo</b>', @view.render(:partial => "test/customer", :layout => 'test/b_layout_for_partial_with_object', :collection => [ Customer.new("Amazon"), Customer.new("Yahoo") ])
   end
 
+  def test_render_partial_with_layout_using_object_and_template_makes_object_available_in_template
+    assert_equal '<b class="amazon">Hello: Amazon</b>', @view.render(:partial => "test/customer", :layout => 'test/b_layout_for_partial_with_object', :object => Customer.new("Amazon"))
+  end
+
   def test_render_partial_with_empty_array_should_return_nil
     assert_nil @view.render(:partial => [])
   end

--- a/guides/source/layouts_and_rendering.textile
+++ b/guides/source/layouts_and_rendering.textile
@@ -1193,6 +1193,16 @@ h5. Spacer Templates
 
 Rails will render the +_product_ruler+ partial (with no data passed in to it) between each pair of +_product+ partials.
 
+h5. Partial Layouts
+
+When rendering collections it is also possible to use the +:layout+ option:
+
+<erb>
+<%= render :partial => "product", :collection => @products, :layout => "special_layout" %>
+</erb>
+
+The layout will be rendered together with the partial for each item in the collection. The current object and object_counter variables will be available in the layout as well, the same way they do within the partial.
+
 h4. Using Nested Layouts
 
 You may find that your application requires a layout that differs slightly from your regular application layout to support one particular controller. Rather than repeating the main layout and editing it, you can accomplish this by using nested layouts (sometimes called sub-templates). Here's an example:


### PR DESCRIPTION
Pull request #5310 added the possibility to render layouts with collections. This patch allows access to the current object and object_counter being rendered inside the layout, the same way they are inside the partial.

Let me know if something needs to be improved. Thanks.

_ps: I'm working on some refactorings in PartialRenderer, that I'll be sending as a separate pull request._
