### PR TITLE
Add uuid datatype support to PostgreSQL adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -223,6 +223,7 @@ module ActiveRecord
         alias_type 'bit',      'text'
         alias_type 'varbit',   'text'
         alias_type 'macaddr',  'text'
+        alias_type 'uuid',     'text'
 
         # FIXME: I don't think this is correct. We should probably be returning a parsed date,
         # but the tests pass with a string returned.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -89,7 +89,6 @@ module ActiveRecord
           else
             string
           end
-
         end
 
         def cidr_to_string(object)
@@ -256,7 +255,7 @@ module ActiveRecord
           :integer
         # UUID type
         when 'uuid'
-          :string
+          :uuid
         # Small and big integer types
         when /^(?:small|big)int$/
           :integer
@@ -319,6 +318,10 @@ module ActiveRecord
         def macaddr(name, options = {})
           column(name, 'macaddr', options)
         end
+
+        def uuid(name, options = {})
+          column(name, 'uuid', options)
+        end
       end
 
       ADAPTER_NAME = 'PostgreSQL'
@@ -341,7 +344,8 @@ module ActiveRecord
         :hstore      => { :name => "hstore" },
         :inet        => { :name => "inet" },
         :cidr        => { :name => "cidr" },
-        :macaddr     => { :name => "macaddr" }
+        :macaddr     => { :name => "macaddr" },
+        :uuid        => { :name => "uuid" }
       }
 
       # Returns 'PostgreSQL' as adapter name for identification purposes.

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -27,6 +27,9 @@ end
 class PostgresqlTimestampWithZone < ActiveRecord::Base
 end
 
+class PostgresqlUUID < ActiveRecord::Base
+end
+
 class PostgresqlDataTypeTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
 
@@ -61,6 +64,9 @@ class PostgresqlDataTypeTest < ActiveRecord::TestCase
     @first_oid = PostgresqlOid.find(1)
 
     @connection.execute("INSERT INTO postgresql_timestamp_with_zones (time) VALUES ('2010-01-01 10:00:00-1')")
+
+    @connection.execute("INSERT INTO postgresql_uuids (guid, compact_guid) VALUES('d96c3da0-96c1-012f-1316-64ce8f32c6d8', 'f06c715096c1012f131764ce8f32c6d8')")
+    @first_uuid = PostgresqlUUID.find(1)
   end
 
   def test_data_type_of_array_types
@@ -98,6 +104,10 @@ class PostgresqlDataTypeTest < ActiveRecord::TestCase
 
   def test_data_type_of_oid_types
     assert_equal :integer, @first_oid.column_for_attribute(:obj_id).type
+  end
+
+  def test_data_type_of_uuid_types
+    assert_equal :uuid, @first_uuid.column_for_attribute(:guid).type
   end
 
   def test_array_values
@@ -141,6 +151,11 @@ class PostgresqlDataTypeTest < ActiveRecord::TestCase
     assert_equal cidr_address, @first_network_address.cidr_address
     assert_equal inet_address, @first_network_address.inet_address
     assert_equal '01:23:45:67:89:0a', @first_network_address.mac_address
+  end
+
+  def test_uuid_values
+    assert_equal 'd96c3da0-96c1-012f-1316-64ce8f32c6d8', @first_uuid.guid
+    assert_equal 'f06c7150-96c1-012f-1317-64ce8f32c6d8', @first_uuid.compact_guid
   end
 
   def test_bit_string_values

--- a/activerecord/test/cases/column_definition_test.rb
+++ b/activerecord/test/cases/column_definition_test.rb
@@ -136,12 +136,6 @@ module ActiveRecord
           smallint_column = PostgreSQLColumn.new('number', nil, oid, "smallint")
           assert_equal :integer, smallint_column.type
         end
-
-        def test_uuid_column_should_map_to_string
-          oid = PostgreSQLAdapter::OID::Identity.new
-          uuid_column = PostgreSQLColumn.new('unique_id', nil, oid, "uuid")
-          assert_equal :string, uuid_column.type
-        end
       end
     end
   end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -257,6 +257,13 @@ class SchemaDumperTest < ActiveRecord::TestCase
       end
     end
 
+    def test_schema_dump_includes_uuid_shorthand_definition
+      output = standard_dump
+      if %r{create_table "poistgresql_uuids"} =~ output
+        assert_match %r{t.uuid "guid"}, output
+      end
+    end
+
     def test_schema_dump_includes_hstores_shorthand_definition
       output = standard_dump
       if %r{create_table "postgresql_hstores"} =~ output

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -1,6 +1,6 @@
 ActiveRecord::Schema.define do
 
-  %w(postgresql_tsvectors postgresql_hstores postgresql_arrays postgresql_moneys postgresql_numbers postgresql_times postgresql_network_addresses postgresql_bit_strings
+  %w(postgresql_tsvectors postgresql_hstores postgresql_arrays postgresql_moneys postgresql_numbers postgresql_times postgresql_network_addresses postgresql_bit_strings postgresql_uuids
       postgresql_oids postgresql_xml_data_type defaults geometrics postgresql_timestamp_with_zones postgresql_partitioned_table postgresql_partitioned_table_parent).each do |table_name|
     execute "DROP TABLE IF EXISTS #{quote_table_name table_name}"
   end
@@ -55,6 +55,14 @@ _SQL
     id SERIAL PRIMARY KEY,
     commission_by_quarter INTEGER[],
     nicknames TEXT[]
+  );
+_SQL
+
+  execute <<_SQL
+  CREATE TABLE postgresql_uuids (
+    id SERIAL PRIMARY KEY,
+    guid uuid,
+    compact_guid uuid
   );
 _SQL
 


### PR DESCRIPTION
Adds possibility to use [uuid-datatype](http://www.postgresql.org/docs/9.1/static/datatype-uuid.html) instead of saving uuids in strings.

Hope I didn't messed up anything.
