### PR TITLE
Rails::Queueing::TestQueue run order

### DIFF
--- a/railties/lib/rails/queueing.rb
+++ b/railties/lib/rails/queueing.rb
@@ -18,7 +18,7 @@ module Rails
         # run the jobs in a separate thread so assumptions of synchronous
         # jobs are caught in test mode.
         t = Thread.new do
-          while job = @contents.pop
+          while job = @contents.shift
             job.run
           end
         end

--- a/railties/test/queueing/test_queue_test.rb
+++ b/railties/test/queueing/test_queue_test.rb
@@ -27,14 +27,14 @@ class TestQueueTest < ActiveSupport::TestCase
 
   def test_order
     time1 = time2 = nil
-    
+
     job1 = Job.new(1) { time1 = Time.now }
     job2 = Job.new(2) { time2 = Time.now }
-    
+
     @queue.push job1
     @queue.push job2
     @queue.drain
-    
+
     assert time1 < time2, "Jobs run in the same order they were added"
   end
 

--- a/railties/test/queueing/test_queue_test.rb
+++ b/railties/test/queueing/test_queue_test.rb
@@ -25,6 +25,19 @@ class TestQueueTest < ActiveSupport::TestCase
     assert_equal [job], @queue.contents
   end
 
+  def test_order
+    time1 = time2 = nil
+    
+    job1 = Job.new(1) { time1 = Time.now }
+    job2 = Job.new(2) { time2 = Time.now }
+    
+    @queue.push job1
+    @queue.push job2
+    @queue.drain
+    
+    assert time1 < time2, "Jobs run in the same order they were added"
+  end
+
   def test_drain
     t = nil
     ran = false


### PR DESCRIPTION
`Rails::Queueing::TestQueue` is working as a LIFO while it should be a FIFO (as we expect the first queued job to be run first).
