### PR TITLE
BufferedLogger level while creation

### DIFF
--- a/activesupport/lib/active_support/buffered_logger.rb
+++ b/activesupport/lib/active_support/buffered_logger.rb
@@ -45,7 +45,6 @@ module ActiveSupport
     deprecate :auto_flushing
 
     def initialize(log, level = DEBUG)
-      @level         = level
       @log_dest      = log
 
       unless log.respond_to?(:write)
@@ -58,6 +57,7 @@ Automatic directory creation for '#{log}' is deprecated.  Please make sure the d
       end
 
       @log = open_logfile log
+      self.level = level
     end
 
     def open_log(log, mode)
@@ -91,7 +91,7 @@ Automatic directory creation for '#{log}' is deprecated.  Please make sure the d
         end                                                             # end
 
         def #{severity.downcase}?                                       # def debug?
-          #{severity} >= level                                         #   DEBUG >= @level
+          #{severity} >= level                                         #   DEBUG >= level
         end                                                             # end
       EOT
     end

--- a/activesupport/test/buffered_logger_test.rb
+++ b/activesupport/test/buffered_logger_test.rb
@@ -62,6 +62,11 @@ class BufferedLoggerTest < Test::Unit::TestCase
     File.unlink fname
   end
 
+  def test_should_default_logger_level_to_one_passed_while_creating_it
+    logger = Logger.new(@output, Logger::ERROR)
+    assert_equal Logger::ERROR, logger.level
+  end
+
   def test_should_log_debugging_message_when_debugging
     @logger.level = Logger::DEBUG
     @logger.add(Logger::DEBUG, @message)


### PR DESCRIPTION
BufferedLogger accepts `level` as a parameter to the constructor. It was ignoring this parameter and was not setting the appropriate log level of the underlying Logger.
