### PR TITLE
Improve support for minitest's spec DSL

### DIFF
--- a/actionmailer/lib/action_mailer/test_case.rb
+++ b/actionmailer/lib/action_mailer/test_case.rb
@@ -10,6 +10,13 @@ module ActionMailer
   end
 
   class TestCase < ActiveSupport::TestCase
+
+    # Use AM::TestCase for the base class when describing a mailer
+    register_spec_type(self) do |desc|
+      Class === desc && desc < ActionMailer::Base
+    end
+    register_spec_type(/Mailer( ?Test)?\z/i, self)
+
     module Behavior
       extend ActiveSupport::Concern
 

--- a/actionmailer/lib/action_mailer/test_case.rb
+++ b/actionmailer/lib/action_mailer/test_case.rb
@@ -49,9 +49,11 @@ module ActionMailer
         end
 
         def determine_default_mailer(name)
-          name.sub(/Test$/, '').constantize
-        rescue NameError
-          raise NonInferrableMailerError.new(name)
+          mailer = determine_constant_from_test_name(name) do |constant|
+            Class === constant && constant < ActionMailer::Base
+          end
+          raise NonInferrableMailerError.new(name) if mailer.nil?
+          mailer
         end
       end
 

--- a/actionmailer/test/spec_type_test.rb
+++ b/actionmailer/test/spec_type_test.rb
@@ -1,0 +1,37 @@
+require 'abstract_unit'
+
+class NotificationMailer < ActionMailer::Base; end
+class Notifications < ActionMailer::Base; end
+
+class SpecTypeTest < ActiveSupport::TestCase
+  def assert_mailer actual
+    assert_equal ActionMailer::TestCase, actual
+  end
+
+  def refute_mailer actual
+    refute_equal ActionMailer::TestCase, actual
+  end
+
+  def test_spec_type_resolves_for_class_constants
+    assert_mailer MiniTest::Spec.spec_type(NotificationMailer)
+    assert_mailer MiniTest::Spec.spec_type(Notifications)
+  end
+
+  def test_spec_type_resolves_for_matching_strings
+    assert_mailer MiniTest::Spec.spec_type("WidgetMailer")
+    assert_mailer MiniTest::Spec.spec_type("WidgetMailerTest")
+    assert_mailer MiniTest::Spec.spec_type("Widget Mailer Test")
+    # And is not case sensitive
+    assert_mailer MiniTest::Spec.spec_type("widgetmailer")
+    assert_mailer MiniTest::Spec.spec_type("widgetmailertest")
+    assert_mailer MiniTest::Spec.spec_type("widget mailer test")
+  end
+
+  def test_spec_type_wont_match_non_space_characters
+    refute_mailer MiniTest::Spec.spec_type("Widget Mailer\tTest")
+    refute_mailer MiniTest::Spec.spec_type("Widget Mailer\rTest")
+    refute_mailer MiniTest::Spec.spec_type("Widget Mailer\nTest")
+    refute_mailer MiniTest::Spec.spec_type("Widget Mailer\fTest")
+    refute_mailer MiniTest::Spec.spec_type("Widget MailerXTest")
+  end
+end

--- a/actionmailer/test/test_test.rb
+++ b/actionmailer/test/test_test.rb
@@ -26,3 +26,147 @@ class CrazyStringNameMailerTest < ActionMailer::TestCase
     assert_equal TestTestMailer, self.class.mailer_class
   end
 end
+
+describe TestTestMailer do
+  it "gets the mailer from the test name" do
+    assert_equal TestTestMailer, self.class.mailer_class
+  end
+end
+
+describe TestTestMailer, :action do
+  it "gets the mailer from the test name" do
+    assert_equal TestTestMailer, self.class.mailer_class
+  end
+end
+
+describe TestTestMailer do
+  describe "nested" do
+    it "gets the mailer from the test name" do
+      assert_equal TestTestMailer, self.class.mailer_class
+    end
+  end
+end
+
+describe TestTestMailer, :action do
+  describe "nested" do
+    it "gets the mailer from the test name" do
+      assert_equal TestTestMailer, self.class.mailer_class
+    end
+  end
+end
+
+describe "TestTestMailer" do
+  it "gets the mailer from the test name" do
+    assert_equal TestTestMailer, self.class.mailer_class
+  end
+end
+
+describe "TestTestMailerTest" do
+  it "gets the mailer from the test name" do
+    assert_equal TestTestMailer, self.class.mailer_class
+  end
+end
+
+describe "TestTestMailer" do
+  describe "nested" do
+    it "gets the mailer from the test name" do
+      assert_equal TestTestMailer, self.class.mailer_class
+    end
+  end
+end
+
+describe "TestTestMailerTest" do
+  describe "nested" do
+    it "gets the mailer from the test name" do
+      assert_equal TestTestMailer, self.class.mailer_class
+    end
+  end
+end
+
+describe "AnotherCrazySymbolNameMailerTest" do
+  tests :test_test_mailer
+
+  it "gets the mailer after setting it with a symbol" do
+    assert_equal TestTestMailer, self.class.mailer_class
+  end
+end
+
+describe "AnotherCrazyStringNameMailerTest" do
+  tests 'test_test_mailer'
+
+  it "gets the mailer after setting it with a string" do
+    assert_equal TestTestMailer, self.class.mailer_class
+  end
+end
+
+describe "Another Crazy Name Mailer Test" do
+  tests TestTestMailer
+
+  it "gets the mailer after setting it manually" do
+    assert_equal TestTestMailer, self.class.mailer_class
+  end
+end
+
+describe "Another Crazy Symbol Name Mailer Test" do
+  tests :test_test_mailer
+
+  it "gets the mailer after setting it with a symbol" do
+    assert_equal TestTestMailer, self.class.mailer_class
+  end
+end
+
+describe "Another Crazy String Name Mailer Test" do
+  tests 'test_test_mailer'
+
+  it "gets the mailer after setting it with a string" do
+    assert_equal TestTestMailer, self.class.mailer_class
+  end
+end
+
+describe "AnotherCrazySymbolNameMailerTest" do
+  tests :test_test_mailer
+
+  describe "nested" do
+    it "gets the mailer after setting it with a symbol" do
+      assert_equal TestTestMailer, self.class.mailer_class
+    end
+  end
+end
+
+describe "AnotherCrazyStringNameMailerTest" do
+  tests 'test_test_mailer'
+
+  describe "nested" do
+    it "gets the mailer after setting it with a string" do
+      assert_equal TestTestMailer, self.class.mailer_class
+    end
+  end
+end
+
+describe "Another Crazy Name Mailer Test" do
+  tests TestTestMailer
+
+  describe "nested" do
+    it "gets the mailer after setting it manually" do
+      assert_equal TestTestMailer, self.class.mailer_class
+    end
+  end
+end
+
+describe "Another Crazy Symbol Name Mailer Test" do
+  tests :test_test_mailer
+
+  describe "nested" do
+    it "gets the mailer after setting it with a symbol" do
+      assert_equal TestTestMailer, self.class.mailer_class
+    end
+  end
+end
+
+describe "Another Crazy String Name Mailer Test" do
+  tests 'test_test_mailer'
+
+  it "gets the mailer after setting it with a string" do
+    assert_equal TestTestMailer, self.class.mailer_class
+  end
+end

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -351,6 +351,7 @@ module ActionController
     register_spec_type(self) do |desc|
       Class === desc && desc < ActionController::Metal
     end
+    register_spec_type(/Controller( ?Test)?\z/i, self)
 
     module Behavior
       extend ActiveSupport::Concern

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -347,9 +347,9 @@ module ActionController
   #  assert_redirected_to page_url(:title => 'foo')
   class TestCase < ActiveSupport::TestCase
 
-    # Use AS::TestCase for the base class when describing a model
+    # Use AC::TestCase for the base class when describing a controller
     register_spec_type(self) do |desc|
-      Class === desc && desc < ActionController::Base
+      Class === desc && desc < ActionController::Metal
     end
 
     module Behavior
@@ -391,7 +391,9 @@ module ActionController
         end
 
         def determine_default_controller_class(name)
-          name.sub(/Test$/, '').safe_constantize
+          determine_constant_from_test_name(name) do |constant|
+            Class === constant && constant < ActionController::Metal
+          end
         end
 
         def prepare_controller_class(new_class)

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -490,6 +490,9 @@ module ActionDispatch
     include ActionController::TemplateAssertions
     include ActionDispatch::Routing::UrlFor
 
+    # Use AD::IntegrationTest for acceptance tests
+    register_spec_type(/(Acceptance|Integration) ?Test\z/i, self)
+
     @@app = nil
 
     def self.app

--- a/actionpack/lib/action_view/test_case.rb
+++ b/actionpack/lib/action_view/test_case.rb
@@ -61,10 +61,9 @@ module ActionView
         end
 
         def determine_default_helper_class(name)
-          mod = name.sub(/Test$/, '').constantize
-          mod.is_a?(Class) ? nil : mod
-        rescue NameError
-          nil
+          determine_constant_from_test_name(name) do |constant|
+            Module === constant && !(Class === constant)
+          end
         end
 
         def helper_method(*methods)

--- a/actionpack/lib/action_view/test_case.rb
+++ b/actionpack/lib/action_view/test_case.rb
@@ -30,6 +30,9 @@ module ActionView
       end
     end
 
+    # Use AV::TestCase for the base class for helpers and views
+    register_spec_type(/(Helper|View)( ?Test)?\z/i, self)
+
     module Behavior
       extend ActiveSupport::Concern
 

--- a/actionpack/test/controller/spec_style_test.rb
+++ b/actionpack/test/controller/spec_style_test.rb
@@ -1,0 +1,116 @@
+require "abstract_unit"
+
+class ApplicationController < ActionController::Base; end
+class ModelsController      < ApplicationController;  end
+module Admin
+  class WidgetsController < ApplicationController; end
+end
+
+# ApplicationController
+describe ApplicationController do
+  describe "nested" do
+    describe "even deeper" do
+      it "exists" do
+        assert_kind_of ApplicationController, @controller
+      end
+    end
+  end
+end
+
+describe ApplicationController, :index do
+  describe "nested" do
+    describe "even deeper" do
+      it "exists" do
+        assert_kind_of ApplicationController, @controller
+      end
+    end
+  end
+end
+
+describe ApplicationController, "unauthenticated user" do
+  describe "nested" do
+    describe "even deeper" do
+      it "exists" do
+        assert_kind_of ApplicationController, @controller
+      end
+    end
+  end
+end
+
+# ModelsController
+describe ModelsController do
+  describe "nested" do
+    describe "even deeper" do
+      it "exists" do
+        assert_kind_of ModelsController, @controller
+      end
+    end
+  end
+end
+
+describe ModelsController, :index do
+  describe "nested" do
+    describe "even deeper" do
+      it "exists" do
+        assert_kind_of ModelsController, @controller
+      end
+    end
+  end
+end
+
+describe ModelsController, "unauthenticated user" do
+  describe "nested" do
+    describe "even deeper" do
+      it "exists" do
+        assert_kind_of ModelsController, @controller
+      end
+    end
+  end
+end
+
+# Nested Admin::WidgetsControllerTest
+module Admin
+  class WidgetsControllerTest < ActionController::TestCase
+    test "exists" do
+      assert_kind_of Admin::WidgetsController, @controller
+    end
+  end
+
+  describe WidgetsController do
+    describe "index" do
+      it "respond successful" do
+        assert_kind_of Admin::WidgetsController, @controller
+      end
+    end
+  end
+
+  describe WidgetsController, "unauthenticated users" do
+    describe "index" do
+      it "respond successful" do
+        assert_kind_of Admin::WidgetsController, @controller
+      end
+    end
+  end
+end
+
+class Admin::WidgetsControllerTest < ActionController::TestCase
+  test "exists here too" do
+    assert_kind_of Admin::WidgetsController, @controller
+  end
+end
+
+describe Admin::WidgetsController do
+  describe "index" do
+    it "respond successful" do
+      assert_kind_of Admin::WidgetsController, @controller
+    end
+  end
+end
+
+describe Admin::WidgetsController, "unauthenticated users" do
+  describe "index" do
+    it "respond successful" do
+      assert_kind_of Admin::WidgetsController, @controller
+    end
+  end
+end

--- a/actionpack/test/controller/spec_style_test.rb
+++ b/actionpack/test/controller/spec_style_test.rb
@@ -37,6 +37,36 @@ describe ApplicationController, "unauthenticated user" do
   end
 end
 
+describe "ApplicationControllerTest" do
+  describe "nested" do
+    describe "even deeper" do
+      it "exists" do
+        assert_kind_of ApplicationController, @controller
+      end
+    end
+  end
+end
+
+describe "ApplicationControllerTest", :index do
+  describe "nested" do
+    describe "even deeper" do
+      it "exists" do
+        assert_kind_of ApplicationController, @controller
+      end
+    end
+  end
+end
+
+describe "ApplicationControllerTest", "unauthenticated user" do
+  describe "nested" do
+    describe "even deeper" do
+      it "exists" do
+        assert_kind_of ApplicationController, @controller
+      end
+    end
+  end
+end
+
 # ModelsController
 describe ModelsController do
   describe "nested" do
@@ -59,6 +89,36 @@ describe ModelsController, :index do
 end
 
 describe ModelsController, "unauthenticated user" do
+  describe "nested" do
+    describe "even deeper" do
+      it "exists" do
+        assert_kind_of ModelsController, @controller
+      end
+    end
+  end
+end
+
+describe "ModelsControllerTest" do
+  describe "nested" do
+    describe "even deeper" do
+      it "exists" do
+        assert_kind_of ModelsController, @controller
+      end
+    end
+  end
+end
+
+describe "ModelsControllerTest", :index do
+  describe "nested" do
+    describe "even deeper" do
+      it "exists" do
+        assert_kind_of ModelsController, @controller
+      end
+    end
+  end
+end
+
+describe "ModelsControllerTest", "unauthenticated user" do
   describe "nested" do
     describe "even deeper" do
       it "exists" do
@@ -108,6 +168,38 @@ describe Admin::WidgetsController do
 end
 
 describe Admin::WidgetsController, "unauthenticated users" do
+  describe "index" do
+    it "respond successful" do
+      assert_kind_of Admin::WidgetsController, @controller
+    end
+  end
+end
+
+describe "Admin::WidgetsController" do
+  describe "index" do
+    it "respond successful" do
+      assert_kind_of Admin::WidgetsController, @controller
+    end
+  end
+end
+
+describe "Admin::WidgetsControllerTest" do
+  describe "index" do
+    it "respond successful" do
+      assert_kind_of Admin::WidgetsController, @controller
+    end
+  end
+end
+
+describe "Admin::WidgetsController", "unauthenticated users" do
+  describe "index" do
+    it "respond successful" do
+      assert_kind_of Admin::WidgetsController, @controller
+    end
+  end
+end
+
+describe "Admin::WidgetsControllerTest", "unauthenticated users" do
   describe "index" do
     it "respond successful" do
       assert_kind_of Admin::WidgetsController, @controller

--- a/actionpack/test/controller/spec_type_test.rb
+++ b/actionpack/test/controller/spec_type_test.rb
@@ -1,0 +1,37 @@
+require "abstract_unit"
+
+class ApplicationController < ActionController::Base; end
+class ModelsController      < ApplicationController;  end
+
+class SpecTypeTest < ActiveSupport::TestCase
+  def assert_controller actual
+    assert_equal ActionController::TestCase, actual
+  end
+
+  def refute_controller actual
+    refute_equal ActionController::TestCase, actual
+  end
+
+  def test_spec_type_resolves_for_class_constants
+    assert_controller MiniTest::Spec.spec_type(ApplicationController)
+    assert_controller MiniTest::Spec.spec_type(ModelsController)
+  end
+
+  def test_spec_type_resolves_for_matching_strings
+    assert_controller MiniTest::Spec.spec_type("WidgetController")
+    assert_controller MiniTest::Spec.spec_type("WidgetControllerTest")
+    assert_controller MiniTest::Spec.spec_type("Widget Controller Test")
+    # And is not case sensitive
+    assert_controller MiniTest::Spec.spec_type("widgetcontroller")
+    assert_controller MiniTest::Spec.spec_type("widgetcontrollertest")
+    assert_controller MiniTest::Spec.spec_type("widget controller test")
+  end
+
+  def test_spec_type_wont_match_non_space_characters
+    refute_controller MiniTest::Spec.spec_type("Widget Controller\tTest")
+    refute_controller MiniTest::Spec.spec_type("Widget Controller\rTest")
+    refute_controller MiniTest::Spec.spec_type("Widget Controller\nTest")
+    refute_controller MiniTest::Spec.spec_type("Widget Controller\fTest")
+    refute_controller MiniTest::Spec.spec_type("Widget ControllerXTest")
+  end
+end

--- a/actionpack/test/dispatch/spec_type_test.rb
+++ b/actionpack/test/dispatch/spec_type_test.rb
@@ -1,0 +1,41 @@
+require "abstract_unit"
+
+class SpecTypeTest < ActiveSupport::TestCase
+  def assert_dispatch actual
+    assert_equal ActionDispatch::IntegrationTest, actual
+  end
+
+  def refute_dispatch actual
+    refute_equal ActionDispatch::IntegrationTest, actual
+  end
+
+  def test_spec_type_resolves_for_matching_acceptance_strings
+    assert_dispatch MiniTest::Spec.spec_type("WidgetAcceptanceTest")
+    assert_dispatch MiniTest::Spec.spec_type("Widget Acceptance Test")
+    assert_dispatch MiniTest::Spec.spec_type("widgetacceptancetest")
+    assert_dispatch MiniTest::Spec.spec_type("widget acceptance test")
+  end
+
+  def test_spec_type_wont_match_non_space_characters_acceptance
+    refute_dispatch MiniTest::Spec.spec_type("Widget Acceptance\tTest")
+    refute_dispatch MiniTest::Spec.spec_type("Widget Acceptance\rTest")
+    refute_dispatch MiniTest::Spec.spec_type("Widget Acceptance\nTest")
+    refute_dispatch MiniTest::Spec.spec_type("Widget Acceptance\fTest")
+    refute_dispatch MiniTest::Spec.spec_type("Widget AcceptanceXTest")
+  end
+
+  def test_spec_type_resolves_for_matching_integration_strings
+    assert_dispatch MiniTest::Spec.spec_type("WidgetIntegrationTest")
+    assert_dispatch MiniTest::Spec.spec_type("Widget Integration Test")
+    assert_dispatch MiniTest::Spec.spec_type("widgetintegrationtest")
+    assert_dispatch MiniTest::Spec.spec_type("widget integration test")
+  end
+
+  def test_spec_type_wont_match_non_space_characters_integration
+    refute_dispatch MiniTest::Spec.spec_type("Widget Integration\tTest")
+    refute_dispatch MiniTest::Spec.spec_type("Widget Integration\rTest")
+    refute_dispatch MiniTest::Spec.spec_type("Widget Integration\nTest")
+    refute_dispatch MiniTest::Spec.spec_type("Widget Integration\fTest")
+    refute_dispatch MiniTest::Spec.spec_type("Widget IntegrationXTest")
+  end
+end

--- a/actionpack/test/template/spec_type_test.rb
+++ b/actionpack/test/template/spec_type_test.rb
@@ -1,0 +1,39 @@
+require 'abstract_unit'
+
+class SpecTypeTest < ActiveSupport::TestCase
+  def assert_view actual
+    assert_equal ActionView::TestCase, actual
+  end
+
+  def refute_view actual
+    refute_equal ActionView::TestCase, actual
+  end
+
+  def test_spec_type_resolves_for_matching_helper_strings
+    assert_view MiniTest::Spec.spec_type("WidgetHelper")
+    assert_view MiniTest::Spec.spec_type("WidgetHelperTest")
+    assert_view MiniTest::Spec.spec_type("Widget Helper Test")
+    # And is not case sensitive
+    assert_view MiniTest::Spec.spec_type("widgethelper")
+    assert_view MiniTest::Spec.spec_type("widgethelpertest")
+    assert_view MiniTest::Spec.spec_type("widget helper test")
+  end
+
+  def test_spec_type_resolves_for_matching_view_strings
+    assert_view MiniTest::Spec.spec_type("WidgetView")
+    assert_view MiniTest::Spec.spec_type("WidgetViewTest")
+    assert_view MiniTest::Spec.spec_type("Widget View Test")
+    # And is not case sensitive
+    assert_view MiniTest::Spec.spec_type("widgetview")
+    assert_view MiniTest::Spec.spec_type("widgetviewtest")
+    assert_view MiniTest::Spec.spec_type("widget view test")
+  end
+
+  def test_spec_type_wont_match_non_space_characters
+    refute_view MiniTest::Spec.spec_type("Widget Helper\tTest")
+    refute_view MiniTest::Spec.spec_type("Widget Helper\rTest")
+    refute_view MiniTest::Spec.spec_type("Widget Helper\nTest")
+    refute_view MiniTest::Spec.spec_type("Widget Helper\fTest")
+    refute_view MiniTest::Spec.spec_type("Widget HelperXTest")
+  end
+end

--- a/actionpack/test/template/test_case_test.rb
+++ b/actionpack/test/template/test_case_test.rb
@@ -64,7 +64,7 @@ module ActionView
       assert_equal 'Howdy!', from_another_helper
     end
 
-    test "determine_default_helper_class returns nil if name.sub(/Test$/, '').constantize resolves to a class" do
+    test "determine_default_helper_class returns nil if the test name constant resolves to a class" do
       assert_nil self.class.determine_default_helper_class("String")
     end
 

--- a/actionpack/test/template/test_test.rb
+++ b/actionpack/test/template/test_test.rb
@@ -78,3 +78,59 @@ class CrazyStringHelperTest < ActionView::TestCase
     assert_equal PeopleHelper, self.class.helper_class
   end
 end
+
+describe PeopleHelper do
+  it "resolves the right helper_class" do
+    assert_equal PeopleHelper, self.class.helper_class
+  end
+end
+
+describe PeopleHelper, :helper_class do
+  it "resolves the right helper_class" do
+    assert_equal PeopleHelper, self.class.helper_class
+  end
+end
+
+describe PeopleHelper do
+  describe "even while nested" do
+    it "resolves the right helper_class" do
+      assert_equal PeopleHelper, self.class.helper_class
+    end
+  end
+end
+
+describe PeopleHelper, :helper_class do
+  describe "even while nested" do
+    it "resolves the right helper_class" do
+      assert_equal PeopleHelper, self.class.helper_class
+    end
+  end
+end
+
+describe "PeopleHelper" do
+  it "resolves the right helper_class" do
+    assert_equal PeopleHelper, self.class.helper_class
+  end
+end
+
+describe "PeopleHelperTest" do
+  it "resolves the right helper_class" do
+    assert_equal PeopleHelper, self.class.helper_class
+  end
+end
+
+describe "PeopleHelper" do
+  describe "even while nested" do
+    it "resolves the right helper_class" do
+      assert_equal PeopleHelper, self.class.helper_class
+    end
+  end
+end
+
+describe "PeopleHelperTest" do
+  describe "even while nested" do
+    it "resolves the right helper_class" do
+      assert_equal PeopleHelper, self.class.helper_class
+    end
+  end
+end

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -5,6 +5,7 @@ require 'active_support/testing/assertions'
 require 'active_support/testing/deprecation'
 require 'active_support/testing/isolation'
 require 'active_support/testing/mocha_module'
+require 'active_support/testing/constant_lookup'
 require 'active_support/core_ext/kernel/reporting'
 require 'active_support/deprecation'
 
@@ -35,6 +36,7 @@ module ActiveSupport
     include ActiveSupport::Testing::SetupAndTeardown
     include ActiveSupport::Testing::Assertions
     include ActiveSupport::Testing::Deprecation
+    include ActiveSupport::Testing::ConstantLookup
 
     def self.describe(text)
       if block_given?

--- a/activesupport/lib/active_support/testing/constant_lookup.rb
+++ b/activesupport/lib/active_support/testing/constant_lookup.rb
@@ -1,0 +1,53 @@
+require "active_support/concern"
+
+module ActiveSupport
+  module Testing
+    # Resolves a constant from a minitest spec name.
+    #
+    # Given the following spec-style test:
+    #
+    #   describe WidgetsController, :index do
+    #     describe "authenticated user" do
+    #       describe "returns widgets" do
+    #         it "has a controller that exists" do
+    #           assert_kind_of WidgetsController, @controller
+    #         end
+    #       end
+    #     end
+    #   end
+    #
+    # The test will have the following name:
+    #
+    #   "WidgetsController::index::authenticated user::returns widgets"
+    #
+    # The constant WidgetsController can be resolved from the name.
+    # The following code will resolve the constant:
+    #
+    #   controller = determine_constant_from_test_name(name) do |constant|
+    #     Class === constant && constant < ::ActionController::Metal
+    #   end
+    module ConstantLookup
+      extend ::ActiveSupport::Concern
+
+      module ClassMethods
+        def determine_constant_from_test_name(test_name)
+          names = test_name.split "::"
+          while names.size > 0 do
+            names.last.sub! /Test$/, ""
+            # Rails 3.0 doesn't have safe_constantize,
+            # so we'll do it the hard way.
+            begin
+              constant = names.join("::").constantize
+              break(constant) if yield(constant)
+            rescue NameError
+              # Constant wasn't found, move on
+            ensure
+              names.pop
+            end
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/activesupport/test/spec_type_test.rb
+++ b/activesupport/test/spec_type_test.rb
@@ -1,0 +1,23 @@
+require "abstract_unit"
+require "active_record"
+
+class SomeRandomModel < ActiveRecord::Base; end
+
+class SpecTypeTest < ActiveSupport::TestCase
+
+  def assert_support actual
+    assert_equal ActiveSupport::TestCase, actual
+  end
+
+  def assert_spec actual
+    assert_equal MiniTest::Spec, actual
+  end
+
+  def test_spec_type_resolves_for_actitive_record_constants
+    assert_support MiniTest::Spec.spec_type(SomeRandomModel)
+  end
+
+  def test_spec_type_doesnt_resolve_random_strings
+    assert_spec MiniTest::Spec.spec_type("Unmatched String")
+  end
+end

--- a/activesupport/test/testing/constant_lookup_test.rb
+++ b/activesupport/test/testing/constant_lookup_test.rb
@@ -1,0 +1,58 @@
+require 'abstract_unit'
+
+class Foo; end
+class Bar < Foo;
+  def index; end
+  def self.index; end
+end
+class Baz < Bar; end
+module FooBar; end
+
+class TestLookup < ActiveSupport::TestCase
+
+  def find_foo(name)
+    self.class.determine_constant_from_test_name(name) do |constant|
+      Class === constant && constant < Foo
+    end
+  end
+
+  def find_module(name)
+    self.class.determine_constant_from_test_name(name) do |constant|
+      Module === constant
+    end
+  end
+
+  def test_find_bar_from_foo
+    assert_equal Bar, find_foo("Bar")
+    assert_equal Bar, find_foo("Bar::index")
+    assert_equal Bar, find_foo("Bar::index::authenticated")
+    assert_equal Bar, find_foo("BarTest")
+    assert_equal Bar, find_foo("BarTest::index")
+    assert_equal Bar, find_foo("BarTest::index::authenticated")
+  end
+
+  def test_find_module
+    assert_equal FooBar, find_module("FooBar")
+    assert_equal FooBar, find_module("FooBar::index")
+    assert_equal FooBar, find_module("FooBar::index::authenticated")
+    assert_equal FooBar, find_module("FooBarTest")
+    assert_equal FooBar, find_module("FooBarTest::index")
+    assert_equal FooBar, find_module("FooBarTest::index::authenticated")
+  end
+
+  def test_returns_nil_when_cant_find_foo
+    assert_nil find_foo("DoesntExist")
+    assert_nil find_foo("DoesntExistTest")
+    assert_nil find_foo("DoesntExist::Nadda")
+    assert_nil find_foo("DoesntExist::Nadda::Nope")
+    assert_nil find_foo("DoesntExist::Nadda::Nope::NotHere")
+  end
+
+  def test_returns_nil_when_cant_find_module
+    assert_nil find_module("DoesntExist")
+    assert_nil find_module("DoesntExistTest")
+    assert_nil find_module("DoesntExist::Nadda")
+    assert_nil find_module("DoesntExist::Nadda::Nope")
+    assert_nil find_module("DoesntExist::Nadda::Nope::NotHere")
+  end
+end


### PR DESCRIPTION
The Rails testing infrastructure is built on minitest, but there are some rough edges if you want to use the spec DSL. Currently its not possible to have a nested describe on a controller test.

```
describe WidgetsController, :index do
  describe "authenticated user" do
    it "is accessible" do
      assert_response :success
    end
  end
end
```

This request makes this possible by adding the ability to resolve constants from the test name. It also includes additional spec registration for mailer, helper, and integration tests. Oh, and a bunch of tests too. (All of this code was taken from minitest-rails.)

Fixes #7748
