### PR TITLE
Raise Assertion instead of RoutingError for routing assertion failures.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -186,6 +186,9 @@
 *   `ActionView::Helpers::TextHelper#highlight` now defaults to the
     HTML5 `mark` element. *Brian Cardarella*
 
+*   `assert_generates`, `assert_recognizes`, and `assert_routing` all raise
+    `Assertion` instead of `RoutingError` *David Chelimsky*
+
 
 ## Rails 3.2.3 (March 30, 2012) ##
 

--- a/actionpack/test/controller/resources_test.rb
+++ b/actionpack/test/controller/resources_test.rb
@@ -109,7 +109,7 @@ class ResourcesTest < ActionController::TestCase
     expected_options = {:controller => 'messages', :action => 'show', :id => '1.1.1'}
 
     with_restful_routing :messages do
-      assert_raise(ActionController::RoutingError) do
+      assert_raise(Assertion) do
         assert_recognizes(expected_options, :path => 'messages/1.1.1', :method => :get)
       end
     end
@@ -660,15 +660,15 @@ class ResourcesTest < ActionController::TestCase
       options = { :controller => controller_name.to_s }
       collection_path = "/#{controller_name}"
 
-      assert_raise(ActionController::RoutingError) do
+      assert_raise(Assertion) do
         assert_recognizes(options.merge(:action => 'update'), :path => collection_path, :method => :patch)
       end
 
-      assert_raise(ActionController::RoutingError) do
+      assert_raise(Assertion) do
         assert_recognizes(options.merge(:action => 'update'), :path => collection_path, :method => :put)
       end
 
-      assert_raise(ActionController::RoutingError) do
+      assert_raise(Assertion) do
         assert_recognizes(options.merge(:action => 'destroy'), :path => collection_path, :method => :delete)
       end
     end
@@ -1353,7 +1353,7 @@ class ResourcesTest < ActionController::TestCase
     end
 
     def assert_not_recognizes(expected_options, path)
-      assert_raise ActionController::RoutingError, Assertion do
+      assert_raise Assertion do
         assert_recognizes(expected_options, path)
       end
     end

--- a/actionpack/test/dispatch/routing_assertions_test.rb
+++ b/actionpack/test/dispatch/routing_assertions_test.rb
@@ -54,21 +54,21 @@ class RoutingAssertionsTest < ActionController::TestCase
   end
 
   def test_assert_recognizes_with_hash_constraint
-    assert_raise(ActionController::RoutingError) do
+    assert_raise(Assertion) do
       assert_recognizes({ :controller => 'secure_articles', :action => 'index' }, 'http://test.host/secure/articles')
     end
     assert_recognizes({ :controller => 'secure_articles', :action => 'index', :protocol => 'https://' }, 'https://test.host/secure/articles')
   end
 
   def test_assert_recognizes_with_block_constraint
-    assert_raise(ActionController::RoutingError) do
+    assert_raise(Assertion) do
       assert_recognizes({ :controller => 'block_articles', :action => 'index' }, 'http://test.host/block/articles')
     end
     assert_recognizes({ :controller => 'block_articles', :action => 'index' }, 'https://test.host/block/articles')
   end
 
   def test_assert_recognizes_with_query_constraint
-    assert_raise(ActionController::RoutingError) do
+    assert_raise(Assertion) do
       assert_recognizes({ :controller => 'query_articles', :action => 'index', :use_query => 'false' }, '/query/articles', { :use_query => 'false' })
     end
     assert_recognizes({ :controller => 'query_articles', :action => 'index', :use_query => 'true' }, '/query/articles', { :use_query => 'true' })
@@ -87,14 +87,14 @@ class RoutingAssertionsTest < ActionController::TestCase
   end
 
   def test_assert_routing_with_hash_constraint
-    assert_raise(ActionController::RoutingError) do
+    assert_raise(Assertion) do
       assert_routing('http://test.host/secure/articles', { :controller => 'secure_articles', :action => 'index' })
     end
     assert_routing('https://test.host/secure/articles', { :controller => 'secure_articles', :action => 'index', :protocol => 'https://' })
   end
 
   def test_assert_routing_with_block_constraint
-    assert_raise(ActionController::RoutingError) do
+    assert_raise(Assertion) do
       assert_routing('http://test.host/block/articles', { :controller => 'block_articles', :action => 'index' })
     end
     assert_routing('https://test.host/block/articles', { :controller => 'block_articles', :action => 'index' })
@@ -107,7 +107,7 @@ class RoutingAssertionsTest < ActionController::TestCase
       end
 
       assert_routing('/artikel', :controller => 'articles', :action => 'index')
-      assert_raise(ActionController::RoutingError) do
+      assert_raise(Assertion) do
         assert_routing('/articles', { :controller => 'articles', :action => 'index' })
       end
     end


### PR DESCRIPTION
- Fixes #5899
