### PR TITLE
Fix newlines in rack logging

### DIFF
--- a/railties/lib/rails/rack/logger.rb
+++ b/railties/lib/rails/rack/logger.rb
@@ -22,7 +22,7 @@ module Rails
       def call_app(env)
         request = ActionDispatch::Request.new(env)
         path = request.filtered_path
-        Rails.logger.info "\n\nStarted #{request.request_method} \"#{path}\" for #{request.ip} at #{Time.now.to_default_s}"
+        Rails.logger.info "Started #{request.request_method} \"#{path}\" for #{request.ip} at #{Time.now.to_default_s}"
         @app.call(env)
       ensure
         ActiveSupport::LogSubscriber.flush_all!


### PR DESCRIPTION
When you include more tags in the logging, for example:

``` ruby
config.log_tags = [:uuid, :remote_ip]
```

Then the first log line for request looks like this:

```
[c6cbd2272812fe3417bb48f7a9bab919] [127.0.0.1] 

Started POST "/products" for 127.0.0.1 at 2012-07-25 08:49:35 +0200
[c6cbd2272812fe3417bb48f7a9bab919] [127.0.0.1] Processing by ProductsController#create as JSON
```

So when you want to grep through the logs, the line "Started ..." does not lineup with the "metadata" like request uuid and ip address, because it has \n\n newlines in the beginning and grep does not like that.

My fix removes the two newlines.

This has also been discussed in issue #3697
