### PR TITLE
Postgresql doesn't accept limits on binary (bytea) columns.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1216,14 +1216,25 @@ module ActiveRecord
 
       # Maps logical Rails types to PostgreSQL-specific data types.
       def type_to_sql(type, limit = nil, precision = nil, scale = nil)
-        return super unless type.to_s == 'integer'
-        return 'integer' unless limit
-
-        case limit
-          when 1, 2; 'smallint'
-          when 3, 4; 'integer'
-          when 5..8; 'bigint'
-          else raise(ActiveRecordError, "No integer type has byte size #{limit}. Use a numeric with precision 0 instead.")
+        case type.to_s
+        when 'binary'
+          # PostgreSQL doesn't support limits on binary (bytea) columns.
+          # The hard limit is 1Gb, because of a 32-bit size field, and TOAST.
+          case limit
+          when nil, 0..0x3fffffff; super(type)
+          else raise(ActiveRecordError, "No binary type has byte size #{limit}.")
+          end
+        when 'integer'
+          return 'integer' unless limit
+  
+          case limit
+            when 1, 2; 'smallint'
+            when 3, 4; 'integer'
+            when 5..8; 'bigint'
+            else raise(ActiveRecordError, "No integer type has byte size #{limit}. Use a numeric with precision 0 instead.")
+          end
+        else
+          super
         end
       end
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define do
   create_table :binaries, :force => true do |t|
     t.string :name
     t.binary :data
+    t.binary :short_data, :limit => 2048
   end
 
   create_table :birds, :force => true do |t|


### PR DESCRIPTION
PostgreSQL doesn't take a limit for binary columns so developers must choose between removing :limit from their binary column definitions, and not being able to target pgsql.

This change drops :limit specifications, when migrations are applied against a pgsql database. It's not ideal, because the limit information is lost. However, the mysql adapters do something similar to :text columns, so I hope the approach is OK.

This is a pain point for other developers:
http://stackoverflow.com/questions/4976368/heroku-migration-type-modifier-is-not-allowed-for-type-bytea
http://forums.xkcd.com/viewtopic.php?f=11&t=19087

The schema change in my commit makes the AcitiveRecord test suite fail on pgsql. After the adapter change, the tests pass again.
