### PR TITLE
Add wrap_with to Relation; simplify decorator / presenter / etc. code

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -8,7 +8,7 @@ module ActiveRecord
     delegate :find_each, :find_in_batches, :to => :all
     delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins,
              :where, :preload, :eager_load, :includes, :from, :lock, :readonly,
-             :having, :create_with, :uniq, :references, :none, :to => :all
+             :having, :create_with, :wrap_with, :uniq, :references, :none, :to => :all
     delegate :count, :average, :minimum, :maximum, :sum, :calculate, :pluck, :ids, :to => :all
 
     # Executes a custom SQL query against your database and returns all the results. The results will

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -10,7 +10,7 @@ module ActiveRecord
                             :extending]
 
     SINGLE_VALUE_METHODS = [:limit, :offset, :lock, :readonly, :from, :reordering,
-                            :reverse_order, :uniq, :create_with]
+                            :reverse_order, :uniq, :create_with, :wrap_with]
 
     VALUE_METHODS = MULTI_VALUE_METHODS + SINGLE_VALUE_METHODS
 
@@ -568,6 +568,8 @@ module ActiveRecord
         # are JOINS and no explicit SELECT.
         readonly = readonly_value.nil? ? @implicit_readonly : readonly_value
         @records.each { |record| record.readonly! } if readonly
+
+        @records.map! { |record| wrap_with_value.new(record) } if wrap_with_value
       else
         @records = default_scoped.to_a
       end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -510,6 +510,28 @@ module ActiveRecord
       self
     end
 
+    # Wrap every record in the specified class. Each record retrieved is
+    # passed to the specified class's constructor.
+    #
+    # class UserWrapper < DelegateClass(User)
+    # end
+    #
+    # users = User.where(name: 'Oscar').wrap_with(UserWrapper)
+    # users.where(email: 'foo@example.com').first.class # => UserWrapper
+    # users.last.class # => UserWrapper
+    #
+    def wrap_with(value)
+      spawn.wrap_with!(value)
+    end
+
+    # Like #wrap_with but modifies the relation in place. Raises
+    # +ImmutableRelation+ if the relation has already been loaded.
+    #
+    def wrap_with!(value)
+      self.wrap_with_value = value
+      self
+    end
+
     # Specifies table from which the records will be fetched. For example:
     #
     #   Topic.select('title').from('posts')

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -248,6 +248,12 @@ module ActiveRecord
       assert_equal({foo: 'bar'}, relation.create_with_value)
     end
 
+    test 'wrap_with!' do
+      klass = Class.new
+      assert relation.wrap_with!(klass).equal?(relation)
+      assert_equal(klass, relation.wrap_with_value)
+    end
+
     test 'merge!' do
       assert relation.merge!(where: :foo).equal?(relation)
       assert_equal [:foo], relation.where_values

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1381,4 +1381,13 @@ class RelationTest < ActiveRecord::TestCase
     end
     assert_no_queries { relation.to_a }
   end
+
+  test '#wrap_with' do
+    wrapper_class = Struct.new(:wrapped)
+    relation = Post.wrap_with(wrapper_class)
+
+    assert_equal wrapper_class, relation.first.class
+    assert_equal Post.first, relation.first.wrapped
+  end
+
 end


### PR DESCRIPTION
The attached code adds a `wrap_with` method to Relation that wraps objects retrieved from the relation in the specified class. A trivial example:

``` ruby
class UserWrapper < DelegateClass(User)
  def magic_thing
    puts 'wat'
  end
end

User.where(:name => 'Bob').wrap_with(UserWrapper).first.magic_thing # => prints 'wat'
```

A short test is included - suggestions for additional testing (or more meaningful testing) are welcome.

There are also a number of additional features that could be included here, if they make sense:
- wrapping with additional classes may be useful; currently, chaining another `wrap_with` call overwrites the value set in the first one. This would be a simple change, given the existing plumbing for dealing with multi-valued data on Relation.
- passing additional arguments to the method could be useful; for instance, `some_relation.wrap_with(SomeClass, :foo, :bar, :baz)` would pass the additional arguments on to the constructor, so each record in `some_relation` would be wrapped via `SomeClass.new(record, :foo, :bar, :baz)`. Again, a fairly trivial modification.
- for extreme cases, passing a block may make more sense. For instance:

``` ruby
some_relation.wrap_with(SomeClass) { |some_class| some_class.do_something }
# which wraps as:
SomeClass.new(record).tap { |some_class| some_class.do_something }
```
- of course, there's also an argument that a zero-arg block version might make sense:

``` ruby
some_relation.wrap_with { |record| SomeClass.new(record) }
```

Here, `wrap_with` is just calling the block with the record directly.
- the current code doesn't do anything when building / creating new records; it was extracted from a live app that used `wrap_with` solely for read-only views. I'm not certain what the desirable behavior is here.
