### PR TITLE
Rename to test_mysql_no_override_global_sql_mode

### DIFF
--- a/activerecord/test/cases/adapters/mysql/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql/connection_test.rb
@@ -128,11 +128,12 @@ class MysqlConnectionTest < ActiveRecord::TestCase
     assert_equal [["STRICT_ALL_TABLES"]], result.rows
   end
 
-  def test_mysql_strict_mode_disabled
+  def test_mysql_strict_mode_disabled_dont_override_global_sql_mode
     run_without_connection do |orig_connection|
       ActiveRecord::Model.establish_connection(orig_connection.merge({:strict => false}))
-      result = ActiveRecord::Model.connection.exec_query "SELECT @@SESSION.sql_mode"
-      assert_equal [['']], result.rows
+      global_sql_mode = ActiveRecord::Model.connection.exec_query "SELECT @@GLOBAL.sql_mode"
+      session_sql_mode = ActiveRecord::Model.connection.exec_query "SELECT @@SESSION.sql_mode"
+      assert_equal global_sql_mode.rows, session_sql_mode.rows
     end
   end
 

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -44,11 +44,12 @@ class MysqlConnectionTest < ActiveRecord::TestCase
     assert_equal [["STRICT_ALL_TABLES"]], result.rows
   end
 
-  def test_mysql_strict_mode_disabled
+  def test_mysql_strict_mode_disabled_dont_override_global_sql_mode
     run_without_connection do |orig_connection|
       ActiveRecord::Model.establish_connection(orig_connection.merge({:strict => false}))
-      result = ActiveRecord::Model.connection.exec_query "SELECT @@SESSION.sql_mode"
-      assert_equal [['']], result.rows
+      global_sql_mode = ActiveRecord::Model.connection.exec_query "SELECT @@GLOBAL.sql_mode"
+      session_sql_mode = ActiveRecord::Model.connection.exec_query "SELECT @@SESSION.sql_mode"
+      assert_equal global_sql_mode.rows, session_sql_mode.rows
     end
   end
 


### PR DESCRIPTION
This pull request addresses two failures tested with MySQL 5.6.6 m9 (milestone 9).

``` ruby
$ mysql --version
mysql  Ver 14.14 Distrib 5.6.6-m9, for Linux (x86_64) using  EditLine wrapper
```
- Failure with mysql adapter

``` ruby
$ rake test_mysql

... snip ...
Finished tests in 199.465809s, 17.8427 tests/s, 52.2947 assertions/s.

  1) Failure:
test_mysql_strict_mode_disabled(MysqlConnectionTest) [/home/yahonda/git/rails/activerecord/test/cases/adapters/mysql/connection_test.rb:135]:
Expected: [[""]]
  Actual: [["NO_ENGINE_SUBSTITUTION"]]

3559 tests, 10431 assertions, 1 failures, 0 errors, 6 skips
rake aborted!
Command failed with status (1): [/home/yahonda/.rvm/rubies/ruby-1.9.3-p194/...]

Tasks: TOP => test_mysql
(See full trace by running task with --trace)
$ 
```
- Failure with mysql2 adapter

``` ruby

$ rake test_mysql2

... snip ...
Finished tests in 166.461722s, 21.3683 tests/s, 62.6330 assertions/s.

1) Failure:
test_mysql_strict_mode_disabled(MysqlConnectionTest) [/home/yahonda/git/rails/activerecord/test/cases/adapters/mysql2/connection_test.rb:51]:
Expected: [[""]]
Actual: [["NO_ENGINE_SUBSTITUTION"]]

3557 tests, 10426 assertions, 1 failures, 0 errors, 18 skips
rake aborted!
Command failed with status (1): [/home/yahonda/.rvm/rubies/ruby-1.9.3-p194/...]

Tasks: TOP => test_mysql2
(See full trace by running task with --trace)
$
```
- sql_mode default value as of MySQL 5.6.6 m9.

It might have caused sql_mode default value as of MySQL 5.6.6 m9 is `NO_ENGINE_SUBSTITUTION`, which was empty at older versions.

``` sql

mysql> select @@global.sql_mode;
+------------------------+
| @@global.sql_mode      |
+------------------------+
| NO_ENGINE_SUBSTITUTION |
+------------------------+
1 row in set (0.00 sec)

mysql> select @@session.sql_mode;
+------------------------+
| @@session.sql_mode     |
+------------------------+
| NO_ENGINE_SUBSTITUTION |
+------------------------+
1 row in set (0.00 sec)

mysql> quit
```

This default parameter change is out of control from Rails, then these test verify Rails not overriding the default `@@GLOBAL.sql_mode` value by checking if `@@GLOBAL.sql_mode` is the same as `@@SESSION.sql_mode`. 
