### PR TITLE
multiple_of for Numericality

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Added `:multiple_of` options to `NumericalityValidator` *Brian Cardarella*
+
 *   Changed `AM::Serializers::JSON.include_root_in_json' default value to false.
     Now, AM Serializers and AR objects have the same default behaviour. Fixes #6578.
 

--- a/activemodel/lib/active_model/locale/en.yml
+++ b/activemodel/lib/active_model/locale/en.yml
@@ -26,3 +26,4 @@ en:
       other_than: "must be other than %{count}"
       odd: "must be odd"
       even: "must be even"
+      multiple_of: "must be a multiple of %{multiple_of}"

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -37,6 +37,12 @@ module ActiveModel
           end
         end
 
+        if options[:multiple_of]
+          unless value % options[:multiple_of] == 0
+            record.errors.add(attr_name, :multiple_of, filtered_options(raw_value))
+          end
+        end
+
         options.slice(*CHECKS.keys).each do |option, option_value|
           case option
           when :odd, :even

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -113,6 +113,13 @@ class NumericalityValidationTest < ActiveModel::TestCase
     valid!([-1, 42])
   end
 
+  def test_validates_numericality_with_multiple_of
+    Topic.validates_numericality_of :approved, :multiple_of => 2
+
+    invalid!([1, 1.1])
+    valid!([4, 8.0])
+  end
+
   def test_validates_numericality_with_proc
     Topic.send(:define_method, :min_approved, lambda { 5 })
     Topic.validates_numericality_of :approved, :greater_than_or_equal_to => Proc.new {|topic| topic.min_approved }


### PR DESCRIPTION
Adds support for validating multiples of a value to the numericality validator
