### PR TITLE
Rake assets:precompile shouldn't fail quietly.

### DIFF
--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -19,13 +19,10 @@ module ApplicationTests
 
     def precompile!(env = nil)
       quietly do
-        precompile_task = 'bundle exec rake assets:precompile'
-        precompile_task += ' ' + env if env
-        out = Dir.chdir(app_path){  %x[ #{precompile_task} ] }
-        assert $?.exitstatus == 0,
-               "#{precompile_task} has failed: #{out}.\
-                Probably you didn't install JavaScript runtime."
-        return out
+        precompile_task = "bundle exec rake assets:precompile #{env} 2>&1"
+        output = Dir.chdir(app_path) { %x[ #{precompile_task} ] }
+        assert $?.success?, output
+        output
       end
     end
 


### PR DESCRIPTION
Current realization refactored because there's no sense to capture output in quiet block.

I added commented block in code with my thoughts about this. Since rake task should be always invoked successfully we can check exit status and show to user original error instead of showing "Probably you didn't install JavaScript runtime". I'd like to use capture(:stderr) but it's not impossible because it doesn't reopen $std{out,err} and just reassigns it, that does impossible to capture subprocesses.
