### PR TITLE
Update documentation for Rails::Application#env_config

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -157,9 +157,12 @@ module Rails
     # Rails.application.env_config stores some of the Rails initial environment parameters.
     # Currently stores:
     #
-    #   * action_dispatch.parameter_filter" => config.filter_parameters,
-    #   * action_dispatch.secret_token"     => config.secret_token,
-    #   * action_dispatch.show_exceptions"  => config.action_dispatch.show_exceptions
+    #   * "action_dispatch.parameter_filter"         => config.filter_parameters,
+    #   * "action_dispatch.secret_token"             => config.secret_token,
+    #   * "action_dispatch.show_exceptions"          => config.action_dispatch.show_exceptions,
+    #   * "action_dispatch.show_detailed_exceptions" => config.consider_all_requests_local,
+    #   * "action_dispatch.logger"                   => Rails.logger,
+    #   * "action_dispatch.backtrace_cleaner"        => Rails.backtrace_cleaner
     #
     # These parameters will be used by middlewares and engines to configure themselves.
     #


### PR DESCRIPTION
The documentation for Rails::Application#env_config was incorrect and missing some information. This pull request fixes it.
