### PR TITLE
Reorder deep_symbolize_keys methods

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -104,17 +104,17 @@ class Hash
     deep_transform_keys!{ |key| key.to_s }
   end
 
-  # Destructively convert all keys to symbols, as long as they respond
-  # to +to_sym+. This includes the keys from the root hash and from all
-  # nested hashes.
-  def deep_symbolize_keys!
-    deep_transform_keys!{ |key| key.to_sym rescue key }
-  end
-
   # Return a new hash with all keys converted to symbols, as long as
   # they respond to +to_sym+. This includes the keys from the root hash
   # and from all nested hashes.
   def deep_symbolize_keys
     deep_transform_keys{ |key| key.to_sym rescue key }
+  end
+
+  # Destructively convert all keys to symbols, as long as they respond
+  # to +to_sym+. This includes the keys from the root hash and from all
+  # nested hashes.
+  def deep_symbolize_keys!
+    deep_transform_keys!{ |key| key.to_sym rescue key }
   end
 end


### PR DESCRIPTION
One little thing...all the methods in this file are normal method followed by bang....until you get down to the end...this PR just switches the order of `deep_symbolize_keys` and `deep_symbolize_keys!` to follow that convention.

I know it's small...but it's been bugging me.

I think this is last time I touch this file...maybe...hopefully...not sure what else I could do to it. ;)

cc/ @rafaelfranca
