### PR TITLE
Nice and easy delegation to the class

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -123,6 +123,9 @@ class Module
     file, line = caller.first.split(':', 2)
     line = line.to_i
 
+    to = to.to_s
+    to = 'self.class' if to == 'class'
+
     methods.each do |method|
       # Attribute writer methods only accept one argument. Makes sure []=
       # methods still accept two arguments.

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -34,6 +34,12 @@ class Someone < Struct.new(:name, :place)
   delegate :street, :city, :to_f, :to => :place
   delegate :name=, :to => :place, :prefix => true
   delegate :upcase, :to => "place.city"
+  delegate :table_name, :to => :class
+  delegate :table_name, :to => :class, :prefix => true
+
+  def self.table_name
+    'some_table'
+  end
 
   FAILED_DELEGATE_LINE = __LINE__ + 1
   delegate :foo, :to => :place
@@ -109,6 +115,11 @@ class ModuleTest < ActiveSupport::TestCase
   def test_delegation_to_instance_variable
     david = Name.new("David", "Hansson")
     assert_equal "DAVID HANSSON", david.upcase
+  end
+
+  def test_delegation_to_class_method
+    assert_equal 'some_table', @david.table_name
+    assert_equal 'some_table', @david.class_table_name
   end
 
   def test_missing_delegation_target


### PR DESCRIPTION
Simple patch to allow delegation to class. With it, one can:

```
class FooFeatureController < ActionController::Base
  def self.feature_name
    controller_name.sub /_feature$/, ''
  end
  # In the same way that controller_name is available from the instances too:
  delegate :feature_name, :to => :class
end
```

Without it, one gets a relatively obscure syntax error message.

```
rails/activesupport/lib/active_support/core_ext/module/delegation.rb:142:in `module_eval': test/core_ext/module_test.rb:37: syntax error, unexpected '.' (SyntaxError)
            class.table_name(*args, &block)    ...
                  ^
test/core_ext/module_test.rb:39: syntax error, unexpected '.'
            if class.nil?                         ...
                     ^
test/core_ext/module_test.rb:44: syntax error, unexpected keyword_end, expecting $end
          end                                                 # end
             ^
```

It's already possible to use `delegate :foo, :to => 'self.class'` but that is less obvious (and also won't give the expected result with `:prefix => true`)
