### PR TITLE
Raise generic ParseError exception when ParamsParser fails parsing request params

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/params_parser.rb
+++ b/actionpack/lib/action_dispatch/middleware/params_parser.rb
@@ -4,6 +4,8 @@ require 'active_support/core_ext/hash/indifferent_access'
 
 module ActionDispatch
   class ParamsParser
+    class ParseError < StandardError; end
+
     DEFAULT_PARSERS = {
       Mime::XML => :xml_simple,
       Mime::JSON => :json
@@ -52,9 +54,10 @@ module ActionDispatch
           false
         end
       rescue Exception => e # YAML, XML or Ruby code block errors
-        logger(env).debug "Error occurred while parsing request parameters.\nContents:\n\n#{request.raw_post}"
+        message = "Error occurred while parsing request parameters.\nContents:\n\n#{request.raw_post}"
+        logger(env).debug message
 
-        raise e
+        raise ParseError, message
       end
 
       def content_type_from_legacy_post_data_format_header(env)

--- a/actionpack/lib/action_dispatch/middleware/params_parser.rb
+++ b/actionpack/lib/action_dispatch/middleware/params_parser.rb
@@ -40,14 +40,12 @@ module ActionDispatch
         when Proc
           strategy.call(request.raw_post)
         when :xml_simple, :xml_node
-          data = Hash.from_xml(request.body.read) || {}
-          request.body.rewind if request.body.respond_to?(:rewind)
+          data = Hash.from_xml(request.raw_post) || {}
           data.with_indifferent_access
         when :yaml
           YAML.load(request.raw_post)
         when :json
-          data = ActiveSupport::JSON.decode(request.body)
-          request.body.rewind if request.body.respond_to?(:rewind)
+          data = ActiveSupport::JSON.decode(request.raw_post)
           data = {:_json => data} unless data.is_a?(Hash)
           data.with_indifferent_access
         else

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -46,7 +46,7 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
       begin
         $stderr = StringIO.new # suppress the log
         json = "[\"person]\": {\"name\": \"David\"}}"
-        assert_raise(MultiJson::DecodeError) { post "/parse", json, {'CONTENT_TYPE' => 'application/json', 'action_dispatch.show_exceptions' => false} }
+        assert_raise(ActionDispatch::ParamsParser::ParseError) { post "/parse", json, {'CONTENT_TYPE' => 'application/json', 'action_dispatch.show_exceptions' => false} }
       ensure
         $stderr = STDERR
       end

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -47,7 +47,8 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
         $stderr = StringIO.new # suppress the log
         json = "[\"person]\": {\"name\": \"David\"}}"
         exception = assert_raise(ActionDispatch::ParamsParser::ParseError) { post "/parse", json, {'CONTENT_TYPE' => 'application/json', 'action_dispatch.show_exceptions' => false} }
-        assert_match json, exception.message
+        assert_equal MultiJson::DecodeError, exception.original_exception.class
+        assert_equal exception.original_exception.message, exception.message
       ensure
         $stderr = STDERR
       end

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -46,7 +46,8 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
       begin
         $stderr = StringIO.new # suppress the log
         json = "[\"person]\": {\"name\": \"David\"}}"
-        assert_raise(ActionDispatch::ParamsParser::ParseError) { post "/parse", json, {'CONTENT_TYPE' => 'application/json', 'action_dispatch.show_exceptions' => false} }
+        exception = assert_raise(ActionDispatch::ParamsParser::ParseError) { post "/parse", json, {'CONTENT_TYPE' => 'application/json', 'action_dispatch.show_exceptions' => false} }
+        assert_match json, exception.message
       ensure
         $stderr = STDERR
       end

--- a/actionpack/test/dispatch/request/xml_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/xml_params_parsing_test.rb
@@ -68,7 +68,7 @@ class XmlParamsParsingTest < ActionDispatch::IntegrationTest
       begin
         $stderr = StringIO.new # suppress the log
         xml = "<person><name>David</name></pineapple>"
-        assert_raise(REXML::ParseException) { post "/parse", xml, default_headers.merge('action_dispatch.show_exceptions' => false) }
+        assert_raise(ActionDispatch::ParamsParser::ParseError) { post "/parse", xml, default_headers.merge('action_dispatch.show_exceptions' => false) }
       ensure
         $stderr = STDERR
       end

--- a/actionpack/test/dispatch/request/xml_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/xml_params_parsing_test.rb
@@ -68,7 +68,8 @@ class XmlParamsParsingTest < ActionDispatch::IntegrationTest
       begin
         $stderr = StringIO.new # suppress the log
         xml = "<person><name>David</name></pineapple>"
-        assert_raise(ActionDispatch::ParamsParser::ParseError) { post "/parse", xml, default_headers.merge('action_dispatch.show_exceptions' => false) }
+        exception = assert_raise(ActionDispatch::ParamsParser::ParseError) { post "/parse", xml, default_headers.merge('action_dispatch.show_exceptions' => false) }
+        assert_match xml, exception.message
       ensure
         $stderr = STDERR
       end

--- a/actionpack/test/dispatch/request/xml_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/xml_params_parsing_test.rb
@@ -69,7 +69,8 @@ class XmlParamsParsingTest < ActionDispatch::IntegrationTest
         $stderr = StringIO.new # suppress the log
         xml = "<person><name>David</name></pineapple>"
         exception = assert_raise(ActionDispatch::ParamsParser::ParseError) { post "/parse", xml, default_headers.merge('action_dispatch.show_exceptions' => false) }
-        assert_match xml, exception.message
+        assert_equal REXML::ParseException, exception.original_exception.class
+        assert_equal exception.original_exception.message, exception.message
       ensure
         $stderr = STDERR
       end


### PR DESCRIPTION
@tenderlove this PR is based on our discussion in #7424

When `ActionDispatch::ParamsParser#parse_formatted_parameters` raises an exception, it's re-raised as `ActionDispatch::ParamsParser::ParseError` instead of the original exception - we're assuming that the only thing that can raise an exception there is a parser. This way it's much easier to catch parsing error that originated in `ParamsParser` (skipping parsing errors raised later down the chain e.g. in actions) and return a custom response e.g. 400.

BTW. There's a funky thing going on with request body in `ParamsParser#parse_formatted_parameters` ([link](https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/params_parser.rb#L37-58)). Proc and Yaml strategies use `request.raw_post` (which reads request body and then rewinds it before being parsed), but JSON and XML ones read and rewind request body on their own e.g.:

``` ruby
when :json
  data = ActiveSupport::JSON.decode(request.body)
  request.body.rewind if request.body.respond_to?(:rewind)
  ...
```

The issue is that if JSON.decode raises an exception, request body is not rewinded and thus calling `request.raw_post` later inside the error handler returns nil. Is there any reason why not all strategies use `request.raw_post`? This should most likely fix this issue.
