### PR TITLE
Remove `:confirm` in favor of `:data => { :confirm => 'Text' }` option

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Remove `:confirm` in favor of `:data => { :confirm => "Text" }` option for `button_to`, `button_tag`, `image_submit_tag`, `link_to` and `submit_tag` helpers.
+
+    *Carlos Galdino*
+
 *   Show routes in exception page while debugging a `RoutingError` in development. *Richard Schneeman and Mattt Thompson*
 
 *   Add `ActionController::Flash.add_flash_types` method to allow people to register their own flash types. e.g.:

--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -382,9 +382,7 @@ module ActionView
       # Creates a submit button with the text <tt>value</tt> as the caption.
       #
       # ==== Options
-      # * <tt>:confirm => 'question?'</tt> - If present the unobtrusive JavaScript
-      #   drivers will provide a prompt with the question specified. If the user accepts,
-      #   the form is processed normally, otherwise no action is taken.
+      # * <tt>:data</tt> - This option can be used to add custom data attributes.
       # * <tt>:disabled</tt> - If true, the user will not be able to use this input.
       # * Any other key creates standard HTML options for the tag.
       #
@@ -407,15 +405,11 @@ module ActionView
       #   submit_tag "Edit", :class => "edit_button"
       #   # => <input class="edit_button" name="commit" type="submit" value="Edit" />
       #
-      #   submit_tag "Save", :confirm => "Are you sure?"
+      #   submit_tag "Save", :data => { :confirm => "Are you sure?" }
       #   # => <input name='commit' type='submit' value='Save' data-confirm="Are you sure?" />
       #
       def submit_tag(value = "Save changes", options = {})
         options = options.stringify_keys
-
-        if confirm = options.delete("confirm")
-          options["data-confirm"] = confirm
-        end
 
         tag :input, { "type" => "submit", "name" => "commit", "value" => value }.update(options)
       end
@@ -428,10 +422,7 @@ module ActionView
       # so this helper will also accept a block.
       #
       # ==== Options
-      # * <tt>:confirm => 'question?'</tt> - If present, the
-      #   unobtrusive JavaScript drivers will provide a prompt with
-      #   the question specified. If the user accepts, the form is
-      #   processed normally, otherwise no action is taken.
+      # * <tt>:data</tt> - This option can be used to add custom data attributes.
       # * <tt>:disabled</tt> - If true, the user will not be able to
       #   use this input.
       # * Any other key creates standard HTML options for the tag.
@@ -452,10 +443,6 @@ module ActionView
         options ||= {}
         options = options.stringify_keys
 
-        if confirm = options.delete("confirm")
-          options["data-confirm"] = confirm
-        end
-
         options.reverse_merge! 'name' => 'button', 'type' => 'submit'
 
         content_tag :button, content_or_options || 'Button', options, &block
@@ -466,9 +453,7 @@ module ActionView
       # <tt>source</tt> is passed to AssetTagHelper#path_to_image
       #
       # ==== Options
-      # * <tt>:confirm => 'question?'</tt> - This will add a JavaScript confirm
-      #   prompt with the question specified. If the user accepts, the form is
-      #   processed normally, otherwise no action is taken.
+      # * <tt>:data</tt> - This option can be used to add custom data attributes.
       # * <tt>:disabled</tt> - If set to true, the user will not be able to use this input.
       # * Any other key creates standard HTML options for the tag.
       #
@@ -485,14 +470,10 @@ module ActionView
       #   image_submit_tag("agree.png", :disabled => true, :class => "agree_disagree_button")
       #   # => <input class="agree_disagree_button" disabled="disabled" src="/images/agree.png" type="image" />
       #
-      #   image_submit_tag("save.png", :confirm => "Are you sure?")
+      #   image_submit_tag("save.png", :data => { :confirm => "Are you sure?" })
       #   # => <input src="/images/save.png" data-confirm="Are you sure?" type="image" />
       def image_submit_tag(source, options = {})
         options = options.stringify_keys
-
-        if confirm = options.delete("confirm")
-          options["data-confirm"] = confirm
-        end
 
         tag :input, { "type" => "image", "src" => path_to_image(source) }.update(options)
       end

--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -132,8 +132,7 @@ module ActionView
       #     # posts_path
       #
       #   link_to(body, url_options = {}, html_options = {})
-      #     # url_options, except :confirm or :method,
-      #     # is passed to url_for
+      #     # url_options, except :method, is passed to url_for
       #
       #   link_to(options = {}, html_options = {}) do
       #     # name
@@ -144,9 +143,7 @@ module ActionView
       #   end
       #
       # ==== Options
-      # * <tt>:confirm => 'question?'</tt> - This will allow the unobtrusive JavaScript
-      #   driver to prompt with the question specified. If the user accepts, the link is
-      #   processed normally, otherwise no action is taken.
+      # * <tt>:data</tt> - This option can be used to add custom data attributes.
       # * <tt>:method => symbol of HTTP verb</tt> - This modifier will dynamically
       #   create an HTML form and immediately submit the form for processing using
       #   the HTTP verb specified. Useful for having links perform a POST operation
@@ -226,13 +223,15 @@ module ActionView
       #   link_to "Nonsense search", searches_path(:foo => "bar", :baz => "quux")
       #   # => <a href="/searches?foo=bar&amp;baz=quux">Nonsense search</a>
       #
-      # The two options specific to +link_to+ (<tt>:confirm</tt> and <tt>:method</tt>) are used as follows:
+      # The only option specific to +link_to+ (<tt>:method</tt>) is used as follows:
       #
-      #   link_to "Visit Other Site", "http://www.rubyonrails.org/", :confirm => "Are you sure?"
+      #   link_to("Destroy", "http://www.example.com", :method => :delete)
+      #   # => <a href='http://www.example.com' rel="nofollow" data-method="delete">Destroy</a>
+      #
+      # You can also use custom data attributes using the <tt>:data</tt> option:
+      #
+      #   link_to "Visit Other Site", "http://www.rubyonrails.org/", :data => { :confirm => "Are you sure?" }
       #   # => <a href="http://www.rubyonrails.org/" data-confirm="Are you sure?"">Visit Other Site</a>
-      #
-      #   link_to("Destroy", "http://www.example.com", :method => :delete, :confirm => "Are you sure?")
-      #   # => <a href='http://www.example.com' rel="nofollow" data-method="delete" data-confirm="Are you sure?">Destroy</a>
       def link_to(name = nil, options = nil, html_options = nil, &block)
         html_options, options = options, name if block_given?
         options ||= {}
@@ -255,10 +254,9 @@ module ActionView
       # to allow styling of the form itself and its children. This can be changed
       # using the <tt>:form_class</tt> modifier within +html_options+. You can control
       # the form submission and input element behavior using +html_options+.
-      # This method accepts the <tt>:method</tt> and <tt>:confirm</tt> modifiers
-      # described in the +link_to+ documentation. If no <tt>:method</tt> modifier
-      # is given, it will default to performing a POST operation. You can also
-      # disable the button by passing <tt>:disabled => true</tt> in +html_options+.
+      # This method accepts the <tt>:method</tt> modifier described in the +link_to+ documentation.
+      # If no <tt>:method</tt> modifier is given, it will default to performing a POST operation.
+      # You can also disable the button by passing <tt>:disabled => true</tt> in +html_options+.
       # If you are using RESTful routes, you can pass the <tt>:method</tt>
       # to change the HTTP verb used to submit the form.
       #
@@ -269,9 +267,7 @@ module ActionView
       # * <tt>:method</tt> - Symbol of HTTP verb. Supported verbs are <tt>:post</tt>, <tt>:get</tt>,
       #   <tt>:delete</tt>, <tt>:patch</tt>, and <tt>:put</tt>. By default it will be <tt>:post</tt>.
       # * <tt>:disabled</tt> - If set to true, it will generate a disabled button.
-      # * <tt>:confirm</tt> - This will use the unobtrusive JavaScript driver to
-      #   prompt with the question specified. If the user accepts, the link is
-      #   processed normally, otherwise no action is taken.
+      # * <tt>:data</tt> - This option can be used to add custom data attributes.
       # * <tt>:remote</tt> -  If set to true, will allow the Unobtrusive JavaScript drivers to control the
       #   submit behavior. By default this behavior is an ajax submit.
       # * <tt>:form</tt> - This hash will be form attributes
@@ -311,7 +307,7 @@ module ActionView
       #
       #
       #   <%= button_to "Delete Image", { :action => "delete", :id => @image.id },
-      #             :confirm => "Are you sure?", :method => :delete %>
+      #                                   :method => :delete, :data => { :confirm => "Are you sure?" } %>
       #   # => "<form method="post" action="/images/delete/1" class="button_to">
       #   #      <div>
       #   #        <input type="hidden" name="_method" value="delete" />
@@ -321,8 +317,8 @@ module ActionView
       #   #    </form>"
       #
       #
-      #   <%= button_to('Destroy', 'http://www.example.com', :confirm => 'Are you sure?',
-      #             :method => "delete", :remote => true) %>
+      #   <%= button_to('Destroy', 'http://www.example.com',
+      #             :method => "delete", :remote => true, :data => { :confirm' => 'Are you sure?' }) %>
       #   # => "<form class='button_to' method='post' action='http://www.example.com' data-remote='true'>
       #   #       <div>
       #   #         <input name='_method' value='delete' type='hidden' />
@@ -627,10 +623,8 @@ module ActionView
             html_options = html_options.stringify_keys
             html_options['data-remote'] = 'true' if link_to_remote_options?(options) || link_to_remote_options?(html_options)
 
-            confirm = html_options.delete('confirm')
             method  = html_options.delete('method')
 
-            html_options["data-confirm"] = confirm if confirm
             add_method_to_attributes!(html_options, method) if method
 
             html_options

--- a/actionpack/test/template/form_tag_helper_test.rb
+++ b/actionpack/test/template/form_tag_helper_test.rb
@@ -382,7 +382,7 @@ class FormTagHelperTest < ActionView::TestCase
   def test_submit_tag_with_confirmation
     assert_dom_equal(
       %(<input name='commit' type='submit' value='Save' data-confirm="Are you sure?" />),
-      submit_tag("Save", :confirm => "Are you sure?")
+      submit_tag("Save", :data => { :confirm => "Are you sure?" })
     )
   end
 
@@ -437,10 +437,17 @@ class FormTagHelperTest < ActionView::TestCase
     assert_dom_equal('<button name="temptation" type="button"><strong>Do not press me</strong></button>', output)
   end
 
+  def test_button_tag_with_confirmation
+    assert_dom_equal(
+      %(<button name="button" type="submit" data-confirm="Are you sure?">Save</button>),
+      button_tag("Save", :type => "submit", :data => { :confirm => "Are you sure?" })
+    )
+  end
+
   def test_image_submit_tag_with_confirmation
     assert_dom_equal(
       %(<input type="image" src="/images/save.gif" data-confirm="Are you sure?" />),
-      image_submit_tag("save.gif", :confirm => "Are you sure?")
+      image_submit_tag("save.gif", :data => { :confirm => "Are you sure?" })
     )
   end
 

--- a/actionpack/test/template/url_helper_test.rb
+++ b/actionpack/test/template/url_helper_test.rb
@@ -90,7 +90,7 @@ class UrlHelperTest < ActiveSupport::TestCase
   def test_button_to_with_javascript_confirm
     assert_dom_equal(
       "<form method=\"post\" action=\"http://www.example.com\" class=\"button_to\"><div><input data-confirm=\"Are you sure?\" type=\"submit\" value=\"Hello\" /></div></form>",
-      button_to("Hello", "http://www.example.com", :confirm => "Are you sure?")
+      button_to("Hello", "http://www.example.com", :data => { :confirm => "Are you sure?" })
     )
   end
 
@@ -108,7 +108,7 @@ class UrlHelperTest < ActiveSupport::TestCase
   def test_button_to_with_remote_and_javascript_confirm
     assert_dom_equal(
       "<form method=\"post\" action=\"http://www.example.com\" class=\"button_to\" data-remote=\"true\"><div><input data-confirm=\"Are you sure?\" type=\"submit\" value=\"Hello\" /></div></form>",
-      button_to("Hello", "http://www.example.com", :remote => true, :confirm => "Are you sure?")
+      button_to("Hello", "http://www.example.com", :remote => true, :data => { :confirm => "Are you sure?" })
     )
   end
 
@@ -208,15 +208,15 @@ class UrlHelperTest < ActiveSupport::TestCase
   def test_link_tag_with_javascript_confirm
     assert_dom_equal(
       "<a href=\"http://www.example.com\" data-confirm=\"Are you sure?\">Hello</a>",
-      link_to("Hello", "http://www.example.com", :confirm => "Are you sure?")
+      link_to("Hello", "http://www.example.com", :data => { :confirm => "Are you sure?" })
     )
     assert_dom_equal(
       "<a href=\"http://www.example.com\" data-confirm=\"You can't possibly be sure, can you?\">Hello</a>",
-      link_to("Hello", "http://www.example.com", :confirm => "You can't possibly be sure, can you?")
+      link_to("Hello", "http://www.example.com", :data => { :confirm => "You can't possibly be sure, can you?" })
     )
     assert_dom_equal(
       "<a href=\"http://www.example.com\" data-confirm=\"You can't possibly be sure,\n can you?\">Hello</a>",
-      link_to("Hello", "http://www.example.com", :confirm => "You can't possibly be sure,\n can you?")
+      link_to("Hello", "http://www.example.com", :data => { :confirm => "You can't possibly be sure,\n can you?" })
     )
   end
 
@@ -265,14 +265,14 @@ class UrlHelperTest < ActiveSupport::TestCase
   def test_link_tag_using_post_javascript_and_confirm
     assert_dom_equal(
       "<a href=\"http://www.example.com\" data-method=\"post\" rel=\"nofollow\" data-confirm=\"Are you serious?\">Hello</a>",
-      link_to("Hello", "http://www.example.com", :method => :post, :confirm => "Are you serious?")
+      link_to("Hello", "http://www.example.com", :method => :post, :data => { :confirm => "Are you serious?" })
     )
   end
 
   def test_link_tag_using_delete_javascript_and_href_and_confirm
     assert_dom_equal(
       "<a href='\#' rel=\"nofollow\" data-confirm=\"Are you serious?\" data-method=\"delete\">Destroy</a>",
-      link_to("Destroy", "http://www.example.com", :method => :delete, :href => '#', :confirm => "Are you serious?"),
+      link_to("Destroy", "http://www.example.com", :method => :delete, :href => '#', :data => { :confirm => "Are you serious?" }),
       "When specifying url, form should be generated with it, but not this.href"
     )
   end

--- a/guides/code/getting_started/app/views/comments/_comment.html.erb
+++ b/guides/code/getting_started/app/views/comments/_comment.html.erb
@@ -10,6 +10,6 @@
 
 <p>
   <%= link_to 'Destroy Comment', [comment.post, comment],
-               :confirm => 'Are you sure?',
-               :method => :delete %>
+               :method => :delete,
+               :data => { :confirm => 'Are you sure?' } %>
 </p>

--- a/guides/code/getting_started/app/views/posts/index.html.erb
+++ b/guides/code/getting_started/app/views/posts/index.html.erb
@@ -17,7 +17,7 @@
     <td><%= post.text %></td>
     <td><%= link_to 'Show', :action => :show, :id => post.id %>
     <td><%= link_to 'Edit', :action => :edit, :id => post.id %>
-    <td><%= link_to 'Destroy', { :action => :destroy, :id => post.id }, :method => :delete, :confirm => 'Are you sure?' %>
+    <td><%= link_to 'Destroy', { :action => :destroy, :id => post.id }, :method => :delete, :data => { :confirm => 'Are you sure?' } %>
   </tr>
 <% end %>
 </table>

--- a/guides/source/ajax_on_rails.textile
+++ b/guides/source/ajax_on_rails.textile
@@ -129,7 +129,7 @@ will produce
 
 <ruby>
 button_to 'Delete Image', { action: 'delete', id: @image.id },
-             confirm: 'Are you sure?', method: :delete
+             method: :delete, data: { confirm: 'Are you sure?' }
 </ruby>
 
 will produce
@@ -144,8 +144,8 @@ will produce
 </html>
 
 <ruby>
-button_to 'Destroy', 'http://www.example.com', confirm: 'Are you sure?',
-             method: 'delete', remote: true, data: { disable_with: 'loading...' }
+button_to 'Destroy', 'http://www.example.com',
+             method: 'delete', remote: true, data: { disable_with: 'loading...', confirm: 'Are you sure?' }
 </ruby>
 
 will produce
@@ -217,7 +217,6 @@ link_to_remote "Delete the item",
 Note that if we wouldn't override the default behavior (POST), the above snippet would route to the create action rather than destroy.
 
 ** *JavaScript filters* You can customize the remote call further by wrapping it with some JavaScript code. Let's say in the previous example, when deleting a link, you'd like to ask for a confirmation by showing a simple modal text box to the user. This is a typical example what you can accomplish with these options - let's see them one by one:
-*** +:confirm+ =&gt; +msg+ Pops up a JavaScript confirmation dialog, displaying +msg+. If the user chooses 'OK', the request is launched, otherwise canceled.
 *** +:condition+ =&gt; +code+ Evaluates +code+ (which should evaluate to a boolean) and proceeds if it's true, cancels the request otherwise.
 *** +:before+ =&gt; +code+ Evaluates the +code+ just before launching the request. The output of the code has no influence on the execution. Typically used show a progress indicator (see this in action in the next example).
 *** +:after+ =&gt; +code+ Evaluates the +code+ after launching the request. Note that this is different from the +:success+ or +:complete+ callback (covered in the next section) since those are triggered after the request is completed, while the code snippet passed to +:after+ is evaluated after the remote call is made. A common example is to disable elements on the page or otherwise prevent further action while the request is completed.

--- a/guides/source/getting_started.textile
+++ b/guides/source/getting_started.textile
@@ -1144,7 +1144,7 @@ together.
     <td><%= post.text %></td>
     <td><%= link_to 'Show', :action => :show, :id => post.id %></td>
     <td><%= link_to 'Edit', :action => :edit, :id => post.id %></td>
-    <td><%= link_to 'Destroy', { :action => :destroy, :id => post.id }, :method => :delete, :confirm => 'Are you sure?' %></td>
+    <td><%= link_to 'Destroy', { :action => :destroy, :id => post.id }, :method => :delete, :data => { :confirm => 'Are you sure?' } %></td>
   </tr>
 <% end %>
 </table>
@@ -1152,13 +1152,12 @@ together.
 
 Here we're using +link_to+ in a different way. We wrap the
 +:action+ and +:id+ attributes in a hash so that we can pass those two keys in
-first as one argument, and then the final two keys as another argument. The +:method+ and +:confirm+
+first as one argument, and then the final two keys as another argument. The +:method+ and +:'data-confirm'+
 options are used as HTML5 attributes so that when the link is clicked,
-Rails will first show a confirm dialog to the user, and then submit the
-link with method +delete+. This is done via the JavaScript file +jquery_ujs+
-which is automatically included into your application's layout
-(+app/views/layouts/application.html.erb+) when you generated the application.
-Without this file, the confirmation dialog box wouldn't appear.
+Rails will first show a confirm dialog to the user, and then submit the link with method +delete+.
+This is done via the JavaScript file +jquery_ujs+ which is automatically included
+into your application's layout (+app/views/layouts/application.html.erb+) when you
+generated the application. Without this file, the confirmation dialog box wouldn't appear.
 
 !images/getting_started/confirm_dialog.png(Confirm Dialog)!
 
@@ -1627,8 +1626,8 @@ So first, let's add the delete link in the
 
 <p>
   <%= link_to 'Destroy Comment', [comment.post, comment],
-               :confirm => 'Are you sure?',
-               :method => :delete %>
+               :method => :delete,
+               :data => { :confirm => 'Are you sure?' } %>
 </p>
 </erb>
 

--- a/guides/source/layouts_and_rendering.textile
+++ b/guides/source/layouts_and_rendering.textile
@@ -78,7 +78,7 @@ If we want to display the properties of all the books in our view, we can do so 
     <td><%= book.content %></td>
     <td><%= link_to "Show", book %></td>
     <td><%= link_to "Edit", edit_book_path(book) %></td>
-    <td><%= link_to "Remove", book, :confirm => "Are you sure?", :method => :delete %></td>
+    <td><%= link_to "Remove", book, :method => :delete, :data => { :confirm => "Are you sure?" } %></td>
   </tr>
 <% end %>
 </table>

--- a/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb
@@ -19,7 +19,7 @@
   <% end -%>
       <td><%%= link_to 'Show', <%= singular_table_name %> %></td>
       <td><%%= link_to 'Edit', edit_<%= singular_table_name %>_path(<%= singular_table_name %>) %></td>
-      <td><%%= link_to 'Destroy', <%= singular_table_name %>, confirm: 'Are you sure?', method: :delete %></td>
+      <td><%%= link_to 'Destroy', <%= singular_table_name %>, method: :delete, data: { confirm: 'Are you sure?' } %></td>
     <%% end %>
   </tbody>
 </table>


### PR DESCRIPTION
Just like [683fc4d](https://github.com/rails/rails/commit/683fc4db00f496e5225928afb4d4e932e0fcdc48) this removes the :confirm option.

/cc @rafaelfranca

The PR adding the deprecation is #6613
