### PR TITLE
Improve Process::Status#to_json

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/to_json.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_json.rb
@@ -17,3 +17,11 @@ end
     end
   end
 end
+
+module Process
+  class Status
+    def as_json(options = nil)
+      { :exitstatus => exitstatus, :pid => pid }
+    end
+  end
+end


### PR DESCRIPTION
Because Process::Status has no instance_variables, the
ActiveSupport version of #to_json produces {}, which isn't good.

Therefore, we implement our own #as_json, which makes it useful
again.

Fixes #4857
