### PR TITLE
changed the firm of changes_from_zero_to_string?

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -78,7 +78,7 @@ module ActiveRecord
       def _field_changed?(attr, old, value)
         if column = column_for_attribute(attr)
           if column.number? && (changes_from_nil_to_empty_string?(column, old, value) ||
-                                changes_from_zero_to_string?(column, old, value))
+                                changes_from_zero_to_string?(old, value))
             value = nil
           else
             value = column.type_cast(value)
@@ -96,7 +96,7 @@ module ActiveRecord
         column.null && (old.nil? || old == 0) && value.blank?
       end
 
-      def changes_from_zero_to_string?(column, old, value)
+      def changes_from_zero_to_string?(old, value)
         # For columns with old 0 and value non-empty string
         old == 0 && value.present? && value != '0'
       end


### PR DESCRIPTION
delete _column_ because is unused by the method.
