### PR TITLE
Fix pluralize helper to properly handle minus one

### DIFF
--- a/actionpack/lib/action_view/helpers/text_helper.rb
+++ b/actionpack/lib/action_view/helpers/text_helper.rb
@@ -161,9 +161,9 @@ module ActionView
         prefix + text[start_pos..end_pos].strip + postfix
       end
 
-      # Attempts to pluralize the +singular+ word unless +count+ is 1. If
-      # +plural+ is supplied, it will use that when count is > 1, otherwise
-      # it will use the Inflector to determine the plural form.
+      # Attempts to pluralize the +singular+ word unless +count+ is 1 or -1.
+      # If +plural+ is supplied, it will use that when count is not 1 or -1,
+      # otherwise it will use the Inflector to determine the plural form.
       #
       #   pluralize(1, 'person')
       #   # => 1 person
@@ -176,8 +176,14 @@ module ActionView
       #
       #   pluralize(0, 'person')
       #   # => 0 people
+      #
+      #   pluralize(-1, 'character')
+      #   # => -1 character
+      #
+      #   pluralize(-2, 'character')
+      #   # => -2 characters
       def pluralize(count, singular, plural = nil)
-        word = if (count == 1 || count =~ /^1(\.0+)?$/)
+        word = if (count == 1 || count == -1 || count =~ /^1(\.0+)?$/)
           singular
         else
           plural || singular.pluralize

--- a/actionpack/test/template/text_helper_test.rb
+++ b/actionpack/test/template/text_helper_test.rb
@@ -333,6 +333,8 @@ class TextHelperTest < ActionView::TestCase
     assert_equal("10 buffaloes", pluralize(10, "buffalo"))
     assert_equal("1 berry", pluralize(1, "berry"))
     assert_equal("12 berries", pluralize(12, "berry"))
+    assert_equal("-1 character", pluralize(-1, "character"))
+    assert_equal("-2 characters", pluralize(-2, "character"))
   end
 
   def test_cycle_class


### PR DESCRIPTION
Here is a good explanation:
http://neilwhitfield.wordpress.com/2007/10/31/good-question-are-fractions-and-decimals-singular-or-plural/

'If the number one is used, whether it is +/-1, the following noun will be
singular. So it would be -1 apple. We’re talking grammar, not logic; and yes we
say zero apples, probably because zero is thought of as a number that is not
one, even though zero is neither singular nor plural logically.'
