### PR TITLE
Refactor migration generator

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
@@ -12,10 +12,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration
   def up
 <% attributes.each do |attribute| -%>
   <%- if migration_action -%>
-    <%= migration_action %>_column :<%= table_name %>, :<%= attribute.name %><% if migration_action == 'add' %>, :<%= attribute.type %><%= attribute.inject_options %><% end %>
-    <%- if attribute.has_index? && migration_action == 'add' -%>
-    add_index :<%= table_name %>, :<%= attribute.index_name %><%= attribute.inject_index_options %>
-    <%- end -%>
+    <%= migration_action %>_column :<%= table_name %>, :<%= attribute.name %>
   <%- end -%>
 <%- end -%>
   end
@@ -23,8 +20,8 @@ class <%= migration_class_name %> < ActiveRecord::Migration
   def down
 <% attributes.reverse.each do |attribute| -%>
   <%- if migration_action -%>
-    <%= migration_action == 'add' ? 'remove' : 'add' %>_column :<%= table_name %>, :<%= attribute.name %><% if migration_action == 'remove' %>, :<%= attribute.type %><%= attribute.inject_options %><% end %>
-    <%- if attribute.has_index? && migration_action == 'remove' -%>
+    add_column :<%= table_name %>, :<%= attribute.name %>, :<%= attribute.type %><%= attribute.inject_options %>
+    <%- if attribute.has_index? -%>
     add_index :<%= table_name %>, :<%= attribute.index_name %><%= attribute.inject_index_options %>
     <%- end -%>
   <%- end -%>


### PR DESCRIPTION
In the `up`, `down` methods the migration action can never be `add`, as that is handled in the `change` method,
