### PR TITLE
Restoring documentation for env_config

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -102,6 +102,17 @@ module Rails
 
     # Stores some of the Rails initial environment parameters which
     # will be used by middlewares and engines to configure themselves.
+    # Currently stores:
+    #
+    #   * "action_dispatch.parameter_filter"         => config.filter_parameters,
+    #   * "action_dispatch.secret_token"             => config.secret_token,
+    #   * "action_dispatch.show_exceptions"          => config.action_dispatch.show_exceptions,
+    #   * "action_dispatch.show_detailed_exceptions" => config.consider_all_requests_local,
+    #   * "action_dispatch.logger"                   => Rails.logger,
+    #   * "action_dispatch.backtrace_cleaner"        => Rails.backtrace_cleaner
+    #
+    # These parameters will be used by middlewares and engines to configure themselves
+    #
     def env_config
       @env_config ||= super.merge({
         "action_dispatch.parameter_filter" => config.filter_parameters,


### PR DESCRIPTION
I am restoring documentation for env_config as discussed in issue #7070.

cc @vijaydev @fxn
