### PR TITLE
[tiny fixes] Remove more duplicated code.

### DIFF
--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -86,7 +86,7 @@ module ActiveRecord
 
             stmt = relation.where(
               relation.table[self.class.primary_key].eq(id).and(
-                relation.table[lock_col].eq(quote_value(previous_lock_value))
+                relation.table[lock_col].eq(self.class.quote_value(previous_lock_value))
               )
             ).arel.compile_update(arel_attributes_with_values_for_update(attribute_names))
 

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -148,15 +148,8 @@ module ActiveRecord
     end
 
     # TODO: Deprecate this
-    def quoted_id #:nodoc:
-      quote_value(id, column_for_attribute(self.class.primary_key))
-    end
-
-    private
-
-    # Quote strings appropriately for SQL statements.
-    def quote_value(value, column = nil)
-      self.class.connection.quote(value, column)
+    def quoted_id
+      self.class.quote_value(id, column_for_attribute(self.class.primary_key))
     end
   end
 end

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -7,7 +7,11 @@ module ActiveRecord
     attr_accessible :version
 
     def self.table_name
-      Base.table_name_prefix + 'schema_migrations' + Base.table_name_suffix
+      "#{Base.table_name_prefix}schema_migrations#{Base.table_name_suffix}"
+    end
+
+    def self.index_name
+      "#{Base.table_name_prefix}unique_schema_migrations#{Base.table_name_suffix}"
     end
 
     def self.create_table
@@ -15,14 +19,13 @@ module ActiveRecord
         connection.create_table(table_name, :id => false) do |t|
           t.column :version, :string, :null => false
         end
-        connection.add_index table_name, :version, :unique => true,
-          :name => "#{Base.table_name_prefix}unique_schema_migrations#{Base.table_name_suffix}"
+        connection.add_index table_name, :version, :unique => true, :name => index_name
       end
     end
 
     def self.drop_table
       if connection.table_exists?(table_name)
-        connection.remove_index table_name, :name => "#{Base.table_name_prefix}unique_schema_migrations#{Base.table_name_suffix}"
+        connection.remove_index table_name, :name => index_name
         connection.drop_table(table_name)
       end
     end


### PR DESCRIPTION
Sorry, so tiny fixes.

first: there are two quote_value methods, instance / class method.
        The class method is public (the instance one is private), so I guess we should the instance one.

second: unique index names to be added / removed are duplicated. 
