### PR TITLE
Deprecate ActiveSupport::Benchmarkable#silence.

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1619,26 +1619,32 @@ class BasicsTest < ActiveRecord::TestCase
 
   def test_silence_sets_log_level_to_error_in_block
     original_logger = ActiveRecord::Base.logger
-    log = StringIO.new
-    ActiveRecord::Base.logger = ActiveSupport::Logger.new(log)
-    ActiveRecord::Base.logger.level = Logger::DEBUG
-    ActiveRecord::Base.silence do
-      ActiveRecord::Base.logger.warn "warn"
-      ActiveRecord::Base.logger.error "error"
+
+    assert_deprecated do
+      log = StringIO.new
+      ActiveRecord::Base.logger = ActiveSupport::Logger.new(log)
+      ActiveRecord::Base.logger.level = Logger::DEBUG
+      ActiveRecord::Base.silence do
+        ActiveRecord::Base.logger.warn "warn"
+        ActiveRecord::Base.logger.error "error"
+      end
+      assert_equal "error\n", log.string
     end
-    assert_equal "error\n", log.string
   ensure
     ActiveRecord::Base.logger = original_logger
   end
 
   def test_silence_sets_log_level_back_to_level_before_yield
     original_logger = ActiveRecord::Base.logger
-    log = StringIO.new
-    ActiveRecord::Base.logger = ActiveSupport::Logger.new(log)
-    ActiveRecord::Base.logger.level = Logger::WARN
-    ActiveRecord::Base.silence do
+
+    assert_deprecated do
+      log = StringIO.new
+      ActiveRecord::Base.logger = ActiveSupport::Logger.new(log)
+      ActiveRecord::Base.logger.level = Logger::WARN
+      ActiveRecord::Base.silence do
+      end
+      assert_equal Logger::WARN, ActiveRecord::Base.logger.level
     end
-    assert_equal Logger::WARN, ActiveRecord::Base.logger.level
   ensure
     ActiveRecord::Base.logger = original_logger
   end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   ActiveSupport::Benchmarkable#silence has been deprecated due to its lack of
+    thread safety. It will be removed without replacement in Rails 4.1. *Steve
+    Klabnik*
+
 *   An optional block can be passed to `Hash#deep_merge`. The block will be invoked for each duplicated key
     and used to resolve the conflict. *Pranas Kiziela*
 

--- a/activesupport/lib/active_support/benchmarkable.rb
+++ b/activesupport/lib/active_support/benchmarkable.rb
@@ -46,6 +46,7 @@ module ActiveSupport
     # Silence the logger during the execution of the block.
     #
     def silence
+      ActiveSupport::Deprecation.warn "ActiveSupport::Benchmarkable#silence is deprecated. It will be removed from Rails 4.1."
       old_logger_level, logger.level = logger.level, ::Logger::ERROR if logger
       yield
     ensure


### PR DESCRIPTION
It's not thread safe at all.

I also removed two tests that were testing its behavior so that the suite doesn't throw deprecation warnings. I'm not 100% sure this is the right thing to do.

I'm also not sure if this is a 'deprecate in 3-2-stable, remove in master' situation or a 'deprecate in master, remove in 4.1' situation.

This fixes #4060.

/cc @tenderlove
