### PR TITLE
No longer require AS::TestCase

### DIFF
--- a/railties/lib/rails/console/app.rb
+++ b/railties/lib/rails/console/app.rb
@@ -1,8 +1,5 @@
 require 'active_support/all'
-require 'active_support/test_case'
 require 'action_controller'
-
-# work around the at_exit hook in test/unit, which kills IRB
 
 module Rails
   module ConsoleMethods


### PR DESCRIPTION
We don't need this any more.

Fixes #6907.
