### PR TITLE
Better ActionView::Digestor nested template inference

### DIFF
--- a/actionpack/lib/action_view/digestor.rb
+++ b/actionpack/lib/action_view/digestor.rb
@@ -15,9 +15,9 @@ module ActionView
     #   render(topics)         => render("topics/topic")
     #   render(message.topics) => render("topics/topic")
     RENDER_DEPENDENCY = /
-      render\s?                # render, followed by an optional space
+      render\s*                # render, followed by an optional space
       \(?                      # start a optional parenthesis for the render call
-      (partial:)?\s?           # naming the partial, used with collection -- 1st capture
+      (partial:)?\s*           # naming the partial, used with collection -- 1st capture
       ([@a-z"'][@a-z_\/\."']+) # the template name itself -- 2nd capture
     /x
 

--- a/actionpack/lib/action_view/digestor.rb
+++ b/actionpack/lib/action_view/digestor.rb
@@ -15,10 +15,10 @@ module ActionView
     #   render(topics)         => render("topics/topic")
     #   render(message.topics) => render("topics/topic")
     RENDER_DEPENDENCY = /
-      render\s*                # render, followed by an optional space
-      \(?                      # start a optional parenthesis for the render call
-      (partial:)?\s*           # naming the partial, used with collection -- 1st capture
-      ([@a-z"'][@a-z_\/\."']+) # the template name itself -- 2nd capture
+      render\s*                     # render, followed by an optional space
+      \(?                           # start a optional parenthesis for the render call
+      (partial:|:partial\s+=>)?\s*  # naming the partial, used with collection -- 1st capture
+      ([@a-z"'][@a-z_\/\."']+)      # the template name itself -- 2nd capture
     /x
 
     cattr_accessor(:cache)  { Hash.new }

--- a/actionpack/lib/action_view/digestor.rb
+++ b/actionpack/lib/action_view/digestor.rb
@@ -15,7 +15,7 @@ module ActionView
     #   render(topics)         => render("topics/topic")
     #   render(message.topics) => render("topics/topic")
     RENDER_DEPENDENCY = /
-      render\s*                     # render, followed by an optional space
+      render\s*                     # render, followed by optional whitespace
       \(?                           # start a optional parenthesis for the render call
       (partial:|:partial\s+=>)?\s*  # naming the partial, used with collection -- 1st capture
       ([@a-z"'][@a-z_\/\."']+)      # the template name itself -- 2nd capture

--- a/actionpack/lib/action_view/digestor.rb
+++ b/actionpack/lib/action_view/digestor.rb
@@ -16,7 +16,7 @@ module ActionView
     #   render(message.topics) => render("topics/topic")
     RENDER_DEPENDENCY = /
       render\s*                     # render, followed by optional whitespace
-      \(?                           # start a optional parenthesis for the render call
+      \(?                           # start an optional parenthesis for the render call
       (partial:|:partial\s+=>)?\s*  # naming the partial, used with collection -- 1st capture
       ([@a-z"'][@a-z_\/\."']+)      # the template name itself -- 2nd capture
     /x

--- a/actionpack/test/fixtures/digestor/messages/edit.html.erb
+++ b/actionpack/test/fixtures/digestor/messages/edit.html.erb
@@ -1,0 +1,4 @@
+<%= render              "header" %>
+<%= render    partial:  "form" %>
+<%= render              @message %>
+<%= render ( @message.events ) %>

--- a/actionpack/test/fixtures/digestor/messages/edit.html.erb
+++ b/actionpack/test/fixtures/digestor/messages/edit.html.erb
@@ -2,3 +2,4 @@
 <%= render    partial:  "form" %>
 <%= render              @message %>
 <%= render ( @message.events ) %>
+<%= render    :partial =>    "comments/comment", :collection => @message.comments %>

--- a/actionpack/test/template/digestor_test.rb
+++ b/actionpack/test/template/digestor_test.rb
@@ -116,6 +116,12 @@ class TemplateDigestorTest < ActionView::TestCase
     end
   end
 
+  def test_old_style_hash_in_render_invocation
+    assert_digest_difference("messages/edit") do
+      change_template("comments/_comment")
+    end
+  end
+
   private
     def assert_logged(message)
       log = StringIO.new

--- a/actionpack/test/template/digestor_test.rb
+++ b/actionpack/test/template/digestor_test.rb
@@ -92,6 +92,29 @@ class TemplateDigestorTest < ActionView::TestCase
     end
   end
 
+  def test_extra_whitespace_in_render_partial
+    assert_digest_difference("messages/edit") do
+      change_template("messages/_form")
+    end
+  end
+
+  def test_extra_whitespace_in_render_named_partial
+    assert_digest_difference("messages/edit") do
+      change_template("messages/_header")
+    end
+  end
+
+  def test_extra_whitespace_in_render_record
+    assert_digest_difference("messages/edit") do
+      change_template("messages/_message")
+    end
+  end
+
+  def test_extra_whitespace_in_render_with_parenthesis
+    assert_digest_difference("messages/edit") do
+      change_template("events/_event")
+    end
+  end
 
   private
     def assert_logged(message)


### PR DESCRIPTION
This pull request improves the regular expression used by `ActionView::Digestor` ( introduced in 502d5e24e28b3634910495d0fb71cb20b1426aee)
- Ignore whitespace before/after Hash keys, (which usually appear when people indent their Hash keys)
- Ignore whitespace before/after parenthesis (some people are just sloppy)
- Correctly parse 1.8.7 style Hash keys (for some of us the new style is still not in our muscle memory)
