### PR TITLE
[3-2-stable] Fix #6962. AS::TimeWithZone#strftime responds incorrectly to %:z and %::z format strings.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Rails 3.2.9 (unreleased)
+
+*  Add %:z and %::z format string support to ActiveSupport::TimeWithZone#strftime. [fixes #6962] *kennyj*
+
 ## Rails 3.2.8 (Aug 9, 2012) ##
 
 *   Fix ActiveSupport integration with Mocha > 0.12.1. *Mike Gunderloy*

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -177,7 +177,10 @@ module ActiveSupport
     # Replaces <tt>%Z</tt> and <tt>%z</tt> directives with +zone+ and +formatted_offset+, respectively, before passing to
     # Time#strftime, so that zone information is correct
     def strftime(format)
-      format = format.gsub('%Z', zone).gsub('%z', formatted_offset(false))
+      format = format.gsub('%Z', zone)
+                     .gsub('%z',   formatted_offset(false))
+                     .gsub('%:z',  formatted_offset(true))
+                     .gsub('%::z', formatted_offset(true) + ":00")
       time.strftime(format)
     end
 

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -235,6 +235,14 @@ class TimeZoneTest < Test::Unit::TestCase
     assert_equal "-0500", zone.formatted_offset(false)
   end
 
+  def test_z_format_strings
+    zone = ActiveSupport::TimeZone['Tokyo']
+    twz = zone.now
+    assert_equal '+0900',     twz.strftime('%z')
+    assert_equal '+09:00',    twz.strftime('%:z')
+    assert_equal '+09:00:00', twz.strftime('%::z')
+  end
+
   def test_formatted_offset_zero
     zone = ActiveSupport::TimeZone['London']
     assert_equal "+00:00", zone.formatted_offset


### PR DESCRIPTION
This PR is backported to 3-2-stalbe about #7703.

Please see #6962.

AS::TWZ#strftime's behavior isn't equals to Time#strftime.
It seems %:z and %::z format are ignored.

/cc @rafaelfranca 
