### PR TITLE
Change check_box to work inverting the checked and unchecked value

### DIFF
--- a/actionpack/lib/action_view/helpers/tags/check_box.rb
+++ b/actionpack/lib/action_view/helpers/tags/check_box.rb
@@ -41,17 +41,15 @@ module ActionView
         def checked?(value)
           case value
           when TrueClass, FalseClass
-            value
+            value == !!@checked_value
           when NilClass
             false
-          when Integer
-            value != 0
           when String
             value == @checked_value
           when Array
             value.include?(@checked_value)
           else
-            value.to_i != 0
+            value.to_i == @checked_value.to_i
           end
         end
 

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -350,36 +350,52 @@ class FormHelperTest < ActionView::TestCase
       text_field("user", "email", :type => "email")
   end
 
-  def test_check_box
+  def test_check_box_is_html_safe
     assert check_box("post", "secret").html_safe?
+  end
+
+  def test_check_box_checked_if_object_value_is_same_that_check_value
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
       check_box("post", "secret")
     )
+  end
+
+  def test_check_box_not_checked_if_object_value_is_same_that_unchecked_value
     @post.secret = 0
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" /><input id="post_secret" name="post[secret]" type="checkbox" value="1" />',
       check_box("post", "secret")
     )
+  end
+
+  def test_check_box_checked_if_option_checked_is_present
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
       check_box("post", "secret" ,{"checked"=>"checked"})
     )
+  end
+
+  def test_check_box_checked_if_object_value_is_true
     @post.secret = true
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
       check_box("post", "secret")
     )
+
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
       check_box("post", "secret?")
     )
+  end
 
+  def test_check_box_checked_if_object_value_includes_checked_value
     @post.secret = ['0']
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" /><input id="post_secret" name="post[secret]" type="checkbox" value="1" />',
       check_box("post", "secret")
     )
+
     @post.secret = ['1']
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
@@ -392,11 +408,91 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal('<input id="post_secret" name="post[secret]" type="checkbox" value="1" />', check_box("post", "secret", :include_hidden => false))
   end
 
-  def test_check_box_with_explicit_checked_and_unchecked_values
+  def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_string
     @post.secret = "on"
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="on" />',
       check_box("post", "secret", {}, "on", "off")
+    )
+
+    @post.secret = "off"
+    assert_dom_equal(
+      '<input name="post[secret]" type="hidden" value="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="on" />',
+      check_box("post", "secret", {}, "on", "off")
+    )
+  end
+
+  def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_boolean
+    @post.secret = false
+    assert_dom_equal(
+      '<input name="post[secret]" type="hidden" value="true" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="false" />',
+      check_box("post", "secret", {}, false, true)
+    )
+
+    @post.secret = true
+    assert_dom_equal(
+      '<input name="post[secret]" type="hidden" value="true" /><input id="post_secret" name="post[secret]" type="checkbox" value="false" />',
+      check_box("post", "secret", {}, false, true)
+    )
+  end
+
+  def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_integer
+    @post.secret = 0
+    assert_dom_equal(
+      '<input name="post[secret]" type="hidden" value="1" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      check_box("post", "secret", {}, 0, 1)
+    )
+
+    @post.secret = 1
+    assert_dom_equal(
+      '<input name="post[secret]" type="hidden" value="1" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      check_box("post", "secret", {}, 0, 1)
+    )
+
+    @post.secret = 2
+    assert_dom_equal(
+      '<input name="post[secret]" type="hidden" value="1" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      check_box("post", "secret", {}, 0, 1)
+    )
+  end
+
+  def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_float
+    @post.secret = 0.0
+    assert_dom_equal(
+      '<input name="post[secret]" type="hidden" value="1" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      check_box("post", "secret", {}, 0, 1)
+    )
+
+    @post.secret = 1.1
+    assert_dom_equal(
+      '<input name="post[secret]" type="hidden" value="1" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      check_box("post", "secret", {}, 0, 1)
+    )
+
+    @post.secret = 2.2
+    assert_dom_equal(
+      '<input name="post[secret]" type="hidden" value="1" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      check_box("post", "secret", {}, 0, 1)
+    )
+  end
+
+  def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_big_decimal
+    @post.secret = BigDecimal.new(0)
+    assert_dom_equal(
+      '<input name="post[secret]" type="hidden" value="1" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      check_box("post", "secret", {}, 0, 1)
+    )
+
+    @post.secret = BigDecimal.new(1)
+    assert_dom_equal(
+      '<input name="post[secret]" type="hidden" value="1" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      check_box("post", "secret", {}, 0, 1)
+    )
+
+    @post.secret = BigDecimal.new(2.2, 1)
+    assert_dom_equal(
+      '<input name="post[secret]" type="hidden" value="1" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      check_box("post", "secret", {}, 0, 1)
     )
   end
 


### PR DESCRIPTION
This fixes:
- Boolean with inverted logic
- Integer with inverted logic
- BigDecimal with inverted logic

Fixes #3995

cc @sobrinho @carlosantoniodasilva
