### PR TITLE
Prevent concurrent compilation of templates - closes #6400

### DIFF
--- a/actionpack/lib/action_view/template.rb
+++ b/actionpack/lib/action_view/template.rb
@@ -1,6 +1,7 @@
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/object/try'
 require 'active_support/core_ext/kernel/singleton_class'
+require 'thread'
 
 module ActionView
   # = Action View Template
@@ -122,6 +123,7 @@ module ActionView
       @virtual_path      = details[:virtual_path]
       @updated_at        = details[:updated_at] || Time.now
       @formats           = Array(format).map { |f| f.is_a?(Mime::Type) ? f.ref : f }
+      @compile_mutex     = Mutex.new
     end
 
     # Returns if the underlying handler supports streaming. If so,
@@ -223,18 +225,28 @@ module ActionView
       def compile!(view) #:nodoc:
         return if @compiled
 
-        if view.is_a?(ActionView::CompiledTemplates)
-          mod = ActionView::CompiledTemplates
-        else
-          mod = view.singleton_class
+        # Templates can be used concurrently in threaded environments
+        # so compilation and any instance variable modification must
+        # be synchronized
+        @compile_mutex.synchronize do
+          # Any thread holding this lock will be compiling the template needed
+          # by the threads waiting. So re-check the @compiled flag to avoid
+          # re-compilation
+          return if @compiled
+
+          if view.is_a?(ActionView::CompiledTemplates)
+            mod = ActionView::CompiledTemplates
+          else
+            mod = view.singleton_class
+          end
+
+          compile(view, mod)
+
+          # Just discard the source if we have a virtual path. This
+          # means we can get the template back.
+          @source = nil if @virtual_path
+          @compiled = true
         end
-
-        compile(view, mod)
-
-        # Just discard the source if we have a virtual path. This
-        # means we can get the template back.
-        @source = nil if @virtual_path
-        @compiled = true
       end
 
       # Among other things, this method is responsible for properly setting


### PR DESCRIPTION
This was already applied to 3-2 in commit 565c1b0a0772ac6cf91c77e9285806f7b028614c, so here's the 'forward-port'.

This addresses an issue where in multi-threaded environments
multiple threads can attempt to compile a template at the same time,
which occasionally causes particular templates to end up in a bad
state.

So, add synchronization such that only a single thread can attempt to
compile a template at one time.
