### PR TITLE
improve tests for bundle_command

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -249,13 +249,14 @@ module Rails
         # We unset temporary bundler variables to load proper bundler and Gemfile.
         #
         # Thanks to James Tucker for the Gem tricks involved in this call.
+        _bundle_command = Gem.bin_path('bundler', 'bundle')
 
-        bundle_gemfile, rubyopt = ENV['BUNDLE_GEMFILE'], ENV['RUBYOPT']
-        ENV['BUNDLE_GEMFILE'], ENV['RUBYOPT'] = "", ""
+        bundle_bin_path, bundle_gemfile, rubyopt = ENV['BUNDLE_BIN_PATH'], ENV['BUNDLE_GEMFILE'], ENV['RUBYOPT']
+        ENV['BUNDLE_BIN_PATH'], ENV['BUNDLE_GEMFILE'], ENV['RUBYOPT'] = "", "", ""
 
-        print `"#{Gem.ruby}" "#{Gem.bin_path('bundler', 'bundle')}" #{command}`
+        print `"#{Gem.ruby}" "#{_bundle_command}" #{command}`
 
-        ENV['BUNDLE_GEMFILE'], ENV['RUBYOPT'] = bundle_gemfile, rubyopt
+        ENV['BUNDLE_BIN_PATH'], ENV['BUNDLE_GEMFILE'], ENV['RUBYOPT'] = bundle_bin_path, bundle_gemfile, rubyopt
       end
 
       def run_bundle

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -100,6 +100,12 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
 
   def test_generation_runs_bundle_install_with_full_and_mountable
     result = run_generator [destination_root, "--mountable", "--full"]
+    assert_file "#{destination_root}/Gemfile.lock" do |contents|
+      assert_match(/bukkits/, contents)
+    end
+    assert_match(/run  bundle install/, result)
+    assert_match(/Using bukkits \(0\.0\.1\)/, result)
+    assert_match(/Your bundle is complete/, result)
     assert_equal 1, result.scan("Your bundle is complete").size
   end
 
@@ -348,4 +354,3 @@ protected
     silence(:stdout){ generator.send(*args, &block) }
   end
 end
-


### PR DESCRIPTION
Travis exports `BUNDLE_GEMFILE`, this overwrites current dir `Gemfile` here: https://github.com/rails/rails/blob/master/railties/lib/rails/generators/app_base.rb#L256.
It was changing context and running `install` command on `BUNDLE_GEMFILE` instead of `Gemfile` here https://github.com/rails/rails/blob/master/railties/test/generators/plugin_new_generator_test.rb#L102.

Most important addition here is validating that `#{destination_root}/Gemfile.lock` was created - which assures `bundle install` was run in proper `Gemfile` context.

As I had to run `ruby install.rb 4.0.0.beta` to make the test pass I assume it might still be failing - unless `rails ~> 4.0.0.beta` is installed ... maybe it already is?
