### PR TITLE
Changing the indentation level of the block comment close for Sass

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/assets/stylesheets/application.css
+++ b/railties/lib/rails/generators/rails/app/templates/app/assets/stylesheets/application.css
@@ -4,4 +4,4 @@
  * the top of the compiled file, but it's generally better to create a new file per style scope.
  *= require_self
  *= require_tree . 
-*/
+ */


### PR DESCRIPTION
If one wants to use use Sass for application.css.sass the comment block indentation is invalid.
