### PR TITLE
Adds zero_counter method for zeroing out counter caches

### DIFF
--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -110,6 +110,22 @@ module ActiveRecord
       def decrement_counter(counter_name, id)
         update_counters(id, counter_name => -1)
       end
+
+      # Zeros out counter_cache in a single transaction
+      # This is useful after destroying associated objects that 
+      # are being counted
+      #
+      # ==== Parameters
+      #
+      # * +counter_name+ - Counter name to be zerod out
+      #
+      # ==== Examples
+      #
+      #   # For Post model, reset the comments_count to zero
+      #   Post.zero_counters(:comments)
+      def zero_counter(counter_name)
+        update_all("#{counter_name}_count" => 0)
+      end
     end
   end
 end

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -109,4 +109,13 @@ class CounterCacheTest < ActiveRecord::TestCase
       Topic.update_counters([t1.id, t2.id], :replies_count => 2)
     end
   end
+
+  test "zero counter" do
+    Topic.increment_counter(:replies_count, @topic.id)
+
+    Topic.zero_counter(:replies)
+
+    # check that it is zerod out
+    assert_equal 0, @topic.reload.replies_count
+  end
 end


### PR DESCRIPTION
There exists no way to zero out counter caches other than to iterate over every record and call #reset_counters. This commit adds a #zero_counter method that zeros out the supplied counter.

`Usage: Topic.zero_counter(:replies)`
