### PR TITLE
Allows assert_redirected_to to accept a regular expression

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Allows `assert_redirected_to` to match against a regular expression. *Andy Lindeman*
+
 *   Add backtrace to development routing error page. *Richard Schneeman*
 
 *   Replace `include_seconds` boolean argument with `:include_seconds => true` option

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -179,6 +179,9 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
         assert_redirected_to 'http://test.host/route_two'
       end
       assert_raise(ActiveSupport::TestCase::Assertion) do
+        assert_redirected_to %r(^http://test.host/route_two)
+      end
+      assert_raise(ActiveSupport::TestCase::Assertion) do
         assert_redirected_to :controller => 'action_pack_assertions', :action => 'nothing', :id => 'two'
       end
       assert_raise(ActiveSupport::TestCase::Assertion) do
@@ -212,6 +215,7 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
       process :redirect_to_top_level_named_route
       # assert_redirected_to "http://test.host/action_pack_assertions/foo" would pass because of exact match early return
       assert_redirected_to "/action_pack_assertions/foo"
+      assert_redirected_to %r(/action_pack_assertions/foo)
     end
   end
 


### PR DESCRIPTION
I have a few places where I really only care to assert that the URL matches a regular expression.

This patch allows it while keeping the semantics the same when a `String` or `Hash` is passed to `assert_redirected_to`
