### PR TITLE
Allow delivery method options to be set per mail instance

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## Rails 4.0.0 (unreleased) ##
 
+* Allow delivery method options to be set per mail instance *Aditya Sanghi*
+
+  If your smtp delivery settings are dynamic,
+  you can now override settings per mail instance for e.g.
+
+      def my_mailer(user,company)
+        mail to: customer.email, subject: "Welcome!",
+             delivery_method_options: {user_name: company.smtp_user,
+                                       password: company.smtp_password}
+      end
+
+  This will ensure that your default SMTP settings will be overridden
+  by the company specific ones. You only have to override the settings
+  that are dynamic and leave the static setting in your environment
+  configuration file (e.g. config/environments/production.rb)
+
 * Allow to set default Action Mailer options via `config.action_mailer.default_options=` *Robert Pankowecki*
 
 * Raise an `ActionView::MissingTemplate` exception when no implicit template could be found. *Damien Mathieu*

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -683,7 +683,7 @@ module ActionMailer #:nodoc:
       m.charset = charset = headers[:charset]
 
       # Set configure delivery behavior
-      wrap_delivery_behavior!(headers.delete(:delivery_method))
+      wrap_delivery_behavior!(headers.delete(:delivery_method),headers.delete(:delivery_method_options))
 
       # Assign all headers except parts_order, content_type and body
       assignable = headers.except(:parts_order, :content_type, :body, :template_name, :template_path)

--- a/actionmailer/lib/action_mailer/delivery_methods.rb
+++ b/actionmailer/lib/action_mailer/delivery_methods.rb
@@ -57,7 +57,7 @@ module ActionMailer
         self.delivery_methods = delivery_methods.merge(symbol.to_sym => klass).freeze
       end
 
-      def wrap_delivery_behavior(mail, method=nil) #:nodoc:
+      def wrap_delivery_behavior(mail, method=nil, options=nil) #:nodoc:
         method ||= self.delivery_method
         mail.delivery_handler = self
 
@@ -66,7 +66,7 @@ module ActionMailer
           raise "Delivery method cannot be nil"
         when Symbol
           if klass = delivery_methods[method]
-            mail.delivery_method(klass, send(:"#{method}_settings"))
+            mail.delivery_method(klass,(send(:"#{method}_settings") || {}).merge!(options || {}))
           else
             raise "Invalid delivery method #{method.inspect}"
           end


### PR DESCRIPTION
There is a common use case where mail settings are dynamic based on settings saved in database. For example, we could let companies provide us with their SMTP credentials which can be used to send email on their behalf. My particular use case dealt with creating a delivery method which sends SMSes based on company's credentials to company's users.

This PR allows the user to easily set delivery method settings from within the mail instance

``` ruby
class MySmsMailer < ActionMailer::Base
  def send_sms(company,telephone_number,message)
    mail :to => telephone_number, 
         :body => message, 
         :delivery_method => :sms_sender, 
         :delivery_method_options => company.sms_credentials
  end
end
```

or

``` ruby
class UserMailer < ActionMailer::Base
  def campaign_blast(company,telephone_number,message)
    mail :to => telephone_number, 
         :body => message, 
         :delivery_method_options => {:username => company.smtp_user, 
                                      :password => company.smtp_password}
  end
end
```

The alternative to doing this would be rather ugly

``` ruby
m = MySmsMailer.send_sms(company,number,message)
m.delivery_method.some_method_that_sets_options_on_sms_sender_instance(company.sms_credentials)
m.deliver
```

We could try to set delivery options by resetting them on classes but I dont imagine it would be threadsafe to do that!

/cc @josevalim @mikel 
