### PR TITLE
refactored html_escape method to be safer and better self documenting

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -21,7 +21,7 @@ class ERB
       if s.html_safe?
         s
       else
-        s.encode(s.encoding, :xml => :attr)[1...-1].html_safe
+        s.encode(s.encoding, :xml => :attr).gsub(/^"|"$/,'').html_safe
       end
     end
 


### PR DESCRIPTION
The previous approach lead to some hard to understand test failures in jRuby.
