### PR TITLE
correct handling of date selects when using both disabled and discard options

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix handling of date selects when using both disabled and discard options.
+    Fixes #7431.
+
+    *Vasiliy Ermolovich*
+
 *   `ActiveRecord::SessionStore` is extracted out of Rails into a gem `activerecord-session_store`.
     Setting `config.session_store` to `:active_record_store` will no longer work and will break
     if the `activerecord-session_store` gem isn't available. *Prem Sichanugrist*

--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -963,12 +963,15 @@ module ActionView
         #  build_hidden(:year, 2008)
         #  => "<input id="post_written_on_1i" name="post[written_on(1i)]" type="hidden" value="2008" />"
         def build_hidden(type, value)
-          (tag(:input, {
+          select_options = {
             :type => "hidden",
             :id => input_id_from_type(type),
             :name => input_name_from_type(type),
             :value => value
-          }.merge(@html_options.slice(:disabled))) + "\n").html_safe
+          }.merge(@html_options.slice(:disabled))
+          select_options.merge!(:disabled => 'disabled') if @options[:disabled]
+
+          tag(:input, select_options) + "\n".html_safe
         end
 
         # Returns the name attribute for the input tag.

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -2658,6 +2658,30 @@ class DateHelperTest < ActionView::TestCase
     assert_dom_equal expected, datetime_select("post", "updated_at", :discard_minute => true)
   end
 
+  def test_datetime_select_disabled_and_discard_minute
+    @post = Post.new
+    @post.updated_at = Time.local(2004, 6, 15, 15, 16, 35)
+
+    expected = %{<select id="post_updated_at_1i" disabled="disabled" name="post[updated_at(1i)]">\n}
+    1999.upto(2009) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == 2004}>#{i}</option>\n) }
+    expected << "</select>\n"
+    expected << %{<select id="post_updated_at_2i" disabled="disabled" name="post[updated_at(2i)]">\n}
+    1.upto(12) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == 6}>#{Date::MONTHNAMES[i]}</option>\n) }
+    expected << "</select>\n"
+    expected << %{<select id="post_updated_at_3i" disabled="disabled" name="post[updated_at(3i)]">\n}
+    1.upto(31) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == 15}>#{i}</option>\n) }
+    expected << "</select>\n"
+
+    expected << " &mdash; "
+
+    expected << %{<select id="post_updated_at_4i" disabled="disabled" name="post[updated_at(4i)]">\n}
+    0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
+    expected << "</select>\n"
+    expected << %{<input type="hidden" id="post_updated_at_5i" disabled="disabled" name="post[updated_at(5i)]" value="16" />\n}
+
+    assert_dom_equal expected, datetime_select("post", "updated_at", :discard_minute => true, :disabled => true)
+  end
+
   def test_datetime_select_invalid_order
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 15, 16, 35)


### PR DESCRIPTION
we should take disabled option not only from `html_options` hash but from
`options` hash too like `build_select` method does it. So

datetime_select("post", "updated_at", { :discard_minute => true }, { :disabled => true })
datetime_select("post", "updated_at", :discard_minute => true , :disabled => true)

both these variants work now

closes #7431
