### PR TITLE
reference Arel constant unambiguously (to run tests)

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -161,7 +161,7 @@ module ActiveRecord
 end
 
 ActiveSupport.on_load(:active_record) do
-  Arel::Table.engine = self
+  ::Arel::Table.engine = self
 end
 
 ActiveSupport.on_load(:i18n) do


### PR DESCRIPTION
this got the tests running on my machine and fixed the following error:

```
/Users/username/Projects/rails/activesupport/lib/active_support/dependencies.rb:475:in `load_missing_constant': Object is not missing constant Arel! (NameError)
    from /Users/username/Projects/rails/activesupport/lib/active_support/dependencies.rb:202:in `block in const_missing'
    from /Users/username/Projects/rails/activesupport/lib/active_support/dependencies.rb:200:in `each'
    from /Users/username/Projects/rails/activesupport/lib/active_support/dependencies.rb:200:in `const_missing'
    from /Users/username/Projects/rails/activerecord/lib/active_record.rb:164:in `block in <top (required)>'
    from /Users/username/Projects/rails/activesupport/lib/active_support/lazy_load_hooks.rb:36:in `instance_eval'
    from /Users/username/Projects/rails/activesupport/lib/active_support/lazy_load_hooks.rb:36:in `execute_hook'
    from /Users/username/Projects/rails/activesupport/lib/active_support/lazy_load_hooks.rb:43:in `block in run_load_hooks'
    from /Users/username/Projects/rails/activesupport/lib/active_support/lazy_load_hooks.rb:42:in `each'
    from /Users/username/Projects/rails/activesupport/lib/active_support/lazy_load_hooks.rb:42:in `run_load_hooks'
    from /Users/username/Projects/rails/activerecord/lib/active_record/base.rb:328:in `<top (required)>'
    from /Users/username/Projects/rails/activerecord/test/models/arunit2_model.rb:1:in `<top (required)>'
    from /Users/username/Projects/rails/activesupport/lib/active_support/dependencies.rb:450:in `load'
    from /Users/username/Projects/rails/activesupport/lib/active_support/dependencies.rb:450:in `block in load_file'
    from /Users/username/Projects/rails/activesupport/lib/active_support/dependencies.rb:624:in `new_constants_in'
    from /Users/username/Projects/rails/activesupport/lib/active_support/dependencies.rb:449:in `load_file'
    from /Users/username/Projects/rails/activesupport/lib/active_support/dependencies.rb:352:in `require_or_load'
    from /Users/username/Projects/rails/activesupport/lib/active_support/dependencies.rb:317:in `depend_on'
    from /Users/username/Projects/rails/activesupport/lib/active_support/dependencies.rb:235:in `require_dependency'
    from /Users/username/Projects/rails/activerecord/test/models/college.rb:1:in `<top (required)>'
    from /Users/username/Projects/rails/activesupport/lib/active_support/dependencies.rb:257:in `require'
    from /Users/username/Projects/rails/activesupport/lib/active_support/dependencies.rb:257:in `block in require'
    from /Users/username/Projects/rails/activesupport/lib/active_support/dependencies.rb:242:in `load_dependency'
    from /Users/username/Projects/rails/activesupport/lib/active_support/dependencies.rb:257:in `require'
    from /Users/username/Projects/rails/activerecord/test/support/connection.rb:2:in `<top (required)>'
    from /Users/username/Projects/rails/activesupport/lib/active_support/dependencies.rb:257:in `require'
    from /Users/username/Projects/rails/activesupport/lib/active_support/dependencies.rb:257:in `block in require'
    from /Users/username/Projects/rails/activesupport/lib/active_support/dependencies.rb:242:in `load_dependency'
    from /Users/username/Projects/rails/activesupport/lib/active_support/dependencies.rb:257:in `require'
    from /Users/username/Projects/rails/activerecord/test/cases/helper.rb:15:in `<top (required)>'
    from <internal:lib/rubygems/custom_require>:29:in `require'
    from <internal:lib/rubygems/custom_require>:29:in `require'
    from /Users/username/Projects/rails/activerecord/test/cases/adapter_test.rb:1:in `<top (required)>'
    from <internal:lib/rubygems/custom_require>:29:in `require'
    from <internal:lib/rubygems/custom_require>:29:in `require'
    from /Users/username/.rvm/gems/ruby-1.9.2-p290@rails/gems/rake-0.9.2.2/lib/rake/rake_test_loader.rb:15:in `block in <main>'
    from /Users/username/.rvm/gems/ruby-1.9.2-p290@rails/gems/rake-0.9.2.2/lib/rake/rake_test_loader.rb:4:in `select'
    from /Users/username/.rvm/gems/ruby-1.9.2-p290@rails/gems/rake-0.9.2.2/lib/rake/rake_test_loader.rb:4:in `<main>'
```

I used ruby 1.9.2 p290.
