### PR TITLE
Set up config_accessor with a default value by block

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   An optional block can be passed to `config_accessor` to set its default value
+
+        class User
+          include ActiveSupport::Configurable
+          config_accessor :hair_colors do
+            [:brown, :black, :blonde, :red]
+          end
+        end
+
+        User.hair_colors # => [:brown, :black, :blonde, :red]
+
+    *Larry Lv*
+
 *   ActiveSupport::Benchmarkable#silence has been deprecated due to its lack of
     thread safety. It will be removed without replacement in Rails 4.1. *Steve
     Klabnik*

--- a/activesupport/lib/active_support/configurable.rb
+++ b/activesupport/lib/active_support/configurable.rb
@@ -39,7 +39,7 @@ module ActiveSupport
 
       # Allows you to add shortcut so that you don't have to refer to attribute
       # through config. Also look at the example for config to contrast.
-      # 
+      #
       # Defines both class and instance config accessors.
       #
       #   class User
@@ -47,16 +47,16 @@ module ActiveSupport
       #     config_accessor :allowed_access
       #   end
       #
-      #   User.allowed_access # => nil 
+      #   User.allowed_access # => nil
       #   User.allowed_access = false
-      #   User.allowed_access # => false   
-      # 
+      #   User.allowed_access # => false
+      #
       #   user = User.new
       #   user.allowed_access # => false
       #   user.allowed_access = true
       #   user.allowed_access # => true
       #
-      #   User.allowed_access # => false  
+      #   User.allowed_access # => false
       #
       # The attribute name must be a valid method name in Ruby.
       #
@@ -91,7 +91,18 @@ module ActiveSupport
       #   User.allowed_access # => false
       #
       #   User.new.allowed_access = true # => NoMethodError
-      #   User.new.allowed_access        # => NoMethodError  
+      #   User.new.allowed_access        # => NoMethodError
+      #
+      # Also you can pass a block to set up the attribute with a default value.
+      #
+      #   class User
+      #     include ActiveSupport::Configurable
+      #     config_accessor :hair_colors do
+      #       [:brown, :black, :blonde, :red]
+      #     end
+      #   end
+      #
+      #   User.hair_colors # => [:brown, :black, :blonde, :red]
       def config_accessor(*names)
         options = names.extract_options!
 
@@ -108,6 +119,7 @@ module ActiveSupport
             class_eval reader, __FILE__, reader_line unless options[:instance_reader] == false
             class_eval writer, __FILE__, writer_line unless options[:instance_writer] == false
           end
+          send("#{name}=", yield) if block_given?
         end
       end
     end

--- a/activesupport/test/configurable_test.rb
+++ b/activesupport/test/configurable_test.rb
@@ -48,6 +48,18 @@ class ConfigurableActiveSupport < ActiveSupport::TestCase
     assert !instance.respond_to?(:baz=)
   end
 
+  test "configuration accessors can take a default value" do
+    parent = Class.new do
+      include ActiveSupport::Configurable
+      config_accessor :hair_colors, :tshirt_colors do
+        [:black, :blue, :white]
+      end
+    end
+
+    assert_equal [:black, :blue, :white], parent.hair_colors
+    assert_equal [:black, :blue, :white], parent.tshirt_colors
+  end
+
   test "configuration hash is available on instance" do
     instance = Parent.new
     assert_equal :bar, instance.config.foo
@@ -78,7 +90,7 @@ class ConfigurableActiveSupport < ActiveSupport::TestCase
 
   test "should raise name error if attribute name is invalid" do
     assert_raises NameError do
-      Class.new do 
+      Class.new do
         include ActiveSupport::Configurable
         config_accessor "invalid attribute name"
       end


### PR DESCRIPTION
- ActiveSupport::Configurable should allow config_accessor to take
  default value by block, just like `cattr_accessor`.
  
  ```
    class User
      include ActiveSupport::Configurable
      config_accessor :hair_colors do
        [:brown, :black, :blonde, :red]
      end
    end
  
    User.hair_colors # => [:brown, :black, :blonde, :red]
  ```
- remove trailing whitespaces in configurable.rb and its test file.

It's an old pull request #5730, but no one implement it . I just implement it like someone suggested, change the interface to just like `cattr_accessor`.
