### PR TITLE
Proper mime negotiation in case of non-ajax request

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -118,11 +118,8 @@ module ActionDispatch
 
       protected
 
-      BROWSER_LIKE_ACCEPTS = /,\s*\*\/\*|\*\/\*\s*,/
-
       def valid_accept_header
-        (xhr? && (accept || content_mime_type)) ||
-          (accept && accept !~ BROWSER_LIKE_ACCEPTS)
+        accept || content_mime_type
       end
 
       def use_accept_header

--- a/actionpack/test/controller/mime_responds_test.rb
+++ b/actionpack/test/controller/mime_responds_test.rb
@@ -248,12 +248,12 @@ class RespondToControllerTest < ActionController::TestCase
 
   def test_json_or_yaml_with_leading_star_star
     @request.accept = "*/*, application/json"
-    get :json_xml_or_html
-    assert_equal 'HTML', @response.body
+    get :json_or_yaml
+    assert_equal 'JSON', @response.body
 
     @request.accept = "*/* , application/json"
-    get :json_xml_or_html
-    assert_equal 'HTML', @response.body
+    get :json_or_yaml
+    assert_equal 'JSON', @response.body
   end
 
   def test_json_or_yaml
@@ -411,7 +411,11 @@ class RespondToControllerTest < ActionController::TestCase
 
     @request.accept = "application/json, application/xml, */*"
     get :json_xml_or_html
-    assert_equal 'HTML', @response.body
+    assert_equal 'JSON', @response.body
+
+    @request.accept = "application/xml, application/json, */*"
+    get :json_xml_or_html
+    assert_equal 'XML', @response.body
   end
 
   def test_html_type_with_layout

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -96,6 +96,12 @@ class MimeTypeTest < ActiveSupport::TestCase
     assert_equal expect, Mime::Type.parse(accept).collect { |c| c.to_s }
   end
 
+  test "parse text with trailing star at the end" do
+    accept = "application/json, text/javascript, */*"
+    expect = [Mime::JSON, Mime::JS, Mime::ALL]
+    assert_equal expect, Mime::Type.parse(accept)
+  end
+
   test "custom type" do
     begin
       Mime::Type.register("image/foo", :foo)

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -569,6 +569,10 @@ class RequestTest < ActiveSupport::TestCase
     request.expects(:parameters).at_least_once.returns({})
     assert_equal with_set(Mime::XML), request.formats
 
+    request = stub_request 'HTTP_ACCEPT' => 'application/json, text/javascript, */*'
+    request.expects(:parameters).at_least_once.returns({})
+    assert_equal with_set(Mime::JSON, Mime::JS, Mime::ALL), request.formats
+
     request = stub_request
     request.expects(:parameters).at_least_once.returns({ :format => :txt })
     assert_equal with_set(Mime::TEXT), request.formats


### PR DESCRIPTION
Currently when client send request to rails with proper `Accept` header rails will return always HTML. When I need `JSON` or other format I can of course add `.(:format)` and rails will recognize this. Why is this the only option?
- I do not want nor need to use :format in routes
- I use jQuery.getJSON method with cross-domain option `HTTP_X_REQUESTED_WITH` is not set
- There is a proper Accept header : `application/json, text/javascript, */*; q=0.0`
- There is respond_to `:json` in controller definition
- I use `respond_with` in action and give it an object that has `to_json` and `as_json` method implemented

When I ask for `JSON` rails should respond with `JSON`.
