### PR TITLE
Missed extend for eager_autoload

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -104,6 +104,7 @@ module ActiveRecord
 
   # See ActiveRecord::Associations::ClassMethods for documentation.
   module Associations # :nodoc:
+    extend ActiveSupport::Autoload
     extend ActiveSupport::Concern
 
     # These classes will be loaded when associations are created.


### PR DESCRIPTION
In this commit https://github.com/rails/rails/commit/a052fc95a7e5176f66f0f896f3ced60e41794eed was added eager_autoload but missed extend.
