### PR TITLE
Update tranasaction state when record gets commited 

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -302,12 +302,8 @@ module ActiveRecord
     def remember_transaction_record_state #:nodoc:
       @_start_transaction_state ||= {}
       @_start_transaction_state[:id] = id if has_attribute?(self.class.primary_key)
-      unless @_start_transaction_state.include?(:new_record)
-        @_start_transaction_state[:new_record] = @new_record
-      end
-      unless @_start_transaction_state.include?(:destroyed)
-        @_start_transaction_state[:destroyed] = @destroyed
-      end
+      @_start_transaction_state[:new_record] = @new_record
+      @_start_transaction_state[:destroyed] = @destroyed
       @_start_transaction_state[:level] = (@_start_transaction_state[:level] || 0) + 1
     end
 

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -290,3 +290,28 @@ class TransactionObserverCallbacksTest < ActiveRecord::TestCase
     assert_equal %w{ after_rollback }, topic.history
   end
 end
+
+class SaveFromAfterCommitBlockTest < ActiveRecord::TestCase
+  self.use_transactional_fixtures = false
+
+  class TopicWithSaveInCallback < ActiveRecord::Base
+    self.table_name = :topics
+    after_commit :cache_topic, :on => :create
+    attr_accessor :cached
+
+    def cache_topic
+      unless cached
+        self.cached = true
+        self.save
+      else
+        self.cached = false
+      end
+    end
+  end
+
+  def test_after_commit_in_save
+    topic = TopicWithSaveInCallback.new()
+    topic.save
+    assert_equal true, topic.cached
+  end
+end

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -298,8 +298,7 @@ class SaveFromAfterCommitBlockTest < ActiveRecord::TestCase
     self.table_name = :topics
     after_commit :cache_topic, :on => :create
     after_commit :call_update, :on => :update
-    attr_accessor :cached
-    attr_accessor :record_updated
+    attr_accessor :cached, :record_updated
 
     def call_update
       self.record_updated = true

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -297,7 +297,13 @@ class SaveFromAfterCommitBlockTest < ActiveRecord::TestCase
   class TopicWithSaveInCallback < ActiveRecord::Base
     self.table_name = :topics
     after_commit :cache_topic, :on => :create
+    after_commit :call_update, :on => :update
     attr_accessor :cached
+    attr_accessor :record_updated
+
+    def call_update
+      self.record_updated = true
+    end
 
     def cache_topic
       unless cached
@@ -313,5 +319,6 @@ class SaveFromAfterCommitBlockTest < ActiveRecord::TestCase
     topic = TopicWithSaveInCallback.new()
     topic.save
     assert_equal true, topic.cached
+    assert_equal true, topic.record_updated
   end
 end


### PR DESCRIPTION
The pull request ensures that, when record gets committed to DB, transaction state gets updated from latest values. Without the patch, calling `save` from `after_commit :on => :create` callback will trigger `after_commit :on => :create` again, which I think is wrong. The current behaviour is also not historically consistent with, https://github.com/freelancing-god/after_commit . 
