### PR TITLE
Fix markdown rendering of the ActionPack changelog

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 *   Added controller-level etag additions that will be part of the action etag computation *Jeremy Kemper/DHH*
 
-      class InvoicesController < ApplicationController
-        etag { current_user.try :id }
-        
-        def show
-          # Etag will differ even for the same invoice when it's viewed by a different current_user
-          @invoice = Invoice.find(params[:id])
-          fresh_when(@invoice)
+        class InvoicesController < ApplicationController
+          etag { current_user.try :id }
+
+          def show
+            # Etag will differ even for the same invoice when it's viewed by a different current_user
+            @invoice = Invoice.find(params[:id])
+            fresh_when(@invoice)
+          end
         end
-      end
 
 *   Add automatic template digests to all CacheHelper#cache calls (originally spiked in the cache_digests plugin) *DHH*
 


### PR DESCRIPTION
The new controller-level etag feature's description in the ActionPack changelog wasn't formatted correctly.
