### PR TITLE
log 404 status when ActiveRecord::RecordNotFound was raised (#7646)

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix #7646, the log now displays the correct status code when an exception is raised.
+
+    *Yves Senn*
+
 *   Allow pass couple extensions to ActionView::Template.register_template_handler call. *Tima Maslyuchenko*
 
 *   Sprockets integration has been extracted from Action Pack and the `sprockets-rails` 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -6,16 +6,16 @@
 
 *   Allow pass couple extensions to ActionView::Template.register_template_handler call. *Tima Maslyuchenko*
 
-*   Sprockets integration has been extracted from Action Pack and the `sprockets-rails` 
+*   Sprockets integration has been extracted from Action Pack and the `sprockets-rails`
     gem should be added to Gemfile (under the assets group) in order to use Rails asset
-    pipeline in future versions of Rails. 
+    pipeline in future versions of Rails.
 
     *Guillermo Iguaran*
 
-*   `ActionDispatch::Session::MemCacheStore` now uses `dalli` instead of the deprecated 
-    `memcache-client` gem. As side effect the autoloading of unloaded classes objects 
-    saved as values in session isn't supported anymore when mem_cache session store is 
-    used, this can have an impact in apps only when config.cache_classes is false. 
+*   `ActionDispatch::Session::MemCacheStore` now uses `dalli` instead of the deprecated
+    `memcache-client` gem. As side effect the autoloading of unloaded classes objects
+    saved as values in session isn't supported anymore when mem_cache session store is
+    used, this can have an impact in apps only when config.cache_classes is false.
 
     *Arun Agrawal + Guillermo Iguaran*
 

--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -19,7 +19,8 @@ module ActionController
 
       status = payload[:status]
       if status.nil? && payload[:exception].present?
-        status = ActionDispatch::ExceptionWrapper.new({}, payload[:exception]).status_code
+        exception_class_name = payload[:exception].first
+        status = ActionDispatch::ExceptionWrapper.status_code_for_exception(exception_class_name)
       end
       message = "Completed #{status} #{Rack::Utils::HTTP_STATUS_CODES[status]} in %.0fms" % event.duration
       message << " (#{additions.join(" | ")})" unless additions.blank?

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -37,7 +37,7 @@ module ActionDispatch
     end
 
     def status_code
-      Rack::Utils.status_code(@@rescue_responses[@exception.class.name])
+      self.class.status_code_for_exception(@exception.class.name)
     end
 
     def application_trace
@@ -50,6 +50,10 @@ module ActionDispatch
 
     def full_trace
       clean_backtrace(:all)
+    end
+
+    def self.status_code_for_exception(class_name)
+      Rack::Utils.status_code(@@rescue_responses[class_name])
     end
 
     private

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -54,6 +54,10 @@ module Another
     def with_rescued_exception
       raise SpecialException
     end
+
+    def with_action_not_found
+      raise AbstractController::ActionNotFound
+    end
   end
 end
 
@@ -223,6 +227,17 @@ class ACLogSubscriberTest < ActionController::TestCase
 
     assert_equal 2, logs.size
     assert_match(/Completed 406/, logs.last)
+  end
+
+  def test_process_action_with_with_action_not_found_logs_404
+    begin
+      get :with_action_not_found
+      wait
+    rescue AbstractController::ActionNotFound
+    end
+
+    assert_equal 2, logs.size
+    assert_match(/Completed 404/, logs.last)
   end
 
   def logs


### PR DESCRIPTION
As described in #7646 when an ActiveRecord::RecordNotFound was raised rails returned a 404 to the client but logged a status code of 500.

This is a bug fix for the issue described above.

The problem was caused by the following line:

``` ruby
status = ActionDispatch::ExceptionWrapper.new({}, payload[:exception]).status_code
```

Since `payload[:exception]` is an Array with two elements: the exception class and the message, the lookup in the `ActionDispatch::ExceptionWrapper` class got confused. The `ExceptionWrapper` used the following lookup machanics:

``` ruby
Rack::Utils.status_code(@@rescue_responses[@exception.class.name])
```

which resulted in a lookup for `'Array'` and eventually in a 500.

To fix the bug I did:
- Added a test to `log_subscriber_test` in actionpack (I used a different exception class because `ActiveRecord::RecordNotFound` is not available but they share the same problem)
- Change the lookup in `LogSubscriber` to use the `rescue_responses` hash directly (because I don't have an Exception instance)
