### PR TITLE
Changing AR:CollectionAssociation#empty? to use #exists?

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -270,12 +270,20 @@ module ActiveRecord
         load_target.size
       end
 
-      # Returns true if the collection is empty. Equivalent to
-      # <tt>collection.size.zero?</tt>. If the collection has not been already
+      # Returns true if the collection is empty.
+      #
+      # If the collection has been loaded or the <tt>:counter_sql</tt> option
+      # is provided, it is equivalent to <tt>collection.size.zero?</tt>. If the
+      # collection has not been loaded, it is equivalent to
+      # <tt>collection.exists?</tt>. If the collection has not already been
       # loaded and you are going to fetch the records anyway it is better to
       # check <tt>collection.length.zero?</tt>.
       def empty?
-        size.zero?
+        if loaded? || options[:counter_sql]
+          size.zero?
+        else
+          !scope.exists?
+        end
       end
 
       # Returns true if the collections is not empty.


### PR DESCRIPTION
COUNT(*) queries can be slow in PostgreSQL, #exists? avoids this by selecting a single record. @jonleighton suggested in issue #3179 that #empty? should be patched to use #exists? for the same benefit. I couldn't think of a great way to test it since the external behavior is not changing. If anyone has any suggestions for tests though, I would be more than happy to add them.
