### PR TITLE
Fixed generated whitespace in routes when using namespaced resource.

### DIFF
--- a/railties/lib/rails/generators/rails/resource_route/resource_route_generator.rb
+++ b/railties/lib/rails/generators/rails/resource_route/resource_route_generator.rb
@@ -3,9 +3,9 @@ module Rails
     class ResourceRouteGenerator < NamedBase
       def add_resource_route
         return if options[:actions].present?
-        route_config =  regular_class_path.collect{ |namespace| "namespace :#{namespace} do " }.join(" ")
-        route_config << "resources :#{file_name.pluralize}"
-        route_config << " end" * regular_class_path.size
+        route_config =  regular_class_path.collect{ |namespace| "namespace :#{namespace} do" }.join(" ")
+        route_config << "\n    resources :#{file_name.pluralize}"
+        route_config << "\n  end" * regular_class_path.size
         route route_config
       end
     end

--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -297,7 +297,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Route
     assert_file "config/routes.rb" do |route|
-      assert_match(/namespace :admin do resources :roles end$/, route)
+      assert_match(/  namespace :admin do\n    resources :roles\n  end$/, route)
     end
 
     # Controller


### PR DESCRIPTION
Currently, running `rails generate resource admin/blog_post` gives the following:

``` ruby
MyApplication::Application.routes.draw do
  namespace :admin do resources :blog_posts end
end
```

This patch fixes the whitespace, so it's generated as follows:

``` ruby
MyApplication::Application.routes.draw do
  namespace :admin do
    resources :blog_posts
  end
end
```

It's something that's been bugging me for ages, so I figured it was worth fixing. I haven't checked to see if this is still an issue on master, but I'll add another PR if so.

Thanks guys!
