### PR TITLE
activerecord: Avoid mysql non-null text column defaulting to empty string

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -68,17 +68,7 @@ module ActiveRecord
       end
 
       def create(*)
-        if partial_updates?
-          keys = keys_for_partial_update
-
-          # This is an extremely bloody annoying necessity to work around mysql being crap.
-          # See test_mysql_text_not_null_defaults
-          keys.concat self.class.columns.select(&:explicit_default?).map(&:name)
-
-          super keys
-        else
-          super
-        end
+        partial_updates? ? super(keys_for_partial_update) : super
       end
 
       # Serialized attributes should always be written in case they've been

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -14,7 +14,7 @@ module ActiveRecord
         def extract_default(default)
           if sql_type =~ /blob/i || type == :text
             if default.blank?
-              return null ? nil : ''
+              return nil
             else
               raise ArgumentError, "#{type} columns cannot have a default value: #{default.inspect}"
             end
@@ -28,10 +28,6 @@ module ActiveRecord
         def has_default?
           return false if sql_type =~ /blob/i || type == :text #mysql forbids defaults on blob and text columns
           super
-        end
-
-        def explicit_default?
-          !null && (sql_type =~ /blob/i || type == :text)
         end
 
         # Must return the relevant concrete adapter

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -14,7 +14,7 @@ module ActiveRecord
         def extract_default(default)
           if sql_type =~ /blob/i || type == :text
             if default.blank?
-              return nil
+              nil
             else
               raise ArgumentError, "#{type} columns cannot have a default value: #{default.inspect}"
             end

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -53,10 +53,6 @@ module ActiveRecord
         !default.nil?
       end
 
-      def explicit_default?
-        false
-      end
-
       # Returns the Ruby class that corresponds to the abstract data type.
       def klass
         case type

--- a/activerecord/test/cases/column_definition_test.rb
+++ b/activerecord/test/cases/column_definition_test.rb
@@ -78,7 +78,7 @@ module ActiveRecord
           assert_equal nil, text_column.default
 
           not_null_text_column = MysqlAdapter::Column.new("title", nil, "text", false)
-          assert_equal "", not_null_text_column.default
+          assert_equal nil, not_null_text_column.default
         end
 
         def test_has_default_should_return_false_for_blog_and_test_data_types
@@ -112,7 +112,7 @@ module ActiveRecord
           assert_equal nil, text_column.default
 
           not_null_text_column = Mysql2Adapter::Column.new("title", nil, "text", false)
-          assert_equal "", not_null_text_column.default
+          assert_equal nil, not_null_text_column.default
         end
 
         def test_has_default_should_return_false_for_blog_and_test_data_types

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -51,10 +51,6 @@ if current_adapter?(:MysqlAdapter) or current_adapter?(:Mysql2Adapter)
     # We don't want that to happen, so we disable transactional fixtures here.
     self.use_transactional_fixtures = false
 
-    # MySQL 5 and higher is quirky with not null text/blob columns.
-    # With MySQL Text/blob columns cannot have defaults. If the column is not
-    # null MySQL will report that the column has a null default
-    # but it behaves as though the column had a default of ''
     def test_mysql_text_not_null_defaults
       klass = Class.new(ActiveRecord::Base)
       klass.table_name = 'test_mysql_text_not_null_defaults'
@@ -64,14 +60,14 @@ if current_adapter?(:MysqlAdapter) or current_adapter?(:Mysql2Adapter)
         t.column :null_text, :text, :null => true
         t.column :null_blob, :blob, :null => true
       end
-      assert_equal '', klass.columns_hash['non_null_blob'].default
-      assert_equal '', klass.columns_hash['non_null_text'].default
+      assert_equal nil, klass.columns_hash['non_null_blob'].default
+      assert_equal nil, klass.columns_hash['non_null_text'].default
 
       assert_nil klass.columns_hash['null_blob'].default
       assert_nil klass.columns_hash['null_text'].default
 
       assert_nothing_raised do
-        instance = klass.create!
+        instance = klass.create!(:non_null_text => '', :non_null_blob => '')
         assert_equal '', instance.non_null_text
         assert_equal '', instance.non_null_blob
         assert_nil instance.null_text

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -51,32 +51,6 @@ if current_adapter?(:MysqlAdapter) or current_adapter?(:Mysql2Adapter)
     # We don't want that to happen, so we disable transactional fixtures here.
     self.use_transactional_fixtures = false
 
-    def test_mysql_text_not_null_defaults
-      klass = Class.new(ActiveRecord::Base)
-      klass.table_name = 'test_mysql_text_not_null_defaults'
-      klass.connection.create_table klass.table_name do |t|
-        t.column :non_null_text, :text, :null => false
-        t.column :non_null_blob, :blob, :null => false
-        t.column :null_text, :text, :null => true
-        t.column :null_blob, :blob, :null => true
-      end
-      assert_equal nil, klass.columns_hash['non_null_blob'].default
-      assert_equal nil, klass.columns_hash['non_null_text'].default
-
-      assert_nil klass.columns_hash['null_blob'].default
-      assert_nil klass.columns_hash['null_text'].default
-
-      assert_nothing_raised do
-        instance = klass.create!(:non_null_text => '', :non_null_blob => '')
-        assert_equal '', instance.non_null_text
-        assert_equal '', instance.non_null_blob
-        assert_nil instance.null_text
-        assert_nil instance.null_blob
-      end
-    ensure
-      klass.connection.drop_table(klass.table_name) rescue nil
-    end
-
     # MySQL uses an implicit default 0 rather than NULL unless in strict mode.
     # We use an implicit NULL so schema.rb is compatible with other databases.
     def test_mysql_integer_not_null_defaults

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -343,12 +343,7 @@ class MigrationTest < ActiveRecord::TestCase
 
     columns = Person.connection.columns(:binary_testings)
     data_column = columns.detect { |c| c.name == "data" }
-
-    if current_adapter?(:MysqlAdapter) or current_adapter?(:Mysql2Adapter)
-      assert_equal '', data_column.default
-    else
-      assert_nil data_column.default
-    end
+    assert_nil data_column.default
 
     Person.connection.drop_table :binary_testings rescue nil
   end


### PR DESCRIPTION
The mysql database adaptor assumes that non-null text columns behave as if the default value is an empty string. This is the default behaviour for mysql connections, but putting the connection in strict mode with `SET SQL_MODE='STRICT_ALL_TABLES'` makes like other databases, where the default value is NULL so the value must be specified.

The mysql adaptor defaults to using this strict mode, although it can be disabled with setting `strict: false` in the database configuration. However, the mysql adapter has a hack based on non-strict mode behaviour to detect an empty string default value. So even though strict mode is used, this hack is continuing non-strict mode behaviour within strict mode.

I propose just removing this hack to mimic the non-strict behaviour to make its behaviour consistent with other databases.  This is what this pull request does.
