### PR TITLE
Add support for macaddr, inet, and cidr types to PostgreSQL adapter

### DIFF
--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |s|
   s.add_dependency('arel',          '~> 3.0.2')
 
   s.add_dependency('active_record_deprecated_finders', '0.0.1')
-  s.add_dependency('netaddr', '~> 1.5.0')
 end

--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_dependency('arel',          '~> 3.0.2')
 
   s.add_dependency('active_record_deprecated_finders', '0.0.1')
+  s.add_dependency('netaddr', '~> 1.5.0')
 end

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -124,6 +124,7 @@ module ActiveRecord
         when :binary               then "#{klass}.binary_to_string(#{var_name})"
         when :boolean              then "#{klass}.value_to_boolean(#{var_name})"
         when :hstore               then "#{klass}.string_to_hstore(#{var_name})"
+        when :inet, :cidr          then "#{klass}.string_to_cidr(#{var_name})"
         else var_name
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -137,6 +137,14 @@ module ActiveRecord
           end
         end
 
+        class Cidr < Type
+          def type_cast(value)
+            return if value.nil?
+
+            ConnectionAdapters::PostgreSQLColumn.string_to_cidr value
+          end
+        end
+
         class TypeMap
           def initialize
             @mapping = {}
@@ -212,11 +220,9 @@ module ActiveRecord
         # FIXME: why are we keeping these types as strings?
         alias_type 'tsvector', 'text'
         alias_type 'interval', 'text'
-        alias_type 'cidr',     'text'
-        alias_type 'inet',     'text'
-        alias_type 'macaddr',  'text'
         alias_type 'bit',      'text'
         alias_type 'varbit',   'text'
+        alias_type 'macaddr',  'text'
 
         # FIXME: I don't think this is correct. We should probably be returning a parsed date,
         # but the tests pass with a string returned.
@@ -237,6 +243,9 @@ module ActiveRecord
         register_type 'polygon', OID::Identity.new
         register_type 'circle', OID::Identity.new
         register_type 'hstore', OID::Hstore.new
+
+        register_type 'cidr', OID::Cidr.new
+        alias_type 'inet', 'cidr'
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -197,6 +197,13 @@ module ActiveRecord
           :decimal
         when 'hstore'
           :hstore
+        # Network address types
+        when 'inet'
+          :inet
+        when 'cidr'
+          :cidr
+        when 'macaddr'
+          :macaddr
         # Character types
         when /^(?:character varying|bpchar)(?:\(\d+\))?$/
           :string
@@ -210,9 +217,6 @@ module ActiveRecord
           :string
         # Geometric types
         when /^(?:point|line|lseg|box|"?path"?|polygon|circle)$/
-          :string
-        # Network address types
-        when /^(?:cidr|inet|macaddr)$/
           :string
         # Bit strings
         when /^bit(?: varying)?(?:\(\d+\))?$/
@@ -282,6 +286,18 @@ module ActiveRecord
         def hstore(name, options = {})
           column(name, 'hstore', options)
         end
+
+        def inet(name, options = {})
+          column(name, 'inet', options)
+        end
+
+        def cidr(name, options = {})
+          column(name, 'cidr', options)
+        end
+
+        def macaddr(name, options = {})
+          column(name, 'macaddr', options)
+        end
       end
 
       ADAPTER_NAME = 'PostgreSQL'
@@ -301,7 +317,10 @@ module ActiveRecord
         :boolean     => { :name => "boolean" },
         :xml         => { :name => "xml" },
         :tsvector    => { :name => "tsvector" },
-        :hstore      => { :name => "hstore" }
+        :hstore      => { :name => "hstore" },
+        :inet        => { :name => "inet" },
+        :cidr        => { :name => "cidr" },
+        :macaddr     => { :name => "macaddr" }
       }
 
       # Returns 'PostgreSQL' as adapter name for identification purposes.

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -86,9 +86,9 @@ class PostgresqlDataTypeTest < ActiveRecord::TestCase
   end
 
   def test_data_type_of_network_address_types
-    assert_equal :string, @first_network_address.column_for_attribute(:cidr_address).type
-    assert_equal :string, @first_network_address.column_for_attribute(:inet_address).type
-    assert_equal :string, @first_network_address.column_for_attribute(:mac_address).type
+    assert_equal :cidr, @first_network_address.column_for_attribute(:cidr_address).type
+    assert_equal :inet, @first_network_address.column_for_attribute(:inet_address).type
+    assert_equal :macaddr, @first_network_address.column_for_attribute(:mac_address).type
   end
 
   def test_data_type_of_bit_string_types

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -135,8 +135,10 @@ class PostgresqlDataTypeTest < ActiveRecord::TestCase
   end
 
   def test_network_address_values
-    assert_equal '192.168.0.0/24', @first_network_address.cidr_address
-    assert_equal '172.16.1.254', @first_network_address.inet_address
+    cidr_address = NetAddr::CIDR.create '192.168.0.0/24'
+    inet_address = NetAddr::CIDR.create '172.16.1.254'
+    assert_equal cidr_address, @first_network_address.cidr_address
+    assert_equal inet_address, @first_network_address.inet_address
     assert_equal '01:23:45:67:89:0a', @first_network_address.mac_address
   end
 
@@ -200,8 +202,8 @@ class PostgresqlDataTypeTest < ActiveRecord::TestCase
   end
 
   def test_update_network_address
-    new_cidr_address = '10.1.2.3/32'
-    new_inet_address = '10.0.0.0/8'
+    new_inet_address = '10.1.2.3/32'
+    new_cidr_address = '10.0.0.0/8'
     new_mac_address = 'bc:de:f0:12:34:56'
     assert @first_network_address.cidr_address = new_cidr_address
     assert @first_network_address.inet_address = new_inet_address

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -134,9 +134,10 @@ class PostgresqlDataTypeTest < ActiveRecord::TestCase
     assert_equal '-1 years -2 days', @first_time.time_interval
   end
 
-  def test_network_address_values
-    cidr_address = NetAddr::CIDR.create '192.168.0.0/24'
-    inet_address = NetAddr::CIDR.create '172.16.1.254'
+  def test_network_address_values_ipaddr
+    cidr_address = IPAddr.new '192.168.0.0/24'
+    inet_address = IPAddr.new '172.16.1.254'
+
     assert_equal cidr_address, @first_network_address.cidr_address
     assert_equal inet_address, @first_network_address.inet_address
     assert_equal '01:23:45:67:89:0a', @first_network_address.mac_address

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -236,6 +236,27 @@ class SchemaDumperTest < ActiveRecord::TestCase
       end
     end
 
+    def test_schema_dump_includes_inet_shorthand_definition
+      output = standard_dump
+      if %r{create_table "postgresql_network_address"} =~ output
+        assert_match %r{t.inet "inet_address"}, output
+      end
+    end
+
+    def test_schema_dump_includes_cidr_shorthand_definition
+      output = standard_dump
+      if %r{create_table "postgresql_network_address"} =~ output
+        assert_match %r{t.cidr "cidr_address"}, output
+      end
+    end
+
+    def test_schema_dump_includes_macaddr_shorthand_definition
+      output = standard_dump
+      if %r{create_table "postgresql_network_address"} =~ output
+        assert_match %r{t.macaddr "macaddr_address"}, output
+      end
+    end
+
     def test_schema_dump_includes_hstores_shorthand_definition
       output = standard_dump
       if %r{create_table "postgresql_hstores"} =~ output


### PR DESCRIPTION
Adds migration and schema dump support for macaddr, inet and cidr column types in the PostgreSQL adapter.

Converst inet and cidr types to NetAddr::CIDR objects, instead of using IPAddr, since NetAddr::CIDR handles subnets better.
