### PR TITLE
method_name sometimes can be unreachable

### DIFF
--- a/activesupport/lib/active_support/testing/setup_and_teardown.rb
+++ b/activesupport/lib/active_support/testing/setup_and_teardown.rb
@@ -38,6 +38,7 @@ module ActiveSupport
           rescue *PASSTHROUGH_EXCEPTIONS => e
             raise e
           rescue Exception => e
+            raise unless defined?(method_name)
             result = runner.puke(self.class, method_name, e)
           ensure
             begin


### PR DESCRIPTION
In my test I have mistake:

```
/Users/route/.rvm/gems/ruby-1.9.3-p194@grabber/gems/actionpack-3.2.8/lib/action_dispatch/testing/assertions/routing.rb:176:in `method_missing': undefined local variable or method `method_name' for #<#<Class:0x007fa795b12f80>:0x007fa7931773b0> (NameError)
```

because of this.
