### PR TITLE
option_tags coerced to "" instead of nil

### DIFF
--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -118,6 +118,7 @@ module ActionView
       #   # => <select disabled="disabled" id="destination" name="destination"><option>NYC</option>
       #   #    <option>Paris</option><option>Rome</option></select>
       def select_tag(name, option_tags = nil, options = {})
+        option_tags ||= ""
         html_name = (options[:multiple] == true && !name.to_s.ends_with?("[]")) ? "#{name}[]" : name
 
         if options.delete(:include_blank)

--- a/actionpack/test/template/form_tag_helper_test.rb
+++ b/actionpack/test/template/form_tag_helper_test.rb
@@ -225,6 +225,18 @@ class FormTagHelperTest < ActionView::TestCase
     assert_dom_equal expected, actual
   end
 
+  def test_select_tag_with_nil_option_tags_and_include_blank
+    actual = select_tag "places", nil, :include_blank => true
+    expected = %(<select id="places" name="places"><option value=""></option></select>)
+    assert_dom_equal expected, actual
+  end
+
+  def test_select_tag_with_nil_option_tags_and_prompt
+    actual = select_tag "places", nil, :prompt => "string"
+    expected = %(<select id="places" name="places"><option value="">string</option></select>)
+    assert_dom_equal expected, actual
+  end
+
   def test_text_area_tag_size_string
     actual = text_area_tag "body", "hello world", "size" => "20x40"
     expected = %(<textarea cols="20" id="body" name="body" rows="40">\nhello world</textarea>)


### PR DESCRIPTION
This fixes [#7404](https://github.com/rails/rails/issues/7404)
- This exception is thrown only when include_blank => true and /or prompt options are added.
