### PR TITLE
Put the table name between backticks... harden exploitation of CVE-2012-...

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -366,7 +366,7 @@ module ActiveRecord
 
       def tables(name = nil, database = nil, like = nil) #:nodoc:
         sql = "SHOW TABLES "
-        sql << "IN #{quote_table_name(database)} " if database
+        sql << "IN `#{quote_table_name(database)}` " if database
         sql << "LIKE #{quote(like)}" if like
 
         execute_and_free(sql, 'SCHEMA') do |result|


### PR DESCRIPTION
Put the table name between backticks... harden exploitation of CVE-2012-2661

So far the only exploitation path I found, is using the lack of backtick in this part of the statement
