### PR TITLE
Fix: 'rake rails:templates:copy' doesn't work

### DIFF
--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -20,7 +20,7 @@ namespace :rails do
       project_templates = "#{Rails.root}/lib/templates"
 
       default_templates = { "erb"   => %w{controller mailer scaffold},
-                            "rails" => %w{controller helper scaffold_controller stylesheets} }
+                            "rails" => %w{controller helper scaffold_controller assets} }
 
       default_templates.each do |type, names|
         local_template_type_dir = File.join(project_templates, type)

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -190,5 +190,16 @@ module ApplicationTests
       end
     end
 
+    def test_copy_templates
+      Dir.chdir(app_path) do
+        `bundle exec rake rails:templates:copy`
+        %w(controller mailer scaffold).each do |dir|
+          assert File.exists?(File.join(app_path, 'lib', 'templates', 'erb', dir))
+        end
+        %w(controller helper scaffold_controller assets).each do |dir|
+          assert File.exists?(File.join(app_path, 'lib', 'templates', 'rails', dir))
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
I fixed the copy source dir of stylesheet templates.

```
% rake rails:templates:copy
rake aborted!
No such file or directory - /Users/suginoyasuhiro/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/railties-3.2.5/lib/rails/generators/rails/stylesheets/templates
```
