### PR TITLE
Remove ActiveRelation#inspect

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `ActiveRelation#inspect` no longer calls `#to_a`
+
+    *Brian Cardarella*
+
 *   Add `collate` and `ctype` support to PostgreSQL. These are available for PostgreSQL 8.4 or later.
     Example:
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -492,10 +492,6 @@ module ActiveRecord
       end
     end
 
-    def inspect
-      to_a.inspect
-    end
-
     def pretty_print(q)
       q.pp(self.to_a)
     end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -193,7 +193,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_no_sql_should_be_fired_if_association_already_loaded
     Car.create(:name => 'honda')
     bulbs = Car.first.bulbs
-    bulbs.inspect # to load all instances of bulbs
+    bulbs.to_a # to load all instances of bulbs
 
     assert_no_queries do
       bulbs.first()


### PR DESCRIPTION
Before this gets rejected outright I would like to have a conversation.

I submit that the harm of hiding the ActiveRelation object outweighs any benefit gained in the Rails console with having the object inspect `#to_a`

I know others feel the same way, I believe it is not worth the hassle of trying to dig into the Relation object to find out what is going on and just have it return that relation.
