### PR TITLE
Add an optional parameter to blank? method

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -11,8 +11,16 @@ class Object
   # ...to:
   #
   #   if address.blank?
-  def blank?
-    respond_to?(:empty?) ? empty? : !self
+  #
+  # And also :
+  #
+  # foo["bar"].blank? ? "f00" : foo["bar"]
+  #
+  # ...to:
+  #
+  # foo["bar"].blank?("f00")
+  def blank?(val=nil)
+    (respond_to?(:empty?) ? empty? : !self) ? (val.nil? ? true : val) : (val.nil? ? false : self)
   end
 
   # An object is present if it's not <tt>blank?</tt>.


### PR DESCRIPTION
Add an optional parameter to blank? method, which is returned when self is blank.

A little sugar to be more DRY:

```
a = b["foo"]["bar"]["stuff"].blank? ? b["foo"]["stuff"] : b["foo"]["bar"]["stuff"]
```

becomes

```
a = b["foo"]["bar"]["stuff"].blank? b["foo"]["stuff"]
```

We could use try() also, but I don't know which is the best. Maybe both would be good ?
