### PR TITLE
ignoring .gitkeep and .empty files when clearing the cache

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -14,6 +14,7 @@ module ActiveSupport
       DIR_FORMATTER = "%03X"
       FILENAME_MAX_SIZE = 228 # max filename size on file system is 255, minus room for timestamp and random characters appended by Tempfile (used by atomic write)
       EXCLUDED_DIRS = ['.', '..'].freeze
+      EXCLUDED_FILES = ['.gitkeep', '.empty'].freeze
 
       def initialize(cache_path, options = nil)
         super(options)
@@ -21,8 +22,14 @@ module ActiveSupport
         extend Strategy::LocalCache
       end
 
+      # Clears all the files from +chache_path+ except defaults.
+      #
+      # Options:
+      #  excluded_paths: %w(paths to exclude)
       def clear(options = nil)
-        root_dirs = Dir.entries(cache_path).reject {|f| (EXCLUDED_DIRS + [".gitkeep"]).include?(f)}
+        excluded = EXCLUDED_DIRS + EXCLUDED_FILES
+        excluded += Array(options[:excluded_paths]) if options && options[:excluded_paths]
+        root_dirs = Dir.entries(cache_path).reject{|f| f.in?(excluded)}
         FileUtils.rm_r(root_dirs.collect{|f| File.join(cache_path, f)})
       end
 

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -580,6 +580,13 @@ class FileStoreTest < ActiveSupport::TestCase
     assert File.exist?(filepath)
   end
 
+  def test_clear_with_exclude_dir
+    filepath = File.join(cache_dir, "dont_delete_me")
+    FileUtils.touch(filepath)
+    @cache.clear(excluded_paths: %w(dont_delete_me))
+    assert File.exist?(filepath)
+  end
+
   def test_key_transformation
     key = @cache.send(:key_file_path, "views/index?id=1")
     assert_equal "views/index?id=1", @cache.send(:file_path_key, key)


### PR DESCRIPTION
providing a (simple) possibility to prevent the default cache store used in tests to delete all the files in tmp/cache so that git will keep the folder and ci-systems won't stumble over it.
