### PR TITLE
Generate config/initializers/version.rb file

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/version.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/version.rb.tt
@@ -1,0 +1,6 @@
+module <%= app_const_base %>
+  class Application
+    # Use this constant to specify your app's version
+    # VERSION = "0.1.0"
+  end
+end


### PR DESCRIPTION
I often find myself specifiying version number for my apps. And usually do this by creating `version.rb` file inside `config/initializers` directory. I also think that rails should encourage developers to version their apps.

This patch adds `version.rb` template to rails app generator. Initially file is commented out, so It does not specify any version number unless developer manually enables it.

**edit**

As @josevalim mentioned, this can also be done using `config/applicatoin.rb` file.
