### PR TITLE
add instance_accessor option to config_accesor

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add `:instance_accessor` option for `config_accessor`.
+
+        class User
+          include ActiveSupport::Configurable
+          config_accessor :allowed_access, instance_accessor: false
+        end
+
+        User.new.allowed_access = true # => NoMethodError
+        User.new.allowed_access        # => NoMethodError
+
+    *Francesco Rodriguez*
+
 *   ActionView::Helpers::NumberHelper methods have been moved to ActiveSupport::NumberHelper and are now available via
     Numeric#to_s.  Numeric#to_s now accepts the formatting  options :phone, :currency, :percentage, :delimited,
     :rounded, :human, and :human_size. *Andrew Mutz*

--- a/activesupport/test/configurable_test.rb
+++ b/activesupport/test/configurable_test.rb
@@ -5,7 +5,8 @@ class ConfigurableActiveSupport < ActiveSupport::TestCase
   class Parent
     include ActiveSupport::Configurable
     config_accessor :foo
-    config_accessor :bar, :instance_reader => false, :instance_writer => false
+    config_accessor :bar, instance_reader: false, instance_writer: false
+    config_accessor :baz, instance_accessor: false
   end
 
   class Child < Parent
@@ -19,13 +20,13 @@ class ConfigurableActiveSupport < ActiveSupport::TestCase
   end
 
   test "adds a configuration hash" do
-    assert_equal({ :foo => :bar }, Parent.config)
+    assert_equal({ foo: :bar }, Parent.config)
   end
 
   test "adds a configuration hash to a module as well" do
     mixin = Module.new { include ActiveSupport::Configurable }
     mixin.config.foo = :bar
-    assert_equal({ :foo => :bar }, mixin.config)
+    assert_equal({ foo: :bar }, mixin.config)
   end
 
   test "configuration hash is inheritable" do
@@ -39,8 +40,12 @@ class ConfigurableActiveSupport < ActiveSupport::TestCase
 
   test "configuration accessors is not available on instance" do
     instance = Parent.new
+
     assert !instance.respond_to?(:bar)
     assert !instance.respond_to?(:bar=)
+
+    assert !instance.respond_to?(:baz)
+    assert !instance.respond_to?(:baz=)
   end
 
   test "configuration hash is available on instance" do
@@ -69,6 +74,15 @@ class ConfigurableActiveSupport < ActiveSupport::TestCase
     assert_method_defined parent.config, :bar
     assert_method_defined child.config, :bar
     assert_method_defined child.new.config, :bar
+  end
+
+  test "should raise name error if attribute name is invalid" do
+    assert_raises NameError do
+      Class.new do 
+        include ActiveSupport::Configurable
+        config_accessor "invalid attribute name"
+      end
+    end
   end
 
   def assert_method_defined(object, method)


### PR DESCRIPTION
Changes:
- Add `instance_accessor` option to opt out of the instance writer and
  instance reader methods.
- Raises `NameError` if the name of the attribute is not valid.
- Update documentation and tests.
- Add CHANGELOG entry in activesupport.
