### PR TITLE
Allow assert_recognizes and recognize_path to support url redirects from...

### DIFF
--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -1723,6 +1723,9 @@ class RackMountIntegrationTests < ActiveSupport::TestCase
   Model = Struct.new(:to_param)
 
   Mapping = lambda {
+    get '/redirect' => redirect("http://example.org/")
+    get '/redirect' => "redirect#index"
+
     namespace :admin do
       resources :users, :posts
     end
@@ -1778,6 +1781,12 @@ class RackMountIntegrationTests < ActiveSupport::TestCase
   def setup
     @routes = ActionDispatch::Routing::RouteSet.new
     @routes.draw(&Mapping)
+  end
+
+  def test_recognize_path_redirect
+    status, headers, body = @routes.recognize_path('/redirect', method: :get)
+    assert_equal("http://example.org/", headers['Location'])
+    assert_equal(301, status)
   end
 
   def test_recognize_path

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -1,4 +1,5 @@
 require 'abstract_unit'
+require 'controller/fake_controllers'
 
 module AbstractController
   module Testing

--- a/actionpack/test/dispatch/routing_assertions_test.rb
+++ b/actionpack/test/dispatch/routing_assertions_test.rb
@@ -7,9 +7,39 @@ class QueryArticlesController < ArticlesController; end
 
 class RoutingAssertionsTest < ActionController::TestCase
 
+  class YoutubeFavoritesRedirector
+    def self.call(params, request)
+      "http://www.youtube.com/watch?v=#{params[:youtube_id]}"
+    end
+  end
+
   def setup
     @routes = ActionDispatch::Routing::RouteSet.new
     @routes.draw do
+
+      get 'redirect' => redirect("http://thisisaredirect.org/")
+      get 'redirect' => "redirect#index"
+      get 'not_redirect' => "redirect#not"
+      get 'not_redirect' => redirect("http://thisisnotaredirect.org/")
+      get 'account/login', :to => redirect("/login")
+      get 'account/logout' => redirect("/logout"), :as => :logout_redirect
+      get 'account/modulo/:name', :to => redirect("/%{name}s")
+      get 'account/proc/:name', :to => redirect {|params, req| "/#{params[:name].pluralize}" }
+      get 'account/proc_req' => redirect {|params, req| "/#{req.method}" }
+      get 'out' => redirect{|params, req| params[:to]}
+      get 'mobile', :to => redirect(:subdomain => 'mobile')
+      get 'documentation', :to => redirect(:subdomain => false, :domain => 'example-documentation.com', :path => '')
+      get 'new_documentation', :to => redirect(:path => '/documentation/new')
+      get 'super_new_documentation', :to => redirect(:host => 'super-docs.com')
+      get 'stores/:name', :to => redirect(:subdomain => 'stores', :path => '/%{name}')
+      get 'stores/:name(*rest)', :to => redirect(:subdomain => 'stores', :path => '/%{name}%{rest}')
+      get 'youtube_favorites/:youtube_id/:name', :to => redirect(YoutubeFavoritesRedirector)
+      get 'account/google' => redirect('http://www.google.com/', :status => 302)
+
+      namespace :private do
+        root to: redirect('/private/index')
+      end
+
       resources :articles
 
       scope 'secure', :constraints => { :protocol => 'https://' } do
@@ -23,6 +53,103 @@ class RoutingAssertionsTest < ActionController::TestCase
       scope 'query', :constraints => lambda { |r| r.params[:use_query] == 'true' } do
         resources :articles, :controller => 'query_articles'
       end
+    end
+  end
+
+  def test_assert_recognizes_accounts_for_redirects
+    assert_raise Assertion do
+      assert_recognizes({ controller: 'redirect', action: 'index' }, '/redirect')
+    end
+  end
+
+  def test_assert_generates_accounts_for_redirects
+    assert_raise Assertion do
+      assert_generates('/redirect', { controller: 'redirect', action: 'index' })
+    end
+  end
+
+  def test_assert_routing_accounts_for_redirects
+    assert_raise Assertion do
+      assert_routing('/redirect', { controller: 'redirect', action: 'index' })
+    end
+  end
+
+  def test_assert_redirects_accounts_for_non_redirects
+    assert_raise Assertion do
+      assert_redirects('http://thisisnotaredirect.org/', '/not_redirect')
+    end
+  end
+
+  def test_assert_redirects_with_url
+    assert_redirects('http://thisisaredirect.org/', '/redirect')
+  end
+
+  def test_assert_redirects_with_to
+    assert_redirects('http://example.org/login', '/account/login')
+  end
+
+  def test_assert_redirects_with_as
+    assert_redirects('http://example.org/logout', @routes.url_helpers.logout_redirect_path)
+  end
+
+  def test_assert_redirects_with_namespace
+    assert_redirects('http://example.org/private/index', '/private')
+  end
+
+  def test_assert_redirects_with_modulo
+    assert_redirects('http://example.org/names', '/account/modulo/name')
+  end
+
+  def test_assert_redirects_with_proc
+    assert_redirects('http://example.org/people', '/account/proc/people')
+  end
+
+  def test_assert_redirects_with_proc_with_request
+    assert_redirects('http://example.org/GET', '/account/proc_req')
+  end
+
+  def test_assert_redirects_with_with_subdomain
+    assert_redirects('http://mobile.example.org/mobile', '/mobile')
+  end
+
+  def test_assert_redirects_with_domain_and_path
+    assert_redirects('http://example-documentation.com', '/documentation')
+  end
+
+  def test_assert_redirects_with_path
+    assert_redirects('http://example.org/documentation/new', '/new_documentation')
+  end
+
+  def test_assert_redirects_with_host
+    assert_redirects('http://super-docs.com/super_new_documentation?section=top', '/super_new_documentation?section=top')
+  end
+
+  def test_assert_redirects_with_path_substitution
+    assert_redirects('http://stores.example.org/iernest', '/stores/iernest')
+  end
+
+  def test_assert_redirects_with_path_substitution_with_catch_all
+    assert_redirects('http://stores.example.org/iernest/products', '/stores/iernest/products')
+  end
+
+  def test_assert_redirects_with_class
+    assert_redirects('http://www.youtube.com/watch?v=oHg5SJYRHA0', '/youtube_favorites/oHg5SJYRHA0/rick-rolld')
+  end
+
+  def test_assert_redirects_with_status
+    assert_raise Assertion do
+      assert_redirects('http://www.google.com/', '/account/google')
+    end
+    assert_redirects('http://www.google.com/', '/account/google', {}, 302)
+  end
+
+  def test_assert_redirects_with_extras
+    assert_redirects('http://customredirect.com/', '/out', { to: 'http://customredirect.com/' })
+  end
+
+  def test_assert_not_redirects_with_extras
+    assert_raise Assertion do
+      assert_not_redirects('/out', { to: 'http://customredirect.com/' })
     end
   end
 

--- a/actionpack/test/lib/controller/fake_controllers.rb
+++ b/actionpack/test/lib/controller/fake_controllers.rb
@@ -22,13 +22,16 @@ class BooksController < ActionController::Base; end
 class CarsController < ActionController::Base; end
 class CcController < ActionController::Base; end
 class CController < ActionController::Base; end
+class ControllerController < ActionController::Base; end
 class FooController < ActionController::Base; end
 class GeocodeController < ActionController::Base; end
+class ImageController < ActionController::Base; end
 class NewsController < ActionController::Base; end
 class NotesController < ActionController::Base; end
 class PagesController < ActionController::Base; end
 class PeopleController < ActionController::Base; end
 class PostsController < ActionController::Base; end
+class RedirectController < ActionController::Base; end
 class SubpathBooksController < ActionController::Base; end
 class SymbolsController < ActionController::Base; end
 class UserController < ActionController::Base; end


### PR DESCRIPTION
Currently, there is no way to unit test the Redirection module in ActionDispatch::Routing. Also, redirects are not recognized as paths using `recognize_path`. These problems lead to a potential false positive. If you have this routing:

``` ruby
get 'help' => redirect('http://help.example.org/')
get 'help' => 'help#index'
```

and this test:

``` ruby
test "should recognize /help as help#index" do
  assert_recognizes({:controller => 'help', :action => 'index'}, '/help')
end
```

the test passes, but actually, it should recognize /help as a redirect.

With this commit, it fixes the false negative and allows for url redirection:

``` ruby
get 'help' => redirect("http://example.org/")
assert_recognizes("http://example.org/", "/help")
```

This is just a start to fix this issue, as the Redirection module offers much more than just external url redirection. Would definitely be willing to discuss other ways to unit test redirection; however, i think it is a bug that assert_recognizes does not recognize redirection routes.

More referenced <a href="https://github.com/rails/rails/issues/2488">here</a>.
