### PR TITLE
Fixes the build break caused by 9ee8528 in #6445.

### DIFF
--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -363,10 +363,12 @@ class TransactionTest < ActiveRecord::TestCase
   end
 
   def test_rollback_when_saving_a_frozen_record
+    expected_raise = (RUBY_VERSION < '1.9') ? TypeError : RuntimeError
+
     topic = Topic.new(:title => 'test')
     topic.freeze
-    e = assert_raise(RuntimeError) { topic.save }
-    assert_equal "can't modify frozen Hash", e.message
+    e = assert_raise(expected_raise) { topic.save }
+    assert_equal "can't modify frozen hash", e.message.downcase
     assert !topic.persisted?, 'not persisted'
     assert_nil topic.id
     assert topic.frozen?, 'not frozen'


### PR DESCRIPTION
Ruby 1.8 raises a TypeError when trying to modify a frozen Hash, while
Ruby 1.9 raises a RuntimeError instead. Also, Ruby < 1.9.3 uses a
lowercase 'hash' in the exception message while Ruby >= 1.9.3 uses an
uppercase 'Hash' instead. This commit normalizes those issues in the
test case.
