### PR TITLE
"Password digest can't be blank" message from has_secure_password

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -40,7 +40,7 @@ module ActiveModel
         attr_reader :password
 
         validates_confirmation_of :password
-        validates_presence_of     :password_digest
+        validates_presence_of     :password
 
         include InstanceMethodsOnActivation
 


### PR DESCRIPTION
To avoid suicide when users see the message
"Password digest can't be blank" followed by message
"Password can't be blank"
