### PR TITLE
Fix a typo in AD

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -20,7 +20,7 @@ module ActionDispatch
       # - +headers+: Additional headers to pass, as a Hash. The headers will be
       #   merged into the Rack env hash.
       #
-      # This method returns an Response object, which one can use to
+      # This method returns a Response object, which one can use to
       # inspect the details of the response. Furthermore, if this method was
       # called from an ActionDispatch::IntegrationTest object, then that
       # object's <tt>@response</tt> instance variable will point to the same


### PR DESCRIPTION
Hello,

Sorry to make a useless pull request but I found a typo in the documentation of the `get` method. I didn't add an entry to the CHANGELOG but if I have to, please let me know and I will update the commit.

Have a nice day.
