### PR TITLE
Bug with FileUpdateChecker with wrong mtime

### DIFF
--- a/activesupport/lib/active_support/file_update_checker.rb
+++ b/activesupport/lib/active_support/file_update_checker.rb
@@ -101,7 +101,9 @@ module ActiveSupport
     end
 
     def updated_at(paths)
-      @updated_at || paths.map { |path| File.mtime(path) }.max || Time.at(0)
+      time_now = Time.now
+      @updated_at || paths.map { |path| File.mtime(path) }.
+        reject { |time| time > time_now }.max || Time.at(0)
     end
 
     def compile_glob(hash)

--- a/activesupport/test/file_update_checker_test.rb
+++ b/activesupport/test/file_update_checker_test.rb
@@ -48,6 +48,20 @@ class FileUpdateCheckerWithEnumerableTest < ActiveSupport::TestCase
     assert_equal 1, i
   end
 
+  def test_should_be_robust_to_handle_files_with_wrong_modified_time
+    i = 0
+    time = 1.year.from_now # wrong mtime from the future
+    File.utime time, time, FILES[2]
+
+    checker = ActiveSupport::FileUpdateChecker.new(FILES){ i += 1 }
+
+    sleep(0.1)
+    FileUtils.touch(FILES[0..1])
+
+    assert checker.execute_if_updated
+    assert_equal 1, i
+  end
+
   def test_should_cache_updated_result_until_execute
     i = 0
     checker = ActiveSupport::FileUpdateChecker.new(FILES){ i += 1 }


### PR DESCRIPTION
Sometimes mtime in files can be wrong (e.g. when you change your local time in travel or on other reasons). In this case code reload in rails don't work at all. This is very frustrating.
