### PR TITLE
Add Hash#transform_keys and Hash#transform_keys!

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add `Hash#transform_keys` and `Hash#transform_keys!`. *Mark McSpadden*
+
 *   Changed xml type `datetime` to `dateTime` (with upper case letter `T`). *Angelo Capilleri*  
 
 *   Add `:instance_accessor` option for `class_attribute`. *Alexey Vakhov*

--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -1,23 +1,37 @@
 class Hash
+  # Return a new hash with all keys converted using the block operation.
+  #
+  #  { :name => 'Rob', :years => '28' }.transform_keys{ |key| key.to_s.upcase }
+  #  # => { "NAME" => "Rob", "YEARS" => "28" }
+  def transform_keys
+    result = {}
+    keys.each do |key|
+      result[yield(key)] = self[key]
+    end
+    result
+  end
+
+  # Destructively convert all keys using the block operations.
+  # Same as transform_keys but modifies +self+
+  def transform_keys!
+    keys.each do |key|
+      self[yield(key)] = delete(key)
+    end
+    self
+  end
+
   # Return a new hash with all keys converted to strings.
   #
   #   { :name => 'Rob', :years => '28' }.stringify_keys
   #   #=> { "name" => "Rob", "years" => "28" }
   def stringify_keys
-    result = {}
-    keys.each do |key|
-      result[key.to_s] = self[key]
-    end
-    result
+    transform_keys{ |key| key.to_s }
   end
 
   # Destructively convert all keys to strings. Same as
   # +stringify_keys+, but modifies +self+.
   def stringify_keys!
-    keys.each do |key|
-      self[key.to_s] = delete(key)
-    end
-    self
+    transform_keys!{ |key| key.to_s }
   end
 
   # Return a new hash with all keys converted to symbols, as long as
@@ -26,21 +40,14 @@ class Hash
   #   { 'name' => 'Rob', 'years' => '28' }.symbolize_keys
   #   #=> { :name => "Rob", :years => "28" }
   def symbolize_keys
-    result = {}
-    keys.each do |key|
-      result[(key.to_sym rescue key)] = self[key]
-    end
-    result
+    transform_keys{ |key| key.to_sym rescue key }
   end
   alias_method :to_options,  :symbolize_keys
 
   # Destructively convert all keys to symbols, as long as they respond
   # to +to_sym+. Same as +symbolize_keys+, but modifies +self+.
   def symbolize_keys!
-    keys.each do |key|
-      self[(key.to_sym rescue key)] = delete(key)
-    end
-    self
+    transform_keys!{ |key| key.to_sym rescue key }
   end
   alias_method :to_options!, :symbolize_keys!
 

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -28,16 +28,31 @@ class HashExtTest < ActiveSupport::TestCase
     @mixed   = { :a  => 1, 'b' => 2 }
     @fixnums = {  0  => 1,  1  => 2 }
     @illegal_symbols = { [] => 3 }
+    @upcase_strings = { 'A' => 1, 'B' => 2 }
   end
 
   def test_methods
     h = {}
+    assert_respond_to h, :transform_keys
+    assert_respond_to h, :transform_keys!
     assert_respond_to h, :symbolize_keys
     assert_respond_to h, :symbolize_keys!
     assert_respond_to h, :stringify_keys
     assert_respond_to h, :stringify_keys!
     assert_respond_to h, :to_options
     assert_respond_to h, :to_options!
+  end
+
+  def test_transform_keys
+    assert_equal @upcase_strings, @strings.transform_keys{ |key| key.to_s.upcase }
+    assert_equal @upcase_strings, @symbols.transform_keys{ |key| key.to_s.upcase }
+    assert_equal @upcase_strings, @mixed.transform_keys{ |key| key.to_s.upcase }
+  end
+
+  def test_transform_keys!
+    assert_equal @upcase_strings, @symbols.dup.transform_keys!{ |key| key.to_s.upcase }
+    assert_equal @upcase_strings, @strings.dup.transform_keys!{ |key| key.to_s.upcase }
+    assert_equal @upcase_strings, @mixed.dup.transform_keys!{ |key| key.to_s.upcase }
   end
 
   def test_symbolize_keys

--- a/guides/source/active_support_core_extensions.textile
+++ b/guides/source/active_support_core_extensions.textile
@@ -2549,6 +2549,38 @@ There's also the bang variant +except!+ that removes keys in the very receiver.
 
 NOTE: Defined in +active_support/core_ext/hash/except.rb+.
 
+h5. +transform_keys+ and +transform_keys!+
+
+The method +transform_keys+ accepts a block and returns a hash that has applied the block operations to each of the keys in the receiver:
+
+<ruby>
+{nil => nil, 1 => 1, :a => :a}.transform_keys{ |key| key.to_s.upcase }
+# => {"" => nil, "A" => :a, "1" => 1}
+</ruby>
+
+The result in case of collision is undefined:
+
+<ruby>
+{"a" => 1, :a => 2}.transform_keys{ |key| key.to_s.upcase }
+# => {"A" => 2}, in my test, can't rely on this result though
+</ruby>
+
+This method may be useful for example to build specialized conversions. For instance +stringify_keys+ and +symbolize_keys+ use +transform_keys+ to perform their key conversions:
+
+<ruby>
+def stringify_keys
+  transform_keys{ |key| key.to_s }
+end
+...
+def symbolize_keys
+  transform_keys{ |key| key.to_sym rescue key }
+end
+</ruby>
+
+There's also the bang variant +transform_keys!+ that applies the block operations to keys in the very receiver.
+
+NOTE: Defined in +active_support/core_ext/hash/keys.rb+.
+
 h5. +stringify_keys+ and +stringify_keys!+
 
 The method +stringify_keys+ returns a hash that has a stringified version of the keys in the receiver. It does so by sending +to_s+ to them:


### PR DESCRIPTION
Having been in discussions about the "best" way convert hash keys to a) integers last week and b) camelcase strings this week, I thought this would be helpful.

Also refactored `Hash#stringify_keys`, `Hash#stringify_keys!`, `Hash#symbolize_keys`, `Hash#symbolize_keys!` methods to use the transform_key methods.
