### PR TITLE
:update_details method no more exists on @lookup_context

### DIFF
--- a/actionpack/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionpack/lib/action_view/renderer/abstract_renderer.rb
@@ -1,7 +1,6 @@
 module ActionView
   class AbstractRenderer #:nodoc:
-    delegate :find_template, :template_exists?, :with_fallbacks, :update_details,
-      :with_layout_format, :formats, :to => :@lookup_context
+    delegate :find_template, :template_exists?, :with_fallbacks, :with_layout_format, :formats, :to => :@lookup_context
 
     def initialize(lookup_context)
       @lookup_context = lookup_context


### PR DESCRIPTION
the method has gone in this commit: 119e9e2dafb0cdc5b85613b730333679aef534af
