### PR TITLE
Change 'Hash' to 'hash'.

### DIFF
--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -366,7 +366,7 @@ class TransactionTest < ActiveRecord::TestCase
     topic = Topic.new(:title => 'test')
     topic.freeze
     e = assert_raise(RuntimeError) { topic.save }
-    assert_equal "can't modify frozen Hash", e.message
+    assert_equal "can't modify frozen hash", e.message
     assert !topic.persisted?, 'not persisted'
     assert_nil topic.id
     assert topic.frozen?, 'not frozen'


### PR DESCRIPTION
test_rollback_when_saving_a_frozen_record in transactions_test.rb failed.
The runtime error's message returned 'hash' instead of 'Hash.' This commit 
changes the test to reflect the message, which makes the test pass.
