### PR TITLE
change form div css display attribute to 'none' 

### DIFF
--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -744,7 +744,7 @@ module ActionView
           end
 
           tags = utf8_enforcer_tag << method_tag
-          content_tag(:div, tags, :style => 'margin:0;padding:0;display:inline')
+          content_tag(:div, tags, :style => 'margin:0;padding:0;display:none')
         end
 
         def form_tag_html(html_options)


### PR DESCRIPTION
resolve old browser (IE6/IE7) line height issue
