### PR TITLE
Skip two tests with polymorphic if current adapter is Oracle Adapter.

### DIFF
--- a/activerecord/test/cases/migration/references_index_test.rb
+++ b/activerecord/test/cases/migration/references_index_test.rb
@@ -51,6 +51,8 @@ module ActiveRecord
       end
 
       def test_creates_polymorphic_index
+        return skip "Oracle Adapter does not support foreign keys if :polymorphic => true is used" if current_adapter? :OracleAdapter
+
         connection.create_table table_name do |t|
           t.references :foo, :polymorphic => true, :index => true
         end
@@ -86,6 +88,7 @@ module ActiveRecord
       end
 
       def test_creates_polymorphic_index_for_existing_table
+        return skip "Oracle Adapter does not support foreign keys if :polymorphic => true is used" if current_adapter? :OracleAdapter
         connection.create_table table_name
         connection.change_table table_name do |t|
           t.references :foo, :polymorphic => true, :index => true


### PR DESCRIPTION
Oracle Adapter does not support foreign keys if :polymorphic => true is used.

See [line 105](https://github.com/rsim/oracle-enhanced/blob/master/lib/active_record/connection_adapters/oracle_enhanced_schema_definitions.rb).

This pull request has been tested with sqlite3, mysql, mysql2 and postgresql adapters.
