### PR TITLE
ActiveSupport require and dependencies

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/access.rb
+++ b/activesupport/lib/active_support/core_ext/string/access.rb
@@ -1,5 +1,3 @@
-require 'active_support/multibyte'
-
 class String
   # If you pass a single Fixnum, returns a substring of one character at that
   # position. The first character of the string is at position 0, the next at

--- a/activesupport/lib/active_support/core_ext/string/filters.rb
+++ b/activesupport/lib/active_support/core_ext/string/filters.rb
@@ -1,5 +1,3 @@
-require 'active_support/core_ext/string/multibyte'
-
 class String
   # Returns the string, first removing all whitespace on both ends of
   # the string, and then changing remaining consecutive whitespace

--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -76,7 +76,7 @@ module ActiveSupport #:nodoc:
       #
       #   'Café périferôl'.mb_chars.split(/é/).map { |part| part.upcase.to_s } # => ["CAF", " P", "RIFERÔL"]
       def split(*args)
-        @wrapped_string.split(*args).map { |i| i.mb_chars }
+        @wrapped_string.split(*args).map { |i| self.class.new(i) }
       end
 
       # Works like like <tt>String#slice!</tt>, but returns an instance of Chars, or nil if the string was not


### PR DESCRIPTION
Commits:
- remove unnecessary require
  
  AS::Multibyte are no longer required by access and filters string
  core extensions.
- make AS::Multibyte::Chars work w/o multibyte core ext
  
  Use ActiveSupport::Multibyte::Chars.new instead of String#mb_chars.
  It allows to use ActiveSupport::Multibyte::Chars without requiring
  String multibyte core extension.
