### PR TITLE
Stop showing deprecations for Ruby 1.8.7 with remove_column

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -269,13 +269,15 @@ module ActiveRecord
       #  remove_column(:suppliers, :qualification)
       #  remove_columns(:suppliers, :qualification, :experience)
       def remove_column(table_name, *column_names)
-        if column_names.first.kind_of?(Enumerable)
+        if column_names.flatten!
           message = 'Passing array to remove_columns is deprecated, please use ' +
                     'multiple arguments, like: `remove_columns(:posts, :foo, :bar)`'
           ActiveSupport::Deprecation.warn message, caller
         end
 
-        columns_for_remove(table_name, *column_names).each {|column_name| execute "ALTER TABLE #{quote_table_name(table_name)} DROP #{column_name}" }
+        columns_for_remove(table_name, *column_names).each do |column_name|
+          execute "ALTER TABLE #{quote_table_name(table_name)} DROP #{column_name}"
+        end
       end
       alias :remove_columns :remove_column
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
@@ -408,13 +408,13 @@ module ActiveRecord
       def remove_column(table_name, *column_names) #:nodoc:
         raise ArgumentError.new("You must specify at least one column name. Example: remove_column(:people, :first_name)") if column_names.empty?
 
-        if column_names.first.kind_of?(Enumerable)
+        if column_names.flatten!
           message = 'Passing array to remove_columns is deprecated, please use ' +
                     'multiple arguments, like: `remove_columns(:posts, :foo, :bar)`'
           ActiveSupport::Deprecation.warn message, caller
         end
 
-        column_names.flatten.each do |column_name|
+        column_names.each do |column_name|
           alter_table(table_name) do |definition|
             definition.columns.delete(definition[column_name])
           end


### PR DESCRIPTION
String is Enumerable in 1.8.7, which means that passing a String to remove_column was generating deprecation warnings during tests.

http://travis-ci.org/#!/rails/rails/jobs/1283165
