### PR TITLE
Require bundler when running a new app generator

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -5,6 +5,7 @@ require 'rails/version' unless defined?(Rails::VERSION)
 require 'rbconfig'
 require 'open-uri'
 require 'uri'
+require 'bundler'
 
 module Rails
   module Generators


### PR DESCRIPTION
When attempting to generate a new Rails app via the executable `railties/bin/rails` an [exception](https://gist.github.com/3577771) occurs because Bundler has not be required prior to its use.

This is the interesting line from the backtrace:

```
/Users/jcf/Code/rails/railties/lib/rails/generators/app_base.rb:254:in `bundle_command': uninitialized constant Rails::Generators::AppBase::Bundler (NameError)
    from /Users/jcf/Code/rails/railties/lib/rails/generators/app_base.rb:260:in `run_bundle'
```

The change I've made is to simply require Bundler in `railties/lib/rails/generators/app_base.rb`.

``` ruby
def bundle_command(command)
  # …
  _bundle_command = Gem.bin_path('bundler', 'bundle')

  Bundler.with_clean_env do
    print `"#{Gem.ruby}" "#{_bundle_command}" #{command}`
  end
end
```

The only way to integration test that comes to mind this is to do so in a separate process. Otherwise requiring bundler in the test suite will fix the issue.
