### PR TITLE
refactored extracting :size => 'XxY' into an extract_size! method

### DIFF
--- a/actionpack/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helper.rb
@@ -393,9 +393,7 @@ module ActionView
           options[:alt] = options.fetch(:alt){ image_alt(src) }
         end
 
-        if size = options.delete(:size)
-          options[:width], options[:height] = size.split("x") if size =~ %r{^\d+x\d+$}
-        end
+        extract_size!(options, :width, :height)
 
         if mouseover = options.delete(:mouseover)
           options[:onmouseover] = "this.src='#{path_to_image(mouseover)}'"
@@ -448,9 +446,7 @@ module ActionView
         multiple_sources_tag('video', sources) do |options|
           options[:poster] = path_to_image(options[:poster]) if options[:poster]
 
-          if size = options.delete(:size)
-            options[:width], options[:height] = size.split("x") if size =~ %r{^\d+x\d+$}
-          end
+          extract_size!(options, :width, :height)
         end
       end
 

--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -317,9 +317,7 @@ module ActionView
       def text_area_tag(name, content = nil, options = {})
         options = options.stringify_keys
 
-        if size = options.delete("size")
-          options["cols"], options["rows"] = size.split("x") if size.respond_to?(:split)
-        end
+        extract_size!(options, 'cols', 'rows')
 
         escape = options.delete("escape") { true }
         content = ERB::Util.html_escape(content) if escape

--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -137,6 +137,12 @@ module ActionView
           "<#{name}#{tag_options}>#{PRE_CONTENT_STRINGS[name.to_sym]}#{content}</#{name}>".html_safe
         end
 
+        def extract_size!(options, x_attribute, y_attribute)
+          if size = options.delete(:size)
+            options[x_attribute], options[y_attribute] = size.split("x") if size =~ %r{^\d+x\d+$}
+          end
+        end
+
         def tag_options(options, escape = true)
           return if options.blank?
           attrs = []

--- a/actionpack/lib/action_view/helpers/tags/text_area.rb
+++ b/actionpack/lib/action_view/helpers/tags/text_area.rb
@@ -6,9 +6,7 @@ module ActionView
           options = @options.stringify_keys
           add_default_name_and_id(options)
 
-          if size = options.delete("size")
-            options["cols"], options["rows"] = size.split("x") if size.respond_to?(:split)
-          end
+          extract_size!(options, 'cols', 'rows')
 
           content_tag("textarea", options.delete('value') || value_before_type_cast(object), options)
         end


### PR DESCRIPTION
There were several places where parsing the :size option took 3 lines:

``` ruby
if size = options.delete(:size)
  options[:width], options[:height] = size.split("x") if size =~ %r{^\d+x\d+$}
end
```

I refactored it so now you do this:

``` ruby
extract_size!(options, :width, :height)
# OR
extract_size!(options, :cols, :rows)
```
