### PR TITLE
Fixes Issue #7490: Chained scopes will preload properly

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 3.2.13 (Feb 17, 2013) ##
 
+*   Chaining multiple preloaded scopes will correctly preload all the scopes
+    at the same time.
+
+    *Chris Geihsler*
+
 *   Reverted 921a296a3390192a71abeec6d9a035cc6d1865c8, 'Quote numeric values
     compared to string columns.' This caused several regressions.
 

--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -17,14 +17,14 @@ module ActiveRecord
           if method == :includes
             merged_relation = merged_relation.includes(value)
           else
-            merged_relation.send(:"#{method}_values=", value)
+            merge_relation_method(merged_relation, method, value)
           end
         end
       end
 
       (Relation::MULTI_VALUE_METHODS - [:joins, :where, :order]).each do |method|
         value = r.send(:"#{method}_values")
-        merged_relation.send(:"#{method}_values=", merged_relation.send(:"#{method}_values") + value) if value.present?
+        merge_relation_method(merged_relation, method, value) if value.present?
       end
 
       merged_relation.joins_values += r.joins_values
@@ -144,5 +144,10 @@ module ActiveRecord
       relation
     end
 
+    private
+
+      def merge_relation_method(relation, method, value)
+        relation.send(:"#{method}_values=", relation.send(:"#{method}_values") + value)
+      end
   end
 end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -332,6 +332,13 @@ class RelationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_preload_applies_to_all_chained_preloaded_scopes
+    assert_queries(3) do
+      post = Post.with_tags.with_comments.first
+      assert post
+    end
+  end
+
   def test_find_with_included_associations
     assert_queries(2) do
       posts = Post.includes(:comments).order('posts.id')

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -76,6 +76,9 @@ class Post < ActiveRecord::Base
     end
   end
 
+  scope :with_comments, preload(:comments)
+  scope :with_tags, preload(:taggings)
+
   has_many :interpolated_taggings, :class_name => 'Tagging', :as => :taggable, :conditions => proc { "1 = #{1}" }
   has_many :interpolated_tags, :through => :taggings
   has_many :interpolated_tags_2, :through => :interpolated_taggings, :source => :tag


### PR DESCRIPTION
If scopes are chained and they are all configured to `preload`, only the last scope was being preloaded. Added a test and made the fix suggested in Issue #7490.
