### PR TITLE
Issue with JSON serialization

### DIFF
--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -62,7 +62,7 @@ module ActiveSupport
             # hashes and arrays need to get encoder in the options, so that they can detect circular references
             options.merge(:encoder => self)
           else
-            options
+            options.dup
           end
         end
 

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -85,6 +85,19 @@ class TestJSONEncoding < ActiveSupport::TestCase
     end
   end
 
+  class TestClass
+    def as_json(options={})
+      options[:methods] ||= []
+      options[:methods].push(:some_method)
+    end
+  end
+
+  def test_as_json_doesnt_modify_options_var
+    options = {}
+    ([TestClass.new] * 2).as_json(options)
+    assert_equal({}, options)
+  end
+
   def test_hash_encoding
     assert_equal %({\"a\":\"b\"}), ActiveSupport::JSON.encode(:a => :b)
     assert_equal %({\"a\":1}), ActiveSupport::JSON.encode('a' => 1)


### PR DESCRIPTION
Suppose we have simple model with custom `as_json`:

``` ruby
class TestModel < ActiveRecord::Base

  def some_method
    'test output'
  end

  def as_json(options={})
    options[:methods] ||= []
    options[:methods].push(:some_method)
    super options
  end
end
```

And we want to serialize array of 10 records:

``` ruby
([TestModel.new] * 10).as_json
```

Expected behaviour (for me) is that `some_method` will be called just 10 times. But I get 55 instead :smile:. This is because of modification of `options` variable, which passed in `super`

I've tested it with rails 3.2, 3.0.9 and latest master. With ActiveRecord and MongoMapper.
