### PR TITLE
require "rubygems" is obsolete in Ruby 1.9.3

### DIFF
--- a/guides/source/action_view_overview.textile
+++ b/guides/source/action_view_overview.textile
@@ -59,7 +59,6 @@ Now we'll create a simple "Hello World" application that uses the +titleize+ met
 *hello_world.rb:*
 
 <ruby>
-require 'rubygems'
 require 'active_support/core_ext/string/inflections'
 require 'rack'
 
@@ -94,7 +93,6 @@ Now we'll create the same "Hello World" application in Sinatra.
 *hello_world.rb:*
 
 <ruby>
-require 'rubygems'
 require 'action_view'
 require 'sinatra'
 

--- a/guides/source/active_model_basics.textile
+++ b/guides/source/active_model_basics.textile
@@ -95,7 +95,6 @@ h4. Dirty
 An object becomes dirty when an object is gone through one or more changes to its attributes and not yet saved. This gives the ability to check whether an object has been changed or not. It also has attribute based accessor methods. Lets consider a Person class with attributes first_name and last_name
 
 <ruby>
-require 'rubygems'
 require 'active_model'
 
 class Person

--- a/load_paths.rb
+++ b/load_paths.rb
@@ -1,4 +1,3 @@
 # bust gem prelude
-require 'rubygems' unless defined? Gem
 require 'bundler'
 Bundler.setup

--- a/railties/lib/rails/commands/application.rb
+++ b/railties/lib/rails/commands/application.rb
@@ -19,7 +19,6 @@ else
   end
 end
 
-require 'rubygems' if ARGV.include?("--dev")
 require 'rails/generators'
 require 'rails/generators/rails/app/app_generator'
 

--- a/railties/lib/rails/commands/plugin_new.rb
+++ b/railties/lib/rails/commands/plugin_new.rb
@@ -1,5 +1,3 @@
-require 'rubygems' if ARGV.include?("--dev")
-
 if ARGV.first != "new"
   ARGV[0] = "--help"
 else

--- a/railties/lib/rails/generators/rails/app/templates/config/boot.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/boot.rb
@@ -1,5 +1,3 @@
-require 'rubygems'
-
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 

--- a/railties/lib/rails/generators/rails/plugin_new/templates/rails/boot.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/rails/boot.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 gemfile = File.expand_path('../../../../Gemfile', __FILE__)
 
 if File.exist?(gemfile)

--- a/railties/lib/rails/generators/test_unit/plugin/templates/test_helper.rb
+++ b/railties/lib/rails/generators/test_unit/plugin/templates/test_helper.rb
@@ -1,3 +1,2 @@
-require 'rubygems'
 require 'minitest/autorun'
 require 'active_support'

--- a/tools/profile
+++ b/tools/profile
@@ -7,7 +7,6 @@ ENV['NO_RELOAD'] ||= '1'
 ENV['RAILS_ENV'] ||= 'development'
 
 GC.enable_stats
-require 'rubygems'
 Gem.source_index
 require 'benchmark'
 


### PR DESCRIPTION
Requiring RubyGems does nothing on Ruby 1.9.3, since it is already loaded:

```
ruby -e 'p require "rubygems"'
false
```

So, I think we can remove it safely from boot.rb and other files, since Rails 4 will require Ruby 1.9.3+.
