### PR TITLE
Provide a more useful definition of json_escape

### DIFF
--- a/actionpack/test/template/erb_util_test.rb
+++ b/actionpack/test/template/erb_util_test.rb
@@ -8,12 +8,10 @@ class ErbUtilTest < ActiveSupport::TestCase
     define_method "test_html_escape_#{expected.gsub(/\W/, '')}" do
       assert_equal expected, html_escape(given)
     end
+  end
 
-    unless given == '"'
-      define_method "test_json_escape_#{expected.gsub(/\W/, '')}" do
-        assert_equal ERB::Util::JSON_ESCAPE[given], json_escape(given)
-      end
-    end
+  def test_json_escape_escapes_slashes
+    assert_equal '<\/script>', json_escape('</script>')
   end
 
   def test_json_escape_returns_unsafe_strings_when_passed_unsafe_strings


### PR DESCRIPTION
The existing definition removes double quote characters, and hence returns invalid JSON, making it unsuitable for the most common use case: [bootstrapping JSON within a `<script>` element](http://jfire.io/blog/2012/04/30/how-to-securely-bootstrap-json-in-a-rails-view/).

I am unaware of any use cases satisfied by the current behavior, which was [previously discussed on lighthouse](https://rails.lighthouseapp.com/projects/8994/tickets/1485-json_escape-eats-away-double-quotes) without coming to a satisfactory resolution. The original commit at 0ff7a2d89fc95dcb0a32ed92aab7156b0778a7ea does not indicate that the double quote behavior was intentional. It seems likely that it was simply an oversight after copy and pasting the definition of `html_escape`.

Since Rails does not make it easy to correctly escape bootstrapped JSON, incorrect and insecure methods are widespread and incorrectly recommended: [1](https://github.com/search?utf8=%E2%9C%93&q=raw+to_json&repo=&langOverride=&start_value=1&type=Code&language=HTML%2BERB), [2](https://github.com/search?utf8=%E2%9C%93&q=to_json+html_safe&repo=&langOverride=&start_value=1&type=Code&language=HTML%2BERB), [3](http://stackoverflow.com/a/3758055/52207). This change, together with community education, would alleviate the situation.

It's worth discussion whether `json_escape` should always return HTML-safe strings, such that it can be used without explicitly calling `html_safe`:

``` erb
<script>
  var data = <%=j @data.to_json %>;
</script>
```

Also related is the discussion of the other `j` helper at #3578.
