### PR TITLE
SQLite3 doesn't actually support the 'time' type.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -195,7 +195,7 @@ module ActiveRecord
           :decimal     => { :name => "decimal" },
           :datetime    => { :name => "datetime" },
           :timestamp   => { :name => "datetime" },
-          :time        => { :name => "time" },
+          :time        => { :name => "datetime" },
           :date        => { :name => "date" },
           :binary      => { :name => "blob" },
           :boolean     => { :name => "boolean" }

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -35,6 +35,11 @@ module ActiveRecord
         assert(!result.rows.first.include?("blob"), "should not store blobs")
       end
 
+      def test_time_column
+        owner = Owner.create!(:eats_at => Time.utc(1995,1,1,6,0))
+        assert_match /1995-01-01/, owner.reload.eats_at.to_s
+      end
+
       def test_exec_insert
         column = @conn.columns('items').find { |col| col.name == 'number' }
         vals   = [[column, 10]]

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -522,7 +522,7 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   # Oracle, and Sybase do not have a TIME datatype.
-  unless current_adapter?(:OracleAdapter, :SybaseAdapter)
+  unless current_adapter?(:OracleAdapter, :SybaseAdapter, :SQLite3Adapter)
     def test_utc_as_time_zone
       Topic.default_timezone = :utc
       attributes = { "bonus_time" => "5:42:00AM" }
@@ -764,6 +764,9 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_multiparameter_attributes_on_time_will_ignore_hour_if_missing
+    ActiveRecord::Base.time_zone_aware_attributes = false
+    ActiveRecord::Base.default_timezone = :local
+    Time.zone = nil
     attributes = {
       "written_on(1i)" => "2004", "written_on(2i)" => "12", "written_on(3i)" => "12",
       "written_on(5i)" => "12", "written_on(6i)" => "02"
@@ -870,7 +873,7 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   # Oracle, and Sybase do not have a TIME datatype.
-  unless current_adapter?(:OracleAdapter, :SybaseAdapter)
+  unless current_adapter?(:OracleAdapter, :SybaseAdapter, :SQLite3Adapter)
     def test_multiparameter_attributes_on_time_only_column_with_time_zone_aware_attributes_does_not_do_time_zone_conversion
       ActiveRecord::Base.time_zone_aware_attributes = true
       ActiveRecord::Base.default_timezone = :utc
@@ -891,6 +894,9 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_multiparameter_attributes_on_time_with_empty_seconds
+    ActiveRecord::Base.time_zone_aware_attributes = false
+    ActiveRecord::Base.default_timezone = :local
+    Time.zone = nil
     attributes = {
       "written_on(1i)" => "2004", "written_on(2i)" => "6", "written_on(3i)" => "24",
       "written_on(4i)" => "16", "written_on(5i)" => "24", "written_on(6i)" => ""
@@ -946,7 +952,7 @@ class BasicsTest < ActiveRecord::TestCase
 
   def test_attributes_on_dummy_time
     # Oracle, and Sybase do not have a TIME datatype.
-    return true if current_adapter?(:OracleAdapter, :SybaseAdapter)
+    return true if current_adapter?(:OracleAdapter, :SybaseAdapter, :SQLite3Adapter)
 
     attributes = {
       "bonus_time" => "5:42:00AM"

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -431,6 +431,7 @@ ActiveRecord::Schema.define do
     t.string :name
     t.column :updated_at, :datetime
     t.column :happy_at,   :datetime
+    t.column :eats_at,    :time
     t.string :essay_id
   end
 


### PR DESCRIPTION
Relates to #6247.

SQLite3 does not support the 'time' data type.  I feel like we shouldn't pretend it does.

As it is now, if you create a new record with time only, the year gets set as the current year in the database.  However, as in issue #6247 when you do `Alert.all` it shows the year as being 2000.  Subsequently you get this behavior:

``` irb
irb(main):028:0> Alert.create(start: Time.now)
   (0.1ms)  begin transaction
  SQL (0.8ms)  INSERT INTO "alerts" ("created_at", "start", "updated_at") VALUES (?, ?, ?)  [["created_at", Wed, 16 May 2012 03:54:09 UTC +00:00], ["start", 2012-05-15 22:54:09 -0500], ["updated_at", Wed, 16 May 2012 03:54:09 UTC +00:00]]
   (2.4ms)  commit transaction
=> #<Alert id: 7, start: "2012-05-15 22:54:09", created_at: "2012-05-16 03:54:09", updated_at: "2012-05-16 03:54:09">
irb(main):029:0> Alert.all
  Alert Load (0.3ms)  SELECT "alerts".* FROM "alerts" 
=> [#<Alert id: 7, start: "2000-01-01 03:54:09", created_at: "2012-05-16 03:54:09", updated_at: "2012-05-16 03:54:09">]
irb(main):030:0> Alert.last.start < Time.utc(2000, 1, 1, 3, 55, 0)
  Alert Load (0.2ms)  SELECT "alerts".* FROM "alerts" ORDER BY "alerts"."id" DESC LIMIT 1
=> true
irb(main):031:0> Alert.where('start < ?', Time.utc(2000, 1, 1, 3, 55, 0))
  Alert Load (0.3ms)  SELECT "alerts".* FROM "alerts" WHERE (start < '2000-01-01 03:55:00.000000')
=> []

```

It isn't very consistent to show `start: "2000-01-01"` and yet not find it.  The reason is it really has year 2012 in the database.

I realize the year is just a dummy year since Ruby doesn't support any concept of time only.  But the difference is MySQL and PostgreSQL don't actually store the year in the database, where as SQLite does, and it doesn't match what Rails displays.

As an aside, I had to add:

``` ruby
ActiveRecord::Base.time_zone_aware_attributes = false
ActiveRecord::Base.default_timezone = :local
Time.zone = nil
```

to a couple of the tests, because when I changed line 955 to skip SQLite3 adapter, those lines getting skipped at the end were causing those other two tests to fail.  I don't see any tests that set those attributes and not set them back, but I guess something funny is going on there.
