### PR TITLE
Adds missing dependency to ActionView::TestCase::Behavior

### DIFF
--- a/actionmailer/lib/action_mailer/test_case.rb
+++ b/actionmailer/lib/action_mailer/test_case.rb
@@ -20,6 +20,7 @@ module ActionMailer
     module Behavior
       extend ActiveSupport::Concern
 
+      include ActiveSupport::Testing::ConstantLookup
       include TestHelper
 
       included do

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -356,6 +356,7 @@ module ActionController
     module Behavior
       extend ActiveSupport::Concern
       include ActionDispatch::TestProcess
+      include ActiveSupport::Testing::ConstantLookup
 
       attr_reader :response, :request
 

--- a/actionpack/lib/action_view/test_case.rb
+++ b/actionpack/lib/action_view/test_case.rb
@@ -47,6 +47,8 @@ module ActionView
       include ActionView::RecordIdentifier
       include ActionView::RoutingUrlFor
 
+      include ActiveSupport::Testing::ConstantLookup
+
       delegate :lookup_context, :to => :controller
       attr_accessor :controller, :output_buffer, :rendered
 

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -38,7 +38,6 @@ module ActiveSupport
     include ActiveSupport::Testing::SetupAndTeardown
     include ActiveSupport::Testing::Assertions
     include ActiveSupport::Testing::Deprecation
-    include ActiveSupport::Testing::ConstantLookup
 
     def self.describe(text)
       if block_given?

--- a/activesupport/test/testing/constant_lookup_test.rb
+++ b/activesupport/test/testing/constant_lookup_test.rb
@@ -9,6 +9,7 @@ class Baz < Bar; end
 module FooBar; end
 
 class ConstantLookupTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::ConstantLookup
 
   def find_foo(name)
     self.class.determine_constant_from_test_name(name) do |constant|


### PR DESCRIPTION
- The module is needed for the `determine_constant_from_test_name`
  method.
- Without it, the including class is required to also include
  `ActiveSupport::Testing::ConstantLookup` or a `NoMethodError` will be
  raised upon instantiation of that class.
- Issue introduced in c0a24555f9e2749fb94efe1967cb9943db0b6a7e
