### PR TITLE
Fixes issue where SQL fragments prevented type casting based on column

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -147,17 +147,12 @@ module ActiveRecord
       end
 
       result = klass.connection.select_all(select(column_name).arel, nil, bind_values)
-      types  = result.column_types.merge klass.column_types
-      column = types[key]
+      column = klass.column_types[key] || result.column_types.values.first
 
       result.map do |attributes|
         raise ArgumentError, "Pluck expects to select just one attribute: #{attributes.inspect}" unless attributes.one?
-        value = klass.initialize_attributes(attributes).first[1]
-        if column
-          column.type_cast value
-        else
-          value
-        end
+        value = klass.initialize_attributes(attributes).values.first
+        column ? column.type_cast(value) : value
       end
     end
 

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -468,6 +468,9 @@ class CalculationsTest < ActiveRecord::TestCase
 
   def test_pluck_with_selection_clause
     assert_equal [50, 53, 55, 60], Account.pluck('DISTINCT credit_limit').sort
+    assert_equal [50, 53, 55, 60], Account.pluck('DISTINCT accounts.credit_limit').sort
+    assert_equal [50, 53, 55, 60], Account.pluck('DISTINCT(credit_limit)').sort
+    assert_equal [50 + 53 + 55 + 60], Account.pluck('SUM(DISTINCT(credit_limit))')
   end
 
   def test_pluck_expects_a_single_selection


### PR DESCRIPTION
3f352d0 introduced a failing test on PostgreSQL.  The column lookup would be 'DISTINCT credit_limit', which isn't a column in the database.  As a result, the pluck returns an array of strings, and the test fails.  I'm not familiar enough with the guts of AR to know why it doesn't fail for the other databases.

I'm not really sure that my change is the way to go about fixing this.  It seems a bit sloppy.  I'm sure some of you will have better ideas.
