### PR TITLE
+ ActiveRecord::Base#destroy!

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Added `#destroy!` which acts like `#destroy` but will raise an
+    `ActiveRecord::RecordNotDestroyed` exception instead of returning `false`.
+
+    *Marc-André Lafortune*
+
 *   Allow blocks for `count` with `ActiveRecord::Relation`, to work similar as
     `Array#count`:
 

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -53,6 +53,10 @@ module ActiveRecord
   class RecordNotSaved < ActiveRecordError
   end
 
+  # Raised by ActiveRecord::Base.destroy! when a call to destroy would return false.
+  class RecordNotDestroyed < ActiveRecordError
+  end
+
   # Raised when SQL statement cannot be executed by the database (for example, it's often the case for
   # MySQL when Ruby driver used is too old).
   class StatementInvalid < ActiveRecordError

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -122,12 +122,28 @@ module ActiveRecord
 
     # Deletes the record in the database and freezes this instance to reflect
     # that no changes should be made (since they can't be persisted).
+    #
+    # There's a series of callbacks associated with <tt>destroy</tt>. If
+    # the <tt>before_destroy</tt> callback return +false+ the action is cancelled
+    # and <tt>destroy</tt> returns +false+. See
+    # ActiveRecord::Callbacks for further details.
     def destroy
       raise ReadOnlyRecord if readonly?
       destroy_associations
       destroy_row if persisted?
       @destroyed = true
       freeze
+    end
+
+    # Deletes the record in the database and freezes this instance to reflect
+    # that no changes should be made (since they can't be persisted).
+    #
+    # There's a series of callbacks associated with <tt>destroy!</tt>. If
+    # the <tt>before_destroy</tt> callback return +false+ the action is cancelled
+    # and <tt>destroy!</tt> raises ActiveRecord::RecordNotDestroyed. See
+    # ActiveRecord::Callbacks for further details.
+    def destroy!
+      destroy || raise(ActiveRecord::RecordNotDestroyed)
     end
 
     # Returns an instance of the specified +klass+ with the attributes of the

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -426,11 +426,13 @@ class CallbacksTest < ActiveRecord::TestCase
   def test_before_destroy_returning_false
     david = ImmutableDeveloper.find(1)
     assert !david.destroy
+    assert_raise(ActiveRecord::RecordNotDestroyed) { david.destroy! }
     assert_not_nil ImmutableDeveloper.find_by_id(1)
 
     someone = CallbackCancellationDeveloper.find(1)
     someone.cancel_before_destroy = true
     assert !someone.destroy
+    assert_raise(ActiveRecord::RecordNotDestroyed) { someone.destroy! }
     assert !someone.after_destroy_called
   end
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -305,6 +305,13 @@ class PersistencesTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::RecordNotFound) { Topic.find(topic.id) }
   end
 
+  def test_destroy!
+    topic = Topic.find(1)
+    assert_equal topic, topic.destroy!, 'topic.destroy! did not return self'
+    assert topic.frozen?, 'topic not frozen after destroy!'
+    assert_raise(ActiveRecord::RecordNotFound) { Topic.find(topic.id) }
+  end
+
   def test_record_not_found_exception
     assert_raise(ActiveRecord::RecordNotFound) { Topic.find(99999) }
   end


### PR DESCRIPTION
`save!` and variants are super useful when we have some generic exception handler setup, for example with `rescue_from`, and we expect the operation to succeed.

`destroy` actions would benefit the same way of a `destroy!` version in the same way (especially since they so often succeed).

Doesn't it sound great too? destroy!
