### PR TITLE
Fix #5990 Against 3-2 Stable

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -177,9 +177,17 @@ module ActiveRecord
     #   Person.where(:confirmed => true).limit(5).pluck(:id)
     #
     def pluck(column_name)
-      column_name = column_name.to_s
-      klass.connection.select_all(select(column_name).arel).map! do |attributes|
-        klass.type_cast_attribute(attributes.keys.first, klass.initialize_attributes(attributes))
+
+      if column_name.is_a?(Symbol) && column_names.include?(column_name.to_s)
+        column_name = "#{table_name}.#{column_name}"
+      end
+
+      if eager_loading? || (includes_values.present? && references_eager_loaded_tables?)
+        return construct_relation_for_association_calculations.pluck(column_name)
+      else
+        klass.connection.select_all(select(column_name).arel).map! do |attributes|
+          klass.type_cast_attribute(attributes.keys.first, klass.initialize_attributes(attributes))
+        end
       end
     end
 

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -478,4 +478,9 @@ class CalculationsTest < ActiveRecord::TestCase
   def test_pluck_with_qualified_column_name
     assert_equal [1,2,3,4], Topic.order(:id).pluck("topics.id")
   end
+
+  def test_pluck_if_table_included
+    c = Company.create!(:name => "test", :contracts => [Contract.new(:developer_id => 7)])
+    assert_equal [c.id], Company.includes(:contracts).where("contracts.id" => c.contracts.first).pluck(:id)
+  end
 end


### PR DESCRIPTION
Title says it all. Same thing as #6086, but working against 3-2 stable. This patch also appends the table name if a symbol is given, so `pluck(:id)` will select the id from the correct table when includes/joins are used.
