### PR TITLE
Use Rack::Cache middleware only if is in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'arel', github: 'rails/arel', branch: 'master'
 
 gem 'mocha', '>= 0.11.2', :require => false
 gem 'rack-test', github: 'brynary/rack-test'
+gem 'rack-cache', "~> 1.2"
 gem 'bcrypt-ruby', '~> 3.0.0'
 gem 'jquery-rails'
 

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency('activesupport', version)
-  s.add_dependency('rack-cache',    '~> 1.2')
   s.add_dependency('builder',       '~> 3.1.0')
   s.add_dependency('rack',          '~> 1.4.1')
   s.add_dependency('rack-test',     '~> 0.6.1')

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -282,6 +282,12 @@ module Rails
       ActionDispatch::MiddlewareStack.new.tap do |middleware|
         app = self
         if rack_cache = config.action_controller.perform_caching && config.action_dispatch.rack_cache
+          begin
+            require 'rack/cache'
+          rescue LoadError => error
+            error.message << ' Be sure to add rack-cache to your Gemfile'
+            raise
+          end
           require "action_dispatch/http/rack_cache"
           middleware.use ::Rack::Cache, rack_cache
         end

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -9,6 +9,10 @@ source 'https://rubygems.org'
 <%= assets_gemfile_entry %>
 <%= javascript_gemfile_entry %>
 
+# Puts a simple HTTP cache in front of your app.
+# For large-scale production use, consider using a caching reverse proxy like nginx, varnish, or squid.
+gem 'rack-cache', '~> 1.2'
+
 # To use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.0.0'
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -300,6 +300,11 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "Gemfile", /# gem 'debugger'/
   end
 
+  def test_inclusion_of_rack_cache
+    run_generator
+    assert_file "Gemfile", /gem 'rack-cache'/
+  end
+
   def test_template_from_dir_pwd
     FileUtils.cd(Rails.root)
     assert_match(/It works from file!/, run_generator([destination_root, "-m", "lib/template.rb"]))


### PR DESCRIPTION
This being discussed by Rails core right now, IMO this PR is a fair solution, if the user want to use rack-cache then it should be specified in Gemfile explicitly 
