### PR TITLE
Make sure :environment task is executed before db:schema:load or db:structure:load

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -242,7 +242,7 @@ db_namespace = namespace :db do
       end
     end
 
-    task :load_if_ruby => 'db:create' do
+    task :load_if_ruby => [:environment, 'db:create'] do
       db_namespace["schema:load"].invoke if ActiveRecord::Base.schema_format == :ruby
     end
 
@@ -327,7 +327,7 @@ db_namespace = namespace :db do
       end
     end
 
-    task :load_if_sql => 'db:create' do
+    task :load_if_sql => [:environment, 'db:create'] do
       db_namespace["structure:load"].invoke if ActiveRecord::Base.schema_format == :sql
     end
   end


### PR DESCRIPTION
Otherwise, if schema_format = :sql, you will see:

```
$ rake db:setup --trace
** Invoke db:setup (first_time)
** Invoke db:schema:load_if_ruby (first_time)
** Invoke db:create (first_time)
** Invoke db:load_config (first_time)
** Invoke rails_env (first_time)
** Execute rails_env
** Execute db:load_config
** Execute db:create
db_example_development already exists
db_example_test already exists
** Execute db:schema:load_if_ruby       #<-------- :environment hasn't been executed yet
** Invoke db:schema:load (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute db:schema:load
~/db_example/db/schema.rb doesn't exist yet. Run `rake db:migrate` to create it then try again.
```
