### PR TITLE
Use template0 option for creating activerecord test databases in build_database task with postgres

### DIFF
--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -112,8 +112,8 @@ namespace :postgresql do
   desc 'Build the PostgreSQL test databases'
   task :build_databases do
     config = ARTest.config['connections']['postgresql']
-    %x( createdb -E UTF8 #{config['arunit']['database']} )
-    %x( createdb -E UTF8 #{config['arunit2']['database']} )
+    %x( createdb -E UTF8 -T template0 #{config['arunit']['database']} )
+    %x( createdb -E UTF8 -T template0 #{config['arunit2']['database']} )
 
     # prepare hstore
     version = %x( createdb --version ).strip.gsub(/(.*)(\d\.\d\.\d)$/, "\\2")


### PR DESCRIPTION
It seems like this could eliminate some annoyances for other people as well. `template0` as I understand it is a pristine database template where the default template to use is`template1` which may include some options. In my case using the new rails-dev-box vagrant setup; `template1` default encoding is SQL_ASCII and raises an error because it conflicts with the UTF-8 option passed in.
