### PR TITLE
Move root method at TOP of routes file

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/routes.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/routes.rb
@@ -1,6 +1,10 @@
 <%= app_const %>.routes.draw do
   # The priority is based upon order of creation:
   # first created -> highest priority.
+  
+  # You can have the root of your site routed with "root"
+  # just remember to delete public/index.html.
+  # root :to => 'welcome#index'
 
   # Sample of regular route:
   #   get 'products/:id' => 'catalog#view'
@@ -46,9 +50,6 @@
   #     resources :products
   #   end
 
-  # You can have the root of your site routed with "root"
-  # just remember to delete public/index.html.
-  # root :to => 'welcome#index'
 
   # See how all your routes lay out with "rake routes"
 end


### PR DESCRIPTION
Made the change as per the following text in [routing guide](http://edgeguides.rubyonrails.org/routing.html#using-root):-
_"You should put the root route at the top of the file,
because it is the most popular route and should be matched first."_

However, if root is best left at bottom. We will have change text in guide. so both things don't contradict
