### PR TITLE
Create hstore extension when building PostgreSQL databases (for rails contributor).

### DIFF
--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -114,6 +114,16 @@ namespace :postgresql do
     config = ARTest.config['connections']['postgresql']
     %x( createdb -E UTF8 #{config['arunit']['database']} )
     %x( createdb -E UTF8 #{config['arunit2']['database']} )
+
+    # prepare hstore
+    version = %x( createdb --version ).strip.gsub(/(.*)(\d\.\d\.\d)$/, "\\2")
+    %w(arunit arunit2).each do |db|
+      if version < "9.1.0"
+        puts "Please prepare hstore data type. See http://www.postgresql.org/docs/9.0/static/hstore.html"
+      else
+        %x( psql #{config[db]['database']} -c "CREATE EXTENSION hstore;" )
+      end
+    end
   end
 
   desc 'Drop the PostgreSQL test databases'

--- a/guides/source/contributing_to_ruby_on_rails.textile
+++ b/guides/source/contributing_to_ruby_on_rails.textile
@@ -190,6 +190,8 @@ $ rake postgresql:build_databases
 
 NOTE: Using the rake task to create the test databases ensures they have the correct character set and collation.
 
+NOTE: You'll see the following warning (or localized warning) during activating HStore extension in PostgreSQL 9.1.x or earlier: "WARNING: => is deprecated as an operator".
+
 If you’re using another database, check the files under +activerecord/test/connections+ for default connection information. You can edit these files to provide different credentials on your machine if you must, but obviously you should not push any such changes back to Rails.
 
 You can now run the tests as you did for +sqlite3+. The tasks are respectively


### PR DESCRIPTION
I didn't know _hstore_, I didn't know that hstore_test.rb was skipped.
I think that we should create _hstore_ when building databases.

or should guides be updated ?
