### PR TITLE
hidden_data - sugar for hidden tags

### DIFF
--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -745,6 +745,13 @@ module ActionView
           end
 
           tags = utf8_enforcer_tag << method_tag
+
+          if hidden_data = html_options.delete("hidden_data")
+            hidden_data.map{|name, value|
+              tags << text_field_tag(name, value, {"type" => "hidden"})
+            }
+          end
+          
           content_tag(:div, tags, :style => 'margin:0;padding:0;display:inline')
         end
 

--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -746,10 +746,8 @@ module ActionView
 
           tags = utf8_enforcer_tag << method_tag
 
-          if hidden_data = html_options.delete("hidden_data")
-            hidden_data.map{|name, value|
-              tags << text_field_tag(name, value, {"type" => "hidden"})
-            }
+          html_options.fetch("hidden_data", []).each do |name, value|
+            tags << text_field_tag(name, value, {"type" => "hidden"})  
           end
           
           content_tag(:div, tags, :style => 'margin:0;padding:0;display:inline')


### PR DESCRIPTION
Before:

```
<%= form_tag({action: :authorize, controller: :charm}) do %>
<%=hidden_field_tag :client_id, @client.id %>
<%=hidden_field_tag :scope, @client.scope %>
...
<% end %>
```

now

```
<%= form_tag({action: :authorize_accept, controller: :charm}, hidden_data:{client_id: @client.id, scope: @client.scope}) do %>
...
<% end %>

```

Why adding it as parameter in form_for is a nice solution? because the only purpose of type=hidden is to add some parameters to request, only data payload and there is no difference where will you put this tag inside of form. 
Also, we already have a `<div style="margin:0;padding:0;display:inline">` to keep all our hidden datas there. 

/cc @tenderlove @josevalim 
