### PR TITLE
Accept a block in FormHelper#button

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -1311,10 +1311,21 @@ module ActionView
       #         post:
       #           create: "Add %{model}"
       #
-      def button(value=nil, options={})
+      # ==== Examples
+      #   button("Create a post")
+      #   # => <button name='button' type='submit'>Create post</button>
+      #
+      #   button do
+      #     content_tag(:strong, 'Ask me!')
+      #   end
+      #   # => <button name='button' type='submit'>
+      #   #      <strong>Ask me!</strong>
+      #   #    </button>
+      #
+      def button(value = nil, options = {}, &block)
         value, options = nil, value if value.is_a?(Hash)
         value ||= submit_default_value
-        @template.button_tag(value, options)
+        @template.button_tag(value, options, &block)
       end
 
       def emitted_hidden_id?

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -1054,6 +1054,9 @@ class FormHelperTest < ActionView::TestCase
       concat f.check_box(:secret)
       concat f.submit('Create post')
       concat f.button('Create post')
+      concat f.button {
+        concat content_tag(:span, 'Create post')
+      }
     end
 
     expected = whole_form("/posts/123", "create-post" , "edit_post", :method => 'patch') do
@@ -1063,7 +1066,8 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[secret]' type='hidden' value='0' />" +
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />" +
       "<input name='commit' type='submit' value='Create post' />" +
-      "<button name='button' type='submit'>Create post</button>"
+      "<button name='button' type='submit'>Create post</button>" +
+      "<button name='button' type='submit'><span>Create post</span></button>"
     end
 
     assert_dom_equal expected, output_buffer


### PR DESCRIPTION
Hi,

I would like to use a block in button helper like this:

``` erb
<%= form_for @message do |f| %>

  <%= f.button do %>
    Send a message to <strong><%= @user.name %></strong>
  <% end %>
  # => <button name='button' type='submit'>
  #      Send a message to <strong>Name</strong>
  #    </button>

<% end %>
```

This pull request is similar to #6556, but for _FormHelper#button_. I also added the example section containing 2 examples. Thanks!
