### PR TITLE
Redirect route inspect

### DIFF
--- a/actionpack/lib/action_dispatch/routing/redirection.rb
+++ b/actionpack/lib/action_dispatch/routing/redirection.rb
@@ -35,6 +35,10 @@ module ActionDispatch
       def path(params, request)
         block.call params, request
       end
+
+      def inspect
+        "Redirect (#{status})"
+      end
     end
 
     class OptionRedirect < Redirect # :nodoc:

--- a/railties/lib/rails/application/route_inspector.rb
+++ b/railties/lib/rails/application/route_inspector.rb
@@ -16,7 +16,7 @@ module Rails
           class_name = app.class.name.to_s
           if class_name == "ActionDispatch::Routing::Mapper::Constraints"
             rack_app(app.app)
-          elsif class_name !~ /^ActionDispatch::Routing/
+          elsif class_name == "ActionDispatch::Routing::Redirect" || class_name !~ /^ActionDispatch::Routing/
             app
           end
         end
@@ -67,7 +67,7 @@ module Rails
         @engines = Hash.new
       end
 
-      def format all_routes, filter = nil
+      def format(all_routes, filter = nil)
         if filter
           all_routes = all_routes.select{ |route| route.defaults[:controller] == filter }
         end

--- a/railties/test/application/route_inspect_test.rb
+++ b/railties/test/application/route_inspect_test.rb
@@ -152,5 +152,14 @@ module ApplicationTests
       assert_no_match(/RackApp/, output.first)
       assert_no_match(/\/sprockets/, output.first)
     end
+
+    def test_redirect
+      output = draw do
+        match '/foo' => redirect("/bar")
+        match '/foo2' => redirect("/bar", status: 307)
+      end
+      assert_equal " foo  /foo(.:format)  Redirect (301)", output[0]
+      assert_equal "foo2  /foo2(.:format) Redirect (307)", output[1]
+    end
   end
 end

--- a/railties/test/application/route_inspect_test.rb
+++ b/railties/test/application/route_inspect_test.rb
@@ -16,6 +16,11 @@ module ApplicationTests
       Rails.stubs(:env).returns("development")
     end
 
+    def draw(&block)
+      @set.draw(&block)
+      @inspector.format(@set.routes)
+    end
+
     def test_displaying_routes_for_engines
       engine = Class.new(Rails::Engine) do
         def self.to_s
@@ -26,12 +31,11 @@ module ApplicationTests
         get '/cart', :to => 'cart#show'
       end
 
-      @set.draw do
+      output = draw do
         get '/custom/assets', :to => 'custom_assets#show'
         mount engine => "/blog", :as => "blog"
       end
 
-      output = @inspector.format @set.routes
       expected = [
         "custom_assets GET /custom/assets(.:format) custom_assets#show",
         "         blog     /blog                    Blog::Engine",
@@ -42,26 +46,23 @@ module ApplicationTests
     end
 
     def test_cart_inspect
-      @set.draw do
+      output = draw do
         get '/cart', :to => 'cart#show'
       end
-      output = @inspector.format @set.routes
       assert_equal ["cart GET /cart(.:format) cart#show"], output
     end
 
     def test_inspect_shows_custom_assets
-      @set.draw do
+      output = draw do
         get '/custom/assets', :to => 'custom_assets#show'
       end
-      output = @inspector.format @set.routes
       assert_equal ["custom_assets GET /custom/assets(.:format) custom_assets#show"], output
     end
 
     def test_inspect_routes_shows_resources_route
-      @set.draw do
+      output = draw do
         resources :articles
       end
-      output = @inspector.format @set.routes
       expected = [
         "    articles GET    /articles(.:format)          articles#index",
         "             POST   /articles(.:format)          articles#create",
@@ -75,50 +76,44 @@ module ApplicationTests
     end
 
     def test_inspect_routes_shows_root_route
-      @set.draw do
+      output = draw do
         root :to => 'pages#main'
       end
-      output = @inspector.format @set.routes
       assert_equal ["root GET / pages#main"], output
     end
 
     def test_inspect_routes_shows_dynamic_action_route
-      @set.draw do
+      output = draw do
         get 'api/:action' => 'api'
       end
-      output = @inspector.format @set.routes
       assert_equal [" GET /api/:action(.:format) api#:action"], output
     end
 
     def test_inspect_routes_shows_controller_and_action_only_route
-      @set.draw do
+      output = draw do
         get ':controller/:action'
       end
-      output = @inspector.format @set.routes
       assert_equal [" GET /:controller/:action(.:format) :controller#:action"], output
     end
 
     def test_inspect_routes_shows_controller_and_action_route_with_constraints
-      @set.draw do
+      output = draw do
         get ':controller(/:action(/:id))', :id => /\d+/
       end
-      output = @inspector.format @set.routes
       assert_equal [" GET /:controller(/:action(/:id))(.:format) :controller#:action {:id=>/\\d+/}"], output
     end
 
     def test_rake_routes_shows_route_with_defaults
-      @set.draw do
+      output = draw do
         get 'photos/:id' => 'photos#show', :defaults => {:format => 'jpg'}
       end
-      output = @inspector.format @set.routes
       assert_equal [%Q[ GET /photos/:id(.:format) photos#show {:format=>"jpg"}]], output
     end
 
     def test_rake_routes_shows_route_with_constraints
-      @set.draw do
+      output = draw do
         get 'photos/:id' => 'photos#show', :id => /[A-Z]\d{5}/
       end
-      output = @inspector.format @set.routes
       assert_equal [" GET /photos/:id(.:format) photos#show {:id=>/[A-Z]\\d{5}/}"], output
     end
 
@@ -128,10 +123,9 @@ module ApplicationTests
     end
 
     def test_rake_routes_shows_route_with_rack_app
-      @set.draw do
+      output = draw do
         get 'foo/:id' => RackApp, :id => /[A-Z]\d{5}/
       end
-      output = @inspector.format @set.routes
       assert_equal [" GET /foo/:id(.:format) #{RackApp.name} {:id=>/[A-Z]\\d{5}/}"], output
     end
 
@@ -142,21 +136,19 @@ module ApplicationTests
         end
       end
 
-      @set.draw do
+      output = draw do
         scope :constraint => constraint.new do
           mount RackApp => '/foo'
         end
       end
 
-      output = @inspector.format @set.routes
       assert_equal ["  /foo #{RackApp.name} {:constraint=>( my custom constraint )}"], output
     end
 
     def test_rake_routes_dont_show_app_mounted_in_assets_prefix
-      @set.draw do
+      output = draw do
         get '/sprockets' => RackApp
       end
-      output = @inspector.format @set.routes
       assert_no_match(/RackApp/, output.first)
       assert_no_match(/\/sprockets/, output.first)
     end


### PR DESCRIPTION
This pull request fixes route inspection for routes that are redirection.

routes.rb:

``` ruby
FooBar::Application.routes.draw do
  match "/foo" => redirect("/bar")
end
```

`rake routes` now:

```
foo  /foo(.:format) :controller#:action"
```

after patch, fixed:

```
foo  /foo(.:format)  Redirect (301)
```
