### PR TITLE
Fix controller_class_name for anonymous controllers.

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -472,7 +472,7 @@ module ActionController
 
         parameters ||= {}
         controller_class_name = @controller.class.anonymous? ?
-          "anonymous_controller" :
+          "anonymous" :
           @controller.class.name.underscore.sub(/_controller$/, '')
 
         @request.assign_parameters(@routes, controller_class_name, action.to_s, parameters)


### PR DESCRIPTION
TestCase#process generates an incorrect controller_class_name for anonymous classes. The name has a "_controller" suffix, which ought not to be there. This change simply removes that suffix.
