### PR TITLE
fix calculation for a relation with multiple selected columns

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -362,8 +362,13 @@ module ActiveRecord
 
     def select_for_count
       if select_values.present?
-        select = select_values.join(", ")
-        select if select !~ /[,*]/
+        select = select_values.join(', ')
+
+        if select =~ /[,*]/
+          raise ActiveRecordError.new('calculation of multiple columns is not supported')
+        end
+
+        select
       end
     end
 

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -65,7 +65,7 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
   end
 
   def test_find_with_implicit_inner_joins_does_not_set_associations
-    authors = Author.joins(:posts).select('authors.*')
+    authors = Author.joins(:posts).select('authors.*').reload
     assert !authors.empty?, "expected authors to be non-empty"
     assert authors.all? { |a| !a.instance_variable_defined?(:@posts) }, "expected no authors to have the @posts association loaded"
   end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -368,6 +368,16 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_raise(ArgumentError) { Account.count(1, 2, 3) }
   end
 
+  def test_count_select_distinct_with_multiple_columns_raises
+    assert_raise(ActiveRecord::ActiveRecordError) do
+      Account.select('distinct id, credit_limit').count
+    end
+
+    assert_raise(ActiveRecord::ActiveRecordError) do
+      Account.select('distinct accounts.*').count
+    end
+  end
+
   def test_should_sum_expression
     # Oracle adapter returns floating point value 636.0 after SUM
     if current_adapter?(:OracleAdapter)


### PR DESCRIPTION
Before this patch, `count` returns an incorrect result when is
executed with multiple columns:

```
User.select('distinct username, email').count
# => SELECT count(*) FROM "users"

User.select('distinct users.*').count
# => SELECT count(*) FROM "users"
```

It proposes to raise an ActiveRecordError instead.

```
>> User.select('distinct username, email').count
# => ActiveRecord::ActiveRecordError: calculation of multiple columns is not
#    supported

>> User.select('distinct users.*').count
# => ActiveRecord::ActiveRecordError: calculation of multiple columns is not
#    supported
```

Fixes #5554.
