### PR TITLE
Feature presence validation for boolen parameters

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -320,7 +320,7 @@ module ActiveModel
     def add_on_blank(attributes, options = {})
       [attributes].flatten.each do |attribute|
         value = @base.send(:read_attribute_for_validation, attribute)
-        add(attribute, :blank, options) if value.blank?
+        add(attribute, :blank, options) if value.to_s.blank?
       end
     end
 

--- a/activemodel/test/cases/validations/presence_validation_test.rb
+++ b/activemodel/test/cases/validations/presence_validation_test.rb
@@ -14,15 +14,17 @@ class PresenceValidationTest < ActiveModel::TestCase
   end
 
   def test_validate_presences
-    Topic.validates_presence_of(:title, :content)
+    Topic.validates_presence_of(:title, :content, :promoted)
 
     t = Topic.new
     assert t.invalid?
     assert_equal ["can't be blank"], t.errors[:title]
     assert_equal ["can't be blank"], t.errors[:content]
+    assert_equal ["can't be blank"], t.errors[:promoted]
 
     t.title = "something"
     t.content  = "   "
+    t.promoted = false
 
     assert t.invalid?
     assert_equal ["can't be blank"], t.errors[:content]
@@ -33,11 +35,12 @@ class PresenceValidationTest < ActiveModel::TestCase
   end
 
   def test_accepts_array_arguments
-    Topic.validates_presence_of %w(title content)
+    Topic.validates_presence_of %w(title content promoted)
     t = Topic.new
     assert t.invalid?
     assert_equal ["can't be blank"], t.errors[:title]
     assert_equal ["can't be blank"], t.errors[:content]
+    assert_equal ["can't be blank"], t.errors[:promoted]
   end
 
   def test_validates_acceptance_of_with_custom_error_using_quotes

--- a/activemodel/test/models/topic.rb
+++ b/activemodel/test/models/topic.rb
@@ -6,7 +6,7 @@ class Topic
     super | [ :message ]
   end
 
-  attr_accessor :title, :author_name, :content, :approved
+  attr_accessor :title, :author_name, :content, :promoted, :approved
   attr_accessor :after_validation_performed
 
   after_validation :perform_after_validation


### PR DESCRIPTION
Hello,
this fix situation when I want add presence validation for boolean value which by default fails when hold "false" value

that is because `false.blank? # => true` and `true.blank? # => false`

Thus with this fix: `"false".blank? # => false` as is expected.

I'm only not sure what with empty arrays
`[].blank? # => true` and with this patch `"[]".blank? # => false`
but I suppose this would be right behaviour.
