### PR TITLE
ActionDispatch: remove trailing slash when root_url is called

### DIFF
--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -31,8 +31,16 @@ module ActionDispatch
           params.reject! {|k,v| v.to_param.nil? }
 
           result = build_host_url(options)
+          result << path
 
-          result << (options[:trailing_slash] ? path.sub(/\?|\z/) { "/" + $& } : path)
+          
+          if options[:trailing_slash] && result.last != "/"
+            result << "/"
+          elsif result.last == "/" 
+            # if result is '/' this is still working
+            result = result[0..result.size-2] 
+          end
+
           result << "?#{params.to_query}" unless params.empty?
           result << "##{Journey::Router::Utils.escape_fragment(options[:anchor].to_param.to_s)}" if options[:anchor]
           result

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -361,7 +361,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     rs.draw do
       root :to => 'content#list', :as => 'home'
     end
-    assert_equal("http://test.host/", setup_for_named_route.send(:home_url))
+    assert_equal("http://test.host", setup_for_named_route.send(:home_url))
   end
 
   def test_named_route_with_option
@@ -443,7 +443,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
       root :to => "hello#index"
     end
     routes = setup_for_named_route
-    assert_equal("http://test.host/", routes.send(:root_url))
+    assert_equal("http://test.host", routes.send(:root_url))
     assert_equal("/", routes.send(:root_path))
   end
 
@@ -452,7 +452,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
       root "hello#index"
     end
     routes = setup_for_named_route
-    assert_equal("http://test.host/", routes.send(:root_url))
+    assert_equal("http://test.host", routes.send(:root_url))
     assert_equal("/", routes.send(:root_path))
   end
 
@@ -654,7 +654,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     assert_equal '/', url_for(rs, { :controller => 'content', :action => 'index' })
     assert_equal '/', url_for(rs, { :controller => 'content' })
 
-    assert_equal("http://test.host/", setup_for_named_route.send(:home_url))
+    assert_equal("http://test.host", setup_for_named_route.send(:home_url))
   end
 
   def test_named_route_method

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -325,7 +325,7 @@ module AbstractController
           params = {:action => :index, :controller => :posts, :format => :xml}
           assert_equal("http://www.basecamphq.com/posts.xml", controller.send(:url_for, params))
           params[:format] = nil
-          assert_equal("http://www.basecamphq.com/", controller.send(:url_for, params))
+          assert_equal("http://www.basecamphq.com", controller.send(:url_for, params))
         end
       end
 

--- a/actionpack/test/dispatch/prefix_generation_test.rb
+++ b/actionpack/test/dispatch/prefix_generation_test.rb
@@ -238,7 +238,7 @@ module TestGenerationPrefix
 
     test "[OBJECT] generating application's route includes default_url_options[:script_name]" do
       RailsApplication.routes.default_url_options = {:script_name => "/something"}
-      assert_equal "/something/", app_object.root_path
+      assert_equal "/something", app_object.root_path
     end
 
     test "[OBJECT] generating engine's route with url_for" do

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -2657,21 +2657,21 @@ class TestUrlConstraints < ActionDispatch::IntegrationTest
   def app; Routes end
 
   test "constraints are copied to defaults when using constraints method" do
-    assert_equal 'http://admin.example.com/', admin_root_url
+    assert_equal 'http://admin.example.com', admin_root_url
 
     get 'http://admin.example.com/'
     assert_response :success
   end
 
   test "constraints are copied to defaults when using scope constraints hash" do
-    assert_equal 'https://www.example.com/', secure_root_url
+    assert_equal 'https://www.example.com', secure_root_url
 
     get 'https://www.example.com/'
     assert_response :success
   end
 
   test "constraints are copied to defaults when using route constraints hash" do
-    assert_equal 'http://www.example.com:8080/', alternate_root_url
+    assert_equal 'http://www.example.com:8080', alternate_root_url
 
     get 'http://www.example.com:8080/'
     assert_response :success

--- a/actionpack/test/template/url_helper_test.rb
+++ b/actionpack/test/template/url_helper_test.rb
@@ -204,7 +204,7 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   def test_link_tag_with_host_option
     hash = hash_for(:host => "www.example.com")
-    expected = %q{<a href="http://www.example.com/">Test Link</a>}
+    expected = %q{<a href="http://www.example.com">Test Link</a>}
     assert_dom_equal(expected, link_to('Test Link', hash))
   end
 


### PR DESCRIPTION
`root_url` is always returning a trailing slash.
That is actually no way to remove it.

So patched `#url_for` to remove trailing slash if present.
