### PR TITLE
Do not eager load models that are observerd

### DIFF
--- a/activerecord/lib/active_record/observer.rb
+++ b/activerecord/lib/active_record/observer.rb
@@ -83,12 +83,9 @@ module ActiveRecord
   # == Loading
   #
   # Observers register themselves in the model class they observe, since it is the class that
-  # notifies them of events when they occur. As a side-effect, when an observer is loaded its
-  # corresponding model class is loaded.
+  # notifies them of events when they occur.
   #
-  # Up to (and including) Rails 2.0.2 observers were instantiated between plugins and
-  # application initializers. Now observers are loaded after application initializers,
-  # so observed models can make use of extensions.
+  # Observers are loaded after application initializers, so observed models can make use of extensions.
   #
   # If by any chance you are using observed models in the initialization you can still
   # load their observers by calling <tt>ModelObserver.instance</tt> before. Observers are
@@ -97,11 +94,6 @@ module ActiveRecord
   class Observer < ActiveModel::Observer
 
     protected
-
-      def observed_classes
-        klasses = super
-        klasses + klasses.map { |klass| klass.descendants }.flatten
-      end
 
       def add_observer!(klass)
         super

--- a/activerecord/test/cases/lifecycle_test.rb
+++ b/activerecord/test/cases/lifecycle_test.rb
@@ -137,7 +137,7 @@ class LifecycleTest < ActiveRecord::TestCase
   def test_auto_observer
     topic_observer = TopicaAuditor.instance
     assert_nil TopicaAuditor.observed_class
-    assert_equal [Topic], TopicaAuditor.observed_classes.to_a
+    assert_equal ([Topic] + Topic.descendants).map(&:name), TopicaAuditor.observed_classes.to_a
 
     topic = Topic.find(1)
     assert_equal topic.title, topic_observer.topic.title
@@ -145,7 +145,7 @@ class LifecycleTest < ActiveRecord::TestCase
 
   def test_inferred_auto_observer
     topic_observer = TopicObserver.instance
-    assert_equal Topic, TopicObserver.observed_class
+    assert_equal "Topic", TopicObserver.observed_class
 
     topic = Topic.find(1)
     assert_equal topic.title, topic_observer.topic.title
@@ -176,7 +176,7 @@ class LifecycleTest < ActiveRecord::TestCase
 
   def test_after_find_can_be_observed_when_its_not_defined_on_the_model
     observer = MinimalisticObserver.instance
-    assert_equal Minimalistic, MinimalisticObserver.observed_class
+    assert_equal "Minimalistic", MinimalisticObserver.observed_class
 
     minimalistic = Minimalistic.find(1)
     assert_equal minimalistic, observer.minimalistic
@@ -184,7 +184,7 @@ class LifecycleTest < ActiveRecord::TestCase
 
   def test_after_find_can_be_observed_when_its_defined_on_the_model
     observer = TopicObserver.instance
-    assert_equal Topic, TopicObserver.observed_class
+    assert_equal "Topic", TopicObserver.observed_class
 
     topic = Topic.find(1)
     assert_equal topic, observer.topic


### PR DESCRIPTION
Observers are one of the few things eager-loading stuff, whereas associations/helpers etc are all lazy.

this pull adds lazy_observe to Observer, so that models can be observed when they are loaded and not when observers are loaded.

in our app: rails c loads 45 AR models,
with lazy_observe this can be reduced to 0

loadtime:
45 -> 14.2s
0 -> 12.0s
- faster application startup
- less memory on startup
- less db queries on startup
- gems can do their monkey-patching safely before models are loaded
- easier to fork+test since less is loaded (spork / spin)
- can boot an application with a database that is in a bad state (before migration / columns missing etc)

this pull is still missing tests, I'll convert the tests from https://github.com/grosser/lazy_observers if there is a consensus that this is wanted feature.
