### PR TITLE
Allow newer versions of Sprockets

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency('rack',          '~> 1.4.0')
   s.add_dependency('rack-test',     '~> 0.6.1')
   s.add_dependency('journey',       '~> 1.0.4')
-  s.add_dependency('sprockets',     '~> 2.1.3')
+  s.add_dependency('sprockets',     '~> 2.1')
   s.add_dependency('erubis',        '~> 2.7.0')
 
   s.add_development_dependency('tzinfo', '~> 0.3.29')


### PR DESCRIPTION
Theres a ton of new bug fixes in the newer releases of sprockets. Rails is still locked to a really old version that I'm not backporting fixes for.

Whatever regression 2.2+ caused needs to be addressed.

This change still allows 2.1.x so people can just stay on the version they are now if its working for them.

/cc @dhh 
