### PR TITLE
Decoupling ActiveSupport from ActionView

### DIFF
--- a/activesupport/lib/active_support/testing/performance.rb
+++ b/activesupport/lib/active_support/testing/performance.rb
@@ -3,7 +3,8 @@ require 'rails/version'
 require 'active_support/concern'
 require 'active_support/core_ext/class/delegating_attributes'
 require 'active_support/core_ext/string/inflections'
-require 'action_view/helpers/number_helper'
+require 'active_support/core_ext/module/delegation'
+require 'active_support/number_helper'
 
 module ActiveSupport
   module Testing
@@ -195,8 +196,7 @@ module ActiveSupport
         end
 
         class Base
-          include ActionView::Helpers::NumberHelper
-          include ActionView::Helpers::OutputSafetyHelper
+          include ActiveSupport::NumberHelper
 
           attr_reader :total
 
@@ -240,7 +240,7 @@ module ActiveSupport
 
         class Amount < Base
           def format(measurement)
-            number_with_delimiter(measurement.floor)
+            number_to_delimited(measurement.floor)
           end
         end
 

--- a/activesupport/test/testing/performance_test.rb
+++ b/activesupport/test/testing/performance_test.rb
@@ -1,0 +1,40 @@
+require 'abstract_unit'
+require 'active_support/testing/performance'
+
+
+module ActiveSupport
+  module Testing
+    class PerformanceTest < ActiveSupport::TestCase
+      def test_amount_format
+        amount_metric = ActiveSupport::Testing::Performance::Metrics[:amount].new
+        assert_equal "0", amount_metric.format(0)
+        assert_equal "1", amount_metric.format(1.23)
+        assert_equal "40,000,000", amount_metric.format(40000000)
+      end
+      
+      def test_time_format
+        time_metric = ActiveSupport::Testing::Performance::Metrics[:time].new
+        assert_equal "0 ms", time_metric.format(0)
+        assert_equal "40 ms", time_metric.format(0.04)
+        assert_equal "41 ms", time_metric.format(0.0415)
+        assert_equal "1.23 sec", time_metric.format(1.23)
+        assert_equal "40000.00 sec", time_metric.format(40000)
+        assert_equal "-5000 ms", time_metric.format(-5)
+      end
+      
+      def test_space_format
+        space_metric = ActiveSupport::Testing::Performance::Metrics[:digital_information_unit].new
+        assert_equal "0 Bytes", space_metric.format(0)
+        assert_equal "0 Bytes", space_metric.format(0.4)
+        assert_equal "1 Byte", space_metric.format(1.23)
+        assert_equal "123 Bytes", space_metric.format(123)
+        assert_equal "123 Bytes", space_metric.format(123.45)
+        assert_equal "12 KB", space_metric.format(12345)
+        assert_equal "1.2 MB", space_metric.format(1234567)
+        assert_equal "9.3 GB", space_metric.format(10**10)
+        assert_equal "91 TB", space_metric.format(10**14)
+        assert_equal "910000 TB", space_metric.format(10**18)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi,

I'm interested in using the ActiveSupport::Testing::Performance module and was surprised to see that it requires and calls code from ActionView.  I'd like to use this module in a context without ActionView, and now that we've moved NumberHelpers to ActiveSupport (https://github.com/rails/rails/pull/6315), we can do this.

In this pull request I'm changing ActiveSupport::Testing::Performance to use ActiveSupport::NumberHelper instead of ActionView::Helpers::NumberHelper.  Also, to my knowledge this logic was untested, so I have added tests for the formatting logic (which pass before and after the code change).

Any and all feedback is welcome.

Thanks!
-Andrew.
