### PR TITLE
Add config which enables gzip compression, Disabled by default

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -260,6 +260,9 @@ module Rails
           middleware.use ::ActionDispatch::Static, paths["public"].first, config.static_cache_control
         end
 
+        if config.gzip_compression
+          middleware.use ::Rack::Deflater
+        end
         middleware.use ::Rack::Lock unless config.allow_concurrency
         middleware.use ::Rack::Runtime
         middleware.use ::Rack::MethodOverride

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -8,7 +8,7 @@ module Rails
       attr_accessor :allow_concurrency, :asset_host, :asset_path, :assets, :autoflush_log,
                     :cache_classes, :cache_store, :consider_all_requests_local, :console,
                     :dependency_loading, :exceptions_app, :file_watcher, :filter_parameters,
-                    :force_ssl, :helpers_paths, :logger, :log_formatter, :log_tags,
+                    :force_ssl, :gzip_compression, :helpers_paths, :logger, :log_formatter, :log_tags,
                     :preload_frameworks, :railties_order, :relative_url_root, :secret_token,
                     :serve_static_assets, :ssl_options, :static_cache_control, :session_options,
                     :time_zone, :reload_classes_only_on_change, :use_schema_cache_dump,

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -1,6 +1,9 @@
 <%= app_const %>.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # If you want to enable Enable gzip compression, uncomment this line.
+  # config.gzip_compression = true
+  
   # Code is not reloaded between requests.
   config.cache_classes = true
 


### PR DESCRIPTION
Setting `config.gzip_compression = true` will load the `Rack::Deflater` middleware & enable gzip compression. 

This config setting is useful if the HTTP requests terminates directly at app server & no longer goes through a web  server(Example Heroku's Cedar stack). Therefore, gzip compression becomes responsibility of rack middleware. 

In absence of this setting, people have resorted to hacking [config.ru directly](http://stackoverflow.com/questions/7236583/where-to-insert-rackdeflater-in-the-rack). this patch provides a clean way, if anyone want to enable gzip compression at app server level
