### PR TITLE
Use string datatype for the setting attribute

### DIFF
--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -37,7 +37,7 @@ ActiveRecord::Schema.define do
 
   create_table :admin_users, :force => true do |t|
     t.string :name
-    t.text :settings, :null => true
+    t.string :settings, :null => true, :limit => 1024
     # MySQL does not allow default values for blobs. Fake it out with a
     # big varchar below.
     t.string :preferences, :null => false, :default => '', :limit => 1024


### PR DESCRIPTION
This commit addresses the following failure with Oracle enhanced adapter.

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/store_test.rb
Using oracle
Run options: --seed 1895

# Running tests:

........F.........

Finished tests in 0.683039s, 26.3528 tests/s, 42.4573 assertions/s.

  1) Failure:
test_0009_convert store attributes from Hash to HashWithIndifferentAccess saving the data and access attributes indifferently(StoreTest) [test/cases/store_test.rb:63]:
Expected: "symbol"
  Actual: nil

18 tests, 29 assertions, 1 failures, 0 errors, 0 skips
$
```

1024 character should be enough to store this purpose.  This fix also works with sqlite3, mysql, mysql2 and postgresql adapters.
