### PR TITLE
remove duplicate build runs in travis

### DIFF
--- a/ci/travis.rb
+++ b/ci/travis.rb
@@ -100,9 +100,6 @@ ENV['GEM'].split(',').each do |gem|
     build = Build.new(gem, :isolated => isolated)
     results[build.key] = build.run!
 
-    if build.activerecord?
-      results[build.key] = build.run!
-    end
   end
 end
 


### PR DESCRIPTION
These extra runs were used to test identity map and not fully removed when the feature was removed.

When identity map was removed, ci/travis.rb was updated to remove the line in the if build.activerecord? clause that sets the :identity_map build option to true.  However, the entire if build.activerecord? clause needs to be removed to remove the extra build.run! inside the clause.

Currently, for each database, activerecord tests are run 4 times, twice not in isolation, and twice in isolation.  They only need to be run twice, once not in isolation, and once in isolation. 

To validate the fix, I have run ci/travis.rb against all the variations of the GEM environment variable as specified in .travis.yml.  All tests ran successfully and there were no duplicate runs.  I ran the tests using ruby 1.9.3 in a vagrant box provisioned based on the same travis cookbook recipes that the travis standard worker box uses.

Please let me know any more work I need to do for this fix.
