### PR TITLE
AS::Callbacks: deprecate monkey patch code

### DIFF
--- a/actionpack/action_pack_url_generator.rb
+++ b/actionpack/action_pack_url_generator.rb
@@ -1,0 +1,1 @@
+/home/bogdan/makabu/my/benchmarks/action_pack_url_generator.rb

--- a/actionpack/lib/action_controller/caching/sweeping.rb
+++ b/actionpack/lib/action_controller/caching/sweeping.rb
@@ -72,6 +72,12 @@ module ActionController #:nodoc:
           self.controller = nil
         end
 
+        def around(controller)
+          before(controller)
+          yield
+          after(controller)
+        end
+
         protected
           # gets the action cache path for the given options.
           def action_path_for(options)

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -326,6 +326,12 @@ class FilterTest < ActionController::TestCase
       controller.instance_variable_set(:"@after_ran", true)
       controller.class.execution_log << " after aroundfilter " if controller.respond_to? :execution_log
     end
+
+    def around(controller)
+      before(controller)
+      yield
+      after(controller)
+    end
   end
 
   class AppendedAroundFilter
@@ -335,6 +341,12 @@ class FilterTest < ActionController::TestCase
 
     def after(controller)
       controller.class.execution_log << " after appended aroundfilter "
+    end
+
+    def around(controller)
+      before(controller)
+      yield
+      after(controller)
     end
   end
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   AS::Callbacks: deprecate usage of filter object with `#before` and `#after` methods as `around` callback. *Bogdan Gusiev*
+
 *   Add `Time#prev_quarter' and 'Time#next_quarter' short-hands for months_ago(3) and months_since(3). *SungHee Kang*
 
 *   Remove obsolete and unused `require_association` method from dependencies. *fxn*

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -283,7 +283,8 @@ module ActiveSupport
           filter.singleton_class.class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
             def #{kind}(context, &block) filter(context, &block) end
           RUBY_EVAL
-        elsif filter.respond_to?(:before) && filter.respond_to?(:after) && kind == :around
+        elsif filter.respond_to?(:before) && filter.respond_to?(:after) && kind == :around && !filter.respond_to?(:around)
+          ActiveSupport::Deprecation.warn("Filter object with #before and #after methods is deprecated. Define #around method instead.")
           def filter.around(context)
             should_continue = before(context)
             yield if should_continue


### PR DESCRIPTION
Deprecate usage of filter object with #before and #after
methods as around callback.

There is some code monkey patches objects passed to `set_callback` method. This should never happen.
The only one usage of this is found in `ActionController::Caching::Sweeper` which is easy to fix.
