### PR TITLE
Fix method redefined warnings.

### DIFF
--- a/activemodel/test/cases/validations/exclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/exclusion_validation_test.rb
@@ -78,6 +78,9 @@ class ExclusionValidationTest < ActiveModel::TestCase
     assert p.invalid?
     assert_equal ["is reserved"], p.errors[:karma]
 
+    p = Person.new
+    p.karma = "abe"
+
     def p.reserved_karmas
       %w()
     end

--- a/activemodel/test/cases/validations/inclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/inclusion_validation_test.rb
@@ -110,6 +110,9 @@ class InclusionValidationTest < ActiveModel::TestCase
     assert p.invalid?
     assert_equal ["is not included in the list"], p.errors[:karma]
 
+    p = Person.new
+    p.karma = "Lifo"
+
     def p.available_karmas
       %w(Lifo)
     end


### PR DESCRIPTION
I saw the following warnings when executing rake test in activemodel.

```
...
warning: method redefined; discarding old reserved_karmas
...
```
