### PR TITLE
Give descriptive error message when :id missing

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -552,8 +552,17 @@ module ActionDispatch
           raise_routing_error
         end
 
+        def descriptive_routing_error
+          error = "No route matches #{options.inspect}"
+          case options[:action]
+          when "show", "edit", "update", "destroy"
+            error << ", :id key is missing" if options.key?(:id).blank?
+          end
+          error
+        end
+
         def raise_routing_error
-          raise ActionController::RoutingError, "No route matches #{options.inspect}"
+          raise ActionController::RoutingError, descriptive_routing_error
         end
 
         def different_controller?


### PR DESCRIPTION
When using proper restful routes an :id parameter is expected on the show, edit, update and delete. If omitted in the view layer an error will be thrown. So a link to the show action like this:

```
<%= link_to 'user', user_path %>
```

This will produce an error like this:

```
No route matches {:action=>"show", :controller=>"users"}
```

Since we know that the :id is missing, and this route likely needs it we can add extra debugging information to the error message.

```
No route matches {:action=>"show", :controller=>"users"}, :id key is missing
```

This will help new and seasoned developers look closer at their :id parameter in their view helpers. While not all errors will be a result of a missing :id key, this error message implies the most likely cause without declaring it the culprit.

Before PR: http://cl.ly/121J0o3x2F2m2s3j0F3q
After PR: http://cl.ly/2t0A082x2L3k3e2M2Q0U
After PR (other params): http://cl.ly/3N1w0N161b213n0x2c0U
