### PR TITLE
Freeze columns before using them as hash keys

### DIFF
--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -11,7 +11,7 @@ module ActiveRecord
     attr_reader :columns, :rows, :column_types
 
     def initialize(columns, rows, column_types = {})
-      @columns      = columns
+      @columns      = columns.map{|c| c.freeze}
       @rows         = rows
       @hash_rows    = nil
       @column_types = column_types


### PR DESCRIPTION
This reduces the number of allocated strings from columns \* (rows + 1) to just columns.  This should fix #7629.
