### PR TITLE
Fix for time type columns with invalid time value

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix time column type casting for invalid time string values to correctly return nil.
+
+    *Adam Meehan*
+
 *   Allow to pass Symbol or Proc into :limit option of #accepts_nested_attributes_for
 
     *Mikhail Dieterle*

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -178,7 +178,13 @@ module ActiveRecord
           return string unless string.is_a?(String)
           return nil if string.blank?
 
-          string_to_time "2000-01-01 #{string}"
+          dummy_time_string = "2000-01-01 #{string}"
+
+          fast_string_to_time(dummy_time_string) || begin
+            time_hash = Date._parse(dummy_time_string)
+            return nil if time_hash[:hour].nil?
+            new_time(*time_hash.values_at(:year, :mon, :mday, :hour, :min, :sec, :sec_fraction))
+          end
         end
 
         # convert something to a boolean

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -970,6 +970,18 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal Time.local(2000, 1, 1, 5, 42, 0), topic.bonus_time
   end
 
+  def test_attributes_on_dummy_time_with_invalid_time
+    # Oracle, and Sybase do not have a TIME datatype.
+    return true if current_adapter?(:OracleAdapter, :SybaseAdapter)
+
+    attributes = {
+      "bonus_time" => "not a time"
+    }
+    topic = Topic.find(1)
+    topic.attributes = attributes
+    assert_nil topic.bonus_time
+  end
+
   def test_boolean
     b_nil = Boolean.create({ "value" => nil })
     nil_id = b_nil.id


### PR DESCRIPTION
The string_to_dummy_time method was blindly parsing the dummy time string
with Date._parse which returns a hash for the date part regardless
of whether the time part is an invalid time string.
