### PR TITLE
Reduce number of String instance

### DIFF
--- a/actionpack/lib/abstract_controller/collector.rb
+++ b/actionpack/lib/abstract_controller/collector.rb
@@ -4,7 +4,7 @@ module AbstractController
   module Collector
     def self.generate_method_for_mime(mime)
       sym = mime.is_a?(Symbol) ? mime : mime.to_sym
-      const = sym.to_s.upcase
+      const = sym.upcase
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
         def #{sym}(*args, &block)                # def html(*args, &block)
           custom(Mime::#{const}, *args, &block)  #   custom(Mime::HTML, *args, &block)
@@ -19,7 +19,7 @@ module AbstractController
   protected
 
     def method_missing(symbol, &block)
-      mime_constant = Mime.const_get(symbol.to_s.upcase)
+      mime_constant = Mime.const_get(symbol.upcase)
 
       if Mime::SET.include?(mime_constant)
         AbstractController::Collector.generate_method_for_mime(mime_constant)

--- a/actionpack/lib/action_controller/caching/pages.rb
+++ b/actionpack/lib/action_controller/caching/pages.rb
@@ -110,7 +110,7 @@ module ActionController #:nodoc:
           gzip_level = options.fetch(:gzip, page_cache_compression)
           gzip_level = case gzip_level
           when Symbol
-            Zlib.const_get(gzip_level.to_s.upcase)
+            Zlib.const_get(gzip_level.upcase)
           when Fixnum
             gzip_level
           when false

--- a/actionpack/test/controller/helper_test.rb
+++ b/actionpack/test/controller/helper_test.rb
@@ -109,13 +109,13 @@ class HelperTest < ActiveSupport::TestCase
 
   def test_helper_method
     assert_nothing_raised { @controller_class.helper_method :delegate_method }
-    assert master_helper_methods.include?('delegate_method')
+    assert master_helper_methods.include?(:delegate_method)
   end
 
   def test_helper_attr
     assert_nothing_raised { @controller_class.helper_attr :delegate_attr }
-    assert master_helper_methods.include?('delegate_attr')
-    assert master_helper_methods.include?('delegate_attr=')
+    assert master_helper_methods.include?(:delegate_attr)
+    assert master_helper_methods.include?(:delegate_attr=)
   end
 
   def call_controller(klass, action)
@@ -160,16 +160,16 @@ class HelperTest < ActiveSupport::TestCase
   end
 
   def test_all_helpers
-    methods = AllHelpersController._helpers.instance_methods.map {|m| m.to_s}
+    methods = AllHelpersController._helpers.instance_methods
 
     # abc_helper.rb
-    assert methods.include?('bare_a')
+    assert methods.include?(:bare_a)
 
     # fun/games_helper.rb
-    assert methods.include?('stratego')
+    assert methods.include?(:stratego)
 
     # fun/pdf_helper.rb
-    assert methods.include?('foobar')
+    assert methods.include?(:foobar)
   end
 
   def test_all_helpers_with_alternate_helper_dir
@@ -180,35 +180,35 @@ class HelperTest < ActiveSupport::TestCase
     @controller_class.helper :all
 
     # helpers/abc_helper.rb should not be included
-    assert !master_helper_methods.include?('bare_a')
+    assert !master_helper_methods.include?(:bare_a)
 
     # alternate_helpers/foo_helper.rb
-    assert master_helper_methods.include?('baz')
+    assert master_helper_methods.include?(:baz)
   end
 
   def test_helper_proxy
-    methods = AllHelpersController.helpers.methods.map(&:to_s)
+    methods = AllHelpersController.helpers.methods
 
     # Action View
-    assert methods.include?('pluralize')
+    assert methods.include?(:pluralize)
 
     # abc_helper.rb
-    assert methods.include?('bare_a')
+    assert methods.include?(:bare_a)
 
     # fun/games_helper.rb
-    assert methods.include?('stratego')
+    assert methods.include?(:stratego)
 
     # fun/pdf_helper.rb
-    assert methods.include?('foobar')
+    assert methods.include?(:foobar)
   end
 
   private
     def expected_helper_methods
-      TestHelper.instance_methods.map {|m| m.to_s }
+      TestHelper.instance_methods
     end
 
     def master_helper_methods
-      @controller_class._helpers.instance_methods.map {|m| m.to_s }
+      @controller_class._helpers.instance_methods
     end
 
     def missing_methods

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -548,7 +548,7 @@ module ActiveRecord
           if options.is_a?(Hash) && order = options[:order]
             case order
             when Hash
-              column_names.each {|name| option_strings[name] += " #{order[name].to_s.upcase}" if order.has_key?(name)}
+              column_names.each {|name| option_strings[name] += " #{order[name].upcase}" if order.has_key?(name)}
             when String
               column_names.each {|name| option_strings[name] += " #{order.upcase}"}
             end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -175,7 +175,7 @@ HEADER
         when BigDecimal
           value.to_s
         when Date, DateTime, Time
-          "'" + value.to_s(:db) + "'"
+          "'#{value.to_s(:db)}'"
         else
           value.inspect
         end

--- a/activerecord/test/cases/finder_respond_to_test.rb
+++ b/activerecord/test/cases/finder_respond_to_test.rb
@@ -80,7 +80,6 @@ class FinderRespondToTest < ActiveRecord::TestCase
   private
 
   def ensure_topic_method_is_not_cached(method_id)
-    class << Topic; self; end.send(:remove_method, method_id) if Topic.public_methods.any? { |m| m.to_s == method_id.to_s }
+    class << Topic; self; end.send(:remove_method, method_id) if Topic.public_methods.include? method_id
   end
-
 end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -629,7 +629,7 @@ class FinderTest < ActiveRecord::TestCase
 
   def test_dynamic_finder_on_one_attribute_with_conditions_returns_same_results_after_caching
     # ensure this test can run independently of order
-    class << Account; self; end.send(:remove_method, :find_by_credit_limit) if Account.public_methods.any? { |m| m.to_s == 'find_by_credit_limit' }
+    class << Account; self; end.send(:remove_method, :find_by_credit_limit) if Account.public_methods.include?(:find_by_credit_limit)
     a = Account.where('firm_id = ?', 6).find_by_credit_limit(50)
     assert_equal a, Account.where('firm_id = ?', 6).find_by_credit_limit(50) # find_by_credit_limit has been cached
   end

--- a/activesupport/lib/active_support/core_ext/date_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/conversions.rb
@@ -39,7 +39,7 @@ class DateTime
       to_default_s
     end
   end
-  alias_method :to_default_s, :to_s unless (instance_methods(false) & [:to_s, 'to_s']).empty?
+  alias_method :to_default_s, :to_s if instance_methods(false).include?(:to_s)
   alias_method :to_s, :to_formatted_s
 
   #

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -107,7 +107,6 @@ class Module
       raise ArgumentError, 'Delegation needs a target. Supply an options hash with a :to key as the last argument (e.g. delegate :hello, :to => :greeter).'
     end
 
-    to = to.to_s
     prefix, allow_nil = options.values_at(:prefix, :allow_nil)
 
     if prefix == true && to =~ /^[^a-z_]/
@@ -125,8 +124,6 @@ class Module
     line = line.to_i
 
     methods.each do |method|
-      method = method.to_s
-
       # Attribute writer methods only accept one argument. Makes sure []=
       # methods still accept two arguments.
       definition = (method =~ /[^\]]=$/) ? 'arg' : '*args, &block'

--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -114,7 +114,7 @@ module ActiveSupport
     #
     def color(text, color, bold=false)
       return text unless colorize_logging
-      color = self.class.const_get(color.to_s.upcase) if color.is_a?(Symbol)
+      color = self.class.const_get(color.upcase) if color.is_a?(Symbol)
       bold  = bold ? BOLD : ""
       "#{bold}#{color}#{text}#{CLEAR}"
     end

--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -61,7 +61,7 @@ module ActiveSupport
         @@flushable_loggers = nil
 
         log_subscriber.public_methods(false).each do |event|
-          next if 'call' == event.to_s
+          next if :call == event
 
           notifier.subscribe("#{event}.#{namespace}", log_subscriber)
         end

--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -83,7 +83,7 @@ module ActiveSupport
       if name.is_a?(Module)
         @backend = name
       else
-        require "active_support/xml_mini/#{name.to_s.downcase}"
+        require "active_support/xml_mini/#{name.downcase}"
         @backend = ActiveSupport.const_get("XmlMini_#{name}")
       end
     end

--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -135,7 +135,7 @@ module Rails
         end
 
         def route_url
-          @route_url ||= class_path.collect{|dname| "/" + dname  }.join('') + "/" + plural_file_name
+          @route_url ||= class_path.collect {|dname| "/" + dname }.join + "/" + plural_file_name
         end
 
         # Tries to retrieve the application name or simple return application.

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -1009,9 +1009,7 @@ YAML
 
       boot_rails
 
-      methods = Bukkits::Engine.helpers.public_instance_methods.collect(&:to_s).sort
-      expected = ["bar", "baz"]
-      assert_equal expected, methods
+      assert_equal [:bar, :baz], Bukkits::Engine.helpers.public_instance_methods.sort
     end
 
     test "setting priority for engines with config.railties_order" do


### PR DESCRIPTION
Inspired by @elisehuard's GC talk at EuRuKo, I tried to reduce instances of `String` in Rails code.

I haven't done actual performance benchmarks, but number of `ObjectSpace.each_object(String).count` was significantly decreased on my simple test app.

```
before: 128696
after: 121995
```
