### PR TITLE
Added a feature to add a database task. e.g. OracleDatabaseTasks

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -3,12 +3,16 @@ module ActiveRecord
     module DatabaseTasks # :nodoc:
       extend self
 
-      TASKS_PATTERNS = {
-        /mysql/      => ActiveRecord::Tasks::MySQLDatabaseTasks,
-        /postgresql/ => ActiveRecord::Tasks::PostgreSQLDatabaseTasks,
-        /sqlite/     => ActiveRecord::Tasks::SQLiteDatabaseTasks
-      }
       LOCAL_HOSTS    = ['127.0.0.1', 'localhost']
+
+      def register_task(pattern, task)
+        @tasks ||= {}
+        @tasks[pattern] = task
+      end
+
+      register_task(/mysql/, ActiveRecord::Tasks::MySQLDatabaseTasks)
+      register_task(/postgresql/, ActiveRecord::Tasks::PostgreSQLDatabaseTasks)
+      register_task(/sqlite/, ActiveRecord::Tasks::SQLiteDatabaseTasks)
 
       def create(*arguments)
         configuration = arguments.first
@@ -75,8 +79,8 @@ module ActiveRecord
       private
 
       def class_for_adapter(adapter)
-        key = TASKS_PATTERNS.keys.detect { |pattern| adapter[pattern] }
-        TASKS_PATTERNS[key]
+        key = @tasks.keys.detect { |pattern| adapter[pattern] }
+        @tasks[key]
       end
 
       def each_current_configuration(environment)

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -16,6 +16,22 @@ module ActiveRecord
      :postgresql => :postgresql_tasks,
      :sqlite3    => :sqlite_tasks
   }
+
+  class DatabaseTasksRegisterTask < ActiveRecord::TestCase
+    def test_register_task
+      klazz = Class.new do
+        def initialize(*arguments); end
+        def structure_dump(filename); end
+      end
+      instance = klazz.new
+
+      klazz.stubs(:new).returns instance
+      instance.expects(:structure_dump).with("awesome-file.sql")
+
+      ActiveRecord::Tasks::DatabaseTasks.register_task(/foo/, klazz)
+      ActiveRecord::Tasks::DatabaseTasks.structure_dump({'adapter' => :foo}, "awesome-file.sql")
+    end
+  end
  
   class DatabaseTasksCreateTest < ActiveRecord::TestCase
     include DatabaseTasksSetupper


### PR DESCRIPTION
If we want to add a database tasks (e.g. OracleDatabaseTasks) by external gems, according to the current implementation, we can't do it.
