### PR TITLE
Fixes AP isolated test. Rails::Railtie is required when loading dalli.

### DIFF
--- a/actionpack/test/dispatch/session/mem_cache_store_test.rb
+++ b/actionpack/test/dispatch/session/mem_cache_store_test.rb
@@ -1,5 +1,4 @@
 require 'abstract_unit'
-require 'fixtures/session_autoload_test/session_autoload_test/foo'
 
 # You need to start a memcached server inorder to run these tests
 class MemCacheStoreTest < ActionDispatch::IntegrationTest

--- a/actionpack/test/dispatch/session/mem_cache_store_test.rb
+++ b/actionpack/test/dispatch/session/mem_cache_store_test.rb
@@ -35,6 +35,7 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
   end
 
   begin
+    require 'rails/railtie'
     require 'dalli'
     ss = Dalli::Client.new('localhost:11211').stats
     raise Dalli::DalliError unless ss['localhost:11211']


### PR DESCRIPTION
I saw the following error in travis's log.

```
  1) Failure:
/home/vagrant/builds/rails/rails/actionpack/test/dispatch/session/mem_cache_store_test.rb(TestIsolated) [/home/vagrant/builds/rails/rails/actionpack/test/ts_isolated.rb:12]:
```

According to my investigation, I think dalli requires rails/railtie. But when testing (isolated), we don't load 'rails/railtie' 
