### PR TITLE
Changing the indentation level of the block comment close for Sass

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/assets/stylesheets/application.css
+++ b/railties/lib/rails/generators/rails/app/templates/app/assets/stylesheets/application.css
@@ -10,4 +10,4 @@
  *
  *= require_self
  *= require_tree .
-*/
+ */


### PR DESCRIPTION
If one wants to use use Sass for application.css.sass the comment block indentation is invalid.
