### PR TITLE
add lazy look up in abstract controller's translate method

### DIFF
--- a/actionpack/lib/abstract_controller/translation.rb
+++ b/actionpack/lib/abstract_controller/translation.rb
@@ -1,6 +1,12 @@
 module AbstractController
   module Translation
     def translate(*args)
+      key = args.first
+      if key.is_a?(String) && (key[0] == '.')
+        key = "#{ controller_path.gsub('/', '.') }.#{ action_name }#{ key }"
+        args[0] = key
+      end
+
       I18n.translate(*args)
     end
     alias :t :translate

--- a/actionpack/test/abstract/translation_test.rb
+++ b/actionpack/test/abstract/translation_test.rb
@@ -23,4 +23,17 @@ class TranslationControllerTest < ActiveSupport::TestCase
   def test_action_controller_base_responds_to_l
     assert_respond_to @controller, :l
   end
+
+  def test_lazy_lookup
+    expected = 'bar'
+    @controller.stubs(:action_name => :index)
+    I18n.stubs(:translate).with('action_controller.base.index.foo').returns(expected)
+    assert_equal expected, @controller.t('.foo')
+  end
+
+  def test_default_translation
+    key, expected = 'one.two' 'bar'
+    I18n.stubs(:translate).with(key).returns(expected)
+    assert_equal expected, @controller.t(key)
+  end
 end


### PR DESCRIPTION
As we know in views rails provides a lazy lookup to translate the text. This facilitates reducing code size. But I've always seemed very strange that such a functional is not in the controllers and mailers. In every new project I had a similar method. It would be nice if this was part of the core. So 

``` ruby

class ProductController < ApplicationController

  def create
    if @product.save
      redirect_to root_path, :notice => t('.saved')
    else
      flash[:error] = t('.failed')
    end
  end

end

# will equal to 

class ProductController < ApplicationController

  def create
    if @product.save
      redirect_to root_path, :notice => t('product.create.saved')
    else
      flash[:error] = t('product.create.failed')
    end
  end

end
```
