### PR TITLE
Fix build about TemplateDigestorTest.

### DIFF
--- a/actionpack/test/template/digestor_test.rb
+++ b/actionpack/test/template/digestor_test.rb
@@ -16,7 +16,7 @@ class FixtureFinder
   TMP_DIR      = "#{File.dirname(__FILE__)}/../tmp"
   
   def find(logical_name, keys, partial, options)
-    FixtureTemplate.new("#{TMP_DIR}/#{partial ? logical_name.gsub(%r|/([^/]+)$|, '/_\1') : logical_name}.#{options[:formats].first}.erb")
+    FixtureTemplate.new("#{TMP_DIR}/digestor/#{partial ? logical_name.gsub(%r|/([^/]+)$|, '/_\1') : logical_name}.#{options[:formats].first}.erb")
   end
 end
 
@@ -26,7 +26,7 @@ class TemplateDigestorTest < ActionView::TestCase
   end
   
   def teardown
-    FileUtils.rm_r FixtureFinder::TMP_DIR
+    FileUtils.rm_r File.join(FixtureFinder::TMP_DIR, "digestor")
     ActionView::Digestor.cache.clear
   end
 
@@ -150,7 +150,7 @@ class TemplateDigestorTest < ActionView::TestCase
     end
     
     def change_template(template_name)
-      File.open("#{FixtureFinder::TMP_DIR}/#{template_name}.html.erb", "w") do |f|
+      File.open("#{FixtureFinder::TMP_DIR}/digestor/#{template_name}.html.erb", "w") do |f|
         f.write "\nTHIS WAS CHANGED!"
       end
     end


### PR DESCRIPTION
I found the following test failure.

```
  1) Error:
143test_collection_dependency(TemplateDigestorTest):
144Errno::ENOENT: No such file or directory - /home/vagrant/builds/rails/rails/actionpack/test/template/../tmp/messages/_message.html.erb
145    /home/vagrant/builds/rails/rails/actionpack/test/template/digestor_test.rb:153:in `initialize'
...
```

This problem came from FiltUtils.cp_r(src, dest) specific.
According to API reference, `if  dest is directory, files were copied to dest/src directory`.
We copy files in setup, and remove directory in teardown.
Thus if we execute tests twice, tests are failure at first, and tests are success at second.
