### PR TITLE
Optimize ActiveSupport::Cache::Entry to reduce overhead

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -237,4 +237,6 @@
 
 *   Remove deprecated ActiveSupport::JSON::Variable. *Erich Menge*
 
+*   Optimize ActiveSupport::Cache::Entry to reduce memory and processing overhead. *Brian Durand*
+
 Please check [3-2-stable](https://github.com/rails/rails/blob/3-2-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -135,6 +135,7 @@ module ActiveSupport
         end
 
         def write_entry(key, entry, options) # :nodoc:
+          entry.dup_value!
           synchronize do
             old_entry = @data[key]
             return false if @data.key?(key) && options[:unless_exist]


### PR DESCRIPTION
This code provides a more efficient implementation of ActiveSupport::Cache::Entry that reduces the costs of serialization.
