### PR TITLE
fix quoting for ActiveSupport::Duration instances

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -31,7 +31,7 @@ module ActiveRecord
           # BigDecimals need to be put in a non-normalized form and quoted.
         when nil        then "NULL"
         when BigDecimal then value.to_s('F')
-        when Numeric    then value.to_s
+        when Numeric, ActiveSupport::Duration then value.to_s
         when Date, Time then "'#{quoted_date(value)}'"
         when Symbol     then "'#{quote_string(value.to_s)}'"
         when Class      then "'#{value.to_s}'"

--- a/activerecord/test/cases/column_test.rb
+++ b/activerecord/test/cases/column_test.rb
@@ -76,6 +76,12 @@ module ActiveRecord
         date_string = Time.now.utc.strftime("%F")
         assert_equal date_string, column.type_cast(date_string).strftime("%F")
       end
+
+      def test_type_cast_duration_to_integer
+        column = Column.new("field", nil, "integer")
+        assert_equal 1800, column.type_cast(30.minutes)
+        assert_equal 7200, column.type_cast(2.hours)
+      end
     end
   end
 end

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -216,6 +216,14 @@ module ActiveRecord
       def test_string_with_crazy_column
         assert_equal "'lo\\\\l'", @quoter.quote('lo\l', FakeColumn.new(:foo))
       end
+
+      def test_quote_duration
+        assert_equal "1800", @quoter.quote(30.minutes)
+      end
+
+      def test_quote_duration_int_column
+        assert_equal "7200", @quoter.quote(2.hours, FakeColumn.new(:integer))
+      end
     end
   end
 end


### PR DESCRIPTION
This patch fixes quoting for ActiveSupport::Duration instances:

```
# before
>> ActiveRecord::Base.connection.quote 30.minutes
=> "'--- 1800\n...\n'"

# after
>> ActiveRecord::Base.connection.quote 30.minutes
=> "1800"
```

Also, adds a test for type casting ActiveSupport::Duration instances.

Related to #1119.
