### PR TITLE
Error message generation now supports more flexible error format lookup

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -324,7 +324,6 @@ module ActiveModel
           defaults << :"errors.models.#{klass.model_name.i18n_key}.attributes.#{attribute}.format"
           defaults << :"errors.models.#{klass.model_name.i18n_key}.format"
         end
-        
       end
 
       defaults << :"errors.attributes.#{attribute}.format"

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -56,9 +56,24 @@ class I18nValidationTest < ActiveModel::TestCase
   end
 
   def test_errors_full_messages_uses_format
-    I18n.backend.store_translations('en', :errors => {:format => "Field %{attribute} %{message}"})
     @person.errors.add('name', 'empty')
+    assert_equal ["Name empty"], @person.errors.full_messages
+    
+    I18n.backend.store_translations('en', :errors => {:format => "Field %{attribute} %{message}"})
     assert_equal ["Field Name empty"], @person.errors.full_messages
+
+    I18n.backend.store_translations('en', :errors => {:attributes => {:name => {:format => 'errors.attributes.attribute.format %{attribute} %{message}'}}})
+    assert_equal ["errors.attributes.attribute.format Name empty"], @person.errors.full_messages
+
+    I18n.backend.store_translations('en', :errors => {:models => {:person => {:attributes => {:name => {:format => 'errors.models.person.attributes.name.format %{attribute} %{message}'}}}}})
+    assert_equal ["errors.models.person.attributes.name.format Name empty"], @person.errors.full_messages
+
+    child = Child.new
+    child.errors.add('name', 'empty')
+    assert_equal ["errors.models.person.attributes.name.format Name empty"], child.errors.full_messages
+    
+    I18n.backend.store_translations('en', :errors => {:models => {:child => {:attributes => {:name => {:format => 'errors.models.child.attributes.name.format %{attribute} %{message}'}}}}})
+    assert_equal ["errors.models.child.attributes.name.format Name empty"], child.errors.full_messages
   end
 
   # ActiveModel::Validations


### PR DESCRIPTION
When generating an error message, a format lookup is done for the
following keys:
errors.models.MODEL.attributes.ATTRIBUTE.format
errors.models.SUPERCLASS.attributes.ATTRIBUTE.format (if there's a superclass with I18n support)
errors.attributes.ATTRIBUTE.format
errors.format

If none of these keys are associated with an error format, the default
'%{attribute} %{message}' is used.
