### PR TITLE
ActiveResource::TimeoutError is not loaded

### DIFF
--- a/activeresource/lib/active_resource.rb
+++ b/activeresource/lib/active_resource.rb
@@ -29,6 +29,7 @@ $:.unshift(activemodel_path) if File.directory?(activemodel_path) && !$:.include
 
 require 'active_support'
 require 'active_model'
+require 'active_resource/exceptions'
 require 'active_resource/version'
 
 module ActiveResource

--- a/activeresource/lib/active_resource/base.rb
+++ b/activeresource/lib/active_resource/base.rb
@@ -12,7 +12,6 @@ require 'set'
 require 'uri'
 
 require 'active_support/core_ext/uri'
-require 'active_resource/exceptions'
 require 'active_resource/connection'
 require 'active_resource/formats'
 require 'active_resource/schema'


### PR DESCRIPTION
Hi there,

Upgrading Rails 2.3 application to Rails 3 I run into issue where `ActiveResource::TimeoutError` doesn't load when application starts.

This is the vanilla Rails app to reproduce this issue https://github.com/spectator/rails_activeresource_exception

Given this line in a controller

``` ruby
rescue_from ActiveResource::TimeoutError, :with => :service_error
```

application fails to start with `uninitialized constant ActiveResource::TimeoutError` unless `ActiveResource::Base` is explicitly called.

For example (rails console):

``` shell
Loading development environment (Rails 3.2.3)
1.9.3p194 :001 > ActiveResource::TimeoutError
NameError: uninitialized constant ActiveResource::TimeoutError
    from (irb):1
    from /Users/spectator/.rvm/gems/ruby-1.9.3-p194@rails_activeresource_exception/gems/railties-3.2.3/lib/rails/commands/console.rb:47:in `start'
    from /Users/spectator/.rvm/gems/ruby-1.9.3-p194@rails_activeresource_exception/gems/railties-3.2.3/lib/rails/commands/console.rb:8:in `start'
    from /Users/spectator/.rvm/gems/ruby-1.9.3-p194@rails_activeresource_exception/gems/railties-3.2.3/lib/rails/commands.rb:41:in `<top (required)>'
    from script/rails:6:in `require'
    from script/rails:6:in `<main>'
1.9.3p194 :002 > ActiveResource::Base
 => ActiveResource::Base 
1.9.3p194 :003 > ActiveResource::TimeoutError
 => ActiveResource::TimeoutError 
```

Autoloading this constant helps to solve this issue.

Submitting to 3-2-stable, because `ActiveResource` is gone in master. All tests pass.
