### PR TITLE
fix update_all with blank argument

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -529,6 +529,10 @@
 
 *   PostgreSQL hstore types are automatically deserialized from the database.
 
+*   Raise `ArgumentError` if list of attributes to change is empty in `update_all`.
+
+    *Roman Shatsov*
+
 
 ## Rails 3.2.5 (Jun 1, 2012) ##
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -296,6 +296,8 @@ module ActiveRecord
     #   # Update all books that match conditions, but limit it to 5 ordered by date
     #   Book.where('title LIKE ?', '%Rails%').order(:created_at).limit(5).update_all(:author => 'David')
     def update_all(updates)
+      raise ArgumentError, "Empty list of attributes to change" if updates.blank?
+
       stmt = Arel::UpdateManager.new(arel.engine)
 
       stmt.set Arel.sql(@klass.send(:sanitize_sql_for_assignment, updates))
@@ -483,7 +485,7 @@ module ActiveRecord
     # Returns sql statement for the relation.
     #
     #   Users.where(name: 'Oscar').to_sql
-    #   # => SELECT "users".* FROM "users"  WHERE "users"."name" = 'Oscar' 
+    #   # => SELECT "users".* FROM "users"  WHERE "users"."name" = 'Oscar'
     def to_sql
       @to_sql ||= klass.connection.to_sql(arel, bind_values.dup)
     end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1122,6 +1122,10 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal authors(:david), Author.order('id DESC , name DESC').last
   end
 
+  def test_update_all_with_blank_argument
+    assert_raises(ArgumentError) { Comment.update_all({}) }
+  end
+
   def test_update_all_with_joins
     comments = Comment.joins(:post).where('posts.id' => posts(:welcome).id)
     count    = comments.count


### PR DESCRIPTION
Without this commit `Comment.update_all({})` gives `UPDATE "comments" SET` sql and raises exception. Now `update_all` returns number of rows in scope even if argument is blank.
