### PR TITLE
Fix typo in submit_tag helper documentation

### DIFF
--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -408,7 +408,7 @@ module ActionView
       #   # => <input class="form_submit" name="commit" type="submit" />
       #
       #   submit_tag "Edit", :disable_with => "Editing...", :class => "edit_button"
-      #   # => <input class="edit_button" data-disable_with="Editing..." name="commit" type="submit" value="Edit" />
+      #   # => <input class="edit_button" data-disable-with="Editing..." name="commit" type="submit" value="Edit" />
       #
       #   submit_tag "Save", :confirm => "Are you sure?"
       #   # => <input name='commit' type='submit' value='Save' data-confirm="Are you sure?" />


### PR DESCRIPTION
Replace "data-disable_with" with "data-disable-with".
