### PR TITLE
Switched to use `display:none` in extra_tags_for_form method.

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -55,7 +55,7 @@ module ActionView
     # The HTML generated for this would be (modulus formatting):
     #
     #   <form action="/people" class="new_person" id="new_person" method="post">
-    #     <div style="margin:0;padding:0;display:inline">
+    #     <div style="margin:0;padding:0;display:none">
     #       <input name="authenticity_token" type="hidden" value="NrOp5bsjoLRuK8IW5+dQEYjKGUJDe7TQoZVvq95Wteg=" />
     #     </div>
     #     <label for="person_first_name">First name</label>:
@@ -85,7 +85,7 @@ module ActionView
     # the code above as is would yield instead:
     #
     #   <form action="/people/256" class="edit_person" id="edit_person_256" method="post">
-    #     <div style="margin:0;padding:0;display:inline">
+    #     <div style="margin:0;padding:0;display:none">
     #       <input name="_method" type="hidden" value="put" />
     #       <input name="authenticity_token" type="hidden" value="NrOp5bsjoLRuK8IW5+dQEYjKGUJDe7TQoZVvq95Wteg=" />
     #     </div>
@@ -323,7 +323,7 @@ module ActionView
       # The HTML generated for this would be:
       #
       #   <form action='http://www.example.com' method='post' data-remote='true'>
-      #     <div style='margin:0;padding:0;display:inline'>
+      #     <div style='margin:0;padding:0;display:none'>
       #       <input name='_method' type='hidden' value='put' />
       #     </div>
       #     ...

--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -705,7 +705,7 @@ module ActionView
           end
 
           tags = utf8_enforcer_tag << method_tag
-          content_tag(:div, tags, :style => 'margin:0;padding:0;display:inline')
+          content_tag(:div, tags, :style => 'margin:0;padding:0;display:none')
         end
 
         def form_tag_html(html_options)

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -2654,7 +2654,7 @@ class FormHelperTest < ActionView::TestCase
   protected
 
   def hidden_fields(method = nil)
-    txt =  %{<div style="margin:0;padding:0;display:inline">}
+    txt =  %{<div style="margin:0;padding:0;display:none">}
     txt << %{<input name="utf8" type="hidden" value="&#x2713;" />}
     if method && !method.to_s.in?(['get', 'post'])
       txt << %{<input name="_method" type="hidden" value="#{method}" />}

--- a/actionpack/test/template/form_tag_helper_test.rb
+++ b/actionpack/test/template/form_tag_helper_test.rb
@@ -14,7 +14,7 @@ class FormTagHelperTest < ActionView::TestCase
   def hidden_fields(options = {})
     method = options[:method]
 
-    txt =  %{<div style="margin:0;padding:0;display:inline">}
+    txt =  %{<div style="margin:0;padding:0;display:none">}
     txt << %{<input name="utf8" type="hidden" value="&#x2713;" />}
     if method && !method.to_s.in?(['get','post'])
       txt << %{<input name="_method" type="hidden" value="#{method}" />}


### PR DESCRIPTION
The use of `display:inline` with the content_tag call in the
extra_tags_for_form method potentially causes display issues with some
browsers, namely Internet Explorer. IE's behaviour of not collapsing
the line height on divs with ostensibly no content means that the
automatically added div containing the hidden authenticity_token, utf8
and _method form input tags may interfere with other visible form
elements in certain circumstances. The use of `display:none` rather
than `display:inline` fixes this problem.

Closes #6403.
