### PR TITLE
remote_ip was failing under unix socks (puma)

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -95,7 +95,8 @@ module ActionDispatch
           client_ips.first
         else
           # If there is no client ip we can return first valid proxy ip from REMOTE_ADDR
-          remote_addrs.find { |ip| valid_ip? ip }
+          # NOTE: remote_addrs can be empty if served over a unix socket
+          [remote_addrs, client_ip, forwarded_ip].flatten.find { |ip| valid_ip? ip }
         end
       end
 


### PR DESCRIPTION
was crashing under puma, needed to ensure we always get an ip even if we are being served over a unix sock where remote_addr is empty
