### PR TITLE
update ConnectionAdapter::Column#type_cast_code to be compatible with rails 3.2 branch

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -114,7 +114,7 @@ module ActiveRecord
 
         case type
         when :string, :text        then var_name
-        when :integer              then "(#{var_name}.to_i rescue #{var_name} ? 1 : 0)"
+        when :integer              then "(#{var_name}.to_i)"
         when :float                then "#{var_name}.to_f"
         when :decimal              then "#{klass}.value_to_decimal(#{var_name})"
         when :datetime, :timestamp then "#{klass}.string_to_time(#{var_name})"


### PR DESCRIPTION
Hi Folks,

This commits makes the legacy method ConnectionAdapter::Column#type_cast_code compatible with the fix applied to the 3.2 branch in the pull request #7509.

cc @rafaelfranca @carlosantoniodasilva
