### PR TITLE
Fix skip_[before|after]_filter to not skip an *around-filter* when...

### DIFF
--- a/actionpack/lib/action_controller/filters.rb
+++ b/actionpack/lib/action_controller/filters.rb
@@ -27,7 +27,8 @@ module ActionController #:nodoc:
       def skip_filter_in_chain(*filters, &test)
         filters, conditions = extract_options(filters)
         filters.each do |filter|
-          if callback = find(filter) then delete(callback) end
+          callback = block_given? ? find(filter, &test) : find(filter)
+          delete callback if callback
         end if conditions.empty?
         update_filter_in_chain(filters, :skip => conditions, &test)
       end
@@ -448,7 +449,7 @@ module ActionController #:nodoc:
     # <tt>before_filter</tt> and <tt>around_filter</tt> may halt the request
     # before a controller action is run. This is useful, for example, to deny
     # access to unauthenticated users or to redirect from HTTP to HTTPS.
-    # Simply call render or redirect. After filters will not be executed if the filter 
+    # Simply call render or redirect. After filters will not be executed if the filter
     # chain is halted.
     #
     # Around filters halt the request unless the action block is called.


### PR DESCRIPTION
...no options are passed (to match the behavior when options are passed).
