### PR TITLE
CollectionAssociation#empty? can take a block to define a criteria

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -274,7 +274,11 @@ module ActiveRecord
       # not been already loaded and you are going to fetch the records anyway
       # it is better to check <tt>collection.length.zero?</tt>.
       def empty?
-        size.zero?
+        if block_given?
+          load_target.empty? { |*block_args| yield(*block_args) }
+        else
+          size.zero?
+        end
       end
 
       def any?

--- a/activerecord/test/cases/named_scope_test.rb
+++ b/activerecord/test/cases/named_scope_test.rb
@@ -165,6 +165,14 @@ class NamedScopeTest < ActiveRecord::TestCase
     end
   end
 
+  def test_empty_should_call_proxy_found_if_using_a_block
+    topics = Topic.base
+    assert_queries(1) do
+      topics.expects(:size).never
+      topics.empty? { true }
+    end
+  end
+
   def test_any_should_not_load_results
     topics = Topic.base
     assert_queries(2) do


### PR DESCRIPTION
Example:

``` ruby
# Having a class with a collection:
class Person < ActiveRecord::Base
  has_many :pets
end

person.pets.size   # => 2
person.pets.empty? # => false

# defining a criteria inside a block
person.pets.empty? { |pet| pet.name.nil? } # => true
```

If it's accepted, i will update CollectionProxy#empty? documentation.
