### PR TITLE
TimeZone format is always /[+-]\d{2}:\d{2}/ in Ruby 1.9

### DIFF
--- a/activerecord/test/cases/migration/column_attributes_test.rb
+++ b/activerecord/test/cases/migration/column_attributes_test.rb
@@ -174,7 +174,7 @@ module ActiveRecord
               assert_not_equal "Z", bob.moment_of_truth.zone
               # US/Eastern is -5 hours from GMT
               assert_equal Rational(-5, 24), bob.moment_of_truth.offset
-              assert_match(/\A-05:?00\Z/, bob.moment_of_truth.zone) #ruby 1.8.6 uses HH:MM, prior versions use HHMM
+              assert_match(/\A-05:00\Z/, bob.moment_of_truth.zone)
               assert_equal DateTime::ITALY, bob.moment_of_truth.start
             end
           end


### PR DESCRIPTION
Removed Ruby < 1.8.6 support in a test case.
