### PR TITLE
Skip test_remove_column_with_array_as_an_argument_is_deprecated with Oracle

### DIFF
--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -874,6 +874,8 @@ if ActiveRecord::Base.connection.supports_migrations?
     end
 
     def test_remove_column_with_array_as_an_argument_is_deprecated
+      return skip "remove_column with array as argument is not supported with OracleAdapter" if current_adapter? :OracleAdapter
+
       ActiveRecord::Base.connection.create_table(:hats) do |table|
         table.column :hat_name, :string, :limit => 100
         table.column :hat_size, :integer
@@ -884,7 +886,7 @@ if ActiveRecord::Base.connection.supports_migrations?
         Person.connection.remove_column("hats", ["hat_name", "hat_size"])
       end
     ensure
-      ActiveRecord::Base.connection.drop_table(:hats)
+      ActiveRecord::Base.connection.drop_table(:hats) rescue nil
     end
 
     def test_change_type_of_not_null_column


### PR DESCRIPTION
Skip test_remove_column_with_array_as_an_argument_is_deprecated with Oracle adapter.

Because Oracle adapter supports only remove_column :table_name, :column_name syntax
and it has never supported remove_column :table_name, [:column_name].

``` ruby
$ cd activerecord
$ rake test_oracle

... snip ..

  1) Error:
test_remove_column_with_array_as_an_argument_is_deprecated(MigrationTest):
ActiveRecord::StatementInvalid: OCIError: ORA-00904: "[hat_name, hat_size]": invalid identifier: ALTER TABLE "HATS" DROP COLUMN "[hat_name, hat_size]"
    stmt.c:253:in oci8lib_191.so
    /home/yahonda/.rvm/gems/ruby-1.9.3-p194@v324rc1/gems/ruby-oci8-2.1.2/lib/oci8/oci8.rb:474:in `exec'
    /home/yahonda/.rvm/gems/ruby-1.9.3-p194@v324rc1/gems/ruby-oci8-2.1.2/lib/oci8/oci8.rb:282:in `exec_internal'
    /home/yahonda/.rvm/gems/ruby-1.9.3-p194@v324rc1/gems/ruby-oci8-2.1.2/lib/oci8/oci8.rb:275:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:471:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:88:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:595:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:280:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:275:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1312:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:595:in `execute'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:261:in `remove_column'
    /home/yahonda/git/rails/activerecord/test/cases/migration_test.rb:884:in `block in test_remove_column_with_array_as_an_argument_is_deprecated'
    /home/yahonda/git/rails/activesupport/lib/active_support/testing/deprecation.rb:29:in `collect_deprecations'
    /home/yahonda/git/rails/activesupport/lib/active_support/testing/deprecation.rb:7:in `assert_deprecated'
    /home/yahonda/git/rails/activerecord/test/cases/migration_test.rb:883:in `test_remove_column_with_array_as_an_argument_is_deprecated'
    /home/yahonda/.rvm/gems/ruby-1.9.3-p194@v324rc1/gems/mocha-0.11.4/lib/mocha/integration/mini_test/version_230_to_262.rb:28:in `run'

```

This test has been committed to 3-2-stable branch only #6219 .
