### PR TITLE
Add new inflection for singular (SS)

### DIFF
--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -25,6 +25,7 @@ module ActiveSupport
     inflect.plural(/(quiz)$/i, '\1zes')
 
     inflect.singular(/s$/i, '')
+    inflect.singular(/(ss)$/i, '\1')
     inflect.singular(/(n)ews$/i, '\1ews')
     inflect.singular(/([ti])a$/i, '\1um')
     inflect.singular(/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$/i, '\1\2sis')

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -257,6 +257,13 @@ class InflectorTest < Test::Unit::TestCase
     end
   end
 
+  def test_classify_with_complex_singular
+    assert_nothing_raised do
+      assert_equal 'Address', ActiveSupport::Inflector.classify(:address)
+      assert_equal 'Address', ActiveSupport::Inflector.classify(:addresses)
+    end
+  end
+
   def test_classify_with_symbol
     assert_nothing_raised do
       assert_equal 'FooBar', ActiveSupport::Inflector.classify(:foo_bars)
@@ -295,7 +302,7 @@ class InflectorTest < Test::Unit::TestCase
       ActiveSupport::Inflector.constantize(string)
     end
   end
-  
+
   def test_safe_constantize
     run_safe_constantize_tests_on do |string|
       ActiveSupport::Inflector.safe_constantize(string)


### PR DESCRIPTION
I got a bug when trying to call a simple "business".classify. 
Because inflections configuration, it returns "Busines". 

This PR adds a new entry for singular inflections and asserts with a unit test.
