### PR TITLE
add :nodoc: to AM::AttributeMethods::AttributeMethodMatcher

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -314,7 +314,7 @@ module ActiveModel
           RUBY
         end
 
-        class AttributeMethodMatcher
+        class AttributeMethodMatcher #:nodoc:
           attr_reader :prefix, :suffix, :method_missing_target
 
           AttributeMethodMatch = Struct.new(:target, :attr_name, :method_name)


### PR DESCRIPTION
We have `attribute_method_prefix`, `attribute_method_suffix` and `attribute_method_affix`.
