### PR TITLE
Generate a complete Bundler.require(...) statement for plugins

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/templates/rails/application.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/rails/application.rb
@@ -11,7 +11,13 @@ require "action_mailer/railtie"
 <%= comment_if :skip_test_unit %>require "rails/test_unit/railtie"
 <% end -%>
 
-Bundler.require
+if defined?(Bundler)
+  # If you precompile assets before deploying to production, use this line
+  Bundler.require(*Rails.groups(:assets => %w(development test)))
+  # If you want your assets lazily compiled in production, use this line
+  # Bundler.require(:default, :assets, Rails.env)
+end
+
 require "<%= name %>"
 
 <%= application_definition %>


### PR DESCRIPTION
The issue I encountered was that Rails mountable engines didn't work
correctly with SASS and the Asset Pipeline.

In my testcase, I have an engine that specifies some asset gem in its `foo.gemspec`. In the `lib/foo/engine.rb` it requires the gem. Then `application.css.scss` did:

```
@import 'file_from_gem';
```

That file would not be able to be found when trying out the engine
using the dummy application (`cd test/dummy && rails server`).

It _would_ all work fine when the engine is tried out using a "full" Rails application as generated with `rails new fullapp`. Going over the diff between the generated test dummy and the full app, I found that changing the `Bundler.require` statement in `config/application.rb` fixed the issue, even though I'm not completely sure why.

TL;DR: The change in this commit fixes that @import statements that load css found in gems work correctly in the generated `test/dummy` application for Rails engines.
