### PR TITLE
Deprecate old APIs for highlight, excerpt and word_wrap

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 3.2.4 (unreleased) ##
 
+*   Deprecate old APIs for highlight, excerpt and word_wrap *Jeremy Walker*
+
 *   Deprecate `:disable_with` in favor of `'data-disable-with'` option for `button_to`, `button_tag` and `submit_tag` helpers.
 
     *Carlos Galdino + Rafael Mendonça França*

--- a/actionpack/lib/action_view/helpers/text_helper.rb
+++ b/actionpack/lib/action_view/helpers/text_helper.rb
@@ -111,6 +111,9 @@ module ActionView
       def highlight(text, phrases, *args)
         options = args.extract_options!
         unless args.empty?
+          ActiveSupport::Deprecation.warn "Calling highlight with a highlighter as an argument is deprecated. " \
+          "Please call with :highlighter => '#{args[0]}' instead.", caller
+          
           options[:highlighter] = args[0] || '<strong class="highlight">\1</strong>'
         end
         options.reverse_merge!(:highlighter => '<strong class="highlight">\1</strong>')
@@ -156,6 +159,9 @@ module ActionView
 
         options = args.extract_options!
         unless args.empty?
+          ActiveSupport::Deprecation.warn "Calling excerpt with radius and omission as arguments is deprecated. " \
+          "Please call with :radius => #{args[0]}#{", :omission => '#{args[1]}'" if args[1]} instead.", caller
+          
           options[:radius] = args[0] || 100
           options[:omission] = args[1] || "..."
         end
@@ -217,6 +223,9 @@ module ActionView
       def word_wrap(text, *args)
         options = args.extract_options!
         unless args.blank?
+          ActiveSupport::Deprecation.warn "Calling word_wrap with line_width as an argument is deprecated. " \
+          "Please call with :line_width => #{args[0]} instead.", caller
+
           options[:line_width] = args[0] || 80
         end
         options.reverse_merge!(:line_width => 80)


### PR DESCRIPTION
Deprecation messages to go with #6371 (cc @rafaelfranca)
