### PR TITLE
add lock!/unlock! to Rails

### DIFF
--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -95,11 +95,11 @@ module Rails
       @_env = ActiveSupport::StringInquirer.new(environment)
     end
     
-    def modify_lock
+    def lock!
       @_modify_lock = true
     end
     
-    def modify_unlock
+    def unlock!
       @_modify_lock = false
     end
 

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -29,6 +29,7 @@ module Rails
     end
 
     def application=(application)
+      raise "application cannot be changed." if @_modify_lock
       @application = application
     end
 
@@ -69,6 +70,7 @@ module Rails
     end
 
     def logger=(logger)
+      raise "logger cannot be changed." if @_modify_lock
       @logger = logger
     end
 
@@ -89,7 +91,16 @@ module Rails
     end
 
     def env=(environment)
+      raise "env cannot be changed." if @_modify_lock
       @_env = ActiveSupport::StringInquirer.new(environment)
+    end
+    
+    def modify_lock
+      @_modify_lock = true
+    end
+    
+    def modify_unlock
+      @_modify_lock = false
     end
 
     def cache

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -29,7 +29,7 @@ module Rails
     end
 
     def application=(application)
-      raise "application cannot be changed." if @_modify_lock
+      raise "application cannot be changed." if @_lock
       @application = application
     end
 
@@ -70,7 +70,7 @@ module Rails
     end
 
     def logger=(logger)
-      raise "logger cannot be changed." if @_modify_lock
+      raise "logger cannot be changed." if @_lock
       @logger = logger
     end
 
@@ -91,16 +91,16 @@ module Rails
     end
 
     def env=(environment)
-      raise "env cannot be changed." if @_modify_lock
+      raise "env cannot be changed." if @_lock
       @_env = ActiveSupport::StringInquirer.new(environment)
     end
     
     def lock!
-      @_modify_lock = true
+      @_lock = true
     end
     
     def unlock!
-      @_modify_lock = false
+      @_lock = false
     end
 
     def cache

--- a/railties/test/railties/railtie_test.rb
+++ b/railties/test/railties/railtie_test.rb
@@ -203,5 +203,25 @@ module RailtiesTest
         assert_equal(original_env, Rails.env)
       end
     end
+
+    test "we cannot change the Rails field when it is locked" do
+      begin
+        original_env = Rails.env
+        Rails.lock!
+        assert_raise RuntimeError do 
+          Rails.env = 'foo'
+        end
+        assert_raise RuntimeError do
+          Rails.logger = Logger.new($stdout)
+        end
+        assert_raise RuntimeError do
+          Rails.application = nil
+        end
+      ensure
+        Rails.unlock!
+        Rails.env = original_env
+        assert_equal(original_env, Rails.env)
+      end
+    end
   end
 end


### PR DESCRIPTION
I had write a code like this:

```
if Rails.env=='test' || Rails.env='cucumber'
```

This mistake is too easy to make. 
So I want to lock the Rails field which is not changed in most cases.
