### PR TITLE
Extract collation tasks to database tasks.

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -148,14 +148,9 @@ db_namespace = namespace :db do
 
   # desc "Retrieves the collation for the current environment's database"
   task :collation => [:environment, :load_config] do
-    config = ActiveRecord::Base.configurations[Rails.env || 'development']
-    case config['adapter']
-    when /mysql/
-      ActiveRecord::Base.establish_connection(config)
-      puts ActiveRecord::Base.connection.collation
-    else
-      $stderr.puts 'sorry, your database adapter is not supported yet, feel free to submit a patch'
-    end
+    puts ActiveRecord::Tasks::DatabaseTasks.collation_current
+  ensure NoMethodError
+    $stderr.puts 'sorry, your database adapter is not supported yet, feel free to submit a patch'
   end
 
   desc 'Retrieves the current schema version number'

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -56,6 +56,15 @@ module ActiveRecord
         class_for_adapter(configuration['adapter']).new(*arguments).charset
       end
 
+      def collation_current(environment = Rails.env)
+        collation ActiveRecord::Base.configurations[environment]
+      end
+
+      def collation(*arguments)
+        configuration = arguments.first
+        class_for_adapter(configuration['adapter']).new(*arguments).collation
+      end
+
       def purge(configuration)
         class_for_adapter(configuration['adapter']).new(configuration).purge
       end

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -44,6 +44,10 @@ module ActiveRecord
         connection.charset
       end
 
+      def collation
+        connection.collation
+      end
+
       def structure_dump(filename)
         establish_connection configuration
         File.open(filename, "w:utf-8") { |f| f << ActiveRecord::Base.connection.structure_dump }

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -29,6 +29,10 @@ module ActiveRecord
         connection.encoding
       end
 
+      def collation
+        connection.collate
+      end
+
       def purge
         clear_active_connections!
         drop

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -251,6 +251,17 @@ module ActiveRecord
     end
   end
 
+  class DatabaseTasksCollationTest < ActiveRecord::TestCase
+    include DatabaseTasksSetupper
+ 
+    ADAPTERS_TASKS.each do |k, v|
+      define_method("test_#{k}_collation") do
+        eval("@#{v}").expects(:collation)
+        ActiveRecord::Tasks::DatabaseTasks.collation 'adapter' => k
+      end
+    end
+  end
+
   class DatabaseTasksStructureDumpTest < ActiveRecord::TestCase
     include DatabaseTasksSetupper
 

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -195,6 +195,24 @@ module ActiveRecord
     end
   end
 
+  class MysqlDBCollationTest < ActiveRecord::TestCase
+    def setup
+      @connection    = stub(:create_database => true)
+      @configuration = {
+        'adapter'  => 'mysql',
+        'database' => 'my-app-db'
+      }
+
+      ActiveRecord::Base.stubs(:connection).returns(@connection)
+      ActiveRecord::Base.stubs(:establish_connection).returns(true)
+    end
+
+    def test_db_retrieves_collation
+      @connection.expects(:collation)
+      ActiveRecord::Tasks::DatabaseTasks.collation @configuration
+    end
+  end
+
   class MySQLStructureDumpTest < ActiveRecord::TestCase
     def setup
       @connection    = stub(:structure_dump => true)

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -159,6 +159,24 @@ module ActiveRecord
     end
   end
 
+  class PostgreSQLDBCollationTest < ActiveRecord::TestCase
+    def setup
+      @connection    = stub(:create_database => true)
+      @configuration = {
+        'adapter'  => 'postgresql',
+        'database' => 'my-app-db'
+      }
+
+      ActiveRecord::Base.stubs(:connection).returns(@connection)
+      ActiveRecord::Base.stubs(:establish_connection).returns(true)
+    end
+
+    def test_db_retrieves_collation
+      @connection.expects(:collate)
+      ActiveRecord::Tasks::DatabaseTasks.collation @configuration
+    end
+  end
+
   class PostgreSQLStructureDumpTest < ActiveRecord::TestCase
     def setup
       @connection    = stub(:structure_dump => true)

--- a/activerecord/test/cases/tasks/sqlite_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlite_rake_test.rb
@@ -124,6 +124,27 @@ module ActiveRecord
     end
   end
 
+  class SqliteDBCollationTest < ActiveRecord::TestCase
+    def setup
+      @database      = 'db_create.sqlite3'
+      @connection    = stub :connection
+      @configuration = {
+        'adapter'  => 'sqlite3',
+        'database' => @database
+      }
+
+      File.stubs(:exist?).returns(false)
+      ActiveRecord::Base.stubs(:connection).returns(@connection)
+      ActiveRecord::Base.stubs(:establish_connection).returns(true)
+    end
+
+    def test_db_retrieves_collation
+      assert_raise NoMethodError do
+        ActiveRecord::Tasks::DatabaseTasks.collation @configuration, '/rails/root'
+      end
+    end
+  end
+
   class SqliteStructureDumpTest < ActiveRecord::TestCase
     def setup
       @database      = "db_create.sqlite3"


### PR DESCRIPTION
Since fda24312d3, we have collation support for PostgreSQL.
Thus I extracted collation task implementation to database tasks.
