### PR TITLE
Asset host doesn't recognize protocol agnostic "//" links.

### DIFF
--- a/actionpack/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helper.rb
@@ -755,7 +755,7 @@ module ActionView
         end
 
         def is_uri?(path)
-          path =~ %r{^[-a-z]+://|^cid:}
+          path =~ %r{^[-a-z]+://|^cid:|^//}
         end
 
         # Pick an asset host for this source. Returns +nil+ if no host is set,

--- a/actionpack/test/template/asset_tag_helper_test.rb
+++ b/actionpack/test/template/asset_tag_helper_test.rb
@@ -1045,6 +1045,11 @@ class AssetTagHelperNonVhostTest < ActionView::TestCase
     assert_equal 'gopher://a.example.com/files/go/here/collaboration/hieraki/images/xml.png', image_path('xml.png')
   end
 
+  def test_asset_host_with_protocol_agnostic_link
+    @controller.config.asset_host = '//a.example.com'
+    assert_equal '//a.example.com/collaboration/hieraki/images/pants.png', image_path('pants.png')
+  end
+
   def test_assert_css_and_js_of_the_same_name_return_correct_extension
     assert_dom_equal(%(/collaboration/hieraki/javascripts/foo.js), javascript_path("foo"))
     assert_dom_equal(%(/collaboration/hieraki/stylesheets/foo.css), stylesheet_path("foo"))


### PR DESCRIPTION
It is common practice to use protocol-less URIs when serving a site from both http and https.  This form ("//cdn.host/blah/foo.css") allows the same content to be served (and cached) for both normal and secure sites, leaving the user agent to resolve the protocol.

Currently, the asset host plumbing doesn't recognize this as a valid URI form (it is, says RFC 3986 section 4.2).  If I specify my asset host of "//a.example.com/assets", loading asset "foo.png" results in an invalid URI "http:////a.example.com/assets/foo.png" on HTTP and "https:////a.example.com/assets/foo.png" on HTTPS.

This patch correctly recognizes my protocol-less URI as valid and doesn't attempt to add the proto.
