### PR TITLE
Proc always respond_to :binding

### DIFF
--- a/activesupport/test/test_test.rb
+++ b/activesupport/test/test_test.rb
@@ -15,68 +15,64 @@ class AssertDifferenceTest < ActiveSupport::TestCase
     @object.num = 0
   end
 
-  if lambda { }.respond_to?(:binding)
-    def test_assert_no_difference
-      assert_no_difference '@object.num' do
-        # ...
-      end
+  def test_assert_no_difference
+    assert_no_difference '@object.num' do
+      # ...
     end
+  end
 
-    def test_assert_difference
-      assert_difference '@object.num', +1 do
+  def test_assert_difference
+    assert_difference '@object.num', +1 do
+      @object.increment
+    end
+  end
+
+  def test_assert_difference_with_implicit_difference
+    assert_difference '@object.num' do
+      @object.increment
+    end
+  end
+
+  def test_arbitrary_expression
+    assert_difference '@object.num + 1', +2 do
+      @object.increment
+      @object.increment
+    end
+  end
+
+  def test_negative_differences
+    assert_difference '@object.num', -1 do
+      @object.decrement
+    end
+  end
+
+  def test_expression_is_evaluated_in_the_appropriate_scope
+    silence_warnings do
+      local_scope = local_scope = 'foo'
+      assert_difference('local_scope; @object.num') { @object.increment }
+    end
+  end
+
+  def test_array_of_expressions
+    assert_difference [ '@object.num', '@object.num + 1' ], +1 do
+      @object.increment
+    end
+  end
+
+  def test_array_of_expressions_identify_failure
+    assert_raises(MiniTest::Assertion) do
+      assert_difference ['@object.num', '1 + 1'] do
         @object.increment
       end
     end
+  end
 
-    def test_assert_difference_with_implicit_difference
-      assert_difference '@object.num' do
+  def test_array_of_expressions_identify_failure_when_message_provided
+    assert_raises(MiniTest::Assertion) do
+      assert_difference ['@object.num', '1 + 1'], 1, 'something went wrong' do
         @object.increment
       end
     end
-
-    def test_arbitrary_expression
-      assert_difference '@object.num + 1', +2 do
-        @object.increment
-        @object.increment
-      end
-    end
-
-    def test_negative_differences
-      assert_difference '@object.num', -1 do
-        @object.decrement
-      end
-    end
-
-    def test_expression_is_evaluated_in_the_appropriate_scope
-      silence_warnings do
-        local_scope = local_scope = 'foo'
-        assert_difference('local_scope; @object.num') { @object.increment }
-      end
-    end
-
-    def test_array_of_expressions
-      assert_difference [ '@object.num', '@object.num + 1' ], +1 do
-        @object.increment
-      end
-    end
-
-    def test_array_of_expressions_identify_failure
-      assert_raises(MiniTest::Assertion) do
-        assert_difference ['@object.num', '1 + 1'] do
-          @object.increment
-        end
-      end
-    end
-
-    def test_array_of_expressions_identify_failure_when_message_provided
-      assert_raises(MiniTest::Assertion) do
-        assert_difference ['@object.num', '1 + 1'], 1, 'something went wrong' do
-          @object.increment
-        end
-      end
-    end
-  else
-    def default_test; end
   end
 end
 


### PR DESCRIPTION
This if statement was introduced in 6ea4dd4a65f85f165f71cf1c866dea578dae9e49.
The comment says, "no Proc#binding in Ruby 2" in this commit, but the actual plan for Ruby 2 now is "100% compatible with Ruby 1.9.3" (Matz) http://vimeo.com/43590847
