### PR TITLE
Modity the :json_data_empty attribute from `:null => false` to `:null => true`

### DIFF
--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define do
     # big varchar below.
     t.string :preferences, :null => true, :default => '', :limit => 1024
     t.string :json_data, :null => true, :limit => 1024
-    t.string :json_data_empty, :null => false, :default => "", :limit => 1024
+    t.string :json_data_empty, :null => true, :default => "", :limit => 1024
     t.references :account
   end
 


### PR DESCRIPTION
This pull request address ORA-01400 errors reported in #7178 with Oracle enhanced adapter.

The commit 3c0bf04 requires :json_data_empty `:null => false` OR `:default => ""`. No `:null => false` AND `:default => ""` required. 

See https://github.com/rails/rails/issues/7178#issuecomment-7314663 for detail.
