### PR TITLE
i18n error messages: custom formats by attribute

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -355,8 +355,8 @@ module ActiveModel
       return message if attribute == :base
       attr_name = attribute.to_s.tr('.', '_').humanize
       attr_name = @base.class.human_attribute_name(attribute, :default => attr_name)
-      I18n.t(:"errors.format", {
-        :default   => "%{attribute} %{message}",
+      I18n.t(:"errors.formats.attributes.#{attribute}", {
+        :default   => [:"errors.format","%{attribute} %{message}"],
         :attribute => attr_name,
         :message   => message
       })

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -61,6 +61,12 @@ class I18nValidationTest < ActiveModel::TestCase
     assert_equal ["Field Name empty"], @person.errors.full_messages
   end
 
+  def test_errors_full_messages_looks_up_custom_attribute_format
+    I18n.backend.store_translations('en', :errors => {:formats => {:attributes => {:name => "Name is: %{message}"}}})
+    @person.errors.add('name', 'empty')
+    assert_equal ["Name is: empty"], @person.errors.full_messages
+  end
+
   # ActiveModel::Validations
 
   # A set of common cases for ActiveModel::Validations message generation that


### PR DESCRIPTION
First place lookup is now: errors.formats.attributes.#{attribute}

Example use case:

```
errors:
  attributes:
    last_name:
      blank: you must provide your full name
  formats:
    attributes:
      last_name: "%{message}"
```

(same fallbacks as before)
