### PR TITLE
Fixes _field_changed? 

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -64,6 +64,10 @@
 
     *Damien Mathieu*
 
+*   Fix *_changed? behavior of columns when assigning various strings to a numerical field originally containing 0.
+
+    *Bertrand Kuo*
+
 *   Fix creation of through association models when using `collection=[]`
     on a `has_many :through` association from an unsaved model.
     Fix #7661.

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -75,29 +75,13 @@ module ActiveRecord
 
       def _field_changed?(attr, old, value)
         if column = column_for_attribute(attr)
-          if column.number? && (changes_from_nil_to_empty_string?(column, old, value) ||
-                                changes_from_zero_to_string?(old, value))
-            value = nil
-          else
-            value = column.type_cast(value)
-          end
+          # We consider the field changed if the new value after type-casting is different from the old value
+          value = column.type_cast(column.type_cast_for_write(value))
         end
 
         old != value
       end
 
-      def changes_from_nil_to_empty_string?(column, old, value)
-        # For nullable numeric columns, NULL gets stored in database for blank (i.e. '') values.
-        # Hence we don't record it as a change if the value changes from nil to ''.
-        # If an old value of 0 is set to '' we want this to get changed to nil as otherwise it'll
-        # be typecast back to 0 (''.to_i => 0)
-        column.null && (old.nil? || old == 0) && value.blank?
-      end
-
-      def changes_from_zero_to_string?(old, value)
-        # For columns with old 0 and value non-empty string
-        old == 0 && value.is_a?(String) && value.present? && value != '0'
-      end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -70,7 +70,7 @@ module ActiveRecord
         type == :binary
       end
 
-      # Casts a Ruby value to something appropriate for writing to the database.
+      # If column is numerical, then casts the Ruby value to something appropriate for writing into a numerical column.
       def type_cast_for_write(value)
         return value unless number?
 

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -225,6 +225,26 @@ class DirtyTest < ActiveRecord::TestCase
     assert !pirate.changed?
   end
 
+  def test_integer_zero_to_string_non_zero_not_marked_as_changed
+    pirate = Pirate.new
+    pirate.parrot_id = 0
+    pirate.catchphrase = 'arrr'  # Casts to 0
+    assert pirate.save!
+
+    assert !pirate.changed?
+
+    pirate.parrot_id = 'arrr'    # Casts to 0
+    assert !pirate.changed?
+
+    pirate.parrot_id = '123arrr' # Casts to 123
+    assert pirate.changed?
+
+    pirate.parrot_id = 'arrr123'  # Casts to 0
+    assert !pirate.changed?
+
+    pirate.parrot_id = ''        # Casts to nil
+    assert pirate.changed?
+  end
 
   def test_zero_to_blank_marked_as_changed
     pirate = Pirate.new

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -803,9 +803,15 @@ module NestedAttributesOnACollectionAssociationTests
     repair_validations(Interest) do
       Interest.validates_numericality_of(:zine_id)
       man = Man.create(name: 'John')
-      interest = man.interests.create(topic: 'bar', zine_id: 0)
+      interest = man.interests.build(topic: 'bar', zine_id: 0)
       assert interest.save
-      assert !man.update_attributes({interests_attributes: { id: interest.id, zine_id: 'foo' }})
+      man.assign_attributes( {interests_attributes: { id: interest.id, zine_id: 'foo' }})
+      assert !man.interests.first.changed?
+      assert !man.interests.first.zine_id_changed?
+      man.assign_attributes( {interests_attributes: { id: interest.id, zine_id: '' }})
+      assert man.interests.first.changed?
+      assert man.interests.first.zine_id_changed?
+      assert man.update_attributes({interests_attributes: { id: interest.id, zine_id: 'foo' }})
     end
   end
 


### PR DESCRIPTION
When a non-empty string that casts to zero is assigned to a number column already containing zero, then _field_changed?  should not become true.
