### PR TITLE
How to use the "type" column without STI

### DIFF
--- a/activerecord/lib/active_record/model.rb
+++ b/activerecord/lib/active_record/model.rb
@@ -103,9 +103,19 @@ module ActiveRecord
       def abstract_class?
         false
       end
-      
+
       # Defines the name of the table column which will store the class name on single-table
       # inheritance situations.
+      #
+      # The default inheritance column name is +type+, which means it's a
+      # reserved word inside Active Record. To be able to use single-table
+      # inheritance with another column name, or to use the column +type+ in
+      # your own model for something else, you can override this method to
+      # return a different name:
+      #
+      #   def self.inheritance_column
+      #     'zoink'
+      #   end
       def inheritance_column
         'type'
       end


### PR DESCRIPTION
I've added additional comments on how to use the "type" column without STI by overriding it in your ActiveRecord Model.
