### PR TITLE
Enable to enforce Postgresql Adapter query search_path from database every time.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -19,7 +19,7 @@ module ActiveRecord
       # Forward any unused config params to PGconn.connect.
       [:statement_limit, :encoding, :min_messages, :schema_search_path,
        :schema_order, :adapter, :pool, :checkout_timeout, :template,
-       :reaping_frequency, :insert_returning].each do |key|
+       :reaping_frequency, :insert_returning, :always_query_search_path].each do |key|
         conn_params.delete key
       end
       conn_params.delete_if { |k,v| v.nil? }
@@ -439,6 +439,8 @@ module ActiveRecord
         connection_parameters.delete :prepared_statements
 
         @connection_parameters, @config = connection_parameters, config
+
+        @always_query_search_path = config.fetch('always_query_search_path', false)
 
         # @local_tz is initialized as nil to avoid warnings when connect tries to use it
         @local_tz = nil
@@ -1113,7 +1115,23 @@ module ActiveRecord
 
       # Returns the active schema search path.
       def schema_search_path
-        @schema_search_path ||= query('SHOW search_path', 'SCHEMA')[0][0]
+        if @always_query_search_path
+          query('SHOW search_path', 'SCHEMA')[0][0]
+        else
+          @schema_search_path ||= query('SHOW search_path', 'SCHEMA')[0][0]
+        end
+      end
+
+      # Set the always_query_search_path to true to enforce adapter query current
+      # search path from database rather than use the cached value.
+      # Used when you need to use raw SQL query to set search_path
+      def always_query_search_path=(value)
+        @always_query_search_path = value
+      end
+
+      # Returns whether adapter will query search_path from database directly.
+      def always_query_search_path
+        @always_query_search_path
       end
 
       # Returns the current client message level.

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -318,6 +318,19 @@ class SchemaTest < ActiveRecord::TestCase
     @connection.schema_search_path = SCHEMA2_NAME
     assert_equal 1, Thing5.count
   end
+  
+  def test_schema_search_path_after_set_schema_with_sql
+    connection = ActiveRecord::Base.postgresql_connection(ActiveRecord::Base.configurations['arunit'].merge('always_query_search_path' => true))
+
+    connection.execute "SET search_path TO #{SCHEMA_NAME};"
+    assert_equal SCHEMA_NAME, connection.schema_search_path
+
+    connection.execute "SET search_path TO #{SCHEMA2_NAME};"
+    assert_equal SCHEMA2_NAME, connection.schema_search_path
+
+    connection.execute "SET search_path TO #{SCHEMA_NAME};"
+    assert_equal SCHEMA_NAME, connection.schema_search_path
+  end
 
   def test_schema_exists?
     {
@@ -329,7 +342,7 @@ class SchemaTest < ActiveRecord::TestCase
       assert_equal expect, @connection.schema_exists?(given)
     end
   end
-
+  
   private
     def columns(table_name)
       @connection.send(:column_definitions, table_name).map do |name, type, default|


### PR DESCRIPTION
Add always_query_search_path attribute to PostgresqlAdapter.
By setting the attribute to true to enforce adapter query search_path from database every time rather than return the cached value.
