### PR TITLE
#becomes works with configured inheritance_column

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -161,7 +161,7 @@ module ActiveRecord
       became.instance_variable_set("@new_record", new_record?)
       became.instance_variable_set("@destroyed", destroyed?)
       became.instance_variable_set("@errors", errors)
-      became.type = klass.name unless self.class.descends_from_active_record?
+      became.public_send("#{klass.inheritance_column}=", klass.name) unless self.class.descends_from_active_record?
       became
     end
 

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -5,9 +5,10 @@ require 'models/post'
 require 'models/project'
 require 'models/subscriber'
 require 'models/teapot'
+require 'models/vegetables'
 
 class InheritanceTest < ActiveRecord::TestCase
-  fixtures :companies, :projects, :subscribers, :accounts
+  fixtures :companies, :projects, :subscribers, :accounts, :vegetables
 
   def test_class_with_store_full_sti_class_returns_full_name
     old = ActiveRecord::Base.store_full_sti_class
@@ -125,6 +126,13 @@ class InheritanceTest < ActiveRecord::TestCase
     switch_to_alt_inheritance_column
     test_inheritance_find
     switch_to_default_inheritance_column
+  end
+
+  def test_alt_becomes_works_with_sti
+    vegetable = Vegetable.find(1)
+    assert_kind_of Vegetable, vegetable
+    cabbage = vegetable.becomes(Cabbage)
+    assert_kind_of Cabbage, cabbage
   end
 
   def test_inheritance_find_all

--- a/activerecord/test/fixtures/vegetables.yml
+++ b/activerecord/test/fixtures/vegetables.yml
@@ -1,0 +1,9 @@
+first_cucumber:
+  id: 1
+  custom_type: Cucumber
+  name: 'my cucumber'
+
+first_cabbage:
+  id: 2
+  custom_type: Cabbage
+  name: 'my cabbage'

--- a/activerecord/test/models/vegetables.rb
+++ b/activerecord/test/models/vegetables.rb
@@ -1,0 +1,14 @@
+class Vegetable < ActiveRecord::Base
+
+  validates_presence_of :name
+
+  def self.inheritance_column
+    'custom_type'
+  end
+end
+
+class Cucumber < Vegetable
+end
+
+class Cabbage < Vegetable
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -184,6 +184,11 @@ ActiveRecord::Schema.define do
   add_index :companies, [:firm_id, :type, :rating, :ruby_type], :name => "company_index"
   add_index :companies, [:firm_id, :type], :name => "company_partial_index", :where => "rating > 10"
 
+  create_table :vegetables, :force => true do |t|
+    t.string :name
+    t.string :custom_type
+  end
+
   create_table :computers, :force => true do |t|
     t.integer :developer, :null => false
     t.integer :extendedWarranty, :null => false


### PR DESCRIPTION
This is a patch for #7503

I had to create a new table and a model since the current STI models all relied on `type` and it was important for this issue not to have a field named `type`
