### PR TITLE
Missing require breaks Time.=== when selectively loading ActiveSupport core_exts in 3.2.4+

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -1,5 +1,6 @@
 require 'active_support/duration'
 require 'active_support/core_ext/time/conversions'
+require 'active_support/time_with_zone'
 
 class Time
   COMMON_YEAR_DAYS_IN_MONTH = [nil, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]


### PR DESCRIPTION
If you selectively require core_exts (e.g., `require 'active_support/core_ext/string'`), it is possible for
`active_support/core_ext/time/calculations` to be required when `ActiveSupport::TimeWithZone` is not available. If this happens, the next call to `Time.=== will` fail with a `NameError`. This pull fixes this issue.

Then nature of this problem is not amenable to unit testing, but I can provide a [script](https://gist.github.com/2990831/) which demonstrates the problem.

This bug was introduced in Rails 3.2.4 and is present in 3.2.5, 3.2.6, 3-2-stable, and master.
