### PR TITLE
Give descriptive error message when :id missing

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -18,7 +18,7 @@ module ActionDispatch
         if response[1]['X-Cascade'] == 'pass'
           body = response[2]
           body.close if body.respond_to?(:close)
-          raise ActionController::RoutingError, "No route matches [#{env['REQUEST_METHOD']}] #{env['PATH_INFO'].inspect}"
+          raise ActionController::RoutingError, "No route matches [#{env['REQUEST_METHOD']}] #{env['PATH_INFO'].inspect} blah"
         end
       rescue Exception => exception
         raise exception if env['action_dispatch.show_exceptions'] == false

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -575,7 +575,7 @@ module ActionDispatch
         end
 
         def raise_routing_error
-          raise ActionController::RoutingError, "No route matches #{options.inspect}"
+          raise ActionController::RoutingError, "No route matches #{options.inspect} blah2"
         end
 
         def different_controller?
@@ -682,7 +682,7 @@ module ActionDispatch
           end
         end
 
-        raise ActionController::RoutingError, "No route matches #{path.inspect}"
+        raise ActionController::RoutingError, "No route matches #{path.inspect} blah3"
       end
 
       private

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -574,8 +574,17 @@ module ActionDispatch
           raise_routing_error
         end
 
+        def descriptive_routing_error
+          error = "No route matches #{options.inspect}"
+          case options[:action]
+          when "show", "edit", "update", "destroy"
+            error << ", :id key is missing" if options.key?(:id).blank?
+          end
+          error
+        end
+
         def raise_routing_error
-          raise ActionController::RoutingError, "No route matches #{options.inspect} blah2"
+          raise ActionController::RoutingError, descriptive_routing_error
         end
 
         def different_controller?

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -76,7 +76,8 @@ module ActiveSupport
     #
     def run_callbacks(kind, key = nil, &block)
       #TODO: deprecate key argument
-      self.class.__run_callbacks(kind, self, &block)
+      runner_name = self.class.__define_callbacks(kind, self)
+      send(runner_name, &block)
     end
 
     private
@@ -323,18 +324,17 @@ module ActiveSupport
         method << callbacks
 
         method << "halted ? false : (block_given? ? value : true)"
-        method.flatten.compact.join("\n")
+        method.join("\n")
       end
 
     end
 
     module ClassMethods
 
-      # This method runs callback chain for the given kind.
-      # If this called first time it creates a new callback method for the kind.
+      # This method defines callback chain method for the given kind
+      # if it was not yet defined.
       # This generated method plays caching role.
-      #
-      def __run_callbacks(kind, object, &blk) #:nodoc:
+      def __define_callbacks(kind, object) #:nodoc:
         name = __callback_runner_name(kind)
         unless object.respond_to?(name, true)
           str = object.send("_#{kind}_callbacks").compile
@@ -343,7 +343,7 @@ module ActiveSupport
             protected :#{name}
           RUBY_EVAL
         end
-        object.send(name, &blk)
+        name
       end
 
       def __reset_runner(symbol)

--- a/railties/test/application/middleware/exceptions_test.rb
+++ b/railties/test/application/middleware/exceptions_test.rb
@@ -83,7 +83,7 @@ module ApplicationTests
 
       assert_nothing_raised(ActionController::RoutingError) do
         get '/foo'
-        assert_match "No route matches", last_response.body
+        assert_match "No route matches blah4", last_response.body
       end
     end
 


### PR DESCRIPTION
When using proper restful routes an :id parameter is expected on the show, edit, update and delete. If omitted in the view layer an error will be thrown. So a link to the s

```
<%= link_to 'user', user_path %>
```

This will produce an error like this:

```
No route matches {:action=>"show", :controller=>"users"}
```

Since we know that the :id is missing, and this route likely needs it we can add extra debugging information to the error message.

```
No route matches {:action=>"show", :controller=>"users"}, :id key is missing
```

This will help new and seasoned developers look closer at their :id parameter in their view helpers. While not all errors will be a result of a missing :id key, this error message implies the most likely cause without declaring it the culprit.

Before PR: http://cl.ly/121J0o3x2F2m2s3j0F3q
After PR: http://cl.ly/2t0A082x2L3k3e2M2Q0U
After PR (other params): http://cl.ly/3N1w0N161b213n0x2c0U
