### PR TITLE
Memcached to dalli for actionpack test.

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/session/mem_cache_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/mem_cache_store.rb
@@ -1,15 +1,15 @@
 require 'action_dispatch/middleware/session/abstract_store'
-require 'rack/session/memcache'
+require 'rack/session/dalli'
 
 module ActionDispatch
   module Session
-    class MemCacheStore < Rack::Session::Memcache
+    class MemCacheStore < Rack::Session::Dalli
       include Compatibility
       include StaleSessionCheck
       include SessionObject
 
       def initialize(app, options = {})
-        require 'memcache'
+        require 'dalli'
         options[:expire_after] ||= options[:expires]
         super
       end

--- a/actionpack/test/dispatch/session/mem_cache_store_test.rb
+++ b/actionpack/test/dispatch/session/mem_cache_store_test.rb
@@ -34,9 +34,9 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
   end
 
   begin
-    require 'memcache'
-    memcache = MemCache.new('localhost:11211')
-    memcache.set('ping', '')
+    require 'dalli'
+    ss = Dalli::Client.new('localhost:11211').stats
+    raise Dalli::DalliError unless ss['localhost:11211']
 
     def test_setting_and_getting_session_value
       with_test_route_set do
@@ -165,7 +165,7 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
         assert_not_equal session_id, cookies['_session_id']
       end
     end
-  rescue LoadError, RuntimeError
+  rescue LoadError, RuntimeError, Dalli::DalliError
     $stderr.puts "Skipping MemCacheStoreTest tests. Start memcached and try again."
   end
 


### PR DESCRIPTION
Right now no memcache test running because no memcache gem left in repo.

There is one test failing in my local need help to fix that.

``` ruby

  1) Error:
test_deserializes_unloaded_class(MemCacheStoreTest):
Dalli::DalliError: Unable to unmarshal value: undefined class/module SessionAutoloadTest::
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/dalli-2.1.0/lib/dalli/server.rb:305:in `rescue in deserialize'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/dalli-2.1.0/lib/dalli/server.rb:301:in `deserialize'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/dalli-2.1.0/lib/dalli/server.rb:345:in `generic_response'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/dalli-2.1.0/lib/dalli/server.rb:155:in `get'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/dalli-2.1.0/lib/dalli/server.rb:48:in `request'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/dalli-2.1.0/lib/dalli/options.rb:18:in `block in request'
    /Users/arunagw/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/dalli-2.1.0/lib/dalli/options.rb:17:in `request'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/dalli-2.1.0/lib/dalli/client.rb:251:in `perform'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/dalli-2.1.0/lib/dalli/client.rb:50:in `get'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/dalli-2.1.0/lib/rack/session/dalli.rb:28:in `get_session'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/rack-1.4.1/lib/rack/session/abstract/id.rb:246:in `load_session'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb:43:in `block in load_session'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb:51:in `stale_session_check!'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb:43:in `load_session'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_dispatch/request/session.rb:161:in `load!'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_dispatch/request/session.rb:153:in `load_for_read!'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_dispatch/request/session.rb:79:in `[]'
    /Users/arunagw/checkouts/rails/actionpack/test/dispatch/session/mem_cache_store_test.rb:21:in `get_session_value'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_controller/metal/implicit_render.rb:4:in `send_action'
    /Users/arunagw/checkouts/rails/actionpack/lib/abstract_controller/base.rb:179:in `process_action'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_controller/metal/rendering.rb:10:in `process_action'
    /Users/arunagw/checkouts/rails/actionpack/lib/abstract_controller/callbacks.rb:18:in `block in process_action'
    /Users/arunagw/checkouts/rails/activesupport/lib/active_support/callbacks.rb:337:in `_run__500462852611207954__process_action__callbacks'
    /Users/arunagw/checkouts/rails/activesupport/lib/active_support/callbacks.rb:74:in `run_callbacks'
    /Users/arunagw/checkouts/rails/actionpack/lib/abstract_controller/callbacks.rb:17:in `process_action'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_controller/metal/rescue.rb:29:in `process_action'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_controller/metal/instrumentation.rb:30:in `block in process_action'
    /Users/arunagw/checkouts/rails/activesupport/lib/active_support/notifications.rb:147:in `block in instrument'
    /Users/arunagw/checkouts/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
    /Users/arunagw/checkouts/rails/activesupport/lib/active_support/notifications.rb:147:in `instrument'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_controller/metal/instrumentation.rb:29:in `process_action'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_controller/metal/params_wrapper.rb:205:in `process_action'
    /Users/arunagw/checkouts/rails/actionpack/lib/abstract_controller/base.rb:126:in `process'
    /Users/arunagw/checkouts/rails/actionpack/lib/abstract_controller/rendering.rb:44:in `process'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_controller/metal.rb:195:in `dispatch'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_controller/metal/rack_delegation.rb:13:in `dispatch'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_controller/metal.rb:238:in `block in action'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_controller/metal.rb:224:in `call'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_controller/metal.rb:224:in `call'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/bundler/gems/journey-d876c016240d/lib/journey/router.rb:68:in `block in call'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/bundler/gems/journey-d876c016240d/lib/journey/router.rb:56:in `each'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/bundler/gems/journey-d876c016240d/lib/journey/router.rb:56:in `call'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_dispatch/routing/route_set.rb:620:in `call'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/rack-1.4.1/lib/rack/session/abstract/id.rb:205:in `context'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/rack-1.4.1/lib/rack/session/abstract/id.rb:200:in `call'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/rack-1.4.1/lib/rack/head.rb:9:in `call'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_dispatch/middleware/flash.rb:219:in `call'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_dispatch/middleware/cookies.rb:345:in `call'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_dispatch/middleware/params_parser.rb:21:in `call'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_dispatch/middleware/callbacks.rb:29:in `block in call'
    /Users/arunagw/checkouts/rails/activesupport/lib/active_support/callbacks.rb:337:in `_run__3343764749036863876__call__callbacks'
    /Users/arunagw/checkouts/rails/activesupport/lib/active_support/callbacks.rb:74:in `run_callbacks'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_dispatch/middleware/callbacks.rb:27:in `call'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb:19:in `call'
    /Users/arunagw/checkouts/rails/actionpack/test/abstract_unit.rb:138:in `call'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/bundler/gems/rack-test-8153c07db7a9/lib/rack/mock_session.rb:30:in `request'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/bundler/gems/rack-test-8153c07db7a9/lib/rack/test.rb:228:in `process_request'
    /Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/bundler/gems/rack-test-8153c07db7a9/lib/rack/test.rb:123:in `request'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_dispatch/testing/integration.rb:315:in `process'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_dispatch/testing/integration.rb:31:in `get'
    /Users/arunagw/checkouts/rails/actionpack/lib/action_dispatch/testing/integration.rb:349:in `block (2 levels) in <module:Runner>'
    /Users/arunagw/checkouts/rails/actionpack/test/dispatch/session/mem_cache_store_test.rb:135:in `block (2 levels) in test_deserializes_unloaded_class'
    /Users/arunagw/checkouts/rails/actionpack/test/abstract_unit.rb:218:in `with_autoload_path'
    /Users/arunagw/checkouts/rails/actionpack/test/dispatch/session/mem_cache_store_test.rb:134:in `block in test_deserializes_unloaded_class'
    /Users/arunagw/checkouts/rails/actionpack/test/dispatch/session/mem_cache_store_test.rb:184:in `block in with_test_route_set'
    /Users/arunagw/checkouts/rails/actionpack/test/abstract_unit.rb:205:in `with_routing'
    /Users/arunagw/checkouts/rails/actionpack/test/dispatch/session/mem_cache_store_test.rb:174:in `with_test_route_set'
    /Users/arunagw/checkouts/rails/actionpack/test/dispatch/session/mem_cache_store_test.rb:124:in `test_deserializes_unloaded_class'


```
