### PR TITLE
Close #5990 - Make #pluck respect includes

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -127,9 +127,9 @@ module ActiveRecord
 
       if eager_loading? || (includes_values.present? && references_eager_loaded_tables?)
         return construct_relation_for_association_calculations.pluck(column_name)
-      else
-        result = klass.connection.select_all(select(column_name).arel, nil, bind_values)
       end
+
+      result = klass.connection.select_all(select(column_name).arel, nil, bind_values)
 
       types  = result.column_types.merge klass.column_types
       column = types[key]

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -128,10 +128,9 @@ module ActiveRecord
       if eager_loading? || (includes_values.present? && references_eager_loaded_tables?)
         return construct_relation_for_association_calculations.pluck(column_name)
       else
-        result = @klass.connection.select_all(select(column_name).arel, nil, bind_values)
+        result = klass.connection.select_all(select(column_name).arel, nil, bind_values)
       end
 
-      result = klass.connection.select_all(select(column_name).arel, nil, bind_values)
       types  = result.column_types.merge klass.column_types
       column = types[key]
 

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -125,6 +125,12 @@ module ActiveRecord
         column_name = "#{table_name}.#{column_name}"
       end
 
+      if eager_loading? || (includes_values.present? && references_eager_loaded_tables?)
+        return construct_relation_for_association_calculations.pluck(column_name)
+      else
+        result = @klass.connection.select_all(select(column_name).arel, nil, bind_values)
+      end
+
       result = klass.connection.select_all(select(column_name).arel, nil, bind_values)
       types  = result.column_types.merge klass.column_types
       column = types[key]

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -465,4 +465,9 @@ class CalculationsTest < ActiveRecord::TestCase
     Company.create!(:name => "test", :contracts => [Contract.new(:developer_id => 7)])
     assert_equal [7], Company.joins(:contracts).pluck(:developer_id)
   end
+
+  def test_pluck_if_table_included
+    c = Company.create!(:name => "test", :contracts => [Contract.new(:developer_id => 7)])
+    assert_equal [c.id], Company.includes(:contracts).where("contracts.id" => c.contracts.first).pluck(:id)
+  end
 end


### PR DESCRIPTION
Title says it all. This makes `ActiveRecord#pluck` respect `includes`. I'm also making a fix against 3.2-stable
