### PR TITLE
Sprockets should ignore :cache and :concat options

### DIFF
--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -23,7 +23,7 @@ module Sprockets
         body  = options.key?(:body)  ? options.delete(:body)  : false
         digest  = options.key?(:digest)  ? options.delete(:digest)  : digest_assets?
 
-        ignore_legacy_options(options)
+        options.except!(:cache, :concat)
 
         sources.collect do |source|
           if debug && asset = asset_paths.asset_for(source, 'js')
@@ -42,7 +42,7 @@ module Sprockets
         body    = options.key?(:body)  ? options.delete(:body)  : false
         digest  = options.key?(:digest)  ? options.delete(:digest)  : digest_assets?
 
-        ignore_legacy_options(options)
+        options.except!(:cache, :concat)
 
         sources.collect do |source|
           if debug && asset = asset_paths.asset_for(source, 'css')
@@ -116,11 +116,6 @@ module Sprockets
       # at the prefix returned by +asset_prefix+.
       def asset_environment
         Rails.application.assets
-      end
-
-      def ignore_legacy_options(options = {})
-        options.delete(:cache)
-        options.delete(:concat)
       end
 
       class AssetPaths < ::ActionView::AssetPaths #:nodoc:

--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -23,6 +23,8 @@ module Sprockets
         body  = options.key?(:body)  ? options.delete(:body)  : false
         digest  = options.key?(:digest)  ? options.delete(:digest)  : digest_assets?
 
+        ignore_legacy_options(options)
+
         sources.collect do |source|
           if debug && asset = asset_paths.asset_for(source, 'js')
             asset.to_a.map { |dep|
@@ -39,6 +41,8 @@ module Sprockets
         debug   = options.key?(:debug) ? options.delete(:debug) : debug_assets?
         body    = options.key?(:body)  ? options.delete(:body)  : false
         digest  = options.key?(:digest)  ? options.delete(:digest)  : digest_assets?
+
+        ignore_legacy_options(options)
 
         sources.collect do |source|
           if debug && asset = asset_paths.asset_for(source, 'css')
@@ -112,6 +116,11 @@ module Sprockets
       # at the prefix returned by +asset_prefix+.
       def asset_environment
         Rails.application.assets
+      end
+
+      def ignore_legacy_options(options = {})
+        options.delete(:cache)
+        options.delete(:concat)
       end
 
       class AssetPaths < ::ActionView::AssetPaths #:nodoc:

--- a/actionpack/test/template/sprockets_helper_test.rb
+++ b/actionpack/test/template/sprockets_helper_test.rb
@@ -268,6 +268,38 @@ class SprocketsHelperTest < ActionView::TestCase
       javascript_include_tag(:application)
   end
 
+  test "javascript_include_tag with cache option" do
+    @config.assets.debug = false
+
+    assert_match %r{\A<script src="/assets/jquery.plugin.js" type="text/javascript"></script>\n<script src="/assets/xmlhr-[0-9a-f]+.js" type="text/javascript"></script>\Z},
+      javascript_include_tag('jquery.plugin', 'xmlhr', :cache => true)
+
+    @config.assets.debug = true
+
+    assert_match %r{\A<script src="/assets/jquery.plugin.js" type="text/javascript"></script>\n<script src="/assets/xmlhr-[0-9a-f]+.js\?body=1" type="text/javascript"></script>\Z},
+      javascript_include_tag('jquery.plugin', 'xmlhr', :cache => true)
+
+    @config.perform_caching = false
+
+    assert_match %r{\A<script src="/assets/jquery.plugin.js" type="text/javascript"></script>\n<script src="/assets/xmlhr-[0-9a-f]+.js\?body=1" type="text/javascript"></script>\Z},
+      javascript_include_tag('jquery.plugin', 'xmlhr', :cache => true)
+
+    assert_match %r{\A<script src="/assets/jquery.plugin.js" type="text/javascript"></script>\n<script src="/assets/xmlhr-[0-9a-f]+.js\?body=1" type="text/javascript"></script>\Z},
+      javascript_include_tag('jquery.plugin', 'xmlhr', :cache => "foobar")
+  end
+
+  test "javascript_include_tag with concat option" do
+    @config.assets.debug = false
+
+    assert_match %r{\A<script src="/assets/jquery.plugin.js" type="text/javascript"></script>\n<script src="/assets/xmlhr-[0-9a-f]+.js" type="text/javascript"></script>\Z},
+      javascript_include_tag('jquery.plugin', 'xmlhr', :cache => "foobar")
+
+    @config.assets.debug = true
+
+    assert_match %r{\A<script src="/assets/jquery.plugin.js" type="text/javascript"></script>\n<script src="/assets/xmlhr-[0-9a-f]+.js\?body=1" type="text/javascript"></script>\Z},
+      javascript_include_tag('jquery.plugin', 'xmlhr', :cache => "foobar")
+  end
+
   test "stylesheet path through asset_path" do
     assert_match %r{/assets/application-[0-9a-f]+.css}, asset_path(:application, :ext => "css")
 
@@ -326,6 +358,38 @@ class SprocketsHelperTest < ActionView::TestCase
 
     assert_match %r{<link href="/assets/style-[0-9a-f]+.css\?body=1" media="print" rel="stylesheet" type="text/css" />\n<link href="/assets/application-[0-9a-f]+.css\?body=1" media="print" rel="stylesheet" type="text/css" />},
       stylesheet_link_tag(:application, :media => "print")
+  end
+
+  test "stylesheet_link_tag with cache option" do
+    @config.assets.debug = false
+
+    assert_match %r{\A<link href="/assets/extra-[0-9a-f]+.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/assets/style-[0-9a-f]+.css" media="screen" rel="stylesheet" type="text/css" />\Z},
+      stylesheet_link_tag("extra", "style", :cache => true)
+
+    @config.assets.debug = true
+
+    assert_match %r{\A<link href="/assets/extra-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />\n<link href="/assets/style-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />\Z},
+      stylesheet_link_tag("extra", "style", :cache => true)
+
+    @config.perform_caching = false
+
+    assert_match %r{\A<link href="/assets/extra-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />\n<link href="/assets/style-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />\Z},
+      stylesheet_link_tag("extra", "style", :cache => true)
+
+    assert_match %r{\A<link href="/assets/extra-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />\n<link href="/assets/style-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />\Z},
+      stylesheet_link_tag("extra", "style", :cache => "foobar")
+  end
+
+  test "stylesheet_link_tag with concat option" do
+    @config.assets.debug = false
+
+    assert_match %r{\A<link href="/assets/extra-[0-9a-f]+.css" media="screen" rel="stylesheet" type="text/css" />\n<link href="/assets/style-[0-9a-f]+.css" media="screen" rel="stylesheet" type="text/css" />\Z},
+      stylesheet_link_tag("extra", "style", :concat => "foobar")
+
+    @config.assets.debug = true
+
+    assert_match %r{\A<link href="/assets/extra-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />\n<link href="/assets/style-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />\Z},
+      stylesheet_link_tag("extra", "style", :concat => "foobar")
   end
 
   test "alternate asset prefix" do


### PR DESCRIPTION
By some reasons, if someone will put these options in javascript_include_tag or stylesheet_link_tag it will
cause strange errors (when sprockets is enable for app). For me it took about work day to detect what exactly happened.

You can easy reproduce the error: just create new rails 3.2 app, generate simple controller with one action, specify root action in routes and add :cache => true, :cache => "foo" or :concat => "foo" to the end of any javascript_include_tag or stylesheet_link_tag helpers.

I am in the middle of migrating 2.3.x app to 3.2.x for my current project, so I have a lot of legacy :cache options. Unfortunately current exception is too hard to undersand situation for developers, without spending time to debugging Rails. 

I suggest to ignore :cache and :concat options for js and css sprockets tag helpers (like I have done). Also I think that sprockets may detect these options and say something (for example it can show warning). 

If something wrong in my commit let me know and I will fix it asap. Hope it will help someone.
