### PR TITLE
Fix find_in_batches with customized primary_key

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix `find_in_batches` when primary_key is set other than id.
+    You can now use this method with the primary key which is not integer-based.
+
+    Example:
+
+        class Post < ActiveRecord::Base
+          self.primary_key = :title
+        end
+
+        Post.find_in_batches(:start => 'My First Post') do |batch|
+          batch.each { |post| post.author.greeting }
+        end
+
+    *Toshiyuki Kawanishi*
+
 *   You can now override the generated accessor methods for stored attributes
     and reuse the original behavior with `read_store_attribute` and `write_store_attribute`,
     which are counterparts to `read_attribute` and `write_attribute`.

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -124,4 +124,15 @@ class EachTest < ActiveRecord::TestCase
     assert_equal special_posts_ids, posts.map(&:id)
   end
 
+  def test_find_in_batches_should_use_any_column_as_primary_key
+    title_order_posts = Post.order('title asc')
+    start_title = title_order_posts.first.title
+
+    posts = []
+    PostWithTitlePrimaryKey.find_in_batches(:batch_size => 1, :start => start_title) do |batch|
+      posts.concat(batch)
+    end
+
+    assert_equal title_order_posts.map(&:id), posts.map(&:id)
+  end
 end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -186,3 +186,8 @@ class SpecialPostWithDefaultScope < ActiveRecord::Base
   self.table_name = 'posts'
   default_scope { where(:id => [1, 5,6]) }
 end
+
+class PostWithTitlePrimaryKey < ActiveRecord::Base
+  self.table_name = 'posts'
+  self.primary_key = :title
+end


### PR DESCRIPTION
Although we set primary_key other than id, we should compute offsets by  any primary_key.
