### PR TITLE
Fix collection= on hm:t join models when unsaved

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix creation of through association models when using collection=[]
+    on a hm:t association from an unsaved model.
+
+    *Ernie Miller*
+
 *   Explain only normal CRUD sql (select / update / insert / delete).
     Fix problem that explains unexplainable sql. Closes #7544 #6458.
 

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -37,6 +37,20 @@ module ActiveRecord
         super
       end
 
+      def concat_records(records)
+        ensure_not_nested
+
+        records = super
+
+        if owner.new_record? && records
+          records.flatten.each do |record|
+            build_through_record(record)
+          end
+        end
+
+        records
+      end
+
       def insert_record(record, validate = true, raise = false)
         ensure_not_nested
 

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -838,6 +838,11 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_assign_array_to_new_record_builds_join_records
+    c = Category.new(:name => 'Fishing', :authors => [Author.first])
+    assert_equal 1, c.categorizations.size
+  end
+
   def test_create_bang_should_raise_exception_when_join_record_has_errors
     repair_validations(Categorization) do
       Categorization.validate { |r| r.errors[:base] << 'Invalid Categorization' }


### PR DESCRIPTION
If assigning to a has_many :through collection against an unsaved
object using the collection=[<array_of_items>] syntax, the join models
were not properly created, previously.

This bug is present in the current 3.2.8 release, as well.
