### PR TITLE
Make callstack attribute optional in AS:Deprecation

### DIFF
--- a/actionpack/lib/action_controller/record_identifier.rb
+++ b/actionpack/lib/action_controller/record_identifier.rb
@@ -8,12 +8,12 @@ module ActionController
               'ActionView::RecodIdentifier module.'
 
     def dom_id(record, prefix = nil)
-      ActiveSupport::Deprecation.warn('dom_id ' + MESSAGE, caller)
+      ActiveSupport::Deprecation.warn('dom_id ' + MESSAGE)
       ActionView::RecordIdentifier.dom_id(record, prefix)
     end
 
     def dom_class(record, prefix = nil)
-      ActiveSupport::Deprecation.warn('dom_class ' + MESSAGE, caller)
+      ActiveSupport::Deprecation.warn('dom_class ' + MESSAGE)
       ActionView::RecordIdentifier.dom_class(record, prefix)
     end
   end

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -275,12 +275,12 @@ module Mime
     # Returns true if Action Pack should check requests using this Mime Type for possible request forgery. See
     # ActionController::RequestForgeryProtection.
     def verify_request?
-      ActiveSupport::Deprecation.warn("Mime::Type#verify_request? is deprecated and will be removed in Rails 4.1", caller)
+      ActiveSupport::Deprecation.warn "Mime::Type#verify_request? is deprecated and will be removed in Rails 4.1"
       @@browser_generated_types.include?(to_sym)
     end
 
     def self.browser_generated_types
-      ActiveSupport::Deprecation.warn("Mime::Type.browser_generated_types is deprecated and will be removed in Rails 4.1", caller)
+      ActiveSupport::Deprecation.warn "Mime::Type.browser_generated_types is deprecated and will be removed in Rails 4.1"
       @@browser_generated_types
     end
 

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -498,8 +498,7 @@ module ActionDispatch
 
     def self.app
       if !@@app && !ActionDispatch.test_app
-        ActiveSupport::Deprecation.warn "Rails application fallback is deprecated " \
-          "and no longer works, please set ActionDispatch.test_app", caller
+        ActiveSupport::Deprecation.warn "Rails application fallback is deprecated and no longer works, please set ActionDispatch.test_app"
       end
 
       @@app || ActionDispatch.test_app

--- a/actionpack/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helper.rb
@@ -125,7 +125,7 @@ module ActionView
                     "the :type option key. This behavior is deprecated and will be remove in Rails 4.1. You should pass " +
                     ":type option explicitly if you want to use other types, for example: " +
                     "auto_discovery_link_tag(:xml, '/feed.xml', :type => 'application/xml')"
-          ActiveSupport::Deprecation.warn(message, caller)
+          ActiveSupport::Deprecation.warn message
         end
 
         tag(

--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -69,7 +69,7 @@ module ActionView
           options = include_seconds_or_options
         else
           ActiveSupport::Deprecation.warn "distance_of_time_in_words and time_ago_in_words now accept :include_seconds " +
-                                          "as a part of options hash, not a boolean argument", caller
+                                          "as a part of options hash, not a boolean argument"
           options[:include_seconds] ||= !!include_seconds_or_options
         end
 

--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -1181,8 +1181,7 @@ module ActionView
 
       def initialize(object_name, object, template, options, block=nil)
         if block
-          message = "Giving a block to FormBuilder is deprecated and has no effect anymore."
-          ActiveSupport::Deprecation.warn(message, caller)
+          ActiveSupport::Deprecation.warn "Giving a block to FormBuilder is deprecated and has no effect anymore."
         end
 
         @nested_child_index = {}

--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -521,7 +521,7 @@ module ActionView
           options = {}
           message = "Passing the prompt to grouped_options_for_select as an argument is deprecated. " \
                     "Please use an options hash like `{ prompt: #{prompt.inspect} }`."
-          ActiveSupport::Deprecation.warn(message, caller)
+          ActiveSupport::Deprecation.warn message
         end
 
         body = "".html_safe

--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -427,7 +427,7 @@ module ActionView
         if disable_with = options.delete("disable_with")
           message = ":disable_with option is deprecated and will be removed from Rails 4.1. " \
                     "Use 'data: { disable_with: \'Text\' }' instead."
-          ActiveSupport::Deprecation.warn(message, caller)
+          ActiveSupport::Deprecation.warn message
 
           options["data-disable-with"] = disable_with
         end
@@ -435,7 +435,7 @@ module ActionView
         if confirm = options.delete("confirm")
           message = ":confirm option is deprecated and will be removed from Rails 4.1. " \
                     "Use 'data: { confirm: \'Text\' }' instead'."
-          ActiveSupport::Deprecation.warn(message, caller)
+          ActiveSupport::Deprecation.warn message
 
           options["data-confirm"] = confirm
         end
@@ -489,7 +489,7 @@ module ActionView
         if disable_with = options.delete("disable_with")
           message = ":disable_with option is deprecated and will be removed from Rails 4.1. " \
                     "Use 'data: { disable_with: \'Text\' }' instead."
-          ActiveSupport::Deprecation.warn(message, caller)
+          ActiveSupport::Deprecation.warn message
 
           options["data-disable-with"] = disable_with
         end
@@ -497,7 +497,7 @@ module ActionView
         if confirm = options.delete("confirm")
           message = ":confirm option is deprecated and will be removed from Rails 4.1. " \
                     "Use 'data: { confirm: \'Text\' }' instead'."
-          ActiveSupport::Deprecation.warn(message, caller)
+          ActiveSupport::Deprecation.warn message
 
           options["data-confirm"] = confirm
         end
@@ -543,7 +543,7 @@ module ActionView
         if confirm = options.delete("confirm")
           message = ":confirm option is deprecated and will be removed from Rails 4.1. " \
                     "Use 'data: { confirm: \'Text\' }' instead'."
-          ActiveSupport::Deprecation.warn(message, caller)
+          ActiveSupport::Deprecation.warn message
 
           options["data-confirm"] = confirm
         end

--- a/actionpack/lib/action_view/helpers/javascript_helper.rb
+++ b/actionpack/lib/action_view/helpers/javascript_helper.rb
@@ -80,7 +80,7 @@ module ActionView
       def button_to_function(name, function=nil, html_options={})
         message = "button_to_function is deprecated and will be removed from Rails 4.1. We recomend to use Unobtrusive JavaScript instead. " +
           "See http://guides.rubyonrails.org/working_with_javascript_in_rails.html#unobtrusive-javascript"
-        ActiveSupport::Deprecation.warn(message, caller)
+        ActiveSupport::Deprecation.warn message
 
         onclick = "#{"#{html_options[:onclick]}; " if html_options[:onclick]}#{function};"
 
@@ -102,7 +102,7 @@ module ActionView
       def link_to_function(name, function, html_options={})
         message = "link_to_function is deprecated and will be removed from Rails 4.1. We recomend to use Unobtrusive JavaScript instead. " +
           "See http://guides.rubyonrails.org/working_with_javascript_in_rails.html#unobtrusive-javascript"
-        ActiveSupport::Deprecation.warn(message, caller)
+        ActiveSupport::Deprecation.warn message
 
         onclick = "#{"#{html_options[:onclick]}; " if html_options[:onclick]}#{function}; return false;"
         href = html_options[:href] || '#'

--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -579,7 +579,7 @@ module ActionView
             if confirm
               message = ":confirm option is deprecated and will be removed from Rails 4.1. " \
                         "Use 'data: { confirm: \'Text\' }' instead."
-              ActiveSupport::Deprecation.warn(message, caller)
+              ActiveSupport::Deprecation.warn message
 
               html_options["data-confirm"] = confirm
             end
@@ -589,7 +589,7 @@ module ActionView
             if disable_with
               message = ":disable_with option is deprecated and will be removed from Rails 4.1. " \
                         "Use 'data: { disable_with: \'Text\' }' instead."
-              ActiveSupport::Deprecation.warn(message, caller)
+              ActiveSupport::Deprecation.warn message
 
               html_options["data-disable-with"] = disable_with
             end

--- a/actionpack/lib/action_view/template.rb
+++ b/actionpack/lib/action_view/template.rb
@@ -150,7 +150,7 @@ module ActionView
 
     def mime_type
       message = 'Template#mime_type is deprecated and will be removed in Rails 4.1. Please use type method instead.'
-      ActiveSupport::Deprecation.warn(message, caller)
+      ActiveSupport::Deprecation.warn message
       @mime_type ||= Mime::Type.lookup_by_extension(@formats.first.to_s) if @formats.first
     end
 

--- a/actionpack/lib/action_view/template/resolver.rb
+++ b/actionpack/lib/action_view/template/resolver.rb
@@ -237,7 +237,7 @@ module ActionView
       unless extension
         message = "The file #{path} did not specify a template handler. The default is currently ERB, " \
                   "but will change to RAW in the future."
-        ActiveSupport::Deprecation.warn(message, caller)
+        ActiveSupport::Deprecation.warn message
       end
 
       handler = Template.handler_for_extension(extension)

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -387,7 +387,7 @@ module ActiveModel
                         "necessary. If the un-prefixed/suffixed version of the method has not been " \
                         "defined when `define_attribute_methods` is called, it will be defined " \
                         "automatically."
-              ActiveSupport::Deprecation.warn(message, caller)
+              ActiveSupport::Deprecation.warn message
             end
 
             @prefix, @suffix = options.fetch(:prefix, ''), options.fetch(:suffix, '')

--- a/activemodel/lib/active_model/observing.rb
+++ b/activemodel/lib/active_model/observing.rb
@@ -172,7 +172,7 @@ module ActiveModel
       # <tt>count_observers</tt> is deprecated. Use #observers_count.
       def count_observers
         msg = "count_observers is deprecated in favor of observers_count"
-        ActiveSupport::Deprecation.warn(msg, caller)
+        ActiveSupport::Deprecation.warn msg
         observers_count
       end
 

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -85,7 +85,7 @@ module ActiveRecord
       end
 
       def scoped
-        ActiveSupport::Deprecation.warn("#scoped is deprecated. use #scope instead.", caller)
+        ActiveSupport::Deprecation.warn "#scoped is deprecated. use #scope instead."
         scope
       end
 

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -46,7 +46,7 @@ module ActiveRecord
 
       def serialized_attributes
         message = "Instance level serialized_attributes method is deprecated, please use class level method."
-        ActiveSupport::Deprecation.warn(message, caller)
+        ActiveSupport::Deprecation.warn message
         defined?(@serialized_attributes) ? @serialized_attributes : self.class.serialized_attributes
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -3,7 +3,7 @@ require 'bigdecimal'
 require 'bigdecimal/util'
 require 'active_support/core_ext/benchmark'
 require 'active_record/connection_adapters/schema_cache'
-require 'active_record/connection_adapters/abstract/schema_dumper' 
+require 'active_record/connection_adapters/abstract/schema_dumper'
 require 'monitor'
 require 'active_support/deprecation'
 
@@ -255,16 +255,16 @@ module ActiveRecord
       end
 
       def increment_open_transactions
-        ActiveSupport::Deprecation.warn("#increment_open_transactions is deprecated and has no effect", caller)
+        ActiveSupport::Deprecation.warn "#increment_open_transactions is deprecated and has no effect"
       end
 
       def decrement_open_transactions
-        ActiveSupport::Deprecation.warn("#decrement_open_transactions is deprecated and has no effect", caller)
+        ActiveSupport::Deprecation.warn "#decrement_open_transactions is deprecated and has no effect"
       end
 
       def transaction_joinable=(joinable)
         message = "#transaction_joinable= is deprecated. Please pass the :joinable option to #begin_transaction instead."
-        ActiveSupport::Deprecation.warn(message, caller)
+        ActiveSupport::Deprecation.warn message
         @transaction.joinable = joinable
       end
 

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -109,7 +109,7 @@ module ActiveRecord
       def type_cast_code(var_name)
         message = "Column#type_cast_code is deprecated in favor of using Column#type_cast only, " \
                   "and it is going to be removed in future Rails versions."
-        ActiveSupport::Deprecation.warn(message, caller)
+        ActiveSupport::Deprecation.warn message
 
         klass = self.class.name
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -223,7 +223,7 @@ module ActiveRecord
         def outside_transaction?
           message = "#outside_transaction? is deprecated. This method was only really used " \
                     "internally, but you can use #transaction_open? instead."
-          ActiveSupport::Deprecation.warn(message, caller)
+          ActiveSupport::Deprecation.warn message
           @connection.transaction_status == PGconn::PQTRANS_IDLE
         end
 

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -733,7 +733,7 @@ module ActiveRecord
 
       if block_given?
         message = "block argument to migrate is deprecated, please filter migrations before constructing the migrator"
-        ActiveSupport::Deprecation.warn(message, caller)
+        ActiveSupport::Deprecation.warn message
         running.select! { |m| yield m }
       end
 

--- a/activerecord/lib/active_record/readonly_attributes.rb
+++ b/activerecord/lib/active_record/readonly_attributes.rb
@@ -23,7 +23,7 @@ module ActiveRecord
 
     def _attr_readonly
       message = "Instance level _attr_readonly method is deprecated, please use class level method."
-      ActiveSupport::Deprecation.warn(message, caller)
+      ActiveSupport::Deprecation.warn message
       defined?(@_attr_readonly) ? @_attr_readonly : self.class._attr_readonly
     end
   end

--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -95,8 +95,7 @@ module ActiveRecord
               "Calling #default_scope without a block is deprecated. For example instead " \
               "of `default_scope where(color: 'red')`, please use " \
               "`default_scope { where(color: 'red') }`. (Alternatively you can just redefine " \
-              "self.default_scope.)",
-              caller
+              "self.default_scope.)"
             )
           end
 

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -156,8 +156,7 @@ module ActiveRecord
               "`scope :red, -> { where(color: 'red') }`. There are numerous gotchas " \
               "in the former usage and it makes the implementation more complicated " \
               "and buggy. (If you prefer, you can just define a class method named " \
-              "`self.red`.)",
-              caller
+              "`self.red`.)"
             )
           end
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Make callstack attribute optional in
+    ActiveSupport::Deprecation::Reporting methods `warn` and `deprecation_warning`
+
+    *Alexey Gaziev*
+
 *   Implement HashWithIndifferentAccess#replace so key? works correctly. *David Graham*
 
 *   Handle the possible Permission Denied errors atomic.rb might trigger due to its chown and chmod calls. *Daniele Sluijters*

--- a/activesupport/lib/active_support/benchmarkable.rb
+++ b/activesupport/lib/active_support/benchmarkable.rb
@@ -49,7 +49,7 @@ module ActiveSupport
     # Silence the logger during the execution of the block.
     def silence
       message = "ActiveSupport::Benchmarkable#silence is deprecated. It will be removed from Rails 4.1."
-      ActiveSupport::Deprecation.warn(message, caller)
+      ActiveSupport::Deprecation.warn message
       old_logger_level, logger.level = logger.level, ::Logger::ERROR if logger
       yield
     ensure

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -284,13 +284,13 @@ module ActiveSupport
         if !filter.respond_to?(kind) && filter.respond_to?(:filter)
           message = "Filter object with #filter method is deprecated. Define method corresponding " \
                     "to filter type (#before, #after or #around)."
-          ActiveSupport::Deprecation.warn(message, caller)
+          ActiveSupport::Deprecation.warn message
           filter.singleton_class.class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
             def #{kind}(context, &block) filter(context, &block) end
           RUBY_EVAL
         elsif filter.respond_to?(:before) && filter.respond_to?(:after) && kind == :around && !filter.respond_to?(:around)
           message = "Filter object with #before and #after methods is deprecated. Define #around method instead."
-          ActiveSupport::Deprecation.warn(message, caller)
+          ActiveSupport::Deprecation.warn message
           def filter.around(context)
             should_continue = before(context)
             yield if should_continue

--- a/activesupport/lib/active_support/core_ext/array/uniq_by.rb
+++ b/activesupport/lib/active_support/core_ext/array/uniq_by.rb
@@ -5,7 +5,7 @@ class Array
   #
   #   [1, 2, 3, 4].uniq_by { |i| i.odd? } # => [1, 2]
   def uniq_by(&block)
-    ActiveSupport::Deprecation.warn 'uniq_by is deprecated. Use Array#uniq instead', caller
+    ActiveSupport::Deprecation.warn 'uniq_by is deprecated. Use Array#uniq instead'
     uniq(&block)
   end
 
@@ -13,7 +13,7 @@ class Array
   #
   # Same as +uniq_by+, but modifies +self+.
   def uniq_by!(&block)
-    ActiveSupport::Deprecation.warn 'uniq_by! is deprecated. Use Array#uniq! instead', caller
+    ActiveSupport::Deprecation.warn 'uniq_by! is deprecated. Use Array#uniq! instead'
     uniq!(&block)
   end
 end

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -4,7 +4,7 @@ class DateTime
   class << self
     # *DEPRECATED*: Use +DateTime.civil_from_format+ directly.
     def local_offset
-      ActiveSupport::Deprecation.warn 'DateTime.local_offset is deprecated. Use DateTime.civil_from_format directly.', caller
+      ActiveSupport::Deprecation.warn 'DateTime.local_offset is deprecated. Use DateTime.civil_from_format directly.'
 
       ::Time.local(2012).utc_offset.to_r / 86400
     end

--- a/activesupport/lib/active_support/core_ext/module/introspection.rb
+++ b/activesupport/lib/active_support/core_ext/module/introspection.rb
@@ -72,7 +72,7 @@ class Module
   # This method is useful for forward compatibility, since Ruby 1.8 returns
   # constant names as strings, whereas 1.9 returns them as symbols.
   def local_constant_names
-    ActiveSupport::Deprecation.warn 'Module#local_constant_names is deprecated, use Module#local_constants instead', caller
+    ActiveSupport::Deprecation.warn 'Module#local_constant_names is deprecated, use Module#local_constants instead'
     local_constants.map { |c| c.to_s }
   end
 end

--- a/activesupport/lib/active_support/core_ext/proc.rb
+++ b/activesupport/lib/active_support/core_ext/proc.rb
@@ -3,7 +3,7 @@ require "active_support/deprecation"
 
 class Proc #:nodoc:
   def bind(object)
-    ActiveSupport::Deprecation.warn 'Proc#bind is deprecated and will be removed in future versions', caller
+    ActiveSupport::Deprecation.warn 'Proc#bind is deprecated and will be removed in future versions'
 
     block, time = self, Time.now
     object.class_eval do

--- a/activesupport/lib/active_support/core_ext/string/encoding.rb
+++ b/activesupport/lib/active_support/core_ext/string/encoding.rb
@@ -2,7 +2,7 @@ require 'active_support/deprecation'
 
 class String
   def encoding_aware?
-    ActiveSupport::Deprecation.warn 'String#encoding_aware? is deprecated', caller
+    ActiveSupport::Deprecation.warn 'String#encoding_aware? is deprecated'
     true
   end
 end

--- a/activesupport/lib/active_support/deprecation/method_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/method_wrappers.rb
@@ -33,7 +33,7 @@ module ActiveSupport
         method_names.each do |method_name|
           target_module.alias_method_chain(method_name, :deprecation) do |target, punctuation|
             target_module.send(:define_method, "#{target}_with_deprecation#{punctuation}") do |*args, &block|
-              deprecator.deprecation_warning(method_name, options[method_name], caller)
+              deprecator.deprecation_warning(method_name, options[method_name])
               send(:"#{target}_without_deprecation#{punctuation}", *args, &block)
             end
           end

--- a/activesupport/lib/active_support/deprecation/reporting.rb
+++ b/activesupport/lib/active_support/deprecation/reporting.rb
@@ -11,8 +11,10 @@ module ActiveSupport
       #
       #   ActiveSupport::Deprecation.warn('something broke!')
       #   # => "DEPRECATION WARNING: something broke! (called from your_code.rb:1)"
-      def warn(message = nil, callstack = caller)
+      def warn(message = nil, callstack = nil)
         return if silenced
+
+        callstack ||= caller(2)
         deprecation_message(callstack, message).tap do |m|
           behavior.each { |b| b.call(m, callstack) }
         end
@@ -34,7 +36,8 @@ module ActiveSupport
         @silenced = old_silenced
       end
 
-      def deprecation_warning(deprecated_method_name, message = nil, caller_backtrace = caller)
+      def deprecation_warning(deprecated_method_name, message = nil, caller_backtrace = nil)
+        caller_backtrace ||= caller(2)
         deprecated_method_warning(deprecated_method_name, message).tap do |msg|
           warn(msg, caller_backtrace)
         end

--- a/activesupport/lib/active_support/json/variable.rb
+++ b/activesupport/lib/active_support/json/variable.rb
@@ -7,7 +7,7 @@ module ActiveSupport
       def initialize(*args)
         message = 'ActiveSupport::JSON::Variable is deprecated and will be removed in Rails 4.1. ' \
                   'For your own custom JSON literals, define #as_json and #encode_json yourself.'
-        ActiveSupport::Deprecation.warn(message, caller)
+        ActiveSupport::Deprecation.warn message
         super
       end
 

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -44,7 +44,7 @@ module ActiveSupport
         super
       else
         message = "`describe` without a block is deprecated, please switch to: `def self.name; #{text.inspect}; end`\n"
-        ActiveSupport::Deprecation.warn(message, caller)
+        ActiveSupport::Deprecation.warn message
 
         class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
           def self.name

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -9,7 +9,7 @@ class Deprecatee
   def old_request; @request end
 
   def partially(foo = nil)
-    ActiveSupport::Deprecation.warn('calling with foo=nil is out', caller) if foo.nil?
+    ActiveSupport::Deprecation.warn('calling with foo=nil is out') if foo.nil?
   end
 
   def not() 2 end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -91,7 +91,7 @@ module Rails
         message = "config.threadsafe! is deprecated. Rails applications " \
                   "behave by default as thread safe in production as long as config.cache_classes and " \
                   "config.eager_load are set to true"
-        ActiveSupport::Deprecation.warn(message, caller)
+        ActiveSupport::Deprecation.warn message
         @cache_classes = true
         @eager_load = true
         self
@@ -142,8 +142,7 @@ module Rails
       end
 
       def whiny_nils=(*)
-        ActiveSupport::Deprecation.warn "config.whiny_nils option " \
-          "is deprecated and no longer works", caller
+        ActiveSupport::Deprecation.warn "config.whiny_nils option is deprecated and no longer works"
       end
     end
   end


### PR DESCRIPTION
It's unnecessary to send caller from all places where used ActiveSupport::Deprecation.warn, because we can only call `caller(2)` from `warn` method and get the same callstack
