### PR TITLE
Fixes _field_changed?

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -4,6 +4,10 @@
 
     *Akira Matsuda*, backported by *Steve Klabnik*
 
+*   Fix *_changed? behavior of columns when assigning various strings to a numerical field originally containing 0.
+
+    *Bertrand Kuo*
+
 *   Fix creation of through association models when using `collection=[]`
     on a `has_many :through` association from an unsaved model.
     Fix #7661.

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -225,6 +225,26 @@ class DirtyTest < ActiveRecord::TestCase
     assert !pirate.changed?
   end
 
+  def test_integer_zero_to_string_non_zero_not_marked_as_changed
+    pirate = Pirate.new
+    pirate.parrot_id = 0
+    pirate.catchphrase = 'arrr'  # Casts to 0
+    assert pirate.save!
+
+    assert !pirate.changed?
+
+    pirate.parrot_id = 'arrr'    # Casts to 0
+    assert !pirate.changed?
+
+    pirate.parrot_id = '123arrr' # Casts to 123
+    assert pirate.changed?
+
+    pirate.parrot_id = 'arrr123'  # Casts to 0
+    assert !pirate.changed?
+
+    pirate.parrot_id = ''        # Casts to nil
+    assert pirate.changed?
+  end
 
   def test_zero_to_blank_marked_as_changed
     pirate = Pirate.new

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -774,12 +774,20 @@ module NestedAttributesOnACollectionAssociationTests
 
   def test_numeric_colum_changes_from_zero_to_no_empty_string
     Man.accepts_nested_attributes_for(:interests)
-    Interest.validates_numericality_of(:zine_id)
-    man = Man.create(:name => 'John')
-    interest = man.interests.create(:topic=>'bar',:zine_id => 0)
-    assert  interest.save
 
-    assert  !man.update_attributes({:interests_attributes => { :id => interest.id, :zine_id => 'foo' }})
+    repair_validations(Interest) do
+      Interest.validates_numericality_of(:zine_id)
+      man = Man.create(name: 'John')
+      interest = man.interests.build(topic: 'bar', zine_id: 0)
+      assert interest.save
+      man.assign_attributes( {interests_attributes: { id: interest.id, zine_id: 'foo' }})
+      assert !man.interests.first.changed?
+      assert !man.interests.first.zine_id_changed?
+      man.assign_attributes( {interests_attributes: { id: interest.id, zine_id: '' }})
+      assert man.interests.first.changed?
+      assert man.interests.first.zine_id_changed?
+      assert man.update_attributes({interests_attributes: { id: interest.id, zine_id: 'foo' }})
+    end
   end
 
   private


### PR DESCRIPTION
When a non-empty string that casts to zero is assigned to a number column already containing zero, then _field_changed? should not become true.

Fixes a bug(?)  introduced some time in 3.2
(It is working in 3.0.15, but broken in 3.2.8)
