### PR TITLE
Show in log correct wrapped keys

### DIFF
--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -193,7 +193,8 @@ module ActionController
     def process_action(*args)
       if _wrapper_enabled?
         wrapped_hash = _wrap_parameters request.request_parameters
-        wrapped_filtered_hash = _wrap_parameters request.filtered_parameters
+        wrapped_keys = request.request_parameters.keys
+        wrapped_filtered_hash = _wrap_parameters request.filtered_parameters.slice(*wrapped_keys)
 
         # This will make the wrapped hash accessible from controller and view
         request.parameters.merge! wrapped_hash

--- a/actionpack/test/controller/params_wrapper_test.rb
+++ b/actionpack/test/controller/params_wrapper_test.rb
@@ -37,6 +37,14 @@ class ParamsWrapperTest < ActionController::TestCase
     UsersController.last_parameters = nil
   end
 
+  def test_filtered_parameters
+    with_default_wrapper_options do
+      @request.env['CONTENT_TYPE'] = 'application/json'
+      post :parse, { 'username' => 'sikachu' }
+      assert_equal @request.filtered_parameters, { 'controller' => 'params_wrapper_test/users', 'action' => 'parse', 'username' => 'sikachu', 'user' => { 'username' => 'sikachu' } }
+    end
+  end
+
   def test_derived_name_from_controller
     with_default_wrapper_options do
       @request.env['CONTENT_TYPE'] = 'application/json'


### PR DESCRIPTION
I've noticed that my log contains wrong incoming parameters like this
Parameters: {"user_id"=>1, "users"=>{"user_id"=>1, "action"=>"update", "controller"=>"users"}}
When it should be {"user_id"=>1, "action"=>"update", "controller"=>"users", "users"=>{"user_id"=>1}}
But incoming parameters in controller look ok.
