### PR TITLE
Add activemodel dep to actionpack gemspec

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency('activesupport', version)
+  s.add_dependency('activemodel',   version)
   s.add_dependency('rack-cache',    '~> 1.2')
   s.add_dependency('builder',       '~> 3.0.0')
   s.add_dependency('rack',          '~> 1.4.1')


### PR DESCRIPTION
`require 'action_dispatch'` immediately tries to pull in activemodel.

https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch.rb#L29

ought to be declared in the gemspec so AP can be used as a standalone gem definition.

/cc @tenderlove 
