### PR TITLE
Validates_numericality_of is skipped when changing 0 to to non-empty str...

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -72,11 +72,8 @@ module ActiveRecord
 
       def _field_changed?(attr, old, value)
         if column = column_for_attribute(attr)
-          if column.number? && column.null && (old.nil? || old == 0) && value.blank?
-            # For nullable numeric columns, NULL gets stored in database for blank (i.e. '') values.
-            # Hence we don't record it as a change if the value changes from nil to ''.
-            # If an old value of 0 is set to '' we want this to get changed to nil as otherwise it'll
-            # be typecast back to 0 (''.to_i => 0)
+          if numeric_changes_from_nil_to_empty_string?(column, old, value) ||
+            numeric_changes_from_zero_to_string?(column, old, value)
             value = nil
           else
             value = column.type_cast(value)
@@ -84,6 +81,19 @@ module ActiveRecord
         end
 
         old != value
+      end
+
+      def numeric_changes_from_nil_to_empty_string?(column, old, value)
+        # For nullable numeric columns, NULL gets stored in database for blank (i.e. '') values.
+        # Hence we don't record it as a change if the value changes from nil to ''.
+        # If an old value of 0 is set to '' we want this to get changed to nil as otherwise it'll
+        # be typecast back to 0 (''.to_i => 0)
+        column.number? && column.null && (old.nil? || old == 0) && value.blank?
+      end
+
+      def numeric_changes_from_zero_to_string?(column, old, value)
+        # For numeric columns with old 0 and value non-empty string
+        column.number? && old == 0 && value != '0' && !value.blank? && !old.nil?
       end
     end
   end

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -781,6 +781,16 @@ module NestedAttributesOnACollectionAssociationTests
     assert_nothing_raised(NoMethodError) { @pirate.save! }
   end
 
+  def test_numeric_colum_changes_from_zero_to_no_empty_string
+    Man.accepts_nested_attributes_for(:interests)
+    Interest.validates_numericality_of(:zine_id)
+    man = Man.create(:name => 'John')
+    interest = man.interests.create(:topic=>'bar',:zine_id => 0)
+    assert  interest.save
+
+    assert  !man.update_attributes({:interests_attributes => { :id => interest.id, :zine_id => 'foo' }})
+  end
+
   private
 
   def association_setter


### PR DESCRIPTION
...ing, fixes #6393

This happens when A has_many many B and A accepts_nested_attributes B that has a numeric colum
with initial 0 value. So a.update_attributes({:b_attributes => { :id => b.id, :numeric => 'foo' }})
passes the validation test but, the value of :numeric doesn't change.
his commit forces that the update fails with the above conditions.
