### PR TITLE
Bring SqlByPassTest to light and fix broken tests

### DIFF
--- a/activerecord/lib/active_record/session_store.rb
+++ b/activerecord/lib/active_record/session_store.rb
@@ -201,10 +201,10 @@ module ActiveRecord
 
       class << self
         alias :data_column_name :data_column
-        
+
         # Use the ActiveRecord::Base.connection by default.
         attr_writer :connection
-        
+
         # Use the ActiveRecord::Base.connection_pool by default.
         attr_writer :connection_pool
 
@@ -218,12 +218,12 @@ module ActiveRecord
 
         # Look up a session by id and unmarshal its data if found.
         def find_by_session_id(session_id)
-          if record = connection.select_one("SELECT * FROM #{@@table_name} WHERE #{@@session_id_column}=#{connection.quote(session_id)}")
+          if record = connection.select_one("SELECT * FROM #{@@table_name} WHERE #{@@session_id_column}=#{connection.quote(session_id.to_s)}")
             new(:session_id => session_id, :marshaled_data => record['data'])
           end
         end
       end
-      
+
       delegate :connection, :connection=, :connection_pool, :connection_pool=, :to => self
 
       attr_reader :session_id, :new_record
@@ -239,6 +239,11 @@ module ActiveRecord
         @data           = attributes[:data]
         @marshaled_data = attributes[:marshaled_data]
         @new_record     = @marshaled_data.nil?
+      end
+
+      # Returns true if the record is persisted, i.e. it's not a new record
+      def persisted?
+        !@new_record
       end
 
       # Lazy-unmarshal session state.
@@ -287,7 +292,7 @@ module ActiveRecord
         connect = connection
         connect.delete <<-end_sql, 'Destroy session'
           DELETE FROM #{table_name}
-          WHERE #{connect.quote_column_name(session_id_column)}=#{connect.quote(session_id)}
+          WHERE #{connect.quote_column_name(session_id_column)}=#{connect.quote(session_id.to_s)}
         end_sql
       end
     end

--- a/activerecord/test/cases/session_store/sql_bypass_test.rb
+++ b/activerecord/test/cases/session_store/sql_bypass_test.rb
@@ -18,6 +18,11 @@ module ActiveRecord
         assert !Session.table_exists?
       end
 
+      def test_new_record?
+        s = SqlBypass.new :data => 'foo', :session_id => 10
+        assert s.new_record?, 'this is a new record!'
+      end
+
       def test_persisted?
         s = SqlBypass.new :data => 'foo', :session_id => 10
         assert !s.persisted?, 'this is a new record!'


### PR DESCRIPTION
Test file `activerecord/test/cases/session_store/sql_bypass.rb` wasn't sufixed by `_test.rb` and so wasn't caught by the test suite.

Also, `SqlBypass` implemented a `new_record?` interface while the tests where expecting it to offer `persisted?`. Since this was part of a [commit](https://github.com/rails/rails/commit/f1c13b0dd7b22b5f6289ca1a09f1d7a8c7c8584b) that was then [reverted](https://github.com/rails/rails/commit/75015d1b5cae80826ef41add3c84d1dd51fee259) I wasn't sure which one was preferred. I went with `persisted?`.

And last but not least, forced session_id to be passed as a string to the sql queries since postgresql was complaining about type mismatch (string column vs integer value on where clause).

Cheers
