### PR TITLE
Allow to set custom error handler for ActionDispatch::ParamsParser.

### DIFF
--- a/actionpack/test/dispatch/request/custom_exception_handler_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/custom_exception_handler_params_parsing_test.rb
@@ -1,0 +1,49 @@
+require 'abstract_unit'
+
+class CustomExceptionHandlerParamsParsingTest < ActionDispatch::IntegrationTest
+  class TestController < ActionController::Base
+    def parse
+      head :ok
+    end
+  end
+
+  def self.build_app(routes = nil)
+    custom_error_handler = lambda { |e| [400, {}, ["Bad Request"]]}
+
+    RoutedRackApp.new(routes || ActionDispatch::Routing::RouteSet.new) do |middleware|
+      middleware.use "ActionDispatch::ShowExceptions", ActionDispatch::PublicExceptions.new("#{FIXTURE_LOAD_PATH}/public")
+      middleware.use "ActionDispatch::DebugExceptions"
+      middleware.use "ActionDispatch::Callbacks"
+      middleware.use "ActionDispatch::ParamsParser", {}, custom_error_handler
+      middleware.use "ActionDispatch::Cookies"
+      middleware.use "ActionDispatch::Flash"
+      middleware.use "Rack::Head"
+    end
+  end
+
+  self.app = build_app
+
+  test "calls provided exception handler if parsing unsuccessful" do
+    with_test_routing do
+      begin
+        $stderr = StringIO.new # suppress the log
+        json = "[\"person]\": {\"name\": \"David\"}}"
+        post "/parse", json, {'CONTENT_TYPE' => 'application/json', 'action_dispatch.show_exceptions' => false}
+        assert_response :bad_request
+      ensure
+        $stderr = STDERR
+      end
+    end
+  end
+
+
+  private
+    def with_test_routing
+      with_routing do |set|
+        set.draw do
+          post ':action', :to => ::CustomExceptionHandlerParamsParsingTest::TestController
+        end
+        yield
+      end
+    end
+end


### PR DESCRIPTION
This allows to set a custom response (e.g. 400) when `ParamsParser` raises an exception when parsing request params. One can do it by swapping the default `ActionDispatch::ParamsParser`:

``` ruby
config.middleware.swap ActionDispatch::ParamsParser, 
                       ActionDispatch::ParamsParser, {}, lambda { |e| [400, {}, ["Bad request"]]}
```

This is still a bit awkward, so it could be further simplified to e.g. 

``` ruby
config.action_dispatch.params_parser_error_handler = lambda { ... }
```

but it's not implemented in this patch.

Without this patch it's of course still possible to return custom response, however slightly more difficult. Here's one of possible solutions:

``` ruby
class MyParamsParser < ActionDispatch::ParamsParser
  def call
    super
  rescue MultiJson::DecodeError
    [400, {}, ["Bad Request"]]
  end
end

config.middleware.swap ActionDispatch::ParamsParser, MyParamsParser
```

The other question is why Rails doesn't return 400 by default instead of 500 when parsing request params fails :)
