### PR TITLE
Refactor to reset_table_name

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -144,16 +144,12 @@ module ActiveRecord
 
       # Computes the table name, (re)sets it internally, and returns it.
       def reset_table_name #:nodoc:
-        if abstract_class?
-          self.table_name = if active_record_super == Base || active_record_super.abstract_class?
-                              nil
-                            else
-                              active_record_super.table_name
-                            end
+        self.table_name = if abstract_class?
+          active_record_super == Base ? nil : active_record_super.table_name
         elsif active_record_super.abstract_class?
-          self.table_name = active_record_super.table_name || compute_table_name
+          active_record_super.table_name || compute_table_name
         else
-          self.table_name = compute_table_name
+          compute_table_name
         end
       end
 


### PR DESCRIPTION
That commit https://github.com/rails/rails/commit/6951014c05fa64f533072d21dc7e4c55f59162d4 fixed behavior for abstract classes, but it was fixed by correct order. Case `if abstract_class?` must go first and no need add extra `active_record_super.abstract_class?` on this line. https://github.com/rails/rails/commit/6951014c05fa64f533072d21dc7e4c55f59162d4#L0R132
