### PR TITLE
Fixes warning: & interpreted as argument prefix

### DIFF
--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -166,7 +166,7 @@ module ActionController
     
     private
       def combine_etags(etag)
-        [ etag, *etaggers.map { |etagger| instance_exec &etagger }.compact ]
+        [ etag, *etaggers.map { |etagger| instance_exec(&etagger) }.compact ]
       end
   end
 end


### PR DESCRIPTION
I found the following warning.

```
...
/home/vagrant/builds/rails/rails/actionpack/lib/action_controller/metal/conditional_get.rb:169: warning: `&' interpreted as argument prefix
...
```
