### PR TITLE
[3-2-stable back ported] Fix #6591 Rails 3.2.5 Regression: incorrect _changed? for datetimes

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -42,8 +42,9 @@ module ActiveRecord
                     time = time.is_a?(String) ? Time.zone.parse(time) : time.to_time rescue time
                   end
                   time = time.in_time_zone rescue nil if time
+                  changed = read_attribute(:#{attr_name}) != time
                   write_attribute(:#{attr_name}, original_time)
-                  #{attr_name}_will_change!
+                  #{attr_name}_will_change! if changed
                   @attributes_cache["#{attr_name}"] = time
                 end
               EOV

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -78,6 +78,17 @@ class DirtyTest < ActiveRecord::TestCase
       assert_equal old_created_on, pirate.created_on_was
     end
   end
+  
+  def test_setting_time_attributes_with_time_zone_field_to_itself_should_not_be_marked_as_a_change
+    in_time_zone 'Paris' do
+      target = Class.new(ActiveRecord::Base)
+      target.table_name = 'pirates'
+
+      pirate = target.create
+      pirate.created_on = pirate.created_on
+      assert !pirate.created_on_changed?
+    end
+  end
 
   def test_time_attributes_changes_without_time_zone_by_skip
     in_time_zone 'Paris' do


### PR DESCRIPTION
The original PR (on the master) was https://github.com/rails/rails/pull/6619.

There is a problem when dealing with Time with Timezone field.
If value is not change, definitely _will_change! method is executed.

Please see https://github.com/rails/rails/issues/6591.
