### PR TITLE
Fix: Mime type names conflict with Object methods

### DIFF
--- a/actionpack/lib/abstract_controller/collector.rb
+++ b/actionpack/lib/abstract_controller/collector.rb
@@ -16,6 +16,10 @@ module AbstractController
       generate_method_for_mime(mime)
     end
 
+    Mime::Type.register_callback do |mime|
+      generate_method_for_mime(mime) unless self.instance_methods.include?(mime.to_sym)
+    end
+
   protected
 
     def method_missing(symbol, &block)

--- a/actionpack/test/controller/mime_responds_test.rb
+++ b/actionpack/test/controller/mime_responds_test.rb
@@ -505,7 +505,7 @@ class RespondToControllerTest < ActionController::TestCase
 end
 
 class RespondWithController < ActionController::Base
-  respond_to :html, :json
+  respond_to :html, :json, :touch
   respond_to :xml, :except => :using_resource_with_block
   respond_to :js,  :only => [ :using_resource_with_block, :using_resource, 'using_hash_resource' ]
 
@@ -623,12 +623,14 @@ class RespondWithControllerTest < ActionController::TestCase
     super
     @request.host = "www.example.com"
     Mime::Type.register_alias('text/html', :iphone)
+    Mime::Type.register_alias('text/html', :touch)
     Mime::Type.register('text/x-mobile', :mobile)
   end
 
   def teardown
     super
     Mime::Type.unregister(:iphone)
+    Mime::Type.unregister(:touch)
     Mime::Type.unregister(:mobile)
   end
 

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -118,6 +118,20 @@ class MimeTypeTest < ActiveSupport::TestCase
     end
   end
 
+  test "register callbacks" do
+    begin
+      registered_mimes = []
+      Mime::Type.register_callback do |mime|
+        registered_mimes << mime
+      end
+
+      Mime::Type.register("text/foo", :foo)
+      assert_equal registered_mimes, [Mime::FOO]
+    ensure
+      Mime::Type.unregister(:FOO)
+    end
+  end
+
   test "custom type with extension aliases" do
     begin
       Mime::Type.register "text/foobar", :foobar, [], [:foo, "bar"]


### PR DESCRIPTION
We discovered this issue in one of our production apps, because we tried to use `touch` as a custom mime type, which led to the `touch` method of `Object` being executed sometimes, causing vexing errors.

This is the case for any mime type with the same name as a method on Object, even private ones.

This is caused by the following execution path:
1. `respond_to :touch` is called in a controller. This adds `:touch` to the list of mimes.
2. `retrieve_collector_from_mimes` calls `Collector.new(mimes)`
3. `initialize` calls `mimes.each { |mime| send(mime) }`
4. `send(:touch)`, instead of triggering `method_missing` on the `AbstractController::Collector`, actually calls `Object.touch`. This can lead to any sort of behavior.

A proposed fix for this issue is attached. It is based on generating the required methods on `Collector` after each mime type is registered, instead of relying on `method_missing`. That way, `send` always hits them instead of going up to `Object`.

Check out the commit messages for more info.
