### PR TITLE
Use instance_accessor: false instead of instance_writer.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `serialized_attributes` and `_attr_readonly` become class method only. Instance reader methods are deprecated.
+
+    *kennyj*
+
 *   Round usec when comparing timestamp attributes in the dirty tracking.
     Fixes #6975.
 

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       included do
         # Returns a hash of all the attributes that have been specified for serialization as
         # keys and their class restriction as values.
-        class_attribute :serialized_attributes, instance_writer: false
+        class_attribute :serialized_attributes, instance_accessor: false
         self.serialized_attributes = {}
       end
 
@@ -39,6 +39,11 @@ module ActiveRecord
           # has its own hash of own serialized attributes
           self.serialized_attributes = serialized_attributes.merge(attr_name.to_s => coder)
         end
+      end
+
+      def serialized_attributes
+        ActiveSupport::Deprecation.warn("Instance level serialized_attributes method is deprecated, please use class level method.")
+        defined?(@serialized_attributes) ? @serialized_attributes : self.class.serialized_attributes
       end
 
       class Type # :nodoc:
@@ -114,7 +119,7 @@ module ActiveRecord
         end
 
         def read_attribute_before_type_cast(attr_name)
-          if serialized_attributes.include?(attr_name)
+          if self.class.serialized_attributes.include?(attr_name)
             super.unserialized_value
           else
             super

--- a/activerecord/lib/active_record/readonly_attributes.rb
+++ b/activerecord/lib/active_record/readonly_attributes.rb
@@ -4,7 +4,7 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :_attr_readonly, instance_writer: false
+      class_attribute :_attr_readonly, instance_accessor: false
       self._attr_readonly = []
     end
 
@@ -19,6 +19,11 @@ module ActiveRecord
       def readonly_attributes
         self._attr_readonly
       end
+    end
+
+    def _attr_readonly
+      ActiveSupport::Deprecation.warn("Instance level _attr_readonly method is deprecated, please use class level method.")
+      defined?(@_attr_readonly) ? @_attr_readonly : self.class._attr_readonly
     end
   end
 end

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -41,7 +41,7 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :stored_attributes, instance_writer: false
+      class_attribute :stored_attributes, instance_accessor: false
       self.stored_attributes = {}
     end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -604,6 +604,12 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal "changed", post.body
   end
 
+  def test_attr_readonly_is_class_level_setting
+    post = ReadonlyTitlePost.new
+    assert_raise(NoMethodError) { post._attr_readonly = [:title] }
+    assert_deprecated { post._attr_readonly }
+  end
+
   def test_non_valid_identifier_column_name
     weird = Weird.create('a$b' => 'value')
     weird.reload

--- a/activerecord/test/cases/serialization_test.rb
+++ b/activerecord/test/cases/serialization_test.rb
@@ -53,9 +53,8 @@ class SerializationTest < ActiveRecord::TestCase
   end
 
   def test_serialized_attributes_are_class_level_settings
-    assert_raise NoMethodError do
-      topic = Topic.new
-      topic.serialized_attributes = []
-    end
+    topic = Topic.new
+    assert_raise(NoMethodError) { topic.serialized_attributes = [] }
+    assert_deprecated { topic.serialized_attributes }
   end
 end

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -122,9 +122,8 @@ class StoreTest < ActiveRecord::TestCase
   end
 
   test "stores_attributes are class level settings" do
-    assert_raise NoMethodError do
-      @john.stored_attributes = {}
-    end
+    assert_raise(NoMethodError) { @john.stored_attributes = Hash.new }
+    assert_raise(NoMethodError) { @john.stored_attributes }
   end
 
 end

--- a/guides/source/upgrading_ruby_on_rails.textile
+++ b/guides/source/upgrading_ruby_on_rails.textile
@@ -44,6 +44,8 @@ The <tt>delete</tt> method in collection associations can now receive <tt>Fixnum
 
 Rails 4.0 has changed how orders get stacked in +ActiveRecord::Relation+. In previous versions of rails new order was applied after previous defined order. But this is no long true. Check "ActiveRecord Query guide":active_record_querying.html#ordering for more information.
 
+Rails 4.0 has changed <tt>serialized_attributes</tt> and <tt>_attr_readonly</tt> to class methods only. Now you shouldn't use instance methods, it's deprecated. You must change them, e.g. <tt>self.serialized_attributes</tt> to <tt>self.class.serialized_attributes</tt>.
+
 h4(#active_model4_0). Active Model
 
 Rails 4.0 has changed how errors attach with the <tt>ActiveModel::Validations::ConfirmationValidator</tt>. Now when confirmation validations fail the error will be attached to <tt>:#{attribute}_confirmation</tt> instead of <tt>attribute</tt>.


### PR DESCRIPTION
`stored_attributes` and `serialized_attributes` are changed to class method only.

Please see #6997 comments.
cc/ @carlosantoniodasilva @josevalim
