### PR TITLE
Add the ability to pass drop_* when generating a new migration

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add the ability to pass `drop_table` or `DropTable` when generating a new migration
+
 *   Fix time column type casting for invalid time string values to correctly return nil.
 
     *Adam Meehan*

--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -18,6 +18,9 @@ module ActiveRecord
         when /^(add|remove)_.*_(?:to|from)_(.*)/
           @migration_action = $1
           @table_name       = $2.pluralize
+        when /^drop_(.*)/
+          @migration_action = "drop"
+          @table_name       = $1.pluralize
         when /join_table/
           if attributes.length == 2
             @migration_action = 'join'

--- a/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
@@ -12,6 +12,10 @@ class <%= migration_class_name %> < ActiveRecord::Migration
   <%- end -%>
 <%- end -%>
   end
+<%- elsif migration_action == "drop" -%>
+  def change
+    drop_table :<%= table_name %>
+  end
 <%- elsif migration_action == 'join' -%>
   def change
     create_join_table :<%= join_tables.first %>, :<%= join_tables.second %> do |t|

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add a test when the user pass drop_* when generating a migration and add an example of use in migration/USAGE
+
 *   Correctly handle SCRIPT_NAME when generating routes to engine in application
     that's mounted at a sub-uri. With this behavior, you *should not* use
     default_url_options[:script_name] to set proper application's mount point by

--- a/railties/lib/rails/generators/rails/migration/USAGE
+++ b/railties/lib/rails/generators/rails/migration/USAGE
@@ -7,7 +7,7 @@ Description:
     You can name your migration in either of these formats to generate add/remove
     column lines from supplied attributes: AddColumnsToTable or RemoveColumnsFromTable
 
-Example:
+Examples:
     `rails generate migration AddSslFlag`
 
     If the current date is May 14, 2008 and the current time 09:09:12, this creates the AddSslFlag migration
@@ -27,3 +27,10 @@ Example:
       remove_column :posts, :published
       remove_column :posts, :body
       remove_column :posts, :title
+
+    `rails generate migration DropArticles`
+
+    If the current date is May 14, 2008 and the current time 10:07:22, this creates the DropArticles migration class in
+    db/migrate/20080514100722_drop_articles.rb with this in the Change migration:
+
+      drop_table :articles

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -180,6 +180,17 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_drop_table_migration
+    migration = "drop_books"
+    run_generator [migration]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/drop_table :books/, change)
+      end
+    end
+  end
+
   def test_should_create_empty_migrations_if_name_not_start_with_add_or_remove
     migration = "create_books"
     run_generator [migration, "title:string", "content:text"]


### PR DESCRIPTION
Hello,

This is just a little pull request that allows the user to pass `drop_articles` for example in order to create a migration that will drop the articles table. 

For the moment, I update two changelogs, I don't know if I have to and if I don't, please let me know.

Have a nice day.
