### PR TITLE
fix order dependent test in AR::BasicsTest

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -466,13 +466,13 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_singular_table_name_guesses_for_individual_table
-    CreditCard.pluralize_table_names = false
-    CreditCard.reset_table_name
-    assert_equal "credit_card", CreditCard.table_name
+    Post.pluralize_table_names = false
+    Post.reset_table_name
+    assert_equal "post", Post.table_name
     assert_equal "categories", Category.table_name
   ensure
-    CreditCard.pluralize_table_names = true
-    CreditCard.reset_table_name
+    Post.pluralize_table_names = true
+    Post.reset_table_name
   end
 
   if current_adapter?(:MysqlAdapter) or current_adapter?(:Mysql2Adapter)


### PR DESCRIPTION
This test https://github.com/rails/rails/blob/master/activerecord/test/cases/base_test.rb#L381
is failing because is not setting `CreditCard.pluralize_table_name` to `false`.

In this case, i prefer to change to another model that is not in the `GUESSED_CLASSES`
array.
