### PR TITLE
Allow perform_deliveries to be set within mailer action

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -684,7 +684,7 @@ module ActionMailer #:nodoc:
       m.charset = charset = headers[:charset]
 
       # Set configure delivery behavior
-      wrap_delivery_behavior!(headers.delete(:delivery_method))
+      wrap_delivery_behavior!(headers.delete(:delivery_method),headers.delete(:perform_deliveries))
 
       # Assign all headers except parts_order, content_type and body
       assignable = headers.except(:parts_order, :content_type, :body, :template_name, :template_path)

--- a/actionmailer/lib/action_mailer/delivery_methods.rb
+++ b/actionmailer/lib/action_mailer/delivery_methods.rb
@@ -57,7 +57,7 @@ module ActionMailer
         self.delivery_methods = delivery_methods.merge(symbol.to_sym => klass).freeze
       end
 
-      def wrap_delivery_behavior(mail, method=nil) #:nodoc:
+      def wrap_delivery_behavior(mail, method=nil, perform_deliveries_header=nil) #:nodoc:
         method ||= self.delivery_method
         mail.delivery_handler = self
 
@@ -74,7 +74,7 @@ module ActionMailer
           mail.delivery_method(method)
         end
 
-        mail.perform_deliveries    = perform_deliveries
+        mail.perform_deliveries    = perform_deliveries && (perform_deliveries_header.nil? || perform_deliveries_header)
         mail.raise_delivery_errors = raise_delivery_errors
       end
     end

--- a/actionmailer/test/delivery_methods_test.rb
+++ b/actionmailer/test/delivery_methods_test.rb
@@ -82,6 +82,7 @@ class MailDeliveryTest < ActiveSupport::TestCase
     def welcome(hash={})
       mail(DEFAULT_HEADERS.merge(hash))
     end
+
   end
 
   def setup
@@ -127,6 +128,18 @@ class MailDeliveryTest < ActiveSupport::TestCase
     DeliveryMailer.deliveries.clear
     Mail::Message.any_instance.expects(:deliver!).never
     DeliveryMailer.welcome.deliver
+  end
+
+  test "does not perform deliveries if customized per instance" do
+    DeliveryMailer.perform_deliveries = true
+    m = DeliveryMailer.welcome(:perform_deliveries => false)
+    assert_equal(false,m.perform_deliveries)
+  end
+
+  test "does not perform deliveries if globally set to off but instance instructs delivery" do
+    DeliveryMailer.perform_deliveries = false
+    m = DeliveryMailer.welcome(:perform_deliveries => true)
+    assert_equal(false,m.perform_deliveries)
   end
 
   test "does not append the deliveries collection if told not to perform the delivery" do


### PR DESCRIPTION
It was found that there were some good use cases where it was prudent to `prevent_deliveries` even if `prevent_deliveries` was globally set to true for e.g. you wish to not send emails to users who are unsubscribed or users who are blocked or unconfirmed. 

There are other use cases as well, such as spam detection within the body should prevent delivery.

This currently requires a common pattern which goes something like this

``` ruby
SomeMailer.someemail(user).deliver if user.sendable?
```

With this change it can be written alternatively as 

``` ruby
def somemail(user)
  mail :to => user.email, :subject => ... , :perform_deliveries => user.sendable?
end
SomeMailer.somemail(user).deliver # expect no delivery if user was unsendable
```

This allows for conditional deliveries based on user's own logic.

The way I've implemented this, ensures that if `perform_deliveries` is switched_off globally, then it cant be switched on by the mail message instance.

After checking further it was found that `perform_deliveries` could be overridden in interceptors but at that stage you do not always have access to the underlying models used for decisions.

/cc @schneems / @josevalim / @mikel
