### PR TITLE
Don't assign the attributes if the list is empty

### DIFF
--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -64,7 +64,7 @@ module ActiveRecord
     #   user.name       # => "Josh"
     #   user.is_admin?  # => true
     def assign_attributes(new_attributes, options = {})
-      return unless new_attributes
+      return if new_attributes.blank?
 
       attributes = new_attributes.stringify_keys
       multi_parameter_attributes = []

--- a/activerecord/test/cases/mass_assignment_security_test.rb
+++ b/activerecord/test/cases/mass_assignment_security_test.rb
@@ -98,6 +98,10 @@ class MassAssignmentSecurityTest < ActiveRecord::TestCase
     Firm.new.assign_attributes(nil)
   end
 
+  def test_mass_assigning_does_not_choke_on_empty_hash
+    Firm.new.assign_attributes({})
+  end
+
   def test_assign_attributes_uses_default_role_when_no_role_is_provided
     p = LoosePerson.new
     p.assign_attributes(attributes_hash)


### PR DESCRIPTION
This will skip assigning the attributes if an empty Hash was provided.

I've noticed this behavior kicking in when using something like collection#others.build (without any parameters):

``` ruby
class Task < ActiveRecord::Base
  belongs_to :account
end

class Account < ActiveRecord::Base
  has_many :tasks
end

account = Account.first
account.tasks.build
```

This will call assign_attributes on task twice:
- first with {} as a parameter when Task object is initialized
- second when the association is created with {:account_id => 666} as parameter (replace 666 with the actual account id).

Should also apply to 3.2 branch.
