### PR TITLE
improve readability of AR explain result

### DIFF
--- a/activerecord/lib/active_record/explain.rb
+++ b/activerecord/lib/active_record/explain.rb
@@ -52,7 +52,7 @@ module ActiveRecord
     # Makes the adapter execute EXPLAIN for the tuples of queries and bindings.
     # Returns a formatted string ready to be logged.
     def exec_explain(queries) # :nodoc:
-      queries && queries.map do |sql, bind|
+      str = queries && queries.map do |sql, bind|
         [].tap do |msg|
           msg << "EXPLAIN for: #{sql}"
           unless bind.empty?
@@ -62,6 +62,12 @@ module ActiveRecord
           msg << connection.explain(sql, bind)
         end.join("\n")
       end.join("\n")
+
+      # overriding inspect to be more human readable
+      def str.inspect
+        self
+      end
+      str
     end
 
     # Silences automatic EXPLAIN logging for the duration of the block.


### PR DESCRIPTION
AR `explain` returns nicely formatted String, but it looks miserable on our Rails console.

```
> User.where(id: 2).explain
  User Load (0.1ms)  SELECT "users".* FROM "users" WHERE "users"."id" = 2
  EXPLAIN (0.1ms)  EXPLAIN QUERY PLAN SELECT "users".* FROM "users" WHERE "users"."id" = 2
 => "EXPLAIN for: SELECT \"users\".* FROM \"users\"  WHERE \"users\".\"id\" = 2\n0|0|0|SEARCH TABLE users USING INTEGER PRIMARY KEY (rowid=?) (~1 rows)\n" 
```

With this patch, `explain` returns a `p`-friendly String instance.

```
> User.where(id: 2).explain
  User Load (0.2ms)  SELECT "users".* FROM "users" WHERE "users"."id" = 2
  EXPLAIN (0.1ms)  EXPLAIN QUERY PLAN SELECT "users".* FROM "users" WHERE "users"."id" = 2
 => EXPLAIN for: SELECT "users".* FROM "users"  WHERE "users"."id" = 2
0|0|0|SEARCH TABLE users USING INTEGER PRIMARY KEY (rowid=?) (~1 rows)
```
