### PR TITLE
Absolute partial paths need to be preserved in namespace

### DIFF
--- a/actionpack/lib/action_view/renderer/partial_renderer.rb
+++ b/actionpack/lib/action_view/renderer/partial_renderer.rb
@@ -431,7 +431,7 @@ module ActionView
     end
 
     def merge_prefix_into_object_path(prefix, object_path)
-      if prefix.include?(?/) && object_path.include?(?/)
+      if prefix.include?(?/) && object_path.include?(?/) && object_path[0] != '/'
         prefixes = []
         prefix_array = File.dirname(prefix).split('/')
         object_path_array = object_path.split('/')[0..-3] # skip model dir & partial

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -19,6 +19,10 @@ module Quiz
     def new
       render :partial => Quiz::Question.new("Namespaced Partial")
     end
+    
+    def absolute
+      render :partial => Quiz::Absolute.new
+    end
   end
 end
 
@@ -1376,6 +1380,14 @@ class RenderTest < ActionController::TestCase
     get :new
     assert_equal "Namespaced Partial", @response.body
   end
+  
+  def test_namespaced_object_partial_absolute_path
+    @controller = Quiz::QuestionsController.new
+    get :absolute
+    assert_template "_top_level_partial"
+    assert_equal "top level partial html", @response.body
+  end
+  
 
   def test_partial_collection
     get :partial_collection

--- a/actionpack/test/lib/controller/fake_models.rb
+++ b/actionpack/test/lib/controller/fake_models.rb
@@ -56,6 +56,10 @@ module Quiz
 
   class Store < Question
   end
+  
+  class Absolute < Question
+    def to_partial_path() "/top_level_partial" end
+  end
 end
 
 class Post < Struct.new(:title, :author_name, :body, :secret, :persisted, :written_on, :cost)


### PR DESCRIPTION
I got feeling that solution for https://github.com/rails/rails/issues/1951 are incorrect by nature. We include path namespacing in partial so even if we define custom resolver or just modify append_view_path we can't avoid namespacing. I am not sure how to fix this, but for my needs (defining one partial template for front/backend of my application using to_partial_path) this simple fix works. 
