### PR TITLE
Backported #7572 to 3-2-stable. Use config['encoding'], because database configuration use not charset but encoding.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## Rails 3.2.9 (unreleased)
+*   Use config['encoding'] instead of config['charset'] when executing
+    databases.rake in the mysql/mysql2. A correct option for a database.yml
+    is 'encoding'.
+
+    *kennyj*
+
 *   Fix ConnectionAdapters::Column.type_cast_code integer conversion,
     to always convert values to integer calling #to_i. Fixes #7509.
 

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -44,7 +44,7 @@ db_namespace = namespace :db do
   def mysql_creation_options(config)
     @charset   = ENV['CHARSET']   || 'utf8'
     @collation = ENV['COLLATION'] || 'utf8_unicode_ci'
-    {:charset => (config['charset'] || @charset), :collation => (config['collation'] || @collation)}
+    {:charset => (config['encoding'] || @charset), :collation => (config['collation'] || @collation)}
   end
 
   def create_database(config)
@@ -96,8 +96,8 @@ db_namespace = namespace :db do
             ActiveRecord::Base.establish_connection(config)
           else
             $stderr.puts sqlerr.error
-            $stderr.puts "Couldn't create database for #{config.inspect}, charset: #{config['charset'] || @charset}, collation: #{config['collation'] || @collation}"
-            $stderr.puts "(if you set the charset manually, make sure you have a matching collation)" if config['charset']
+            $stderr.puts "Couldn't create database for #{config.inspect}, charset: #{config['encoding'] || @charset}, collation: #{config['collation'] || @collation}"
+            $stderr.puts "(if you set the charset manually, make sure you have a matching collation)" if config['encoding']
           end
         end
       when /postgresql/


### PR DESCRIPTION
Related to #7572.

cc/  @rafaelfranca

Updated:
If we don't merge this, we should add a changelog entry about #7572 to master.
