### PR TITLE
Fix railties (and tests) for latest rubygems

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Rails 2.3 stable development setup
+
+### Setup RVM (optional)
+
+```bash
+echo 'rvm 1.8.7-p334@rails-2-3-stable' > .rvmrc
+```
+
+### OSX tips
+
+```bash
+brew install fcgi
+```
+
+## Gems
+
+```bash
+gem install geminstaller -v '>= 0.4.3'
+gem install fcgi -v '= 0.8.7' -- --with-fcgi-dir=/usr/local/Cellar/fcgi/2.4.0
+gem install i18n -v '= 0.4.1'
+gem install memcache-client -v '= 1.5.0'
+gem install mocha -v '= 0.9.8'
+gem install mysql -v '= 2.8.1' -- --with-mysql-config=`which mysql_config`
+gem install nokogiri -v '= 1.3.3'
+gem install pg -v '= 0.8.0'
+gem install rack -v '~> 1.1.0' # WAS: gem install rack -v '> 1.1.0'
+gem install rake -v '= 0.8.1'
+gem install sqlite-ruby -v '= 2.2.3' # failing...
+gem install sqlite3-ruby -v '= 1.2.5'
+gem install tzinfo -v '= 0.3.18'
+
+# railties
+gem install rdoc
+```

--- a/railties/environments/boot.rb
+++ b/railties/environments/boot.rb
@@ -62,7 +62,7 @@ module Rails
         gem 'rails'
       end
     rescue Gem::LoadError => load_error
-      if load_error.message =~ /Could not find RubyGem rails/
+      if load_error.message =~ /Could not find( RubyGem)? rails/
         STDERR.puts %(Missing the Rails #{version} gem. Please `gem install -v=#{version} rails`, update your RAILS_GEM_VERSION setting in config/environment.rb for the Rails version you do have installed, or comment out RAILS_GEM_VERSION to use the latest version installed.)
         exit 1
       else

--- a/railties/lib/rails/gem_dependency.rb
+++ b/railties/lib/rails/gem_dependency.rb
@@ -270,7 +270,7 @@ module Rails
     end
 
     def ==(other)
-      Gem::Dependency === other.class &&
+      Gem::Dependency === other &&
         self.name == other.name && self.requirement == other.requirement
     end
     alias_method :eql?, :"=="
@@ -297,7 +297,7 @@ module Rails
 
       def unpack_command
         cmd = %w(unpack) << name
-        cmd << "--version" << "= "+specification.version.to_s if requirement
+        cmd << "--version" << %("#{requirement.to_s}") if requirement
         cmd
       end
 

--- a/railties/lib/rails/vendor_gem_source_index.rb
+++ b/railties/lib/rails/vendor_gem_source_index.rb
@@ -97,7 +97,12 @@ module Rails
         end
         vendor_gems[File.basename(d)] = spec
       end
-      @vendor_source_index = Gem::SourceIndex.new(vendor_gems)
+      if Gem::VERSION.to_f < 1.7
+        @vendor_source_index = Gem::SourceIndex.new(vendor_gems)
+      else
+        @vendor_source_index = Gem::SourceIndex.new
+        @vendor_source_index.add_specs *vendor_gems.values
+      end
     end
 
     def version_for_dir(d)

--- a/railties/lib/rails_generator/lookup.rb
+++ b/railties/lib/rails_generator/lookup.rb
@@ -209,7 +209,7 @@ module Rails
       # Yield latest versions of generator gems.
       def each
         dependency = Gem::Dependency.new(/_generator$/, Gem::Requirement.default)
-        Gem::cache.search(dependency).inject({}) { |latest, gem|
+        (Gem::VERSION.to_f < 1.6 ? Gem::cache : Gem::source_index).search(dependency).inject({}) { |latest, gem|
           hem = latest[gem.name]
           latest[gem.name] = gem if hem.nil? or gem.version > hem.version
           latest
@@ -231,7 +231,7 @@ module Rails
       private
         def generator_full_paths
           @generator_full_paths ||=
-            Gem::cache.inject({}) do |latest, name_gem|
+            (Gem::VERSION.to_f < 1.6 ? Gem::cache : Gem::source_index).inject({}) do |latest, name_gem|
               name, gem = name_gem
               hem = latest[gem.name]
               latest[gem.name] = gem if hem.nil? or gem.version > hem.version

--- a/railties/test/boot_test.rb
+++ b/railties/test/boot_test.rb
@@ -114,7 +114,6 @@ class GemBootTest < Test::Unit::TestCase
     GemBoot.stubs(:gem_version).returns('0.0.1')
 
     boot = GemBoot.new
-    boot.expects(:gem).with('rails', '0.0.1').raises(Gem::LoadError, 'missing rails 0.0.1 gem')
     STDERR.expects(:puts)
     boot.expects(:exit).with(1)
     boot.load_rails_gem

--- a/railties/test/console_app_test.rb
+++ b/railties/test/console_app_test.rb
@@ -1,5 +1,5 @@
 require 'abstract_unit'
-
+require 'stringio' # to eat unintended output
 require 'action_controller' # console_app uses 'action_controller/integration'
 
 unless defined? ApplicationController
@@ -25,6 +25,7 @@ if Test::Unit.respond_to?(:run=)
     end
 
     def test_reload_should_fire_preparation_callbacks
+      stdout, $stdout = $stdout, StringIO.new # hide output during tests
       a = b = c = nil
 
       Dispatcher.to_prepare { a = b = c = 1 }
@@ -37,6 +38,8 @@ if Test::Unit.respond_to?(:run=)
       assert_equal 1, a
       assert_equal 2, b
       assert_equal 3, c
+
+      $stdout = stdout # restore output
     end
   end
 end

--- a/railties/test/gem_dependency_test.rb
+++ b/railties/test/gem_dependency_test.rb
@@ -1,4 +1,5 @@
 require 'plugin_test_helper'
+require 'stringio' # to eat unintended output
 
 class Rails::GemDependency
   public :install_command, :unpack_command
@@ -115,7 +116,7 @@ class GemDependencyTest < Test::Unit::TestCase
   end
 
   def test_gem_load_frozen_when_platform_string_is_present
-    Gem::Platform.expects(:match).returns(true) # pretend we're always on windows
+    Gem::Platform.stubs(:match).returns(true) # pretend we're always on windows
     dummy_gem = Rails::GemDependency.new "dummy-gem-l"
     dummy_gem.add_load_paths
     dummy_gem.load
@@ -218,11 +219,15 @@ class GemDependencyTest < Test::Unit::TestCase
   end
 
   def test_gem_build_passes_options_to_dependencies
+    stdout, $stdout = $stdout, StringIO.new # hide output during tests
+
     start_gem = Rails::GemDependency.new("dummy-gem-g")
     dep_gem = Rails::GemDependency.new("dummy-gem-f")
     start_gem.stubs(:dependencies).returns([dep_gem])
     dep_gem.expects(:build).with({ :force => true }).once
     start_gem.build(:force => true)
+
+    $stdout = stdout # restore output
   end
 
 end

--- a/railties/test/gem_dependency_test.rb
+++ b/railties/test/gem_dependency_test.rb
@@ -11,8 +11,8 @@ class GemDependencyTest < Test::Unit::TestCase
     @gem              = Rails::GemDependency.new "xhpricotx"
     @gem_with_source  = Rails::GemDependency.new "xhpricotx", :source => "http://code.whytheluckystiff.net"
     @gem_with_version = Rails::GemDependency.new "xhpricotx", :version => "= 0.6"
-    @gem_with_lib     = Rails::GemDependency.new "xaws-s3x", :lib => "aws/s3"
-    @gem_without_load  = Rails::GemDependency.new "xhpricotx", :lib => false
+    @gem_with_lib     = Rails::GemDependency.new "xaws-s3x",  :lib => "aws/s3"
+    @gem_without_load = Rails::GemDependency.new "xhpricotx", :lib => false
   end
 
   def test_configuration_adds_gem_dependency
@@ -22,11 +22,11 @@ class GemDependencyTest < Test::Unit::TestCase
   end
 
   def test_gem_creates_install_command
-    assert_equal %w(install xhpricotx), @gem.install_command
+    assert_equal ['install', 'xhpricotx', '--version', '">= 0"'], @gem.install_command
   end
 
   def test_gem_with_source_creates_install_command
-    assert_equal %w(install xhpricotx --source http://code.whytheluckystiff.net), @gem_with_source.install_command
+    assert_equal ['install', 'xhpricotx', '--version', '">= 0"', '--source', 'http://code.whytheluckystiff.net'], @gem_with_source.install_command
   end
 
   def test_gem_with_version_creates_install_command
@@ -34,7 +34,7 @@ class GemDependencyTest < Test::Unit::TestCase
   end
 
   def test_gem_creates_unpack_command
-    assert_equal %w(unpack xhpricotx), @gem.unpack_command
+    assert_equal ["unpack", "xhpricotx", "--version", '">= 0"'], @gem.unpack_command
   end
 
   def test_gem_with_version_unpack_install_command
@@ -42,22 +42,22 @@ class GemDependencyTest < Test::Unit::TestCase
     mock_spec = mock()
     mock_spec.stubs(:version).returns('0.6')
     @gem_with_version.stubs(:specification).returns(mock_spec)
-    assert_equal ["unpack", "xhpricotx", "--version", '= 0.6'], @gem_with_version.unpack_command
+    assert_equal ["unpack", "xhpricotx", "--version", '"= 0.6"'], @gem_with_version.unpack_command
   end
 
   def test_gem_adds_load_paths
-    @gem.expects(:gem).with(@gem)
+    @gem.expects(:gem).with(@gem.name, Gem::Requirement.new)
     @gem.add_load_paths
   end
 
   def test_gem_with_version_adds_load_paths
-    @gem_with_version.expects(:gem).with(@gem_with_version)
+    @gem_with_version.expects(:gem).with(@gem_with_version.name, @gem_with_version.requirement)
     @gem_with_version.add_load_paths
     assert @gem_with_version.load_paths_added?
   end
 
   def test_gem_loading
-    @gem.expects(:gem).with(@gem)
+    @gem.expects(:gem).with(@gem.name, Gem::Requirement.new)
     @gem.expects(:require).with(@gem.name)
     @gem.add_load_paths
     @gem.load
@@ -65,7 +65,7 @@ class GemDependencyTest < Test::Unit::TestCase
   end
 
   def test_gem_with_lib_loading
-    @gem_with_lib.expects(:gem).with(@gem_with_lib)
+    @gem_with_lib.expects(:gem).with(@gem_with_lib.name, Gem::Requirement.new)
     @gem_with_lib.expects(:require).with(@gem_with_lib.lib)
     @gem_with_lib.add_load_paths
     @gem_with_lib.load
@@ -73,21 +73,21 @@ class GemDependencyTest < Test::Unit::TestCase
   end
 
   def test_gem_without_lib_loading
-    @gem_without_load.expects(:gem).with(@gem_without_load)
+    @gem_without_load.expects(:gem).with(@gem_without_load.name, Gem::Requirement.new)
     @gem_without_load.expects(:require).with(@gem_without_load.lib).never
     @gem_without_load.add_load_paths
     @gem_without_load.load
   end
 
   def test_gem_dependencies_compare_for_uniq
-    gem1 = Rails::GemDependency.new "gem1"
+    gem1  = Rails::GemDependency.new "gem1"
     gem1a = Rails::GemDependency.new "gem1"
-    gem2 = Rails::GemDependency.new "gem2"
+    gem2  = Rails::GemDependency.new "gem2"
     gem2a = Rails::GemDependency.new "gem2"
-    gem3 = Rails::GemDependency.new "gem2", :version => ">=0.1"
+    gem3  = Rails::GemDependency.new "gem2", :version => ">=0.1"
     gem3a = Rails::GemDependency.new "gem2", :version => ">=0.1"
-    gem4 = Rails::GemDependency.new "gem3"
-    gems = [gem1, gem2, gem1a, gem3, gem2a, gem4, gem3a, gem2, gem4]
+    gem4  = Rails::GemDependency.new "gem3"
+    gems  = [gem1, gem2, gem1a, gem3, gem2a, gem4, gem3a, gem2, gem4]
     assert_equal 4, gems.uniq.size
   end
 
@@ -113,8 +113,9 @@ class GemDependencyTest < Test::Unit::TestCase
     assert_not_nil DUMMY_GEM_C_VERSION
     assert_equal '0.6.0', DUMMY_GEM_C_VERSION
   end
-  
-  def test_gem_load_frozen_when_platform_string_is_present    
+
+  def test_gem_load_frozen_when_platform_string_is_present
+    Gem::Platform.expects(:match).returns(true) # pretend we're always on windows
     dummy_gem = Rails::GemDependency.new "dummy-gem-l"
     dummy_gem.add_load_paths
     dummy_gem.load
@@ -206,13 +207,13 @@ class GemDependencyTest < Test::Unit::TestCase
     assert_equal true,  Rails::GemDependency.new("dummy-gem-i").built?
     assert_equal false, Rails::GemDependency.new("dummy-gem-j").built?
   end
-  
+
   def test_gem_determines_build_status_only_on_vendor_gems
     framework_gem = Rails::GemDependency.new('dummy-framework-gem')
     framework_gem.stubs(:framework_gem?).returns(true)  # already loaded
     framework_gem.stubs(:vendor_rails?).returns(false)  # but not in vendor/rails
     framework_gem.stubs(:vendor_gem?).returns(false)  # and not in vendor/gems
-    framework_gem.add_load_paths  # freeze framework gem early 
+    framework_gem.add_load_paths  # freeze framework gem early
     assert framework_gem.built?
   end
 


### PR DESCRIPTION
This is a bunch of fixes that make railties tests working with rubygems from version 1.3 up to 1.7.
Also adds some info on setting up dev environment in the README, their incomplete but helpful in order to run the railties tests.

Replaces #4422

/cc @jeremy @rafaelfranca
