### PR TITLE
Failing test case for values not persisting after add_column

### DIFF
--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -311,6 +311,27 @@ module ActiveRecord
         end
       end
 
+      def test_add_column_persists_values
+        connection.create_table :testings do |t|
+          t.column :title, :string
+        end
+        person_klass = Class.new(ActiveRecord::Base)
+        person_klass.table_name = 'testings'
+        2.times do
+          person_klass.create!(title:'foo')
+        end
+
+        person_klass.connection.add_column 'testings', 'body', :text
+        person_klass.find_each do |person|
+          person.body = 'Ba Ba Black Sheep'
+          person.save!
+        end
+
+        person_klass.find_each do |person|
+          assert_equal 'Ba Ba Black Sheep', person.body
+        end
+      end
+
       private
       def testing_table_with_only_foo_attribute
         connection.create_table :testings, :id => false do |t|


### PR DESCRIPTION
Given a migration like

``` ruby
  puts Post.inspect
  add_column :posts, :body, :string
  Post.find_each do |p|
    p.body = 'foo'
    p.save!
  end
```

both the assignment to 'body' and the save will succeed, but the value isn't written into the database, and you're left with nil values for 'body'.

(Obviously the "puts Post.inspect" is artificial - in our case, I think a plugin is loading our models prematurely, and so ActiveRecord caches the pre-migration column information)

The attached (failing) test checks that the new column's value is persisted properly.  Perhaps this could be achieved by implicitly calling reset_column_information after each schema change.  However, I don't care too much about that behaviour - I'd be just as happy with getting NoMethodError on trying to assign to 'body'.  We were caught out and lost some production data because the model update appeared to work fine, when it was actually just dropping the values assigned to it.

See https://github.com/rails/rails/issues/6679 for prior discussion.
