### PR TITLE
Postgresql doesn't accept limits on binary (bytea) columns (for 3-2-stable)

### DIFF
--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define do
   create_table :binaries, :force => true do |t|
     t.string :name
     t.binary :data
+    t.binary :short_data, :limit => 2048
   end
 
   create_table :birds, :force => true do |t|


### PR DESCRIPTION
This is the diff in #6238 applied to 3-2-stable.

/cc @tenderlove Thank you for merging #6238. Can you please consider this one as well, so Heroku app devs don't have to wait for Rails 4 to get the fix?

Thanks so much!
