### PR TITLE
Added customizable STI type serialization.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Allow customization of STI type serialization/deserialization for legacy databases.
+
+    *Ian Lesperance & Matthew Kane Parker*
+
 *   Fix bug when call `store_accessor` multiple times.
     Fixes #7532.
 

--- a/activerecord/lib/active_record/model.rb
+++ b/activerecord/lib/active_record/model.rb
@@ -107,6 +107,12 @@ module ActiveRecord
       def inheritance_column
         'type'
       end
+
+      def inheritance_serializer
+      end
+
+      def inheritance_deserializer
+      end
     end
 
     class DeprecationProxy < BasicObject #:nodoc:

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -1,5 +1,6 @@
 require "cases/helper"
 require 'models/company'
+require 'models/dog'
 require 'models/person'
 require 'models/post'
 require 'models/project'
@@ -269,8 +270,18 @@ class InheritanceTest < ActiveRecord::TestCase
     assert_kind_of SpecialSubscriber, SpecialSubscriber.find("webster132")
     assert_nothing_raised { s = SpecialSubscriber.new("name" => "And breaaaaathe!"); s.id = 'roger'; s.save }
   end
-end
 
+  def test_inheritance_with_custom_type_serialization
+    labrador = Labrador.create
+    assert_kind_of Labrador, Dog.find(labrador.id)
+
+    retriever = Retriever.create
+    assert_kind_of Retriever, Dog.find(retriever.id)
+
+    dog = Dog.create
+    assert_kind_of Dog, Dog.find(dog.id)
+  end
+end
 
 class InheritanceComputeTypeTest < ActiveRecord::TestCase
   fixtures :companies

--- a/activerecord/test/models/dog.rb
+++ b/activerecord/test/models/dog.rb
@@ -1,4 +1,19 @@
 class Dog < ActiveRecord::Base
+  INHERITANCE_TYPE_MAP = {
+    2 => 'Labrador',
+    3 => 'Retriever'
+  }
+
+  self.inheritance_column = 'dog_type'
+  self.inheritance_serializer = ->(klass) { INHERITANCE_TYPE_MAP.invert[klass.name] }
+  self.inheritance_deserializer = ->(type_before_cast) { INHERITANCE_TYPE_MAP[type_before_cast.to_i].constantize }
+
   belongs_to :breeder, :class_name => "DogLover", :counter_cache => :bred_dogs_count
   belongs_to :trainer, :class_name => "DogLover", :counter_cache => :trained_dogs_count
+end
+
+class Labrador < Dog
+end
+
+class Retriever < Dog
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -235,6 +235,7 @@ ActiveRecord::Schema.define do
   create_table :dogs, :force => true do |t|
     t.integer :trainer_id
     t.integer :breeder_id
+    t.integer :dog_type
   end
 
   create_table :edges, :force => true, :id => false do |t|


### PR DESCRIPTION
Rails will store the name of a child class in the database to use for re-instantiating the record as the correct class later. By specifying an `inheritance_serializer` and `inheritance_deserializer`, you can customize the stored identifier.

This is primarily useful for working with legacy data models.

``` ruby
class Foo < ActiveRecord::Base
  self.inheritance_serializer = ->(klass) do
    # Map the class to the appropriate type identifier.
    # Defaults to `klass.name`.
    if klass == Child1
      1
    elsif klass == Child2
      2
    end
  end

  self.inheritance_deserializer = ->(type_before_cast) do
    # Map the type identifier back into the appropriate class.
    # Defaults (approximately) to `type_before_cast.constantize`.
    case type_before_cast.to_i
    when 1
      Child1
    when 2
      Child2
    end
  end
end

class Child1 < Foo; end
class Child2 < Foo; end
```
