### PR TITLE
Add Prompt to 404 & 500 Pages to Check Logs in Production

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/public/404.html
+++ b/railties/lib/rails/generators/rails/app/templates/public/404.html
@@ -22,5 +22,6 @@
     <h1>The page you were looking for doesn't exist.</h1>
     <p>You may have mistyped the address or the page may have moved.</p>
   </div>
+  <p>If you are the application owner check the logs for more information.</p>
 </body>
 </html>

--- a/railties/lib/rails/generators/rails/app/templates/public/500.html
+++ b/railties/lib/rails/generators/rails/app/templates/public/500.html
@@ -21,5 +21,6 @@
   <div class="dialog">
     <h1>We're sorry, but something went wrong.</h1>
   </div>
+  <p>If you are the application owner check the logs for more information.</p>
 </body>
 </html>


### PR DESCRIPTION
When new programmers push their code to a production server and receive an error they often don't know to check the logs, this simple reminder will help. Most professional applications have custom error pages so this change shouldn't affect them. The wording of the message should not confuse non-developer visitors.

I run into this while going through getting started tutorials like Rails Girls: http://guides.railsgirls.com/heroku/ with users. Specifically when users push their code to Heroku and then don't migrate their databases. They're often confused about what to do next and won't instinctively check the logs without someone else telling them to. Hopefully this should help.

Screenshot of 404: http://cl.ly/3j1S0k3I3K292u3x2q3K
