### PR TITLE
Fix class_eval without __FILE__ and __LINE__.

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -333,7 +333,7 @@ module ActionDispatch
           end
         end
 
-        MountedHelpers.class_eval <<-RUBY
+        MountedHelpers.class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
           def #{name}
             @#{name} ||= _#{name}
           end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1467,7 +1467,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_defining_has_many_association_with_delete_all_dependency_lazily_evaluates_target_class
     ActiveRecord::Reflection::AssociationReflection.any_instance.expects(:class_name).never
-    class_eval <<-EOF
+    class_eval(<<-EOF, __FILE__, __LINE__ + 1)
       class DeleteAllModel < ActiveRecord::Base
         has_many :nonentities, :dependent => :delete_all
       end
@@ -1476,7 +1476,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_defining_has_many_association_with_nullify_dependency_lazily_evaluates_target_class
     ActiveRecord::Reflection::AssociationReflection.any_instance.expects(:class_name).never
-    class_eval <<-EOF
+    class_eval(<<-EOF, __FILE__, __LINE__ + 1)
       class NullifyModel < ActiveRecord::Base
         has_many :nonentities, :dependent => :nullify
       end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -816,7 +816,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   end
 
   def privatize(method_signature)
-    @target.class_eval <<-private_method
+    @target.class_eval(<<-private_method, __FILE__, __LINE__ + 1)
       private
       def #{method_signature}
         "I'm private"

--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -110,7 +110,7 @@ class MultibyteCharsUTF8BehaviourTest < ActiveSupport::TestCase
   end
 
   %w{capitalize downcase lstrip reverse rstrip swapcase upcase}.each do |method|
-    class_eval(<<-EOTESTS)
+    class_eval(<<-EOTESTS, __FILE__, __LINE__ + 1)
       def test_#{method}_bang_should_return_self_when_modifying_wrapped_string
         chars = ' él piDió Un bUen café '
         assert_equal chars.object_id, chars.send("#{method}!").object_id

--- a/railties/test/generators_test.rb
+++ b/railties/test/generators_test.rb
@@ -167,7 +167,7 @@ class GeneratorsTest < Rails::Generators::TestCase
   def test_developer_options_are_overwriten_by_user_options
     Rails::Generators.options[:with_options] = { :generate => false }
 
-    self.class.class_eval <<-end_eval
+    self.class.class_eval(<<-end_eval, __FILE__, __LINE__ + 1)
       class WithOptionsGenerator < Rails::Generators::Base
         class_option :generate, :default => true
       end


### PR DESCRIPTION
I checked rails source tree with the following command.

```
$ find . -name "*.rb" -print | xargs grep class_eval | grep -v __FILE__ | grep "<<"
```

I found class_eval without file/line, so I added them.
