### PR TITLE
update test_help to config properly turn natural language option

### DIFF
--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -10,7 +10,10 @@ require 'action_dispatch/testing/integration'
 # Enable turn if it is available
 begin
   require 'turn'
-  MiniTest::Unit.use_natural_language_case_names = true
+
+  Turn.config do |c|
+    c.natural = true
+  end
 rescue LoadError
 end
 


### PR DESCRIPTION
Last versions of Turn don't monkey patch MiniTest to setup
the natural language option. Here is an
[example](https://github.com/TwP/turn/blob/master/try/test_autorun_minitest.rb#L3).

This patches the following behaviour:

```
$ rake test:units
`<top (required)>': undefined method `use_natural_language_case_names='
for MiniTest::Unit:Class (NoMethodError)
```
