### PR TITLE
Moves column dump specific code to a module included in AbstractAdapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -1,0 +1,41 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module ColumnDumper
+      def column_spec(column, types)
+        spec = {}
+        spec[:name]      = column.name.inspect
+
+        # AR has an optimization which handles zero-scale decimals as integers. This
+        # code ensures that the dumper still dumps the column as a decimal.
+        spec[:type]      = if column.type == :integer && /^(numeric|decimal)/ =~ column.sql_type
+                             'decimal'
+                           else
+                             column.type.to_s
+                           end
+        spec[:limit]     = column.limit.inspect if column.limit != types[column.type][:limit] && spec[:type] != 'decimal'
+        spec[:precision] = column.precision.inspect if column.precision
+        spec[:scale]     = column.scale.inspect if column.scale
+        spec[:null]      = 'false' unless column.null
+        spec[:default]   = default_string(column.default) if column.has_default?
+        (spec.keys - [:name, :type]).each{ |k| spec[k].insert(0, "#{k.inspect} => ")}
+        spec
+      end
+
+      def migration_keys
+        [:name, :limit, :precision, :scale, :default, :null]
+      end
+
+      def default_string(value)
+        case value
+        when BigDecimal
+          value.to_s
+        when Date, DateTime, Time
+          "'#{value.to_s(:db)}'"
+        else
+          value.inspect
+        end
+      end
+
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -1,6 +1,10 @@
 module ActiveRecord
-  module ConnectionAdapters
-    module ColumnDumper
+  module ConnectionAdapters # :nodoc:
+    module ColumnDumper # The goal of this module is to move Adapter specific column definitions to the Adapter
+                        # instead of having it in the schema dumper itself. This code represents the normal case.
+                        # We can then redefine how certain data types may be handled in the schema dumper on the 
+                        # Adapter level by over-writing this code inside the database specific adapters
+    
       def column_spec(column, types)
         spec = {}
         spec[:name]      = column.name.inspect

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -3,6 +3,7 @@ require 'bigdecimal'
 require 'bigdecimal/util'
 require 'active_support/core_ext/benchmark'
 require 'active_record/connection_adapters/schema_cache'
+require 'active_record/connection_adapters/abstract/schema_dumper' 
 require 'monitor'
 
 module ActiveRecord
@@ -52,6 +53,7 @@ module ActiveRecord
       include QueryCache
       include ActiveSupport::Callbacks
       include MonitorMixin
+      include ColumnDumper
 
       define_callbacks :checkout, :checkin
 

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -107,27 +107,11 @@ HEADER
           column_specs = columns.map do |column|
             raise StandardError, "Unknown type '#{column.sql_type}' for column '#{column.name}'" if @types[column.type].nil?
             next if column.name == pk
-            spec = {}
-            spec[:name]      = column.name.inspect
-
-            # AR has an optimization which handles zero-scale decimals as integers. This
-            # code ensures that the dumper still dumps the column as a decimal.
-            spec[:type]      = if column.type == :integer && /^(numeric|decimal)/ =~ column.sql_type
-                                 'decimal'
-                               else
-                                 column.type.to_s
-                               end
-            spec[:limit]     = column.limit.inspect if column.limit != @types[column.type][:limit] && spec[:type] != 'decimal'
-            spec[:precision] = column.precision.inspect if column.precision
-            spec[:scale]     = column.scale.inspect if column.scale
-            spec[:null]      = 'false' unless column.null
-            spec[:default]   = default_string(column.default) if column.has_default?
-            (spec.keys - [:name, :type]).each{ |k| spec[k].insert(0, "#{k.inspect} => ")}
-            spec
+            @connection.column_spec(column, @types)
           end.compact
 
           # find all migration keys used in this table
-          keys = [:name, :limit, :precision, :scale, :default, :null]
+          keys = @connection.migration_keys
 
           # figure out the lengths for each column based on above keys
           lengths = keys.map { |key|
@@ -168,17 +152,6 @@ HEADER
         end
 
         stream
-      end
-
-      def default_string(value)
-        case value
-        when BigDecimal
-          value.to_s
-        when Date, DateTime, Time
-          "'#{value.to_s(:db)}'"
-        else
-          value.inspect
-        end
       end
 
       def indexes(table, stream)


### PR DESCRIPTION
Moves column related schema dumper code into the AbstractAdapter. The
code remains the same, but by placing it in the AbstractAdapter, we can
then overwrite it with Adapter specific methods that will help with
Adapter specific data types.

The goal of moving this code here is to create a new migration key for
PostgreSQL's array type. Since any datatype can be an array, the goal is
to have ':array => true' as a migration option, turning the datatype
into an array. I've implemented this in postgres_ext, the syntax is
shown here: https://github.com/dockyard/postgres_ext#arrays
