### PR TITLE
modulize AR::NullRelation

### DIFF
--- a/activerecord/lib/active_record/null_relation.rb
+++ b/activerecord/lib/active_record/null_relation.rb
@@ -2,7 +2,7 @@
 
 module ActiveRecord
   # = Active Record Null Relation
-  class NullRelation < Relation
+  module NullRelation
     def exec_queries
       @records = []
     end

--- a/activerecord/lib/active_record/null_relation.rb
+++ b/activerecord/lib/active_record/null_relation.rb
@@ -7,19 +7,19 @@ module ActiveRecord
       @records = []
     end
 
-    def pluck(column_name)
+    def pluck(_column_name)
       []
     end
 
-    def delete_all(conditions = nil)
+    def delete_all(_conditions = nil)
       0
     end
 
-    def update_all(updates, conditions = nil, options = {})
+    def update_all(_updates, _conditions = nil, _options = {})
       0
     end
 
-    def delete(id_or_array)
+    def delete(_id_or_array)
       0
     end
 
@@ -51,13 +51,12 @@ module ActiveRecord
       0
     end
 
-    def calculate(operation, column_name, options = {})
+    def calculate(_operation, _column_name, _options = {})
       nil
     end
 
-    def exists?(id = false)
+    def exists?(_id = false)
       false
     end
-
   end
 end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -279,7 +279,7 @@ module ActiveRecord
     #   end
     #
     def none
-      NullRelation.new(@klass, @table)
+      scoped.extending(NullRelation)
     end
 
     def readonly(value = true)

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -226,13 +226,18 @@ class RelationTest < ActiveRecord::TestCase
     assert_no_queries do
       assert_equal [], Developer.none
       assert_equal [], Developer.scoped.none
-      assert           Developer.none.is_a?(ActiveRecord::NullRelation)
     end
   end
 
   def test_none_chainable
     assert_no_queries do
       assert_equal [], Developer.none.where(:name => 'David')
+    end
+  end
+
+  def test_none_chainable_to_existing_scope_extension_method
+    assert_no_queries do
+      assert_equal 1, Topic.anonymous_extension.none.one
     end
   end
 


### PR DESCRIPTION
Current implementation of `AR::Relation#none` replaces the `Relation` instance, and consequently clears all extension methods defined on self by proceeding scopes.

For example, with this AR model and scope,

``` ruby
class User < ActiveRecord::Base
  scope :anonymous_extension, -> { scoped } do
    def one
      1
    end
  end
end
```

The `one` method was removed from `none`ed relation before this patch,

```
> User.anonymous_extension.none.one
NoMethodError: undefined method `one' for []:ActiveRecord::NullRelation
```

Now `one` properly calls the extension method.

```
> User.anonymous_extension.none.one
 => 1
```
