### PR TITLE
Check for Blank Record in form_for

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -423,6 +423,7 @@ module ActionView
           object      = nil
         else
           object      = record.is_a?(Array) ? record.last : record
+          raise ArgumentError, "First argument in form cannot contain nil or be empty" if object.blank?
           object_name = options[:as] || model_name_from_record_or_class(object).param_key
           apply_form_for_options!(record, object, options)
         end

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -1045,6 +1045,20 @@ class FormHelperTest < ActionView::TestCase
     end
   end
 
+  def test_form_for_requires_arguments
+    error = assert_raises(ArgumentError) do
+      form_for(nil, :html => { :id => 'create-post' }) do
+      end
+    end
+    assert_equal "First argument in form cannot contain nil or be empty", error.message
+
+    error = assert_raises(ArgumentError) do
+      form_for([nil, nil], :html => { :id => 'create-post' }) do
+      end
+    end
+    assert_equal "First argument in form cannot contain nil or be empty", error.message
+  end
+
   def test_form_for
     form_for(@post, :html => { :id => 'create-post' }) do |f|
       concat f.label(:title) { "The Title" }


### PR DESCRIPTION
If nil or an empty array is passed into `form_for` you get a horrible error message, this one is much more indicative of what the programmer needs to know to fix the problem.

ATP in actionpack

Screenshot goodness:  

![](http://f.cl.ly/items/1R323K2e1u2k1u2E3N0u/Screen%20Shot%202012-08-10%20at%2012.08.24%20AM.png)
