### PR TITLE
Add the ability to pass a --pry option to add 'pry-rails' to the Gemfile

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add ability to pass a `--pry` option which add a line in the Gemfile to make
+    Pry the default REPL when starting a Rails console.
+
 *   Correctly handle SCRIPT_NAME when generating routes to engine in application
     that's mounted at a sub-uri. With this behavior, you *should not* use
     default_url_options[:script_name] to set proper application's mount point by

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -61,6 +61,9 @@ module Rails
         class_option :skip_test_unit,     :type => :boolean, :aliases => "-T", :default => false,
                                           :desc => "Skip Test::Unit files"
 
+        class_option :pry,                :type => :boolean, 
+                                          :desc => "Add pry-rails gem to the Gemfile"
+
         class_option :help,               :type => :boolean, :aliases => "-h", :group => :rails,
                                           :desc => "Show this help message and quit"
       end

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -9,6 +9,8 @@ source 'https://rubygems.org'
 <%= assets_gemfile_entry %>
 <%= javascript_gemfile_entry %>
 
+<%= "gem 'pry-rails', :group => 'development'" if options[:pry] -%>
+
 # To use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.0.0'
 


### PR DESCRIPTION
Hello,

I allow myself to open a pull request related to [#6549](https://github.com/rails/rails/pull/6549). This pull request add the ability for the user to pass a `--pry` option when creating a new Rails application adding the pry-rails gem to the project's Gemfile.

Have a nice day.
