### PR TITLE
Refactor ActiveRecord::Inheritance.base_class logic

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1619,18 +1619,6 @@ class BasicsTest < ActiveRecord::TestCase
     assert_nil AbstractCompany.table_name
   end
 
-  def test_base_class
-    assert_equal LoosePerson,     LoosePerson.base_class
-    assert_equal LooseDescendant, LooseDescendant.base_class
-    assert_equal TightPerson,     TightPerson.base_class
-    assert_equal TightPerson,     TightDescendant.base_class
-
-    assert_equal Post, Post.base_class
-    assert_equal Post, SpecialPost.base_class
-    assert_equal Post, StiPost.base_class
-    assert_equal SubStiPost, SubStiPost.base_class
-  end
-
   def test_descends_from_active_record
     assert !ActiveRecord::Base.descends_from_active_record?
 

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -1,7 +1,10 @@
 require "cases/helper"
 require 'models/company'
+require 'models/person'
+require 'models/post'
 require 'models/project'
 require 'models/subscriber'
+require 'models/teapot'
 
 class InheritanceTest < ActiveRecord::TestCase
   fixtures :companies, :projects, :subscribers, :accounts
@@ -68,6 +71,33 @@ class InheritanceTest < ActiveRecord::TestCase
     assert AbstractCompany.descends_from_active_record?, 'AbstractCompany should descend from ActiveRecord::Base'
     assert Company.descends_from_active_record?, 'Company should descend from ActiveRecord::Base'
     assert !Class.new(Company).descends_from_active_record?, 'Company subclass should not descend from ActiveRecord::Base'
+  end
+
+  def test_inheritance_base_class
+    assert_equal Post, Post.base_class
+    assert_equal Post, SpecialPost.base_class
+    assert_equal Post, StiPost.base_class
+    assert_equal SubStiPost, SubStiPost.base_class
+  end
+
+  def test_active_record_model_included_base_class
+    assert_equal Teapot, Teapot.base_class
+  end
+
+  def test_abstract_inheritance_base_class
+    assert_equal LoosePerson, LoosePerson.base_class
+    assert_equal LooseDescendant, LooseDescendant.base_class
+    assert_equal TightPerson, TightPerson.base_class
+    assert_equal TightPerson, TightDescendant.base_class
+  end
+
+  def test_base_class_activerecord_error
+    klass = Class.new {
+      extend ActiveRecord::Configuration
+      include ActiveRecord::Inheritance
+    }
+
+    assert_raise(ActiveRecord::ActiveRecordError) { klass.base_class }
   end
 
   def test_a_bad_type_column


### PR DESCRIPTION
Removed protected method `class_of_active_record_descendant` and moved logic to the `base_class` method. The `class_of_active_record_descendant` method was confusing because it required an argument, but that argument was 'self' and was not used outside this context.

Also moved base_class tests to inheritance_test.rb and added some test coverage for some untested cases.
