### PR TITLE
resource and resources do no longer modify passed options

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `resource` and `resources` don't modify the passed options hash
+    Fix #7777
+
+    *Yves Senn*
+
 *   Precompiled assets include aliases from foo.js to foo/index.js and vice versa.
 
         # Precompiles phone-<digest>.css and aliases phone/index.css to phone.css.

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1038,7 +1038,7 @@ module ActionDispatch
         # === Options
         # Takes same options as +resources+.
         def resource(*resources, &block)
-          options = resources.extract_options!
+          options = resources.extract_options!.dup
 
           if apply_common_behavior_for(:resource, resources, options, &block)
             return self
@@ -1204,7 +1204,7 @@ module ActionDispatch
         #   # resource actions are at /admin/posts.
         #   resources :posts, :path => "admin/posts"
         def resources(*resources, &block)
-          options = resources.extract_options!
+          options = resources.extract_options!.dup
 
           if apply_common_behavior_for(:resources, resources, options, &block)
             return self

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1124,6 +1124,26 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal '/sheep/1/_it', _it_sheep_path(1)
   end
 
+  def test_resource_does_not_modify_passed_options
+    options = {:id => /.+?/, :format => /json|xml/}
+    self.class.stub_controllers do |routes|
+      routes.draw do
+        resource :user, options
+      end
+    end
+    assert_equal({:id => /.+?/, :format => /json|xml/}, options)
+  end
+
+  def test_resources_does_not_modify_passed_options
+    options = {:id => /.+?/, :format => /json|xml/}
+    self.class.stub_controllers do |routes|
+      routes.draw do
+        resources :users, options
+      end
+    end
+    assert_equal({:id => /.+?/, :format => /json|xml/}, options)
+  end
+
   def test_path_names
     get '/pt/projetos'
     assert_equal 'projects#index', @response.body


### PR DESCRIPTION
this is a patch for #7777. I could not modify the shared `apply_common_behavior_for` method because the outer methods rely on the fact, that those keys are deleted. Adding the `dup` call inside `apply_common_behavior_for` resultated in 8 error when running the tests.

I added two test cases to make sure the options are not modified.
