### PR TITLE
exists?(false) returns false

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `FinderMethods#exists?` now returns `false` with the `false` argument.
+
+    *Egor Lynko*
+
 *   Added support for specifying the precision of a timestamp in the postgresql
     adapter. So, instead of having to incorrectly specify the precision using the
     `:limit` option, you may use `:precision`, as intended. For example, in a migration:

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -170,19 +170,19 @@ module ActiveRecord
     #   Person.exists?(['name LIKE ?', "%#{query}%"])
     #   Person.exists?(:name => "David")
     #   Person.exists?
-    def exists?(id = false)
-      id = id.id if ActiveRecord::Model === id
-      return false if id.nil?
+    def exists?(conditions = :none)
+      conditions = conditions.id if ActiveRecord::Model === conditions
+      return false if !conditions
 
       join_dependency = construct_join_dependency_for_association_find
       relation = construct_relation_for_association_find(join_dependency)
       relation = relation.except(:select, :order).select("1 AS one").limit(1)
 
-      case id
+      case conditions
       when Array, Hash
-        relation = relation.where(id)
+        relation = relation.where(conditions)
       else
-        relation = relation.where(table[primary_key].eq(id)) if id
+        relation = relation.where(table[primary_key].eq(conditions)) if conditions != :none
       end
 
       connection.select_value(relation, "#{name} Exists", relation.bind_values)

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -55,6 +55,10 @@ class FinderTest < ActiveRecord::TestCase
     assert Topic.exists?
   end
 
+  def test_exists_returns_false_with_false_arg
+    assert !Topic.exists?(false)
+  end
+
   # exists? should handle nil for id's that come from URLs and always return false
   # (example: Topic.exists?(params[:id])) where params[:id] is nil
   def test_exists_with_nil_arg


### PR DESCRIPTION
_exists?_ finder method now returns _false_ with the _false_ argument

``` ruby
Topic.exists?(false)
=> false
```

I would like to propose this solution. I think it may be acceptable.
Changes don't affect on any other cases.
Discussion in issue #6431.
