### PR TITLE
Add changelog entry for jsonp mimetype change, fix failing test

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   JSONP now uses mimetype application/javascript instead of application/json *omjokine*
+
 *   Allow to lazy load `default_form_builder` by passing a `String` instead of a constant. *Piotr Sarnacki*
 
 *   Session arguments passed to `process` calls in functional tests are now merged into

--- a/actionpack/test/controller/render_json_test.rb
+++ b/actionpack/test/controller/render_json_test.rb
@@ -102,7 +102,7 @@ class RenderJsonTest < ActionController::TestCase
   def test_render_json_with_callback
     get :render_json_hello_world_with_callback
     assert_equal 'alert({"hello":"world"})', @response.body
-    assert_equal 'application/javascript', @response.content_type
+    assert_equal 'text/javascript', @response.content_type
   end
 
   def test_render_json_with_custom_content_type


### PR DESCRIPTION
Add changelog entry for the mimetype change for jsonp requests:
d4dd1af341dcc1908b594567991845324df0ee56

Fix failing test: Mime::JS generates "text/javascript" instead of
"application/javascript"
