### PR TITLE
Remove unncessary code.

### DIFF
--- a/activesupport/test/queueing/threaded_consumer_test.rb
+++ b/activesupport/test/queueing/threaded_consumer_test.rb
@@ -47,7 +47,6 @@ class TestThreadConsumer < ActiveSupport::TestCase
   end
 
   test "shutting down the queue synchronously drains the jobs" do
-    runnable = ::Queue.new
     ran = false
     job = Job.new do
       sleep 0.1


### PR DESCRIPTION
Unfortunately, I found new warning. This code doesn't be used.
If removing, tests are still green.
