### PR TITLE
Restore frozen state on rollback, fixes #6417

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -329,7 +329,8 @@ module ActiveRecord
         @_start_transaction_state[:level] = (@_start_transaction_state[:level] || 0) - 1
         if @_start_transaction_state[:level] < 1
           restore_state = remove_instance_variable(:@_start_transaction_state)
-          @attributes = @attributes.dup if @attributes.frozen?
+          was_frozen = @attributes.frozen?
+          @attributes = @attributes.dup if was_frozen
           @new_record = restore_state[:new_record]
           @destroyed  = restore_state[:destroyed]
           if restore_state.has_key?(:id)
@@ -338,6 +339,7 @@ module ActiveRecord
             @attributes.delete(self.class.primary_key)
             @attributes_cache.delete(self.class.primary_key)
           end
+          @attributes.freeze if was_frozen
         end
       end
     end

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -362,6 +362,16 @@ class TransactionTest < ActiveRecord::TestCase
     end
   end
 
+  def test_rollback_when_saving_a_frozen_record
+    topic = Topic.new(:title => 'test')
+    topic.freeze
+    e = assert_raise(RuntimeError) { topic.save }
+    assert_equal "can't modify frozen Hash", e.message
+    assert !topic.persisted?, 'not persisted'
+    assert_nil topic.id
+    assert topic.frozen?, 'not frozen'
+  end
+
   def test_restore_active_record_state_for_all_records_in_a_transaction
     topic_1 = Topic.new(:title => 'test_1')
     topic_2 = Topic.new(:title => 'test_2')


### PR DESCRIPTION
My first patch for rails!

When saving a frozen? record, active record would raise an exception to complain about the frozen attributes, rollback the transaction. However, it also has the side effect of unfreezing the record after the rollback. This behaviour is undesirable and incorrect (saving a frozen? record twice in a roll would fail for the first time and succeed in the second time). This patch fixes the bug by explicitly restoring the frozen? state after a rollback.
