### PR TITLE
Added refute_difference method as alias for assert_no_difference

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Added `refute_difference` method as alias for `assert_no_difference` *Wojciech Wnętrzak*
+
 *   Tests tag the Rails log with the current test class and test case:
 
         [SessionsControllerTest] [test_0002_sign in] Processing by SessionsController#create as HTML

--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -76,6 +76,7 @@ module ActiveSupport
       def assert_no_difference(expression, message = nil, &block)
         assert_difference expression, 0, message, &block
       end
+      alias :refute_difference :assert_no_difference
 
       # Test if an expression is blank. Passes if <tt>object.blank?</tt>
       # is +true+.

--- a/activesupport/test/test_test.rb
+++ b/activesupport/test/test_test.rb
@@ -21,6 +21,12 @@ class AssertDifferenceTest < ActiveSupport::TestCase
     end
   end
 
+  def test_refute_difference
+    refute_difference '@object.num' do
+      # ...
+    end
+  end
+
   def test_assert_difference
     assert_difference '@object.num', +1 do
       @object.increment


### PR DESCRIPTION
Since we can use minitest in Rails, why not to follow convention of `refute` methods?

Let me know if you like it and I can add `refute_blank` as alias for `assert_present` and `refute_present` as alias for `assert_blank` also.
