### PR TITLE
Extracted redirect logic from ActionController::Force::ClassMethods.forc...

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Extracted redirect logic from `ActionController::ForceSSL::ClassMethods.force_ssl`  into `ActionController::ForceSSL#force_ssl_redirect`
+
+    *Jeremy Friesen*
+
 *   Make possible to use a block in button_to helper if button text is hard
     to fit into the name parameter, e.g.:
 

--- a/actionpack/lib/action_controller/metal/force_ssl.rb
+++ b/actionpack/lib/action_controller/metal/force_ssl.rb
@@ -40,14 +40,22 @@ module ActionController
       def force_ssl(options = {})
         host = options.delete(:host)
         before_filter(options) do
-          unless request.ssl?
-            redirect_options = {:protocol => 'https://', :status => :moved_permanently}
-            redirect_options.merge!(:host => host) if host
-            redirect_options.merge!(:params => request.query_parameters)
-            flash.keep if respond_to?(:flash)
-            redirect_to redirect_options
-          end
+          force_ssl_redirect(host)
         end
+      end
+    end
+
+    # Redirect the existing request to use the HTTPS protocol.
+    #
+    # ==== Parameters
+    # * <tt>host</tt> - Redirect to a different host name
+    def force_ssl_redirect(host = nil)
+      unless request.ssl?
+        redirect_options = {:protocol => 'https://', :status => :moved_permanently}
+        redirect_options.merge!(:host => host) if host
+        redirect_options.merge!(:params => request.query_parameters)
+        flash.keep if respond_to?(:flash)
+        redirect_to redirect_options
       end
     end
   end

--- a/actionpack/test/controller/force_ssl_test.rb
+++ b/actionpack/test/controller/force_ssl_test.rb
@@ -49,6 +49,15 @@ class ForceSSLFlash < ForceSSLController
   end
 end
 
+class RedirectToSSL < ForceSSLController
+  def banana
+    force_ssl_redirect || render(:text => 'monkey')
+  end
+  def cheeseburger
+    force_ssl_redirect('secure.cheeseburger.host') || render(:text => 'ihaz')
+  end
+end
+
 class ForceSSLControllerLevelTest < ActionController::TestCase
   tests ForceSSLControllerLevel
 
@@ -147,5 +156,27 @@ class ForceSSLFlashTest < ActionController::TestCase
     get :use_flash
     assert_equal "hello", assigns["flash_copy"]["that"]
     assert_equal "hello", assigns["flashy"]
+  end
+end
+
+class RedirectToSSLTest < ActionController::TestCase
+  tests RedirectToSSL
+  def test_banana_redirects_to_https_if_not_https
+    get :banana
+    assert_response 301
+    assert_equal "https://test.host/redirect_to_ssl/banana", redirect_to_url
+  end
+
+  def test_cheeseburgers_redirects_to_https_with_new_host_if_not_https
+    get :cheeseburger
+    assert_response 301
+    assert_equal "https://secure.cheeseburger.host/redirect_to_ssl/cheeseburger", redirect_to_url
+  end
+
+  def test_banana_does_not_redirect_if_already_https
+    request.env['HTTPS'] = 'on'
+    get :cheeseburger
+    assert_response 200
+    assert_equal 'ihaz', response.body
   end
 end


### PR DESCRIPTION
Extracted redirect logic from ActionController::Force::ClassMethods.force_ssl

Prior to this patch the existing .force_ssl method handles both defining
the filter and handling the logic for performing the redirect.

With this patch the logic for redirecting to the HTTPS protocol is
separated from the filter logic that determines if a redirect should
occur.  By separating the two levels of behavior, an instance method
for ActionController (i.e. #force_ssl_redirect) is exposed and available
for more granular SSL enforcement.

Cleaned up indentation.
