### PR TITLE
Don't paramify ActionDispatch::Http::UploadedFile in tests

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -450,7 +450,7 @@ module ActionController
           Hash[hash_or_array_or_value.map{|key, value| [key, paramify_values(value)] }]
         when Array
           hash_or_array_or_value.map {|i| paramify_values(i)}
-        when Rack::Test::UploadedFile
+        when Rack::Test::UploadedFile, ActionDispatch::Http::UploadedFile
           hash_or_array_or_value
         else
           hash_or_array_or_value.to_param

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -813,6 +813,13 @@ XML
     assert_equal '159528', @response.body
   end
 
+  def test_action_dispatch_uploaded_file_upload
+    filename = 'mona_lisa.jpg'
+    path = "#{FILES_DIR}/#{filename}"
+    post :test_file_upload, :file => ActionDispatch::Http::UploadedFile.new(:filename => path, :type => "image/jpg", :tempfile => File.open(path))
+    assert_equal '159528', @response.body
+  end
+
   def test_test_uploaded_file_exception_when_file_doesnt_exist
     assert_raise(RuntimeError) { Rack::Test::UploadedFile.new('non_existent_file') }
   end


### PR DESCRIPTION
To test uploading a file without using fixture_file_upload, a posted ActionDispatch::Http::UploadedFile should not be paramified (just like Rack::Test::UploadedFile).
(Rack::Test::UploadedFile and ActionDispatch::Http::UploadedFile don't share the same API, tempfile is not 
accessible on Rack::Test::UploadedFile as discussed in https://github.com/brynary/rack-test/issues/30)
