### PR TITLE
Fixed missing require

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -1,5 +1,6 @@
 require 'set'
 require 'active_support/core_ext/class/attribute_accessors'
+require 'active_support/core_ext/string/starts_ends_with'
 
 module Mime
   class Mimes < Array


### PR DESCRIPTION
Missing require caused fail of guide generation (in
action_dispatch/http/mime_type, line 295, undefined method `ends_with`
for "to_ary":String)
With this fix guides were normally generated
