### PR TITLE
shebang line and exec attr has been removed from new app Rakefile templa...

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Rakefile
+++ b/railties/lib/rails/generators/rails/app/templates/Rakefile
@@ -1,4 +1,3 @@
-#!/usr/bin/env rake
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 


### PR DESCRIPTION
...te

Rakefile is a config. There is no reason to run this file directly.
