### PR TITLE
Fix non sequence pkey dumps

### DIFF
--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -86,9 +86,11 @@ HEADER
           tbl = StringIO.new
 
           # first dump primary key column
+          pk = nil
           if @connection.respond_to?(:pk_and_sequence_for)
             pk, _ = @connection.pk_and_sequence_for(table)
-          elsif @connection.respond_to?(:primary_key)
+          end
+          if pk.nil? && @connection.respond_to?(:primary_key)
             pk = @connection.primary_key(table)
           end
 


### PR DESCRIPTION
Previously if you had a primary key without a sequence on a db whose connector
responded to :pk_and_sequence_for, the primary key would be missed by the schema
dumper. This fixes that problem by checking :pk_and_sequence_for, then
:primary_key.

Not sure how to go about testing this - it's easy to get into this state in a DB like postgres
by creating a table with a normal sequence ID, then later migrating to drop that ID and
create a new primary key column of e.g. varchar. None of the other tests seem to do
anything like that, though, so I thought I'd ask before venturing out myself.
