### PR TITLE
Make Pry(a feature rich console) default rails console

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -66,6 +66,13 @@ module <%= app_const_base %>
 
     # Version of your assets, change this if you want to expire all your assets.
     config.assets.version = '1.0'
+    
+    # Make Pry default Rails console
+    console do
+      require "pry"
+      config.console = Pry
+    end    
+    
 <% end -%>
   end
 end


### PR DESCRIPTION
Pry allows developer to go deep inside of ruby and rails class infrastructure - https://github.com/pry/pry
The console becomes very powerful, `cd` and `ls` make class/method navigation extremely comfortable.
Bonuses: highlighting, nice inspects, shell shortcuts and other - check the manual.

Huge thanks to @drogus for https://github.com/rails/rails/commit/dd655d88d660da8c094d20948ee721d29852f723 and https://github.com/rails/rails/commit/951b58206255791587e2491435a80cf0ab3b797b 

To discuss: 
How to handle if user has no pry installed? Probably just downgrade to IRB and show a message "Pry is not found, using IRB"?
What about moving requirement process inside of rails? I mean `config.console = :pry` looks more neat.
