### PR TITLE
Fixed around callback with lambda example

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -367,7 +367,7 @@ module ActiveSupport
       #
       #   set_callback :save, :before, :before_meth
       #   set_callback :save, :after,  :after_meth, :if => :condition
-      #   set_callback :save, :around, lambda { |r| stuff; result = yield; stuff }
+      #   set_callback :save, :around, lambda { |r, &block| stuff; result = block.call; stuff }
       #
       # The second arguments indicates whether the callback is to be run +:before+,
       # +:after+, or +:around+ the event. If omitted, +:before+ is assumed. This


### PR DESCRIPTION
This is a follow up to issue #7535. The existing example of using yield in an around callback lambda throws
a "no block given (yield)" error.
