### PR TITLE
Allow define_attribute_methods to pass multiple values

### DIFF
--- a/activemodel/README.rdoc
+++ b/activemodel/README.rdoc
@@ -41,7 +41,7 @@ behavior out of the box:
       include ActiveModel::AttributeMethods
 
       attribute_method_prefix 'clear_'
-      define_attribute_methods [:name, :age]
+      define_attribute_methods :name, :age
 
       attr_accessor :name, :age
 

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -28,7 +28,7 @@ module ActiveModel
   #     attribute_method_affix  :prefix => 'reset_', :suffix => '_to_default!'
   #     attribute_method_suffix '_contrived?'
   #     attribute_method_prefix 'clear_'
-  #     define_attribute_methods ['name']
+  #     define_attribute_methods 'name'
   #
   #     attr_accessor :name
   #
@@ -86,7 +86,7 @@ module ActiveModel
       #     include ActiveModel::AttributeMethods
       #     attr_accessor :name
       #     attribute_method_prefix 'clear_'
-      #     define_attribute_methods [:name]
+      #     define_attribute_methods :name
       #
       #     private
       #
@@ -124,7 +124,7 @@ module ActiveModel
       #     include ActiveModel::AttributeMethods
       #     attr_accessor :name
       #     attribute_method_suffix '_short?'
-      #     define_attribute_methods [:name]
+      #     define_attribute_methods :name
       #
       #     private
       #
@@ -162,7 +162,7 @@ module ActiveModel
       #     include ActiveModel::AttributeMethods
       #     attr_accessor :name
       #     attribute_method_affix :prefix => 'reset_', :suffix => '_to_default!'
-      #     define_attribute_methods [:name]
+      #     define_attribute_methods :name
       #
       #     private
       #
@@ -216,7 +216,7 @@ module ActiveModel
       #     # Call to define_attribute_methods must appear after the
       #     # attribute_method_prefix, attribute_method_suffix or
       #     # attribute_method_affix declares.
-      #     define_attribute_methods [:name, :age, :address]
+      #     define_attribute_methods :name, :age, :address
       #
       #     private
       #
@@ -224,8 +224,8 @@ module ActiveModel
       #       ...
       #     end
       #   end
-      def define_attribute_methods(attr_names)
-        attr_names.each { |attr_name| define_attribute_method(attr_name) }
+      def define_attribute_methods(*attr_names)
+        attr_names.flatten.each { |attr_name| define_attribute_method(attr_name) }
       end
 
       def define_attribute_method(attr_name)

--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -30,7 +30,7 @@ module ActiveModel
   #
   #     include ActiveModel::Dirty
   #
-  #     define_attribute_methods [:name]
+  #     define_attribute_methods :name
   #
   #     def name
   #       @name

--- a/activemodel/test/cases/attribute_methods_test.rb
+++ b/activemodel/test/cases/attribute_methods_test.rb
@@ -10,7 +10,7 @@ class ModelWithAttributes
   end
 
   def attributes
-    { :foo => 'value of foo' }
+    { :foo => 'value of foo', :baz => 'value of baz' }
   end
 
 private
@@ -127,29 +127,36 @@ class AttributeMethodsTest < ActiveModel::TestCase
     assert_equal "value of a?b", ModelWithWeirdNamesAttributes.new.send('a?b')
   end
 
+  test '#define_attribute_methods works passing multiple arguments' do
+    ModelWithAttributes.define_attribute_methods(:foo, :baz)
+
+    assert_equal "value of foo", ModelWithAttributes.new.foo
+    assert_equal "value of baz", ModelWithAttributes.new.baz
+  end
+
   test '#define_attribute_methods generates attribute methods' do
-    ModelWithAttributes.define_attribute_methods([:foo])
+    ModelWithAttributes.define_attribute_methods(:foo)
 
     assert_respond_to ModelWithAttributes.new, :foo
     assert_equal "value of foo", ModelWithAttributes.new.foo
   end
 
   test '#define_attribute_methods generates attribute methods with spaces in their names' do
-    ModelWithAttributesWithSpaces.define_attribute_methods([:'foo bar'])
+    ModelWithAttributesWithSpaces.define_attribute_methods(:'foo bar')
 
     assert_respond_to ModelWithAttributesWithSpaces.new, :'foo bar'
     assert_equal "value of foo bar", ModelWithAttributesWithSpaces.new.send(:'foo bar')
   end
 
   test '#alias_attribute works with attributes with spaces in their names' do
-    ModelWithAttributesWithSpaces.define_attribute_methods([:'foo bar'])
+    ModelWithAttributesWithSpaces.define_attribute_methods(:'foo bar')
     ModelWithAttributesWithSpaces.alias_attribute(:'foo_bar', :'foo bar')
 
     assert_equal "value of foo bar", ModelWithAttributesWithSpaces.new.foo_bar
   end
 
   test '#undefine_attribute_methods removes attribute methods' do
-    ModelWithAttributes.define_attribute_methods([:foo])
+    ModelWithAttributes.define_attribute_methods(:foo)
     ModelWithAttributes.undefine_attribute_methods
 
     assert !ModelWithAttributes.new.respond_to?(:foo)
@@ -170,7 +177,7 @@ class AttributeMethodsTest < ActiveModel::TestCase
     assert_deprecated { klass.attribute_method_suffix '' }
     assert_deprecated { klass.attribute_method_prefix '' }
 
-    klass.define_attribute_methods([:foo])
+    klass.define_attribute_methods(:foo)
 
     assert_equal 'value of foo', klass.new.foo
   end

--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -3,7 +3,7 @@ require "cases/helper"
 class DirtyTest < ActiveModel::TestCase
   class DirtyModel
     include ActiveModel::Dirty
-    define_attribute_methods [:name, :color]
+    define_attribute_methods :name, :color
 
     def initialize
       @name = nil

--- a/guides/source/active_model_basics.textile
+++ b/guides/source/active_model_basics.textile
@@ -20,7 +20,7 @@ class Person
 
   attribute_method_prefix 'reset_'
   attribute_method_suffix '_highest?'
-  define_attribute_methods ['age']
+  define_attribute_methods 'age'
 
   attr_accessor :age
 
@@ -99,7 +99,7 @@ require 'active_model'
 
 class Person
   include ActiveModel::Dirty
-  define_attribute_methods [:first_name, :last_name]
+  define_attribute_methods :first_name, :last_name
 
   def first_name
     @first_name


### PR DESCRIPTION
From:

```
define_attribute_methods [:name, :age]
```

To:

```
define_attribute_methods :name, :age
```
