### PR TITLE
Disable query cache for lock queries

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -56,7 +56,7 @@ module ActiveRecord
       end
 
       def select_all(arel, name = nil, binds = [])
-        if @query_cache_enabled
+        if @query_cache_enabled && !locked?(arel)
           sql = to_sql(arel, binds)
           cache_sql(sql, binds) { super(sql, name, binds) }
         else
@@ -81,6 +81,14 @@ module ActiveRecord
           result.dup
         else
           result.collect { |row| row.dup }
+        end
+      end
+
+      def locked?(arel)
+        if arel.respond_to?(:locked)
+          arel.locked
+        else
+          false
         end
       end
     end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -164,6 +164,14 @@ class QueryCacheTest < ActiveRecord::TestCase
       end
     end
   end
+
+  def test_cache_is_ignored_for_locked_relations
+    task = Task.find 1
+
+    Task.cache do
+      assert_queries(2) { task.lock!; task.lock! }
+    end
+  end
 end
 
 class QueryCacheExpiryTest < ActiveRecord::TestCase


### PR DESCRIPTION
Query caching should be disabled for queries asking for a pessimistic lock. Otherwise the lock query may not reach the database, thus breaking the expected functionality.

Fixes #867
