### PR TITLE
clean the erros if an object that includes validation  is duped.

### DIFF
--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -177,6 +177,12 @@ module ActiveModel
         super
       end
     end
+    
+    # Clean the +Errors+ object if instance is duped
+    def initialize_dup(other) # :nodoc:
+      @errors = nil
+      super
+    end    
 
     # Returns the +Errors+ object that holds all information about attribute error messages.
     def errors

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -344,4 +344,19 @@ class ValidationsTest < ActiveModel::TestCase
     Topic.validates :title, options
     assert_equal({ :presence => true }, options)
   end
+  
+  def test_dup_validity_is_independent
+    Topic.validates_presence_of :title
+    topic = Topic.new("title" => "Litterature")
+    topic.valid?
+
+    duped = topic.dup
+    duped.title = nil
+    assert duped.invalid?
+
+    topic.title = nil
+    duped.title = 'Mathematics'
+    assert topic.invalid?
+    assert duped.valid?
+  end
 end


### PR DESCRIPTION
If an istance that include validation is duped it keep track of errors of its 'parent', because both errors instances point to the same ActiveModel::Errors instance. This happen when before to call dup, `save or valid?` is called. This Fixes #5953 and it was discussed on the pull request https://github.com/rails/rails/pull/5958
