### PR TITLE
Gem const presence checking has been removed

### DIFF
--- a/railties/lib/rails/backtrace_cleaner.rb
+++ b/railties/lib/rails/backtrace_cleaner.rb
@@ -17,8 +17,6 @@ module Rails
 
     private
       def add_gem_filters
-        return unless defined?(Gem)
-
         gems_paths = (Gem.path | [Gem.default_dir]).map { |p| Regexp.escape(p) }
         return if gems_paths.empty?
 

--- a/railties/test/backtrace_cleaner_test.rb
+++ b/railties/test/backtrace_cleaner_test.rb
@@ -1,26 +1,24 @@
 require 'abstract_unit'
 require 'rails/backtrace_cleaner'
 
-if defined? Gem
-  class BacktraceCleanerVendorGemTest < ActiveSupport::TestCase
-    def setup
-      @cleaner = Rails::BacktraceCleaner.new
-    end
+class BacktraceCleanerVendorGemTest < ActiveSupport::TestCase
+  def setup
+    @cleaner = Rails::BacktraceCleaner.new
+  end
 
-    test "should format installed gems correctly" do
-      @backtrace = [ "#{Gem.path[0]}/gems/nosuchgem-1.2.3/lib/foo.rb" ]
+  test "should format installed gems correctly" do
+    @backtrace = [ "#{Gem.path[0]}/gems/nosuchgem-1.2.3/lib/foo.rb" ]
+    @result = @cleaner.clean(@backtrace, :all)
+    assert_equal "nosuchgem (1.2.3) lib/foo.rb", @result[0]
+  end
+
+  test "should format installed gems not in Gem.default_dir correctly" do
+    @target_dir = Gem.path.detect { |p| p != Gem.default_dir }
+    # skip this test if default_dir is the only directory on Gem.path
+    if @target_dir
+      @backtrace = [ "#{@target_dir}/gems/nosuchgem-1.2.3/lib/foo.rb" ]
       @result = @cleaner.clean(@backtrace, :all)
       assert_equal "nosuchgem (1.2.3) lib/foo.rb", @result[0]
-    end
-
-    test "should format installed gems not in Gem.default_dir correctly" do
-      @target_dir = Gem.path.detect { |p| p != Gem.default_dir }
-      # skip this test if default_dir is the only directory on Gem.path
-      if @target_dir
-        @backtrace = [ "#{@target_dir}/gems/nosuchgem-1.2.3/lib/foo.rb" ]
-        @result = @cleaner.clean(@backtrace, :all)
-        assert_equal "nosuchgem (1.2.3) lib/foo.rb", @result[0]
-      end
     end
   end
 end


### PR DESCRIPTION
Rails boot.rb permanently depends from rubygems.
https://github.com/rails/rails/blob/master/railties/lib/rails/generators/rails/app/templates/config/boot.rb#L1

Checking Gem const presence doe's not make sense.
