### PR TITLE
Fix failing AR test on Oracle

### DIFF
--- a/activerecord/test/cases/relation_scoping_test.rb
+++ b/activerecord/test/cases/relation_scoping_test.rb
@@ -84,7 +84,7 @@ class RelationScopingTest < ActiveRecord::TestCase
 
   def test_scope_select_concatenates
     Developer.select("id, name").scoping do
-      developer = Developer.select('id, salary').where("name = 'David'").first
+      developer = Developer.select('salary').where("name = 'David'").first
       assert_equal 80000, developer.salary
       assert developer.has_attribute?(:id)
       assert developer.has_attribute?(:name)


### PR DESCRIPTION
Having a duplicated column specified in a select with order on the same column makes Oracle complain about "ORA-00918: column ambiguously defined" when an order is defined on such column.

This was introduced in #5153 with `first`s default order and discussed in #6147.

I believe this change keeps the test purpose without stepping on Oracle's toes.

Cheers!

/cc @tenderlove @yahonda
