### PR TITLE
auto_link shouldn't always sanitize

### DIFF
--- a/actionpack/lib/action_view/helpers/text_helper.rb
+++ b/actionpack/lib/action_view/helpers/text_helper.rb
@@ -463,7 +463,7 @@ module ActionView
         end
 
         AUTO_LINK_RE = %r{
-            (?: ([\w+.:-]+:)// | www\. )
+            (?: ((?:ed2k|ftp|http|https|irc|mailto|news|gopher|nntp|telnet|webcal|xmpp|callto|feed|svn|urn|aim|rsync|tag|ssh|sftp|rtsp|afs):)// | www\. )
             [^\s<]+
           }x
 
@@ -499,7 +499,7 @@ module ActionView
               href = 'http://' + href unless scheme
 
               sanitize_link = options[:sanitize] != false
-              sanitize(content_tag(:a, link_text, link_attributes.merge('href' => href), sanitize_link) + punctuation.reverse.join(''))
+              content_tag(:a, link_text, link_attributes.merge('href' => href), sanitize_link) + punctuation.reverse.join('')
             end
           end
         end


### PR DESCRIPTION
sanitize is not always required so we cannot force it by default. let's just
whitelist protocols and everybody's happy

My commit was wrong - I didn't realize how it will impact on `raw` text.

@tenderlove also should I bump gem version of rails_autolink ? It's bugfix so I just pushed it to the 1.0.8
