### PR TITLE
ConnectionPool accepts spec key 'checkout_timeout' (Backport)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 3.2.9 (unreleased)
 
+*   ConnectionPool recognizes checkout_timeout spec key as taking
+    precedence over legacy wait_timeout spec key, can be used to avoid
+    conflict with mysql2 use of wait_timeout.  Closes #7684.
+
+    *jrochkind*
+
 *   Rename field_changed? to _field_changed? so that users can create a field named field
 
     *Akira Matsuda*, backported by *Steve Klabnik*

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -54,8 +54,11 @@ module ActiveRecord
     # your database connection configuration:
     #
     # * +pool+: number indicating size of connection pool (default 5)
-    # * +wait_timeout+: number of seconds to block and wait for a connection
-    #   before giving up and raising a timeout error (default 5 seconds).
+    # * +checkout _timeout+: number of seconds to block and wait for a 
+    #   connection before giving up and raising a timeout error 
+    #   (default 5 seconds). ('wait_timeout' supported for backwards
+    #   compatibility, but conflicts with key used for different purpose
+    #   by mysql2 adapter). 
     class ConnectionPool
       include MonitorMixin
 
@@ -77,7 +80,10 @@ module ActiveRecord
         @reserved_connections = {}
 
         @queue = new_cond
-        @timeout = spec.config[:wait_timeout] || 5
+        # 'wait_timeout', the backward-compatible key, conflicts with spec key 
+        # used by mysql2 for something entirely different, checkout_timeout
+        # preferred to avoid conflict and allow independent values. 
+        @timeout = spec.config[:checkout_timeout] || spec.config[:wait_timeout] || 5
 
         # default max pool size to 5
         @size = (spec.config[:pool] && spec.config[:pool].to_i) || 5

--- a/activerecord/test/cases/pooled_connections_test.rb
+++ b/activerecord/test/cases/pooled_connections_test.rb
@@ -17,7 +17,7 @@ class PooledConnectionsTest < ActiveRecord::TestCase
   end
 
   def checkout_connections
-    ActiveRecord::Base.establish_connection(@connection.merge({:pool => 2, :wait_timeout => 0.3}))
+    ActiveRecord::Base.establish_connection(@connection.merge({:pool => 2, :checkout_timeout => 0.3}))
     @connections = []
     @timed_out = 0
 
@@ -42,7 +42,7 @@ class PooledConnectionsTest < ActiveRecord::TestCase
   end
 
   def checkout_checkin_connections(pool_size, threads)
-    ActiveRecord::Base.establish_connection(@connection.merge({:pool => pool_size, :wait_timeout => 0.5}))
+    ActiveRecord::Base.establish_connection(@connection.merge({:pool => pool_size, :checkout_timeout => 0.5}))
     @connection_count = 0
     @timed_out = 0
     threads.times do


### PR DESCRIPTION
Backport of applicable parts of #6441 cb6f83935, in a backwards compatible way. 

Previously, ConnectionPool uses connection spec key 'wait_timeout' (default 5 seconds) to decide how long a thread can block waiting for a connection to be avail before raising. 

However, mysql2 adapter uses this same 'wait_timeout' key for an entirely different value -- setting the MySQL server's own 'wait timeout', how long the server will allow a connection to be idle before closing it. Default is several hours. 

Extreme differences in default shows you often do not want these two values to be the same. But if you don't want them to be default, there is no supported API to change one without changing the other to be the same, since they both use 'wait_timeout'. 

So this change maeks ConnectionPool use `checkout_timeout` in the spec, prefering it over `wait_timeout`.  But `wait_timeout` IS (unlike in master) still used if there without `checkout_timeout`.  If you want mysql2's `wait_timeout` to be differnet than ConnectionPool's timeout, you can (and have to) set them both -- mysql2 will use the `wait_timeout`, ConnectionPool will use the `checkout_timeout`.  But prior to this patch there was _no_ way to do that. 

The actual code change is very straightforward. But I wasn't sure how to write the test. The test is a bit wonky, if someone has a suggestion of how to organize the test better, please do share. @rafaelfranca  , any interest/feedback?
