### PR TITLE
Remove useless check of adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -21,10 +21,6 @@ module ActiveRecord
         config[:database] = File.expand_path(config[:database], Rails.root)
       end
 
-      unless 'sqlite3' == config[:adapter]
-        raise ArgumentError, 'adapter name should be "sqlite3"'
-      end
-
       db = SQLite3::Database.new(
         config[:database],
         :results_as_hash => true


### PR DESCRIPTION
No other adapter makes this check, and if we're already here, I'm pretty sure that check is useless.
