### PR TITLE
Improve syntax of schema dumps index columns.

### DIFF
--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -159,7 +159,7 @@ HEADER
           add_index_statements = indexes.map do |index|
             statement_parts = [
               ('add_index ' + remove_prefix_and_suffix(index.table).inspect),
-              index.columns.inspect,
+              ('%w(' + index.columns.join(' ') + ')'),
               ('name: ' + index.name.inspect),
             ]
             statement_parts << 'unique: true' if index.unique

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -182,15 +182,15 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
   def test_schema_dumps_index_columns_in_right_order
     index_definition = standard_dump.split(/\n/).grep(/add_index.*companies/).first.strip
-    assert_equal 'add_index "companies", ["firm_id", "type", "rating"], name: "company_index"', index_definition
+    assert_equal 'add_index "companies", %w(firm_id type rating), name: "company_index"', index_definition
   end
 
   def test_schema_dumps_partial_indices
     index_definition = standard_dump.split(/\n/).grep(/add_index.*company_partial_index/).first.strip
     if current_adapter?(:PostgreSQLAdapter)
-      assert_equal 'add_index "companies", ["firm_id", "type"], name: "company_partial_index", where: "(rating > 10)"', index_definition
+      assert_equal 'add_index "companies", %w(firm_id type), name: "company_partial_index", where: "(rating > 10)"', index_definition
     else
-      assert_equal 'add_index "companies", ["firm_id", "type"], name: "company_partial_index"', index_definition
+      assert_equal 'add_index "companies", %w(firm_id type), name: "company_partial_index"', index_definition
     end
   end
 


### PR DESCRIPTION
Change array syntax in auto-generated ruby file.
I follow the https://github.com/bbatsov/ruby-style-guide.
"Prefer %w to the literal array syntax when you need an array of strings."
