### PR TITLE
Add ActiveSupport::KeyGenerator as a simple wrapper around PBKDF2

### DIFF
--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -48,6 +48,7 @@ module ActiveSupport
     autoload :Gzip
     autoload :Inflector
     autoload :JSON
+    autoload :KeyGenerator
     autoload :MessageEncryptor
     autoload :MessageVerifier
     autoload :Multibyte

--- a/activesupport/lib/active_support/key_generator.rb
+++ b/activesupport/lib/active_support/key_generator.rb
@@ -1,0 +1,23 @@
+require 'openssl'
+
+module ActiveSupport
+  # KeyGenerator is a simple wrapper around OpenSSL's implementation of PBKDF2
+  # It can be used to derive a number of keys for various purposes from a given secret.
+  # This lets rails applications have a single secure secret, but avoid reusing that
+  # key in multiple incompatible contexts.
+  class KeyGenerator
+    def initialize(secret, options = {})
+      @secret = secret
+      # The default iterations are higher than required for our key derivation uses
+      # on the off chance someone uses this for password storage
+      @iterations = options[:iterations] || 2**16
+    end
+
+    # Returns a derived key suitable for use.  The default key_size is chosen
+    # to be compatible with the default settings of ActiveSupport::MessageVerifier.
+    # i.e. OpenSSL::Digest::SHA1#block_length
+    def generate_key(salt, key_size=64)
+      OpenSSL::PKCS5.pbkdf2_hmac_sha1(@secret, salt, @iterations, key_size)
+    end
+  end
+end

--- a/activesupport/test/key_generator_test.rb
+++ b/activesupport/test/key_generator_test.rb
@@ -1,0 +1,32 @@
+require 'abstract_unit'
+
+begin
+  require 'openssl'
+  OpenSSL::PKCS5
+rescue LoadError, NameError
+  $stderr.puts "Skipping KeyGenerator test: broken OpenSSL install"
+else
+
+require 'active_support/time'
+require 'active_support/json'
+
+class KeyGeneratorTest < ActiveSupport::TestCase
+  def setup
+    @secret    = SecureRandom.hex(64)
+    @generator = ActiveSupport::KeyGenerator.new(@secret, :iterations=>2)
+  end
+
+  test "Generating a key of the default length" do
+    derived_key = @generator.generate_key("some_salt")
+    assert_kind_of String, derived_key
+    assert_equal OpenSSL::Digest::SHA1.new.block_length, derived_key.length, "Should have generated a key of the default size"
+  end
+
+  test "Generating a key of an alternative length" do
+    derived_key = @generator.generate_key("some_salt", 32)
+    assert_kind_of String, derived_key
+    assert_equal 32, derived_key.length, "Should have generated a key of the right size"
+  end
+end
+
+end

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -101,6 +101,14 @@ module Rails
       routes_reloader.reload!
     end
 
+
+    # Return the application's KeyGenerator
+    def key_generator
+      # number of iterations selected based on consultation with the google security
+      # team. Details at https://github.com/rails/rails/pull/6952#issuecomment-7661220
+      @key_generator ||= ActiveSupport::KeyGenerator.new(config.secret_token, :iterations=>1000)
+    end
+
     # Stores some of the Rails initial environment parameters which
     # will be used by middlewares and engines to configure themselves.
     # Currently stores:
@@ -121,7 +129,8 @@ module Rails
         "action_dispatch.show_exceptions" => config.action_dispatch.show_exceptions,
         "action_dispatch.show_detailed_exceptions" => config.consider_all_requests_local,
         "action_dispatch.logger" => Rails.logger,
-        "action_dispatch.backtrace_cleaner" => Rails.backtrace_cleaner
+        "action_dispatch.backtrace_cleaner" => Rails.backtrace_cleaner,
+        "action_dispatch.key_generator" => key_generator
       })
     end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -634,6 +634,7 @@ module ApplicationTests
       assert_equal      app.env_config['action_dispatch.show_exceptions'],   app.config.action_dispatch.show_exceptions
       assert_equal      app.env_config['action_dispatch.logger'],            Rails.logger
       assert_equal      app.env_config['action_dispatch.backtrace_cleaner'], Rails.backtrace_cleaner
+      assert_equal      app.env_config['action_dispatch.key_generator'],     Rails.application.key_generator
     end
 
     test "config.colorize_logging default is true" do


### PR DESCRIPTION
As part of the changes for Rails4 we want to sort out all the cryptography related things we have in place right now.  The first part of this will be to add PBKDF2 for key derivation, then we can switch the session store and cookies.signed to use derived keys instead of using the bare secret.

Similarly future functionality like encrypted cookies / sessions can utilize derived keys.

So before merging I want to get some feedback from @meder and @thaidn on the particulars of our implementation.  In particular, what are suitable default values for `iterations` and `key_size`.

This is a pre-requisite for #3955 #5034 and possibly others.

Note to other committers: Please leave this one for me to merge
