### PR TITLE
Integrate strong_parameters by default

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add strong_parameters to default Gemfile, new generated controllers
+    will use it by default. *Guillermo Iguaran*
+
 *   The application generator generates `public/humans.txt` with some basic data. *Paul Campbell*
 
 *   Add `config.queue_consumer` to allow the default consumer to be configurable. *Carlos Antonio da Silva*

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -9,6 +9,9 @@ source 'https://rubygems.org'
 <%= assets_gemfile_entry %>
 <%= javascript_gemfile_entry %>
 
+# To whitelist permissible parameters in controllers
+gem 'strong_parameters'
+
 # To use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.0.0'
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -308,6 +308,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_inclusion_of_strong_parameters
+    run_generator
+    assert_file "Gemfile" do |contents|
+      assert_match(/gem 'strong_parameters'/, contents)
+    end
+  end
+
   def test_template_from_dir_pwd
     FileUtils.cd(Rails.root)
     assert_match(/It works from file!/, run_generator([destination_root, "-m", "lib/template.rb"]))


### PR DESCRIPTION
This add strong_parameters by default in new 4.0 apps.

See also rails/strong_parameters#23
