### PR TITLE
Address ORA-00911 errors because of the heading underscore.

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -176,7 +176,7 @@ module ActiveRecord
 
       join_dependency = construct_join_dependency_for_association_find
       relation = construct_relation_for_association_find(join_dependency)
-      relation = relation.except(:select, :order).select("1 AS _one").limit(1)
+      relation = relation.except(:select, :order).select("1 AS one").limit(1)
 
       case id
       when Array, Hash

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -46,7 +46,7 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_exists_does_not_select_columns_without_alias
-    assert_sql(/SELECT\W+1 AS _one FROM ["`]topics["`]\W+LIMIT 1/) do
+    assert_sql(/SELECT\W+1 AS one FROM ["`]topics["`]/i) do
       Topic.exists?
     end
   end


### PR DESCRIPTION
This pull request address errors discussed in be4ecdcc87984e9421ff5d5c90d33f475e0fbc01 for master branch.

``` ruby
  1) Error:
test_dont_add_if_before_callback_raises_exception(AssociationCallbacksTest):
ActiveRecord::StatementInvalid: OCIError: ORA-00911: invalid character: SELECT  1 AS _one FROM "POSTS"  WHERE "POSTS"."AUTHOR_ID" = 1 AND "POSTS"."ID" = 3 AND ROWNUM <= 1
    stmt.c:253:in oci8lib_191.so
```

Tested with postgresql, mysql, mysql2 and sqlite3 adapters also.
