### PR TITLE
Persist glob when replacing a path

### DIFF
--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -51,7 +51,8 @@ module Rails
       end
 
       def []=(path, value)
-        add(path, :with => value)
+        glob = self[path] ? self[path].glob : nil
+        add(path, :with => value, :glob => glob)
       end
 
       def add(path, options={})

--- a/railties/test/paths_test.rb
+++ b/railties/test/paths_test.rb
@@ -200,6 +200,13 @@ class PathsTest < ActiveSupport::TestCase
     assert_equal "*.rb", @root["app"].glob
   end
 
+  test "it should be possible to replace a path and persist the original paths glob" do
+    @root.add "app", :glob => "*.rb"
+    @root["app"] = "app2"
+    assert_equal ["/foo/bar/app2"], @root["app"].paths
+    assert_equal "*.rb", @root["app"].glob
+  end
+
   test "a path can be added to the load path" do
     @root["app"] = "app"
     @root["app"].load_path!


### PR DESCRIPTION
When Rails::Paths::Root's []= is used to replace a path it should persist the previous path's glob.  Without passing the glob along we get gnarly bugs when trying to wire up things like engines.

/cc @josevalim

---

From rails/engine.rb docs:

```
#   class MyEngine < Rails::Engine
#     paths["app/controllers"] = "lib/controllers"
#   end
```

This works great. but if you did the same with something that was configured with a glob, like app/initializers, you get errors like this:

```
lib/active_support/dependencies.rb:245:in `load': cannot load such file -- /Users/nick/Desktop/foo_engine/lib/foo_engine/initializers (LoadError)
```

``` ruby
module FooEngine
  class Engine < ::Rails::Engine
    isolate_namespace FooEngine

    config.paths['config/initializers'] = "lib/foo_engine/initializers"
  end
end

# Before the initializer override:
>> FooEngine::Engine.config.paths["config/initializers"].glob
=> "**/*.rb"

# After the initializer override:
>> FooEngine::Engine.config.paths["config/initializers"].glob
=> nil
```
