### PR TITLE
Index js css fix

### DIFF
--- a/actionpack/lib/sprockets/static_compiler.rb
+++ b/actionpack/lib/sprockets/static_compiler.rb
@@ -16,8 +16,8 @@ module Sprockets
     def compile
       manifest = {}
       env.each_logical_path do |logical_path|
-        if File.basename(logical_path)[/[^\.]+/, 0] == 'index'
-          logical_path.sub!(/\/index\./, '.')
+        if File.directory?(logical_path)
+          logical_path.sub!(/(\.[^\.]+)$/, "/index\1")
         end
         next unless compile_path?(logical_path)
         if asset = env.find_asset(logical_path)


### PR DESCRIPTION
Issue #3993 was about Sprockets not acting as documented in production environments.

Specifically, during assets precompile, 'javascript_include_tag' is supposed to notice when the included path is a directory, and use an 'index.js' or 'index.css' file from inside that directory as a manifest:

http://guides.rubyonrails.org/asset_pipeline.html#using-index-files

#3993 was closed when a fix (SHA: df8457748ebbfa092c4c10aedda57aeef2f28776) was merged.  The problem is that the fix is not only incorrect, it actually introduced a new bug.

The fix as merged converts paths pointing to index.\* files into paths pointing at their enclosing directories.  This is the opposite of the documented behavior -- if the original path is a directory, 'index' needs to be _added_ to the path to find the file inside the directory.

That commit therefore broke asset precompile such that any existing asset files named 'index.(js|css)' are completely skipped over, without fixing the original issue.  This commit fixes the new bug and makes the feature work as documented, actually resolving #3993.
