### PR TITLE
Clear aggregation cache after setter method calls.

### DIFF
--- a/activerecord/test/cases/aggregations_test.rb
+++ b/activerecord/test/cases/aggregations_test.rb
@@ -137,6 +137,12 @@ class AggregationsTest < ActiveRecord::TestCase
     assert_equal 'Barnoit GUMBLEAU', customers(:barney).fullname.to_s
     assert_kind_of Fullname, customers(:barney).fullname
   end
+
+  def test_caching
+    customers(:barney).address
+    customers(:barney).address_street = "Noisy Road"
+    assert_equal "Noisy Road", customers(:barney).address.street
+  end
 end
 
 class OverridingAggregationsTest < ActiveRecord::TestCase


### PR DESCRIPTION
Solve this issue:

```
customer.address.street # => "Quiet Road"
customer.address_street = "Noisy Road"
customer.address.street # => "Quiet Road"
```

Where:

```
class Customer
  composed_of :address, :mapping => [ %w(address_street street), %w(address_city city) ]
end


class Address
  attr_reader :street, :city, :country

  def initialize(street, city, country)
    @street, @city, @country = street, city, country
  end
end
```
