### PR TITLE
Fix collisions with before and after validation callbacks.

### DIFF
--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -57,7 +57,7 @@ module ActiveModel
           if options.is_a?(Hash) && options[:on]
             options[:if] = Array(options[:if])
             options[:on] = Array(options[:on])
-            options[:if].unshift("self.validation_context.in? #{options[:on]}")
+            options[:if].unshift("#{options[:on]}.include? self.validation_context")
           end
           set_callback(:validation, :before, *args, &block)
         end
@@ -95,7 +95,7 @@ module ActiveModel
           options[:if] = Array(options[:if])
           if options[:on]
             options[:on] = Array(options[:on])
-            options[:if].unshift("self.validation_context.in? #{options[:on]}")
+            options[:if].unshift("#{options[:on]}.include? self.validation_context")
           end
           set_callback(:validation, :after, *(args << options), &block)
         end

--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -56,7 +56,8 @@ module ActiveModel
           options = args.last
           if options.is_a?(Hash) && options[:on]
             options[:if] = Array(options[:if])
-            options[:if].unshift("self.validation_context == :#{options[:on]}")
+            options[:on] = Array(options[:on])
+            options[:if].unshift("self.validation_context.in? #{options[:on]}")
           end
           set_callback(:validation, :before, *args, &block)
         end
@@ -92,7 +93,10 @@ module ActiveModel
           options = args.extract_options!
           options[:prepend] = true
           options[:if] = Array(options[:if])
-          options[:if].unshift("self.validation_context == :#{options[:on]}") if options[:on]
+          if options[:on]
+            options[:on] = Array(options[:on])
+            options[:if].unshift("self.validation_context.in? #{options[:on]}")
+          end
           set_callback(:validation, :after, *(args << options), &block)
         end
       end

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Allow before and after validations to take an array of lifecycle events
+
+    *John Foley*
+
 *   Support for specifying transaction isolation level
 
     If your database supports setting the isolation level for a transaction, you can set

--- a/guides/source/active_record_validations_callbacks.md
+++ b/guides/source/active_record_validations_callbacks.md
@@ -995,6 +995,25 @@ class User < ActiveRecord::Base
 end
 ```
 
+Callbacks can also be registered to only fire on certain lifecycle events:
+<ruby>
+class User < ActiveRecord::Base
+  before_validation :normalize_name, :on => :create
+  
+  # :on takes an array as well
+  after_validation :set_location, :on => [ :create, :update ]
+
+  protected
+  def normalize_name
+    self.name = self.name.downcase.titleize
+  end
+
+  def set_location
+    self.location = LocationService.query(self)
+  end
+end
+</ruby>
+
 It is considered good practice to declare callback methods as protected or private. If left public, they can be called from outside of the model and violate the principle of object encapsulation.
 
 Available Callbacks


### PR DESCRIPTION
This commit allows a user to do something like:

``` ruby
    before_validation :do_stuff, :on => [ :create, :update ]
    after_validation :do_more, :on => [ :create, :update ]
```

This addresses issue #6744.

This also uses the unit tests from mandrews/rails/@0f115f4012779ec8691d2c20ad3be8033861c1b0
(lightly modified) 
