### PR TITLE
Fix Build

### DIFF
--- a/activemodel/test/models/book.rb
+++ b/activemodel/test/models/book.rb
@@ -1,3 +1,3 @@
-class Book < Hash
+class Book < ActiveSupport::OrderedHash
   include ActiveModel::Validations
 end


### PR DESCRIPTION
In Ruby 1.8, the order in which `keys` will return keys, or `each` yield pairs is undefined.

I guess, this is why the following test is breaking the build:

``` ruby
def test_dup_call_parent_dup_when_include_validations
    book = Book.new
    book['title'] = "Litterature"
    book['author'] = "Foo"
    duped = book.dup

    assert_equal book.keys, duped.keys
    assert_equal book.values, duped.values
end
```
