### PR TITLE
Remove leading divider from grouped_options_for_select when divider option is passed

### DIFF
--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -500,7 +500,7 @@ module ActionView
       #   grouped_options_for_select(grouped_options, nil, divider: '---------')
       #
       # Possible output:
-      #   <optgroup label="---------">
+      #   <optgroup>
       #     <option value="Denmark">Denmark</option>
       #     <option value="Germany">Germany</option>
       #     <option value="France">France</option>
@@ -529,6 +529,14 @@ module ActionView
         end
 
         grouped_options = grouped_options.sort if grouped_options.is_a?(Hash)
+
+        container = grouped_options.shift
+        if divider
+          label = nil
+        else
+          label, container = container
+        end
+        body.safe_concat content_tag(:optgroup, options_for_select(container, selected_key), :label => label)
 
         grouped_options.each do |container|
           if divider

--- a/actionpack/test/template/form_options_helper_test.rb
+++ b/actionpack/test/template/form_options_helper_test.rb
@@ -297,7 +297,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
   def test_grouped_options_for_select_with_optional_divider
     assert_dom_equal(
-      "<optgroup label=\"----------\"><option value=\"US\">US</option>\n<option value=\"Canada\">Canada</option></optgroup><optgroup label=\"----------\"><option value=\"GB\">GB</option>\n<option value=\"Germany\">Germany</option></optgroup>",
+      "<optgroup><option value=\"US\">US</option>\n<option value=\"Canada\">Canada</option></optgroup><optgroup label=\"----------\"><option value=\"GB\">GB</option>\n<option value=\"Germany\">Germany</option></optgroup>",
 
       grouped_options_for_select([['US',"Canada"] , ["GB", "Germany"]], nil, divider: "----------")
     )


### PR DESCRIPTION
This will omit the first divider in grouped_options_for_select (I would
expect a divider to go between things only).

Currently, the grouped options divider will make a select like so:

<pre>
Please Select:
-----
USA
Canada
-----
Denmark
United Kingdom
-----
China
India
</pre>

It is more symmetric and more typical to only seperate the groups:

<pre>
Please Select:

USA
Canada
-----
Denmark
United Kingdom
-----
China
India
</pre>
