### PR TITLE
Use new hash syntax for generators gem method

### DIFF
--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -27,7 +27,7 @@ module Rails
         log :gemfile, message
 
         options.each do |option, value|
-          parts << ":#{option} => #{value.inspect}"
+          parts << "#{option}: #{value.inspect}"
         end
 
         in_root do

--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -139,7 +139,7 @@ task :default => :test
 
       gemfile_in_app_path = File.join(rails_app_path, "Gemfile")
       if File.exist? gemfile_in_app_path
-        entry = "gem '#{name}', :path => '#{relative_path}'"
+        entry = "gem '#{name}', path: '#{relative_path}'"
         append_file gemfile_in_app_path, entry
       end
     end

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -67,6 +67,14 @@ class ActionsTest < Rails::Generators::TestCase
     assert_file 'Gemfile', /^gem "rspec-rails"$/
   end
 
+  def test_gem_should_include_options
+    run_generator
+
+    action :gem, 'rspec', github: 'dchelimsky/rspec', tag: '1.2.9.rc1'
+
+    assert_file 'Gemfile', /gem "rspec", github: "dchelimsky\/rspec", tag: "1\.2\.9\.rc1"/
+  end
+
   def test_gem_group_should_wrap_gems_in_a_group
     run_generator
 

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -279,7 +279,7 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
 
     run_generator [destination_root]
 
-    assert_file gemfile_path, /gem 'bukkits', :path => 'tmp\/bukkits'/
+    assert_file gemfile_path, /gem 'bukkits', path: 'tmp\/bukkits'/
   ensure
     Object.send(:remove_const, 'APP_PATH')
     FileUtils.rm gemfile_path
@@ -294,7 +294,7 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
     run_generator [destination_root, "--skip-gemfile-entry"]
 
     assert_file gemfile_path do |contents|
-      assert_no_match(/gem 'bukkits', :path => 'tmp\/bukkits'/, contents)
+      assert_no_match(/gem 'bukkits', path: 'tmp\/bukkits'/, contents)
     end
   ensure
     Object.send(:remove_const, 'APP_PATH')


### PR DESCRIPTION
The Gemfile of new application uses ruby 1.9 hashes. Gem method of
generators should use them too. It prevents from mixing two kinds of
syntax in one file.
