### PR TITLE
Added a method for retrieving a random record.

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -3,7 +3,7 @@ require 'active_support/deprecation'
 
 module ActiveRecord
   module Querying
-    delegate :find, :take, :take!, :first, :first!, :last, :last!, :all, :exists?, :any?, :many?, :to => :scoped
+    delegate :find, :take, :take!, :first, :first!, :last, :last!, :all, :exists?, :random, :any?, :many?, :to => :scoped
     delegate :first_or_create, :first_or_create!, :first_or_initialize, :to => :scoped
     delegate :find_by, :find_by!, :to => :scoped
     delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, :to => :scoped

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -198,7 +198,7 @@ module ActiveRecord
     #
     #   Post.random
     def random
-      random_offset = rand(count)
+      random_offset = Kernel.rand(count)
       offset(random_offset).first
     end
 

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -192,6 +192,16 @@ module ActiveRecord
       false
     end
 
+    # Finds a random record.
+    #
+    # If no record is found, returns <tt>nil</tt>.
+    #
+    #   Post.random
+    def random
+      random_offset = rand(count)
+      offset(random_offset).first
+    end
+
     protected
 
     def find_with_associations

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -722,6 +722,10 @@ class FinderTest < ActiveRecord::TestCase
     assert_nothing_raised(ActiveRecord::StatementInvalid) { Topic.scoped(:offset => "3").all }
   end
 
+  def test_random
+    assert_equal "Topic", Topic.random.class.name
+  end
+
   protected
     def bind(statement, *vars)
       if vars.first.is_a?(Hash)

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -723,7 +723,8 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_random
-    assert_equal "Topic", Topic.random.class.name
+    Kernel.stubs(:rand).returns(0)
+    assert_equal Topic.random, topics(:first)
   end
 
   protected


### PR DESCRIPTION
Often it's useful to retrieve a random record. This provides
an alternative to the often used .first or .last when a random record
is actually what is intended.

```
Post.random
# => Returns a random Post record or nil
```
