### PR TITLE
Removing unused local vars in Queue tests

### DIFF
--- a/railties/test/application/queue_test.rb
+++ b/railties/test/application/queue_test.rb
@@ -32,7 +32,6 @@ module ApplicationTests
 
     test "in development mode, an enqueued job will be processed in a separate thread" do
       app("development")
-      current = Thread.current
 
       job = Struct.new(:origin, :target).new(Thread.current)
       def job.run
@@ -48,7 +47,6 @@ module ApplicationTests
 
     test "in test mode, explicitly draining the queue will process it in a separate thread" do
       app("test")
-      current = Thread.current
 
       job = Struct.new(:origin, :target).new(Thread.current)
       def job.run


### PR DESCRIPTION
Reading through the Queue code I found a couple of local vars assigned and never used, I guess no one will miss them :-)
