### PR TITLE
fix method redefined warning in Ruby2.0

### DIFF
--- a/activesupport/lib/active_support/core_ext/load_error.rb
+++ b/activesupport/lib/active_support/core_ext/load_error.rb
@@ -6,12 +6,14 @@ class LoadError
     /^cannot load such file -- (.+)$/i,
   ]
 
-  def path
-    @path ||= begin
-      REGEXPS.find do |regex|
-        message =~ regex
+  unless method_defined?(:path)
+    def path
+      @path ||= begin
+        REGEXPS.find do |regex|
+          message =~ regex
+        end
+        $1
       end
-      $1
     end
   end
 


### PR DESCRIPTION
I found following warning in Ruby2.0.0dev(2012-06-12 trunk 36037).

```
activesuport/lib/active_support/core_ext/load_error.rb:9: warning: method redefined; discarding old path
```

Ruby2.0 already has LoadError#path.

see http://bugs.ruby-lang.org/issues/show/5221
