### PR TITLE
Don't read csv file during executing db:fixtures:load.

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -318,7 +318,7 @@ db_namespace = namespace :db do
       base_dir     = File.join [Rails.root, ENV['FIXTURES_PATH'] || %w{test fixtures}].flatten
       fixtures_dir = File.join [base_dir, ENV['FIXTURES_DIR']].compact
 
-      (ENV['FIXTURES'] ? ENV['FIXTURES'].split(/,/) : Dir["#{fixtures_dir}/**/*.{yml,csv}"].map {|f| f[(fixtures_dir.size + 1)..-5] }).each do |fixture_file|
+      (ENV['FIXTURES'] ? ENV['FIXTURES'].split(/,/) : Dir["#{fixtures_dir}/**/*.yml"].map {|f| f[(fixtures_dir.size + 1)..-5] }).each do |fixture_file|
         ActiveRecord::Fixtures.create_fixtures(fixtures_dir, fixture_file)
       end
     end

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -122,6 +122,18 @@ module ApplicationTests
       assert_equal 0, ::AppTemplate::Application::User.count
     end
 
+    def test_loading_only_yml_fixtures
+      Dir.chdir(app_path) do
+        `rake db:migrate`
+      end
+
+      app_file "test/fixtures/products.csv", ""
+
+      require "#{rails_root}/config/environment"
+      errormsg = Dir.chdir(app_path) { `rake db:fixtures:load` }
+      assert $?.success?, errormsg
+    end
+
     def test_scaffold_tests_pass_by_default
       output = Dir.chdir(app_path) do
         `rails generate scaffold user username:string password:string;


### PR DESCRIPTION
We removed csv fixture support by https://github.com/rails/rails/commit/1716da07204193c8acf967e2d75a53a82e4c7c28 .

But db:fixtures:load task try to read csv file yet.
