### PR TITLE
Make activemodel tests runnable without -Itest and from non-root folders

### DIFF
--- a/activemodel/Rakefile
+++ b/activemodel/Rakefile
@@ -5,7 +5,6 @@ require 'rake/testtask'
 task :default => :test
 
 Rake::TestTask.new do |t|
-  t.libs << "test"
   t.test_files = Dir.glob("#{dir}/test/cases/**/*_test.rb").sort
   t.warning = true
   t.verbose = true
@@ -15,7 +14,7 @@ namespace :test do
   task :isolated do
     ruby = File.join(*RbConfig::CONFIG.values_at('bindir', 'RUBY_INSTALL_NAME'))
     Dir.glob("#{dir}/test/**/*_test.rb").all? do |file|
-      sh(ruby, '-w', "-I#{dir}/lib", "-I#{dir}/test", file)
+      sh(ruby, '-w', file)
     end or raise "Failures"
   end
 end

--- a/activemodel/test/cases/attribute_methods_test.rb
+++ b/activemodel/test/cases/attribute_methods_test.rb
@@ -1,4 +1,4 @@
-require 'cases/helper'
+require_relative '../cases/helper'
 
 class ModelWithAttributes
   include ActiveModel::AttributeMethods

--- a/activemodel/test/cases/callbacks_test.rb
+++ b/activemodel/test/cases/callbacks_test.rb
@@ -1,4 +1,4 @@
-require "cases/helper"
+require_relative '../cases/helper'
 
 class CallbacksTest < ActiveModel::TestCase
 

--- a/activemodel/test/cases/conversion_test.rb
+++ b/activemodel/test/cases/conversion_test.rb
@@ -1,4 +1,4 @@
-require 'cases/helper'
+require_relative '../cases/helper'
 require 'models/contact'
 require 'models/helicopter'
 

--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -1,4 +1,4 @@
-require "cases/helper"
+require_relative '../cases/helper'
 
 class DirtyTest < ActiveModel::TestCase
   class DirtyModel

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -1,4 +1,4 @@
-require "cases/helper"
+require_relative '../cases/helper'
 
 class ErrorsTest < ActiveModel::TestCase
   class Person

--- a/activemodel/test/cases/helper.rb
+++ b/activemodel/test/cases/helper.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../../../../load_paths', __FILE__)
+$LOAD_PATH << File.expand_path('../../../test', __FILE__)
 
 require 'config'
 require 'active_model'

--- a/activemodel/test/cases/lint_test.rb
+++ b/activemodel/test/cases/lint_test.rb
@@ -1,4 +1,4 @@
-require 'cases/helper'
+require_relative '../cases/helper'
 
 class LintTest < ActiveModel::TestCase
   include ActiveModel::Lint::Tests

--- a/activemodel/test/cases/mass_assignment_security/black_list_test.rb
+++ b/activemodel/test/cases/mass_assignment_security/black_list_test.rb
@@ -1,4 +1,4 @@
-require "cases/helper"
+require_relative '../../cases/helper'
 
 class BlackListTest < ActiveModel::TestCase
 

--- a/activemodel/test/cases/mass_assignment_security/permission_set_test.rb
+++ b/activemodel/test/cases/mass_assignment_security/permission_set_test.rb
@@ -1,4 +1,4 @@
-require "cases/helper"
+require_relative '../../cases/helper'
 
 class PermissionSetTest < ActiveModel::TestCase
 

--- a/activemodel/test/cases/mass_assignment_security/sanitizer_test.rb
+++ b/activemodel/test/cases/mass_assignment_security/sanitizer_test.rb
@@ -1,4 +1,4 @@
-require "cases/helper"
+require_relative '../../cases/helper'
 require 'active_support/logger'
 require 'active_support/core_ext/object/inclusion'
 

--- a/activemodel/test/cases/mass_assignment_security/white_list_test.rb
+++ b/activemodel/test/cases/mass_assignment_security/white_list_test.rb
@@ -1,4 +1,4 @@
-require "cases/helper"
+require_relative '../../cases/helper'
 
 class WhiteListTest < ActiveModel::TestCase
 

--- a/activemodel/test/cases/mass_assignment_security_test.rb
+++ b/activemodel/test/cases/mass_assignment_security_test.rb
@@ -1,4 +1,4 @@
-require "cases/helper"
+require_relative '../cases/helper'
 require 'models/mass_assignment_specific'
 
 

--- a/activemodel/test/cases/model_test.rb
+++ b/activemodel/test/cases/model_test.rb
@@ -1,4 +1,4 @@
-require 'cases/helper'
+require_relative '../cases/helper'
 
 class ModelTest < ActiveModel::TestCase
   include ActiveModel::Lint::Tests

--- a/activemodel/test/cases/naming_test.rb
+++ b/activemodel/test/cases/naming_test.rb
@@ -1,4 +1,4 @@
-require 'cases/helper'
+require_relative '../cases/helper'
 require 'models/contact'
 require 'models/sheep'
 require 'models/track_back'

--- a/activemodel/test/cases/observer_array_test.rb
+++ b/activemodel/test/cases/observer_array_test.rb
@@ -1,4 +1,4 @@
-require 'cases/helper'
+require_relative '../cases/helper'
 require 'models/observers'
 
 class ObserverArrayTest < ActiveModel::TestCase

--- a/activemodel/test/cases/observing_test.rb
+++ b/activemodel/test/cases/observing_test.rb
@@ -1,4 +1,4 @@
-require 'cases/helper'
+require_relative '../cases/helper'
 
 class ObservedModel
   include ActiveModel::Observing

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -1,4 +1,4 @@
-require 'cases/helper'
+require_relative '../cases/helper'
 require 'models/user'
 require 'models/visitor'
 require 'models/administrator'

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -1,4 +1,4 @@
-require "cases/helper"
+require_relative '../cases/helper'
 require 'active_support/core_ext/object/instance_variables'
 
 class SerializationTest < ActiveModel::TestCase

--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -1,4 +1,4 @@
-require 'cases/helper'
+require_relative '../../cases/helper'
 require 'models/contact'
 require 'models/automobile'
 require 'active_support/core_ext/object/instance_variables'

--- a/activemodel/test/cases/serializers/xml_serialization_test.rb
+++ b/activemodel/test/cases/serializers/xml_serialization_test.rb
@@ -1,4 +1,4 @@
-require 'cases/helper'
+require_relative '../../cases/helper'
 require 'models/contact'
 require 'active_support/core_ext/object/instance_variables'
 require 'ostruct'

--- a/activemodel/test/cases/translation_test.rb
+++ b/activemodel/test/cases/translation_test.rb
@@ -1,4 +1,4 @@
-require 'cases/helper'
+require_relative '../cases/helper'
 require 'models/person'
 
 class ActiveModelI18nTests < ActiveModel::TestCase

--- a/activemodel/test/cases/validations/acceptance_validation_test.rb
+++ b/activemodel/test/cases/validations/acceptance_validation_test.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require 'cases/helper'
+require_relative '../../cases/helper'
 
 require 'models/topic'
 require 'models/reply'

--- a/activemodel/test/cases/validations/callbacks_test.rb
+++ b/activemodel/test/cases/validations/callbacks_test.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require 'cases/helper'
+require_relative '../../cases/helper'
 
 class Dog
   include ActiveModel::Validations

--- a/activemodel/test/cases/validations/conditional_validation_test.rb
+++ b/activemodel/test/cases/validations/conditional_validation_test.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require 'cases/helper'
+require_relative '../../cases/helper'
 
 require 'models/topic'
 

--- a/activemodel/test/cases/validations/confirmation_validation_test.rb
+++ b/activemodel/test/cases/validations/confirmation_validation_test.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require 'cases/helper'
+require_relative '../../cases/helper'
 
 require 'models/topic'
 require 'models/person'

--- a/activemodel/test/cases/validations/exclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/exclusion_validation_test.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require 'cases/helper'
+require_relative '../../cases/helper'
 
 require 'models/topic'
 require 'models/person'

--- a/activemodel/test/cases/validations/format_validation_test.rb
+++ b/activemodel/test/cases/validations/format_validation_test.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require 'cases/helper'
+require_relative '../../cases/helper'
 
 require 'models/topic'
 require 'models/person'

--- a/activemodel/test/cases/validations/i18n_generate_message_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_generate_message_validation_test.rb
@@ -1,4 +1,4 @@
-require "cases/helper"
+require_relative '../../cases/helper'
 
 require 'models/person'
 

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-require "cases/helper"
+require_relative '../../cases/helper'
 require 'models/person'
 
 class I18nValidationTest < ActiveModel::TestCase

--- a/activemodel/test/cases/validations/inclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/inclusion_validation_test.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require 'cases/helper'
+require_relative '../../cases/helper'
 
 require 'models/topic'
 require 'models/person'

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require 'cases/helper'
+require_relative '../../cases/helper'
 
 require 'models/topic'
 require 'models/person'

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require 'cases/helper'
+require_relative '../../cases/helper'
 
 require 'models/topic'
 require 'models/person'

--- a/activemodel/test/cases/validations/presence_validation_test.rb
+++ b/activemodel/test/cases/validations/presence_validation_test.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require 'cases/helper'
+require_relative '../../cases/helper'
 
 require 'models/topic'
 require 'models/person'

--- a/activemodel/test/cases/validations/validates_test.rb
+++ b/activemodel/test/cases/validations/validates_test.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require 'cases/helper'
+require_relative '../../cases/helper'
 require 'models/person'
 require 'models/topic'
 require 'models/person_with_validator'

--- a/activemodel/test/cases/validations/validations_context_test.rb
+++ b/activemodel/test/cases/validations/validations_context_test.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require 'cases/helper'
+require_relative '../../cases/helper'
 
 require 'models/topic'
 

--- a/activemodel/test/cases/validations/with_validation_test.rb
+++ b/activemodel/test/cases/validations/with_validation_test.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require 'cases/helper'
+require_relative '../../cases/helper'
 
 require 'models/topic'
 

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require 'cases/helper'
+require_relative '../cases/helper'
 
 require 'models/topic'
 require 'models/reply'


### PR DESCRIPTION
I try to make testing as easy as possible, which means for me that every test file should be runnable with `ruby pat/to/file_test.rb` from everywhere, which is also a requirement for a few editors, this failed in activemodel.
(I'll make more pull requests for the other rails parts if this one is accepted)
