### PR TITLE
#4938 Fix launching performance tests

### DIFF
--- a/activesupport/lib/active_support/testing/performance.rb
+++ b/activesupport/lib/active_support/testing/performance.rb
@@ -17,7 +17,7 @@ module ActiveSupport
 
       # each implementation should define metrics and freeze the defaults
       DEFAULTS =
-        if ARGV.include?('--benchmark') # HAX for rake test
+        if ENV["BENCHMARK_TESTS"]
           { :runs => 4,
             :output => 'tmp/performance',
             :benchmark => true }

--- a/activesupport/lib/active_support/testing/performance/jruby.rb
+++ b/activesupport/lib/active_support/testing/performance/jruby.rb
@@ -6,7 +6,7 @@ module ActiveSupport
   module Testing
     module Performance
       DEFAULTS.merge!(
-        if ARGV.include?('--benchmark')
+        if ENV["BENCHMARK_TESTS"]
           {:metrics => [:wall_time, :user_time, :memory, :gc_runs, :gc_time]}
         else
           { :metrics => [:wall_time],

--- a/activesupport/lib/active_support/testing/performance/rubinius.rb
+++ b/activesupport/lib/active_support/testing/performance/rubinius.rb
@@ -4,7 +4,7 @@ module ActiveSupport
   module Testing
     module Performance
       DEFAULTS.merge!(
-        if ARGV.include?('--benchmark')
+        if ENV["BENCHMARK_TESTS"]
           {:metrics => [:wall_time, :memory, :objects, :gc_runs, :gc_time]}
         else
           { :metrics => [:wall_time],

--- a/activesupport/lib/active_support/testing/performance/ruby.rb
+++ b/activesupport/lib/active_support/testing/performance/ruby.rb
@@ -9,7 +9,7 @@ module ActiveSupport
   module Testing
     module Performance
       DEFAULTS.merge!(
-        if ARGV.include?('--benchmark')
+        if ENV["BENCHMARK_TESTS"]
           { :metrics => [:wall_time, :memory, :objects, :gc_runs, :gc_time] }
         else
           { :min_percent => 0.01,

--- a/railties/lib/rails/commands/benchmarker.rb
+++ b/railties/lib/rails/commands/benchmarker.rb
@@ -2,9 +2,7 @@ require 'optparse'
 require 'rails/test_help'
 require 'rails/performance_test_help'
 
-ARGV.push('--benchmark') # HAX
 require 'active_support/testing/performance'
-ARGV.pop
 
 def options
   options = {}

--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -126,7 +126,7 @@ namespace :test do
   Rails::SubTestTask.new(:benchmark => 'test:prepare') do |t|
     t.libs << 'test'
     t.pattern = 'test/performance/**/*_test.rb'
-    t.options = '-- --benchmark'
+    ENV["BENCHMARK_TESTS"] = '1'
   end
 
   Rails::SubTestTask.new(:profile => 'test:prepare') do |t|


### PR DESCRIPTION
When we run `rake test:benchmark` for performance tests it raises
ArgumentError that file --benchmark not found. It happens because
gem 'test-unit' passes remaining options to the tests, whereas mintest
doesn't do it.
