### PR TITLE
Expand the caveat about models in migrations in the rails guide.

### DIFF
--- a/guides/source/migrations.md
+++ b/guides/source/migrations.md
@@ -889,6 +889,27 @@ class AddFuzzToProduct < ActiveRecord::Migration
 end
 ```
 
+There are other ways in which the above example could have gone badly.
+
+For example, imagine that Alice creates a migration that selectively
+updates the +description+ field on certain products. She runs the
+migration, commits the code, and then begins working on the next feature,
+which is to add a new column +fuzz+ to the products table.
+
+She creates two migrations for this new feature, one which adds the new
+column, and a second which selectively updates the +fuzz+ column based on
+other product attributes.
+
+These migrations run just fine, but when Bob comes back from his vacation
+and calls `rake db:migrate` to run all the outstanding migrations, he gets a
+subtle bug: The descriptions have defaults, and the +fuzz+ column is present,
+but +fuzz+ is nil on all products.
+
+The solution is again to use +Product.reset_column_information+ before
+referencing the Product model in a migration, ensuring the Active Record's
+knowledge of the table structure is current before manipulating data in those
+records.
+
 Schema Dumping and You
 ----------------------
 


### PR DESCRIPTION
This is an attempt to address issue #6939, where an earlier migration
added a column to the database, and a later migration uses a model and
references that column.

When both migrations were run together with `rake db:migrate` the column
information in memory still referenced the old table structure.

Running the migrations separately fixed this, as a new connection was
then established before referencing the model. Explicitly calling
`reset_column_information` is a more reliable workaround.
