### PR TITLE
Postgresql adapter: fix handling of BC timestamps

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix postgresql adapter to handle BC timestamps correctly
+
+        HistoryEvent.create!(:name => "something", :occured_at => Date.new(0) - 5.years)
+
+    *Bogdan Gusiev*
+
 *   When running migrations on Postgresql, the `:limit` option for `binary` and `text` columns is silently dropped.
     Previously, these migrations caused sql exceptions, because Postgresql doesn't support limits on these types.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -8,6 +8,8 @@ module ActiveRecord
           case string
           when 'infinity'; 1.0 / 0.0
           when '-infinity'; -1.0 / 0.0
+          when / BC$/
+            super("-" + string.sub(/ BC$/, ""))
           else
             super
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -129,11 +129,15 @@ module ActiveRecord
         # Quote date/time values for use in SQL input. Includes microseconds
         # if the value is a Time responding to usec.
         def quoted_date(value) #:nodoc:
+          result = super
           if value.acts_like?(:time) && value.respond_to?(:usec)
-            "#{super}.#{sprintf("%06d", value.usec)}"
-          else
-            super
+            result = "#{result}.#{sprintf("%06d", value.usec)}"
           end
+
+          if value.year < 0
+            result = result.sub(/^-/, "") + " BC"
+          end
+          result
         end
       end
     end

--- a/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
@@ -75,6 +75,15 @@ class TimestampTest < ActiveRecord::TestCase
     assert_equal '4', pg_datetime_precision('foos', 'updated_at')
   end
 
+  def test_bc_timestamp
+    unless current_adapter?(:PostgreSQLAdapter)
+      return skip("only tested on postgresql")
+    end
+    date = Date.new(0) - 1.second
+    Developer.create!(:name => "aaron", :updated_at => date)
+    assert_equal date, Developer.find_by_name("aaron").updated_at
+  end
+
   private
 
     def pg_datetime_precision(table_name, column_name)


### PR DESCRIPTION
Ruby and Postgresql representation of BC(before christ) time stamps is different:

Ruby serializes it with negative number of years. Postgresql adds `BC` suffix instead.
This cause a bug.

This patch fixes datetime conversion in postgresql adapter to handle this edge case correctly.

If you know a better way of fixing it - please advice.
