### PR TITLE
Support collate for postgresql

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -916,7 +916,8 @@ module ActiveRecord
       end
 
       # Create a new PostgreSQL database. Options include <tt>:owner</tt>, <tt>:template</tt>,
-      # <tt>:encoding</tt>, <tt>:tablespace</tt>, and <tt>:connection_limit</tt> (note that MySQL uses
+      # <tt>:encoding</tt>, <tt>:collate</tt>, <tt>:ctype</tt>,
+      # <tt>:tablespace</tt>, and <tt>:connection_limit</tt> (note that MySQL uses
       # <tt>:charset</tt> while PostgreSQL uses <tt>:encoding</tt>).
       #
       # Example:
@@ -933,6 +934,10 @@ module ActiveRecord
             " TEMPLATE = \"#{value}\""
           when :encoding
             " ENCODING = '#{value}'"
+          when :collate
+            " LC_COLLATE = '#{value}'"
+          when :ctype
+            " LC_CTYPE = '#{value}'"
           when :tablespace
             " TABLESPACE = \"#{value}\""
           when :connection_limit
@@ -1056,6 +1061,20 @@ module ActiveRecord
         query(<<-end_sql, 'SCHEMA')[0][0]
           SELECT pg_encoding_to_char(pg_database.encoding) FROM pg_database
           WHERE pg_database.datname LIKE '#{current_database}'
+        end_sql
+      end
+
+      # Returns the current database collate.
+      def collate
+        query(<<-end_sql, 'SCHEMA')[0][0]
+          SELECT pg_database.datcollate FROM pg_database WHERE pg_database.datname LIKE '#{current_database}'
+        end_sql
+      end
+
+      # Returns the current database ctype.
+      def ctype
+        query(<<-end_sql, 'SCHEMA')[0][0]
+          SELECT pg_database.datctype FROM pg_database WHERE pg_database.datname LIKE '#{current_database}'
         end_sql
       end
 

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -21,6 +21,10 @@ class PostgresqlActiveSchemaTest < ActiveRecord::TestCase
     assert_equal %(CREATE DATABASE "aimonetti" ENCODING = 'latin1'), create_database(:aimonetti, :encoding => :latin1)
   end
 
+  def test_create_database_with_collate_and_ctype
+    assert_equal %(CREATE DATABASE "aimonetti" ENCODING = 'UTF8' LC_COLLATE = 'ja_JP.UTF8' LC_CTYPE = 'ja_JP.UTF8'), create_database(:aimonetti, :encoding => :"UTF8", :collate => :"ja_JP.UTF8", :ctype => :"ja_JP.UTF8")
+  end
+
   def test_add_index
     # add_index calls index_name_exists? which can't work since execute is stubbed
     ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send(:define_method, :index_name_exists?) do |*|

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -21,6 +21,14 @@ module ActiveRecord
       assert_not_nil @connection.encoding
     end
 
+    def test_collate
+      assert_not_nil @connection.collate
+    end
+
+    def test_ctype
+      assert_not_nil @connection.ctype
+    end
+
     def test_default_client_min_messages
       assert_equal "warning", @connection.client_min_messages
     end

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -38,6 +38,14 @@ module ActiveRecord
         merge('encoding' => 'latin')
     end
 
+    def test_creates_database_with_given_collate_and_ctype
+      @connection.expects(:create_database).
+        with('my-app-db', @configuration.merge('encoding' => 'utf8', 'collate' => 'ja_JP.UTF8', 'ctype' => 'ja_JP.UTF8'))
+
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration.
+        merge('collate' => 'ja_JP.UTF8', 'ctype' => 'ja_JP.UTF8')
+    end
+
     def test_establishes_connection_to_new_database
       ActiveRecord::Base.expects(:establish_connection).with(@configuration)
 


### PR DESCRIPTION
Since PostgreSQL 8.4, Collate and Ctype options are supported when creating database.

Please see also http://www.postgresql.jp/document/9.1/html/sql-createdatabase.html.
