### PR TITLE
Remove support for CollectionAssociation#destroy by Fixnum or String

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -240,7 +240,6 @@ module ActiveRecord
       # Note that this method will _always_ remove records from the database
       # ignoring the +:dependent+ option.
       def destroy(*records)
-        records = find(records) if records.any? { |record| record.kind_of?(Fixnum) || record.kind_of?(String) }
         delete_or_destroy(records, :destroy)
       end
 

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -603,38 +603,6 @@ module ActiveRecord
       #   person.pets       # => []
       #
       #   Pet.find(1, 2, 3) # => ActiveRecord::RecordNotFound: Couldn't find all Pets with IDs (1, 2, 3)
-      #
-      # You can pass +Fixnum+ or +String+ values, it finds the records
-      # responding to the +id+ and then deletes them from the database.
-      #
-      #   person.pets.size # => 3
-      #   person.pets
-      #   # => [
-      #   #       #<Pet id: 4, name: "Benny", person_id: 1>,
-      #   #       #<Pet id: 5, name: "Brain", person_id: 1>,
-      #   #       #<Pet id: 6, name: "Boss",  person_id: 1>
-      #   #    ]
-      #
-      #   person.pets.destroy("4")
-      #   # => #<Pet id: 4, name: "Benny", person_id: 1>
-      #
-      #   person.pets.size # => 2
-      #   person.pets
-      #   # => [
-      #   #       #<Pet id: 5, name: "Brain", person_id: 1>,
-      #   #       #<Pet id: 6, name: "Boss",  person_id: 1>
-      #   #    ]
-      #
-      #   person.pets.destroy(5, 6)
-      #   # => [
-      #   #       #<Pet id: 5, name: "Brain", person_id: 1>,
-      #   #       #<Pet id: 6, name: "Boss",  person_id: 1>
-      #   #    ]
-      #
-      #   person.pets.size  # => 0
-      #   person.pets       # => []
-      #
-      #   Pet.find(4, 5, 6) # => ActiveRecord::RecordNotFound: Couldn't find all Pets with IDs (4, 5, 6)
 
       ##
       # :method: uniq

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -959,26 +959,26 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 0, companies(:first_firm).clients_of_firm(true).size
   end
 
-  def test_destroying_by_fixnum_id
+  def test_destroying_by_fixnum_id_raises_type_mismatch
     force_signal37_to_load_all_clients_of_firm
 
-    assert_difference "Client.count", -1 do
-      companies(:first_firm).clients_of_firm.destroy(companies(:first_firm).clients_of_firm.first.id)
-    end
+    company = companies(:first_firm)
+    client  = company.clients_of_firm.first
 
-    assert_equal 0, companies(:first_firm).reload.clients_of_firm.size
-    assert_equal 0, companies(:first_firm).clients_of_firm(true).size
+    assert_raise(ActiveRecord::AssociationTypeMismatch) do
+      company.clients_of_firm.destroy(client.id)
+    end
   end
 
-  def test_destroying_by_string_id
+  def test_destroying_by_string_id_raises_type_mismatch
     force_signal37_to_load_all_clients_of_firm
 
-    assert_difference "Client.count", -1 do
-      companies(:first_firm).clients_of_firm.destroy(companies(:first_firm).clients_of_firm.first.id.to_s)
-    end
+    company = companies(:first_firm)
+    client  = company.clients_of_firm.first
 
-    assert_equal 0, companies(:first_firm).reload.clients_of_firm.size
-    assert_equal 0, companies(:first_firm).clients_of_firm(true).size
+    assert_raise(ActiveRecord::AssociationTypeMismatch) do
+      company.clients_of_firm.destroy(client.id.to_s)
+    end
   end
 
   def test_destroying_a_collection


### PR DESCRIPTION
I found the next issue between CollectionAssociation `delete` and `destroy`:

```
class Person < ActiveRecord::Base
  has_many :pets
end

person.pets.destroy(1)
# => OK, returns the destroyed object

person.pets.destroy("2")
# => OK, returns the destroyed object

person.pets.delete(1)
# => ActiveRecord::AssociationTypeMismatch

person.pets.delete("2")
# => ActiveRecord::AssociationTypeMismatch
```

I was not sure about adding support for delete by fixnum or string.
That's why i prefer to remove destroy by fixnum or string option.
I sincerely think that is better to delete or destroy passing a record
or an object.
