### PR TITLE
Properly reset the session on reset_session

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -227,8 +227,11 @@ module ActionDispatch
     # TODO This should be broken apart into AD::Request::Session and probably
     # be included by the session middleware.
     def reset_session
-      session.destroy if session && session.respond_to?(:destroy)
-      self.session = {}
+      if session && session.respond_to?(:destroy)
+        session.destroy
+      else
+        self.session = {}
+      end
       @env['action_dispatch.request.flash_hash'] = nil
     end
 

--- a/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
@@ -44,6 +44,14 @@ module ActionDispatch
       include StaleSessionCheck
       include SessionObject
 
+      # Override rack's method
+      def destroy_session(env, session_id, options)
+        new_sid = super
+        # Reset hash and Assign the new session id
+        env["action_dispatch.request.unsigned_session_cookie"] = new_sid ? { "session_id" => new_sid } : {}
+        new_sid
+      end
+
       private
 
       def unpacked_cookie_data(env)

--- a/actionpack/lib/action_dispatch/request/session.rb
+++ b/actionpack/lib/action_dispatch/request/session.rb
@@ -72,7 +72,10 @@ module ActionDispatch
         options = self.options || {}
         new_sid = @by.send(:destroy_session, @env, options[:id], options)
         options[:id] = new_sid # Reset session id with a new value or nil
+
+        # Load the new sid to be written with the response
         @loaded = false
+        load_for_write!
       end
 
       def [](key)

--- a/actionpack/lib/action_dispatch/request/session.rb
+++ b/actionpack/lib/action_dispatch/request/session.rb
@@ -70,8 +70,8 @@ module ActionDispatch
       def destroy
         clear
         options = self.options || {}
-        @by.send(:destroy_session, @env, options[:id], options)
-        options[:id] = nil
+        new_sid = @by.send(:destroy_session, @env, options[:id], options)
+        options[:id] = new_sid # Reset session id with a new value or nil
         @loaded = false
       end
 


### PR DESCRIPTION
Fixes #7478

Well, it would if it were actually finished. There is one test failure:

```
  1) Failure:
test_setting_session_value_after_session_reset(CookieStoreTest) [/Users/steve/src/rails/actionpack/test/dispatch/session/cookie_store_test.rb:190]:
Expected "BAh7B0kiD3Nlc3Npb25faWQGOgZFRkkiJTlmZTczNjc4NThiNWZhODIzNjg2Mjk2NDVlZGNkYTMwBjsAVEkiCGZvbwY7AEZJIghiYXIGOwBG--84236482786035ade1225b520f9439784ea16fb1" to not be equal to "BAh7B0kiD3Nlc3Npb25faWQGOgZFRkkiJTlmZTczNjc4NThiNWZhODIzNjg2Mjk2NDVlZGNkYTMwBjsAVEkiCGZvbwY7AEZJIghiYXIGOwBG--84236482786035ade1225b520f9439784ea16fb1".
```

I am not sure why `#destroy` does not reset the session. [It claims to](https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/request/session.rb#L73), and following the trail of code, looks like it does. But it doesn't. Anybody have any ideas?
