### PR TITLE
Fix a bug that has_many dependent: destroy not delete child records 

### DIFF
--- a/activerecord/lib/active_record/associations/builder/has_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_many.rb
@@ -36,6 +36,7 @@ module ActiveRecord::Associations::Builder
           end
 
           send(name).delete_all
+          send(name).reload.empty?
         end
       end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -19,6 +19,7 @@ require 'models/line_item'
 require 'models/car'
 require 'models/bulb'
 require 'models/engine'
+require 'models/wheel'
 
 class HasManyAssociationsTestForCountWithFinderSql < ActiveRecord::TestCase
   class Invoice < ActiveRecord::Base
@@ -1653,5 +1654,14 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   test ":counter_sql is deprecated" do
     klass = Class.new(ActiveRecord::Base)
     assert_deprecated { klass.has_many :foo, :counter_sql => 'lol' }
+  end
+
+  test "cascade destroy incase that associated model before_destroy returns false" do
+    car = Car.create!(:name => "De Lorean")
+    car.wheels << Wheel.create!
+    assert_no_difference 'Wheel.count'  do
+      car.destroy
+    end
+    assert !car.destroyed?
   end
 end

--- a/activerecord/test/models/wheel.rb
+++ b/activerecord/test/models/wheel.rb
@@ -1,6 +1,5 @@
 class Wheel < ActiveRecord::Base
   belongs_to :wheelable, :polymorphic => true, :counter_cache => true
-  attr_accessor :brand_new
   before_destroy :detachable?
 
   def detachable?

--- a/activerecord/test/models/wheel.rb
+++ b/activerecord/test/models/wheel.rb
@@ -1,3 +1,9 @@
 class Wheel < ActiveRecord::Base
   belongs_to :wheelable, :polymorphic => true, :counter_cache => true
+  attr_accessor :brand_new
+  before_destroy :detachable?
+
+  def detachable?
+    wheelable.name != "De Lorean"
+  end
 end


### PR DESCRIPTION
Hi.
I have found a bug that has_many dependant destroy don't destroy all child records.

``` ruby
class Post < ActiveRecord::Base
  has_many :comments, :dependent => :destroy
end

class Comment < ActiveRecord::Base
  belongs_to :post
  before_destroy do
    false
  end
end

post = Post.create(title: "new post")
post.comments << Comment.create(body: "hello")
post.destroy
p Post.all #=> []
p Comment.all #=> [#<Comment id: 980190963, body: "hello", post_id: 980190963, created_at: "2012-08-05 10:31:37", updated_at: "2012-08-05 10:31:37">]
```

I add a judge all records is deleted into has_many dependent callback.

Thanks.
