### PR TITLE
configuration for active_support and JSON Encoding

### DIFF
--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -10,7 +10,17 @@ module Rails
       initializer :load_environment_hook, :group => :all do end
 
       initializer :load_active_support, :group => :all do
-        require "active_support/all" unless config.active_support.bare
+        unless config.active_support.bare
+          require "active_support/all" 
+          
+          # Assign config options of JSON encoding
+          [:escape_html_entities_in_json, :use_standard_json_time_format, :encode_big_decimal_as_string].each do |option|
+            value = config.active_support.send(option)
+            if !value.nil?
+              ActiveSupport::JSON::Encoding.send("#{option}=", value)
+            end
+          end
+        end
       end
 
       # Preload all frameworks specified by the Configuration#frameworks.


### PR DESCRIPTION
Currently, documented "escape_html_entities_in_json" option is not working. As well as use_standard_json_time_format and encode_big_decimal_as_string parameters for JSON Encoder.

Developer should add them to application.rb (because it is an env-independent options). At the moment additions will not impact on JSON encoder settings - the patch fixes it.

Not sure about adding it to the generator of application.rb.
escape_html_entities_in_json is a very important option though, what about only this? / @wycats @josevalim

Bonus question: Why escape_html_entities_in_json is false? It was true a while ago and everything was OK.. thanks
