### PR TITLE
Use internal instance variable naming scheme for mounted URL helpers

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -319,7 +319,7 @@ module ActionDispatch
 
         MountedHelpers.class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
           def #{name}
-            @#{name} ||= _#{name}
+            @_#{name} ||= _#{name}
           end
         RUBY
       end

--- a/actionpack/test/dispatch/prefix_generation_test.rb
+++ b/actionpack/test/dispatch/prefix_generation_test.rb
@@ -57,6 +57,7 @@ module TestGenerationPrefix
             get "/polymorphic_path_for_engine", :to => "outside_engine_generating#polymorphic_path_for_engine"
             get "/polymorphic_with_url_for", :to => "outside_engine_generating#polymorphic_with_url_for"
             get "/conflicting_url", :to => "outside_engine_generating#conflicting"
+            get "/ivar_usage", :to => "outside_engine_generating#ivar_usage"
             root :to => "outside_engine_generating#index"
           end
 
@@ -124,6 +125,11 @@ module TestGenerationPrefix
 
       def conflicting
         render :text => "application"
+      end
+
+      def ivar_usage
+        @blog_engine = "Not the engine route helper"
+        render :text => blog_engine.post_path(:id => 1)
       end
     end
 
@@ -201,6 +207,11 @@ module TestGenerationPrefix
     test "[APP] generating engine's url with url_for(@post)" do
       get "/polymorphic_with_url_for"
       assert_equal "http://example.org/awesome/blog/posts/1", last_response.body
+    end
+
+    test "[APP] instance variable with same name as engine" do
+      get "/ivar_usage"
+      assert_equal "/awesome/blog/posts/1", last_response.body
     end
 
     # Inside any Object


### PR DESCRIPTION
Using the canonical blog example, given an isolated/mounted engine within a module `Blog`, the current behaviour of the mounted URL helpers is to create a method `blog` which sets an instance variable `@blog`.

This effectively prevents the instance variable `@blog` from being usable anywhere else within the application where we also want to refer to the blog engine's routes. For example the home page controller action will raise an error if we assign the `@blog` ivar and then try to refer to `blog.post_path(@blog)`.

The straight-forward fix for this is to name the instance variable for the mounted helpers using internal naming conventions, in this case `@_blog`.
