### PR TITLE
Fix for 2 broken ar-mysql2 tests

### DIFF
--- a/activerecord/test/cases/xml_serialization_test.rb
+++ b/activerecord/test/cases/xml_serialization_test.rb
@@ -185,7 +185,7 @@ class NilXmlSerializationTest < ActiveRecord::TestCase
   end
 
   def test_should_serialize_string
-    assert_match %r{<name nil="true"></name>},     @xml
+    assert_match %r{<name nil="true"/>}, @xml
   end
 
   def test_should_serialize_integer
@@ -218,7 +218,7 @@ class NilXmlSerializationTest < ActiveRecord::TestCase
   end
 
   def test_should_serialize_yaml
-    assert_match %r{<preferences nil=\"true\"></preferences>}, @xml
+    assert_match %r{<preferences nil=\"true\"/>}, @xml
   end
 end
 


### PR DESCRIPTION
Hi,

Newbie here. Saw 2 failing tests on AR on travis and locally -

 5) Failure:
144test_should_serialize_string(NilXmlSerializationTest) [/home/vagrant/builds/rails/rails/activerecord/test/cases/xml_serialization_test.rb:188]:
145Expected /<name nil="true"><\/name>/ to match "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<xml-contact>\n  <name nil=\"true\"/>\n  <age type=\"integer\" nil=\"true\"/>\n  <avatar type=\"binary\" nil=\"true\" encoding=\"base64\"/>\n  <created-at type=\"dateTime\" nil=\"true\"/>\n  <awesome type=\"boolean\" nil=\"true\"/>\n  <preferences nil=\"true\"/>\n  <alternative-id type=\"integer\" nil=\"true\"/>\n  <id type=\"NilClass\" nil=\"true\"/>\n</xml-contact>\n".
146
147  6) Failure:
148test_should_serialize_yaml(NilXmlSerializationTest) [/home/vagrant/builds/rails/rails/activerecord/test/cases/xml_serialization_test.rb:221]:
149Expected /<preferences nil=\"true\"><\/preferences>/ to match "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<xml-contact>\n  <name nil=\"true\"/>\n  <age type=\"integer\" nil=\"true\"/>\n  <avatar type=\"binary\" nil=\"true\" encoding=\"base64\"/>\n  <created-at type=\"dateTime\" nil=\"true\"/>\n  <awesome type=\"boolean\" nil=\"true\"/>\n  <preferences nil=\"true\"/>\n  <alternative-id type=\"integer\" nil=\"true\"/>\n  <id type=\"NilClass\" nil=\"true\"/>\n</xml-contact>\n".

This is the fix for them.

Thanks.
