### PR TITLE
Don't EXPLAIN the unexplainable in postgresql

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -7,7 +7,7 @@ module ActiveRecord
         def explain(arel, binds = [])
           sql = to_sql(arel, binds)
           # taken from http://www.postgresql.org/docs/current/static/sql-explain.html
-          if sql =~ /^(SELECT|INSERT|UPDATE|DELETE|VALUES|EXECUTE|DECLARE|CREATE +TABLE)/i
+          if sql =~ /^(WITH|SELECT|INSERT|UPDATE|DELETE|VALUES|EXECUTE|DECLARE|CREATE +TABLE)/i
             ExplainPrettyPrinter.new.pp(exec_query("EXPLAIN #{sql}", 'EXPLAIN', binds))
           else
             "cannot EXPLAIN #{sql.match(/\w+/)[0]}"

--- a/activerecord/test/cases/adapters/postgresql/explain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/explain_test.rb
@@ -23,6 +23,12 @@ module ActiveRecord
           assert_match %(Seq Scan on audit_logs), explain
         end
 
+        def test_explain_with_cte
+          explain = ActiveRecord::Base.connection.explain "with y as (select 1) select * from y"
+          assert_match %(QUERY PLAN), explain
+          assert_match %(CTE Scan on y), explain
+        end
+
         def test_warn_about_unexplainable
           explain = ActiveRecord::Base.connection.explain "SHOW search_path;"
           assert_match %(cannot EXPLAIN SHOW), explain

--- a/activerecord/test/cases/adapters/postgresql/explain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/explain_test.rb
@@ -23,12 +23,16 @@ module ActiveRecord
           assert_match %(Seq Scan on audit_logs), explain
         end
 
+        def test_warn_about_unexplainable
+          explain = ActiveRecord::Base.connection.explain "SHOW search_path;"
+          assert_match %(cannot EXPLAIN SHOW), explain
+        end
+
         def test_dont_explain_for_set_search_path
           queries = Thread.current[:available_queries_for_explain] = []
           ActiveRecord::Base.connection.schema_search_path = "public"
           assert queries.empty?
         end
-
       end
     end
   end


### PR DESCRIPTION
Only run EXPLAIN for statements that are supported. Really fixes Issue #5430.
