### PR TITLE
Exceptions like Interrupt & NoMemoryError should not be rescued in tests.

### DIFF
--- a/activesupport/lib/active_support/testing/setup_and_teardown.rb
+++ b/activesupport/lib/active_support/testing/setup_and_teardown.rb
@@ -28,11 +28,15 @@ module ActiveSupport
           run_callbacks :setup do
             result = super
           end
+        rescue *::MiniTest::Unit::TestCase::PASSTHROUGH_EXCEPTIONS
+          raise
         rescue Exception => e
           result = runner.puke(self.class, method_name, e)
         ensure
           begin
             run_callbacks :teardown
+          rescue *::MiniTest::Unit::TestCase::PASSTHROUGH_EXCEPTIONS
+            raise
           rescue Exception => e
             result = runner.puke(self.class, method_name, e)
           end

--- a/activesupport/lib/active_support/testing/setup_and_teardown.rb
+++ b/activesupport/lib/active_support/testing/setup_and_teardown.rb
@@ -4,6 +4,14 @@ require 'active_support/callbacks'
 module ActiveSupport
   module Testing
     module SetupAndTeardown
+
+      PASSTHROUGH_EXCEPTIONS = [
+        NoMemoryError,
+        SignalException,
+        Interrupt,
+        SystemExit
+      ]
+
       extend ActiveSupport::Concern
 
       included do
@@ -28,14 +36,14 @@ module ActiveSupport
           run_callbacks :setup do
             result = super
           end
-        rescue *::MiniTest::Unit::TestCase::PASSTHROUGH_EXCEPTIONS
+        rescue *PASSTHROUGH_EXCEPTIONS
           raise
         rescue Exception => e
           result = runner.puke(self.class, method_name, e)
         ensure
           begin
             run_callbacks :teardown
-          rescue *::MiniTest::Unit::TestCase::PASSTHROUGH_EXCEPTIONS
+          rescue *PASSTHROUGH_EXCEPTIONS
             raise
           rescue Exception => e
             result = runner.puke(self.class, method_name, e)

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -18,11 +18,9 @@ module ActiveSupport
       end
     end
 
-    def test_callback_with_exception
+    def test_standard_error_raised_within_setup_callback_is_puked
       tc = Class.new(TestCase) do
-        def self.name
-          nil
-        end
+        def self.name; nil; end
 
         setup :bad_callback
         def bad_callback; raise 'oh noes' end
@@ -41,11 +39,9 @@ module ActiveSupport
       assert_equal 'oh noes', exception.message
     end
 
-    def test_teardown_callback_with_exception
+    def test_standard_error_raised_within_teardown_callback_is_puked
       tc = Class.new(TestCase) do
-        def self.name
-          nil
-        end
+        def self.name; nil; end
 
         teardown :bad_callback
         def bad_callback; raise 'oh noes' end
@@ -62,6 +58,52 @@ module ActiveSupport
       assert_equal tc, klass
       assert_equal test_name, name
       assert_equal 'oh noes', exception.message
+    end
+
+    def test_passthrough_exception_raised_within_test_method_is_not_rescued
+      tc = Class.new(TestCase) do
+        def self.name; nil; end
+
+        def test_which_raises_interrupt; raise Interrupt; end
+      end
+
+      test_name = 'test_which_raises_interrupt'
+      fr = FakeRunner.new
+
+      test = tc.new test_name
+      assert_raises(Interrupt) { test.run fr }
+    end
+
+    def test_passthrough_exception_raised_within_setup_callback_is_not_rescued
+      tc = Class.new(TestCase) do
+        def self.name; nil; end
+
+        setup :callback_which_raises_interrupt
+        def callback_which_raises_interrupt; raise Interrupt; end
+        def test_true; assert true end
+      end
+
+      test_name = 'test_true'
+      fr = FakeRunner.new
+
+      test = tc.new test_name
+      assert_raises(Interrupt) { test.run fr }
+    end
+
+    def test_passthrough_exception_raised_within_teardown_callback_is_not_rescued
+      tc = Class.new(TestCase) do
+        def self.name; nil; end
+
+        teardown :callback_which_raises_interrupt
+        def callback_which_raises_interrupt; raise Interrupt; end
+        def test_true; assert true end
+      end
+
+      test_name = 'test_true'
+      fr = FakeRunner.new
+
+      test = tc.new test_name
+      assert_raises(Interrupt) { test.run fr }
     end
   end
 end


### PR DESCRIPTION
Neither Test::Unit nor MiniTest rescue exceptions like Interrupt or
NoMemoryError, but ActiveSupport::Testing::SetupAndTeardown#run which
overrides MiniTest::Unit::TestCase#run currently rescues them.

Rescuing an Interrupt exception is annoying, because it means when you
are running a lot of tests e.g. when running one of the rake test tasks,
you cannot break out using ctrl-C.

Rescuing exceptions like NoMemoryError is foolish, because the most
sensible thing to happen is for the process to terminate as soon as
possible.

This solution probably needs some finessing e.g. I'm not clear whether
the assumption is that only MiniTest is supported. Also early versions
of MiniTest did not have this behaviour. Finally
ActiveSupport::Testing::Performance also suffers from the same
problem, but I have not fixed it here.

Integrating with Test::Unit & MiniTest has always been a pain. It would
be great if both of them provided sensible extension points for the kind
of things that both Rails and Mocha want to do, but in the meantime
hopefully this is of some help.
