### PR TITLE
Fix CollectionAssociation#replace to return new target (closes #6231)

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -474,6 +474,8 @@ module ActiveRecord
             raise RecordNotSaved, "Failed to replace #{reflection.name} because one or more of the " \
                                   "new records could not be saved."
           end
+
+          new_target
         end
 
         def concat_records(records)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1692,6 +1692,18 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal [bulb2], car.reload.bulbs
   end
 
+  def test_replace_returns_new_target
+    car = Car.create(:name => 'honda')
+    bulb1 = car.bulbs.create
+    bulb2 = car.bulbs.create
+    bulb3 = Bulb.create
+
+    assert_equal [bulb1, bulb2], car.bulbs
+    result = car.bulbs.replace([bulb1, bulb3])
+    assert_equal [bulb1, bulb3], car.bulbs
+    assert_equal [bulb1, bulb3], result
+  end
+
   def test_building_has_many_association_with_restrict_dependency
     option_before = ActiveRecord::Base.dependent_restrict_raises
     ActiveRecord::Base.dependent_restrict_raises = true


### PR DESCRIPTION
I would like to get some feedback before pushing it. Is it safe to return `new_target` from `replace`? I think that it should be fine as this becomes new target anyway, but maybe I'm missing something.

Another way would be to return new collection object, but target seems better as that's what you also get in `replace` in ruby.

/cc @tenderlove @jonleighton
