### PR TITLE
Inflector: Added missing tests cases to ensure idempotency of singularize and pluralize

### DIFF
--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -413,6 +413,16 @@ class InflectorTest < ActiveSupport::TestCase
     end
   end
 
+  Irregularities.each do |irregularity|
+    singular, plural = *irregularity
+    ActiveSupport::Inflector.inflections do |inflect|
+      define_method("test_singularize_of_irregularity_#{singular}_should_be_the_same") do
+        inflect.irregular(singular, plural)
+        assert_equal singular, ActiveSupport::Inflector.singularize(singular)
+      end
+    end
+  end
+
   [ :all, [] ].each do |scope|
     ActiveSupport::Inflector.inflections do |inflect|
       define_method("test_clear_inflections_with_#{scope.kind_of?(Array) ? "no_arguments" : scope}") do

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -308,5 +308,7 @@ module InflectorTestCases
     'child'  => 'children',
     'sex'    => 'sexes',
     'move'   => 'moves',
+    'cow'    => 'kine',
+    'zombie' => 'zombies',
   }
 end


### PR DESCRIPTION
This is a follow up to #4719. It appears that singularize and pluralize are supposed to be idempotent - i.e. when you call singularize or pluralize multiple times on the same string, you should get the same result. (At least for the "officially supported" cases that the stock inflector is designed to handle.) #4719 added the missing tests for regular cases, and this commit added the missing tests for the irregularities.

While I'm at that, I also synced up the irregularity test cases with the current set of irregularity cases that we ship out-of-the-box.
