### PR TITLE
Clarify and correct the description for the --full option of the plugin_...

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -155,7 +155,7 @@ task :default => :test
                                   :desc => "Create dummy application at given path"
 
       class_option :full,         :type => :boolean, :default => false,
-                                  :desc => "Generate rails engine with integration tests"
+                                  :desc => "Generate a rails engine with bundled Rails application for testing"
 
       class_option :mountable,    :type => :boolean, :default => false,
                                   :desc => "Generate mountable isolated application"


### PR DESCRIPTION
rails plugin new --full generates a full rails application as an engine, but the --help description suggests that the --full option just adds integration testing... it's much more than that
