### PR TITLE
AR::Integration must be included after AM::Conversion

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -697,9 +697,9 @@ module ActiveRecord #:nodoc:
     include Scoping
     extend DynamicMatchers
     include Sanitization
-    include Integration
     include AttributeAssignment
     include ActiveModel::Conversion
+    include Integration
     include Validations
     extend CounterCache
     include Locking::Optimistic, Locking::Pessimistic

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1911,6 +1911,12 @@ class BasicsTest < ActiveRecord::TestCase
     assert_kind_of String, Client.find(:first).to_param
   end
 
+  def test_to_param_returns_id_even_if_not_persisted
+    client = Client.new
+    client.id = 1
+    assert_equal "1", client.to_param
+  end
+
   def test_inspect_class
     assert_equal 'ActiveRecord::Base', ActiveRecord::Base.inspect
     assert_equal 'LoosePerson(abstract)', LoosePerson.inspect


### PR DESCRIPTION
Integration's definition of #to_param must override Conversion's. Otherwise,
there is a regression from 3.1 in the behavior of a non-persisted AR::Base
instance which nevertheless has an id.

On master, a similar change is needed -- or we can remove AR::Integration#to_param
and accept the behavioral change, or we can remove AR::Integration#to_param and
change AM::Conversion#to_param to have the AR::Integration behavior.
