### PR TITLE
Rails db console improvements

### DIFF
--- a/railties/lib/rails/commands/console.rb
+++ b/railties/lib/rails/commands/console.rb
@@ -22,7 +22,7 @@ module Rails
         options = {}
 
         OptionParser.new do |opt|
-          opt.banner = "Usage: console [environment] [options]"
+          opt.banner = "Usage: rails console [environment] [options]"
           opt.on('-s', '--sandbox', 'Rollback database modifications on exit.') { |v| options[:sandbox] = v }
           opt.on("-e", "--environment=name", String,
                   "Specifies the environment to run this console under (test/development/production).",

--- a/railties/lib/rails/commands/dbconsole.rb
+++ b/railties/lib/rails/commands/dbconsole.rb
@@ -42,7 +42,7 @@ module Rails
       include_password = false
       options = {}
       OptionParser.new do |opt|
-        opt.banner = "Usage: dbconsole [environment] [options]"
+        opt.banner = "Usage: rails dbconsole [environment] [options]"
         opt.on("-p", "--include-password", "Automatically provide the password from database.yml") do |v|
           include_password = true
         end
@@ -54,6 +54,11 @@ module Rails
 
         opt.on("--header") do |h|
           options['header'] = h
+        end
+
+        opt.on("-h", "--help", "Show this help message.") do
+          puts opt
+          exit
         end
 
         opt.parse!(arguments)

--- a/railties/lib/rails/commands/dbconsole.rb
+++ b/railties/lib/rails/commands/dbconsole.rb
@@ -96,7 +96,7 @@ module Rails
 
         args << "-#{options['mode']}" if options['mode']
         args << "-header" if options['header']
-        args << config['database']
+        args << File.expand_path(config['database'], Rails.root)
 
         find_cmd_and_exec('sqlite3', *args)
 

--- a/railties/lib/rails/commands/runner.rb
+++ b/railties/lib/rails/commands/runner.rb
@@ -9,7 +9,7 @@ if ARGV.first.nil?
 end
 
 ARGV.clone.options do |opts|
-  opts.banner = "Usage: runner [options] ('Some.ruby(code)' or a filename)"
+  opts.banner = "Usage: rails runner [options] ('Some.ruby(code)' or a filename)"
 
   opts.separator ""
 

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -92,20 +92,25 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
   end
 
   def test_sqlite3
-    dbconsole.expects(:find_cmd_and_exec).with('sqlite3', 'db')
-    start(adapter: 'sqlite3', database: 'db')
+    dbconsole.expects(:find_cmd_and_exec).with('sqlite3', Rails.root.join('db.sqlite3').to_s)
+    start(adapter: 'sqlite3', database: 'db.sqlite3')
     assert !aborted
   end
 
   def test_sqlite3_mode
-    dbconsole.expects(:find_cmd_and_exec).with('sqlite3', '-html', 'db')
-    start({adapter: 'sqlite3', database: 'db'}, ['--mode', 'html'])
+    dbconsole.expects(:find_cmd_and_exec).with('sqlite3', '-html', Rails.root.join('db.sqlite3').to_s)
+    start({adapter: 'sqlite3', database: 'db.sqlite3'}, ['--mode', 'html'])
     assert !aborted
   end
 
   def test_sqlite3_header
-    dbconsole.expects(:find_cmd_and_exec).with('sqlite3', '-header', 'db')
-    start({adapter: 'sqlite3', database: 'db'}, ['--header'])
+    dbconsole.expects(:find_cmd_and_exec).with('sqlite3', '-header', Rails.root.join('db.sqlite3').to_s)
+    start({adapter: 'sqlite3', database: 'db.sqlite3'}, ['--header'])
+  end
+
+  def test_sqlite3_db_absolute_path
+    dbconsole.expects(:find_cmd_and_exec).with('sqlite3', '/tmp/db.sqlite3')
+    start(adapter: 'sqlite3', database: '/tmp/db.sqlite3')
     assert !aborted
   end
 

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -132,6 +132,24 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
     assert_match /Unknown command-line client for db/, output
   end
 
+  def test_print_help_short
+    stdout = capture(:stdout) do
+      start({}, ['-h'])
+    end
+    assert aborted
+    assert_equal '', output
+    assert_match /Usage:.*dbconsole/, stdout
+  end
+
+  def test_print_help_long
+    stdout = capture(:stdout) do
+      start({}, ['--help'])
+    end
+    assert aborted
+    assert_equal '', output
+    assert_match /Usage:.*dbconsole/, stdout
+  end
+
   private
   attr_reader :aborted, :output
 


### PR DESCRIPTION
The code in [active_record/connection_adapters/sqlite3_adapter.rb](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb) is slightly dublicated by [rails/commands/dbconsole.rb#L76-83](https://github.com/rails/rails/blob/master/railties/lib/rails/commands/dbconsole.rb#L76-83).

I don't think it's very bad, but I suggest to improve db console a little more. In #6012 I covered db console with tests and we can now improve it a little.

The first commit - abort if we execute `rails db` on memory dtabase. The second - to use rails root expand path as here: [connection_adapters/sqlite3_adapter.rb#L21](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L21).

The first improvment I found only investigating code, but the second is from real life. I developed gem and executed dummy server `./spec/dummy/scripts/rails server`. It worked well. But  `./spec/dummy/scripts/rails db` failed with not resolved path to db file.
