### PR TITLE
Fix calculation of seconds since epoch

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/conversions.rb
@@ -94,8 +94,18 @@ class DateTime
 
   private
 
+  # 'Seconds Since the Epoch' in Single Unix Specification:
+  #
+  #   tm_sec + tm_min*60 + tm_hour*3600 + tm_yday*86400 +
+  #     (tm_year-70)*31536000 + ((tm_year-69)/4)*86400 -
+  #     ((tm_year-1)/100)*86400 + ((tm_year+299)/400)*86400
   def seconds_since_unix_epoch
-    seconds_per_day = 86_400
-    (self - ::DateTime.civil(1970)) * seconds_per_day
+    tm_year = utc.year - 1900
+    tm_yday = utc.yday() - 1
+    tm_hour = utc.hour
+
+    sec + min*60 + tm_hour*3_600 + tm_yday*86_400 +
+      (tm_year-70)*31_536_000 + ((tm_year-69)/4)*86_400 -
+      ((tm_year-1)/100)*86_400 + ((tm_year+299)/400)*86_400
   end
 end

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -423,6 +423,7 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
   def test_to_f
     assert_equal 946684800.0, DateTime.civil(2000).to_f
     assert_equal 946684800.0, DateTime.civil(1999,12,31,19,0,0,Rational(-5,24)).to_f
+    assert_equal(-22610116560.0, DateTime.civil(1253,7,6,20,4,0).to_f)
   end
 
   def test_to_i


### PR DESCRIPTION
Previous calculation was simple, but not correct when leap seconds get
involved. Implemented 'Seconds Since the Epoch' according to 'Single
Unix Specification'.
