### PR TITLE
Relation#from to accept other Relation objects

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Added ability to ActiveRecord::Relation#from to accept other ActiveRecord::Relation objects
+
+      Record.from(subquery)
+      Record.from(subquery, :a)
+
+    *Radoslav Stankov*
+
 *   Added custom coders support for ActiveRecord::Store. Now you can set
     your custom coder like this:
 

--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -43,7 +43,7 @@ module ActiveRecord
       def normal_values
         Relation::SINGLE_VALUE_METHODS +
           Relation::MULTI_VALUE_METHODS -
-          [:where, :order, :bind, :reverse_order, :lock, :create_with, :reordering]
+          [:where, :order, :bind, :reverse_order, :lock, :create_with, :reordering, :from]
       end
 
       def merge
@@ -76,6 +76,7 @@ module ActiveRecord
       end
 
       def merge_single_values
+        relation.from_value          = values[:from] unless relation.from_value
         relation.lock_value          = values[:lock] unless relation.lock_value
         relation.reverse_order_value = values[:reverse_order]
 

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -203,11 +203,16 @@ module ActiveRecord
       assert_equal [], relation.extending_values
     end
 
-    (Relation::SINGLE_VALUE_METHODS - [:lock, :reordering, :reverse_order, :create_with]).each do |method|
+    (Relation::SINGLE_VALUE_METHODS - [:from, :lock, :reordering, :reverse_order, :create_with]).each do |method|
       test "##{method}!" do
         assert relation.public_send("#{method}!", :foo).equal?(relation)
         assert_equal :foo, relation.public_send("#{method}_value")
       end
+    end
+
+    test '#from!' do
+      assert relation.from!('foo').equal?(relation)
+      assert_equal ['foo', nil], relation.from_value
     end
 
     test '#lock!' do

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -133,6 +133,13 @@ class RelationTest < ActiveRecord::TestCase
     assert topics.loaded?
   end
 
+  def test_finiding_with_subquery
+    relation = Topic.where(:approved => true)
+    assert_equal relation.to_a, Topic.select('*').from(relation).to_a
+    assert_equal relation.to_a, Topic.select('subquery.*').from(relation).to_a
+    assert_equal relation.to_a, Topic.select('a.*').from(relation, :a).to_a
+  end
+
   def test_finding_with_conditions
     assert_equal ["David"], Author.where(:name => 'David').map(&:name)
     assert_equal ['Mary'],  Author.where(["name = ?", 'Mary']).map(&:name)


### PR DESCRIPTION
I had to use subqueries in my project, several times. And I used this pattern:

``` ruby
Record.from("(#{sub_query.to_sql})")
Record.from("(#{sub_query.to_sql}) a")
```

Which doesn't feel right. I much prefer just to pass ActiveRecord::Relation objects:

``` ruby
Record.from("(#{sub_query.to_sql})")    -> Record.from(sub_query)
Record.from("(#{sub_query.to_sql}) a")  -> Record.from(:a => sub_query)
```

So this pull request add this functionality.
