### PR TITLE
Fixed a few method redefine warnings

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/deep_merge.rb
+++ b/activesupport/lib/active_support/core_ext/hash/deep_merge.rb
@@ -1,4 +1,7 @@
 class Hash
+  undef :deep_merge  if instance_methods.include?(:deep_merge)
+  undef :deep_merge! if instance_methods.include?(:deep_merge!)
+
   # Returns a new hash with +self+ and +other_hash+ merged recursively.
   #
   #   h1 = {x: {y: [4,5,6]}, z: [7,8,9]}

--- a/activesupport/lib/active_support/core_ext/hash/except.rb
+++ b/activesupport/lib/active_support/core_ext/hash/except.rb
@@ -1,4 +1,6 @@
 class Hash
+  undef :except if instance_methods.include?(:except)
+
   # Return a hash that includes everything but the given keys. This is useful for
   # limiting a set of parameters to everything but a few known toggles:
   #

--- a/activesupport/lib/active_support/core_ext/hash/slice.rb
+++ b/activesupport/lib/active_support/core_ext/hash/slice.rb
@@ -1,4 +1,6 @@
 class Hash
+  undef :slice if instance_methods.include?(:slice)
+
   # Slice a hash to include only the given keys. This is useful for
   # limiting an options hash to valid keys before passing to a method:
   #

--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -1,6 +1,8 @@
 # encoding: utf-8
 
 class Object
+  undef :blank? if instance_methods.include?(:blank?)
+
   # An object is blank if it's false, empty, or a whitespace string.
   # For example, '', '   ', +nil+, [], and {} are all blank.
   #
@@ -40,6 +42,8 @@ class Object
 end
 
 class NilClass
+  undef :blank? if instance_methods.include?(:blank?)
+
   # +nil+ is blank:
   #
   #   nil.blank? # => true


### PR DESCRIPTION
I wasn't certain if doing conditional `undef`s in the actual source was OK or if this stuff should be done on the objects in the test suite. If the later please say so and I'll update the PR.
