### PR TITLE
Allow extra arguments for Observers

### DIFF
--- a/activemodel/lib/active_model/observing.rb
+++ b/activemodel/lib/active_model/observing.rb
@@ -112,13 +112,21 @@ module ActiveModel
     private
       # Fires notifications to model's observers
       #
-      # def save
-      #   notify_observers(:before_save)
-      #   ...
-      #   notify_observers(:after_save)
-      # end
-      def notify_observers(method)
-        self.class.notify_observers(method, self)
+      #   def save
+      #     notify_observers(:before_save)
+      #     ...
+      #     notify_observers(:after_save)
+      #   end
+      #
+      # Custom notifications can be sent in a similar fashion:
+      #
+      #   notify_observers(:custom_notification, :foo)
+      #
+      # This will call +custom_notification+, passing as arguments
+      # the current object and :foo.
+      #
+      def notify_observers(method, *extra_args)
+        self.class.notify_observers(method, self, *extra_args)
       end
   end
 
@@ -229,10 +237,10 @@ module ActiveModel
 
     # Send observed_method(object) if the method exists and
     # the observer is enabled for the given object's class.
-    def update(observed_method, object, &block) #:nodoc:
+    def update(observed_method, object, *extra_args, &block) #:nodoc:
       return unless respond_to?(observed_method)
       return if disabled_for?(object)
-      send(observed_method, object, &block)
+      send(observed_method, object, *extra_args, &block)
     end
 
     # Special method sent by the observed class when it is inherited.

--- a/activemodel/test/cases/observing_test.rb
+++ b/activemodel/test/cases/observing_test.rb
@@ -14,8 +14,8 @@ class FooObserver < ActiveModel::Observer
 
   attr_accessor :stub
 
-  def on_spec(record)
-    stub.event_with(record) if stub
+  def on_spec(record, *args)
+    stub.event_with(record, *args) if stub
   end
 
   def around_save(record)
@@ -131,6 +131,13 @@ class ObserverTest < ActiveModel::TestCase
     FooObserver.instance.stub = stub
     FooObserver.instance.stub.expects(:event_with).with(foo)
     Foo.send(:notify_observers, :on_spec, foo)
+  end
+
+  test "passes extra arguments" do
+    foo = Foo.new
+    FooObserver.instance.stub = stub
+    FooObserver.instance.stub.expects(:event_with).with(foo, :bar)
+    Foo.send(:notify_observers, :on_spec, foo, :bar)
   end
 
   test "skips nonexistent observer event" do


### PR DESCRIPTION
I wanted to use observers to send custom events and noticed that #notify_observers only accepts one argument.

Unless there's a good reason not too, it woud be nice to accept extra arguments and pass them on.

Thanks
