### PR TITLE
Backport #6995 to 3-2 stable

### DIFF
--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -17,8 +17,8 @@ if defined?(MiniTest)
   begin
     require 'turn'
 
-    if MiniTest::Unit.respond_to?(:use_natural_language_case_names=)
-      MiniTest::Unit.use_natural_language_case_names = true
+    Turn.config do |c|
+      c.natural = true
     end
   rescue LoadError
   end


### PR DESCRIPTION
Update `test_help` to config properly turn natural language option.
Last versions of Turn don't monkey patch MiniTest to setup
the natural language option. Here is an [example](https://github.com/TwP/turn/blob/master/try/test_autorun_minitest.rb#L3).

This patches the following behaviour:

```
$ rake test:units
`<top (required)>': undefined method `use_natural_language_case_names='
for MiniTest::Unit:Class (NoMethodError)
```
