### PR TITLE
remove unneeded blank line from !namespeced? generated controllers

### DIFF
--- a/railties/lib/rails/generators/rails/controller/templates/controller.rb
+++ b/railties/lib/rails/generators/rails/controller/templates/controller.rb
@@ -1,7 +1,7 @@
 <% if namespaced? -%>
 require_dependency "<%= namespaced_file_path %>/application_controller"
-<% end -%>
 
+<% end -%>
 <% module_namespacing do -%>
 class <%= class_name %>Controller < ApplicationController
 <% actions.each do |action| -%>

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
@@ -1,7 +1,7 @@
 <% if namespaced? -%>
 require_dependency "<%= namespaced_file_path %>/application_controller"
-<% end -%>
 
+<% end -%>
 <% module_namespacing do -%>
 class <%= controller_class_name %>Controller < ApplicationController
   # GET <%= route_url %>


### PR DESCRIPTION
The controllers generated by `rails g` have an extra blank line at the very top.
These blank lines were introduce by 7c95be54b4c3f8ad2273eea39afa233f8f8b31c1
