### PR TITLE
Attributes in validations should be unique

### DIFF
--- a/activemodel/lib/active_model/validations/with.rb
+++ b/activemodel/lib/active_model/validations/with.rb
@@ -4,7 +4,7 @@ module ActiveModel
       private
         def _merge_attributes(attr_names)
           options = attr_names.extract_options!
-          options.merge(:attributes => attr_names.flatten)
+          options.merge(:attributes => attr_names.flatten.uniq)
         end
     end
 

--- a/activemodel/test/cases/validations/presence_validation_test.rb
+++ b/activemodel/test/cases/validations/presence_validation_test.rb
@@ -14,7 +14,7 @@ class PresenceValidationTest < ActiveModel::TestCase
   end
 
   def test_validate_presences
-    Topic.validates_presence_of(:title, :content)
+    Topic.validates_presence_of(:title, :content, :content)
 
     t = Topic.new
     assert t.invalid?


### PR DESCRIPTION
I see duplicated error messages while validations. It happens because of attribute was passed to `validate_presence_of` two times by different developers. It could be useful if `ActiveModel` will make attributes unique.
