### PR TITLE
Reducing ActiveSupport::Cache::FILENAME_MAX_SIZE to 116 to support ecryptfs

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -12,7 +12,7 @@ module ActiveSupport
       attr_reader :cache_path
 
       DIR_FORMATTER = "%03X"
-      FILENAME_MAX_SIZE = 228 # max filename size on file system is 255, minus room for timestamp and random characters appended by Tempfile (used by atomic write)
+      FILENAME_MAX_SIZE = 116 # max filename size on file system is normally 255 (but 143 on ecryptfs), minus room for timestamp and random characters appended by Tempfile (used by atomic write)
       EXCLUDED_DIRS = ['.', '..'].freeze
 
       def initialize(cache_path, options = nil)


### PR DESCRIPTION
I have just tried to run rake within rails/activesupport (on master)

That generated

```
Errno::ENAMETOOLONG: File name too long - /home/jarl/projects/rails/activesupport/tmp_cache/5F0/AEA/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
    /home/jarl/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/fileutils.rb:247:in `mkdir'
    /home/jarl/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/fileutils.rb:247:in `fu_mkdir'
    /home/jarl/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/fileutils.rb:221:in `block (2 levels) in mkdir_p'
    /home/jarl/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/fileutils.rb:219:in `reverse_each'
    /home/jarl/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/fileutils.rb:219:in `block in mkdir_p'
    /home/jarl/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/fileutils.rb:205:in `each'
    /home/jarl/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/fileutils.rb:205:in `mkdir_p'
    /home/jarl/projects/rails/activesupport/lib/active_support/cache/file_store.rb:161:in `ensure_cache_path'
    /home/jarl/projects/rails/activesupport/lib/active_support/cache/file_store.rb:90:in `write_entry'
    /home/jarl/projects/rails/activesupport/lib/active_support/cache/strategy/local_cache.rb:140:in `write_entry'
    /home/jarl/projects/rails/activesupport/lib/active_support/cache.rb:368:in `block in write'
    /home/jarl/projects/rails/activesupport/lib/active_support/cache.rb:525:in `instrument'
    /home/jarl/projects/rails/activesupport/lib/active_support/cache.rb:366:in `write'
    /home/jarl/projects/rails/activesupport/test/caching_test.rb:384:in `test_really_long_keys'
```

I googled a bit and discovered that ecryptfs has a much lower limitation on filename length (approximately 143 characters): http://unix.stackexchange.com/a/32834

That basically means that running a rails app on an ecryptfs will
fail in a situation where the key is rather long.

If rails is supported on ecryptfs the
`ActiveSupport::Cache::FILENAME_MAX_SIZE` must be reduced to 116
