### PR TITLE
Correct the use of to_model in polymorphic routing

### DIFF
--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -97,7 +97,7 @@ module ActionDispatch
         end
 
         record = extract_record(record_or_hash_or_array)
-        record = record.to_model if record.respond_to?(:to_model)
+        record = convert_to_model(record)
 
         args = Array === record_or_hash_or_array ?
           record_or_hash_or_array.dup :
@@ -123,6 +123,8 @@ module ActionDispatch
         unless url_options.empty?
           args.last.kind_of?(Hash) ? args.last.merge!(url_options) : args << url_options
         end
+
+        args.collect! { |a| convert_to_model(a) }
 
         (proxy || self).send(named_route, *args)
       end
@@ -152,6 +154,10 @@ module ActionDispatch
       private
         def action_prefix(options)
           options[:action] ? "#{options[:action]}_" : ''
+        end
+
+        def convert_to_model(object)
+          object.respond_to?(:to_model) ? object.to_model : object
         end
 
         def routing_type(options)


### PR DESCRIPTION
This pull is against 3-2-stable, not master.  If accepted, I'll quickly put together a pull for master, as well.

Polymorphic routes currently only use `arg.to_model` when [generating the path directory or name portion](https://github.com/rails/rails/blob/3-2-stable/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb#L100) of a route. They do not use the `to_param` value from the delegated model for the generated route IDs (since it currently [passes the arguments directly](https://github.com/rails/rails/blob/3-2-stable/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb#L127) to the named route functions without converting them to models).

Since `to_model` is supposed to act as the ActiveModel stand-in for an object, and the polymorphic routing mechanism already takes `to_model` in to account for a small bit of it, I think this is a bug in the router to not fully follow through with its usage.  It also significantly limits the usefulness of creating `to_model` stand-ins.

So, this pull has a test to exploit the bug where I exercise that the delegate is not currently being used for to_param.  And, then the fix simply passes the args collection after having converted it to models.
