### PR TITLE
alias Hash#slice as #extract

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/slice.rb
+++ b/activesupport/lib/active_support/core_ext/hash/slice.rb
@@ -16,6 +16,7 @@ class Hash
     keys.map! { |key| convert_key(key) } if respond_to?(:convert_key, true)
     keys.each_with_object(self.class.new) { |k, hash| hash[k] = self[k] if has_key?(k) }
   end
+  alias_method :extract, :slice
 
   # Replaces the hash with only the given keys.
   # Returns a hash containing the removed key/value pairs.


### PR DESCRIPTION
I find myself looking at the ActiveSupport [Hash#extract! documentation](http://api.rubyonrails.org/classes/Hash.html#method-i-extract-21) over and over, wishing it didn't modify the original hash.  Of course, I simply forget that [#slice](http://api.rubyonrails.org/classes/Hash.html#method-i-slice) is available, but I figure I'm not the only one missing this.
