### PR TITLE
Ensure that queued jobs are marshallable

### DIFF
--- a/railties/lib/rails/queueing.rb
+++ b/railties/lib/rails/queueing.rb
@@ -22,6 +22,13 @@ module Rails
         @que.dup
       end
 
+      # Marshal and unmarshal job before pushing it onto the queue.  This will
+      # raise an exception on any attempts in tests to push jobs that can't (or
+      # shouldn't) be marshalled.
+      def push(job)
+        super Marshal.load(Marshal.dump(job))
+      end
+
       # Drain the queue, running all jobs in a different thread. This method
       # may not be available on production queues.
       def drain

--- a/railties/test/application/queue_test.rb
+++ b/railties/test/application/queue_test.rb
@@ -109,6 +109,21 @@ module ApplicationTests
       end
     end
 
+    test "attempting to marshal a queue will raise an exception" do
+      app("test")
+      assert_raises TypeError do
+        Marshal.dump Rails.queue
+      end
+    end
+
+    test "attempting to add a reference to itself to the queue will raise an exception" do
+      app("test")
+      job = {reference: Rails.queue}
+      assert_raises TypeError do
+        Rails.queue.push job
+      end
+    end
+
     def setup_custom_queue
       add_to_env_config "production", <<-RUBY
         require "my_queue"

--- a/railties/test/queueing/test_queue_test.rb
+++ b/railties/test/queueing/test_queue_test.rb
@@ -2,22 +2,18 @@ require 'abstract_unit'
 require 'rails/queueing'
 
 class TestQueueTest < ActiveSupport::TestCase
-  class Job
-    def initialize(&block)
-      @block = block
-    end
-
-    def run
-      @block.call if @block
-    end
-  end
-
   def setup
     @queue = Rails::Queueing::TestQueue.new
   end
 
+  class ExceptionRaisingJob
+    def run
+      raise
+    end
+  end
+
   def test_drain_raises
-    @queue.push Job.new { raise }
+    @queue.push ExceptionRaisingJob.new
     assert_raises(RuntimeError) { @queue.drain }
   end
 
@@ -27,41 +23,80 @@ class TestQueueTest < ActiveSupport::TestCase
     assert_equal [1,2], @queue.jobs
   end
 
+  class EquivalentJob
+    def initialize
+      @initial_id = self.object_id
+    end
+
+    def run
+    end
+
+    def ==(other)
+      other.same_initial_id?(@initial_id)
+    end
+
+    def same_initial_id?(other_id)
+      other_id == @initial_id
+    end
+  end
+
   def test_contents
     assert @queue.empty?
-    job = Job.new
+    job = EquivalentJob.new
     @queue.push job
     refute @queue.empty?
     assert_equal job, @queue.pop
   end
 
-  def test_order
-    processed = []
+  class ProcessingJob
+    def self.clear_processed
+      @processed = []
+    end
 
-    job1 = Job.new { processed << 1 }
-    job2 = Job.new { processed << 2 }
+    def self.processed
+      @processed
+    end
+
+    def initialize(object)
+      @object = object
+    end
+
+    def run
+      self.class.processed << @object
+    end
+  end
+
+  def test_order
+    ProcessingJob.clear_processed
+    job1 = ProcessingJob.new(1)
+    job2 = ProcessingJob.new(2)
 
     @queue.push job1
     @queue.push job2
     @queue.drain
 
-    assert_equal [1,2], processed
+    assert_equal [1,2], ProcessingJob.processed
+  end
+
+  class ThreadTrackingJob
+    attr_reader :thread_id
+
+    def run
+      @thread_id = Thread.current.object_id
+    end
+
+    def ran?
+      @thread_id
+    end
   end
 
   def test_drain
-    t = nil
-    ran = false
-
-    job = Job.new do
-      ran = true
-      t = Thread.current
-    end
-
-    @queue.push job
+    @queue.push ThreadTrackingJob.new
+    job = @queue.jobs.last
     @queue.drain
 
     assert @queue.empty?
-    assert ran, "The job runs synchronously when the queue is drained"
-    assert_not_equal t, Thread.current
+    assert job.ran?, "The job runs synchronously when the queue is drained"
+    assert_not_equal job.thread_id, Thread.current.object_id
   end
 end


### PR DESCRIPTION
By marshalling and unmarshalling jobs when adding them to the test queue, we can ensure that jobs created during test runs are valid candidates for marshalling, and, thus, that they can be used with queueing backends other than the default simple in-process implementation.

As Rails::Queueing::Queue (and TestQueue) are not marshallable, this ensures that a queued job does not contain a reference to the queue itself.

This establishes marshallability and a constrained object graph as a standard expectation for jobs, which is, I think, a reasonable expectation. Where an application explicitly does not care about this, authors are free to configure a different test queue implementation in the application's test environment.
