### PR TITLE
Backport 89ebd28 to 3-2-stable

### DIFF
--- a/actionpack/lib/action_dispatch/testing/test_request.rb
+++ b/actionpack/lib/action_dispatch/testing/test_request.rb
@@ -12,7 +12,7 @@ module ActionDispatch
     end
 
     def initialize(env = {})
-      env = Rails.application.env_config.merge(env) if defined?(Rails.application)
+      env = Rails.application.env_config.merge(env) if defined?(Rails.application) && Rails.application
       super(DEFAULT_ENV.merge(env))
 
       self.host        = 'test.host'

--- a/actionpack/test/dispatch/test_request_test.rb
+++ b/actionpack/test/dispatch/test_request_test.rb
@@ -55,6 +55,13 @@ class TestRequestTest < ActiveSupport::TestCase
     assert_cookies({"user_name" => "david"}, req.cookie_jar)
   end
 
+  test "does not complain when Rails.application is nil" do
+    Rails.stubs(:application).returns(nil)
+    req = ActionDispatch::TestRequest.new
+
+    assert_equal false, req.env.empty?
+  end
+
   private
     def assert_cookies(expected, cookie_jar)
       assert_equal(expected, cookie_jar.instance_variable_get("@cookies"))


### PR DESCRIPTION
This was added to master in c5fc159, but it'd be nice to have this fix in 3-2-stable too.

See #6429 for the original pull request.
