### PR TITLE
ignore Gemfile.lock

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/templates/gitignore
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/gitignore
@@ -1,4 +1,5 @@
 .bundle/
+Gemfile.lock
 log/*.log
 pkg/
 <%= dummy_path %>/db/*.sqlite3


### PR DESCRIPTION
Simple update to ignore the Gemfile.lock when generating an engine.
