### PR TITLE
A missing require is added to fix build. When performing rake test:isolated in actionmailer, test/base_test.rb was break.

### DIFF
--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -2,6 +2,7 @@
 require 'abstract_unit'
 require 'set'
 
+require 'action_dispatch'
 require 'active_support/time'
 
 require 'mailers/base_mailer'


### PR DESCRIPTION
I fixed some warnings related to `mime_type` method's deprecation on master (#7469).

But I got some another problems.
When executing `rake test:isolated` in ActionMailer, test/base_test.rb was break.

```
 1) Failure:
test_0007_should set template content type if mail has only one part(BaseTest) [test/base_test.rb:69]:
Expected: "text/html"
Actual: "text/plain"
...
```

After investigating, I realized the cause of problem.
If we didn't load `action_dispatch`, we also didn't execute `ActionView::Template::Types.delegate_to Mime`
Please see also https://github.com/rails/rails/commit/67f55e282236eef53adc6036e735190b1dda5a47#L0R107.

If we delegate to Mime, build is success.
