### PR TITLE
[Very experimental] AM::MassAssignmentSecurity: add ability to mark Hash as safe

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `AM::MassAssignmentSecurity`: add ability to mark Hash as `assignment_safe`
+
 *   Changed `AM::Serializers::JSON.include_root_in_json' default value to false.
     Now, AM Serializers and AR objects have the same default behaviour. Fixes #6578.
 

--- a/activemodel/lib/active_model/mass_assignment_security.rb
+++ b/activemodel/lib/active_model/mass_assignment_security.rb
@@ -2,6 +2,7 @@ require 'active_support/core_ext/class/attribute'
 require 'active_support/core_ext/string/inflections'
 require 'active_model/mass_assignment_security/permission_set'
 require 'active_model/mass_assignment_security/sanitizer'
+require 'active_model/mass_assignment_security/assignment_safety'
 
 module ActiveModel
   # = Active Model Mass-Assignment Security
@@ -229,6 +230,7 @@ module ActiveModel
   protected
 
     def sanitize_for_mass_assignment(attributes, role = nil)
+      return attributes if attributes.assignment_safe?
       _mass_assignment_sanitizer.sanitize(self.class, attributes, mass_assignment_authorizer(role))
     end
 

--- a/activemodel/lib/active_model/mass_assignment_security/assignment_safety.rb
+++ b/activemodel/lib/active_model/mass_assignment_security/assignment_safety.rb
@@ -1,0 +1,42 @@
+class Hash
+
+  def assignment_safe?
+    false
+  end
+
+  def assignment_safe
+    ActiveModel::MassAssignmentSecurity::SafeHash.new.replace(self)
+  end
+end
+
+
+class ActiveModel::MassAssignmentSecurity::SafeHash < Hash
+
+  def initialize(*)
+    super
+    @assignment_safe = true
+  end
+
+  def assignment_safe?
+    @assignment_safe
+  end
+
+  def assignment_safe=(value)
+    @assignment_safe = value
+  end
+
+  def merge(other)
+    result = super
+    result.assignment_safe = false unless other.assignment_safe?
+    result
+  end
+
+  def merge!(other)
+    super
+    @assignment_safe = false unless other.assignment_safe?
+    self
+  end
+
+  alias update merge!
+
+end

--- a/activemodel/test/cases/mass_assignment_security/assignment_safety_test.rb
+++ b/activemodel/test/cases/mass_assignment_security/assignment_safety_test.rb
@@ -1,0 +1,51 @@
+
+class AssignmentSafetyTest < ActiveModel::TestCase
+
+  def test_assignment_safe_hash
+    user = User.new
+    attributes = { "name" => "John Smith", "email" => "john@smith.com", "admin" => true }.assignment_safe
+    assert_equal attributes, user.sanitize_for_mass_assignment(attributes)
+  end
+
+  def test_hash_assignment_safe_property
+    assert_safe(safe_hash)
+    assert_not_safe(unsafe_hash)
+    attributes = {}
+    assert_not_equal attributes.object_id,  attributes.assignment_safe
+  end
+
+
+  def test_merge
+
+    assert_not_safe(safe_hash.merge(unsafe_hash))
+    assert_not_safe(safe_hash.merge!(unsafe_hash))
+    assert_not_safe({}.merge(safe_hash))
+    assert_not_safe({}.merge!(safe_hash))
+
+    assert_safe(safe_hash.merge(safe_hash))
+    assert_safe(safe_hash.merge!(safe_hash))
+
+  end
+
+  def test_update
+    assert_not_safe(safe_hash.update(unsafe_hash))
+    assert_not_safe({}.update(safe_hash))
+  end
+
+  protected 
+
+  def safe_hash
+    {}.assignment_safe
+  end
+
+  def unsafe_hash
+    {}
+  end
+
+  def assert_safe(hash)
+    assert hash.assignment_safe?
+  end
+  def assert_not_safe(hash)
+    assert !hash.assignment_safe?
+  end
+end


### PR DESCRIPTION
This patch adds the ability to mark `Hash` as as mass-assignment safe:

``` ruby
User.attr_protected :admin

# In rake task:
User.new({:admin => true, :email => "a@b.com"}.assignment_safe) 

# While in controller
User.new(params[:user]) # still secure
```
