### PR TITLE
Increase numeric-timestamp precision to µseconds

### DIFF
--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -39,7 +39,7 @@ module ActiveRecord
       when new_record?
         "#{self.class.model_name.cache_key}/new"
       when timestamp = self[:updated_at]
-        timestamp = timestamp.utc.to_s(:number)
+        timestamp = timestamp.utc.to_s(:nsec)
         "#{self.class.model_name.cache_key}/#{id}-#{timestamp}"
       else
         "#{self.class.model_name.cache_key}/#{id}"

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1939,7 +1939,7 @@ class BasicsTest < ActiveRecord::TestCase
 
   def test_cache_key_format_for_existing_record_with_updated_at
     dev = Developer.first
-    assert_equal "developers/#{dev.id}-#{dev.updated_at.utc.to_s(:number)}", dev.cache_key
+    assert_equal "developers/#{dev.id}-#{dev.updated_at.utc.to_s(:nsec)}", dev.cache_key
   end
 
   def test_cache_key_format_for_existing_record_with_nil_updated_at

--- a/activesupport/lib/active_support/core_ext/time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/time/conversions.rb
@@ -5,6 +5,7 @@ class Time
   DATE_FORMATS = {
     :db           => '%Y-%m-%d %H:%M:%S',
     :number       => '%Y%m%d%H%M%S',
+    :nsec         => '%Y%m%d%H%M%S%9N',
     :time         => '%H:%M',
     :short        => '%d %b %H:%M',
     :long         => '%B %d, %Y %H:%M',

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -557,12 +557,14 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
   end
 
   def test_to_s
-    time = Time.utc(2005, 2, 21, 17, 44, 30)
+    time = Time.utc(2005, 2, 21, 17, 44, 30.12345678901)
     assert_equal time.to_default_s,                 time.to_s
     assert_equal time.to_default_s,                 time.to_s(:doesnt_exist)
     assert_equal "2005-02-21 17:44:30",             time.to_s(:db)
     assert_equal "21 Feb 17:44",                    time.to_s(:short)
     assert_equal "17:44",                           time.to_s(:time)
+    assert_equal "20050221174430",                  time.to_s(:number)
+    assert_equal "20050221174430123456789",         time.to_s(:nsec)
     assert_equal "February 21, 2005 17:44",         time.to_s(:long)
     assert_equal "February 21st, 2005 17:44",       time.to_s(:long_ordinal)
     with_env_tz "UTC" do


### PR DESCRIPTION
The current implementation of numeric timestamps is to only include up
to the second. Unfortunately, when running tests, many things can (and
should) happen within a single second and precision of a full second
isn't enough. Milliseconds may be good here, but with fast-enough
CPUs, a single test example may execute within that one-millisecond
boundary, which may include multiple calls.

More importantly, in a production environment, precision of one second can
be far too much for cache invalidation (`AR::Base#cache_key` uses
`Time#to_s(:numeric)`), as when two clients update the same record
simultaneously, the first update will be cached. Since the second update
assigns the same value to `updated_at`, the first cached value is not
invalidated unless done so manually.
