### PR TITLE
ConnectionPool, unify exceptions, ConnectionTimeoutError

### DIFF
--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -89,7 +89,7 @@ module ActiveRecord
       end
 
       def test_full_pool_exception
-        assert_raises(PoolFullError) do
+        assert_raises(ConnectionTimeoutError) do
           (@pool.size + 1).times do
             @pool.checkout
           end


### PR DESCRIPTION
As a result of different commits, ConnectionPool had become
of two minds about exceptions, sometimes using PoolFullError
and sometimes using ConnectionTimeoutError. In fact, it was
using ConnectionTimeoutError internally, but then recueing
and re-raising as a PoolFullError.

There's no reason for this bifurcation, standardize on
ConnectionTimeoutError, which is the rails2 name and still
accurately describes semantics at this point.

History

In Rails2, ConnectionPool raises a ConnectionTimeoutError if
it can't get a connection within timeout.

Originally in master/rails3, @tenderlove had planned on removing
wait/blocking in connectionpool entirely, at that point he changed
exception to PoolFullError.

But then later wait/blocking came back, but exception remained
PoolFullError.

Then in 02b233556377 pmahoney introduced fair waiting logic, and
brought back ConnectionTimeoutError, introducing the weird bifurcation.

ConnectionTimeoutError accurately describes semantics as of this
point, and is backwards compat with rails2, there's no reason
for PoolFullError to be introduced, and no reason for two
different exception types to be used internally, no reason
to rescue one and re-raise as another.  Unify!
