### PR TITLE
[Guide] Fix broken links

### DIFF
--- a/guides/source/2_2_release_notes.textile
+++ b/guides/source/2_2_release_notes.textile
@@ -118,9 +118,9 @@ h4. Transactional Migrations
 
 Historically, multiple-step Rails migrations have been a source of trouble. If something went wrong during a migration, everything before the error changed the database and everything after the error wasn't applied. Also, the migration version was stored as having been executed, which means that it couldn't be simply rerun by +rake db:migrate:redo+ after you fix the problem. Transactional migrations change this by wrapping migration steps in a DDL transaction, so that if any of them fail, the entire migration is undone. In Rails 2.2, transactional migrations are supported on PostgreSQL out of the box. The code is extensible to other database types in the future - and IBM has already extended it to support the DB2 adapter.
 
-* Lead Contributor: "Adam Wiggins":http://adam.blog.heroku.com/
+* Lead Contributor: "Adam Wiggins":http://adam.heroku.com/
 * More information:
-** "DDL Transactions":http://adam.blog.heroku.com/past/2008/9/3/ddl_transactions/
+** "DDL Transactions":http://adam.heroku.com/past/2008/9/3/ddl_transactions/
 ** "A major milestone for DB2 on Rails":http://db2onrails.com/2008/11/08/a-major-milestone-for-db2-on-rails/
 
 h4. Connection Pooling

--- a/guides/source/2_3_release_notes.textile
+++ b/guides/source/2_3_release_notes.textile
@@ -561,7 +561,7 @@ This will layer the changes from the template on top of whatever code the projec
 
 h4. Quieter Backtraces
 
-Building on Thoughtbot's "Quiet Backtrace":http://www.thoughtbot.com/projects/quietbacktrace plugin, which allows you to selectively remove lines from +Test::Unit+ backtraces, Rails 2.3 implements +ActiveSupport::BacktraceCleaner+ and +Rails::BacktraceCleaner+ in core. This supports both filters (to perform regex-based substitutions on backtrace lines) and silencers (to remove backtrace lines entirely). Rails automatically adds silencers to get rid of the most common noise in a new application, and builds a +config/backtrace_silencers.rb+ file to hold your own additions. This feature also enables prettier printing from any gem in the backtrace.
+Building on Thoughtbot's "Quiet Backtrace":https://github.com/thoughtbot/quietbacktrace plugin, which allows you to selectively remove lines from +Test::Unit+ backtraces, Rails 2.3 implements +ActiveSupport::BacktraceCleaner+ and +Rails::BacktraceCleaner+ in core. This supports both filters (to perform regex-based substitutions on backtrace lines) and silencers (to remove backtrace lines entirely). Rails automatically adds silencers to get rid of the most common noise in a new application, and builds a +config/backtrace_silencers.rb+ file to hold your own additions. This feature also enables prettier printing from any gem in the backtrace.
 
 h4. Faster Boot Time in Development Mode with Lazy Loading/Autoload
 

--- a/guides/source/debugging_rails_applications.textile
+++ b/guides/source/debugging_rails_applications.textile
@@ -708,4 +708,4 @@ h3. References
 * "Debugging with ruby-debug":http://bashdb.sourceforge.net/ruby-debug.html
 * "ruby-debug cheat sheet":http://cheat.errtheblog.com/s/rdebug/
 * "Ruby on Rails Wiki: How to Configure Logging":http://wiki.rubyonrails.org/rails/pages/HowtoConfigureLogging
-* "Bleak House Documentation":http://blog.evanweaver.com/files/doc/fauna/bleak_house/files/README.html
+* "Bleak House Documentation":http://blog.evanweaver.com/files/doc/fauna/bleak_house/

--- a/guides/source/i18n.textile
+++ b/guides/source/i18n.textile
@@ -220,7 +220,7 @@ Every helper method dependent on +url_for+ (e.g. helpers for named routes like +
 
 You may be satisfied with this. It does impact the readability of URLs, though, when the locale "hangs" at the end of every URL in your application. Moreover, from the architectural standpoint, locale is usually hierarchically above the other parts of the application domain: and URLs should reflect this.
 
-You probably want URLs to look like this: +www.example.com/en/books+ (which loads the English locale) and +www.example.com/nl/books+ (which loads the Dutch locale). This is achievable with the "over-riding +default_url_options+" strategy from above: you just have to set up your routes with "+path_prefix+":http://api.rubyonrails.org/classes/ActionController/Resources.html#M000354 option in this way:
+You probably want URLs to look like this: +www.example.com/en/books+ (which loads the English locale) and +www.example.com/nl/books+ (which loads the Dutch locale). This is achievable with the "over-riding +default_url_options+" strategy from above: you just have to set up your routes with "+scoping+":http://api.rubyonrails.org/classes/ActionDispatch/Routing/Mapper/Scoping.html option in this way:
 
 <ruby>
 # config/routes.rb

--- a/guides/source/plugins.textile
+++ b/guides/source/plugins.textile
@@ -427,4 +427,4 @@ h4. References
 * "Developing a RubyGem using Bundler":https://github.com/radar/guides/blob/master/gem-development.md
 * "Using Gemspecs As Intended":http://yehudakatz.com/2010/04/02/using-gemspecs-as-intended/
 * "Gemspec Reference":http://docs.rubygems.org/read/chapter/20
-* "GemPlugins":http://www.mbleigh.com/2008/06/11/gemplugins-a-brief-introduction-to-the-future-of-rails-plugins
+* "GemPlugins":http://www.intridea.com/blog/2008/6/11/gemplugins-a-brief-introduction-to-the-future-of-rails-plugins

--- a/guides/source/security.textile
+++ b/guides/source/security.textile
@@ -851,7 +851,7 @@ Network traffic is mostly based on the limited Western alphabet, so new characte
   &amp;#108;&amp;#101;&amp;#114;&amp;#116;&amp;#40;&amp;#39;&amp;#88;&amp;#83;&amp;#83;&amp;#39;&amp;#41;>
 </html>
 
-This example pops up a message box. It will be recognized by the above sanitize() filter, though. A great tool to obfuscate and encode strings, and thus “get to know your enemy”, is the "Hackvertor":http://www.businessinfo.co.uk/labs/hackvertor/hackvertor.php. Rails' sanitize() method does a good job to fend off encoding attacks.
+This example pops up a message box. It will be recognized by the above sanitize() filter, though. A great tool to obfuscate and encode strings, and thus “get to know your enemy”, is the "Hackvertor":https://hackvertor.co.uk/public. Rails' sanitize() method does a good job to fend off encoding attacks.
 
 h5. Examples from the Underground
 


### PR DESCRIPTION
Hey guys,

I fixed some broken links in 2.2 release notes, i18n, debugging, security, 2.3 release notes and plugins. 

Unfortunately, there are some broken links which I couldn't fix because I haven't found their new url yet.
- httpOnly in security
- in-place-editor plugin in security
- deprecation_page in 2.2 release notes
- rg in 2.3 release notes
