### PR TITLE
Ignore sqlite3 files only for new application with sqlite3 database

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -126,6 +126,17 @@ module Rails
         options[:skip_active_record] ? "" : "gem '#{gem_for_database}'"
       end
 
+      def gitingore_sqlite3
+        if options[:database] == 'sqlite3' || options[:database] == 'jdbcsqlite3'
+          <<-GITIGNORE.strip_heredoc
+            # Ignore the default SQLite database.
+            /db/*.sqlite3
+            /db/*.sqlite3-journal
+
+          GITIGNORE
+        end
+      end
+
       def include_all_railties?
         !options[:skip_active_record] && !options[:skip_test_unit] && !options[:skip_sprockets]
       end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -50,7 +50,7 @@ module Rails
     end
 
     def gitignore
-      copy_file "gitignore", ".gitignore"
+      template "gitignore", ".gitignore"
     end
 
     def app

--- a/railties/lib/rails/generators/rails/app/templates/gitignore
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore
@@ -7,10 +7,7 @@
 # Ignore bundler config
 /.bundle
 
-# Ignore the default SQLite database.
-/db/*.sqlite3
-/db/*.sqlite3-journal
-
+<%= gitingore_sqlite3 -%>
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -383,6 +383,18 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_match(/run  bundle install/, output)
   end
 
+  def test_sqlite3_database_ignores_sqlite3_files
+    run_generator
+    assert_file ".gitignore", /db.*sqlite3.*db.*sqlite3-journal/m
+  end
+
+  def test_postgresql_database_doesnt_ignore_sqlite3_files
+    run_generator [destination_root, '-d', 'postgresql']
+    assert_file ".gitignore" do |content|
+      assert_no_match /db.*sqlite3.*db.*sqlite3-journal/m, content
+    end
+  end
+
 protected
 
   def action(*args, &block)


### PR DESCRIPTION
We don't need ingore these files for PostgreSQL for example.
