### PR TITLE
Skip tests for non-supported isolation levels

### DIFF
--- a/activerecord/test/cases/transaction_isolation_test.rb
+++ b/activerecord/test/cases/transaction_isolation_test.rb
@@ -44,7 +44,9 @@ class TransactionIsolationTest < ActiveRecord::TestCase
   # specifies what must not happen at a certain level, not what must happen. At
   # the read uncommitted level, there is nothing that must not happen.
   test "read uncommitted" do
-    return skip "Oracle does not support read uncommitted" if current_adapter? :OracleAdapter
+    unless ActiveRecord::Base.connection.transaction_isolation_levels.include?(:read_uncommitted)
+      skip "database does not support read uncommitted isolation level"
+    end
     Tag.transaction(isolation: :read_uncommitted) do
       assert_equal 0, Tag.count
       Tag2.create
@@ -68,7 +70,9 @@ class TransactionIsolationTest < ActiveRecord::TestCase
 
   # We are testing that a nonrepeatable read does not happen
   test "repeatable read" do
-    return skip "Oracle does not support repeatble read" if current_adapter? :OracleAdapter
+    unless ActiveRecord::Base.connection.transaction_isolation_levels.include?(:repeatable_read)
+      skip "database does not support repeatable read isolation level"
+    end
     tag = Tag.create(name: 'jon')
 
     Tag.transaction(isolation: :repeatable_read) do


### PR DESCRIPTION
i.e. Oracle database does not support these isolation levels.
`:read_uncommitted` `:repeatable_read`

This pull request modifies #7756 to these tests database adapter name independent.
