### PR TITLE
Back-port #6874 to 3.2: psql adapter should rename a default pk sequence during rename_table

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1005,12 +1005,19 @@ module ActiveRecord
       end
 
       # Renames a table.
+      # Also renames a table's primary key sequence if the sequence name matches the
+      # Active Record default.
       #
       # Example:
       #   rename_table('octopuses', 'octopi')
       def rename_table(name, new_name)
         clear_cache!
         execute "ALTER TABLE #{quote_table_name(name)} RENAME TO #{quote_table_name(new_name)}"
+        pk, seq = pk_and_sequence_for(new_name)
+        if seq == "#{name}_#{pk}_seq"
+          new_seq = "#{new_name}_#{pk}_seq"
+          execute "ALTER TABLE #{quote_table_name(seq)} RENAME TO #{quote_table_name(new_seq)}"
+        end
       end
 
       # Adds a new column to the named table.

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -949,6 +949,26 @@ if ActiveRecord::Base.connection.supports_migrations?
       end
     end
 
+    if current_adapter?(:PostgreSQLAdapter)
+      def test_rename_table_for_postgresql_should_also_rename_default_sequence
+        begin
+          ActiveRecord::Base.connection.create_table :octopuses do |t|
+            t.column :url, :string
+          end
+          ActiveRecord::Base.connection.rename_table :octopuses, :octopi
+
+          pk, seq = ActiveRecord::Base.connection.pk_and_sequence_for('octopi')
+
+          assert_equal "octopi_#{pk}_seq", seq
+
+        ensure
+          ActiveRecord::Base.connection.drop_table :octopuses rescue nil
+          ActiveRecord::Base.connection.drop_table :octopi rescue nil
+        end
+      end
+    end
+
+
     def test_change_column_nullability
       Person.delete_all
       Person.connection.add_column "people", "funny", :boolean


### PR DESCRIPTION
Requestng #6874 be back-ported to 3.2.

Discussion there had two of us (@steveklabnik and myself) thinking this may be a bug fix rather than new behavior.

Test was written in the style of the existing 3.2 rename_table tests. I like the ones in master much more.
