### PR TITLE
Avoid unnecessary catching of Exception instead of StandardError.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -370,7 +370,7 @@ module ActiveRecord
             records.uniq.each do |record|
               begin
                 record.rolledback!(rollback)
-              rescue Exception => e
+              rescue => e
                 record.logger.error(e) if record.respond_to?(:logger) && record.logger
               end
             end
@@ -385,7 +385,7 @@ module ActiveRecord
             records.uniq.each do |record|
               begin
                 record.committed!
-              rescue Exception => e
+              rescue => e
                 record.logger.error(e) if record.respond_to?(:logger) && record.logger
               end
             end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -286,7 +286,7 @@ module ActiveRecord
           :name          => name,
           :connection_id => object_id,
           :binds         => binds) { yield }
-      rescue Exception => e
+      rescue => e
         message = "#{e.class.name}: #{e.message}: #{sql}"
         @logger.error message if @logger
         exception = translate_exception(e, message)

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -264,19 +264,19 @@ module ActiveRecord
 
       def begin_db_transaction
         execute "BEGIN"
-      rescue Exception
+      rescue
         # Transactions aren't supported
       end
 
       def commit_db_transaction #:nodoc:
         execute "COMMIT"
-      rescue Exception
+      rescue
         # Transactions aren't supported
       end
 
       def rollback_db_transaction #:nodoc:
         execute "ROLLBACK"
-      rescue Exception
+      rescue
         # Transactions aren't supported
       end
 

--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -92,7 +92,7 @@ module ActiveSupport
       method = message.split('.').first
       begin
         send(method, ActiveSupport::Notifications::Event.new(message, *args))
-      rescue Exception => e
+      rescue => e
         logger.error "Could not log #{message.inspect} event. #{e.class}: #{e.message} #{e.backtrace}"
       end
     end

--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -331,7 +331,7 @@ module ActiveSupport
         def load
           begin
             @codepoints, @composition_exclusion, @composition_map, @boundary, @cp1252 = File.open(self.class.filename, 'rb') { |f| Marshal.load f.read }
-          rescue Exception => e
+          rescue => e
               raise IOError.new("Couldn't load the Unicode tables for UTF8Handler (#{e.message}), ActiveSupport::Multibyte is unusable")
           end
 


### PR DESCRIPTION
Non-`StandardError` `Exception`s are generally not meant to be caught without re-raising the exception, because they are often unrecoverable errors. I found some instances of these exceptions being unnecessarily caught.

For reference, here are a list of non-`StandardError` exceptions from a fresh irb session.

``` ruby
ObjectSpace.each_object(Class) do |c|
  c < Exception && !(c < StandardError) && puts("#{c.name} < #{c.superclass}")
end
```

``` ruby
Gem::LoadError < LoadError
SystemStackError < Exception
NoMemoryError < Exception
SecurityError < Exception
NotImplementedError < ScriptError
LoadError < ScriptError
SyntaxError < ScriptError
ScriptError < Exception
StandardError < Exception
Interrupt < SignalException
SignalException < Exception
fatal < Exception
SystemExit < Exception
Gem::SystemExitException < SystemExit
IRB::Abort < Exception
```

If one of the above exceptions does need to be caught, it would make more sense to specify a more specific exception class to catch (e.g. `ScriptError` when dynamically loading scripts).  However, the lines I changed didn't need to catch serious errors like those listed above.
