### PR TITLE
Fix that #exists? can produce invalid SQL: "SELECT DISTINCT DISTINCT"

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -240,6 +240,7 @@ module ActiveRecord
       values = @klass.connection.distinct("#{@klass.connection.quote_table_name table_name}.#{primary_key}", orders)
 
       relation = relation.dup
+      relation.uniq_value = false # avoids SELECT DISTINCT DISTINCT
 
       ids_array = relation.select(values).collect {|row| row[primary_key]}
       ids_array.empty? ? raise(ThrowResult) : table[primary_key].in(ids_array)

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -74,6 +74,18 @@ class FinderTest < ActiveRecord::TestCase
     assert !Topic.includes(:replies).limit(1).where('0 = 1').exists?
   end
 
+  def test_exists_with_distinct_association_includes_and_limit
+    author = Author.first
+    assert !author.unique_categorized_posts.includes(:special_comments).limit(0).exists?
+    assert author.unique_categorized_posts.includes(:special_comments).limit(1).exists?
+  end
+
+  def test_exists_with_distinct_association_includes_limit_and_order
+    author = Author.first
+    assert !author.unique_categorized_posts.includes(:special_comments).order('comments.taggings_count DESC').limit(0).exists?
+    assert author.unique_categorized_posts.includes(:special_comments).order('comments.taggings_count DESC').limit(1).exists?
+  end
+
   def test_exists_with_empty_table_and_no_args_given
     Topic.delete_all
     assert !Topic.exists?


### PR DESCRIPTION
The combination of a :uniq => true association and the #distinct call in construct_limited_ids_condition combine to create invalid SQL, because we're explicitly selecting DISTINCT, and also sending #distinct on to AREL, via the relation#uniq_value.

I unset relation#uniq_value in the limited ids lookup so that Arel doesn't apply the DISTINCT that we're already applying. This only affects the limited ids lookup query, and only in the problematic case where uniq_value was true. Everything else is unchanged.

Bug is present on 3-2-stable as well.

Previously failed with:

```
ActiveRecord::StatementInvalid: SQLite3::SQLException: near "DISTINCT": syntax error: SELECT  DISTINCT DISTINCT "posts".id FROM "posts" LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id" AND "comments"."type" IN ('SpecialComment', 'SubSpecialComment') INNER JOIN "categorizations" ON "posts"."id" = "categorizations"."post_id" WHERE "categorizations"."author_id" = ? LIMIT 0
    sqlite3-1.3.6/lib/sqlite3/database.rb:91:in `initialize'
    sqlite3-1.3.6/lib/sqlite3/database.rb:91:in `new'
    sqlite3-1.3.6/lib/sqlite3/database.rb:91:in `prepare'
    rails/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb:288:in `block in exec_query'
    rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:288:in `block in log'
    rails/activesupport/lib/active_support/notifications/instrumenter.rb:18:in `instrument'
    rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:283:in `log'
    rails/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb:277:in `exec_query'
    rails/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb:495:in `select'
    rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:18:in `select_all'
    rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:63:in `select_all'
    rails/activerecord/lib/active_record/querying.rb:40:in `block in find_by_sql'
    rails/activerecord/lib/active_record/explain.rb:37:in `logging_query_plan'
    rails/activerecord/lib/active_record/querying.rb:39:in `find_by_sql'
    rails/activerecord/lib/active_record/relation.rb:174:in `exec_queries'
    rails/activerecord/lib/active_record/relation.rb:164:in `block in to_a'
    rails/activerecord/lib/active_record/explain.rb:37:in `logging_query_plan'
    rails/activerecord/lib/active_record/relation.rb:163:in `to_a'
    rails/activerecord/lib/active_record/relation/delegation.rb:6:in `collect'
    rails/activerecord/lib/active_record/relation/finder_methods.rb:241:in `construct_limited_ids_condition'
    rails/activerecord/lib/active_record/relation/finder_methods.rb:226:in `apply_join_dependency'
    rails/activerecord/lib/active_record/relation/finder_methods.rb:215:in `construct_relation_for_association_find'
    rails/activerecord/lib/active_record/relation/finder_methods.rb:177:in `exists?'
    test/cases/finder_test.rb:68:in `test_exists_with_distinct_association_includes_and_limit'
```
