### PR TITLE
ORDER BY xx NULLS first/last will break reverse_sql_order

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Oracle and PostgreSQL supports "NULLS FIRST/LAST" in order by statement.
+    And `reverse_order` will now revert `NULLS FIRST/LAST` when
+    they're part of the order by statement.  For example,
+
+        User.order("name ASC NULLS LAST").reverse_order # generated SQL has 'ORDER BY name DESC NULLS FIRST'
+
+    Fixes #7423.
+
+    *Dingding Ye*
+
 *   Deprecate `ConnectionAdapters::SchemaStatements#distinct`,
     as it is no longer used by internals.
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1133,6 +1133,18 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal Developer.all.merge!(:order => 'id desc').first, Developer.last
   end
 
+  if current_adapter?(:PostgreSQLAdapter, :OracleAdapter)
+    def test_last_with_null_order_first
+      first = Topic.all.merge!(order: 'author_email_address ASC').first
+      assert_equal first, Topic.order('author_email_address DESC NULLS FIRST').last
+    end
+
+    def test_last_with_null_order_last
+      first = Topic.all.merge!(order: 'author_email_address DESC').first
+      assert_equal first, Topic.order('author_email_address ASC NULLS LAST').last
+    end
+  end
+
   def test_all
     developers = Developer.all
     assert_kind_of ActiveRecord::Relation, developers


### PR DESCRIPTION
Oracle and PostgreSQL supports "NULLS first/last" in order by statement. It
will break the reverse_sql_order by concating " DESC" to the order by statement.

For example,

``` ruby
    User.order("name ASC NULLS FIRST").last
```
