### PR TITLE
Specified column type for quote_value

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   When using optimisitc locking, `update` whas not passing the column type to `quote_value`
+    to allow the connection adapter to properly determine how to quote the value. This was
+    affecting certain databases that use specific colmn types.
+    Fix #6763
+
+    *Alfred Wong*
+
 *   Do not log the binding values for binary columns.
 
     *Matthew M. Boedicker*

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -82,7 +82,7 @@ module ActiveRecord
 
             stmt = relation.where(
               relation.table[self.class.primary_key].eq(id).and(
-                relation.table[lock_col].eq(self.class.quote_value(previous_lock_value))
+                relation.table[lock_col].eq(self.class.quote_value(previous_lock_value, self.class.columns_hash[lock_col]))
               )
             ).arel.compile_update(arel_attributes_with_values_for_update(attribute_names))
 

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -86,7 +86,7 @@ module ActiveRecord
 
             stmt = relation.where(
               relation.table[self.class.primary_key].eq(id).and(
-                relation.table[lock_col].eq(quote_value(previous_lock_value))
+                relation.table[lock_col].eq(quote_value(previous_lock_value, self.class.columns_hash[lock_col]))
               )
             ).arel.compile_update(arel_attributes_with_values_for_update(attribute_names))
 

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -1,4 +1,5 @@
 require 'thread'
+require 'mocha/setup'
 require "cases/helper"
 require 'models/person'
 require 'models/job'
@@ -25,6 +26,18 @@ end
 
 class OptimisticLockingTest < ActiveRecord::TestCase
   fixtures :people, :legacy_things, :references, :string_key_objects, :peoples_treasures
+
+  def test_quote_value_passed_lock_col
+    p1 = Person.find(1)
+    assert_equal 0, p1.lock_version
+
+    Person.expects(:quote_value).with(0, Person.columns_hash[Person.locking_column]).returns('0').once
+
+    p1.first_name = 'anika2'
+    p1.save!
+
+    assert_equal 1, p1.lock_version
+  end
 
   def test_non_integer_lock_existing
     s1 = StringKeyObject.find("record1")


### PR DESCRIPTION
When calling quote_value the underlying connection sometimes requires
more information about the column to properly return the correct quoted
value.

I ran into this issue when using optimistic locking in JRuby and the
activerecord-jdbcmssql-adapter. In SQLSever 2000, we aren't allowed to
insert a integer into a NVARCHAR column type so we need to format it as
N'3' if we want to insert into the NVARCHAR type. Unfortuantely, without
the column type being passed the connection adapter cannot properly return
the correct quote value because it doesn't know to return N'3' or '3'.

This patch is fairly straight forward where it just passes in the column
type into the quote_value so it can properly handle at the connection level. I feel it does not need any specific unit tests as the current tests should cover all of the cases, as I'm not extending or adding new functionality. The implementing connections should have their own tests to make sure that they make use of the column parameter.

Overall I feel it's better to pass in the column type and let the concrete connection classes determine how to return a quoted_value.
