### PR TITLE
Map (PUT) action for resourceful routes

### DIFF
--- a/actionpack/Rakefile
+++ b/actionpack/Rakefile
@@ -31,6 +31,11 @@ namespace :test do
     t.libs << 'test'
     t.pattern = 'test/template/**/*.rb'
   end
+
+  Rake::TestTask.new(:dispatch) do |t|
+    t.libs << 'test'
+    t.pattern = 'test/dispatch/**/*.rb'
+  end
 end
 
 desc 'ActiveRecord Integration Tests'

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -903,7 +903,7 @@ module ActionDispatch
         # a path appended since they fit properly in their scope level.
         VALID_ON_OPTIONS  = [:new, :collection, :member]
         RESOURCE_OPTIONS  = [:as, :controller, :path, :only, :except, :param]
-        CANONICAL_ACTIONS = %w(index create new show update destroy)
+        CANONICAL_ACTIONS = %w(index map create new show update destroy)
 
         class Resource #:nodoc:
           attr_reader :controller, :path, :options, :param
@@ -918,7 +918,7 @@ module ActionDispatch
           end
 
           def default_actions
-            [:index, :create, :new, :show, :update, :destroy, :edit]
+            [:index, :map, :create, :new, :show, :update, :destroy, :edit]
           end
 
           def actions
@@ -1195,6 +1195,7 @@ module ActionDispatch
 
             collection do
               get  :index if parent_resource.actions.include?(:index)
+              put  :map if parent_resource.actions.include?(:map)
               post :create if parent_resource.actions.include?(:create)
             end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -862,6 +862,9 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     post '/projects'
     assert_equal 'project#create', @response.body
 
+    put '/projects'
+    assert_equal 'project#map', @response.body
+
     get '/projects.xml'
     assert_equal 'project#index', @response.body
     assert_equal '/projects.xml', projects_path(:format => 'xml')


### PR DESCRIPTION
A bare-bones proposal to support a PUT request on resources:

PUT /photos

This would result in a call to PhotosController#map. The purpose of this is to create a new convention for bulk updates on collections. The obvious corresponding database action would be update_all.

This implementation is by no means complete and only meant as a starting point for discussion. 
Suggestions and comments are welcome.
