### PR TITLE
Suppress  annoy warning, when executing AR's testcases.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -7,8 +7,6 @@ require 'mysql'
 
 class Mysql
   class Time
-    ###
-    # This monkey patch is for test_additional_columns_from_join_table
     def to_date
       Date.new(year, month, day)
     end

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -22,6 +22,8 @@ ActiveSupport::Deprecation.debug = true
 # Connect to the database
 ARTest.connect
 
+require 'support/mysql'
+
 # Quote "type" if it's a reserved word for the current connection.
 QUOTED_TYPE = ActiveRecord::Base.connection.quote_column_name('type')
 

--- a/activerecord/test/support/mysql.rb
+++ b/activerecord/test/support/mysql.rb
@@ -1,0 +1,11 @@
+if defined?(Mysql)
+  class Mysql
+    class Error
+      # This monkey patch fixes annoy warning with mysql-2.8.1.gem when executing testcases.
+      def errno_with_fix_warnings
+        silence_warnings { errno_without_fix_warnings }
+      end
+      alias_method_chain :errno, :fix_warnings
+    end
+  end
+end


### PR DESCRIPTION
We always see the follwing warning, when executing `rake test_mysql`

```
...warning: instance variable errno not initialized...
```

I know we shouldn't hide warnings, but I guess that development for mysql gem is not active.

BTW:
according to https://github.com/luislavena/mysql-gem/blob/master/ext/mysql_api/mysql.c#L1873
and https://github.com/luislavena/mysql-gem/blob/master/ext/mysql_api/mysql.c#L171, we can't access this iv ?
