### PR TITLE
Use *args for cache view helper.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*  `cache` view helper now accepts splat args. `cache current_user,
+    @post` is the same as `cache [current_user, @post]` *Adam Hawkins*
+
 *   Show routes in exception page while debugging a `RoutingError` in development. *Richard Schneeman and Mattt Thompson*
 
 *   Add `ActionController::Flash.add_flash_types` method to allow people to register their own flash types. e.g.:

--- a/actionpack/lib/action_view/helpers/cache_helper.rb
+++ b/actionpack/lib/action_view/helpers/cache_helper.rb
@@ -30,9 +30,10 @@ module ActionView
       #      <%= render :partial => "topics", :collection => @topic_list %>
       #      <i>Topics listed alphabetically</i>
       #    <% end %>
-      def cache(name = {}, options = nil, &block)
+      def cache(*args, &block)
         if controller.perform_caching
-          safe_concat(fragment_for(name, options, &block))
+          options = args.extract_options!
+          safe_concat(fragment_for(args, options, &block))
         else
           yield
         end

--- a/actionpack/lib/action_view/helpers/cache_helper.rb
+++ b/actionpack/lib/action_view/helpers/cache_helper.rb
@@ -32,8 +32,15 @@ module ActionView
       #    <% end %>
       def cache(*args, &block)
         if controller.perform_caching
-          options = args.extract_options!
-          safe_concat(fragment_for(args, options, &block))
+          if args.size > 0
+            options = args.extract_options!
+            safe_concat(fragment_for(args, options, &block))
+          elsif args.size > 0 && args.first.is_a?(Hash)
+            options = args.extract_options!
+            safe_concat(fragment_for(args.first, options, &block))
+          else
+            safe_concat(fragment_for({}, nil, &block))
+          end
         else
           yield
         end


### PR DESCRIPTION
This has always bugged me. Previously you had to do `cache [foo, bar, baz]` if you wanted a composite key. This PR allows you to do `cache foo, bar, baz, :with => { :these => :options }`. 
