### PR TITLE
Modified generated Gemfile to allow patch versions of Rails.

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -151,7 +151,7 @@ module Rails
           GEMFILE
         else
           <<-GEMFILE.strip_heredoc
-            gem 'rails', '#{Rails::VERSION::STRING}'
+            gem 'rails', '~> #{Rails::VERSION::STRING}'
 
             # Bundle edge Rails instead:
             # gem 'rails', github: 'rails/rails'


### PR DESCRIPTION
Fixes #6604 which was a great idea by @mpapis

This change allows, for example when generating an application using Rails 3.2.5, the application to use 3.2.5 -> 3.2.x but not 3.3 or greater and not less than 3.2.5.

I believe that this is a good idea given that security issues are often fixed with patch releases and that it is safe to do so as these versions are tested for regressions which, when found, are solved with a subsequent release.

I couldn't find any tests that are related to this change and all railties tests passed (eventually). 

Thanks :-)
