### PR TITLE
Enable ActionDispatch::Http::Headers to support fetch

### DIFF
--- a/actionpack/lib/action_dispatch/http/headers.rb
+++ b/actionpack/lib/action_dispatch/http/headers.rb
@@ -14,17 +14,18 @@ module ActionDispatch
       end
 
       def [](header_name)
-        if include?(header_name)
-          super
-        else
-          super(env_name(header_name))
-        end
+        super env_name(header_name)
+      end
+
+      def fetch(header_name, default=nil, &block)
+        super env_name(header_name), default, &block
       end
 
       private
-        # Converts a HTTP header name to an environment variable name.
+        # Converts a HTTP header name to an environment variable name if it is
+        # not contained within the headers hash.
         def env_name(header_name)
-          @@env_cache[header_name]
+          include?(header_name) ? header_name : @@env_cache[header_name]
         end
     end
   end

--- a/actionpack/test/dispatch/header_test.rb
+++ b/actionpack/test/dispatch/header_test.rb
@@ -13,4 +13,9 @@ class HeaderTest < ActiveSupport::TestCase
     assert_equal "text/plain", @headers["CONTENT_TYPE"]
     assert_equal "text/plain", @headers["HTTP_CONTENT_TYPE"]
   end
+
+  test "fetch" do
+    assert_equal "text/plain", @headers.fetch("content-type", nil)
+    assert_equal "not found", @headers.fetch('not-found', 'not found')
+  end
 end


### PR DESCRIPTION
ActionDispatch::Http::Headers should support the common Ruby idiom of using #fetch to return the value or a default.
