### PR TITLE
add :nodoc: to ActiveModel::AttributeMethods#attribute_method?

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -400,7 +400,7 @@ module ActiveModel
     end
 
     protected
-      def attribute_method?(attr_name)
+      def attribute_method?(attr_name) #:nodoc:
         respond_to_without_attributes?(:attributes) && attributes.include?(attr_name)
       end
 


### PR DESCRIPTION
With this pr, the documentation of ActiveModel::AttributeMethods is covered :)
