### PR TITLE
Support cookie jar options for all cookie stores

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
@@ -74,6 +74,13 @@ module ActionDispatch
     class AbstractStore < Rack::Session::Abstract::ID
       include Compatibility
       include StaleSessionCheck
+
+      private
+
+      def set_cookie(env, session_id, cookie)
+        request = ActionDispatch::Request.new(env)
+        request.cookie_jar[key] = cookie
+      end
     end
   end
 end

--- a/actionpack/test/activerecord/active_record_store_test.rb
+++ b/actionpack/test/activerecord/active_record_store_test.rb
@@ -254,6 +254,13 @@ class ActiveRecordStoreTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_session_store_with_all_domains
+    with_test_route_set(:domain => :all) do
+      get '/set_session_value'
+      assert_response :success
+    end
+  end
+
   private
 
     def with_test_route_set(options = {})


### PR DESCRIPTION
It fixes  #3047, #2483.

The bug can be easily reproduced:

```
rails new foobar
cd foobar
rails generate scaffold post
rake db:sessions:create db:migrate
sed -i '' "s/cookie_store.*/active_record_store, key: '_foobar_session', domain: :all/" config/initializers/session_store.rb
rails server # open http://localhost:3000/posts
```

Also I've provided failing test.

This patch introduces support of domain option for all stores not only cookie store.
