### PR TITLE
Remove Unnecessary Test from route_inspect_test

### DIFF
--- a/railties/test/application/route_inspect_test.rb
+++ b/railties/test/application/route_inspect_test.rb
@@ -164,14 +164,5 @@ module ApplicationTests
       assert_equal "   bar GET /bar(.:format)    redirect(307, path: /foo/bar)", output[1]
       assert_equal "foobar GET /foobar(.:format) redirect(301)", output[2]
     end
-
-    def test_presenter
-      output = draw do
-        get "/foo"    => redirect("/foo/bar"), :constraints => { :subdomain => "admin" }
-        get "/bar"    => redirect(path: "/foo/bar", status: 307)
-        get "/foobar" => redirect{ "/foo/bar" }
-      end
-      assert_equal output.join("\n"), Rails::Application::RoutePresenter.display_routes(@set.routes)
-    end
   end
 end


### PR DESCRIPTION
RoutePresenter has been removed, this test is not needed. Related conversation:

https://github.com/rails/rails/commit/c3e3102904c98a6e05bee33616288323278692b8#commitcomment-1374990

``` shell
~/documents/projects/rails/railties (schneems/sextant-routes)   
→ bundle exec rake test:regular TEST=test/application/route_inspect_test.rb 
/Users/schneems/.rvm/rubies/ruby-1.9.3-rc1/bin/ruby -w -I"lib:test:/Users/schneems/Documents/projects/rails/railties/../activesupport/lib" -I"/Users/schneems/.rvm/gems/ruby-1.9.3-rc1@railscore/gems/rake-0.9.2.2/lib" "/Users/schneems/.rvm/gems/ruby-1.9.3-rc1@railscore/gems/rake-0.9.2.2/lib/rake/rake_test_loader.rb" "test/application/route_inspect_test.rb" 
Run options: --seed 18733

# Running tests:

..............

Finished tests in 0.223237s, 62.7136 tests/s, 85.1113 assertions/s.

14 tests, 19 assertions, 0 failures, 0 errors, 0 skips

```

Fixes the tests for route_inspect_test
