### PR TITLE
Dup validation fix backport for 1 9 3

### DIFF
--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -168,8 +168,9 @@ module ActiveModel
     # Clean the +Errors+ object if instance is duped
     def initialize_dup(other) # :nodoc:
       @errors = nil
+      super if defined?(super)
     end
-    
+
     # Backport dup from 1.9 so that #initialize_dup gets called
     unless Object.respond_to?(:initialize_dup)
       def dup # :nodoc:

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -5,6 +5,7 @@ require 'models/topic'
 require 'models/reply'
 require 'models/custom_reader'
 require 'models/automobile'
+require 'models/book'
 
 require 'active_support/json'
 require 'active_support/xml_mini'
@@ -353,5 +354,15 @@ class ValidationsTest < ActiveModel::TestCase
     duped.title = 'Mathematics'
     assert topic.invalid?
     assert duped.valid?
+  end
+
+  def test_dup_call_parent_dup_when_include_validations
+    book = Book.new
+    book['title'] = "Litterature"
+    book['author'] = "Foo"
+    duped = book.dup
+
+    assert_equal book.keys, duped.keys
+    assert_equal book.values, duped.values
   end
 end

--- a/activemodel/test/models/book.rb
+++ b/activemodel/test/models/book.rb
@@ -1,0 +1,3 @@
+class Book < Hash
+  include ActiveModel::Validations
+end


### PR DESCRIPTION
At the end of initialize_dup was added the call to super if it exists,
so it also works with 1.8.7 where initialize_dup doesn't exist.
This issu was introduced with the pull request #6324
