### PR TITLE
Exceptions like Interrupt should not be rescued in tests.

### DIFF
--- a/activesupport/lib/active_support/testing/setup_and_teardown.rb
+++ b/activesupport/lib/active_support/testing/setup_and_teardown.rb
@@ -28,17 +28,22 @@ module ActiveSupport
       end
 
       module ForMiniTest
+        PASSTHROUGH_EXCEPTIONS = MiniTest::Unit::TestCase::PASSTHROUGH_EXCEPTIONS rescue [NoMemoryError, SignalException, Interrupt, SystemExit]
         def run(runner)
           result = '.'
           begin
             run_callbacks :setup do
               result = super
             end
+          rescue *PASSTHROUGH_EXCEPTIONS => e
+            raise e
           rescue Exception => e
             result = runner.puke(self.class, method_name, e)
           ensure
             begin
               run_callbacks :teardown
+            rescue *PASSTHROUGH_EXCEPTIONS => e
+              raise e
             rescue Exception => e
               result = runner.puke(self.class, method_name, e)
             end

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -19,7 +19,7 @@ module ActiveSupport
     end
 
     if defined?(MiniTest::Assertions) && TestCase < MiniTest::Assertions
-      def test_callback_with_exception
+      def test_standard_error_raised_within_setup_callback_is_puked
         tc = Class.new(TestCase) do
           setup :bad_callback
           def bad_callback; raise 'oh noes' end
@@ -38,7 +38,7 @@ module ActiveSupport
         assert_equal 'oh noes', exception.message
       end
 
-      def test_teardown_callback_with_exception
+      def test_standard_error_raised_within_teardown_callback_is_puked
         tc = Class.new(TestCase) do
           teardown :bad_callback
           def bad_callback; raise 'oh noes' end
@@ -55,6 +55,46 @@ module ActiveSupport
         assert_equal tc, klass
         assert_equal test_name, name
         assert_equal 'oh noes', exception.message
+      end
+
+      def test_passthrough_exception_raised_within_test_method_is_not_rescued
+        tc = Class.new(TestCase) do
+          def test_which_raises_interrupt; raise Interrupt; end
+        end
+
+        test_name = 'test_which_raises_interrupt'
+        fr = FakeRunner.new
+
+        test = tc.new test_name
+        assert_raises(Interrupt) { test.run fr }
+      end
+
+      def test_passthrough_exception_raised_within_setup_callback_is_not_rescued
+        tc = Class.new(TestCase) do
+          setup :callback_which_raises_interrupt
+          def callback_which_raises_interrupt; raise Interrupt; end
+          def test_true; assert true end
+        end
+
+        test_name = 'test_true'
+        fr = FakeRunner.new
+
+        test = tc.new test_name
+        assert_raises(Interrupt) { test.run fr }
+      end
+
+      def test_passthrough_exception_raised_within_teardown_callback_is_not_rescued
+        tc = Class.new(TestCase) do
+          teardown :callback_which_raises_interrupt
+          def callback_which_raises_interrupt; raise Interrupt; end
+          def test_true; assert true end
+        end
+
+        test_name = 'test_true'
+        fr = FakeRunner.new
+
+        test = tc.new test_name
+        assert_raises(Interrupt) { test.run fr }
       end
     end
   end


### PR DESCRIPTION
This is a back-port of rails/rails#6525. See the commit notes there for
details.
