### PR TITLE
Add #cast and #cast! to Relation.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -91,20 +91,7 @@ module ActiveRecord
         return nil if value.nil?
         return coder.load(value) if encoded?
 
-        klass = self.class
-
-        case type
-        when :string, :text        then value
-        when :integer              then value.to_i
-        when :float                then value.to_f
-        when :decimal              then klass.value_to_decimal(value)
-        when :datetime, :timestamp then klass.string_to_time(value)
-        when :time                 then klass.string_to_dummy_time(value)
-        when :date                 then klass.value_to_date(value)
-        when :binary               then klass.binary_to_string(value)
-        when :boolean              then klass.value_to_boolean(value)
-        else value
-        end
+        self.class.cast(type, value)
       end
 
       def type_cast_code(var_name)
@@ -147,6 +134,21 @@ module ActiveRecord
       end
 
       class << self
+        def cast(type, value)
+          case type
+          when :string, :text        then value
+          when :integer              then value.to_i
+          when :float                then value.to_f
+          when :decimal              then value_to_decimal(value)
+          when :datetime, :timestamp then string_to_time(value)
+          when :time                 then string_to_dummy_time(value)
+          when :date                 then value_to_date(value)
+          when :binary               then binary_to_string(value)
+          when :boolean              then value_to_boolean(value)
+          else value
+          end
+        end
+
         # Used to convert from Strings to BLOBs
         def string_to_binary(value)
           value

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -52,6 +52,10 @@ module ActiveRecord
         end
       end
 
+      def column_type
+        Column
+      end
+
       def new_column(field, default, type, null, collation) # :nodoc:
         Column.new(field, default, type, null, collation)
       end

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -151,6 +151,10 @@ module ActiveRecord
         end
       end
 
+      def column_type
+        Column
+      end
+
       def new_column(field, default, type, null, collation) # :nodoc:
         Column.new(field, default, type, null, collation)
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -819,10 +819,9 @@ module ActiveRecord
           result.fields.each_with_index do |fname, i|
             ftype = result.ftype i
             fmod  = result.fmod i
-            types[fname] = OID::TYPE_MAP.fetch(ftype, fmod) { |oid, mod|
-              warn "unknown OID: #{fname}(#{oid}) (#{sql})"
-              OID::Identity.new
-            }
+            if oid_type = OID::TYPE_MAP.fetch(ftype, fmod) { nil }
+              types[fname] = oid_type
+            end
           end
 
           ret = Result.new(result.fields, result.values, types)
@@ -1033,6 +1032,10 @@ module ActiveRecord
 
           column_names.empty? ? nil : IndexDefinition.new(table_name, index_name, unique, column_names, [], orders, where)
         end.compact
+      end
+
+      def column_type
+        PostgreSQLColumn
       end
 
       # Returns the list of all column definitions for a table.

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -390,6 +390,10 @@ module ActiveRecord
         end
       end
 
+      def column_type
+        SQLite3Column
+      end
+
       # Returns an array of indexes for the given table.
       def indexes(table_name, name = nil) #:nodoc:
         exec_query("PRAGMA index_list(#{quote_table_name(table_name)})", 'SCHEMA').map do |row|

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -12,7 +12,7 @@ module ActiveRecord
                             :extending]
 
     SINGLE_VALUE_METHODS = [:limit, :offset, :lock, :readonly, :from, :reordering,
-                            :reverse_order, :uniq, :create_with]
+                            :reverse_order, :uniq, :create_with, :cast]
 
     VALUE_METHODS = MULTI_VALUE_METHODS + SINGLE_VALUE_METHODS
 
@@ -183,6 +183,7 @@ module ActiveRecord
         # are JOINS and no explicit SELECT.
         readonly = readonly_value.nil? ? @implicit_readonly : readonly_value
         @records.each { |record| record.readonly! } if readonly
+        @records.each { |record| record.cast_columns!(cast_value) } unless cast_value.empty?
       else
         @records = default_scoped.to_a
       end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -18,7 +18,7 @@ module ActiveRecord
       CODE
     end
 
-    (Relation::SINGLE_VALUE_METHODS - [:create_with]).each do |name|
+    (Relation::SINGLE_VALUE_METHODS - [:create_with, :cast]).each do |name|
       class_eval <<-CODE, __FILE__, __LINE__ + 1
         def #{name}_value                    # def readonly_value
           @values[:#{name}]                  #   @values[:readonly]
@@ -37,6 +37,10 @@ module ActiveRecord
 
     def create_with_value
       @values[:create_with] || {}
+    end
+
+    def cast_value
+      @values[:cast] || {}
     end
 
     alias extensions extending_values
@@ -421,6 +425,15 @@ module ActiveRecord
     #
     def none
       scoped.extending(NullRelation)
+    end
+
+    def cast(value)
+      spawn.cast!(value)
+    end
+
+    def cast!(value)
+      self.cast_value = value ? cast_value.merge(value.stringify_keys) : {}
+      self
     end
 
     def readonly(value = true)

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -21,7 +21,7 @@ module ActiveRecord
 
     def test_initialize_single_values
       relation = Relation.new :a, :b
-      (Relation::SINGLE_VALUE_METHODS - [:create_with]).each do |method|
+      (Relation::SINGLE_VALUE_METHODS - [:create_with, :cast]).each do |method|
         assert_nil relation.send("#{method}_value"), method.to_s
       end
       assert_equal({}, relation.create_with_value)
@@ -203,7 +203,7 @@ module ActiveRecord
       assert_equal [], relation.extending_values
     end
 
-    (Relation::SINGLE_VALUE_METHODS - [:from, :lock, :reordering, :reverse_order, :create_with]).each do |method|
+    (Relation::SINGLE_VALUE_METHODS - [:from, :lock, :reordering, :reverse_order, :create_with, :cast]).each do |method|
       test "##{method}!" do
         assert relation.public_send("#{method}!", :foo).equal?(relation)
         assert_equal :foo, relation.public_send("#{method}_value")


### PR DESCRIPTION
These allow you to declare a mapping from generated column names to simplified
database column types (i.e. those used in migrations). This way scopes with
columns generated in their select lists can also include the information as to what
form that data takes. This saves the user from having to translate the data
from a sql string wherever it's used.

Here's an example of where I'd use this:

``` ruby

class Topic < ActiveRecord::Base
  has_many :replies
  scope :by_most_recently_replied, joins(:replies).group('topics.id')
      .select('topics.*, MAX(replies_topics.written_on) AS latest_reply_written_on')
      .order('latest_reply_written_on DESC').cast(latest_reply_written_on: :datetime)
end

>> topic = Topic.by_most_recently_replied.first
>> topic.latest_reply_written_on.class
=> Time
```

The cast is applied to postgres columns only when there is no OID info for the column.

What do you guys think? Remaining work is to test handling of binary data - not quite sure how to go about that but I don't expect any surprises.
