### PR TITLE
Added assert_required_keys method to hash

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -70,6 +70,21 @@ class Hash
       raise ArgumentError.new("Unknown key: #{k}") unless valid_keys.include?(k)
     end
   end
+  
+  # Validate all *required_keys keys exist in hash keys, raising ArgumentError if not.
+  # Note that keys are NOT treated indifferently, meaning if you use strings for keys but assert symbols
+  # as keys, this will fail.
+  #
+  #   { :year => 2012 }.assert_required_keys(:year, :month) # => raises "ArgumentError: Key month is required"
+  #   { :year => 2012, :month => 12 }.assert_required_keys(:year, 'month') # => raises "ArgumentError: Key month is required"
+  #   { :year => 2012, :month => 12 }.assert_required_keys(:year, :month) # => passes, raises nothing
+  def assert_required_keys(*required_keys)
+    required_keys.flatten!
+    required_keys.each do |k|
+      raise(ArgumentError, "Key #{k} is required") unless has_key?(k)
+    end
+    self
+  end
 
   # Return a new hash with all keys converted by the block operation.
   # This includes the keys from the root hash and from all

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -54,6 +54,7 @@ class HashExtTest < ActiveSupport::TestCase
     assert_respond_to h, :deep_stringify_keys!
     assert_respond_to h, :to_options
     assert_respond_to h, :to_options!
+    assert_respond_to h, :assert_required_keys
   end
 
   def test_transform_keys
@@ -724,6 +725,23 @@ class HashExtTest < ActiveSupport::TestCase
     original = { :a => 'x', :b => 'y' }
     original.expects(:delete).never
     original.except(:a)
+  end
+  
+  def test_assert_required_keys
+    assert_nothing_raised do
+      { :req_key_1 => "value1", :req_key_2 => "value2" }.assert_required_keys([ :req_key_1, :req_key_2 ])
+      { :req_key_1 => "value1", :req_key_2 => "value2" }.assert_required_keys(:req_key_1, :req_key_2)
+      { :req_key_1 => "value1", :req_key_2 => "value2", :opt_key_1 => "value3" }.assert_required_keys([ :req_key_1, :req_key_2 ])
+      { :req_key_1 => "value1", :req_key_2 => "value2", :opt_key_1 => "value3" }.assert_required_keys(:req_key_1, :req_key_2)
+    end
+
+    assert_raise(ArgumentError, "Key req_key_1 is required") do
+      { :req_key_2 => "value2" }.assert_required_keys([ :req_key_1, :req_key_2 ])
+      { :req_key_2 => "value2" }.assert_required_keys(:req_key_1, :req_key_2)
+    end
+    
+    h = { :req_key_1 => "value1", :req_key_2 => "value2", :opt_key_1 => "value3" }
+    assert_equal h, h.assert_required_keys(:req_key_1, :req_key_2)
   end
 end
 


### PR DESCRIPTION
Similar to assert_valid_keys method, assert_required_keys method validates if all required_keys that was passed exists in hash keys

For example

``` ruby
{ :year => 2012 }.assert_required_keys(:year, :month) # => raises "ArgumentError: Key month is required"
```

Useful when you need check if required options was passed
