### PR TITLE
ActionView: Ensure that NumberHelper is requireable on its own

### DIFF
--- a/actionpack/lib/action_view/helpers/number_helper.rb
+++ b/actionpack/lib/action_view/helpers/number_helper.rb
@@ -1,8 +1,10 @@
 # encoding: utf-8
 
+require 'active_support/i18n'
 require 'active_support/core_ext/big_decimal/conversions'
+require 'active_support/core_ext/hash/keys'
 require 'active_support/core_ext/object/blank'
-require 'active_support/core_ext/string/output_safety'
+require 'action_view/helpers/output_safety_helper'
 
 module ActionView
   # = Action View Number Helpers
@@ -15,6 +17,7 @@ module ActionView
     # Most methods expect a +number+ argument, and will return it
     # unchanged if can't be converted into a valid number.
     module NumberHelper
+      include OutputSafetyHelper
 
       DEFAULT_CURRENCY_VALUES = { :format => "%u%n", :negative_format => "-%u%n", :unit => "$", :separator => ".", :delimiter => ",",
                                   :precision => 2, :significant => false, :strip_insignificant_zeros => false }


### PR DESCRIPTION
I would like to start a discussion about ensuring that every helper is requireable on its own. In my project at work, I have tests that sits outside of Rails. One of my classes uses a helper out of ActionView. I shouldn't have to require all of ActionView or ActionPack just to be able to use one method from one helper. I should be able to just require the file I need and keep going.

Unfortunately, this is not the case for NumberHelper -- if you require it and then try to use one of its methods, you get:

```
~/code/github/forks/rails/actionpack on ruby 1.9.3-p125-falcon (master)
$ ruby -I actionpack/lib -r action_view/helpers/number_helper -e 'h = Object.new.extend(ActionView::Helpers::NumberHelper); h.number_to_currency(2)'
/Users/elliot/code/github/forks/rails/actionpack/lib/action_view/helpers/number_helper.rb:131:in `number_to_currency': undefined method `symbolize_keys' for {}:Hash (NoMethodError)
    from -e:1:in `<main>'
```

I've quickly patched NumberHelper so that this is possible. However, I imagine that some of the other helpers are this way, too, and if so I'd be happy to fix them and add tests to confirm that this works.

I appreciate how Yehuda Katz tried to keep this in mind when working on Rails 3, but it seems that this mindset has been abandoned since he left, which is a bit of a shame. What's the consensus on this issue?
