### PR TITLE
Removed sorting of attribute names in controller generator.

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
@@ -94,7 +94,7 @@ class <%= controller_class_name %>Controller < ApplicationController
       <%- if attributes.empty? -%>
       params[<%= ":#{singular_table_name}" %>]
       <%- else -%>
-      params.require(<%= ":#{singular_table_name}" %>).permit(<%= attributes.map {|a| ":#{a.name}" }.sort.join(', ') %>)
+      params.require(<%= ":#{singular_table_name}" %>).permit(<%= attributes.map {|a| ":#{a.name}" }.join(', ') %>)
       <%- end -%>
     end
 end

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -50,7 +50,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       end
 
       assert_match(/def user_params/, content)
-      assert_match(/params\.require\(:user\)\.permit\(:age, :name\)/, content)
+      assert_match(/params\.require\(:user\)\.permit\(:name, :age\)/, content)
     end
   end
 


### PR DESCRIPTION
I believe when people use generators, they typically order the
parameters on the command line in an order that makes sense
to them.  Sorting them in the generated code  makes the order
seem more arbitrary to humans, even though it's less arbitrary
to computers. :-)

Example:

```
rails g scaffold Post title:string content:text
```

The human chose to put title before content. Sorted
attributes in the generated code work but don't match the
human's intent:

```
params.require(:posts).permit(:content, :title)
```
