### PR TITLE
Make non English title indexable (such as Chinese or Japanese) using MD5

### DIFF
--- a/guides/rails_guides/indexer.rb
+++ b/guides/rails_guides/indexer.rb
@@ -59,8 +59,9 @@ module RailsGuides
 
     def title_to_idx(title)
       idx = title.strip.parameterize.sub(/^\d+/, '')
-      if warnings && idx.blank?
-        puts "BLANK ID: please put an explicit ID for section #{title}, as in h5(#my-id)"
+      if idx.blank?
+        puts "BLANK ID: please put an explicit ID for section #{title}, as in h5(#my-id)" if warnings
+        idx = ("id-"+Digest::MD5.hexdigest(title.strip)).parameterize.sub(/^\d+/, '')
       end
       idx
     end

--- a/guides/rails_guides/indexer.rb
+++ b/guides/rails_guides/indexer.rb
@@ -57,11 +57,11 @@ module RailsGuides
       level_hash
     end
 
-    def title_to_idx(title)
-      idx = title.strip.parameterize.sub(/^\d+/, '')
+   def title_to_idx(title)
+      idx = title=~/[^\u0000-\u007F]/ ? ("id-"+Digest::MD5.hexdigest(title.strip)) : title.strip
+      idx = idx.parameterize.sub(/^\d+/, '')
       if idx.blank?
         puts "BLANK ID: please put an explicit ID for section #{title}, as in h5(#my-id)" if warnings
-        idx = ("id-"+Digest::MD5.hexdigest(title.strip)).parameterize.sub(/^\d+/, '')
       end
       idx
     end


### PR DESCRIPTION
For example:
`h3. 前情提要` -> `<h3 id="id-b06fb2be768e9ac684d9f7788d3333de">1 前情提要</h3>`

When there is non English header, it may cause mistake when guide generation.
For example: 
`h3. This Guide Assumes` -> `<h3 id="this-guide-assumes">1 This Guide Assumes</h3>`
`h3. 前情提要` -> `<p>h3(#). 1 前情提要</p>`
