### PR TITLE
Add references statements to migration generator

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
@@ -2,29 +2,41 @@ class <%= migration_class_name %> < ActiveRecord::Migration
 <%- if migration_action == 'add' -%>
   def change
 <% attributes.each do |attribute| -%>
+  <%- if attribute.reference? -%>
+    add_reference :<%= table_name %>, :<%= attribute.name %><%= attribute.inject_options %>
+  <%- else -%>
     add_column :<%= table_name %>, :<%= attribute.name %>, :<%= attribute.type %><%= attribute.inject_options %>
     <%- if attribute.has_index? -%>
     add_index :<%= table_name %>, :<%= attribute.index_name %><%= attribute.inject_index_options %>
     <%- end -%>
+  <%- end -%>
 <%- end -%>
   end
 <%- else -%>
   def up
 <% attributes.each do |attribute| -%>
-  <%- if migration_action -%>
-    <%= migration_action %>_column :<%= table_name %>, :<%= attribute.name %>
+<%- if migration_action -%>
+  <%- if attribute.reference? -%>
+    remove_reference :<%= table_name %>, :<%= attribute.name %><%= ', polymorphic: true' if attribute.polymorphic? %>
+  <%- else -%>
+    remove_column :<%= table_name %>, :<%= attribute.name %>
   <%- end -%>
+<%- end -%>
 <%- end -%>
   end
 
   def down
 <% attributes.reverse.each do |attribute| -%>
-  <%- if migration_action -%>
+<%- if migration_action -%>
+  <%- if attribute.reference? -%>
+    add_reference :<%= table_name %>, :<%= attribute.name %><%= attribute.inject_options %>
+  <%- else -%>
     add_column :<%= table_name %>, :<%= attribute.name %>, :<%= attribute.type %><%= attribute.inject_options %>
     <%- if attribute.has_index? -%>
     add_index :<%= table_name %>, :<%= attribute.index_name %><%= attribute.inject_index_options %>
     <%- end -%>
   <%- end -%>
+<%- end -%>
 <%- end -%>
   end
 <%- end -%>

--- a/guides/source/migrations.textile
+++ b/guides/source/migrations.textile
@@ -111,6 +111,7 @@ Active Record provides methods that perform common data definition tasks in a
 database independent way (you'll read about them in detail later):
 
 * +add_column+
+* +add_reference+
 * +add_index+
 * +change_column+
 * +change_table+
@@ -120,6 +121,7 @@ database independent way (you'll read about them in detail later):
 * +remove_column+
 * +remove_index+
 * +rename_column+
+* +remove_reference+
 
 If you need to perform tasks specific to your database (for example create a
 "foreign key":#active-record-and-referential-integrity constraint) then the
@@ -331,6 +333,51 @@ db/migrate/YYYYMMDDHHMMSS_add_details_to_products.rb file.
 NOTE: The generated migration file for destructive migrations will still be
 old-style using the +up+ and +down+ methods. This is because Rails needs to know
 the original data types defined when you made the original changes.
+
+Also the generator accepts column type as +references+(also available as +belongs_to+), for instance
+
+<shell>
+$ rails generate migration AddUserRefToProducts user:references
+</shell>
+
+generates
+
+<ruby>
+class AddUserRefToProducts < ActiveRecord::Migration
+  def change
+    add_reference :products, :user, :index => true
+  end
+end
+</ruby>
+
+This migration will create a user_id column and appropriate index.
+
+h4. Supported type modifiers
+
+You can also specify some options just after the field type between curly braces. You can use the
+following modifiers:
+
+* +limit+        Sets the maximum size of the +string/text/binary/integer+ fields
+* +precision+    Defines the precision for the +decimal+ fields
+* +scale+        Defines the scale for the +decimal+ fields
+* +polymorphic+  Adds a +type+ column for +belongs_to+ associations
+
+For instance running
+
+<shell>
+$ rails generate migration AddDetailsToProducts price:decimal{5,2} supplier:references{polymorphic}
+</shell>
+
+will produce a migration that looks like this
+
+<ruby>
+class AddDetailsToProducts < ActiveRecord::Migration
+  def change
+		add_column :products, :price, :precision => 5, :scale => 2
+    add_reference :products, :user, :polymorphic => true, :index => true
+  end
+end
+</ruby>
 
 h3. Writing a Migration
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   The migration generator will now produce AddXXXToYYY/RemoveXXXFromYYY migrations with references statements, for instance
+
+        rails g migration AddReferencesToProducts user:references supplier:references{polymorphic}
+
+    will generate the migration with:
+
+        add_reference :products, :user, index: true
+        add_reference :products, :supplier, polymorphic: true, index: true
+
+    *Aleksey Magusev*
+
 *   Allow scaffold/model/migration generators to accept a `polymorphic` modifier
     for `references`/`belongs_to`, for instance
 

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -76,6 +76,23 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_remove_migration_with_references_options
+    migration = "remove_references_from_books"
+    run_generator [migration, "author:belongs_to", "distributor:references{polymorphic}"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :up, content do |up|
+        assert_match(/remove_reference :books, :author/, up)
+        assert_match(/remove_reference :books, :distributor, polymorphic: true/, up)
+      end
+
+      assert_method :down, content do |down|
+        assert_match(/add_reference :books, :author, index: true/, down)
+        assert_match(/add_reference :books, :distributor, polymorphic: true, index: true/, down)
+      end
+    end
+  end
+
   def test_add_migration_with_attributes_and_indices
     migration = "add_title_with_index_and_body_to_posts"
     run_generator [migration, "title:string:index", "body:text", "user_id:integer:uniq"]
@@ -135,6 +152,18 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
       assert_match(/add_index :books, :title/, content)
       assert_match(/add_index :books, :price/, content)
       assert_match(/add_index :books, :discount, unique: true/, content)
+    end
+  end
+
+  def test_add_migration_with_references_options
+    migration = "add_references_to_books"
+    run_generator [migration, "author:belongs_to", "distributor:references{polymorphic}"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :change, content do |up|
+        assert_match(/add_reference :books, :author, index: true/, up)
+        assert_match(/add_reference :books, :distributor, polymorphic: true, index: true/, up)
+      end
     end
   end
 


### PR DESCRIPTION
For instance, `$ rails g migration AddReferencesToProduct user:references supplier:references{polymorphic}` will generate:

```
add_reference :products, :user, index: true
add_reference :products, :supplier, polymorphic: true, index: true
```
