### PR TITLE
Deletion of an extra blank line in configuration template file

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -47,7 +47,6 @@ module <%= app_const_base %>
     # config.active_record.schema_format = :sql
 
 <% unless options.skip_sprockets? -%>
-
     # Enable the asset pipeline.
     config.assets.enabled = true
 


### PR DESCRIPTION
When we generate new application we have two blank lines in configuration file (application.rb) without this commit.
