### PR TITLE
Fixes encoding of 4 byte unicode characters to JSON

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
+*   Properly encode unicode characters over 0xFFFF to JSON
+
+    *Brett Carter*
 
 *   Replace deprecated `memcache-client` gem with `dalli` in ActiveSupport::Cache::MemCacheStore
 

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -130,7 +130,8 @@ module ActiveSupport
             gsub(/([\xC0-\xDF][\x80-\xBF]|
                    [\xE0-\xEF][\x80-\xBF]{2}|
                    [\xF0-\xF7][\x80-\xBF]{3})+/nx) { |s|
-            s.unpack("U*").pack("n*").unpack("H*")[0].gsub(/.{4}/n, '\\\\u\&')
+              s = s.encode('utf-16be', 'utf-8')
+              s.unpack("H*")[0].gsub(/.{4}/n, '\\\\u\&')
           }
           json = %("#{json}")
           json.force_encoding(::Encoding::UTF_8)

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -118,6 +118,12 @@ class TestJSONEncoding < ActiveSupport::TestCase
     assert_equal Encoding::UTF_8, result.encoding
   end
 
+  def test_wide_utf8_chars
+    w = '𠜎'
+    result = ActiveSupport::JSON.encode(w)
+    assert_equal '"\ud841\udf0e"', result
+  end
+
   def test_exception_raised_when_encoding_circular_reference_in_array
     a = [1]
     a << a


### PR DESCRIPTION
Fixes encoding of large unicode characters (> 0xFFFF) to JSON.  For Javascript / JSON these need to be encoded as a surrogate pair.  Fixes Issue #3727
