### PR TITLE
Escape path before redirection

### DIFF
--- a/actionpack/lib/action_dispatch/routing/redirection.rb
+++ b/actionpack/lib/action_dispatch/routing/redirection.rb
@@ -30,7 +30,7 @@ module ActionDispatch
       end
 
       def path(params, request)
-        block.call params, request
+        URI.escape(block.call params, request)
       end
     end
 


### PR DESCRIPTION
I have got an error while trying to redirect non ASCII url. So lets escape it.
