### PR TITLE
show exception middleware accepts multiple apps 

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
@@ -1,4 +1,6 @@
 module ActionDispatch
+  # This middleware takes exceptions from the application and renders
+  # the corresponding static error page from the public directory.
   class PublicExceptions
     attr_accessor :public_path
 

--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -4,6 +4,8 @@ require 'action_dispatch/middleware/exception_wrapper'
 module ActionDispatch
   # This middleware rescues any exception returned by the application
   # and calls an exceptions app that will wrap it in a format for the end user.
+  # Multiple exception apps can be specified, in case there is an error in one
+  # of the apps, the first app with a valid response will be used.
   #
   # The exceptions app should be passed as parameter on initialization
   # of ShowExceptions. Everytime there is an exception, ShowExceptions will
@@ -12,8 +14,8 @@ module ActionDispatch
   #
   # If the application returns a "X-Cascade" pass response, this middleware
   # will send an empty response as result with the correct status code.
-  # If any exception happens inside the exceptions app, this middleware
-  # catches the exceptions and returns a FAILSAFE_RESPONSE.
+  # If an exception happens inside the all the exceptions apps, this middleware
+  # catches the exception and returns a FAILSAFE_RESPONSE.
   class ShowExceptions
     FAILSAFE_RESPONSE = [500, { 'Content-Type' => 'text/plain' },
       ["500 Internal Server Error\n" <<
@@ -21,9 +23,9 @@ module ActionDispatch
        "application's log file and/or the web server's log file to find out what " <<
        "went wrong."]]
 
-    def initialize(app, exceptions_app)
+    def initialize(app, *exception_apps)
       @app = app
-      @exceptions_app = exceptions_app
+      @exception_apps = exception_apps.flatten.compact.uniq
     end
 
     def call(env)
@@ -38,16 +40,38 @@ module ActionDispatch
 
     private
 
+    def name_for_app(app)
+      if app.is_a? ActionDispatch::PublicExceptions
+        "static error pages from public dir (#{app.class.name})"
+      elsif app.is_a? ActionDispatch::Routing::RouteSet
+        "action specified in routes (#{app.class.name})"
+      else
+        "middleware (#{app.class.name})"
+      end
+    end
+
     def render_exception(env, exception)
       wrapper = ExceptionWrapper.new(env, exception)
       status  = wrapper.status_code
       env["action_dispatch.exception"] = wrapper.exception
       env["PATH_INFO"] = "/#{status}"
-      response = @exceptions_app.call(env)
-      response[1]['X-Cascade'] == 'pass' ? pass_response(status) : response
-    rescue Exception => failsafe_error
-      $stderr.puts "Error during failsafe response: #{failsafe_error}\n  #{failsafe_error.backtrace * "\n  "}"
-      FAILSAFE_RESPONSE
+      response = nil
+
+      # iterate over each exception app, store for first valid response
+      @exception_apps.each do |exception_app|
+        begin
+          $stdout.puts "Rendering exception status: #{status} with #{name_for_app(exception_app)}"
+          response ||= exception_app.call(env)
+        rescue Exception => rescue_error
+          $stderr.puts "Error rendering exception #{status} with #{name_for_app(exception_app)}: #{rescue_error}\n  #{rescue_error.backtrace * "\n  "}"
+        end
+      end
+
+      if response
+        response[1]['X-Cascade'] == 'pass' ? pass_response(status) : response
+      else
+        FAILSAFE_RESPONSE
+      end
     end
 
     def pass_response(status)

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -327,7 +327,7 @@ module Rails
         middleware.use ::Rack::MethodOverride
         middleware.use ::ActionDispatch::RequestId
         middleware.use ::Rails::Rack::Logger, config.log_tags # must come after Rack::MethodOverride to properly log overridden methods
-        middleware.use ::ActionDispatch::ShowExceptions, config.exceptions_app || ActionDispatch::PublicExceptions.new(Rails.public_path)
+        middleware.use ::ActionDispatch::ShowExceptions, config.exceptions_app, ActionDispatch::PublicExceptions.new(Rails.public_path)
         middleware.use ::ActionDispatch::DebugExceptions, app
         middleware.use ::ActionDispatch::RemoteIp, config.action_dispatch.ip_spoofing_check, config.action_dispatch.trusted_proxies
 


### PR DESCRIPTION
The show exception middleware allows developers to use custom error rendering apps. As error rendering applications become more complicated the chance for errors in the error rendering applications increases. By allowing multiple exception apps to be used instead of just one, a developer can provide a fallback application. This provides a better experience for the end user and decreases the chances that the `FAILSAFE_RESPONSE` will be used.

By default the public exception app will be put after any applications specified using `config.exceptions_app` in rails. This will provide a fallback in case an error is introduced by the exceptions_app.

Errors from within exception_apps will still be shown in the logs for debugging. This was inspired by the desire to have safer dynamic error pages #7772 but with or without that PR, I believe this PR still provides valuable behavior. 

ATP Railties and Action Pack. Btw, it's my birthday.
