### PR TITLE
improve redability

### DIFF
--- a/actionpack/lib/action_controller/metal/exceptions.rb
+++ b/actionpack/lib/action_controller/metal/exceptions.rb
@@ -1,9 +1,7 @@
 module ActionController
-  class ActionControllerError < StandardError #:nodoc:
-  end
+  ActionControllerError = Class.new StandardError
 
-  class RenderError < ActionControllerError #:nodoc:
-  end
+  RenderError = Class.new ActionControllerError
 
   class RoutingError < ActionControllerError #:nodoc:
     attr_reader :failures
@@ -19,14 +17,11 @@ module ActionController
     end
   end
 
-  class NotImplemented < MethodNotAllowed #:nodoc:
-  end
+  NotImplemented = Class.new MethodNotAllowed
 
-  class UnknownController < ActionControllerError #:nodoc:
-  end
+  UnknownController = Class.new ActionControllerError
 
-  class MissingFile < ActionControllerError #:nodoc:
-  end
+  MissingFile = Class.new ActionControllerError #:nodoc:
 
   class SessionOverflowError < ActionControllerError #:nodoc:
     DEFAULT_MESSAGE = 'Your session data is larger than the data column in which it is to be stored. You must increase the size of your data column if you intend to store large data.'
@@ -36,6 +31,5 @@ module ActionController
     end
   end
 
-  class UnknownHttpMethod < ActionControllerError #:nodoc:
-  end
+  UnknownHttpMethod = Class.new ActionControllerError #:nodoc:
 end

--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -1,6 +1,6 @@
 module ActionDispatch
   class RemoteIp
-    class IpSpoofAttackError < StandardError ; end
+    IpSpoofAttackError = Class.new StandardError
 
     # IP addresses that are "trusted proxies" that can be stripped from
     # the comma-delimited list in the X-Forwarded-For header. See also:

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -30,7 +30,7 @@ module ActiveSupport
     end
 
     module Encoding #:nodoc:
-      class CircularReferenceError < StandardError; end
+      CircularReferenceError = Class.new StandardError
 
       class Encoder
         attr_reader :options
@@ -117,7 +117,9 @@ module ActiveSupport
         end
 
         def escape(string)
-          string = string.encode(::Encoding::UTF_8, :undef => :replace).force_encoding(::Encoding::BINARY)
+          string = string.
+            encode(::Encoding::UTF_8, :undef => :replace).
+            force_encoding(::Encoding::BINARY)
           json = string.
             gsub(escape_regex) { |s| ESCAPED_CHARS[s] }.
             gsub(/([\xC0-\xDF][\x80-\xBF]|
@@ -138,13 +140,7 @@ module ActiveSupport
 end
 
 class Object
-  def as_json(options = nil) #:nodoc:
-    if respond_to?(:to_hash)
-      to_hash
-    else
-      instance_values
-    end
-  end
+  def as_json(options = nil) respond_to?(:to_hash) ? to_hash : instance_values end #:nodoc:
 end
 
 class Struct #:nodoc:
@@ -215,7 +211,8 @@ end
 class Array
   def as_json(options = nil) #:nodoc:
     # use encoder as a proxy to call as_json on all elements, to protect from circular references
-    encoder = options && options[:encoder] || ActiveSupport::JSON::Encoding::Encoder.new(options)
+    encoder = options && options[:encoder] ||
+      ActiveSupport::JSON::Encoding::Encoder.new(options)
     map { |v| encoder.as_json(v, options) }
   end
 
@@ -241,7 +238,8 @@ class Hash
     end
 
     # use encoder as a proxy to call as_json on all values in the subset, to protect from circular references
-    encoder = options && options[:encoder] || ActiveSupport::JSON::Encoding::Encoder.new(options)
+    encoder = options && options[:encoder] ||
+      ActiveSupport::JSON::Encoding::Encoder.new(options)
     Hash[subset.map { |k, v| [k.to_s, encoder.as_json(v, options)] }]
   end
 

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -10,10 +10,10 @@ module ActiveSupport
   # This can be used in situations similar to the <tt>MessageVerifier</tt>, but where you don't
   # want users to be able to determine the value of the payload.
   #
-  #   key = OpenSSL::Digest::SHA256.new('password').digest        # => "\x89\xE0\x156\xAC..." 
-  #   crypt = ActiveSupport::MessageEncryptor.new(key)            # => #<ActiveSupport::MessageEncryptor ...> 
-  #   encrypted_data = crypt.encrypt_and_sign('my secret data')   # => "NlFBTTMwOUV5UlA1QlNEN2xkY2d6eThYWWh..." 
-  #   crypt.decrypt_and_verify(encrypted_data)                    # => "my secret data" 
+  #   key = OpenSSL::Digest::SHA256.new('password').digest        # => "\x89\xE0\x156\xAC..."
+  #   crypt = ActiveSupport::MessageEncryptor.new(key)            # => #<ActiveSupport::MessageEncryptor ...>
+  #   encrypted_data = crypt.encrypt_and_sign('my secret data')   # => "NlFBTTMwOUV5UlA1QlNEN2xkY2d6eThYWWh..."
+  #   crypt.decrypt_and_verify(encrypted_data)                    # => "my secret data"
   class MessageEncryptor
     module NullSerializer #:nodoc:
       def self.load(value)
@@ -25,7 +25,8 @@ module ActiveSupport
       end
     end
 
-    class InvalidMessage < StandardError; end
+    InvalidMessage = Class.new StandardError
+
     OpenSSLCipherError = OpenSSL::Cipher.const_defined?(:CipherError) ? OpenSSL::Cipher::CipherError : OpenSSL::CipherError
 
     # Initialize a new MessageEncryptor.
@@ -36,7 +37,6 @@ module ActiveSupport
     # Options:
     # * <tt>:cipher</tt>      - Cipher to use. Can be any cipher returned by <tt>OpenSSL::Cipher.ciphers</tt>. Default is 'aes-256-cbc'
     # * <tt>:serializer</tt>  - Object serializer to use. Default is +Marshal+.
-    # 
     def initialize(secret, options = {})
       @secret = secret
       @cipher = options[:cipher] || 'aes-256-cbc'

--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -24,7 +24,7 @@ module ActiveSupport
   #
   #   @verifier.serializer = YAML
   class MessageVerifier
-    class InvalidSignature < StandardError; end
+    InvalidSignature = Class.new StandardError
 
     def initialize(secret, options = {})
       @secret = secret


### PR DESCRIPTION
Hi guys,

I did some refactoring of single-line class definitions. `Class.new` seems more readable than using semicolon, don't you think?

Looking forward for your feedback.
