### PR TITLE
Allow simple symbols in routes

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1252,7 +1252,7 @@ module ActionDispatch
         def match(path, *rest)
           if rest.empty? && Hash === path
             options  = path
-            path, to = options.find { |name, value| name.is_a?(String) }
+            path, to = options.find { |name, value| name.is_a?(String) || name.is_a?(Symbol) }
             options[:to] = to
             options.delete(path)
             paths = [path]

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -54,9 +54,11 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
       scope "pagemark", :controller => "pagemarks", :as => :pagemark do
         get  "new", :path => "build"
         post "create", :as => ""
-        put  "update"
+        put :update
         get  "remove", :action => :destroy, :as => :remove
       end
+
+      put :pagemark_upload => 'pagemarks#upload'
 
       match 'account/logout' => redirect("/logout"), :as => :logout_redirect
       match 'account/login', :to => redirect("/login")
@@ -821,6 +823,10 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
       get '/pagemark/remove'
       assert_equal 'pagemarks#destroy', @response.body
       assert_equal '/pagemark/remove', pagemark_remove_path
+
+      put '/pagemark_upload'
+      assert_equal 'pagemarks#upload', @response.body
+      assert_equal '/pagemark_upload', pagemark_upload_path
     end
   end
 


### PR DESCRIPTION
allow routes like

``` ruby
get :index => 'a#b'
```

in addition to

``` ruby
get 'index' => 'a#b'
```
