### PR TITLE
observed_classes get redefined properly - fixes #3505

### DIFF
--- a/activemodel/lib/active_model/observing.rb
+++ b/activemodel/lib/active_model/observing.rb
@@ -195,7 +195,9 @@ module ActiveModel
       def observe(*models)
         models.flatten!
         models.collect! { |model| model.respond_to?(:to_sym) ? model.to_s.camelize.constantize : model }
-        redefine_method(:observed_classes) { models }
+        unless self.singleton_class.respond_to?(:observed_classes)
+          define_singleton_method(:observed_classes) { models }
+        end
       end
 
       # Returns an array of Classes to observe.

--- a/activemodel/test/cases/observing_test.rb
+++ b/activemodel/test/cases/observing_test.rb
@@ -95,15 +95,16 @@ end
 class ObserverTest < ActiveModel::TestCase
   def setup
     ObservedModel.observers = :foo_observer
+
     FooObserver.instance_eval do
-      alias_method :original_observed_classes, :observed_classes
+      alias :original_observed_classes :observed_classes
     end
   end
 
   def teardown
     FooObserver.instance_eval do
-      undef_method :observed_classes
-      alias_method :observed_classes, :original_observed_classes
+      undef :observed_classes
+      alias :observed_classes :original_observed_classes
     end
   end
 
@@ -159,5 +160,13 @@ class ObserverTest < ActiveModel::TestCase
       yielded_value = val
     end
     assert_equal :in_around_save, yielded_value
+  end
+
+  test "observe redefines observed_classes class method" do
+    class BarObserver < ActiveModel::Observer
+      observe :foo
+    end
+
+    assert BarObserver.observed_classes.include?(Foo), "Foo is not in #{BarObserver.observed_classes.inspect}"
   end
 end


### PR DESCRIPTION
I'm trying to fix #3505 issue:

I need help with this:

```
rails/activemodel/lib/active_model/observing.rb:199: warning: previous definition of observed_classes was here
rails/activemodel/lib/active_model/observing.rb:199: warning: method redefined; discarding old observed_classes
```

I'm getting those warnings in this test:

```
test "passes observers to subclasses" do
    FooObserver.instance
    bar = Class.new(Foo)
    assert_equal Foo.observers_count, bar.observers_count
end
```

I don't know how to check if the method is already defined in the subclass?

```
  def observe(*models)
    models.flatten!
    models.collect! { |model| model.respond_to?(:to_sym) ? model.to_s.camelize.constantize : model }

    unless self.singleton_class.respond_to?(:observed_classes)
      define_singleton_method(:observed_classes) { models }
    end
  end
```
