### PR TITLE
Make connection pool fair

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -426,10 +426,10 @@ module ActiveRecord
         else
           t0 = Time.now
           begin
-            @available.poll(@timeout)
+            @available.poll(@checkout_timeout)
           rescue ConnectionTimeoutError
             msg = 'could not obtain a database connection within %0.3f seconds (waited %0.3f seconds)' %
-              [@timeout, Time.now - t0]
+              [@checkout_timeout, Time.now - t0]
             raise PoolFullError, msg
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -82,6 +82,13 @@ module ActiveRecord
           @queue = []
         end
 
+        # Test if any threads are currently waiting on the queue.
+        def any_waiting?
+          synchronize do
+            @num_waiting > 0
+          end
+        end
+
         # Return the number of threads currently waiting on this
         # queue.
         def num_waiting

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -355,7 +355,7 @@ module ActiveRecord
       # Returns: an AbstractAdapter object.
       #
       # Raises:
-      # - ConnectionTimeoutError: no connection can be obtained from the pool.
+      # - PoolFullError: no connection can be obtained from the pool.
       def checkout
         synchronize do
           conn = acquire_connection

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -2,7 +2,6 @@ require 'thread'
 require 'monitor'
 require 'set'
 require 'active_support/core_ext/module/deprecation'
-require 'timeout'
 
 module ActiveRecord
   # Raised when a connection could not be obtained within the connection
@@ -100,21 +99,6 @@ module ActiveRecord
       attr_accessor :automatic_reconnect, :checkout_timeout, :dead_connection_timeout
       attr_reader :spec, :connections, :size, :reaper
 
-      class Latch # :nodoc:
-        def initialize
-          @mutex = Mutex.new
-          @cond  = ConditionVariable.new
-        end
-
-        def release
-          @mutex.synchronize { @cond.broadcast }
-        end
-
-        def await
-          @mutex.synchronize { @cond.wait @mutex }
-        end
-      end
-
       # Creates a new ConnectionPool object. +spec+ is a ConnectionSpecification
       # object which describes database connection information (e.g. adapter,
       # host name, username, password, etc), as well as the maximum size for
@@ -137,9 +121,25 @@ module ActiveRecord
         # default max pool size to 5
         @size = (spec.config[:pool] && spec.config[:pool].to_i) || 5
 
-        @latch = Latch.new
         @connections         = []
         @automatic_reconnect = true
+
+        # connections available to be checked out
+        @available = []
+
+        # number of threads waiting to check out a connection
+        @num_waiting = 0
+
+        # signal threads waiting
+        @cond = new_cond
+      end
+
+      # Hack for tests to be able to add connections.  Do not call outside of tests
+      def insert_connection_for_test!(c)
+        synchronize do
+          @connections << c
+          @available << c
+        end
       end
 
       # Retrieve the connection associated with the current thread, or call
@@ -197,6 +197,7 @@ module ActiveRecord
             conn.disconnect!
           end
           @connections = []
+          @available = []
         end
       end
 
@@ -209,6 +210,9 @@ module ActiveRecord
             conn.disconnect! if conn.requires_reloading?
           end
           @connections.delete_if do |conn|
+            conn.requires_reloading?
+          end
+          @available.delete_if do |conn|
             conn.requires_reloading?
           end
         end
@@ -234,23 +238,19 @@ module ActiveRecord
       # Raises:
       # - PoolFullError: no connection can be obtained from the pool.
       def checkout
-        loop do
-          # Checkout an available connection
-          synchronize do
-            # Try to find a connection that hasn't been leased, and lease it
-            conn = connections.find { |c| c.lease }
+        synchronize do
+          conn = nil
 
-            # If all connections were leased, and we have room to expand,
-            # create a new connection and lease it.
-            if !conn && connections.size < size
-              conn = checkout_new_connection
-              conn.lease
-            end
-
-            return checkout_and_verify(conn) if conn
+          if @num_waiting == 0
+            conn = acquire_connection
           end
 
-          Timeout.timeout(@checkout_timeout, PoolFullError) { @latch.await }
+          unless conn
+            conn = wait_until(@timeout) { acquire_connection }
+          end
+
+          conn.lease
+          checkout_and_verify(conn)
         end
       end
 
@@ -266,8 +266,10 @@ module ActiveRecord
           end
 
           release conn
+
+          @available.unshift conn
+          @cond.signal
         end
-        @latch.release
       end
 
       # Remove a connection from the connection pool.  The connection will
@@ -275,12 +277,14 @@ module ActiveRecord
       def remove(conn)
         synchronize do
           @connections.delete conn
+          @available.delete conn
 
           # FIXME: we might want to store the key on the connection so that removing
           # from the reserved hash will be a little easier.
           release conn
+
+          @cond.signal          # can make a new connection now
         end
-        @latch.release
       end
 
       # Removes dead connections from the pool.  A dead connection can occur
@@ -292,11 +296,59 @@ module ActiveRecord
           connections.dup.each do |conn|
             remove conn if conn.in_use? && stale > conn.last_use && !conn.active?
           end
+          @cond.broadcast       # may violate fairness
         end
-        @latch.release
       end
 
       private
+
+      # Take an available connection or, if possible, create a new
+      # one, or nil.
+      #
+      # Monitor must be held while calling this method.
+      #
+      # Returns: a newly acquired connection.
+      def acquire_connection
+        if @available.any?
+          @available.pop
+        elsif connections.size < size
+          checkout_new_connection
+        end
+      end
+
+      # Wait on +@cond+ until the block returns non-nil.  Note that
+      # unlike MonitorMixin::ConditionVariable#wait_until, this method
+      # does not test the block before the first wait period.
+      #
+      # Monitor must be held when calling this method.
+      #
+      # +timeout+: Integer timeout in seconds
+      #
+      # Returns: the result of the block
+      #
+      # Raises:
+      # - PoolFullError: timeout elapsed before +&block+ returned a connection
+      def wait_until(timeout, &block)
+        @num_waiting += 1
+        begin
+          t0 = Time.now
+          loop do
+            elapsed = Time.now - t0
+            if elapsed >= timeout
+              msg = 'could not obtain a database connection within %0.3f seconds (waited %0.3f seconds)' %
+                [timeout, elapsed]
+              raise PoolFullError, msg
+            end
+
+            @cond.wait(timeout - elapsed)
+
+            conn = yield
+            return conn if conn
+          end
+        ensure
+          @num_waiting -= 1
+        end
+      end
 
       def release(conn)
         thread_id = if @reserved_connections[current_connection_id] == conn

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -962,6 +962,10 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_loading_with_conditions_on_joined_table_preloads
+    # cache metadata in advance to avoid extra sql statements executed while testing
+    Tagging.first
+    Tag.first
+
     posts = assert_queries(2) do
       Post.scoped(:select => 'distinct posts.*', :includes => :author, :joins => [:comments], :where => "comments.body like 'Thank you%'", :order => 'posts.id').all
     end
@@ -1011,6 +1015,9 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_eager_loading_with_conditions_on_join_model_preloads
     Author.columns
+    
+    # cache metadata in advance to avoid extra sql statements executed while testing
+    AuthorAddress.first
 
     authors = assert_queries(2) do
       Author.scoped(:includes => :author_address, :joins => :comments, :where => "posts.title like 'Welcome%'").all

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1339,6 +1339,9 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     author = Author.new(:name => "David")
     assert !author.essays.loaded?
 
+    # cache metadata in advance to avoid extra sql statements executed while testing
+    Essay.first
+
     assert_queries 1 do
       assert_equal 1, author.essays.size
     end

--- a/activerecord/test/cases/connection_adapters/abstract_adapter_test.rb
+++ b/activerecord/test/cases/connection_adapters/abstract_adapter_test.rb
@@ -36,7 +36,7 @@ module ActiveRecord
 
       def test_close
         pool = ConnectionPool.new(ConnectionSpecification.new({}, nil))
-        pool.connections << adapter
+        pool.insert_connection_for_test! adapter
         adapter.pool = pool
 
         # Make sure the pool marks the connection in use

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -200,6 +200,121 @@ module ActiveRecord
         end.join
       end
 
+      # The connection pool is "fair" if threads waiting for
+      # connections receive them the order in which they began
+      # waiting.  This ensures that we don't timeout one HTTP request
+      # even while well under capacity in a multi-threaded environment
+      # such as a Java servlet container.
+      #
+      # We don't need strict fairness: if two connections become
+      # available at the same time, it's fine of two threads that were
+      # waiting acquire the connections out of order.
+      #
+      # Thus this test prepares waiting threads and then trickles in
+      # available connections slowly, ensuring the wakeup order is
+      # correct in this case.
+      #
+      # Try a few times since it might work out just by chance.
+      def test_checkout_fairness
+        4.times { setup; do_checkout_fairness }
+      end
+
+      def do_checkout_fairness
+        expected = (1..@pool.size).to_a.freeze
+        # check out all connections so our threads start out waiting
+        conns = expected.map { @pool.checkout }
+        mutex = Mutex.new
+        order = []
+        errors = []
+
+        threads = expected.map do |i|
+          t = Thread.new {
+            begin
+              conn = @pool.checkout # never checked back in
+              mutex.synchronize { order << i }
+            rescue => e
+              mutex.synchronize { errors << e }
+            end
+          }
+          Thread.pass until t.status == "sleep"
+          t
+        end
+
+        # this should wake up the waiting threads one by one in order
+        conns.each { |conn| @pool.checkin(conn); sleep 0.1 }
+
+        threads.each(&:join)
+
+        raise errors.first if errors.any?
+
+        assert_equal(expected, order)
+      end
+
+      # As mentioned in #test_checkout_fairness, we don't care about
+      # strict fairness.  This test creates two groups of threads:
+      # group1 whose members all start waiting before any thread in
+      # group2.  Enough connections are checked in to wakeup all
+      # group1 threads, and the fact that only group1 and no group2
+      # threads acquired a connection is enforced.
+      #
+      # Try a few times since it might work out just by chance.
+      def test_checkout_fairness_by_group
+        4.times { setup; do_checkout_fairness_by_group }
+      end
+
+      def do_checkout_fairness_by_group
+        @pool.instance_variable_set(:@size, 10)
+        # take all the connections
+        conns = (1..10).map { @pool.checkout }
+        mutex = Mutex.new
+        successes = []    # threads that successfully got a connection
+        errors = []
+
+        make_thread = proc do |i|
+          t = Thread.new {
+            begin
+              conn = @pool.checkout # never checked back in
+              mutex.synchronize { successes << i }
+            rescue => e
+              mutex.synchronize { errors << e }
+            end
+          }
+          Thread.pass until t.status == "sleep"
+          t
+        end
+
+        # all group1 threads start waiting before any in group2
+        group1 = (1..5).map(&make_thread)
+        group2 = (6..10).map(&make_thread)
+
+        # checkin n connections back to the pool
+        checkin = proc do |n|
+          n.times do
+            c = conns.pop
+            @pool.checkin(c)
+          end
+        end
+
+        checkin.call(group1.size)         # should wake up all group1
+
+        loop do
+          sleep 0.1
+          break if mutex.synchronize { (successes.size + errors.size) == group1.size }
+        end
+
+        winners = mutex.synchronize { successes.dup }
+        checkin.call(group2.size)         # should wake up everyone remaining
+
+        group1.each(&:join)
+        group2.each(&:join)
+
+        assert_equal((1..group1.size).to_a, winners.sort)
+
+        if errors.any?
+          raise errors.first
+        end
+      end
+
       def test_automatic_reconnect=
         pool = ConnectionPool.new ActiveRecord::Base.connection_pool.spec
         assert pool.automatic_reconnect

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -213,13 +213,8 @@ module ActiveRecord
       # Thus this test prepares waiting threads and then trickles in
       # available connections slowly, ensuring the wakeup order is
       # correct in this case.
-      #
-      # Try a few times since it might work out just by chance.
       def test_checkout_fairness
-        4.times { setup; do_checkout_fairness }
-      end
-
-      def do_checkout_fairness
+        @pool.instance_variable_set(:@size, 10)
         expected = (1..@pool.size).to_a.freeze
         # check out all connections so our threads start out waiting
         conns = expected.map { @pool.checkout }
@@ -256,13 +251,7 @@ module ActiveRecord
       # group2.  Enough connections are checked in to wakeup all
       # group1 threads, and the fact that only group1 and no group2
       # threads acquired a connection is enforced.
-      #
-      # Try a few times since it might work out just by chance.
       def test_checkout_fairness_by_group
-        4.times { setup; do_checkout_fairness_by_group }
-      end
-
-      def do_checkout_fairness_by_group
         @pool.instance_variable_set(:@size, 10)
         # take all the connections
         conns = (1..10).map { @pool.checkout }


### PR DESCRIPTION
This is a second attempt of https://github.com/rails/rails/pull/6416

It makes the connection pool "fair" with respect to waiting threads.  I've done some more measurements here: http://polycrystal.org/2012/05/24/activerecord_connection_pool_fairness.html  The patch is also cleaned up compared to the first attempt; the code is much more readable.

It includes some test fixes from @yahonda that this patch triggered (though the failures seem unrelated to the code)

I am still getting test failures, but I see the same failures against master: https://gist.github.com/2788538  And none of these seem related to the connection pool.
