### PR TITLE
Thread safety

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,12 @@ gem 'rack-test', github: "brynary/rack-test"
 gem 'bcrypt-ruby', '~> 3.0.0'
 gem 'jquery-rails'
 
+if ENV['THREAD_SAFE']
+  gem 'thread_safe', path: ENV['THREAD_SAFE']
+else
+  gem 'thread_safe', github: 'headius/thread_safe'
+end
+
 if ENV['JOURNEY']
   gem 'journey', path: ENV['JOURNEY']
 else

--- a/actionpack/lib/action_controller/metal/hide_actions.rb
+++ b/actionpack/lib/action_controller/metal/hide_actions.rb
@@ -27,20 +27,14 @@ module ActionController
         self.hidden_actions = hidden_actions.dup.merge(args.map(&:to_s)).freeze
       end
 
-      def inherited(klass)
-        klass.class_eval { @visible_actions = {} }
-        super
-      end
-
       def visible_action?(action_name)
-        return @visible_actions[action_name] if @visible_actions.key?(action_name)
-        @visible_actions[action_name] = !hidden_actions.include?(action_name)
+        action_methods.include?(action_name)
       end
 
       # Overrides AbstractController::Base#action_methods to remove any methods
       # that are listed as hidden methods.
       def action_methods
-        @action_methods ||= Set.new(super.reject { |name| hidden_actions.include?(name) })
+        @action_methods ||= Set.new(super.reject { |name| hidden_actions.include?(name) }).freeze
       end
     end
   end

--- a/actionpack/lib/action_dispatch/http/filter_parameters.rb
+++ b/actionpack/lib/action_dispatch/http/filter_parameters.rb
@@ -1,3 +1,4 @@
+require 'active_support/concurrent/cache'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/hash/keys'
 require 'active_support/core_ext/object/duplicable'
@@ -23,7 +24,7 @@ module ActionDispatch
     module FilterParameters
       extend ActiveSupport::Concern
 
-      @@parameter_filter_for  = {}
+      @@parameter_filter_for = ActiveSupport::Concurrent::LowWriteCache.new
 
       # Return a hash of parameters with all sensitive data replaced.
       def filtered_parameters

--- a/actionpack/lib/action_dispatch/http/headers.rb
+++ b/actionpack/lib/action_dispatch/http/headers.rb
@@ -1,7 +1,9 @@
+require 'active_support/concurrent/cache'
+
 module ActionDispatch
   module Http
     class Headers < ::Hash
-      @@env_cache = Hash.new { |h,k| h[k] = "HTTP_#{k.upcase.gsub(/-/, '_')}" }
+      @@env_cache = ActiveSupport::Concurrent::LowWriteCache.new { |h,k| h[k] = "HTTP_#{k.upcase.gsub(/-/, '_')}" }
 
       def initialize(*args)
 

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -2,6 +2,7 @@ require 'tempfile'
 require 'stringio'
 require 'strscan'
 
+require 'active_support/concurrent/cache'
 require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/core_ext/string/access'
 require 'active_support/inflector'
@@ -59,7 +60,7 @@ module ActionDispatch
     RFC5789 = %w(PATCH)
 
     HTTP_METHODS = RFC2616 + RFC2518 + RFC3253 + RFC3648 + RFC3744 + RFC5323 + RFC5789
-    HTTP_METHOD_LOOKUP = Hash.new { |h, m| h[m] = m.underscore.to_sym if HTTP_METHODS.include?(m) }
+    HTTP_METHOD_LOOKUP = ActiveSupport::Concurrent::LowWriteCache.new { |h, m| h[m] = m.underscore.to_sym if HTTP_METHODS.include?(m) }
 
     # Returns the HTTP \method that the application should see.
     # In the case where the \method was overridden by a middleware

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -1,5 +1,6 @@
 require 'journey'
 require 'forwardable'
+require 'active_support/concurrent/cache'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/object/to_query'
 require 'active_support/core_ext/hash/slice'
@@ -21,7 +22,7 @@ module ActionDispatch
         def initialize(options={})
           @defaults = options[:defaults]
           @glob_param = options.delete(:glob)
-          @controllers = {}
+          @controllers = ActiveSupport::Concurrent::LowWriteCache.new
         end
 
         def call(env)

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -22,7 +22,7 @@ module ActionDispatch
         def initialize(options={})
           @defaults = options[:defaults]
           @glob_param = options.delete(:glob)
-          @controllers = ActiveSupport::Concurrent::LowWriteCache.new
+          @controller_class_names = ActiveSupport::Concurrent::LowWriteCache.new
         end
 
         def call(env)
@@ -70,13 +70,8 @@ module ActionDispatch
       private
 
         def controller_reference(controller_param)
-          controller_name = "#{controller_param.camelize}Controller"
-
-          unless controller = @controllers[controller_param]
-            controller = @controllers[controller_param] =
-              ActiveSupport::Dependencies.reference(controller_name)
-          end
-          controller.get(controller_name)
+          const_name = @controller_class_names[controller_param] ||= "#{controller_param.camelize}Controller"
+          ActiveSupport::Dependencies.constantize(const_name)
         end
 
         def dispatch(controller, action, env)

--- a/actionpack/lib/action_view/lookup_context.rb
+++ b/actionpack/lib/action_view/lookup_context.rb
@@ -184,8 +184,12 @@ module ActionView
     # add :html as fallback to :js.
     def formats=(values)
       if values
-        values.concat(default_formats) if values.delete "*/*"
-        values << :html if values == [:js]
+        if values.include?("*/*")
+          values = values.dup
+          values.delete("*/*")
+          values.concat(default_formats)
+        end
+        values = [:js, :html] if values == [:js]
       end
       super(values)
     end

--- a/actionpack/lib/action_view/lookup_context.rb
+++ b/actionpack/lib/action_view/lookup_context.rb
@@ -1,3 +1,4 @@
+require 'active_support/concurrent/cache'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/module/remove_method'
 
@@ -52,7 +53,7 @@ module ActionView
       alias :object_hash :hash
 
       attr_reader :hash
-      @details_keys = Hash.new
+      @details_keys = ActiveSupport::Concurrent::LowWriteCache.new
 
       def self.get(details)
         @details_keys[details] ||= new

--- a/actionpack/lib/action_view/renderer/partial_renderer.rb
+++ b/actionpack/lib/action_view/renderer/partial_renderer.rb
@@ -1,3 +1,4 @@
+require 'active_support/concurrent/cache'
 require 'active_support/core_ext/object/blank'
 
 module ActionView
@@ -249,7 +250,9 @@ module ActionView
   #     <%- end -%>
   #   <% end %>
   class PartialRenderer < AbstractRenderer
-    PREFIXED_PARTIAL_NAMES = Hash.new { |h,k| h[k] = {} }
+    PREFIXED_PARTIAL_NAMES = ActiveSupport::Concurrent::LowWriteCache.new do |h, k|
+      h[k] = ActiveSupport::Concurrent::LowWriteCache.new
+    end
 
     def initialize(*)
       super

--- a/actionpack/lib/action_view/template/resolver.rb
+++ b/actionpack/lib/action_view/template/resolver.rb
@@ -1,4 +1,3 @@
-require "pathname"
 require "active_support/core_ext/class"
 require "active_support/core_ext/class/attribute_accessors"
 require "action_view/template"

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -1,3 +1,4 @@
+require 'active_support/concurrent/cache'
 require 'active_support/core_ext/class/attribute'
 require 'active_support/deprecation'
 
@@ -331,7 +332,7 @@ module ActiveModel
         # significantly (in our case our test suite finishes 10% faster with
         # this cache).
         def attribute_method_matchers_cache #:nodoc:
-          @attribute_method_matchers_cache ||= {}
+          @attribute_method_matchers_cache ||= ActiveSupport::Concurrent::LowWriteCache.new
         end
 
         def attribute_method_matcher(method_name) #:nodoc:
@@ -341,7 +342,7 @@ module ActiveModel
             matchers = attribute_method_matchers.partition(&:plain?).reverse.flatten(1)
             match = nil
             matchers.detect { |method| match = method.match(name) }
-            attribute_method_matchers_cache[name] = match
+            match
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1,6 +1,5 @@
 require 'thread'
 require 'monitor'
-require 'set'
 require 'active_support/core_ext/module/deprecation'
 
 module ActiveRecord

--- a/activesupport/lib/active_support/concurrent.rb
+++ b/activesupport/lib/active_support/concurrent.rb
@@ -1,0 +1,10 @@
+require "active_support/dependencies/autoload"
+
+module ActiveSupport
+  module Concurrent
+    extend ActiveSupport::Autoload
+
+    autoload :Cache
+    autoload :LowWriteCache, 'active_support/concurrent/cache'
+  end
+end

--- a/activesupport/lib/active_support/concurrent/cache.rb
+++ b/activesupport/lib/active_support/concurrent/cache.rb
@@ -1,0 +1,16 @@
+require 'thread_safe'
+
+module ActiveSupport
+  module Concurrent
+    Cache = ThreadSafe::Cache
+
+    class LowWriteCache < Cache
+      # Use as little memory as possible, while sacrificing insert/update/remove concurrency/speed.
+      LOW_WRITE_DEFAULTS = {:concurrency_level => 1, :initial_capacity => 1}
+
+      def initialize(options = {}, &block)
+        super(LOW_WRITE_DEFAULTS.merge(options), &block)
+      end
+    end
+  end
+end

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -1,6 +1,7 @@
 require 'set'
 require 'thread'
 require 'pathname'
+require 'active_support/concurrent/cache'
 require 'active_support/core_ext/module/aliasing'
 require 'active_support/core_ext/module/attribute_accessors'
 require 'active_support/core_ext/module/introspection'
@@ -507,7 +508,7 @@ module ActiveSupport #:nodoc:
 
     class ClassCache
       def initialize
-        @store = Hash.new
+        @store = Concurrent::LowWriteCache.new
       end
 
       def empty?

--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -107,7 +107,10 @@ module ActiveSupport
       options = options.symbolize_keys
 
       currency = translations_for('currency', options[:locale])
-      currency[:negative_format] ||= "-" + currency[:format] if currency[:format]
+      if currency[:format] && !currency[:negative_format]
+        currency = currency.dup
+        currency[:negative_format] = "-" + currency[:format]
+      end
 
       defaults  = DEFAULT_CURRENCY_VALUES.merge(defaults_translations(options[:locale])).merge!(currency)
       defaults[:negative_format] = "-" + options[:format] if options[:format]

--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -106,20 +106,21 @@ module ActiveSupport
       return unless number
       options = options.symbolize_keys
 
+      is_negative = number.to_f.phase != 0
       currency = translations_for('currency', options[:locale])
-      if currency[:format] && !currency[:negative_format]
+      if is_negative && currency[:format] && !currency[:negative_format]
         currency = currency.dup
         currency[:negative_format] = "-" + currency[:format]
       end
 
       defaults  = DEFAULT_CURRENCY_VALUES.merge(defaults_translations(options[:locale])).merge!(currency)
-      defaults[:negative_format] = "-" + options[:format] if options[:format]
+      defaults[:negative_format] = "-" + options[:format] if is_negative && options[:format]
       options   = defaults.merge!(options)
 
       unit      = options.delete(:unit)
       format    = options.delete(:format)
 
-      if number.to_f.phase != 0
+      if is_negative
         format = options.delete(:negative_format)
         number = number.respond_to?("abs") ? number.abs : number.sub(/^-/, '')
       end

--- a/activesupport/test/descendants_tracker_test_cases.rb
+++ b/activesupport/test/descendants_tracker_test_cases.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module DescendantsTrackerTestCases
   class Parent
     extend ActiveSupport::DescendantsTracker
@@ -18,15 +20,15 @@ module DescendantsTrackerTestCases
   ALL = [Parent, Child1, Child2, Grandchild1, Grandchild2]
 
   def test_descendants
-    assert_equal [Child1, Grandchild1, Grandchild2, Child2], Parent.descendants
-    assert_equal [Grandchild1, Grandchild2], Child1.descendants
-    assert_equal [], Child2.descendants
+    assert_equal_sets [Child1, Grandchild1, Grandchild2, Child2], Parent.descendants
+    assert_equal_sets [Grandchild1, Grandchild2], Child1.descendants
+    assert_equal_sets [], Child2.descendants
   end
 
   def test_direct_descendants
-    assert_equal [Child1, Child2], Parent.direct_descendants
-    assert_equal [Grandchild1, Grandchild2], Child1.direct_descendants
-    assert_equal [], Child2.direct_descendants
+    assert_equal_sets [Child1, Child2], Parent.direct_descendants
+    assert_equal_sets [Grandchild1, Grandchild2], Child1.direct_descendants
+    assert_equal_sets [], Child2.direct_descendants
   end
 
   def test_clear
@@ -39,6 +41,10 @@ module DescendantsTrackerTestCases
   end
 
   protected
+
+  def assert_equal_sets(expected, actual)
+    Set.new(expected) == Set.new(actual)
+  end
 
   def mark_as_autoloaded(*klasses)
     # If ActiveSupport::Dependencies is not loaded, forget about autoloading.

--- a/activesupport/test/descendants_tracker_with_autoloading_test.rb
+++ b/activesupport/test/descendants_tracker_with_autoloading_test.rb
@@ -18,17 +18,17 @@ class DescendantsTrackerWithAutoloadingTest < ActiveSupport::TestCase
   def test_clear_with_autoloaded_children_and_granchildren
     mark_as_autoloaded Child1, Grandchild1, Grandchild2 do
       ActiveSupport::DescendantsTracker.clear
-      assert_equal [Child2], Parent.descendants
-      assert_equal [], Child2.descendants
+      assert_equal_sets [Child2], Parent.descendants
+      assert_equal_sets [], Child2.descendants
     end
   end
 
   def test_clear_with_autoloaded_granchildren
     mark_as_autoloaded Grandchild1, Grandchild2 do
       ActiveSupport::DescendantsTracker.clear
-      assert_equal [Child1, Child2], Parent.descendants
-      assert_equal [], Child1.descendants
-      assert_equal [], Child2.descendants
+      assert_equal_sets [Child1, Child2], Parent.descendants
+      assert_equal_sets [], Child1.descendants
+      assert_equal_sets [], Child2.descendants
     end
   end
 end


### PR DESCRIPTION
## EDIT: posted more information.

I might have posted too much code and did too little explaining the reasoning. The problem is that there are heaps of non thread safe usage of Hashes in Rails and the surrounding gems. This needs to be fixed. Instead of littering the whole code base with the `synchronize {}` blocks, it is better done by creating a fully thread-safe hash-like data structure.

This is where `ThreadSafe::Cache` comes in. It is:
- a thread-safe hash-like data structure
- reads are lock-free
- writes might be using locks, but this is fixable in the future
- storing an item in `Cache` constitutes safe publication
- reads have volatile semantics (allows for properly done double-checked locking idiom)
- writes have volatile semantics

Why is it better than explicit synchronisation?

A thread-safe hash is a very useful abstraction, it simplifies the code and allows to avoid worrying about thread-safety most of the time. Explicit locking is not so easily done and is prone to missing some code paths. As the amount of explicit locks increases, so does the probability of deadlocks. Locks are slightly slower than lock-free volatile reads and scale horribly as the concurrency level increases.

---
## Original pull request text:

---

Finally bit the bullet and wrote a thread safe hash-like `Cache` implementation. It is going to be available through [thread_safe](https://github.com/headius/thread_safe) gem.

I used a custom middleware to hunt down concurrent collection usage: [ThreadSafetyTester](https://github.com/thedarkone/rack-contrib/blob/thread-safety-tester/lib/rack/contrib/thread_safety_tester.rb).

``` ruby
thread_safety_test_options = {
  :skip_paths => [/\A\/assets\//],
  :whitelist => {
    Hash => [
      'active_support/descendants_tracker.rb', # ok, when eager loaded in production mode
      'active_support/dependencies.rb', # dev. mode related
      'active_record/connection_adapters/sqlite3_adapter.rb',
      'active_record/connection_adapters/abstract/query_cache.rb', # query cache is connection confined
      'active_record/connection_adapters/abstract_adapter.rb', # query cache usage
      'active_record/connection_adapters/schema_cache.rb', # SchemaCache is connection confined
      'webrick/utils.rb',
      'webrick/httpresponse.rb'
    ],
    Set => 'active_support/dependencies.rb', # dev. mode related
    Array => [
      'active_support/dependencies.rb', # dev. mode related
      'active_support/log_subscriber.rb', # Thread local array
      'active_support/tagged_logging.rb', # Thread local array
      'active_record/connection_adapters/abstract/connection_pool.rb', # Synchronized array queue
      'active_record/connection_adapters/abstract/database_statements.rb' # connection confined
    ]
  }
}

config.middleware.insert_before 'ActionDispatch::Static', 'Rack::ThreadSafetyTester', thread_safety_test_options
```

I'm not looking to get this merged right away. A feedback on the `ThreadSafe::Cache` API is also welcomed.
