### PR TITLE
Use last version of sprockets-rails and sync tests for assets.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ end
 
 # This needs to be with require false to avoid
 # it being automatically loaded by sprockets
-gem 'uglifier', '>= 1.0.3', require: false
+gem 'uglifier', require: false
 gem 'sprockets-rails', github: 'rails/sprockets-rails'
 
 group :doc do

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ end
 # This needs to be with require false to avoid
 # it being automatically loaded by sprockets
 gem 'uglifier', '>= 1.0.3', require: false
+gem 'sprockets-rails', github: 'rails/sprockets-rails'
 
 group :doc do
   # The current sdoc cannot generate GitHub links due

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 require 'isolation/abstract_unit'
-require 'active_support/core_ext/kernel/reporting'
 require 'rack/test'
 
 module ApplicationTests
@@ -28,8 +27,16 @@ module ApplicationTests
 
     def clean_assets!
       quietly do
-        assert Dir.chdir(app_path){ system('bundle exec rake assets:clean') }
+        assert Dir.chdir(app_path) { system('bundle exec rake assets:clean') }
       end
+    end
+
+    def assert_file_exists(filename)
+      assert File.exists?(filename), "missing #{filename}"
+    end
+
+    def assert_no_file_exists(filename)
+      assert !File.exists?(filename), "#{filename} does exist"
     end
 
     test "assets routes have higher priority" do
@@ -92,9 +99,8 @@ module ApplicationTests
 
       images_should_compile = ["a.png", "happyface.png", "happy_face.png", "happy.face.png",
                                "happy-face.png", "happy.happy_face.png", "happy_happy.face.png",
-                               "happy.happy.face.png", "happy", "happy.face", "-happyface",
-                               "-happy.png", "-happy.face.png", "_happyface", "_happy.face.png",
-                               "_happy.png"]
+                               "happy.happy.face.png", "-happy.png", "-happy.face.png",
+                               "_happy.face.png", "_happy.png"]
 
       images_should_compile.each do |filename|
         app_file "app/assets/images/#{filename}", "happy"
@@ -103,7 +109,7 @@ module ApplicationTests
       precompile!
 
       images_should_compile.each do |filename|
-        assert_file_exists "#{app_path}/public/assets/#{filename}"
+        assert_file_exists("#{app_path}/public/assets/#{filename}")
       end
 
       assert_file_exists("#{app_path}/public/assets/application.js")
@@ -119,12 +125,13 @@ module ApplicationTests
       assert_no_file_exists("#{app_path}/public/assets/something.else.css")
     end
 
-    def assert_file_exists(filename)
-      assert File.exists?(filename), "missing #{filename}"
-    end
+    test "precompile something.js for directory containing index file" do
+      add_to_config "config.assets.precompile = [ 'something.js' ]"
+      app_file "app/assets/javascripts/something/index.js.erb", "alert();"
 
-    def assert_no_file_exists(filename)
-      assert !File.exists?(filename), "#{filename} does exist"
+      precompile!
+
+      assert_file_exists("#{app_path}/public/assets/something.js")
     end
 
     test "asset pipeline should use a Sprockets::Index when config.assets.digest is true" do
@@ -151,21 +158,6 @@ module ApplicationTests
       assert_match(/application-([0-z]+)\.css/, assets["application.css"])
     end
 
-    test "precompile creates a manifest file in a custom path with all the assets listed" do
-      app_file "app/assets/stylesheets/application.css.erb", "<%= asset_path('rails.png') %>"
-      app_file "app/assets/javascripts/application.js", "alert();"
-      # digest is default in false, we must enable it for test environment
-      add_to_config "config.assets.digest = true"
-      add_to_config "config.assets.manifest = '#{app_path}/shared'"
-
-      precompile!
-      manifest = "#{app_path}/shared/manifest.yml"
-
-      assets = YAML.load_file(manifest)
-      assert_match(/application-([0-z]+)\.js/, assets["application.js"])
-      assert_match(/application-([0-z]+)\.css/, assets["application.css"])
-    end
-
     test "the manifest file should be saved by default in the same assets folder" do
       app_file "app/assets/javascripts/application.js", "alert();"
       # digest is default in false, we must enable it for test environment
@@ -186,8 +178,8 @@ module ApplicationTests
 
       precompile!
 
-      assert File.exists?("#{app_path}/public/assets/application.js")
-      assert File.exists?("#{app_path}/public/assets/application.css")
+      assert_file_exists("#{app_path}/public/assets/application.js")
+      assert_file_exists("#{app_path}/public/assets/application.css")
 
       manifest = "#{app_path}/public/assets/manifest.yml"
 
@@ -238,7 +230,7 @@ module ApplicationTests
 
       get '/posts'
       assert_match(/AssetNotPrecompiledError/, last_response.body)
-      assert_match(/app.js isn&#39;t precompiled/, last_response.body)
+      assert_match(/app\.js isn&#39;t precompiled/, last_response.body)
     end
 
     test "assets raise AssetNotPrecompiledError when manifest file is present and requested file isn't precompiled if digest is disabled" do
@@ -262,7 +254,7 @@ module ApplicationTests
 
       get '/posts'
       assert_match(/AssetNotPrecompiledError/, last_response.body)
-      assert_match(/app.js isn&#39;t precompiled/, last_response.body)
+      assert_match(/app\.js isn&#39;t precompiled/, last_response.body)
     end
 
     test "precompile properly refers files referenced with asset_path and and run in the provided RAILS_ENV" do
@@ -318,7 +310,7 @@ module ApplicationTests
 
       get "/assets/#{URI.parser.escape(filename)}"
       assert_match "not a image really", last_response.body
-      assert File.exists?("#{app_path}/public/assets/#{filename}")
+      assert_file_exists("#{app_path}/public/assets/#{filename}")
     end
 
     test "assets are cleaned up properly" do
@@ -454,7 +446,6 @@ module ApplicationTests
       add_to_config "config.assets.compile = true"
       add_to_config "config.assets.digest = true"
 
-      clean_assets!
       precompile!
 
       files = Dir["#{app_path}/public/assets/application-*.js"]
@@ -502,6 +493,18 @@ module ApplicationTests
       precompile!
 
       assert_match 'src="/sub/uri/assets/rails.png"', File.read("#{app_path}/public/assets/app.js")
+    end
+
+    test "html assets are compiled when executing precompile" do
+      app_file "app/assets/pages/page.html.erb", "<%= javascript_include_tag :application %>"
+      ENV["RAILS_ENV"]   = "production"
+      ENV["RAILS_GROUP"] = "assets"
+
+      quietly do
+        Dir.chdir(app_path){ `bundle exec rake assets:precompile` }
+      end
+
+      assert_file_exists("#{app_path}/public/assets/page.html")
     end
 
     test "assets:cache:clean should clean cache" do


### PR DESCRIPTION
For now tests are a bit outdated and we're using sprockets-rails from rubygems, I think to use it from github sounds more reasonable.

/cc @guilleiguaran

BTW: We should add changelog entry about removing manifest option, I think.
