### PR TITLE
polymorphic_url with an array generates a query string

### DIFF
--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -62,6 +62,7 @@ module ActionDispatch
       #
       #   # calls post_url(post)
       #   polymorphic_url(post) # => "http://example.com/posts/1"
+      #   polymorphic_url([post, :foo => 'bar']) # => "http://example.com/posts/1?foo=bar"
       #   polymorphic_url([blog, post]) # => "http://example.com/blogs/1/posts/1"
       #   polymorphic_url([:admin, blog, post]) # => "http://example.com/admin/blogs/1/posts/1"
       #   polymorphic_url([user, :blog, post]) # => "http://example.com/users/1/blog/posts/1"
@@ -164,6 +165,7 @@ module ActionDispatch
 
         def build_named_route_call(records, inflection, options = {})
           if records.is_a?(Array)
+            query_string = records.pop if records.last.is_a?(Hash)
             record = records.pop
             route = records.map do |parent|
               if parent.is_a?(Symbol) || parent.is_a?(String)
@@ -196,7 +198,8 @@ module ActionDispatch
 
         def extract_record(record_or_hash_or_array)
           case record_or_hash_or_array
-            when Array; record_or_hash_or_array.last
+            when Array
+              record_or_hash_or_array.last.is_a?(Hash) ? record_or_hash_or_array[-2] : record_or_hash_or_array.last
             when Hash;  record_or_hash_or_array[:id]
             else        record_or_hash_or_array
           end

--- a/actionpack/test/activerecord/polymorphic_routes_test.rb
+++ b/actionpack/test/activerecord/polymorphic_routes_test.rb
@@ -309,6 +309,20 @@ class PolymorphicRoutesTest < ActionController::TestCase
     end
   end
 
+  def test_with_array_containing_simple_hash
+    with_test_routes do
+      @project.save
+      assert_equal "http://example.com/projects/#{@project.id}?foo=bar", polymorphic_url([@project, :foo => 'bar' ])
+    end
+  end
+
+  def test_with_array_containing_complex_hash
+    with_test_routes do
+      @project.save
+      assert_equal "http://example.com/projects/#{@project.id}?foo=bar&nested%5Bfoo%5D=bar", polymorphic_url([@project, :nested => { :foo => 'bar' }, :foo => 'bar'])
+    end
+  end
+
   def test_with_array_containing_single_name
     with_test_routes do
       @project.save


### PR DESCRIPTION
Generating an URL with an array of records is now able to build a query
string if the last item of the array is a hash.
