### PR TITLE
Dup'ed ActiveRecord objects may not share the errors object 

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -269,6 +269,11 @@
 
     *Ari Pollak*
 
+*   Fix AR#dup to nullify the validation errors in the dup'ed object. Previously the original
+    and the dup'ed object shared the same errors.
+
+    * Christian Seiler*
+
 *   Raise `ArgumentError` if list of attributes to change is empty in `update_all`.
 
     *Roman Shatsov*

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -42,6 +42,7 @@ module ActiveRecord
 
     def initialize_dup(other) # :nodoc:
       clear_timestamp_attributes
+      super
     end
 
   private

--- a/activerecord/test/cases/dup_test.rb
+++ b/activerecord/test/cases/dup_test.rb
@@ -107,5 +107,19 @@ module ActiveRecord
       assert Topic.after_initialize_called
     end
 
+    def test_dup_validity_is_independent
+      Topic.validates_presence_of :title
+      topic = Topic.new("title" => "Litterature")
+      topic.valid?
+
+      duped = topic.dup
+      duped.title = nil
+      assert duped.invalid?
+
+      topic.title = nil
+      duped.title = 'Mathematics'
+      assert topic.invalid?
+      assert duped.valid?
+    end
   end
 end


### PR DESCRIPTION
Call super to nullify the reference to the original errors object in the dup'ed object (call ActiveModel::Validations#initialize_dup)
