### PR TITLE
Only use prepared statements when bind variables are present

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -327,7 +327,7 @@ module ActiveRecord
         select_all(sql).map { |table|
           table.delete('Table_type')
           sql = "SHOW CREATE TABLE #{quote_table_name(table.to_a.first.last)}"
-          exec_without_stmt(sql).first['Create Table'] + ";\n\n"
+          exec_query(sql).first['Create Table'] + ";\n\n"
         }.join
       end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -282,10 +282,14 @@ module ActiveRecord
       end
 
       def exec_query(sql, name = 'SQL', binds = [])
-        log(sql, name, binds) do
-          exec_stmt(sql, name, binds) do |cols, stmt|
-            ActiveRecord::Result.new(cols, stmt.to_a) if cols
-          end
+        # If the configuration sets prepared_statements:false, binds will
+        # always be empty, since the bind variables will have been already
+        # substituted and removed from binds by BindVisitor, so this will
+        # effectively disable prepared statement usage completely.
+        if binds.empty?
+          exec_without_stmt(sql, name)
+        else
+          exec_stmt(sql, name, binds)
         end
       end
 
@@ -342,41 +346,43 @@ module ActiveRecord
 
       def exec_stmt(sql, name, binds)
         cache = {}
-        if binds.empty?
-          stmt = @connection.prepare(sql)
-        else
-          cache = @statements[sql] ||= {
-            :stmt => @connection.prepare(sql)
-          }
-          stmt = cache[:stmt]
+        log(sql, name, binds) do
+          if binds.empty?
+            stmt = @connection.prepare(sql)
+          else
+            cache = @statements[sql] ||= {
+              :stmt => @connection.prepare(sql)
+            }
+            stmt = cache[:stmt]
+          end
+
+          begin
+            stmt.execute(*binds.map { |col, val| type_cast(val, col) })
+          rescue Mysql::Error => e
+            # Older versions of MySQL leave the prepared statement in a bad
+            # place when an error occurs. To support older mysql versions, we
+            # need to close the statement and delete the statement from the
+            # cache.
+            stmt.close
+            @statements.delete sql
+            raise e
+          end
+
+          cols = nil
+          if metadata = stmt.result_metadata
+            cols = cache[:cols] ||= metadata.fetch_fields.map { |field|
+              field.name
+            }
+          end
+
+          result = ActiveRecord::Result.new(cols, stmt.to_a)
+
+          stmt.result_metadata.free if cols
+          stmt.free_result
+          stmt.close if binds.empty?
+
+          result
         end
-
-        begin
-          stmt.execute(*binds.map { |col, val| type_cast(val, col) })
-        rescue Mysql::Error => e
-          # Older versions of MySQL leave the prepared statement in a bad
-          # place when an error occurs. To support older mysql versions, we
-          # need to close the statement and delete the statement from the
-          # cache.
-          stmt.close
-          @statements.delete sql
-          raise e
-        end
-
-        cols = nil
-        if metadata = stmt.result_metadata
-          cols = cache[:cols] ||= metadata.fetch_fields.map { |field|
-            field.name
-          }
-        end
-
-        result = yield [cols, stmt]
-
-        stmt.result_metadata.free if cols
-        stmt.free_result
-        stmt.close if binds.empty?
-
-        result
       end
 
       def connect

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -214,7 +214,7 @@ module ActiveRecord
 
       def select_rows(sql, name = nil)
         @connection.query_with_result = true
-        rows = exec_without_stmt(sql, name).rows
+        rows = exec_query(sql, name).rows
         @connection.more_results && @connection.next_result    # invoking stored procedures with CLIENT_MULTI_RESULTS requires this to tidy up else connection will be dropped
         rows
       end
@@ -287,10 +287,14 @@ module ActiveRecord
         # substituted and removed from binds by BindVisitor, so this will
         # effectively disable prepared statement usage completely.
         if binds.empty?
-          exec_without_stmt(sql, name)
+          result_set, affected_rows = exec_without_stmt(sql, name)
         else
-          exec_stmt(sql, name, binds)
+          result_set, affected_rows = exec_stmt(sql, name, binds)
         end
+
+        yield affected_rows if block_given?
+
+        result_set
       end
 
       def last_inserted_id(result)
@@ -302,15 +306,17 @@ module ActiveRecord
         # statement API. For those queries, we need to use this method. :'(
         log(sql, name) do
           result = @connection.query(sql)
-          cols = []
-          rows = []
+          affected_rows = @connection.affected_rows
 
           if result
             cols = result.fetch_fields.map { |field| field.name }
-            rows = result.to_a
+            result_set = ActiveRecord::Result.new(cols, result.to_a)
             result.free
+          else
+            result_set = ActiveRecord::Result.new([], [])
           end
-          ActiveRecord::Result.new(cols, rows)
+
+          [result_set, affected_rows]
         end
       end
 
@@ -328,16 +334,18 @@ module ActiveRecord
       alias :create :insert_sql
 
       def exec_delete(sql, name, binds)
-        log(sql, name, binds) do
-          exec_stmt(sql, name, binds) do |cols, stmt|
-            stmt.affected_rows
-          end
+        affected_rows = 0
+
+        exec_query(sql, name, binds) do |n|
+          affected_rows = n
         end
+
+        affected_rows
       end
       alias :exec_update :exec_delete
 
       def begin_db_transaction #:nodoc:
-        exec_without_stmt "BEGIN"
+        exec_query "BEGIN"
       rescue Mysql::Error
         # Transactions aren't supported
       end
@@ -375,13 +383,14 @@ module ActiveRecord
             }
           end
 
-          result = ActiveRecord::Result.new(cols, stmt.to_a)
+          result_set = ActiveRecord::Result.new(cols, stmt.to_a) if cols
+          affected_rows = stmt.affected_rows
 
           stmt.result_metadata.free if cols
           stmt.free_result
           stmt.close if binds.empty?
 
-          result
+          [result_set, affected_rows]
         end
       end
 


### PR DESCRIPTION
Prepared statements (prepare/execute/close) were being used unnecessarily
when no bind variables were present, and disabling prepared statement using
prepared_statements:false was principally broken. While bind variables were
correctly substituted with prepared_statements:false, the prepared statement
interface was still used, costing an extra two round trips per query.

In addition to making this behavioral change, I also cleaned up the internals
of exec_stmt and exec_without_stmt so that they behave the same (calling log
and constructing the ActiveRecord::Result in the same way).

Moving the check for binds.empty? to exec_query also will mean that several
code paths explicitly calling exec_without_stmt could be cleaned up to once
again call exec_query instead. I have also left the check for binds.empty? in
exec_stmt, since it is not a private method and could be called directly with
an empty binds array. For the sake of clarity in this patch, I have not made
those changes.
# The previous behavior

When issuing a Foo.find(1) with prepared_statements:true, the bind variable
is present in the prepared query, and execute shows a value passed:

```
Connect root@localhost on rails_test
Query   SET SQL_AUTO_IS_NULL=0
Statistics
Query   SHOW FULL FIELDS FROM `foos`
Query   SHOW TABLES LIKE 'foos'
Query   SHOW CREATE TABLE `foos`
Prepare SELECT  `foos`.* FROM `foos`  WHERE `foos`.`id` = ? LIMIT 1
Execute SELECT  `foos`.* FROM `foos`  WHERE `foos`.`id` = 1 LIMIT 1
Close stmt
Quit
```

When issuing a Foo.find(1) with prepared_statements:false, the bind variable
has already been removed and substituted with the value, but the prepared
statement interface is used anyway:

```
Connect root@localhost on rails_test
Query   SET SQL_AUTO_IS_NULL=0
Statistics
Query   SHOW FULL FIELDS FROM `foos`
Query   SHOW TABLES LIKE 'foos'
Query   SHOW CREATE TABLE `foos`
Prepare SELECT  `foos`.* FROM `foos`  WHERE `foos`.`id` = 1 LIMIT 1
Execute SELECT  `foos`.* FROM `foos`  WHERE `foos`.`id` = 1 LIMIT 1
Close stmt
Quit
```
# With this patch applied

When issuing a Foo.find(1) with prepared_statements:true, the bind variable
is present in the prepared query, and execute shows a value passed:

```
Connect root@localhost on rails_test
Query   SET SQL_AUTO_IS_NULL=0
Statistics
Query   SHOW FULL FIELDS FROM `foos`
Query   SHOW TABLES LIKE 'foos'
Query   SHOW CREATE TABLE `foos`
Prepare SELECT  `foos`.* FROM `foos`  WHERE `foos`.`id` = ? LIMIT 1
Execute SELECT  `foos`.* FROM `foos`  WHERE `foos`.`id` = 1 LIMIT 1
Close stmt
Quit
```

When issuing a Foo.find(1) with prepared_statements:false, the bind variable
has been removed and substituted with the value, and the query interface is
used instead of the prepared statement interface:

```
Connect root@localhost on rails_test
Query   SET SQL_AUTO_IS_NULL=0
Statistics
Query   SHOW FULL FIELDS FROM `foos`
Query   SHOW TABLES LIKE 'foos'
Query   SHOW CREATE TABLE `foos`
Query   SELECT  `foos`.* FROM `foos`  WHERE `foos`.`id` = 1 LIMIT 1
Quit
```
