### PR TITLE
Added ActiveRecord::Relation#none! method

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Added `#none!` method for mutating `ActiveRecord::Relation` objects to a NullRelation.
+    It acts like `#none` but modifies relation in place.
+
+    *Juanjo Bazán*
+
 *   Fix bug where `update_columns` and `update_column` would not let you update the primary key column.
 
     *Henrik Nyh*

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -496,6 +496,11 @@ module ActiveRecord
       extending(NullRelation)
     end
 
+    # Like #none, but modifies relation in place.
+    def none!
+      extending!(NullRelation)
+    end
+
     # Sets readonly attributes for the returned relation. If value is
     # true (default), attempting to update a record will result in an error.
     #

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -256,5 +256,11 @@ module ActiveRecord
     test 'merge with a proc' do
       assert_equal [:foo], relation.merge(-> { where(:foo) }).where_values
     end
+
+    test 'none!' do
+      assert relation.none!.equal?(relation)
+      assert_equal [NullRelation], relation.extending_values
+      assert relation.is_a?(NullRelation)
+    end
   end
 end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1391,6 +1391,15 @@ class RelationTest < ActiveRecord::TestCase
     end
   end
 
+  test "loaded relations cannot be mutated by extending!" do
+    relation = Post.all
+    relation.to_a
+
+    assert_raises(ActiveRecord::ImmutableRelation) do
+      relation.extending! Module.new
+    end
+  end
+
   test "relations show the records in #inspect" do
     relation = Post.limit(2)
     assert_equal "#<ActiveRecord::Relation [#{Post.limit(2).map(&:inspect).join(', ')}]>", relation.inspect


### PR DESCRIPTION
The none bang method in AR::Relation to modify objects in place was missing.
