### PR TITLE
Fix #6635. We should call Scoping methods, before calling Array methods.

### DIFF
--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -32,12 +32,12 @@ module ActiveRecord
     protected
 
     def method_missing(method, *args, &block)
-      if Array.method_defined?(method)
-        ::ActiveRecord::Delegation.delegate method, :to => :to_a
-        to_a.send(method, *args, &block)
-      elsif @klass.respond_to?(method)
+      if @klass.respond_to?(method)
         ::ActiveRecord::Delegation.delegate_to_scoped_klass(method)
         scoping { @klass.send(method, *args, &block) }
+      elsif Array.method_defined?(method)
+        ::ActiveRecord::Delegation.delegate method, :to => :to_a
+        to_a.send(method, *args, &block)
       elsif arel.respond_to?(method)
         ::ActiveRecord::Delegation.delegate method, :to => :arel
         arel.send(method, *args, &block)

--- a/activerecord/test/cases/named_scope_test.rb
+++ b/activerecord/test/cases/named_scope_test.rb
@@ -45,6 +45,15 @@ class NamedScopeTest < ActiveRecord::TestCase
     assert_equal Topic.average(:replies_count), Topic.base.average(:replies_count)
   end
 
+  def test_method_missing_priority_when_delegating
+    klazz = Class.new(ActiveRecord::Base) do
+      self.table_name = "topics"
+      scope :since, Proc.new { where('written_on >= ?', Time.now - 1.day) }
+      scope :to,    Proc.new { where('written_on <= ?', Time.now) }
+    end
+    assert_equal klazz.to.since.all, klazz.since.to.all
+  end
+
   def test_scope_should_respond_to_own_methods_and_methods_of_the_proxy
     assert Topic.approved.respond_to?(:limit)
     assert Topic.approved.respond_to?(:count)


### PR DESCRIPTION
If You've the following model

``` ruby
class Post < ActiveRecord::Base
  scope :since, Proc.new { where('written_on >= ?', Time.now - 1.day) }
  scope :to,    Proc.new { where('written_on <= ?', Time.now) }
end
```

and you call `Post.since.to`, we get an exception.

Because `since` method return ActiveRecord::Relation instance, and this class's method_missing call Array's method firstly.
Thus ActiveRecord::Relation#to is same to Array#to, we get an exception.
