### PR TITLE
Removing dead code. attribute_cast_code isn't called.

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -98,16 +98,6 @@ module ActiveRecord
 
             attributes
           end
-
-          private
-
-          def attribute_cast_code(attr_name)
-            if serialized_attributes.include?(attr_name)
-              "v.unserialized_value"
-            else
-              super
-            end
-          end
         end
 
         def type_cast_attribute_for_write(column, value)

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -34,21 +34,6 @@ module ActiveRecord
 
       module ClassMethods
         protected
-        # The enhanced read method automatically converts the UTC time stored in the database to the time
-        # zone stored in Time.zone.
-        def attribute_cast_code(attr_name)
-          column = columns_hash[attr_name]
-
-          if create_time_zone_conversion_attribute?(attr_name, column)
-            typecast             = "v = #{super}"
-            time_zone_conversion = "v.acts_like?(:time) ? v.in_time_zone : v"
-
-            "((#{typecast}) && (#{time_zone_conversion}))"
-          else
-            super
-          end
-        end
-
         # Defined for all +datetime+ and +timestamp+ attributes when +time_zone_aware_attributes+ are enabled.
         # This enhanced write method will automatically convert the time passed to it to the zone stored in Time.zone.
         def define_method_attribute=(attr_name)


### PR DESCRIPTION
attribute_cast_code isn't called. And when removing this method, testcases were all green.
