### PR TITLE
JSON: encode BigDecimal NaN/Infinity as null.

### DIFF
--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -183,6 +183,8 @@ class Numeric
 end
 
 class Float
+  # Encoding Infinity or NaN to JSON should return "null". The default returns
+  # "Infinity" or "NaN" what breaks parsing the JSON. E.g. JSON.parse('[NaN]').
   def as_json(options = nil) finite? ? self : NilClass::AS_JSON end #:nodoc:
 end
 
@@ -195,7 +197,7 @@ class BigDecimal
   # That's why a JSON string is returned. The JSON literal is not numeric, but if
   # the other end knows by contract that the data is supposed to be a BigDecimal,
   # it still has the chance to post-process the string and get the real value.
-  def as_json(options = nil) to_s end #:nodoc:
+  def as_json(options = nil) finite? ? to_s : NilClass::AS_JSON end #:nodoc:
 end
 
 class Regexp

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -30,6 +30,7 @@ class TestJSONEncoding < ActiveSupport::TestCase
                    [ 0.0/0.0,   %(null) ],
                    [ 1.0/0.0,   %(null) ],
                    [ -1.0/0.0,  %(null) ],
+                   [ BigDecimal('0.0')/BigDecimal('0.0'),  %(null) ],
                    [ BigDecimal('2.5'), %("#{BigDecimal('2.5').to_s}") ]]
 
   StringTests   = [[ 'this is the <string>',     %("this is the \\u003Cstring\\u003E")],


### PR DESCRIPTION
This is an addendum to https://github.com/rails/rails/pull/2532 

Adds the same to_json behaviour to BigDecimal NaN and +/-Infinity.

``` ruby
  {'nan' => BigDecimal(0.0)/(0.0) }.to_json
  # => { 'nan' : null }
```
