### PR TITLE
Added missing require 'active_support/concern' in Active Record

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -1,3 +1,4 @@
+require 'active_support/concern'
 require 'active_support/core_ext/enumerable'
 require 'active_support/deprecation'
 

--- a/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
+++ b/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
@@ -1,3 +1,5 @@
+require 'active_support/concern'
+
 module ActiveRecord
   module AttributeMethods
     module BeforeTypeCast

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -1,3 +1,4 @@
+require 'active_support/concern'
 require 'active_support/core_ext/class/attribute'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/module/attribute_accessors'

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -1,4 +1,5 @@
 require 'set'
+require 'active_support/concern'
 
 module ActiveRecord
   module AttributeMethods

--- a/activerecord/lib/active_record/attribute_methods/query.rb
+++ b/activerecord/lib/active_record/attribute_methods/query.rb
@@ -1,3 +1,4 @@
+require 'active_support/concern'
 require 'active_support/core_ext/object/blank'
 
 module ActiveRecord

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -1,3 +1,5 @@
+require 'active_support/concern'
+
 module ActiveRecord
   ActiveSupport.on_load(:active_record_config) do
     mattr_accessor :attribute_types_cached_by_default, instance_accessor: false

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -1,3 +1,5 @@
+require 'active_support/concern'
+
 module ActiveRecord
   module AttributeMethods
     module Serialization

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -1,3 +1,4 @@
+require 'active_support/concern'
 require 'active_support/core_ext/class/attribute'
 require 'active_support/core_ext/object/inclusion'
 

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -1,3 +1,5 @@
+require 'active_support/concern'
+
 module ActiveRecord
   module AttributeMethods
     module Write

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -1,3 +1,5 @@
+require 'active_support/concern'
+
 module ActiveRecord
   # = Active Record Autosave Association
   #

--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -1,3 +1,5 @@
+require 'active_support/concern'
+
 module ActiveRecord
   # = Active Record Callbacks
   #

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -1,3 +1,5 @@
+require 'active_support/concern'
+
 module ActiveRecord
   # = Active Record Counter Cache
   module CounterCache

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -1,6 +1,7 @@
 require 'erb'
 require 'yaml'
 require 'zlib'
+require 'active_support/concern'
 require 'active_support/dependencies'
 require 'active_support/core_ext/object/blank'
 require 'active_record/fixtures/file'

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -1,3 +1,5 @@
+require 'active_support/concern'
+
 module ActiveRecord
   ActiveSupport.on_load(:active_record_config) do
     mattr_accessor :lock_optimistically, instance_accessor: false

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -1,3 +1,4 @@
+require 'active_support/concern'
 require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/object/try'
 require 'active_support/core_ext/object/blank'

--- a/activerecord/lib/active_record/railties/controller_runtime.rb
+++ b/activerecord/lib/active_record/railties/controller_runtime.rb
@@ -1,3 +1,4 @@
+require 'active_support/concern'
 require 'active_support/core_ext/module/attr_internal'
 require 'active_record/log_subscriber'
 

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -1,3 +1,4 @@
+require 'active_support/concern'
 require 'active_support/core_ext/class/attribute'
 require 'active_support/core_ext/object/inclusion'
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1,3 +1,4 @@
+require 'active_support/concern'
 require 'active_support/core_ext/array/wrap'
 require 'active_support/core_ext/object/blank'
 

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -1,3 +1,4 @@
+require 'active_support/concern'
 require 'active_support/core_ext/array'
 require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/kernel/singleton_class'

--- a/activerecord/lib/active_record/serialization.rb
+++ b/activerecord/lib/active_record/serialization.rb
@@ -1,3 +1,5 @@
+require 'active_support/concern'
+
 module ActiveRecord #:nodoc:
   ActiveSupport.on_load(:active_record_config) do
     mattr_accessor :include_root_in_json, instance_accessor: false

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -1,3 +1,4 @@
+require 'active_support/concern'
 require 'active_support/core_ext/class/attribute'
 
 module ActiveRecord

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -1,4 +1,5 @@
 require 'thread'
+require 'active_support/concern'
 
 module ActiveRecord
   # See ActiveRecord::Transactions::ClassMethods for documentation.

--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -1,3 +1,5 @@
+require 'active_support/concern'
+
 module ActiveRecord
   # = Active Record RecordInvalid
   #

--- a/activerecord/test/cases/associations/eager_load_nested_include_test.rb
+++ b/activerecord/test/cases/associations/eager_load_nested_include_test.rb
@@ -6,6 +6,7 @@ require 'models/comment'
 require 'models/category'
 require 'models/categorization'
 require 'models/tagging'
+require 'active_support/concern'
 
 module Remembered
   extend ActiveSupport::Concern

--- a/activerecord/test/cases/validations_repair_helper.rb
+++ b/activerecord/test/cases/validations_repair_helper.rb
@@ -1,3 +1,5 @@
+require 'active_support/concern'
+
 module ActiveRecord
   module ValidationsRepairHelper
     extend ActiveSupport::Concern

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -1,4 +1,5 @@
 require 'ostruct'
+require 'active_support/concern'
 
 module DeveloperProjectsAssociationExtension
   def find_most_recent


### PR DESCRIPTION
I listed files to use `extend ActiveSupport::Concern` and not to require `active_support/concern`.
