### PR TITLE
set escaping HTML in json encoding to +true+

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -44,8 +44,8 @@ module <%= app_const_base %>
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password]
     
-    # Enable escaping HTML in JSON. The default is false.
-    # config.active_support.escape_html_entities_in_json = true
+    # Enable escaping HTML in JSON.
+    config.active_support.escape_html_entities_in_json = true
 
     # Use SQL instead of Active Record's schema dumper when creating the database.
     # This is necessary if your schema can't be completely dumped by the schema dumper,


### PR DESCRIPTION
related #6277
@spastorino @josevalim are OK to turn it true by default 
I :thumbsup: it too, this will mitigate some XSS holes - check showcases I made in that issue.
but seems @wycats didn't like this idea and proposed me to use escaping on the client side. It looks a little bit weird to me(escaping HTML on client side). I see no single reason to send smht like this 

```
{"body": "<p>body</p>"} 
```

it's definitely not the Rails way. Anyway, it's just an option that saves JSON-backend based apps from XSS and lame code either :). 
