### PR TITLE
Postgresql auto reconnect

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -778,20 +778,16 @@ module ActiveRecord
 
       # Queries the database and returns the results in an Array-like object
       def query(sql, name = nil) #:nodoc:
-        with_auto_reconnect do
-          log(sql, name) do
-            result_as_array @connection.async_exec(sql)
-          end
+        wrap_execute(sql, name) do
+          result_as_array @connection.async_exec(sql)
         end
       end
 
       # Executes an SQL statement, returning a PGresult object on success
       # or raising a PGError exception otherwise.
       def execute(sql, name = nil)
-        with_auto_reconnect do
-          log(sql, name) do
-            @connection.async_exec(sql)
-          end
+        wrap_execute(sql, name) do
+          @connection.async_exec(sql)
         end
       end
 
@@ -807,37 +803,33 @@ module ActiveRecord
       end
 
       def exec_query(sql, name = 'SQL', binds = [])
-        with_auto_reconnect do
-          log(sql, name, binds) do
-            result = binds.empty? ? exec_no_cache(sql, binds) :
-                                    exec_cache(sql, binds)
+        wrap_execute(sql, name, binds) do
+          result = binds.empty? ? exec_no_cache(sql, binds) :
+                                  exec_cache(sql, binds)
 
-            types = {}
-            result.fields.each_with_index do |fname, i|
-              ftype = result.ftype i
-              fmod  = result.fmod i
-              types[fname] = OID::TYPE_MAP.fetch(ftype, fmod) { |oid, mod|
-                warn "unknown OID: #{fname}(#{oid}) (#{sql})"
-                OID::Identity.new
-              }
-            end
-
-            ret = Result.new(result.fields, result.values, types)
-            result.clear
-            return ret
+          types = {}
+          result.fields.each_with_index do |fname, i|
+            ftype = result.ftype i
+            fmod  = result.fmod i
+            types[fname] = OID::TYPE_MAP.fetch(ftype, fmod) { |oid, mod|
+              warn "unknown OID: #{fname}(#{oid}) (#{sql})"
+              OID::Identity.new
+            }
           end
+
+          ret = Result.new(result.fields, result.values, types)
+          result.clear
+          return ret
         end
       end
 
       def exec_delete(sql, name = 'SQL', binds = [])
-        with_auto_reconnect do
-          log(sql, name, binds) do
-            result = binds.empty? ? exec_no_cache(sql, binds) :
-                                    exec_cache(sql, binds)
-            affected = result.cmd_tuples
-            result.clear
-            affected
-          end
+        wrap_execute(sql, name, binds) do
+          result = binds.empty? ? exec_no_cache(sql, binds) :
+                                  exec_cache(sql, binds)
+          affected = result.cmd_tuples
+          result.clear
+          affected
         end
       end
       alias :exec_update :exec_delete
@@ -1355,6 +1347,14 @@ module ActiveRecord
             InvalidForeignKey.new(message, exception)
           else
             super
+          end
+        end
+
+        def wrap_execute(sql, name = "SQL", binds = [])
+          with_auto_reconnect do
+            log(sql, name, binds) do
+              yield
+            end
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1348,7 +1348,7 @@ module ActiveRecord
         UNIQUE_VIOLATION      = "23505"
 
         def translate_exception(exception, message)
-          case exception.result.error_field(PGresult::PG_DIAG_SQLSTATE)
+          case exception.result.try(:error_field, PGresult::PG_DIAG_SQLSTATE)
           when UNIQUE_VIOLATION
             RecordNotUnique.new(message, exception)
           when FOREIGN_KEY_VIOLATION

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -844,9 +844,9 @@ module ActiveRecord
         end
         @fixture_connections = enlist_fixture_connections
         @fixture_connections.each do |connection|
+          connection.begin_db_transaction
           connection.increment_open_transactions
           connection.transaction_joinable = false
-          connection.begin_db_transaction
         end
       # Load fixtures for every test.
       else

--- a/activerecord/lib/active_record/test_case.rb
+++ b/activerecord/lib/active_record/test_case.rb
@@ -59,9 +59,12 @@ module ActiveRecord
 
     self.ignored_sql = [/^PRAGMA (?!(table_info))/, /^SELECT currval/, /^SELECT CAST/, /^SELECT @@IDENTITY/, /^SELECT @@ROWCOUNT/, /^SAVEPOINT/, /^ROLLBACK TO SAVEPOINT/, /^RELEASE SAVEPOINT/, /^SHOW max_identifier_length/, /^BEGIN/, /^COMMIT/]
 
-    # FIXME: this needs to be refactored so specific database can add their own
-    # ignored SQL.  This ignored SQL is for Oracle.
+    # FIXME: these need to be refactored so specific database can add their own
+    # ignored SQL.
+    # This ignored SQL is for Oracle.
     ignored_sql.concat [/^select .*nextval/i, /^SAVEPOINT/, /^ROLLBACK TO/, /^\s*select .* from all_triggers/im]
+    # This ignored is for PostgreSQL.
+    ignored_sql.concat [/^\s*select\b.*\bfrom\b.*pg_namespace\b/im, /^\s*select\b.*\battname\b.*\bfrom\b.*\bpg_attribute\b/im]
 
 
     attr_reader :ignore

--- a/activerecord/test/cases/adapters/postgresql/auto_reconnection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/auto_reconnection_test.rb
@@ -97,21 +97,23 @@ module ActiveRecord
         # To restart PostgreSQL 9.1 on OS X, installed via MacPorts, ...
         # sudo su postgres -c "pg_ctl restart -D /opt/local/var/db/postgresql91/defaultdb/ -m fast"
         def test_reconnect_with_actual_killed_connection
-          skip "with_manual_interventions is false in configuration" unless ARTest.config['with_manual_interventions']
+          skip "with_manual_interventions is set to false in configuration" unless ARTest.config['with_manual_interventions']
 
-          original_connection_pid = @conn.query('select pg_backend_pid()')
+          original_connection_pid = @conn.query('select pg_backend_pid()').flatten.first
 
-          puts 'Kill the connection now (e.g. by restarting the PostgreSQL ' +
-               'server with the "-m fast" option) and then press enter.'
+          puts
+          puts "Kill the PostgreSQL connection with pid #{original_connection_pid} " +
+               "now (e.g. by restarting the PostgreSQL server with the \"-m fast\" option) " +
+               "and then press enter."
           $stdin.gets
 
           # If we get no exception here, then either we re-connected successfully, or
           # we never actually got disconnected.
-          new_connection_pid = @conn.query('select pg_backend_pid()')
+          new_connection_pid = @conn.query('select pg_backend_pid()').flatten.first
 
           assert_not_equal original_connection_pid, new_connection_pid,
             "umm -- looks like you didn't break the connection, because we're still " +
-            "successfully querying with the same connection pid."
+            "connected to PostgreSQL using the original connection pid."
         end
       end
     end

--- a/activerecord/test/cases/adapters/postgresql/auto_reconnection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/auto_reconnection_test.rb
@@ -1,0 +1,119 @@
+require "cases/helper"
+
+module ActiveRecord
+  module ConnectionAdapters
+    class PostgreSQLAdapter
+      class AutoReconnectionTest < ActiveRecord::TestCase
+        self.use_transactional_fixtures = false
+
+        def setup
+          @conn = ActiveRecord::Base.connection
+        end
+
+        def test_invoke_once_on_success
+          call_count = 0
+          @conn.send(:with_auto_reconnect){
+            call_count += 1
+          }
+          assert_equal 1, call_count
+        end
+
+        def test_return_block_value_on_success
+          result = @conn.send(:with_auto_reconnect) do
+            :the_result
+          end
+          assert_equal :the_result, result
+        end
+
+        def test_invoke_once_on_statement_invalid_with_good_connection
+          call_count = 0
+          assert_raise StatementInvalid do
+            @conn.send(:with_auto_reconnect) do
+              call_count += 1
+              raise StatementInvalid
+            end
+          end
+          assert_equal 1, call_count
+        end
+
+        def test_invoke_once_on_statement_invalid_with_bad_connection_in_transaction
+          @conn.raw_connection.stubs(:status).returns(PG::CONNECTION_BAD)
+          @conn.stubs(:open_transactions).returns(1)
+
+          call_count = 0
+          assert_raise StatementInvalid do
+            @conn.send(:with_auto_reconnect) do
+              call_count += 1
+              raise StatementInvalid
+            end
+          end
+          assert_equal 1, call_count
+        end
+
+        def test_invoke_once_on_general_error_with_bad_connection
+          call_count = 0
+          assert_raise StandardError do
+            @conn.send(:with_auto_reconnect) do
+              call_count += 1
+              raise StandardError
+            end
+          end
+          assert_equal 1, call_count
+        end
+
+        def test_retry_once_on_persistent_statement_invalid_with_bad_connection
+          @conn.raw_connection.stubs(:status).returns(PG::CONNECTION_BAD)
+
+          @conn.expects(:reconnect!)
+
+          call_count = 0
+          assert_raise StatementInvalid do
+            @conn.send(:with_auto_reconnect) do
+              call_count += 1
+              raise StatementInvalid
+            end
+          end
+          assert_equal 2, call_count
+        end
+
+        def test_retry_once_and_return_result_with_initial_bad_connection
+          @conn.raw_connection.stubs(:status).returns(PG::CONNECTION_BAD)
+
+          @conn.expects(:reconnect!)
+
+          call_count = 0
+          result = @conn.send(:with_auto_reconnect){
+            call_count += 1
+            raise StatementInvalid if call_count == 1
+            :the_result
+          }
+          assert_equal 2, call_count
+          assert_equal result, :the_result
+        end
+
+        # When prompted, restart the PostgreSQL server with the "-m fast" option
+        # or kill the individual connection assuming you know the incantation to
+        # do that.
+        # To restart PostgreSQL 9.1 on OS X, installed via MacPorts, ...
+        # sudo su postgres -c "pg_ctl restart -D /opt/local/var/db/postgresql91/defaultdb/ -m fast"
+        def test_reconnect_with_actual_killed_connection
+          skip "with_manual_interventions is false in configuration" unless ARTest.config['with_manual_interventions']
+
+          original_connection_pid = @conn.query('select pg_backend_pid()')
+
+          puts 'Kill the connection now (e.g. by restarting the PostgreSQL ' +
+               'server with the "-m fast" option) and then press enter.'
+          $stdin.gets
+
+          # If we get no exception here, then either we re-connected successfully, or
+          # we never actually got disconnected.
+          new_connection_pid = @conn.query('select pg_backend_pid()')
+
+          assert_not_equal original_connection_pid, new_connection_pid,
+            "umm -- looks like you didn't break the connection, because we're still " +
+            "successfully querying with the same connection pid."
+        end
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/adapters/postgresql/auto_reconnection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/auto_reconnection_test.rb
@@ -61,7 +61,7 @@ module ActiveRecord
           assert_equal 1, call_count
         end
 
-        def test_retry_once_on_persistent_statement_invalid_with_bad_connection
+        def test_retry_once_on_permanent_statement_invalid_with_bad_connection
           @conn.raw_connection.stubs(:status).returns(PG::CONNECTION_BAD)
 
           @conn.expects(:reconnect!)

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -817,11 +817,11 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     # clear cache possibly created by other tests
     david.projects.reset_column_information
 
-    assert_queries(1) { david.projects.columns; david.projects.columns }
+    assert_queries(1, :ignore_none => true) { david.projects.columns; david.projects.columns }
 
     ## and again to verify that reset_column_information clears the cache correctly
     david.projects.reset_column_information
-    assert_queries(1) { david.projects.columns; david.projects.columns }
+    assert_queries(1, :ignore_none => true) { david.projects.columns; david.projects.columns }
   end
 
   def test_attributes_are_being_set_when_initialized_from_habm_association_with_where_clause

--- a/activerecord/test/config.example.yml
+++ b/activerecord/test/config.example.yml
@@ -1,5 +1,7 @@
 default_connection: <%= defined?(JRUBY_VERSION) ? 'jdbcsqlite3' : 'sqlite3' %>
 
+with_manual_interventions: false
+
 connections:
   jdbcderby:
     arunit:  activerecord_unittest


### PR DESCRIPTION
After a Rails process has opened a connection to a PostgreSQL server, if the PostgreSQL server is subsequently restarted, or the connection has been otherwise severed, the connection would fail with an exception the next time a query was attempted using that connection.

With these changes, the connection will automatically be repaired on the next query, assuming it is safe to do so (e.g. we were not in the middle of a transaction).

Some of the commits on this branch are also to fix test failures or intermittent test failures/fragilities that are unrelated or only tangentially related to the auto-reconnect changes (2 failures on TC before I started, tests that fail only when run in certain combinations, etc.)
