### PR TITLE
Use strict mode in mysql

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `mysql` and `mysql2` connections will set `SQL_MODE=STRICT_ALL_TABLES` by
+    default to avoid silent data loss. This can be disabled by specifying
+    `strict: false` in your `database.yml`.
+
+    *Michael Pearson*
+
 *   Added default order to `first` to assure consistent results among
     diferent database engines. Introduced `take` as a replacement to
     the old behavior of `first`.

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -253,6 +253,12 @@ module ActiveRecord
         # By default, MySQL 'where id is null' selects the last inserted id.
         # Turn this off. http://dev.rubyonrails.org/ticket/6778
         variable_assignments = ['SQL_AUTO_IS_NULL=0']
+
+        # Make MySQL reject illegal values rather than truncating or
+        # blanking them. See
+        # http://dev.mysql.com/doc/refman/5.0/en/server-sql-mode.html#sqlmode_strict_all_tables
+        variable_assignments << "SQL_MODE='STRICT_ALL_TABLES'"
+
         encoding = @config[:encoding]
 
         # make sure we set the encoding

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -256,8 +256,10 @@ module ActiveRecord
 
         # Make MySQL reject illegal values rather than truncating or
         # blanking them. See
-        # http://dev.mysql.com/doc/refman/5.0/en/server-sql-mode.html#sqlmode_strict_all_tables
-        variable_assignments << "SQL_MODE='STRICT_ALL_TABLES'"
+        # http://dev.mysql.com/doc/refman/5.5/en/server-sql-mode.html#sqlmode_strict_all_tables
+        if @config.fetch(:strict, true)
+          variable_assignments << "SQL_MODE='STRICT_ALL_TABLES'"
+        end
 
         encoding = @config[:encoding]
 

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -53,6 +53,7 @@ module ActiveRecord
     # * <tt>:database</tt> - The name of the database. No default, must be provided.
     # * <tt>:encoding</tt> - (Optional) Sets the client encoding by executing "SET NAMES <encoding>" after connection.
     # * <tt>:reconnect</tt> - Defaults to false (See MySQL documentation: http://dev.mysql.com/doc/refman/5.0/en/auto-reconnect.html).
+    # * <tt>:strict</tt> - Defaults to true. Enable STRICT_ALL_TABLES. (See MySQL documentation: http://dev.mysql.com/doc/refman/5.5/en/server-sql-mode.html)
     # * <tt>:sslca</tt> - Necessary to use MySQL with an SSL connection.
     # * <tt>:sslkey</tt> - Necessary to use MySQL with an SSL connection.
     # * <tt>:sslcert</tt> - Necessary to use MySQL with an SSL connection.
@@ -407,8 +408,10 @@ module ActiveRecord
 
         # Make MySQL reject illegal values rather than truncating or
         # blanking them. See
-        # http://dev.mysql.com/doc/refman/5.0/en/server-sql-mode.html#sqlmode_strict_all_tables
-        execute("SET SQL_MODE='STRICT_ALL_TABLES'", :skip_logging)
+        # http://dev.mysql.com/doc/refman/5.5/en/server-sql-mode.html#sqlmode_strict_all_tables
+        if @config.fetch(:strict, true)
+          execute("SET SQL_MODE='STRICT_ALL_TABLES'", :skip_logging)
+        end
       end
 
       def select(sql, name = nil, binds = [])

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -404,6 +404,11 @@ module ActiveRecord
         # By default, MySQL 'where id is null' selects the last inserted id.
         # Turn this off. http://dev.rubyonrails.org/ticket/6778
         execute("SET SQL_AUTO_IS_NULL=0", :skip_logging)
+
+        # Make MySQL reject illegal values rather than truncating or
+        # blanking them. See
+        # http://dev.mysql.com/doc/refman/5.0/en/server-sql-mode.html#sqlmode_strict_all_tables
+        execute("SET SQL_MODE='STRICT_ALL_TABLES'", :skip_logging)
       end
 
       def select(sql, name = nil, binds = [])

--- a/activerecord/test/cases/adapters/mysql/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql/connection_test.rb
@@ -120,6 +120,19 @@ class MysqlConnectionTest < ActiveRecord::TestCase
     end
   end
 
+  def test_mysql_default_in_strict_mode
+    result = @connection.exec_query "SELECT @@SESSION.sql_mode"
+    assert_equal [["STRICT_ALL_TABLES"]], result.rows
+  end
+
+  def test_mysql_strict_mode_disabled
+    run_without_connection do |orig_connection|
+      ActiveRecord::Model.establish_connection(orig_connection.merge({:strict => false}))
+      result = ActiveRecord::Model.connection.exec_query "SELECT @@SESSION.sql_mode"
+      assert_equal [['']], result.rows
+    end
+  end
+
   private
 
   def run_without_connection

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -29,6 +29,22 @@ class MysqlConnectionTest < ActiveRecord::TestCase
     assert @connection.active?
   end
 
+  # TODO: Below is a straight up copy/paste from mysql/connection_test.rb
+  # I'm not sure what the correct way is to share these tests between
+  # adapters in minitest.
+  def test_mysql_default_in_strict_mode
+    result = @connection.exec_query "SELECT @@SESSION.sql_mode"
+    assert_equal [["STRICT_ALL_TABLES"]], result.rows
+  end
+
+  def test_mysql_strict_mode_disabled
+    run_without_connection do |orig_connection|
+      ActiveRecord::Model.establish_connection(orig_connection.merge({:strict => false}))
+      result = ActiveRecord::Model.connection.exec_query "SELECT @@SESSION.sql_mode"
+      assert_equal [['']], result.rows
+    end
+  end
+
   private
 
   def run_without_connection

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -38,7 +38,9 @@ ActiveRecord::Schema.define do
   create_table :admin_users, :force => true do |t|
     t.string :name
     t.text :settings, :null => true
-    t.text :preferences, :null => false, :default => ""
+    # MySQL does not allow default values for blobs. Fake it out with a
+    # big varchar below.
+    t.string :preferences, :null => false, :default => '', :limit => 1024
     t.references :account
   end
 


### PR DESCRIPTION
MySQL, by default, opts to truncate or replace rather than 'fail fast' on incompatible data. This can lead to confusion, frustration and data loss.

This is inconsistent with two other popular database engines: PostgreSQL will error (since v 7.2) and sqlite will simply allow the original data (rather than modifying it).

Defaulting to STRICT_ALL_TABLES will ease error discovery and prevent new applications from depending on MySQL's quirks.

Original issue: #5988
