### PR TITLE
Delegate ActionDispatch::Http::UploadedFile#close to tempfile

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -493,4 +493,6 @@
 *   `ActionView::Helpers::TextHelper#highlight` now defaults to the
     HTML5 `mark` element. *Brian Cardarella*
 
+*   `ActionDispatch::Http::UploadedFile` now delegates `close` to its tempfile. *Sergio Gil*
+
 Please check [3-2-stable](https://github.com/rails/rails/blob/3-2-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_dispatch/http/upload.rb
+++ b/actionpack/lib/action_dispatch/http/upload.rb
@@ -17,7 +17,7 @@ module ActionDispatch
       end
 
       # Delegate these methods to the tempfile.
-      [:open, :path, :rewind, :size, :eof?].each do |method|
+      [:open, :close, :path, :rewind, :size, :eof?].each do |method|
         class_eval "def #{method}; @tempfile.#{method}; end"
       end
 

--- a/actionpack/lib/action_dispatch/http/upload.rb
+++ b/actionpack/lib/action_dispatch/http/upload.rb
@@ -12,13 +12,9 @@ module ActionDispatch
         @headers           = hash[:head]
       end
 
-      def read(*args)
-        @tempfile.read(*args)
-      end
-
       # Delegate these methods to the tempfile.
-      [:open, :close, :path, :rewind, :size, :eof?].each do |method|
-        class_eval "def #{method}; @tempfile.#{method}; end"
+      [:read, :open, :close, :path, :rewind, :size, :eof?].each do |method|
+        class_eval "def #{method}(*args); @tempfile.#{method}(*args); end"
       end
 
       private

--- a/actionpack/test/dispatch/uploaded_file_test.rb
+++ b/actionpack/test/dispatch/uploaded_file_test.rb
@@ -45,6 +45,12 @@ module ActionDispatch
       assert_equal 'thunderhorse', uf.open
     end
 
+    def test_delegates_close_to_tempfile
+      tf = Class.new { def close; 'thunderhorse' end }
+      uf = Http::UploadedFile.new(:tempfile => tf.new)
+      assert_equal 'thunderhorse', uf.close
+    end
+
     def test_delegates_to_tempfile
       tf = Class.new { def read; 'thunderhorse' end }
       uf = Http::UploadedFile.new(:tempfile => tf.new)

--- a/actionpack/test/dispatch/uploaded_file_test.rb
+++ b/actionpack/test/dispatch/uploaded_file_test.rb
@@ -51,6 +51,12 @@ module ActionDispatch
       assert_equal 'thunderhorse', uf.close
     end
 
+    def test_close_accepts_parameter
+      tf = Class.new { def close(optional = false); "thunderhorse: #{optional}" end }
+      uf = Http::UploadedFile.new(:tempfile => tf.new)
+      assert_equal 'thunderhorse: true', uf.close(true)
+    end
+
     def test_delegates_to_tempfile
       tf = Class.new { def read; 'thunderhorse' end }
       uf = Http::UploadedFile.new(:tempfile => tf.new)


### PR DESCRIPTION
This tiny PR adds one more delegated method (`close` in addition to `open`, `close`, `path`, `rewind`, `size` and `eof?`) in order to interact with the underlying tempfile. Sometimes I've needed to do and doing it through the tempfile is ugly and breaks code which works with the `IO` interface.
