### PR TITLE
Bump sqlite3 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ platforms :ruby do
   gem 'nokogiri', '>= 1.4.5'
 
   # AR
-  gem 'sqlite3', '~> 1.3.5'
+  gem 'sqlite3', '~> 1.3.6'
 
   group :db do
     gem 'pg', '>= 0.11.0'


### PR DESCRIPTION
The reason for this is that the sqlite3 adapter requires 1.3.6

https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
