### PR TITLE
fix warning in Ruby2.0.0

### DIFF
--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -133,7 +133,7 @@ module ActiveSupport #:nodoc:
       #   "ÉL QUE SE ENTERÓ".mb_chars.titleize    # => "Él Que Se Enteró"
       #   "日本語".mb_chars.titleize                 # => "日本語"
       def titleize
-        chars(downcase.to_s.gsub(/\b('?[\S])/u) { Unicode.upcase($1)})
+        chars(downcase.to_s.gsub(/\b('?\S)/u) { Unicode.upcase($1)})
       end
       alias_method :titlecase, :titleize
 


### PR DESCRIPTION
I found following warning in Ruby2.0.0dev(2012-06-11 trunk 36028).

```
rails/activesupport/lib/active_support/multibyte/chars.rb:136: warning:
character class has duplicated range: /\b('?[\S])/
```
