### PR TITLE
Force given path to http methods in mapper to skip canonical action checking

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -535,7 +535,8 @@ module ActionDispatch
         private
           def map_method(method, args, &block)
             options = args.extract_options!
-            options[:via] = method
+            options[:via]    = method
+            options[:path] ||= args.first if args.first.is_a?(String)
             match(*args, options, &block)
             self
           end
@@ -1509,7 +1510,7 @@ module ActionDispatch
             prefix = shallow_scoping? ?
               "#{@scope[:shallow_path]}/#{parent_resource.path}/:id" : @scope[:path]
 
-            path = if canonical_action?(action, path.blank?)
+            if canonical_action?(action, path.blank?)
               prefix.to_s
             else
               "#{prefix}/#{action_path(action, path)}"

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -1405,7 +1405,7 @@ class RouteSetTest < ActiveSupport::TestCase
       end
     end
   end
-  
+
   def test_route_with_subdomain_and_constraints_must_receive_params
     name_param = nil
     set.draw do
@@ -1418,7 +1418,7 @@ class RouteSetTest < ActiveSupport::TestCase
       set.recognize_path('http://subdomain.example.org/page/mypage'))
     assert_equal(name_param, 'mypage')
   end
-  
+
   def test_route_requirement_recognize_with_ignore_case
     set.draw do
       get 'page/:name' => 'pages#show',

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -171,6 +171,8 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
             post :preview, :on => :collection
           end
         end
+
+        post 'new', :action => 'new', :on => :collection, :as => :new
       end
 
       resources :replies do
@@ -874,6 +876,12 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     get '/projects/1/edit'
     assert_equal 'project#edit', @response.body
     assert_equal '/projects/1/edit', edit_project_path(:id => '1')
+  end
+
+  def test_projects_with_post_action_and_new_path_on_collection
+    post '/projects/new'
+    assert_equal "project#new", @response.body
+    assert_equal "/projects/new", new_projects_path
   end
 
   def test_projects_involvements
@@ -2450,7 +2458,6 @@ class TestMultipleNestedController < ActionDispatch::IntegrationTest
     get "/foo/bar/baz"
     assert_equal "/pooh", @response.body
   end
-
 end
 
 class TestTildeAndMinusPaths < ActionDispatch::IntegrationTest


### PR DESCRIPTION
This fixes the following scenario:

```
resources :contacts do
  post 'new', action: 'new', on: :collection, as: :new
end
```

Where the /new path is not generated because it's considered a canonical
action, part of the normal resource actions:

```
new_contacts POST   /contacts(.:format)          contacts#new
```

ActionPack tests are ok (except for 3 failing on master related to latest session changes). 
Fixes #2999
