### PR TITLE
Added X-Content-Type-Options to the header defaults.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -51,8 +51,9 @@
 
     *Richard Schneeman*
 
-*   Add 'X-Frame-Options' => 'SAMEORIGIN' and
-    'X-XSS-Protection' => '1; mode=block'
+*   Add 'X-Frame-Options' => 'SAMEORIGIN'
+    'X-XSS-Protection' => '1; mode=block' and
+    'X-Content-Type-Options' => 'nosniff'
     as default headers.
 
     *Egor Homakov*

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -21,7 +21,8 @@ module ActionDispatch
 
     config.action_dispatch.default_headers = {
       'X-Frame-Options' => 'SAMEORIGIN',
-      'X-XSS-Protection' => '1; mode=block'
+      'X-XSS-Protection' => '1; mode=block',
+      'X-Content-Type-Options' => 'nosniff'
     }
 
     initializer "action_dispatch.configure" do |app|

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -177,9 +177,10 @@ class ResponseTest < ActiveSupport::TestCase
     end
   end
 
-  test "read x_frame_options and x_xss_protection" do
+  test "read x_frame_options, x_content_type_options and x_xss_protection" do
     ActionDispatch::Response.default_headers = {
       'X-Frame-Options' => 'DENY',
+      'X-Content-Type-Options' => 'nosniff',
       'X-XSS-Protection' => '1;'
     }
     resp = ActionDispatch::Response.new.tap { |response|
@@ -188,6 +189,7 @@ class ResponseTest < ActiveSupport::TestCase
     resp.to_a
 
     assert_equal('DENY', resp.headers['X-Frame-Options'])
+    assert_equal('nosniff', resp.headers['X-Content-Type-Options'])
     assert_equal('1;', resp.headers['X-XSS-Protection'])
   end  
 

--- a/guides/source/configuring.textile
+++ b/guides/source/configuring.textile
@@ -341,7 +341,7 @@ h4. Configuring Action Dispatch
 * +config.action_dispatch.default_headers+ is a hash with HTTP headers that are set by default in each response. By default, this is defined as:
 
 <ruby>
-config.action_dispatch.default_headers = { 'X-Frame-Options' => 'SAMEORIGIN', 'X-XSS-Protection' => '1; mode=block' }
+config.action_dispatch.default_headers = { 'X-Frame-Options' => 'SAMEORIGIN', 'X-XSS-Protection' => '1; mode=block', 'X-Content-Type-Options' => 'nosniff' }
 </ruby>
 
 * +config.action_dispatch.tld_length+ sets the TLD (top-level domain) length for the application. Defaults to +1+.


### PR DESCRIPTION
With a value of "nosniff", this prevents Internet Explorer from MIME-sniffing a response away from the declared content-type.
