### PR TITLE
Correctly apply inflection rules on multi-word strings. (Fixes #7132)

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -313,7 +313,7 @@ module ActiveSupport
     def apply_inflections(word, rules)
       result = word.to_s.dup
 
-      if word.empty? || inflections.uncountables.include?(result.downcase[/\b\w+\Z/])
+      if word.empty? || inflections.uncountables.include?(result.downcase[/[a-z0-9]+\Z/])
         result
       else
         rules.each { |(rule, replacement)| break if result.sub!(rule, replacement) }

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -312,12 +312,28 @@ module ActiveSupport
     #  apply_inflections("posts", inflections.singulars) # => "post"
     def apply_inflections(word, rules)
       result = word.to_s.dup
+      prefix, last_word = split_phrase(result)
 
-      if word.empty? || inflections.uncountables.include?(result.downcase[/[a-z0-9]+\Z/])
+      if word.empty? || inflections.uncountables.include?(last_word.downcase)
         result
       else
-        rules.each { |(rule, replacement)| break if result.sub!(rule, replacement) }
-        result
+        rules.each { |(rule, replacement)| break if last_word.sub!(rule, replacement) }
+        prefix + last_word
+      end
+    end
+
+    # Split a phrase into two chunks for +apply_inflections+:
+    #  split_phrase('word') # => ['', 'word']
+    #  split_phrase('two words') # => ['two ', 'words']
+    #  split_phrase('two_words') # => ['two_', 'words']
+    #  split_phrase('two-words') # => ['two-', 'words']
+    #  split_phrase('myWord') # => ['my','Word']
+    #  split_phrase('many many words') # => ['many many ','words']
+    def split_phrase(phrase)
+      if last_word = underscore(phrase)[/[a-z0-9]+\Z/i]
+        [phrase[0...-last_word.length], phrase[-last_word.length..-1]]
+      else
+        [phrase, '']
       end
     end
   end

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -17,6 +17,18 @@ class InflectorTest < ActiveSupport::TestCase
     assert_equal "", ActiveSupport::Inflector.pluralize("")
   end
 
+  def test_pluralize_camel_case_string
+    assert_equal "camelCases", ActiveSupport::Inflector.pluralize("camelCase")
+    assert_equal "OpticalMice", ActiveSupport::Inflector.pluralize("OpticalMouse")
+    assert_equal "SawFish", ActiveSupport::Inflector.pluralize("SawFish")
+  end
+
+  def test_singularize_camel_case_string
+    assert_equal "camelCase", ActiveSupport::Inflector.singularize("camelCases")
+    assert_equal "OpticalMouse", ActiveSupport::Inflector.singularize("OpticalMice")
+    assert_equal "SawFish", ActiveSupport::Inflector.singularize("SawFish")
+  end
+
   ActiveSupport::Inflector.inflections.uncountable.each do |word|
     define_method "test_uncountability_of_#{word}" do
       assert_equal word, ActiveSupport::Inflector.singularize(word)

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -62,6 +62,9 @@ module InflectorTestCases
     "old_news"    => "old_news",
     "news"        => "news",
 
+    "funky_jeans" => "funky_jeans",
+    "stinky_fish" => "stinky_fish",
+
     "series"      => "series",
     "species"     => "species",
 

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -15,6 +15,7 @@ module InflectorTestCases
     "jeans"       => "jeans",
     "funky jeans" => "funky jeans",
     "my money"    => "my money",
+    "your mouse"  => "your mice",
 
     "category"    => "categories",
     "query"       => "queries",
@@ -84,7 +85,6 @@ module InflectorTestCases
     "status"      => "statuses",
     "status_code" => "status_codes",
     "mouse"       => "mice",
-
     "louse"       => "lice",
     "house"       => "houses",
     "octopus"     => "octopi",


### PR DESCRIPTION
_Edit: see my comment below for a more general version of this problem/fix._

Currently, `apply_inflections` does not take into account that the input might be a multi-word string separated by underscore. (`tableize` etc relies on this behavior to work correctly.) This bug affects only uncountable multi-word strings separated by underscores:

``` ruby
   "funky jeans".singularize # => "funky jeans"
   "client information".pluralize # => "client information"

   "funky_jeans".singularize # => "funky_jean"
   "client_information".pluralize # => "client_informations"
```

It's also worth pointing out that `"funky_jeans".singularize` used to work correctly before 9b4622a483319f3d1e7f4489442f0d86afb6da36, which was merged almost 2 years ago so this is essentially broken since Rails 3.

On the other hand, it appears that `"client_information".pluralize` has always been broken, so this does change the behavior of `tableize` and could potentially break some older apps out there.

Closes #7132.
