### PR TITLE
Add the options method to action_controller testcase.

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -430,8 +430,13 @@ module ActionController
       end
 
       # Executes a request simulating HEAD HTTP method and set/volley the response
-      def head(action, parameters = nil, session = nil, flash = nil)
-        process(action, "HEAD", parameters, session, flash)
+      def head(action, *args)
+        process(action, "HEAD", *args)
+      end
+
+      # Executes a request simulating OPTIONS HTTP method and set/volley the response
+      def options(action, *args)
+        process(action, "OPTIONS", *args)
       end
 
       def xml_http_request(request_method, action, parameters = nil, session = nil, flash = nil)

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -197,6 +197,11 @@ XML
     assert_raise(NoMethodError) { head :test_params, "document body", :id => 10 }
   end
 
+  def test_options
+    options :test_params
+    assert_equal 200, @response.status
+  end
+
   def test_process_without_flash
     process :set_flash
     assert_equal '><', flash['test']


### PR DESCRIPTION
It was not possible to test options request from a controller test_case. 

Just added the method options and refactored the head one.
