### PR TITLE
Add Object#peek as helper method to inspect object

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add `Object#peek` as helper method to print out and inspect the object.
+
 *   Inflections can now be defined per locale. `singularize` and `pluralize` accept locale as an extra argument. *David Celis*
 
 *   `Object#try` will now return nil instead of raise a NoMethodError if the receiving object does not implement the method, but you can still get the old behavior by using the new `Object#try!` *DHH*

--- a/activesupport/lib/active_support/core_ext/object.rb
+++ b/activesupport/lib/active_support/core_ext/object.rb
@@ -4,6 +4,7 @@ require 'active_support/core_ext/object/duplicable'
 require 'active_support/core_ext/object/deep_dup'
 require 'active_support/core_ext/object/try'
 require 'active_support/core_ext/object/inclusion'
+require 'active_support/core_ext/object/peek'
 
 require 'active_support/core_ext/object/conversions'
 require 'active_support/core_ext/object/instance_variables'

--- a/activesupport/lib/active_support/core_ext/object/peek.rb
+++ b/activesupport/lib/active_support/core_ext/object/peek.rb
@@ -1,0 +1,7 @@
+class Object
+  # Call +#tap+ on the object, then print out the inspect version of the object to your standard
+  # output. This is the shortcut for: +object.tap { |o| puts o.inspect }+
+  def peek
+    tap { |object| puts object.inspect }
+  end
+end

--- a/activesupport/test/core_ext/object/peek_test.rb
+++ b/activesupport/test/core_ext/object/peek_test.rb
@@ -1,0 +1,38 @@
+require 'abstract_unit'
+require 'active_support/core_ext/object'
+
+class PeekTest < ActiveSupport::TestCase
+  class Sister
+    class << self
+      def inspect
+        "My Sister"
+      end
+
+      def cute?
+        false
+      end
+
+      def name
+        "Kirino"
+      end
+    end
+  end
+
+  def test_peek_on_nil
+    assert_equal "nil\n", capture(:stdout) { nil.peek }
+  end
+
+  def test_peek_on_class
+    assert_equal "My Sister\n", capture(:stdout) { Sister.peek }
+  end
+
+  def test_peek_on_string
+    assert_equal "\"Kirino\"\n", capture(:stdout) { Sister.name.peek }
+  end
+
+  def test_peek_chain
+    assert_equal "false\n", capture(:stdout) {
+      assert_equal "FALSE", Sister.cute?.peek.to_s.upcase
+    }
+  end
+end

--- a/guides/source/active_support_core_extensions.textile
+++ b/guides/source/active_support_core_extensions.textile
@@ -498,6 +498,15 @@ Examples of +in?+:
 
 NOTE: Defined in +active_support/core_ext/object/inclusion.rb+.
 
+h4. +peek+
+
+This method will print the inspect version of your object to the standard output. It's very useful for debugging your object. This method will return +self+, so it's chainable.
+
+<ruby>
+object.peek              # Same as object.tap{ |o| puts o.inspect }
+object.peek.do_something # Same as object.tap{ |o| puts o.inspect }.do_somethign
+</ruby>
+
 h3. Extensions to +Module+
 
 h4. +alias_method_chain+


### PR DESCRIPTION
This method is very helpful when inspecting and debug the code. So, instead of you having to do this:

```
@user.tap{ |u| puts u.inspect }.activate!
```

Now you can do:

```
@user.peek.activate!
```
