### PR TITLE
Invalid ruby18 syntax in habtm

### DIFF
--- a/activerecord/lib/active_record/associations/has_and_belongs_to_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_and_belongs_to_many_association.rb
@@ -52,8 +52,8 @@ module ActiveRecord
 
             unless records == :all
               condition = condition.and(
-                relation[reflection.association_foreign_key]
-                  .in(records.map { |x| x.id }.compact)
+                relation[reflection.association_foreign_key].
+                  in(records.map { |x| x.id }.compact)
               )
             end
 


### PR DESCRIPTION
@jonleighton I feel guilty even submitting a pull request this small, but it looks like a 1.8-incompatible syntax change made it into a backport from 4.0. :)
