### PR TITLE
Don't use assert_block method. It will be removed.

### DIFF
--- a/actionpack/test/ts_isolated.rb
+++ b/actionpack/test/ts_isolated.rb
@@ -9,7 +9,7 @@ class TestIsolated < ActiveSupport::TestCase
     define_method("test #{file}") do
       command = "#{ruby} -Ilib:test #{file}"
       result = silence_stderr { `#{command}` }
-      assert_block("#{command}\n#{result}") { $?.to_i.zero? }
+      assert $?.to_i.zero?, "#{command}\n#{result}"
     end
   end
 end

--- a/activesupport/test/ts_isolated.rb
+++ b/activesupport/test/ts_isolated.rb
@@ -10,7 +10,7 @@ class TestIsolated < ActiveSupport::TestCase
     define_method("test #{file}") do
       command = "#{ruby} -Ilib:test #{file}"
       result = silence_stderr { `#{command}` }
-      assert_block("#{command}\n#{result}") { $?.to_i.zero? }
+      assert $?.to_i.zero?, "#{command}\n#{result}"
     end
   end
 end


### PR DESCRIPTION
I found the following output in the Travis CI.

```
...
.NOTE: MiniTest::Unit::TestCase#assert_block is deprecated, use assert. It will be removed on or after 2012-06-01. Called from /home/vagrant/builds/rails/rails/activesupport/test/ts_isolated.rb:13:in `block (2 levels) in <class:TestIsolated>'
...
```

I can reproduct this problem by the following command.

```
$ bundle exec rake test:isolated
```
