### PR TITLE
Changing scope in a mounted engine

### DIFF
--- a/actionpack/test/dispatch/prefix_generation_test.rb
+++ b/actionpack/test/dispatch/prefix_generation_test.rb
@@ -31,6 +31,7 @@ module TestGenerationPrefix
             match "/polymorphic_path_for_engine", :to => "inside_engine_generating#polymorphic_path_for_engine"
             match "/conflicting_url", :to => "inside_engine_generating#conflicting"
             match "/foo", :to => "never#invoked", :as => :named_helper_that_should_be_invoked_only_in_respond_to_test
+            match "/link_to_another_scope", :to => "inside_engine_generating#link_to_another_scope", :as => :link_to_another_scope
           end
 
           routes
@@ -99,6 +100,10 @@ module TestGenerationPrefix
 
       def conflicting
         render :text => "engine"
+      end
+      
+      def link_to_another_scope
+        render :text => url_for(:omg => "more-awesomeness", :only_path => true)
       end
     end
 
@@ -186,6 +191,11 @@ module TestGenerationPrefix
     test "[ENGINE] url_helpers from engine have higher priotity than application's url_helpers" do
       get "/awesome/blog/conflicting_url"
       assert_equal "engine", last_response.body
+    end
+
+    test "[ENGINE] link to another scope" do
+      get "/some-awesomeness/blog/link_to_another_scope"
+      assert_equal "/more-awesomeness/blog/link_to_another_scope", last_response.body
     end
 
     # Inside Application


### PR DESCRIPTION
Within an engine mounted in a dynamic scope, I'm trying to make an link to the same action but another scope (ie. changing the dynamic part of the scope) and it doesn't work.

I need this to build a link to the current page in another locale. The scope defines the locale, and the current page is handled by the engine.

I wrote a failing test to demonstrate the current behavior, which doesn't work. Rails generates an URL with the new scope in the query string, and the old scope in the path.

Is there another way to change the dynamic scope inside the engine ?
Or is this a bug that should be fixed ?

The output is:
"/more-awesomeness/blog/link_to_another_scope" expected but was
"/some-awesomeness/blog/link_to_another_scope?omg=more-awesomeness"
