### PR TITLE
Ignore RubyMine configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ debug.log
 /.bundle
 /.rbenv-version
 /.rvmrc
+/.idea
 /Gemfile.lock
 /pkg
 /dist


### PR DESCRIPTION
Adding /.idea will allow us to ignore all configuration files when using the Jetbrains RubyMine editor.  There are about ten or so .xml files RubyMine uses for configuration settings which should be ignored.
