### PR TITLE
Addresses ORA-01400 errors and also supports #6115

### DIFF
--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -178,7 +178,7 @@ ActiveRecord::Schema.define do
     t.integer :client_of
     t.integer :rating, :default => 1
     t.integer :account_id
-    t.string :description, :null => false, :default => ""
+    t.string :description, :default => ""
   end
 
   add_index :companies, [:firm_id, :type, :rating, :ruby_type], :name => "company_index"


### PR DESCRIPTION
Issue #6115 has been fixed and tested with the attribute `:null => false, :default => ""`.
However `:null => false` attribute is not necessary to test this issue, which causes many ORA-01400 errors with Oracle enhanced adapter.

Please see https://github.com/rails/rails/issues/6195#issuecomment-7218313 for detail.

This pull request has been tested with sqlite3, postgresql, mysql, mysql2 and oracle enhanced adapters.
