### PR TITLE
Master branch: Fixed generated whitespace in routes when using namespaced resource.

### DIFF
--- a/railties/lib/rails/generators/rails/resource_route/resource_route_generator.rb
+++ b/railties/lib/rails/generators/rails/resource_route/resource_route_generator.rb
@@ -1,13 +1,50 @@
 module Rails
   module Generators
     class ResourceRouteGenerator < NamedBase
+
+      # Properly nests namespaces passed into a generator
+      #
+      #   $ rails generate resource admin/users/products
+      #
+      # should give you
+      #
+      #   namespace :admin do
+      #     namespace :users
+      #       resources :products
+      #     end
+      #   end
       def add_resource_route
         return if options[:actions].present?
-        route_config =  regular_class_path.collect{ |namespace| "namespace :#{namespace} do " }.join(" ")
-        route_config << "resources :#{file_name.pluralize}"
-        route_config << " end" * regular_class_path.size
-        route route_config
+
+        # iterates over all namespaces and opens up blocks
+        regular_class_path.each_with_index do |namespace, index|
+          write("namespace :#{namespace} do", index + 1)
+        end
+
+        # inserts the primary resource
+        write("resources :#{file_name.pluralize}", route_length + 1)
+
+        # ends blocks
+        regular_class_path.each_index do |index|
+          write("end", route_length - index)
+        end
+
+        # route prepends two spaces onto the front of the string that is passed, this corrects that
+        route route_string[2..-1]
       end
+      
+      private
+        def route_string
+          @route_string ||= ""
+        end
+
+        def write(str, indent)
+          route_string << "#{"  " * indent}#{str}\n"
+        end
+
+        def route_length
+          regular_class_path.length
+        end
     end
   end
 end

--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -304,7 +304,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Route
     assert_file "config/routes.rb" do |route|
-      assert_match(/namespace :admin do resources :roles end$/, route)
+      assert_match(/^  namespace :admin do\n    resources :roles\n  end$/, route)
     end
 
     # Controller
@@ -346,7 +346,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Route
     assert_file "config/routes.rb" do |route|
-      assert_no_match(/namespace :admin do resources :roles end$/, route)
+      assert_no_match(/^  namespace :admin do\n    resources :roles\n  end$$/, route)
     end
 
     # Controller
@@ -360,6 +360,78 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
     # Helpers
     assert_no_file "app/helpers/test_app/admin/roles_helper.rb"
     assert_no_file "test/unit/helpers/test_app/admin/roles_helper_test.rb"
+
+    # Stylesheets (should not be removed)
+    assert_file "app/assets/stylesheets/scaffold.css"
+  end
+  
+  def test_scaffold_with_nested_namespace_on_invoke
+    run_generator [ "admin/user/special/role", "name:string", "description:string" ]
+
+    # Model
+    assert_file "app/models/test_app/admin/user/special.rb", /module TestApp\n  module Admin/
+    assert_file "app/models/test_app/admin/user/special/role.rb", /module TestApp\n  class Admin::User::Special::Role < ActiveRecord::Base/
+    assert_file "test/unit/test_app/admin/user/special/role_test.rb", /module TestApp\n  class Admin::User::Special::RoleTest < ActiveSupport::TestCase/
+    assert_file "test/fixtures/test_app/admin/user/special/roles.yml"
+    assert_migration "db/migrate/create_test_app_admin_user_special_roles.rb"
+
+    # Route
+    assert_file "config/routes.rb" do |route|
+      assert_match(/^  namespace :admin do\n    namespace :user do\n      namespace :special do\n        resources :roles\n      end\n    end\n  end$/, route)
+    end
+
+    # Controller
+    assert_file "app/controllers/test_app/admin/user/special/roles_controller.rb" do |content|
+      assert_match(/module TestApp\n  class Admin::User::Special::RolesController < ApplicationController/, content)
+    end
+
+    assert_file "test/functional/test_app/admin/user/special/roles_controller_test.rb",
+                /module TestApp\n  class Admin::User::Special::RolesControllerTest < ActionController::TestCase/
+
+    # Views
+    %w(
+      index
+      edit
+      new
+      show
+      _form
+    ).each { |view| assert_file "app/views/test_app/admin/user/special/roles/#{view}.html.erb" }
+    assert_no_file "app/views/layouts/admin/user/special/roles.html.erb"
+
+    # Helpers
+    assert_file "app/helpers/test_app/admin/user/special/roles_helper.rb"
+    assert_file "test/unit/helpers/test_app/admin/user/special/roles_helper_test.rb"
+
+    # Stylesheets
+    assert_file "app/assets/stylesheets/scaffold.css"
+  end
+
+  def test_scaffold_with_nested_namespace_on_revoke
+    run_generator [ "admin/user/special/role", "name:string", "description:string" ]
+    run_generator [ "admin/user/special/role" ], :behavior => :revoke
+
+    # Model
+    assert_file "app/models/test_app/admin/user/special.rb"	# ( should not be remove )
+    assert_no_file "app/models/test_app/admin/user/special/role.rb"
+    assert_no_file "test/unit/test_app/admin/user/special/role_test.rb"
+    assert_no_file "test/fixtures/test_app/admin/user/special/roles.yml"
+    assert_no_migration "db/migrate/create_test_app_admin_user_special_roles.rb"
+
+    # Route
+    assert_file "config/routes.rb" do |route|
+      assert_no_match(/^  namespace :admin do\n    namespace :user do\n      namespace :special do\n        resources :roles\n      end\n    end\n  end$/, route)
+    end
+
+    # Controller
+    assert_no_file "app/controllers/test_app/admin/user/special/roles_controller.rb"
+    assert_no_file "test/functional/test_app/admin/user/special/roles_controller_test.rb"
+
+    # Views
+    assert_no_file "app/views/test_app/admin/user/special/roles"
+
+    # Helpers
+    assert_no_file "app/helpers/test_app/admin/user/special/roles_helper.rb"
+    assert_no_file "test/unit/helpers/test_app/admin/user/special/roles_helper_test.rb"
 
     # Stylesheets (should not be removed)
     assert_file "app/assets/stylesheets/scaffold.css"


### PR DESCRIPTION
A version of #6449 on the master branch.

Currently, running rails generate resource admin/blog_post gives the following:

``` ruby
MyApplication::Application.routes.draw do
  namespace :admin do resources :blog_posts end
end
```

This patch fixes the whitespace, so it's generated as follows:

``` ruby
MyApplication::Application.routes.draw do
  namespace :admin do
    resources :blog_posts
  end
end
```

It's something that's been bugging me for ages, so I figured it was worth fixing. 

All feedback welcome. Thanks guys!
