### PR TITLE
remind user a good way to generate a secret code.

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/secret_token.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/secret_token.rb.tt
@@ -2,8 +2,11 @@
 
 # Your secret key for verifying the integrity of signed cookies.
 # If you change this key, all old signed cookies will become invalid!
+
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
+# You can generate a safe secret key with the command `rake secret`.
+
 # Make sure your secret_token is kept private
 # if you're sharing your code publicly.
 <%= app_const %>.config.secret_token = '<%= app_secret %>'


### PR DESCRIPTION
Suggest user a better way to generate a secret token via the available `rake secret` command from Rails.

Better formatting for easier readable too.
