### PR TITLE
Accept a symbol for `:in` option on inclusion and exclusion validators

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Changed inclusion and exclusion validators to accept a symbol for `:in` option.
+
+    This allows to use dynamic inclusion/exclusion values using methods, besides the current lambda/proc support.
+
+    *Gabriel Sobrinho*
+
 *   `AM::Validation#validates` ability to pass custom exception to `:strict` option.
 
     *Bogdan Gusiev*

--- a/activemodel/lib/active_model/validations/exclusion.rb
+++ b/activemodel/lib/active_model/validations/exclusion.rb
@@ -24,11 +24,12 @@ module ActiveModel
       #     validates_exclusion_of :format, in: %w( mov avi ), message: "extension %{value} is not allowed"
       #     validates_exclusion_of :password, in: ->(person) { [person.username, person.first_name] },
       #                            message: 'should not be the same as your username or first name'
+      #     validates_exclusion_of :karma, in: :reserved_karmas
       #   end
       #
       # Configuration options:
       # * <tt>:in</tt> - An enumerable object of items that the value shouldn't
-      #   be part of. This can be supplied as a proc or lambda which returns an
+      #   be part of. This can be supplied as a proc, lambda or symbol which returns an
       #   enumerable. If the enumerable is a range the test is performed with
       # * <tt>:within</tt> - A synonym(or alias) for <tt>:in</tt>
       #   <tt>Range#cover?</tt>, otherwise with <tt>include?</tt>.

--- a/activemodel/lib/active_model/validations/inclusion.rb
+++ b/activemodel/lib/active_model/validations/inclusion.rb
@@ -23,11 +23,12 @@ module ActiveModel
       #     validates_inclusion_of :age, in: 0..99
       #     validates_inclusion_of :format, in: %w( jpg gif png ), message: "extension %{value} is not included in the list"
       #     validates_inclusion_of :states, in: ->(person) { STATES[person.country] }
+      #     validates_inclusion_of :karma, in: :available_karmas
       #   end
       #
       # Configuration options:
       # * <tt>:in</tt> - An enumerable object of available items. This can be
-      #   supplied as a proc or lambda which returns an enumerable. If the
+      #   supplied as a proc, lambda or symbol which returns an enumerable. If the
       #   enumerable is a range the test is performed with <tt>Range#cover?</tt>,
       #   otherwise with <tt>include?</tt>.
       # * <tt>:within</tt> - A synonym(or alias) for <tt>:in</tt>

--- a/activemodel/test/cases/validations/exclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/exclusion_validation_test.rb
@@ -64,4 +64,26 @@ class ExclusionValidationTest < ActiveModel::TestCase
     t.title = "wasabi"
     assert t.valid?
   end
+
+  def test_validates_inclusion_of_with_symbol
+    Person.validates_exclusion_of :karma, :in => :reserved_karmas
+
+    p = Person.new
+    p.karma = "abe"
+
+    def p.reserved_karmas
+      %w(abe)
+    end
+
+    assert p.invalid?
+    assert_equal ["is reserved"], p.errors[:karma]
+
+    def p.reserved_karmas
+      %w()
+    end
+
+    assert p.valid?
+  ensure
+    Person.reset_callbacks(:validate)
+  end
 end

--- a/activemodel/test/cases/validations/inclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/inclusion_validation_test.rb
@@ -96,4 +96,26 @@ class InclusionValidationTest < ActiveModel::TestCase
     t.title = "elephant"
     assert t.valid?
   end
+
+  def test_validates_inclusion_of_with_symbol
+    Person.validates_inclusion_of :karma, :in => :available_karmas
+
+    p = Person.new
+    p.karma = "Lifo"
+
+    def p.available_karmas
+      %w()
+    end
+
+    assert p.invalid?
+    assert_equal ["is not included in the list"], p.errors[:karma]
+
+    def p.available_karmas
+      %w(Lifo)
+    end
+
+    assert p.valid?
+  ensure
+    Person.reset_callbacks(:validate)
+  end
 end


### PR DESCRIPTION
I'm not sure about my english on documentation but the feature is fine :)

I was in doubt about this line:

``` ruby
unless [:include?, :call].any?{ |method| delimiter.respond_to?(method) } || delimiter.is_a?(Symbol)
```

It may be more clear about what is happening, but this is not a big deal:

``` ruby
unless delimiter.respond_to?(:include?) || delimiter.respond_to?(:call) || delimiter.is_a?(Symbol)
```

What do you think?
