### PR TITLE
Support for multiple etags in an If-None-Match header

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Support multiple etags in If-None-Match header. *Travis Warlick*
+
 *   Allow to configure how unverified request will be handled using `:with`
     option in `protect_from_forgery` method.
 

--- a/actionpack/lib/action_dispatch/http/cache.rb
+++ b/actionpack/lib/action_dispatch/http/cache.rb
@@ -17,12 +17,18 @@ module ActionDispatch
           env[HTTP_IF_NONE_MATCH]
         end
 
+        def if_none_match_etags
+          (if_none_match ? if_none_match.split(/\s*,\s*/) : []).collect do |etag|
+            etag.gsub(/^\"|\"$/, "")
+          end
+        end
+
         def not_modified?(modified_at)
           if_modified_since && modified_at && if_modified_since >= modified_at
         end
 
         def etag_matches?(etag)
-          if_none_match && if_none_match == etag
+          if_none_match_etags.include?(etag)
         end
 
         # Check response freshness (Last-Modified and ETag) against request


### PR DESCRIPTION
This is a rebased version of #2520.
