### PR TITLE
Switch token_tag if block

### DIFF
--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -670,11 +670,11 @@ module ActionView
         end
 
         def token_tag(token=nil)
-          if token == false || !protect_against_forgery?
-            ''
-          else
+          if token != false && protect_against_forgery?
             token ||= form_authenticity_token
             tag(:input, :type => "hidden", :name => request_forgery_protection_token.to_s, :value => token)
+          else
+            ''
           end
         end
 


### PR DESCRIPTION
Rationale: easier to understand what's going on, easier to read.
