### PR TITLE
SignedCookieJar and PermanentCookieJar properly delegate everything to parent_jar

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -395,7 +395,7 @@ module ActionDispatch
           @encryptor.decrypt_and_verify(encrypted_message)
         end
       rescue ActiveSupport::MessageVerifier::InvalidSignature,
-             ActiveSupport::MessageVerifier::InvalidMessage
+             ActiveSupport::MessageEncryptor::InvalidMessage
         nil
       end
 

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -382,6 +382,8 @@ class CookiesTest < ActionController::TestCase
     assert_nil @controller.send(:cookies)[:user_name]
     assert_nil @controller.send(:cookies).signed.permanent.encrypted[:user_name]
     assert_equal @controller.send(:cookies).signed.permanent.encrypted[:user_surname], 'Smith'
+    assert_not_equal @controller.send(:cookies)[:user_surname], 'Smith'
+    assert_not_equal @controller.send(:cookies).encrypted[:user_surname], 'Smith'
   end
 
   def test_delete_and_set_cookie

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -109,6 +109,12 @@ class CookiesTest < ActionController::TestCase
       head :ok
     end
 
+    def delete_and_set_signed_permanent_encrypted_cookie
+      cookies.signed.permanent.encrypted.delete :user_name
+      cookies.signed.permanent.encrypted[:user_surname] = 'Smith'
+      head :ok
+    end
+
     def set_cookie_with_domain
       cookies[:user_name] = {:value => "rizwanreza", :domain => :all}
       head :ok
@@ -368,6 +374,14 @@ class CookiesTest < ActionController::TestCase
     assert_nil @controller.send(:cookies)[:user_surname]
     assert @controller.send(:cookies).deleted?(:user_name)
     assert @controller.send(:cookies).encrypted.deleted?(:user_name)
+  end
+
+  def test_delete_and_set_signed_permanent_encrypted_cookie
+    @controller.send(:cookies).signed.permanent.encrypted[:user_name] = 'Joe'
+    get :delete_and_set_signed_permanent_encrypted_cookie
+    assert_nil @controller.send(:cookies)[:user_name]
+    assert_nil @controller.send(:cookies).signed.permanent.encrypted[:user_name]
+    assert_equal @controller.send(:cookies).signed.permanent.encrypted[:user_surname], 'Smith'
   end
 
   def test_delete_and_set_cookie

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -94,6 +94,21 @@ class CookiesTest < ActionController::TestCase
       head :ok
     end
 
+    def delete_signed_cookie
+      cookies.signed.delete :user_name
+      head :ok
+    end
+
+    def delete_permanent_cookie
+      cookies.permanent.delete :user_name
+      head :ok
+    end
+
+    def clear_encrypted_cookie
+      cookies.encrypted.clear
+      head :ok
+    end
+
     def set_cookie_with_domain
       cookies[:user_name] = {:value => "rizwanreza", :domain => :all}
       head :ok
@@ -325,6 +340,34 @@ class CookiesTest < ActionController::TestCase
     get :set_permanent_signed_cookie
     assert_match(%r(#{20.years.from_now.utc.year}), @response.headers["Set-Cookie"])
     assert_equal 100, @controller.send(:cookies).signed[:remember_me]
+  end
+
+  def test_delete_signed_cookie
+    @controller.send(:cookies).signed[:user_name] = 'Joe'
+    get :delete_signed_cookie
+    assert_nil @controller.send(:cookies).signed[:user_name]
+    assert_nil @controller.send(:cookies)[:user_name]
+    assert @controller.send(:cookies).deleted?(:user_name)
+    assert @controller.send(:cookies).signed.deleted?(:user_name)
+  end
+
+  def test_delete_permanent_cookie
+    @controller.send(:cookies).permanent[:user_name] = 'Joe'
+    get :delete_permanent_cookie
+    assert_nil @controller.send(:cookies).permanent[:user_name]
+    assert_nil @controller.send(:cookies)[:user_name]
+    assert @controller.send(:cookies).deleted?(:user_name)
+    assert @controller.send(:cookies).permanent.deleted?(:user_name)
+  end
+
+  def test_clear_encrypted_cookie
+    @controller.send(:cookies).permanent[:user_name] = 'Joe'
+    @controller.send(:cookies).permanent[:user_surname] = 'Smith'
+    get :clear_encrypted_cookie
+    assert_nil @controller.send(:cookies)[:user_name]
+    assert_nil @controller.send(:cookies)[:user_surname]
+    assert @controller.send(:cookies).deleted?(:user_name)
+    assert @controller.send(:cookies).encrypted.deleted?(:user_name)
   end
 
   def test_delete_and_set_cookie


### PR DESCRIPTION
Earlier it was not possible to do cookies.signed.delete or cookies.permanent.clear, cause this and other methods were not properly delegated to parent jar and were called on SignedCookieJar (or PermanentCookieJar) itself, which raised errors. Now SignedCookieJar and PermanentCookieJar can be used anywhere, where regular CookieJar is acceptable.
