### PR TITLE
A more informative comment for config.asset.debug

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -35,7 +35,7 @@
   # Do not compress assets.
   config.assets.compress = false
 
-  # Expands the lines which load the assets.
+  # Debug mode disables concatenation and preprocessing of assets.
   config.assets.debug = true
   <%- end -%>
 


### PR DESCRIPTION
This comment from the generator:

``` ruby
    # Expands the lines which load the assets.
    config.assets.debug = true
```

could be more informative, eg.

``` ruby
    # Turn debug mode off to concatenate and preprocess assets
    config.assets.debug = true
```

Original post: #7005
