### PR TITLE
fixed tests with JRuby

### DIFF
--- a/actionpack/test/dispatch/session/mem_cache_store_test.rb
+++ b/actionpack/test/dispatch/session/mem_cache_store_test.rb
@@ -1,4 +1,5 @@
 require 'abstract_unit'
+require 'fixtures/session_autoload_test/session_autoload_test/foo'
 
 # You need to start a memcached server inorder to run these tests
 class MemCacheStoreTest < ActionDispatch::IntegrationTest


### PR DESCRIPTION
test_deserializes_unloaded_classes_on_get_id(CookieStoreTest):
ArgumentError: SessionAutoloadTest::Foo does not refer class
    org/jruby/RubyMarshal.java:148:in `load'
