### PR TITLE
remove unnecessary require

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/access.rb
+++ b/activesupport/lib/active_support/core_ext/string/access.rb
@@ -1,5 +1,3 @@
-require 'active_support/multibyte'
-
 class String
   # If you pass a single Fixnum, returns a substring of one character at that
   # position. The first character of the string is at position 0, the next at

--- a/activesupport/lib/active_support/core_ext/string/filters.rb
+++ b/activesupport/lib/active_support/core_ext/string/filters.rb
@@ -1,5 +1,3 @@
-require 'active_support/core_ext/string/multibyte'
-
 class String
   # Returns the string, first removing all whitespace on both ends of
   # the string, and then changing remaining consecutive whitespace

--- a/activesupport/lib/active_support/inflector/transliterate.rb
+++ b/activesupport/lib/active_support/inflector/transliterate.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require 'active_support/core_ext/string/multibyte'
+require 'active_support/multibyte'
 require 'active_support/i18n'
 
 module ActiveSupport


### PR DESCRIPTION
- access & filters don't use multibyte ext
- transliterate requires only AS::Multibyte but not multibyte ext
