### PR TITLE
Add test Hash#except can receive more than one argument.

### DIFF
--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -500,6 +500,12 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal expected, original
   end
 
+  def test_except_with_more_than_one_argument
+    original = { :a => 'x', :b => 'y', :c => 10 }
+    expected = { :a => 'x' }
+    assert_equal expected, original.except(:b, :c)
+  end
+
   def test_except_with_original_frozen
     original = { :a => 'x', :b => 'y' }
     original.freeze


### PR DESCRIPTION
The same how it done in Hash#slice test. https://github.com/edtsech/rails/blob/master/activesupport/test/core_ext/hash_ext_test.rb#L414
