### PR TITLE
Do not enforce SSL for Tor Hidden Service .onion URLs

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/ssl.rb
@@ -19,12 +19,17 @@ module ActionDispatch
 
     def call(env)
       request = Request.new(env)
-
+      
       if request.ssl?
         status, headers, body = @app.call(env)
         headers = hsts_headers.merge(headers)
         flag_cookies_as_secure!(headers)
         [status, headers, body]
+      elsif URI(request.url).host =~ /\.onion$/
+        # Do not enforce SSL on Tor hidden services (e.g. if this server hosts content both over SSL and Tor).
+        # CAs cannot verify .onion ownership for SSL (so it provides no auth),and SSL introduces leaks that actually degrade Tor security/privacy.
+        # Cf. https://trac.torproject.org/projects/tor/wiki/doc/TorFAQ?version=1390#WhyisitbettertoprovideahiddenserviceWebsitewithHTTPratherthanHTTPSaccess
+        @app.call(env)
       else
         redirect_to_https(request)
       end

--- a/actionpack/lib/action_dispatch/middleware/ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/ssl.rb
@@ -25,7 +25,7 @@ module ActionDispatch
         headers = hsts_headers.merge(headers)
         flag_cookies_as_secure!(headers)
         [status, headers, body]
-      elsif URI(request.url).host =~ /\.onion$/
+      elsif request.host =~ /\.onion$/
         # Do not enforce SSL on Tor hidden services (e.g. if this server hosts content both over SSL and Tor).
         # CAs cannot verify .onion ownership for SSL (so it provides no auth),and SSL introduces leaks that actually degrade Tor security/privacy.
         # Cf. https://trac.torproject.org/projects/tor/wiki/doc/TorFAQ?version=1390#WhyisitbettertoprovideahiddenserviceWebsitewithHTTPratherthanHTTPSaccess

--- a/actionpack/test/dispatch/ssl_test.rb
+++ b/actionpack/test/dispatch/ssl_test.rb
@@ -31,6 +31,16 @@ class SSLTest < ActionDispatch::IntegrationTest
       response.headers['Location']
   end
 
+  def test_tor_host_does_not_redirect
+    self.app = ActionDispatch::SSL.new(default_app, :host => "example.onion")
+  
+    get "http://example.onion/"
+    assert_response :success
+  
+    get "https://example.onion/"
+    assert_response :success
+  end
+
   def test_hsts_header_by_default
     get "https://example.org/"
     assert_equal "max-age=31536000",


### PR DESCRIPTION
Do not enforce SSL on Tor hidden services (e.g. if this server hosts content both over SSL and Tor).

CAs cannot verify .onion ownership for SSL (so it provides no auth),and SSL introduces leaks that actually degrade Tor security/privacy.

Cf. https://trac.torproject.org/projects/tor/wiki/doc/TorFAQ?version=1390#WhyisitbettertoprovideahiddenserviceWebsitewithHTTPratherthanHTTPSaccess
