### PR TITLE
Allow routing concerns to accept a callable

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1613,8 +1613,8 @@ module ActionDispatch
         #   end
         #
         # Any routing helpers can be used inside a concern.
-        def concern(name, &block)
-          @concerns[name] = block
+        def concern(name, callable = nil, &block)
+          @concerns[name] = callable || block
         end
 
         # Use the named concerns
@@ -1631,7 +1631,7 @@ module ActionDispatch
         def concerns(*names)
           names.flatten.each do |name|
             if concern = @concerns[name]
-              instance_eval(&concern)
+              concern.call(self)
             else
               raise ArgumentError, "No concern named #{name} was found!"
             end
@@ -1643,6 +1643,10 @@ module ActionDispatch
         @set = set
         @scope = { :path_names => @set.resources_path_names }
         @concerns = {}
+      end
+
+      def current_scope
+        @scope
       end
 
       include Base

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1585,7 +1585,7 @@ module ActionDispatch
           end
       end
 
-      # Routing Concerns allows you to declare common routes that can be reused
+      # Routing Concerns allow you to declare common routes that can be reused
       # inside others resources and routes.
       #
       #   concern :commentable do
@@ -1606,32 +1606,65 @@ module ActionDispatch
       #     concerns :commentable
       #   end
       module Concerns
-        # Define a routing concern using a name. If a second parameter is
-        # supplied, it should respond to call, which will receive the mapper
-        # as a parameter, allowing for customized behavior based on the current
-        # scope.
+        # Define a routing concern using a name.
         #
-        #   concern :commentable do
-        #     resources :comments
+        # Concerns may be defined inline, using a block, or handled by
+        # another object, by passing that object as the second parameter.
+        #
+        # The concern object, if supplied, should respond to <tt>call</tt>,
+        # which will receive two parameters:
+        #
+        #   * The current mapper
+        #   * A hash of options which the concern object may use
+        #
+        # Options may also be used by concerns defined in a block by accepting
+        # a block parameter. So, using a block, you might do something as
+        # simple as limit the actions available on certain resources, passing
+        # standard resource options through the concern:
+        #
+        #   concern :commentable do |options|
+        #     resources :comments, options
         #   end
         #
-        #   # - or -
+        #   resources :posts, concerns: :commentable
+        #   resources :archived_posts do
+        #     # Don't allow comments on archived posts
+        #     concerns :commentable, only: [:index, :show]
+        #   end
         #
-        #   class Commentable
-        #     def self.call(mapper)
-        #       if mapper.current_scope[:controller] == 'videos'
-        #         mapper.resources :video_comments, as: :comments
-        #       else
-        #         mapper.resources :comments
-        #       end
+        # Or, using a callable object, you might implement something more
+        # specific to your application, which would be out of place in your
+        # routes file.
+        #
+        #   # purchasable.rb
+        #   class Purchasable
+        #     def initialize(defaults = {})
+        #       @defaults = defaults
+        #     end
+        #
+        #     def call(mapper, options = {})
+        #       options = @defaults.merge(options)
+        #       mapper.resources :purchases
+        #       mapper.resources :receipts
+        #       mapper.resources :returns if options[:returnable]
         #     end
         #   end
         #
-        #   concern :commentable, Commentable
+        #   # routes.rb
+        #   concern :purchasable, Purchasable.new(returnable: true)
         #
-        # Any routing helpers can be used inside a concern.
+        #   resources :toys, concerns: :purchasable
+        #   resources :electronics, concerns: :purchasable
+        #   resources :pets do
+        #     concerns :purchasable, returnable: false
+        #   end
+        #
+        # Any routing helpers can be used inside a concern. If using a
+        # callable, they're accessible from the Mapper that's passed to
+        # <tt>call</tt>.
         def concern(name, callable = nil, &block)
-          @concerns[name] = callable || lambda { |m| m.instance_eval(&block) }
+          callable ||= lambda { |mapper, options| mapper.instance_exec(options, &block) }
+          @concerns[name] = callable
         end
 
         # Use the named concerns
@@ -1645,10 +1678,11 @@ module ActionDispatch
         #   namespace :posts do
         #     concerns :commentable
         #   end
-        def concerns(*names)
-          names.flatten.each do |name|
+        def concerns(*args)
+          options = args.extract_options!
+          args.flatten.each do |name|
             if concern = @concerns[name]
-              concern.call(self)
+              concern.call(self, options)
             else
               raise ArgumentError, "No concern named #{name} was found!"
             end
@@ -1660,10 +1694,6 @@ module ActionDispatch
         @set = set
         @scope = { :path_names => @set.resources_path_names }
         @concerns = {}
-      end
-
-      def current_scope
-        @scope
       end
 
       include Base

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1606,15 +1606,32 @@ module ActionDispatch
       #     concerns :commentable
       #   end
       module Concerns
-        # Define a routing concern using a name.
+        # Define a routing concern using a name. If a second parameter is
+        # supplied, it should respond to call, which will receive the mapper
+        # as a parameter, allowing for customized behavior based on the current
+        # scope.
         #
         #   concern :commentable do
         #     resources :comments
         #   end
         #
+        #   # - or -
+        #
+        #   class Commentable
+        #     def self.call(mapper)
+        #       if mapper.current_scope[:controller] == 'videos'
+        #         mapper.resources :video_comments, as: :comments
+        #       else
+        #         mapper.resources :comments
+        #       end
+        #     end
+        #   end
+        #
+        #   concern :commentable, Commentable
+        #
         # Any routing helpers can be used inside a concern.
         def concern(name, callable = nil, &block)
-          @concerns[name] = callable || block
+          @concerns[name] = callable || lambda { |m| m.instance_eval(&block) }
         end
 
         # Use the named concerns

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -358,6 +358,7 @@ end
 class ThreadsController  < ResourcesController; end
 class MessagesController < ResourcesController; end
 class CommentsController < ResourcesController; end
+class ReviewsController < ResourcesController; end
 class AuthorsController < ResourcesController; end
 class LogosController < ResourcesController; end
 

--- a/actionpack/test/dispatch/routing/concerns_test.rb
+++ b/actionpack/test/dispatch/routing/concerns_test.rb
@@ -103,4 +103,14 @@ class RoutingConcernsTest < ActionDispatch::IntegrationTest
 
     assert_equal "No concern named foo was found!", e.message
   end
+
+  def test_concerns_executes_block_in_context_of_current_mapper
+    mapper = ActionDispatch::Routing::Mapper.new(ActionDispatch::Routing::RouteSet.new)
+    mapper.concern :test_concern do
+      resources :things
+      return self
+    end
+
+    assert_equal mapper, mapper.concerns(:test_concern)
+  end
 end


### PR DESCRIPTION
This allows us to make alterations to the generated routes based on the
scope of the current mapper, and otherwise allows us to move larger
blocks of concerns out of the routes file, altogether.

I'm not really convinced of the whole concerns idea, but it seems at least that if we implement it, we should have it allow for separation of concerns.

This seems in keeping with @dhh's perceived benefit of reducing noise in the routes.rb file, while enhancing the already existing functionality.
