### PR TITLE
predicate xhr? on ActionDispatch::Request returns Boolean again

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -156,7 +156,7 @@ module ActionDispatch
     # (case-insensitive). All major JavaScript libraries send this header with
     # every Ajax request.
     def xml_http_request?
-      @env['HTTP_X_REQUESTED_WITH'] =~ /XMLHttpRequest/i
+      (@env['HTTP_X_REQUESTED_WITH'] =~ /XMLHttpRequest/i) == 0
     end
     alias :xhr? :xml_http_request?
 

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -380,16 +380,16 @@ class RequestTest < ActiveSupport::TestCase
   test "xml http request" do
     request = stub_request
 
-    assert !request.xml_http_request?
-    assert !request.xhr?
+    assert_equal false, request.xml_http_request?
+    assert_equal false, request.xhr?
 
     request = stub_request 'HTTP_X_REQUESTED_WITH' => 'DefinitelyNotAjax1.0'
-    assert !request.xml_http_request?
-    assert !request.xhr?
+    assert_equal false, request.xml_http_request?
+    assert_equal false, request.xhr?
 
     request = stub_request 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'
-    assert request.xml_http_request?
-    assert request.xhr?
+    assert_equal true, request.xml_http_request?
+    assert_equal true, request.xhr?
   end
 
   test "reports ssl" do


### PR DESCRIPTION
Returning either nil or 0 is rather confusing for a predicate and changes behaviour of this method. Test is adapted accordingly.
