### PR TITLE
Using strings in association definition methods breaks eager loading

### DIFF
--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -14,7 +14,7 @@ module ActiveRecord::Associations::Builder
 
     def initialize(model, name, scope, options)
       @model   = model
-      @name    = name
+      @name    = name.to_sym
 
       if scope.is_a?(Hash)
         @scope   = nil

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -10,7 +10,8 @@ class Post < ActiveRecord::Base
 
   scope :limit_by, lambda {|l| limit(l) }
 
-  belongs_to :author do
+  # to test string as association name
+  belongs_to "author" do
     def greeting
       "hello"
     end


### PR DESCRIPTION
ActiveRecord::Associations::Preloader#records_by_reflection uses symbolized association name to find a reflection. If association was defined using string as it's name, model reflections hash would contain that string as a key — so Preloader fails to find that reflection. I think storing symbolized association names in reflections hash is a good solution.

Failing example:

``` ruby
class Post < ActiveRecord::Base
  belongs_to "author"
end

class Author < ActiveRecord::Base
  has_many :posts
end
```

```
rails> Post.includes(:author).where(:id => 1)
ActiveRecord::ConfigurationError: Association named 'author' was not found; perhaps you misspelled it?
```
