### PR TITLE
Compact array of values added to PermissionSet instance

### DIFF
--- a/activemodel/lib/active_model/mass_assignment_security/permission_set.rb
+++ b/activemodel/lib/active_model/mass_assignment_security/permission_set.rb
@@ -5,7 +5,7 @@ module ActiveModel
     class PermissionSet < Set
 
       def +(values)
-        super(values.map(&:to_s))
+        super(values.compact.map(&:to_s))
       end
 
       def include?(key)

--- a/activemodel/test/cases/mass_assignment_security/permission_set_test.rb
+++ b/activemodel/test/cases/mass_assignment_security/permission_set_test.rb
@@ -13,6 +13,12 @@ class PermissionSetTest < ActiveModel::TestCase
     assert new_list.include?('admin'), "did not add collection to #{@permission_list.inspect}}"
   end
 
+  test "+ compacts added collection values" do
+    added_collection = [ nil ]
+    new_list = @permission_list + added_collection
+    assert_equal new_list, @permission_list, "did not add collection to #{@permission_list.inspect}}"
+  end
+
   test "include? normalizes multi-parameter keys" do
     multi_param_key = 'admin(1)'
     new_list = @permission_list += [ 'admin' ]


### PR DESCRIPTION
It is necessary to compact arrays with nil values.

For example, if we enforce

``` ruby
  config.active_record.whitelist_attributes = true
```

on_load hook will call attr_accessible(nil) on ActiveRecord
and it appears that ActiveRecord class attribute _accessible_attributes now is set to 

``` ruby
{ :default => #<ActiveModel::MassAssignmentSecurity::WhiteList: {""}> }
```

(https://github.com/rails/rails/blob/master/activemodel/lib/active_model/mass_assignment_security.rb#L183)

And when we try to set attr_accessible on any other model, for example

``` ruby
  class User < ActiveRecord
    attr_accessible :admin
  end
```

and call accessible_attributes,  we can get a blank value together with 'admin'

``` ruby
  User.accessible_attributes = ["", "admin"]
```
