### PR TITLE
added compress options for gzip

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   ActiveSupport::Gzip.compress allows two optional arguments for compression
+    level and strategy.
+
+    *Beyond*
+
 *   Modify `TimeWithZone#as_json` to include 3 decimal places of sub-second accuracy
     by default, which is optional as per the ISO8601 spec, but extremely useful. Also
     the default behaviour of Date#toJSON() in recent versions of Chrome, Safari and

--- a/activesupport/lib/active_support/gzip.rb
+++ b/activesupport/lib/active_support/gzip.rb
@@ -25,9 +25,9 @@ module ActiveSupport
     end
 
     # Compresses a string using gzip.
-    def self.compress(source)
+    def self.compress(source, level=Zlib::DEFAULT_COMPRESSION, strategy=Zlib::DEFAULT_STRATEGY)
       output = Stream.new
-      gz = Zlib::GzipWriter.new(output)
+      gz = Zlib::GzipWriter.new(output, level, strategy)
       gz.write(source)
       gz.close
       output.string

--- a/activesupport/test/gzip_test.rb
+++ b/activesupport/test/gzip_test.rb
@@ -4,6 +4,12 @@ require 'active_support/core_ext/object/blank'
 class GzipTest < ActiveSupport::TestCase
   def test_compress_should_decompress_to_the_same_value
     assert_equal "Hello World", ActiveSupport::Gzip.decompress(ActiveSupport::Gzip.compress("Hello World"))
+    assert_equal "Hello World", ActiveSupport::Gzip.decompress(ActiveSupport::Gzip.compress("Hello World", Zlib::NO_COMPRESSION))
+    assert_equal "Hello World", ActiveSupport::Gzip.decompress(ActiveSupport::Gzip.compress("Hello World", Zlib::BEST_SPEED))
+    assert_equal "Hello World", ActiveSupport::Gzip.decompress(ActiveSupport::Gzip.compress("Hello World", Zlib::BEST_COMPRESSION))
+    assert_equal "Hello World", ActiveSupport::Gzip.decompress(ActiveSupport::Gzip.compress("Hello World", nil, Zlib::FILTERED))
+    assert_equal "Hello World", ActiveSupport::Gzip.decompress(ActiveSupport::Gzip.compress("Hello World", nil, Zlib::HUFFMAN_ONLY))
+    assert_equal "Hello World", ActiveSupport::Gzip.decompress(ActiveSupport::Gzip.compress("Hello World", nil, nil))
   end
 
   def test_compress_should_return_a_binary_string
@@ -11,5 +17,17 @@ class GzipTest < ActiveSupport::TestCase
 
     assert_equal Encoding.find('binary'), compressed.encoding
     assert !compressed.blank?, "a compressed blank string should not be blank"
+  end
+
+  def test_compress_should_return_gzipped_string_by_compression_level
+    source_string = "Hello World"*100
+
+    gzipped_by_speed = ActiveSupport::Gzip.compress(source_string, Zlib::BEST_SPEED)
+    assert_equal 1, Zlib::GzipReader.new(StringIO.new(gzipped_by_speed)).level
+
+    gzipped_by_best_compression = ActiveSupport::Gzip.compress(source_string, Zlib::BEST_COMPRESSION)
+    assert_equal 9, Zlib::GzipReader.new(StringIO.new(gzipped_by_best_compression)).level
+
+    assert_equal true, (gzipped_by_best_compression.bytesize < gzipped_by_speed.bytesize)
   end
 end


### PR DESCRIPTION
Zlib::GzipWriter can take two optional arguments, compression level and strategy. This fix is to pass these arguments.

http://www.ensta-paristech.fr/~diam/ruby/online/ruby-doc-stdlib/libdoc/zlib/rdoc/classes/Zlib/GzipWriter.html
