### PR TITLE
Add a separation option for the excerpt function

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add `separation` option for `ActionView::Helpers::TextHelper.excerpt`. *Guirec Corbel*
+
 *   Added controller-level etag additions that will be part of the action etag computation *Jeremy Kemper/DHH*
 
         class InvoicesController < ApplicationController

--- a/actionpack/test/template/text_helper_test.rb
+++ b/actionpack/test/template/text_helper_test.rb
@@ -303,6 +303,19 @@ class TextHelperTest < ActionView::TestCase
     assert_equal options, passed_options
   end
 
+  def test_excerpt_with_separator
+    options = { :separator => ' ', :radius => 1 }
+    assert_equal('...a very beautiful...', excerpt('This is a very beautiful morning', 'very', options))
+    assert_equal('This is...', excerpt('This is a very beautiful morning', 'this', options))
+    assert_equal('...beautiful morning', excerpt('This is a very beautiful morning', 'morning', options))
+
+    options = { :separator => "\n", :radius => 0 }
+    assert_equal("...very long...", excerpt("my very\nvery\nvery long\nstring", 'long', options))
+
+    options = { :separator => "\n", :radius => 1 }
+    assert_equal("...very\nvery long\nstring", excerpt("my very\nvery\nvery long\nstring", 'long', options))
+  end
+
   def test_word_wrap
     assert_equal("my very very\nvery long\nstring", word_wrap("my very very very long string", :line_width => 15))
   end


### PR DESCRIPTION
The separation option enable to keep entire words, lines or anything.
To split by line, like github, we can set the separation option as \n.
To split by word, like google, we can set the separation option as " ".
The radius option represent the number of lines or words we want to
have in the result.
The default behaviour is the same. If we don't set the separation
option, it split the text any where.
