### PR TITLE
Allowing pass couple extension to one register_template_handler call

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Allow pass couple extensions to ActionView::Template.register_template_handler call. *Tima Maslyuchenko*
+
 *   Sprockets integration has been extracted from Action Pack and the `sprockets-rails` 
     gem should be added to Gemfile (under the assets group) in order to use Rails asset
     pipeline in future versions of Rails. 

--- a/actionpack/lib/action_view/template/handlers.rb
+++ b/actionpack/lib/action_view/template/handlers.rb
@@ -21,11 +21,14 @@ module ActionView #:nodoc:
       end
 
       # Register an object that knows how to handle template files with the given
-      # extension. This can be used to implement new template types.
+      # extensions. This can be used to implement new template types.
       # The handler must respond to `:call`, which will be passed the template
       # and should return the rendered template as a String.
-      def register_template_handler(extension, handler)
-        @@template_handlers[extension.to_sym] = handler
+      def register_template_handler(*extensions, handler)
+        raise(ArgumentError, "Extension is required") if extensions.empty?
+        extensions.each do |extension|
+          @@template_handlers[extension.to_sym] = handler
+        end
         @@template_extensions = nil
       end
 

--- a/actionpack/test/template/render_test.rb
+++ b/actionpack/test/template/render_test.rb
@@ -451,6 +451,15 @@ module RenderTestCases
     assert_equal %(<title>David</title>),
       @view.render(:file => "test/layout_render_object")
   end
+  
+  def test_render_with_passing_couple_extensions_to_one_register_template_handler_function_call
+    ActionView::Template.register_template_handler :foo1, :foo2, CustomHandler
+    assert_equal @view.render(:inline => "Hello, World!", :type => :foo1), @view.render(:inline => "Hello, World!", :type => :foo2)
+  end
+  
+  def test_render_throws_exception_when_no_extensions_passed_to_register_template_handler_function_call
+    assert_raises(ArgumentError) { ActionView::Template.register_template_handler CustomHandler }
+  end
 end
 
 class CachedViewRenderTest < ActiveSupport::TestCase


### PR DESCRIPTION
To make possible add synonyms extension by one function call

``` ruby
ActionView::Template.register_template_handler :md, :markdown, markdown_handler
```
