### PR TITLE
Backport "Don't paramify ActionDispatch::Http::UploadedFile in tests"

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -46,6 +46,12 @@
 
     *Jeremy Kemper & Erich Menge*
 
+*   Handle `ActionDispatch::Http::UploadedFile` like `Rack::Test::UploadedFile`, don't call to_param on it. Since
+    `Rack::Test::UploadedFile` isn't API compatible this is needed to test file uploads that rely on `tempfile`
+    being available.
+
+    *Tim Vandecasteele*
+
 
 ## Rails 3.2.8 (Aug 9, 2012) ##
 

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -422,7 +422,7 @@ module ActionController
           Hash[hash_or_array_or_value.map{|key, value| [key, paramify_values(value)] }]
         when Array
           hash_or_array_or_value.map {|i| paramify_values(i)}
-        when Rack::Test::UploadedFile
+        when Rack::Test::UploadedFile, ActionDispatch::Http::UploadedFile
           hash_or_array_or_value
         else
           hash_or_array_or_value.to_param

--- a/actionpack/test/controller/test_test.rb
+++ b/actionpack/test/controller/test_test.rb
@@ -766,6 +766,13 @@ XML
     assert_equal '159528', @response.body
   end
 
+  def test_action_dispatch_uploaded_file_upload
+    filename = 'mona_lisa.jpg'
+    path = "#{FILES_DIR}/#{filename}"
+    post :test_file_upload, :file => ActionDispatch::Http::UploadedFile.new(:filename => path, :type => "image/jpg", :tempfile => File.open(path))
+    assert_equal '159528', @response.body
+  end
+
   def test_test_uploaded_file_exception_when_file_doesnt_exist
     assert_raise(RuntimeError) { Rack::Test::UploadedFile.new('non_existent_file') }
   end


### PR DESCRIPTION
This is a backport of commit rails/rails@8471edc6725aa905dc9f7b800438acb255b1512e (see pull request #6805) to 3.2-stable to allow testing with ActionDispatch::Http::UploadedFile since Rack::Test::UploadedFile and ActionDispatch::Http::UploadedFile don't
share the same API. For further details see mentioned pull request
