### PR TITLE
Evented notifications should take priority over Timed

### DIFF
--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -59,10 +59,10 @@ module ActiveSupport
 
       module Subscribers # :nodoc:
         def self.new(pattern, listener)
-          if listener.respond_to?(:call)
-            subscriber = Timed.new pattern, listener
-          else
+          if listener.respond_to?(:start) and listener.respond_to?(:finish)
             subscriber = Evented.new pattern, listener
+          else
+            subscriber = Timed.new pattern, listener
           end
 
           unless pattern

--- a/activesupport/test/notifications/evented_notification_test.rb
+++ b/activesupport/test/notifications/evented_notification_test.rb
@@ -19,6 +19,12 @@ module ActiveSupport
         end
       end
 
+      class ListenerWithTimedSupport < Listener
+        def call(name, start, finish, id, payload)
+          @events << [:call, name, start, finish, id, payload]
+        end
+      end
+
       def test_evented_listener
         notifier = Fanout.new
         listener = Listener.new
@@ -60,6 +66,20 @@ module ActiveSupport
           [:start,  'world', 1, {}],
           [:finish,  'world', 1, {}],
           [:finish,  'hello', 1, {}],
+        ], listener.events
+      end
+
+      def test_evented_listener_priority
+        notifier = Fanout.new
+        listener = ListenerWithTimedSupport.new
+        notifier.subscribe 'hi', listener
+
+        notifier.start 'hi', 1, {}
+        notifier.finish 'hi', 1, {}
+
+        assert_equal [
+          [:start, 'hi', 1, {}],
+          [:finish, 'hi', 1, {}]
         ], listener.events
       end
     end


### PR DESCRIPTION
In cases where a notification subscriber includes methods to support
both Evented and Timed events, Evented should take priority over Timed.
This allows subscribers to be backwards compatible (older Rails only
allows Timed events) while defaulting to newer behavior.
