### PR TITLE
Refactor AR::Result or inherits. Because we have redundant codes about column_types.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -298,13 +298,6 @@ module ActiveRecord
         @connection.insert_id
       end
 
-      class Result < ActiveRecord::Result
-        def initialize(columns, rows, column_types)
-          super(columns, rows)
-          @column_types = column_types
-        end
-      end
-
       module Fields
         class Type
           def type; end
@@ -437,7 +430,7 @@ module ActiveRecord
                 }
               end
             }
-            result_set = Result.new(types.keys, result.to_a, types)
+            result_set = ActiveRecord::Result.new(types.keys, result.to_a, types)
             result.free
           else
             result_set = ActiveRecord::Result.new([], [])

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -803,13 +803,6 @@ module ActiveRecord
         Arel::Nodes::BindParam.new "$#{index + 1}"
       end
 
-      class Result < ActiveRecord::Result
-        def initialize(columns, rows, column_types)
-          super(columns, rows)
-          @column_types = column_types
-        end
-      end
-
       def exec_query(sql, name = 'SQL', binds = [])
         log(sql, name, binds) do
           result = binds.empty? ? exec_no_cache(sql, binds) :
@@ -825,7 +818,7 @@ module ActiveRecord
             }
           end
 
-          ret = Result.new(result.fields, result.values, types)
+          ret = ActiveRecord::Result.new(result.fields, result.values, types)
           result.clear
           return ret
         end

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -10,11 +10,11 @@ module ActiveRecord
 
     attr_reader :columns, :rows, :column_types
 
-    def initialize(columns, rows)
+    def initialize(columns, rows, column_types = {})
       @columns      = columns
       @rows         = rows
       @hash_rows    = nil
-      @column_types = {}
+      @column_types = column_types
     end
 
     def each


### PR DESCRIPTION
I added 3rd argument to AR::Result#initialize, and removed mysql/postgresql's own Result class.
If we add the 3rd argument, inherited Result class is unnecessary.
