### PR TITLE
Use single quote instead of %Q on route_inspect_test

### DIFF
--- a/railties/test/application/route_inspect_test.rb
+++ b/railties/test/application/route_inspect_test.rb
@@ -107,7 +107,7 @@ module ApplicationTests
       output = draw do
         get 'photos/:id' => 'photos#show', :defaults => {:format => 'jpg'}
       end
-      assert_equal [%Q[ GET /photos/:id(.:format) photos#show {:format=>"jpg"}]], output
+      assert_equal [' GET /photos/:id(.:format) photos#show {:format=>"jpg"}'], output
     end
 
     def test_rake_routes_shows_route_with_constraints


### PR DESCRIPTION
`%Q[]` was originally used because there's a `\n` [inside the string](https://github.com/rails/rails/blob/193e4de20646a025bf6dd3f90d1f9a53edb1cecf/railties/test/application/rake_test.rb#L157).

Now that the `\n` is no longer there, it is more readable to use single quotes instead.
