### PR TITLE
Tidied and standardised text_helper implementations.

### DIFF
--- a/actionpack/test/template/text_helper_test.rb
+++ b/actionpack/test/template/text_helper_test.rb
@@ -60,6 +60,20 @@ class TextHelperTest < ActionView::TestCase
     simple_format(text)
     assert_equal text_clone, text
   end
+  
+  def test_simple_format_does_not_modify_the_html_options_hash
+    options = { :class => "foobar"}
+    passed_options = options.dup
+    simple_format("some text", passed_options)
+    assert_equal options, passed_options
+  end
+  
+  def test_simple_format_does_not_modify_the_options_hash
+    options = { :wrapper_tag => :div, :sanitize => false }
+    passed_options = options.dup
+    simple_format("some text", {}, passed_options)
+    assert_equal options, passed_options
+  end
 
   def test_truncate_should_not_be_html_safe
     assert !truncate("Hello World!", :length => 12).html_safe?
@@ -91,6 +105,13 @@ class TextHelperTest < ActionView::TestCase
   def test_truncate_multibyte
     assert_equal "\354\225\204\353\246\254\353\236\221 \354\225\204\353\246\254 ...".force_encoding('UTF-8'),
       truncate("\354\225\204\353\246\254\353\236\221 \354\225\204\353\246\254 \354\225\204\353\235\274\353\246\254\354\230\244".force_encoding('UTF-8'), :length => 10)
+  end
+  
+  def test_truncate_does_not_modify_the_options_hash
+    options = { :length => 10 }
+    passed_options = options.dup
+    truncate("some text", passed_options)
+    assert_equal options, passed_options
   end
 
   def test_highlight_should_be_html_safe
@@ -182,6 +203,13 @@ class TextHelperTest < ActionView::TestCase
       highlight("<div>abc div</div>", "div", :highlighter => '<b>\1</b>')
     )
   end
+  
+  def test_highlight_does_not_modify_the_options_hash
+    options = { :highlighter => '<b>\1</b>', :sanitize => false }
+    passed_options = options.dup
+    highlight("<div>abc div</div>", "div", passed_options)
+    assert_equal options, passed_options
+  end
 
   def test_excerpt
     assert_equal("...is a beautiful morn...", excerpt("This is a beautiful morning", "beautiful", :radius => 5))
@@ -228,6 +256,13 @@ class TextHelperTest < ActionView::TestCase
   def test_excerpt_with_utf8
     assert_equal("...\357\254\203ciency could not be...".force_encoding('UTF-8'), excerpt("That's why e\357\254\203ciency could not be helped".force_encoding('UTF-8'), 'could', :radius => 8))
   end
+  
+  def test_excerpt_does_not_modify_the_options_hash
+    options = { :omission => "[...]",:radius => 5 }
+    passed_options = options.dup
+    excerpt("This is a beautiful morning", "beautiful", passed_options)
+    assert_equal options, passed_options
+  end
 
   def test_word_wrap
     assert_equal("my very very\nvery long\nstring", word_wrap("my very very very long string", :line_width => 15))
@@ -235,6 +270,13 @@ class TextHelperTest < ActionView::TestCase
 
   def test_word_wrap_with_extra_newlines
     assert_equal("my very very\nvery long\nstring\n\nwith another\nline", word_wrap("my very very very long string\n\nwith another line", :line_width => 15))
+  end
+  
+  def test_word_wrap_does_not_modify_the_options_hash
+    options = { :line_width => 15 }
+    passed_options = options.dup
+    word_wrap("some text", passed_options)
+    assert_equal options, passed_options
   end
 
   def test_pluralization


### PR DESCRIPTION
I've just made various small changes to the text_helpers file to make it more readable and standardise it a little. The only tiny functionality change is a `===` vs `==` which I've annotated inline.

I've symbolised the keys of the options hash and used `options.fetch(:foobar, x)` instead of `options[:foobar] ||= x` as per discussion at https://groups.google.com/forum/?hl=en&fromgroups#!topic/rubyonrails-core/jjIDHOhqT9E

I'm happy to revert or change any bits that people don't like, but I'm also happy to implement the changes that people do like more widely, just to try and standardise the style as much as possible. It just takes less brain cycles if the code all looks the same.

I hope it's helpful.
