### PR TITLE
add common flash types, such as error, warning

### DIFF
--- a/actionpack/lib/action_controller/metal/flash.rb
+++ b/actionpack/lib/action_controller/metal/flash.rb
@@ -4,18 +4,27 @@ module ActionController #:nodoc:
 
     included do
       delegate :flash, :to => :request
-      delegate :alert, :notice, :to => "request.flash"
-      helper_method :alert, :notice
+      delegate :alert, :notice, :error, :warning, :to => "request.flash"
+      helper_method :alert, :notice, :error, :warning
     end
 
     protected
       def redirect_to(options = {}, response_status_and_flash = {}) #:doc:
+
         if alert = response_status_and_flash.delete(:alert)
           flash[:alert] = alert
         end
 
         if notice = response_status_and_flash.delete(:notice)
           flash[:notice] = notice
+        end
+
+        if error = response_status_and_flash.delete(:error)
+          flash[:error] = error
+        end
+
+        if warning = response_status_and_flash.delete(:warning)
+          flash[:warning] = warning
         end
 
         if other_flashes = response_status_and_flash.delete(:flash)


### PR DESCRIPTION
"notice" , "error", "warning" are common flash types.

ex. notice_stickie, twitter bootstrap.

But only notice, alert exist on current helper.It's highly inconvenient.

see https://github.com/xdite/bootstrap-helper
