### PR TITLE
Don't mark the store as changed if an attribute isn't changed.

### DIFF
--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -58,8 +58,11 @@ module ActiveRecord
         keys.each do |key|
           define_method("#{key}=") do |value|
             initialize_store_attribute(store_attribute)
-            send(store_attribute)[key] = value
-            send :"#{store_attribute}_will_change!"
+            attribute = send(store_attribute)
+            if value != attribute[key]
+              attribute[key] = value
+              send :"#{store_attribute}_will_change!"
+            end
           end
 
           define_method(key) do

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -34,6 +34,11 @@ class StoreTest < ActiveRecord::TestCase
     assert @john.settings_changed?
   end
 
+  test "updating the store won't mark it as changed if an attribute isn't changed" do
+    @john.color = @john.color
+    assert !@john.settings_changed?
+  end
+
   test "object initialization with not nullable column" do
     assert_equal true, @john.remember_login
   end


### PR DESCRIPTION
If an attribute isn't modified, I think we shouldn't mark the store as changed.
