### PR TITLE
ActiveRecord: sum expression returns string '0' for no records, fixed

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -906,3 +906,8 @@
     *Aaron Patterson*
 
 Please check [3-2-stable](https://github.com/rails/rails/blob/3-2-stable/activerecord/CHANGELOG.md) for previous changes.
+
+*   Fix bug where sum(expression) returns string '0' for no matching records
+    Fixes #7439
+
+    *Tim Macfarlane*

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -349,7 +349,7 @@ module ActiveRecord
     def type_cast_calculated_value(value, column, operation = nil)
       case operation
         when 'count'   then value.to_i
-        when 'sum'     then type_cast_using_column(value || '0', column)
+        when 'sum'     then type_cast_using_column(value || 0, column)
         when 'average' then value.respond_to?(:to_d) ? value.to_d : value
         else type_cast_using_column(value, column)
       end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -378,6 +378,10 @@ class CalculationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_sum_expression_returns_zero_when_no_records_to_sum
+    assert_equal 0, Account.where('1 = 2').sum("2 * credit_limit")
+  end
+
   def test_count_with_from_option
     assert_equal Company.count(:all), Company.from('companies').count(:all)
     assert_equal Account.where("credit_limit = 50").count(:all),


### PR DESCRIPTION
The bug:

```
Account.where('1 = 2').sum("2 * credit_limit") => '0'
```

That is, sum with an expression (not a column name) on a condition or collection that returns no records returns the string "0", whereas it should return an integer, 0.
