### PR TITLE
Remove Unused Route Reloading Code

### DIFF
--- a/railties/lib/rails/tasks/routes.rake
+++ b/railties/lib/rails/tasks/routes.rake
@@ -1,8 +1,6 @@
 desc 'Print out all defined routes in match order, with names. Target specific controller with CONTROLLER=x.'
 task :routes => :environment do
-  Rails.application.reload_routes!
   all_routes = Rails.application.routes.routes
-
   require 'rails/application/route_inspector'
   inspector = Rails::Application::RouteInspector.new
   puts inspector.format(all_routes, ENV['CONTROLLER']).join "\n"


### PR DESCRIPTION
Since the environment is initialized each time rake is run, routes don't need to be re-loaded. This comes form a discussion on another pull request: https://github.com/rails/rails/pull/6461#r869953
