### PR TITLE
Revert "Only include Rake::DSL if it's defined."

### DIFF
--- a/railties/lib/rails/tasks/documentation.rake
+++ b/railties/lib/rails/tasks/documentation.rake
@@ -2,7 +2,7 @@ require 'rdoc/task'
 
 # Monkey-patch to remove redoc'ing and clobber descriptions to cut down on rake -T noise
 class RDocTaskWithoutDescriptions < RDoc::Task
-  include ::Rake::DSL if defined?(::Rake::DSL)
+  include ::Rake::DSL
 
   def define
     task rdoc_task_name


### PR DESCRIPTION
Because Ruby >= 1.9.3 is shipped with Rake > 0.9

```
% ruby -v -rrake -e 'p defined? Rake::DSL'
ruby 1.9.3p0 (2011-10-30 revision 33570) [x86_64-darwin11.1.0]
"constant"
```
