### PR TITLE
AR: make #save! and #update_attributes! return self

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -101,6 +101,7 @@ module ActiveRecord
     # ActiveRecord::Callbacks for further details.
     def save!(*)
       create_or_update || raise(RecordNotSaved)
+      self
     end
 
     # Deletes the record in the database and freezes this instance to

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -181,6 +181,11 @@ class PersistencesTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::RecordInvalid) { reply.save! }
   end
 
+  def test_save_with_bang_returns_self
+    topic = Topic.new(:title => "New Topic")
+    assert_equal topic, topic.save!
+  end
+
   def test_save_null_string_attributes
     topic = Topic.find(1)
     topic.attributes = { "title" => "null", "author_name" => "null" }
@@ -566,6 +571,11 @@ class PersistencesTest < ActiveRecord::TestCase
     topic.reload
     assert !topic.approved?
     assert_equal "The First Topic", topic.title
+  end
+
+  def test_update_attributes_with_bang_returns_self
+    topic = Topic.find(1)
+    assert_equal topic, topic.update_attributes!("approved" => true)
   end
 
   def test_update_attributes_as_admin


### PR DESCRIPTION
`save!` and `update_attributes!` always returns `true`

I think returning `self` instead will be more useful in cases like:

``` ruby
def create_something
  s = Something.new
  ....
  s.save!
end
```
