### PR TITLE
add --skip-ignore and --skip-keeps options to generators.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Change `rails new` and `rails plugin new` generators to name the `.gitkeep` files
+    as `.keep` in a more SCM-agnostic way.
+
+    Change `--skip-git` option to only skip the `.gitignore` file and still generate
+    the `.keep` files.
+
+    Add `--skip-keeps` option to skip the `.keep` files.
+
+    *Derek Prior & Francesco Rodriguez*
+
 *   Fixed support for DATABASE_URL environment variable for rake db tasks. *Grace Liu*
 
 *   rails dbconsole now can use SSL for MySQL. The database.yml options sslca, sslcert, sslcapath, sslcipher,

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -16,53 +16,56 @@ module Rails
       attr_accessor :rails_template
       add_shebang_option!
 
-      argument :app_path,               :type => :string
+      argument :app_path, type: :string
 
       def self.add_shared_options_for(name)
-        class_option :builder,            :type => :string, :aliases => "-b",
-                                          :desc => "Path to a #{name} builder (can be a filesystem path or URL)"
+        class_option :builder,            type: :string, aliases: '-b',
+                                          desc: "Path to a #{name} builder (can be a filesystem path or URL)"
 
-        class_option :template,           :type => :string, :aliases => "-m",
-                                          :desc => "Path to an #{name} template (can be a filesystem path or URL)"
+        class_option :template,           type: :string, aliases: '-m',
+                                          desc: "Path to an #{name} template (can be a filesystem path or URL)"
 
-        class_option :skip_gemfile,       :type => :boolean, :default => false,
-                                          :desc => "Don't create a Gemfile"
+        class_option :skip_gemfile,       type: :boolean, default: false,
+                                          desc: "Don't create a Gemfile"
 
-        class_option :skip_bundle,        :type => :boolean, :default => false,
-                                          :desc => "Don't run bundle install"
+        class_option :skip_bundle,        type: :boolean, default: false,
+                                          desc: "Don't run bundle install"
 
-        class_option :skip_git,           :type => :boolean, :aliases => "-G", :default => false,
-                                          :desc => "Skip Git ignores and keeps"
+        class_option :skip_git,           type: :boolean, aliases: '-G', default: false,
+                                          desc: 'Skip .gitignore file'
 
-        class_option :skip_active_record, :type => :boolean, :aliases => "-O", :default => false,
-                                          :desc => "Skip Active Record files"
+        class_option :skip_keeps,         type: :boolean, default: false,
+                                          desc: 'Skip source control .keep files'
 
-        class_option :skip_sprockets,     :type => :boolean, :aliases => "-S", :default => false,
-                                          :desc => "Skip Sprockets files"
+        class_option :skip_active_record, type: :boolean, aliases: '-O', default: false,
+                                          desc: 'Skip Active Record files'
 
-        class_option :database,           :type => :string, :aliases => "-d", :default => "sqlite3",
-                                          :desc => "Preconfigure for selected database (options: #{DATABASES.join('/')})"
+        class_option :skip_sprockets,     type: :boolean, aliases: '-S', default: false,
+                                          desc: 'Skip Sprockets files'
 
-        class_option :javascript,         :type => :string, :aliases => '-j', :default => 'jquery',
-                                          :desc => 'Preconfigure for selected JavaScript library'
+        class_option :database,           type: :string, aliases: '-d', default: 'sqlite3',
+                                          desc: "Preconfigure for selected database (options: #{DATABASES.join('/')})"
 
-        class_option :skip_javascript,    :type => :boolean, :aliases => "-J", :default => false,
-                                          :desc => "Skip JavaScript files"
+        class_option :javascript,         type: :string, aliases: '-j', default: 'jquery',
+                                          desc: 'Preconfigure for selected JavaScript library'
 
-        class_option :skip_index_html,    :type => :boolean, :aliases => "-I", :default => false,
-                                          :desc => "Skip public/index.html and app/assets/images/rails.png files"
+        class_option :skip_javascript,    type: :boolean, aliases: '-J', default: false,
+                                          desc: 'Skip JavaScript files'
 
-        class_option :dev,                :type => :boolean, :default => false,
-                                          :desc => "Setup the #{name} with Gemfile pointing to your Rails checkout"
+        class_option :skip_index_html,    type: :boolean, aliases: '-I', default: false,
+                                          desc: 'Skip public/index.html and app/assets/images/rails.png files'
 
-        class_option :edge,               :type => :boolean, :default => false,
-                                          :desc => "Setup the #{name} with Gemfile pointing to Rails repository"
+        class_option :dev,                type: :boolean, default: false,
+                                          desc: "Setup the #{name} with Gemfile pointing to your Rails checkout"
 
-        class_option :skip_test_unit,     :type => :boolean, :aliases => "-T", :default => false,
-                                          :desc => "Skip Test::Unit files"
+        class_option :edge,               type: :boolean, default: false,
+                                          desc: "Setup the #{name} with Gemfile pointing to Rails repository"
 
-        class_option :help,               :type => :boolean, :aliases => "-h", :group => :rails,
-                                          :desc => "Show this help message and quit"
+        class_option :skip_test_unit,     type: :boolean, aliases: '-T', default: false,
+                                          desc: 'Skip Test::Unit files'
+
+        class_option :help,               type: :boolean, aliases: '-h', group: :rails,
+                                          desc: 'Show this help message and quit'
       end
 
       def initialize(*args)
@@ -261,13 +264,13 @@ module Rails
         bundle_command('install') unless options[:skip_gemfile] || options[:skip_bundle] || options[:pretend]
       end
 
-      def empty_directory_with_gitkeep(destination, config = {})
+      def empty_directory_with_keep_file(destination, config = {})
         empty_directory(destination, config)
-        git_keep(destination)
+        keep_file(destination)
       end
 
-      def git_keep(destination)
-        create_file("#{destination}/.gitkeep") unless options[:skip_git]
+      def keep_file(destination)
+        create_file("#{destination}/.keep") unless options[:skip_keeps]
       end
     end
   end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -11,7 +11,7 @@ module Rails
 
     private
       %w(template copy_file directory empty_directory inside
-         empty_directory_with_gitkeep create_file chmod shebang).each do |method|
+         empty_directory_with_keep_file create_file chmod shebang).each do |method|
         class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def #{method}(*args, &block)
             @generator.send(:#{method}, *args, &block)
@@ -55,8 +55,8 @@ module Rails
 
     def app
       directory 'app'
-      git_keep  'app/mailers'
-      git_keep  'app/models'
+      keep_file  'app/mailers'
+      keep_file  'app/models'
     end
 
     def config
@@ -86,13 +86,13 @@ module Rails
     end
 
     def lib
-      empty_directory "lib"
-      empty_directory_with_gitkeep "lib/tasks"
-      empty_directory_with_gitkeep "lib/assets"
+      empty_directory 'lib'
+      empty_directory_with_keep_file 'lib/tasks'
+      empty_directory_with_keep_file 'lib/assets'
     end
 
     def log
-      empty_directory_with_gitkeep "log"
+      empty_directory_with_keep_file 'log'
     end
 
     def public_directory
@@ -100,7 +100,7 @@ module Rails
       if options[:skip_index_html]
         remove_file "public/index.html"
         remove_file 'app/assets/images/rails.png'
-        git_keep 'app/assets/images'
+        keep_file 'app/assets/images'
       end
     end
 
@@ -112,13 +112,13 @@ module Rails
     end
 
     def test
-      empty_directory_with_gitkeep "test/fixtures"
-      empty_directory_with_gitkeep "test/functional"
-      empty_directory_with_gitkeep "test/integration"
-      empty_directory_with_gitkeep "test/unit"
+      empty_directory_with_keep_file 'test/fixtures'
+      empty_directory_with_keep_file 'test/functional'
+      empty_directory_with_keep_file 'test/integration'
+      empty_directory_with_keep_file 'test/unit'
 
-      template "test/performance/browsing_test.rb"
-      template "test/test_helper.rb"
+      template 'test/performance/browsing_test.rb'
+      template 'test/test_helper.rb'
     end
 
     def tmp
@@ -132,11 +132,11 @@ module Rails
     end
 
     def vendor_javascripts
-      empty_directory_with_gitkeep "vendor/assets/javascripts"
+      empty_directory_with_keep_file 'vendor/assets/javascripts'
     end
 
     def vendor_stylesheets
-      empty_directory_with_gitkeep "vendor/assets/stylesheets"
+      empty_directory_with_keep_file 'vendor/assets/stylesheets'
     end
   end
 

--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -10,15 +10,15 @@ module Rails
 
     def app
       if mountable?
-        directory "app"
-        empty_directory_with_gitkeep "app/assets/images/#{name}"
+        directory 'app'
+        empty_directory_with_keep_file "app/assets/images/#{name}"
       elsif full?
-        empty_directory_with_gitkeep "app/models"
-        empty_directory_with_gitkeep "app/controllers"
-        empty_directory_with_gitkeep "app/views"
-        empty_directory_with_gitkeep "app/helpers"
-        empty_directory_with_gitkeep "app/mailers"
-        empty_directory_with_gitkeep "app/assets/images/#{name}"
+        empty_directory_with_keep_file 'app/models'
+        empty_directory_with_keep_file 'app/controllers'
+        empty_directory_with_keep_file 'app/views'
+        empty_directory_with_keep_file 'app/helpers'
+        empty_directory_with_keep_file 'app/mailers'
+        empty_directory_with_keep_file "app/assets/images/#{name}"
       end
     end
 
@@ -110,7 +110,7 @@ task :default => :test
         copy_file "#{app_templates_dir}/app/assets/stylesheets/application.css",
                   "app/assets/stylesheets/#{name}/application.css"
       elsif full?
-        empty_directory_with_gitkeep "app/assets/stylesheets/#{name}"
+        empty_directory_with_keep_file "app/assets/stylesheets/#{name}"
       end
     end
 
@@ -121,7 +121,7 @@ task :default => :test
         template "#{app_templates_dir}/app/assets/javascripts/application.js.tt",
                   "app/assets/javascripts/#{name}/application.js"
       elsif full?
-        empty_directory_with_gitkeep "app/assets/javascripts/#{name}"
+        empty_directory_with_keep_file "app/assets/javascripts/#{name}"
       end
     end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -250,10 +250,10 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_generator_if_skip_index_html_is_given
-    run_generator [destination_root, "--skip-index-html"]
-    assert_no_file "public/index.html"
-    assert_no_file "app/assets/images/rails.png"
-    assert_file "app/assets/images/.gitkeep"
+    run_generator [destination_root, '--skip-index-html']
+    assert_no_file 'public/index.html'
+    assert_no_file 'app/assets/images/rails.png'
+    assert_file 'app/assets/images/.keep'
   end
 
   def test_creation_of_a_test_directory

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -127,6 +127,18 @@ module SharedGeneratorTests
     # generated.
     assert_file 'Gemfile'
   end
+
+  def test_skip_git
+    run_generator [destination_root, '--skip-git', '--full']
+    assert_no_file('.gitignore')
+    assert_file('app/mailers/.keep')
+  end
+
+  def test_skip_keeps
+    run_generator [destination_root, '--skip-keeps', '--full']
+    assert_file('.gitignore')
+    assert_no_file('app/mailers/.keep')
+  end
 end
 
 module SharedCustomGeneratorTests


### PR DESCRIPTION
This is an updated version of #2808.

It closes #2800. Users of other SCM's can now generate rails
apps that will add the "empty" directories to source control,
but will not have a useless .gitignore or mis-named .gitkeep
files.
