### PR TITLE
ActiveSupport::Inflector optimization: minimize objects created

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -12,6 +12,9 @@ module ActiveSupport
   module Inflector
     extend self
 
+    # A hash of cached regular expressions for matching uncountables.
+    UNCOUNTABLE_REGEXPS = {}
+
     # Returns the plural form of the word in the string.
     #
     # Examples:
@@ -309,7 +312,7 @@ module ActiveSupport
     def apply_inflections(word, rules)
       result = word.to_s.dup
 
-      if word.empty? || inflections.uncountables.any? { |inflection| result =~ /\b#{inflection}\Z/i }
+      if word.empty? || inflections.uncountables.any? { |inflection| result =~ (UNCOUNTABLE_REGEXPS[inflection] ||= /\b#{inflection}\Z/i) }
         result
       else
         rules.each { |(rule, replacement)| break if result.gsub!(rule, replacement) }


### PR DESCRIPTION
#### WHAT

Avoid creating many throwaway `String` and `Regexp` objects while using ActiveSupport's inflections.
#### WHY

Both the `pluralize` and `singularize` methods are widely used in Rails (`AssetTagHelper` is a good example). They both call `apply_inflections`, which first tries to match against every `uncountables`, cycling thru and creating a new `Regexp` and `String` for each `uncountable`.  
#### HOW

This patch seemed to be the simplest solution to caching `uncountable` regexp's that I could write. Here is the memprof and benchmark before the patch (w/1.8.7 REE):

```
Memprof.track { 1000.times { "hey".pluralize } }
   9000 /.../activesupport-3.2.6/lib/active_support/inflector/methods.rb:312:String
   9000 /.../activesupport-3.2.6/lib/active_support/inflector/methods.rb:312:Regexp
   1000 /.../activesupport-3.2.6/lib/active_support/inflector/methods.rb:315:__unknown__
   1000 /.../activesupport-3.2.6/lib/active_support/inflector/methods.rb:315:String
   1000 /.../activesupport-3.2.6/lib/active_support/inflector/methods.rb:315:MatchData
   1000 /.../activesupport-3.2.6/lib/active_support/inflector/methods.rb:312:__node__
   1000 /.../activesupport-3.2.6/lib/active_support/inflector/methods.rb:310:String
   1000 (irb):1:String
      1 (irb):1:__varmap__

Benchmark.ms { 1000.times { "hey".pluralize } }
 => 100.382089614868 
```

And after the patch:

```
Memprof.track { 1000.times { "hey".pluralize } }
   1000 /.../activesupport-3.2.6/lib/active_support/inflector/methods.rb:318:__unknown__
   1000 /.../activesupport-3.2.6/lib/active_support/inflector/methods.rb:318:String
   1000 /.../activesupport-3.2.6/lib/active_support/inflector/methods.rb:318:MatchData
   1000 /.../activesupport-3.2.6/lib/active_support/inflector/methods.rb:315:__node__
   1000 /.../activesupport-3.2.6/lib/active_support/inflector/methods.rb:313:String
   1000 (irb):3:String
      1 (irb):3:__varmap__

Benchmark.ms { 1000.times { "hey".pluralize } }
 => 51.4700412750244 
```
