### PR TITLE
Fallback behavior for class_attribute

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -67,14 +67,28 @@ class Class
   #   object.setting = false  # => NoMethodError
   #
   # To opt out of both instance methods, pass :instance_accessor => false.
+  #
+  # Passing the the :default option with a proc changes the default from nil
+  # to whatever that proc evaluates to:
+  #
+  #   class Base
+  #     class_attribute :setting, :default => proc { :foo }
+  #   end
+  #
+  #   Base.setting     # => :foo
+  #
   def class_attribute(*attrs)
     options = attrs.extract_options!
     instance_reader = options.fetch(:instance_accessor, true) && options.fetch(:instance_reader, true)
     instance_writer = options.fetch(:instance_accessor, true) && options.fetch(:instance_writer, true)
+    default = options.fetch(:default, nil)
 
     attrs.each do |name|
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
-        def self.#{name}() nil end
+        singleton_class.class_eval do
+          define_method(name) { default.call if default }
+        end
+
         def self.#{name}?() !!#{name} end
 
         def self.#{name}=(val)

--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -72,10 +72,10 @@ class Class
   # to whatever that proc evaluates to:
   #
   #   class Base
-  #     class_attribute :setting, :default => proc { :foo }
+  #     class_attribute :setting, :default => proc { |name| name }
   #   end
   #
-  #   Base.setting     # => :foo
+  #   Base.setting            # => :setting
   #
   def class_attribute(*attrs)
     options = attrs.extract_options!
@@ -86,7 +86,7 @@ class Class
     attrs.each do |name|
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
         singleton_class.class_eval do
-          define_method(name) { default.call if default }
+          define_method(name) { default.call(name) if default }
         end
 
         def self.#{name}?() !!#{name} end

--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -86,7 +86,11 @@ class Class
     attrs.each do |name|
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
         singleton_class.class_eval do
-          define_method(name) { default.call(name) if default }
+          if default.respond_to?(:call)
+            define_method(name) { default.call(name) }
+          else
+            define_method(name) { default }
+          end
         end
 
         def self.#{name}?() !!#{name} end

--- a/activesupport/test/core_ext/class/attribute_test.rb
+++ b/activesupport/test/core_ext/class/attribute_test.rb
@@ -12,6 +12,19 @@ class ClassAttributeTest < ActiveSupport::TestCase
     assert_nil @sub.setting
   end
 
+  test 'can take a defaulting proc' do
+    klass = Class.new { class_attribute :setting, :default => proc { :default } }
+    sub = Class.new(klass)
+    assert_equal :default, klass.setting
+    assert_equal :default, sub.setting
+  end
+
+  test 'can override the defaulting proc' do
+    klass = Class.new { class_attribute :setting, :default => proc { } }
+    klass.setting = 1
+    assert_equal 1, klass.setting
+  end
+
   test 'inheritable' do
     @klass.setting = 1
     assert_equal 1, @sub.setting

--- a/activesupport/test/core_ext/class/attribute_test.rb
+++ b/activesupport/test/core_ext/class/attribute_test.rb
@@ -13,10 +13,10 @@ class ClassAttributeTest < ActiveSupport::TestCase
   end
 
   test 'can take a defaulting proc' do
-    klass = Class.new { class_attribute :setting, :default => proc { :default } }
+    klass = Class.new { class_attribute :setting, :default => proc { |name| name } }
     sub = Class.new(klass)
-    assert_equal :default, klass.setting
-    assert_equal :default, sub.setting
+    assert_equal :setting, klass.setting
+    assert_equal :setting, sub.setting
   end
 
   test 'can override the defaulting proc' do

--- a/activesupport/test/core_ext/class/attribute_test.rb
+++ b/activesupport/test/core_ext/class/attribute_test.rb
@@ -12,15 +12,24 @@ class ClassAttributeTest < ActiveSupport::TestCase
     assert_nil @sub.setting
   end
 
-  test 'can take a defaulting proc' do
-    klass = Class.new { class_attribute :setting, :default => proc { |name| name } }
+  test 'can take a defaulting callable' do
+    klass = Class.new do
+      class_attribute :setting, :default => proc { |name| name }
+    end
     sub = Class.new(klass)
     assert_equal :setting, klass.setting
     assert_equal :setting, sub.setting
   end
 
-  test 'can override the defaulting proc' do
-    klass = Class.new { class_attribute :setting, :default => proc { } }
+  test 'can take a plain default value' do
+    klass = Class.new { class_attribute :setting, :default => :setting }
+    sub = Class.new(klass)
+    assert_equal :setting, klass.setting
+    assert_equal :setting, sub.setting
+  end
+
+  test 'can override the default' do
+    klass = Class.new { class_attribute :setting, :default => :setting }
     klass.setting = 1
     assert_equal 1, klass.setting
   end


### PR DESCRIPTION
Currently, ActiveSupport's `class_attribute` method allows for specification of class-level attributes that also propagate down to instances of a given class. However, when there is no value explicitly defined, methods defined by `class_attribute` return nil. In most circumstances this is okay, however, if you're implementing a pseudo-abstract class, it is probably better to raise a NotImplementedError than return nil if this method gets called on the abstract class.

Current behavior is as follows:

``` ruby
class Foo
  class_attribute :bar
end

class Baz < Foo
end

class Qux < Foo
  self.bar = 'quux'
end

puts Foo.bar.inspect #=> nil
puts Baz.bar.inspect #=> nil
puts Qux.bar.inspect #=> "quux"
puts Foo.new.bar.inspect #=> nil
puts Baz.new.bar.inspect #=> nil
puts Qux.new.bar.inspect #=> "quux"
```

I propose that the following behavior be supported:

``` ruby
class Foo
  class_attribute :bar, :default => lambda do |attribute|
    raise NotImplementedError.new("#{attribute} is undefined")
  end
end

class Baz < Foo
end

class Qux < Foo
  self.bar = 'quux'
end

puts Foo.bar.inspect # raises error
puts Baz.bar.inspect # raises error
puts Qux.bar.inspect #=> "quux"
puts Foo.new.bar.inspect #=> raises error
puts Baz.new.bar.inspect #=> raises error
puts Qux.new.bar.inspect #=> "quux"
```

By allowing `class_attribute` to take a default lambda (and perhaps a raw value), classes can cleanly implement abstract values in a generic fashion. Of course, if `:default` isn't provided, the behavior would not change; thus, backward compatibility would be ensured.
