### PR TITLE
Use configuration['encoding'], because database configuration use not charset but encoding.

### DIFF
--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -27,7 +27,7 @@ module ActiveRecord
       rescue error_class => error
         $stderr.puts error.error
         $stderr.puts "Couldn't create database for #{configuration.inspect}, #{creation_options.inspect}"
-        $stderr.puts "(If you set the charset manually, make sure you have a matching collation)" if configuration['charset']
+        $stderr.puts "(If you set the charset manually, make sure you have a matching collation)" if configuration['encoding']
       end
 
       def drop
@@ -57,7 +57,7 @@ module ActiveRecord
         args = ['mysql']
         args.concat(['--user', configuration['username']]) if configuration['username']
         args << "--password=#{configuration['password']}" if configuration['password']
-        args.concat(['--default-character-set', configuration['charset']]) if configuration['charset']
+        args.concat(['--default-character-set', configuration['encoding']]) if configuration['encoding']
         configuration.slice('host', 'port', 'socket', 'database').each do |k, v|
           args.concat([ "--#{k}", v ]) if v
         end
@@ -77,7 +77,7 @@ module ActiveRecord
 
       def creation_options
         {
-          charset:   (configuration['charset']   || DEFAULT_CHARSET),
+          charset:   (configuration['encoding']  || DEFAULT_CHARSET),
           collation: (configuration['collation'] || DEFAULT_COLLATION)
         }
       end

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -32,7 +32,7 @@ module ActiveRecord
         with('my-app-db', {:charset => 'latin', :collation => 'latin_ci'})
 
       ActiveRecord::Tasks::DatabaseTasks.create @configuration.merge(
-        'charset' => 'latin', 'collation' => 'latin_ci'
+        'encoding' => 'latin', 'collation' => 'latin_ci'
       )
     end
 
@@ -176,7 +176,7 @@ module ActiveRecord
         with('test-db', {:charset => 'latin', :collation => 'latin_ci'})
 
       ActiveRecord::Tasks::DatabaseTasks.purge @configuration.merge(
-        'charset' => 'latin', 'collation' => 'latin_ci'
+        'encoding' => 'latin', 'collation' => 'latin_ci'
       )
     end
   end


### PR DESCRIPTION
When investigating for #7564, I found potentially bug. In database.yml, we use not `charset` but `encoding`.
