### PR TITLE
parameterize() removes quotes before processing

### DIFF
--- a/activesupport/lib/active_support/inflector/transliterate.rb
+++ b/activesupport/lib/active_support/inflector/transliterate.rb
@@ -80,6 +80,8 @@ module ActiveSupport
     def parameterize(string, sep = '-')
       # replace accented chars with their ascii equivalents
       parameterized_string = transliterate(string)
+      # Remove single and double quotes
+      parameterized_string.gsub!(/['|"]+/, '')
       # Turn unwanted chars into the separator
       parameterized_string.gsub!(/[^a-z0-9\-_]+/i, sep)
       unless sep.nil? || sep.empty?


### PR DESCRIPTION
Changed parameterize() to remove single and double quotes before inserting separators. E.g. "Jon's house is nice" becomes "jons-house-is-nice".
