### PR TITLE
Metal controller doesn't have logger method, check it and then delegate

### DIFF
--- a/actionpack/lib/action_view/helpers/controller_helper.rb
+++ b/actionpack/lib/action_view/helpers/controller_helper.rb
@@ -10,12 +10,18 @@ module ActionView
       delegate :request_forgery_protection_token, :params, :session, :cookies, :response, :headers,
                :flash, :action_name, :controller_name, :controller_path, :to => :controller
 
-      delegate :logger, :to => :controller, :allow_nil => true
-
       def assign_controller(controller)
         if @_controller = controller
           @_request = controller.request if controller.respond_to?(:request)
           @_config  = controller.config.inheritable_copy if controller.respond_to?(:config)
+        end
+      end
+
+      def logger
+        if controller.respond_to?(:logger)
+          controller.logger
+        else
+          nil
         end
       end
     end


### PR DESCRIPTION
When I use Metal controller and my template contains some errors, I'm getting `undefined method`logger' for` because Metal controller doesn't contain logger method. When error is raised in my template, this line https://github.com/rails/rails/blob/master/actionpack/lib/action_view/template.rb#L297 trying to check logger but checking pass because this method have already been delegated.
