### PR TITLE
Integer limit out of range should be allowed to raise. Closes #6272

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -23,7 +23,7 @@ module ActiveRecord
       end
 
       def sql_type
-        base.type_to_sql(type.to_sym, limit, precision, scale) rescue type
+        base.type_to_sql(type.to_sym, limit, precision, scale)
       end
 
       def to_sql

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -83,7 +83,6 @@ module ActiveRecord
           t.column :one_int,    :integer, :limit => 1
           t.column :four_int,   :integer, :limit => 4
           t.column :eight_int,  :integer, :limit => 8
-          t.column :eleven_int, :integer, :limit => 11
         end
 
         columns = connection.columns(:testings)
@@ -94,20 +93,17 @@ module ActiveRecord
         one     = columns.detect { |c| c.name == "one_int"     }
         four    = columns.detect { |c| c.name == "four_int"    }
         eight   = columns.detect { |c| c.name == "eight_int"   }
-        eleven  = columns.detect { |c| c.name == "eleven_int"   }
 
         if current_adapter?(:PostgreSQLAdapter)
           assert_equal 'integer', default.sql_type
           assert_equal 'smallint', one.sql_type
           assert_equal 'integer', four.sql_type
           assert_equal 'bigint', eight.sql_type
-          assert_equal 'integer', eleven.sql_type
         elsif current_adapter?(:MysqlAdapter) or current_adapter?(:Mysql2Adapter)
           assert_match 'int(11)', default.sql_type
           assert_match 'tinyint', one.sql_type
           assert_match 'int', four.sql_type
           assert_match 'bigint', eight.sql_type
-          assert_match 'int(11)', eleven.sql_type
         elsif current_adapter?(:OracleAdapter)
           assert_equal 'NUMBER(38)', default.sql_type
           assert_equal 'NUMBER(1)', one.sql_type

--- a/activerecord/test/cases/migration/column_attributes_test.rb
+++ b/activerecord/test/cases/migration/column_attributes_test.rb
@@ -183,6 +183,16 @@ module ActiveRecord
         assert_instance_of TrueClass, bob.male?
         assert_kind_of BigDecimal, bob.wealth
       end
+
+      def test_out_of_range_limit_should_raise
+        skip("MySQL and PostgreSQL only") unless current_adapter?(:MysqlAdapter, :Mysql2Adapter, :PostgreSQLAdapter)
+
+        assert_raise(ActiveRecordError) { add_column :test_models, :integer_too_big, :integer, :limit => 10 }
+
+        unless current_adapter?(:PostgreSQLAdapter)
+          assert_raise(ActiveRecordError) { add_column :test_models, :text_too_big, :integer, :limit => 0xfffffffff }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
As it is if you enter an out of range `:limit` for a migration or new table, the raise is rescued and it defaults to `integer`.  Based on `change_schema_test.rb` I guess it must have been because it was expected some people would use `:limit => 11` for MySQL expecting an `int(11)`, which isn't the same thing as an 11 byte int, which is what :limit is for.

I believe this should raise, if it isn't a valid value, rather than silently changing what the user has specified, wrong as it may be.
