### PR TITLE
Fix that #exists? can blow up with ThrowResult exception

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -186,6 +186,8 @@ module ActiveRecord
       end
 
       connection.select_value(relation, "#{name} Exists", relation.bind_values)
+    rescue ThrowResult
+      false
     end
 
     protected

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -69,7 +69,12 @@ class FinderTest < ActiveRecord::TestCase
     assert Topic.order(:id).uniq.exists?
   end
 
-  def test_does_not_exist_with_empty_table_and_no_args_given
+  def test_exists_with_includes_limit_and_empty_result
+    assert !Topic.includes(:replies).limit(0).exists?
+    assert !Topic.includes(:replies).limit(1).where('0 = 1').exists?
+  end
+
+  def test_exists_with_empty_table_and_no_args_given
     Topic.delete_all
     assert !Topic.exists?
   end


### PR DESCRIPTION
FinderMethods#construct_limited_ids_condition will raise ThrowResult if the limited reflection comes back empty. The other callers of #construct_limited_ids_condition handle this exception (more specifically, the callers of construct_relation_for*), but #exists? didn't until now.

The included test hits this condition, and after the tests runs green.
