### PR TITLE
Log query plan when we use count_by_sql method.

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -62,8 +62,10 @@ module ActiveRecord
     #
     #   Product.count_by_sql "SELECT COUNT(*) FROM sales s, customers c WHERE s.customer_id = c.id"
     def count_by_sql(sql)
-      sql = sanitize_conditions(sql)
-      connection.select_value(sql, "#{name} Count").to_i
+      logging_query_plan do
+        sql = sanitize_conditions(sql)
+        connection.select_value(sql, "#{name} Count").to_i
+      end
     end
   end
 end

--- a/activerecord/test/cases/explain_test.rb
+++ b/activerecord/test/cases/explain_test.rb
@@ -68,6 +68,16 @@ if ActiveRecord::Base.connection.supports_explain?
       assert_equal [cars(:honda)], result
     end
 
+    def test_logging_query_plan_when_counting_by_sql
+      base.logger.expects(:warn).with do |message|
+        message.starts_with?('EXPLAIN for:')
+      end
+
+      with_threshold(0) do
+        Car.count_by_sql "SELECT COUNT(*) FROM cars WHERE name = 'honda'"
+      end
+    end
+
     def test_exec_explain_with_no_binds
       sqls    = %w(foo bar)
       binds   = [[], []]


### PR DESCRIPTION
In the `find_by_sql` method, we use `logging_query_plan` method.
But In the `count_by_sql` method, we don't use one.
