### PR TITLE
warning removed.

### DIFF
--- a/actionpack/test/fixtures/ruby_template.rb
+++ b/actionpack/test/fixtures/ruby_template.rb
@@ -1,3 +1,2 @@
 body = ""
 body << ["Hello", "from", "Ruby", "code"].join(" ")
-body

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -424,7 +424,6 @@ module ActiveRecord
         elsif @connections.size < @size
           checkout_new_connection
         else
-          t0 = Time.now
           @available.poll(@checkout_timeout)
         end
       end


### PR DESCRIPTION
1. Unused variable
2. possibly useless use of a variable in 
   void context
