### PR TITLE
Added inflector method 'articleize'

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -291,6 +291,18 @@ module ActiveSupport
     def ordinalize(number)
       "#{number}#{ordinal(number)}"
     end
+    
+    # Selects the correct article for a given word e.g. 'an' or 'a'
+    #
+    # "apple".articleize         #=> "an apple"
+    # "daffodil".articleize      #=> "a daffodil"
+    # "awesome apple".articleize #=> "an awesome apple"
+    def articleize(word)
+      articles = ["a","an"]
+      vowels = ["a","e","i","o","u"]
+      return "an #{word}" if vowels.include?(word.downcase[0].chr)
+      return "a #{word}"
+    end
 
     private
 

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -298,10 +298,11 @@ module ActiveSupport
     # "daffodil".articleize      #=> "a daffodil"
     # "awesome apple".articleize #=> "an awesome apple"
     def articleize(word)
-      articles = ["a","an"]
-      vowels = ["a","e","i","o","u"]
-      return "an #{word}" if vowels.include?(word.downcase[0].chr)
-      return "a #{word}"
+      if ["a","e","i","o","u"].include?(word.downcase[0].chr)
+        return "an #{word}" 
+      else
+        return "a #{word}"
+      end
     end
 
     private

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -294,6 +294,12 @@ class InflectorTest < ActiveSupport::TestCase
     assert_equal("Reported bugs", ActiveSupport::Inflector.humanize("col_rpted_bugs"))
     assert_equal("Col rpted bugs", ActiveSupport::Inflector.humanize("COL_rpted_bugs"))
   end
+  
+  def test_articleize_by_string
+    assert_equal("an apple", ActiveSupport::Inflector.articleize("apple"))
+    assert_equal("a daffodil", ActiveSupport::Inflector.articleize("daffodil"))
+    assert_equal("an awesome apple", ActiveSupport::Inflector.articleize("awesome apple"))
+  end
 
   def test_constantize
     run_constantize_tests_on do |string|


### PR DESCRIPTION
- Correctly shows a noun article e.g. 'a' or 'an'.
  
  `"apple".articleize    #=> "an apple"`
  `"daffodil".articleize #=> "a daffodil"`
