### PR TITLE
Add some common Array methods to the middleware stack

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -75,6 +75,11 @@ module ActionDispatch
       middlewares[i]
     end
 
+    def unshift(*args, &block)
+      middleware = self.class::Middleware.new(*args, &block)
+      middlewares.unshift(middleware)
+    end
+
     def initialize_copy(other)
       self.middlewares = other.middlewares.dup
     end

--- a/actionpack/test/dispatch/middleware_stack_test.rb
+++ b/actionpack/test/dispatch/middleware_stack_test.rb
@@ -45,7 +45,7 @@ class MiddlewareStackTest < ActiveSupport::TestCase
     assert_equal BazMiddleware, @stack.last.klass
     assert_equal([true, {:foo => "bar"}], @stack.last.args)
   end
-  
+
   test "use should push middleware class with block arguments onto the stack" do
     proc = Proc.new {}
     assert_difference "@stack.size" do
@@ -54,7 +54,7 @@ class MiddlewareStackTest < ActiveSupport::TestCase
     assert_equal BlockMiddleware, @stack.last.klass
     assert_equal proc, @stack.last.block
   end
-  
+
   test "insert inserts middleware at the integer index" do
     @stack.insert(1, BazMiddleware)
     assert_equal BazMiddleware, @stack[1].klass
@@ -85,6 +85,11 @@ class MiddlewareStackTest < ActiveSupport::TestCase
     assert_equal FooMiddleware, @stack[0].klass
     @stack.swap(FooMiddleware, FooMiddleware, Proc.new { |env| [500, {}, ['error!']] })
     assert_equal FooMiddleware, @stack[0].klass
+  end
+
+  test "unshift adds a new middleware at the beginning of the stack" do
+    @stack.unshift :"MiddlewareStackTest::BazMiddleware"
+    assert_equal BazMiddleware, @stack.first.klass
   end
 
   test "raise an error on invalid index" do


### PR DESCRIPTION
The docs suggest that the middleware stack is an Array, and yet some
common Array methods do not work (#unshift #shift #pop and #push) are
the most common array operations that are not implemented that I can
think of.

To this end, I have implemented them simply by delegating to the
middlewares Array directly

( This commit also fixes two whitespace issues, I will rebase them out if they shouldn't get to piggyback)
