### PR TITLE
Removing to_shorthand to fix #6497

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -4,9 +4,19 @@
 
     *Yves Senn*
 
-*   Allow pass couple extensions to ActionView::Template.register_template_handler call. *Tima Maslyuchenko*
+*   Allow pass couple extensions to `ActionView::Template.register_template_handler` call. *Tima Maslyuchenko*
 
-*   Sprockets integration has been extracted from Action Pack and the `sprockets-rails`
+*   Fixed a bug with shorthand routes scoped with the `:module` option not
+    adding the module to the controller as described in issue #6497.
+    This should now work properly:
+
+        scope :module => "engine" do
+          get "api/version" # routes to engine/api#version
+        end
+ 
+    *Luiz Felipe Garcia Pereira*
+
+*   Sprockets integration has been extracted from Action Pack and the `sprockets-rails` 
     gem should be added to Gemfile (under the assets group) in order to use Rails asset
     pipeline in future versions of Rails.
 

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -182,7 +182,7 @@ module ActionDispatch
               controller ||= default_controller
               action     ||= default_action
 
-              unless controller.is_a?(Regexp) || to_shorthand
+              unless controller.is_a?(Regexp)
                 controller = [@scope[:module], controller].compact.join("/").presence
               end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -363,6 +363,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
         resources :errors, :shallow => true do
           resources :notices
         end
+        get 'api/version'
       end
 
       scope :path => 'api' do
@@ -1278,6 +1279,12 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal '/account/shorthand', account_shorthand_path
     get '/account/shorthand'
     assert_equal 'account#shorthand', @response.body
+  end
+
+  def test_match_shorthand_with_module
+    assert_equal '/api/version', api_version_path
+    get '/api/version'
+    assert_equal 'api/api#version', @response.body
   end
 
   def test_dynamically_generated_helpers_on_collection_do_not_clobber_resources_url_helper


### PR DESCRIPTION
When using shortcut routes inside an engine the "to_shorthand" variable
is set to true, causing the module scope of the route to not be applied.
