### PR TITLE
Add backtrace to development routing error page

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/routing_error.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/routing_error.erb
@@ -13,3 +13,5 @@
 <p>
   Try running <code>rake routes</code> for more information on available routes.
 </p>
+
+<%= render :template => "rescues/_trace" %>


### PR DESCRIPTION
If a user gets a routing error due to a view helper such as using user_path without an :id they must go to their logs to see the backtrace. By adding in the trace template, a user can see which line the error occurred on without leaving the browser.

When a routing error occurs outside of the view the application trace will be blank and will not confuse developers.

Before PR: http://cl.ly/3x332b0V2d0E0Q1G0C1t
After PR: http://cl.ly/2O431D0A1u2Q2p130A3t
