### PR TITLE
Change generators controller help from singular to plural example.

### DIFF
--- a/railties/lib/rails/generators/rails/controller/USAGE
+++ b/railties/lib/rails/generators/rails/controller/USAGE
@@ -9,10 +9,10 @@ Description:
     template engine and test framework generators.
 
 Example:
-    `rails generate controller CreditCard open debit credit close`
+    `rails generate controller CreditCards open debit credit close`
 
-    Credit card controller with URLs like /credit_card/debit.
-        Controller:      app/controllers/credit_card_controller.rb
-        Functional Test: test/functional/credit_card_controller_test.rb
-        Views:           app/views/credit_card/debit.html.erb [...]
-        Helper:          app/helpers/credit_card_helper.rb
+    CreditCards controller with URLs like /credit_cards/debit.
+        Controller:      app/controllers/credit_cards_controller.rb
+        Functional Test: test/functional/credit_cards_controller_test.rb
+        Views:           app/views/credit_cards/debit.html.erb [...]
+        Helper:          app/helpers/credit_cards_helper.rb


### PR DESCRIPTION
When running `rails generate controller --help` an example
with creating a (singular) "CreditCard" controller is
shown. The convention is to generate controllers with plural
names though.

Due to docrails strict "no code can be touched whatsoever"
policy I thought I should not push this change to docrails.
