### PR TITLE
Fix incorrect usage `require mysql` in the activerecord/.../mysql_rake_test

### DIFF
--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -1,5 +1,4 @@
 require 'cases/helper'
-require 'mysql'
 
 module ActiveRecord
   class MysqlDBCreateTest < ActiveRecord::TestCase
@@ -46,6 +45,10 @@ module ActiveRecord
 
   class MysqlDBCreateAsRootTest < ActiveRecord::TestCase
     def setup
+      unless current_adapter?(:MysqlAdapter)
+        return skip("only tested on mysql")
+      end
+
       @connection    = stub(:create_database => true, :execute => true)
       @error         = Mysql::Error.new "Invalid permissions"
       @configuration = {
@@ -64,6 +67,7 @@ module ActiveRecord
     end
 
     def test_root_password_is_requested
+      skip "only if mysql is available" unless defined?(::Mysql)
       $stdin.expects(:gets).returns("secret\n")
 
       ActiveRecord::Tasks::DatabaseTasks.create @configuration


### PR DESCRIPTION
`require mysql` used here for the 6 **hard** mysql-spesifics tests only (see [MysqlDBCreateAsRootTest](https://github.com/rimidl/rails/pull/new/fix-incorrect-require-mysql-in-mysql_rake_test#L0R46)). But we don't should run it for the sqlite or postgresql database contexts. And of course we don't should `require mysql`, when we run tests only for sqlite (`ARCONN=sqlite3 ruby -Itest .../mysql_rake_test.rb`), for example.

\+ if we follow the guides [Set up and Run the Tests](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#set-up-and-run-the-tests) ,
we naturally catch error bellow:

```
rails/ $ rm .bundle/config
rails/ $ bundle install --without db
rails/ $ cd activerecord
activerecord/ $ ARCONN=mysql ruby -Itest test/cases/tasks/mysql_rake_test.rb
...
(mysql is not part of the bundle. Add it to Gemfile.) (LoadError)
...
```

This pull-request fix this error.

_Note:_ `MysqlDBCreateAsRootTest` don't pass with mysql2 adapter, only with mysql.
