### PR TITLE
Clean up Sweeper controller accessor when an Error is raised

### DIFF
--- a/actionpack/lib/action_controller/caching/sweeping.rb
+++ b/actionpack/lib/action_controller/caching/sweeping.rb
@@ -68,14 +68,14 @@ module ActionController #:nodoc:
         def after(controller)
           self.controller = controller
           callback(:after) if controller.perform_caching
-          # Clean up, so that the controller can be collected after this request
-          self.controller = nil
         end
 
         def around(controller)
           before(controller)
           yield
           after(controller)
+        ensure
+          clean_up
         end
 
         protected
@@ -90,6 +90,11 @@ module ActionController #:nodoc:
           end
 
         private
+          def clean_up
+            # Clean up, so that the controller can be collected after this request
+            self.controller = nil
+          end
+
           def callback(timing)
             controller_callback_method_name = "#{timing}_#{controller.controller_name.underscore}"
             action_callback_method_name     = "#{controller_callback_method_name}_#{controller.action_name}"

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -505,6 +505,10 @@ class FilterTest < ActionController::TestCase
     def show
       render :text => 'hello world'
     end
+
+    def error
+      raise StandardError.new
+    end
   end
 
   class ImplicitActionsController < ActionController::Base
@@ -532,6 +536,13 @@ class FilterTest < ActionController::TestCase
   def test_sweeper_should_not_block_rendering
     response = test_process(SweeperTestController)
     assert_equal 'hello world', response.body
+  end
+
+  def test_sweeper_should_clean_up_if_exception_is_raised
+    assert_raise StandardError do
+      test_process(SweeperTestController, 'error')
+    end
+    assert_nil AppSweeper.instance.controller
   end
 
   def test_before_method_of_sweeper_should_always_return_true


### PR DESCRIPTION
There are a couple of reasons why this is beneficial:
- the controller accessor will be able to be garbage collected
- if the sweeper has logic that is dependent upon the controller accessor, it will behave properly when run outside of the request process (i.e. via a queue job)
