### PR TITLE
resolver tests fail if mysql adapter not installed

### DIFF
--- a/activerecord/test/cases/connection_specification/resolver_test.rb
+++ b/activerecord/test/cases/connection_specification/resolver_test.rb
@@ -9,6 +9,7 @@ module ActiveRecord
         end
 
         def test_url_host_no_db
+          skip "only if mysql is available" unless defined?(MysqlAdapter)
           spec = resolve 'mysql://foo?encoding=utf8'
           assert_equal({
             :adapter  => "mysql",
@@ -18,6 +19,7 @@ module ActiveRecord
         end
 
         def test_url_host_db
+          skip "only if mysql is available" unless defined?(MysqlAdapter)
           spec = resolve 'mysql://foo/bar?encoding=utf8'
           assert_equal({
             :adapter  => "mysql",
@@ -27,6 +29,7 @@ module ActiveRecord
         end
 
         def test_url_port
+          skip "only if mysql is available" unless defined?(MysqlAdapter)
           spec = resolve 'mysql://foo:123?encoding=utf8'
           assert_equal({
             :adapter  => "mysql",


### PR DESCRIPTION
The resolver tests fail if the mysql gem is not installed; this breaks
being able to run the sqlite3 tests without that gem. 

To reproduce:

bundle install --without db
cd active record
bundle exec rake test_sqlite3

This fix ensures the tests will only run if the mysql gem is installed.

A better solution might be to move these tests into the per-adapter tests,
and test each adapter's resolver.
