### PR TITLE
Documentation: make the 'Using Models in Your Migrations' example code more concise.

### DIFF
--- a/guides/source/migrations.textile
+++ b/guides/source/migrations.textile
@@ -737,9 +737,7 @@ column.
 class AddFlagToProduct < ActiveRecord::Migration
   def change
     add_column :products, :flag, :boolean
-    Product.all.each do |product|
-      product.update_attributes!(:flag => false)
-    end
+    Product.update_all :flag => false
   end
 end
 </ruby>
@@ -762,9 +760,7 @@ column.
 class AddFuzzToProduct < ActiveRecord::Migration
   def change
     add_column :products, :fuzz, :string
-    Product.all.each do |product|
-      product.update_attributes! :fuzz => 'fuzzy'
-    end
+    Product.update_all :fuzz => 'fuzzy'
   end
 end
 </ruby>
@@ -816,9 +812,7 @@ class AddFlagToProduct < ActiveRecord::Migration
   def change
     add_column :products, :flag, :boolean
     Product.reset_column_information
-    Product.all.each do |product|
-      product.update_attributes!(:flag => false)
-    end
+    Product.update_all :flag => false
   end
 end
 </ruby>
@@ -833,9 +827,7 @@ class AddFuzzToProduct < ActiveRecord::Migration
   def change
     add_column :products, :fuzz, :string
     Product.reset_column_information
-    Product.all.each do |product|
-      product.update_attributes!(:fuzz => 'fuzzy')
-    end
+    Product.update_all :fuzz => 'fuzzy'
   end
 end
 </ruby>


### PR DESCRIPTION
Along with this change simply being more concise, I think it's also preferable that we teach people to use the `update_all` method where possible instead of:

```
Product.all.each do |product|
  product.update_attributes!(:flag => 'false')
end
```

This example above can get _extremely_ slow with a lot of records because it first loads all the products into memory before writing to the database.
