### PR TITLE
Relocating find_by_sql into Relation

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -45,6 +45,7 @@ module ActiveRecord
     autoload :Relation
 
     autoload_under 'relation' do
+      autoload :Quering
       autoload :QueryMethods
       autoload :FinderMethods
       autoload :Calculations
@@ -72,7 +73,7 @@ module ActiveRecord
     autoload :Observer
     autoload :Persistence
     autoload :QueryCache
-    autoload :Querying
+    autoload :QueryDelegation
     autoload :ReadonlyAttributes
     autoload :Reflection
     autoload :Result

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -688,7 +688,7 @@ module ActiveRecord #:nodoc:
     extend ActiveSupport::Benchmarkable
     extend ActiveSupport::DescendantsTracker
 
-    extend Querying
+    extend QueryDelegation
     include ReadonlyAttributes
     include ModelSchema
     extend Translation

--- a/activerecord/lib/active_record/query_delegation.rb
+++ b/activerecord/lib/active_record/query_delegation.rb
@@ -1,0 +1,15 @@
+require 'active_support/core_ext/module/delegation'
+
+module ActiveRecord
+  module QueryDelegation
+    delegate :find, :first, :first!, :last, :last!, :all, :exists?, :any?, :many?, :to => :scoped
+    delegate :first_or_create, :first_or_create!, :first_or_initialize, :to => :scoped
+    delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, :to => :scoped
+    delegate :find_each, :find_in_batches, :to => :scoped
+    delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins,
+             :where, :preload, :eager_load, :includes, :from, :lock, :readonly,
+             :having, :create_with, :uniq, :to => :scoped
+    delegate :count, :average, :minimum, :maximum, :sum, :calculate, :pluck, :to => :scoped
+    delegate :find_by_sql, :count_by_sql, :to => :scoped
+  end
+end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -9,7 +9,7 @@ module ActiveRecord
     MULTI_VALUE_METHODS = [:select, :group, :order, :joins, :where, :having, :bind]
     SINGLE_VALUE_METHODS = [:limit, :offset, :lock, :readonly, :from, :reordering, :reverse_order, :uniq]
 
-    include FinderMethods, Calculations, SpawnMethods, QueryMethods, Batches, Explain, Delegation
+    include FinderMethods, Calculations, SpawnMethods, Quering, QueryMethods, Batches, Explain, Delegation
 
     attr_reader :table, :klass, :loaded
     attr_accessor :extensions, :default_scoped
@@ -168,10 +168,10 @@ module ActiveRecord
 
       if default_scoped.equal?(self)
         @records = if @readonly_value.nil? && !@klass.locking_enabled?
-          eager_loading? ? find_with_associations : @klass.find_by_sql(arel, @bind_values)
+          eager_loading? ? find_with_associations : find_by_sql(arel, @bind_values)
         else
           IdentityMap.without do
-            eager_loading? ? find_with_associations : @klass.find_by_sql(arel, @bind_values)
+            eager_loading? ? find_with_associations : find_by_sql(arel, @bind_values)
           end
         end
 

--- a/activerecord/lib/active_record/relation/quering.rb
+++ b/activerecord/lib/active_record/relation/quering.rb
@@ -1,15 +1,5 @@
-require 'active_support/core_ext/module/delegation'
-
 module ActiveRecord
-  module Querying
-    delegate :find, :first, :first!, :last, :last!, :all, :exists?, :any?, :many?, :to => :scoped
-    delegate :first_or_create, :first_or_create!, :first_or_initialize, :to => :scoped
-    delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, :to => :scoped
-    delegate :find_each, :find_in_batches, :to => :scoped
-    delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins,
-             :where, :preload, :eager_load, :includes, :from, :lock, :readonly,
-             :having, :create_with, :uniq, :to => :scoped
-    delegate :count, :average, :minimum, :maximum, :sum, :calculate, :pluck, :to => :scoped
+  module Quering
 
     # Executes a custom SQL query against your database and returns all the results. The results will
     # be returned as an array with columns requested encapsulated as attributes of the model you call
@@ -35,7 +25,7 @@ module ActiveRecord
     #   > [#<Post:0x36bff9c @attributes={"title"=>"The Cheap Man Buys Twice"}>, ...]
     def find_by_sql(sql, binds = [])
       logging_query_plan do
-        connection.select_all(sanitize_sql(sql), "#{name} Load", binds).collect! { |record| instantiate(record) }
+        connection.select_all(klass.send(:sanitize_sql,sql), "#{name} Load", binds).collect! { |record| klass.instantiate(record) }
       end
     end
 
@@ -51,7 +41,7 @@ module ActiveRecord
     #
     #   Product.count_by_sql "SELECT COUNT(*) FROM sales s, customers c WHERE s.customer_id = c.id"
     def count_by_sql(sql)
-      sql = sanitize_conditions(sql)
+      sql = klass.send(:sanitize_conditions,sql)
       connection.select_value(sql, "#{name} Count").to_i
     end
   end


### PR DESCRIPTION
Ragrding #6331 issue. Two methods, find_by_sql and count_by_sql are moved into Relation class. This should allow to easily manipulate the connection. Tests are passing.
