### PR TITLE
Removing key argument from run_callbacks method in abstract_controller

### DIFF
--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -14,7 +14,7 @@ module AbstractController
     # Override AbstractController::Base's process_action to run the
     # process_action callbacks around the normal behavior.
     def process_action(*args)
-      run_callbacks(:process_action, action_name) do
+      run_callbacks(:process_action) do
         super
       end
     end


### PR DESCRIPTION
@josevalim this fix the build.
