### PR TITLE
RouteSet: optimize routes generation when globbing is used

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -202,7 +202,7 @@ module ActionDispatch
 
           # Clause check about when we need to generate an optimized helper.
           def optimize_helper?(route) #:nodoc:
-            route.ast.grep(Journey::Nodes::Star).empty? && route.requirements.except(:controller, :action).empty?
+            route.requirements.except(:controller, :action).empty?
           end
 
           # Generates the interpolation to be used in the optimized helper.
@@ -214,7 +214,10 @@ module ActionDispatch
             end
 
             route.required_parts.each_with_index do |part, i|
-              string_route.gsub!(part.inspect, "\#{Journey::Router::Utils.escape_fragment(args[#{i}].to_param)}")
+              # Replace each route parameter
+              # e.g. :id for regular parameter or *path for globbing
+              # with ruby string interpolation code
+              string_route.gsub!(/(\*|:)#{part}/, "\#{Journey::Router::Utils.escape_fragment(args[#{i}].to_param)}")
             end
 
             string_route


### PR DESCRIPTION
One small step to get rid of conditional optimization in routes.
Now routes are optimized even when globbing is used.

See performance difference for: `URL generation with globbing`
https://gist.github.com/f42886c14e3661623c65

```

Running benchmark with current working tree
PROFILE: interrupts/evictions/bytes = 7/0/1136
Checkout HEAD^
Running benchmark with HEAD^
PROFILE: interrupts/evictions/bytes = 8/0/1168
Checkout to previous HEAD again

                    user     system      total        real
------------------------------------------------draw routes
After patch:    0.300000   0.000000   0.300000 (  0.303803)
Before patch:   0.300000   0.010000   0.310000 (  0.312239)

--------------------------------------simple URL generation
After patch:    0.010000   0.000000   0.010000 (  0.006227)
Before patch:   0.010000   0.000000   0.010000 (  0.006297)

-------------------------URL generation with params as hash
After patch:    0.070000   0.000000   0.070000 (  0.074639)
Before patch:   0.070000   0.010000   0.080000 (  0.075167)

-----------------URL generation with handle_positional_args
After patch:    0.080000   0.000000   0.080000 (  0.082639)
Before patch:   0.080000   0.000000   0.080000 (  0.083506)

-------------------------------URL generation with globbing
After patch:    0.010000   0.000000   0.010000 (  0.007267)
Before patch:   0.070000   0.010000   0.080000 (  0.078637)

-------------------------------------handle_positional_args
After patch:    0.000000   0.010000   0.010000 (  0.003361)
Before patch:   0.000000   0.010000   0.010000 (  0.003353)
```
