### PR TITLE
Coerce strings in create_join_table.

### DIFF
--- a/activerecord/lib/active_record/migration/join_table.rb
+++ b/activerecord/lib/active_record/migration/join_table.rb
@@ -8,7 +8,7 @@ module ActiveRecord
       end
 
       def join_table_name(table_1, table_2)
-        [table_1, table_2].sort.join("_").to_sym
+        [table_1.to_s, table_2.to_s].sort.join("_").to_sym
       end
     end
   end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -759,4 +759,11 @@ class CopyMigrationsTest < ActiveRecord::TestCase
   ensure
     clear
   end
+
+  def test_create_join_table_with_symbol_and_string
+    connection.create_join_table :artists, 'musics'
+
+    assert_equal %w(artist_id music_id), connection.columns(:artists_musics).map(&:name).sort
+  end
+
 end


### PR DESCRIPTION
If you accidentally pass a string and a symbol, this breaks. So
we coerce them both to strings.

Fixes #7715.

I'm not 100% sure we care to be this defensive, but the change was easy enough.

/cc @tenderlove @jonleighton
