### PR TITLE
View your Routes without waiting on Rake

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add `/rails/info/routes` path, displays same information as `rake routes` *Richard Schneeman & Andrew White*
+
 *   Improved `rake routes` output for redirects *Łukasz Strzałkowski & Andrew White*
 
 *   Load all environments available in `config.paths["config/environments"]`. *Piotr Sarnacki*

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -23,6 +23,8 @@ module Rails
         if Rails.env.development?
           app.routes.append do
             get '/rails/info/properties' => "rails/info#properties"
+            get '/rails/info/routes'     => "rails/info#routes"
+            get '/rails/info'            => "rails/info#index"
           end
         end
       end

--- a/railties/lib/rails/application/route_inspector.rb
+++ b/railties/lib/rails/application/route_inspector.rb
@@ -51,7 +51,7 @@ module Rails
       end
 
       def internal?
-        path =~ %r{/rails/info/properties|^#{Rails.application.config.assets.prefix}}
+        path =~ %r{/rails/info.*|^#{Rails.application.config.assets.prefix}}
       end
 
       def engine?

--- a/railties/lib/rails/info_controller.rb
+++ b/railties/lib/rails/info_controller.rb
@@ -1,15 +1,33 @@
+require 'rails/application/route_inspector'
+
 class Rails::InfoController < ActionController::Base
+  self.view_paths = File.join(File.dirname(__FILE__), 'templates')
+  layout 'application'
+
+  before_filter :require_local!
+
+  def index
+    redirect_to '/rails/info/routes'
+  end
+
   def properties
-    if consider_all_requests_local? || request.local?
-      render :inline => Rails::Info.to_html
-    else
-      render :text => '<p>For security purposes, this information is only available to local requests.</p>', :status => :forbidden
-    end
+    @info = Rails::Info.to_html
+  end
+
+  def routes
+    inspector = Rails::Application::RouteInspector.new
+    @info     = inspector.format(_routes.routes).join("\n")
   end
 
   protected
 
-  def consider_all_requests_local?
-    Rails.application.config.consider_all_requests_local
+  def require_local!
+    unless local_request?
+      render :text => '<p>For security purposes, this information is only available to local requests.</p>', :status => :forbidden
+    end
+  end
+
+  def local_request?
+    Rails.application.config.consider_all_requests_local || request.local?
   end
 end

--- a/railties/lib/rails/templates/layouts/application.html.erb
+++ b/railties/lib/rails/templates/layouts/application.html.erb
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Routes</title>
+  <style>
+    body { background-color: #fff; color: #333; }
+
+    body, p, ol, ul, td {
+      font-family: helvetica, verdana, arial, sans-serif;
+      font-size:   13px;
+      line-height: 18px;
+    }
+
+    pre {
+      background-color: #eee;
+      padding: 10px;
+      font-size: 11px;
+      white-space: pre-wrap;
+    }
+
+    a { color: #000; }
+    a:visited { color: #666; }
+    a:hover { color: #fff; background-color:#000; }
+  </style>
+</head>
+<body>
+<h2>Your App: <%= link_to 'properties', '/rails/info/properties' %> | <%= link_to 'routes', '/rails/info/routes' %></h2>
+<%= yield %>
+
+</body>
+</html>

--- a/railties/lib/rails/templates/rails/info/properties.html.erb
+++ b/railties/lib/rails/templates/rails/info/properties.html.erb
@@ -1,0 +1,1 @@
+<%= @info.html_safe %>

--- a/railties/lib/rails/templates/rails/info/routes.html.erb
+++ b/railties/lib/rails/templates/rails/info/routes.html.erb
@@ -1,0 +1,9 @@
+<h2>
+  Routes
+</h2>
+
+<p>
+  Routes match in priority from top to bottom
+</p>
+
+<p><pre><%= @info %></pre></p>

--- a/railties/test/application/route_inspect_test.rb
+++ b/railties/test/application/route_inspect_test.rb
@@ -164,5 +164,14 @@ module ApplicationTests
       assert_equal "   bar GET /bar(.:format)    redirect(307, path: /foo/bar)", output[1]
       assert_equal "foobar GET /foobar(.:format) redirect(301)", output[2]
     end
+
+    def test_presenter
+      output = draw do
+        get "/foo"    => redirect("/foo/bar"), :constraints => { :subdomain => "admin" }
+        get "/bar"    => redirect(path: "/foo/bar", status: 307)
+        get "/foobar" => redirect{ "/foo/bar" }
+      end
+      assert_equal output.join("\n"), Rails::Application::RoutePresenter.display_routes(@set.routes)
+    end
   end
 end

--- a/railties/test/application/routing_test.rb
+++ b/railties/test/application/routing_test.rb
@@ -15,10 +15,22 @@ module ApplicationTests
       teardown_app
     end
 
+    test "rails/info/routes in development" do
+      app("development")
+      get "/rails/info/routes"
+      assert_equal 200, last_response.status
+    end
+
     test "rails/info/properties in development" do
       app("development")
       get "/rails/info/properties"
       assert_equal 200, last_response.status
+    end
+
+    test "rails/info/routes in production" do
+      app("production")
+      get "/rails/info/routes"
+      assert_equal 404, last_response.status
     end
 
     test "rails/info/properties in production" do

--- a/railties/test/rails_info_controller_test.rb
+++ b/railties/test/rails_info_controller_test.rb
@@ -12,29 +12,28 @@ class InfoControllerTest < ActionController::TestCase
   def setup
     Rails.application.routes.draw do
       get '/rails/info/properties' => "rails/info#properties"
+      get '/rails/info/routes'     => "rails/info#routes"
     end
-    @request.stubs(:local? => true)
-    @controller.stubs(:consider_all_requests_local? => false)
+    @controller.stubs(:local_request? => true)
     @routes = Rails.application.routes
 
     Rails::InfoController.send(:include, @routes.url_helpers)
   end
 
   test "info controller does not allow remote requests" do
-    @request.stubs(:local? => false)
+    @controller.stubs(:local_request? => false)
     get :properties
     assert_response :forbidden
   end
 
   test "info controller renders an error message when request was forbidden" do
-    @request.stubs(:local? => false)
+    @controller.stubs(:local_request? => false)
     get :properties
     assert_select 'p'
   end
 
   test "info controller allows requests when all requests are considered local" do
-    @request.stubs(:local? => false)
-    @controller.stubs(:consider_all_requests_local? => true)
+    @controller.stubs(:local_request? => true)
     get :properties
     assert_response :success
   end
@@ -48,4 +47,10 @@ class InfoControllerTest < ActionController::TestCase
     get :properties
     assert_select 'table'
   end
+
+  test "info controller renders with routes" do
+    get :routes
+    assert_select 'pre'
+  end
+
 end


### PR DESCRIPTION
Bring the functionality of [Sextant](http://github.com/schneems/sextant) natively to Rails 4. Rather than having to initialize your Rails application ever time you run `$ rake routes` we can utilize the currently running server to generate routes in much less time. To view routes go to `/rails/info/routes`, the section in `<pre>` will match `$ rake routes`

![](http://f.cl.ly/items/2q2U3l2S340X1Q3i0K2F/Screen%20Shot%202012-05-22%20at%205.36.39%20PM.png)

cc/ @pixeltrix
