### PR TITLE
NumberHelper.number_with_delimiter should html_escape both delimiters and separators

### DIFF
--- a/actionpack/lib/action_view/helpers/number_helper.rb
+++ b/actionpack/lib/action_view/helpers/number_helper.rb
@@ -254,7 +254,7 @@ module ActionView
 
         parts = number.to_s.to_str.split('.')
         parts[0].gsub!(/(\d)(?=(\d\d\d)+(?!\d))/, "\\1#{options[:delimiter]}")
-        parts.join(options[:separator]).html_safe
+        safe_join(parts, options[:separator])
       end
 
       # Formats a +number+ with the specified level of

--- a/actionpack/test/template/number_helper_test.rb
+++ b/actionpack/test/template/number_helper_test.rb
@@ -78,6 +78,8 @@ class NumberHelperTest < ActionView::TestCase
     assert_equal '12,345,678-05', number_with_delimiter(12345678.05, :separator => '-')
     assert_equal '12.345.678,05', number_with_delimiter(12345678.05, :separator => ',', :delimiter => '.')
     assert_equal '12.345.678,05', number_with_delimiter(12345678.05, :delimiter => '.', :separator => ',')
+    assert_equal '1&lt;script&gt;&lt;/script&gt;01', number_with_delimiter(1.01, :separator => "<script></script>")
+    assert_equal '1&lt;script&gt;&lt;/script&gt;000', number_with_delimiter(1000, :delimiter => "<script></script>")
   end
 
   def test_number_with_precision

--- a/activesupport/lib/active_support/testing/performance.rb
+++ b/activesupport/lib/active_support/testing/performance.rb
@@ -196,6 +196,7 @@ module ActiveSupport
 
         class Base
           include ActionView::Helpers::NumberHelper
+          include ActionView::Helpers::OutputSafetyHelper
 
           attr_reader :total
 


### PR DESCRIPTION
Recently, the dependency on safe_join was removed from number_helper.  When this happened, delimiters and separators were no longer being html_escaped.

For example, 

``` ruby
number_with_delimiter(1000, :delimiter =>'<script></script>')
```

will produce the string

``` ruby
"1<script></script>000" 
```

marked as html_safe.

This pull request makes both delimiters and separators html_escaped, and adds tests for this behavior.

See https://github.com/rails/rails/commit/ecfb32cd165c0763befb7eed7e348438db928cef for more info

Likely interested parties: @carlosantoniodasilva and @josevalim
