### PR TITLE
Simplify AV.prepare

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -49,9 +49,10 @@ module AbstractController
     module ClassMethods
       def view_context_class
         @view_context_class ||= begin
-          routes  = _routes  if respond_to?(:_routes)
-          helpers = _helpers if respond_to?(:_helpers)
-          ActionView::Base.prepare(routes, helpers)
+          view_modules = []
+          view_modules += [_routes.url_helpers, _routes.mounted_helpers]  if respond_to?(:_routes)
+          view_modules << _helpers if respond_to?(:_helpers)
+          ActionView::Base.prepare(view_modules)
         end
       end
     end

--- a/actionpack/lib/action_view/base.rb
+++ b/actionpack/lib/action_view/base.rb
@@ -178,7 +178,6 @@ module ActionView #:nodoc:
 
           if helpers
             include helpers
-            self.helpers = helpers
           end
         end
       end

--- a/actionpack/lib/action_view/base.rb
+++ b/actionpack/lib/action_view/base.rb
@@ -169,16 +169,9 @@ module ActionView #:nodoc:
 
       # This method receives routes and helpers from the controller
       # and return a subclass ready to be used as view context.
-      def prepare(routes, helpers) #:nodoc:
+      def prepare(modules) #:nodoc:
         Class.new(self) do
-          if routes
-            include routes.url_helpers
-            include routes.mounted_helpers
-          end
-
-          if helpers
-            include helpers
-          end
+          include *modules.reverse  # include works from right to left, but we want core helpers to be included before mounted helpers.
         end
       end
     end


### PR DESCRIPTION
Move all helper and routes logic into the AbstractController instead of letting the view decide which modules to include.

This is another step in decoupling view and controller.
