### PR TITLE
correct line numbers for reader and writer methods

### DIFF
--- a/activesupport/lib/active_support/configurable.rb
+++ b/activesupport/lib/active_support/configurable.rb
@@ -98,15 +98,15 @@ module ActiveSupport
         names.each do |name|
           raise NameError.new('invalid config attribute name') unless name =~ /^[_A-Za-z]\w*$/
 
-          reader, line = "def #{name}; config.#{name}; end", __LINE__
-          writer, line = "def #{name}=(value); config.#{name} = value; end", __LINE__
+          reader, reader_line = "def #{name}; config.#{name}; end", __LINE__
+          writer, writer_line = "def #{name}=(value); config.#{name} = value; end", __LINE__
 
-          singleton_class.class_eval reader, __FILE__, line
-          singleton_class.class_eval writer, __FILE__, line
+          singleton_class.class_eval reader, __FILE__, reader_line
+          singleton_class.class_eval writer, __FILE__, writer_line
 
           unless options[:instance_accessor] == false
-            class_eval reader, __FILE__, line unless options[:instance_reader] == false
-            class_eval writer, __FILE__, line unless options[:instance_writer] == false
+            class_eval reader, __FILE__, reader_line unless options[:instance_reader] == false
+            class_eval writer, __FILE__, writer_line unless options[:instance_writer] == false
           end
         end
       end


### PR DESCRIPTION
The line number for the reader method is off by one due to the local variable `line` being reassigned to the writer's line.

This commit would provide correct line numbers for backtraces and method introspection (for example, `method(:reader).source_location`).

I apologize in advance for the brevity of this commit -- I am submitting this from a phone using GitHub's "Edit this file" feature.
