### PR TITLE
Use mysqldump native commands when rake db:structure:dump.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Use native `mysqldump` command instead of `structure_dump` method
+    when dumping the database structure to a sql file. Fixes #5547.
+
+    *kennyj*
+
 *   Attribute predicate methods, such as `article.title?`, will now raise
     `ActiveModel::MissingAttributeError` if the attribute being queried for
     truthiness was not read from the database, instead of just returning false.

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -27,7 +27,7 @@ module ActiveRecord
       rescue error_class => error
         $stderr.puts error.error
         $stderr.puts "Couldn't create database for #{configuration.inspect}, #{creation_options.inspect}"
-        $stderr.puts "(If you set the charset manually, make sure you have a matching collation)" if configuration['charset']
+        $stderr.puts "(If you set the charset manually, make sure you have a matching collation)" if configuration['encoding']
       end
 
       def drop
@@ -75,7 +75,7 @@ module ActiveRecord
 
       def creation_options
         {
-          charset:   (configuration['charset']   || DEFAULT_CHARSET),
+          charset:   (configuration['encoding']   || DEFAULT_CHARSET),
           collation: (configuration['collation'] || DEFAULT_COLLATION)
         }
       end
@@ -116,7 +116,7 @@ IDENTIFIED BY '#{configuration['password']}' WITH GRANT OPTION;
         args = [command]
         args.concat(['--user', configuration['username']]) if configuration['username']
         args << "--password=#{configuration['password']}"  if configuration['password']
-        args.concat(['--default-character-set', configuration['charset']]) if configuration['charset']
+        args.concat(['--default-character-set', configuration['encoding']]) if configuration['encoding']
         configuration.slice('host', 'port', 'socket').each do |k, v|
           args.concat([ "--#{k}", v ]) if v
         end

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -32,7 +32,7 @@ module ActiveRecord
         with('my-app-db', {:charset => 'latin', :collation => 'latin_ci'})
 
       ActiveRecord::Tasks::DatabaseTasks.create @configuration.merge(
-        'charset' => 'latin', 'collation' => 'latin_ci'
+        'encoding' => 'latin', 'collation' => 'latin_ci'
       )
     end
 
@@ -176,7 +176,7 @@ module ActiveRecord
         with('test-db', {:charset => 'latin', :collation => 'latin_ci'})
 
       ActiveRecord::Tasks::DatabaseTasks.purge @configuration.merge(
-        'charset' => 'latin', 'collation' => 'latin_ci'
+        'encoding' => 'latin', 'collation' => 'latin_ci'
       )
     end
   end

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -219,44 +219,31 @@ module ActiveRecord
 
   class MySQLStructureDumpTest < ActiveRecord::TestCase
     def setup
-      @connection    = stub(:structure_dump => true)
       @configuration = {
         'adapter'  => 'mysql',
         'database' => 'test-db'
       }
-
-      ActiveRecord::Base.stubs(:connection).returns(@connection)
-      ActiveRecord::Base.stubs(:establish_connection).returns(true)
     end
 
     def test_structure_dump
       filename = "awesome-file.sql"
-      ActiveRecord::Base.expects(:establish_connection).with(@configuration)
-      @connection.expects(:structure_dump)
+      Kernel.expects(:system).with("mysqldump", "--result-file", filename, "--no-data", "test-db")
 
       ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
-      assert File.exists?(filename)
-    ensure
-      FileUtils.rm(filename)
     end
   end
 
   class MySQLStructureLoadTest < ActiveRecord::TestCase
     def setup
-      @connection    = stub
       @configuration = {
         'adapter'  => 'mysql',
         'database' => 'test-db'
       }
-
-      ActiveRecord::Base.stubs(:connection).returns(@connection)
-      ActiveRecord::Base.stubs(:establish_connection).returns(true)
-      Kernel.stubs(:system)
     end
 
     def test_structure_load
       filename = "awesome-file.sql"
-      Kernel.expects(:system).with('mysql', '--database', 'test-db', '--execute', %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1})
+      Kernel.expects(:system).with('mysql', '--execute', %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}, "--database", "test-db")
 
       ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
     end


### PR DESCRIPTION
This PR is related to #7525 , #6648 and #5547.
We should use mysqldump native command when dumping db structure.

cc/  @rafaelfranca @seamusabshere
