### PR TITLE
Deprecate composed of

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 3.2.7 (unreleased) ##
 
+*   `composed_of` has been deprecated. You'll have to write your own accessor
+    and mutator methods if you'd like to use value objects to represent some
+    portion of your models.
+
+    *Steve Klabnik*
+
 *   `update_attribute` has been deprecated. Use `update_column` if
     you want to bypass mass-assignment protection, validations, callbacks,
     and touching of updated_at. Otherwise please use `update_attributes`.

--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -161,6 +161,8 @@ module ActiveRecord
     #
     #   Customer.where(:balance => Money.new(20, "USD")).all
     #
+    # Note: +composed_of+ has been deprecated, and will be removed (with no
+    # replacement) in Rails 4.
     module ClassMethods
       # Adds reader and writer methods for manipulating a value object:
       # <tt>composed_of :address</tt> adds <tt>address</tt> and <tt>address=(new_address)</tt> methods.
@@ -203,6 +205,7 @@ module ActiveRecord
       #               :converter => Proc.new { |ip| ip.is_a?(Integer) ? IPAddr.new(ip, Socket::AF_INET) : IPAddr.new(ip.to_s) }
       #
       def composed_of(part_id, options = {})
+        ActiveSupport::Deprecation.warn("composed_of is deprecated, and will be removed in Rails 4. There is no replacement.")
         options.assert_valid_keys(:class_name, :mapping, :allow_nil, :constructor, :converter)
 
         name        = part_id.id2name

--- a/activerecord/test/cases/aggregations_test.rb
+++ b/activerecord/test/cases/aggregations_test.rb
@@ -126,11 +126,15 @@ class OverridingAggregationsTest < ActiveRecord::TestCase
   class DifferentName; end
 
   class Person < ActiveRecord::Base
-    composed_of :composed_of, :mapping => %w(person_first_name first_name)
+    ActiveSupport::Deprecation.silence do
+      composed_of :composed_of, :mapping => %w(person_first_name first_name)
+    end
   end
 
   class DifferentPerson < Person
-    composed_of :composed_of, :class_name => 'DifferentName', :mapping => %w(different_person_first_name first_name)
+    ActiveSupport::Deprecation.silence do
+      composed_of :composed_of, :class_name => 'DifferentName', :mapping => %w(different_person_first_name first_name)
+    end
   end
 
   def test_composed_of_aggregation_redefinition_reflections_should_differ_and_not_inherited

--- a/activerecord/test/models/customer.rb
+++ b/activerecord/test/models/customer.rb
@@ -1,8 +1,10 @@
 class Customer < ActiveRecord::Base
-  composed_of :address, :mapping => [ %w(address_street street), %w(address_city city), %w(address_country country) ], :allow_nil => true
-  composed_of :balance, :class_name => "Money", :mapping => %w(balance amount), :converter => Proc.new { |balance| balance.to_money }
-  composed_of :gps_location, :allow_nil => true
-  composed_of :fullname, :mapping => %w(name to_s), :constructor => Proc.new { |name| Fullname.parse(name) }, :converter => :parse
+  ActiveSupport::Deprecation.silence do
+    composed_of :address, :mapping => [ %w(address_street street), %w(address_city city), %w(address_country country) ], :allow_nil => true
+    composed_of :balance, :class_name => "Money", :mapping => %w(balance amount), :converter => Proc.new { |balance| balance.to_money }
+    composed_of :gps_location, :allow_nil => true
+    composed_of :fullname, :mapping => %w(name to_s), :constructor => Proc.new { |name| Fullname.parse(name) }, :converter => :parse
+  end
 end
 
 class Address

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -73,7 +73,9 @@ end
 DeveloperSalary = Struct.new(:amount)
 class DeveloperWithAggregate < ActiveRecord::Base
   self.table_name = 'developers'
-  composed_of :salary, :class_name => 'DeveloperSalary', :mapping => [%w(salary amount)]
+  ActiveSupport::Deprecation.silence do
+    composed_of :salary, :class_name => 'DeveloperSalary', :mapping => [%w(salary amount)]
+  end
 end
 
 class DeveloperWithBeforeDestroyRaise < ActiveRecord::Base


### PR DESCRIPTION
composed_of is a complicated feature that's rarely used. So let's deprecate it. And remove it in Rails 4.

Related: #6743

/cc @jonleighton @tenderlove
