### PR TITLE
MiniTest::Spec shipped with Ruby >= 1.9.3 always responds_to __name__

### DIFF
--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -22,8 +22,7 @@ module ActiveSupport
     end
 
     Assertion = MiniTest::Assertion
-    alias_method :method_name, :name if method_defined? :name
-    alias_method :method_name, :__name__ if method_defined? :__name__
+    alias_method :method_name, :__name__
 
     $tags = {}
     def self.for_tag(tag)


### PR DESCRIPTION
This code was [originally written](https://github.com/rails/rails/commit/9d7aae7) this way in order to absorb API difference between MiniTest < 1.4 and >= 1.4.

Ruby >= 1.9.3 is shipped with MiniTest >= 2.5.1, so we can simplify the code here.

```
% ruby -v -rminitest/spec -e 'p MiniTest::Spec.instance_methods.include?(:__name__)'
ruby 1.9.3p0 (2011-10-30 revision 33570) [x86_64-darwin11.1.0]
true
```
