### PR TITLE
a test case that ensures AR::Relation#merge can merge associations

### DIFF
--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -695,6 +695,14 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal 1, comments.count
   end
 
+  def test_relation_merging_with_association
+    assert_queries(2) do  # one for loading post, and another one merged query
+      post = Post.where(:body => 'Such a lovely day').first
+      comments = Comment.where(:body => 'Thank you for the welcome').merge(post.comments)
+      assert_equal 1, comments.count
+    end
+  end
+
   def test_count
     posts = Post.scoped
 


### PR DESCRIPTION
I was writing a tiny patch enabling `AR::Relation#merge` to accept a collection association instance.
In AR 3 we need to call `scoped` like this, but I thought it could be done implicitly.

```
euruko = Conference.find_by_name('euruko')
# runs separate queries for Relation and association
Attendee.where(name: 'matz').merge(euruko.attendees)

  Attendee Load (0.3ms)  SELECT "attendees".* FROM "attendees" WHERE "attendees"."conference_id" = 1
  Attendee Load (0.2ms)  SELECT "attendees".* FROM "attendees" WHERE "attendees"."name" = 'matz'
```

```
# merging into one query
Attendee.where(name: 'matz').merge(euruko.attendees.scoped)

  Attendee Load (0.3ms)  SELECT "attendees".* FROM "attendees" WHERE "attendees"."name" = 'matz' AND "attendees"."conference_id" = 1
```

So I finished writing my patch, rebased my patch against master, then noticed that this feature was already implemented in the series of `merge` refactoring done by @jonleighton
I'm not sure whether this was intentional or not (because there's no explicit test case for this), but I love this feature to be officially supported. So let me push my test case alone.
