### PR TITLE
To address sequence name differences at test_clear_cash_when_setting_table_name

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1516,8 +1516,13 @@ class BasicsTest < ActiveRecord::TestCase
     assert_not_equal before_columns, after_columns
     unless before_seq.nil? && after_seq.nil?
       assert_not_equal before_seq, after_seq
-      assert_equal "cold_jokes_id_seq", before_seq
-      assert_equal "funny_jokes_id_seq", after_seq
+      if current_adapter?(:OracleAdapter)
+        assert_equal "cold_jokes_seq", before_seq
+        assert_equal "funny_jokes_seq", after_seq
+      else
+        assert_equal "cold_jokes_id_seq", before_seq
+        assert_equal "funny_jokes_id_seq", after_seq
+      end
     end
   end
 


### PR DESCRIPTION
This pull request addresses a failure at test_clear_cash_when_setting_table_name with Oracle.

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/base_test.rb  -n test_clear_cash_when_setting_table_name
Using oracle
Run options: -n test_clear_cash_when_setting_table_name --seed 1556

# Running tests:

F

Finished tests in 5.911268s, 0.1692 tests/s, 0.5075 assertions/s.

  1) Failure:
test_clear_cash_when_setting_table_name(BasicsTest) [test/cases/base_test.rb:1519]:
Expected: "cold_jokes_id_seq"
  Actual: "cold_jokes_seq"

1 tests, 3 assertions, 1 failures, 0 errors, 0 skips
```

This pull request has been tested with sqlite3,postgresql, mysql and mysql2 adapters.
