### PR TITLE
Enable threadsafe! by default

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -56,7 +56,7 @@
   # config.action_mailer.raise_delivery_errors = false
 
   # Enable threaded mode.
-  # config.threadsafe!
+  config.threadsafe!
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation can not be found).


### PR DESCRIPTION
No one uses thread-safe mode because it's disabled by default
This makes thread-safe mode configuration over convention

If thread-safe mode were the happy path, more people would use it
