### PR TITLE
Correct parameter access.

### DIFF
--- a/actionpack/test/controller/parameters/nested_parameters_test.rb
+++ b/actionpack/test/controller/parameters/nested_parameters_test.rb
@@ -28,7 +28,7 @@ class NestedParametersTest < ActiveSupport::TestCase
     assert_equal "Christopher Marlowe", permitted[:book][:authors][1][:name]
     assert_equal 200, permitted[:book][:details][:pages]
     assert_nil permitted[:book][:details][:genre]
-    assert_nil permitted[:book][:authors][1][:born]
+    assert_nil permitted[:book][:authors][0][:born]
     assert_nil permitted[:magazine]
   end
 


### PR DESCRIPTION
- The params as supplied pass born in authors[0] but not authors[1] so it seems like the test isn't covering what it should be covering.
