### PR TITLE
Stop assuming strings for grouped calculations

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -61,6 +61,11 @@ class CalculationsTest < ActiveRecord::TestCase
     [1,6,2].each { |firm_id| assert c.keys.include?(firm_id) }
   end
 
+  def test_should_group_by_arel_attribute
+    c = Account.sum(:credit_limit, :group => Account.arel_table[:firm_id])
+    [1,6,2].each { |firm_id| assert c.keys.include?(firm_id) }
+  end
+
   def test_should_group_by_multiple_fields
     c = Account.group('firm_id', :credit_limit).count(:all)
     [ [nil, 50], [1, 50], [6, 50], [6, 55], [9, 53], [2, 60] ].each { |firm_and_limit| assert c.keys.include?(firm_and_limit) }


### PR DESCRIPTION
Execute_grouped_calculation is one of those places where
ActiveRecord forgets that it has ARel underpinnings, and
assumes that the values provided to group_values are
strings. This artificially hobbles otherwise functional
code. This patch stops assuming that incoming values
respond to to_sym, stops using string interpolation for
table aliases on objects that support aliasing, and stops
unnecessarily joining group_values on the relation.

Additionally, it calls to_sql, if available, on objects
sent to column_alias_for, in order to get a more reasonable
alias string than a non-string's default to_str method.
