### PR TITLE
Stronger wording in Contributing file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 Ruby on Rails is a volunteer effort. We encourage you to pitch in. [Join the team](http://contributors.rubyonrails.org)!
 
-Please check the [Contributing to Ruby on Rails guide](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html) for a comprehensive introduction to contributing to Ruby on Rails. 
+Read the [Contributing to Ruby on Rails](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html) guide before submitting any code, it is a comprehensive introduction.
 
 Please note that *we only accept bug reports and pull requests in GitHub*.
 
-If you have a question about how to use Ruby on Rails, please [ask the Rails mailing list](https://groups.google.com/forum/?fromgroups#!forum/rubyonrails-talk).
+If you have a question about how to use Ruby on Rails, please [ask the rubyonrails-talk mailing list](https://groups.google.com/forum/?fromgroups#!forum/rubyonrails-talk).
 
-If you have a change or new feature in mind, please [suggest it on the Rails-core mailing list](https://groups.google.com/forum/?fromgroups#!forum/rubyonrails-core) and start writing code.
+If you have a change or new feature in mind, please [suggest it on the rubyonrails-core mailing list](https://groups.google.com/forum/?fromgroups#!forum/rubyonrails-core) and start writing code.
 
 Thanks! :heart: :heart: :heart: <br />
 Rails Team


### PR DESCRIPTION
Explicitly tell users to read the guide before submitting code. re: #7677. Specify the name of the mailing list for Rails-talk to help differentiate it from Rails-core mailing list.
