### PR TITLE
Adds rbx-19mode and jruby-19mode to Travis CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ before_install:
   - gem install bundler
 rvm:
   - 1.9.3
+  - jruby-19mode
+  - rbx-19mode
+matrix:
+  allow_failures:
+    - rvm: jruby-19mode
+    - rvm: rbx-19mode
 env:
   - "GEM=railties"
   - "GEM=ap,am,amo,as"


### PR DESCRIPTION
I've added the rubies to allow_failures so that the build status is not interrupted.  I would love to see Rails run CI against these rubies as I believe it will help to fix bugs in the rubies themselves and also Rails.

Both are running only in 1.9 mode as master does not support 1.8 anymore.

Thanks for the time taken to review this.
