### PR TITLE
Check cookie overflow

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -86,7 +86,9 @@ module ActionDispatch
 
     class CookieJar #:nodoc:
       include Enumerable
-
+      
+      MAX_COOKIE_SIZE = 4096 # Cookies can typically store 4096 bytes.
+      
       # This regular expression is used to split the levels of a domain.
       # The top level domain can be any string without a period or
       # **.**, ***.** style TLDs like co.uk or com.au
@@ -168,6 +170,8 @@ module ActionDispatch
           value = options
           options = { :value => value }
         end
+        
+        raise CookieOverflow if options[:value].to_s.size > MAX_COOKIE_SIZE
 
         @cookies[key.to_s] = value
 
@@ -274,7 +278,6 @@ module ActionDispatch
     end
 
     class SignedCookieJar < CookieJar #:nodoc:
-      MAX_COOKIE_SIZE = 4096 # Cookies can typically store 4096 bytes.
       SECRET_MIN_LENGTH = 30 # Characters
 
       def initialize(parent_jar, secret)
@@ -299,7 +302,6 @@ module ActionDispatch
           options = { :value => @verifier.generate(options) }
         end
 
-        raise CookieOverflow if options[:value].size > MAX_COOKIE_SIZE
         @parent_jar[key] = options
       end
 

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -64,7 +64,17 @@ class CookiesTest < ActionController::TestCase
     end
 
     def raise_data_overflow
-      cookies.signed[:foo] = 'bye!' * 1024
+      cookies[:foo] = 'bye!' * 1024 + "a"
+      head :ok
+    end
+
+    def raise_data_overflow_permanent
+      cookies.permanent[:foo] = 'bye!' * 1024 + "a"
+      head :ok
+    end
+
+    def raise_data_overflow_signed
+      cookies.signed[:foo] = 'bye!' * 1024 + "a"
       head :ok
     end
 
@@ -281,6 +291,18 @@ class CookiesTest < ActionController::TestCase
   def test_raise_data_overflow
     assert_raise(ActionDispatch::Cookies::CookieOverflow) do
       get :raise_data_overflow
+    end
+  end
+
+  def test_raise_data_overflow_permanent
+    assert_raise(ActionDispatch::Cookies::CookieOverflow) do
+      get :raise_data_overflow_permanent
+    end
+  end
+
+  def test_raise_data_overflow_signed
+    assert_raise(ActionDispatch::Cookies::CookieOverflow) do
+      get :raise_data_overflow_signed
     end
   end
 


### PR DESCRIPTION
Rails does not check the length of the value of normal and permanent cookies, just signed cookies. This pull request changes this, so all cookies are checked.
