### PR TITLE
Fix test_can_wait_until_commit(ResponseTest) in /actionpack/test/dispatch/response_test.rb

### DIFF
--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -7,11 +7,11 @@ class ResponseTest < ActiveSupport::TestCase
 
   def test_can_wait_until_commit
     t = Thread.new {
-      assert @response.await_commit
+      @response.await_commit
     }
     @response.commit!
     assert @response.committed?
-    t.join
+    assert t.join(0.5)
   end
 
   def test_response_body_encoding


### PR DESCRIPTION
```
bundle exec rake test TEST=rails/actionpack/test/dispatch/response_test.rb
...
  1) Failure:
test_can_wait_until_commit(ResponseTest) [/home/rimidl/projects/gems/rails/actionpack/test/dispatch/response_test.rb:10]:
Failed assertion, no message given.
```

This pull-request corrects this test case.
