### PR TITLE
Address test_basic_model test error with Oracle enhanced adapter

### DIFF
--- a/activerecord/test/cases/inclusion_test.rb
+++ b/activerecord/test/cases/inclusion_test.rb
@@ -4,7 +4,7 @@ require 'models/teapot'
 class BasicInclusionModelTest < ActiveRecord::TestCase
   def test_basic_model
     Teapot.create!(:name => "Ronnie Kemper")
-    assert_equal "Ronnie Kemper", Teapot.find(1).name
+    assert_equal "Ronnie Kemper", Teapot.first.name
   end
 
   def test_initialization


### PR DESCRIPTION
This pull request addresses a test_basic_model test error with Oracle enhanced adapter which ids start from 1000 as a default.

This fix has been tested with sqlite3, mysql, mysql2 and postgresql adapters.

``` ruby
$ cd activerecord
$ ARCONN=oracle ruby -Itest test/cases/inclusion_test.rb -n test_basic_model
Using oracle
Run options: -n test_basic_model --seed 53307

# Running tests:

E

Finished tests in 0.110588s, 9.0426 tests/s, 0.0000 assertions/s.

  1) Error:
test_basic_model(BasicInclusionModelTest):
ActiveRecord::RecordNotFound: Couldn't find Teapot with id=1
    /home/yahonda/git/rails/activerecord/lib/active_record/relation/finder_methods.rb:279:in `find_one'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation/finder_methods.rb:260:in `find_with_ids'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation/finder_methods.rb:38:in `find'
    /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/bundler/gems/active_record_deprecated_finders-c5418c5119b3/lib/active_record_deprecated_finders/relation.rb:123:in `find'
    /home/yahonda/git/rails/activerecord/lib/active_record/querying.rb:6:in `find'
    test/cases/inclusion_test.rb:7:in `test_basic_model'
    /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/mocha-0.11.4/lib/mocha/integration/mini_test/version_230_to_262.rb:28:in `run'
    /home/yahonda/git/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:37:in `block in run'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:348:in `_run__3118453750921688770__setup__callbacks'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:75:in `run_callbacks'
    /home/yahonda/git/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:36:in `run'

1 tests, 0 assertions, 0 failures, 1 errors, 0 skips
$
```
