### PR TITLE
bundle exec rake assets:precompile shouldn't fail quietly.

### DIFF
--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -17,9 +17,21 @@ module ApplicationTests
       teardown_app
     end
 
-    def precompile!
+    def precompile!(env = nil)
       quietly do
-        Dir.chdir(app_path){ `bundle exec rake assets:precompile` }
+        precompile_task = 'bundle exec rake assets:precompile'
+        precompile_task += ' ' + env if env
+        out = Dir.chdir(app_path){  %x[ #{precompile_task} ] }
+        assert $?.exitstatus == 0,
+               "#{precompile_task} has failed: #{out}.\
+                Probably you didn't install JavaScript runtime."
+        return out
+      end
+    end
+
+    def clean_assets!
+      quietly do
+        assert Dir.chdir(app_path){ system('bundle exec rake assets:clean') }
       end
     end
 
@@ -253,9 +265,8 @@ module ApplicationTests
       # digest is default in false, we must enable it for test environment
       add_to_env_config "test", "config.assets.digest = true"
 
-      quietly do
-        Dir.chdir(app_path){ `bundle exec rake assets:precompile RAILS_ENV=test` }
-      end
+      precompile!('RAILS_ENV=test')
+
       file = Dir["#{app_path}/public/assets/application.css"].first
       assert_match(/\/assets\/rails\.png/, File.read(file))
       file = Dir["#{app_path}/public/assets/application-*.css"].first
@@ -285,9 +296,9 @@ module ApplicationTests
       add_to_config "config.assets.compile = true"
 
       ENV["RAILS_ENV"] = nil
-      quietly do
-        Dir.chdir(app_path){ `bundle exec rake assets:precompile RAILS_GROUPS=assets` }
-      end
+
+      precompile!('RAILS_GROUPS=assets')
+
       file = Dir["#{app_path}/public/assets/application-*.css"].first
       assert_match(/\/assets\/rails-([0-z]+)\.png/, File.read(file))
     end
@@ -310,9 +321,7 @@ module ApplicationTests
       app_file "public/assets/application.css", "a { color: green; }"
       app_file "public/assets/subdir/broken.png", "not really an image file"
 
-      quietly do
-        Dir.chdir(app_path){ `bundle exec rake assets:clean` }
-      end
+      clean_assets!
 
       files = Dir["#{app_path}/public/assets/**/*", "#{app_path}/tmp/cache/assets/*"]
       assert_equal 0, files.length, "Expected no assets, but found #{files.join(', ')}"
@@ -440,9 +449,8 @@ module ApplicationTests
       add_to_config "config.assets.compile = true"
       add_to_config "config.assets.digest = true"
 
-      quietly do
-        Dir.chdir(app_path){ `bundle exec rake assets:clean assets:precompile` }
-      end
+      clean_assets!
+      precompile!
 
       files = Dir["#{app_path}/public/assets/application-*.js"]
       assert_equal 1, files.length, "Expected digested application.js asset to be generated, but none found"
@@ -453,9 +461,8 @@ module ApplicationTests
       add_to_env_config "production", "config.assets.prefix = 'production_assets'"
 
       ENV["RAILS_ENV"] = nil
-      quietly do
-        Dir.chdir(app_path){ `bundle exec rake assets:clean` }
-      end
+
+      clean_assets!
 
       files = Dir["#{app_path}/public/production_assets/application.js"]
       assert_equal 0, files.length, "Expected application.js asset to be removed, but still exists"


### PR DESCRIPTION
If JavaScript runtime is not installed, execjs fails with error quietly,
while tests continue to run. This should not happen since it causes tests
to fail for unknown reason (#6621).

This commit assures that if JavaScript runtime is not installed, an assertion
is raised.
