### PR TITLE
Return Pathname from Rails::Paths::Path#paths. Fixes build 4008.1

### DIFF
--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -1,3 +1,5 @@
+require 'pathname'
+
 module Rails
   module Paths
     # This object is an extended hash that behaves as root of the <tt>Rails::Paths</tt> system.
@@ -184,7 +186,7 @@ module Rails
         raise "You need to set a path root" unless @root.path
 
         map do |p|
-          File.join @root.path, p
+          Pathname.new(@root.path).join(p)
         end
       end
 


### PR DESCRIPTION
This fixes changes made in railties/lib/rails/paths.rb in
4001835db00ce44cb75bca33ec02cd76b8ccc790. This also makes sure failures
in build 4008.1[1] pass.

Also closes #6482 and #6473

[1] http://travis-ci.org/#!/rails/rails/jobs/1429671/L203
