### PR TITLE
convert float and decimal to int for association preload

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -83,8 +83,9 @@ module ActiveRecord
           # Each record may have multiple owners, and vice-versa
           records_by_owner = Hash[owners.map { |owner| [owner, []] }]
           records.each do |record|
-            owner_key = record[association_key_name].to_s
-
+            raw_key   = record[association_key_name]
+            owner_key = raw_key.kind_of?(BigDecimal) ? raw_key.to_i.to_s : raw_key.to_s
+            
             owners_map[owner_key].each do |owner|
               records_by_owner[owner] << record
             end


### PR DESCRIPTION
Several db's I write tools for have BigDecimal primary keys. Rails handles this very well except for when I try to do eager loading of associations. This patch fixes this problem for me and I don't think it will cause any problems, but please let me know if you think otherwise. I can demonstrate this with a simple app but couldn't see an easy way to write a failing for the project given my experience with it.  If there is anything else I can do though, please let me know.
