### PR TITLE
Respect absolute paths in compute_source_path.

### DIFF
--- a/actionpack/lib/action_view/asset_paths.rb
+++ b/actionpack/lib/action_view/asset_paths.rb
@@ -35,7 +35,13 @@ module ActionView
     # Return the filesystem path for the source
     def compute_source_path(source, dir, ext)
       source = rewrite_extension(source, dir, ext) if ext
-      File.join(config.assets_dir, dir, source)
+
+      sources = []
+      sources << config.assets_dir
+      sources << dir unless source[0] == ?/
+      sources << source
+
+      File.join(sources)
     end
 
     def is_uri?(path)

--- a/actionpack/test/fixtures/public/foo/baz.css
+++ b/actionpack/test/fixtures/public/foo/baz.css
@@ -1,0 +1,3 @@
+body {
+background: #000;
+}

--- a/actionpack/test/template/asset_tag_helper_test.rb
+++ b/actionpack/test/template/asset_tag_helper_test.rb
@@ -1267,9 +1267,6 @@ class AssetTagHelperTest < ActionView::TestCase
     assert !File.exist?(File.join(ActionView::Helpers::AssetTagHelper::STYLESHEETS_DIR, 'money.css'))
   end
 
-
-
-
   def test_caching_stylesheet_include_tag_when_caching_off
     ENV["RAILS_ASSET_ID"] = ""
     config.perform_caching = false
@@ -1297,6 +1294,17 @@ class AssetTagHelperTest < ActionView::TestCase
     )
 
     assert !File.exist?(File.join(ActionView::Helpers::AssetTagHelper::STYLESHEETS_DIR, 'money.css'))
+  end
+
+  def test_caching_stylesheet_include_tag_with_absolute_uri
+    ENV["RAILS_ASSET_ID"] = ""
+
+    assert_dom_equal(
+      %(<link href="/stylesheets/all.css" media="screen" rel="stylesheet" />),
+      stylesheet_link_tag("/foo/baz", :cache => true)
+    )
+
+    FileUtils.rm(File.join(ActionView::Helpers::AssetTagHelper::STYLESHEETS_DIR, 'all.css'))
   end
 end
 


### PR DESCRIPTION
When using compute_source_path to determine the full path of an
asset, if our source begins with '/', we don't want to include
the directory. Examples are illustrative:

```
compute_source_path("foo", "stylesheets", "css")
# => "/Users/steve/src/my_app/public/stylesheets/foo.css"
compute_source_path("/foo", "stylesheets", "css")
# => "/Users/steve/src/my_app/public/foo.css"
```

Before this patch, the second example would return the same as the
first.

Fixes #5680.

If this is accepted, I will also backport to 3.2.
