### PR TITLE
Require URI in ConnectionSpecification

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 module ActiveRecord
   module ConnectionAdapters
     class ConnectionSpecification #:nodoc:


### PR DESCRIPTION
Missing dependency as described in #6898
