### PR TITLE
Refactor date related input helpers

### DIFF
--- a/actionpack/lib/action_view/helpers/tags/date_field.rb
+++ b/actionpack/lib/action_view/helpers/tags/date_field.rb
@@ -1,13 +1,12 @@
 module ActionView
   module Helpers
     module Tags
-      class DateField < TextField #:nodoc:
-        def render
-          options = @options.stringify_keys
-          options["value"] = @options.fetch("value") { value(object).try(:to_date) }
-          @options = options
-          super
-        end
+      class DateField < DatetimeField #:nodoc:
+        private
+
+          def format_date(value)
+            value.try(:strftime, "%Y-%m-%d")
+          end
       end
     end
   end

--- a/actionpack/lib/action_view/helpers/tags/datetime_field.rb
+++ b/actionpack/lib/action_view/helpers/tags/datetime_field.rb
@@ -4,16 +4,16 @@ module ActionView
       class DatetimeField < TextField #:nodoc:
         def render
           options = @options.stringify_keys
-          options["value"] = @options.fetch("value") { format_global_date_time_string(value(object)) }
-          options["min"] = format_global_date_time_string(options["min"])
-          options["max"] = format_global_date_time_string(options["max"])
+          options["value"] = @options.fetch("value") { format_date(value(object)) }
+          options["min"] = format_date(options["min"])
+          options["max"] = format_date(options["max"])
           @options = options
           super
         end
 
         private
 
-          def format_global_date_time_string(value)
+          def format_date(value)
             value.try(:strftime, "%Y-%m-%dT%T.%L%z")
           end
       end

--- a/actionpack/lib/action_view/helpers/tags/datetime_local_field.rb
+++ b/actionpack/lib/action_view/helpers/tags/datetime_local_field.rb
@@ -1,20 +1,16 @@
 module ActionView
   module Helpers
     module Tags
-      class DatetimeLocalField < TextField #:nodoc:
-        def render
-          options = @options.stringify_keys
-          options["type"] = "datetime-local"
-          options["value"] = @options.fetch("value") { format_local_date_time_string(value(object)) }
-          options["min"] = format_local_date_time_string(options["min"])
-          options["max"] = format_local_date_time_string(options["max"])
-          @options = options
-          super
+      class DatetimeLocalField < DatetimeField #:nodoc:
+        class << self
+          def field_type
+            @field_type ||= "datetime-local"
+          end
         end
 
         private
 
-          def format_local_date_time_string(value)
+          def format_date(value)
             value.try(:strftime, "%Y-%m-%dT%T")
           end
       end

--- a/actionpack/lib/action_view/helpers/tags/month_field.rb
+++ b/actionpack/lib/action_view/helpers/tags/month_field.rb
@@ -1,19 +1,10 @@
 module ActionView
   module Helpers
     module Tags
-      class MonthField < TextField #:nodoc:
-        def render
-          options = @options.stringify_keys
-          options["value"] = @options.fetch("value") { format_month_string(value(object)) }
-          options["min"] = format_month_string(options["min"])
-          options["max"] = format_month_string(options["max"])
-          @options = options
-          super
-        end
-
+      class MonthField < DatetimeField #:nodoc:
         private
 
-          def format_month_string(value)
+          def format_date(value)
             value.try(:strftime, "%Y-%m")
           end
       end

--- a/actionpack/lib/action_view/helpers/tags/time_field.rb
+++ b/actionpack/lib/action_view/helpers/tags/time_field.rb
@@ -1,13 +1,12 @@
 module ActionView
   module Helpers
     module Tags
-      class TimeField < TextField #:nodoc:
-        def render
-          options = @options.stringify_keys
-          options["value"] = @options.fetch("value") { value(object).try(:strftime, "%T.%L") }
-          @options = options
-          super
-        end
+      class TimeField < DatetimeField #:nodoc:
+        private
+
+          def format_date(value)
+            value.try(:strftime, "%T.%L")
+          end
       end
     end
   end

--- a/actionpack/lib/action_view/helpers/tags/week_field.rb
+++ b/actionpack/lib/action_view/helpers/tags/week_field.rb
@@ -1,19 +1,10 @@
 module ActionView
   module Helpers
     module Tags
-      class WeekField < TextField #:nodoc:
-        def render
-          options = @options.stringify_keys
-          options["value"] = @options.fetch("value") { format_week_string(value(object)) }
-          options["min"] = format_week_string(options["min"])
-          options["max"] = format_week_string(options["max"])
-          @options = options
-          super
-        end
-
+      class WeekField < DatetimeField #:nodoc:
         private
 
-          def format_week_string(value)
+          def format_date(value)
             value.try(:strftime, "%Y-W%W")
           end
       end

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -644,6 +644,15 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal(expected, date_field("post", "written_on"))
   end
 
+  def test_date_field_with_extra_attrs
+    expected = %{<input id="post_written_on" step="2" max="2010-08-15" min="2000-06-15" name="post[written_on]" type="date" value="2004-06-15" />}
+    @post.written_on = DateTime.new(2004, 6, 15)
+    min_value = DateTime.new(2000, 6, 15)
+    max_value = DateTime.new(2010, 8, 15)
+    step = 2
+    assert_dom_equal(expected, date_field("post", "written_on", :min => min_value, :max => max_value, :step => step))
+  end
+
   def test_date_field_with_timewithzone_value
     previous_time_zone, Time.zone = Time.zone, 'UTC'
     expected = %{<input id="post_written_on" name="post[written_on]" type="date" value="2004-06-15" />}
@@ -668,6 +677,15 @@ class FormHelperTest < ActionView::TestCase
     expected = %{<input id="post_written_on" name="post[written_on]" type="time" value="01:02:03.000" />}
     @post.written_on = DateTime.new(2004, 6, 15, 1, 2, 3)
     assert_dom_equal(expected, time_field("post", "written_on"))
+  end
+
+  def test_time_field_with_extra_attrs
+    expected = %{<input id="post_written_on" step="60" max="10:25:00.000" min="20:45:30.000" name="post[written_on]" type="time" value="01:02:03.000" />}
+    @post.written_on = DateTime.new(2004, 6, 15, 1, 2, 3)
+    min_value = DateTime.new(2000, 6, 15, 20, 45, 30)
+    max_value = DateTime.new(2010, 8, 15, 10, 25, 00)
+    step = 60
+    assert_dom_equal(expected, time_field("post", "written_on", :min => min_value, :max => max_value, :step => step))
   end
 
   def test_time_field_with_timewithzone_value


### PR DESCRIPTION
Since all date related helpers share the same behavior, I decided to remove some unnecessary duplication.
