### PR TITLE
ConnectionPool wait_timeout no longer used for different types of timeouts. #6441

### DIFF
--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -124,7 +124,7 @@ module ActiveRecord
         @pool.checkout
         @pool.checkout
         @pool.checkout
-        @pool.timeout = 0
+        @pool.dead_connection_timeout = 0
 
         connections = @pool.connections.dup
 
@@ -137,7 +137,7 @@ module ActiveRecord
         @pool.checkout
         @pool.checkout
         @pool.checkout
-        @pool.timeout = 0
+        @pool.dead_connection_timeout = 0
 
         connections = @pool.connections.dup
         connections.each do |conn|

--- a/activerecord/test/cases/pooled_connections_test.rb
+++ b/activerecord/test/cases/pooled_connections_test.rb
@@ -17,7 +17,7 @@ class PooledConnectionsTest < ActiveRecord::TestCase
   end
 
   def checkout_connections
-    ActiveRecord::Model.establish_connection(@connection.merge({:pool => 2, :wait_timeout => 0.3}))
+    ActiveRecord::Model.establish_connection(@connection.merge({:pool => 2, :checkout_timeout => 0.3}))
     @connections = []
     @timed_out = 0
 
@@ -34,7 +34,7 @@ class PooledConnectionsTest < ActiveRecord::TestCase
 
   # Will deadlock due to lack of Monitor timeouts in 1.9
   def checkout_checkin_connections(pool_size, threads)
-    ActiveRecord::Model.establish_connection(@connection.merge({:pool => pool_size, :wait_timeout => 0.5}))
+    ActiveRecord::Model.establish_connection(@connection.merge({:pool => pool_size, :checkout_timeout => 0.5}))
     @connection_count = 0
     @timed_out = 0
     threads.times do

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -64,7 +64,7 @@ module ActiveRecord
         spec.config[:reaping_frequency] = 0.0001
 
         pool = ConnectionPool.new spec
-        pool.timeout = 0
+        pool.dead_connection_timeout = 0
 
         conn = pool.checkout
         count = pool.connections.length


### PR DESCRIPTION
An AR ConnectionSpec `wait_timeout` is pre-patch used for three
different things:
- mysql2 uses it for MySQL's own wait_timeout (how long MySQL
  should allow an idle connection before closing it), and
  defaults to 2592000 seconds.
- ConnectionPool uses it for "number of seconds to block and
  wait for a connection before giving up and raising a timeout error",
  default 5 seconds.
- ConnectionPool uses it for the Reaper, for deciding if a 'dead'
  connection can be reaped. Default 5 seconds.

Previously, if you want to change these from defaults, you need
to change them all together. This is problematic _especially_
for the mysql2/ConnectionPool conflict, you will generally _not_
want them to be the same, as evidenced by their wildly different
defaults. This has caused real problems for people #6441 #2894

But as long as we're changing this, forcing renaming the
ConnectionPool key to be more specific, it made sense
to seperate the two ConnectionPool uses too -- these two
types of ConnectionPool timeouts ought to be able to be
changed independently, you won't neccesarily want them
to be the same, even though the defaults are (currently)
the same.
