### PR TITLE
accept a block in button_to helper

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Make possible to use a block in button_to helper if button text is hard
+    to fit into the name parameter, e.g.:
+
+        <%= button_to [:make_happy, @user] do %>
+          Make happy <strong><%= @user.name %></strong>
+        <% end %>
+        # => "<form method="post" action="/users/1/make_happy" class="button_to">
+        #      <div>
+        #        <button type="submit">
+        #          Make happy <strong>Name</strong>
+        #        </button>
+        #      </div>
+        #    </form>"
+
+    *Sergey Nartimov*
+
 *   change a way of ordering helpers from several directories. Previously,
     when loading helpers from multiple paths, all of the helpers files were
     gathered into one array an then they were sorted. Helpers from different

--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -294,6 +294,16 @@ module ActionView
       #   #      <div><input value="New" type="submit" /></div>
       #   #    </form>"
       #
+      #   <%= button_to [:make_happy, @user] do %>
+      #     Make happy <strong><%= @user.name %></strong>
+      #   <% end %>
+      #   # => "<form method="post" action="/users/1/make_happy" class="button_to">
+      #   #      <div>
+      #   #        <button type="submit">
+      #   #          Make happy <strong><%= @user.name %></strong>
+      #   #        </button>
+      #   #      </div>
+      #   #    </form>"
       #
       #   <%= button_to "New", :action => "new", :form_class => "new-thing" %>
       #   # => "<form method="post" action="/controller/new" class="new-thing">
@@ -331,7 +341,16 @@ module ActionView
       #   #       </div>
       #   #     </form>"
       #   #
-      def button_to(name, options = {}, html_options = {})
+      def button_to(*args, &block)
+        if block_given?
+          options      = args[0] || {}
+          html_options = args[1] || {}
+        else
+          name         = args[0]
+          options      = args[1] || {}
+          html_options = args[2] || {}
+        end
+
         html_options = html_options.stringify_keys
         convert_boolean_attributes!(html_options, %w(disabled))
 
@@ -350,9 +369,15 @@ module ActionView
         request_token_tag = form_method == 'post' ? token_tag : ''
 
         html_options = convert_options_to_data_attributes(options, html_options)
-        html_options.merge!("type" => "submit", "value" => name || url)
+        html_options['type'] = 'submit'
 
-        inner_tags = method_tag.safe_concat tag('input', html_options).safe_concat request_token_tag
+        button = if block_given?
+          content_tag('button', html_options, &block)
+        else
+          tag('input', html_options.merge('value' => name || url))
+        end
+
+        inner_tags = method_tag.safe_concat(button).safe_concat(request_token_tag)
         content_tag('form', content_tag('div', inner_tags), form_options)
       end
 

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -9,7 +9,7 @@ module RequestForgeryProtectionActions
   end
 
   def show_button
-    render :inline => "<%= button_to('New', '/') {} %>"
+    render :inline => "<%= button_to('New', '/') %>"
   end
 
   def external_form
@@ -79,7 +79,7 @@ class FreeCookieController < RequestForgeryProtectionController
   end
 
   def show_button
-    render :inline => "<%= button_to('New', '/') {} %>"
+    render :inline => "<%= button_to('New', '/') %>"
   end
 end
 

--- a/actionpack/test/template/url_helper_test.rb
+++ b/actionpack/test/template/url_helper_test.rb
@@ -144,6 +144,13 @@ class UrlHelperTest < ActiveSupport::TestCase
     )
   end
 
+  def test_button_to_with_block
+    assert_dom_equal(
+      "<form method=\"post\" action=\"http://www.example.com\" class=\"button_to\"><div><button type=\"submit\"><span>Hello</span></button></div></form>",
+      button_to("http://www.example.com") { content_tag(:span, 'Hello') }
+    )
+  end
+
   def test_link_tag_with_straight_url
     assert_dom_equal "<a href=\"http://www.example.com\">Hello</a>", link_to("Hello", "http://www.example.com")
   end


### PR DESCRIPTION
Make possible to use a block in button_to helper if button text is hard
to fit into the name parameter, e.g.:

```
<%= button_to [:make_happy, @user] do %>
  Make happy <strong><%= @user.name %></strong>
<% end %>
# => "<form method="post" action="/users/1/make_happy" class="button_to">
#      <div>
#        <button type="submit">
#          Make happy <strong>Name</strong>
#        </button>
#      </div>
#    </form>"
```
