### PR TITLE
check checkboxes with array of strings as :checked option

### DIFF
--- a/actionpack/lib/action_view/helpers/tags/collection_helpers.rb
+++ b/actionpack/lib/action_view/helpers/tags/collection_helpers.rb
@@ -49,7 +49,7 @@ module ActionView
             accept = if current_value.respond_to?(:call)
               current_value.call(item)
             else
-              Array(current_value).include?(value)
+              Array(current_value).map(&:to_s).include?(value.to_s)
             end
 
             if accept

--- a/actionpack/test/template/form_collections_helper_test.rb
+++ b/actionpack/test/template/form_collections_helper_test.rb
@@ -195,6 +195,15 @@ class FormCollectionsHelperTest < ActionView::TestCase
     assert_no_select 'input[type=checkbox][value=2][checked=checked]'
   end
 
+  test 'collection check boxes accepts selected string values as :checked option' do
+    collection = (1..3).map{|i| [i, "Category #{i}"] }
+    with_collection_check_boxes :user, :category_ids, collection, :first, :last, :checked => ['1', '3']
+
+    assert_select 'input[type=checkbox][value=1][checked=checked]'
+    assert_select 'input[type=checkbox][value=3][checked=checked]'
+    assert_no_select 'input[type=checkbox][value=2][checked=checked]'
+  end
+
   test 'collection check boxes accepts a single checked value' do
     collection = (1..3).map{|i| [i, "Category #{i}"] }
     with_collection_check_boxes :user, :category_ids, collection, :first, :last, :checked => 3


### PR DESCRIPTION
common use-case when you are passing `params` as `:checked` option:

``` ruby
:checked => params[:contact_ids]
```

in this case params[:contact_ids] is an array of strings so you should convert it with `to_i` if you want this work. 
