### PR TITLE
make Hash#extract! more symmetric with Hash#slice

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,12 +1,12 @@
 ## Rails 4.0.0 (unreleased) ##
 
-*   Hash#extract! returns only those keys that present in the reciever.
+*   Hash#extract! returns only those keys that present in the receiver.
 
         {:a => 1, :b => 2}.extract!(:a, :x) # => {:a => 1}
 
     *Mikhail Dieterle*
 
-*   Hash#extract! returns the same subclass, that the reciever is. I.e.
+*   Hash#extract! returns the same subclass, that the receiver is. I.e.
     HashWithIndifferentAccess#extract! returns HashWithIndifferentAccess instance.
 
     *Mikhail Dieterle*

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Hash#extract! returns only those keys that present in the reciever.
+
+        {:a => 1, :b => 2}.extract!(:a, :x) # => {:a => 1}
+
+    *Mikhail Dieterle*
+
+*   Hash#extract! returns the same subclass, that the reciever is. I.e.
+    HashWithIndifferentAccess#extract! returns HashWithIndifferentAccess instance.
+
+    *Mikhail Dieterle*
+
 *   Optimize ActiveSupport::Cache::Entry to reduce memory and processing overhead. *Brian Durand*
 
 *   Tests tag the Rails log with the current test class and test case:

--- a/activesupport/lib/active_support/core_ext/hash/slice.rb
+++ b/activesupport/lib/active_support/core_ext/hash/slice.rb
@@ -32,9 +32,9 @@ class Hash
 
   # Removes and returns the key/value pairs matching the given keys.
   #
-  #   { a: 1, b: 2, c: 3, d: 4 }.extract!(:a, :b)
-  #   # => {:a => 1, :b => 2}
+  #   { a: 1, b: 2, c: 3, d: 4 }.extract!(:a, :b) # => { a: 1, b: 2 }
+  #   { a: 1, b: 2 }.extract!(:a, :x) # => { a: 1 }
   def extract!(*keys)
-    keys.each_with_object({}) { |key, result| result[key] = delete(key) }
+    keys.each_with_object(self.class.new) { |key, result| result[key] = delete(key) if has_key?(key) }
   end
 end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -724,8 +724,10 @@ class HashExtTest < ActiveSupport::TestCase
   def test_extract
     original = {:a => 1, :b => 2, :c => 3, :d => 4}
     expected = {:a => 1, :b => 2}
+    remaining = {:c => 3, :d => 4}
 
     assert_equal expected, original.extract!(:a, :b, :x)
+    assert_equal remaining, original
   end
 
   def test_extract_nils
@@ -739,10 +741,15 @@ class HashExtTest < ActiveSupport::TestCase
   end
 
   def test_indifferent_extract
-    original = {:a => 1, :b => 2, :c => 3, :d => 4}.with_indifferent_access
+    original = {:a => 1, 'b' => 2, :c => 3, 'd' => 4}.with_indifferent_access
     expected = {:a => 1, :b => 2}.with_indifferent_access
+    remaining = {:c => 3, :d => 4}.with_indifferent_access
 
-    assert_equal expected, original.extract!(:a, :b)
+    [['a', 'b'], [:a, :b]].each do |keys|
+      copy = original.dup
+      assert_equal expected, copy.extract!(*keys)
+      assert_equal remaining, copy
+    end
   end
 
   def test_except

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -725,6 +725,23 @@ class HashExtTest < ActiveSupport::TestCase
     original = {:a => 1, :b => 2, :c => 3, :d => 4}
     expected = {:a => 1, :b => 2}
 
+    assert_equal expected, original.extract!(:a, :b, :x)
+  end
+
+  def test_extract_nils
+    original = {:a => nil, :b => nil}
+    expected = {:a => nil}
+    extracted = original.extract!(:a, :x)
+
+    assert_equal expected, extracted
+    assert_equal nil, extracted[:a]
+    assert_equal nil, extracted[:x]
+  end
+
+  def test_indifferent_extract
+    original = {:a => 1, :b => 2, :c => 3, :d => 4}.with_indifferent_access
+    expected = {:a => 1, :b => 2}.with_indifferent_access
+
     assert_equal expected, original.extract!(:a, :b)
   end
 

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2867,8 +2867,16 @@ The method `extract!` removes and returns the key/value pairs matching the given
 
 ```ruby
 hash = {:a => 1, :b => 2}
-rest = hash.extract!(:a) # => {:a => 1}
-hash                     # => {:b => 2}
+rest = hash.extract!(:a, :x) # => {:a => 1}     # non-existing keys are ignored
+hash                         # => {:b => 2}
+```
+
+The method `extract!` returns the same subclass of Hash, that the receiver is.
+
+```ruby
+hash = {:a => 1, :b => 2}.with_indifferent_access
+rest = hash.extract!(:a).class
+# => ActiveSupport::HashWithIndifferentAccess
 ```
 
 NOTE: Defined in `active_support/core_ext/hash/slice.rb`.


### PR DESCRIPTION
This version of `extract!` doesn't return pairs with nil values, if key is absent in receiver.

Also, it returns extracted hash of the same type as reciever (for example, on hash with indifferent access it returns hash with indifferent access)
