### PR TITLE
Always encode double quotes in HTML attributes values.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Ensure TagHelper#tag always encodes double quotes in HTML attribute values. *Joshua Flanagan*
+
 *   Add .rb template handler, this handler simply allows arbitrary Ruby code as a template. *Guillermo Iguaran*
 
 *   Add `separator` option for `ActionView::Helpers::TextHelper#excerpt`:

--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -166,7 +166,7 @@ module ActionView
         def tag_option(key, value, escape)
           value = value.join(" ") if value.is_a?(Array)
           value = ERB::Util.h(value) if escape
-          %(#{key}="#{value}")
+          %(#{key}="#{value.gsub('"', ERB::Util::HTML_ESCAPE['"'])}")
         end
     end
   end

--- a/actionpack/test/template/tag_helper_test.rb
+++ b/actionpack/test/template/tag_helper_test.rb
@@ -106,6 +106,20 @@ class TagHelperTest < ActionView::TestCase
     end
   end
 
+  def test_tag_always_encodes_double_quotes_in_attribute_value_when_escaping_enabled
+    ['completely "untrusted"', 'supposedly "safe"'.html_safe].each do |has_quotes|
+      assert_equal %(<input value="#{has_quotes.gsub(/"/, '&quot;')}" />),
+        tag('input', {:value => has_quotes}, false, true)
+    end
+  end
+
+  def test_tag_always_encodes_double_quotes_in_attribute_value_when_escaping_disabled
+    ['completely "untrusted"', 'supposedly "safe"'.html_safe].each do |has_quotes|
+      assert_equal %(<input value="#{has_quotes.gsub(/"/, '&quot;')}" />),
+        tag('input', {:value => has_quotes}, false, false)
+    end
+  end
+
   def test_skip_invalid_escaped_attributes
     ['&1;', '&#1dfa3;', '& #123;'].each do |escaped|
       assert_equal %(<a href="#{escaped.gsub(/&/, '&amp;')}" />), tag('a', :href => escaped)
@@ -118,8 +132,8 @@ class TagHelperTest < ActionView::TestCase
 
   def test_data_attributes
     ['data', :data].each { |data|
-      assert_dom_equal '<a data-a-float="3.14" data-a-big-decimal="-123.456" data-a-number="1" data-array="[1,2,3]" data-hash="{&quot;key&quot;:&quot;value&quot;}" data-string="hello" data-symbol="foo" />',
-        tag('a', { data => { :a_float => 3.14, :a_big_decimal => BigDecimal.new("-123.456"), :a_number => 1, :string => 'hello', :symbol => :foo, :array => [1, 2, 3], :hash => { :key => 'value'} } })
+      assert_dom_equal '<a data-a-float="3.14" data-a-big-decimal="-123.456" data-a-number="1" data-array="[1,2,3]" data-hash="{&quot;key&quot;:&quot;value&quot;}" data-safe-string-with-quote="supposedly &quot;safe&quot;" data-string-with-quote="completely &quot;harmless&quot;" data-string="hello" data-symbol="foo" />',
+        tag('a', { data => { :a_float => 3.14, :a_big_decimal => BigDecimal.new("-123.456"), :a_number => 1, :string => 'hello', :string_with_quote => 'completely "harmless"', :safe_string_with_quote => 'supposedly "safe"'.html_safe, :symbol => :foo, :array => [1, 2, 3], :hash => { :key => 'value'} } })
     }
   end
 end


### PR DESCRIPTION
HTML tags generated by `TagHelper#tag` always enclose their attribute values in double quotes ("). Therefore, it never makes sense to allow an unescaped double quote within an attribute value. It shouldn't matter if the attribute value is a `SafeBuffer` (html_safe). It shouldn't matter if the `escape` parameter is `false`. No matter what the caller provides as an attribute value, `#tag` should ensure the HTML it generates properly encloses that value in double quotes.

This is an example failing test:

```
def test_not_really_safe
  assert_equal %(<input value="supposedly &quot;safe&quot;" />), tag('input', :value => 'supposedly "safe"'.html_safe)
  # generates: <input value="supposedly "safe"" />, and the browser will see the value as "supposedly "
end
```

Closes issue #7609 (previous pull request sent for 3.2 stable branch)
