### PR TITLE
i18n locale fallback for localized views

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## unreleased ##
 
+*   Include I18n locale fallbacks in view lookup.
+    Fixes GH#3512.
+
+    *Juan Barreneche*
+
 *   Fix incorrectly appended square brackets to a multiple select box
     if an explicit name has been given and it already ends with "[]".
 

--- a/actionpack/lib/action_view/lookup_context.rb
+++ b/actionpack/lib/action_view/lookup_context.rb
@@ -44,7 +44,13 @@ module ActionView
     module Accessors #:nodoc:
     end
 
-    register_detail(:locale)  { [I18n.locale, I18n.default_locale].uniq }
+    register_detail(:locale) do
+      locales = [I18n.locale]
+      locales.concat(I18n.fallbacks[I18n.locale]) if I18n.respond_to? :fallbacks
+      locales << I18n.default_locale
+      locales.uniq!
+      locales
+    end
     register_detail(:formats) { Mime::SET.symbols }
     register_detail(:handlers){ Template::Handlers.extensions }
 

--- a/actionpack/test/controller/localized_templates_test.rb
+++ b/actionpack/test/controller/localized_templates_test.rb
@@ -19,4 +19,13 @@ class LocalizedTemplatesTest < ActionController::TestCase
     get :hello_world
     assert_equal "Hello World", @response.body
   end
+
+  def test_use_fallback_locales
+    I18n.locale = :"de-AT"
+    I18n.backend.class.send(:include, I18n::Backend::Fallbacks)
+    I18n.fallbacks[:"de-AT"] = [:de]
+
+    get :hello_world
+    assert_equal "Gutten Tag", @response.body
+  end
 end


### PR DESCRIPTION
This change fixes issue #3512

Any suggestion on how to improve the detail definition?

Also, the test is changing global state (because it's including the Fallback module), I can change it to stub the `.fallbacks` method if you think that's better (or any other change also).

Thanks!
