### PR TITLE
Length validation handles correctly nil. Fix #7180

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fixed length validator to correctly handle nil values. Fixes #7180.
+
+    *Michal Zima*
+
 *   Use BCrypt's MIN_COST in the test environment for speedier tests when using `has_secure_pasword`.
 
     *Brian Cardarella + Jeremy Kemper + Trevor Turk*

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -375,4 +375,43 @@ class LengthValidationTest < ActiveModel::TestCase
     t.author_name = "A very long author name that should still be valid." * 100
     assert t.valid?
   end
+
+  def test_validates_length_of_using_maximum_should_not_allow_nil_when_nil_not_allowed
+    Topic.validates_length_of :title, :maximum => 10, :allow_nil => false
+    t = Topic.new
+    assert t.invalid?
+  end
+
+  def test_validates_length_of_using_maximum_should_not_allow_nil_and_empty_string_when_blank_not_allowed
+    Topic.validates_length_of :title, :maximum => 10, :allow_blank => false
+    t = Topic.new
+    assert t.invalid?
+
+    t.title = ""
+    assert t.invalid?
+  end
+
+  def test_validates_length_of_using_both_minimum_and_maximum_should_not_allow_nil
+    Topic.validates_length_of :title, :minimum => 5, :maximum => 10
+    t = Topic.new
+    assert t.invalid?
+  end
+
+  def test_validates_length_of_using_minimum_0_should_not_allow_nil
+    Topic.validates_length_of :title, :minimum => 0
+    t = Topic.new
+    assert t.invalid?
+
+    t.title = ""
+    assert t.valid?
+  end
+
+  def test_validates_length_of_using_is_0_should_not_allow_nil
+    Topic.validates_length_of :title, :is => 0
+    t = Topic.new
+    assert t.invalid?
+
+    t.title = ""
+    assert t.valid?
+  end
 end


### PR DESCRIPTION
When nil or empty string are not allowed, they are not valid.
