### PR TITLE
Add support for CollectionAssociation#delete by Fixnum or String

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Rails 3.2.4 (unreleased) ##
 
+*   Added support to `CollectionAssociation#delete` for passing `fixnum`
+    or `string` values as record ids. This finds the records responding
+    to the `id` and executes delete on them.
+
+        class Person < ActiveRecord::Base
+          has_many :pets
+        end
+
+        person.pets.delete("1") # => [#<Pet id: 1>]
+        person.pets.delete(2, 3) # => [#<Pet id: 2>, #<Pet id: 3>]
+
+    *Francesco Rodriguez*
+
 *   Perf fix: Don't load the records when doing assoc.delete_all.
     GH #6289. *Jon Leighton*
 

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -235,6 +235,7 @@ module ActiveRecord
             delete_records(:all, dependent)
           end
         else
+          records = find(records) if records.any? { |record| record.kind_of?(Fixnum) || record.kind_of?(String) }
           delete_or_destroy(records, dependent)
         end
       end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1043,10 +1043,24 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 2, summit.client_of
   end
 
-  def test_deleting_type_mismatch
+  def test_deleting_by_fixnum_id
     david = Developer.find(1)
-    david.projects.reload
-    assert_raise(ActiveRecord::AssociationTypeMismatch) { david.projects.delete(1) }
+
+    assert_difference 'david.projects.count', -1 do
+      assert_equal 1, david.projects.delete(1).size
+    end
+
+    assert_equal 1, david.projects.size
+  end
+
+  def test_deleting_by_string_id
+    david = Developer.find(1)
+
+    assert_difference 'david.projects.count', -1 do
+      assert_equal 1, david.projects.delete('1').size
+    end
+
+    assert_equal 1, david.projects.size
   end
 
   def test_deleting_self_type_mismatch

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -595,7 +595,27 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
   end
 
   def test_deleting_junk_from_has_many_through_should_raise_type_mismatch
-    assert_raise(ActiveRecord::AssociationTypeMismatch) { posts(:thinking).tags.delete("Uhh what now?") }
+    assert_raise(ActiveRecord::AssociationTypeMismatch) { posts(:thinking).tags.delete(Object.new) }
+  end
+
+  def test_deleting_by_fixnum_id_from_has_many_through
+    post = posts(:thinking)
+
+    assert_difference 'post.tags.count', -1 do
+      assert_equal 1, post.tags.delete(1).size
+    end
+
+    assert_equal 0, post.tags.size
+  end
+
+  def test_deleting_by_string_id_from_has_many_through
+    post = posts(:thinking)
+
+    assert_difference 'post.tags.count', -1 do
+      assert_equal 1, post.tags.delete('1').size
+    end
+
+    assert_equal 0, post.tags.size
   end
 
   def test_has_many_through_sum_uses_calculations


### PR DESCRIPTION
I found the next issue between CollectionAssociation `delete`
and `destroy`.

```
class Person < ActiveRecord::Base
  has_many :pets
end

person.pets.destroy(1)
# => OK, returns the destroyed object

person.pets.destroy("2")
# => OK, returns the destroyed object

person.pets.delete(1)
# => ActiveRecord::AssociationTypeMismatch

person.pets.delete("2")
# => ActiveRecord::AssociationTypeMismatch
```

Adding support for deleting with a fixnum or string like
`destroy` method. Backport of #6511.
