### PR TITLE
Fix a problem of translate_exception method in a Japanese (non English) environment.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1336,11 +1336,15 @@ module ActiveRecord
           @connection.server_version
         end
 
+        # See http://www.postgresql.org/docs/9.1/static/errcodes-appendix.html
+        FOREIGN_KEY_VIOLATION = "23503"
+        UNIQUE_VIOLATION      = "23505"
+
         def translate_exception(exception, message)
-          case exception.message
-          when /duplicate key value violates unique constraint/
+          case exception.result.error_field(PGresult::PG_DIAG_SQLSTATE)
+          when UNIQUE_VIOLATION
             RecordNotUnique.new(message, exception)
-          when /violates foreign key constraint/
+          when FOREIGN_KEY_VIOLATION
             InvalidForeignKey.new(message, exception)
           else
             super


### PR DESCRIPTION
When I executed rake command in activerecord directory, I had 2 failures.
I realize the cause of this problem - exception.message method returns localized messesage string.

```
$ ARCONN=postgresql ruby -Ilib:test test/cases/adapter_test.rb

  1) Failure:
test_foreign_key_violations_are_translated_to_specific_exception(ActiveRecord::AdapterTest) [test/cases/adapter_test.rb:134]:
[ActiveRecord::InvalidForeignKey] exception expected, not
Class: <ActiveRecord::StatementInvalid>
Message: <"PG::Error: ERROR:  テーブル\"fk_test_has_fk\"への挿入、更新は外部キー制約\"fk_name\"に違反しています\nDETAIL:  テーブル\"fk_test_has_pk\"にキー(fk_id)=(0)がありません\n: INSERT INTO fk_test_has_fk (fk_id) VALUES (0)">
---Backtrace---
/home/kennyj/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:790:in `async_exec'
/home/kennyj/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:790:in `block in execute'
/home/kennyj/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:288:in `block in log'
/home/kennyj/rails/activesupport/lib/active_support/notifications/instrumenter.rb:18:in `instrument'
/home/kennyj/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:283:in `log'
/home/kennyj/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:789:in `execute'
test/cases/adapter_test.rb:140:in `block in test_foreign_key_violations_are_translated_to_specific_exception'
---------------

  2) Failure:
test_uniqueness_violations_are_translated_to_specific_exception(ActiveRecord::AdapterTest) [test/cases/adapter_test.rb:127]:
[ActiveRecord::RecordNotUnique] exception expected, not
Class: <ActiveRecord::StatementInvalid>
Message: <"PG::Error: ERROR:  重複キーが一意性制約\"index_subscribers_on_nick\"に違反しています\nDETAIL:  キー (nick)=(me) はすでに存在します\n: INSERT INTO subscribers(nick) VALUES('me')">
---Backtrace---
/home/kennyj/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:790:in `async_exec'
/home/kennyj/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:790:in `block in execute'
/home/kennyj/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:288:in `block in log'
/home/kennyj/rails/activesupport/lib/active_support/notifications/instrumenter.rb:18:in `instrument'
/home/kennyj/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:283:in `log'
/home/kennyj/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:789:in `execute'
test/cases/adapter_test.rb:128:in `block in test_uniqueness_violations_are_translated_to_specific_exception'
```
