### PR TITLE
Don't run explain on slow queries for database adapters that don't support it

### DIFF
--- a/activerecord/lib/active_record/explain.rb
+++ b/activerecord/lib/active_record/explain.rb
@@ -6,11 +6,12 @@ module ActiveRecord
       base.mattr_accessor :auto_explain_threshold_in_seconds, instance_accessor: false
     end
 
-    # If auto explain is enabled, this method triggers EXPLAIN logging for the
-    # queries triggered by the block if it takes more than the threshold as a
-    # whole. That is, the threshold is not checked against each individual
-    # query, but against the duration of the entire block. This approach is
-    # convenient for relations.
+    # If the database adapter supports explain and auto explain is enabled,
+    # this method triggers EXPLAIN logging for the queries triggered by the
+    # block if it takes more than the threshold as a whole. That is, the
+    # threshold is not checked against each individual query, but against the
+    # duration of the entire block. This approach is convenient for relations.
+
     #
     # The available_queries_for_explain thread variable collects the queries
     # to be explained. If the value is nil, it means queries are not being
@@ -21,7 +22,7 @@ module ActiveRecord
 
       threshold = auto_explain_threshold_in_seconds
       current   = Thread.current
-      if threshold && current[:available_queries_for_explain].nil?
+      if connection.supports_explain? && threshold && current[:available_queries_for_explain].nil?
         begin
           queries = current[:available_queries_for_explain] = []
           start = Time.now

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -136,6 +136,13 @@ module ActiveRecord
       end
     end
 
+    initializer "active_record.validate_explain_support" do |app|
+      if app.config.active_record[:auto_explain_threshold_in_seconds] &&
+        !ActiveRecord::Base.connection.supports_explain?
+        warn "auto_explain_threshold_in_seconds is set but will be ignored because your adapter does not support this feature. Please unset the configuration to avoid this warning."
+      end
+    end
+
     # Expose database runtime to controller for logging.
     initializer "active_record.log_runtime" do |app|
       require "active_record/railties/controller_runtime"

--- a/activerecord/test/cases/explain_test.rb
+++ b/activerecord/test/cases/explain_test.rb
@@ -108,6 +108,16 @@ if ActiveRecord::Base.connection.supports_explain?
       assert_equal expected, base.exec_explain(queries)
     end
 
+    def test_unsupported_connection_adapter
+      connection.stubs(:supports_explain?).returns(false)
+
+      base.logger.expects(:warn).never
+
+      with_threshold(0) do
+        Car.where(:name => 'honda').to_a
+      end
+    end
+
     def test_silence_auto_explain
       base.expects(:collecting_sqls_for_explain).never
       base.logger.expects(:warn).never


### PR DESCRIPTION
When using the activerecord-jdbcmysql connection adapter, I received this exception after a slow query fired:

```

NoMethodError: undefined method `explain' for #<ActiveRecord::ConnectionAdapters::MysqlAdapter:0x1c92233b>
    from /Users/blake/.rvm/gems/jruby-1.6.7-d19@myapp/gems/activerecord-3.2.3/lib/active_record/explain.rb:65:in `exec_explain'
    from org/jruby/RubyKernel.java:1787:in `tap'
    from /Users/blake/.rvm/gems/jruby-1.6.7-d19@myapp/gems/activerecord-3.2.3/lib/active_record/explain.rb:59:in `exec_explain'
    from org/jruby/RubyArray.java:2339:in `collect'
    from /Users/blake/.rvm/gems/jruby-1.6.7-d19@myapp/gems/activerecord-3.2.3/lib/active_record/explain.rb:58:in `exec_explain'
    from /Users/blake/.rvm/gems/jruby-1.6.7-d19@myapp/gems/activerecord-3.2.3/lib/active_record/explain.rb:34:in `logging_query_plan'
    from /Users/blake/.rvm/gems/jruby-1.6.7-d19@myapp/gems/activerecord-3.2.3/lib/active_record/relation.rb:159:in `to_a'
    from /Users/blake/.rvm/gems/jruby-1.6.7-d19@myapp/gems/activerecord-3.2.3/lib/active_record/relation/finder_methods.rb:377:in `find_first'
    from /Users/blake/.rvm/gems/jruby-1.6.7-d19@myapp/gems/activerecord-3.2.3/lib/active_record/relation/finder_methods.rb:122:in `first'
    from org/jruby/RubyBasicObject.java:1698:in `__send__'
    from /Users/blake/.rvm/gems/jruby-1.6.7-d19@myapp/gems/activerecord-3.2.3/lib/active_record/querying.rb:5:in `first'
    from (irb):1:in `evaluate'
    from org/jruby/RubyKernel.java:1088:in `eval'
    from org/jruby/RubyKernel.java:1410:in `loop'
    from org/jruby/RubyKernel.java:1197:in `catch'
    from org/jruby/RubyKernel.java:1197:in `catch'
    from /Users/blake/.rvm/gems/jruby-1.6.7-d19@myapp/gems/railties-3.2.3/lib/rails/commands/console.rb:47:in `start'
    from /Users/blake/.rvm/gems/jruby-1.6.7-d19@myapp/gems/railties-3.2.3/lib/rails/commands/console.rb:8:in `start'
    from /Users/blake/.rvm/gems/jruby-1.6.7-d19@myapp/gems/railties-3.2.3/lib/rails/commands.rb:41:in `(root)'
    from org/jruby/RubyKernel.java:1042:in `require'
    from script/rails:6:in `(root)'jruby-1.6.7-d19 :002 > 
```

Digging a little deeper, it seems that only mysql2, postgres and sqlite3 support explain on the connection adapter. This change prevents the slow query explain from running if the connection adapter does not support it. Ideally, the test wouldn't stub out 'supports_explain?' on a connection that does indeed support it, but we don't yet have any tests that run end-to-end against a jruby runtime and use the jdbc drivers.

Feedback appreciated!

Blake
