### PR TITLE
Use database value for uniqueness validation scope

### DIFF
--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -26,7 +26,7 @@ module ActiveRecord
         relation = relation.and(table[finder_class.primary_key.to_sym].not_eq(record.send(:id))) if record.persisted?
 
         Array(options[:scope]).each do |scope_item|
-          scope_value = record.send(scope_item)
+          scope_value = record.read_attribute(scope_item)
           reflection = record.class.reflect_on_association(scope_item)
           if reflection
             scope_value = record.send(reflection.foreign_key)

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -22,6 +22,14 @@ end
 class Thaumaturgist < IneptWizard
 end
 
+class ReplyTitle; end
+
+class ReplyWithTitleObject < Reply
+  validates_uniqueness_of :content, :scope => :title
+
+  def title; ReplyTitle.new; end
+end
+
 class UniquenessValidationTest < ActiveRecord::TestCase
   fixtures :topics, 'warehouse-things', :developers
 
@@ -101,6 +109,14 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     assert r1.valid?, "Saving r1"
 
     r2 = t.replies.create "title" => "r2", "content" => "hello world"
+    assert !r2.valid?, "Saving r2 first time"
+  end
+
+  def test_validate_uniqueness_with_composed_attribute_scope
+    r1 = ReplyWithTitleObject.create "title" => "r1", "content" => "hello world"
+    assert r1.valid?, "Saving r1"
+
+    r2 = ReplyWithTitleObject.create "title" => "r1", "content" => "hello world"
     assert !r2.valid?, "Saving r2 first time"
   end
 


### PR DESCRIPTION
Fixes issue an with overrding ActiveRecord reader methods with a composed object and using that attribute as the scope of a validates_uniqueness_of validation. This changes the validation to use the attribute's database value as opposed to the return value of the method call. 

From the [original discussion](https://groups.google.com/forum/?fromgroups#!topic/rubyonrails-core/Z-k4zyW7XvI):

The following code will raise "TypeError: Cannot visit CatBreed" when trying to create a new Cat:

``` ruby
class Cat < ActiveRecord::Base
  validates :name, :uniqueness => { :scope => [:breed] }

  def breed
    CatBreed.new(super)
  end
end

class CatBreed
  def initialize(breed)
    @breed = breed
  end

  def to_s
    @breed
  end
end
```
