### PR TITLE
Ensure DATABASE_URL is not ignored when database.yml isn't loaded

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_specification.rb
@@ -31,6 +31,7 @@ module ActiveRecord
         private
         def resolve_string_connection(spec) # :nodoc:
           hash = configurations.fetch(spec) do |k|
+            k = ENV['DATABASE_URL'] if ENV['DATABASE_URL'] && !k.include?(':')
             connection_url_to_hash(k)
           end
 

--- a/activerecord/test/cases/connection_specification/resolver_test.rb
+++ b/activerecord/test/cases/connection_specification/resolver_test.rb
@@ -8,6 +8,13 @@ module ActiveRecord
           Resolver.new(spec, {}).spec.config
         end
 
+        def with_database_url(new_url)
+          old_url, ENV['DATABASE_URL'] = ENV['DATABASE_URL'], new_url
+          yield
+        ensure
+          old_url ? ENV['DATABASE_URL'] = old_url : ENV.delete('DATABASE_URL')
+        end
+
         def test_url_host_no_db
           spec = resolve 'mysql://foo?encoding=utf8'
           assert_equal({
@@ -34,6 +41,21 @@ module ActiveRecord
             :port     => 123,
             :host     => "foo",
             :encoding => "utf8" }, spec)
+        end
+
+        def test_url_no_database_yml
+          with_database_url 'sqlite3://localhost/db/production.sqlite3' do
+            spec = Resolver.new(ENV["DATABASE_URL"],{}).spec.config
+            assert_equal({
+              :adapter  => "sqlite3",
+              :database => "db/production.sqlite3",
+              :host     => "localhost" }, spec)
+            spec = Resolver.new("production",{}).spec.config
+            assert_equal({
+              :adapter  => "sqlite3",
+              :database => "db/production.sqlite3",
+              :host     => "localhost" }, spec)
+          end
         end
       end
     end

--- a/activerecord/test/cases/connection_specification/resolver_test.rb
+++ b/activerecord/test/cases/connection_specification/resolver_test.rb
@@ -45,12 +45,12 @@ module ActiveRecord
 
         def test_url_no_database_yml
           with_database_url 'sqlite3://localhost/db/production.sqlite3' do
-            spec = Resolver.new(ENV["DATABASE_URL"],{}).spec.config
+            spec = resolve ENV["DATABASE_URL"]
             assert_equal({
               :adapter  => "sqlite3",
               :database => "db/production.sqlite3",
               :host     => "localhost" }, spec)
-            spec = Resolver.new("production",{}).spec.config
+            spec = resolve 'production'
             assert_equal({
               :adapter  => "sqlite3",
               :database => "db/production.sqlite3",


### PR DESCRIPTION
Currently specifying an environment name when DATABASE_URL is present
prevents a sucessful connection. Passing a string such as "production"
causes DATABASE_URL to be ignored because
ActiveRecord::Base.establish_connection only uses it if no name is
passed, but database.yml isn't loaded by the initializer if DATABASE_URL
is defined.

This change causes the resolver to use DATABASE_URL instead of failing
on an unusable environment name without breaking the ability to
pass a valid url in a string.

Among other things, this fixes rake db:fixtures:load on Heroku Cedar.
