### PR TITLE
Replace boolean argument with an options hash.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Replace `include_seconds` boolean argument with `:include_seconds => true` option
+    in `distance_of_time_in_words` and `time_ago_in_words` signature. *Dmitriy Kiriyenko*
+
 *   Remove `button_to_function` and `link_to_function` helpers. *Rafael Mendonça França*
 
 *   Make current object and counter (when it applies) variables accessible when

--- a/actionpack/test/template/date_helper_i18n_test.rb
+++ b/actionpack/test/template/date_helper_i18n_test.rb
@@ -12,24 +12,24 @@ class DateHelperDistanceOfTimeInWordsI18nTests < ActiveSupport::TestCase
 
   def test_distance_of_time_in_words_calls_i18n
     { # with include_seconds
-      [2.seconds,  true]  => [:'less_than_x_seconds', 5],
-      [9.seconds,  true]  => [:'less_than_x_seconds', 10],
-      [19.seconds, true]  => [:'less_than_x_seconds', 20],
-      [30.seconds, true]  => [:'half_a_minute',       nil],
-      [59.seconds, true]  => [:'less_than_x_minutes', 1],
-      [60.seconds, true]  => [:'x_minutes',           1],
+      [2.seconds,  { :include_seconds => true }]  => [:'less_than_x_seconds', 5],
+      [9.seconds,  { :include_seconds => true }]  => [:'less_than_x_seconds', 10],
+      [19.seconds, { :include_seconds => true }]  => [:'less_than_x_seconds', 20],
+      [30.seconds, { :include_seconds => true }]  => [:'half_a_minute',       nil],
+      [59.seconds, { :include_seconds => true }]  => [:'less_than_x_minutes', 1],
+      [60.seconds, { :include_seconds => true }]  => [:'x_minutes',           1],
 
       # without include_seconds
-      [29.seconds,          false] => [:'less_than_x_minutes', 1],
-      [60.seconds,          false] => [:'x_minutes',           1],
-      [44.minutes,          false] => [:'x_minutes',           44],
-      [61.minutes,          false] => [:'about_x_hours',       1],
-      [24.hours,            false] => [:'x_days',              1],
-      [30.days,             false] => [:'about_x_months',      1],
-      [60.days,             false] => [:'x_months',            2],
-      [1.year,              false] => [:'about_x_years',       1],
-      [3.years + 6.months,  false] => [:'over_x_years',        3],
-      [3.years + 10.months, false] => [:'almost_x_years',      4]
+      [29.seconds,          { :include_seconds => false }] => [:'less_than_x_minutes', 1],
+      [60.seconds,          { :include_seconds => false }] => [:'x_minutes',           1],
+      [44.minutes,          { :include_seconds => false }] => [:'x_minutes',           44],
+      [61.minutes,          { :include_seconds => false }] => [:'about_x_hours',       1],
+      [24.hours,            { :include_seconds => false }] => [:'x_days',              1],
+      [30.days,             { :include_seconds => false }] => [:'about_x_months',      1],
+      [60.days,             { :include_seconds => false }] => [:'x_months',            2],
+      [1.year,              { :include_seconds => false }] => [:'about_x_years',       1],
+      [3.years + 6.months,  { :include_seconds => false }] => [:'over_x_years',        3],
+      [3.years + 10.months, { :include_seconds => false }] => [:'almost_x_years',      4]
 
       }.each do |passed, expected|
       assert_distance_of_time_in_words_translates_key passed, expected
@@ -37,7 +37,7 @@ class DateHelperDistanceOfTimeInWordsI18nTests < ActiveSupport::TestCase
   end
 
   def assert_distance_of_time_in_words_translates_key(passed, expected)
-    diff, include_seconds = *passed
+    diff, passed_options = *passed
     key, count = *expected
     to = @from + diff
 
@@ -45,7 +45,12 @@ class DateHelperDistanceOfTimeInWordsI18nTests < ActiveSupport::TestCase
     options[:count] = count if count
 
     I18n.expects(:t).with(key, options)
-    distance_of_time_in_words(@from, to, include_seconds, :locale => 'en')
+    distance_of_time_in_words(@from, to, passed_options.merge(:locale => 'en'))
+  end
+
+  def test_time_ago_in_words_passes_locale
+    I18n.expects(:t).with(:less_than_x_minutes, :scope => :'datetime.distance_in_words', :count => 1, :locale => 'ru')
+    time_ago_in_words(15.seconds.ago, :locale => 'ru')
   end
 
   def test_distance_of_time_pluralizations

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -21,20 +21,33 @@ class DateHelperTest < ActionView::TestCase
   def assert_distance_of_time_in_words(from, to=nil)
     to ||= from
 
-    # 0..1 with include_seconds
-    assert_equal "less than 5 seconds", distance_of_time_in_words(from, to + 0.seconds, true)
-    assert_equal "less than 5 seconds", distance_of_time_in_words(from, to + 4.seconds, true)
-    assert_equal "less than 10 seconds", distance_of_time_in_words(from, to + 5.seconds, true)
-    assert_equal "less than 10 seconds", distance_of_time_in_words(from, to + 9.seconds, true)
-    assert_equal "less than 20 seconds", distance_of_time_in_words(from, to + 10.seconds, true)
-    assert_equal "less than 20 seconds", distance_of_time_in_words(from, to + 19.seconds, true)
-    assert_equal "half a minute", distance_of_time_in_words(from, to + 20.seconds, true)
-    assert_equal "half a minute", distance_of_time_in_words(from, to + 39.seconds, true)
-    assert_equal "less than a minute", distance_of_time_in_words(from, to + 40.seconds, true)
-    assert_equal "less than a minute", distance_of_time_in_words(from, to + 59.seconds, true)
-    assert_equal "1 minute", distance_of_time_in_words(from, to + 60.seconds, true)
-    assert_equal "1 minute", distance_of_time_in_words(from, to + 89.seconds, true)
+    # 0..1 with :include_seconds => true
+    assert_equal "less than 5 seconds", distance_of_time_in_words(from, to + 0.seconds, :include_seconds => true)
+    assert_equal "less than 5 seconds", distance_of_time_in_words(from, to + 4.seconds, :include_seconds => true)
+    assert_equal "less than 10 seconds", distance_of_time_in_words(from, to + 5.seconds, :include_seconds => true)
+    assert_equal "less than 10 seconds", distance_of_time_in_words(from, to + 9.seconds, :include_seconds => true)
+    assert_equal "less than 20 seconds", distance_of_time_in_words(from, to + 10.seconds, :include_seconds => true)
+    assert_equal "less than 20 seconds", distance_of_time_in_words(from, to + 19.seconds, :include_seconds => true)
+    assert_equal "half a minute", distance_of_time_in_words(from, to + 20.seconds, :include_seconds => true)
+    assert_equal "half a minute", distance_of_time_in_words(from, to + 39.seconds, :include_seconds => true)
+    assert_equal "less than a minute", distance_of_time_in_words(from, to + 40.seconds, :include_seconds => true)
+    assert_equal "less than a minute", distance_of_time_in_words(from, to + 59.seconds, :include_seconds => true)
+    assert_equal "1 minute", distance_of_time_in_words(from, to + 60.seconds, :include_seconds => true)
+    assert_equal "1 minute", distance_of_time_in_words(from, to + 89.seconds, :include_seconds => true)
 
+    # 0..1 with :include_seconds => false
+    assert_equal "less than a minute", distance_of_time_in_words(from, to + 0.seconds, :include_seconds => false)
+    assert_equal "less than a minute", distance_of_time_in_words(from, to + 4.seconds, :include_seconds => false)
+    assert_equal "less than a minute", distance_of_time_in_words(from, to + 5.seconds, :include_seconds => false)
+    assert_equal "less than a minute", distance_of_time_in_words(from, to + 9.seconds, :include_seconds => false)
+    assert_equal "less than a minute", distance_of_time_in_words(from, to + 10.seconds, :include_seconds => false)
+    assert_equal "less than a minute", distance_of_time_in_words(from, to + 19.seconds, :include_seconds => false)
+    assert_equal "less than a minute", distance_of_time_in_words(from, to + 20.seconds, :include_seconds => false)
+    assert_equal "1 minute", distance_of_time_in_words(from, to + 39.seconds, :include_seconds => false)
+    assert_equal "1 minute", distance_of_time_in_words(from, to + 40.seconds, :include_seconds => false)
+    assert_equal "1 minute", distance_of_time_in_words(from, to + 59.seconds, :include_seconds => false)
+    assert_equal "1 minute", distance_of_time_in_words(from, to + 60.seconds, :include_seconds => false)
+    assert_equal "1 minute", distance_of_time_in_words(from, to + 89.seconds, :include_seconds => false)
     # First case 0..1
     assert_equal "less than a minute", distance_of_time_in_words(from, to + 0.seconds)
     assert_equal "less than a minute", distance_of_time_in_words(from, to + 29.seconds)
@@ -95,12 +108,18 @@ class DateHelperTest < ActionView::TestCase
 
     # test to < from
     assert_equal "about 4 hours", distance_of_time_in_words(from + 4.hours, to)
-    assert_equal "less than 20 seconds", distance_of_time_in_words(from + 19.seconds, to, true)
+    assert_equal "less than 20 seconds", distance_of_time_in_words(from + 19.seconds, to, :include_seconds => true)
+    assert_equal "less than a minute", distance_of_time_in_words(from + 19.seconds, to, :include_seconds => false)
   end
 
   def test_distance_in_words
     from = Time.utc(2004, 6, 6, 21, 45, 0)
     assert_distance_of_time_in_words(from)
+  end
+
+  def test_time_ago_in_words_passes_include_seconds
+    assert_equal "less than 20 seconds", time_ago_in_words(15.seconds.ago, :include_seconds => true)
+    assert_equal "less than a minute", time_ago_in_words(15.seconds.ago, :include_seconds => false)
   end
 
   def test_distance_in_words_with_time_zones
@@ -148,10 +167,10 @@ class DateHelperTest < ActionView::TestCase
     assert_equal "about 1 hour", distance_of_time_in_words(60.minutes)
 
     # include seconds
-    assert_equal "half a minute", distance_of_time_in_words(39.seconds, 0, true)
-    assert_equal "less than a minute", distance_of_time_in_words(40.seconds, 0, true)
-    assert_equal "less than a minute", distance_of_time_in_words(59.seconds, 0, true)
-    assert_equal "1 minute", distance_of_time_in_words(60.seconds, 0, true)
+    assert_equal "half a minute", distance_of_time_in_words(39.seconds, 0, :include_seconds => true)
+    assert_equal "less than a minute", distance_of_time_in_words(40.seconds, 0, :include_seconds => true)
+    assert_equal "less than a minute", distance_of_time_in_words(59.seconds, 0, :include_seconds => true)
+    assert_equal "1 minute", distance_of_time_in_words(60.seconds, 0, :include_seconds => true)
   end
 
   def test_time_ago_in_words

--- a/guides/source/action_view_overview.textile
+++ b/guides/source/action_view_overview.textile
@@ -833,7 +833,7 @@ Reports the approximate distance in time between two Time or Date objects or int
 
 <ruby>
 distance_of_time_in_words(Time.now, Time.now + 15.seconds)        # => less than a minute
-distance_of_time_in_words(Time.now, Time.now + 15.seconds, true)  # => less than 20 seconds
+distance_of_time_in_words(Time.now, Time.now + 15.seconds, :include_seconds => true)  # => less than 20 seconds
 </ruby>
 
 h5. select_date


### PR DESCRIPTION
_Remake of #2173_.

Boolean arguments are bad. You guys knew it when changing `ActiveRecord::Base#save` from `save(false)` to `save(:validate => false)`.

I suggest also remove boolean argument `include_seconds` from `distance_of_time_in_words` and `time_ago_in_words`, replacing in with `include_seconds => true` hash option. Of course to keep it as deprecated option. This is somehow a resurrection of #898.

Also it makes `time_ago_in_words` to pass options hash, including a `locale` key, which makes in compatible with `distance_of_time_in_words`.
