### PR TITLE
Address failures by setting default_timezone explicitly.

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -764,6 +764,8 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_multiparameter_attributes_on_time_will_ignore_hour_if_missing
+    original_timezone = Topic.default_timezone
+    Topic.default_timezone = :local
     attributes = {
       "written_on(1i)" => "2004", "written_on(2i)" => "12", "written_on(3i)" => "12",
       "written_on(5i)" => "12", "written_on(6i)" => "02"
@@ -771,6 +773,8 @@ class BasicsTest < ActiveRecord::TestCase
     topic = Topic.find(1)
     topic.attributes = attributes
     assert_equal Time.local(2004, 12, 12, 0, 12, 2), topic.written_on
+  ensure
+    Topic.default_timezone = original_timezone
   end
 
   def test_multiparameter_attributes_on_time_will_ignore_hour_if_blank
@@ -891,6 +895,8 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_multiparameter_attributes_on_time_with_empty_seconds
+    original_timezone = Topic.default_timezone
+    Topic.default_timezone = :local
     attributes = {
       "written_on(1i)" => "2004", "written_on(2i)" => "6", "written_on(3i)" => "24",
       "written_on(4i)" => "16", "written_on(5i)" => "24", "written_on(6i)" => ""
@@ -898,6 +904,8 @@ class BasicsTest < ActiveRecord::TestCase
     topic = Topic.find(1)
     topic.attributes = attributes
     assert_equal Time.local(2004, 6, 24, 16, 24, 0), topic.written_on
+  ensure
+    Topic.default_timezone = original_timezone
   end
 
   def test_multiparameter_assignment_of_aggregation


### PR DESCRIPTION
test_multiparameter_attributes_on_time_will_ignore_hour_if_missing and test_multiparameter_attributes_on_time_with_empty_seconds tests in BasicTest always got a Failure
when executed separably with -n option with sqlite3, mysql, mysql2 and postgresql adapters.
It always successfully finished when 'rake test' 

It looks when each test executed default_timezone is :utc, however all of unit test executed 
it is set to :local.

``` ruby
$ for i in sqlite3 postgresql mysql mysql2
> do
> ARCONN=$i ruby -Itest test/cases/base_test.rb  -n test_multiparameter_attributes_on_time_will_ignore_hour_if_missing
> ARCONN=$i ruby -Itest test/cases/base_test.rb  -n test_multiparameter_attributes_on_time_with_empty_seconds
> done
Using sqlite3
Run options: -n test_multiparameter_attributes_on_time_will_ignore_hour_if_missing --seed 17766

# Running tests:

F

Finished tests in 0.189333s, 5.2817 tests/s, 5.2817 assertions/s.

  1) Failure:
test_multiparameter_attributes_on_time_will_ignore_hour_if_missing(BasicsTest) [test/cases/base_test.rb:773]:
Expected: 2004-12-12 00:12:02 +0900
  Actual: 2004-12-12 00:12:02 UTC

1 tests, 1 assertions, 1 failures, 0 errors, 0 skips
Using sqlite3
Run options: -n test_multiparameter_attributes_on_time_with_empty_seconds --seed 16678

# Running tests:

F

Finished tests in 0.189986s, 5.2636 tests/s, 5.2636 assertions/s.

  1) Failure:
test_multiparameter_attributes_on_time_with_empty_seconds(BasicsTest) [test/cases/base_test.rb:900]:
Expected: 2004-06-24 16:24:00 +0900
  Actual: 2004-06-24 16:24:00 UTC

1 tests, 1 assertions, 1 failures, 0 errors, 0 skips
Using postgresql
Run options: -n test_multiparameter_attributes_on_time_will_ignore_hour_if_missing --seed 33097

# Running tests:

F

Finished tests in 0.382025s, 2.6176 tests/s, 2.6176 assertions/s.

  1) Failure:
test_multiparameter_attributes_on_time_will_ignore_hour_if_missing(BasicsTest) [test/cases/base_test.rb:773]:
Expected: 2004-12-12 00:12:02 +0900
  Actual: 2004-12-12 00:12:02 UTC

1 tests, 1 assertions, 1 failures, 0 errors, 0 skips
Using postgresql
Run options: -n test_multiparameter_attributes_on_time_with_empty_seconds --seed 9872

# Running tests:

F

Finished tests in 0.366155s, 2.7311 tests/s, 2.7311 assertions/s.

  1) Failure:
test_multiparameter_attributes_on_time_with_empty_seconds(BasicsTest) [test/cases/base_test.rb:900]:
Expected: 2004-06-24 16:24:00 +0900
  Actual: 2004-06-24 16:24:00 UTC

1 tests, 1 assertions, 1 failures, 0 errors, 0 skips
Using mysql
Run options: -n test_multiparameter_attributes_on_time_will_ignore_hour_if_missing --seed 1384

# Running tests:

F

Finished tests in 0.301228s, 3.3197 tests/s, 3.3197 assertions/s.

  1) Failure:
test_multiparameter_attributes_on_time_will_ignore_hour_if_missing(BasicsTest) [test/cases/base_test.rb:773]:
Expected: 2004-12-12 00:12:02 +0900
  Actual: 2004-12-12 00:12:02 UTC

1 tests, 1 assertions, 1 failures, 0 errors, 0 skips
Using mysql
Run options: -n test_multiparameter_attributes_on_time_with_empty_seconds --seed 34149

# Running tests:

F

Finished tests in 0.274967s, 3.6368 tests/s, 3.6368 assertions/s.

  1) Failure:
test_multiparameter_attributes_on_time_with_empty_seconds(BasicsTest) [test/cases/base_test.rb:900]:
Expected: 2004-06-24 16:24:00 +0900
  Actual: 2004-06-24 16:24:00 UTC

1 tests, 1 assertions, 1 failures, 0 errors, 0 skips
Using mysql2
Run options: -n test_multiparameter_attributes_on_time_will_ignore_hour_if_missing --seed 21813

# Running tests:

F

Finished tests in 0.371418s, 2.6924 tests/s, 2.6924 assertions/s.

  1) Failure:
test_multiparameter_attributes_on_time_will_ignore_hour_if_missing(BasicsTest) [test/cases/base_test.rb:773]:
Expected: 2004-12-12 00:12:02 +0900
  Actual: 2004-12-12 00:12:02 UTC

1 tests, 1 assertions, 1 failures, 0 errors, 0 skips
Using mysql2
Run options: -n test_multiparameter_attributes_on_time_with_empty_seconds --seed 12874

# Running tests:

F

Finished tests in 0.328632s, 3.0429 tests/s, 3.0429 assertions/s.

  1) Failure:
test_multiparameter_attributes_on_time_with_empty_seconds(BasicsTest) [test/cases/base_test.rb:900]:
Expected: 2004-06-24 16:24:00 +0900
  Actual: 2004-06-24 16:24:00 UTC

1 tests, 1 assertions, 1 failures, 0 errors, 0 skips
$
```
