### PR TITLE
Backport cache key patch

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -91,6 +91,7 @@ module ActiveSupport
         case
         when key.respond_to?(:cache_key) then key.cache_key
         when key.is_a?(Array)            then key.map { |element| retrieve_cache_key(element) }.to_param
+        when key.respond_to?(:to_a)      then retrieve_cache_key(key.to_a)
         else                                  key.to_param
         end.to_s
       end

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -69,6 +69,10 @@ class CacheKeyTest < ActiveSupport::TestCase
   def test_expand_cache_key_of_true
     assert_equal 'true', ActiveSupport::Cache.expand_cache_key(true)
   end
+  
+  def test_expand_cache_key_of_array_like_object
+    assert_equal 'foo/bar/baz', ActiveSupport::Cache.expand_cache_key(%w{foo bar baz}.to_enum)
+  end
 end
 
 class CacheStoreSettingTest < ActiveSupport::TestCase


### PR DESCRIPTION
Backport of be623677 #5394

When I made that PR 3 months ago I wasn't sure what the procedure was regarding backports. I believe this should be backported as I don't believe anyone is using cache_key and expecting to get the encoded object id on instances of `ActiveRecord::Relation` for example.

In that way I feel that it is more on the side of 'bugfix' vs change of behavior.
