### PR TITLE
Format errors should not crash MessageVerifier

### DIFF
--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -37,7 +37,11 @@ module ActiveSupport
 
       data, digest = signed_message.split("--")
       if data.present? && digest.present? && secure_compare(digest, generate_digest(data))
-        @serializer.load(::Base64.decode64(data))
+        begin
+          @serializer.load(::Base64.decode64(data))
+        rescue StandardError => e
+          e.is_a?(NameError) ? raise : raise(InvalidSignature)
+        end
       else
         raise InvalidSignature
       end


### PR DESCRIPTION
It seems logical to treat incompatibly marshaled data the same way as unsigned. This would fix issues like #2509 when class signature changes or serializer gets replaced. Motivation for changing session secret hash should not be connected to changes in implementation details of flash or session serialization.
