### PR TITLE
revert Default timestamps to non-null

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -271,7 +271,7 @@ module ActiveRecord
       # Appends <tt>:datetime</tt> columns <tt>:created_at</tt> and
       # <tt>:updated_at</tt> to the table.
       def timestamps(*args)
-        options = { :null => false }.merge(args.extract_options!)
+        options = args.extract_options!
         column(:created_at, :datetime, options)
         column(:updated_at, :datetime, options)
       end

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -141,8 +141,8 @@ module ActiveRecord
         created_at_column = created_columns.detect {|c| c.name == 'created_at' }
         updated_at_column = created_columns.detect {|c| c.name == 'updated_at' }
 
-        assert !created_at_column.null
-        assert !updated_at_column.null
+        assert created_at_column.null
+        assert updated_at_column.null
       end
 
       def test_create_table_with_timestamps_should_create_datetime_columns_with_options

--- a/activerecord/test/cases/migration/column_attributes_test.rb
+++ b/activerecord/test/cases/migration/column_attributes_test.rb
@@ -54,13 +54,13 @@ module ActiveRecord
 
         # Do a manual insertion
         if current_adapter?(:OracleAdapter)
-          connection.execute "insert into test_models (id, wealth, created_at, updated_at) values (people_seq.nextval, 12345678901234567890.0123456789, sysdate, sysdate)"
+          connection.execute "insert into test_models (id, wealth) values (people_seq.nextval, 12345678901234567890.0123456789)"
         elsif current_adapter?(:OpenBaseAdapter) || (current_adapter?(:MysqlAdapter) && Mysql.client_version < 50003) #before mysql 5.0.3 decimals stored as strings
-          connection.execute "insert into test_models (wealth, created_at, updated_at) values ('12345678901234567890.0123456789', 0, 0)"
+          connection.execute "insert into test_models (wealth) values ('12345678901234567890.0123456789')"
         elsif current_adapter?(:PostgreSQLAdapter)
-          connection.execute "insert into test_models (wealth, created_at, updated_at) values (12345678901234567890.0123456789, now(), now())"
+          connection.execute "insert into test_models (wealth) values (12345678901234567890.0123456789)"
         else
-          connection.execute "insert into test_models (wealth, created_at, updated_at) values (12345678901234567890.0123456789, 0, 0)"
+          connection.execute "insert into test_models (wealth) values (12345678901234567890.0123456789)"
         end
 
         # SELECT


### PR DESCRIPTION
Commit 3dbedd2 added NOT NULL constraints to timestamps.
Commit fcef728 started to revert this, but was incomplete.
With this commit, 3dbedd2 should be fully reverted and
timestamps will no longer default to NOT NULL.
