### PR TITLE
Make constantize look down the ancestor chain (excluding Object)

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -214,7 +214,7 @@ module ActiveSupport
 
       names.inject(Object) do |constant, name|
         candidate = constant.const_get(name)
-        if constant.const_defined?(name, false) || !Object.const_defined?(name)
+        if constant.const_defined?(name, false) || constant == Object || !Object.const_defined?(name)
           candidate
         else
           # Go down the ancestors to check it it's owned

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -213,7 +213,19 @@ module ActiveSupport
       names.shift if names.empty? || names.first.empty?
 
       names.inject(Object) do |constant, name|
-        constant.const_get(name, false)
+        candidate = constant.const_get(name)
+        if constant.const_defined?(name, false) || !Object.const_defined?(name)
+          candidate
+        else
+          # Go down the ancestors to check it it's owned
+          # directly before we reach Object or the end of ancestors.
+          constant.ancestors.each do |ancestor|
+            break if ancestor == Object
+            return candidate if ancestor.const_defined?(name, false)
+          end
+          # owner is in Object, so raise
+          constant.const_get(name, false)
+        end
       end
     end
 

--- a/activesupport/test/constantize_test_cases.rb
+++ b/activesupport/test/constantize_test_cases.rb
@@ -1,7 +1,14 @@
 module Ace
   module Base
     class Case
+      class Dice
+      end
     end
+    class Fase < Case
+    end
+  end
+  class Gas
+    include Base
   end
 end
 
@@ -9,6 +16,9 @@ module ConstantizeTestCases
   def run_constantize_tests_on
     assert_nothing_raised { assert_equal Ace::Base::Case, yield("Ace::Base::Case") }
     assert_nothing_raised { assert_equal Ace::Base::Case, yield("::Ace::Base::Case") }
+    assert_nothing_raised { assert_equal Ace::Base::Case::Dice, yield("Ace::Base::Case::Dice") }
+    assert_nothing_raised { assert_equal Ace::Base::Fase::Dice, yield("Ace::Base::Fase::Dice") }
+    assert_nothing_raised { assert_equal Ace::Gas::Case, yield("Ace::Gas::Case") }
     assert_nothing_raised { assert_equal ConstantizeTestCases, yield("ConstantizeTestCases") }
     assert_nothing_raised { assert_equal ConstantizeTestCases, yield("::ConstantizeTestCases") }
     assert_raise(NameError) { yield("UnknownClass") }
@@ -18,11 +28,16 @@ module ConstantizeTestCases
     assert_raise(NameError) { yield("InvalidClass\n") }
     assert_raise(NameError) { yield("Ace::ConstantizeTestCases") }
     assert_raise(NameError) { yield("Ace::Base::ConstantizeTestCases") }
+    assert_raise(NameError) { yield("Ace::Gas::Base") }
+    assert_raise(NameError) { yield("Ace::Gas::ConstantizeTestCases") }
   end
 
   def run_safe_constantize_tests_on
     assert_nothing_raised { assert_equal Ace::Base::Case, yield("Ace::Base::Case") }
     assert_nothing_raised { assert_equal Ace::Base::Case, yield("::Ace::Base::Case") }
+    assert_nothing_raised { assert_equal Ace::Base::Case::Dice, yield("Ace::Base::Case::Dice") }
+    assert_nothing_raised { assert_equal Ace::Base::Fase::Dice, yield("Ace::Base::Fase::Dice") }
+    assert_nothing_raised { assert_equal Ace::Gas::Case, yield("Ace::Gas::Case") }
     assert_nothing_raised { assert_equal ConstantizeTestCases, yield("ConstantizeTestCases") }
     assert_nothing_raised { assert_equal ConstantizeTestCases, yield("::ConstantizeTestCases") }
     assert_nothing_raised { assert_equal nil, yield("UnknownClass") }
@@ -33,6 +48,8 @@ module ConstantizeTestCases
     assert_nothing_raised { assert_equal nil, yield("blargle") }
     assert_nothing_raised { assert_equal nil, yield("Ace::ConstantizeTestCases") }
     assert_nothing_raised { assert_equal nil, yield("Ace::Base::ConstantizeTestCases") }
+    assert_nothing_raised { assert_equal nil, yield("Ace::Gas::Base") }
+    assert_nothing_raised { assert_equal nil, yield("Ace::Gas::ConstantizeTestCases") }
     assert_nothing_raised { assert_equal nil, yield("#<Class:0x7b8b718b>::Nested_1") }
   end
 end

--- a/activesupport/test/constantize_test_cases.rb
+++ b/activesupport/test/constantize_test_cases.rb
@@ -12,6 +12,16 @@ module Ace
   end
 end
 
+class Object
+  module AddtlGlobalConstants
+    class Case
+      class Dice
+      end
+    end
+  end
+  include AddtlGlobalConstants
+end
+
 module ConstantizeTestCases
   def run_constantize_tests_on
     assert_nothing_raised { assert_equal Ace::Base::Case, yield("Ace::Base::Case") }
@@ -19,8 +29,12 @@ module ConstantizeTestCases
     assert_nothing_raised { assert_equal Ace::Base::Case::Dice, yield("Ace::Base::Case::Dice") }
     assert_nothing_raised { assert_equal Ace::Base::Fase::Dice, yield("Ace::Base::Fase::Dice") }
     assert_nothing_raised { assert_equal Ace::Gas::Case, yield("Ace::Gas::Case") }
+    assert_nothing_raised { assert_equal Case::Dice, yield("Case::Dice") }
+    assert_nothing_raised { assert_equal Case::Dice, yield("Object::Case::Dice") }
     assert_nothing_raised { assert_equal ConstantizeTestCases, yield("ConstantizeTestCases") }
     assert_nothing_raised { assert_equal ConstantizeTestCases, yield("::ConstantizeTestCases") }
+    assert_nothing_raised { assert_equal Object, yield("") }
+    assert_nothing_raised { assert_equal Object, yield("::") }
     assert_raise(NameError) { yield("UnknownClass") }
     assert_raise(NameError) { yield("UnknownClass::Ace") }
     assert_raise(NameError) { yield("UnknownClass::Ace::Base") }
@@ -38,8 +52,12 @@ module ConstantizeTestCases
     assert_nothing_raised { assert_equal Ace::Base::Case::Dice, yield("Ace::Base::Case::Dice") }
     assert_nothing_raised { assert_equal Ace::Base::Fase::Dice, yield("Ace::Base::Fase::Dice") }
     assert_nothing_raised { assert_equal Ace::Gas::Case, yield("Ace::Gas::Case") }
+    assert_nothing_raised { assert_equal Case::Dice, yield("Case::Dice") }
+    assert_nothing_raised { assert_equal Case::Dice, yield("Object::Case::Dice") }
     assert_nothing_raised { assert_equal ConstantizeTestCases, yield("ConstantizeTestCases") }
     assert_nothing_raised { assert_equal ConstantizeTestCases, yield("::ConstantizeTestCases") }
+    assert_nothing_raised { assert_equal Object, yield("") }
+    assert_nothing_raised { assert_equal Object, yield("::") }
     assert_nothing_raised { assert_equal nil, yield("UnknownClass") }
     assert_nothing_raised { assert_equal nil, yield("UnknownClass::Ace") }
     assert_nothing_raised { assert_equal nil, yield("UnknownClass::Ace::Base") }


### PR DESCRIPTION
`constantize` is meant to avoid looking up in `Object`, e.g. so that `"String::Fixnum".constantize` raises an error.

Unfortunately, the ancestor chain is not looked up at all.

```
class A
  Foo = :bar
end
class B < A
end
"B::Foo".constantize # => raises an error, should return B::Foo (which is == A::Foo)
```

I ran into this when registering an observer (say "some_class/observer"), where `SomeClass::Observer` is defined in a base class of `SomeClass`. That currently fails, as `Observer` has to be defined directly in `SomeClass`.

One solution is for me to write:

```
class SomeClass < SomeBaseClass
  Observer = Observer # to satisfy Rails constantize lookup!!
end
```

I hope you appreciate the irony :-)

I feel that there is no reason for `constantize` to be so strict, though. The attached patch fixes this.

Thanks.
