### PR TITLE
Added *instance_writer: false* to stored/serialized attributes.

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       included do
         # Returns a hash of all the attributes that have been specified for serialization as
         # keys and their class restriction as values.
-        class_attribute :serialized_attributes
+        class_attribute :serialized_attributes, instance_writer: false
         self.serialized_attributes = {}
       end
 

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -43,7 +43,7 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :stored_attributes
+      class_attribute :stored_attributes, instance_writer: false
       self.stored_attributes = {}
     end
 

--- a/activerecord/test/cases/serialization_test.rb
+++ b/activerecord/test/cases/serialization_test.rb
@@ -51,4 +51,11 @@ class SerializationTest < ActiveRecord::TestCase
       assert_equal @contact_attributes[:awesome], contact.awesome, "For #{format}"
     end
   end
+
+  def test_serialized_attributes_are_class_level_settings
+    assert_raise NoMethodError do
+      topic = Topic.new
+      topic.serialized_attributes = []
+    end
+  end
 end

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -120,4 +120,11 @@ class StoreTest < ActiveRecord::TestCase
   test "stored attributes are returned" do
     assert_equal [:color, :homepage], Admin::User.stored_attributes[:settings]
   end
+
+  test "stores_attributes are class level settings" do
+    assert_raise NoMethodError do
+      @john.stored_attributes = {}
+    end
+  end
+
 end


### PR DESCRIPTION
I think stored_attributes and serialized_attributes should be class level attributes.
