### PR TITLE
More useful Rails.application.routes.url_helpers

### DIFF
--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -30,6 +30,7 @@ module ActionDispatch
           params = options[:params] || {}
           params.reject! {|k,v| v.to_param.nil? }
 
+          add_options_from_thread_current!(options)
           result = build_host_url(options)
 
           result << (options[:trailing_slash] ? path.sub(/\?|\z/) { "/" + $& } : path)
@@ -39,6 +40,12 @@ module ActionDispatch
         end
 
         private
+
+        def add_options_from_thread_current!(options)
+          options[:host] ||= Thread.current["ActionDispatch::UrlHelper.host"]
+          options[:port] ||= Thread.current["ActionDispatch::UrlHelper.port"]
+          options[:protocol] ||= Thread.current["ActionDispatch::UrlHelper.protocol"]
+        end
 
         def build_host_url(options)
           if options[:host].blank? && options[:only_path].blank?

--- a/actionpack/lib/action_dispatch/middleware/url_helper.rb
+++ b/actionpack/lib/action_dispatch/middleware/url_helper.rb
@@ -1,0 +1,16 @@
+module ActionDispatch
+  class UrlHelper
+
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      req = ActionDispatch::Request.new(env)
+      Thread.current["ActionDispatch::UrlHelper.host"] = req.host
+      Thread.current["ActionDispatch::UrlHelper.port"] = req.optional_port
+      Thread.current["ActionDispatch::UrlHelper.protocol"] = req.protocol
+      @app.call(env)
+    end
+  end
+end

--- a/actionpack/lib/action_dispatch/testing/test_process.rb
+++ b/actionpack/lib/action_dispatch/testing/test_process.rb
@@ -1,4 +1,5 @@
 require 'action_dispatch/middleware/cookies'
+require 'action_dispatch/middleware/url_helper'
 require 'action_dispatch/middleware/flash'
 require 'active_support/core_ext/hash/indifferent_access'
 

--- a/actionpack/test/dispatch/url_generation_test.rb
+++ b/actionpack/test/dispatch/url_generation_test.rb
@@ -6,14 +6,26 @@ module TestUrlGeneration
     include Routes.url_helpers
 
     class ::MyRouteGeneratingController < ActionController::Base
+      use ::ActionDispatch::UrlHelper
       include Routes.url_helpers
       def index
         render :text => foo_path
+      end
+      def fullfoo
+        render :text => MyObject.new.generate_foo_url
+      end
+    end
+
+    class MyObject
+      include Routes.url_helpers
+      def generate_foo_url
+        foo_url
       end
     end
 
     Routes.draw do
       get "/foo", :to => "my_route_generating#index", :as => :foo
+      get "/fullfoo", :to => "my_route_generating#fullfoo", :as => :fullfoo
 
       mount MyRouteGeneratingController.action(:index), at: '/bar'
     end
@@ -28,6 +40,11 @@ module TestUrlGeneration
 
     test "generating URLS normally" do
       assert_equal "/foo", foo_path
+    end
+
+    test "generating URLS in objects" do
+      get "/fullfoo"
+      assert_equal "http://www.example.com/foo", response.body
     end
 
     test "accepting a :script_name option" do


### PR DESCRIPTION
Right now if you include url_helpers the host, port and scheme aren't
set which gives you an exception or the wrong url when included in
places other than controller and views (where we have access to the
request). This adds that missing information in Thread.current via
a middleware and thus allows access which works.

What do you think? Wanted to get opinions before I dig into figuring out how to add a middleware to the default stack (and test that it's in the default stack).

Without the fix we get things like:

```
ArgumentError: Missing host to link to! Please provide the :host parameter, set default_url_options[:host], or set :only_path to true
```

And end up with ugly app code, with workarounds that look like this:

```
class RailsAndUrlHelpersHowDoTheyWork
  include Rails.application.routes.url_helpers
  def initialize(request)
    default_url_options[:host] = request.host
    default_url_options[:protocol] = request.scheme
    default_url_options[:port] = request.port
  end
end
```
