### PR TITLE
to_xml dasherize option should be passed to included associations

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Changed `ActiveModel::Serializers::Xml::Serializer#add_associations` to by default propagate `:skip_types, :dasherize, :camelize` keys to included associations. It can be overriden on each association by explicitly specifying the option on one or more associations *Anthony Alberto*
+
 *   Changed `AM::Serializers::JSON.include_root_in_json' default value to false.
     Now, AM Serializers and AR objects have the same default behaviour. Fixes #6578.
 

--- a/activemodel/lib/active_model/serializers/xml.rb
+++ b/activemodel/lib/active_model/serializers/xml.rb
@@ -115,6 +115,10 @@ module ActiveModel
           merged_options = opts.merge(options.slice(:builder, :indent))
           merged_options[:skip_instruct] = true
 
+          [:skip_types, :dasherize, :camelize].each do |key|
+            merged_options[key] = options[key] if merged_options[key].nil? && !options[key].nil?
+          end
+
           if records.respond_to?(:to_ary)
             records = records.to_ary
 


### PR DESCRIPTION
Following the false issue reported here : https://github.com/rails/rails/issues/6958

Here's the commit that passes the dasherize parameter to included associations when using to_xml.
This way we don't have to repeat :dasherize on every single included models. It can become messy pretty fast on big xml dumps!

bundle exec rake test passes in activemodel.

Tell me if anything's missing!
