### PR TITLE
Don't use default separator in tagged logger

### DIFF
--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -31,7 +31,7 @@ module ActiveSupport
       def tags_text
         tags = current_tags
         if tags.any?
-          tags.collect { |tag| "[#{tag}] " }.join
+          tags.collect { |tag| "[#{tag}] " }.join('')
         end
       end
     end

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -10,8 +10,13 @@ class TaggedLoggingTest < ActiveSupport::TestCase
   end
 
   setup do
-    @output = StringIO.new
-    @logger = ActiveSupport::TaggedLogging.new(MyLogger.new(@output))
+    @output     = StringIO.new
+    @logger     = ActiveSupport::TaggedLogging.new(MyLogger.new(@output))
+    @separator  = $,
+  end
+
+  after do
+    $, = @separator
   end
 
   test "tagged once" do
@@ -68,5 +73,11 @@ class TaggedLoggingTest < ActiveSupport::TestCase
     end
 
     assert_equal "[BCX] [Jason] Funky time\n[BCX] Junky time!\n", @output.string
+  end
+
+  test "using the correct separator" do
+    $, = "_"
+    @logger.tagged("BCX", "BDX") { @logger.info "Funky time" }
+    assert_equal "[BCX] [BDX] Funky time\n", @output.string
   end
 end


### PR DESCRIPTION
When the default separator is set logger will create incorrect output

``` ruby
$, = "_"
@logger.tagged("BCX", "BDX") { @logger.info "Funky time" }
# => [BCX] _[BDX] Funky time
```
