### PR TITLE
Add support for using the :layout option when calling render @variable

### DIFF
--- a/actionpack/lib/action_view/renderer/partial_renderer.rb
+++ b/actionpack/lib/action_view/renderer/partial_renderer.rb
@@ -257,6 +257,8 @@ module ActionView
 
       if !block && (layout = @options[:layout])
         layout = find_template(layout)
+      elsif !block && (layout = @locals[:layout])
+        layout = find_template(layout)
       end
 
       object ||= locals[as]


### PR DESCRIPTION
Currently in Rails, it is not possible to specify a :layout when
directly calling
render @variable
More specifically, the following code doesn't work:

render @variable, layout: 'different_layout'

This patch allows specifying a layout. To pass locals to the layout,
omit the locals: {} brackets. Thus, instead of writing

render 'variables/variable', layout: 'different_layout', locals:
{variable: @variable, some_local: 'foo'}

you can just write:

render @variable, layout: 'different_layout', some_local: 'foo'

One drawback is that a local may not be named "layout", else it won't
work. It is quite obvious though since locals are passed "inline"
(without the locals: {} brackets).
