### PR TITLE
Fixed the Gemfile when gemspec is skipped in the 'rails plugin new' command

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/Gemfile
@@ -1,17 +1,32 @@
 source "http://rubygems.org"
 
+<% if options[:skip_gemspec] -%>
+<%= '# ' if options.dev? || options.edge? -%>gem "rails", "~> <%= Rails::VERSION::STRING %>"
+<% if full? && !options[:skip_javascript] -%>
+# gem "<%= "#{options[:javascript]}-rails" %>"
+<% end -%>
+<% else -%>
 # Declare your gem's dependencies in <%= name %>.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and
 # development dependencies will be added by default to the :development group.
 gemspec
+<% end -%>
 
+<% unless options[:javascript] == 'jquery' -%>
 # jquery-rails is used by the dummy application
 gem "jquery-rails"
 
+<% end -%>
+<% if options[:skip_gemspec] -%>
+group :development do
+  gem "<%= gem_for_database %>"
+end
+<% else -%>
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
+<% end -%>
 
 <% if options.dev? || options.edge? -%>
 # Your gem is dependent on dev or edge Rails. Once you can lock this

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -269,6 +269,32 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
   def test_skipping_gemspec
     run_generator [destination_root, "--skip-gemspec"]
     assert_no_file "bukkits.gemspec"
+    assert_file "Gemfile" do |contents|
+      assert_no_match('gemspec', contents)
+      assert_match(/gem "rails", "~> #{Rails::VERSION::STRING}"/, contents)
+      assert_match(/group :development do\n  gem "sqlite3"\nend/, contents)
+      assert_no_match(/# gem "jquery-rails"/, contents)
+    end
+  end
+
+  def test_skipping_gemspec_in_full_mode
+    run_generator [destination_root, "--skip-gemspec", "--full"]
+    assert_no_file "bukkits.gemspec"
+    assert_file "Gemfile" do |contents|
+      assert_no_match('gemspec', contents)
+      assert_match(/gem "rails", "~> #{Rails::VERSION::STRING}"/, contents)
+      assert_match(/group :development do\n  gem "sqlite3"\nend/, contents)
+      assert_match(/# gem "jquery-rails"/, contents)
+      assert_no_match(/# jquery-rails is used by the dummy application\ngem "jquery-rails"/, contents)
+    end
+  end
+
+  def test_skipping_gemspec_in_full_mode_with_javascript_option
+    run_generator [destination_root, "--skip-gemspec", "--full", "--javascript=prototype"]
+    assert_file "Gemfile" do |contents|
+      assert_match(/# gem "prototype-rails"/, contents)
+      assert_match(/# jquery-rails is used by the dummy application\ngem "jquery-rails"/, contents)
+    end
   end
 
   def test_creating_plugin_in_app_directory_adds_gemfile_entry


### PR DESCRIPTION
When using `rails plugin new app_name --skip-gemspec`, the generated Gemfile still references (the now invalid) `gemspec` command. This patch allows the Gemfile to still have valid content.
