### PR TITLE
Deprecate `:confirm` in favor of `:data => { :confirm => 'Text' }` option

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 3.2.6 (unreleased) ##
 
+*   Deprecate `:confirm` in favor of `':data => { :confirm => "Text" }'` option for `button_to`, `button_tag`, `image_submit_tag`, `link_to` and `submit_tag` helpers.
+
+    *Carlos Galdino*
+
 *   Allow to use mounted_helpers (helpers for accessing mounted engines) in ActionView::TestCase. *Piotr Sarnacki*
 
 *   Include mounted_helpers (helpers for accessing mounted engines) in ActionDispatch::IntegrationTest by default. *Piotr Sarnacki*

--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -423,6 +423,8 @@ module ActionView
         end
 
         if confirm = options.delete("confirm")
+          ActiveSupport::Deprecation.warn ":confirm option is deprecated and will be removed from Rails 4.0. Use ':data => { :confirm => \'Text\' }' instead"
+
           options["data-confirm"] = confirm
         end
 
@@ -475,6 +477,8 @@ module ActionView
         end
 
         if confirm = options.delete("confirm")
+          ActiveSupport::Deprecation.warn ":confirm option is deprecated and will be removed from Rails 4.0. Use ':data => { :confirm => \'Text\' }' instead"
+
           options["data-confirm"] = confirm
         end
 
@@ -510,6 +514,8 @@ module ActionView
         options = options.stringify_keys
 
         if confirm = options.delete("confirm")
+          ActiveSupport::Deprecation.warn ":confirm option is deprecated and will be removed from Rails 4.0. Use ':data => { :confirm => \'Text\' }' instead"
+
           options["data-confirm"] = confirm
         end
 

--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -628,8 +628,13 @@ module ActionView
               html_options["data-disable-with"] = disable_with
             end
 
-            html_options["data-confirm"] = confirm if confirm
-            add_method_to_attributes!(html_options, method)   if method
+            if confirm
+              ActiveSupport::Deprecation.warn ":confirm option is deprecated and will be removed from Rails 4.0. Use ':data => { :confirm => \'Text\' }' instead"
+
+              html_options["data-confirm"] = confirm
+            end
+
+            add_method_to_attributes!(html_options, method) if method
 
             html_options
           else

--- a/actionpack/test/template/form_tag_helper_test.rb
+++ b/actionpack/test/template/form_tag_helper_test.rb
@@ -385,9 +385,18 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_submit_tag_with_confirmation
+    assert_deprecated ":confirm option is deprecated and will be removed from Rails 4.0. Use ':data => { :confirm => \'Text\' }' instead" do
+      assert_dom_equal(
+        %(<input name='commit' type='submit' value='Save' data-confirm="Are you sure?" />),
+        submit_tag("Save", :confirm => "Are you sure?")
+      )
+    end
+  end
+
+  def test_submit_tag_with_confirmation_without_deprecation_warning
     assert_dom_equal(
       %(<input name='commit' type='submit' value='Save' data-confirm="Are you sure?" />),
-      submit_tag("Save", :confirm => "Are you sure?")
+      submit_tag("Save", :data => { :confirm => "Are you sure?" })
     )
   end
 
@@ -418,6 +427,22 @@ class FormTagHelperTest < ActionView::TestCase
     assert_dom_equal(
       %(<button name="button" type="button">Button</button>),
       button_tag("Button", :type => "button")
+    )
+  end
+
+  def test_button_tag_with_confirmation
+    assert_deprecated ":confirm option is deprecated and will be removed from Rails 4.0. Use ':data => { :confirm => \'Text\' }' instead" do
+      assert_dom_equal(
+        %(<button name="button" type="submit" data-confirm="Are you sure?">Save</button>),
+        button_tag("Save", :type => "submit", :confirm => "Are you sure?")
+      )
+    end
+  end
+
+  def test_button_tag_with_confirmation_without_deprecation_warning
+    assert_dom_equal(
+      %(<button name="button" type="submit" data-confirm="Are you sure?">Save</button>),
+      button_tag("Save", :type => "submit", :data => { :confirm => "Are you sure?" })
     )
   end
 
@@ -461,9 +486,18 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_image_submit_tag_with_confirmation
+    assert_deprecated ":confirm option is deprecated and will be removed from Rails 4.0. Use ':data => { :confirm => \'Text\' }' instead" do
+      assert_dom_equal(
+        %(<input type="image" src="/images/save.gif" data-confirm="Are you sure?" />),
+        image_submit_tag("save.gif", :confirm => "Are you sure?")
+      )
+    end
+  end
+
+  def test_image_submit_tag_with_confirmation_without_deprecation_warning
     assert_dom_equal(
       %(<input type="image" src="/images/save.gif" data-confirm="Are you sure?" />),
-      image_submit_tag("save.gif", :confirm => "Are you sure?")
+      image_submit_tag("save.gif", :data => { :confirm => "Are you sure?" })
     )
   end
 

--- a/actionpack/test/template/url_helper_test.rb
+++ b/actionpack/test/template/url_helper_test.rb
@@ -75,9 +75,18 @@ class UrlHelperTest < ActiveSupport::TestCase
   end
 
   def test_button_to_with_javascript_confirm
+    assert_deprecated ":confirm option is deprecated and will be removed from Rails 4.0. Use ':data => { :confirm => \'Text\' }' instead" do
+      assert_dom_equal(
+        "<form method=\"post\" action=\"http://www.example.com\" class=\"button_to\"><div><input data-confirm=\"Are you sure?\" type=\"submit\" value=\"Hello\" /></div></form>",
+        button_to("Hello", "http://www.example.com", :confirm => "Are you sure?")
+      )
+    end
+  end
+
+  def test_button_to_confirm_without_deprecation_warning
     assert_dom_equal(
       "<form method=\"post\" action=\"http://www.example.com\" class=\"button_to\"><div><input data-confirm=\"Are you sure?\" type=\"submit\" value=\"Hello\" /></div></form>",
-      button_to("Hello", "http://www.example.com", :confirm => "Are you sure?")
+      button_to("Hello", "http://www.example.com", :data => { :confirm => "Are you sure?" })
     )
   end
 
@@ -95,9 +104,18 @@ class UrlHelperTest < ActiveSupport::TestCase
   end
 
   def test_button_to_with_remote_and_javascript_confirm
+    assert_deprecated ":confirm option is deprecated and will be removed from Rails 4.0. Use ':data => { :confirm => \'Text\' }' instead" do
+      assert_dom_equal(
+        "<form method=\"post\" action=\"http://www.example.com\" class=\"button_to\" data-remote=\"true\"><div><input data-confirm=\"Are you sure?\" type=\"submit\" value=\"Hello\" /></div></form>",
+        button_to("Hello", "http://www.example.com", :remote => true, :confirm => "Are you sure?")
+      )
+    end
+  end
+
+  def test_button_to_with_remote_and_javascript_confirm_without_deprecation_warning
     assert_dom_equal(
       "<form method=\"post\" action=\"http://www.example.com\" class=\"button_to\" data-remote=\"true\"><div><input data-confirm=\"Are you sure?\" type=\"submit\" value=\"Hello\" /></div></form>",
-      button_to("Hello", "http://www.example.com", :remote => true, :confirm => "Are you sure?")
+      button_to("Hello", "http://www.example.com", :remote => true, :data => { :confirm => "Are you sure?" })
     )
   end
 
@@ -110,13 +128,20 @@ class UrlHelperTest < ActiveSupport::TestCase
     end
   end
 
-  def test_button_to_with_remote_and_javascript_confirm_and_javascript_disable_with
-    assert_deprecated ":disable_with option is deprecated and will be removed from Rails 4.0. Use 'data-disable-with' instead" do
+  def test_button_to_with_remote_and_javascript_confirm
+    assert_deprecated ":confirm option is deprecated and will be removed from Rails 4.0. Use ':data => { :confirm => \'Text\' }' instead" do
       assert_dom_equal(
-        "<form method=\"post\" action=\"http://www.example.com\" class=\"button_to\" data-remote=\"true\"><div><input data-disable-with=\"Greeting...\" data-confirm=\"Are you sure?\" type=\"submit\" value=\"Hello\" /></div></form>",
-        button_to("Hello", "http://www.example.com", :remote => true, :confirm => "Are you sure?", :disable_with => "Greeting...")
+        "<form method=\"post\" action=\"http://www.example.com\" class=\"button_to\" data-remote=\"true\"><div><input data-confirm=\"Are you sure?\" type=\"submit\" value=\"Hello\" /></div></form>",
+        button_to("Hello", "http://www.example.com", :remote => true, :confirm => "Are you sure?")
       )
     end
+  end
+
+  def test_button_to_with_remote_and_javascript_confirm_without_deprecation_warning
+    assert_dom_equal(
+      "<form method=\"post\" action=\"http://www.example.com\" class=\"button_to\" data-remote=\"true\"><div><input data-confirm=\"Are you sure?\" type=\"submit\" value=\"Hello\" /></div></form>",
+      button_to("Hello", "http://www.example.com", :remote => true, :data => { :confirm => "Are you sure?" })
+    )
   end
 
   def test_button_to_with_remote_false
@@ -206,17 +231,30 @@ class UrlHelperTest < ActiveSupport::TestCase
   end
 
   def test_link_tag_with_javascript_confirm
+    assert_deprecated ":confirm option is deprecated and will be removed from Rails 4.0. Use ':data => { :confirm => \'Text\' }' instead" do
+      assert_dom_equal(
+        "<a href=\"http://www.example.com\" data-confirm=\"Are you sure?\">Hello</a>",
+        link_to("Hello", "http://www.example.com", :confirm => "Are you sure?")
+      )
+    end
+    assert_deprecated ":confirm option is deprecated and will be removed from Rails 4.0. Use ':data => { :confirm => \'Text\' }' instead" do
+      assert_dom_equal(
+        "<a href=\"http://www.example.com\" data-confirm=\"You can't possibly be sure, can you?\">Hello</a>",
+        link_to("Hello", "http://www.example.com", :confirm => "You can't possibly be sure, can you?")
+      )
+    end
+    assert_deprecated ":confirm option is deprecated and will be removed from Rails 4.0. Use ':data => { :confirm => \'Text\' }' instead" do
+      assert_dom_equal(
+        "<a href=\"http://www.example.com\" data-confirm=\"You can't possibly be sure,\n can you?\">Hello</a>",
+        link_to("Hello", "http://www.example.com", :confirm => "You can't possibly be sure,\n can you?")
+      )
+    end
+  end
+
+  def test_link_tag_confirm_without_deprecation_warning
     assert_dom_equal(
       "<a href=\"http://www.example.com\" data-confirm=\"Are you sure?\">Hello</a>",
-      link_to("Hello", "http://www.example.com", :confirm => "Are you sure?")
-    )
-    assert_dom_equal(
-      "<a href=\"http://www.example.com\" data-confirm=\"You can't possibly be sure, can you?\">Hello</a>",
-      link_to("Hello", "http://www.example.com", :confirm => "You can't possibly be sure, can you?")
-    )
-    assert_dom_equal(
-      "<a href=\"http://www.example.com\" data-confirm=\"You can't possibly be sure,\n can you?\">Hello</a>",
-      link_to("Hello", "http://www.example.com", :confirm => "You can't possibly be sure,\n can you?")
+      link_to("Hello", "http://www.example.com", :data => { :confirm => "Are you sure?" })
     )
   end
 
@@ -263,16 +301,35 @@ class UrlHelperTest < ActiveSupport::TestCase
   end
 
   def test_link_tag_using_post_javascript_and_confirm
+    assert_deprecated ":confirm option is deprecated and will be removed from Rails 4.0. Use ':data => { :confirm => \'Text\' }' instead" do
+      assert_dom_equal(
+        "<a href=\"http://www.example.com\" data-method=\"post\" rel=\"nofollow\" data-confirm=\"Are you serious?\">Hello</a>",
+        link_to("Hello", "http://www.example.com", :method => :post, :confirm => "Are you serious?")
+      )
+    end
+  end
+
+  def test_link_tag_using_post_javascript_and_confirm_without_deprecation_warning
     assert_dom_equal(
       "<a href=\"http://www.example.com\" data-method=\"post\" rel=\"nofollow\" data-confirm=\"Are you serious?\">Hello</a>",
-      link_to("Hello", "http://www.example.com", :method => :post, :confirm => "Are you serious?")
+      link_to("Hello", "http://www.example.com", :method => :post, :data => { :confirm => "Are you serious?" })
     )
   end
 
   def test_link_tag_using_delete_javascript_and_href_and_confirm
+    assert_deprecated ":confirm option is deprecated and will be removed from Rails 4.0. Use ':data => { :confirm => \'Text\' }' instead" do
+      assert_dom_equal(
+        "<a href='\#' rel=\"nofollow\" data-confirm=\"Are you serious?\" data-method=\"delete\">Destroy</a>",
+        link_to("Destroy", "http://www.example.com", :method => :delete, :href => '#', :confirm => "Are you serious?"),
+        "When specifying url, form should be generated with it, but not this.href"
+      )
+    end
+  end
+
+  def test_link_tag_using_delete_javascript_and_href_and_confirm_without_deprecation_warning
     assert_dom_equal(
       "<a href='\#' rel=\"nofollow\" data-confirm=\"Are you serious?\" data-method=\"delete\">Destroy</a>",
-      link_to("Destroy", "http://www.example.com", :method => :delete, :href => '#', :confirm => "Are you serious?"),
+      link_to("Destroy", "http://www.example.com", :method => :delete, :href => '#', :data => { :confirm => "Are you serious?" }),
       "When specifying url, form should be generated with it, but not this.href"
     )
   end

--- a/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb
@@ -17,7 +17,7 @@
 <% end -%>
     <td><%%= link_to 'Show', <%= singular_table_name %> %></td>
     <td><%%= link_to 'Edit', edit_<%= singular_table_name %>_path(<%= singular_table_name %>) %></td>
-    <td><%%= link_to 'Destroy', <%= singular_table_name %>, <%= key_value :confirm, "'Are you sure?'" %>, <%= key_value :method, ":delete" %> %></td>
+    <td><%%= link_to 'Destroy', <%= singular_table_name %>, <%= key_value :method, ":delete" %>, <%= key_value :data, "{ #{key_value :confirm, "'Are you sure?'"} }" %> %></td>
   </tr>
 <%% end %>
 </table>


### PR DESCRIPTION
Just like [21141e7](https://github.com/rails/rails/commit/21141e777bdce8534e3755c8de7268324b3d8714) this PR deprecates the `:confirm` option.

/cc @rafaelfranca

Related to #6614
