### PR TITLE
Properly discover a connection is closed in postgresql_adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -457,7 +457,8 @@ module ActiveRecord
 
       # Is this connection alive and ready for queries?
       def active?
-        @connection.status == PGconn::CONNECTION_OK
+        @connection.query 'SELECT 1'
+        true
       rescue PGError
         false
       end


### PR DESCRIPTION
PQstatus doesn't properly test if future operations will succeed. A
PQping function is added to libpq in PostgreSQL 9.1, but if we rely
on it, everyone on earlier versions of Postgres is out of luck,
and the pg gem wouldn't have the 'fix' until the next release.

Thanks to @cbrecabarren and @ged for handling all the dirty details.

Closes #3392.

/cc @tenderlove @jonleighton
