### PR TITLE
Have rails dbconsole pass sslca to the mysql command line client.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   rails dbconsole now can use SSL for MySQL. The database.yml options sslca, sslcert, sslcapath, sslcipher,
+    and sslkey now affect rails dbconsole. *Jim Kingdon and Lars Petrus*
+
 *   Correctly handle SCRIPT_NAME when generating routes to engine in application
     that's mounted at a sub-uri. With this behavior, you *should not* use
     default_url_options[:script_name] to set proper application's mount point by

--- a/railties/lib/rails/commands/dbconsole.rb
+++ b/railties/lib/rails/commands/dbconsole.rb
@@ -26,7 +26,12 @@ module Rails
           'port'      => '--port',
           'socket'    => '--socket',
           'username'  => '--user',
-          'encoding'  => '--default-character-set'
+          'encoding'  => '--default-character-set',
+          'sslca'     => '--ssl-ca',
+          'sslcert'   => '--ssl-cert',
+          'sslcapath' => '--ssl-capath',
+          'sslcipher' => '--ssh-cipher',
+          'sslkey'    => '--ssl-key'
         }.map { |opt, arg| "#{arg}=#{config[opt]}" if config[opt] }.compact
 
         if config['password'] && options['include_password']


### PR DESCRIPTION
Currently, using mysql one can specify sslca in database.yml to say that one should connect to the database using SSL.

However, rails dbconsole does not honor this setting. The enclosed patch fixes this.

-Lars and Jim
