### PR TITLE
Refactor AMo::Translation, avoid changing options in human attr name

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -54,7 +54,7 @@ module ActiveModel
       defaults << options[:default] if options[:default]
       defaults << @human
 
-      options = {:scope => [@klass.i18n_scope, :models], :count => 1, :default => defaults}.merge(options.except(:default))
+      options = { :scope => [@klass.i18n_scope, :models], :count => 1, :default => defaults }.merge!(options.except(:default))
       I18n.translate(defaults.shift, options)
     end
 

--- a/activemodel/lib/active_model/translation.rb
+++ b/activemodel/lib/active_model/translation.rb
@@ -1,5 +1,3 @@
-require 'active_support/core_ext/hash/reverse_merge'
-
 module ActiveModel
 
   # == Active Model Translation
@@ -43,6 +41,7 @@ module ActiveModel
     #
     # Specify +options+ with additional translating options.
     def human_attribute_name(attribute, options = {})
+      options   = { :count => 1 }.merge!(options)
       defaults  = []
       parts     = attribute.to_s.split(".", 2)
       attribute = parts.pop
@@ -63,7 +62,7 @@ module ActiveModel
       defaults << options.delete(:default) if options[:default]
       defaults << attribute.humanize
 
-      options.reverse_merge! :count => 1, :default => defaults
+      options[:default] = defaults
       I18n.translate(defaults.shift, options)
     end
   end

--- a/activemodel/lib/active_model/translation.rb
+++ b/activemodel/lib/active_model/translation.rb
@@ -42,19 +42,19 @@ module ActiveModel
     # Specify +options+ with additional translating options.
     def human_attribute_name(attribute, options = {})
       options   = { :count => 1 }.merge!(options)
-      defaults  = []
       parts     = attribute.to_s.split(".", 2)
       attribute = parts.pop
       namespace = parts.pop
+      attributes_scope = "#{self.i18n_scope}.attributes"
 
       if namespace
-        lookup_ancestors.each do |klass|
-          defaults << :"#{self.i18n_scope}.attributes.#{klass.model_name.i18n_key}/#{namespace}.#{attribute}"
+        defaults = lookup_ancestors.map do |klass|
+          :"#{attributes_scope}.#{klass.model_name.i18n_key}/#{namespace}.#{attribute}"
         end
-        defaults << :"#{self.i18n_scope}.attributes.#{namespace}.#{attribute}"
+        defaults << :"#{attributes_scope}.#{namespace}.#{attribute}"
       else
-        lookup_ancestors.each do |klass|
-          defaults << :"#{self.i18n_scope}.attributes.#{klass.model_name.i18n_key}.#{attribute}"
+        defaults = lookup_ancestors.map do |klass|
+          :"#{attributes_scope}.#{klass.model_name.i18n_key}.#{attribute}"
         end
       end
 

--- a/activemodel/test/cases/translation_test.rb
+++ b/activemodel/test/cases/translation_test.rb
@@ -82,9 +82,15 @@ class ActiveModelI18nTests < ActiveModel::TestCase
   end
 
   def test_human_does_not_modify_options
-    options = {:default => 'person model'}
+    options = { :default => 'person model' }
     Person.model_name.human(options)
-    assert_equal({:default => 'person model'}, options)
+    assert_equal({ :default => 'person model' }, options)
+  end
+
+  def test_human_attribute_name_does_not_modify_options
+    options = { :default => 'Cool gender' }
+    Person.human_attribute_name('gender', options)
+    assert_equal({ :default => 'Cool gender' }, options)
   end
 end
 


### PR DESCRIPTION
Avoid changing the given options hash in #human_attribute_name, and some
minor refactoring. Any feedback is welcome, thanks!
