### PR TITLE
Don't proxy Duration#object_id, #send, #tap, and #try

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -8,7 +8,7 @@ module ActiveSupport
   # Example:
   #
   #   1.month.ago       # equivalent to Time.now.advance(:months => -1)
-  class Duration < BasicObject
+  class Duration
     attr_accessor :value, :parts
 
     def initialize(value, parts) #:nodoc:
@@ -83,6 +83,12 @@ module ActiveSupport
     def as_json(options = nil) #:nodoc:
       to_i
     end
+
+    PROXIED_OBJECT_METHODS = (Object.public_instance_methods | [:duplicable?]) -
+                               BasicObject.public_instance_methods -
+                               public_instance_methods(false) -
+                               [:object_id, :send, :tap, :try]
+    delegate(*PROXIED_OBJECT_METHODS, to: :value)
 
     protected
 

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -84,6 +84,10 @@ module ActiveSupport
       to_i
     end
 
+    # Delegate all of Object's methods that aren't either:
+    #   * defined in BasicObject
+    #   * defined already here in Duration
+    #   * would break basic expectations about objects (e.g. send, try)
     PROXIED_OBJECT_METHODS = (Object.public_instance_methods | [:duplicable?]) -
                                BasicObject.public_instance_methods -
                                public_instance_methods(false) -

--- a/activesupport/test/core_ext/duplicable_test.rb
+++ b/activesupport/test/core_ext/duplicable_test.rb
@@ -18,7 +18,7 @@ class DuplicableTest < ActiveSupport::TestCase
 
   def test_duplicable
     (RAISE_DUP + NO).each do |v|
-      assert !v.duplicable?
+      assert !v.duplicable?, "#{v.class} should not be duplicable"
     end
 
     YES.each do |v|

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -21,7 +21,6 @@ class DurationTest < ActiveSupport::TestCase
     assert ActiveSupport::Duration === 1.day
     assert !(ActiveSupport::Duration === 1.day.to_i)
     assert !(ActiveSupport::Duration === 'foo')
-    assert !(ActiveSupport::Duration === ActiveSupport::BasicObject.new)
   end
 
   def test_equals
@@ -39,6 +38,21 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal '10 years, 2 months, and 1 day',   (10.years + 2.months + 1.day).inspect
     assert_equal '7 days',                          1.week.inspect
     assert_equal '14 days',                         1.fortnight.inspect
+  end
+
+  def test_comparison
+    assert_equal(-1, 1.days <=> 1.year)
+    assert_equal 1, 3.years <=> 4.seconds
+    assert_equal 0, (60.seconds <=> 1.minute)
+  end
+
+  def test_unproxied_object_methods
+    assert 1.day.try(:is_a?, ActiveSupport::Duration),
+      "Duration#try should invoke Duration's instance methods"
+    assert 1.day.send(:is_a?, ActiveSupport::Duration),
+      "Duration#send should invoke Duration's instance methods"
+    assert 1.day.tap {|d| d }.is_a?(ActiveSupport::Duration),
+      "Duration#send should invoke Duration's instance methods"
   end
 
   def test_minus_with_duration_does_not_break_subtraction_of_date_from_date
@@ -131,7 +145,7 @@ class DurationTest < ActiveSupport::TestCase
       assert_equal Time.local(2009,3,29,0,0,0) + 1.day, Time.local(2009,3,30,0,0,0)
     end
   end
-  
+
   def test_delegation_with_block_works
     counter = 0
     assert_nothing_raised do


### PR DESCRIPTION
Proxying these methods causes unexpected behavior:

```
d = 1.day
d.inspect                #=> "1 day"
d.try(:inspect) || "N/A" #=> "86400"
# ^^^ standard null checking goes pear-shaped
```

related to #320, #334
