### PR TITLE
Indentation should consider line number character count.

### DIFF
--- a/actionpack/lib/action_view/template/error.rb
+++ b/actionpack/lib/action_view/template/error.rb
@@ -84,13 +84,13 @@ module ActionView
         start_on_line = [ num - SOURCE_CODE_RADIUS - 1, 0 ].max
         end_on_line   = [ num + SOURCE_CODE_RADIUS - 1, source_code.length].min
 
-        indent = ' ' * indentation
+        indent = end_on_line.to_s.size + indentation
         line_counter = start_on_line
         return unless source_code = source_code[start_on_line..end_on_line]
 
         source_code.sum do |line|
           line_counter += 1
-          "#{indent}#{line_counter}: #{line}\n"
+          "%#{indent}s: %s\n" % [line_counter, line]
         end
       end
 

--- a/actionpack/test/fixtures/test/_raise_indentation.html.erb
+++ b/actionpack/test/fixtures/test/_raise_indentation.html.erb
@@ -1,0 +1,13 @@
+<p>First paragraph</p>
+<p>Second paragraph</p>
+<p>Third paragraph</p>
+<p>Fourth paragraph</p>
+<p>Fifth paragraph</p>
+<p>Sixth paragraph</p>
+<p>Seventh paragraph</p>
+<p>Eight paragraph</p>
+<p>Ninth paragraph</p>
+<p>Tenth paragraph</p>
+<%= raise "error here!" %>
+<p>Eleventh paragraph</p>
+<p>Twelfth paragraph</p>

--- a/actionpack/test/template/render_test.rb
+++ b/actionpack/test/template/render_test.rb
@@ -203,6 +203,15 @@ module RenderTestCases
     assert_equal File.expand_path("#{FIXTURE_LOAD_PATH}/test/_raise.html.erb"), e.file_name
   end
 
+  def test_render_error_indentation
+    e = assert_raises(ActionView::Template::Error) { @view.render(:partial => "test/raise_indentation") }
+    error_lines = e.annoted_source_code.split("\n")
+    assert_match %r!error\shere!, e.message
+    assert_equal "11", e.line_number
+    assert_equal "     9: <p>Ninth paragraph</p>", error_lines.second
+    assert_equal "    10: <p>Tenth paragraph</p>", error_lines.third
+  end
+
   def test_render_sub_template_with_errors
     e = assert_raises(ActionView::Template::Error) { @view.render(:template => "test/sub_template_raise") }
     assert_match %r!method.*doesnt_exist!, e.message


### PR DESCRIPTION
If you have an error page that shows lines 8-12 for example, the source would not be aligned properly from line 10 onwards.

This commit fixes that.
