### PR TITLE
Don't enable validations when passing false hash values to ActiveModel.validates

### DIFF
--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -88,6 +88,7 @@ module ActiveModel
         defaults.merge!(:attributes => attributes)
 
         validations.each do |key, options|
+          next unless options
           key = "#{key.to_s.camelize}Validator"
 
           begin

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -331,6 +331,11 @@ class ValidationsTest < ActiveModel::TestCase
     end
   end
 
+  def test_validates_with_false_hash_value
+    Topic.validates :title,  :presence => false
+    assert Topic.new.valid?
+  end
+
   def test_strict_validation_error_message
     Topic.validates :title, :strict => true, :presence => true
 


### PR DESCRIPTION
Passing a falsey option value for a validator currently causes that validator to
be enabled, just like "true":

```
ActiveModel.validates :foo, :presence => false
```

This is rather counterintuitive, and makes it inconvenient to wrap `validates` in
methods which may conditionally enable different validators.

As an example, one is currently forced to write:

```
  def has_slug(source_field, options={:unique => true})
    slugger = Proc.new { |r| r[:slug] = self.class.sluggify(r[source_field]) if r[:slug].blank? }
    before_validation slugger
    validations = { :presence => true, :slug => true }
    if options[:unique]
      validations[:uniqueness] = true
    end
    validates :slug, validations
  end
```

because the following reasonable-looking alternative fails to work as expected:

```
  def has_slug(source_field, options={:unique => true})
    slugger = Proc.new { |r| r[:slug] = self.class.sluggify(r[source_field]) if r[:slug].blank? }
    before_validation slugger
    validates :slug, :presence => true, :slug => true, :uniqueness => options[:unique]
  end
```

(This commit includes a test, and all activemodel and activerecord tests pass as before.)
