### PR TITLE
Respond to missing

### DIFF
--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -62,8 +62,8 @@ module ActiveSupport #:nodoc:
 
       # Returns +true+ if _obj_ responds to the given method. Private methods are included in the search
       # only if the optional second parameter evaluates to +true+.
-      def respond_to?(method, include_private=false)
-        super || @wrapped_string.respond_to?(method, include_private)
+      def respond_to_missing?(method, include_private)
+        @wrapped_string.respond_to?(method, include_private)
       end
 
       # Returns +true+ when the proxy class can handle the string. Returns +false+ otherwise.

--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -36,7 +36,7 @@ module ActiveSupport #:nodoc:
       end
     end
 
-    def respond_to?(name)
+    def respond_to_missing?(name, include_private)
       true
     end
   end

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -311,10 +311,10 @@ module ActiveSupport
     end
 
     # Ensure proxy class responds to all methods that underlying time instance responds to.
-    def respond_to?(sym, include_priv = false)
+    def respond_to_missing?(sym, include_priv)
       # consistently respond false to acts_like?(:date), regardless of whether #time is a Time or DateTime
-      return false if sym.to_s == 'acts_like_date?'
-      super || time.respond_to?(sym, include_priv)
+      return false if sym.to_sym == :acts_like_date?
+      time.respond_to?(sym, include_priv)
     end
 
     # Send the missing method to +time+ instance, and wrap result in a new TimeWithZone with the existing +time_zone+.

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -450,6 +450,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
   def test_ruby_19_weekday_name_query_methods
     %w(sunday? monday? tuesday? wednesday? thursday? friday? saturday?).each do |name|
       assert_respond_to @twz, name
+      assert_equal @twz.send(name), @twz.method(name).call
     end
   end
 

--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -458,6 +458,15 @@ class MultibyteCharsUTF8BehaviourTest < ActiveSupport::TestCase
     assert !''.mb_chars.respond_to?(:undefined_method) # Not defined
   end
 
+  def test_method_works_for_proxyed_methods
+    assert_equal 'll', 'hello'.mb_chars.method(:slice).call(2..3) # Defined on Chars
+    chars = 'hello'.mb_chars
+    assert_equal 'Hello', chars.method(:capitalize!).call # Defined on Chars
+    assert_equal 'Hello', chars
+    assert_equal 'jello', 'hello'.mb_chars.method(:gsub).call(/h/, 'j') # Defined on String
+    assert_raise(NameError){ ''.mb_chars.method(:undefined_method) } # Not defined
+  end
+
   def test_acts_like_string
     assert 'Bambi'.mb_chars.acts_like_string?
   end

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -77,4 +77,12 @@ class OrderedOptionsTest < ActiveSupport::TestCase
     assert copy.kind_of?(original.class)
     assert_not_equal copy.object_id, original.object_id
   end
+
+  def test_introspection
+    a = ActiveSupport::OrderedOptions.new
+    assert a.respond_to?(:blah)
+    assert a.respond_to?(:blah=)
+    assert_equal 42, a.method(:blah=).call(42)
+    assert_equal 42, a.method(:blah).call
+  end
 end


### PR DESCRIPTION
In Ruby 1.9.2, it's better to use `respond_to_missing?` than `respond_to?`, as it also handles method creation.

I see there are others in other rails packages, I'll create additional pull requests when I get a chance.

Thanks
