### PR TITLE
Added changelog entry for table name prefix fix [ci skip]

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fixed table name prefix that is generated in engines for namespaced models
+    *Wojciech Wnętrzak*
+
 *   Make sure `:environment` task is executed before `db:schema:load` or `db:structure:load`
     Fixes #4772.
 


### PR DESCRIPTION
Regarding updated contribution guide: https://github.com/rails/rails/commit/adf3ea373660c50c7bcead0f52ab2d63a25fc57e

I'm adding changelog entry for merged #6993
