### PR TITLE
Extended documentation for `time_ago_in_words` helper

### DIFF
--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -139,12 +139,19 @@ module ActionView
 
       # Like <tt>distance_of_time_in_words</tt>, but where <tt>to_time</tt> is fixed to <tt>Time.now</tt>.
       #
+      # The <tt>from_time</tt> argument must be of type <tt>Time</tt> rather than type <tt>Numeric</tt>. For example,
+      # to get the <tt>time_ago_in_words</tt> for 30 minutes you would use <tt>30.minutes.ago</tt> as the argument
+      # rather than just <tt>30.minutes</tt>.
+      #
       #   time_ago_in_words(3.minutes.from_now)                 # => 3 minutes
       #   time_ago_in_words(Time.now - 15.hours)                # => about 15 hours
       #   time_ago_in_words(Time.now)                           # => less than a minute
       #   time_ago_in_words(Time.now, :include_seconds => true) # => less than 5 seconds
       #
       #   from_time = Time.now - 3.days - 14.minutes - 25.seconds
+      #   time_ago_in_words(from_time)      # => 3 days
+      #
+      #   from_time = (3.days + 14.minutes + 25.seconds).ago
       #   time_ago_in_words(from_time)      # => 3 days
       def time_ago_in_words(from_time, include_seconds_or_options = {})
         distance_of_time_in_words(from_time, Time.now, include_seconds_or_options)


### PR DESCRIPTION
I'm submitting this pull request because of some confusion I had using this method (and its alias). When I originally tried the method, I attempted to do something like `time_ago_in_words 15.minutes` which now I realize was an error on my part because this method expects its argument to be a `Time`.

My initial reaction was that this is a pretty obvious bug in rails since it didn't jump out to me in the docs that the argument must be a `Time` and writing it as `time_ago_in_words 15.minutes.ago` felt a little clumsy with the "ago" redundancy.

It was even a little more confusing going from using the `distance_of_time_in_words` method with simple `15.minutes` (because the default `from_time` is simply `0`) to the alias method `distance_of_time_in_words_to_now` and having to supply a `Time`.

Anyway, at the very least, it seems some minor improvements to the docs (perhaps what I've attached?) may help the situation, and at the most perhaps some retinkering of this API (a job I currently feel unqualified of).

Thanks for the awesome work!
