### PR TITLE
Fix mistake in assertion about content of permanent cookie

### DIFF
--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -190,7 +190,7 @@ class CookiesTest < ActionController::TestCase
   def test_setting_the_same_value_to_permanent_cookie
     request.cookies[:user_name] = 'Jamie'
     get :set_permanent_cookie
-    assert response.cookies, 'user_name' => 'Jamie'
+    assert_equal response.cookies, 'user_name' => 'Jamie'
   end
 
   def test_setting_with_escapable_characters


### PR DESCRIPTION
Currently
  `assert response.cookies, 'user_name' => 'Jamie'`
only tests whether cookies are present or not instead of checking value.

Changing `assert` to `assert_equal` fixes it.
