### PR TITLE
Ensure valid migration filename on generating migration

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -7,6 +7,7 @@ module ActiveRecord
 
       def create_migration_file
         set_local_assigns!
+        validate_file_name!
         migration_template "migration.rb", "db/migrate/#{file_name}.rb"
       end
 
@@ -41,6 +42,14 @@ module ActiveRecord
           attribute.name.singularize.foreign_key
         end.to_sym
       end
+      
+      private
+
+        def validate_file_name!
+          unless file_name =~ /^[_a-z0-9]+$/
+            raise IllegalMigrationNameError.new(file_name)
+          end
+        end
     end
   end
 end

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -28,6 +28,13 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     run_generator [migration]
     assert_migration "db/migrate/change_title_body_from_posts.rb", /class #{migration} < ActiveRecord::Migration/
   end
+  
+  def test_migration_with_invalid_file_name
+    migration = "add_something:datetime"
+    assert_raise ActiveRecord::IllegalMigrationNameError do
+      run_generator [migration]
+    end
+  end
 
   def test_add_migration_with_attributes
     migration = "add_title_body_to_posts"


### PR DESCRIPTION
``` bash
rails g migration add_statistic_updated_at:datetime

create    db/migrate/20120822103649_add_statistic_updated_at:datetime.rb

rake db:migrate

llegal name for migration file: ...db/migrate/20120822103649_add_statistic_updated_at:datetime.rb
    (only lower case letters, numbers, and '_' allowed)
```
