### PR TITLE
Synchronize the body of the ConnectionPool#release method to improve thread safety.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -290,17 +290,19 @@ connection.  For example: ActiveRecord::Base.connection.close
       private
 
       def release(conn)
-        thread_id = nil
+        synchronize do
+          thread_id = nil
 
-        if @reserved_connections[current_connection_id] == conn
-          thread_id = current_connection_id
-        else
-          thread_id = @reserved_connections.keys.find { |k|
-            @reserved_connections[k] == conn
-          }
+          if @reserved_connections[current_connection_id] == conn
+            thread_id = current_connection_id
+          else
+            thread_id = @reserved_connections.keys.find { |k|
+              @reserved_connections[k] == conn
+            }
+          end
+
+          @reserved_connections.delete thread_id if thread_id
         end
-
-        @reserved_connections.delete thread_id if thread_id
       end
 
       def new_connection


### PR DESCRIPTION
Fixes #6464

Synchronize the contents of the release method in ConnectionPool due to
errors when running in high concurrency environments.

```
Detected invalid hash contents due to unsynchronized modifications with concurrent users
org/jruby/RubyHash.java:1356:in `keys'
/usr/local/rvm/gems/jruby-1.6.7@new_import/gems/activerecord-3.2.3/lib/active_record/connection_adapters/abstract/connection_pool.rb:294:in `release'
/usr/local/rvm/gems/jruby-1.6.7@new_import/gems/activerecord-3.2.3/lib/active_record/connection_adapters/abstract/connection_pool.rb:282:in `checkin'
```
