### PR TITLE
Corrected small bug that puts the message in place of the progname

### DIFF
--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -39,8 +39,8 @@ module ActiveSupport
 
     %w( fatal error warn info debug unknown ).each do |severity|
       eval <<-EOM, nil, __FILE__, __LINE__ + 1
-        def #{severity}(progname = nil, &block)
-          add(Logger::#{severity.upcase}, nil, progname, &block)
+        def #{severity}(message = nil, progname = nil, &block)
+          add(Logger::#{severity.upcase}, message, progname, &block)
         end
       EOM
     end


### PR DESCRIPTION
TaggedLogging places the message part in the progname. This does not cause an issue with the standard Logger. However, with Loggers like Syslogger the end message looks like:

My message: [0123] My message

This is a simple fixe that solves the issue.
