### PR TITLE
Change query pattern case insensitive

### DIFF
--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -554,7 +554,7 @@ class DirtyTest < ActiveRecord::TestCase
   test "partial insert" do
     with_partial_updates Person do
       jon = nil
-      assert_sql(/first_name/) do
+      assert_sql(/first_name/i) do
         jon = Person.create! first_name: 'Jon'
       end
 


### PR DESCRIPTION
This pull request address the failure below.
This failure happens because Oracle adapter uses upper case attribute/column name.

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/dirty_test.rb
Using oracle
Run options: --seed 63746

Running tests:
F................................

Finished tests in 1.533941s, 21.5132 tests/s, 116.0410 assertions/s.

1) Failure:
test_0001_partial insert(DirtyTest) [test/cases/dirty_test.rb:557]:
Query pattern(s) /first_name/ not found.
Queries:
INSERT INTO "PEOPLE" ("CREATED_AT", "FIRST_NAME", "ID", "UPDATED_AT") VALUES (:a1, :a2, :a3, :a4)

33 tests, 178 assertions, 1 failures, 0 errors, 0 skips
$
```

This fix has been tested with sqlite3, mysql, mysql2 and postgresql adapters also.
