### PR TITLE
Refactor Filter Methods

### DIFF
--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -8,7 +8,7 @@ module AbstractController
     include ActiveSupport::Callbacks
 
     included do
-      define_callbacks :process_action, :terminator => "response_body", :skip_after_callbacks_if_terminated => true
+      define_callbacks :process_action, terminator: "response_body", skip_after_callbacks_if_terminated: true
     end
 
     # Override AbstractController::Base's process_action to run the
@@ -160,34 +160,32 @@ module AbstractController
       # set up before_filter, prepend_before_filter, skip_before_filter, etc.
       # for each of before, after, and around.
       [:before, :after, :around].each do |filter|
-        class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
-          # Append a before, after or around filter. See _insert_callbacks
-          # for details on the allowed parameters.
-          def #{filter}_filter(*names, &blk)                                                    # def before_filter(*names, &blk)
-            _insert_callbacks(names, blk) do |name, options|                                    #   _insert_callbacks(names, blk) do |name, options|
-              set_callback(:process_action, :#{filter}, name, options)                          #     set_callback(:process_action, :before, name, options)
-            end                                                                                 #   end
-          end                                                                                   # end
+        # Append a before, after or around filter. See _insert_callbacks
+        # for details on the allowed parameters.
+        define_method("#{filter}_filter") do |*names, &blk|                                   # def before_filter(*names, &blk)
+          _insert_callbacks(names, blk) do |name, options|                                    #   _insert_callbacks(names, blk) do |name, options|
+            set_callback(:process_action, filter, name, options)                              #     set_callback(:process_action, :before, name, options)
+          end                                                                                 #   end
+        end                                                                                   # end
 
-          # Prepend a before, after or around filter. See _insert_callbacks
-          # for details on the allowed parameters.
-          def prepend_#{filter}_filter(*names, &blk)                                            # def prepend_before_filter(*names, &blk)
-            _insert_callbacks(names, blk) do |name, options|                                    #   _insert_callbacks(names, blk) do |name, options|
-              set_callback(:process_action, :#{filter}, name, options.merge(:prepend => true))  #     set_callback(:process_action, :before, name, options.merge(:prepend => true))
-            end                                                                                 #   end
-          end                                                                                   # end
+        # Prepend a before, after or around filter. See _insert_callbacks
+        # for details on the allowed parameters.
+        define_method("prepend_#{filter}_filter") do |*names, &blk|                           # def prepend_before_filter(*names, &blk)
+          _insert_callbacks(names, blk) do |name, options|                                    #   _insert_callbacks(names, blk) do |name, options|
+            set_callback(:process_action, filter, name, options.merge(prepend: true))         #     set_callback(:process_action, :before, name, options.merge(:prepend => true))
+          end                                                                                 #   end
+        end                                                                                   # end
 
-          # Skip a before, after or around filter. See _insert_callbacks
-          # for details on the allowed parameters.
-          def skip_#{filter}_filter(*names)                                                     # def skip_before_filter(*names)
-            _insert_callbacks(names) do |name, options|                                         #   _insert_callbacks(names) do |name, options|
-              skip_callback(:process_action, :#{filter}, name, options)                         #     skip_callback(:process_action, :before, name, options)
-            end                                                                                 #   end
-          end                                                                                   # end
+        # Skip a before, after or around filter. See _insert_callbacks
+        # for details on the allowed parameters.
+        define_method("skip_#{filter}_filter") do |*names|                                    # def skip_before_filter(*names)
+          _insert_callbacks(names) do |name, options|                                         #   _insert_callbacks(names) do |name, options|
+            skip_callback(:process_action, filter, name, options)                             #     skip_callback(:process_action, :before, name, options)
+          end                                                                                 #   end
+        end                                                                                   # end
 
-          # *_filter is the same as append_*_filter
-          alias_method :append_#{filter}_filter, :#{filter}_filter  # alias_method :append_before_filter, :before_filter
-        RUBY_EVAL
+        # *_filter is the same as append_*_filter
+        alias_method "append_#{filter}_filter", "#{filter}_filter"                            # alias_method "append_before_filter", "before_filter"
       end
     end
   end


### PR DESCRIPTION
Changed `AbstractController::Callbacks` to use `define_method` when creating `before_filter`, `after_filter`, etc. instead of `class_eval`.
