### PR TITLE
AS::Callbacks: deprecate monkey patch of object callbacks

### DIFF
--- a/actionpack/lib/action_controller/caching/actions.rb
+++ b/actionpack/lib/action_controller/caching/actions.rb
@@ -132,7 +132,7 @@ module ActionController #:nodoc:
             options.values_at(:cache_path, :store_options, :layout)
         end
 
-        def filter(controller)
+        def around(controller)
           cache_layout = @cache_layout.respond_to?(:call) ? @cache_layout.call(controller) : @cache_layout
 
           path_options = if @cache_path.respond_to?(:call)

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -193,7 +193,7 @@ class FilterTest < ActionController::TestCase
   end
 
   class ConditionalClassFilter
-    def self.filter(controller) controller.instance_variable_set(:"@ran_class_filter", true) end
+    def self.before(controller) controller.instance_variable_set(:"@ran_class_filter", true) end
   end
 
   class OnlyConditionClassController < ConditionalFilterController
@@ -309,7 +309,7 @@ class FilterTest < ActionController::TestCase
   end
 
   class AuditFilter
-    def self.filter(controller)
+    def self.before(controller)
       controller.instance_variable_set(:"@was_audited", true)
     end
   end
@@ -449,7 +449,7 @@ class FilterTest < ActionController::TestCase
   class ErrorToRescue < Exception; end
 
   class RescuingAroundFilterWithBlock
-    def filter(controller)
+    def around(controller)
       begin
         yield
       rescue ErrorToRescue => ex
@@ -894,7 +894,7 @@ end
 
 class ControllerWithFilterClass < PostsController
   class YieldingFilter < DefaultFilter
-    def self.filter(controller)
+    def self.around(controller)
       yield
       raise After
     end
@@ -905,7 +905,7 @@ end
 
 class ControllerWithFilterInstance < PostsController
   class YieldingFilter < DefaultFilter
-    def filter(controller)
+    def around(controller)
       yield
       raise After
     end
@@ -916,13 +916,13 @@ end
 
 class ControllerWithFilterMethod < PostsController
   class YieldingFilter < DefaultFilter
-    def filter(controller)
+    def around(controller)
       yield
       raise After
     end
   end
 
-  around_filter YieldingFilter.new.method(:filter), :only => :raises_after
+  around_filter YieldingFilter.new.method(:around), :only => :raises_after
 end
 
 class ControllerWithProcFilter < PostsController

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -279,6 +279,7 @@ module ActiveSupport
 
       def _normalize_legacy_filter(kind, filter)
         if !filter.respond_to?(kind) && filter.respond_to?(:filter)
+          ActiveSupport::Deprecation.warn("Filter object with #filter method is deprecated. Define method corresponding to filter type (#before, #after or #around).")
           filter.singleton_class.class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
             def #{kind}(context, &block) filter(context, &block) end
           RUBY_EVAL


### PR DESCRIPTION
Deprecate yet another on the fly monkey patch of objects in AS::Callbacks.
This one is probably related to before_filters:

``` ruby
before_filter MyFilter.new

class MyFilter
  def filter(controller)
  end
end
```

is now deprecated with recommendation to use:

``` ruby
before_filter MyFilter.new

class MyFilter
  def before(controller)
  end
end
```
