### PR TITLE
Respect `config.digest = false` for `asset_path`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Rails 3.2.9 (unreleased) ##
 
+*   Respect `config.digest = false` for `asset_path`
+
+    Previously, the `asset_path` internals only respected the `:digest`
+    option, but ignored the global config setting. This meant that
+    `config.digest = false` could not be used in conjunction with
+    `config.compile = false` this corrects the behavior.
+
+    *Peter Wagenet*
+
 *   Fix #7646, the log now displays the correct status code when an exception is raised.
 
     *Yves Senn*

--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -147,7 +147,9 @@ module Sprockets
           if source[0] == ?/
             source
           else
-            source = digest_for(source) unless options[:digest] == false
+            if digest_assets && options[:digest] != false
+              source = digest_for(source)
+            end
             source = File.join(dir, source)
             source = "/#{source}" unless source =~ /^\//
             source

--- a/actionpack/test/template/sprockets_helper_test.rb
+++ b/actionpack/test/template/sprockets_helper_test.rb
@@ -360,4 +360,12 @@ class SprocketsHelperTest < ActionView::TestCase
     assert_equal '/assets/logo.png',
       asset_path("logo.png")
   end
+
+  test "`config.digest = false` works with `config.compile = false`" do
+    @config.assets.digest = false
+    @config.assets.compile = false
+
+    assert_equal '/assets/logo.png',
+      asset_path("logo.png")
+  end
 end


### PR DESCRIPTION
Previously, the `asset_path` internals only respected the `:digest`
option, but ignored the global config setting. This meant that
`config.digest = false` could not be used in conjunction with
`config.compile = false` this corrects the behavior.
