### PR TITLE
Documentation Fix: Pointing the case when no dependent option is given to a association method

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -941,7 +941,8 @@ module ActiveRecord
     #
     # The <tt>:dependent</tt> option can have different values which specify how the deletion
     # is done. For more information, see the documentation for this option on the different
-    # specific association types.
+    # specific association types. When no option is given, the behaviour is to do nothing
+    # with the associated records when destroying a record.
     #
     # === Delete or destroy?
     #


### PR DESCRIPTION
As I'm not sure if this is an expected behaviour, I'm opening this pull request to merge this documentation related. As no one, commented on #5828, it seems that it is. 

When merged, it closes #5828.

cc @al2o3cr, @rafaelfranca, @schneems
