### PR TITLE
Ensure that cache-control headers are merged

### DIFF
--- a/actionpack/lib/action_dispatch/http/cache.rb
+++ b/actionpack/lib/action_dispatch/http/cache.rb
@@ -84,17 +84,29 @@ module ActionDispatch
         LAST_MODIFIED = "Last-Modified".freeze
         ETAG          = "ETag".freeze
         CACHE_CONTROL = "Cache-Control".freeze
+        SPESHUL_KEYS  = %w[extras no-cache max-age public must-revalidate]
 
-        def prepare_cache_control!
-          @cache_control = {}
-          @etag = self[ETAG]
-
-          if cache_control = self[CACHE_CONTROL]
-            cache_control.split(/,\s*/).each do |segment|
-              first, last = segment.split("=")
-              @cache_control[first.to_sym] = last || true
+        def cache_control_headers
+          cache_control = {}
+          if cc = self[CACHE_CONTROL]
+            cc.delete(' ').split(',').each do |segment|
+              directive, argument = segment.split('=', 2)
+              case directive
+              when *SPESHUL_KEYS
+                key = directive.tr('-', '_')
+                cache_control[key.to_sym] = argument || true
+              else
+                cache_control[:extras] ||= []
+                cache_control[:extras] << segment
+              end
             end
           end
+          cache_control
+        end
+
+        def prepare_cache_control!
+          @cache_control = cache_control_headers
+          @etag = self[ETAG]
         end
 
         def handle_conditional_get!
@@ -110,14 +122,24 @@ module ActionDispatch
         MUST_REVALIDATE       = "must-revalidate".freeze
 
         def set_conditional_cache_control!
-          return if self[CACHE_CONTROL].present?
+          control = {}
+          cc_headers = cache_control_headers
+          if extras = cc_headers.delete(:extras)
+            @cache_control[:extras] ||= []
+            @cache_control[:extras] += extras
+            @cache_control[:extras].uniq!
+          end
 
-          control = @cache_control
+          control.merge! cc_headers
+          control.merge! @cache_control
 
           if control.empty?
             headers[CACHE_CONTROL] = DEFAULT_CACHE_CONTROL
           elsif control[:no_cache]
             headers[CACHE_CONTROL] = NO_CACHE
+            if control[:extras]
+              headers[CACHE_CONTROL] += ", #{control[:extras].join(', ')}"
+            end
           else
             extras  = control[:extras]
             max_age = control[:max_age]

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -116,6 +116,12 @@ class TestController < ActionController::Base
     render :action => 'hello_world'
   end
 
+  def conditional_hello_with_cache_control_headers
+    response.headers['Cache-Control'] = 'no-transform'
+    expires_now
+    render :action => 'hello_world'
+  end
+
   def conditional_hello_with_bangs
     render :action => 'hello_world'
   end
@@ -1510,6 +1516,12 @@ class ExpiresInRenderTest < ActionController::TestCase
   def test_expires_now
     get :conditional_hello_with_expires_now
     assert_equal "no-cache", @response.headers["Cache-Control"]
+  end
+
+  def test_expires_now
+    get :conditional_hello_with_cache_control_headers
+    assert_match /no-cache/, @response.headers["Cache-Control"]
+    assert_match /no-transform/, @response.headers["Cache-Control"]
   end
 
   def test_date_header_when_expires_in


### PR DESCRIPTION
### Scenario

A developer added a before_filter that did: `response.headers['Cache-Control'] = 'no-transform'` in order to avoid mobile carriers from making invalid modifications to content.
### Issues

expires_\* calls were no longer applied (see commit details), and as such, Rack::Cache begun caching all mobile renders.
### Arguments

It may be considered that setting only "no-transform" should result in the above behavior. I would stand by this view point, to a large extent, but many developers find these areas confusing. During investigating the root causes, additional bugs or at least vague semantics were found that were also addressed. It can be argued that the commit aligns a little better with the documentation, and applies some notion of POLS, whereby Rails calls / data structures are authoritative. An alternative POLS for many developers may be that the "last modification to Cache-Control should win", in which case this is still a violation if the header is modified after expires_in in a conflicting way.
### Extended commit message:

There are several aspects to this commit, that don't well fit into broken down
commits, so they are detailed here:
- When a user uses response.headers['Cache-Control'] = some_value, then the
  documented convention in ConditionalGet is not adhered to, in this case,
  response.cache_control is ignored due to `return if
  self[CACHE_CONTROL].present?`
- When a middleware sets cache-control headers that would clobber, they're
  converted to symbols directly, without underscores. This would lead to bugs.
- Items that would live in :extras if set through expires_in, are placed
  directly in the @cache_control hash, and not respected in many cases
  (somewhat adhering to the aforementioned documentation).
- Although quite useless, any directive named 'extras' would be ignored.

The general convention applied is that `expires_*` take precedence, but no longer
overwrite everything and `expires_*` are ALWAYS applied, even if the header is
set.

I am still unhappy about the contents of this commit, and the code in general.
Ideally it should be refactored to no longer use :extras. I'd likely recommend
expanding @cache_control into a class, and giving it the power to handle the
merge in a more efficient fashion. Such a commit would be a larger change that
could have additional semantic changes for other libraries unless they utilize
expires_in in very standard ways.
