### PR TITLE
Add minitest to the Gemfile template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -9,6 +9,8 @@ source 'https://rubygems.org'
 <%= assets_gemfile_entry %>
 <%= javascript_gemfile_entry %>
 
+# gem 'minitest'
+
 # To use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.0.0'
 


### PR DESCRIPTION
Hello,

I don't think it's an issue on my computer but if it is, sorry for this pull request. When I want to start the console typing `rails c`, I have a LoadError like this one:

```
/home/robin/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:251:in `require': cannot load such file -- minitest/unit (LoadError)
```

So I think we can add `minitest` by default in the Gemfile ?

Have a nice day.
