### PR TITLE
Make ActiveSupport::Inflector locale aware and multilingual

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -13,6 +13,11 @@ class String
   # the singular form will be returned if <tt>count == 1</tt>.
   # For any other value of +count+ the plural will be returned.
   #
+  # If the optional parameter +locale+ is specified,
+  # the word will be pluralized as a word of that language.
+  # By default, this parameter is set to <tt>:en</tt>.
+  # You must define your own inflection rules for languages other than English.
+  #
   #   'post'.pluralize             # => "posts"
   #   'octopus'.pluralize          # => "octopi"
   #   'sheep'.pluralize            # => "sheep"
@@ -21,15 +26,23 @@ class String
   #   'CamelOctopus'.pluralize     # => "CamelOctopi"
   #   'apple'.pluralize(1)         # => "apple"
   #   'apple'.pluralize(2)         # => "apples"
-  def pluralize(count = nil)
+  #   'ley'.pluralize(:es)         # => "leyes"
+  #   'ley'.pluralize(1, :es)      # => "ley"
+  def pluralize(count = nil, locale = :en)
+    locale = count if count.is_a?(Symbol)
     if count == 1
       self
     else
-      ActiveSupport::Inflector.pluralize(self)
+      ActiveSupport::Inflector.pluralize(self, locale)
     end
   end
 
   # The reverse of +pluralize+, returns the singular form of a word in a string.
+  # 
+  # If the optional parameter +locale+ is specified,
+  # the word will be singularized as a word of that language.
+  # By default, this paramter is set to <tt>:en</tt>.
+  # You must define your own inflection rules for languages other than English.
   #
   #   'posts'.singularize            # => "post"
   #   'octopi'.singularize           # => "octopus"
@@ -37,8 +50,9 @@ class String
   #   'word'.singularize             # => "word"
   #   'the blue mailmen'.singularize # => "the blue mailman"
   #   'CamelOctopi'.singularize      # => "CamelOctopus"
-  def singularize
-    ActiveSupport::Inflector.singularize(self)
+  #   'leyes'.singularize(:es)       # => "ley"
+  def singularize(locale = :en)
+    ActiveSupport::Inflector.singularize(self, locale)
   end
 
   # +constantize+ tries to find a declared constant with the name specified

--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -1,7 +1,7 @@
 require 'active_support/inflector/inflections'
 
 module ActiveSupport
-  Inflector.inflections do |inflect|
+  Inflector.inflections(:en) do |inflect|
     inflect.plural(/$/, 's')
     inflect.plural(/s$/i, 's')
     inflect.plural(/^(ax|test)is$/i, '\1es')

--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -1,13 +1,15 @@
 require 'active_support/core_ext/array/prepend_and_append'
+require 'active_support/i18n'
 
 module ActiveSupport
   module Inflector
     extend self
 
     # A singleton instance of this class is yielded by Inflector.inflections, which can then be used to specify additional
-    # inflection rules.
+    # inflection rules. If passed an optional locale, rules for other languages can be specified. The default locale is
+    # <tt>:en</tt>. Only rules for English are provided.
     #
-    #   ActiveSupport::Inflector.inflections do |inflect|
+    #   ActiveSupport::Inflector.inflections(:en) do |inflect|
     #     inflect.plural /^(ox)$/i, '\1\2en'
     #     inflect.singular /^(ox)en/i, '\1'
     #
@@ -20,8 +22,9 @@ module ActiveSupport
     # pluralization and singularization rules that is runs. This guarantees that your rules run before any of the rules that may
     # already have been loaded.
     class Inflections
-      def self.instance
-        @__instance__ ||= new
+      def self.instance(locale = :en)
+        @__instance__ ||= Hash.new { |h, k| h[k] = new }
+        @__instance__[locale]
       end
 
       attr_reader :plurals, :singulars, :uncountables, :humans, :acronyms, :acronym_regex
@@ -160,16 +163,18 @@ module ActiveSupport
     end
 
     # Yields a singleton instance of Inflector::Inflections so you can specify additional
-    # inflector rules.
+    # inflector rules. If passed an optional locale, rules for other languages can be specified.
+    # If not specified, defaults to <tt>:en</tt>. Only rules for English are provided.
+    # 
     #
-    #   ActiveSupport::Inflector.inflections do |inflect|
+    #   ActiveSupport::Inflector.inflections(:en) do |inflect|
     #     inflect.uncountable "rails"
     #   end
-    def inflections
+    def inflections(locale = :en)
       if block_given?
-        yield Inflections.instance
+        yield Inflections.instance(locale)
       else
-        Inflections.instance
+        Inflections.instance(locale)
       end
     end
   end

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -10,31 +10,41 @@ module ActiveSupport
   #
   # The Rails core team has stated patches for the inflections library will not be accepted
   # in order to avoid breaking legacy applications which may be relying on errant inflections.
-  # If you discover an incorrect inflection and require it for your application, you'll need
-  # to correct it yourself (explained below).
+  # If you discover an incorrect inflection and require it for your application or wish to
+  # define rules for languages other than English, please correct or add them yourself (explained below).
   module Inflector
     extend self
 
     # Returns the plural form of the word in the string.
+    #
+    # If passed an optional +locale+ parameter, the word will be
+    # pluralized using rules defined for that language. By default,
+    # this parameter is set to <tt>:en</tt>.
     #
     #   "post".pluralize             # => "posts"
     #   "octopus".pluralize          # => "octopi"
     #   "sheep".pluralize            # => "sheep"
     #   "words".pluralize            # => "words"
     #   "CamelOctopus".pluralize     # => "CamelOctopi"
-    def pluralize(word)
-      apply_inflections(word, inflections.plurals)
+    #   "ley".pluralize(:es)         # => "leyes"
+    def pluralize(word, locale = :en)
+      apply_inflections(word, inflections(locale).plurals)
     end
 
     # The reverse of +pluralize+, returns the singular form of a word in a string.
+    #
+    # If passed an optional +locale+ parameter, the word will be
+    # pluralized using rules defined for that language. By default,
+    # this parameter is set to <tt>:en</tt>.
     #
     #   "posts".singularize            # => "post"
     #   "octopi".singularize           # => "octopus"
     #   "sheep".singularize            # => "sheep"
     #   "word".singularize             # => "word"
     #   "CamelOctopi".singularize      # => "CamelOctopus"
-    def singularize(word)
-      apply_inflections(word, inflections.singulars)
+    #   "leyes".singularize(:es)       # => "ley"
+    def singularize(word, locale = :en)
+      apply_inflections(word, inflections(locale).singulars)
     end
 
     # By default, +camelize+ converts strings to UpperCamelCase. If the argument to +camelize+

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -354,6 +354,35 @@ class InflectorTest < ActiveSupport::TestCase
     RUBY
   end
 
+  def test_inflector_locality
+    ActiveSupport::Inflector.inflections(:es) do |inflect|
+      inflect.plural(/$/, 's')
+      inflect.plural(/z$/i, 'ces')
+
+      inflect.singular(/s$/, '')
+      inflect.singular(/es$/, '')
+      
+      inflect.irregular('el', 'los')
+    end
+
+    assert_equal('hijos', 'hijo'.pluralize(:es))
+    assert_equal('luces', 'luz'.pluralize(:es))
+    assert_equal('luzs', 'luz'.pluralize)
+
+    assert_equal('sociedad', 'sociedades'.singularize(:es))
+    assert_equal('sociedade', 'sociedades'.singularize)
+
+    assert_equal('los', 'el'.pluralize(:es))
+    assert_equal('els', 'el'.pluralize)
+
+    ActiveSupport::Inflector.inflections(:es) { |inflect| inflect.clear }
+
+    assert ActiveSupport::Inflector.inflections(:es).plurals.empty?
+    assert ActiveSupport::Inflector.inflections(:es).singulars.empty?
+    assert !ActiveSupport::Inflector.inflections.plurals.empty?
+    assert !ActiveSupport::Inflector.inflections.singulars.empty?
+  end
+
   def test_clear_all
     with_dup do
       ActiveSupport::Inflector.inflections do |inflect|
@@ -467,7 +496,7 @@ class InflectorTest < ActiveSupport::TestCase
   # there are module functions that access ActiveSupport::Inflector.inflections,
   # so we need to replace the singleton itself.
   def with_dup
-    original = ActiveSupport::Inflector.inflections
+    original = ActiveSupport::Inflector::Inflections.instance_variable_get(:@__instance__)
     ActiveSupport::Inflector::Inflections.instance_variable_set(:@__instance__, original.dup)
   ensure
     ActiveSupport::Inflector::Inflections.instance_variable_set(:@__instance__, original)

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/inflections.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/inflections.rb
@@ -1,8 +1,9 @@
 # Be sure to restart your server when you modify this file.
 
-# Add new inflection rules using the following format
-# (all these examples are active by default):
-# ActiveSupport::Inflector.inflections do |inflect|
+# Add new inflection rules using the following format. Inflections
+# are locale specific, and you may define rules for as many different
+# locales as you wish. All of these examples are active by default:
+# ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.plural /^(ox)$/i, '\1en'
 #   inflect.singular /^(ox)en/i, '\1'
 #   inflect.irregular 'person', 'people'
@@ -10,6 +11,6 @@
 # end
 #
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections do |inflect|
+# ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'
 # end


### PR DESCRIPTION
The Inflector is currently not very supportive of internationalized
websites. If a user wants to singularize and/or pluralize words based on
any locale other than English, they must define each case in locale
files. Rather than create large locale files with mappings between
singular and plural words, why not allow the Inflector to accept a
locale?

This patch makes ActiveSupport::Inflector locale aware and uses the
application's `I18n.default_locale` unless otherwise specified. Users
will still be provided a list of English (:en) inflections, but they may
additionally define inflection rules for other locales. Each list is
kept separately and permanently. There is no reason to limit users to
one list of inflections:

``` ruby
ActiveSupport::Inflector.inflections(:es) do |inflect|
  inflect.plural(/$/, 's')
  inflect.plural(/([^aeéiou])$/i, '\1es')
  inflect.plural(/([aeiou]s)$/i, '\1')
  inflect.plural(/z$/i, 'ces')
  inflect.plural(/á([sn])$/i, 'a\1es')
  inflect.plural(/é([sn])$/i, 'e\1es')
  inflect.plural(/í([sn])$/i, 'i\1es')
  inflect.plural(/ó([sn])$/i, 'o\1es')
  inflect.plural(/ú([sn])$/i, 'u\1es')

  inflect.singular(/s$/, '')
  inflect.singular(/es$/, '')

  inflect.irregular('el', 'los')
end

'ley'.pluralize(:es)   # => "leyes"
'ley'.pluralize(:en)   # => "leys"
'avión'.pluralize(:es) # => "aviones"
'avión'.pluralize(:en) # => "avións"
```

A multilingual Inflector should be of use to anybody that is tasked with
internationalizing their Rails application.

Signed-off-by: David Celis david@davidcelis.com
