### PR TITLE
Add fkey attributes to `join_table` migration generator

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -204,11 +204,11 @@ module ActiveRecord
         join_table_name = find_join_table_name(table_1, table_2, options)
 
         column_options = options.delete(:column_options) || {}
-        column_options.reverse_merge!({:null => false})
+        column_options.reverse_merge!(null: false)
 
-        t1_column, t2_column = [table_1, table_2].map{ |t| "#{t.to_s.singularize}_id" }
+        t1_column, t2_column = [table_1, table_2].map{ |t| t.to_s.singularize.foreign_key }
 
-        create_table(join_table_name, options.merge!(:id => false)) do |td|
+        create_table(join_table_name, options.merge!(id: false)) do |td|
           td.integer t1_column, column_options
           td.integer t2_column, column_options
           yield td if block_given?

--- a/activerecord/lib/active_record/migration/join_table.rb
+++ b/activerecord/lib/active_record/migration/join_table.rb
@@ -8,7 +8,7 @@ module ActiveRecord
       end
 
       def join_table_name(table_1, table_2)
-        [table_1, table_2].sort.join("_").to_sym
+        [table_1, table_2].sort.join("_")
       end
     end
   end

--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -21,7 +21,7 @@ module ActiveRecord
         when /join_table/
           if attributes.length == 2
             @migration_action = 'join'
-            @join_tables      = attributes.map(&:name)
+            @join_tables      = attributes.map(&:plural_name)
 
             set_index_names
           end
@@ -30,8 +30,16 @@ module ActiveRecord
 
       def set_index_names
         attributes.each_with_index do |attr, i|
-          attr.index_name = [attr, attributes[i - 1]].map{ |a| :"#{a.name.singularize}_id"}
+          attr.index_name = [attr, attributes[i - 1]].map{ |a| index_name_for(a) }
         end
+      end
+
+      def index_name_for(attribute)
+        if attribute.foreign_key?
+          attribute.name
+        else
+          attribute.name.singularize.foreign_key
+        end.to_sym
       end
     end
   end

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -90,8 +90,12 @@ module Rails
         end
       end
 
+      def plural_name
+        name.sub(/_id$/, '').pluralize
+      end
+
       def human_name
-        name.to_s.humanize
+        name.humanize
       end
 
       def index_name
@@ -100,6 +104,10 @@ module Rails
         else
           name
         end
+      end
+
+      def foreign_key?
+        !!(name =~ /_id$/)
       end
 
       def reference?

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -169,7 +169,7 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
 
   def test_create_join_table_migration
     migration = "add_media_join_table"
-    run_generator [migration, "artists", "musics:uniq"]
+    run_generator [migration, "artist_id", "musics:uniq"]
 
     assert_migration "db/migrate/#{migration}.rb" do |content|
       assert_method :change, content do |up|


### PR DESCRIPTION
In continuation of PR #7028
