### PR TITLE
Added logging of model instantiation.

### DIFF
--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -55,6 +55,16 @@ module ActiveRecord
       debug "  #{name}  #{line}"
     end
 
+    def instantiate(event)
+      self.class.runtime += event.duration
+      return unless logger.debug?
+
+      name  = '%s (%.1fms - %drows)' % [event.payload[:name], event.duration, event.payload[:rows]]
+      name = odd? ? color(name, CYAN, true) : color(name, MAGENTA, true)
+
+      debug "  #{name}"
+    end
+
     def odd?
       @odd_or_even = !@odd_or_even
     end

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -35,7 +35,11 @@ module ActiveRecord
     #   > [#<Post:0x36bff9c @attributes={"title"=>"The Cheap Man Buys Twice"}>, ...]
     def find_by_sql(sql, binds = [])
       logging_query_plan do
-        connection.select_all(sanitize_sql(sql), "#{name} Load", binds).collect! { |record| instantiate(record) }
+        results = connection.select_all(sanitize_sql(sql), "#{name} Load", binds)
+
+        ActiveSupport::Notifications.instrument("instantiate.active_record", :name => "#{name} Inst", :rows => results.length) do
+          results.collect! { |record| instantiate(record) }
+        end
       end
     end
 


### PR DESCRIPTION
The current logging of sql queries only logs the actual query time which is great for finding slow queries.  Unfortunately, it does not log the record instantiation time, which can be slow due to model bugs or inappropriate usage of callbacks.

We use this internally to detect when our models are slow due to callbacks, serialization, or any other potentially slow ActiveRecord hooks.
