### PR TITLE
Bad Regexp exploits "fix" (with warning)

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Rails 4.0.0 (unreleased) ##
 
+## Rails 3.2.6 (unreleased) ##
+
+*	Added the `:multiline` option to `validates_format_of` and a deprecation warning when this option is not used
+	and the provided regular expression contains the `^` or `$` anchor. The purpose of this is to prevent users
+	from mistakenly using these anchors when they meant to use `\A` and `\z` to match the start/end of the
+	string as opposed to the start/end of any line in the string.
+
+
+## Rails 3.2.3 (March 30, 2012) ##
+
 *   Passing false hash values to `validates` will no longer enable the corresponding validators *Steve Purcell*
 
 *   `ConfirmationValidator` error messages will attach to `:#{attribute}_confirmation` instead of `attribute` *Brian Cardarella*

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
 *	When `^` or `$` are used in the regular expression provided to `validates_format_of` and the :multiline option
-	is not set to true, and exception will now be raised instead of displaying a deprecation warning.
+	is not set to true, an exception will now be raised instead of displaying a deprecation warning.
 	
 	
 ## Rails 3.2.6 (unreleased) ##

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*	When `^` or `$` are used in the regular expression provided to `validates_format_of` and the :multiline option
+	is not set to true, and exception will now be raised instead of displaying a deprecation warning.
+	
+	
 ## Rails 3.2.6 (unreleased) ##
 
 *	Added the `:multiline` option to `validates_format_of` and a deprecation warning when this option is not used

--- a/activemodel/lib/active_model/validations/format.rb
+++ b/activemodel/lib/active_model/validations/format.rb
@@ -23,7 +23,7 @@ module ActiveModel
       end
 
       private
-
+      
       def option_call(record, name)
         option = options[name]
         option.respond_to?(:call) ? option.call(record) : option
@@ -32,11 +32,20 @@ module ActiveModel
       def record_error(record, attribute, name, value)
         record.errors.add(attribute, :invalid, options.except(name).merge!(:value => value))
       end
+      
+      def regexp_using_multiline_anchors?(regexp)
+        # only check for most common cases
+        regexp.source.start_with?("^") ||
+          (regexp.source.end_with?("$") && !regexp.source.end_with?("\\$"))
+      end
 
       def check_options_validity(options, name)
         option = options[name]
         if option && !option.is_a?(Regexp) && !option.respond_to?(:call)
           raise ArgumentError, "A regular expression or a proc or lambda must be supplied as :#{name}"
+        elsif option && option.is_a?(Regexp) && # check for multiline regexp
+              regexp_using_multiline_anchors?(option) && options[:multiline] != true
+          raise ArgumentError, "The provided regular expression is using multiline anchors (^ or $), which may present a security risk. Did you mean to use \\A and \\Z, or forgot to add the :multiline => true option?"
         end
       end
     end

--- a/activemodel/lib/active_model/validations/format.rb
+++ b/activemodel/lib/active_model/validations/format.rb
@@ -56,7 +56,7 @@ module ActiveModel
       # attribute matches the regular expression:
       #
       #   class Person < ActiveRecord::Base
-      #     validates_format_of :email, :with => /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/i, :on => :create
+      #     validates_format_of :email, :with => /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, :on => :create
       #   end
       #
       # Alternatively, you can require that the specified attribute does _not_
@@ -72,11 +72,16 @@ module ActiveModel
       #   class Person < ActiveRecord::Base
       #     # Admin can have number as a first letter in their screen name
       #     validates_format_of :screen_name,
-      #                         :with => lambda{ |person| person.admin? ? /\A[a-z0-9][a-z0-9_\-]*\Z/i : /\A[a-z][a-z0-9_\-]*\Z/i }
+      #                         :with => lambda{ |person| person.admin? ? /\A[a-z0-9][a-z0-9_\-]*\z/i : /\A[a-z][a-z0-9_\-]*\z/i }
       #   end
       #
       # Note: use <tt>\A</tt> and <tt>\Z</tt> to match the start and end of the
       # string, <tt>^</tt> and <tt>$</tt> match the start/end of a line.
+      #
+      # Due to frequent misuse of <tt>^</tt> and <tt>$</tt>, you need to pass the
+      # :multiline => true option in case you use any of these two anchors in the provided
+      # regular expression. In most cases, you should be using <tt>\A</tt> and <tt>\z</tt>
+      # instead.
       #
       # You must pass either <tt>:with</tt> or <tt>:without</tt> as an option.
       # In addition, both must be a regular expression or a proc or lambda, or
@@ -107,6 +112,9 @@ module ActiveModel
       #   method, proc or string should return or evaluate to a true or false value.
       # * <tt>:strict</tt> - Specifies whether validation should be strict. 
       #   See <tt>ActiveModel::Validation#validates!</tt> for more information.
+      # * <tt>:multiline</tt> - Set to true if your regular expression contains
+      #   anchors that match the beginning or end of lines as opposed to the
+      #   beginning or end of the string. These anchors are <tt>^</tt> and <tt>$</tt>.
       def validates_format_of(*attr_names)
         validates_with FormatValidator, _merge_attributes(attr_names)
       end

--- a/activemodel/test/cases/validations/format_validation_test.rb
+++ b/activemodel/test/cases/validations/format_validation_test.rb
@@ -11,7 +11,7 @@ class PresenceValidationTest < ActiveModel::TestCase
   end
 
   def test_validate_format
-    Topic.validates_format_of(:title, :content, :with => /^Validation\smacros \w+!$/, :message => "is bad data")
+    Topic.validates_format_of(:title, :content, :with => /^Validation\smacros \w+!$/, :multiline => true, :message => "is bad data")
 
     t = Topic.new("title" => "i'm incorrect", "content" => "Validation macros rule!")
     assert t.invalid?, "Shouldn't be valid"
@@ -27,7 +27,7 @@ class PresenceValidationTest < ActiveModel::TestCase
   end
 
   def test_validate_format_with_allow_blank
-    Topic.validates_format_of(:title, :with => /^Validation\smacros \w+!$/, :allow_blank => true)
+    Topic.validates_format_of(:title, :with => /^Validation\smacros \w+!$/, :multiline => true, :allow_blank => true)
     assert Topic.new("title" => "Shouldn't be valid").invalid?
     assert Topic.new("title" => "").valid?
     assert Topic.new("title" => nil).valid?
@@ -36,7 +36,7 @@ class PresenceValidationTest < ActiveModel::TestCase
 
   # testing ticket #3142
   def test_validate_format_numeric
-    Topic.validates_format_of(:title, :content, :with => /^[1-9][0-9]*$/, :message => "is bad data")
+    Topic.validates_format_of(:title, :content, :with => /^[1-9][0-9]*$/, :multiline => true, :message => "is bad data")
 
     t = Topic.new("title" => "72x", "content" => "6789")
     assert t.invalid?, "Shouldn't be valid"
@@ -63,7 +63,7 @@ class PresenceValidationTest < ActiveModel::TestCase
   end
 
   def test_validate_format_with_formatted_message
-    Topic.validates_format_of(:title, :with => /^Valid Title$/, :message => "can't be %{value}")
+    Topic.validates_format_of(:title, :with => /^Valid Title$/, :multiline => true, :message => "can't be %{value}")
     t = Topic.new(:title => 'Invalid title')
     assert t.invalid?
     assert_equal ["can't be Invalid title"], t.errors[:title]
@@ -80,6 +80,16 @@ class PresenceValidationTest < ActiveModel::TestCase
     t.title = "something else"
     t.valid?
     assert_equal [], t.errors[:title]
+  end
+  
+  def test_validate_format_of_with_multiline_regexp_should_raise_error
+    assert_raise(ArgumentError) { Topic.validates_format_of(:title, :with => /^Valid Title$/) }
+  end
+  
+  def test_validate_format_of_with_multiline_regexp_and_option
+    assert_nothing_raised(ArgumentError) do
+      Topic.validates_format_of(:title, :with => /^Valid Title$/, :multiline => true)
+    end
   end
 
   def test_validate_format_of_without_any_regexp_should_raise_error

--- a/activemodel/test/cases/validations/format_validation_test.rb
+++ b/activemodel/test/cases/validations/format_validation_test.rb
@@ -11,7 +11,7 @@ class PresenceValidationTest < ActiveModel::TestCase
   end
 
   def test_validate_format
-    Topic.validates_format_of(:title, :content, :with => /^Validation\smacros \w+!$/, :multiline => true, :message => "is bad data")
+    Topic.validates_format_of(:title, :content, :with => /\AValidation\smacros \w+!\z/, :message => "is bad data")
 
     t = Topic.new("title" => "i'm incorrect", "content" => "Validation macros rule!")
     assert t.invalid?, "Shouldn't be valid"
@@ -27,7 +27,7 @@ class PresenceValidationTest < ActiveModel::TestCase
   end
 
   def test_validate_format_with_allow_blank
-    Topic.validates_format_of(:title, :with => /^Validation\smacros \w+!$/, :multiline => true, :allow_blank => true)
+    Topic.validates_format_of(:title, :with => /\AValidation\smacros \w+!\z/, :allow_blank => true)
     assert Topic.new("title" => "Shouldn't be valid").invalid?
     assert Topic.new("title" => "").valid?
     assert Topic.new("title" => nil).valid?
@@ -36,7 +36,7 @@ class PresenceValidationTest < ActiveModel::TestCase
 
   # testing ticket #3142
   def test_validate_format_numeric
-    Topic.validates_format_of(:title, :content, :with => /^[1-9][0-9]*$/, :multiline => true, :message => "is bad data")
+    Topic.validates_format_of(:title, :content, :with => /\A[1-9][0-9]*\z/, :message => "is bad data")
 
     t = Topic.new("title" => "72x", "content" => "6789")
     assert t.invalid?, "Shouldn't be valid"
@@ -63,7 +63,7 @@ class PresenceValidationTest < ActiveModel::TestCase
   end
 
   def test_validate_format_with_formatted_message
-    Topic.validates_format_of(:title, :with => /^Valid Title$/, :multiline => true, :message => "can't be %{value}")
+    Topic.validates_format_of(:title, :with => /\AValid Title\z/, :message => "can't be %{value}")
     t = Topic.new(:title => 'Invalid title')
     assert t.invalid?
     assert_equal ["can't be Invalid title"], t.errors[:title]

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -141,9 +141,9 @@ class I18nValidationTest < ActiveModel::TestCase
 
   COMMON_CASES.each do |name, validation_options, generate_message_options|
     test "validates_format_of on generated message #{name}" do
-      Person.validates_format_of :title, validation_options.merge(:with => /^[1-9][0-9]*$/, :multiline => true)
+      Person.validates_format_of :title, validation_options.merge(:with => /\A[1-9][0-9]*\z/)
       @person.title = '72x'
-      @person.errors.expects(:generate_message).with(:title, :invalid, generate_message_options.merge(:value => '72x', :multiline => true))
+      @person.errors.expects(:generate_message).with(:title, :invalid, generate_message_options.merge(:value => '72x'))
       @person.valid?
     end
   end
@@ -291,7 +291,7 @@ class I18nValidationTest < ActiveModel::TestCase
   # validates_format_of w/o mocha
 
   set_expectations_for_validation "validates_format_of", :invalid do |person, options_to_merge|
-    Person.validates_format_of :title, options_to_merge.merge(:with => /^[1-9][0-9]*$/, :multiline => true)
+    Person.validates_format_of :title, options_to_merge.merge(:with => /\A[1-9][0-9]*\z/)
   end
 
   # validates_inclusion_of w/o mocha

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -141,9 +141,9 @@ class I18nValidationTest < ActiveModel::TestCase
 
   COMMON_CASES.each do |name, validation_options, generate_message_options|
     test "validates_format_of on generated message #{name}" do
-      Person.validates_format_of :title, validation_options.merge(:with => /^[1-9][0-9]*$/)
+      Person.validates_format_of :title, validation_options.merge(:with => /^[1-9][0-9]*$/, :multiline => true)
       @person.title = '72x'
-      @person.errors.expects(:generate_message).with(:title, :invalid, generate_message_options.merge(:value => '72x'))
+      @person.errors.expects(:generate_message).with(:title, :invalid, generate_message_options.merge(:value => '72x', :multiline => true))
       @person.valid?
     end
   end
@@ -291,7 +291,7 @@ class I18nValidationTest < ActiveModel::TestCase
   # validates_format_of w/o mocha
 
   set_expectations_for_validation "validates_format_of", :invalid do |person, options_to_merge|
-    Person.validates_format_of :title, options_to_merge.merge(:with => /^[1-9][0-9]*$/)
+    Person.validates_format_of :title, options_to_merge.merge(:with => /^[1-9][0-9]*$/, :multiline => true)
   end
 
   # validates_inclusion_of w/o mocha

--- a/guides/source/active_model_basics.textile
+++ b/guides/source/active_model_basics.textile
@@ -187,7 +187,7 @@ class Person
   attr_accessor :name, :email, :token
   
   validates :name, :presence => true
-  validates_format_of :email, :with => /^([^\s]+)((?:[-a-z0-9]\.)[a-z]{2,})$/i  
+  validates_format_of :email, :with => /\A([^\s]+)((?:[-a-z0-9]\.)[a-z]{2,})\z/i  
   validates! :token, :presence => true
   
 end

--- a/guides/source/security.textile
+++ b/guides/source/security.textile
@@ -592,7 +592,7 @@ Ruby uses a slightly different approach than many other languages to match the e
 
 <ruby>
 class File < ActiveRecord::Base
-  validates :name, :format => /^[\w\.\-\<plus>]<plus>$/
+  validates :name, :format => { :with => /^[\w\.\-\<plus>]<plus>$/, :multiline => true }
 end
 </ruby>
 
@@ -607,6 +607,8 @@ Whereas %0A is a line feed in URL encoding, so Rails automatically converts it t
 <ruby>
 /\A[\w\.\-\<plus>]<plus>\z/
 </ruby>
+
+The format validator (validates_format_of) was changed in Rails 2.3.6 to display a warning if the provided regular expression starts with ^ or ends with $. In the case where the use of these anchors is intended, the :multiline option should be set to true.
 
 h4. Privilege Escalation
 


### PR DESCRIPTION
Explanation of the "issue": http://homakov.blogspot.co.uk/2012/05/saferweb-injects-in-various-ruby.html

While I do not agree with Egor that this is an actual vulnerability in Ruby or something that can be fixed, I do agree it is an issue that should be addressed (e.g. through an educated warning). I propose a "solution" by incorporating a warning into validates_format_of, which I believe is the source of most of related vulnerabilities (caused by programmer error).

The proposed change is to throw an exception from validates_format_of when a Regexp containing the ^ or $ anchor is used, unless the programmer explicitly acknowledges his awareness about the multiline behavior by passing a :multiline => true option to validates_format_of.

I believe this solution is good because of several reasons:
1. The vast majority of users that are using validates_format_of do not want multiline matching. Consequently, the vast majority of users that are using proper Regexp will not be affected by this change at all.
2. The vast majority of users who are using ^ or $ inside validates_format_of are not aware of their multiline behavior, or are copy-pasting Regexp, and will be affected by this change, consequently fixing a security vulnerability in their application.
3. The minority of users who do need multiline behavior in validates_format_of simply need to add the new :multiline => true option to their validators. So if this is mentioned in the changelog or the users are running any kind of tests that at least load the model using validates_format_of (exception is raised when validates_format_of is called on the class - so at model load), they will be aware of what needs to be done (trivial - add an option).
4. When people fix their validators they will most likely become familiar with the issue and will be able to fix potential vulnerabilities related to Regexp used outside of validates_format_of.

While this check does not cover all possible related vulnerabilities, I think it should cover most of them, and the cost of this is very low (not a lot of people need multiline behavior). Performance hit is also negligible as the check is only performed when the model is loaded.

Regarding tests in ActiveModel:
I added a test for this case. Due to the change, some existing test cases needed to have the :multiline => true option added. It may be possible that in these existing tests, use of \A and \Z would be more appropriate - I will let the core developers decide this. In any case I have made all the ActiveModel pass, but I did not run tests of other parts of Rails so the whole test suite should be ran before thinking about merging this commit. The exception message string might also need to be written differently.

I hope this work will be appreciated and considered for merging. I think the issue is important as Egon demonstrated in his blog post - this vulnerability was present in many big Rails projects such as Github, Soundcloud, Tumblr etc., so it should not be completely ignored.
