### PR TITLE
Add Hash#only as alias for Hash#splice.

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/slice.rb
+++ b/activesupport/lib/active_support/core_ext/hash/slice.rb
@@ -16,6 +16,7 @@ class Hash
     keys.map! { |key| convert_key(key) } if respond_to?(:convert_key, true)
     keys.each_with_object(self.class.new) { |k, hash| hash[k] = self[k] if has_key?(k) }
   end
+  alias only slice
 
   # Replaces the hash with only the given keys.
   # Returns a hash containing the removed key/value pairs.
@@ -27,6 +28,7 @@ class Hash
     replace(hash)
     omit
   end
+  alias only! slice!
 
   # Removes and returns the key/value pairs matching the given keys.
   #   {:a => 1, :b => 2, :c => 3, :d => 4}.extract!(:a, :b) # => {:a => 1, :b => 2}

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -415,6 +415,18 @@ class HashExtTest < ActiveSupport::TestCase
     assert_not_equal expected, original
   end
 
+  def test_slice_alias_only
+    original = { :a => 'x', :b => 'y', :c => 10 }
+    expected = { :a => 'x', :b => 'y' }
+    assert_equal expected, original.only(:a, :b)
+  end
+
+  def test_slice_inplace_alias_only
+    original = { :a => 'x', :b => 'y', :c => 10 }
+    expected = { :c => 10 }
+    assert_equal expected, original.only!(:a, :b)
+  end
+
   def test_slice_inplace
     original = { :a => 'x', :b => 'y', :c => 10 }
     expected = { :c => 10 }


### PR DESCRIPTION
I think it will be more intuitive  to have `only` as opposite for `except`. Because everywhere we can find these two methods/keys together.
