### PR TITLE
Allow to easily set default :from option using railties in config/application.rb

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Rails 4.0.0 (unreleased) ##
+
+* Set default Action Mailer options via config.action_mailer.default_options= *Robert Pankowecki*
+
 ## Rails 3.2.5 (Jun 1, 2012) ##
 
 *   No changes.

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -411,33 +411,9 @@ module ActionMailer #:nodoc:
         self.default_params = default_params.merge(value).freeze if value
         default_params
       end
-
-      # Sets the default value of "Who the message is from"
-      #
-      # This is mostly useful when setting the option as a configuration
-      # option in <tt>config/application.rb</tt>:
-      #
-      #   config.action_mailer.default_from = "no-replay@example.org"
-      #
-      # For setting it inside mailer class definition it is better to stick
-      # with <tt>default</tt> method:
-      #
-      #   class Notifier < ActionMailer::Base
-      #     default :from => 'no-reply@example.com'
-      #   end
-      #
-      # But calling it directly is also possible:
-      #
-      #   class OneMailer < ActionMailer::Base
-      #     self.default_from = 'no-reply@example.com'
-      #   end
-      #
-      #   class AnotherMailer < ActionMailer::Base
-      #     default_from=('no-reply@example.com')
-      #   end
-      def default_from=(from)
-        default(from: from)
-      end
+      #Alias so that we can use it in config/application.rb which requires setters
+      #: config.action_mailer.default_options = {from: "no-replay@example.org"}
+      alias :default_options= :default
 
       # Receives a raw email, parses it into an email object, decodes it,
       # instantiates a new mailer, and passes the email object to the mailer

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -412,6 +412,33 @@ module ActionMailer #:nodoc:
         default_params
       end
 
+      # Sets the default value of "Who the message is from"
+      #
+      # This is mostly useful when setting the option as a configuration
+      # option in <tt>config/application.rb</tt>:
+      #
+      #   config.action_mailer.default_from = "no-replay@example.org"
+      #
+      # For setting it inside mailer class definition it is better to stick
+      # with <tt>default</tt> method:
+      #
+      #   class Notifier < ActionMailer::Base
+      #     default :from => 'no-reply@example.com'
+      #   end
+      #
+      # But calling it directly is also possible:
+      #
+      #   class OneMailer < ActionMailer::Base
+      #     self.default_from = 'no-reply@example.com'
+      #   end
+      #
+      #   class AnotherMailer < ActionMailer::Base
+      #     default_from=('no-reply@example.com')
+      #   end
+      def default_from=(from)
+        default(from: from)
+      end
+
       # Receives a raw email, parses it into an email object, decodes it,
       # instantiates a new mailer, and passes the email object to the mailer
       # object's +receive+ method. If you want your mailer to be able to

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -623,6 +623,19 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal "Anonymous mailer body", mailer.welcome.body.encoded.strip
   end
 
+  test "default_from can be set" do
+    class DefaultFromMailer < ActionMailer::Base
+      default :to => 'system@test.lindsaar.net'
+      self.default_from = "robert.pankowecki@gmail.com"
+
+      def welcome
+        mail(subject: "subject")
+      end
+    end
+
+    assert_equal ["robert.pankowecki@gmail.com"], DefaultFromMailer.welcome.from
+  end
+
   protected
 
     # Execute the block setting the given values and restoring old values after

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -626,7 +626,7 @@ class BaseTest < ActiveSupport::TestCase
   test "default_from can be set" do
     class DefaultFromMailer < ActionMailer::Base
       default :to => 'system@test.lindsaar.net'
-      self.default_from = "robert.pankowecki@gmail.com"
+      self.default_options = {from: "robert.pankowecki@gmail.com"}
 
       def welcome
         mail(subject: "subject")

--- a/guides/source/configuring.textile
+++ b/guides/source/configuring.textile
@@ -424,14 +424,12 @@ There are a number of settings available on +config.action_mailer+:
 
 * +config.action_mailer.perform_deliveries+ specifies whether mail will actually be delivered and is true by default. It can be convenient to set it to false for testing.
 
-* +config.action_mailer.default_options+ configures Action Mailer defaults. These default to:
+* +config.action_mailer.default_options+ configures Action Mailer defaults. Use to set options like `from` or `replay_to` for every mailer. These default to:
 <ruby>
 :mime_version => "1.0",
 :charset      => "UTF-8",
 :content_type => "text/plain",
 :parts_order  => [ "text/plain", "text/enriched", "text/html" ],
-:from         => "newsletter@example.org"
-:replay_to    => "no-replay@example.org"
 </ruby>
 
 * +config.action_mailer.observers+ registers observers which will be notified when mail is delivered.

--- a/guides/source/configuring.textile
+++ b/guides/source/configuring.textile
@@ -424,12 +424,14 @@ There are a number of settings available on +config.action_mailer+:
 
 * +config.action_mailer.perform_deliveries+ specifies whether mail will actually be delivered and is true by default. It can be convenient to set it to false for testing.
 
-* +config.action_mailer.default+ configures Action Mailer defaults. These default to:
+* +config.action_mailer.default_options+ configures Action Mailer defaults. These default to:
 <ruby>
 :mime_version => "1.0",
 :charset      => "UTF-8",
 :content_type => "text/plain",
-:parts_order  => [ "text/plain", "text/enriched", "text/html" ]
+:parts_order  => [ "text/plain", "text/enriched", "text/html" ],
+:from         => "newsletter@example.org"
+:replay_to    => "no-replay@example.org"
 </ruby>
 
 * +config.action_mailer.observers+ registers observers which will be notified when mail is delivered.


### PR DESCRIPTION
This is currently not possible using `#default` method because

``` ruby
config.action_mailer.default(from: "no-replay@example.org")
```

is interpreated as reader method and just returns nil. It does not call `ActionMailer::Base.default` method. The only way of calling `ActionMailer::Base` methods from `config/application.rb` is to use the direct syntax which is ugly in my opinion:

``` ruby
config.assets.enabled = false
config.assets.version = '1.0'
config.encoding = "utf-8"
config.action_mailer.default_url_options={host:"example.org", protocol:"https" }
ActionMailer::Base.default(from: "no-replay@example.org")
```

Also the `:from` option is probably the same across multiple mailers. Other options like `:to, :subject, :cc, :bcc` etc. differ between mailing templates but `:from` is usually constant. So i think it deserves a simple way for setting it.
