### PR TITLE
Fixed the application_controller require_dependency path generated by the app generator

### DIFF
--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -84,10 +84,11 @@ module Rails
         end
 
         def namespaced_class_path
-          @namespaced_class_path ||= begin
-            namespace_path = namespace.name.split("::").map {|m| m.underscore }
-            namespace_path + @class_path
-          end
+          @namespaced_class_path ||= [namespace_path] + @class_path
+        end
+
+        def namespace_path
+          @namespace_path ||= namespace.name.split("::").map {|m| m.underscore }[0]
         end
 
         def class_name

--- a/railties/lib/rails/generators/rails/controller/templates/controller.rb
+++ b/railties/lib/rails/generators/rails/controller/templates/controller.rb
@@ -1,5 +1,5 @@
 <% if namespaced? -%>
-require_dependency "<%= namespaced_file_path %>/application_controller"
+require_dependency "<%= namespace_path %>/application_controller"
 
 <% end -%>
 <% module_namespacing do -%>

--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -38,7 +38,9 @@ class NamespacedControllerGeneratorTest < NamespacedGeneratorTestCase
 
   def test_namespaced_controller_with_additional_namespace
     run_generator ["admin/account"]
-    assert_file "app/controllers/test_app/admin/account_controller.rb", /module TestApp/, /  class Admin::AccountController < ApplicationController/
+    assert_file "app/controllers/test_app/admin/account_controller.rb", /module TestApp/, /  class Admin::AccountController < ApplicationController/ do |contents|
+      assert_match %r(require_dependency "test_app/application_controller"), contents
+    end
   end
 
   def test_helpr_is_also_namespaced


### PR DESCRIPTION
`application_controller.rb` is always in the same location, this patch fixes an issue where the path generated in namespaced controllers isn't correct.

e.g. `require_dependency "test_app/application_controller"` instead of `require_dependency "test_app/some/module/application_controller"`.
