### PR TITLE
Introduce config.action_mailer.default_from=

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Asynchronously send messages via the Rails Queue *Brian Cardarella*
 
+* Set default Action Mailer options via config.action_mailer.default_options= *Robert Pankowecki*
+
 ## Rails 3.2.5 (Jun 1, 2012) ##
 
 *   No changes.

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -421,6 +421,9 @@ module ActionMailer #:nodoc:
         self.default_params = default_params.merge(value).freeze if value
         default_params
       end
+      #Alias so that we can use it in config/application.rb which requires setters
+      #: config.action_mailer.default_options = {from: "no-replay@example.org"}
+      alias :default_options= :default
 
       # Receives a raw email, parses it into an email object, decodes it,
       # instantiates a new mailer, and passes the email object to the mailer

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -653,6 +653,19 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal "Anonymous mailer body", mailer.welcome.body.encoded.strip
   end
 
+  test "default_from can be set" do
+    class DefaultFromMailer < ActionMailer::Base
+      default :to => 'system@test.lindsaar.net'
+      self.default_options = {from: "robert.pankowecki@gmail.com"}
+
+      def welcome
+        mail(subject: "subject")
+      end
+    end
+
+    assert_equal ["robert.pankowecki@gmail.com"], DefaultFromMailer.welcome.from
+  end
+
   protected
 
     # Execute the block setting the given values and restoring old values after

--- a/guides/source/configuring.textile
+++ b/guides/source/configuring.textile
@@ -424,12 +424,12 @@ There are a number of settings available on +config.action_mailer+:
 
 * +config.action_mailer.perform_deliveries+ specifies whether mail will actually be delivered and is true by default. It can be convenient to set it to false for testing.
 
-* +config.action_mailer.default+ configures Action Mailer defaults. These default to:
+* +config.action_mailer.default_options+ configures Action Mailer defaults. Use to set options like `from` or `replay_to` for every mailer. These default to:
 <ruby>
 :mime_version => "1.0",
 :charset      => "UTF-8",
 :content_type => "text/plain",
-:parts_order  => [ "text/plain", "text/enriched", "text/html" ]
+:parts_order  => [ "text/plain", "text/enriched", "text/html" ],
 </ruby>
 
 * +config.action_mailer.observers+ registers observers which will be notified when mail is delivered.


### PR DESCRIPTION
Allows to easily set :from, :replay_to, etc. options in
config/application.rb using simple syntax:

```
config.action_mailer.default_options = {from:"no-replay@example.org"}
```

This was not possible using #default method because

```
config.action_mailer.default(from: "no-replay@example.org")
```

is interpreated as reader method and just returns nil.
It would not call ActionMailer::Base.default method. The only
way of calling this method from config/application.rb was to use
the direct syntax which looks ugly in my opinion:

```
  config.assets.enabled = false
  config.assets.version = '1.0'
  config.encoding = "utf-8"
  config.action_mailer.default_url_options= {
    host:"example.org",
    protocol:"https"
  }
  ActionMailer::Base.default(from: "no-replay@example.org")
```
