### PR TITLE
Fix build Rails.queue

### DIFF
--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -26,6 +26,7 @@ require 'active_model'
 require 'active_record'
 require 'action_controller/caching'
 require 'action_controller/caching/sweeping'
+require 'rails/queueing'
 
 require 'pp' # require 'pp' early to prevent hidden_methods from not picking up the pretty-print methods until too late
 
@@ -34,6 +35,11 @@ module Rails
     def env
       @_env ||= ActiveSupport::StringInquirer.new(ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "test")
     end
+
+    def queue
+      @queue ||= Rails::Queueing::Container.new(Rails::Queueing::SynchronousQueue.new)
+    end
+
   end
 end
 


### PR DESCRIPTION
see 34b23e7110a3a13cf157608cefc9b5701017bf39

``` ruby


  1) Error:
test_assert_select_email(AssertSelectTest):
NoMethodError: undefined method `queue' for Rails:Module
    /Users/arunagw/checkouts/rails/actionmailer/lib/action_mailer/base.rb:491:in `queue'
    /Users/arunagw/checkouts/rails/actionmailer/lib/action_mailer/base.rb:484:in `method_missing'
    /Users/arunagw/checkouts/rails/actionpack/test/controller/assert_select_test.rb:319:in `test_assert_select_email'

  2) Error:
test_assert_select_email_multipart(AssertSelectTest):
NoMethodError: undefined method `queue' for Rails:Module
    /Users/arunagw/checkouts/rails/actionmailer/lib/action_mailer/base.rb:491:in `queue'
    /Users/arunagw/checkouts/rails/actionmailer/lib/action_mailer/base.rb:484:in `method_missing'
    /Users/arunagw/checkouts/rails/actionpack/test/controller/assert_select_test.rb:329:in `test_assert_select_email_multipart'

3949 tests, 16952 assertions, 0 failures, 2 errors, 0 skips
rake aborted!
Command failed with status (1): [/Users/arunagw/.rvm/rubies/ruby-1.9.3-p194...]


```

This PR fixes above failures.
