### PR TITLE
Warn when generator cannot load

### DIFF
--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -299,8 +299,8 @@ module Rails
             begin
               path = path.sub("#{base}/", "")
               require path
-            rescue Exception
-              # No problem
+            rescue Exception => e
+              warn "[WARNING] Could not load generator #{path.inspect}. Error: #{e.message}.\n#{e.backtrace.join("\n")}"
             end
           end
         end


### PR DESCRIPTION
[close #6217]  If a generator has an error we should display that error rather than swallowing it while allowing other generator sot be listed. This is useful while developing a generator.

ATP Railties
