### PR TITLE
Bumping mocha!

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ end
 gem 'uglifier', '>= 1.0.3', :require => false
 
 gem 'rake', '>= 0.8.7'
-gem 'mocha', '>= 0.9.8'
+gem 'mocha', '>= 0.12.1'
 
 group :doc do
   # The current sdoc cannot generate GitHub links due


### PR DESCRIPTION
Reason:- 0.12.0 introduced a bug where you got a exception
which is now in 0.12.1 is a warning only!
