### PR TITLE
Fix typo in documentation

### DIFF
--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -102,7 +102,7 @@ module ActionDispatch
         super
       end
 
-      # Hook overriden in controller to add request information
+      # Hook overridden in controller to add request information
       # with `default_url_options`. Application logic should not
       # go into url_options.
       def url_options

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -78,7 +78,7 @@ module ActiveSupport
     private
 
     # A hook invoked everytime a before callback is halted.
-    # This can be overriden in AS::Callback implementors in order
+    # This can be overridden in AS::Callback implementors in order
     # to provide better debugging/logging.
     def halted_callback_hook(filter)
     end


### PR DESCRIPTION
There are quite a lot of such typos in tests files but since in ActionController module exists **response_overridden?** method I think it should be **overridden**.
