### PR TITLE
Remove rescue that is oculting exceptions on integer columns

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Rails 3.2.9 (unreleased)
+*   Fix ConnectionAdapters::Column.type_cast_code integer conversion,
+    to always convert values to integer calling #to_i.
+
+    *Thiago Pradi*
 
 *   Fix `reset_counters` when there are multiple `belongs_to` association with the
     same foreign key and one of them have a counter cache.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Rails 3.2.9 (unreleased)
 *   Fix ConnectionAdapters::Column.type_cast_code integer conversion,
-    to always convert values to integer calling #to_i.
+    to always convert values to integer calling #to_i. Fixes #7509.
 
     *Thiago Pradi*
 

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -75,7 +75,7 @@ module ActiveRecord
 
         case type
         when :string, :text        then value
-        when :integer              then value.to_i rescue value ? 1 : 0
+        when :integer              then value.to_i
         when :float                then value.to_f
         when :decimal              then klass.value_to_decimal(value)
         when :datetime, :timestamp then klass.string_to_time(value)
@@ -92,7 +92,7 @@ module ActiveRecord
 
         case type
         when :string, :text        then var_name
-        when :integer              then "(#{var_name}.to_i rescue #{var_name} ? 1 : 0)"
+        when :integer              then "(#{var_name}.to_i)"
         when :float                then "#{var_name}.to_f"
         when :decimal              then "#{klass}.value_to_decimal(#{var_name})"
         when :datetime, :timestamp then "#{klass}.string_to_time(#{var_name})"

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -63,6 +63,12 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal apple.id, citibank.firm_id
   end
 
+  def test_id_assignment
+    apple = Firm.create("name" => "Apple")
+    citibank = Account.create("credit_limit" => 10)
+    assert_raise(NoMethodError) { citibank.firm_id = apple }
+  end
+
   def test_natural_assignment_with_primary_key
     apple = Firm.create("name" => "Apple")
     citibank = Client.create("name" => "Primary key client")

--- a/activerecord/test/cases/column_test.rb
+++ b/activerecord/test/cases/column_test.rb
@@ -24,6 +24,30 @@ module ActiveRecord
         assert !column.type_cast('off')
         assert !column.type_cast('OFF')
       end
+
+      def test_type_cast_integer
+        column = Column.new("field", nil, "integer")
+        assert_equal 1, column.type_cast(1)
+        assert_equal 1, column.type_cast('1')
+        assert_equal 1, column.type_cast('1ignore')
+        assert_equal 0, column.type_cast('bad1')
+        assert_equal 0, column.type_cast('bad')
+        assert_equal 1, column.type_cast(1.7)
+        assert_nil column.type_cast(nil)
+      end
+
+      def test_type_cast_non_integer_to_integer
+        column = Column.new("field", nil, "integer")
+        assert_raises(NoMethodError) do
+          column.type_cast([])
+        end
+        assert_raises(NoMethodError) do
+          column.type_cast(true)
+        end
+        assert_raises(NoMethodError) do
+          column.type_cast(false)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Hi Folks,

I found this weird behavior when I was programming during my day job. This is the scenario:

``` ruby
class User
  has_many :tasks
end
```

``` ruby
class Task
  belongs_to :user
end
```

so I was building a part of the application, and I made the following mistake, passing a object to the integer field:

``` ruby
t = Task.new
t.user_id = user
t.user_id
=> 1 
```

whenever this code runs, the user_id always became 1, not raising a error or anything. So I took a look in the rails source, and found that this behavior is fixed in rails master, but not in the 3.2 tree. 

I think this could be considered a bug, so I did this patch. What you guys think?
