### PR TITLE
Bad Regexp exploits "fix" master branch

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -37,6 +37,11 @@
 
 *   Trim down Active Model API by removing `valid?` and `errors.full_messages` *José Valim*
 
+*   When `^` or `$` are used in the regular expression provided to `validates_format_of` and the :multiline option is not set to true, an exception will be raised. This is to prevent security vulnerabilities when using `validates_format_of`. The problem is described in detail in the Rails security guide.
+
+## Rails 3.2.6 (Jun 12, 2012) ##
+
+*   No changes.
 
 ## Rails 3.2.5 (Jun 1, 2012) ##
 

--- a/activemodel/test/cases/validations/format_validation_test.rb
+++ b/activemodel/test/cases/validations/format_validation_test.rb
@@ -11,7 +11,7 @@ class PresenceValidationTest < ActiveModel::TestCase
   end
 
   def test_validate_format
-    Topic.validates_format_of(:title, :content, :with => /^Validation\smacros \w+!$/, :message => "is bad data")
+    Topic.validates_format_of(:title, :content, :with => /\AValidation\smacros \w+!\z/, :message => "is bad data")
 
     t = Topic.new("title" => "i'm incorrect", "content" => "Validation macros rule!")
     assert t.invalid?, "Shouldn't be valid"
@@ -27,7 +27,7 @@ class PresenceValidationTest < ActiveModel::TestCase
   end
 
   def test_validate_format_with_allow_blank
-    Topic.validates_format_of(:title, :with => /^Validation\smacros \w+!$/, :allow_blank => true)
+    Topic.validates_format_of(:title, :with => /\AValidation\smacros \w+!\z/, :allow_blank => true)
     assert Topic.new("title" => "Shouldn't be valid").invalid?
     assert Topic.new("title" => "").valid?
     assert Topic.new("title" => nil).valid?
@@ -36,7 +36,7 @@ class PresenceValidationTest < ActiveModel::TestCase
 
   # testing ticket #3142
   def test_validate_format_numeric
-    Topic.validates_format_of(:title, :content, :with => /^[1-9][0-9]*$/, :message => "is bad data")
+    Topic.validates_format_of(:title, :content, :with => /\A[1-9][0-9]*\z/, :message => "is bad data")
 
     t = Topic.new("title" => "72x", "content" => "6789")
     assert t.invalid?, "Shouldn't be valid"
@@ -63,10 +63,20 @@ class PresenceValidationTest < ActiveModel::TestCase
   end
 
   def test_validate_format_with_formatted_message
-    Topic.validates_format_of(:title, :with => /^Valid Title$/, :message => "can't be %{value}")
+    Topic.validates_format_of(:title, :with => /\AValid Title\z/, :message => "can't be %{value}")
     t = Topic.new(:title => 'Invalid title')
     assert t.invalid?
     assert_equal ["can't be Invalid title"], t.errors[:title]
+  end
+  
+  def test_validate_format_of_with_multiline_regexp_should_raise_error
+    assert_raise(ArgumentError) { Topic.validates_format_of(:title, :with => /^Valid Title$/) }
+  end
+  
+  def test_validate_format_of_with_multiline_regexp_and_option
+    assert_nothing_raised(ArgumentError) do
+      Topic.validates_format_of(:title, :with => /^Valid Title$/, :multiline => true)
+    end
   end
 
   def test_validate_format_with_not_option

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -141,7 +141,7 @@ class I18nValidationTest < ActiveModel::TestCase
 
   COMMON_CASES.each do |name, validation_options, generate_message_options|
     test "validates_format_of on generated message #{name}" do
-      Person.validates_format_of :title, validation_options.merge(:with => /^[1-9][0-9]*$/)
+      Person.validates_format_of :title, validation_options.merge(:with => /\A[1-9][0-9]*\z/)
       @person.title = '72x'
       @person.errors.expects(:generate_message).with(:title, :invalid, generate_message_options.merge(:value => '72x'))
       @person.valid?
@@ -291,7 +291,7 @@ class I18nValidationTest < ActiveModel::TestCase
   # validates_format_of w/o mocha
 
   set_expectations_for_validation "validates_format_of", :invalid do |person, options_to_merge|
-    Person.validates_format_of :title, options_to_merge.merge(:with => /^[1-9][0-9]*$/)
+    Person.validates_format_of :title, options_to_merge.merge(:with => /\A[1-9][0-9]*\z/)
   end
 
   # validates_inclusion_of w/o mocha

--- a/guides/source/active_model_basics.textile
+++ b/guides/source/active_model_basics.textile
@@ -187,7 +187,7 @@ class Person
   attr_accessor :name, :email, :token
   
   validates :name, :presence => true
-  validates_format_of :email, :with => /^([^\s]+)((?:[-a-z0-9]\.)[a-z]{2,})$/i  
+  validates_format_of :email, :with => /\A([^\s]+)((?:[-a-z0-9]\.)[a-z]{2,})\z/i  
   validates! :token, :presence => true
   
 end

--- a/guides/source/security.textile
+++ b/guides/source/security.textile
@@ -588,25 +588,42 @@ h4. Regular Expressions
 
 INFO: _A common pitfall in Ruby's regular expressions is to match the string's beginning and end by ^ and $, instead of \A and \z._
 
-Ruby uses a slightly different approach than many other languages to match the end and the beginning of a string. That is why even many Ruby and Rails books make this wrong. So how is this a security threat? Imagine you have a File model and you validate the file name by a regular expression like this:
+Ruby uses a slightly different approach than many other languages to match the end and the beginning of a string. That is why even many Ruby and Rails books make this wrong. So how is this a security threat? Say you wanted to loosely validate a URL field and you used a simple regular expression like this:
 
 <ruby>
-class File < ActiveRecord::Base
-  validates :name, :format => /^[\w\.\-\<plus>]<plus>$/
-end
+  /^https?:\/\/[^\n]+$/i
 </ruby>
 
-This means, upon saving, the model will validate the file name to consist only of alphanumeric characters, dots, + and -. And the programmer added ^ and $ so that file name will contain these characters from the beginning to the end of the string. However, _(highlight)in Ruby ^ and $ matches the *line* beginning and line end_. And thus a file name like this passes the filter without problems:
+This may work fine in some languages. However, _(highlight)in Ruby ^ and $ match the *line* beginning and line end_. And thus a URL like this passes the filter without problems:
 
 <plain>
-file.txt%0A<script>alert('hello')</script>
+javascript:exploit_code();/*
+http://hi.com
+*/
 </plain>
 
-Whereas %0A is a line feed in URL encoding, so Rails automatically converts it to "file.txt\n&lt;script&gt;alert('hello')&lt;/script&gt;". This file name passes the filter because the regular expression matches – up to the line end, the rest does not matter. The correct expression should read:
+This URL passes the filter because the regular expression matches – the second line, the rest does not matter. Now imagine we had a view that showed the URL like this:
 
 <ruby>
-/\A[\w\.\-\<plus>]<plus>\z/
+  link_to "Homepage", @user.homepage
 </ruby>
+
+The link looks innocent to visitors, but when it's clicked, it will execute the javascript function "exploit_code" or any other javascript the attacker provides.
+
+To fix the regular expression, \A and \z should be used instead of ^ and $, like so:
+
+<ruby>
+  /\Ahttps?:\/\/[^\n]+\z/i
+</ruby>
+
+Since this is a frequent mistake, the format validator (validates_format_of) now raises an exception if the provided regular expression starts with ^ or ends with $. If you do need to use ^ and $ instead of \A and \z (which is rare), you can set the :multiline option to true, like so:
+
+<ruby>
+  # content should include a line "Meanwhile" anywhere in the string
+  validates :content, :format => { :with => /^Meanwhile$/, :multiline => true }
+</ruby>
+
+Note that this only protects you against the most common mistake when using the format validator - you always need to keep in mind that ^ and $ match the *line* beginning and line end in Ruby, and not the beginning and end of a string.
 
 h4. Privilege Escalation
 


### PR DESCRIPTION
See https://github.com/rails/rails/pull/6569 for info.

I only ran ActiveModel tests, so if you have bad test isolation you might have to fix some tests outside ActiveModel, if they use validates_format_of.

Discussion:
Obviously the description in the security guides is not enough since ^$ are misused even in most of the ActiveModel tests. You even give an exploitable regexp as an example in http://edgeguides.rubyonrails.org/active_model_basics.html!
So if the problem is present even in core Rails then I don't think there's anything to think about.

We have seen this exploited on Github, Soundcloud, Tumblr, your own docs, your own tests, even veteran Rails developers make this mistake. Yes I always said this only partially solves the problem BUT it is the best solution I've seen, because it does cover the vast majority of vulnerabilities and at the same time the effect on proper code is negligible, even more so because proper code usually does not need to use ^$ in format validation (it really is a corner case). And even if you have this corner case the error goes away by adding one simple option to your validator.
There is no way of completely solving this without changing the Ruby language defaults and breaking loads of existing code, which wouldn't make sense because this is how behavior for RegExp is defined in Ruby and I doubt this will change, nor is there a real reason to change it.
And again I will reiterate, the vast majority of related vulnerabilities come when a bad regexp is used with validates_format_of, and in the vast majority of cases using ^$ in validates_format_of is wrong so this change affects almost no one who already has proper code. The ^$ are mostly useful with gsub and extracting subpatterns, not for validation.

I mean think about it, when did you need a validation that accepts multiline input and only needs 1 of the lines to match the RegExp to be valid? Never? With that in mind it would not be such a stretch anymore to say it's actually a vulnerability or at least poor behavior and not just an educational problem. Using ^$ in format validators is a corner case and should be treated as such. If you need validation like that you are doing something really weird and there's probably a better way to do it without requiring validation like that.
