### PR TITLE
Adding deep versions of stringify_keys and symbolize_keys (plain and bang) for nested hashes

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 *   Add `Hash#transform_keys` and `Hash#transform_keys!`. *Mark McSpadden*
 
-*   Changed xml type `datetime` to `dateTime` (with upper case letter `T`). *Angelo Capilleri*  
+*   Changed xml type `datetime` to `dateTime` (with upper case letter `T`). *Angelo Capilleri*
 
 *   Add `:instance_accessor` option for `class_attribute`. *Alexey Vakhov*
 
 *   `constantize` now looks in the ancestor chain. *Marc-Andre Lafortune & Andrew White*
+
+*   Adds `Hash#deep_stringify_keys` and `Hash#deep_stringify_keys!` to convert all keys from a +Hash+ instance into strings *Lucas Húngaro*
+
+*   Adds `Hash#deep_symbolize_keys` and `Hash#deep_symbolize_keys!` to convert all keys from a +Hash+ instance into symbols *Lucas Húngaro*
 
 *   `Object#try` can't call private methods. *Vasiliy Ermolovich*
 

--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -64,4 +64,48 @@ class Hash
       raise ArgumentError.new("Unknown key: #{k}") unless valid_keys.include?(k)
     end
   end
+
+  # Return a new hash with all keys converted to strings.
+  # This includes the keys from the root hash and from all
+  # nested hashes.
+  def deep_stringify_keys
+    result = {}
+    each do |key, value|
+      result[key.to_s] = value.is_a?(Hash) ? value.deep_stringify_keys : value
+    end
+    result
+  end
+
+  # Destructively convert all keys to strings.
+  # This includes the keys from the root hash and from all
+  # nested hashes.
+  def deep_stringify_keys!
+    keys.each do |key|
+      val = delete(key)
+      self[key.to_s] = val.is_a?(Hash) ? val.deep_stringify_keys! : val
+    end
+    self
+  end
+
+  # Destructively convert all keys to symbols, as long as they respond
+  # to +to_sym+. This includes the keys from the root hash and from all
+  # nested hashes.
+  def deep_symbolize_keys!
+    keys.each do |key|
+      val = delete(key)
+      self[(key.to_sym rescue key)] = val.is_a?(Hash) ? val.deep_stringify_keys! : val
+    end
+    self
+  end
+
+  # Return a new hash with all keys converted to symbols, as long as
+  # they respond to +to_sym+. This includes the keys from the root hash
+  # and from all nested hashes.
+  def deep_symbolize_keys
+    result = {}
+    each do |key, value|
+      result[(key.to_sym rescue key)] = value.is_a?(Hash) ? value.deep_symbolize_keys : value
+    end
+    result
+  end
 end

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -141,9 +141,13 @@ module ActiveSupport
     end
 
     def stringify_keys!; self end
+    def deep_stringify_keys!; self end
     def stringify_keys; dup end
+    def deep_stringify_keys; dup end
     undef :symbolize_keys!
+    undef :deep_symbolize_keys!
     def symbolize_keys; to_hash.symbolize_keys end
+    def deep_symbolize_keys; to_hash.deep_symbolize_keys end
     def to_options!; self end
 
     # Convert to a Hash with String keys.

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -24,11 +24,16 @@ class HashExtTest < ActiveSupport::TestCase
 
   def setup
     @strings = { 'a' => 1, 'b' => 2 }
+    @nested_strings = { 'a' => { 'b' => { 'c' => 3 } } }
     @symbols = { :a  => 1, :b  => 2 }
+    @nested_symbols = { :a => { :b => { :c => 3 } } }
     @mixed   = { :a  => 1, 'b' => 2 }
+    @nested_mixed   = { 'a' => { :b => { 'c' => 3 } } }
     @fixnums = {  0  => 1,  1  => 2 }
+    @nested_fixnums = {  0  => { 1  => { 2 => 3} } }
     @illegal_symbols = { [] => 3 }
     @upcase_strings = { 'A' => 1, 'B' => 2 }
+    @nested_illegal_symbols = { [] => { [] => 3} }
   end
 
   def test_methods
@@ -37,8 +42,12 @@ class HashExtTest < ActiveSupport::TestCase
     assert_respond_to h, :transform_keys!
     assert_respond_to h, :symbolize_keys
     assert_respond_to h, :symbolize_keys!
+    assert_respond_to h, :deep_symbolize_keys
+    assert_respond_to h, :deep_symbolize_keys!
     assert_respond_to h, :stringify_keys
     assert_respond_to h, :stringify_keys!
+    assert_respond_to h, :deep_stringify_keys
+    assert_respond_to h, :deep_stringify_keys!
     assert_respond_to h, :to_options
     assert_respond_to h, :to_options!
   end
@@ -61,10 +70,22 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal @symbols, @mixed.symbolize_keys
   end
 
+  def test_deep_symbolize_keys
+    assert_equal @nested_symbols, @nested_symbols.deep_symbolize_keys
+    assert_equal @nested_symbols, @nested_strings.deep_symbolize_keys
+    assert_equal @nested_symbols, @nested_mixed.deep_symbolize_keys
+  end
+
   def test_symbolize_keys!
     assert_equal @symbols, @symbols.dup.symbolize_keys!
     assert_equal @symbols, @strings.dup.symbolize_keys!
     assert_equal @symbols, @mixed.dup.symbolize_keys!
+  end
+
+  def test_deep_symbolize_keys!
+    assert_equal @nested_symbols, @nested_symbols.dup.deep_symbolize_keys!
+    assert_equal @nested_symbols, @nested_strings.dup.deep_symbolize_keys!
+    assert_equal @nested_symbols, @nested_mixed.dup.deep_symbolize_keys!
   end
 
   def test_symbolize_keys_preserves_keys_that_cant_be_symbolized
@@ -72,9 +93,19 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal @illegal_symbols, @illegal_symbols.dup.symbolize_keys!
   end
 
+  def test_deep_symbolize_keys_preserves_keys_that_cant_be_symbolized
+    assert_equal @nested_illegal_symbols, @nested_illegal_symbols.deep_symbolize_keys
+    assert_equal @nested_illegal_symbols, @nested_illegal_symbols.dup.deep_symbolize_keys!
+  end
+
   def test_symbolize_keys_preserves_fixnum_keys
     assert_equal @fixnums, @fixnums.symbolize_keys
     assert_equal @fixnums, @fixnums.dup.symbolize_keys!
+  end
+
+  def test_deep_symbolize_keys_preserves_fixnum_keys
+    assert_equal @nested_fixnums, @nested_fixnums.deep_symbolize_keys
+    assert_equal @nested_fixnums, @nested_fixnums.dup.deep_symbolize_keys!
   end
 
   def test_stringify_keys
@@ -83,10 +114,22 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal @strings, @mixed.stringify_keys
   end
 
+  def test_deep_stringify_keys
+    assert_equal @nested_strings, @nested_symbols.deep_stringify_keys
+    assert_equal @nested_strings, @nested_strings.deep_stringify_keys
+    assert_equal @nested_strings, @nested_mixed.deep_stringify_keys
+  end
+
   def test_stringify_keys!
     assert_equal @strings, @symbols.dup.stringify_keys!
     assert_equal @strings, @strings.dup.stringify_keys!
     assert_equal @strings, @mixed.dup.stringify_keys!
+  end
+
+  def test_deep_stringify_keys!
+    assert_equal @nested_strings, @nested_symbols.dup.deep_stringify_keys!
+    assert_equal @nested_strings, @nested_strings.dup.deep_stringify_keys!
+    assert_equal @nested_strings, @nested_mixed.dup.deep_stringify_keys!
   end
 
   def test_symbolize_keys_for_hash_with_indifferent_access
@@ -96,10 +139,24 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal @symbols, @mixed.with_indifferent_access.symbolize_keys
   end
 
+  def test_deep_symbolize_keys_for_hash_with_indifferent_access
+    assert_instance_of Hash, @nested_symbols.with_indifferent_access.deep_symbolize_keys
+    assert_equal @nested_symbols, @nested_symbols.with_indifferent_access.deep_symbolize_keys
+    assert_equal @nested_symbols, @nested_strings.with_indifferent_access.deep_symbolize_keys
+    assert_equal @nested_symbols, @nested_mixed.with_indifferent_access.deep_symbolize_keys
+  end
+
+
   def test_symbolize_keys_bang_for_hash_with_indifferent_access
     assert_raise(NoMethodError) { @symbols.with_indifferent_access.dup.symbolize_keys! }
     assert_raise(NoMethodError) { @strings.with_indifferent_access.dup.symbolize_keys! }
     assert_raise(NoMethodError) { @mixed.with_indifferent_access.dup.symbolize_keys! }
+  end
+
+  def test_deep_symbolize_keys_bang_for_hash_with_indifferent_access
+    assert_raise(NoMethodError) { @nested_symbols.with_indifferent_access.dup.deep_symbolize_keys! }
+    assert_raise(NoMethodError) { @nested_strings.with_indifferent_access.dup.deep_symbolize_keys! }
+    assert_raise(NoMethodError) { @nested_mixed.with_indifferent_access.dup.deep_symbolize_keys! }
   end
 
   def test_symbolize_keys_preserves_keys_that_cant_be_symbolized_for_hash_with_indifferent_access
@@ -107,9 +164,19 @@ class HashExtTest < ActiveSupport::TestCase
     assert_raise(NoMethodError) { @illegal_symbols.with_indifferent_access.dup.symbolize_keys! }
   end
 
+  def test_deep_symbolize_keys_preserves_keys_that_cant_be_symbolized_for_hash_with_indifferent_access
+    assert_equal @nested_illegal_symbols, @nested_illegal_symbols.with_indifferent_access.deep_symbolize_keys
+    assert_raise(NoMethodError) { @nested_illegal_symbols.with_indifferent_access.dup.deep_symbolize_keys! }
+  end
+
   def test_symbolize_keys_preserves_fixnum_keys_for_hash_with_indifferent_access
     assert_equal @fixnums, @fixnums.with_indifferent_access.symbolize_keys
     assert_raise(NoMethodError) { @fixnums.with_indifferent_access.dup.symbolize_keys! }
+  end
+
+  def test_deep_symbolize_keys_preserves_fixnum_keys_for_hash_with_indifferent_access
+    assert_equal @nested_fixnums, @nested_fixnums.with_indifferent_access.deep_symbolize_keys
+    assert_raise(NoMethodError) { @nested_fixnums.with_indifferent_access.dup.deep_symbolize_keys! }
   end
 
   def test_stringify_keys_for_hash_with_indifferent_access
@@ -119,11 +186,25 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal @strings, @mixed.with_indifferent_access.stringify_keys
   end
 
+  def test_deep_stringify_keys_for_hash_with_indifferent_access
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, @nested_symbols.with_indifferent_access.deep_stringify_keys
+    assert_equal @nested_strings, @nested_symbols.with_indifferent_access.deep_stringify_keys
+    assert_equal @nested_strings, @nested_strings.with_indifferent_access.deep_stringify_keys
+    assert_equal @nested_strings, @nested_mixed.with_indifferent_access.deep_stringify_keys
+  end
+
   def test_stringify_keys_bang_for_hash_with_indifferent_access
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, @symbols.with_indifferent_access.dup.stringify_keys!
     assert_equal @strings, @symbols.with_indifferent_access.dup.stringify_keys!
     assert_equal @strings, @strings.with_indifferent_access.dup.stringify_keys!
     assert_equal @strings, @mixed.with_indifferent_access.dup.stringify_keys!
+  end
+
+  def test_deep_stringify_keys_bang_for_hash_with_indifferent_access
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, @nested_symbols.with_indifferent_access.dup.deep_stringify_keys!
+    assert_equal @nested_strings, @nested_symbols.with_indifferent_access.dup.deep_stringify_keys!
+    assert_equal @nested_strings, @nested_strings.with_indifferent_access.dup.deep_stringify_keys!
+    assert_equal @nested_strings, @nested_mixed.with_indifferent_access.dup.deep_stringify_keys!
   end
 
   def test_nested_under_indifferent_access
@@ -309,6 +390,17 @@ class HashExtTest < ActiveSupport::TestCase
     h = HashWithIndifferentAccess.new
     h['first'] = 1
     h = h.symbolize_keys
+    assert_equal 1, h[:first]
+  end
+
+  def test_deep_stringify_and_deep_symbolize_keys_on_indifferent_preserves_hash
+    h = HashWithIndifferentAccess.new
+    h[:first] = 1
+    h = h.deep_stringify_keys
+    assert_equal 1, h['first']
+    h = HashWithIndifferentAccess.new
+    h['first'] = 1
+    h = h.deep_symbolize_keys
     assert_equal 1, h[:first]
   end
 

--- a/guides/source/active_support_core_extensions.textile
+++ b/guides/source/active_support_core_extensions.textile
@@ -2611,6 +2611,13 @@ The second line can safely access the "type" key, and let the user to pass eithe
 
 There's also the bang variant +stringify_keys!+ that stringifies keys in the very receiver.
 
+Besides that, one can use +deep_stringify_keys+ and +deep_stringify_keys!+ to stringify all the keys in the given hash and all the hashes nested into it. An example of the result is:
+
+<ruby>
+{nil => nil, 1 => 1, :nested => {:a => 3, 5 => 5}}.deep_stringify_keys
+# => {""=>nil, "1"=>1, "nested"=>{"a"=>3, "5"=>5}}
+</ruby>
+
 NOTE: Defined in +active_support/core_ext/hash/keys.rb+.
 
 h5. +symbolize_keys+ and +symbolize_keys!+
@@ -2644,6 +2651,13 @@ end
 The second line can safely access the +:params+ key, and let the user to pass either +:params+ or "params".
 
 There's also the bang variant +symbolize_keys!+ that symbolizes keys in the very receiver.
+
+Besides that, one can use +deep_symbolize_keys+ and +deep_symbolize_keys!+ to symbolize all the keys in the given hash and all the hashes nested into it. An example of the result is:
+
+<ruby>
+{nil => nil, 1 => 1, "nested" => {"a" => 3, 5 => 5}}.deep_symbolize_keys
+# => {nil=>nil, 1=>1, :nested=>{:a=>3, 5=>5}}
+</ruby>
 
 NOTE: Defined in +active_support/core_ext/hash/keys.rb+.
 


### PR DESCRIPTION
I have to carry around some snippets 'cause I always use these methods (specially deep_symbolize_keys) when I use YAML files with custom app configuration. Some people I know also have their own versions, so I thought adding them to ActiveSupport was a good idea.
