### PR TITLE
Check the size of cookies correctly

### DIFF
--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -66,7 +66,23 @@ class CookiesTest < ActionController::TestCase
     end
 
     def raise_data_overflow
-      cookies.signed[:foo] = 'bye!' * 1024
+      cookies[:foo] = 'bye!' * 1024 + "a"
+      head :ok
+    end
+
+    def raise_data_overflow_permanent
+      cookies.permanent[:foo] = 'bye!' * 1024 + "a"
+      head :ok
+    end
+
+    def raise_data_overflow_signed
+      cookies.signed[:foo] = 'bye!' * 1024 + "a"
+      head :ok
+    end
+
+    def raise_data_overflow_multiple
+      cookies[:foo] = 'bye!' * 512
+      cookies[:bar] = 'bye!' * 512
       head :ok
     end
 
@@ -317,6 +333,24 @@ class CookiesTest < ActionController::TestCase
   def test_raise_data_overflow
     assert_raise(ActionDispatch::Cookies::CookieOverflow) do
       get :raise_data_overflow
+    end
+  end
+
+  def test_raise_data_overflow_permanent
+    assert_raise(ActionDispatch::Cookies::CookieOverflow) do
+      get :raise_data_overflow_permanent
+    end
+  end
+
+  def test_raise_data_overflow_signed
+    assert_raise(ActionDispatch::Cookies::CookieOverflow) do
+      get :raise_data_overflow_signed
+    end
+  end
+
+  def test_raise_data_overflow_multiple
+    assert_raise(ActionDispatch::Cookies::CookieOverflow) do
+      get :raise_data_overflow_multiple
     end
   end
 


### PR DESCRIPTION
This is my new version of #6796, which wasn't pointing to master.

Rails so far did check the size of signed cookies only, permanent and normal cookies aren't checked. Also, it checked the size of the unescaped value of a single cookie only, but browsers check the size of all cookies set by the current request together including names and options.

See http://myownplayground.atspace.com/cookietest.html
