### PR TITLE
has_secure_password should not raise a 'digest missing' error if the calling class has specified for validations to be skipped.

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -43,9 +43,9 @@ module ActiveModel
         if options.fetch(:validations, true)
           validates_confirmation_of :password
           validates_presence_of     :password, :on => :create
+          
+          before_create { raise "Password digest missing on new record" if password_digest.blank? }
         end
-        
-        before_create { raise "Password digest missing on new record" if password_digest.blank? }
 
         include InstanceMethodsOnActivation
 

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -1,5 +1,6 @@
 require 'cases/helper'
 require 'models/user'
+require 'models/oauthed_user'
 require 'models/visitor'
 require 'models/administrator'
 
@@ -8,6 +9,7 @@ class SecurePasswordTest < ActiveModel::TestCase
   setup do
     @user = User.new
     @visitor = Visitor.new
+    @oauthed_user = OauthedUser.new
   end
 
   test "blank password" do
@@ -71,6 +73,12 @@ class SecurePasswordTest < ActiveModel::TestCase
     @user.password = "supersecretpassword"
     assert_nothing_raised do
       @user.run_callbacks :create
+    end
+  end
+  
+  test "Oauthed user can be created with blank digest" do
+    assert_nothing_raised do
+      @oauthed_user.run_callbacks :create
     end
   end
 end

--- a/activemodel/test/models/oauthed_user.rb
+++ b/activemodel/test/models/oauthed_user.rb
@@ -1,0 +1,11 @@
+class OauthedUser
+  extend ActiveModel::Callbacks
+  include ActiveModel::Validations
+  include ActiveModel::SecurePassword
+  
+  define_model_callbacks :create
+
+  has_secure_password(validations: false)
+
+  attr_accessor :password_digest, :password_salt
+end


### PR DESCRIPTION
A pull request was recently merged that allows the has_secure_password to bypass the included password validations. See: https://github.com/rails/rails/commit/0e1e527654f286452fa6f86f5d229f278435319a

However, the same commit raises an explicit error if the password_digest is blank even if validations are disabled. I have altered this behavior to raise the error only if validations are enabled.

An example where the existing version is undesirable is if a user account model is created after an oauth sign in. In that case, a user may be created from Twitter/Facebook/Google/etc. credentials without ever creating a password. I believe this use case should work by default and not require catching an exception.
