### PR TITLE
Convert model name to foreign key in queries

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Accept belongs_to (including polymorphic) association keys in queries
+
+    The following queries are now equivalent:
+
+        Post.where(:author => author)
+        Post.where(:author_id => author)
+
+        PriceEstimate.where(:estimate_of => treasure)
+        PriceEstimate.where(:estimate_of_type => 'Treasure', :estimate_of_id => treasure)
+
+    *Peter Brown*
+
 *   Use native `mysqldump` command instead of `structure_dump` method
     when dumping the database structure to a sql file. Fixes #5547.
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -340,6 +340,24 @@ module ActiveRecord
     #    User.where({ created_at: (Time.now.midnight - 1.day)..Time.now.midnight })
     #    # SELECT * FROM users WHERE (created_at BETWEEN '2012-06-09 07:00:00.000000' AND '2012-06-10 07:00:00.000000')
     #
+    # In the case of a belongs_to relationship, an association key can be used
+    # to specify the model if an ActiveRecord object is used as the value.
+    #
+    #    author = Author.find(1)
+    #
+    #    # The following queries will be equivalent:
+    #    Post.where(:author => author)
+    #    Post.where(:author_id => author)
+    #
+    # This also works with polymorphic belongs_to relationships:
+    #
+    #    treasure = Treasure.create(:name => 'gold coins')
+    #    treasure.price_estimates << PriceEstimate.create(:price => 125)
+    #
+    #    # The following queries will be equivalent:
+    #    PriceEstimate.where(:estimate_of => treasure)
+    #    PriceEstimate.where(:estimate_of_type => 'Treasure', :estimate_of_id => treasure)
+    #
     # === Joins
     #
     # If the relation is the result of a join, you may create a condition which uses any of the

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -1,9 +1,77 @@
 require "cases/helper"
+require 'models/author'
+require 'models/price_estimate'
+require 'models/treasure'
 require 'models/post'
 
 module ActiveRecord
   class WhereTest < ActiveRecord::TestCase
-    fixtures :posts
+    fixtures :posts, :authors
+
+    def test_belongs_to_shallow_where
+      author = Post.first.author
+      query_with_id = Post.where(:author_id => author)
+      query_with_assoc = Post.where(:author => author)
+
+      assert_equal query_with_id.to_sql, query_with_assoc.to_sql
+    end
+
+    def test_belongs_to_nested_where
+      author = Post.first.author
+      query_with_id = Author.where(:posts => {:author_id => author}).joins(:posts)
+      query_with_assoc = Author.where(:posts => {:author => author}).joins(:posts)
+
+      assert_equal query_with_id.to_sql, query_with_assoc.to_sql
+    end
+
+    def test_polymorphic_shallow_where
+      treasure = Treasure.create(:name => 'gold coins')
+      treasure.price_estimates << PriceEstimate.create(:price => 125)
+
+      query_by_column = PriceEstimate.where(:estimate_of_type => 'Treasure', :estimate_of_id => treasure)
+      query_by_model = PriceEstimate.where(:estimate_of => treasure)
+
+      assert_equal query_by_column.to_sql, query_by_model.to_sql
+    end
+
+    def test_polymorphic_sti_shallow_where
+      treasure = HiddenTreasure.create!(:name => 'gold coins')
+      treasure.price_estimates << PriceEstimate.create!(:price => 125)
+
+      query_by_column = PriceEstimate.where(:estimate_of_type => 'Treasure', :estimate_of_id => treasure)
+      query_by_model = PriceEstimate.where(:estimate_of => treasure)
+
+      assert_equal query_by_column.to_sql, query_by_model.to_sql
+    end
+
+    def test_polymorphic_nested_where
+      estimate = PriceEstimate.create :price => 125
+      treasure = Treasure.create :name => 'Booty'
+
+      treasure.price_estimates << estimate
+
+      query_by_column = Treasure.where(:price_estimates => {:estimate_of_type => 'Treasure', :estimate_of_id => treasure}).joins(:price_estimates)
+      query_by_model = Treasure.where(:price_estimates => {:estimate_of => treasure}).joins(:price_estimates)
+
+      assert_equal treasure, query_by_column.first
+      assert_equal treasure, query_by_model.first
+      assert_equal query_by_column.to_a, query_by_model.to_a
+    end
+
+    def test_polymorphic_sti_nested_where
+      estimate = PriceEstimate.create :price => 125
+      treasure = HiddenTreasure.create!(:name => 'gold coins')
+      treasure.price_estimates << PriceEstimate.create!(:price => 125)
+
+      treasure.price_estimates << estimate
+
+      query_by_column = Treasure.where(:price_estimates => {:estimate_of_type => 'Treasure', :estimate_of_id => treasure}).joins(:price_estimates)
+      query_by_model = Treasure.where(:price_estimates => {:estimate_of => treasure}).joins(:price_estimates)
+
+      assert_equal treasure, query_by_column.first
+      assert_equal treasure, query_by_model.first
+      assert_equal query_by_column.to_a, query_by_model.to_a
+    end
 
     def test_where_error
       assert_raises(ActiveRecord::StatementInvalid) do

--- a/activerecord/test/models/treasure.rb
+++ b/activerecord/test/models/treasure.rb
@@ -6,3 +6,6 @@ class Treasure < ActiveRecord::Base
 
   accepts_nested_attributes_for :looter
 end
+
+class HiddenTreasure < Treasure
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -693,6 +693,7 @@ ActiveRecord::Schema.define do
 
   create_table :treasures, :force => true do |t|
     t.column :name, :string
+    t.column :type, :string
     t.column :looter_id, :integer
     t.column :looter_type, :string
   end

--- a/guides/source/active_record_querying.textile
+++ b/guides/source/active_record_querying.textile
@@ -465,6 +465,13 @@ The field name can also be a string:
 Client.where('locked' => true)
 </ruby>
 
+In the case of a belongs_to relationship, an association key can be used to specify the model if an ActiveRecord object is used as the value. This method works with polymorphic relationships as well.
+
+<ruby>
+Post.where(:author => author)
+Author.joins(:posts).where(:posts => {:author => author})
+</ruby>
+
 NOTE: The values cannot be symbols. For example, you cannot do +Client.where(:status => :active)+.
 
 h5(#hash-range_conditions). Range Conditions


### PR DESCRIPTION
This allows you to specify the model in a `belongs_to` relationship instead of the foreign key when querying. It does this by looking up the correct foreign key on the association, and changing the column to use that key when appropriate. It came out of a discussion in issue #1736 that seemed to have some interest.

The following queries are now equivalent:

``` ruby
Post.where(:author_id => Author.first)
Post.where(:author => Author.first)
```

I also think it makes it more consistent with `has_many` queries where the relationship and query key are both plural:

``` ruby
posts = Post.containing_the_letter_a.limit(5)
Author.where(:posts => posts)
```
