### PR TITLE
Do not include application.js if it doesn't exists

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `javascript_include_tag :all` will now not include `application.js` if the file does not exists. *Prem Sichanugrist*
+
 *   Send an empty response body when call `head` with status between 100 and 199, 204, 205 or 304.
 
     *Armand du Plessis*

--- a/actionpack/lib/action_view/helpers/asset_tag_helpers/javascript_tag_helpers.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helpers/javascript_tag_helpers.rb
@@ -141,9 +141,9 @@ module ActionView
         #   javascript_include_tag :all
         #   # => <script src="/javascripts/jquery.js?1284139606"></script>
         #   #    <script src="/javascripts/rails.js?1284139606"></script>
-        #   #    <script src="/javascripts/application.js?1284139606"></script>
         #   #    <script src="/javascripts/shop.js?1284139606"></script>
         #   #    <script src="/javascripts/checkout.js?1284139606"></script>
+        #   #    <script src="/javascripts/application.js?1284139606"></script>
         #
         # Note that your defaults of choice will be included first, so they will be available to all subsequently
         # included files.
@@ -164,9 +164,9 @@ module ActionView
         #   javascript_include_tag :all, :cache => true
         #   # => <script src="/javascripts/jquery.js?1284139606"></script>
         #   #    <script src="/javascripts/rails.js?1284139606"></script>
-        #   #    <script src="/javascripts/application.js?1284139606"></script>
         #   #    <script src="/javascripts/shop.js?1284139606"></script>
         #   #    <script src="/javascripts/checkout.js?1284139606"></script>
+        #   #    <script src="/javascripts/application.js?1284139606"></script>
         #
         #   # assuming config.perform_caching is true
         #   javascript_include_tag :all, :cache => true

--- a/actionpack/lib/action_view/helpers/asset_tag_helpers/javascript_tag_helpers.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helpers/javascript_tag_helpers.rb
@@ -26,7 +26,8 @@ module ActionView
 
           def expand_sources(sources, recursive = false)
             if sources.include?(:all)
-              all_asset_files = (collect_asset_files(custom_dir, ('**' if recursive), "*.#{extension}") - ['application']) << 'application'
+              all_asset_files = (collect_asset_files(custom_dir, ('**' if recursive), "*.#{extension}") - ['application'])
+              add_application_js(all_asset_files, sources)
               ((determine_source(:defaults, expansions).dup & all_asset_files) + all_asset_files).uniq
             else
               expanded_sources = sources.inject([]) do |list, source|
@@ -39,7 +40,7 @@ module ActionView
           end
 
           def add_application_js(expanded_sources, sources)
-            if sources.include?(:defaults) && File.exist?(File.join(custom_dir, "application.#{extension}"))
+            if (sources.include?(:defaults) || sources.include?(:all)) && File.exist?(File.join(custom_dir, "application.#{extension}"))
               expanded_sources.delete('application')
               expanded_sources << "application"
             end
@@ -106,8 +107,8 @@ module ActionView
         #
         #   config.action_view.javascript_expansions[:defaults] = %w(foo.js bar.js)
         #
-        # When using <tt>:defaults</tt>, if an <tt>application.js</tt> file exists in
-        # <tt>public/javascripts</tt> it will be included as well at the end.
+        # When using <tt>:defaults</tt> or <tt>:all</tt>, if an <tt>application.js</tt> file exists
+        # in <tt>public/javascripts</tt> it will be included as well at the end.
         #
         # You can modify the HTML attributes of the script tag by passing a hash as the
         # last argument.
@@ -132,6 +133,8 @@ module ActionView
         #   # => <script src="/javascripts/jquery.js?1284139606"></script>
         #   #    <script src="/javascripts/rails.js?1284139606"></script>
         #   #    <script src="/javascripts/application.js?1284139606"></script>
+        #
+        # Note: The application.js file is only referenced if it exists
         #
         # You can also include all JavaScripts in the +javascripts+ directory using <tt>:all</tt> as the source:
         #

--- a/actionpack/test/template/asset_tag_helper_test.rb
+++ b/actionpack/test/template/asset_tag_helper_test.rb
@@ -417,6 +417,15 @@ class AssetTagHelperTest < ActionView::TestCase
     assert_raise(ArgumentError) { javascript_include_tag(:defaults) }
   end
 
+  def test_all_javascript_expansion_not_include_application_js_if_not_exists
+    FileUtils.mv(File.join(ActionView::Helpers::AssetTagHelper::JAVASCRIPTS_DIR, 'application.js'),
+      File.join(ActionView::Helpers::AssetTagHelper::JAVASCRIPTS_DIR, 'application.bak'))
+    assert_no_match(/application\.js/, javascript_include_tag(:all))
+  ensure
+    FileUtils.mv(File.join(ActionView::Helpers::AssetTagHelper::JAVASCRIPTS_DIR, 'application.bak'),
+      File.join(ActionView::Helpers::AssetTagHelper::JAVASCRIPTS_DIR, 'application.js'))
+  end
+
   def test_stylesheet_path
     ENV["RAILS_ASSET_ID"] = ""
     StylePathToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }


### PR DESCRIPTION
Rails were including 'application.js' to the pack when using `javascript_include_tag :all` even there's no `application.js` in the public directory.

This is for `master`
