### PR TITLE
Fixes warnings when executing rake test in ActionMailer. 

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -756,7 +756,7 @@ module ActionMailer #:nodoc:
 
           responses << {
             :body => render(:template => template),
-            :content_type => template.mime_type.to_s
+            :content_type => template.type.to_s
           }
         end
       end


### PR DESCRIPTION
I saw many deprecation warnings in http://travis-ci.org/#!/rails/rails/jobs/2262213 and in my box.
I think it's related to 582a7f459990487659886b90e54c22e055c65870 .
