### PR TITLE
fix meaningless test case

### DIFF
--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -2363,7 +2363,7 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_form_builder_does_not_have_form_for_method
-    assert ! ActionView::Helpers::FormBuilder.instance_methods.include?('form_for')
+    assert !ActionView::Helpers::FormBuilder.instance_methods.include?(:form_for)
   end
 
   def test_form_for_and_fields_for


### PR DESCRIPTION
`Module#instance_methods` returns an Array of Symbols in Ruby >= 1.9
So this was not actually testing anything
