### PR TITLE
Support initialization of private attributes

### DIFF
--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -82,6 +82,9 @@ module ActiveRecord
     #   user.assign_attributes({ :name => 'Josh', :is_admin => true }, :without_protection => true)
     #   user.name       # => "Josh"
     #   user.is_admin?  # => true
+    #
+    # To bypass attribute writer visibility you can use the :with_private => true
+    # option.
     def assign_attributes(new_attributes, options = {})
       return if new_attributes.blank?
 
@@ -98,7 +101,7 @@ module ActiveRecord
       attributes.each do |k, v|
         if k.include?("(")
           multi_parameter_attributes << [ k, v ]
-        elsif respond_to?("#{k}=")
+        elsif respond_to?("#{k}=", options[:with_private])
           if v.is_a?(Hash)
             nested_parameter_attributes << [ k, v ]
           else

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -171,8 +171,8 @@ module ActiveRecord
     # In both instances, valid attribute keys are determined by the column names of the associated table --
     # hence you can't have attributes that aren't part of the table columns.
     #
-    # +initialize+ respects mass-assignment security and accepts either +:as+ or +:without_protection+ options
-    # in the +options+ parameter.
+    # +:initialize+ respects mass-assignment security and visibility of attribute writer methods, and
+    # accepts +:as+, +:without_protection+, and +:with_private+ options in the +options+ parameter.
     #
     # ==== Examples
     #   # Instantiates a single new object

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -716,6 +716,12 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::UnknownAttributeError) { @target.new.attributes = { :title => "Ants in pants" } }
   end
 
+  def test_bulk_update_skips_visibility_protection_when_with_private_is_used
+    privatize("title=(value)")
+
+    assert_nothing_raised { @target.new({ :title => "Dance with lance" }, :with_private => true) }
+  end
+
   def test_read_attribute_overwrites_private_method_not_considered_implemented
     # simulate a model with a db column that shares its name an inherited
     # private method (e.g. Object#system)


### PR DESCRIPTION
ActiveRecord model constructors accept a hash of parameters which are used to invoke the corresponding attribute writer methods. Attribute writers are privately invoked with #send, but they are first screened with #respond_to? to avoid invoking private methods. This precludes the common practice of encapsulating members by allowing them to be initialized at construction but not reassigned after construction.

This patch enables the constructor to invoke private attribute writers by accepting an additional option (:with_private) along with the options which are used to control mass-assignment protection.
