### PR TITLE
Get logic out of db rake tasks, and into classes and objects

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -141,6 +141,8 @@ module ActiveRecord
     extend ActiveSupport::Autoload
 
     autoload :DatabaseTasks
+    autoload :SQLiteDatabaseTasks, 'active_record/tasks/sqlite_database_tasks'
+    autoload :MySQLDatabaseTasks,  'active_record/tasks/mysql_database_tasks'
   end
 
   autoload :TestCase

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -143,6 +143,8 @@ module ActiveRecord
     autoload :DatabaseTasks
     autoload :SQLiteDatabaseTasks, 'active_record/tasks/sqlite_database_tasks'
     autoload :MySQLDatabaseTasks,  'active_record/tasks/mysql_database_tasks'
+    autoload :PostgreSQLDatabaseTasks,
+      'active_record/tasks/postgresql_database_tasks'
   end
 
   autoload :TestCase

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -137,6 +137,12 @@ module ActiveRecord
     end
   end
 
+  module Tasks
+    extend ActiveSupport::Autoload
+
+    autoload :DatabaseTasks
+  end
+
   autoload :TestCase
   autoload :TestFixtures, 'active_record/fixtures'
 end

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -59,36 +59,7 @@ db_namespace = namespace :db do
     rescue
       case config['adapter']
       when /mysql/
-        if config['adapter'] =~ /jdbc/
-          #FIXME After Jdbcmysql gives this class
-          require 'active_record/railties/jdbcmysql_error'
-          error_class = ArJdbcMySQL::Error
-        else
-          error_class = config['adapter'] =~ /mysql2/ ? Mysql2::Error : Mysql::Error
-        end
-        access_denied_error = 1045
-        begin
-          ActiveRecord::Base.establish_connection(config.merge('database' => nil))
-          ActiveRecord::Base.connection.create_database(config['database'], mysql_creation_options(config))
-          ActiveRecord::Base.establish_connection(config)
-        rescue error_class => sqlerr
-          if sqlerr.errno == access_denied_error
-            print "#{sqlerr.error}. \nPlease provide the root password for your mysql installation\n>"
-            root_password = $stdin.gets.strip
-            grant_statement = "GRANT ALL PRIVILEGES ON #{config['database']}.* " \
-              "TO '#{config['username']}'@'localhost' " \
-              "IDENTIFIED BY '#{config['password']}' WITH GRANT OPTION;"
-            ActiveRecord::Base.establish_connection(config.merge(
-                'database' => nil, 'username' => 'root', 'password' => root_password))
-            ActiveRecord::Base.connection.create_database(config['database'], mysql_creation_options(config))
-            ActiveRecord::Base.connection.execute grant_statement
-            ActiveRecord::Base.establish_connection(config)
-          else
-            $stderr.puts sqlerr.error
-            $stderr.puts "Couldn't create database for #{config.inspect}, charset: #{config['charset'] || @charset}, collation: #{config['collation'] || @collation}"
-            $stderr.puts "(if you set the charset manually, make sure you have a matching collation)" if config['charset']
-          end
-        end
+        ActiveRecord::Tasks::DatabaseTasks.create config
       when /postgresql/
         @encoding = config['encoding'] || ENV['CHARSET'] || 'utf8'
         begin

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -50,18 +50,7 @@ db_namespace = namespace :db do
   def create_database(config)
     begin
       if config['adapter'] =~ /sqlite/
-        if File.exist?(config['database'])
-          $stderr.puts "#{config['database']} already exists"
-        else
-          begin
-            # Create the SQLite database
-            ActiveRecord::Base.establish_connection(config)
-            ActiveRecord::Base.connection
-          rescue Exception => e
-            $stderr.puts e, *(e.backtrace)
-            $stderr.puts "Couldn't create database for #{config.inspect}"
-          end
-        end
+        ActiveRecord::Tasks::DatabaseTasks.create config
         return # Skip the else clause of begin/rescue
       else
         ActiveRecord::Base.establish_connection(config)

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -7,9 +7,20 @@ class ActiveRecord::Tasks::DatabaseTasks
 
   def self.create(configuration)
     class_for_adapter(configuration['adapter']).new(configuration).create
-  rescue Exception => e
-    $stderr.puts e, *(e.backtrace)
+  rescue Exception => error
+    $stderr.puts error, *(error.backtrace)
     $stderr.puts "Couldn't create database for #{configuration.inspect}"
+  end
+
+  def self.drop(configuration)
+    class_for_adapter(configuration['adapter']).new(configuration).drop
+  rescue Exception => error
+    $stderr.puts error, *(error.backtrace)
+    $stderr.puts "Couldn't drop #{configuration['database']}"
+  end
+
+  def self.purge(configuration)
+    class_for_adapter(configuration['adapter']).new(configuration).purge
   end
 
   def self.class_for_adapter(adapter)

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -19,7 +19,7 @@ class ActiveRecord::Tasks::DatabaseTasks
 
   def self.create_current
     each_current_configuration { |configuration| create configuration }
-    ActiveRecord::Base.establish_connection Rails.env.to_sym
+    ActiveRecord::Base.establish_connection Rails.env
   end
 
   def self.drop(configuration)
@@ -44,7 +44,7 @@ class ActiveRecord::Tasks::DatabaseTasks
   private
 
   def self.class_for_adapter(adapter)
-    key = TASKS_PATTERNS.keys.detect { |key| adapter[key] }
+    key = TASKS_PATTERNS.keys.detect { |pattern| adapter[pattern] }
     TASKS_PATTERNS[key]
   end
 
@@ -52,7 +52,7 @@ class ActiveRecord::Tasks::DatabaseTasks
     environments = [Rails.env]
     environments << 'test' if Rails.env.development?
 
-    configurations = ActiveRecord::Base.configurations.values_at *environments
+    configurations = ActiveRecord::Base.configurations.values_at(*environments)
     configurations.compact.each do |configuration|
       yield configuration unless configuration['database'].blank?
     end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -1,0 +1,14 @@
+class ActiveRecord::Tasks::DatabaseTasks
+  def self.create(configuration)
+    if File.exist?(configuration['database'])
+      $stderr.puts "#{configuration['database']} already exists"
+      return
+    end
+
+    ActiveRecord::Base.establish_connection(configuration)
+    ActiveRecord::Base.connection
+  rescue Exception => e
+    $stderr.puts e, *(e.backtrace)
+    $stderr.puts "Couldn't create database for #{configuration.inspect}"
+  end
+end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -1,7 +1,7 @@
 class ActiveRecord::Tasks::DatabaseTasks
   TASKS_PATTERNS = {
     /mysql/      => ActiveRecord::Tasks::MySQLDatabaseTasks,
-    # /postgresql/ => ActiveRecord::Tasks::PostgreSQLTasker,
+    /postgresql/ => ActiveRecord::Tasks::PostgreSQLDatabaseTasks,
     /sqlite/     => ActiveRecord::Tasks::SQLiteDatabaseTasks
   }
 

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -4,12 +4,22 @@ class ActiveRecord::Tasks::DatabaseTasks
     /postgresql/ => ActiveRecord::Tasks::PostgreSQLDatabaseTasks,
     /sqlite/     => ActiveRecord::Tasks::SQLiteDatabaseTasks
   }
+  LOCAL_HOSTS    = ['127.0.0.1', 'localhost']
 
   def self.create(configuration)
     class_for_adapter(configuration['adapter']).new(configuration).create
   rescue Exception => error
     $stderr.puts error, *(error.backtrace)
     $stderr.puts "Couldn't create database for #{configuration.inspect}"
+  end
+
+  def self.create_all
+    each_local_configuration { |configuration| create configuration }
+  end
+
+  def self.create_current
+    each_current_configuration { |configuration| create configuration }
+    ActiveRecord::Base.establish_connection Rails.env.to_sym
   end
 
   def self.drop(configuration)
@@ -19,12 +29,48 @@ class ActiveRecord::Tasks::DatabaseTasks
     $stderr.puts "Couldn't drop #{configuration['database']}"
   end
 
+  def self.drop_all
+    each_local_configuration { |configuration| drop configuration }
+  end
+
+  def self.drop_current
+    each_current_configuration { |configuration| drop configuration }
+  end
+
   def self.purge(configuration)
     class_for_adapter(configuration['adapter']).new(configuration).purge
   end
 
+  private
+
   def self.class_for_adapter(adapter)
     key = TASKS_PATTERNS.keys.detect { |key| adapter[key] }
     TASKS_PATTERNS[key]
+  end
+
+  def self.each_current_configuration
+    environments = [Rails.env]
+    environments << 'test' if Rails.env.development?
+
+    configurations = ActiveRecord::Base.configurations.values_at *environments
+    configurations.compact.each do |configuration|
+      yield configuration unless configuration['database'].blank?
+    end
+  end
+
+  def self.each_local_configuration
+    ActiveRecord::Base.configurations.each_value do |configuration|
+      next unless configuration['database']
+
+      if local_database?(configuration)
+        yield configuration
+      else
+        $stderr.puts "This task only modifies local databases. #{configuration['database']} is on a remote host."
+      end
+    end
+  end
+
+  def self.local_database?(configuration)
+    configuration['host'].in?(LOCAL_HOSTS) || configuration['host'].blank?
   end
 end

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -39,7 +39,9 @@ class ActiveRecord::Tasks::MySQLDatabaseTasks
 
   private
 
-  attr_reader :configuration
+  def configuration
+    @configuration
+  end
 
   def configuration_without_database
     configuration.merge('database' => nil)
@@ -56,7 +58,7 @@ class ActiveRecord::Tasks::MySQLDatabaseTasks
     case configuration['adapter']
     when /jdbc/
       require 'active_record/railties/jdbcmysql_error'
-      error_class = ArJdbcMySQL::Error
+      ArJdbcMySQL::Error
     when /mysql2/
       Mysql2::Error
     else

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -1,0 +1,76 @@
+class ActiveRecord::Tasks::MySQLDatabaseTasks
+  DEFAULT_CHARSET     = ENV['CHARSET']   || 'utf8'
+  DEFAULT_COLLATION   = ENV['COLLATION'] || 'utf8_unicode_ci'
+  ACCESS_DENIED_ERROR = 1045
+
+  delegate :connection, :establish_connection, :to => ActiveRecord::Base
+
+  def initialize(configuration)
+    @configuration = configuration
+  end
+
+  def create
+    establish_connection configuration_without_database
+    connection.create_database configuration['database'], creation_options
+    establish_connection configuration
+  rescue error_class => error
+    raise error unless error.errno == ACCESS_DENIED_ERROR
+
+    $stdout.print error.error
+    establish_connection root_configuration_without_database
+    connection.create_database configuration['database'], creation_options
+    connection.execute grant_statement.gsub(/\s+/, ' ').strip
+    establish_connection configuration
+  rescue error_class => error
+    $stderr.puts error.error
+    $stderr.puts "Couldn't create database for #{configuration.inspect}, #{creation_options.inspect}"
+    $stderr.puts "(If you set the charset manually, make sure you have a matching collation)" if configuration['charset']
+  end
+
+  private
+
+  attr_reader :configuration
+
+  def configuration_without_database
+    configuration.merge('database' => nil)
+  end
+
+  def creation_options
+    {
+      :charset   => (configuration['charset']   || DEFAULT_CHARSET),
+      :collation => (configuration['collation'] || DEFAULT_COLLATION)
+    }
+  end
+
+  def error_class
+    case configuration['adapter']
+    when /jdbc/
+      require 'active_record/railties/jdbcmysql_error'
+      error_class = ArJdbcMySQL::Error
+    when /mysql2/
+      Mysql2::Error
+    else
+      Mysql::Error
+    end
+  end
+
+  def grant_statement
+    <<-SQL
+GRANT ALL PRIVILEGES ON #{configuration['database']}.*
+  TO '#{configuration['username']}'@'localhost'
+IDENTIFIED BY '#{configuration['password']}' WITH GRANT OPTION;
+    SQL
+  end
+
+  def root_configuration_without_database
+    configuration_without_database.merge(
+      'username' => 'root',
+      'password' => root_password
+    )
+  end
+
+  def root_password
+    $stdout.print "Please provide the root password for your mysql installation\n>"
+    $stdin.gets.strip
+  end
+end

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -27,6 +27,16 @@ class ActiveRecord::Tasks::MySQLDatabaseTasks
     $stderr.puts "(If you set the charset manually, make sure you have a matching collation)" if configuration['charset']
   end
 
+  def drop
+    establish_connection configuration
+    connection.drop_database configuration['database']
+  end
+
+  def purge
+    establish_connection :test
+    connection.recreate_database configuration['database'], creation_options
+  end
+
   private
 
   attr_reader :configuration

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -1,0 +1,27 @@
+class ActiveRecord::Tasks::PostgreSQLDatabaseTasks
+  DEFAULT_ENCODING = ENV['CHARSET'] || 'utf8'
+
+  delegate :connection, :establish_connection, :to => ActiveRecord::Base
+
+  def initialize(configuration)
+    @configuration = configuration
+  end
+
+  def create
+    establish_connection configuration.merge(
+      'database' => 'postgres',
+      'schema_search_path' => 'public'
+    )
+    connection.create_database configuration['database'],
+      configuration.merge('encoding' => encoding)
+    establish_connection configuration
+  end
+
+  private
+
+  attr_reader :configuration
+
+  def encoding
+    configuration['encoding'] || DEFAULT_ENCODING
+  end
+end

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -1,20 +1,29 @@
 class ActiveRecord::Tasks::PostgreSQLDatabaseTasks
   DEFAULT_ENCODING = ENV['CHARSET'] || 'utf8'
 
-  delegate :connection, :establish_connection, :to => ActiveRecord::Base
+  delegate :connection, :establish_connection, :clear_active_connections!,
+    :to => ActiveRecord::Base
 
   def initialize(configuration)
     @configuration = configuration
   end
 
-  def create
-    establish_connection configuration.merge(
-      'database' => 'postgres',
-      'schema_search_path' => 'public'
-    )
+  def create(master_established = false)
+    establish_master_connection unless master_established
     connection.create_database configuration['database'],
       configuration.merge('encoding' => encoding)
     establish_connection configuration
+  end
+
+  def drop
+    establish_master_connection
+    connection.drop_database configuration['database']
+  end
+
+  def purge
+    clear_active_connections!
+    drop
+    create true
   end
 
   private
@@ -23,5 +32,12 @@ class ActiveRecord::Tasks::PostgreSQLDatabaseTasks
 
   def encoding
     configuration['encoding'] || DEFAULT_ENCODING
+  end
+
+  def establish_master_connection
+    establish_connection configuration.merge(
+      'database'           => 'postgres',
+      'schema_search_path' => 'public'
+    )
   end
 end

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -28,7 +28,9 @@ class ActiveRecord::Tasks::PostgreSQLDatabaseTasks
 
   private
 
-  attr_reader :configuration
+  def configuration
+    @configuration
+  end
 
   def encoding
     configuration['encoding'] || DEFAULT_ENCODING

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -27,5 +27,7 @@ class ActiveRecord::Tasks::SQLiteDatabaseTasks
 
   private
 
-  attr_reader :configuration
+  def configuration
+    @configuration
+  end
 end

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -1,8 +1,8 @@
 class ActiveRecord::Tasks::SQLiteDatabaseTasks
   delegate :connection, :establish_connection, :to => ActiveRecord::Base
 
-  def initialize(configuration)
-    @configuration = configuration
+  def initialize(configuration, root = Rails.root)
+    @configuration, @root = configuration, root
   end
 
   def create
@@ -18,7 +18,7 @@ class ActiveRecord::Tasks::SQLiteDatabaseTasks
   def drop
     require 'pathname'
     path = Pathname.new configuration['database']
-    file = path.absolute? ? path.to_s : File.join(Rails.root, path)
+    file = path.absolute? ? path.to_s : File.join(root, path)
 
     FileUtils.rm(file)
   end
@@ -29,5 +29,9 @@ class ActiveRecord::Tasks::SQLiteDatabaseTasks
 
   def configuration
     @configuration
+  end
+
+  def root
+    @root
   end
 end

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -1,0 +1,19 @@
+class ActiveRecord::Tasks::SQLiteDatabaseTasks
+  def initialize(configuration)
+    @configuration = configuration
+  end
+
+  def create
+    if File.exist?(configuration['database'])
+      $stderr.puts "#{configuration['database']} already exists"
+      return
+    end
+
+    ActiveRecord::Base.establish_connection(configuration)
+    ActiveRecord::Base.connection
+  end
+
+  private
+
+  attr_reader :configuration
+end

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -15,6 +15,16 @@ class ActiveRecord::Tasks::SQLiteDatabaseTasks
     connection
   end
 
+  def drop
+    require 'pathname'
+    path = Pathname.new configuration['database']
+    file = path.absolute? ? path.to_s : File.join(Rails.root, path)
+
+    FileUtils.rm(file)
+  end
+
+  alias :purge :drop
+
   private
 
   attr_reader :configuration

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -1,16 +1,18 @@
 class ActiveRecord::Tasks::SQLiteDatabaseTasks
+  delegate :connection, :establish_connection, :to => ActiveRecord::Base
+
   def initialize(configuration)
     @configuration = configuration
   end
 
   def create
-    if File.exist?(configuration['database'])
+    if File.exist? configuration['database']
       $stderr.puts "#{configuration['database']} already exists"
       return
     end
 
-    ActiveRecord::Base.establish_connection(configuration)
-    ActiveRecord::Base.connection
+    establish_connection configuration
+    connection
   end
 
   private

--- a/activerecord/test/cases/database_tasks_test.rb
+++ b/activerecord/test/cases/database_tasks_test.rb
@@ -1,0 +1,296 @@
+require 'cases/helper'
+
+module ActiveRecord
+  class DatabaseTasksCreateTest < ActiveRecord::TestCase
+    def setup
+      @mysql_tasks, @postgresql_tasks, @sqlite_tasks = stub, stub, stub
+
+      ActiveRecord::Tasks::MySQLDatabaseTasks.stubs(:new).returns @mysql_tasks
+      ActiveRecord::Tasks::PostgreSQLDatabaseTasks.stubs(:new).
+        returns @postgresql_tasks
+      ActiveRecord::Tasks::SQLiteDatabaseTasks.stubs(:new).returns @sqlite_tasks
+    end
+
+    def test_mysql_create
+      @mysql_tasks.expects(:create)
+
+      ActiveRecord::Tasks::DatabaseTasks.create 'adapter' => 'mysql'
+    end
+
+    def test_mysql2_create
+      @mysql_tasks.expects(:create)
+
+      ActiveRecord::Tasks::DatabaseTasks.create 'adapter' => 'mysql2'
+    end
+
+    def test_postgresql_create
+      @postgresql_tasks.expects(:create)
+
+      ActiveRecord::Tasks::DatabaseTasks.create 'adapter' => 'postgresql'
+    end
+
+    def test_sqlite_create
+      @sqlite_tasks.expects(:create)
+
+      ActiveRecord::Tasks::DatabaseTasks.create 'adapter' => 'sqlite3'
+    end
+  end
+
+  class DatabaseTasksCreateAllTest < ActiveRecord::TestCase
+    def setup
+      @configurations = {'development' => {'database' => 'my-db'}}
+
+      ActiveRecord::Base.stubs(:configurations).returns(@configurations)
+    end
+
+    def test_ignores_configurations_without_databases
+      @configurations['development'].merge!('database' => nil)
+
+      ActiveRecord::Tasks::DatabaseTasks.expects(:create).never
+
+      ActiveRecord::Tasks::DatabaseTasks.create_all
+    end
+
+    def test_ignores_remote_databases
+      @configurations['development'].merge!('host' => 'my.server.tld')
+      $stderr.stubs(:puts).returns(nil)
+
+      ActiveRecord::Tasks::DatabaseTasks.expects(:create).never
+
+      ActiveRecord::Tasks::DatabaseTasks.create_all
+    end
+
+    def test_warning_for_remote_databases
+      @configurations['development'].merge!('host' => 'my.server.tld')
+
+      $stderr.expects(:puts).with('This task only modifies local databases. my-db is on a remote host.')
+
+      ActiveRecord::Tasks::DatabaseTasks.create_all
+    end
+
+    def test_creates_configurations_with_local_ip
+      @configurations['development'].merge!('host' => '127.0.0.1')
+
+      ActiveRecord::Tasks::DatabaseTasks.expects(:create)
+
+      ActiveRecord::Tasks::DatabaseTasks.create_all
+    end
+
+    def test_creates_configurations_with_local_host
+      @configurations['development'].merge!('host' => 'localhost')
+
+      ActiveRecord::Tasks::DatabaseTasks.expects(:create)
+
+      ActiveRecord::Tasks::DatabaseTasks.create_all
+    end
+
+    def test_creates_configurations_with_blank_hosts
+      @configurations['development'].merge!('host' => nil)
+
+      ActiveRecord::Tasks::DatabaseTasks.expects(:create)
+
+      ActiveRecord::Tasks::DatabaseTasks.create_all
+    end
+  end
+
+  class DatabaseTasksCreateCurrentTest < ActiveRecord::TestCase
+    def setup
+      @configurations = {
+        'development' => {'database' => 'dev-db'},
+        'test'        => {'database' => 'test-db'},
+        'production'  => {'database' => 'prod-db'}
+      }
+
+      ActiveRecord::Base.stubs(:configurations).returns(@configurations)
+      ActiveRecord::Base.stubs(:establish_connection).returns(true)
+    end
+
+    def test_creates_current_environment_database
+      Rails.stubs(:env).returns ActiveSupport::StringInquirer.new('production')
+
+      ActiveRecord::Tasks::DatabaseTasks.expects(:create).
+        with('database' => 'prod-db')
+
+      ActiveRecord::Tasks::DatabaseTasks.create_current
+    end
+
+    def test_creates_test_database_when_environment_is_database
+      Rails.stubs(:env).returns ActiveSupport::StringInquirer.new('development')
+
+      ActiveRecord::Tasks::DatabaseTasks.expects(:create).
+        with('database' => 'dev-db')
+      ActiveRecord::Tasks::DatabaseTasks.expects(:create).
+        with('database' => 'test-db')
+
+      ActiveRecord::Tasks::DatabaseTasks.create_current
+    end
+
+    def test_establishes_connection_for_the_given_environment
+      Rails.stubs(:env).returns ActiveSupport::StringInquirer.new('development')
+      ActiveRecord::Tasks::DatabaseTasks.stubs(:create).returns true
+
+      ActiveRecord::Base.expects(:establish_connection).with('development')
+
+      ActiveRecord::Tasks::DatabaseTasks.create_current
+    end
+  end
+
+  class DatabaseTasksDropTest < ActiveRecord::TestCase
+    def setup
+      @mysql_tasks, @postgresql_tasks, @sqlite_tasks = stub, stub, stub
+
+      ActiveRecord::Tasks::MySQLDatabaseTasks.stubs(:new).returns @mysql_tasks
+      ActiveRecord::Tasks::PostgreSQLDatabaseTasks.stubs(:new).
+        returns @postgresql_tasks
+      ActiveRecord::Tasks::SQLiteDatabaseTasks.stubs(:new).returns @sqlite_tasks
+    end
+
+    def test_mysql_create
+      @mysql_tasks.expects(:drop)
+
+      ActiveRecord::Tasks::DatabaseTasks.drop 'adapter' => 'mysql'
+    end
+
+    def test_mysql2_create
+      @mysql_tasks.expects(:drop)
+
+      ActiveRecord::Tasks::DatabaseTasks.drop 'adapter' => 'mysql2'
+    end
+
+    def test_postgresql_create
+      @postgresql_tasks.expects(:drop)
+
+      ActiveRecord::Tasks::DatabaseTasks.drop 'adapter' => 'postgresql'
+    end
+
+    def test_sqlite_create
+      @sqlite_tasks.expects(:drop)
+
+      ActiveRecord::Tasks::DatabaseTasks.drop 'adapter' => 'sqlite3'
+    end
+  end
+
+  class DatabaseTasksDropAllTest < ActiveRecord::TestCase
+    def setup
+      @configurations = {:development => {'database' => 'my-db'}}
+
+      ActiveRecord::Base.stubs(:configurations).returns(@configurations)
+    end
+
+    def test_ignores_configurations_without_databases
+      @configurations[:development].merge!('database' => nil)
+
+      ActiveRecord::Tasks::DatabaseTasks.expects(:drop).never
+
+      ActiveRecord::Tasks::DatabaseTasks.drop_all
+    end
+
+    def test_ignores_remote_databases
+      @configurations[:development].merge!('host' => 'my.server.tld')
+      $stderr.stubs(:puts).returns(nil)
+
+      ActiveRecord::Tasks::DatabaseTasks.expects(:drop).never
+
+      ActiveRecord::Tasks::DatabaseTasks.drop_all
+    end
+
+    def test_warning_for_remote_databases
+      @configurations[:development].merge!('host' => 'my.server.tld')
+
+      $stderr.expects(:puts).with('This task only modifies local databases. my-db is on a remote host.')
+
+      ActiveRecord::Tasks::DatabaseTasks.drop_all
+    end
+
+    def test_creates_configurations_with_local_ip
+      @configurations[:development].merge!('host' => '127.0.0.1')
+
+      ActiveRecord::Tasks::DatabaseTasks.expects(:drop)
+
+      ActiveRecord::Tasks::DatabaseTasks.drop_all
+    end
+
+    def test_creates_configurations_with_local_host
+      @configurations[:development].merge!('host' => 'localhost')
+
+      ActiveRecord::Tasks::DatabaseTasks.expects(:drop)
+
+      ActiveRecord::Tasks::DatabaseTasks.drop_all
+    end
+
+    def test_creates_configurations_with_blank_hosts
+      @configurations[:development].merge!('host' => nil)
+
+      ActiveRecord::Tasks::DatabaseTasks.expects(:drop)
+
+      ActiveRecord::Tasks::DatabaseTasks.drop_all
+    end
+  end
+
+  class DatabaseTasksDropCurrentTest < ActiveRecord::TestCase
+    def setup
+      @configurations = {
+        'development' => {'database' => 'dev-db'},
+        'test'        => {'database' => 'test-db'},
+        'production'  => {'database' => 'prod-db'}
+      }
+
+      ActiveRecord::Base.stubs(:configurations).returns(@configurations)
+    end
+
+    def test_creates_current_environment_database
+      Rails.stubs(:env).returns ActiveSupport::StringInquirer.new('production')
+
+      ActiveRecord::Tasks::DatabaseTasks.expects(:drop).
+        with('database' => 'prod-db')
+
+      ActiveRecord::Tasks::DatabaseTasks.drop_current
+    end
+
+    def test_creates_test_database_when_environment_is_database
+      Rails.stubs(:env).returns ActiveSupport::StringInquirer.new('development')
+
+      ActiveRecord::Tasks::DatabaseTasks.expects(:drop).
+        with('database' => 'dev-db')
+      ActiveRecord::Tasks::DatabaseTasks.expects(:drop).
+        with('database' => 'test-db')
+
+      ActiveRecord::Tasks::DatabaseTasks.drop_current
+    end
+  end
+
+  class DatabaseTasksPurgeTest < ActiveRecord::TestCase
+    def setup
+      @mysql_tasks, @postgresql_tasks, @sqlite_tasks = stub, stub, stub
+
+      ActiveRecord::Tasks::MySQLDatabaseTasks.stubs(:new).returns @mysql_tasks
+      ActiveRecord::Tasks::PostgreSQLDatabaseTasks.stubs(:new).
+        returns @postgresql_tasks
+      ActiveRecord::Tasks::SQLiteDatabaseTasks.stubs(:new).returns @sqlite_tasks
+    end
+
+    def test_mysql_create
+      @mysql_tasks.expects(:purge)
+
+      ActiveRecord::Tasks::DatabaseTasks.purge 'adapter' => 'mysql'
+    end
+
+    def test_mysql2_create
+      @mysql_tasks.expects(:purge)
+
+      ActiveRecord::Tasks::DatabaseTasks.purge 'adapter' => 'mysql2'
+    end
+
+    def test_postgresql_create
+      @postgresql_tasks.expects(:purge)
+
+      ActiveRecord::Tasks::DatabaseTasks.purge 'adapter' => 'postgresql'
+    end
+
+    def test_sqlite_create
+      @sqlite_tasks.expects(:purge)
+
+      ActiveRecord::Tasks::DatabaseTasks.purge 'adapter' => 'sqlite3'
+    end
+  end
+end

--- a/activerecord/test/cases/database_tasks_test.rb
+++ b/activerecord/test/cases/database_tasks_test.rb
@@ -106,32 +106,33 @@ module ActiveRecord
     end
 
     def test_creates_current_environment_database
-      Rails.stubs(:env).returns ActiveSupport::StringInquirer.new('production')
-
       ActiveRecord::Tasks::DatabaseTasks.expects(:create).
         with('database' => 'prod-db')
 
-      ActiveRecord::Tasks::DatabaseTasks.create_current
+      ActiveRecord::Tasks::DatabaseTasks.create_current(
+        ActiveSupport::StringInquirer.new('production')
+      )
     end
 
     def test_creates_test_database_when_environment_is_database
-      Rails.stubs(:env).returns ActiveSupport::StringInquirer.new('development')
-
       ActiveRecord::Tasks::DatabaseTasks.expects(:create).
         with('database' => 'dev-db')
       ActiveRecord::Tasks::DatabaseTasks.expects(:create).
         with('database' => 'test-db')
 
-      ActiveRecord::Tasks::DatabaseTasks.create_current
+      ActiveRecord::Tasks::DatabaseTasks.create_current(
+        ActiveSupport::StringInquirer.new('development')
+      )
     end
 
     def test_establishes_connection_for_the_given_environment
-      Rails.stubs(:env).returns ActiveSupport::StringInquirer.new('development')
       ActiveRecord::Tasks::DatabaseTasks.stubs(:create).returns true
 
       ActiveRecord::Base.expects(:establish_connection).with('development')
 
-      ActiveRecord::Tasks::DatabaseTasks.create_current
+      ActiveRecord::Tasks::DatabaseTasks.create_current(
+        ActiveSupport::StringInquirer.new('development')
+      )
     end
   end
 
@@ -239,23 +240,23 @@ module ActiveRecord
     end
 
     def test_creates_current_environment_database
-      Rails.stubs(:env).returns ActiveSupport::StringInquirer.new('production')
-
       ActiveRecord::Tasks::DatabaseTasks.expects(:drop).
         with('database' => 'prod-db')
 
-      ActiveRecord::Tasks::DatabaseTasks.drop_current
+      ActiveRecord::Tasks::DatabaseTasks.drop_current(
+        ActiveSupport::StringInquirer.new('production')
+      )
     end
 
     def test_creates_test_database_when_environment_is_database
-      Rails.stubs(:env).returns ActiveSupport::StringInquirer.new('development')
-
       ActiveRecord::Tasks::DatabaseTasks.expects(:drop).
         with('database' => 'dev-db')
       ActiveRecord::Tasks::DatabaseTasks.expects(:drop).
         with('database' => 'test-db')
 
-      ActiveRecord::Tasks::DatabaseTasks.drop_current
+      ActiveRecord::Tasks::DatabaseTasks.drop_current(
+        ActiveSupport::StringInquirer.new('development')
+      )
     end
   end
 

--- a/activerecord/test/cases/mysql_rake_test.rb
+++ b/activerecord/test/cases/mysql_rake_test.rb
@@ -1,0 +1,120 @@
+require 'cases/helper'
+
+module ActiveRecord
+  class MysqlDBCreateTest < ActiveRecord::TestCase
+    def setup
+      @connection    = stub(:create_database => true)
+      @configuration = {
+        'adapter'  => 'mysql',
+        'database' => 'my-app-db'
+      }
+
+      ActiveRecord::Base.stubs(:connection).returns(@connection)
+      ActiveRecord::Base.stubs(:establish_connection).returns(true)
+    end
+
+    def test_establishes_connection_without_database
+      ActiveRecord::Base.expects(:establish_connection).
+        with('adapter' => 'mysql', 'database' => nil)
+
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration
+    end
+
+    def test_creates_database_with_default_options
+      @connection.expects(:create_database).
+        with('my-app-db', {:charset => 'utf8', :collation => 'utf8_unicode_ci'})
+
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration
+    end
+
+    def test_creates_database_with_given_options
+      @connection.expects(:create_database).
+        with('my-app-db', {:charset => 'latin', :collation => 'latin_ci'})
+
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration.merge(
+        'charset' => 'latin', 'collation' => 'latin_ci'
+      )
+    end
+
+    def test_establishes_connection_to_database
+      ActiveRecord::Base.expects(:establish_connection).with(@configuration)
+
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration
+    end
+  end
+
+  class MysqlDBCreateAsRootTest < ActiveRecord::TestCase
+    def setup
+      require 'mysql'
+
+      @connection    = stub(:create_database => true, :execute => true)
+      @error         = Mysql::Error.new "Invalid permissions"
+      @configuration = {
+        'adapter'  => 'mysql',
+        'database' => 'my-app-db',
+        'username' => 'pat',
+        'password' => 'wossname'
+      }
+
+      $stdin.stubs(:gets).returns("secret\n")
+      $stdout.stubs(:print).returns(nil)
+      @error.stubs(:errno).returns(1045)
+      ActiveRecord::Base.stubs(:connection).returns(@connection)
+      ActiveRecord::Base.stubs(:establish_connection).raises(@error).then.
+        returns(true)
+    end
+
+    def test_root_password_is_requested
+      $stdin.expects(:gets).returns("secret\n")
+
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration
+    end
+
+    def test_connection_established_as_root
+      ActiveRecord::Base.expects(:establish_connection).with({
+        'adapter'  => 'mysql',
+        'database' => nil,
+        'username' => 'root',
+        'password' => 'secret'
+      })
+
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration
+    end
+
+    def test_database_created_by_root
+      @connection.expects(:create_database).
+        with('my-app-db', :charset => 'utf8', :collation => 'utf8_unicode_ci')
+
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration
+    end
+
+    def test_grant_privileges_for_normal_user
+      @connection.expects(:execute).with("GRANT ALL PRIVILEGES ON my-app-db.* TO 'pat'@'localhost' IDENTIFIED BY 'wossname' WITH GRANT OPTION;")
+
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration
+    end
+
+    def test_connection_established_as_normal_user
+      ActiveRecord::Base.expects(:establish_connection).returns do
+        ActiveRecord::Base.expects(:establish_connection).with({
+          'adapter'  => 'mysql',
+          'database' => 'my-app-db',
+          'username' => 'pat',
+          'password' => 'secret'
+        })
+
+        raise @error
+      end
+
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration
+    end
+
+    def test_sends_output_to_stderr_when_other_errors
+      @error.stubs(:errno).returns(42)
+
+      $stderr.expects(:puts).at_least_once.returns(nil)
+
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration
+    end
+  end
+end

--- a/activerecord/test/cases/postgresql_rake_test.rb
+++ b/activerecord/test/cases/postgresql_rake_test.rb
@@ -1,0 +1,57 @@
+require 'cases/helper'
+
+module ActiveRecord
+  class PostgreSQLDBCreateTest < ActiveRecord::TestCase
+    def setup
+      @connection    = stub(:create_database => true)
+      @configuration = {
+        'adapter'  => 'postgresql',
+        'database' => 'my-app-db'
+      }
+
+      ActiveRecord::Base.stubs(:connection).returns(@connection)
+      ActiveRecord::Base.stubs(:establish_connection).returns(true)
+    end
+
+    def test_establishes_connection_to_postgresql_database
+      ActiveRecord::Base.expects(:establish_connection).with(
+        'adapter'            => 'postgresql',
+        'database'           => 'postgres',
+        'schema_search_path' => 'public'
+      )
+
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration
+    end
+
+    def test_creates_database_with_default_encoding
+      @connection.expects(:create_database).
+        with('my-app-db', @configuration.merge('encoding' => 'utf8'))
+
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration
+    end
+
+    def test_creates_database_with_given_encoding
+      @connection.expects(:create_database).
+        with('my-app-db', @configuration.merge('encoding' => 'latin'))
+
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration.
+        merge('encoding' => 'latin')
+    end
+
+    def test_establishes_connection_to_new_database
+      ActiveRecord::Base.expects(:establish_connection).with(@configuration)
+
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration
+    end
+
+    def test_db_create_with_error_prints_message
+      ActiveRecord::Base.stubs(:establish_connection).raises(Exception)
+
+      $stderr.stubs(:puts).returns(true)
+      $stderr.expects(:puts).
+        with("Couldn't create database for #{@configuration.inspect}")
+
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration
+    end
+  end
+end

--- a/activerecord/test/cases/postgresql_rake_test.rb
+++ b/activerecord/test/cases/postgresql_rake_test.rb
@@ -54,4 +54,82 @@ module ActiveRecord
       ActiveRecord::Tasks::DatabaseTasks.create @configuration
     end
   end
+
+  class PostgreSQLDBDropTest < ActiveRecord::TestCase
+    def setup
+      @connection    = stub(:drop_database => true)
+      @configuration = {
+        'adapter'  => 'postgresql',
+        'database' => 'my-app-db'
+      }
+
+      ActiveRecord::Base.stubs(:connection).returns(@connection)
+      ActiveRecord::Base.stubs(:establish_connection).returns(true)
+    end
+
+    def test_establishes_connection_to_postgresql_database
+      ActiveRecord::Base.expects(:establish_connection).with(
+        'adapter'            => 'postgresql',
+        'database'           => 'postgres',
+        'schema_search_path' => 'public'
+      )
+
+      ActiveRecord::Tasks::DatabaseTasks.drop @configuration
+    end
+
+    def test_drops_database
+      @connection.expects(:drop_database).with('my-app-db')
+
+      ActiveRecord::Tasks::DatabaseTasks.drop @configuration
+    end
+  end
+
+  class PostgreSQLPurgeTest < ActiveRecord::TestCase
+    def setup
+      @connection    = stub(:create_database => true, :drop_database => true)
+      @configuration = {
+        'adapter'  => 'postgresql',
+        'database' => 'my-app-db'
+      }
+
+      ActiveRecord::Base.stubs(:connection).returns(@connection)
+      ActiveRecord::Base.stubs(:clear_active_connections!).returns(true)
+      ActiveRecord::Base.stubs(:establish_connection).returns(true)
+    end
+
+    def test_clears_active_connections
+      ActiveRecord::Base.expects(:clear_active_connections!)
+
+      ActiveRecord::Tasks::DatabaseTasks.purge @configuration
+    end
+
+    def test_establishes_connection_to_postgresql_database
+      ActiveRecord::Base.expects(:establish_connection).with(
+        'adapter'            => 'postgresql',
+        'database'           => 'postgres',
+        'schema_search_path' => 'public'
+      )
+
+      ActiveRecord::Tasks::DatabaseTasks.purge @configuration
+    end
+
+    def test_drops_database
+      @connection.expects(:drop_database).with('my-app-db')
+
+      ActiveRecord::Tasks::DatabaseTasks.purge @configuration
+    end
+
+    def test_creates_database
+      @connection.expects(:create_database).
+        with('my-app-db', @configuration.merge('encoding' => 'utf8'))
+
+      ActiveRecord::Tasks::DatabaseTasks.purge @configuration
+    end
+
+    def test_establishes_connection
+      ActiveRecord::Base.expects(:establish_connection).with(@configuration)
+
+      ActiveRecord::Tasks::DatabaseTasks.purge @configuration
+    end
+  end
 end

--- a/activerecord/test/cases/sqlite_rake_test.rb
+++ b/activerecord/test/cases/sqlite_rake_test.rb
@@ -1,8 +1,6 @@
 require 'cases/helper'
 require 'pathname'
 
-module Rails; end unless defined?(Rails)
-
 module ActiveRecord
   class SqliteDBCreateTest < ActiveRecord::TestCase
     def setup

--- a/activerecord/test/cases/sqlite_rake_test.rb
+++ b/activerecord/test/cases/sqlite_rake_test.rb
@@ -1,7 +1,7 @@
 require 'cases/helper'
 
 module ActiveRecord
-  class SqliteRakeTest < ActiveRecord::TestCase
+  class SqliteDBCreateTest < ActiveRecord::TestCase
     def setup
       @database      = "db_create.sqlite3"
       @connection    = stub :connection
@@ -25,6 +25,15 @@ module ActiveRecord
       File.stubs(:exist?).returns(true)
 
       $stderr.expects(:puts).with("#{@database} already exists")
+
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration
+    end
+
+    def test_db_create_with_file_does_nothing
+      File.stubs(:exist?).returns(true)
+      $stderr.stubs(:puts).returns(nil)
+
+      ActiveRecord::Base.expects(:establish_connection).never
 
       ActiveRecord::Tasks::DatabaseTasks.create @configuration
     end

--- a/activerecord/test/cases/sqlite_rake_test.rb
+++ b/activerecord/test/cases/sqlite_rake_test.rb
@@ -1,0 +1,53 @@
+require 'cases/helper'
+
+module ActiveRecord
+  class SqliteRakeTest < ActiveRecord::TestCase
+    def setup
+      @database      = "db_create.sqlite3"
+      @connection    = stub :connection
+      @configuration = {
+        'adapter'  => 'sqlite3',
+        'database' => @database
+      }
+
+      File.stubs(:exist?).returns(false)
+      ActiveRecord::Base.stubs(:connection).returns(@connection)
+      ActiveRecord::Base.stubs(:establish_connection).returns(true)
+    end
+
+    def test_db_checks_database_exists
+      File.expects(:exist?).with(@database).returns(false)
+
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration
+    end
+
+    def test_db_create_when_file_exists
+      File.stubs(:exist?).returns(true)
+
+      $stderr.expects(:puts).with("#{@database} already exists")
+
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration
+    end
+
+    def test_db_create_establishes_a_connection
+      ActiveRecord::Base.expects(:establish_connection).with(@configuration)
+
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration
+    end
+
+    def test_db_create_returns_the_connection
+      assert_equal ActiveRecord::Tasks::DatabaseTasks.create(@configuration),
+        @connection
+    end
+
+    def test_db_create_with_error_prints_message
+      ActiveRecord::Base.stubs(:establish_connection).raises(Exception)
+
+      $stderr.stubs(:puts).returns(true)
+      $stderr.expects(:puts).
+        with("Couldn't create database for #{@configuration.inspect}")
+
+      ActiveRecord::Tasks::DatabaseTasks.create(@configuration)
+    end
+  end
+end


### PR DESCRIPTION
Right now, this is a work in progress. I'm pushing it here for a few reasons:
- Feedback before I get too carried away is welcome.
- Everyone gets a little more visibility of how (I think) rake tasks should be approached.
- I'm short of time, so others may wish to contribute (and if so, get in touch).

But as to what's happening in these commits, essentially:
- I want to get every single rake task that has a db prefix down to a single line of code
- All the logic ends up in classes and objects.
- Easier to read, easier to maintain, easier to test, easier to reuse.
- Currently, I've done this for db:create, db:drop, db:create:all and db:drop:all.
- My plan is for adapter-specific tasks to end up in DatabaseTasks, but then there'll also be MigrationTasks, SchemaTasks, FixturesTasks, TestTasks, and maybe one or two others.

And finally, my questions for right now:
- Does anyone want to help?
- Core committers, would something like this get accepted, or am I wasting my time?
