### PR TITLE
Make sure that javascript_include_tag/stylesheet_link_tag methods don't consider duplicated assets

### DIFF
--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -31,7 +31,7 @@ module Sprockets
           else
             super(source.to_s, { :src => path_to_asset(source, :ext => 'js', :body => body, :digest => digest) }.merge!(options))
           end
-        end.join("\n").html_safe
+        end.uniq.join("\n").html_safe
       end
 
       def stylesheet_link_tag(*sources)
@@ -48,7 +48,7 @@ module Sprockets
           else
             super(source.to_s, { :href => path_to_asset(source, :ext => 'css', :body => body, :protocol => :request, :digest => digest) }.merge!(options))
           end
-        end.join("\n").html_safe
+        end.uniq.join("\n").html_safe
       end
 
       def asset_path(source, options = {})

--- a/actionpack/test/template/sprockets_helper_test.rb
+++ b/actionpack/test/template/sprockets_helper_test.rb
@@ -254,6 +254,9 @@ class SprocketsHelperTest < ActionView::TestCase
     assert_match %r{<script src="/assets/jquery.plugin.js" type="text/javascript"></script>},
       javascript_include_tag('jquery.plugin', :digest => false)
 
+    assert_match %r{\A<script src="/assets/xmlhr-[0-9a-f]+.js" type="text/javascript"></script>\Z},
+      javascript_include_tag("xmlhr", "xmlhr")
+
     @config.assets.compile = true
     @config.assets.debug = true
     assert_match %r{<script src="/javascripts/application.js" type="text/javascript"></script>},
@@ -300,6 +303,9 @@ class SprocketsHelperTest < ActionView::TestCase
 
     assert_match %r{<link href="/assets/style-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />\n<link href="/assets/application-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />},
       stylesheet_link_tag(:application, :debug => true)
+
+    assert_match %r{\A<link href="/assets/style-[0-9a-f]+.css" media="screen" rel="stylesheet" type="text/css" />\Z},
+      stylesheet_link_tag("style", "style")
 
     @config.assets.compile = true
     @config.assets.debug = true


### PR DESCRIPTION
I would like to make sure these helper methods include only once every asset.

Different expansions could include the same asset, at least in one of the projects I'm working on, so those assets could be included more than once, so it would be great have this change for us :)

I'm doing this pull request for Rails 3.2 because we would like to have it in this version.

In order to have it also done in latest rails, it seems we need to do the change in rails_sprockets gem, it seems this code was moved to there in master.

Cheers,
Jorge
