### PR TITLE
Model.select takes a variable list of arguments

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -146,7 +146,7 @@ module ActiveRecord
     #
     # The argument to the method can also be an array of fields.
     #
-    #   >> Model.select([:field, :other_field, :and_one_more])
+    #   >> Model.select(:field, :other_field, :and_one_more)
     #   => [#<Model field: "value", other_field: "value", and_one_more: "value">]
     #
     # Accessing attributes of an object that do not have fields retrieved by a select
@@ -154,17 +154,18 @@ module ActiveRecord
     #
     #   >> Model.select(:field).first.other_field
     #   => ActiveModel::MissingAttributeError: missing attribute: other_field
-    def select(value = Proc.new)
+    def select(*fields, &block)
       if block_given?
-        to_a.select { |*block_args| value.call(*block_args) }
+        to_a.select { |*block_args| block.call(*block_args) }
       else
-        spawn.select!(value)
+        raise ArgumentError, 'Call this with at least one field' if fields.empty?
+        clone.select!(*fields)
       end
     end
 
     # Like #select, but modifies relation in place.
-    def select!(value)
-      self.select_values += Array.wrap(value)
+    def select!(*fields)
+      self.select_values += fields.flatten
       self
     end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -656,6 +656,13 @@ class RelationTest < ActiveRecord::TestCase
     assert_raises(ActiveRecord::ActiveRecordError) { Author.limit(10).delete_all }
   end
 
+  def test_select_takes_a_variable_list_of_args
+    assert_nothing_raised do
+      Developer.select(:name)
+      Developer.select(:name, :salary)
+    end
+  end
+
   def test_select_argument_error
     assert_raises(ArgumentError) { Developer.select }
   end


### PR DESCRIPTION
This is a cleaner version of #6916 and #6162

This is a change from the behavior of passing in an Array of args.
  This solution attempts to answer issue #3165
