### PR TITLE
True, False, and Nil should be represented in as_json as themselves.

### DIFF
--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -159,18 +159,18 @@ class Struct #:nodoc:
 end
 
 class TrueClass
-  AS_JSON = ActiveSupport::JSON::Variable.new('true').freeze
-  def as_json(options = nil) AS_JSON end #:nodoc:
+  def as_json(options = nil) self end #:nodoc:
+  def encode_json(encoder) to_s end #:nodoc:
 end
 
 class FalseClass
-  AS_JSON = ActiveSupport::JSON::Variable.new('false').freeze
-  def as_json(options = nil) AS_JSON end #:nodoc:
+  def as_json(options = nil) self end #:nodoc:
+  def encode_json(encoder) to_s end #:nodoc:
 end
 
 class NilClass
-  AS_JSON = ActiveSupport::JSON::Variable.new('null').freeze
-  def as_json(options = nil) AS_JSON end #:nodoc:
+  def as_json(options = nil) self end #:nodoc:
+  def encode_json(encoder) 'null' end #:nodoc:
 end
 
 class String
@@ -189,8 +189,8 @@ end
 
 class Float
   # Encoding Infinity or NaN to JSON should return "null". The default returns
-  # "Infinity" or "NaN" what breaks parsing the JSON. E.g. JSON.parse('[NaN]').
-  def as_json(options = nil) finite? ? self : NilClass::AS_JSON end #:nodoc:
+  # "Infinity" or "NaN" breaks parsing the JSON. E.g. JSON.parse('[NaN]').
+  def as_json(options = nil) finite? ? self : nil end #:nodoc:
 end
 
 class BigDecimal
@@ -208,7 +208,7 @@ class BigDecimal
     if finite?
       ActiveSupport.encode_big_decimal_as_string ? to_s : self
     else
-      NilClass::AS_JSON
+      nil
     end
   end
 end

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -285,6 +285,12 @@ class TestJSONEncoding < ActiveSupport::TestCase
     end
   end
 
+  def test_nil_true_and_false_represented_as_themselves
+    assert_equal nil,   nil.as_json
+    assert_equal true,  true.as_json
+    assert_equal false, false.as_json
+  end
+
   protected
 
     def object_keys(json_object)


### PR DESCRIPTION
Tests are a bit lame, but relevant I guess. Let me know if you think they're unnecessary.

Relates to #6536.

as_json should return the closest Ruby representation it can. `nil`, `true`, and `false` are all simple singletons that can be represented easily without using a string representation.
