### PR TITLE
Remove single character body in head(:no_content) response 

### DIFF
--- a/actionpack/lib/action_controller/metal/head.rb
+++ b/actionpack/lib/action_controller/metal/head.rb
@@ -29,19 +29,19 @@ module ActionController
       self.status = status
       self.location = url_for(location) if location
 
-      if include_content_headers?(self.status)
+      if include_content?(self.status)
         self.content_type = content_type || (Mime[formats.first] if formats)
+        self.response_body = " "
       else
         headers.delete('Content-Type')
         headers.delete('Content-Length')
+        self.response_body = ""
       end
-
-      self.response_body = " "
     end
 
     private
     # :nodoc:
-    def include_content_headers?(status)
+    def include_content?(status)
       case status
       when 100..199
         false

--- a/actionpack/test/controller/mime_responds_test.rb
+++ b/actionpack/test/controller/mime_responds_test.rb
@@ -850,7 +850,7 @@ class RespondWithControllerTest < ActionController::TestCase
     put :using_resource
     assert_equal "application/xml", @response.content_type
     assert_equal 204, @response.status
-    assert_equal " ", @response.body
+    assert_equal "", @response.body
   end
 
   def test_using_resource_for_put_with_json_yields_no_content_on_success
@@ -859,7 +859,7 @@ class RespondWithControllerTest < ActionController::TestCase
     put :using_resource
     assert_equal "application/json", @response.content_type
     assert_equal 204, @response.status
-    assert_equal " ", @response.body
+    assert_equal "", @response.body
   end
 
   def test_using_resource_for_put_with_xml_yields_unprocessable_entity_on_failure
@@ -901,7 +901,7 @@ class RespondWithControllerTest < ActionController::TestCase
     delete :using_resource
     assert_equal "application/xml", @response.content_type
     assert_equal 204, @response.status
-    assert_equal " ", @response.body
+    assert_equal "", @response.body
   end
 
   def test_using_resource_for_delete_with_json_yields_no_content_on_success
@@ -911,7 +911,7 @@ class RespondWithControllerTest < ActionController::TestCase
     delete :using_resource
     assert_equal "application/json", @response.content_type
     assert_equal 204, @response.status
-    assert_equal " ", @response.body
+    assert_equal "", @response.body
   end
 
   def test_using_resource_for_delete_with_html_redirects_on_failure

--- a/actionpack/test/controller/new_base/bare_metal_test.rb
+++ b/actionpack/test/controller/new_base/bare_metal_test.rb
@@ -110,6 +110,36 @@ module BareMetalTest
       assert_nil headers['Content-Type']
       assert_nil headers['Content-Length']
     end
+
+    test "head :no_content (204) does not return any content" do
+      content = HeadController.action(:no_content).call(Rack::MockRequest.env_for("/")).third.first
+      assert_empty content
+    end
+
+    test "head :reset_content (205) does not return any content" do
+      content = HeadController.action(:reset_content).call(Rack::MockRequest.env_for("/")).third.first
+      assert_empty content
+    end
+
+    test "head :not_modified (304) does not return any content" do
+      content = HeadController.action(:not_modified).call(Rack::MockRequest.env_for("/")).third.first
+      assert_empty content
+    end
+
+    test "head :continue (100) does not return any content" do
+      content = HeadController.action(:continue).call(Rack::MockRequest.env_for("/")).third.first
+      assert_empty content
+    end
+
+    test "head :switching_protocols (101) does not return any content" do
+      content = HeadController.action(:switching_protocols).call(Rack::MockRequest.env_for("/")).third.first
+      assert_empty content
+    end
+
+    test "head :processing (102) does not return any content" do
+      content = HeadController.action(:processing).call(Rack::MockRequest.env_for("/")).third.first
+      assert_empty content
+    end
   end
 
   class BareControllerTest < ActionController::TestCase


### PR DESCRIPTION
Rails included a single character response body to work around an old Safari bug where headers were ignored if no content was sent.

This patch brings the behavior slightly closer to spec if :no_content/204 is explicity requested via a head only response by sending a no content in the response body. 

The single character body breaks especially JSON parsers on iOS etc that sees it as invalid content. By localising the change to only 204 responses this should allow API implementers to use the 204 status code when no content is sent back.
