### PR TITLE
Truncate now has the ability to receive a html option that allows it to call rails helpers.

### DIFF
--- a/actionpack/lib/action_view/helpers/text_helper.rb
+++ b/actionpack/lib/action_view/helpers/text_helper.rb
@@ -80,8 +80,18 @@ module ActionView
       #
       #   truncate("<p>Once upon a time in a world far far away</p>")
       #   # => "<p>Once upon a time in a wo..."
-      def truncate(text, options = {})
-        text.truncate(options.fetch(:length, 30), options) if text
+      #
+      #   truncate("Once upon a time in a world far far away") { link_to "Continue", "#" }
+      #   # => "Once upon a time in a wo...<a href="#">Continue</a>"
+      def truncate(text, options = {}, &block)
+        return unless text
+
+        options = { :length => 30 }.merge!(options)
+        length  = options.delete(:length)
+
+        content = ERB::Util.html_escape(text.truncate(length, options))
+        content << capture(&block) if block_given? && text.length > length
+        content
       end
 
       # Highlights one or more +phrases+ everywhere in +text+ by inserting it into

--- a/actionpack/test/template/text_helper_test.rb
+++ b/actionpack/test/template/text_helper_test.rb
@@ -75,17 +75,9 @@ class TextHelperTest < ActionView::TestCase
     assert_equal options, passed_options
   end
 
-  def test_truncate_should_not_be_html_safe
-    assert !truncate("Hello World!", :length => 12).html_safe?
-  end
-
   def test_truncate
     assert_equal "Hello World!", truncate("Hello World!", :length => 12)
     assert_equal "Hello Wor...", truncate("Hello World!!", :length => 12)
-  end
-
-  def test_truncate_should_not_escape_input
-    assert_equal "Hello <sc...", truncate("Hello <script>code!</script>World!!", :length => 12)
   end
 
   def test_truncate_should_use_default_length_of_30
@@ -112,6 +104,35 @@ class TextHelperTest < ActionView::TestCase
     passed_options = options.dup
     truncate("some text", passed_options)
     assert_equal options, passed_options
+  end
+
+  def test_truncate_with_link_options
+    assert_equal "Here's a long test and I...<a href=\"#\">Continue</a>",
+    truncate("Here's a long test and I need a continue to read link", :length => 27) { link_to 'Continue', '#' }
+  end
+
+  def test_truncate_should_not_mutate_the_options_hash
+    options = { :length => 27 }
+    truncate("Here's a long test and I need a continue to read link", options) { link_to 'Continue', '#' }
+    assert_equal({ :length => 27 }, options)
+  end
+
+  def test_truncate_should_be_html_safe
+    assert truncate("Hello World!", :length => 12).html_safe?
+  end
+
+  def test_truncate_should_escape_the_input
+    assert_equal "Hello &lt;sc...", truncate("Hello <script>code!</script>World!!", :length => 12)
+  end
+
+  def test_truncate_with_block_should_be_html_safe
+    truncated = truncate("Here's a long test and I need a continue to read link", :length => 27) { link_to 'Continue', '#' }
+    assert truncated.html_safe?
+  end
+
+  def test_truncate_with_block_should_escape_the_input
+    assert_equal "&lt;script&gt;code!&lt;/script&gt;He...<a href=\"#\">Continue</a>",
+      truncate("<script>code!</script>Here's a long test and I need a continue to read link", :length => 27) { link_to 'Continue', '#' }
   end
 
   def test_highlight_should_be_html_safe

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -290,6 +290,10 @@ class StringInflectionsTest < ActiveSupport::TestCase
       "\354\225\204\353\246\254\353\236\221 \354\225\204\353\246\254 \354\225\204\353\235\274\353\246\254\354\230\244".force_encoding('UTF-8').truncate(10)
   end
 
+  def test_truncate_should_not_be_html_safe
+    assert !"Hello World!".truncate(12).html_safe?
+  end
+
   def test_constantize
     run_constantize_tests_on do |string|
       string.constantize


### PR DESCRIPTION
This way if my text is long I don't have to do something like this:

``` haml
.text
  = truncate(@text, :length => 27)
  - if @text.size >= 27
    = link_to "continue", notes_path, .....
```
