### PR TITLE
(Stale) Beginning and end of hour support for Time and DateTime

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -91,6 +91,17 @@ class DateTime
     change(:hour => 23, :min => 59, :sec => 59)
   end
 
+  # Returns a new DateTime representing the start of the hour (hh:00:00)
+  def beginning_of_hour
+    change(:min => 0)
+  end
+  alias :at_beginning_of_hour :beginning_of_hour
+
+  # Returns a new DateTime representing the end of the hour (hh:59:59)
+  def end_of_hour
+    change(:min => 59, :sec => 59)
+  end
+
   # Adjusts DateTime to UTC by adding its offset value; offset is set to 0
   #
   # Example:

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -257,6 +257,21 @@ class Time
     )
   end
 
+  # Returns a new Time representing the start of the hour (x:00)
+  def beginning_of_hour
+    change(:min => 0)
+  end
+  alias :at_beginning_of_hour :beginning_of_hour
+
+  # Returns a new Time representing the end of the hour, x:59:59.999999 (.999999999 in ruby1.9)
+  def end_of_hour
+    change(
+      :min => 59,
+      :sec => 59,
+      :usec => 999999.999
+    )
+  end
+
   # Returns a new Time representing the start of the month (1st of the month, 0:00)
   def beginning_of_month
     #self - ((self.mday-1).days + self.seconds_since_midnight)

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -91,6 +91,14 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal DateTime.civil(2005,2,4,23,59,59), DateTime.civil(2005,2,4,10,10,10).end_of_day
   end
 
+  def test_beginning_of_hour
+    assert_equal DateTime.civil(2005,2,4,19,0,0), DateTime.civil(2005,2,4,19,30,10).beginning_of_hour
+  end
+
+  def test_end_of_hour
+    assert_equal DateTime.civil(2005,2,4,19,59,59), DateTime.civil(2005,2,4,19,30,10).end_of_hour
+  end
+
   def test_beginning_of_month
     assert_equal DateTime.civil(2005,2,1,0,0,0), DateTime.civil(2005,2,22,10,10,10).beginning_of_month
   end

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -93,6 +93,10 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_beginning_of_hour
+    assert_equal Time.local(2005,2,4,19,0,0), Time.local(2005,2,4,19,30,10).beginning_of_hour
+  end
+
   def test_beginning_of_month
     assert_equal Time.local(2005,2,1,0,0,0), Time.local(2005,2,22,10,10,10).beginning_of_month
   end
@@ -125,6 +129,10 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal Time.local(2007,9,2,23,59,59,999999.999), Time.local(2007,8,31,0,0,0).end_of_week #friday
     assert_equal Time.local(2007,9,2,23,59,59,999999.999), Time.local(2007,9,01,0,0,0).end_of_week #saturday
     assert_equal Time.local(2007,9,2,23,59,59,999999.999), Time.local(2007,9,02,0,0,0).end_of_week #sunday
+  end
+
+  def test_end_of_hour
+    assert_equal Time.local(2005,2,4,19,59,59,999999.999), Time.local(2005,2,4,19,30,10).end_of_hour
   end
 
   def test_end_of_month

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -512,6 +512,18 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     assert_equal "Fri, 31 Dec 1999 23:59:59 EST -05:00", @twz.end_of_day.inspect
   end
 
+  def beginning_of_hour
+    twz = ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.utc(2000, 1, 1, 0, 30))
+    assert_equal "Fri, 31 Dec 1999 19:30:00 EST -05:00", twz.inspect
+    assert_equal "Fri, 31 Dec 1999 19:00:00 EST -05:00", twz.beginning_of_hour.inspect
+  end
+
+  def end_of_hour
+    twz = ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.utc(2000, 1, 1, 0, 30))
+    assert_equal "Fri, 31 Dec 1999 19:30:00 EST -05:00", @twz.inspect
+    assert_equal "Fri, 31 Dec 1999 19:59:59 EST -05:00", @twz.end_of_hour.inspect
+  end
+
   def test_since
     assert_equal "Fri, 31 Dec 1999 19:00:01 EST -05:00", @twz.since(1).inspect
   end

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -520,8 +520,8 @@ class TimeWithZoneTest < ActiveSupport::TestCase
 
   def end_of_hour
     twz = ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.utc(2000, 1, 1, 0, 30))
-    assert_equal "Fri, 31 Dec 1999 19:30:00 EST -05:00", @twz.inspect
-    assert_equal "Fri, 31 Dec 1999 19:59:59 EST -05:00", @twz.end_of_hour.inspect
+    assert_equal "Fri, 31 Dec 1999 19:30:00 EST -05:00", twz.inspect
+    assert_equal "Fri, 31 Dec 1999 19:59:59 EST -05:00", twz.end_of_hour.inspect
   end
 
   def test_since


### PR DESCRIPTION
This feature was initially proposed in #598.

This pull request consists of implementations and test coverage fro #beginning_of_hour and #end_of_hour methods for Time and DateTime core extensions within activesupport.  No implementation has been provided for Date (beginning_of_hour and end_of_hour for a Date seems nonsensical).

While this feature has been based on master, I'm more than happy to submit it against 3-2-stable for any future 3.2.x release.
