### PR TITLE
memcache require not needed for cache store

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/session/cache_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cache_store.rb
@@ -1,5 +1,4 @@
 require 'action_dispatch/middleware/session/abstract_store'
-require 'rack/session/memcache'
 
 module ActionDispatch
   module Session


### PR DESCRIPTION
Backports 3fbc8f385bfd5e486cdbd4da6c1604f5c312770b to get rid of unneeded memcache require
