### PR TITLE
Table#remove passed an array to remove_column, which is deprecated.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -391,7 +391,7 @@ module ActiveRecord
       #  t.remove(:qualification)
       #  t.remove(:qualification, :experience)
       def remove(*column_names)
-        @base.remove_column(@table_name, column_names)
+        @base.remove_column(@table_name, *column_names)
       end
 
       # Removes the given index from the table.

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1976,14 +1976,14 @@ if ActiveRecord::Base.connection.supports_migrations?
 
     def test_remove_drops_single_column
       with_change_table do |t|
-        @connection.expects(:remove_column).with(:delete_me, [:bar])
+        @connection.expects(:remove_column).with(:delete_me, :bar)
         t.remove :bar
       end
     end
 
     def test_remove_drops_multiple_columns
       with_change_table do |t|
-        @connection.expects(:remove_column).with(:delete_me, [:bar, :baz])
+        @connection.expects(:remove_column).with(:delete_me, :bar, :baz)
         t.remove :bar, :baz
       end
     end


### PR DESCRIPTION
See 02ca9151a043a4fefbb3f22edd05f0cd392fffaa

I was noticing this warning using 3.2.8 even though I was doing:

`t.remove :some_column`

```
DEPRECATION WARNING: Passing array to remove_columns is deprecated, please use multiple arguments, like: `remove_columns(:posts, :foo, :bar)`
```

Attached is a fix for Table#remove rebased against 3-2-stable and tests updated to reflect that remove_columns should not be passed an array.
