### PR TITLE
Add boolean type conversion for AR::Store

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   You can now override the generated accessor methods for stored attributes
+    and reuse the original behavior with `read_store_attribute` and `write_store_attribute`,
+    which are counterparts to `read_attribute` and `write_attribute`.
+
+    *Matt Jones*
+
 *   Accept belongs_to (including polymorphic) association keys in queries
 
     The following queries are now equivalent:
@@ -38,7 +44,7 @@
 
     *Jan Bernacki*
 
-*   Fix bug when call `store_accessor` multiple times.
+*   Fix bug when calling `store_accessor` multiple times.
     Fixes #7532.
 
     *Matt Jones*

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -37,6 +37,28 @@ module ActiveRecord
   # The stored attribute names can be retrieved using +stored_attributes+.
   #
   #   User.stored_attributes[:settings] # [:color, :homepage]
+  #
+  # == Overwriting default accessors
+  #
+  # All stored values are automatically available through accessors on the Active Record
+  # object, but sometimes you want to specialize this behavior. This can be done by overwriting
+  # the default accessors (using the same name as the attribute) and calling
+  # <tt>read_store_attribute(store_attribute_name, attr_name)</tt> and
+  # <tt>write_store_attribute(store_attribute_name, attr_name, value)</tt> to actually
+  # change things.
+  #
+  #   class Song < ActiveRecord::Base
+  #     # Uses a stored integer to hold the volume adjustment of the song
+  #     store :settings, accessors: [:volume_adjustment]
+  #
+  #     def volume_adjustment=(decibels)
+  #       write_store_attribute(:settings, :volume_adjustment, decibels.to_i)
+  #     end
+  #
+  #     def volume_adjustment
+  #       read_store_attribute(:settings, :volume_adjustment).to_i
+  #     end
+  #   end
   module Store
     extend ActiveSupport::Concern
 
@@ -55,15 +77,11 @@ module ActiveRecord
         keys = keys.flatten
         keys.each do |key|
           define_method("#{key}=") do |value|
-            attribute = initialize_store_attribute(store_attribute)
-            if value != attribute[key]
-              send :"#{store_attribute}_will_change!"
-              attribute[key] = value
-            end
+            write_store_attribute(store_attribute, key, value)
           end
 
           define_method(key) do
-            initialize_store_attribute(store_attribute)[key]
+            read_store_attribute(store_attribute, key)
           end
         end
 
@@ -71,6 +89,20 @@ module ActiveRecord
         self.stored_attributes[store_attribute] |= keys
       end
     end
+
+    protected
+      def read_store_attribute(store_attribute, key)
+        attribute = initialize_store_attribute(store_attribute)
+        attribute[key]
+      end
+
+      def write_store_attribute(store_attribute, key, value)
+        attribute = initialize_store_attribute(store_attribute)
+        if value != attribute[key]
+          send :"#{store_attribute}_will_change!"
+          attribute[key] = value
+        end
+      end
 
     private
       def initialize_store_attribute(store_attribute)

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -29,6 +29,12 @@ class StoreTest < ActiveRecord::TestCase
     assert_equal 'graeters', @john.reload.settings[:icecream]
   end
 
+  test "overriding a read accessor" do
+    @john.settings[:phone_number] = '1234567890'
+
+    assert_equal '(123) 456-7890', @john.phone_number
+  end
+
   test "updating the store will mark it as changed" do
     @john.color = 'red'
     assert @john.settings_changed?
@@ -52,6 +58,12 @@ class StoreTest < ActiveRecord::TestCase
   test "writing with not nullable column" do
     @john.remember_login = false
     assert_equal false, @john.remember_login
+  end
+
+  test "overriding a write accessor" do
+    @john.phone_number = '(123) 456-7890'
+
+    assert_equal '1234567890', @john.settings[:phone_number]
   end
 
   test "preserve store attributes data in HashWithIndifferentAccess format without any conversion" do
@@ -124,7 +136,7 @@ class StoreTest < ActiveRecord::TestCase
   end
 
   test "all stored attributes are returned" do
-    assert_equal [:color, :homepage, :favorite_food], Admin::User.stored_attributes[:settings]
+    assert_equal [:color, :homepage, :favorite_food, :phone_number], Admin::User.stored_attributes[:settings]
   end
 
   test "stores_attributes are class level settings" do

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -1,8 +1,16 @@
 class Admin::User < ActiveRecord::Base
   belongs_to :account
   store :settings, :accessors => [ :color, :homepage ]
-  store_accessor :settings, :favorite_food
+  store_accessor :settings, :favorite_food, :phone_number
   store :preferences, :accessors => [ :remember_login ]
   store :json_data, :accessors => [ :height, :weight ], :coder => JSON
   store :json_data_empty, :accessors => [ :is_a_good_guy ], :coder => JSON
+
+  def phone_number
+    read_store_attribute(:settings, :phone_number).gsub(/(\d{3})(\d{3})(\d{4})/,'(\1) \2-\3')
+  end
+
+  def phone_number=(value)
+    write_store_attribute(:settings, :phone_number, value && value.gsub(/[^\d]/,''))
+  end
 end


### PR DESCRIPTION
Note: the commits here are split to facilitate discussion. Happy to squash before merging.

The attached commits fix two bugs in `ActiveRecord::Store` and add a new feature. 
- the first commit moves the call to `will_change!` above the actual change to the attribute - otherwise, the attribute is marked as changed but attempts to access the previous value (using `_was` or `_change`) will return the _new_ value instead
- the second commit ensures that additional calls to `store_accessor` don't overwrite previously-set values in `stored_attributes`. This functionality is described in the documentation (regarding subclasses) but subsequent calls to `store_accessor` overwrote the list each time.
- the final commit adds a new variant of `store_accessor` that provides type conversion for booleans to simplify (for instance) setting stored attributes with checkboxes. An example:

``` ruby
class User < ActiveRecord::Base
  store :flags
  store_boolean_attribute :flags, :likes_ruby, :likes_python, :likes_clojure
end

User.first.likes_ruby? # => returns true or false

@user.update_attributes(:likes_ruby => '0') # => stores false in flags['likes_ruby']
```

There is some fairly gross duplication between `store_accessor` and `store_boolean_accessor`; any suggestions for a refactor are welcome - as is a better name than `store_boolean_accessor`.

One other open question: would it be better to add more "typed" variants to handle parsing input (for datetimes, etc)? My application only needed booleans, but there's certainly an argument to be made for extending the same type-casting behavior to `store_accessor` attributes as plain attributes.
