### PR TITLE
No, it's false, by default + It's a not working option. 

### DIFF
--- a/guides/source/configuring.textile
+++ b/guides/source/configuring.textile
@@ -448,7 +448,7 @@ There are a few configuration options available in Active Support:
 
 * +config.active_support.bare+ enables or disables the loading of +active_support/all+ when booting Rails. Defaults to +nil+, which means +active_support/all+ is loaded.
 
-* +config.active_support.escape_html_entities_in_json+ enables or disables the escaping of HTML entities in JSON serialization. Defaults to +true+.
+* +config.active_support.escape_html_entities_in_json+ enables or disables the escaping of HTML entities in JSON serialization. Defaults to +false+.
 
 * +config.active_support.use_standard_json_time_format+ enables or disables serializing dates to ISO 8601 format. Defaults to +false+.
 


### PR DESCRIPTION
First of all, it is false, since Rails 3.0, 
- <tt>ActiveSupport.escape_html_entities_in_json</tt> now defaults to false.
- ActiveSupport.escape_html_entities_in_json from true to false to match previously announced Rails 3 defaults _DHH_
