### PR TITLE
added with_indent parameter to strip_heredoc

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/strip.rb
+++ b/activesupport/lib/active_support/core_ext/string/strip.rb
@@ -19,8 +19,12 @@ class String
   #
   # Technically, it looks for the least indented line in the whole string, and removes
   # that amount of leading whitespace.
-  def strip_heredoc
+  #
+  # Use strip_heredoc(2) if you want the result to be preceded by 2 spaces. For instance, if you want to
+  # insert something in a place that already has two spaces indent, like config/environments/production.rb
+  #
+  def strip_heredoc(with_indent = 0)
     indent = scan(/^[ \t]*(?=\S)/).min.try(:size) || 0
-    gsub(/^[ \t]{#{indent}}/, '')
+    gsub(/^[ \t]{#{indent}}/, ' ' * with_indent)
   end
 end

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -52,6 +52,37 @@ class StringInflectionsTest < ActiveSupport::TestCase
     EOS
   end
 
+  def test_strip_heredoc_with_indent_on_an_empty_string
+    assert_equal '  ', ''.strip_heredoc(2)
+  end
+
+  def test_strip_heredoc_with_indent_on_a_string_with_no_lines
+    assert_equal '  x', 'x'.strip_heredoc(2)
+    assert_equal '  x', '    x'.strip_heredoc(2)
+  end
+
+  def test_strip_heredoc_with_indent_on_a_heredoc_with_no_margin
+    assert_equal "  foo\n  bar", "foo\nbar".strip_heredoc(2)
+    assert_equal "  foo\n    bar", "foo\n  bar".strip_heredoc(2)
+  end
+
+  def test_strip_heredoc_with_indent_on_a_regular_indented_heredoc
+    assert_equal "  foo\n    bar\n  baz\n", <<-EOS.strip_heredoc(2)
+      foo
+        bar
+      baz
+    EOS
+  end
+
+  def test_strip_heredoc_with_indent_on_a_regular_indented_heredoc_with_blank_lines
+    assert_equal "  foo\n    bar\n\n  baz\n", <<-EOS.strip_heredoc(2)
+      foo
+        bar
+
+      baz
+    EOS
+  end
+
   def test_pluralize
     SingularToPlural.each do |singular, plural|
       assert_equal(plural, singular.pluralize)

--- a/guides/source/active_support_core_extensions.textile
+++ b/guides/source/active_support_core_extensions.textile
@@ -1320,8 +1320,28 @@ end
 
 the user would see the usage message aligned against the left margin.
 
-Technically, it looks for the least indented line in the whole string, and removes
-that amount of leading whitespace.
+If for some reason the message needs to be indented, then specify the number of spaces
+as a parameter.
+
+For example in
+
+<ruby>
+if options[:usage]
+  puts <<-USAGE.strip_heredoc(2)
+    This command does such and such.
+
+    Supported options are:
+      -h         This message
+      ...
+  USAGE  
+end
+</ruby>
+
+the user would see the usage message aligned 2 spaces from the left margin.
+
+Technically, strip_heredoc looks for the least indented line in the whole string, and
+removes that amount of leading whitespace, and then adds the number of spaces specified in the
+parameter to the beginning of each line.
 
 NOTE: Defined in +active_support/core_ext/string/strip.rb+.
 


### PR DESCRIPTION
strip_heredoc strips all leading spaces/tabs from a heredoc.

But there are situations when you want to retain a certain indent, for instance, when inserting something in config/environments/production.rb

Example:

`````` ruby
module Module
  class Creator < Thor
    desc "dostuff NAME", "do stuff to NAME"
    def dostuff(name)
      insert_into_file "config/environments/production.rb", <<-HEREDOC.strip_heredoc(2), :before => "end\n"
        # mailer settings
        config.action_mailer.smtp_settings = {
          :address => 'YOURMAILSERVER',
          :enable_starttls_auto => true,
          :password => 'YOURPASSWORD',
          :user_name => 'YOURUSERNAME'
        }

      HEREDOC
    end   
  end   
end   
```ruby

The result is that the inserted text is indented by 2 spaces, to align with the rest of production.rb.

Cheers
ace

``````
