### PR TITLE
fix order dependent test in AggregationsTest

### DIFF
--- a/activerecord/test/cases/aggregations_test.rb
+++ b/activerecord/test/cases/aggregations_test.rb
@@ -114,6 +114,8 @@ class AggregationsTest < ActiveRecord::TestCase
     customers(:david).save
     customers(:david).reload
     assert_nil customers(:david).non_blank_gps_location
+  ensure
+    Customer.gps_conversion_was_run = nil
   end
 
   def test_nil_return_from_converter_results_in_failure_when_allow_nil_is_false


### PR DESCRIPTION
Ensure class variable is set to nil.

It prevents the following test to fail:

```
def test_do_not_run_the_converter_when_nil_was_set
  customers(:david).non_blank_gps_location = nil
  assert_nil Customer.gps_conversion_was_run
end
```

Check https://github.com/rails/rails/blob/master/activerecord/test/models/customer.rb#L7
for more information.
