### PR TITLE
partitioning updates working

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -225,10 +225,10 @@ module ActiveRecord
     # type casted for use in an Arel insert/update method.
     def arel_attributes_with_values(attribute_names)
       attrs = {}
-      arel_table = self.class.arel_table
+      actual_arel_table = arel_table
 
       attribute_names.each do |name|
-        attrs[arel_table[name]] = typecasted_attribute_value(name)
+        attrs[actual_arel_table[name]] = typecasted_attribute_value(name)
       end
       attrs
     end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -73,6 +73,14 @@ module ActiveRecord
         @base = base
       end
 
+      #
+      # Builds a SQL check constraint
+      #
+      # @param [String] constraint a SQL constraint
+      def check_constraint(constraint)
+        @columns << Struct.new(:to_sql).new("CHECK (#{constraint})")
+      end
+
       def xml(*args)
         raise NotImplementedError unless %w{
           sqlite mysql mysql2

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -222,9 +222,7 @@ module ActiveRecord
 
         # Returns the sequence name for a table's primary key or some other specified key.
         def default_sequence_name(table_name, pk = nil) #:nodoc:
-          result = serial_sequence(table_name, pk || 'id')
-          return nil unless result
-          result.split('.').last
+          serial_sequence(table_name, pk || 'id')
         rescue ActiveRecord::StatementInvalid
           "#{table_name}_#{pk || 'id'}_seq"
         end
@@ -304,6 +302,81 @@ module ActiveRecord
           [result.first, result.last]
         rescue
           nil
+        end
+
+        #
+        # Get the next value in a sequence. Used on INSERT operation for
+        # partitioning like by_id because the ID is required before the insert
+        # so that the specific child table is known ahead of time.
+        #
+        # @param [String] sequence_name the name of the sequence to fetch the next value from
+        # @return [Integer] the value from the sequence
+        def next_sequence_value(sequence_name)
+          return execute("select nextval('#{sequence_name}')").field_values("nextval").first.to_i
+        end
+
+        #
+        # Get some next values from a sequence.
+        #
+        # @param [String] sequence_name the name of the sequence to fetch the next values from
+        # @param [Integer] batch_size count of values.
+        # @return [Array<Integer>] an array of values from the sequence
+        def next_sequence_values(sequence_name, batch_size)
+          result = execute("select nextval('#{sequence_name}') from generate_series(1, #{batch_size})")
+          return result.field_values("nextval").map(&:to_i)
+        end
+
+        #
+        # Causes active resource to fetch the primary key for the table (using next_sequence_value())
+        # just before an insert. We need the prefetch to happen but we don't have enough information
+        # here to determine if it should happen, so Relation::insert has been modified to request of
+        # the ActiveRecord::Base derived class if it requires a prefetch.
+        #
+        # @param [String] table_name the table name to query
+        # @return [Boolean] returns true if the table should have its primary key prefetched.
+        def prefetch_primary_key?(table_name)
+          return false
+        end
+
+        #
+        # Creates a schema given a name.
+        #
+        # @param [String] name the name of the schema.
+        # @param [Hash] options ({}) options for creating a schema
+        # @option options [Boolean] :unless_exists (false) check if schema exists.
+        # @return [optional] undefined
+        def create_schema(name, options = {})
+          if options[:unless_exists]
+            return if execute("select count(*) from pg_namespace where nspname = '#{name}'").getvalue(0,0).to_i > 0
+          end
+          execute("CREATE SCHEMA #{name}")
+        end
+
+        #
+        # Drop a schema given a name.
+        #
+        # @param [String] name the name of the schema.
+        # @param [Hash] options ({}) options for dropping a schema
+        # @option options [Boolean] :if_exists (false) check if schema exists.
+        # @option options [Boolean] :cascade (false) drop dependant objects
+        # @return [optional] undefined
+        def drop_schema(name, options = {})
+          if options[:if_exists]
+            return if execute("select count(*) from pg_namespace where nspname = '#{name}'").getvalue(0,0).to_i == 0
+          end
+          execute("DROP SCHEMA #{name}#{' cascade' if options[:cascade]}")
+        end
+
+        #
+        # Add foreign key constraint to table.
+        #
+        # @param [String] referencing_table_name the name of the table containing the foreign key
+        # @param [String] referencing_field_name the name of foreign key column
+        # @param [String] referenced_table_name the name of the table referenced by the foreign key
+        # @param [String] referenced_field_name (:id) the name of the column referenced by the foreign key
+        # @return [optional] undefined
+        def add_foreign_key(referencing_table_name, referencing_field_name, referenced_table_name, referenced_field_name = :id)
+          execute("ALTER TABLE #{referencing_table_name} add foreign key (#{referencing_field_name}) references #{referenced_table_name}(#{referenced_field_name})")
         end
 
         # Returns just a table's primary key

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -28,8 +28,9 @@ module ActiveRecord
           reflection   = belongs_to.find { |e| e.foreign_key.to_s == foreign_key && e.options[:counter_cache].present? }
           counter_name = reflection.counter_cache_column
 
-          stmt = unscoped.where(arel_table[primary_key].eq(object.id)).arel.compile_update({
-            arel_table[counter_name] => object.send(association).count
+          actual_arel_table = arel_table
+          stmt = unscoped.where(actual_arel_table[primary_key].eq(object.id)).arel.compile_update({
+            actual_arel_table[counter_name] => object.send(association).count
           })
           connection.update stmt
         end

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -123,7 +123,7 @@ module ActiveRecord
             column      = self.class.columns_hash[column_name]
             substitute  = connection.substitute_at(column, relation.bind_values.length)
 
-            relation = relation.where(self.class.arel_table[column_name].eq(substitute))
+            relation = relation.where(arel_table[column_name].eq(substitute))
             relation.bind_values << [column, self[column_name].to_i]
           end
 

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -50,6 +50,11 @@ module ActiveRecord
       # If true, the default table name for a Product class will be +products+. If false, it would just be +product+.
       # See table_name for the full rules on table/class naming. This is true, by default.
       config_attribute :pluralize_table_names
+
+      def table_name
+        symbolized_attributes = attributes.symbolize_keys
+        return self.class.table_name(*self.class.table_partition_keys.map{|attribute_name| symbolized_attributes[attribute_name]})
+      end
     end
 
     module ClassMethods
@@ -108,7 +113,7 @@ module ActiveRecord
       #     end
       #   end
       #   Post.table_name # => "special_posts"
-      def table_name
+      def table_name(*table_partition_key_values)
         reset_table_name unless defined?(@table_name)
         @table_name
       end
@@ -131,7 +136,7 @@ module ActiveRecord
 
         @table_name        = value
         @quoted_table_name = nil
-        @arel_table        = nil
+        reset_arel_table
         @sequence_name     = nil unless defined?(@explicit_sequence_name) && @explicit_sequence_name
         @relation          = Relation.new(self, arel_table)
       end
@@ -165,6 +170,97 @@ module ActiveRecord
       def inheritance_column=(value)
         @inheritance_column = value.to_s
         @explicit_inheritance_column = true
+      end
+
+      #
+      # Returns an array of attribute names (strings) used to fetch the key value(s)
+      # the determine this specific partition table.
+      #
+      # @return [String] the column name used to partition this table
+      # @return [Array<String>] the column names used to partition this table
+      def table_partition_keys
+        return []
+      end
+
+      #
+      # The specific values for a partition of this active record's type which are defined by
+      # {#self.table_partition_keys}
+      #
+      # @param [Hash] values key/value pairs to extract values from
+      # @return [Object] value of partition key
+      # @return [Array<Object>] values of partition keys
+      def table_partition_key_values(values)
+        symbolized_values = values.symbolize_keys
+        return self.table_partition_keys.map{|key| symbolized_values[key.to_sym]}
+      end
+
+      #
+      # This scoping is used to target the
+      # active record find() to a specific child table and alias it to the name of the
+      # parent table (so activerecord can generally work with it)
+      #
+      # Use as:
+      #
+      #   Foo.from_partition(KEY).find(:first)
+      #
+      # where KEY is the key value(s) used as the check constraint on Foo's table.
+      #
+      # @param [*Array<Object>] partition_field the field values to partition on
+      # @return [Hash] the scoping
+      def from_partition(*partition_field)
+        table_alias_name = table_alias_name(*partition_field)
+        from("#{table_name(*partition_field)} AS #{table_alias_name}").
+          tap{|relation| relation.table.table_alias = table_alias_name}
+      end
+
+      #
+      # This scope is used to target the
+      # active record find() to a specific child table. Is probably best used in advanced
+      # activerecord queries when a number of tables are involved in the query.
+      #
+      # Use as:
+      #
+      #   Foo.from_partitioned_without_alias(KEY).find(:all, :select => "*")
+      #
+      # where KEY is the key value(s) used as the check constraint on Foo's table.
+      #
+      # it's not obvious why :select => "*" is supplied.  note activerecord wants
+      # to use the name of parent table for access to any attributes, so without
+      # the :select argument the sql result would be something like:
+      #
+      #   SELECT foos.* FROM foos_partitions.pXXX
+      #
+      # which fails because table foos is not referenced.  using the form #from_partition
+      # is almost always the correct thing when using activerecord.
+      #
+      # Because the scope is specific to a class (a class method) but unlike
+      # class methods is not inherited, one  must use this form (#from_partitioned_without_alias) instead
+      # of #from_partitioned_without_alias_scope to get the most derived classes specific active record scope.
+      #
+      # @param [*Array<Object>] partition_field the field values to partition on
+      # @return [Hash] the scoping
+      def from_partitioned_without_alias(*partition_field)
+        table_alias_name = table_name(*partition_field)
+        from(table_alias_name).
+          tap{|relation| relation.table.table_alias = table_alias_name}
+      end
+
+      def table_alias_name(*partition_field)
+        return table_name(*partition_field)
+      end
+
+      #
+      # partitioning needs to be able to specify if 
+      # we should prefetch the primary key (to determine
+      # the specific table we will insert in to we
+      # need to know the partition key values.
+      #
+      # this needs to be on the model NOT the connection
+      #
+      # for the simple case we just pass the question on to
+      # the connection
+      def prefetch_primary_key?
+        connection.prefetch_primary_key?(table_name)
       end
 
       def sequence_name

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -113,7 +113,7 @@ module ActiveRecord
     # callbacks, Observer methods, or any <tt>:dependent</tt> association
     # options, use <tt>#destroy</tt>.
     def delete
-      self.class.delete(id) if persisted?
+      self.class.from_partition(*self.class.table_partition_key_values(attributes)).delete(id) if persisted?
       @destroyed = true
       freeze
     end
@@ -303,9 +303,9 @@ module ActiveRecord
 
       fresh_object =
         if options && options[:lock]
-          self.class.unscoped { self.class.lock.find(id) }
+          self.class.unscoped { self.class.lock.from_partition(*self.class.table_partition_key_values(attributes)).find(id) }
         else
-          self.class.unscoped { self.class.find(id) }
+          self.class.unscoped { self.class.from_partition(*self.class.table_partition_key_values(attributes)).find(id) }
         end
 
       @attributes.update(fresh_object.instance_variable_get('@attributes'))
@@ -372,7 +372,7 @@ module ActiveRecord
       substitute = connection.substitute_at(column, 0)
 
       relation = self.class.unscoped.where(
-        self.class.arel_table[pk].eq(substitute))
+        arel_table[pk].eq(substitute))
 
       relation.bind_values = [[column, id]]
       relation
@@ -390,13 +390,24 @@ module ActiveRecord
       attributes_with_values = arel_attributes_with_values_for_update(attribute_names)
       return 0 if attributes_with_values.empty?
       klass = self.class
-      stmt = klass.unscoped.where(klass.arel_table[klass.primary_key].eq(id)).arel.compile_update(attributes_with_values)
+      actual_arel_table = arel_table
+      # This is pretty hacky: we adjust the attributes so they are connected to the correct arel_table
+      # we can do this in two places and I've chosen here (which seems less intrusive).
+      # Alternatively we could hook into any attribute change (model.created_at = Time.now.utc) and
+      # adjust all arel_tables in all attributes when any of this model's partition key values change.
+      # That seems like a lot of work.
+      attributes_with_values = Hash[*attributes_with_values.map{|k,v| [actual_arel_table[k.name], v]}.flatten]
+      stmt = klass.unscoped.where(actual_arel_table[klass.primary_key].eq(id)).arel.compile_update(attributes_with_values)
       klass.connection.update stmt
     end
 
     # Creates a record with values matching those of the instance attributes
     # and returns its id.
     def create
+      if self.id.nil? && self.class.prefetch_primary_key?
+        self.id = connection.next_sequence_value(self.class.sequence_name)
+      end
+
       attributes_values = arel_attributes_with_values_for_create(!id.nil?)
 
       new_id = self.class.unscoped.insert attributes_values

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -41,12 +41,12 @@ module ActiveRecord
 
         if !primary_key_value && connection.prefetch_primary_key?(klass.table_name)
           primary_key_value = connection.next_sequence_value(klass.sequence_name)
-          values[klass.arel_table[klass.primary_key]] = primary_key_value
+          values[arel_table[klass.primary_key]] = primary_key_value
         end
       end
 
       im = arel.create_insert
-      im.into @table
+      im.into arel_table(Hash[*values.map{|k,v| [k.name,v]}.flatten])
 
       conn = @klass.connection
 

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -57,7 +57,7 @@ module ActiveRecord
           array_predicates << values_predicate
           array_predicates.inject { |composite, predicate| composite.or(predicate) }
         when ActiveRecord::Relation
-          value = value.select(value.klass.arel_table[value.klass.primary_key]) if value.select_values.empty?
+          value = value.select(value.arel_table[value.klass.primary_key]) if value.select_values.empty?
           attribute.in(value.arel.ast)
         when Range
           attribute.in(value)


### PR DESCRIPTION
basic work for supporting partitioned tables in postgresql

these changes are associated with this pull request: https://github.com/rails/rails/pull/7573
which were changes associated with rails 3.2.8.

If I were to sum up the work, it would be:
- provide an instance method arel_table used for any operation that has access to the instance should use the instance method to acquire an arel_table associated with the current models attributes.
- alter class method arel_table to handle parameters, with no parameters do original work -- with parameters associate the table with the specific partitioned table determined by key attributes
- provide methods to manage key attributes and values (these are the fields the db table is partitioned on)
- provide an instance method table_name which calls the altered class method table_name which now takes attribute values that should determine the specific partitioned table to name
- bunch of helper methods in postgresql connection area associated with schema management.  this is for reasons 1) create_schema seems like a useful method, 2) adding foreign key is needed because in postgres child partitions need to manage the foreign key references, 3) some sequence method changes to support tables in non-public (well non search path) schema: this is probably generally useful work as rails seems broken about non-public schemas
- change any self.class.arel_table to self.arel_table
- create is a little weird because it needs to acquire the primary key if it isn't supplied (for instance ID where your need to fetch from the sequence -- for this work to be complete we need to supply the model instance method "prefetch_primary_key?" instead of it being on connection since prefetching isn't needed for any tables that aren't partitioned by a primary key)
- some helper methods for finds (from_partition(*x)) which we've found useful in our day to day coding.  this method just sets the table name (this is useful because find from the parent table even when partition keys are provided can take an inordinate time if the number of child tables is large -- so specifying the specific child table is useful).

the rest of the code to support partitioning is here: https://github.com/fiksu/partitioned/tree/rails-3-2-8-patching -- you'll need to pull from that branch (which doesn't try to patch rails -- so use it with this pull request).  the master branch patches rails 3.2.8 correctly -- you can use it on your own.  The current rubygem of partitioned patches rails in a different (and more conservative way) -- I don't think you should look at that code.

You could probably remove a bunch of stuff to make this code faster for the common non-partitioned case.
- instance arel_table could just call class method arel_table
- self.class.arel_table could just do the old work
- instance table_name could just call class method table_name which did just the old work

then one might provide fixups for those methods for models where partitioning is desired.

I think the ugliest part of this code is update -- although I haven't walked down this path, it would seem the best way to manage this would be to add a hook to attribute modifications and fix up the all arel_tables that the attributes point to if the partitioned key values changes

I'm willing to help in any way that makes sense to support partitioning in a future rails version.
