### PR TITLE
Feature/simple format refactoring

### DIFF
--- a/actionpack/lib/action_view/helpers/text_helper.rb
+++ b/actionpack/lib/action_view/helpers/text_helper.rb
@@ -241,6 +241,7 @@ module ActionView
       #
       # ==== Options
       # * <tt>:sanitize</tt> - If +false+, does not sanitize +text+.
+      # * <tt>:wrapper_tag</tt> - String representing the tag wrapper, defaults to <tt>"p"</tt>
       #
       # ==== Examples
       #   my_text = "Here is some basic text...\n...with a line break."
@@ -260,13 +261,14 @@ module ActionView
       #   # => "<p><span>I'm allowed!</span> It's true.</p>"
       def simple_format(text, html_options={}, options={})
         text = sanitize(text) unless options[:sanitize] == false
+        wrapper_tag = options.fetch(:wrapper_tag, :p)
         paragraphs = split_paragraphs(text)
 
         if paragraphs.empty?
-          content_tag('p', nil, html_options)
+          content_tag(wrapper_tag, nil, html_options)
         else
           paragraphs.map { |paragraph|
-            content_tag('p', paragraph, html_options, options[:sanitize])
+            content_tag(wrapper_tag, paragraph, html_options, options[:sanitize])
           }.join("\n\n").html_safe
         end
       end

--- a/actionpack/test/template/text_helper_test.rb
+++ b/actionpack/test/template/text_helper_test.rb
@@ -46,6 +46,14 @@ class TextHelperTest < ActionView::TestCase
     assert_equal "<p><b> test with unsafe string </b><script>code!</script></p>", simple_format("<b> test with unsafe string </b><script>code!</script>", {}, :sanitize => false)
   end
 
+  def test_simple_format_with_custom_wrapper
+    assert_equal "<div></div>", simple_format(nil, {}, :wrapper_tag => "div")
+  end
+
+  def test_simple_format_with_custom_wrapper_and_multi_line_breaks
+    assert_equal "<div>We want to put a wrapper...</div>\n\n<div>...right there.</div>", simple_format("We want to put a wrapper...\n\n...right there.", {}, :wrapper_tag => "div")
+  end
+
   def test_simple_format_should_not_change_the_text_passed
     text = "<b>Ok</b><script>code!</script>"
     text_clone = text.dup


### PR DESCRIPTION
Refactored simple_format into another method called `paragraph_split`

With the `paragraph_split` method, you are now able to split paragraphs and wrap those in any tag you may want without confining yourself to the `<p>` tag.
