### PR TITLE
Restore state on create when ActiveRecord::RecordInvalid is raised

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix AR#create to return an unsaved record when AR::RecordInvalid is
+    raised. Fixes #3217.
+
+    *Dave Yeu*
+
 *   Fixed table name prefix that is generated in engines for namespaced models
     *Wojciech Wnętrzak*
 

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -327,7 +327,7 @@ module ActiveRecord
     def restore_transaction_record_state(force = false) #:nodoc:
       if defined?(@_start_transaction_state)
         @_start_transaction_state[:level] = (@_start_transaction_state[:level] || 0) - 1
-        if @_start_transaction_state[:level] < 1
+        if @_start_transaction_state[:level] < 1 || force
           restore_state = remove_instance_variable(:@_start_transaction_state)
           was_frozen = @attributes.frozen?
           @attributes = @attributes.dup if was_frozen


### PR DESCRIPTION
This fixes issue #3217.

Previously, a call to AR#create that raised AR::RecordInvalid would leave a record in an inconsistent state -- it wouldn't actually be saved in the database, but #persisted? => true and #id would be non-nil. This patch also merges clean into 3-2-stable, for now.
