### PR TITLE
Fixed markup in Upgrading RoR guide

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.textile
+++ b/guides/source/upgrading_ruby_on_rails.textile
@@ -54,11 +54,21 @@ h4(#action_pack4_0). Action Pack
 
 Rails 4.0 changed how <tt>assert_generates</tt>, <tt>assert_recognizes</tt>, and <tt>assert_routing</tt> work. Now all these assertions raise <tt>Assertion</tt> instead of <tt>ActionController::RoutingError</tt>.
 
-Rails 4.0 also changed the way unicode character routes are drawn. Now you can draw unicode character routes directly. If you already draw such routes, you must change them, e.g. <tt>get Rack::Utils.escape('こんにちは'), :controller => 'welcome', :action => 'index'</tt> to <tt>get 'こんにちは', :controller => 'welcome', :action => 'index'</tt>.
+Rails 4.0 also changed the way unicode character routes are drawn. Now you can draw unicode character routes directly. If you already draw such routes, you must change them, for example:
+
+<ruby>
+get Rack::Utils.escape('こんにちは'), :controller => 'welcome', :action => 'index'
+</ruby>
+
+becomes
+
+<ruby>
+get 'こんにちは', :controller => 'welcome', :action => 'index'
+</ruby>
 
 h4(#active_support4_0). Active Support
 
-Rails 4.0 Removed the `j` alias for `ERB::Util#json_escape` since `j` is already used for `ActionView::Helpers::JavaScriptHelper#escape_javascript`.
+Rails 4.0 Removed the <tt>j</tt> alias for <tt>ERB::Util#json_escape</tt> since <tt>j</tt> is already used for <tt>ActionView::Helpers::JavaScriptHelper#escape_javascript</tt>.
 
 h4(#helpers_order). Helpers Loading Order
 


### PR DESCRIPTION
Hi everybody, I've changed a bit a couple of lines in the Upgrading Ruby on Rails guide:
- Using <ruby> syntax for unicode character routes example instead of
  `<tt>` since it causes single quotes to be transformed into inverted
  commas. This makes this required change more eye-catching.
- Using `<tt>` for the j alias and related helpers as written in the
  documentation guidelines.

In particular the second point is the reason for a PR instead of a push in the docrails guide, in the current version of the guide inverted commas are used for code, maybe there was a reason for that (e.g. "j" is very short)?

PS: The guide isn't valid because another markup issue that I've already fixed in docrails: https://github.com/lifo/docrails/commit/70d2d2ced44941162e13cb66125482ebf9097ff4
