### PR TITLE
Add ActiveRecord::Base#ids - Close #5812

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -139,6 +139,16 @@ module ActiveRecord
       end
     end
 
+    # Pluck all the ID's for the relation using the table's primary key
+    #
+    # Examples:
+    #
+    #   Person.ids # SELECT people.id FROM people
+    #   Person.joins(:companies).ids # SELECT people.id FROM PEOPLE INNER JOIN companies ON companies.person_id = people.id
+    def ids
+      pluck primary_key
+    end
+
     private
 
     def perform_calculation(operation, column_name, options = {})

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -465,4 +465,8 @@ class CalculationsTest < ActiveRecord::TestCase
     Company.create!(:name => "test", :contracts => [Contract.new(:developer_id => 7)])
     assert_equal [7], Company.joins(:contracts).pluck(:developer_id)
   end
+
+  def test_plucks_with_ids
+    assert_equal Company.all.map(&:id), Company.ids
+  end
 end


### PR DESCRIPTION
This patch adds a new method for plucking all the IDs from a relation. This is useful when you need ID's for API's.

Original issue here: #5812
