### PR TITLE
Performance testing: add total value of metric

### DIFF
--- a/activesupport/lib/active_support/testing/performance.rb
+++ b/activesupport/lib/active_support/testing/performance.rb
@@ -102,7 +102,7 @@ module ActiveSupport
         def report
           if @supported
             rate = @total / full_profile_options[:runs]
-            '%20s: %s (avg: %s)' % [@metric.name, @metric.format(@total), @metric.format(rate)]
+            '%20s: %s (total: %s)' % [@metric.name, @metric.format(rate), @metric.format(@total)]
           else
             '%20s: unsupported' % @metric.name
           end

--- a/activesupport/lib/active_support/testing/performance.rb
+++ b/activesupport/lib/active_support/testing/performance.rb
@@ -102,7 +102,7 @@ module ActiveSupport
         def report
           if @supported
             rate = @total / full_profile_options[:runs]
-            '%20s: %s' % [@metric.name, @metric.format(rate)]
+            '%20s: %s (avg: %s)' % [@metric.name, @metric.format(@total), @metric.format(rate)]
           else
             '%20s: unsupported' % @metric.name
           end


### PR DESCRIPTION
In most cases, when you benchmarking something you are interested not only in average metric value, but in total metric value.

This change adds total value, along with average. 

By the way: atm, nothing in rails docs saying that you will get average metric value instead of total.

Also, it will be nice to have this change in stable branch too.
