### PR TITLE
Eager autoload ActiveRecord association helpers

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -133,11 +133,13 @@ module ActiveRecord
       autoload :HasAndBelongsToMany, 'active_record/associations/builder/has_and_belongs_to_many'
     end
 
-    autoload :Preloader,        'active_record/associations/preloader'
-    autoload :JoinDependency,   'active_record/associations/join_dependency'
-    autoload :AssociationScope, 'active_record/associations/association_scope'
-    autoload :AliasTracker,     'active_record/associations/alias_tracker'
-    autoload :JoinHelper,       'active_record/associations/join_helper'
+    eager_autoload do
+      autoload :Preloader,        'active_record/associations/preloader'
+      autoload :JoinDependency,   'active_record/associations/join_dependency'
+      autoload :AssociationScope, 'active_record/associations/association_scope'
+      autoload :AliasTracker,     'active_record/associations/alias_tracker'
+      autoload :JoinHelper,       'active_record/associations/join_helper'
+    end
 
     # Clears out the association cache.
     def clear_association_cache #:nodoc:


### PR DESCRIPTION
There's a note above that says "These classes will be loaded when associations are created. So there is no need to eager load them.", which is true for most of the association classes, but not for these. For instance, `AssociationScope` is only ever referenced when `.scoped` is called on an association, so it will only get autoloaded at runtime, rather than at "load time".
