### PR TITLE
fix `bundle exec rails new app` not running `bundle install` properly

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -246,8 +246,16 @@ module Rails
         # is easier to silence stdout in the existing test suite this way. The
         # end-user gets the bundler commands called anyway, so no big deal.
         #
+        # We unset temporary bundler variables to load proper bundler and Gemfile.
+        #
         # Thanks to James Tucker for the Gem tricks involved in this call.
+
+        bundle_gemfile, rubyopt = ENV['BUNDLE_GEMFILE'], ENV['RUBYOPT']
+        ENV['BUNDLE_GEMFILE'], ENV['RUBYOPT'] = "", ""
+
         print `"#{Gem.ruby}" "#{Gem.bin_path('bundler', 'bundle')}" #{command}`
+
+        ENV['BUNDLE_GEMFILE'], ENV['RUBYOPT'] = bundle_gemfile, rubyopt
       end
 
       def run_bundle


### PR DESCRIPTION
the issue can be reproduce with:

```
printf "source :rubygems\n\ngem 'rails'\n" > Gemfile
bundle install
bundle exec rails new app1
rails new app2
ls -l app*/Gemfile.lock
```

In the case of `app1` the command `bundle install` was run in context of already loaded Gemfile, which had totally different effect then expected.

This also fixes #6314.
