### PR TITLE
Fix #6962. AS::TimeWithZone#strftime responds incorrectly to %:z and %::z format strings.

### DIFF
--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -168,7 +168,10 @@ module ActiveSupport
     # Replaces <tt>%Z</tt> and <tt>%z</tt> directives with +zone+ and +formatted_offset+, respectively, before passing to
     # Time#strftime, so that zone information is correct
     def strftime(format)
-      format = format.gsub('%Z', zone).gsub('%z', formatted_offset(false))
+      format = format.gsub('%Z', zone)
+                     .gsub('%z',   formatted_offset(false))
+                     .gsub('%:z',  formatted_offset(true))
+                     .gsub('%::z', formatted_offset(true) + ":00")
       time.strftime(format)
     end
 

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -258,6 +258,14 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal "-0500", zone.formatted_offset(false)
   end
 
+  def test_z_format_strings
+    zone = ActiveSupport::TimeZone['Tokyo']
+    twz = zone.now
+    assert_equal '+0900',     twz.strftime('%z')
+    assert_equal '+09:00',    twz.strftime('%:z')
+    assert_equal '+09:00:00', twz.strftime('%::z')
+  end
+
   def test_formatted_offset_zero
     zone = ActiveSupport::TimeZone['London']
     assert_equal "+00:00", zone.formatted_offset


### PR DESCRIPTION
Please see #6962.

AS::TWZ#strftime's behavior isn't equals to Time#strftime.
It seems `%:z` and `%::z` format are ignored.
