### PR TITLE
Logger in metal backport for 3.2

### DIFF
--- a/actionpack/lib/action_view/helpers/controller_helper.rb
+++ b/actionpack/lib/action_view/helpers/controller_helper.rb
@@ -10,13 +10,15 @@ module ActionView
       delegate :request_forgery_protection_token, :params, :session, :cookies, :response, :headers,
                :flash, :action_name, :controller_name, :controller_path, :to => :controller
 
-      delegate :logger, :to => :controller, :allow_nil => true
-
       def assign_controller(controller)
         if @_controller = controller
           @_request = controller.request if controller.respond_to?(:request)
           @_config  = controller.config.inheritable_copy if controller.respond_to?(:config)
         end
+      end
+
+      def logger
+        controller.logger if controller.respond_to?(:logger)
       end
     end
   end

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -718,6 +718,14 @@ class TestController < ActionController::Base
     end
 end
 
+class MetalTestController < ActionController::Metal
+  include ActionController::Rendering
+
+  def accessing_logger_in_template
+    render :inline =>  "<%= logger.class %>"
+  end
+end
+
 class RenderTest < ActionController::TestCase
   tests TestController
 
@@ -1581,5 +1589,14 @@ class LastModifiedRenderTest < ActionController::TestCase
     @request.if_modified_since = 5.years.ago.httpdate
     get :conditional_hello_with_bangs
     assert_response :success
+  end
+end
+
+class MetalRenderTest < ActionController::TestCase
+  tests MetalTestController
+
+  def test_access_to_logger_in_view
+    get :accessing_logger_in_template
+    assert_equal "NilClass", @response.body
   end
 end


### PR DESCRIPTION
Just backport that metal controller doesn't have logger method for 3.2 /cc @josevalim
