### PR TITLE
Remove highly uncommon `config.assets.manifest` option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,12 @@ end
 # This needs to be with require false to avoid
 # it being automatically loaded by sprockets
 gem 'uglifier', require: false
-gem 'sprockets-rails', github: 'rails/sprockets-rails'
+
+if ENV['SPROCKETS_RAILS']
+  gem 'sprockets-rails', path: ENV['SPROCKETS_RAILS']
+else
+  gem 'sprockets-rails', github: 'rails/sprockets-rails'
+end
 
 group :doc do
   # The current sdoc cannot generate GitHub links due

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -456,12 +456,6 @@ application.css: application-8af74128f904600e41a6e39241464e03.css
 
 The default location for the manifest is the root of the location specified in `config.assets.prefix` ('/assets' by default).
 
-This can be changed with the `config.assets.manifest` option. A fully specified path is required:
-
-```ruby
-config.assets.manifest = '/path/to/some/other/location'
-```
-
 NOTE: If there are missing precompiled files in production you will get an `Sprockets::Helpers::RailsHelper::AssetPaths::AssetNotPrecompiledError` exception indicating the name of the missing file(s).
 
 #### Far-future Expires header
@@ -727,9 +721,6 @@ config.assets.compile = false
 
 # Generate digests for assets URLs.
 config.assets.digest = true
-
-# Defaults to nil and saved in location specified by config.assets.prefix
-# config.assets.manifest = YOUR_PATH
 
 # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
 # config.assets.precompile += %w( search.js )

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -161,8 +161,6 @@ Rails 3.1, by default, is set up to use the `sprockets` gem to manage assets wit
 
 * `config.assets.debug` disables the concatenation and compression of assets. Set to `true` by default in `development.rb`.
 
-* `config.assets.manifest` defines the full path to be used for the asset precompiler's manifest file. Defaults to using `config.assets.prefix`.
-
 * `config.assets.cache_store` defines the cache store that Sprockets will use. The default is the Rails file store.
 
 * `config.assets.version` is an option string that is used in MD5 hash generation. This can be changed to force all files to be recompiled.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Remove highly uncommon `config.assets.manifest` option for moving the manifest path.
+    This option is now unsupported in sprockets-rails. 
+
+    *Guillermo Iguaran & Dmitry Vorotilin*
+
 *   Add `config.action_controller.permit_all_parameters` to disable
     StrongParameters protection, it's false by default.
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -57,7 +57,6 @@ module Rails
         @assets.debug                    = false
         @assets.compile                  = true
         @assets.digest                   = false
-        @assets.manifest                 = nil
         @assets.cache_store              = [ :file_store, "#{root}/tmp/cache/assets/" ]
         @assets.js_compressor            = nil
         @assets.css_compressor           = nil


### PR DESCRIPTION
The other commit is a nice to have during the development of sprockets-rails (while we release a final version for Rails 4)
