### PR TITLE
http basic auth failures respect request.accept for json/xml

### DIFF
--- a/actionpack/test/controller/http_basic_authentication_test.rb
+++ b/actionpack/test/controller/http_basic_authentication_test.rb
@@ -93,6 +93,33 @@ class HttpBasicAuthenticationTest < ActionController::TestCase
     assert_no_match(/\n/, result)
   end
 
+  test "unsuccessful authentication request with application/json Accept header" do
+    @request.env["HTTP_ACCEPT"] = "application/json"
+    get :index
+
+    assert_response :unauthorized
+    assert_equal '{"error":"HTTP Basic: Access denied."}', @response.body
+    assert @response.headers['Content-Type'].start_with? 'application/json'
+  end
+
+  test "unsuccessful authentication request with text/xml Accept header" do
+    @request.env["HTTP_ACCEPT"] = "application/xml"
+    get :index
+
+    assert_response :unauthorized
+    assert_equal '<error>HTTP Basic: Access denied.</error>', @response.body
+    assert @response.headers['Content-Type'].start_with? 'application/xml'
+  end
+
+  test "unsuccessful authentication request defaults to plain text/html output with typical accept header" do
+    @request.env["HTTP_ACCEPT"] = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+    get :index
+
+    assert_response :unauthorized
+    assert_equal "HTTP Basic: Access denied.\n", @response.body
+    assert @response.headers['Content-Type'].start_with? 'text/html'
+  end
+
   test "authentication request without credential" do
     get :display
 


### PR DESCRIPTION
I noticed that rails http authentication currently always returns a string like "HTTP Basic: Access denied." regardless of the request Accept header. 

We got reports of this causing some clients problems (I guess they are expecting json, and always attempting to parse the body as json). 

I thought I'd experiment with modifying rails to respond with some valid json when accept is for json, and likewise for xml.

Is this a good idea?

for json it will now return something like:

``` json
{"error":"HTTP Basic: Access denied."}
```

or xml

``` xml
<error>HTTP Basic: Access denied.</error>
```
