### PR TITLE
Add commas missing in performance tests

### DIFF
--- a/guides/code/getting_started/test/performance/browsing_test.rb
+++ b/guides/code/getting_started/test/performance/browsing_test.rb
@@ -3,7 +3,7 @@ require 'rails/performance_test_help'
 
 class BrowsingTest < ActionDispatch::PerformanceTest
   # Refer to the documentation for all available options
-  # self.profile_options = { :runs => 5, :metrics => [:wall_time, :memory]
+  # self.profile_options = { :runs => 5, :metrics => [:wall_time, :memory],
   #                          :output => 'tmp/performance', :formats => [:flat] }
 
   def test_homepage

--- a/railties/lib/rails/generators/rails/app/templates/test/performance/browsing_test.rb
+++ b/railties/lib/rails/generators/rails/app/templates/test/performance/browsing_test.rb
@@ -3,7 +3,7 @@ require 'rails/performance_test_help'
 
 class BrowsingTest < ActionDispatch::PerformanceTest
   # Refer to the documentation for all available options
-  # self.profile_options = { :runs => 5, :metrics => [:wall_time, :memory]
+  # self.profile_options = { :runs => 5, :metrics => [:wall_time, :memory],
   #                          :output => 'tmp/performance', :formats => [:flat] }
 
   def test_homepage


### PR DESCRIPTION
It misses  two commas in performance tests, the code is commented but we get an error when we use this part of code to configure the performance tests.
