### PR TITLE
Feature: set the same width and height for image if size attribute is a number

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `image_tag` will set the same width and height for image if numerical value
+    passed to `size` option.
+
+    *Nihad Abbasov*
+
 *   Deprecate Mime::Type#verify_request? and Mime::Type.browser_generated_types,
     since they are no longer used inside of Rails, they will be removed in Rails 4.1
 

--- a/actionpack/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helper.rb
@@ -390,7 +390,7 @@ module ActionView
         end
 
         if size = options.delete(:size)
-          options[:width], options[:height] = size.split("x") if size =~ %r{^\d+x\d+$}
+          options[:width], options[:height] = size.split("x") if size =~ %r{\A\d+x\d+\z}
           options[:width] = options[:height] = size if size =~ %r{\A\d+\z}
         end
 

--- a/actionpack/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helper.rb
@@ -364,9 +364,9 @@ module ActionView
       #
       # * <tt>:alt</tt>  - If no alt text is given, the file name part of the
       #   +source+ is used (capitalized and without the extension)
-      # * <tt>:size</tt> - Supplied as "{Width}x{Height}", so "30x45" becomes
-      #   width="30" and height="45". <tt>:size</tt> will be ignored if the
-      #   value is not in the correct format.
+      # * <tt>:size</tt> - Supplied as "{Width}x{Height}" or "{Number}", so "30x45" becomes
+      #   width="30" and height="45", and "50" becomes width="50" and height="50".
+      #   <tt>:size</tt> will be ignored if the value is not in the correct format.
       #
       #  image_tag("icon")
       #  # => <img src="/assets/icon" alt="Icon" />
@@ -374,7 +374,7 @@ module ActionView
       #  # => <img src="/assets/icon.png" alt="Icon" />
       #  image_tag("icon.png", :size => "16x10", :alt => "Edit Entry")
       #  # => <img src="/assets/icon.png" width="16" height="10" alt="Edit Entry" />
-      #  image_tag("/icons/icon.gif", :size => "16x16")
+      #  image_tag("/icons/icon.gif", :size => "16")
       #  # => <img src="/icons/icon.gif" width="16" height="16" alt="Icon" />
       #  image_tag("/icons/icon.gif", :height => '32', :width => '32')
       #  # => <img alt="Icon" height="32" src="/icons/icon.gif" width="32" />
@@ -391,6 +391,7 @@ module ActionView
 
         if size = options.delete(:size)
           options[:width], options[:height] = size.split("x") if size =~ %r{^\d+x\d+$}
+          options[:width] = options[:height] = size if size =~ %r{\A\d+\z}
         end
 
         tag("img", options)

--- a/actionpack/test/template/asset_tag_helper_test.rb
+++ b/actionpack/test/template/asset_tag_helper_test.rb
@@ -192,9 +192,9 @@ class AssetTagHelperTest < ActionView::TestCase
   ImageLinkToTag = {
     %(image_tag("xml.png")) => %(<img alt="Xml" src="/images/xml.png" />),
     %(image_tag("rss.gif", :alt => "rss syndication")) => %(<img alt="rss syndication" src="/images/rss.gif" />),
+    %(image_tag("gold.png", :size => "20")) => %(<img alt="Gold" height="20" src="/images/gold.png" width="20" />),
     %(image_tag("gold.png", :size => "45x70")) => %(<img alt="Gold" height="70" src="/images/gold.png" width="45" />),
     %(image_tag("gold.png", "size" => "45x70")) => %(<img alt="Gold" height="70" src="/images/gold.png" width="45" />),
-    %(image_tag("error.png", "size" => "45")) => %(<img alt="Error" src="/images/error.png" />),
     %(image_tag("error.png", "size" => "45 x 70")) => %(<img alt="Error" src="/images/error.png" />),
     %(image_tag("error.png", "size" => "x")) => %(<img alt="Error" src="/images/error.png" />),
     %(image_tag("google.com.png")) => %(<img alt="Google.com" src="/images/google.com.png" />),


### PR DESCRIPTION
This allows to do:

``` ruby
image_tag("icon.png", :size => "16")
# => <img alt="Icon" height="16" src="/images/icon.png" width="16" />
```
