### PR TITLE
ActiveRecord::Relation select problem

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Centralized connection for ActiveRecord::Relation.
+    Fix #6331.
+
+    *kot-begemot*
+
 *   Fix `find_in_batches` crashing when IDs are strings and start option is not specified.
 
     *Alexis Bernard*

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -48,7 +48,7 @@ module ActiveRecord
   autoload :Observer
   autoload :Persistence
   autoload :QueryCache
-  autoload :Querying
+  autoload :QueryDelegation
   autoload :ReadonlyAttributes
   autoload :Reflection
   autoload :Sanitization
@@ -78,6 +78,7 @@ module ActiveRecord
     autoload :NullRelation
 
     autoload_under 'relation' do
+      autoload :Querying
       autoload :QueryMethods
       autoload :FinderMethods
       autoload :Calculations

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -329,7 +329,7 @@ module ActiveRecord #:nodoc:
 
     extend ConnectionHandling
     extend QueryCache::ClassMethods
-    extend Querying
+    extend QueryDelegation
     extend Translation
     extend DynamicMatchers
     extend Explain

--- a/activerecord/lib/active_record/query_delegation.rb
+++ b/activerecord/lib/active_record/query_delegation.rb
@@ -1,0 +1,15 @@
+module ActiveRecord
+  module QueryDelegation
+    delegate :find, :take, :take!, :first, :first!, :last, :last!, :exists?, :any?, :many?, to: :all
+    delegate :first_or_create, :first_or_create!, :first_or_initialize, to: :all
+    delegate :find_or_create_by, :find_or_create_by!, :find_or_initialize_by, to: :all
+    delegate :find_by, :find_by!, to: :all
+    delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, to: :all
+    delegate :find_each, :find_in_batches, to: :all
+    delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins,
+             :where, :preload, :eager_load, :includes, :from, :lock, :readonly,
+             :having, :create_with, :uniq, :references, :none, to: :all
+    delegate :count, :average, :minimum, :maximum, :sum, :calculate, :pluck, :ids, to: :all
+    delegate :find_by_sql, :count_by_sql, to: :all
+  end
+end

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -165,7 +165,7 @@ module ActiveRecord
       if has_include?(column_names.first)
         construct_relation_for_association_calculations.pluck(*column_names)
       else
-        result  = klass.connection.select_all(select(column_names).arel, nil, bind_values)
+        result  = connection.select_all(select(column_names).arel, nil, bind_values)
         columns = result.columns.map do |key|
           klass.column_types.fetch(key) {
             result.column_types.fetch(key) {
@@ -256,7 +256,7 @@ module ActiveRecord
         query_builder = relation.arel
       end
 
-      result = @klass.connection.select_value(query_builder, nil, relation.bind_values)
+      result = connection.select_value(query_builder, nil, relation.bind_values)
       type_cast_calculated_value(result, column_for(column_name), operation)
     end
 
@@ -276,7 +276,7 @@ module ActiveRecord
         [aliaz, column_for(field)]
       }
 
-      group = @klass.connection.adapter_name == 'FrontBase' ? group_aliases : group_fields
+      group = connection.adapter_name == 'FrontBase' ? group_aliases : group_fields
 
       if operation == 'count' && column_name == :all
         aggregate_alias = 'count_all'
@@ -303,7 +303,7 @@ module ActiveRecord
       relation = except(:group).group(group)
       relation.select_values = select_values
 
-      calculated_data = @klass.connection.select_all(relation, nil, bind_values)
+      calculated_data = connection.select_all(relation, nil, bind_values)
 
       if association
         key_ids     = calculated_data.collect { |row| row[group_aliases.first] }
@@ -338,7 +338,7 @@ module ActiveRecord
       table_name.strip!
       table_name.gsub!(/ +/, '_')
 
-      @klass.connection.table_alias_for(table_name)
+      connection.table_alias_for(table_name)
     end
 
     def column_for(field)

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -4,7 +4,7 @@ module ActiveRecord
     # Set up common delegations for performance (avoids method_missing)
     delegate :to_xml, :to_yaml, :length, :collect, :map, :each, :all?, :include?, :to_ary, :to => :to_a
     delegate :table_name, :quoted_table_name, :primary_key, :quoted_primary_key,
-             :connection, :columns_hash, :auto_explain_threshold_in_seconds, :to => :klass
+             :columns_hash, :auto_explain_threshold_in_seconds, :to => :klass
 
     def self.delegate_to_scoped_klass(method)
       if method.to_s =~ /\A[a-zA-Z_]\w*[!?]?\z/

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -225,7 +225,7 @@ module ActiveRecord
 
     def construct_limited_ids_condition(relation)
       orders = relation.order_values.map { |val| val.presence }.compact
-      values = @klass.connection.distinct("#{@klass.connection.quote_table_name table_name}.#{primary_key}", orders)
+      values = connection.distinct("#{connection.quote_table_name table_name}.#{primary_key}", orders)
 
       relation = relation.dup
 

--- a/activerecord/lib/active_record/relation/querying.rb
+++ b/activerecord/lib/active_record/relation/querying.rb
@@ -1,16 +1,6 @@
 
 module ActiveRecord
   module Querying
-    delegate :find, :take, :take!, :first, :first!, :last, :last!, :exists?, :any?, :many?, :to => :all
-    delegate :first_or_create, :first_or_create!, :first_or_initialize, :to => :all
-    delegate :find_or_create_by, :find_or_create_by!, :find_or_initialize_by, :to => :all
-    delegate :find_by, :find_by!, :to => :all
-    delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, :to => :all
-    delegate :find_each, :find_in_batches, :to => :all
-    delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins,
-             :where, :preload, :eager_load, :includes, :from, :lock, :readonly,
-             :having, :create_with, :uniq, :references, :none, :to => :all
-    delegate :count, :average, :minimum, :maximum, :sum, :calculate, :pluck, :ids, :to => :all
 
     # Executes a custom SQL query against your database and returns all the results. The results will
     # be returned as an array with columns requested encapsulated as attributes of the model you call
@@ -36,7 +26,7 @@ module ActiveRecord
     #   > [#<Post:0x36bff9c @attributes={"title"=>"The Cheap Man Buys Twice"}>, ...]
     def find_by_sql(sql, binds = [])
       logging_query_plan do
-        result_set = connection.select_all(sanitize_sql(sql), "#{name} Load", binds)
+        result_set = connection.select_all(klass.send(:sanitize_sql,sql), "#{name} Load", binds)
         column_types = {}
 
         if result_set.respond_to? :column_types
@@ -62,7 +52,7 @@ module ActiveRecord
     #   Product.count_by_sql "SELECT COUNT(*) FROM sales s, customers c WHERE s.customer_id = c.id"
     def count_by_sql(sql)
       logging_query_plan do
-        sql = sanitize_conditions(sql)
+        sql = klass.send(:sanitize_conditions,sql)
         connection.select_value(sql, "#{name} Count").to_i
       end
     end

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -176,6 +176,12 @@ module ActiveRecord
       relation.merge!(where: ['foo = ?', 'bar'])
       assert_equal ['foo = bar'], relation.where_values
     end
+
+    test 'extracting default connection from klass' do
+      relation = Relation.new Post, Post.arel_table
+
+      assert relation.send(:connection).eql?(Post.connection)
+    end
   end
 
   class RelationMutationTest < ActiveSupport::TestCase


### PR DESCRIPTION
All klass.connection and @klass.connection are now just connection, which is delegated to klass. Tests are passing. find_by_sql and count_by_sql are AR::Relation methods.

This should fully fix #6331.

This patch will also give an opportunity to implement something like:

Post.connection(external_database).all
