### PR TITLE
Bugfix. delete_if accepts symbols and strings indifferently for key comparsion.

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -140,6 +140,20 @@ module ActiveSupport
       super(convert_key(key))
     end
 
+    # Deletes every key-value pair from hash for which block evaluates to true. Symbol and string keys are
+    # compared indifferently.
+    def delete_if(&block)
+      wrapper = lambda do |key, value|
+        key = key.dup
+        key.define_singleton_method("==") do |arg|
+          arg = arg.to_s if arg.kind_of?(Symbol)
+          super(arg)
+        end
+        block.call(key, value)
+      end
+      super(&wrapper)
+    end
+
     def stringify_keys!; self end
     def stringify_keys; dup end
     undef :symbolize_keys!

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -255,6 +255,14 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal hash.delete('a'), nil
   end
 
+  def test_indifferent_delete_if
+    get_hash = proc{ { :a => 'foo' }.with_indifferent_access }
+    hash = get_hash.call
+    assert_equal false, hash.delete_if { |k, v| k == :a }.any?
+    hash = get_hash.call
+    assert_equal false, hash.delete_if { |k, v| k == 'a' }.any?
+  end
+
   def test_indifferent_to_hash
     # Should convert to a Hash with String keys.
     assert_equal @strings, @mixed.with_indifferent_access.to_hash


### PR DESCRIPTION
Writing some tests discovered noisy bug with delete_if behaviour when trying to compare key with symbol.
