### PR TITLE
Remove naming constraints from has_secure_password

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -4,10 +4,10 @@ module ActiveModel
 
     module ClassMethods
       # Adds methods to set and authenticate against a BCrypt password.
-      # This mechanism requires you to have a password_digest attribute.
+      # This mechanism requires you to add an attribute to your model for the digested password
       #
       # Validations for presence of password on create, confirmation of password (using
-      # a "password_confirmation" attribute) are automatically added.
+      # a "password_confirmation" attribute by default) are automatically added.
       # If you wish to turn off validations, pass 'validations: false' as an argument.
       # You can add more validations by hand if need be.
       #
@@ -32,44 +32,73 @@ module ActiveModel
       #   user.authenticate("mUc3m00RsqyRe")                             # => user
       #   User.find_by_name("david").try(:authenticate, "notright")      # => false
       #   User.find_by_name("david").try(:authenticate, "mUc3m00RsqyRe") # => user
+      #
+      # By default, has_secure_password will look for a password_digest attribute on your model,
+      # and will add a password instance method. You may override these methods:
+      #
+      #   # Schema: User(name:string, encrypted_password:string)
+      #   class User < ActiveRecord::Base
+      #     has_secure_password :encrypted_attribute => :encrypted_password, :password_attribute => :passw
+      #   end
+      #
+      # You would then have user.passw available, and the confirmation would look at user.passw_confirmation.
+      #
+      # Note that you will also need to make sure Rails.config.filter_parameters includes the name of the
+      # attribute. Rails adds "password" by default for new projects, but if you're using something different
+      # then your parameters and log files will not be properly filtered.
+      #
+      #   config.filter_parameters += [:passw]
+
       def has_secure_password(options = {})
         # Load bcrypt-ruby only when has_secure_password is used.
         # This is to avoid ActiveModel (and by extension the entire framework) being dependent on a binary library.
         gem 'bcrypt-ruby', '~> 3.0.0'
         require 'bcrypt'
 
-        attr_reader :password
-        
-        if options.fetch(:validations, true)
-          validates_confirmation_of :password
-          validates_presence_of     :password, :on => :create
-        end
-        
-        before_create { raise "Password digest missing on new record" if password_digest.blank? }
+        cattr_accessor :encrypted_attribute, :password_attribute
+        self.encrypted_attribute = options.fetch(:encrypted_attribute, "password_digest").to_sym
+        self.password_attribute = options.fetch(:password_attribute, "password").to_sym
 
+        attr_reader password_attribute
+
+        if options.fetch(:validations, true)
+          validates_confirmation_of password_attribute
+          validates_presence_of     password_attribute, :on => :create
+        end
+
+        before_create { raise "#{encrypted_attribute.to_s.gsub("_", " ").capitalize} missing on new record" if send(encrypted_attribute).blank? }
+
+        extend ClassMethodsOnActivation
         include InstanceMethodsOnActivation
+
+        password_attribute_writer_method(password_attribute)
 
         if respond_to?(:attributes_protected_by_default)
           def self.attributes_protected_by_default
-            super + ['password_digest']
+            super + [send(:encrypted_attribute).to_s]
           end
         end
       end
     end
 
+    module ClassMethodsOnActivation
+      private
+        def password_attribute_writer_method(name)
+          # Encrypts the password into the password_digest attribute, only if the
+          # new password is not blank.
+          define_method("#{name}=") do |unencrypted_password|
+            unless unencrypted_password.blank?
+              instance_variable_set("@#{self.class.password_attribute}", unencrypted_password)
+              send("#{self.class.encrypted_attribute}=", BCrypt::Password.create(unencrypted_password))
+            end
+          end
+        end
+    end
+
     module InstanceMethodsOnActivation
       # Returns self if the password is correct, otherwise false.
       def authenticate(unencrypted_password)
-        BCrypt::Password.new(password_digest) == unencrypted_password && self
-      end
-
-      # Encrypts the password into the password_digest attribute, only if the
-      # new password is not blank.
-      def password=(unencrypted_password)
-        unless unencrypted_password.blank?
-          @password = unencrypted_password
-          self.password_digest = BCrypt::Password.create(unencrypted_password)
-        end
+        BCrypt::Password.new(send(self.class.encrypted_attribute)) == unencrypted_password && self
       end
     end
   end

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -1,6 +1,7 @@
 require 'cases/helper'
 require 'models/user'
 require 'models/visitor'
+require 'models/auth_user'
 require 'models/administrator'
 
 class SecurePasswordTest < ActiveModel::TestCase
@@ -8,18 +9,21 @@ class SecurePasswordTest < ActiveModel::TestCase
   setup do
     @user = User.new
     @visitor = Visitor.new
+    @auth_user = AuthUser.new
   end
 
   test "blank password" do
-    @user.password = @visitor.password = ''
+    @user.password = @visitor.password = @auth_user.pw = ''
     assert !@user.valid?(:create), 'user should be invalid'
     assert @visitor.valid?(:create), 'visitor should be valid'
+    assert !@auth_user.valid?(:create), 'auth user should be valid'
   end
 
   test "nil password" do
-    @user.password = @visitor.password = nil
+    @user.password = @visitor.password = @auth_user.pw = nil
     assert !@user.valid?(:create), 'user should be invalid'
     assert @visitor.valid?(:create), 'visitor should be valid'
+    assert !@auth_user.valid?(:create), 'auth user should be valid'
   end
 
   test "blank password doesn't override previous password" do
@@ -30,26 +34,36 @@ class SecurePasswordTest < ActiveModel::TestCase
 
   test "password must be present" do
     assert !@user.valid?(:create)
+    assert !@auth_user.valid?(:create)
     assert_equal 1, @user.errors.size
+    assert_equal 1, @auth_user.errors.size
+    assert_equal [:password], @user.errors.keys
+    assert_equal [:pw], @auth_user.errors.keys
   end
 
   test "match confirmation" do
-    @user.password = @visitor.password = "thiswillberight"
-    @user.password_confirmation = @visitor.password_confirmation = "wrong"
+    @user.password = @visitor.password = @auth_user.pw = "thiswillberight"
+    @user.password_confirmation = @visitor.password_confirmation = @auth_user.pw_confirmation = "wrong"
 
     assert !@user.valid?
     assert @visitor.valid?
+    assert !@auth_user.valid?
 
-    @user.password_confirmation = "thiswillberight"
+    assert_equal [:password_confirmation], @user.errors.keys
+    assert_equal [:pw_confirmation], @auth_user.errors.keys
 
+    @user.password_confirmation = @auth_user.pw_confirmation = "thiswillberight"
     assert @user.valid?
+    assert @auth_user.valid?
   end
 
   test "authenticate" do
-    @user.password = "secret"
+    @user.password = @auth_user.pw = "secret"
 
     assert !@user.authenticate("wrong")
     assert @user.authenticate("secret")
+    assert !@auth_user.authenticate("wrong")
+    assert @auth_user.authenticate("secret")
   end
 
   test "visitor#password_digest should be protected against mass assignment" do
@@ -63,7 +77,7 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert !active_authorizer.include?(:password_digest)
     assert active_authorizer.include?(:name)
   end
-  
+
   test "User should not be created with blank digest" do
     assert_raise RuntimeError do 
       @user.run_callbacks :create
@@ -72,5 +86,25 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert_nothing_raised do
       @user.run_callbacks :create
     end
+  end
+
+  test "humanizes the column name for error" do
+    begin
+      @auth_user.run_callbacks :create
+    rescue RuntimeError => e
+      assert_equal "Encrypted password missing on new record", e.message
+    end
+  end
+
+  test "recogizes the column name passed in as an attribute" do
+    assert @auth_user.methods.include?(:encrypted_password)
+  end
+
+  test "recognizes the attribute name passed in as an attribute" do
+    assert @auth_user.methods.include?(:pw)
+  end
+
+  test "adds column name passed in to attributes_protected_by_default" do
+    assert @auth_user.class.attributes_protected_by_default.include?("encrypted_password")
   end
 end

--- a/activemodel/test/models/auth_user.rb
+++ b/activemodel/test/models/auth_user.rb
@@ -1,0 +1,12 @@
+class AuthUser
+  extend ActiveModel::Callbacks
+  include ActiveModel::Validations
+  include ActiveModel::SecurePassword
+  include ActiveModel::MassAssignmentSecurity
+
+  define_model_callbacks :create
+
+  has_secure_password :encrypted_attribute => :encrypted_password, :password_attribute => :pw
+
+  attr_accessor :encrypted_password
+end


### PR DESCRIPTION
This commit makes available two new options to has_secure_password:
- encrypted_attribute: The attribute for the encrypted password.
                     Replaces the hard-coded `password_digest` attribute
- password_attribute: The instance method for the password
                    Replaces the hard-coded `password` method

Example usage:

```
# Schema: User(name:string, encrypted_password:string)
class User < ActiveRecord::Base
  has_secure_password :encrypted_attribute => :encrypted_password,
                      :password_attribute  => :passw
end
```

The User model will now use `encrypted_password` for the digested password, and
will make available @user.passw.

With no options specified, defaults are `password_digest` and `password`, so no
action will be required to update this method from older versions.

Note: config.filter_parameters will need to be changed from the default `password` if
something different is being used.

Use cases: Legacy database (eg. Django applications use a `password` column for digest), conflicting plugins 
