### PR TITLE
validates_length with minimum 0 and allow_nil: false accept nil

### DIFF
--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -38,10 +38,12 @@ module ActiveModel
         value_length = value.respond_to?(:length) ? value.length : value.to_s.length
 
         CHECKS.each do |key, validity_check|
-          next unless check_value = options[key]
-          next if value_length.send(validity_check, check_value)
+          unless min_zero_val_nil_allow_nil_false?(options, value)
+            next unless check_value = options[key]
+            next if value_length.send(validity_check, check_value)
+          end
 
-          errors_options = options.except(*RESERVED_OPTIONS)
+          errors_options ||= options.except(*RESERVED_OPTIONS)
           errors_options[:count] = check_value
 
           default_message = options[MESSAGES[key]]
@@ -52,6 +54,11 @@ module ActiveModel
       end
 
       private
+
+      def min_zero_val_nil_allow_nil_false?(options, value)
+        empty_string_is_allowed ||= options[:minimum] == 0 && value.nil? && options[:allow_nil] == false
+        empty_string_is_allowed
+      end
 
       def tokenize(value)
         if options[:tokenizer] && value.kind_of?(String)

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -375,4 +375,17 @@ class LengthValidationTest < ActiveModel::TestCase
     t.author_name = "A very long author name that should still be valid." * 100
     assert t.valid?
   end
+
+  def test_validates_length_of_with_minimum_zero_and_allow_nil
+      Topic.validates_length_of(:title, :minimum => 0, :allow_nil => false)
+
+      t = Topic.new(:title=>"1")
+      assert t.valid?
+
+      t = Topic.new(:title=>"")
+      assert t.valid?
+
+      t = Topic.new
+      assert t.invalid?
+    end
 end


### PR DESCRIPTION
Given a class that include ActiveModel::Validations with a validation like the following:
validates_length_of(:title, :minimum => 0, :allow_nil => false).
This makes incosistent the validation because it not raise error when
title is _nil_.It should accepts only the empty string
With this patch title is _nil_ is handled and the validation accepts only the empty string _""_
