### PR TITLE
Fix only-once stub logic.

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -92,9 +92,9 @@ module ActiveRecord
         def query_fake(*args)
           if !( @called ||= false )
             self.stubs(:status).returns(PGconn::CONNECTION_BAD)
+            @called = true
             raise PGError
           else
-            @called = true
             self.unstub(:status)
             query_unfake(*args)
           end


### PR DESCRIPTION
Follow-up: fix the fix.

Didn't fail the test because adapter#query happens to
not call raw connection's #query, but don't want to count
on that and have a fragile test.
