### PR TITLE
notify_observers should be public

### DIFF
--- a/activemodel/lib/active_model/observing.rb
+++ b/activemodel/lib/active_model/observing.rb
@@ -110,25 +110,24 @@ module ActiveModel
         end
     end
 
-    private
-      # Fires notifications to model's observers
-      #
-      #   def save
-      #     notify_observers(:before_save)
-      #     ...
-      #     notify_observers(:after_save)
-      #   end
-      #
-      # Custom notifications can be sent in a similar fashion:
-      #
-      #   notify_observers(:custom_notification, :foo)
-      #
-      # This will call +custom_notification+, passing as arguments
-      # the current object and :foo.
-      #
-      def notify_observers(method, *extra_args)
-        self.class.notify_observers(method, self, *extra_args)
-      end
+    # Fires notifications to model's observers
+    #
+    #   def save
+    #     notify_observers(:before_save)
+    #     ...
+    #     notify_observers(:after_save)
+    #   end
+    #
+    # Custom notifications can be sent in a similar fashion:
+    #
+    #   notify_observers(:custom_notification, :foo)
+    #
+    # This will call +custom_notification+, passing as arguments
+    # the current object and :foo.
+    #
+    def notify_observers(method, *extra_args)
+      self.class.notify_observers(method, self, *extra_args)
+    end
   end
 
   # == Active Model Observers

--- a/activemodel/test/cases/observing_test.rb
+++ b/activemodel/test/cases/observing_test.rb
@@ -138,7 +138,14 @@ class ObserverTest < ActiveModel::TestCase
     foo = Foo.new
     FooObserver.instance.stub = stub
     FooObserver.instance.stub.expects(:event_with).with(foo)
-    Foo.send(:notify_observers, :on_spec, foo)
+    Foo.notify_observers(:on_spec, foo)
+  end
+
+  test "calls existing observer event from the instance" do
+    foo = Foo.new
+    FooObserver.instance.stub = stub
+    FooObserver.instance.stub.expects(:event_with).with(foo)
+    foo.notify_observers(:on_spec)
   end
 
   test "passes extra arguments" do
@@ -150,7 +157,7 @@ class ObserverTest < ActiveModel::TestCase
 
   test "skips nonexistent observer event" do
     foo = Foo.new
-    Foo.send(:notify_observers, :whatever, foo)
+    Foo.notify_observers(:whatever, foo)
   end
 
   test "update passes a block on to the observer" do


### PR DESCRIPTION
As @twinturbo objected in pull request #6063, here's a separate request for this change and expanded reasoning.

Reasons to make `notify_observers` public:
- consistent with the fact that `notify_observers` in the stdlib's `Observable` is public.
- consistent with the fact that the singleton method `notify_observers` is public:
  
  Foo.notify_observers(:my_event, the_foo) # => currently ok
  the_foo.notify_observers(:my_event) # => currently not ok
- `notify_observers` is not the right level to restrict access. Some actions would be best kept private (say :after_save) but custom actions could very well be triggered by external clients. The class and its instances simply act as a rendez-vous point where complete strangers to the class can communicate.

Example:

An observer implements `:after_save` to detect some state change. If detected, it wants to send a custom notification `:some_state_changed`, so other observers can be notified and don't have to reimplement the state change logic. It shouldn't have to use `send`.

Thanks
