### PR TITLE
activerecord: Fix empty_insert_statement_value for mysql and sqlite.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -298,7 +298,7 @@ module ActiveRecord
         execute "INSERT INTO #{quote_table_name(table_name)} (#{key_list.join(', ')}) VALUES (#{value_list.join(', ')})", 'Fixture Insert'
       end
 
-      def empty_insert_statement_value
+      def empty_insert_statement_value(primary_key)
         "VALUES(DEFAULT)"
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -320,6 +320,10 @@ module ActiveRecord
         end
       end
 
+      def empty_insert_statement_value(primary_key)
+        "VALUES ()"
+      end
+
       # SCHEMA STATEMENTS ========================================
 
       def structure_dump #:nodoc:

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -490,8 +490,8 @@ module ActiveRecord
         alter_table(table_name, :rename => {column_name.to_s => new_column_name.to_s})
       end
 
-      def empty_insert_statement_value
-        "VALUES(NULL)"
+      def empty_insert_statement_value(primary_key)
+        "(#{quote_column_name(primary_key)}) VALUES(NULL)"
       end
 
       protected

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -60,7 +60,7 @@ module ActiveRecord
       end
 
       if values.empty? # empty insert
-        im.values = Arel.sql(connection.empty_insert_statement_value)
+        im.values = Arel.sql(connection.empty_insert_statement_value(primary_key))
       else
         im.insert substitutes
       end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1014,6 +1014,12 @@ class RelationTest < ActiveRecord::TestCase
     assert_raises(ActiveRecord::RecordInvalid) { Bird.where(:color => 'green').first_or_create!([ {:name => 'parrot'}, {:pirate_id => 1} ]) }
   end
 
+  def test_insert_empty_values
+    assert_difference('Bird.count', 1) do
+      assert_not_nil Bird.unscoped.insert({})
+    end
+  end
+
   def test_first_or_initialize
     parrot = Bird.where(:color => 'green').first_or_initialize(:name => 'parrot')
     assert_kind_of Bird, parrot


### PR DESCRIPTION
I found that empty insert values were failing.

Normally this isn't noticed because default values are inserted for all the fields.

I tested with the default adaptors run during tests (mysql, mysql2, sqlite3 and postgresql).  I would appreciate tests run for other supported databases.
