### PR TITLE
Added deprecation warnings because IdentityMap was deprecated.

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -1,6 +1,7 @@
 require "active_record"
 require "rails"
 require "active_model/railtie"
+require "active_support/deprecation"
 
 # For now, action_controller must always be present with
 # rails, so let's make sure that it gets required before
@@ -53,8 +54,11 @@ module ActiveRecord
     end
 
     initializer "active_record.identity_map" do |app|
-      config.app_middleware.insert_after "::ActionDispatch::Callbacks",
-        "ActiveRecord::IdentityMap::Middleware" if config.active_record.delete(:identity_map)
+      if config.active_record.delete(:identity_map)
+        config.app_middleware.insert_after "::ActionDispatch::Callbacks",
+          "ActiveRecord::IdentityMap::Middleware"
+        ActiveSupport::Deprecation.warn "IdentityMap is deprecated. We don't support IdentityMap on Rail 4.0"
+      end
     end
 
     initializer "active_record.set_configs" do |app|

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -144,9 +144,16 @@ module ApplicationTests
     end
 
     test "identity map is inserted" do
-      add_to_config "config.active_record.identity_map = true"
-      boot!
-      assert middleware.include?("ActiveRecord::IdentityMap::Middleware")
+      begin
+        add_to_config "config.active_record.identity_map = true"
+        add_to_config "config.active_support.deprecation = :stderr"
+        old, $stderr = $stderr, StringIO.new
+        boot!
+        assert middleware.include?("ActiveRecord::IdentityMap::Middleware")
+        assert_match(/DEPRECATION WARNING/, $stderr.string)
+      ensure
+        $stderr = old
+      end
     end
 
     test "insert middleware before" do


### PR DESCRIPTION
If we remove Identity Map, we should add deprecation warnings to 3-2-stable.
related to #7456
