### PR TITLE
Call methods on the correct instance in AR::Schema.define

### DIFF
--- a/activerecord/lib/active_record/schema.rb
+++ b/activerecord/lib/active_record/schema.rb
@@ -34,6 +34,15 @@ module ActiveRecord
       ActiveRecord::Migrator.migrations_paths
     end
 
+    def define(info, &block)
+      instance_eval(&block)
+
+      unless info[:version].blank?
+        initialize_schema_migrations_table
+        assume_migrated_upto_version(info[:version], migrations_paths)
+      end
+    end
+
     # Eval the given block. All methods available to the current connection
     # adapter are available within the block, so you can easily use the
     # database definition DSL to build up your schema (+create_table+,
@@ -46,13 +55,7 @@ module ActiveRecord
     #     ...
     #   end
     def self.define(info={}, &block)
-      schema = new
-      schema.instance_eval(&block)
-
-      unless info[:version].blank?
-        initialize_schema_migrations_table
-        assume_migrated_upto_version(info[:version], schema.migrations_paths)
-      end
+      new.define(info, &block)
     end
   end
 end

--- a/activerecord/test/cases/ar_schema_test.rb
+++ b/activerecord/test/cases/ar_schema_test.rb
@@ -37,6 +37,13 @@ if ActiveRecord::Base.connection.supports_migrations?
         end
       end
     end
+
+    def test_schema_subclass
+      Class.new(ActiveRecord::Schema).define(:version => 9) do
+        create_table :fruits
+      end
+      assert_nothing_raised { @connection.select_all "SELECT * FROM fruits" }
+    end
   end
 
 end


### PR DESCRIPTION
Now that migrations support instance methods, we should use the same instance
rather than relying on delegation to a global instance. This allows
subclassing AR::Schema.
