### PR TITLE
Engine table name prefix generator fix

### DIFF
--- a/activerecord/lib/rails/generators/active_record/model/templates/module.rb
+++ b/activerecord/lib/rails/generators/active_record/model/templates/module.rb
@@ -1,7 +1,7 @@
 <% module_namespacing do -%>
 module <%= class_path.map(&:camelize).join('::') %>
   def self.table_name_prefix
-    '<%= class_path.join('_') %>_'
+    '<%= namespaced? ? namespaced_class_path.join('_') : class_path.join('_') %>_'
   end
 end
 <% end -%>

--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -99,7 +99,7 @@ class NamespacedModelGeneratorTest < NamespacedGeneratorTestCase
     run_generator ["admin/account"]
     assert_file "app/models/test_app/admin.rb", /module TestApp/, /module Admin/
     assert_file "app/models/test_app/admin.rb", /def self\.table_name_prefix/
-    assert_file "app/models/test_app/admin.rb", /'admin_'/
+    assert_file "app/models/test_app/admin.rb", /'test_app_admin_'/
     assert_file "app/models/test_app/admin/account.rb", /module TestApp/, /class Admin::Account < ActiveRecord::Base/
   end
 

--- a/railties/test/railties/generators_test.rb
+++ b/railties/test/railties/generators_test.rb
@@ -75,6 +75,18 @@ module RailtiesTests
       end
     end
 
+    def test_table_name_prefix_is_correctly_namespaced_when_engine_is_mountable
+      build_mountable_engine
+      Dir.chdir(engine_path) do
+        bundled_rails("g model namespaced/topic")
+        assert_file "app/models/foo_bar/namespaced.rb", /module FooBar\n  module Namespaced/ do |content|
+          assert_class_method :table_name_prefix, content do |method_content|
+            assert_match(/'foo_bar_namespaced_'/, method_content)
+          end
+        end
+      end
+    end
+
     def test_helpers_are_correctly_namespaced_when_engine_is_mountable
       build_mountable_engine
       Dir.chdir(engine_path) do


### PR DESCRIPTION
When generating namespaced model inside mountable engine, table_name_prefix was not including engine name:

```
cd my_engine
rails g model namespaced/user
```

File: my_engine/app/models/namespaced.rb:

``` ruby
module MyEngine
  module Namespaced
    def self.table_name_prefix
      'namespaced_'
    end
  end
end
```

Table name prefix should include engine name: `my_engine_namespaced_`

I added failing test and fix.
I noticed that one test failed after this change, which I believe was wrong assumption.
I also fixed this test according to current changes
