### PR TITLE
the example for contraint( :ip => XXXX) has an invalid regex

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -757,7 +757,7 @@ module ActionDispatch
         #
         # Routes can also be constrained to an IP or a certain range of IP addresses:
         #
-        #   constraints(:ip => /192.168.\d+.\d+/) do
+        #   constraints(:ip => /192\.168\.\d+\.\d+/) do
         #     resources :posts
         #   end
         #


### PR DESCRIPTION
escape the '.'s  
