### PR TITLE
Allowing customization of id param in resources

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -857,11 +857,16 @@ module ActionDispatch
       #
       # This allows any character other than a slash as part of your +:id+.
       #
+      # You may also wish to change the key for the identifier that comes
+      # through in the params hash:
+      #
+      #   resources :users, :id_as => :social_network_key
+      #
       module Resources
         # CANONICAL_ACTIONS holds all actions that does not need a prefix or
         # a path appended since they fit properly in their scope level.
         VALID_ON_OPTIONS  = [:new, :collection, :member]
-        RESOURCE_OPTIONS  = [:as, :controller, :path, :only, :except]
+        RESOURCE_OPTIONS  = [:as, :controller, :path, :only, :except, :id_as]
         CANONICAL_ACTIONS = %w(index create new show update destroy)
 
         class Resource #:nodoc:
@@ -872,6 +877,7 @@ module ActionDispatch
             @path       = (options[:path] || @name).to_s
             @controller = (options[:controller] || @name).to_s
             @as         = options[:as]
+            @id_as      = options[:id_as]
             @options    = options
           end
 
@@ -916,7 +922,7 @@ module ActionDispatch
           alias :collection_scope :path
 
           def member_scope
-            "#{path}/:id"
+            "#{path}/:#{@id_as || 'id'}"
           end
 
           def new_scope(new_path)

--- a/actionpack/test/controller/resources_test.rb
+++ b/actionpack/test/controller/resources_test.rb
@@ -106,6 +106,13 @@ class ResourcesTest < ActionController::TestCase
     end
   end
 
+  def test_with_id_as
+    expected_options = {:controller => 'messages', :action => 'show', :other_id => '1'}
+    with_restful_routing :messages, :id_as => :other_id do
+      assert_recognizes(expected_options, :path => 'messages/1', :method => :get)
+    end
+  end
+
   def test_irregular_id_with_no_constraints_should_raise_error
     expected_options = {:controller => 'messages', :action => 'show', :id => '1.1.1'}
 


### PR DESCRIPTION
When using resources in your routes, you can customize the key that is
used in the params hash as the id for the resource.

This can be useful if you have to expose an API to a third party
service that has domain specific language concerning identification.
