### PR TITLE
alias attr_accessible to mass_assignable

### DIFF
--- a/activemodel/lib/active_model/mass_assignment_security.rb
+++ b/activemodel/lib/active_model/mass_assignment_security.rb
@@ -184,6 +184,7 @@ module ActiveModel
 
         self._active_authorizer = self._accessible_attributes
       end
+      alias mass_assignable attr_accessible
 
       def protected_attributes(role = :default)
         protected_attributes_configs[role]


### PR DESCRIPTION
attr_accessible is a very confusing name. 

First, it has nothing to do with the other attr_\* macros, which deal with Ruby instance-variable-based getters and setters, not Rails attributes. 

Second, the term "access" is generally understood to refer to reading a value, viz. accessor vs. mutator. Yet this macro is about the _opposite_ of reading; instead, it determines whether an attribute can be _written_, aka assigned.

Third, this is in a module called Mass Assignment, and this macro is literally specifying which values can be mass assigned. So why be so mysterious? Let's just call it mass_assignable and get on with our lives. It will make this feature more understandable to every Rails programmer who has had to figure out what that line is doing there, especially now that it's in every generated model class -- and rightly so, since it's an important and useful feature and deserves to be embraced and understood by all.

This patch is just to show the (trivial) implementation; changes to documentation and to the generators will follow if people agree it's worth doing.
