### PR TITLE
Don't HTML escape ActionMailer plaintext templates

### DIFF
--- a/actionpack/lib/action_view/template/handlers/erb.rb
+++ b/actionpack/lib/action_view/template/handlers/erb.rb
@@ -79,6 +79,7 @@ module ActionView
 
           self.class.erb_implementation.new(
             erb,
+            :escape => template.identifier !~ /\.html/, # only escape HTML templates
             :trim => (self.class.erb_trim_mode == "-")
           ).src
         end

--- a/actionpack/test/template/template_test.rb
+++ b/actionpack/test/template/template_test.rb
@@ -64,6 +64,18 @@ class TestERBTemplate < ActiveSupport::TestCase
     assert_equal "Hello", render
   end
 
+  def test_basic_template_does_not_html_escape
+    @template = new_template("<% array.each do |item| -%><%= item %><% end -%>")
+    @template.locals = [:array]
+    assert_equal '"', render(:array => ['"'])
+  end
+
+  def test_basic_html_template_does_html_escape
+    @template = ActionView::Template.new("<% array.each do |item| -%><%= item %><% end -%>", ".html.erb", ERBHandler, {})
+    @template.locals = [:array]
+    assert_equal '&quot;', render(:array => ['"'])
+  end
+
   def test_raw_template
     @template = new_template("<%= hello %>", :handler => ActionView::Template::Handlers::Raw.new)
     assert_equal "<%= hello %>", render


### PR DESCRIPTION
Here's a test case and fix for issue #687.

The problem only exists when the evaluating block expressions.
