### PR TITLE
fix querying with an empty hash

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix querying with an empty hash *Damien Mathieu*
+
 *   Fix creation of through association models when using `collection=[]`
     on a `has_many :through` association from an unsaved model.
     Fix #7661.

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -10,8 +10,12 @@ module ActiveRecord
           table       = Arel::Table.new(column, default_table.engine)
           association = klass.reflect_on_association(column.to_sym)
 
-          value.each do |k, v|
-            queries.concat expand(association && association.klass, table, k, v)
+          if value.empty?
+            queries.concat ['1 = 2']
+          else
+            value.each do |k, v|
+              queries.concat expand(association && association.klass, table, k, v)
+            end
           end
         else
           column = column.to_s

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -4,10 +4,11 @@ require 'models/price_estimate'
 require 'models/treasure'
 require 'models/post'
 require 'models/comment'
+require 'models/edge'
 
 module ActiveRecord
   class WhereTest < ActiveRecord::TestCase
-    fixtures :posts
+    fixtures :posts, :edges
 
     def test_belongs_to_shallow_where
       author = Author.new
@@ -75,6 +76,14 @@ module ActiveRecord
     def test_where_with_table_name
       post = Post.first
       assert_equal post, Post.where(:posts => { 'id' => post.id }).first
+    end
+
+    def test_where_with_table_name_and_empty_hash
+      assert_equal 0, Post.where(:posts => {}).count
+    end
+
+    def test_where_with_empty_hash_and_no_foreign_key
+      assert_equal 0, Edge.where(:sink => {}).count
     end
   end
 end


### PR DESCRIPTION
Suppose the following query :

```
User.where(token: params[:token])
```

If `params[:token]` equals "abc", the generated sql query will be the following :

```
SELECT * FROM users WHERE token = 'abc';
```

However, if `params[:token]` equals {}, the generated sql query will be :

```
SELECT * FROM users;
```

This can actually be a security issue on some applications.

My patch transforms empty hash conditions to :

```
SELECT * FROM users WHERE users.id IS NULL;
```

This may not be the best way around this issue. But I'm willing to improve it depending of the feedback provided here.
