### PR TITLE
change param name to improve documentation

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -87,8 +87,8 @@ module ActiveModel
     end
 
     # Do the error messages include an error with key +error+?
-    def include?(error)
-      (v = messages[error]) && v.any?
+    def include?(attribute)
+      (v = messages[attribute]) && v.any?
     end
     alias :has_key? :include?
 


### PR DESCRIPTION
The keys of the error messages are actually attribute names. It makes
the documentation easier to understand:

```
# Returns +true+ if the error messages include an error for the given
# +attribute+, +false+ otherwise.
#
#   person.errors.messages # => { :name => ["can not be nil"] }
#   person.errors.include?(:name) # => true
#   person.errors.include?(:age)  # => false
def include?(attribute)
  (v = messages[attribute]) && v.any?
end
```
