### PR TITLE
These lines don't help to mitigate CVE. They only turn [nil] into nil, w...

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -267,9 +267,6 @@ module ActionDispatch
 
     # Remove nils from the params hash
     def deep_munge(hash)
-      keys = hash.keys.find_all { |k| hash[k] == [nil] }
-      keys.each { |k| hash[k] = nil }
-
       hash.each_value do |v|
         case v
         when Array


### PR DESCRIPTION
.../o them [nil] turns into [] and that is quite innocent.

generated  SQL - `IN (NULL)`
compact! did all the job.
