### PR TITLE
[Guides] refactor rakefile to have a :guides namespace and a task that shows help

### DIFF
--- a/guides/Rakefile
+++ b/guides/Rakefile
@@ -28,14 +28,13 @@ namespace :guides do
   task :help do
     puts <<-help
 
-Guides are generated with the rails_guides/generator.rb script, it can be invoked
-directly or via the guides:generate rake task. Here's a full list of available tasks:
-
-#{%x[rake -T]}
 Guides are taken from the source directory, and the resulting HTML goes into the
 output directory. Assets are stored under files, and copied to output/files as
 part of the generation process.
 
+All this process is handled via rake tasks, here's a full list of them:
+
+#{%x[rake -T]}
 Some arguments may be passed via environment variables:
 
   WARNINGS=1
@@ -64,7 +63,6 @@ Some arguments may be passed via environment variables:
     Generate .mobi with all the guides.
 
 Examples:
-  $ ALL=1 ruby rails_guides.rb
   $ rake guides:generate ALL=1
   $ rake guides:generate KINDLE=1
   $ rake guides:generate:kindle

--- a/guides/Rakefile
+++ b/guides/Rakefile
@@ -1,11 +1,27 @@
-desc 'Generate guides (for authors), use ONLY=foo to process just "foo.textile"'
-task :generate_guides do
-  ENV["WARN_BROKEN_LINKS"] = "1" # authors can't disable this
-  ruby "rails_guides.rb"
-end
+namespace :guides do
 
-# Validate guides -------------------------------------------------------------------------
-desc 'Validate guides, use ONLY=foo to process just "foo.html"'
-task :validate_guides do
-  ruby "w3c_validator.rb"
+  desc 'Generate guides (for authors), use ONLY=foo to process just "foo.textile"'
+  task :generate => 'generate:html'
+
+  namespace :generate do
+
+    desc "Generate HTML guides"
+    task :html do
+      ENV["WARN_BROKEN_LINKS"] = "1" # authors can't disable this
+      ruby "rails_guides.rb"
+    end
+
+    desc "Generate .mobi file"
+    task :kindle do
+      ENV['KINDLE'] = '1'
+      Rake::Task['guides:generate:html'].invoke
+    end
+  end
+
+  # Validate guides -------------------------------------------------------------------------
+  desc 'Validate guides, use ONLY=foo to process just "foo.html"'
+  task :validate do
+    ruby "w3c_validator.rb"
+  end
+
 end

--- a/guides/Rakefile
+++ b/guides/Rakefile
@@ -11,7 +11,7 @@ namespace :guides do
       ruby "rails_guides.rb"
     end
 
-    desc "Generate .mobi file"
+    desc "Generate .mobi file. The kindlegen executable must be in your PATH. You can get it for free from http://www.amazon.com/kindlepublishing"
     task :kindle do
       ENV['KINDLE'] = '1'
       Rake::Task['guides:generate:html'].invoke
@@ -59,14 +59,10 @@ Some arguments may be passed via environment variables:
   EDGE=1
     Indicate generated guides should be marked as edge.
 
-  KINDLE=1
-    Generate .mobi with all the guides.
-
 Examples:
   $ rake guides:generate ALL=1
-  $ rake guides:generate KINDLE=1
-  $ rake guides:generate:kindle
   $ rake guides:generate EDGE=1
+  $ rake guides:generate:kindle EDGE=1
   $ rake guides:generate GUIDES_LANGUAGE=es
     help
   end

--- a/guides/Rakefile
+++ b/guides/Rakefile
@@ -24,4 +24,54 @@ namespace :guides do
     ruby "w3c_validator.rb"
   end
 
+  desc "Show help"
+  task :help do
+    puts <<-help
+
+Guides are generated with the rails_guides/generator.rb script, it can be invoked
+directly or via the guides:generate rake task. Here's a full list of available tasks:
+
+#{%x[rake -T]}
+Guides are taken from the source directory, and the resulting HTML goes into the
+output directory. Assets are stored under files, and copied to output/files as
+part of the generation process.
+
+Some arguments may be passed via environment variables:
+
+  WARNINGS=1
+    Internal links (anchors) are checked, also detects duplicated IDs.
+
+  ALL=1
+    Force generation of all guides.
+
+  ONLY=name
+    Useful if you want to generate only one or a set of guides.
+    
+    Generate only association_basics.html:
+      ONLY=assoc
+
+    Separate many using commas:
+      ONLY=assoc,migrations
+
+  GUIDES_LANGUAGE
+    Use it when you want to generate translated guides in
+    source/<GUIDES_LANGUAGE> folder (such as source/es)
+
+  EDGE=1
+    Indicate generated guides should be marked as edge.
+
+  KINDLE=1
+    Generate .mobi with all the guides.
+
+Examples:
+  $ ALL=1 ruby rails_guides.rb
+  $ rake guides:generate ALL=1
+  $ rake guides:generate KINDLE=1
+  $ rake guides:generate:kindle
+  $ rake guides:generate EDGE=1
+  $ rake guides:generate GUIDES_LANGUAGE=es
+    help
+  end
 end
+
+task :default => 'guides:help'

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -47,11 +47,6 @@
 #     Set to "1" to indicate generated guides should be marked as edge. This
 #     inserts a badge and changes the preamble of the home page.
 #
-#   KINDLE
-#     Set to "1" to generate the .mobi with all the guides. The kindlegen
-#     executable must be in your PATH. You can get it for free from
-#     http://www.amazon.com/kindlepublishing
-#
 # ---------------------------------------------------------------------------
 
 require 'set'

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------------
 #
 # This script generates the guides. It can be invoked via the
-# guides:generate rake task within the railties directory.
+# guides:generate rake task within the guides directory.
 #
 # Guides are taken from the source directory, and the resulting HTML goes into the
 # output directory. Assets are stored under files, and copied to output/files as

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------------
 #
 # This script generates the guides. It can be invoked either directly or via the
-# generate_guides rake task within the railties directory.
+# guides:generate rake task within the railties directory.
 #
 # Guides are taken from the source directory, and the resulting HTML goes into the
 # output directory. Assets are stored under files, and copied to output/files as

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -1,6 +1,6 @@
 # ---------------------------------------------------------------------------
 #
-# This script generates the guides. It can be invoked either directly or via the
+# This script generates the guides. It can be invoked via the
 # guides:generate rake task within the railties directory.
 #
 # Guides are taken from the source directory, and the resulting HTML goes into the

--- a/guides/source/ruby_on_rails_guides_guidelines.textile
+++ b/guides/source/ruby_on_rails_guides_guidelines.textile
@@ -47,7 +47,13 @@ h4. Generation
 To generate all the guides, just +cd+ into the *+guides+* directory and execute:
 
 <plain>
-bundle exec rake generate_guides
+bundle exec rake guides:generate
+</plain>
+
+or
+
+<plain>
+bundle exec rake guides:generate:html
 </plain>
 
 (You may need to run +bundle install+ first to install the required gems.)
@@ -56,7 +62,7 @@ To process +my_guide.textile+ and nothing else use the +ONLY+ environment variab
 
 <plain>
 touch my_guide.textile
-bundle exec rake generate_guides ONLY=my_guide
+bundle exec rake guides:generate ONLY=my_guide
 </plain>
 
 By default, guides that have not been modified are not processed, so +ONLY+ is rarely needed in practice.
@@ -68,7 +74,13 @@ It is also recommended that you work with +WARNINGS=1+. This detects duplicate I
 If you want to generate guides in a language other than English, you can keep them in a separate directory under +source+ (eg. <tt>source/es</tt>) and use the +GUIDES_LANGUAGE+ environment variable:
 
 <plain>
-bundle exec rake generate_guides GUIDES_LANGUAGE=es
+bundle exec rake guides:generate GUIDES_LANGUAGE=es
+</plain>
+
+If you want to see all the environment variables you can use to configure the generation script just run:
+
+<plain>
+rake
 </plain>
 
 h4. Validation
@@ -76,7 +88,7 @@ h4. Validation
 Please validate the generated HTML with:
 
 <plain>
-bundle exec rake validate_guides
+bundle exec rake guides:validate
 </plain>
 
 Particularly, titles get an ID generated from their content and this often leads to duplicates. Please set +WARNINGS=1+ when generating guides to detect them. The warning messages suggest a solution.
@@ -88,5 +100,11 @@ h4(#generation-kindle). Generation
 To generate guides for the Kindle, you need to provide +KINDLE=1+ as an environment variable:
 
 <plain>
-KINDLE=1 bundle exec rake generate_guides
+KINDLE=1 bundle exec rake guides:generate
+</plain>
+
+or you can use the following task:
+
+<plain>
+bundle exec rake guides:generate:kindle
 </plain>

--- a/guides/source/ruby_on_rails_guides_guidelines.textile
+++ b/guides/source/ruby_on_rails_guides_guidelines.textile
@@ -97,13 +97,7 @@ h3. Kindle Guides
 
 h4(#generation-kindle). Generation
 
-To generate guides for the Kindle, you need to provide +KINDLE=1+ as an environment variable:
-
-<plain>
-KINDLE=1 bundle exec rake guides:generate
-</plain>
-
-or you can use the following task:
+To generate guides for the Kindle, use the following rake task:
 
 <plain>
 bundle exec rake guides:generate:kindle


### PR DESCRIPTION
Rake tasks:
- guides:generate (executes generate:html)
- guides:validate
- guides:generate:html
- guides:generate:kindle
- help (default) - the text is almost the same than in rails_guides/generator.rb
