### PR TITLE
Add ignore_columns to ActiveRecord

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -615,6 +615,20 @@
 
 *   PostgreSQL hstore types are automatically deserialized from the database.
 
+*   Add `ignore_columns(*names)`.
+
+        class Topic < ActiveRecord::Base
+            ignore_columns :attributes, :class
+
+            self.ignored_column?(:attributes)   # => true
+            self.new.attributes                 # => NoMethodError
+            self.new.respond_to?(:attributes)   # => false
+        end
+
+    Useful on legacy database structures with problematic column names.
+
+    * Nathaniel Jones and Mando Escamilla*
+
 ## Rails 3.2.8 (Aug 9, 2012) ##
 
 *   Do not consider the numeric attribute as changed if the old value is zero and the new value


### PR DESCRIPTION
When dealing with legacy or read-only databases schemas, sometimes you need to tell Rails to ignore one or more columns.  Or, you have meta-columns that are used by a separate daemon or app, but you don't want them cluttering up your rails app. 

`ignore_columns` interfaces cleanly right at the point where the column names are cached by ActiveRecord, using a simple `reject` call.  

The specific case I built this for was a read-only app on top of an AuthLogic database structure.  AuthLogic uses `respond_to?(:column)` calls throughout to determine whether to enable a certain piece of functionality.  This works great with a 1-app-1-database relationship, but in this case, some functionality needed to be enabled on one app, but not the other: specifically the "increment failed login count" module.  `ignore_column :failed_login_count` would be by far the cleanest way to workaround this.

Various monkey-patches floating around Stack Overflow: 
- [How can I permanently ignore a database column in my ActiveRecord::Base class? — Stack Overflow](http://stackoverflow.com/questions/4911174/how-can-i-permanently-ignore-a-database-column-in-my-activerecordbase-class) 
- [How can I use ActiveRecord on a database that has a column named 'attribute'? (DangerousAttributeError)](http://stackoverflow.com/questions/5428987/how-can-i-use-activerecord-on-a-database-that-has-a-column-named-attribute-d?rq=1)
