### PR TITLE
Strong Parameters documentation

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -271,9 +271,9 @@ module ActionController
 
   # == Strong Parameters
   #
-  # It provides an interface for proctecting attributes from end-user
-  # assignment. This makes Action Controller parameters are forbidden
-  # to be used in Active Model mass assignmets until they have been
+  # It provides an interface for protecting attributes from end-user
+  # assignment. This makes Action Controller parameters forbidden
+  # to be used in Active Model mass assignment until they have been
   # whitelisted.
   #
   # In addition, parameters can be marked as required and flow through a
@@ -281,10 +281,12 @@ module ActionController
   # effort.
   #
   #   class PeopleController < ActionController::Base
-  #     # This will raise an ActiveModel::ForbiddenAttributes exception because
-  #     # it's using mass assignment without an explicit permit step.
+  #     # Using "Person.create(params[:person])" would raise an
+  #     # ActiveModel::ForbiddenAttributes exception because it'd
+  #     # be using mass assignment without an explicit permit step.
+  #     # This is the recommended form:
   #     def create
-  #       Person.create(params[:person])
+  #       Person.create(person_params)
   #     end
   #
   #     # This will pass with flying colors as long as there's a person key in the

--- a/activemodel/lib/active_model/deprecated_mass_assignment_security.rb
+++ b/activemodel/lib/active_model/deprecated_mass_assignment_security.rb
@@ -1,15 +1,15 @@
 module ActiveModel
-  module DeprecatedMassAssignmentSecurity
+  module DeprecatedMassAssignmentSecurity # :nodoc:
     extend ActiveSupport::Concern
 
      module ClassMethods
-       def attr_protected(*args)
+       def attr_protected(*args) # :nodoc:
          raise "`attr_protected` is extracted out of Rails into a gem. " \
            "Please use new recommended protection model for params " \
            "or add `protected_attributes` to your Gemfile to use old one."
        end
 
-       def attr_accessible(*args)
+       def attr_accessible(*args) # :nodoc:
          raise "`attr_accessible` is extracted out of Rails into a gem. " \
            "Please use new recommended protection model for params " \
            "or add `protected_attributes` to your Gemfile to use old one."

--- a/activemodel/lib/active_model/deprecated_mass_assignment_security.rb
+++ b/activemodel/lib/active_model/deprecated_mass_assignment_security.rb
@@ -2,14 +2,14 @@ module ActiveModel
   module DeprecatedMassAssignmentSecurity # :nodoc:
     extend ActiveSupport::Concern
 
-     module ClassMethods
-       def attr_protected(*args) # :nodoc:
+     module ClassMethods # :nodoc:
+       def attr_protected(*args)
          raise "`attr_protected` is extracted out of Rails into a gem. " \
            "Please use new recommended protection model for params " \
            "or add `protected_attributes` to your Gemfile to use old one."
        end
 
-       def attr_accessible(*args) # :nodoc:
+       def attr_accessible(*args)
          raise "`attr_accessible` is extracted out of Rails into a gem. " \
            "Please use new recommended protection model for params " \
            "or add `protected_attributes` to your Gemfile to use old one."

--- a/activemodel/lib/active_model/forbidden_attributes_protection.rb
+++ b/activemodel/lib/active_model/forbidden_attributes_protection.rb
@@ -1,4 +1,16 @@
 module ActiveModel
+  # Raised when forbidden attributes are used for mass assignment.
+  #
+  #   class Person < ActiveRecord::Base
+  #   end
+  #
+  #   params = ActionController::Parameters.new(name: 'Bob')
+  #   Person.new(params)
+  #   # => ActiveModel::ForbiddenAttributesError
+  #
+  #   params.permit!
+  #   Person.new(params)
+  #   # => #<Person id: nil, name: "Bob">
   class ForbiddenAttributesError < StandardError
   end
 

--- a/activemodel/lib/active_model/forbidden_attributes_protection.rb
+++ b/activemodel/lib/active_model/forbidden_attributes_protection.rb
@@ -14,13 +14,14 @@ module ActiveModel
   class ForbiddenAttributesError < StandardError
   end
 
-  module ForbiddenAttributesProtection
-    def sanitize_for_mass_assignment(attributes, options = {})
-      if attributes.respond_to?(:permitted?) && !attributes.permitted?
-        raise ActiveModel::ForbiddenAttributesError
-      else
-        attributes
+  module ForbiddenAttributesProtection # :nodoc:
+    protected
+      def sanitize_for_mass_assignment(attributes, options = {})
+        if attributes.respond_to?(:permitted?) && !attributes.permitted?
+          raise ActiveModel::ForbiddenAttributesError
+        else
+          attributes
+        end
       end
-    end
   end
 end


### PR DESCRIPTION
- Fixed typos from AC::StrongParameters documentation.
- update AMo::DeprecatedMassAssignmentSecurity documentation.
- update AMo::ForbiddenAttributesError documentation.
- Change visibility of AMo::ForbiddenAttributesProtection#sanitize_for_mass_assignment to protected.
