### PR TITLE
db:schema:load db:schema:dump: establish_connection(Rails.env) -> establ...

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -314,7 +314,7 @@ db_namespace = namespace :db do
     task :load => :environment do
       require 'active_record/fixtures'
 
-      ActiveRecord::Base.establish_connection(Rails.env)
+      ActiveRecord::Base.establish_connection
       base_dir     = File.join [Rails.root, ENV['FIXTURES_PATH'] || %w{test fixtures}].flatten
       fixtures_dir = File.join [base_dir, ENV['FIXTURES_DIR']].compact
 
@@ -353,7 +353,7 @@ db_namespace = namespace :db do
       require 'active_record/schema_dumper'
       filename = ENV['SCHEMA'] || "#{Rails.root}/db/schema.rb"
       File.open(filename, "w:utf-8") do |file|
-        ActiveRecord::Base.establish_connection(Rails.env)
+        ActiveRecord::Base.establish_connection
         ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, file)
       end
       db_namespace['schema:dump'].reenable


### PR DESCRIPTION
Fix `db:schema:load` + `:dump`: look first in DATABASE_URL, then database.yml.

Currently when I run `heroku run rake db:migrate` on Heroku with the official
Rails 3.2.6 I get:

```
...
<migrations>
...
database configuration does not specify adapter
```

... and then rake fails.

My findings:

This last line is printed by `db:schema:dump` called from within `db:migrate`.

`db:migrate` "itself" (`ActiveRecord::Migrator.migrate`) uses
`with_connection`, which succeeds, while `db:schema:dump` uses
`ActiveRecord::Base.establish_connect(Rails.env)` followed by
`ActiveRecord::Base.connection`, which fails.

The latter call unconditionally looks in config/database.yml for the database
settings, whereas the former uses whatever settings were initialized by Rails.

When Rails is initializing, `Railties::ActiveRecord` calls
ActiveRecord::Base.establish_connection without parameters.

Removing the `Rails.env` argument allows `establish_connect` to probe for the
correct settings itself, and then it picks `DATABASE_URL` first, regardless of
`RAILS_ENV` or `RACK_ENV`. This seems to me the more proper behaviour.

If I set `RAILS_ENV=production`, not only `RACK_ENV=production`, for some reason
that works. Possibly heroku's database.yml contains a `#{RAILS_ENV}:` line or
something along those lines, I haven't checked. Either way, it doesn't affect
the above reasoning for the proper behaviour of `db:schema:dump`.

This pull request also contains the equivalent fix for `db:schema:load`.
