### PR TITLE
Add query methods in ActiveRecord::Base.store for convenience

### DIFF
--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -18,11 +18,12 @@ module ActiveRecord
   # Examples:
   #
   #   class User < ActiveRecord::Base
-  #     store :settings, accessors: [ :color, :homepage ], coder: JSON
+  #     store :settings, accessors: [ :color, :homepage, :editor ], coder: JSON
   #   end
   #
-  #   u = User.new(color: 'black', homepage: '37signals.com')
+  #   u = User.new(color: 'black', homepage: '37signals.com', editor: true)
   #   u.color                          # Accessor stored attribute
+  #   u.editor?                        # Query method for convenience
   #   u.settings[:country] = 'Denmark' # Any attribute, even if not specified with an accessor
   #
   #   # There is no difference between strings and symbols for accessing custom attributes
@@ -36,7 +37,7 @@ module ActiveRecord
   #
   # The stored attribute names can be retrieved using +stored_attributes+.
   #
-  #   User.stored_attributes[:settings] # [:color, :homepage]
+  #   User.stored_attributes[:settings] # [:color, :homepage, :editor]
   #
   # == Overwriting default accessors
   #
@@ -83,6 +84,10 @@ module ActiveRecord
             define_method(key) do
               read_store_attribute(store_attribute, key)
             end
+          end
+
+          define_method("#{key}?") do
+            !!send(key)
           end
         end
 

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -84,10 +84,17 @@ module ActiveRecord
             define_method(key) do
               read_store_attribute(store_attribute, key)
             end
-          end
 
-          define_method("#{key}?") do
-            !!send(key)
+            define_method("#{key}?") do
+              value = send(key)
+              if value.blank?
+                false
+              elsif value.is_a?(Numeric)
+                !value.zero?
+              else
+                !!value
+              end
+            end
           end
         end
 

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -6,12 +6,19 @@ class StoreTest < ActiveRecord::TestCase
   fixtures :'admin/users'
 
   setup do
-    @john = Admin::User.create!(:name => 'John Doe', :color => 'black', :remember_login => true, :height => 'tall', :is_a_good_guy => true)
+    @john = Admin::User.create!(:name => 'John Doe', :color => 'black', :remember_login => true, :height => 'tall', :is_a_good_guy => true, :is_a_bad_guy => false)
   end
 
   test "reading store attributes through accessors" do
     assert_equal 'black', @john.color
     assert_nil @john.homepage
+  end
+
+  test "query store attributes through query accessors" do
+    assert_equal true, @john.is_a_good_guy?
+    assert_equal false, @john.is_a_bad_guy?    
+    assert_equal true, @john.color?
+    assert_equal false, @john.homepage?
   end
 
   test "writing store attributes through accessors" do

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -6,7 +6,14 @@ class StoreTest < ActiveRecord::TestCase
   fixtures :'admin/users'
 
   setup do
-    @john = Admin::User.create!(:name => 'John Doe', :color => 'black', :remember_login => true, :height => 'tall', :is_a_good_guy => true, :is_a_bad_guy => false)
+    @john = Admin::User.create!(:name => 'John Doe',
+                                :color => 'black',
+                                :remember_login => true,
+                                :height => 'tall',
+                                :is_a_good_guy => true,
+                                :is_a_bad_guy => false,
+                                :empty_thing => "",
+                                :zero_thing => 0)
   end
 
   test "reading store attributes through accessors" do
@@ -16,9 +23,17 @@ class StoreTest < ActiveRecord::TestCase
 
   test "query store attributes through query accessors" do
     assert_equal true, @john.is_a_good_guy?
-    assert_equal false, @john.is_a_bad_guy?    
+    assert_equal false, @john.is_a_bad_guy?
     assert_equal true, @john.color?
     assert_equal false, @john.homepage?
+  end
+
+  test "quering attributes should return false in special cases" do
+    assert_equal false, @john.empty_thing?
+    assert_equal false, @john.zero_thing?
+
+    @john.zero_thing = 0.0
+    assert_equal false, @john.zero_thing?
   end
 
   test "writing store attributes through accessors" do

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -17,6 +17,7 @@ class Admin::User < ActiveRecord::Base
   store :settings, :accessors => [ :color, :homepage ]
   store_accessor :settings, :favorite_food
   store :preferences, :accessors => [ :remember_login ]
+  store :quering, :accessors => [ :empty_thing, :zero_thing ]
   store :json_data, :accessors => [ :height, :weight ], :coder => Coder.new
   store :json_data_empty, :accessors => [ :is_a_good_guy, :is_a_bad_guy ], :coder => Coder.new
 

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -18,7 +18,7 @@ class Admin::User < ActiveRecord::Base
   store_accessor :settings, :favorite_food
   store :preferences, :accessors => [ :remember_login ]
   store :json_data, :accessors => [ :height, :weight ], :coder => Coder.new
-  store :json_data_empty, :accessors => [ :is_a_good_guy ], :coder => Coder.new
+  store :json_data_empty, :accessors => [ :is_a_good_guy, :is_a_bad_guy ], :coder => Coder.new
 
   def phone_number
     read_store_attribute(:settings, :phone_number).gsub(/(\d{3})(\d{3})(\d{4})/,'(\1) \2-\3')

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define do
   create_table :admin_users, :force => true do |t|
     t.string :name
     t.string :settings, :null => true, :limit => 1024
+    t.text :quering, :null => true, :limit => 1024
     # MySQL does not allow default values for blobs. Fake it out with a
     # big varchar below.
     t.string :preferences, :null => true, :default => '', :limit => 1024


### PR DESCRIPTION
Example

``` ruby
class User < ActiveRecord::Base
  store :settings, accessors: [ :homepage, :editor ]
end

u = User.new(homepage: '37signals.com', editor: true)
u.editor? # => true
```

Much like how is done in Class.class_attribute
