### PR TITLE
Introduce default_headers. closes #6311 #6515

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -58,6 +58,7 @@ module ActionDispatch # :nodoc:
     LOCATION     = "Location".freeze
 
     cattr_accessor(:default_charset) { "utf-8" }
+    cattr_accessor(:default_headers)
 
     include Rack::Response::Helpers
     include ActionDispatch::Http::Cache::Response
@@ -95,6 +96,10 @@ module ActionDispatch # :nodoc:
 
     def initialize(status = 200, header = {}, body = [])
       super()
+
+      if self.class.default_headers.respond_to?(:merge)
+        header = self.class.default_headers.merge(header)
+      end
 
       self.body, self.header, self.status = body, header, status
 

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -23,6 +23,7 @@ module ActionDispatch
       ActionDispatch::Http::URL.tld_length = app.config.action_dispatch.tld_length
       ActionDispatch::Request.ignore_accept_header = app.config.action_dispatch.ignore_accept_header
       ActionDispatch::Response.default_charset = app.config.action_dispatch.default_charset || app.config.encoding
+      ActionDispatch::Response.default_headers = app.config.action_dispatch.default_headers
 
       ActionDispatch::ExceptionWrapper.rescue_responses.merge!(config.action_dispatch.rescue_responses)
       ActionDispatch::ExceptionWrapper.rescue_templates.merge!(config.action_dispatch.rescue_templates)

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -176,6 +176,33 @@ class ResponseTest < ActiveSupport::TestCase
       ActionDispatch::Response.default_charset = original
     end
   end
+
+  test "read x_frame_options and x_xss_protection" do
+    ActionDispatch::Response.default_headers = {
+      'X-Frame-Options' => 'DENY',
+      'X-XSS-Protection' => '1;'
+    }
+    resp = ActionDispatch::Response.new.tap { |response|
+      response.body = 'Hello'
+    }
+    resp.to_a
+
+    assert_equal('DENY', resp.headers['X-Frame-Options'])
+    assert_equal('1;', resp.headers['X-XSS-Protection'])
+  end  
+
+  test "read custom default_header" do
+    ActionDispatch::Response.default_headers = {
+      'X-XX-XXXX' => 'Here is my phone number'
+    }
+    resp = ActionDispatch::Response.new.tap { |response|
+      response.body = 'Hello'
+    }
+    resp.to_a
+    
+    assert_equal('Here is my phone number', resp.headers['X-XX-XXXX'])
+  end  
+
 end
 
 class ResponseIntegrationTest < ActionDispatch::IntegrationTest

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -41,6 +41,11 @@ module <%= app_const_base %>
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password]
 
+    config.action_dispatch.default_headers = {
+        'X-Frame-Options' => 'SAMEORIGIN',
+        'X-XSS-Protection' => '1; mode=block'
+    }
+
     # Use SQL instead of Active Record's schema dumper when creating the database.
     # This is necessary if your schema can't be completely dumped by the schema dumper,
     # like if you have constraints or database-specific column types.


### PR DESCRIPTION
4.0 feature, everybody agreed to merge it.
Default headers are really useful for various security options and mitigations.

discuss: should we add "Sniff content type" header 
