### PR TITLE
Backport of "Support cookie jar options for all cookie stores" for 3.2-stable

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 *   `javascript_include_tag :all` will now not include `application.js` if the file does not exists. *Prem Sichanugrist*
 
+*   Support cookie jar options (e.g., domain :all) for all session stores.
+    Fixes GH#3047, GH#2483.
+
+    *Ravil Bayramgalin*
+
 
 ## Rails 3.2.8 (Aug 9, 2012) ##
 

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -170,12 +170,14 @@ module ActionDispatch
           options = { :value => value }
         end
 
-        @cookies[key.to_s] = value
-
         handle_options(options)
 
-        @set_cookies[key.to_s] = options
-        @delete_cookies.delete(key.to_s)
+        if @cookies[key.to_s] != value or options[:expires]
+          @cookies[key.to_s] = value
+          @set_cookies[key.to_s] = options
+          @delete_cookies.delete(key.to_s)
+        end
+
         value
       end
 

--- a/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
@@ -74,6 +74,13 @@ module ActionDispatch
     class AbstractStore < Rack::Session::Abstract::ID
       include Compatibility
       include StaleSessionCheck
+
+      private
+
+      def set_cookie(env, session_id, cookie)
+        request = ActionDispatch::Request.new(env)
+        request.cookie_jar[key] = cookie
+      end
     end
   end
 end

--- a/actionpack/test/activerecord/active_record_store_test.rb
+++ b/actionpack/test/activerecord/active_record_store_test.rb
@@ -256,6 +256,13 @@ class ActiveRecordStoreTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_session_store_with_all_domains
+    with_test_route_set(:domain => :all) do
+      get '/set_session_value'
+      assert_response :success
+    end
+  end
+
   private
 
     def with_test_route_set(options = {})

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -188,7 +188,7 @@ class CookiesTest < ActionController::TestCase
   def test_setting_the_same_value_to_permanent_cookie
     request.cookies[:user_name] = 'Jamie'
     get :set_permanent_cookie
-    assert response.cookies, 'user_name' => 'Jamie'
+    assert_equal response.cookies, 'user_name' => 'Jamie'
   end
 
   def test_setting_with_escapable_characters

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -179,6 +179,18 @@ class CookiesTest < ActionController::TestCase
     assert_equal({"user_name" => "david"}, @response.cookies)
   end
 
+  def test_setting_the_same_value_to_cookie
+    request.cookies[:user_name] = 'david'
+    get :authenticate
+    assert response.cookies.empty?
+  end
+
+  def test_setting_the_same_value_to_permanent_cookie
+    request.cookies[:user_name] = 'Jamie'
+    get :set_permanent_cookie
+    assert response.cookies, 'user_name' => 'Jamie'
+  end
+
   def test_setting_with_escapable_characters
     get :set_with_with_escapable_characters
     assert_cookie_header "that+%26+guy=foo+%26+bar+%3D%3E+baz; path=/"


### PR DESCRIPTION
It fixes #3047, #2483.

@rafaelfranca I've backported two commits, first to support jar options on all stores and second to fix issue with re-streaming of cookie jar with the same value. Also I've found that one of the tests in the second commit was wrongly written, so I've corrected that as well.

All tests pass.
