### PR TITLE
Fix test schema.rb 

### DIFF
--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -38,7 +38,9 @@ ActiveRecord::Schema.define do
   create_table :admin_users, :force => true do |t|
     t.string :name
     t.text :settings, :null => true
-    t.text :preferences, :null => false, :default => ""
+    # MySQL does not allow default values for blobs. Fake it out with a
+    # big varchar below.
+    t.string :preferences, :null => false, :default => '', :limit => 1024
     t.references :account
   end
 


### PR DESCRIPTION
MySQL does not allow defaults on TEXT/BLOB types. In strict mode this causes an error, in 'default' mode they are ignored.

Modify test schema.rb to use a VARCHAR rather than a TEXT in this case.

Part of #5988
