### PR TITLE
Ruby prof fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ instance_eval File.read local_gemfile if File.exists? local_gemfile
 
 platforms :mri do
   group :test do
-    gem 'ruby-prof', '0.10.8'
+    gem 'ruby-prof', '~> 0.11.2'
   end
 end
 

--- a/activesupport/lib/active_support/testing/performance.rb
+++ b/activesupport/lib/active_support/testing/performance.rb
@@ -196,6 +196,7 @@ module ActiveSupport
 
         class Base
           include ActionView::Helpers::NumberHelper
+          include ActionView::Helpers::OutputSafetyHelper
 
           attr_reader :total
 

--- a/activesupport/lib/active_support/testing/performance/ruby.rb
+++ b/activesupport/lib/active_support/testing/performance/ruby.rb
@@ -36,7 +36,7 @@ module ActiveSupport
           RubyProf.pause
           full_profile_options[:runs].to_i.times { run_test(@metric, :profile) }
           @data = RubyProf.stop
-          @total = @data.threads.values.sum(0) { |method_infos| method_infos.max.total_time }
+          @total = @data.threads.sum(0) { |thread| thread.methods.max.total_time }
         end
 
         def record


### PR DESCRIPTION
finally got green build with ruby-prof changes.

second commit fixes 

``` ruby


/Users/arunagw/checkouts/rails/actionpack/lib/action_view/helpers/number_helper.rb:257:in `number_with_delimiter': undefined method `safe_join' for #<ActiveSupport::Testing::Performance::Metrics::Objects:0x007f97305de098> (NoMethodError)
    from /Users/arunagw/checkouts/rails/activesupport/lib/active_support/testing/performance.rb:242:in `format'
    from /Users/arunagw/checkouts/rails/activesupport/lib/active_support/testing/performance.rb:105:in `report'
    from /Users/arunagw/checkouts/rails/activesupport/lib/active_support/testing/performance.rb:91:in `run_profile'
    from /Users/arunagw/checkouts/rails/activesupport/lib/active_support/testing/performance.rb:45:in `block in run'
    from /Users/arunagw/checkouts/rails/activesupport/lib/active_support/testing/performance.rb:43:in `each'
    from /Users/arunagw/checkouts/rails/activesupport/lib/active_support/testing/performance.rb:43:in `run'
    from /Users/arunagw/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/minitest/unit.rb:787:in `block in _run_suite'
    from /Users/arunagw/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/minitest/unit.rb:780:in `map'
    from /Users/arunagw/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/minitest/unit.rb:780:in `_run_suite'
    from /Users/arunagw/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/minitest/unit.rb:770:in `block in _run_suites'
    from /Users/arunagw/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/minitest/unit.rb:770:in `map'
    from /Users/arunagw/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/minitest/unit.rb:770:in `_run_suites'
    from /Users/arunagw/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/minitest/unit.rb:746:in `_run_anything'
    from /Users/arunagw/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/minitest/unit.rb:909:in `run_tests'
    from /Users/arunagw/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/minitest/unit.rb:896:in `block in _run'
    from /Users/arunagw/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/minitest/unit.rb:895:in `each'
    from /Users/arunagw/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/minitest/unit.rb:895:in `_run'
    from /Users/arunagw/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/minitest/unit.rb:884:in `run'
    from /Users/arunagw/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/minitest/unit.rb:664:in `block in autorun'
[[:puke, [ApplicationTests::TestTest, "test_performance_test", #<MiniTest::Assertion: Run options: --seed 42815


```
