### PR TITLE
ignore .gitignore'd files in rake test:uncomitted

### DIFF
--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -87,7 +87,7 @@ namespace :test do
       if File.directory?(".svn")
         changed_since_checkin = silence_stderr { `svn status` }.split.map { |path| path.chomp[7 .. -1] }
       elsif File.directory?(".git")
-        changed_since_checkin = silence_stderr { `git ls-files --modified --others` }.split.map { |path| path.chomp }
+        changed_since_checkin = silence_stderr { `git ls-files --modified --others --exclude-standard` }.split.map { |path| path.chomp }
       else
         abort "Not a Subversion or Git checkout."
       end


### PR DESCRIPTION
`git ls-files` has `--exclude-standard` option that excludes standard git exclusions from the list, which totally fits the purpose of `git ls-files`ing in this case.
