### PR TITLE
Bugfix: Namespace collision with test-unit-activesupport 1.0.0

### DIFF
--- a/activesupport/lib/active_support/testing/deprecation.rb
+++ b/activesupport/lib/active_support/testing/deprecation.rb
@@ -45,7 +45,7 @@ else
       class Error #:nodoc:
         # Silence warnings when reporting test errors.
         def message_with_silenced_deprecation
-          ActiveSupport::Deprecation.silence { message_without_silenced_deprecation }
+          ::ActiveSupport::Deprecation.silence { message_without_silenced_deprecation }
         end
         alias_method :message_without_silenced_deprecation, :message
         alias_method :message, :message_with_silenced_deprecation


### PR DESCRIPTION
_Problem_

Unable to run functional / integration tests with Rails 2.3.5 and Test-Unit 2.5 due to 

```
gems/activesupport-3.2.5/lib/active_support/testing/deprecation.rb:48:in `message': uninitialized constant Test::Unit::ActiveSupport::Deprecation (NameError)
    from gems/test-unit-2.4.9/lib/test/unit/ui/console/testrunner.rb:182:in `output_fault_in_detail'
```

_Reason and Fix_

active_support/testing/deprecation.rb surrounds Test::Unit::Error#message with a call to ActiveSupport::Deprecation.silence, however Test::Unit now declares it's own Test::Unit::ActiveSupport module, which of course lacks the Deprecation module.

Prepending the call with :: fixes the problem.
