### PR TITLE
Fix various bugs with console arguments and improve test coverage

### DIFF
--- a/railties/lib/rails/commands.rb
+++ b/railties/lib/rails/commands.rb
@@ -36,9 +36,17 @@ when 'benchmarker', 'profiler'
 
 when 'console'
   require 'rails/commands/console'
+  options = Rails::Console.parse_arguments(ARGV)
+
+  # RAILS_ENV needs to be set before config/application is required
+  ENV['RAILS_ENV'] = options[:environment] if options[:environment]
+
+  # shift ARGV so IRB doesn't freak
+  ARGV.shift if ARGV.first && ARGV.first[0] != '-'
+
   require APP_PATH
   Rails.application.require_environment!
-  Rails::Console.start(Rails.application)
+  Rails::Console.start(Rails.application, options)
 
 when 'server'
   # Change to the application's path if there is no config.ru file in current dir.

--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -32,11 +32,6 @@ module Rails
 
         opt_parser.parse! args
 
-        # Handle's environment like RAILS_ENV=production passed in directly
-        if index = args.index {|arg| arg.include?("RAILS_ENV")}
-          options[:environment] ||= args.delete_at(index).split('=').last
-        end
-
         options[:server] = args.shift
         options
       end

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -10,35 +10,36 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
     Rails::DBConsole.const_set(:APP_PATH, "erb")
 
     app_config({})
-    capture_abort { Rails::DBConsole.config }
+    capture_abort { Rails::DBConsole.new.config }
     assert aborted
     assert_match(/No database is configured for the environment '\w+'/, output)
 
     app_config(test: "with_init")
-    assert_equal Rails::DBConsole.config, "with_init"
+    assert_equal Rails::DBConsole.new.config, "with_init"
 
     app_db_file("test:\n  without_init")
-    assert_equal Rails::DBConsole.config, "without_init"
+    assert_equal Rails::DBConsole.new.config, "without_init"
 
     app_db_file("test:\n  <%= Rails.something_app_specific %>")
-    assert_equal Rails::DBConsole.config, "with_init"
+    assert_equal Rails::DBConsole.new.config, "with_init"
 
     app_db_file("test:\n\ninvalid")
-    assert_equal Rails::DBConsole.config, "with_init"
+    assert_equal Rails::DBConsole.new.config, "with_init"
   end
 
   def test_env
-    assert_equal Rails::DBConsole.env, "test"
-
-    Rails.stubs(:respond_to?).with(:env).returns(false)
-    assert_equal Rails::DBConsole.env, "test"
+    assert_equal Rails::DBConsole.new.environment, "test"
 
     ENV['RAILS_ENV'] = nil
+
+    Rails.stubs(:respond_to?).with(:env).returns(false)
+    assert_equal Rails::DBConsole.new.environment, "development"
+
     ENV['RACK_ENV'] = "rack_env"
-    assert_equal Rails::DBConsole.env, "rack_env"
+    assert_equal Rails::DBConsole.new.environment, "rack_env"
 
     ENV['RAILS_ENV'] = "rails_env"
-    assert_equal Rails::DBConsole.env, "rails_env"
+    assert_equal Rails::DBConsole.new.environment, "rails_env"
   ensure
     ENV['RAILS_ENV'] = "test"
   end

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -4,14 +4,14 @@ require 'rails/commands/server'
 class Rails::ServerTest < ActiveSupport::TestCase
 
   def test_environment_with_server_option
-    args    = ["thin", "RAILS_ENV=production"]
+    args    = ["thin", "-e", "production"]
     options = Rails::Server::Options.new.parse!(args)
     assert_equal 'production', options[:environment]
     assert_equal 'thin', options[:server]
   end
 
   def test_environment_without_server_option
-    args    = ["RAILS_ENV=production"]
+    args    = ["-e", "production"]
     options = Rails::Server::Options.new.parse!(args)
     assert_equal 'production', options[:environment]
     assert_nil options[:server]


### PR DESCRIPTION
Fixes these bugs with rails console:

``` term
$ rails c special-production
Loading development environment

$ rails c -e test
invalid option: -e (OptionParser::InvalidOption)

$ rails c --environment=test
invalid option: --environment=test (OptionParser::InvalidOption)

$ rails c RAILS_ENV=test
Loading development environment
No such file or directory - special-test (Errno::ENOENT)
```

Console commands that use IRB need the ENV['RAILS_ENV'] to be set before config/application.rb loads and shifts ARGV so IRB doesn't fail.

The code to set this up was previously executed outside of a class definition in commands/console.rb and commands/dbconsole.rb . I've moved it to a class to remove duplication and add tests.

It seems that the original intention was that all these methods of setting the environment should be supported. (Plus it makes it consistent with other commands.)

``` term
$ rails c --help
Usage: console [environment] [options]
    -s, --sandbox                    Rollback database modifications on exit.
    -e, --environment=name           Specifies the environment to run this console under (test/development/production).
                                     Default: development
        --debugger                   Enable the debugger.
```

See also https://github.com/rails/rails/pull/3949 which this pull request replaces.
