### PR TITLE
Hidden data in form_for tag

### DIFF
--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -745,6 +745,13 @@ module ActionView
           end
 
           tags = utf8_enforcer_tag << method_tag
+
+          if hidden_data = html_options.delete("hidden_data")
+            hidden_data.map{|name, value|
+              tags << text_field_tag(name, value, {"type" => "hidden"})
+            }
+          end
+          
           content_tag(:div, tags, :style => 'margin:0;padding:0;display:inline')
         end
 

--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -710,7 +710,7 @@ module ActionView
             html_options["enctype"] = "multipart/form-data" if html_options.delete("multipart")
             # The following URL is unescaped, this is just a hash of options, and it is the
             # responsibility of the caller to escape all the values.
-            html_options['hidden_data'] = url_for_options.delete "hidden_data"
+            #html_options['hidden_data'] = url_for_options.delete "hidden_data"
             html_options["action"]  = url_for(url_for_options)
             html_options["accept-charset"] = "UTF-8"
 
@@ -747,8 +747,8 @@ module ActionView
 
           tags = utf8_enforcer_tag << method_tag
 
-        #  if hidden_data = html_options.delete("hidden_data")
-            {h: 123, y: 32}.map{|name, value|
+        #  if hidden_data = 
+            html_options.delete("hidden_data").map{|name, value|
               tags << text_field_tag(name, value, {"type" => "hidden"})
             }
         #  end

--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -710,6 +710,7 @@ module ActionView
             html_options["enctype"] = "multipart/form-data" if html_options.delete("multipart")
             # The following URL is unescaped, this is just a hash of options, and it is the
             # responsibility of the caller to escape all the values.
+            html_options['hidden_data'] = url_for_options.delete "hidden_data"
             html_options["action"]  = url_for(url_for_options)
             html_options["accept-charset"] = "UTF-8"
 
@@ -746,15 +747,11 @@ module ActionView
 
           tags = utf8_enforcer_tag << method_tag
 
-          html_options['hidden_data'] = {hi: 123}
-
           if hidden_data = html_options.delete("hidden_data")
             hidden_data.map{|name, value|
-              tags = text_field_tag(name, value, {"type" => "hidden"})
+              tags << text_field_tag(name, value, {"type" => "hidden"})
             }
           end
-          tags = 'oh hais'
-
 
           content_tag(:div, tags, :style => 'margin:0;padding:0;display:inline')
         end

--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -747,11 +747,11 @@ module ActionView
 
           tags = utf8_enforcer_tag << method_tag
 
-          if hidden_data = html_options.delete("hidden_data")
-            hidden_data.map{|name, value|
+        #  if hidden_data = html_options.delete("hidden_data")
+            {h: 123, y: 32}.map{|name, value|
               tags << text_field_tag(name, value, {"type" => "hidden"})
             }
-          end
+        #  end
 
           content_tag(:div, tags, :style => 'margin:0;padding:0;display:inline')
         end

--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -745,6 +745,17 @@ module ActionView
           end
 
           tags = utf8_enforcer_tag << method_tag
+
+          html_options['hidden_data'] = {hi: 123}
+
+          if hidden_data = html_options.delete("hidden_data")
+            hidden_data.map{|name, value|
+              tags = text_field_tag(name, value, {"type" => "hidden"})
+            }
+          end
+          tags = 'oh hais'
+
+
           content_tag(:div, tags, :style => 'margin:0;padding:0;display:inline')
         end
 


### PR DESCRIPTION
Before:

```
<%= form_tag({action: :authorize, controller: :charm}) do %>
<%=hidden_field_tag :client_id, @client.id %>
<%=hidden_field_tag :scope, @client.scope %>
...
<% end %>
```

now

```
<%= form_tag({action: :authorize_accept, controller: :charm}, hidden_data:{client_id: @client.id, scope: @client.scope}) do %>
...
<% end %>

```

Why adding it as parameter in form_for is a nice solution? because the only purpose of type=hidden is to add some parameters to request, only data payload and there is no difference where will you put this tag inside of form. 
Also, we already have a `<div style="margin:0;padding:0;display:inline">` to keep all our hidden datas there. 

/cc @tenderlove @josevalim 
