### PR TITLE
Fixes #6825, adds tests covering cases and error possibilities

### DIFF
--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -106,13 +106,11 @@ module ActiveRecord
     attr_reader :record, :attempted_action
 
     def initialize(record, attempted_action)
+      super("Attempted to #{attempted_action} a stale object: #{record.class.name}")
       @record = record
       @attempted_action = attempted_action
     end
 
-    def message
-      "Attempted to #{attempted_action} a stale object: #{record.class.name}"
-    end
   end
 
   # Raised when association is being configured improperly or
@@ -168,9 +166,9 @@ module ActiveRecord
   class AttributeAssignmentError < ActiveRecordError
     attr_reader :exception, :attribute
     def initialize(message, exception, attribute)
+      super(message)
       @exception = exception
       @attribute = attribute
-      @message = message
     end
   end
 
@@ -189,12 +187,10 @@ module ActiveRecord
     attr_reader :model
 
     def initialize(model)
+      super("Unknown primary key for table #{model.table_name} in model #{model}.")
       @model = model
     end
 
-    def message
-      "Unknown primary key for table #{model.table_name} in model #{model}."
-    end
   end
 
   class ImmutableRelation < ActiveRecordError

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -791,6 +791,39 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_equal "lol", topic.author_name
   end
 
+  def test_setting_time_attribute
+    topic = Topic.new( "bonus_time(4i)"=> "01", "bonus_time(5i)" => "05" )
+    assert_equal 1, topic.bonus_time.hour
+    assert_equal 5, topic.bonus_time.min
+  end
+
+  def test_setting_date_attribute
+    topic = Topic.new( "written_on(1i)" => "1952", "written_on(2i)" => "3", "written_on(3i)" => "11" )
+    assert_equal 1952, topic.written_on.year
+    assert_equal 3, topic.written_on.month
+    assert_equal 11, topic.written_on.day
+  end
+
+  def test_setting_date_and_time_attribute
+    topic = Topic.new(
+        "written_on(1i)" => "1952",
+        "written_on(2i)" => "3",
+        "written_on(3i)" => "11",
+        "written_on(4i)" => "13",
+        "written_on(5i)" => "55")
+    assert_equal 1952, topic.written_on.year
+    assert_equal 3, topic.written_on.month
+    assert_equal 11, topic.written_on.day
+    assert_equal 13, topic.written_on.hour
+    assert_equal 55, topic.written_on.min
+  end
+
+  def test_setting_time_but_not_date_on_date_field
+    assert_raise( ActiveRecord::MultiparameterAssignmentErrors ) do
+      Topic.new( "written_on(4i)" => "13", "written_on(5i)" => "55" )
+    end
+  end
+
   private
   def cached_columns
     Topic.columns.find_all { |column|


### PR DESCRIPTION
The current implementation on Rails is not capable of handling an object with time only, it only allows you to create an object with both time and date, which isn't really nice as you can create a time only column in almost all database systems.

This fix adds support for time only object creation (if the column is created as :time) by using Ruby's Time object. The date fields will default to "January 1, 1970" since Ruby doesn't have an object for time only. Implementation also includes specs showing what's the correct behavior and also a failure if you try to create a time only object of a column of type datetime.

This pull request fixes issue #6825.
