### PR TITLE
remove side effects on :controller option in #url_for

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -412,7 +412,7 @@ module ActionDispatch
           normalize_options!
           normalize_controller_action_id!
           use_relative_controller!
-          controller.sub!(%r{^/}, '') if controller
+          normalize_controller_leading_slash
           handle_nil_action!
         end
 
@@ -476,6 +476,11 @@ module ActionDispatch
             parts = old_parts[0...-size] << controller
             @controller = @options[:controller] = parts.join("/")
           end
+        end
+
+        # remove leading slashes from the controller: '/foo/bar' becomes 'foo/bar'
+        def normalize_controller_leading_slash
+          @controller = @options[:controller] = controller.sub(%r{^/}, '') if controller
         end
 
         # This handles the case of :action => nil being explicitly passed.

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -333,6 +333,14 @@ module AbstractController
         assert_equal("/c/a?show=false", W.new.url_for(:only_path => true, :controller => 'c', :action => 'a', :show => false))
       end
 
+      def test_url_for_has_no_side_effects
+        add_host!
+
+        controller_name = '/C'
+        assert_equal('http://www.basecamphq.com/C', W.new.url_for(:controller => controller_name))
+        assert_equal('/C', controller_name)
+      end
+
       private
         def extract_params(url)
           url.split('?', 2).last.split('&').sort


### PR DESCRIPTION
# Bug Description:

If the `:controller` option in an url_for call contains a leading slash it
will be removed, which causes side-effects:

``` ruby
my_controller = '/Example'
url_for(:controller => my_controller)
puts my_controller # => 'Example'
```

The side-effects then affect plugins like will_paginate, which store the options to pass to `url_for` in an instance_variable. The functionality then breaks after the first call to `url_for`.
# Resolution:

The route-set does not directly manipulate the string passed into `#url_for`.
It creates a copy without the leading slash if necessary.
