### PR TITLE
Fix handling of negative zero in number_to_currency

### DIFF
--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -111,7 +111,7 @@ module ActiveSupport
       unit      = options.delete(:unit)
       format    = options.delete(:format)
 
-      if number.to_f < 0
+      if number.to_f.phase != 0
         format = options.delete(:negative_format)
         number = number.respond_to?("abs") ? number.abs : number.sub(/^-/, '')
       end

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -64,6 +64,8 @@ module ActiveSupport
           assert_equal("$1,234,567,890.50", number_helper.number_to_currency("1234567890.50"))
           assert_equal("1,234,567,890.50 K&#269;", number_helper.number_to_currency("1234567890.50", {:unit => "K&#269;", :format => "%n %u"}))
           assert_equal("1,234,567,890.50 - K&#269;", number_helper.number_to_currency("-1234567890.50", {:unit => "K&#269;", :format => "%n %u", :negative_format => "%n - %u"}))
+          assert_equal("0.00", number_helper.number_to_currency(+0.0, {:unit => "", :negative_format => "(%n)"}))
+          assert_equal("(0.00)", number_helper.number_to_currency(-0.0, {:unit => "", :negative_format => "(%n)"}))
         end
       end
 


### PR DESCRIPTION
Without this patch, `number_to_currency()` treats `-0.0` as if it were a positive number and fails to apply the `:negative_format` option.  

I tried to write this to support multiple rubies.  In modern rubies, it will invoke `phase()` but looking at the docs for older rubies I couldn't find a satisfactory alternative, and had to settle for slicing the first char off of `to_s()`.  Please tell me there's a better way. :-)
