### PR TITLE
Add new irregular inflection criterion -> criteria

### DIFF
--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -59,6 +59,7 @@ module ActiveSupport
     inflect.irregular('move', 'moves')
     inflect.irregular('cow', 'kine')
     inflect.irregular('zombie', 'zombies')
+    inflect.irregular('criterion', 'criteria')
 
     inflect.uncountable(%w(equipment information rice money species series fish sheep jeans police))
   end


### PR DESCRIPTION
According to http://dictionary.reference.com/browse/criterion the
correct singular form of 'criteria' is 'criterion' and not 'criterium'
which is being returned by ActiveSupport right now.
