### PR TITLE
Warn on name collisions between Array instance methods and base class methods

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -118,7 +118,7 @@ module ActiveRecord
     def last(limit = nil)
       if limit
         if order_values.empty? && primary_key
-          order(arel_table[primary_key].desc).limit(limit).reverse
+          order(arel_table[primary_key].desc).limit(limit).to_a.reverse
         else
           to_a.last(limit)
         end

--- a/activerecord/test/cases/named_scope_test.rb
+++ b/activerecord/test/cases/named_scope_test.rb
@@ -40,9 +40,9 @@ class NamedScopeTest < ActiveRecord::TestCase
   def test_delegates_finds_and_calculations_to_the_base_class
     assert !Topic.all.empty?
 
-    assert_equal Topic.all,               Topic.base.all
-    assert_equal Topic.first,             Topic.base.first
-    assert_equal Topic.count,                    Topic.base.count
+    assert_equal Topic.all,                     Topic.base.all
+    assert_equal Topic.first,                   Topic.base.first
+    assert_equal Topic.count,                   Topic.base.count
     assert_equal Topic.average(:replies_count), Topic.base.average(:replies_count)
   end
 

--- a/activerecord/test/cases/named_scope_test.rb
+++ b/activerecord/test/cases/named_scope_test.rb
@@ -46,6 +46,11 @@ class NamedScopeTest < ActiveRecord::TestCase
     assert_equal Topic.average(:replies_count), Topic.base.average(:replies_count)
   end
 
+  def test_warns_if_there_is_a_method_collision_between_the_base_class_and_array_instance_methods
+    ActiveRecord::Base.logger.expects(:warn)
+    Topic.scoped.reverse
+  end
+
   def test_scope_should_respond_to_own_methods_and_methods_of_the_proxy
     assert Topic.approved.respond_to?(:limit)
     assert Topic.approved.respond_to?(:count)

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -77,6 +77,11 @@ class Topic < ActiveRecord::Base
     write_attribute(:approved, val)
   end
 
+  # Collides with Array#reverse.
+  def self.reverse
+    order(:id => 'desc')
+  end
+
   protected
 
     def default_written_on


### PR DESCRIPTION
Warn users in cases where they have named a scope the same as an Array instance method. Delegation gives precedence to Arrays, so it could confuse the developer as to why their scope is never evaluated.

The following example illustrates this problem:

``` ruby
class Foo < ActiveRecord::Base
  def self.reverse
    order(:id => 'desc')
  end
end
```

When we call:

``` ruby
Foo.scoped.reverse
```

The scope is evaluated to an array and reverse is called on that array. The class method on Foo is never evaluated.
