### PR TITLE
Documentation fix: Note that you can also pass a full url to assert_recognizes and assert_generates

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -110,6 +110,9 @@ module ActionDispatch
       #
       #  # Tests a route with a HTTP method
       #  assert_routing({ :method => 'put', :path => '/product/321' }, { :controller => "product", :action => "update", :id => "321" })
+      #
+      #  # Path can be a full url (with ://) to test routing based on constrains such as subdomain or host
+      #  assert_routing 'http://api.example.com/', :controller => 'api', :action => 'index'
       def assert_routing(path, options, defaults={}, extras={}, message=nil)
         assert_recognizes(options, path, extras, message)
 


### PR DESCRIPTION
Right now the documentation doesn't mention that the path argument for assert_recognizes and assert_generates can be a full url. This has been possible since this pull request was accepted two years ago: https://github.com/rails/rails/commit/7c9bf45b0dd7ad7a1d99a14566bfaeadc77b4665

Let me know if I can improve anything in this PR.
