### PR TITLE
Fixes encoding of 4 byte unicode characters to JSON

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Properly encode unicode characters over 0xFFFF to JSON
+
+    *Brett Carter*
+
 ## Rails 3.1.8 (Aug 9, 2012)
 
 *   ERB::Util.html_escape now escapes single quotes. *Santiago Pastorino*

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -128,7 +128,8 @@ module ActiveSupport
             gsub(/([\xC0-\xDF][\x80-\xBF]|
                    [\xE0-\xEF][\x80-\xBF]{2}|
                    [\xF0-\xF7][\x80-\xBF]{3})+/nx) { |s|
-            s.unpack("U*").pack("n*").unpack("H*")[0].gsub(/.{4}/n, '\\\\u\&')
+              s = s.encode('utf-16be', 'utf-8')
+              s.unpack("H*")[0].gsub(/.{4}/n, '\\\\u\&')
           }
           json = %("#{json}")
           json.force_encoding(::Encoding::UTF_8) if json.respond_to?(:force_encoding)

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -109,6 +109,12 @@ class TestJSONEncoding < Test::Unit::TestCase
     end
   end
 
+  def test_wide_utf8_chars
+    w = '𠜎'
+    result = ActiveSupport::JSON.encode(w)
+    assert_equal '"\ud841\udf0e"', result
+  end
+
   def test_exception_raised_when_encoding_circular_reference_in_array
     a = [1]
     a << a


### PR DESCRIPTION
Fixes encoding of 4 byte (> 0xFFFF) unicode characters to JSON.  Backport of request on master.  Fixes issue #3727
