### PR TITLE
Notify A User they Have Pending Migrations 

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -32,6 +32,12 @@ module ActiveRecord
     end
   end
 
+  class PendingMigrationError < ActiveRecordError#:nodoc:
+    def initialize
+      super("Migrations are pending run 'bundle exec rake db:migrate RAILS_ENV=#{ENV['RAILS_ENV']}' to resolve the issue")
+    end
+  end
+
   # = Active Record Migrations
   #
   # Migrations can manage the evolution of a schema used by several physical
@@ -326,8 +332,26 @@ module ActiveRecord
   class Migration
     autoload :CommandRecorder, 'active_record/migration/command_recorder'
 
+
+    # This class is used to verify that all migrations have been run before
+    # loading a web page if config.active_record.migration_error is set to :page_load
+    class CheckPending
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        ActiveRecord::Migration.check_pending!
+        status, headers, body = @app.call(env)
+      end
+    end
+
     class << self
       attr_accessor :delegate # :nodoc:
+    end
+
+    def self.check_pending!
+      raise ActiveRecord::PendingMigrationError if ActiveRecord::Migrator::needs_migrations?
     end
 
     def self.method_missing(name, *args, &block) # :nodoc:
@@ -605,8 +629,8 @@ module ActiveRecord
         end
       end
 
-      def needs_migration?
-        current_version != last_version
+      def needs_migrations?
+        current_version < last_version
       end
 
       def last_version

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -605,6 +605,14 @@ module ActiveRecord
         end
       end
 
+      def needs_migration?
+        current_version != last_version
+      end
+
+      def last_version
+        migrations(migrations_paths).last.try(:version)||0
+      end
+
       def proper_table_name(name)
         # Use the Active Record objects own table_name, or pre/suffix from ActiveRecord::Base if name is a symbol/string
         name.table_name rescue "#{ActiveRecord::Base.table_name_prefix}#{name}#{ActiveRecord::Base.table_name_suffix}"

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -59,6 +59,13 @@ module ActiveRecord
       ActiveSupport.on_load(:active_record) { self.logger ||= ::Rails.logger }
     end
 
+    initializer "active_record.migration_error" do |app|
+      if config.active_record.delete(:migration_error) == :page_load
+        config.app_middleware.insert_after "::ActionDispatch::Callbacks",
+          "ActiveRecord::Migration::CheckPending"
+      end
+    end
+
     initializer "active_record.set_configs" do |app|
       ActiveSupport.on_load(:active_record) do
         if app.config.active_record.delete(:whitelist_attributes)

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -56,6 +56,21 @@ class MigrationTest < ActiveRecord::TestCase
     Person.reset_column_information
   end
 
+  def test_migrator_versions
+    migrations_path = MIGRATIONS_ROOT + "/valid"
+    ActiveRecord::Migrator.migrations_paths = migrations_path
+
+    ActiveRecord::Migrator.up(migrations_path)
+    assert_equal 3, ActiveRecord::Migrator.current_version
+    assert_equal 3, ActiveRecord::Migrator.last_version
+    assert_equal false, ActiveRecord::Migrator.needs_migration?
+
+    ActiveRecord::Migrator.down(MIGRATIONS_ROOT + "/valid")
+    assert_equal 0, ActiveRecord::Migrator.current_version
+    assert_equal 3, ActiveRecord::Migrator.last_version
+    assert_equal true, ActiveRecord::Migrator.needs_migration?
+  end
+
   def test_create_table_with_force_true_does_not_drop_nonexisting_table
     if Person.connection.table_exists?(:testings2)
       Person.connection.drop_table :testings2

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -63,12 +63,12 @@ class MigrationTest < ActiveRecord::TestCase
     ActiveRecord::Migrator.up(migrations_path)
     assert_equal 3, ActiveRecord::Migrator.current_version
     assert_equal 3, ActiveRecord::Migrator.last_version
-    assert_equal false, ActiveRecord::Migrator.needs_migration?
+    assert_equal false, ActiveRecord::Migrator.needs_migrations?
 
     ActiveRecord::Migrator.down(MIGRATIONS_ROOT + "/valid")
     assert_equal 0, ActiveRecord::Migrator.current_version
     assert_equal 3, ActiveRecord::Migrator.last_version
-    assert_equal true, ActiveRecord::Migrator.needs_migration?
+    assert_equal true, ActiveRecord::Migrator.needs_migrations?
   end
 
   def test_create_table_with_force_true_does_not_drop_nonexisting_table

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -26,6 +26,9 @@
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL).
   config.active_record.auto_explain_threshold_in_seconds = 0.5
+
+  # Raise an error on page load if there are pending migrations
+  config.active_record.migration_error = :page_load
   <%- end -%>
 
   <%- unless options.skip_sprockets? -%>

--- a/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb
+++ b/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb
@@ -4,6 +4,8 @@ require 'rails/test_help'
 
 class ActiveSupport::TestCase
 <% unless options[:skip_active_record] -%>
+  ActiveRecord::Migration.check_pending!
+
   # Setup all fixtures in test/fixtures/*.(yml|csv) for all tests in alphabetical order.
   #
   # Note: You'll currently still have to declare fixtures explicitly in integration tests


### PR DESCRIPTION
## Problem

After a member of a team adds commits new code and a migration, other developers might not notice the migration and will get `NoMethodError`, `UnknownAttributeError`, or other exceptions raised.

I've seen this behavior confuse beginner rails developers and seasoned devs. Usually they are capable of figuring out they need to run migrations, but the error is misleading, frustrating, and potentially time consuming.
## Solution

raise error for pending migration

Can be configured by setting `config.active_record.migration`. Setting to `:page_load` will raise an error on each page refresh if there are migrations that are pending. Setting to `:page_load` is defaulted in development for new applications.

Setting `config.active_record.migration` to `:app_start` will raise an error when the app is initialized if there are pending migrations. Setting to `:app_start` is defaulted in test mode.

This check is turned off in production.

The check can be disabled by setting `config.active_record.skip_migration_errors = true`. This is useful when the error would conflict with fixing the problem such as having an error on `:app_start`  and trying to run `rake db:migrate` which starts the app. A convenience rake task is also included to be run before `:environment` is loaded on crucial tasks.
## Notes

This PR picks up where #4165 left off.

Screenshot of `:page_load` error: http://cl.ly/0Q0t3z1s3R2Z142p2o1B

Screenshot of `:app_start` error: http://cl.ly/1k0c1i2O0v122T3P2Y1n

Railties Tests are green: https://gist.github.com/2885779

AR Tests are green: https://gist.github.com/2885796

cc/ @jonleighton
