### PR TITLE
Add failing test for 3.2.5 datetime attribute regression

### DIFF
--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -78,6 +78,17 @@ class DirtyTest < ActiveRecord::TestCase
       assert_equal old_created_on, pirate.created_on_was
     end
   end
+  
+  def test_setting_time_attributes_with_time_zone_field_to_itself_should_not_be_marked_as_a_change
+    in_time_zone 'Paris' do
+      target = Class.new(ActiveRecord::Base)
+      target.table_name = 'pirates'
+
+      pirate = target.create
+      pirate.created_on = pirate.created_on
+      assert !pirate.created_on_changed?
+    end
+  end
 
   def test_time_attributes_changes_without_time_zone_by_skip
     in_time_zone 'Paris' do


### PR DESCRIPTION
This is a failing test for #6591
