### PR TITLE
Use inversed parent for first and last child of has_many association

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Use inversed parent for first and last child of has_many association.
+
+    *Ravil Bayramgalin*
+
 *   Fix Column.microseconds and Column.fast_string_to_date to avoid converting
     timestamp seconds to a float, since it occasionally results in inaccuracies
     with microsecond-precision times. Fixes #7352.

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -574,7 +574,7 @@ module ActiveRecord
           args.shift if args.first.is_a?(Hash) && args.first.empty?
 
           collection = fetch_first_or_last_using_find?(args) ? scope : load_target
-          collection.send(type, *args)
+          collection.send(type, *args).tap {|it| set_inverse_instance it }
         end
     end
   end

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -259,6 +259,12 @@ class InverseHasManyTests < ActiveRecord::TestCase
     assert_equal m.name, i.man.name, "Name of man should be the same after changes to replaced-child-owned instance"
   end
 
+  def test_parent_instance_should_be_shared_with_first_and_last_child
+    man = Man.first
+    assert man.interests.first.man.equal? man
+    assert man.interests.last.man.equal? man
+  end
+
   def test_trying_to_use_inverses_that_dont_exist_should_raise_an_error
     assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Man.first.secret_interests }
   end


### PR DESCRIPTION
Currently invoking `#first/#last` on not-loaded collection proxy for `has_many` association will not set inversed parent for fetched record. So example from rails guides and docs is actually not correct:

``` ruby
c = Customer.first
o = c.orders.first
c.first_name == o.customer.first_name # => true
c.first_name = 'Manny'
c.first_name == o.customer.first_name # => true
```

In reality last line will return false. I've fixed both methods to take `inversed_of` option into account. So now this example will work as intented, I've provided test to illustrate it.
