### PR TITLE
Remove unused private method

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -678,9 +678,6 @@ module ActiveRecord
         "#{@fixture_path}.yml"
       end
 
-      def yaml_fixtures_key(path)
-        ::File.basename(@fixture_path).split(".").first
-      end
   end
 
   class Fixture #:nodoc:


### PR DESCRIPTION
Remove unused private method `yaml_fixtures_key`.

This method was introduced in the initial commit in 2004, and has been removed form `master` in #4254.
