### PR TITLE
Don't explain except normal CRUD sql.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Explain only normal CRUD sql (select / update / insert / delete).
+    Fix problem that explains unexplainable sql. Closes #7544 #6458.
+
+    *kennyj*
+
 *   Fix `find_in_batches` when primary_key is set other than id.
     You can now use this method with the primary key which is not integer-based.
 

--- a/activerecord/lib/active_record/explain_subscriber.rb
+++ b/activerecord/lib/active_record/explain_subscriber.rb
@@ -18,8 +18,9 @@ module ActiveRecord
     # On the other hand, we want to monitor the performance of our real database
     # queries, not the performance of the access to the query cache.
     IGNORED_PAYLOADS = %w(SCHEMA EXPLAIN CACHE)
+    EXPLAINED_SQLS = /\A\s*(select|update|delete|insert)/i
     def ignore_payload?(payload)
-      payload[:exception] || IGNORED_PAYLOADS.include?(payload[:name])
+      payload[:exception] || IGNORED_PAYLOADS.include?(payload[:name]) || payload[:sql] !~ EXPLAINED_SQLS
     end
 
     ActiveSupport::Notifications.subscribe("sql.active_record", new)

--- a/activerecord/test/cases/explain_subscriber_test.rb
+++ b/activerecord/test/cases/explain_subscriber_test.rb
@@ -38,6 +38,13 @@ if ActiveRecord::Base.connection.supports_explain?
       end
     end
 
+    def test_collects_nothing_if_unexplained_sqls
+      with_queries([]) do |queries|
+        SUBSCRIBER.finish(nil, nil, :name => 'SQL', :sql => 'SHOW max_identifier_length')
+        assert queries.empty?
+      end
+    end
+
     def with_queries(queries)
       Thread.current[:available_queries_for_explain] = queries
       yield queries


### PR DESCRIPTION
In current implementation, it's break when executing un-explainable query.
These query should be ignored for explaining.

closes #7544 #6458

/cc @rafaelfranca
