### PR TITLE
Rename default sequence when table is renamed? [AR:postgres]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1208,12 +1208,19 @@ module ActiveRecord
       end
 
       # Renames a table.
+      # Also renames a table's primary key sequence if the sequence name matches the
+      # Active Record default.
       #
       # Example:
       #   rename_table('octopuses', 'octopi')
       def rename_table(name, new_name)
         clear_cache!
         execute "ALTER TABLE #{quote_table_name(name)} RENAME TO #{quote_table_name(new_name)}"
+        pk, seq = pk_and_sequence_for(new_name)
+        if seq == "#{name}_#{pk}_seq"
+          new_seq = "#{new_name}_#{pk}_seq"
+          execute "ALTER TABLE #{quote_table_name(seq)} RENAME TO #{quote_table_name(new_seq)}"
+        end
       end
 
       # Adds a new column to the named table.

--- a/activerecord/test/cases/migration/rename_table_test.rb
+++ b/activerecord/test/cases/migration/rename_table_test.rb
@@ -67,6 +67,19 @@ module ActiveRecord
 
         rename_table :octopi, :test_models
       end
+
+      def test_rename_table_for_postgresql_should_also_rename_default_sequence
+        skip 'not supported' unless current_adapter?(:PostgreSQLAdapter)
+
+        rename_table :test_models, :octopi
+
+        con = ActiveRecord::Base.connection
+        pk, seq = con.pk_and_sequence_for('octopi')
+
+        assert_equal "octopi_#{pk}_seq", seq
+
+        rename_table :octopi, :test_models
+      end
     end
   end
 end


### PR DESCRIPTION
Does it make sense to rename the default primary key sequence when a table is renamed?

As it is, if I `rename_table :foo, :bar`, I end up with a table named "bar" whose id column is incremented by a sequence named "foo_id_seq". The names being out of sync complicates things when multiple DB users are used in production (e.g. one user for migrations and one user for app connections) and permissions need to be applied to tables and their associated sequences.

Attached is proposed crazy sauce which renames the primary key sequence if its name matches the default PK sequence created by the adapter.
