### PR TITLE
Revert to gsub from encode for faster html escaping

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -21,7 +21,7 @@ class ERB
       if s.html_safe?
         s
       else
-        s.encode(s.encoding, :xml => :attr)[1...-1].html_safe
+        s.gsub(/[&"><]/n, HTML_ESCAPE).html_safe
       end
     end
 


### PR DESCRIPTION
This was changed to use 1.9 String#encode method, however under the initial commit (https://github.com/rails/rails/commit/63cd9432265a32d222353b535d60333c2a6a5125#activesupport/lib/active_support/core_ext/string/output_safety.rb) there was a performance test done (https://gist.github.com/50ec9ab8ae1e223f3b75) by @seanwalbran and I have verified that the results for myself (including our team and server boxes) are consistent with him (results here: https://gist.github.com/3218839).

This issue was found on a project upgrade from 3.0.12 to 3.2.6 making our site 100x slower rendering views. After profiling and such we patched back this method and have got our performance.
