### PR TITLE
refactoring: isolate sql-datatype mapping in postgres adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -204,15 +204,34 @@ module ActiveRecord
           # UUID type
           when 'uuid'
             :uuid
-        # JSON type
-        when 'json'
-          :json
+          # JSON type
+          when 'json'
+            :json
           # Small and big integer types
           when /^(?:small|big)int$/
             :integer
-          # Pass through all types that are not specific to PostgreSQL.
-          else
-            super
+          when /int/i
+            :integer
+          when /float|double/i
+            :float
+          when /decimal|numeric|number/i
+            extract_scale(field_type) == 0 ? :integer : :decimal
+          when /datetime/i
+            :datetime
+          when /timestamp/i
+            :timestamp
+          when /time/i
+            :time
+          when /date/i
+            :date
+          when /clob/i, /text/i
+            :text
+          when /blob/i, /binary/i
+            :binary
+          when /char/i, /string/i
+            :string
+          when /boolean/i
+            :boolean
           end
         end
     end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -157,81 +157,62 @@ module ActiveRecord
         # Maps PostgreSQL-specific data types to logical Rails types.
         def simplified_type(field_type)
           case field_type
-          # Numeric and monetary types
-          when /^(?:real|double precision)$/
+
+          # basic types
+          when /^(?:|small|big)int(?:|eger|\d+)$/
+            :integer
+          when /^(?:real|double precision|float\d*)$/
             :float
-          # Monetary types
+          when /decimal|numeric/
+            :decimal
           when 'money'
             :decimal
-          when 'hstore'
-            :hstore
-          # Network address types
+          when /^(?:character varying|bpchar|char|varchar|character)(?:\(\d+\))?$/
+            :string
+          when 'bytea'
+            :binary
+          when /datetime/
+            :datetime
+          when /^timestamp(?:|tz| with(?:out)? time zone)$/
+            :datetime
+          when /^time(?:|tz| with(?:out)? time zone)$/
+            :time
+          when 'date'
+            :date
+          when 'text'
+            :text
+          when 'boolean', 'bool'
+            :boolean
+
+          # postgres types with custom implementation
           when 'inet'
             :inet
           when 'cidr'
             :cidr
           when 'macaddr'
             :macaddr
-          # Character types
-          when /^(?:character varying|bpchar)(?:\(\d+\))?$/
-            :string
-          # Binary data types
-          when 'bytea'
-            :binary
-          # Date/time types
-          when /^timestamp with(?:out)? time zone$/
-            :datetime
-          when /^interval(?:|\(\d+\))$/
-            :string
-          # Geometric types
-          when /^(?:point|line|lseg|box|"?path"?|polygon|circle)$/
-            :string
-          # Bit strings
-          when /^bit(?: varying)?(?:\(\d+\))?$/
-            :string
-          # XML type
           when 'xml'
             :xml
-          # tsvector type
           when 'tsvector'
             :tsvector
-          # Arrays
-          when /^\D+\[\]$/
-            :string
-          # Object identifier types
-          when 'oid'
-            :integer
-          # UUID type
           when 'uuid'
             :uuid
-          # JSON type
           when 'json'
             :json
-          # Small and big integer types
-          when /^(?:small|big)int$/
-            :integer
-          when /int/i
-            :integer
-          when /float|double/i
-            :float
-          when /decimal|numeric|number/i
-            extract_scale(field_type) == 0 ? :integer : :decimal
-          when /datetime/i
-            :datetime
-          when /timestamp/i
-            :timestamp
-          when /time/i
-            :time
-          when /date/i
-            :date
-          when /clob/i, /text/i
-            :text
-          when /blob/i, /binary/i
-            :binary
-          when /char/i, /string/i
+          when 'hstore'
+            :hstore
+
+          # postgres types without custom implementation
+          when /^interval(?:|\(\d+\))$/
             :string
-          when /boolean/i
-            :boolean
+          when /^(?:point|line|lseg|box|"?path"?|polygon|circle)$/
+            :string
+          when /^bit(?: varying)?(?:\(\d+\))?$/
+            :string
+          when /^\D+\[\]$/
+            :string
+          when 'oid'
+            :integer
           end
         end
     end

--- a/activerecord/test/cases/adapters/postgresql/datatype_mappings_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_mappings_test.rb
@@ -1,0 +1,174 @@
+require "cases/helper"
+
+class PostgresqlDataTypeMappingsTest < ActiveRecord::TestCase
+
+  def test_arrays_are_represented_as_string
+    assert_postgres_sql_type_is_represented_as('integer[]', :string)
+    assert_postgres_sql_type_is_represented_as('text[]', :string)
+    assert_postgres_sql_type_is_represented_as('character[][]', :string)
+  end
+
+  def test_bigint_is_represented_as_integer
+    assert_postgres_sql_type_is_represented_as('bigint', :integer)
+  end
+
+  def test_bit_is_represented_as_string
+    assert_postgres_sql_type_is_represented_as('bit', :string)
+    assert_postgres_sql_type_is_represented_as('bit(10)', :string)
+    assert_postgres_sql_type_is_represented_as('bit varying', :string)
+    assert_postgres_sql_type_is_represented_as('bit varying(7)', :string)
+  end
+
+  def test_boolean_is_represented_as_boolean
+    assert_postgres_sql_type_is_represented_as('boolean', :boolean)
+    # currently not handled
+    # assert_postgres_sql_type_is_represented_as('bool', :boolean)
+  end
+
+  def test_geometric_types_are_represented_as_string
+    assert_postgres_sql_type_is_represented_as('box', :string)
+    assert_postgres_sql_type_is_represented_as('circle', :string)
+    assert_postgres_sql_type_is_represented_as('polygon', :string)
+    assert_postgres_sql_type_is_represented_as('line', :string)
+    assert_postgres_sql_type_is_represented_as('point', :string)
+    assert_postgres_sql_type_is_represented_as('lseg', :string)
+    assert_postgres_sql_type_is_represented_as('path', :string)
+  end
+
+  def test_bytea_is_represented_as_binary
+    assert_postgres_sql_type_is_represented_as('bytea', :binary)
+  end
+
+  def test_varchar_is_represented_as_string
+    assert_postgres_sql_type_is_represented_as('character varying', :string)
+    assert_postgres_sql_type_is_represented_as('character varying(20)', :string)
+    assert_postgres_sql_type_is_represented_as('varchar', :string)
+    assert_postgres_sql_type_is_represented_as('varchar(255)', :string)
+  end
+
+  def test_character_is_represented_as_string
+    assert_postgres_sql_type_is_represented_as('character(23)', :string)
+    assert_postgres_sql_type_is_represented_as('char', :string)
+    assert_postgres_sql_type_is_represented_as('char(2)', :string)
+  end
+
+  def test_cidr_is_represented_as_cidr
+    assert_postgres_sql_type_is_represented_as('cidr', :cidr)
+  end
+
+  def test_date_is_represented_as_date
+    assert_postgres_sql_type_is_represented_as('date', :date)
+  end
+
+  def test_double_precision_is_represented_as_float
+    assert_postgres_sql_type_is_represented_as('double precision', :float)
+    assert_postgres_sql_type_is_represented_as('float8', :float)
+    assert_postgres_sql_type_is_represented_as('float', :float)
+  end
+
+  def test_inet_is_represented_as_inet
+    assert_postgres_sql_type_is_represented_as('inet', :inet)
+  end
+
+  def test_ineger_is_represented_as_integer
+    assert_postgres_sql_type_is_represented_as('integer', :integer)
+    assert_postgres_sql_type_is_represented_as('int', :integer)
+    assert_postgres_sql_type_is_represented_as('int4', :integer)
+  end
+
+  def test_interval_is_represented_as_string
+    assert_postgres_sql_type_is_represented_as('interval', :string)
+    assert_postgres_sql_type_is_represented_as('interval(34)', :string)
+  end
+
+  def test_json_is_represented_as_json
+    assert_postgres_sql_type_is_represented_as('json', :json)
+  end
+
+  def test_macaddr_is_represented_as_macaddr
+    assert_postgres_sql_type_is_represented_as('macaddr', :macaddr)
+  end
+
+  def test_money_is_represented_as_decimal
+    assert_postgres_sql_type_is_represented_as('money', :decimal)
+  end
+
+  def test_numerics_are_represented_as_decimal
+    assert_postgres_sql_type_is_represented_as('decimal', :decimal)
+    assert_postgres_sql_type_is_represented_as('numeric(4, 2)', :decimal)
+    assert_postgres_sql_type_is_represented_as('decimal(10, 3)', :decimal)
+    assert_postgres_sql_type_is_represented_as('numeric(4, 0)', :decimal)
+    assert_postgres_sql_type_is_represented_as('decimal(9, 0)', :decimal)
+  end
+
+  def test_oid_is_represented_as_integer
+    assert_postgres_sql_type_is_represented_as('oid', :integer)
+  end
+
+  def test_real_is_represented_as_float
+    assert_postgres_sql_type_is_represented_as('real', :float)
+    assert_postgres_sql_type_is_represented_as('float4', :float)
+  end
+
+  def test_smallint_is_represented_as_integer
+    assert_postgres_sql_type_is_represented_as('smallint', :integer)
+    assert_postgres_sql_type_is_represented_as('int2', :integer)
+  end
+
+  def test_text_is_represented_as_text
+    assert_postgres_sql_type_is_represented_as('text', :text)
+  end
+
+  def test_time_without_time_zone_is_represented_as_time
+    assert_postgres_sql_type_is_represented_as('time', :time)
+    assert_postgres_sql_type_is_represented_as('time without time zone', :time)
+  end
+
+  def test_time_with_time_zone_is_represented_as_time
+    assert_postgres_sql_type_is_represented_as('time with time zone', :time)
+    assert_postgres_sql_type_is_represented_as('timetz', :time)
+  end
+
+  def test_timestamp_without_time_zone_is_represented_as_datetime
+    # BUG: currently translates to timestamp
+    # assert_postgres_sql_type_is_represented_as('timestamp', :datetime)
+
+    assert_postgres_sql_type_is_represented_as('timestamp without time zone', :datetime)
+  end
+
+  def test_timestamp_with_time_zone_is_represented_as_datetime
+    assert_postgres_sql_type_is_represented_as('timestamp with time zone', :datetime)
+    # BUG: currently translates to timestamp
+    # assert_postgres_sql_type_is_represented_as('timestamptz', :datetime)
+  end
+
+  def test_tsquery_is_not_supported
+    assert_postgres_sql_type_is_represented_as('tsquery', nil)
+  end
+
+  def test_tsvector_is_represented_as_tsvector
+    assert_postgres_sql_type_is_represented_as('tsvector', :tsvector)
+  end
+
+  def test_xml_is_represented_as_xml
+    assert_postgres_sql_type_is_represented_as('xml', :xml)
+  end
+
+  def test_hstore_is_represented_as_hstore
+    assert_postgres_sql_type_is_represented_as('hstore', :hstore)
+  end
+
+  def test_uuid_is_represented_as_uuid
+    assert_postgres_sql_type_is_represented_as('uuid', :uuid)
+  end
+
+  def test_txid_snapshot_is_not_supported
+    assert_postgres_sql_type_is_represented_as('txid_snapshot', nil)
+  end
+
+  private
+  def assert_postgres_sql_type_is_represented_as(sql_type, representation_type)
+    column = ActiveRecord::ConnectionAdapters::PostgreSQLColumn.new("column(#{sql_type})", nil, nil, sql_type)
+    assert_equal representation_type, column.type, "postgres sql type '#{sql_type}' should be represented as '#{representation_type}' but was '#{column.type}'"
+  end
+end


### PR DESCRIPTION
I did this refactoring out of the discussion in #7518. I think it's better to have a minimal amount of duplication between the database adapters. Every adapter should define it's own column mappings and not delegate to a global superclass, which has some knowledge of the different database vendors.

This make the mappings simpler because we just need to care about the datatypes of one vendor and it allows us to issue warnings when unsupported datatypes are detected.
