### PR TITLE
request.xhr? should return boolean value instead of Int

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -167,7 +167,7 @@ module ActionDispatch
     # (case-insensitive). All major JavaScript libraries send this header with
     # every Ajax request.
     def xml_http_request?
-      @env['HTTP_X_REQUESTED_WITH'] =~ /XMLHttpRequest/i
+      !!@env['HTTP_X_REQUESTED_WITH'] =~ /XMLHttpRequest/i
     end
     alias :xhr? :xml_http_request?
 


### PR DESCRIPTION
I've just converted to boolean value

```
request.xhr?
  => 0`
```
