### PR TITLE
Address ActionPack head method not respecting explicitly set content-type #3436

### DIFF
--- a/actionpack/lib/action_controller/metal/head.rb
+++ b/actionpack/lib/action_controller/metal/head.rb
@@ -20,6 +20,7 @@ module ActionController
       options, status = status, nil if status.is_a?(Hash)
       status ||= options.delete(:status) || :ok
       location = options.delete(:location)
+      content_type = options.delete(:content_type)
 
       options.each do |key, value|
         headers[key.to_s.dasherize.split('-').each { |v| v[0] = v[0].chr.upcase }.join('-')] = value.to_s
@@ -27,7 +28,7 @@ module ActionController
 
       self.status = status
       self.location = url_for(location) if location
-      self.content_type = Mime[formats.first] if formats
+      self.content_type = content_type || (Mime[formats.first] if formats)
       self.response_body = " "
     end
   end

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -495,6 +495,14 @@ class TestController < ActionController::Base
     render :text => "hello world!"
   end
 
+  def head_created
+    head :created
+  end
+
+  def head_created_with_application_json_content_type
+    head :created, :content_type => "application/json"
+  end
+
   def head_with_location_header
     head :location => "/foo"
   end
@@ -1170,6 +1178,19 @@ class RenderTest < ActionController::TestCase
 
     get :hello_world_from_rxml_using_action
     assert_equal "<html>\n  <p>Hello</p>\n</html>\n", @response.body
+  end
+
+  def test_head_created
+    post :head_created
+    assert_blank @response.body
+    assert_response :created
+  end
+
+  def test_head_created_with_application_json_content_type
+    post :head_created_with_application_json_content_type
+    assert_blank @response.body
+    assert_equal "application/json", @response.content_type
+    assert_response :created
   end
 
   def test_head_with_location_header


### PR DESCRIPTION
Discussion is in #3436

This allows people using the :head method to pass content_type as an option.

The other issue in #3436 is what the value should be set to by default. As I note, according to the RFC the head method content-type value should be set to the value which would be received under content-negotiation for a GET request to the same resource. As this is a much more complicated and separate issue, I do not attempt to solve it here.
