### PR TITLE
remove unused Mime::Type#verify_request?

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Deprecate Mime::Type#verify_request? and Mime::Type.browser_generated_types,
+    since they are no longer used inside of Rails, they will be removed in Rails 4.1
+
+    *Michael Grosser*
+
 *   `ActionDispatch::Http::UploadedFile` now delegates `close` to its tempfile. *Sergio Gil*
 
 *   Add `ActionController::StrongParameters`, this module converts `params` hash into

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -57,7 +57,6 @@ module Mime
     # i.e. following a link, getting an image or posting a form. CSRF protection
     # only needs to protect against these types.
     @@browser_generated_types = Set.new [:html, :url_encoded_form, :multipart_form, :text]
-    cattr_reader :browser_generated_types
     attr_reader :symbol
 
     @register_callbacks = []
@@ -276,7 +275,13 @@ module Mime
     # Returns true if Action Pack should check requests using this Mime Type for possible request forgery. See
     # ActionController::RequestForgeryProtection.
     def verify_request?
+      ActiveSupport::Deprecation.warn "Mime::Type#verify_request? is deprecated and will be removed in Rails 4.1"
       @@browser_generated_types.include?(to_sym)
+    end
+
+    def self.browser_generated_types
+      ActiveSupport::Deprecation.warn "Mime::Type.browser_generated_types is deprecated and will be removed in Rails 4.1"
+      @@browser_generated_types
     end
 
     def html?

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -185,9 +185,11 @@ class MimeTypeTest < ActiveSupport::TestCase
     all_types.uniq!
     # Remove custom Mime::Type instances set in other tests, like Mime::GIF and Mime::IPHONE
     all_types.delete_if { |type| !Mime.const_defined?(type.upcase) }
-    verified, unverified = all_types.partition { |type| Mime::Type.browser_generated_types.include? type }
-    assert verified.each   { |type| assert  Mime.const_get(type.upcase).verify_request?, "Verifiable Mime Type is not verified: #{type.inspect}" }
-    assert unverified.each { |type| assert !Mime.const_get(type.upcase).verify_request?, "Nonverifiable Mime Type is verified: #{type.inspect}" }
+    assert_deprecated do
+      verified, unverified = all_types.partition { |type| Mime::Type.browser_generated_types.include? type }
+      assert verified.each   { |type| assert  Mime.const_get(type.upcase).verify_request?, "Verifiable Mime Type is not verified: #{type.inspect}" }
+      assert unverified.each { |type| assert !Mime.const_get(type.upcase).verify_request?, "Nonverifiable Mime Type is verified: #{type.inspect}" }
+    end
   end
 
   test "references gives preference to symbols before strings" do

--- a/actionpack/test/dispatch/rack_test.rb
+++ b/actionpack/test/dispatch/rack_test.rb
@@ -176,13 +176,17 @@ end
 
 class RackRequestContentTypeTest < BaseRackTest
   test "html content type verification" do
-    @request.env['CONTENT_TYPE'] = Mime::HTML.to_s
-    assert @request.content_mime_type.verify_request?
+    assert_deprecated do
+      @request.env['CONTENT_TYPE'] = Mime::HTML.to_s
+      assert @request.content_mime_type.verify_request?
+    end
   end
 
   test "xml content type verification" do
-    @request.env['CONTENT_TYPE'] = Mime::XML.to_s
-    assert !@request.content_mime_type.verify_request?
+    assert_deprecated do
+      @request.env['CONTENT_TYPE'] = Mime::XML.to_s
+      assert !@request.content_mime_type.verify_request?
+    end
   end
 end
 


### PR DESCRIPTION
Was [used](https://github.com/rails/rails/blob/2-3-stable/actionpack/lib/action_controller/request_forgery_protection.rb#L102) in Rails 2 but [not anymore](https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/metal/request_forgery_protection.rb#L168) -> cleanup
