### PR TITLE
Don't allow to destroy readonly models

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   It's not possible anymore to destroy a model marked as read only.
+
+    *Johannes Barre*
+
+
 *   Added ability to ActiveRecord::Relation#from to accept other ActiveRecord::Relation objects
 
       Record.from(subquery)

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -123,6 +123,7 @@ module ActiveRecord
     # Deletes the record in the database and freezes this instance to reflect
     # that no changes should be made (since they can't be persisted).
     def destroy
+      raise ReadOnlyRecord if readonly?
       destroy_associations
       destroy_row if persisted?
       @destroyed = true

--- a/activerecord/test/cases/readonly_test.rb
+++ b/activerecord/test/cases/readonly_test.rb
@@ -23,6 +23,7 @@ class ReadOnlyTest < ActiveRecord::TestCase
     end
     assert_raise(ActiveRecord::ReadOnlyRecord) { dev.save  }
     assert_raise(ActiveRecord::ReadOnlyRecord) { dev.save! }
+    assert_raise(ActiveRecord::ReadOnlyRecord) { dev.destroy }
   end
 
 


### PR DESCRIPTION
Rails allows to destroy models marked as read only. This pull request fixes that.

I'm gonna backport this pull request to 3-2-stable, if this one get's accepted.
