### PR TITLE
Add conditional css class to content_tag

### DIFF
--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -142,6 +142,15 @@ module ActionView
               value.each_pair do |k, v|
                 attrs << data_tag_option(k, v, escape)
               end
+            elsif key.to_s == 'class' && value.is_a?(Array)
+              value = value.map do |val|
+                if val.is_a?(Array)
+                  val[0] if val[1]
+                else
+                  val
+                end
+              end.compact.join(" ")
+              attrs << tag_option(key, value, escape)
             elsif BOOLEAN_ATTRIBUTES.include?(key)
               attrs << boolean_tag_option(key) if value
             elsif !value.nil?

--- a/actionpack/test/template/tag_helper_test.rb
+++ b/actionpack/test/template/tag_helper_test.rb
@@ -87,6 +87,14 @@ class TagHelperTest < ActionView::TestCase
     assert_equal "<p class=\"song play>\">limelight</p>", str
   end
 
+  def test_content_tag_with_nested_array_class
+    str = content_tag('p', "limelight", :class => ["song", "play", ["current", true]])
+    assert_equal "<p class=\"song play current\">limelight</p>", str
+
+    str = content_tag('p', "limelight", :class => ["song", "play", ["current", false]])
+    assert_equal "<p class=\"song play\">limelight</p>", str
+  end
+
   def test_cdata_section
     assert_equal "<![CDATA[<hello world>]]>", cdata_section("<hello world>")
   end


### PR DESCRIPTION
Hi,

I'm proposing to extend `content_tag` so that it accepts nested array for `class` key:
# Before

``` erb
<ul>
<% @products.each_with_index do |product, i| %>
  <%- css_classes = ['product']
      css_classes << 'first' if i == 0 %>

  <%= content_tag :li, class: css_classes do %>
    <strong><%= product.title %></strong>
  <% end %>
<% end %>
</ul>
```
# After

``` erb
<ul>
<% @products.each_with_index do |product, i| %>
  <%= content_tag :li, class: ['product', ['first', i == 0]] %>
    <strong><%= product.title %></strong>
  <% end %>
<% end %>
</ul>
```

What do you think about it?
