### PR TITLE
fix sqlite3 column default containing newline character

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -380,9 +380,9 @@ module ActiveRecord
           case field["dflt_value"]
           when /^null$/i
             field["dflt_value"] = nil
-          when /^'(.*)'$/
+          when /\A'(.*)'\z/m
             field["dflt_value"] = $1.gsub("''", "'")
-          when /^"(.*)"$/
+          when /\A"(.*)"\z/m
             field["dflt_value"] = $1.gsub('""', '"')
           end
 

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -272,6 +272,19 @@ module ActiveRecord
         }
         assert_equal 10, column.default
       end
+      
+      def test_column_with_newline_default
+        @conn.execute <<-eosql
+          CREATE TABLE column_with_newline_default (
+            id integer PRIMARY KEY AUTOINCREMENT,
+            body string default '\nRegards\nMatt'
+          )
+        eosql
+        column = @conn.columns('column_with_newline_default').find { |x|
+          x.name == 'body'
+        }
+        assert_equal "\nRegards\nMatt", column.default
+      end
 
       def test_columns_with_not_null
         @conn.execute <<-eosql


### PR DESCRIPTION
Due to incorrect parsing of sqlite3 string column default containing newline character, any string column default containing newline character, e.g. <code>"\n"</code> or <code>"\nRegards\nMatt"</code> is parsed incorrectly by sqlite3 adapter and as a result contains enclosing quote characters ('), e.g. <code>"'\n'"</code> or <code>"'\nRegards\nMatt'"</code>.

The regular expressions stripping column defaults out of enclosing quote/double quote characters did not take into consideration column defaults containing newline characters. More specifically <code>/^'(.*)'$/</code> regular expression would not match <code>"'\n'"</code> since dot (.) in this expression is intended to match any character <b>except for newline</b> character and hence column default was not stripped correctly out of enclosing quotes returned by database when querying for table structure.
