### PR TITLE
Add an optional block to HashWithIndifferentAccess#update and #merge

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   An optional block can be passed to `HashWithIndifferentAccess#update` and `#merge`.
+    The block will be invoked for each duplicated key, and used to resolve the conflict,
+    thus replicating the behaviour of the corresponding methods on the `Hash` class.
+
+    *Leo Cassarani*
+
 *   Remove `j` alias for `ERB::Util#json_escape`.
     The `j` alias is already used for `ActionView::Helpers::JavaScriptHelper#escape_javascript`
     and both modules are included in the view context that would confuse the developers.

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -428,6 +428,29 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal 2, hash['b']
   end
 
+  def test_indifferent_merging_with_block
+    hash = HashWithIndifferentAccess.new
+    hash[:a] = 1
+    hash['b'] = 3
+
+    other = { 'a' => 4, :b => 2, 'c' => 10 }
+
+    merged = hash.merge(other) { |key, old, new| old > new ? old : new }
+
+    assert_equal HashWithIndifferentAccess, merged.class
+    assert_equal 4, merged[:a]
+    assert_equal 3, merged['b']
+    assert_equal 10, merged[:c]
+
+    other_indifferent = HashWithIndifferentAccess.new('a' => 9, :b => 2)
+
+    merged = hash.merge(other_indifferent) { |key, old, new| old + new }
+
+    assert_equal HashWithIndifferentAccess, merged.class
+    assert_equal 10, merged[:a]
+    assert_equal 5, merged[:b]
+  end
+
   def test_indifferent_reverse_merging
     hash = HashWithIndifferentAccess.new('some' => 'value', 'other' => 'value')
     hash.reverse_merge!(:some => 'noclobber', :another => 'clobber')


### PR DESCRIPTION
When a block is passed into `HashWithIndifferentAccess#update` or `#merge`, it will be invoked for each duplicated key with the key in question, the value for the key in the receiver, and the value in the hash being merged. The return value of the block will be used to resolve the conflict:

```
hash_1 = ActiveSupport::HashWithIndifferentAccess.new
hash_1[:key] = 10

hash_2 = ActiveSupport::HashWithIndifferentAccess.new
hash_2['key'] = 20

hash_1.merge(hash_2) { |key, old, new| old + new } # => {"key"=>30}
```

This is consistent with long-standing behaviour of the Standard Library's `Hash` class. Indeed, without this change, it would not be immediately obvious to someone passing a block into `HashWithIndifferentAccess#merge` that its behaviour doesn't reflect `Hash#merge`, as the block will be silently ignored.
