### PR TITLE
Modify the preference attribute from `:null => false` to `:null => true`

### DIFF
--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define do
     t.string :settings, :null => true, :limit => 1024
     # MySQL does not allow default values for blobs. Fake it out with a
     # big varchar below.
-    t.string :preferences, :null => false, :default => '', :limit => 1024
+    t.string :preferences, :null => true, :default => '', :limit => 1024
     t.string :json_data, :null => true, :limit => 1024
     t.string :json_data_empty, :null => false, :default => "", :limit => 1024
     t.references :account


### PR DESCRIPTION
This commit addresses ORA-01400 errors with Oracle enhanced adapter.

Issue #4856 had been fixed and tested with the attribute `:null => false, :default => ""`.
Now `:null => false` attribute is not necessary to test this issue.

You can see investigations [here](https://github.com/rails/rails/issues/7138#issuecomment-7295387).
