### PR TITLE
Fixes issue #5660: Failsafe exception returns text/html and text/plain.

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -13,13 +13,20 @@ module ActionDispatch
   # If the application returns a "X-Cascade" pass response, this middleware
   # will send an empty response as result with the correct status code.
   # If any exception happens inside the exceptions app, this middleware
-  # catches the exceptions and returns a FAILSAFE_RESPONSE.
+  # catches the exceptions and returns a FAILSAFE_RESPONSE_HTML for request
+  # format of HTML, and FAILSAFE_RESPONSE_PLAIN_TEXT for all other formats.
   class ShowExceptions
-    FAILSAFE_RESPONSE = [500, {'Content-Type' => 'text/html'},
+    FAILSAFE_RESPONSE_HTML = [500, { 'Content-Type' => 'text/html' },
       ["<html><body><h1>500 Internal Server Error</h1>" <<
        "If you are the administrator of this website, then please read this web " <<
        "application's log file and/or the web server's log file to find out what " <<
        "went wrong.</body></html>"]]
+
+    FAILSAFE_RESPONSE_PLAIN_TEXT = [500, { 'Content-Type' => 'text/plain' },
+      ["500 Internal Server Error\n" <<
+       "If you are the administrator of this website, then please read this web " <<
+       "application's log file and/or the web server's log file to find out what " <<
+       "went wrong."]]
 
     def initialize(app, exceptions_app)
       @app = app
@@ -47,7 +54,7 @@ module ActionDispatch
       response[1]['X-Cascade'] == 'pass' ? pass_response(status) : response
     rescue Exception => failsafe_error
       $stderr.puts "Error during failsafe response: #{failsafe_error}\n  #{failsafe_error.backtrace * "\n  "}"
-      FAILSAFE_RESPONSE
+      env['HTTP_ACCEPT'] == 'text/html' ? FAILSAFE_RESPONSE_HTML : FAILSAFE_RESPONSE_PLAIN_TEXT
     end
 
     def pass_response(status)

--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -54,7 +54,11 @@ module ActionDispatch
       response[1]['X-Cascade'] == 'pass' ? pass_response(status) : response
     rescue Exception => failsafe_error
       $stderr.puts "Error during failsafe response: #{failsafe_error}\n  #{failsafe_error.backtrace * "\n  "}"
-      env['HTTP_ACCEPT'] == 'text/html' ? FAILSAFE_RESPONSE_HTML : FAILSAFE_RESPONSE_PLAIN_TEXT
+      if Request.new(env).formats.any? { |format| format == :html }
+        FAILSAFE_RESPONSE_HTML
+      else
+        FAILSAFE_RESPONSE_PLAIN_TEXT
+      end
     end
 
     def pass_response(status)

--- a/actionpack/test/controller/show_exceptions_test.rb
+++ b/actionpack/test/controller/show_exceptions_test.rb
@@ -93,4 +93,34 @@ module ShowExceptions
       assert_equal 'text/html', response.content_type.to_s
     end
   end
+
+  class ShowFailsafeExceptionsTest < ActionDispatch::IntegrationTest
+    def test_render_failsafe_html_exception
+      @app = ShowExceptionsOverridenController.action(:boom)
+      @exceptions_app = @app.instance_variable_get(:@exceptions_app)
+      @app.instance_variable_set(:@exceptions_app, nil)
+      $stderr = StringIO.new
+
+      get '/', {}, 'HTTP_ACCEPT' => 'text/html'
+      assert_response :internal_server_error
+      assert_equal 'text/html', response.content_type.to_s
+
+      @app.instance_variable_set(:@exceptions_app, @exceptions_app)
+      $stderr = STDERR
+    end
+
+    def test_render_failsafe_plain_text_exception
+      @app = ShowExceptionsOverridenController.action(:boom)
+      @exceptions_app = @app.instance_variable_get(:@exceptions_app)
+      @app.instance_variable_set(:@exceptions_app, nil)
+      $stderr = StringIO.new
+
+      get '/', {}, 'HTTP_ACCEPT' => 'text/json'
+      assert_response :internal_server_error
+      assert_equal 'text/plain', response.content_type.to_s
+
+      @app.instance_variable_set(:@exceptions_app, @exceptions_app)
+      $stderr = STDERR
+    end
+  end
 end


### PR DESCRIPTION
If the request format is text/html then return the existing failsafe
response. For all other formats return text/plain.

The original issue points out to return JSON at the appropriate time,
however as @wycats pointed out, it's often better to return text/plain.
