### PR TITLE
correct handling of changes in AR::Store, combine multiple store_accessors

### DIFF
--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -57,8 +57,8 @@ module ActiveRecord
           define_method("#{key}=") do |value|
             attribute = initialize_store_attribute(store_attribute)
             if value != attribute[key]
-              attribute[key] = value
               send :"#{store_attribute}_will_change!"
+              attribute[key] = value
             end
           end
 
@@ -67,7 +67,8 @@ module ActiveRecord
           end
         end
 
-        self.stored_attributes[store_attribute] = keys
+        self.stored_attributes[store_attribute] ||= []
+        self.stored_attributes[store_attribute] |= keys
       end
     end
 

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -34,6 +34,12 @@ class StoreTest < ActiveRecord::TestCase
     assert @john.settings_changed?
   end
 
+  test "updating the store populates the changed array correctly" do
+    @john.color = 'red'
+    assert_equal 'black', @john.settings_change[0]['color']
+    assert_equal 'red', @john.settings_change[1]['color']
+  end
+
   test "updating the store won't mark it as changed if an attribute isn't changed" do
     @john.color = @john.color
     assert !@john.settings_changed?
@@ -117,8 +123,8 @@ class StoreTest < ActiveRecord::TestCase
     assert_equal false, @john.is_a_good_guy
   end
 
-  test "stored attributes are returned" do
-    assert_equal [:color, :homepage], Admin::User.stored_attributes[:settings]
+  test "all stored attributes are returned" do
+    assert_equal [:color, :homepage, :favorite_food], Admin::User.stored_attributes[:settings]
   end
 
   test "stores_attributes are class level settings" do

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -1,6 +1,7 @@
 class Admin::User < ActiveRecord::Base
   belongs_to :account
   store :settings, :accessors => [ :color, :homepage ]
+  store_accessor :settings, :favorite_food
   store :preferences, :accessors => [ :remember_login ]
   store :json_data, :accessors => [ :height, :weight ], :coder => JSON
   store :json_data_empty, :accessors => [ :is_a_good_guy ], :coder => JSON


### PR DESCRIPTION
Split off from #7524 - this is just the bugfixes. 
- Call the `_will_change!` method before changing the underlying data. Otherwise, the list of changes is incorrectly populated.
- multiple calls to `store_accessor` should add attributes to `stored_attributes`, not overwrite the ones already present.
