### PR TITLE
Allow html options on option tag

### DIFF
--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -382,7 +382,13 @@ module ActionView
       # should produce the desired results.
       def options_from_collection_for_select(collection, value_method, text_method, selected = nil)
         options = collection.map do |element|
-          [value_for_collection(element, text_method), value_for_collection(element, value_method)]
+          if element.respond_to?(:last) && element.last.is_a?(Hash)
+            [value_for_collection(element, text_method), value_for_collection(element, value_method), element.last]
+          else
+            [value_for_collection(element, text_method), value_for_collection(element, value_method)]
+          end
+
+          #[value_for_collection(element, text_method), value_for_collection(element, value_method)]
         end
         selected, disabled = extract_selected_and_disabled(selected)
         select_deselect = {

--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -387,8 +387,6 @@ module ActionView
           else
             [value_for_collection(element, text_method), value_for_collection(element, value_method)]
           end
-
-          #[value_for_collection(element, text_method), value_for_collection(element, value_method)]
         end
         selected, disabled = extract_selected_and_disabled(selected)
         select_deselect = {

--- a/actionpack/test/template/form_options_helper_test.rb
+++ b/actionpack/test/template/form_options_helper_test.rb
@@ -1164,6 +1164,20 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_hash_included_in_options_for_select
+    assert_dom_equal(
+      "<option value=\"&lt;Denmark&gt;\">&lt;Denmark&gt;</option>\n<option value=\"1\" class=\"bold\">USA</option>\n<option value=\"Sweden\">Sweden</option>",
+      options_for_select([ "<Denmark>", [ "USA", "1", { :class => 'bold' } ], "Sweden" ])
+    )
+  end
+
+  def test_hash_included_in_collection_for_select
+    assert_dom_equal(
+      "<select id=\"world_country_id\" name=\"world[country_id]\"><option value=\"22\">Mexico</option>\n<option value=\"1\" class=\"bold\">USA</option>\n<option value=\"8\">Sweden</option></select>",
+      collection_select(:world, :country_id,[ [22,"Mexico"], [1, "USA", { :class => 'bold' } ], [8,"Sweden"] ], :first, :second)
+    )
+  end
+
   def test_option_html_attributes_with_no_array_element
     assert_equal({}, option_html_attributes('foo'))
   end


### PR DESCRIPTION
According to documentation you should be able to pass something like this as a collection:

``` ruby
  options_for_select([ "Denmark", ["USA", {:class => 'bold'}], "Sweden" ], ["USA", "Sweden"])
```

and get this HTML

``` html
    <option value="Denmark">Denmark</option>
    <option value="USA" class="bold" selected="selected">USA</option>
    <option value="Sweden" selected="selected">Sweden</option>
```

> copy from actionpack/lib/action_view/helpers/form_options_helper.rb line 308

but when you do it from collection_select the :value_method by default is :last
this commit fix it and re-enable the html option for option tag

coauthored by [fedesoria](https://github.com/fedesoria) - [ovargas27](https://github.com/ovargas27)
