### PR TITLE
TagHelper creates invalid data attributes when value is a BigDecimal

### DIFF
--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -138,7 +138,7 @@ module ActionView
             options.each_pair do |key, value|
               if key.to_s == 'data' && value.is_a?(Hash)
                 value.each do |k, v|
-                  if !v.is_a?(String) && !v.is_a?(Symbol)
+                  unless v.is_a?(String) || v.is_a?(Symbol) || v.is_a?(BigDecimal)
                     v = v.to_json
                   end
                   v = ERB::Util.html_escape(v) if escape

--- a/actionpack/test/template/tag_helper_test.rb
+++ b/actionpack/test/template/tag_helper_test.rb
@@ -113,8 +113,8 @@ class TagHelperTest < ActionView::TestCase
 
   def test_data_attributes
     ['data', :data].each { |data|
-      assert_dom_equal '<a data-a-number="1" data-array="[1,2,3]" data-hash="{&quot;key&quot;:&quot;value&quot;}" data-string="hello" data-symbol="foo" />',
-        tag('a', { data => { :a_number => 1, :string => 'hello', :symbol => :foo, :array => [1, 2, 3], :hash => { :key => 'value'} } })
+      assert_dom_equal '<a data-a-float="3.14" data-a-big-decimal="-123.456" data-a-number="1" data-array="[1,2,3]" data-hash="{&quot;key&quot;:&quot;value&quot;}" data-string="hello" data-symbol="foo" />',
+        tag('a', { data => { :a_float => 3.14, :a_big_decimal => BigDecimal.new("-123.456"), :a_number => 1, :string => 'hello', :symbol => :foo, :array => [1, 2, 3], :hash => { :key => 'value'} } })
     }
   end
 end


### PR DESCRIPTION
As requested by @rafaelfranca in this thread: https://github.com/rails/rails/pull/2036
