### PR TITLE
Postgresql auto reconnect 2

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1381,7 +1381,7 @@ module ActiveRecord
         UNIQUE_VIOLATION      = "23505"
 
         def translate_exception(exception, message)
-          case exception.result.error_field(PGresult::PG_DIAG_SQLSTATE)
+          case exception.result.try(:error_field, PGresult::PG_DIAG_SQLSTATE)
           when UNIQUE_VIOLATION
             RecordNotUnique.new(message, exception)
           when FOREIGN_KEY_VIOLATION

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -474,6 +474,7 @@ module ActiveRecord
       def reconnect!
         clear_cache!
         @connection.reset
+        @open_transactions = 0
         configure_connection
       end
 

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -81,5 +81,77 @@ module ActiveRecord
       assert_equal 'SCHEMA', @connection.logged[0][1]
     end
 
+    def test_reconnection_after_simulated_disconnection_with_verify
+      assert @connection.active?
+      original_connection_pid = @connection.query('select pg_backend_pid()')
+
+      # Fail with bad connection after next query attempt.
+      connection_class = class << @connection ; self ; end
+      connection_class.class_eval <<-CODE
+        def query_fake(*args)
+          if @called ||= false
+            @connection.stubs(:status).returns(PCconn::CONNECTION_BAD)
+            raise PGError
+          else
+            @called = true
+            @connection.unstub(:status)
+            query_unfake(*args)
+          end
+        end
+
+        alias  query_unfake    query
+        alias     query     query_fake
+      CODE
+
+      begin
+        @connection.verify!
+        new_connection_pid = @connection.query('select pg_backend_pid()')
+      ensure
+        connection_class.class_eval <<-CODE
+          alias   query    query_unfake
+          undef query_fake
+        CODE
+      end
+
+      assert_equal original_connection_pid, new_connection_pid, "Should have a new underlying connection pid"
+    end
+
+    # Must have with_manual_interventions set to true for this
+    # test to run.
+    # When prompted, restart the PostgreSQL server with the
+    # "-m fast" option or kill the individual connection assuming
+    # you know the incantation to do that.
+    # To restart PostgreSQL 9.1 on OS X, installed via MacPorts, ...
+    # sudo su postgres -c "pg_ctl restart -D /opt/local/var/db/postgresql91/defaultdb/ -m fast"
+    def test_reconnection_after_actual_disconnection_with_verify
+      skip "with_manual_interventions is false in configuration" unless ARTest.config['with_manual_interventions']
+
+      original_connection_pid = @connection.query('select pg_backend_pid()')
+
+      # Sanity check.
+      assert @connection.active?
+
+      puts 'Kill the connection now (e.g. by restarting the PostgreSQL ' +
+           'server with the "-m fast" option) and then press enter.'
+      $stdin.gets
+
+      @connection.verify!
+
+      assert @connection.active?
+
+      # If we get no exception here, then either we re-connected successfully, or
+      # we never actually got disconnected.
+      new_connection_pid = @connection.query('select pg_backend_pid()')
+
+      assert_not_equal original_connection_pid, new_connection_pid,
+        "umm -- looks like you didn't break the connection, because we're still " +
+        "successfully querying with the same connection pid."
+
+      # Repair all fixture connections so other tests won't break.
+      @fixture_connections.each do |c|
+        c.verify!
+      end
+    end
+
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -99,8 +99,8 @@ module ActiveRecord
           end
         end
 
-        alias  query_unfake    query
-        alias     query     query_fake
+        alias query_unfake query
+        alias query        query_fake
       CODE
 
       begin
@@ -108,7 +108,7 @@ module ActiveRecord
         new_connection_pid = @connection.query('select pg_backend_pid()')
       ensure
         connection_class.class_eval <<-CODE
-          alias   query    query_unfake
+          alias query query_unfake
           undef query_fake
         CODE
       end

--- a/activerecord/test/config.example.yml
+++ b/activerecord/test/config.example.yml
@@ -1,5 +1,7 @@
 default_connection: <%= defined?(JRUBY_VERSION) ? 'jdbcsqlite3' : 'sqlite3' %>
 
+with_manual_interventions: false
+
 connections:
   jdbcderby:
     arunit:  activerecord_unittest


### PR DESCRIPTION
Fixes not-quite-working PostgreSQL auto-reconnection on `Connection#verify!` and puts test coverage in place so that it should continue to work.
