### PR TITLE
Add support for pg geometric datatypes point and box

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   PostgreSQL geometric type point is supported by ActiveRecord. Fixes #7324.
+
+    *Martin Schuerrer*
+
 *   Add an `add_index` override in Postgresql adapter and MySQL adapter
     to allow custom index type support. Fixes #6101.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -2,6 +2,17 @@ module ActiveRecord
   module ConnectionAdapters
     class PostgreSQLColumn < Column
       module Cast
+        def point_to_string(point)
+          "(#{point[0]},#{point[1]})"
+        end
+
+        def string_to_point(string)
+          if string[0] == '(' && string[-1] == ')'
+            string = string[1...-1]
+          end
+          string.split(',').map{ |v| Float(v) }
+        end
+
         def string_to_time(string)
           return string unless String === string
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -63,6 +63,16 @@ module ActiveRecord
           end
         end
 
+        class Point < Type
+          def type_cast(value)
+            if String === value
+              ConnectionAdapters::PostgreSQLColumn.string_to_point value
+            else
+              value
+            end
+          end
+        end
+
         class Array < Type
           attr_reader :subtype
           def initialize(subtype)
@@ -330,6 +340,7 @@ module ActiveRecord
         register_type 'time', OID::Time.new
 
         register_type 'path', OID::Identity.new
+        register_type 'point', OID::Point.new
         register_type 'polygon', OID::Identity.new
         register_type 'circle', OID::Identity.new
         register_type 'hstore', OID::Hstore.new

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -28,10 +28,14 @@ module ActiveRecord
               super
             end
           when Array
-            if column.array
-              "'#{PostgreSQLColumn.array_to_string(value, column, self)}'"
+            case sql_type
+            when 'point' then super(PostgreSQLColumn.point_to_string(value))
             else
-              super
+              if column.array
+                "'#{PostgreSQLColumn.array_to_string(value, column, self)}'"
+              else
+                super
+              end
             end
           when Hash
             case sql_type
@@ -92,8 +96,12 @@ module ActiveRecord
               super(value, column)
             end
           when Array
-            return super(value, column) unless column.array
-            PostgreSQLColumn.array_to_string(value, column, self)
+            case column.sql_type
+            when 'point' then PostgreSQLColumn.point_to_string(value)
+            else
+              return super(value, column) unless column.array
+              PostgreSQLColumn.array_to_string(value, column, self)
+            end
           when String
             return super(value, column) unless 'bytea' == column.sql_type
             { :value => value, :format => 1 }

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -83,9 +83,10 @@ module ActiveRecord
         def type_cast(value, column, array_member = false)
           return super(value, column) unless column
 
+          sql_type = type_to_sql(column.type, column.limit, column.precision, column.scale)
           case value
           when Range
-            return super(value, column) unless /range$/ =~ column.sql_type
+            return super(value, column) unless /range$/ =~ sql_type
             PostgreSQLColumn.range_to_string(value)
           when NilClass
             if column.array && array_member
@@ -96,23 +97,23 @@ module ActiveRecord
               super(value, column)
             end
           when Array
-            case column.sql_type
+            case sql_type
             when 'point' then PostgreSQLColumn.point_to_string(value)
             else
               return super(value, column) unless column.array
               PostgreSQLColumn.array_to_string(value, column, self)
             end
           when String
-            return super(value, column) unless 'bytea' == column.sql_type
+            return super(value, column) unless 'bytea' == sql_type
             { :value => value, :format => 1 }
           when Hash
-            case column.sql_type
+            case sql_type
             when 'hstore' then PostgreSQLColumn.hstore_to_string(value)
             when 'json' then PostgreSQLColumn.json_to_string(value)
             else super(value, column)
             end
           when IPAddr
-            return super(value, column) unless ['inet','cidr'].include? column.sql_type
+            return super(value, column) unless ['inet','cidr'].include? sql_type
             PostgreSQLColumn.cidr_to_string(value)
           else
             super(value, column)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -711,7 +711,14 @@ module ActiveRecord
 
           # populate composite types
           nodes.find_all { |row| OID::TYPE_MAP.key? row['typelem'].to_i }.each do |row|
-            vector = OID::Vector.new row['typdelim'], OID::TYPE_MAP[row['typelem'].to_i]
+            if OID.registered_type? row['typname']
+              # this composite type is explicitly registered
+              vector = OID::NAMES[row['typname']]
+            else
+              # use the default for composite types
+              vector = OID::Vector.new row['typdelim'], OID::TYPE_MAP[row['typelem'].to_i]
+            end
+
             OID::TYPE_MAP[row['oid'].to_i] = vector
           end
 


### PR DESCRIPTION
@tenderlove https://twitter.com/tenderlove/statuses/231807764907819008

Today I looked into adding support for the postgresql geo types. Everything went well but I didn't manage to get AR to type cast pg's string representation into an array. (See the failing `base_test.rb`)

Got a pointer for me?
