### PR TITLE
Fixes issue #5660: Failsafe exception returns text/html and text/plain.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Failsafe exception returns text/plain. *Steve Klabnik*
+
 *   Remove actionpack's rack-cache dependency and declare the
     dependency in the Gemfile.
 

--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -15,11 +15,11 @@ module ActionDispatch
   # If any exception happens inside the exceptions app, this middleware
   # catches the exceptions and returns a FAILSAFE_RESPONSE.
   class ShowExceptions
-    FAILSAFE_RESPONSE = [500, {'Content-Type' => 'text/html'},
-      ["<html><body><h1>500 Internal Server Error</h1>" <<
+    FAILSAFE_RESPONSE = [500, { 'Content-Type' => 'text/plain' },
+      ["500 Internal Server Error\n" <<
        "If you are the administrator of this website, then please read this web " <<
        "application's log file and/or the web server's log file to find out what " <<
-       "went wrong.</body></html>"]]
+       "went wrong."]]
 
     def initialize(app, exceptions_app)
       @app = app

--- a/actionpack/test/controller/show_exceptions_test.rb
+++ b/actionpack/test/controller/show_exceptions_test.rb
@@ -93,4 +93,20 @@ module ShowExceptions
       assert_equal 'text/html', response.content_type.to_s
     end
   end
+
+  class ShowFailsafeExceptionsTest < ActionDispatch::IntegrationTest
+    def test_render_failsafe_exception
+      @app = ShowExceptionsOverridenController.action(:boom)
+      @exceptions_app = @app.instance_variable_get(:@exceptions_app)
+      @app.instance_variable_set(:@exceptions_app, nil)
+      $stderr = StringIO.new
+
+      get '/', {}, 'HTTP_ACCEPT' => 'text/json'
+      assert_response :internal_server_error
+      assert_equal 'text/plain', response.content_type.to_s
+
+      @app.instance_variable_set(:@exceptions_app, @exceptions_app)
+      $stderr = STDERR
+    end
+  end
 end


### PR DESCRIPTION
If the request format is text/html then return the existing failsafe
response. For all other formats return text/plain.

The original issue points out to return JSON at the appropriate time,
however as @wycats pointed out, it's often better to return text/plain.
