### PR TITLE
Make ActionController#head pass rack-link

### DIFF
--- a/actionpack/lib/action_controller/metal/head.rb
+++ b/actionpack/lib/action_controller/metal/head.rb
@@ -27,8 +27,27 @@ module ActionController
 
       self.status = status
       self.location = url_for(location) if location
-      self.content_type = Mime[formats.first] if formats
+
+      if include_content_type?(self.status)
+        self.content_type = Mime[formats.first] if formats
+      else
+        headers.delete('Content-Type')
+      end
+
       self.response_body = " "
+    end
+
+    private
+    # :nodoc:
+    def include_content_type?(status)
+      case status
+      when 100..199
+        false
+      when 204, 205, 304
+        false
+      else
+        true
+      end
     end
   end
 end

--- a/actionpack/lib/action_controller/metal/head.rb
+++ b/actionpack/lib/action_controller/metal/head.rb
@@ -28,10 +28,11 @@ module ActionController
       self.status = status
       self.location = url_for(location) if location
 
-      if include_content_type?(self.status)
+      if include_content_headers?(self.status)
         self.content_type = Mime[formats.first] if formats
       else
         headers.delete('Content-Type')
+        headers.delete('Content-Length')
       end
 
       self.response_body = " "
@@ -39,7 +40,7 @@ module ActionController
 
     private
     # :nodoc:
-    def include_content_type?(status)
+    def include_content_headers?(status)
       case status
       when 100..199
         false

--- a/actionpack/test/controller/new_base/bare_metal_test.rb
+++ b/actionpack/test/controller/new_base/bare_metal_test.rb
@@ -78,31 +78,37 @@ module BareMetalTest
     test "head :continue (100) does not return a content-type header" do
       headers = HeadController.action(:continue).call(Rack::MockRequest.env_for("/")).second
       assert_nil headers['Content-Type']
+      assert_nil headers['Content-Length']
     end
 
     test "head :continue (101) does not return a content-type header" do
       headers = HeadController.action(:continue).call(Rack::MockRequest.env_for("/")).second
       assert_nil headers['Content-Type']
+      assert_nil headers['Content-Length']
     end
 
     test "head :processing (102) does not return a content-type header" do
       headers = HeadController.action(:processing).call(Rack::MockRequest.env_for("/")).second
       assert_nil headers['Content-Type']
+      assert_nil headers['Content-Length']
     end
 
     test "head :no_content (204) does not return a content-type header" do
       headers = HeadController.action(:no_content).call(Rack::MockRequest.env_for("/")).second
       assert_nil headers['Content-Type']
+      assert_nil headers['Content-Length']
     end
 
     test "head :reset_content (205) does not return a content-type header" do
       headers = HeadController.action(:reset_content).call(Rack::MockRequest.env_for("/")).second
       assert_nil headers['Content-Type']
+      assert_nil headers['Content-Length']
     end
 
     test "head :not_modified (304) does not return a content-type header" do
       headers = HeadController.action(:not_modified).call(Rack::MockRequest.env_for("/")).second
       assert_nil headers['Content-Type']
+      assert_nil headers['Content-Length']
     end
   end
 

--- a/actionpack/test/controller/new_base/bare_metal_test.rb
+++ b/actionpack/test/controller/new_base/bare_metal_test.rb
@@ -37,12 +37,72 @@ module BareMetalTest
     def index
       head :not_found
     end
+
+    def continue
+      self.content_type = "text/html"
+      head 100
+    end
+
+    def switching_protocols
+      self.content_type = "text/html"
+      head 101
+    end
+
+    def processing
+      self.content_type = "text/html"
+      head 102
+    end
+
+    def no_content
+      self.content_type = "text/html"
+      head 204
+    end
+
+    def reset_content
+      self.content_type = "text/html"
+      head 205
+    end
+
+    def not_modified
+      self.content_type = "text/html"
+      head 304
+    end
   end
 
   class HeadTest < ActiveSupport::TestCase
     test "head works on its own" do
       status = HeadController.action(:index).call(Rack::MockRequest.env_for("/")).first
       assert_equal 404, status
+    end
+
+    test "head :continue (100) does not return a content-type header" do
+      headers = HeadController.action(:continue).call(Rack::MockRequest.env_for("/")).second
+      assert_nil headers['Content-Type']
+    end
+
+    test "head :continue (101) does not return a content-type header" do
+      headers = HeadController.action(:continue).call(Rack::MockRequest.env_for("/")).second
+      assert_nil headers['Content-Type']
+    end
+
+    test "head :processing (102) does not return a content-type header" do
+      headers = HeadController.action(:processing).call(Rack::MockRequest.env_for("/")).second
+      assert_nil headers['Content-Type']
+    end
+
+    test "head :no_content (204) does not return a content-type header" do
+      headers = HeadController.action(:no_content).call(Rack::MockRequest.env_for("/")).second
+      assert_nil headers['Content-Type']
+    end
+
+    test "head :reset_content (205) does not return a content-type header" do
+      headers = HeadController.action(:reset_content).call(Rack::MockRequest.env_for("/")).second
+      assert_nil headers['Content-Type']
+    end
+
+    test "head :not_modified (304) does not return a content-type header" do
+      headers = HeadController.action(:not_modified).call(Rack::MockRequest.env_for("/")).second
+      assert_nil headers['Content-Type']
     end
   end
 


### PR DESCRIPTION
This commit makes head responses pass rack-lint. I came across this bug while implementing HTTP caching in our application. According to rack-lint the content-type header must not be present for 1xx, 204, 205, and 304. I was getting weird 500s in our app because responses were blowing up in rack-lint. This commit fixes that. All the other tests pass.
