### PR TITLE
Fixed bug where enums limit were getting set as 0

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -67,6 +67,8 @@ module ActiveRecord
             else
               super # we could return 65535 here, but we leave it undecorated by default
             end
+          when /^enum\((.*)\)/i
+            $1.split(',').collect{ |value| value.size-2 }.max
           when /^bigint/i;    8
           when /^int/i;       4
           when /^mediumint/i; 3


### PR DESCRIPTION
This is an old bug where rake db:schema:dump imported all columns with the type enum as :limit => 0, making schema.rb don't work on with anything that relies on it(db:schema:load).

This issue were raised here: https://rails.lighthouseapp.com/projects/8994/tickets/997-dbschemadump-saves-enum-columns-as-varchar0-on-mysql

And there's other posts on the web about it.

I solved it by setting the limit as the biggest enum value string size. I wonder if shouldn't we just set it as like 255 to only make it work.

I think it's also time that rails supports enum columns. There's plugins that do that, but I would gadly make it work.

Feel free to comment about the code or the regexp, I will also gadly change it.
