### PR TITLE
Allow explicitly set content-type via head method when status code allows it according to the RFCs

### DIFF
--- a/actionpack/lib/action_controller/metal/head.rb
+++ b/actionpack/lib/action_controller/metal/head.rb
@@ -20,6 +20,7 @@ module ActionController
       options, status = status, nil if status.is_a?(Hash)
       status ||= options.delete(:status) || :ok
       location = options.delete(:location)
+      content_type = options.delete(:content_type)
 
       options.each do |key, value|
         headers[key.to_s.dasherize.split('-').each { |v| v[0] = v[0].chr.upcase }.join('-')] = value.to_s
@@ -29,7 +30,7 @@ module ActionController
       self.location = url_for(location) if location
 
       if include_content_headers?(self.status)
-        self.content_type = Mime[formats.first] if formats
+        self.content_type = content_type || (Mime[formats.first] if formats)
       else
         headers.delete('Content-Type')
         headers.delete('Content-Length')

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -505,6 +505,14 @@ class TestController < ActionController::Base
     render :text => "hello world!"
   end
 
+  def head_created
+    head :created
+  end
+
+  def head_created_with_application_json_content_type
+    head :created, :content_type => "application/json"
+  end
+
   def head_with_location_header
     head :location => "/foo"
   end
@@ -1175,6 +1183,19 @@ class RenderTest < ActionController::TestCase
 
     get :hello_world_from_rxml_using_action
     assert_equal "<html>\n  <p>Hello</p>\n</html>\n", @response.body
+  end
+
+  def test_head_created
+    post :head_created
+    assert_blank @response.body
+    assert_response :created
+  end
+
+  def test_head_created_with_application_json_content_type
+    post :head_created_with_application_json_content_type
+    assert_blank @response.body
+    assert_equal "application/json", @response.content_type
+    assert_response :created
   end
 
   def test_head_with_location_header


### PR DESCRIPTION
Creative title.

@josevalim as per your request, the same pull request made against master which are you already pulled into 3-2-stable ( in https://github.com/rails/rails/pull/6198 )

@twinturbo addresses your concern, no conflict, tests pass and compatible with your accepted pull ( https://github.com/rails/rails/pull/6148 )
