### PR TITLE
Fixes #7381, so activerecord-deprecated_finders gets correctly bundled when creating a new Rails app

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -140,14 +140,14 @@ module Rails
             gem 'rails',     path: '#{Rails::Generators::RAILS_DEV_PATH}'
             gem 'journey',   github: 'rails/journey'
             gem 'arel',      github: 'rails/arel'
-            gem 'active_record_deprecated_finders', github: 'rails/active_record_deprecated_finders'
+            gem 'activerecord-deprecated_finders', require: 'active_record/deprecated_finders', github: 'rails/activerecord-deprecated_finders'
           GEMFILE
         elsif options.edge?
           <<-GEMFILE.strip_heredoc
             gem 'rails',     github: 'rails/rails'
             gem 'journey',   github: 'rails/journey'
             gem 'arel',      github: 'rails/arel'
-            gem 'active_record_deprecated_finders', github: 'rails/active_record_deprecated_finders'
+            gem 'activerecord-deprecated_finders', require: 'active_record/deprecated_finders', github: 'rails/activerecord-deprecated_finders'
           GEMFILE
         else
           <<-GEMFILE.strip_heredoc


### PR DESCRIPTION
Commit 271beddd8929758802e11826297adf92e40cd4af didn't solved the issue, since we need to `require` as "[active_record/deprecated_finders](https://github.com/rails/activerecord-deprecated_finders/blob/master/lib/active_record/deprecated_finders.rb)".

This commit fixes #7381.
