### PR TITLE
Use mysql native commands when dumping/loading on mysql. Partially Fix #5547.

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -399,7 +399,10 @@ db_namespace = namespace :db do
       abcs = ActiveRecord::Base.configurations
       filename = ENV['DB_STRUCTURE'] || File.join(Rails.root, "db", "structure.sql")
       case abcs[Rails.env]['adapter']
-      when /mysql/, 'oci', 'oracle'
+      when /mysql/
+        options = prepare_mysql_env(abcs[Rails.env])
+        `mysqldump -d #{options} > #{Shellwords.escape(filename)}`
+      when 'oci', 'oracle'
         ActiveRecord::Base.establish_connection(abcs[Rails.env])
         File.open(filename, "w:utf-8") { |f| f << ActiveRecord::Base.connection.structure_dump }
       when /postgresql/
@@ -438,11 +441,8 @@ db_namespace = namespace :db do
       filename = ENV['DB_STRUCTURE'] || File.join(Rails.root, "db", "structure.sql")
       case abcs[env]['adapter']
       when /mysql/
-        ActiveRecord::Base.establish_connection(abcs[env])
-        ActiveRecord::Base.connection.execute('SET foreign_key_checks = 0')
-        IO.read(filename).split("\n\n").each do |table|
-          ActiveRecord::Base.connection.execute(table)
-        end
+        options = prepare_mysql_env(abcs[Rails.env])
+        `mysql #{options} < #{Shellwords.escape(filename)}`
       when /postgresql/
         set_psql_env(abcs[env])
         `psql -f "#{filename}" #{abcs[env]['database']}`
@@ -641,4 +641,18 @@ def set_psql_env(config)
   ENV['PGPORT']     = config['port'].to_s     if config['port']
   ENV['PGPASSWORD'] = config['password'].to_s if config['password']
   ENV['PGUSER']     = config['username'].to_s if config['username']
+end
+
+def prepare_mysql_env(config)
+  args = {
+    'host'      => '--host',
+    'port'      => '--port',
+    'socket'    => '--socket',
+    'username'  => '--user',
+    'password'  => '--password',
+    'encoding'  => '--default-character-set'
+  }.map { |opt, arg| "#{arg}=#{Shellwords.escape(config[opt])}" if config[opt] }.compact
+
+  args << Shellwords.escape(config['database'])
+  args.join(" ")
 end


### PR DESCRIPTION
Please see https://github.com/rails/rails/issues/5547.

@daemon says:

> For mysql/oracle rake task db:structure:dump has it's own dumper implementation, but for other databases it uses external utils to build dump.
> 
> And it does matter when you use views/triggers/procedures with mysql: tests are simply failing because mentioned objects are missing in test db after dump/load.

I agree with him.

p.s. I want to tell me where to write the test cases of this (railties ? but this is mysql speficic fix)
