### PR TITLE
Route to the full namespaced resource when generating a controller.

### DIFF
--- a/railties/lib/rails/generators/rails/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/rails/controller/controller_generator.rb
@@ -9,8 +9,9 @@ module Rails
       end
 
       def add_routes
+        route_path = (class_path | [file_name]).join '/'
         actions.reverse.each do |action|
-          route %{get "#{file_name}/#{action}"}
+          route %{get "#{route_path}/#{action}"}
         end
       end
 

--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -60,7 +60,8 @@ class NamespacedControllerGeneratorTest < NamespacedGeneratorTestCase
 
   def test_routes_should_not_be_namespaced
     run_generator
-    assert_file "config/routes.rb", /get "account\/foo"/, /get "account\/bar"/
+    assert_file "config/routes.rb", /get "test_app\/account\/foo"/,
+                                    /get "test_app\/account\/bar"/
   end
 #
   def test_invokes_default_template_engine_even_with_no_action


### PR DESCRIPTION
For example:
rails generate controller foo/bar index

should generate:

``` ruby
get 'foo/bar/index'
```

previously it generated:

``` ruby
get 'bar/index'
```

Please let me know if this is a faulty assumption of mine or whether further work is needed (aka properly nesting inside of scope(s) or something).  Or whether this would be better on the master branch - I picked 3-2-stable because I consider it a bug.

:heart: Thanks!
