### PR TITLE
Fix merge error when Equality LHS is non-attribute

### DIFF
--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -97,11 +97,14 @@ module ActiveRecord
           merged_wheres = relation.where_values + values[:where]
 
           unless relation.where_values.empty?
-            # Remove duplicates, last one wins.
+            # Remove duplicate ARel attributes. Last one wins.
             seen = Hash.new { |h,table| h[table] = {} }
             merged_wheres = merged_wheres.reverse.reject { |w|
               nuke = false
-              if w.respond_to?(:operator) && w.operator == :==
+              # We might have non-attributes on the left side of equality nodes,
+              # so we need to make sure they quack like an attribute.
+              if w.respond_to?(:operator) && w.operator == :== &&
+                w.left.respond_to?(:relation)
                 name              = w.left.name
                 table             = w.left.relation.name
                 nuke              = seen[table][name]

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -668,6 +668,22 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal [developers(:poor_jamis)], dev_with_count.to_a
   end
 
+  def test_relation_merging_with_arel_equalities_keeps_last_equality
+    devs = Developer.where(Developer.arel_table[:salary].eq(80000)).merge(
+      Developer.where(Developer.arel_table[:salary].eq(9000))
+    )
+    assert_equal [developers(:poor_jamis)], devs.to_a
+  end
+
+  def test_relation_merging_with_arel_equalities_with_a_non_attribute_left_hand_ignores_non_attributes_when_discarding_equalities
+    salary_attr = Developer.arel_table[:salary]
+    devs = Developer.where(salary_attr.eq(80000)).merge(
+      Developer.where(salary_attr.eq(9000)).
+        where(Arel::Nodes::NamedFunction.new('abs', [salary_attr]).eq(9000))
+    )
+    assert_equal [developers(:poor_jamis)], devs.to_a
+  end
+
   def test_relation_merging_with_eager_load
     relations = []
     relations << Post.order('comments.id DESC').merge(Post.eager_load(:last_comment)).merge(Post.all)


### PR DESCRIPTION
This is at best a band-aid for a more proper fix, since it won't truly
handle the removal of the previous equality condition of these other
nodes. I'm planning to put in some work on ARel toward supporting that
goal. I'd like to also backport this fix to the 3.x merge code, unless
there are objections.

Related: rails/arel#130, ernie/squeel#153, ernie/squeel#156

Also, I added a test for the more typical equality condition, since
I didn't see one for it yet. Maybe I missed it, since the PredicateBuilder
does create equality nodes in stock AR with a hash, but
the only one I noticed was using order and strings to test.
