### PR TITLE
Fix build. There is journey-1.0.4 on the 1-0-stable branch.

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency('builder',       '~> 3.0.0')
   s.add_dependency('rack',          '~> 1.4.1')
   s.add_dependency('rack-test',     '~> 0.6.1')
-  s.add_dependency('journey',       '~> 1.0.4')
+  s.add_dependency('journey',       '~> 2.0.0')
   s.add_dependency('erubis',        '~> 2.7.0')
 
   s.add_development_dependency('activemodel', version)


### PR DESCRIPTION
Now, we can't success `bundle update`, because we can't find journey-1.0.4.

According to https://github.com/rails/journey, there is 1.0.4 on the 1-0-stable branch.
So I added a :branch option.
