### PR TITLE
Remove ActiveModel dependency from ActionPack

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency('activesupport', version)
-  s.add_dependency('activemodel',   version)
   s.add_dependency('rack-cache',    '~> 1.2')
   s.add_dependency('builder',       '~> 3.0.0')
   s.add_dependency('rack',          '~> 1.4.1')
@@ -26,5 +25,6 @@ Gem::Specification.new do |s|
   s.add_dependency('journey',       '~> 1.0.1')
   s.add_dependency('erubis',        '~> 2.7.0')
 
+  s.add_development_dependency('activemodel', version)
   s.add_development_dependency('tzinfo', '~> 0.3.33')
 end

--- a/actionpack/lib/action_controller/model_naming.rb
+++ b/actionpack/lib/action_controller/model_naming.rb
@@ -1,0 +1,12 @@
+module ActionController
+  module ModelNaming
+    # Converts the given object to an ActiveModel compliant one.
+    def convert_to_model(object)
+      object.respond_to?(:to_model) ? object.to_model : object
+    end
+
+    def model_name_from_record_or_class(record_or_class)
+      (record_or_class.is_a?(Class) ? record_or_class : convert_to_model(record_or_class).class).model_name
+    end
+  end
+end

--- a/actionpack/lib/action_controller/record_identifier.rb
+++ b/actionpack/lib/action_controller/record_identifier.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/module'
+require 'action_controller/model_naming'
 
 module ActionController
   # The record identifier encapsulates a number of naming conventions for dealing with records, like Active Records or
@@ -27,6 +28,8 @@ module ActionController
   module RecordIdentifier
     extend self
 
+    include ModelNaming
+
     JOIN = '_'.freeze
     NEW = 'new'.freeze
 
@@ -40,7 +43,7 @@ module ActionController
     #   dom_class(post, :edit)   # => "edit_post"
     #   dom_class(Person, :edit) # => "edit_person"
     def dom_class(record_or_class, prefix = nil)
-      singular = ActiveModel::Naming.param_key(record_or_class)
+      singular = model_name_from_record_or_class(record_or_class).param_key
       prefix ? "#{prefix}#{JOIN}#{singular}" : singular
     end
 
@@ -73,8 +76,7 @@ module ActionController
     # method that replaces all characters that are invalid inside DOM ids, with valid ones. You need to
     # make sure yourself that your dom ids are valid, in case you overwrite this method.
     def record_key_for_dom_id(record)
-      record = record.to_model if record.respond_to?(:to_model)
-      key = record.to_key
+      key = convert_to_model(record).to_key
       key ? key.join('_') : key
     end
   end

--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -1,3 +1,5 @@
+require 'action_controller/model_naming'
+
 module ActionDispatch
   module Routing
     # Polymorphic URL helpers are methods for smart resolution to a named route call when
@@ -53,6 +55,8 @@ module ActionDispatch
     #   form_for([blog, @post])         # => "/blog/posts/1"
     #
     module PolymorphicRoutes
+      include ActionController::ModelNaming
+
       # Constructs a call to a named RESTful route for the given record and returns the
       # resulting URL string. For example:
       #
@@ -154,10 +158,6 @@ module ActionDispatch
           options[:action] ? "#{options[:action]}_" : ''
         end
 
-        def convert_to_model(object)
-          object.respond_to?(:to_model) ? object.to_model : object
-        end
-
         def routing_type(options)
           options[:routing_type] || :url
         end
@@ -169,7 +169,7 @@ module ActionDispatch
               if parent.is_a?(Symbol) || parent.is_a?(String)
                 parent
               else
-                ActiveModel::Naming.singular_route_key(parent)
+                model_name_from_record_or_class(parent).singular_route_key
               end
             end
           else
@@ -181,9 +181,9 @@ module ActionDispatch
             route << record
           elsif record
             if inflection == :singular
-              route << ActiveModel::Naming.singular_route_key(record)
+              route << model_name_from_record_or_class(record).singular_route_key
             else
-              route << ActiveModel::Naming.route_key(record)
+              route << model_name_from_record_or_class(record).route_key
             end
           else
             raise ArgumentError, "Nil location provided. Can't build URI."


### PR DESCRIPTION
This was requested by @wycats in Rails-core mailing list (https://groups.google.com/forum/#!msg/rubyonrails-core/MhbmIeHBURU/EiXenlob1okJ)

```
activemodel is used for ActiveModel::Naming for a few, mostly optional aspects of ActionPack related to automatically converting an ActiveModel compliant object into a key for params and routing. It uses only two methods of ActiveModel (ActiveModel::Naming.route_key and ActiveModel::Naming.param_key). I think we should remove this dependency, as the point of the ActiveModel API refactor in Rails 3 was to allow *any* object to work in AP. Additionally, only a few areas of the code use even the ActiveModel API.
```
