### PR TITLE
Lock mocha to fix build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "jquery-rails"
 gem "uglifier", ">= 1.0.3", :require => false
 
 gem "rake", ">= 0.8.7"
-gem "mocha", ">= 0.9.8"
+gem "mocha", "0.10.5"
 
 group :doc do
   # The current sdoc cannot generate GitHub links due


### PR DESCRIPTION
nil.stubs is not allowed in new version of mocha

We can lock mocha in 3-1-stable.
