### PR TITLE
Backport #3544 to 3-2-stable

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 3.2.9 (unreleased)
 
+*   Rename field_changed? to _field_changed? so that users can create a field named field
+
+    *Akira Matsuda*, backported by *Steve Klabnik*
+
 *   Fix creation of through association models when using `collection=[]`
     on a `has_many :through` association from an unsaved model.
     Fix #7661.

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -55,12 +55,12 @@ module ActiveRecord
         # The attribute already has an unsaved change.
         if attribute_changed?(attr)
           old = @changed_attributes[attr]
-          @changed_attributes.delete(attr) unless field_changed?(attr, old, value)
+          @changed_attributes.delete(attr) unless _field_changed?(attr, old, value)
         else
           old = clone_attribute_value(:read_attribute, attr)
           # Save Time objects as TimeWithZone if time_zone_aware_attributes == true
           old = old.in_time_zone if clone_with_time_zone_conversion_attribute?(attr, old)
-          @changed_attributes[attr] = old if field_changed?(attr, old, value)
+          @changed_attributes[attr] = old if _field_changed?(attr, old, value)
         end
 
         # Carry on.
@@ -77,7 +77,7 @@ module ActiveRecord
         end
       end
 
-      def field_changed?(attr, old, value)
+      def _field_changed?(attr, old, value)
         if column = column_for_attribute(attr)
           if column.number? && (changes_from_nil_to_empty_string?(column, old, value) ||
                                 changes_from_zero_to_string?(old, value))

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -544,7 +544,7 @@ module ActiveRecord #:nodoc:
 
         @changed_attributes = {}
         self.class.column_defaults.each do |attr, orig_value|
-          @changed_attributes[attr] = orig_value if field_changed?(attr, orig_value, @attributes[attr])
+          @changed_attributes[attr] = orig_value if _field_changed?(attr, orig_value, @attributes[attr])
         end
 
         @aggregation_cache = {}

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -521,6 +521,20 @@ class DirtyTest < ActiveRecord::TestCase
     assert !pirate.previous_changes.key?('created_on')
   end
 
+  if ActiveRecord::Base.connection.supports_migrations?
+    class Testings < ActiveRecord::Base; end
+    def test_field_named_field
+      ActiveRecord::Base.connection.create_table :testings do |t|
+        t.string :field
+      end
+      assert_nothing_raised do
+        Testings.new.attributes
+      end
+    ensure
+      ActiveRecord::Base.connection.drop_table :testings rescue nil
+    end
+  end
+
   def test_setting_time_attributes_with_time_zone_field_to_same_time_should_not_be_marked_as_a_change
     in_time_zone 'Paris' do
       target = Class.new(ActiveRecord::Base)
@@ -530,7 +544,7 @@ class DirtyTest < ActiveRecord::TestCase
 
       pirate = target.create(:created_on => created_on)
       pirate.reload # Here mysql truncate the usec value to 0
-      
+
       pirate.created_on = created_on
       assert !pirate.created_on_changed?
     end


### PR DESCRIPTION
Rename field_changed? to _field_changed? so that users can create a field named field
Conflicts:

```
activerecord/lib/active_record/core.rb
activerecord/test/cases/dirty_test.rb
```
