### PR TITLE
Backport 5c51cd0

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -7,6 +7,12 @@
 
     *Ravil Bayramgalin*
 
+*   Performance Improvement to send_file: Avoid having to pass an open file handle as the response body. Rack::Sendfile
+    will usually intercept the response and just uses the path directly, so no reason to open the file. This performance
+    improvement also resolves an issue with jRuby encodings, and is the reason for the backport, see issue #6844.
+
+    *Jeremy Kemper & Erich Menge*
+
 
 ## Rails 3.2.8 (Aug 9, 2012) ##
 

--- a/actionpack/lib/action_controller/metal/data_streaming.rb
+++ b/actionpack/lib/action_controller/metal/data_streaming.rb
@@ -75,7 +75,27 @@ module ActionController #:nodoc:
 
         self.status = options[:status] || 200
         self.content_type = options[:content_type] if options.key?(:content_type)
-        self.response_body = File.open(path, "rb")
+        self.response_body = FileBody.new(path)
+      end
+
+      # Avoid having to pass an open file handle as the response body.
+      # Rack::Sendfile will usually intercept the response and uses
+      # the path directly, so there is no reason to open the file.
+      class FileBody #:nodoc:
+        attr_reader :to_path
+
+        def initialize(path)
+          @to_path = path
+        end
+
+        # Stream the file's contents if Rack::Sendfile isn't present.
+        def each
+          File.open(to_path, 'rb') do |file|
+            while chunk = file.read(16384)
+              yield chunk
+            end
+          end
+        end
       end
 
       # Sends the given binary data to the browser. This method is similar to
@@ -115,7 +135,7 @@ module ActionController #:nodoc:
     private
       def send_file_headers!(options)
         type_provided = options.has_key?(:type)
-        
+
         options.update(DEFAULT_SEND_FILE_OPTIONS.merge(options))
         [:type, :disposition].each do |arg|
           raise ArgumentError, ":#{arg} option required" if options[arg].nil?


### PR DESCRIPTION
Fixes #6844.
This appears to be a jRuby bug, but it is by-passed by 5c51cd0.

No tests added because `actionpack/test/controller/send_file_test.rb` `send_file_stream` and `send_file_nostream` both fail under jRuby jruby 1.6.7 (ruby-1.9.2-p312) without this patch.
