### PR TITLE
AR::Relation#model would be a better API than AR::Relation#klass

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -20,6 +20,7 @@ module ActiveRecord
 
     attr_reader :table, :klass, :loaded
     attr_accessor :default_scoped
+    alias :model :klass
     alias :loaded? :loaded
     alias :default_scoped? :default_scoped
 

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -19,6 +19,11 @@ module ActiveRecord
       assert !relation.loaded, 'relation is not loaded'
     end
 
+    def test_responds_to_model_and_returns_klass
+      relation = Relation.new :a, :b
+      assert_equal :a, relation.model
+    end
+
     def test_initialize_single_values
       relation = Relation.new :a, :b
       (Relation::SINGLE_VALUE_METHODS - [:create_with]).each do |method|


### PR DESCRIPTION
`model` feels more natural for programmers, and this would make library authors a bit happier since it's compatible with `DM::Collection`
https://github.com/datamapper/dm-core/blob/9d9f739/lib/dm-core/collection.rb#L45
