### PR TITLE
Remove '.rb' from require sentences

### DIFF
--- a/activesupport/test/core_ext/object/to_query_test.rb
+++ b/activesupport/test/core_ext/object/to_query_test.rb
@@ -1,7 +1,7 @@
 require 'abstract_unit'
 require 'active_support/ordered_hash'
 require 'active_support/core_ext/object/to_query'
-require 'active_support/core_ext/string/output_safety.rb'
+require 'active_support/core_ext/string/output_safety'
 
 class ToQueryTest < ActiveSupport::TestCase
   def test_simple_conversion

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1,6 +1,6 @@
 require 'generators/generators_test_helper'
 require 'rails/generators/rails/app/app_generator'
-require 'generators/shared_generator_tests.rb'
+require 'generators/shared_generator_tests'
 
 DEFAULT_APP_FILES = %w(
   .gitignore

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -1,6 +1,6 @@
 require 'generators/generators_test_helper'
 require 'rails/generators/rails/plugin_new/plugin_new_generator'
-require 'generators/shared_generator_tests.rb'
+require 'generators/shared_generator_tests'
 
 DEFAULT_PLUGIN_FILES = %w(
   .gitignore


### PR DESCRIPTION
This is just other cases of [#7615](https://github.com/rails/rails/pull/7615)
