### PR TITLE
Fixed gem deps

### DIFF
--- a/rails.gemspec
+++ b/rails.gemspec
@@ -26,4 +26,6 @@ Gem::Specification.new do |s|
   s.add_dependency('railties',        version)
   s.add_dependency('bundler',         '~> 1.1')
   s.add_dependency('sprockets-rails', '~> 1.0')
+  s.add_dependency('rake',            '~> 0.8')
+  s.add_dependency('rdoc',            '~> 3.0')
 end


### PR DESCRIPTION
I'm not sure if you want rake at 0.8 or 0.9, but I've found "~> 0.8" to be sufficient for everything I'm doing with it.
