### PR TITLE
Do not escape HTML entities in text files

### DIFF
--- a/actionpack/lib/action_view/template/handlers/erb.rb
+++ b/actionpack/lib/action_view/template/handlers/erb.rb
@@ -78,7 +78,10 @@ module ActionView
 
           self.class.erb_implementation.new(
             erb,
-            :trim => (self.class.erb_trim_mode == "-")
+            :trim => (self.class.erb_trim_mode == "-"),
+            # Do not escape HTML entities in text templates (e.g. in text
+            # mails).
+            :escape => template.identifier =~ /\.text/
           ).src
         end
 


### PR DESCRIPTION
Rails escapes HTML entities in erb files. This is great, because it prevents Cross Site Scripting and other evil attacks. However there is one case, where this behavior leads to undesired effects.

Rails escapes HTML entities in plain text mails. When I am using a `message.text.erb` file, `ActionMailer` correctly detects that the mail contains plain text and sets a `text/plain` mime type. However, ERB still handles this as an html file and escapes HTML entities.

For example, if my template contains `Dear <%= @customer_name %>, ...` and `@customer_name` is _Foobar & Partner_, then the mail will contain _Dear Foobar <b>&amp;amp;</b> Partner_.

The following commit just disables HTML escaping in text templates. A text erb template is every file that has `.text` in the file name and is handled by erb.
