### PR TITLE
Update the documentation for the :autosave option on belongs_to

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1137,7 +1137,9 @@ module ActiveRecord
       # [:autosave]
       #   If true, always save the associated objects or destroy them if marked for destruction,
       #   when saving the parent object. If false, never save or destroy the associated objects.
-      #   By default, only save associated objects that are new records.
+      #   By default, only save associated objects that are new records. This option is implemented as a
+      #   before_save callback. Because callbacks are run in the order they are defined, associated objects
+      #   may need to be explicitly saved in any user-defined before_save callbacks.
       #
       #   Note that <tt>accepts_nested_attributes_for</tt> sets <tt>:autosave</tt> to <tt>true</tt>.
       # [:inverse_of]


### PR DESCRIPTION
I've noticed a caveat with the :autosave option biting people before.
Questions arise about why they must explicitly save an associated object
in their own before_save callbacks. I've updated the documentation as
such to note to users that the :autosave callback occurs before any
user defined callbacks. They must save the associated record themselves
if altering it in their own callbacks.

Signed-off-by: David Celis david@davidcelis.com
