### PR TITLE
Clarification to doc of ActionController::MimeResponse.respond_to

### DIFF
--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -182,7 +182,8 @@ module ActionController #:nodoc:
     #     end
     #   end
     #
-    # Be sure to check respond_with and respond_to documentation for more examples.
+    # Be sure to check respond_with and
+    # ActionController::MimeResponds.respond_to documentation for more examples.
     def respond_to(*mimes, &block)
       raise ArgumentError, "respond_to takes either types or a block, never both" if mimes.any? && block_given?
 


### PR DESCRIPTION
- #respond_to's documentation refer to .respond_to, but it was
  written as just <respond_to>. Added class name for clarification.
