### PR TITLE
More polite cleanup for sqlite tests

### DIFF
--- a/activerecord/test/cases/tasks/sqlite_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlite_rake_test.rb
@@ -162,8 +162,8 @@ module ActiveRecord
       assert File.exists?(dbfile)
       assert File.exists?(filename)
     ensure
-      FileUtils.rm(filename)
-      FileUtils.rm(dbfile)
+      FileUtils.rm_f(filename)
+      FileUtils.rm_f(dbfile)
     end
   end
 
@@ -184,8 +184,8 @@ module ActiveRecord
       ActiveRecord::Tasks::DatabaseTasks.structure_load @configuration, filename, '/rails/root'
       assert File.exists?(dbfile)
     ensure
-      FileUtils.rm(filename)
-      FileUtils.rm(dbfile)
+      FileUtils.rm_f(filename)
+      FileUtils.rm_f(dbfile)
     end
   end
 end


### PR DESCRIPTION
These tests are failing before file got created on my side.
`ensure` block should support early fail as well.
