### PR TITLE
Update Migration Docs: Defaults for Boolean Fields

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -50,7 +50,7 @@ module ActiveRecord
   #
   #   class AddSsl < ActiveRecord::Migration
   #     def up
-  #       add_column :accounts, :ssl_enabled, :boolean, :default => 1
+  #       add_column :accounts, :ssl_enabled, :boolean, :default => true
   #     end
   #
   #     def down


### PR DESCRIPTION
A Boolean field will accept `true` or `false` as defaults instead of `0` / `1`.

As shown in the [Rails Migration Guides](http://guides.rubyonrails.org/migrations.html) right in the second box.
