### PR TITLE
Remove deprecated ActiveSupport::JSON::Variable.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
-*   ActionView::Helpers::NumberHelper methods have been moved to ActiveSupport::NumberHelper and are now available via 
-    Numeric#to_s.  Numeric#to_s now accepts the formatting  options :phone, :currency, :percentage, :delimited, 
+*   ActionView::Helpers::NumberHelper methods have been moved to ActiveSupport::NumberHelper and are now available via
+    Numeric#to_s.  Numeric#to_s now accepts the formatting  options :phone, :currency, :percentage, :delimited,
     :rounded, :human, and :human_size. *Andrew Mutz*
 
 *   Add `Hash#transform_keys`, `Hash#transform_keys!`, `Hash#deep_transform_keys`, and `Hash#deep_transform_keys!`. *Mark McSpadden*
@@ -57,11 +57,16 @@
 *   Adds `encode_big_decimal_as_string` option to force JSON serialization of BigDecimals as numeric instead
     of wrapping them in strings for safety.
 
+*   Remove deprecated ActiveSupport::JSON::Variable. *Erich Menge*
+
 
 ## Rails 3.2.4 (unreleased) ##
 
 *   Added #beginning_of_hour and #end_of_hour to Time and DateTime core
     extensions. *Mark J. Titorenko*
+
+*   ActiveSupport::JSON::Variable is deprecated. Define your own #as_json and #encode_json methods
+    for custom JSON string literals. *Erich Menge*
 
 
 ## Rails 3.2.3 (March 30, 2012) ##

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -1,6 +1,5 @@
 require 'active_support/core_ext/object/to_json'
 require 'active_support/core_ext/module/delegation'
-require 'active_support/json/variable'
 
 require 'bigdecimal'
 require 'active_support/core_ext/big_decimal/conversions' # for #to_s

--- a/activesupport/lib/active_support/json/variable.rb
+++ b/activesupport/lib/active_support/json/variable.rb
@@ -1,9 +1,0 @@
-module ActiveSupport
-  module JSON
-    # A string that returns itself as its JSON-encoded form.
-    class Variable < String
-      def as_json(options = nil) self end #:nodoc:
-      def encode_json(encoder) self end #:nodoc:
-    end
-  end
-end

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -54,8 +54,6 @@ class TestJSONEncoding < ActiveSupport::TestCase
   HashlikeTests = [[ Hashlike.new, %({\"a\":1}) ]]
   CustomTests   = [[ Custom.new, '"custom"' ]]
 
-  VariableTests = [[ ActiveSupport::JSON::Variable.new('foo'), 'foo'],
-                   [ ActiveSupport::JSON::Variable.new('alert("foo")'), 'alert("foo")']]
   RegexpTests   = [[ /^a/, '"(?-mix:^a)"' ], [/^\w{1,2}[a-z]+/ix, '"(?ix-m:^\\\\w{1,2}[a-z]+)"']]
 
   DateTests     = [[ Date.new(2005,2,1), %("2005/02/01") ]]


### PR DESCRIPTION
See #6553, which should be accepted first.
