### PR TITLE
Minor ActionMailer tweaks

### DIFF
--- a/actionmailer/lib/action_mailer/delivery_methods.rb
+++ b/actionmailer/lib/action_mailer/delivery_methods.rb
@@ -65,7 +65,7 @@ module ActionMailer
         when NilClass
           raise "Delivery method cannot be nil"
         when Symbol
-          if klass = delivery_methods[method.to_sym]
+          if klass = delivery_methods[method]
             mail.delivery_method(klass, send(:"#{method}_settings"))
           else
             raise "Invalid delivery method #{method.inspect}"

--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -1,16 +1,4 @@
-# Pathname has a warning, so require it first while silencing
-# warnings to shut it up.
-#
-# Also, in 1.9, Bundler creates warnings due to overriding
-# Rubygems methods
-begin
-  old, $VERBOSE = $VERBOSE, nil
-  require 'pathname'
-  require File.expand_path('../../../load_paths', __FILE__)
-ensure
-  $VERBOSE = old
-end
-
+require File.expand_path('../../../load_paths', __FILE__)
 require 'active_support/core_ext/kernel/reporting'
 
 # These are the normal settings that will be set up by Railties


### PR DESCRIPTION
Removing 1.8 targeted code. Despite the 1.9/bundler note I see no warnings.

Removing unnecessary call to `to_sym`.

Cheers!

/cc @josevalim @mikel
