### PR TITLE
IEC prefixes

### DIFF
--- a/actionpack/test/template/number_helper_test.rb
+++ b/actionpack/test/template/number_helper_test.rb
@@ -3,20 +3,20 @@ require 'abstract_unit'
 class NumberHelperTest < ActionView::TestCase
   tests ActionView::Helpers::NumberHelper
 
-  def kilobytes(number)
+  def kibibytes(number)
     number * 1024
   end
 
-  def megabytes(number)
-    kilobytes(number) * 1024
+  def mebibytes(number)
+    kibibytes(number) * 1024
   end
 
-  def gigabytes(number)
-    megabytes(number) * 1024
+  def gibibytes(number)
+    mebibytes(number) * 1024
   end
 
-  def terabytes(number)
-    gigabytes(number) * 1024
+  def tebibytes(number)
+    gibibytes(number) * 1024
   end
 
   def test_number_to_phone
@@ -156,21 +156,21 @@ class NumberHelperTest < ActionView::TestCase
     assert_equal '3 Bytes',   number_to_human_size(3.14159265)
     assert_equal '123 Bytes', number_to_human_size(123.0)
     assert_equal '123 Bytes', number_to_human_size(123)
-    assert_equal '1.21 KB',    number_to_human_size(1234)
-    assert_equal '12.1 KB',   number_to_human_size(12345)
-    assert_equal '1.18 MB',    number_to_human_size(1234567)
-    assert_equal '1.15 GB',    number_to_human_size(1234567890)
-    assert_equal '1.12 TB',    number_to_human_size(1234567890123)
-    assert_equal '1030 TB',   number_to_human_size(terabytes(1026))
-    assert_equal '444 KB',    number_to_human_size(kilobytes(444))
-    assert_equal '1020 MB',   number_to_human_size(megabytes(1023))
-    assert_equal '3 TB',      number_to_human_size(terabytes(3))
-    assert_equal '1.2 MB',   number_to_human_size(1234567, :precision => 2)
+    assert_equal '1.21 KiB',    number_to_human_size(1234)
+    assert_equal '12.1 KiB',   number_to_human_size(12345)
+    assert_equal '1.18 MiB',    number_to_human_size(1234567)
+    assert_equal '1.15 GiB',    number_to_human_size(1234567890)
+    assert_equal '1.12 TiB',    number_to_human_size(1234567890123)
+    assert_equal '1030 TiB',   number_to_human_size(tebibytes(1026))
+    assert_equal '444 KiB',    number_to_human_size(kibibytes(444))
+    assert_equal '1020 MiB',   number_to_human_size(mebibytes(1023))
+    assert_equal '3 TiB',      number_to_human_size(tebibytes(3))
+    assert_equal '1.2 MiB',   number_to_human_size(1234567, :precision => 2)
     assert_equal '3 Bytes',   number_to_human_size(3.14159265, :precision => 4)
     assert_equal '123 Bytes', number_to_human_size('123')
-    assert_equal '1 KB',   number_to_human_size(kilobytes(1.0123), :precision => 2)
-    assert_equal '1.01 KB',   number_to_human_size(kilobytes(1.0100), :precision => 4)
-    assert_equal '10 KB',   number_to_human_size(kilobytes(10.000), :precision => 4)
+    assert_equal '1 KiB',   number_to_human_size(kibibytes(1.0123), :precision => 2)
+    assert_equal '1.01 KiB',   number_to_human_size(kibibytes(1.0100), :precision => 4)
+    assert_equal '10 KiB',   number_to_human_size(kibibytes(10.000), :precision => 4)
     assert_equal '1 Byte',   number_to_human_size(1.1)
     assert_equal '10 Bytes', number_to_human_size(10)
   end
@@ -187,26 +187,26 @@ class NumberHelperTest < ActionView::TestCase
   end
 
   def test_number_to_human_size_with_options_hash
-    assert_equal '1.2 MB',   number_to_human_size(1234567, :precision => 2)
+    assert_equal '1.2 MiB',   number_to_human_size(1234567, :precision => 2)
     assert_equal '3 Bytes',   number_to_human_size(3.14159265, :precision => 4)
-    assert_equal '1 KB',   number_to_human_size(kilobytes(1.0123), :precision => 2)
-    assert_equal '1.01 KB',   number_to_human_size(kilobytes(1.0100), :precision => 4)
-    assert_equal '10 KB',     number_to_human_size(kilobytes(10.000), :precision => 4)
-    assert_equal '1 TB', number_to_human_size(1234567890123, :precision => 1)
-    assert_equal '500 MB', number_to_human_size(524288000, :precision=>3)
-    assert_equal '10 MB', number_to_human_size(9961472, :precision=>0)
-    assert_equal '40 KB', number_to_human_size(41010, :precision => 1)
-    assert_equal '40 KB', number_to_human_size(41100, :precision => 2)
-    assert_equal '1.0 KB',   number_to_human_size(kilobytes(1.0123), :precision => 2, :strip_insignificant_zeros => false)
-    assert_equal '1.012 KB',   number_to_human_size(kilobytes(1.0123), :precision => 3, :significant => false)
-    assert_equal '1 KB',   number_to_human_size(kilobytes(1.0123), :precision => 0, :significant => true) #ignores significant it precision is 0
-    assert_equal '9&lt;script&gt;&lt;/script&gt;86 KB', number_to_human_size(10100, :separator => "<script></script>")
+    assert_equal '1 KiB',   number_to_human_size(kibibytes(1.0123), :precision => 2)
+    assert_equal '1.01 KiB',   number_to_human_size(kibibytes(1.0100), :precision => 4)
+    assert_equal '10 KiB',     number_to_human_size(kibibytes(10.000), :precision => 4)
+    assert_equal '1 TiB', number_to_human_size(1234567890123, :precision => 1)
+    assert_equal '500 MiB', number_to_human_size(524288000, :precision=>3)
+    assert_equal '10 MiB', number_to_human_size(9961472, :precision=>0)
+    assert_equal '40 KiB', number_to_human_size(41010, :precision => 1)
+    assert_equal '40 KiB', number_to_human_size(41100, :precision => 2)
+    assert_equal '1.0 KiB',   number_to_human_size(kibibytes(1.0123), :precision => 2, :strip_insignificant_zeros => false)
+    assert_equal '1.012 KiB',   number_to_human_size(kibibytes(1.0123), :precision => 3, :significant => false)
+    assert_equal '1 KiB',   number_to_human_size(kibibytes(1.0123), :precision => 0, :significant => true) #ignores significant it precision is 0
+    assert_equal '9&lt;script&gt;&lt;/script&gt;86 KiB', number_to_human_size(10100, :separator => "<script></script>")
   end
 
   def test_number_to_human_size_with_custom_delimiter_and_separator
-    assert_equal '1,01 KB',     number_to_human_size(kilobytes(1.0123), :precision => 3, :separator => ',')
-    assert_equal '1,01 KB',     number_to_human_size(kilobytes(1.0100), :precision => 4, :separator => ',')
-    assert_equal '1.000,1 TB',  number_to_human_size(terabytes(1000.1), :precision => 5, :delimiter => '.', :separator => ',')
+    assert_equal '1,01 KiB',     number_to_human_size(kibibytes(1.0123), :precision => 3, :separator => ',')
+    assert_equal '1,01 KiB',     number_to_human_size(kibibytes(1.0100), :precision => 4, :separator => ',')
+    assert_equal '1.000,1 TiB',  number_to_human_size(tebibytes(1000.1), :precision => 5, :delimiter => '.', :separator => ',')
   end
 
   def test_number_to_human

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -161,7 +161,7 @@ module ActiveRecord
       #  td.column(:granted, :boolean)
       #  # granted BOOLEAN
       #
-      #  td.column(:picture, :binary, :limit => 2.megabytes)
+      #  td.column(:picture, :binary, :limit => 2.mebibytes)
       #  # => picture BLOB(2097152)
       #
       #  td.column(:sales_stage, :string, :limit => 20, :default => 'new', :null => false)

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require 'benchmark'
 require 'zlib'
 require 'active_support/core_ext/array/extract_options'
@@ -541,7 +542,7 @@ module ActiveSupport
     # Since cache entries in most instances will be serialized, the internals of this class are highly optimized
     # using short instance variable names that are lazily defined.
     class Entry # :nodoc:
-      DEFAULT_COMPRESS_LIMIT = 16.kilobytes
+      DEFAULT_COMPRESS_LIMIT = 16.kibibytes
 
       # Create a new cache entry for the specified value. Options supported are
       # +:compress+, +:compress_threshold+, and +:expires_in+.

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -21,7 +21,7 @@ module ActiveSupport
         super(options)
         @data = {}
         @key_access = {}
-        @max_size = options[:size] || 32.megabytes
+        @max_size = options[:size] || 32.mebibytes
         @max_prune_time = options[:max_prune_time] || 2
         @cache_size = 0
         @monitor = Monitor.new

--- a/activesupport/lib/active_support/core_ext/numeric/bytes.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/bytes.rb
@@ -1,44 +1,44 @@
 class Numeric
-  KILOBYTE = 1024
-  MEGABYTE = KILOBYTE * 1024
-  GIGABYTE = MEGABYTE * 1024
-  TERABYTE = GIGABYTE * 1024
-  PETABYTE = TERABYTE * 1024
-  EXABYTE  = PETABYTE * 1024
+  KIBIBYTE = 1024
+  MEBIBYTE = KIBIBYTE * 1024
+  GIBIBYTE = MEBIBYTE * 1024
+  TEBIBYTE = GIBIBYTE * 1024
+  PEBIBYTE = TEBIBYTE * 1024
+  EXBIBYTE  = PEBIBYTE * 1024
 
-  # Enables the use of byte calculations and declarations, like 45.bytes + 2.6.megabytes
+  # Enables the use of byte calculations and declarations, like 45.bytes + 2.6.mebibytes
   def bytes
     self
   end
   alias :byte :bytes
 
-  def kilobytes
-    self * KILOBYTE
+  def kibibytes
+    self * KIBIBYTE
   end
-  alias :kilobyte :kilobytes
+  alias :kibibyte :kibibytes
 
-  def megabytes
-    self * MEGABYTE
+  def mebibytes
+    self * MEBIBYTE
   end
-  alias :megabyte :megabytes
+  alias :mebibyte :mebibytes
 
-  def gigabytes
-    self * GIGABYTE
+  def gibibytes
+    self * GIBIBYTE
   end
-  alias :gigabyte :gigabytes
+  alias :gibibyte :gibibytes
 
-  def terabytes
-    self * TERABYTE
+  def tebibytes
+    self * TEBIBYTE
   end
-  alias :terabyte :terabytes
+  alias :tebibyte :tebibytes
 
-  def petabytes
-    self * PETABYTE
+  def pebibytes
+    self * PEBIBYTE
   end
-  alias :petabyte :petabytes
+  alias :pebibyte :pebibytes
 
-  def exabytes
-    self * EXABYTE
+  def exbibytes
+    self * EXBIBYTE
   end
-  alias :exabyte :exabytes
+  alias :exbibyte :exbibytes
 end

--- a/activesupport/lib/active_support/core_ext/numeric/bytes.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/bytes.rb
@@ -12,6 +12,7 @@ class Numeric
   end
   alias :byte :bytes
 
+  ## IEC prefixes
   def kibibytes
     self * KIBIBYTE
   end
@@ -41,4 +42,35 @@ class Numeric
     self * EXBIBYTE
   end
   alias :exbibyte :exbibytes
+
+  ## SI prefixes
+  def kilobytes
+    self * 1000
+  end
+  alias :kilobyte :kilobytes
+
+  def megabytes
+    self * 1000**2
+  end
+  alias :megabyte :megabytes
+
+  def gigabytes
+    self * 1000**3
+  end
+  alias :gigabyte :gigabytes
+
+  def terabytes
+    self * 1000**4
+  end
+  alias :terabyte :terabytes
+
+  def petabytes
+    self * 1000**5
+  end
+  alias :petabyte :petabytes
+
+  def exabytes
+    self * 1000**6
+  end
+  alias :exabyte :exabytes
 end

--- a/activesupport/lib/active_support/locale/en.yml
+++ b/activesupport/lib/active_support/locale/en.yml
@@ -98,7 +98,15 @@ en:
         # Storage units output formatting.
         # %u is the storage unit, %n is the number (default: 2 MB)
         format: "%n %u"
-        units:
+        iec_units:
+          byte:
+            one:   "Byte"
+            other: "Bytes"
+          kb: "KiB"
+          mb: "MiB"
+          gb: "GiB"
+          tb: "TiB"
+        si_units:
           byte:
             one:   "Byte"
             other: "Bytes"

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -163,7 +163,18 @@ class NumericExtSizeTest < ActiveSupport::TestCase
                    2.gibibytes / 4 => 512.mebibytes,
       256.mebibytes * 20 + 5.gibibytes => 10.gibibytes,
       1.kibibyte ** 5 => 1.pebibyte,
-      1.kibibyte ** 6 => 1.exbibyte
+      1.kibibyte ** 6 => 1.exbibyte,
+
+        1000.bytes     =>     1.kilobyte,
+        1000.kilobytes =>     1.megabyte,
+      3584.0.kilobytes => 3.584.megabytes,
+      3584.0.megabytes => 3.584.gigabytes,
+      1.kilobyte ** 4  =>     1.terabyte,
+      1000.kilobytes + 2.megabytes =>   3.megabytes,
+                   2.gigabytes / 4 => 500.megabytes,
+      250.megabytes * 20 + 5.gigabytes => 10.gigabytes,
+      1.kilobyte ** 5 => 1.petabyte,
+      1.kilobyte ** 6 => 1.exabyte,
     }
 
     relationships.each do |left, right|
@@ -184,6 +195,19 @@ class NumericExtSizeTest < ActiveSupport::TestCase
     assert_equal 3377699720527872, 3.pebibyte
     assert_equal 3458764513820540928, 3.exbibytes
     assert_equal 3458764513820540928, 3.exbibyte
+
+    assert_equal 3000000, 3.megabytes
+    assert_equal 3000000, 3.megabyte
+    assert_equal 3000, 3.kilobytes
+    assert_equal 3000, 3.kilobyte
+    assert_equal 3000000000, 3.gigabytes
+    assert_equal 3000000000, 3.gigabyte
+    assert_equal 3000000000000, 3.terabytes
+    assert_equal 3000000000000, 3.terabyte
+    assert_equal 3000000000000000, 3.petabytes
+    assert_equal 3000000000000000, 3.petabyte
+    assert_equal 3000000000000000000, 3.exabytes
+    assert_equal 3000000000000000000, 3.exabyte
   end
 end
 
@@ -338,6 +362,7 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
     assert_equal '10 KiB',     kibibytes(10.000).to_s(:human_size, :precision => 4)
     assert_equal '1 Byte',    1.1.to_s(:human_size)
     assert_equal '10 Bytes',  10.to_s(:human_size)
+    assert_equal '1 MiB',    kibibytes(1024).to_s(:human_size)
   end
 
   def test_to_s__human_size_with_si_prefix
@@ -349,6 +374,10 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
     assert_equal '1.23 MB',    1234567.to_s(:human_size, :prefix => :si)
     assert_equal '1.23 GB',    1234567890.to_s(:human_size, :prefix => :si)
     assert_equal '1.23 TB',    1234567890123.to_s(:human_size, :prefix => :si)
+    assert_equal '1.02 KB',    kibibytes(1).to_s(:human_size, :prefix => :si)
+    assert_equal '1.05 MB',    mebibytes(1).to_s(:human_size, :prefix => :si)
+    assert_equal '1.07 GB',    gibibytes(1).to_s(:human_size, :prefix => :si)
+    assert_equal '1.1 TB',     tebibytes(1).to_s(:human_size, :prefix => :si)
   end
   
   def test_to_s__human_size_with_options_hash

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -154,16 +154,16 @@ end
 class NumericExtSizeTest < ActiveSupport::TestCase
   def test_unit_in_terms_of_another
     relationships = {
-        1024.bytes     =>   1.kilobyte,
-        1024.kilobytes =>   1.megabyte,
-      3584.0.kilobytes => 3.5.megabytes,
-      3584.0.megabytes => 3.5.gigabytes,
-      1.kilobyte ** 4  =>   1.terabyte,
-      1024.kilobytes + 2.megabytes =>   3.megabytes,
-                   2.gigabytes / 4 => 512.megabytes,
-      256.megabytes * 20 + 5.gigabytes => 10.gigabytes,
-      1.kilobyte ** 5 => 1.petabyte,
-      1.kilobyte ** 6 => 1.exabyte
+        1024.bytes     =>   1.kibibyte,
+        1024.kibibytes =>   1.mebibyte,
+      3584.0.kibibytes => 3.5.mebibytes,
+      3584.0.mebibytes => 3.5.gibibytes,
+      1.kibibyte ** 4  =>   1.tebibyte,
+      1024.kibibytes + 2.mebibytes =>   3.mebibytes,
+                   2.gibibytes / 4 => 512.mebibytes,
+      256.mebibytes * 20 + 5.gibibytes => 10.gibibytes,
+      1.kibibyte ** 5 => 1.pebibyte,
+      1.kibibyte ** 6 => 1.exbibyte
     }
 
     relationships.each do |left, right|
@@ -172,36 +172,36 @@ class NumericExtSizeTest < ActiveSupport::TestCase
   end
 
   def test_units_as_bytes_independently
-    assert_equal 3145728, 3.megabytes
-    assert_equal 3145728, 3.megabyte
-    assert_equal 3072, 3.kilobytes
-    assert_equal 3072, 3.kilobyte
-    assert_equal 3221225472, 3.gigabytes
-    assert_equal 3221225472, 3.gigabyte
-    assert_equal 3298534883328, 3.terabytes
-    assert_equal 3298534883328, 3.terabyte
-    assert_equal 3377699720527872, 3.petabytes
-    assert_equal 3377699720527872, 3.petabyte
-    assert_equal 3458764513820540928, 3.exabytes
-    assert_equal 3458764513820540928, 3.exabyte
+    assert_equal 3145728, 3.mebibytes
+    assert_equal 3145728, 3.mebibyte
+    assert_equal 3072, 3.kibibytes
+    assert_equal 3072, 3.kibibyte
+    assert_equal 3221225472, 3.gibibytes
+    assert_equal 3221225472, 3.gibibyte
+    assert_equal 3298534883328, 3.tebibytes
+    assert_equal 3298534883328, 3.tebibyte
+    assert_equal 3377699720527872, 3.pebibytes
+    assert_equal 3377699720527872, 3.pebibyte
+    assert_equal 3458764513820540928, 3.exbibytes
+    assert_equal 3458764513820540928, 3.exbibyte
   end
 end
 
 class NumericExtFormattingTest < ActiveSupport::TestCase
-  def kilobytes(number)
+  def kibibytes(number)
     number * 1024
   end
 
-  def megabytes(number)
-    kilobytes(number) * 1024
+  def mebibytes(number)
+    kibibytes(number) * 1024
   end
 
-  def gigabytes(number)
-    megabytes(number) * 1024
+  def gibibytes(number)
+    mebibytes(number) * 1024
   end
 
-  def terabytes(number)
-    gigabytes(number) * 1024
+  def tebibytes(number)
+    gibibytes(number) * 1024
   end
   
   def test_to_s__phone
@@ -322,20 +322,20 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
     assert_equal '3 Bytes',   3.14159265.to_s(:human_size)
     assert_equal '123 Bytes', 123.0.to_s(:human_size)
     assert_equal '123 Bytes', 123.to_s(:human_size)
-    assert_equal '1.21 KB',   1234.to_s(:human_size)
-    assert_equal '12.1 KB',   12345.to_s(:human_size)
-    assert_equal '1.18 MB',   1234567.to_s(:human_size)
-    assert_equal '1.15 GB',   1234567890.to_s(:human_size)
-    assert_equal '1.12 TB',   1234567890123.to_s(:human_size)
-    assert_equal '1030 TB',   terabytes(1026).to_s(:human_size)
-    assert_equal '444 KB',    kilobytes(444).to_s(:human_size)
-    assert_equal '1020 MB',   megabytes(1023).to_s(:human_size)
-    assert_equal '3 TB',      terabytes(3).to_s(:human_size)
-    assert_equal '1.2 MB',    1234567.to_s(:human_size, :precision => 2)
+    assert_equal '1.21 KiB',   1234.to_s(:human_size)
+    assert_equal '12.1 KiB',   12345.to_s(:human_size)
+    assert_equal '1.18 MiB',   1234567.to_s(:human_size)
+    assert_equal '1.15 GiB',   1234567890.to_s(:human_size)
+    assert_equal '1.12 TiB',   1234567890123.to_s(:human_size)
+    assert_equal '1030 TiB',   tebibytes(1026).to_s(:human_size)
+    assert_equal '444 KiB',    kibibytes(444).to_s(:human_size)
+    assert_equal '1020 MiB',   mebibytes(1023).to_s(:human_size)
+    assert_equal '3 TiB',      tebibytes(3).to_s(:human_size)
+    assert_equal '1.2 MiB',    1234567.to_s(:human_size, :precision => 2)
     assert_equal '3 Bytes',   3.14159265.to_s(:human_size, :precision => 4)
-    assert_equal '1 KB',      kilobytes(1.0123).to_s(:human_size, :precision => 2)
-    assert_equal '1.01 KB',   kilobytes(1.0100).to_s(:human_size, :precision => 4)
-    assert_equal '10 KB',     kilobytes(10.000).to_s(:human_size, :precision => 4)
+    assert_equal '1 KiB',      kibibytes(1.0123).to_s(:human_size, :precision => 2)
+    assert_equal '1.01 KiB',   kibibytes(1.0100).to_s(:human_size, :precision => 4)
+    assert_equal '10 KiB',     kibibytes(10.000).to_s(:human_size, :precision => 4)
     assert_equal '1 Byte',    1.1.to_s(:human_size)
     assert_equal '10 Bytes',  10.to_s(:human_size)
   end
@@ -352,25 +352,25 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
   end
   
   def test_to_s__human_size_with_options_hash
-    assert_equal '1.2 MB',   1234567.to_s(:human_size, :precision => 2)
+    assert_equal '1.2 MiB',   1234567.to_s(:human_size, :precision => 2)
     assert_equal '3 Bytes',  3.14159265.to_s(:human_size, :precision => 4)
-    assert_equal '1 KB',     kilobytes(1.0123).to_s(:human_size, :precision => 2)
-    assert_equal '1.01 KB',  kilobytes(1.0100).to_s(:human_size, :precision => 4)
-    assert_equal '10 KB',    kilobytes(10.000).to_s(:human_size, :precision => 4)
-    assert_equal '1 TB',     1234567890123.to_s(:human_size, :precision => 1)
-    assert_equal '500 MB',   524288000.to_s(:human_size, :precision=>3)
-    assert_equal '10 MB',    9961472.to_s(:human_size, :precision=>0)
-    assert_equal '40 KB',    41010.to_s(:human_size, :precision => 1)
-    assert_equal '40 KB',    41100.to_s(:human_size, :precision => 2)
-    assert_equal '1.0 KB',   kilobytes(1.0123).to_s(:human_size, :precision => 2, :strip_insignificant_zeros => false)
-    assert_equal '1.012 KB', kilobytes(1.0123).to_s(:human_size, :precision => 3, :significant => false)
-    assert_equal '1 KB',     kilobytes(1.0123).to_s(:human_size, :precision => 0, :significant => true) #ignores significant it precision is 0
+    assert_equal '1 KiB',     kibibytes(1.0123).to_s(:human_size, :precision => 2)
+    assert_equal '1.01 KiB',  kibibytes(1.0100).to_s(:human_size, :precision => 4)
+    assert_equal '10 KiB',    kibibytes(10.000).to_s(:human_size, :precision => 4)
+    assert_equal '1 TiB',     1234567890123.to_s(:human_size, :precision => 1)
+    assert_equal '500 MiB',   524288000.to_s(:human_size, :precision=>3)
+    assert_equal '10 MiB',    9961472.to_s(:human_size, :precision=>0)
+    assert_equal '40 KiB',    41010.to_s(:human_size, :precision => 1)
+    assert_equal '40 KiB',    41100.to_s(:human_size, :precision => 2)
+    assert_equal '1.0 KiB',   kibibytes(1.0123).to_s(:human_size, :precision => 2, :strip_insignificant_zeros => false)
+    assert_equal '1.012 KiB', kibibytes(1.0123).to_s(:human_size, :precision => 3, :significant => false)
+    assert_equal '1 KiB',     kibibytes(1.0123).to_s(:human_size, :precision => 0, :significant => true) #ignores significant it precision is 0
   end
   
   def test_to_s__human_size_with_custom_delimiter_and_separator
-    assert_equal '1,01 KB',     kilobytes(1.0123).to_s(:human_size, :precision => 3, :separator => ',')
-    assert_equal '1,01 KB',     kilobytes(1.0100).to_s(:human_size, :precision => 4, :separator => ',')
-    assert_equal '1.000,1 TB',  terabytes(1000.1).to_s(:human_size, :precision => 5, :delimiter => '.', :separator => ',')
+    assert_equal '1,01 KiB',     kibibytes(1.0123).to_s(:human_size, :precision => 3, :separator => ',')
+    assert_equal '1,01 KiB',     kibibytes(1.0100).to_s(:human_size, :precision => 4, :separator => ',')
+    assert_equal '1.000,1 TiB',  tebibytes(1000.1).to_s(:human_size, :precision => 5, :delimiter => '.', :separator => ',')
   end
     
   def test_number_to_human

--- a/activesupport/test/number_helper_i18n_test.rb
+++ b/activesupport/test/number_helper_i18n_test.rb
@@ -19,8 +19,12 @@ module ActiveSupport
           :storage_units => {
             :format => "%n %u",
             :iec_units => {
-              :byte => "b",
-              :kb => "k"
+              :byte => "bi",
+              :kb => "ki"
+            },
+            :si_units => {
+              :byte => "bs",
+              :kb => "ks"
             }
           },
           :decimal_units => {
@@ -115,9 +119,13 @@ module ActiveSupport
     end
 
     def test_number_to_i18n_human_size
-      #b for bytes and k for kbytes
-      assert_equal("2 k", number_to_human_size(2048, :locale => 'ts'))
-      assert_equal("42 b", number_to_human_size(42, :locale => 'ts'))
+      #bi for bytes (IEC) and ki for kibibytes (IEC)
+      assert_equal("2 ki", number_to_human_size(2048, :locale => 'ts'))
+      assert_equal("42 bi", number_to_human_size(42, :locale => 'ts'))
+
+      #bs for bytes (SI) and ks for kilobytes (SI)
+      assert_equal("2 ks", number_to_human_size(2000, :locale => 'ts', :prefix => :si))
+      assert_equal("42 bs", number_to_human_size(42, :locale => 'ts', :prefix => :si))
     end
 
     def test_number_to_i18n_human_size_with_empty_i18n_store
@@ -125,6 +133,9 @@ module ActiveSupport
 
       assert_equal("2 KiB", number_to_human_size(2048, :locale => 'empty'))
       assert_equal("42 Bytes", number_to_human_size(42, :locale => 'empty'))
+
+      assert_equal("2 KB", number_to_human_size(2000, :locale => 'empty', :prefix => :si))
+      assert_equal("42 Bytes", number_to_human_size(42, :locale => 'empty', :prefix => :si))
     end
 
     def test_number_to_human_with_default_translation_scope

--- a/activesupport/test/number_helper_i18n_test.rb
+++ b/activesupport/test/number_helper_i18n_test.rb
@@ -18,7 +18,7 @@ module ActiveSupport
           },
           :storage_units => {
             :format => "%n %u",
-            :units => {
+            :iec_units => {
               :byte => "b",
               :kb => "k"
             }
@@ -123,7 +123,7 @@ module ActiveSupport
     def test_number_to_i18n_human_size_with_empty_i18n_store
       I18n.backend.store_translations 'empty', {}
 
-      assert_equal("2 KB", number_to_human_size(2048, :locale => 'empty'))
+      assert_equal("2 KiB", number_to_human_size(2048, :locale => 'empty'))
       assert_equal("42 Bytes", number_to_human_size(42, :locale => 'empty'))
     end
 

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -17,20 +17,20 @@ module ActiveSupport
         @instance_with_helpers = TestClassWithInstanceNumberHelpers.new
       end
 
-      def kilobytes(number)
+      def kibibytes(number)
         number * 1024
       end
 
-      def megabytes(number)
-        kilobytes(number) * 1024
+      def mebibytes(number)
+        kibibytes(number) * 1024
       end
 
-      def gigabytes(number)
-        megabytes(number) * 1024
+      def gibibytes(number)
+        mebibytes(number) * 1024
       end
 
-      def terabytes(number)
-        gigabytes(number) * 1024
+      def tebibytes(number)
+        gibibytes(number) * 1024
       end
 
       def test_number_to_phone
@@ -179,26 +179,26 @@ module ActiveSupport
 
       def test_number_number_to_human_size
         [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
-          assert_equal '0 Bytes',   number_helper.number_to_human_size(0)
-          assert_equal '1 Byte',    number_helper.number_to_human_size(1)
+          assert_equal '0 Bytes',   number_helper.number_to_human_size(0), number_helper.class
+          assert_equal '1 Byte',    number_helper.number_to_human_size(1), number_helper.class
           assert_equal '3 Bytes',   number_helper.number_to_human_size(3.14159265)
           assert_equal '123 Bytes', number_helper.number_to_human_size(123.0)
           assert_equal '123 Bytes', number_helper.number_to_human_size(123)
-          assert_equal '1.21 KB',    number_helper.number_to_human_size(1234)
-          assert_equal '12.1 KB',   number_helper.number_to_human_size(12345)
-          assert_equal '1.18 MB',    number_helper.number_to_human_size(1234567)
-          assert_equal '1.15 GB',    number_helper.number_to_human_size(1234567890)
-          assert_equal '1.12 TB',    number_helper.number_to_human_size(1234567890123)
-          assert_equal '1030 TB',   number_helper.number_to_human_size(terabytes(1026))
-          assert_equal '444 KB',    number_helper.number_to_human_size(kilobytes(444))
-          assert_equal '1020 MB',   number_helper.number_to_human_size(megabytes(1023))
-          assert_equal '3 TB',      number_helper.number_to_human_size(terabytes(3))
-          assert_equal '1.2 MB',   number_helper.number_to_human_size(1234567, :precision => 2)
+          assert_equal '1.21 KiB',    number_helper.number_to_human_size(1234)
+          assert_equal '12.1 KiB',   number_helper.number_to_human_size(12345)
+          assert_equal '1.18 MiB',    number_helper.number_to_human_size(1234567)
+          assert_equal '1.15 GiB',    number_helper.number_to_human_size(1234567890)
+          assert_equal '1.12 TiB',    number_helper.number_to_human_size(1234567890123)
+          assert_equal '1030 TiB',   number_helper.number_to_human_size(tebibytes(1026))
+          assert_equal '444 KiB',    number_helper.number_to_human_size(kibibytes(444))
+          assert_equal '1020 MiB',   number_helper.number_to_human_size(mebibytes(1023))
+          assert_equal '3 TiB',      number_helper.number_to_human_size(tebibytes(3))
+          assert_equal '1.2 MiB',   number_helper.number_to_human_size(1234567, :precision => 2)
           assert_equal '3 Bytes',   number_helper.number_to_human_size(3.14159265, :precision => 4)
           assert_equal '123 Bytes', number_helper.number_to_human_size('123')
-          assert_equal '1 KB',   number_helper.number_to_human_size(kilobytes(1.0123), :precision => 2)
-          assert_equal '1.01 KB',   number_helper.number_to_human_size(kilobytes(1.0100), :precision => 4)
-          assert_equal '10 KB',   number_helper.number_to_human_size(kilobytes(10.000), :precision => 4)
+          assert_equal '1 KiB',   number_helper.number_to_human_size(kibibytes(1.0123), :precision => 2)
+          assert_equal '1.01 KiB',   number_helper.number_to_human_size(kibibytes(1.0100), :precision => 4)
+          assert_equal '10 KiB',   number_helper.number_to_human_size(kibibytes(10.000), :precision => 4)
           assert_equal '1 Byte',   number_helper.number_to_human_size(1.1)
           assert_equal '10 Bytes', number_helper.number_to_human_size(10)
         end
@@ -219,27 +219,27 @@ module ActiveSupport
 
       def test_number_to_human_size_with_options_hash
         [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
-          assert_equal '1.2 MB',   number_helper.number_to_human_size(1234567, :precision => 2)
+          assert_equal '1.2 MiB',   number_helper.number_to_human_size(1234567, :precision => 2)
           assert_equal '3 Bytes',   number_helper.number_to_human_size(3.14159265, :precision => 4)
-          assert_equal '1 KB',   number_helper.number_to_human_size(kilobytes(1.0123), :precision => 2)
-          assert_equal '1.01 KB',   number_helper.number_to_human_size(kilobytes(1.0100), :precision => 4)
-          assert_equal '10 KB',     number_helper.number_to_human_size(kilobytes(10.000), :precision => 4)
-          assert_equal '1 TB', number_helper.number_to_human_size(1234567890123, :precision => 1)
-          assert_equal '500 MB', number_helper.number_to_human_size(524288000, :precision=>3)
-          assert_equal '10 MB', number_helper.number_to_human_size(9961472, :precision=>0)
-          assert_equal '40 KB', number_helper.number_to_human_size(41010, :precision => 1)
-          assert_equal '40 KB', number_helper.number_to_human_size(41100, :precision => 2)
-          assert_equal '1.0 KB',   number_helper.number_to_human_size(kilobytes(1.0123), :precision => 2, :strip_insignificant_zeros => false)
-          assert_equal '1.012 KB',   number_helper.number_to_human_size(kilobytes(1.0123), :precision => 3, :significant => false)
-          assert_equal '1 KB',   number_helper.number_to_human_size(kilobytes(1.0123), :precision => 0, :significant => true) #ignores significant it precision is 0
+          assert_equal '1 KiB',   number_helper.number_to_human_size(kibibytes(1.0123), :precision => 2)
+          assert_equal '1.01 KiB',   number_helper.number_to_human_size(kibibytes(1.0100), :precision => 4)
+          assert_equal '10 KiB',     number_helper.number_to_human_size(kibibytes(10.000), :precision => 4)
+          assert_equal '1 TiB', number_helper.number_to_human_size(1234567890123, :precision => 1)
+          assert_equal '500 MiB', number_helper.number_to_human_size(524288000, :precision=>3)
+          assert_equal '10 MiB', number_helper.number_to_human_size(9961472, :precision=>0)
+          assert_equal '40 KiB', number_helper.number_to_human_size(41010, :precision => 1)
+          assert_equal '40 KiB', number_helper.number_to_human_size(41100, :precision => 2)
+          assert_equal '1.0 KiB',   number_helper.number_to_human_size(kibibytes(1.0123), :precision => 2, :strip_insignificant_zeros => false)
+          assert_equal '1.012 KiB',   number_helper.number_to_human_size(kibibytes(1.0123), :precision => 3, :significant => false)
+          assert_equal '1 KiB',   number_helper.number_to_human_size(kibibytes(1.0123), :precision => 0, :significant => true) #ignores significant it precision is 0
         end
       end
 
       def test_number_to_human_size_with_custom_delimiter_and_separator
         [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
-          assert_equal '1,01 KB',     number_helper.number_to_human_size(kilobytes(1.0123), :precision => 3, :separator => ',')
-          assert_equal '1,01 KB',     number_helper.number_to_human_size(kilobytes(1.0100), :precision => 4, :separator => ',')
-          assert_equal '1.000,1 TB',  number_helper.number_to_human_size(terabytes(1000.1), :precision => 5, :delimiter => '.', :separator => ',')
+          assert_equal '1,01 KiB',     number_helper.number_to_human_size(kibibytes(1.0123), :precision => 3, :separator => ',')
+          assert_equal '1,01 KiB',     number_helper.number_to_human_size(kibibytes(1.0100), :precision => 4, :separator => ',')
+          assert_equal '1.000,1 TiB',  number_helper.number_to_human_size(tebibytes(1000.1), :precision => 5, :delimiter => '.', :separator => ',')
         end
       end
 

--- a/activesupport/test/testing/performance_test.rb
+++ b/activesupport/test/testing/performance_test.rb
@@ -29,11 +29,11 @@ module ActiveSupport
         assert_equal "1 Byte", space_metric.format(1.23)
         assert_equal "123 Bytes", space_metric.format(123)
         assert_equal "123 Bytes", space_metric.format(123.45)
-        assert_equal "12 KB", space_metric.format(12345)
-        assert_equal "1.2 MB", space_metric.format(1234567)
-        assert_equal "9.3 GB", space_metric.format(10**10)
-        assert_equal "91 TB", space_metric.format(10**14)
-        assert_equal "910000 TB", space_metric.format(10**18)
+        assert_equal "12 KiB", space_metric.format(12345)
+        assert_equal "1.2 MiB", space_metric.format(1234567)
+        assert_equal "9.3 GiB", space_metric.format(10**10)
+        assert_equal "91 TiB", space_metric.format(10**14)
+        assert_equal "910000 TiB", space_metric.format(10**18)
       end
 
       def test_environment_format_without_rails

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -1828,27 +1828,27 @@ All numbers respond to these methods:
 
 ```ruby
 bytes
-kilobytes
-megabytes
-gigabytes
-terabytes
-petabytes
-exabytes
+kibibytes
+mebibytes
+gibibytes
+tebibytes
+pebibytes
+exbibytes
 ```
 
 They return the corresponding amount of bytes, using a conversion factor of 1024:
 
 ```ruby
-2.kilobytes   # => 2048
-3.megabytes   # => 3145728
-3.5.gigabytes # => 3758096384
--4.exabytes   # => -4611686018427387904
+2.kibibytes   # => 2048
+3.mebibytes   # => 3145728
+3.5.gibibytes # => 3758096384
+-4.exbibytes   # => -4611686018427387904
 ```
 
 Singular forms are aliased so you are able to say:
 
 ```ruby
-1.megabyte # => 1048576
+1.mebibyte # => 1048576
 ```
 
 NOTE: Defined in `active_support/core_ext/numeric/bytes.rb`.

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -659,7 +659,7 @@ config.assets.cache_store = :memory_store
 The options accepted by the assets cache store are the same as the application's cache store.
 
 ```ruby
-config.assets.cache_store = :memory_store, { :size => 32.megabytes }
+config.assets.cache_store = :memory_store, { :size => 32.mebibytes }
 ```
 
 Adding Assets to Your Gems

--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -326,7 +326,7 @@ There are some common options used by all cache implementations. These can be pa
 
 * `:compress` - This option can be used to indicate that compression should be used in the cache. This can be useful for transferring large cache entries over a slow network.
 
-* `:compress_threshold` - This options is used in conjunction with the `:compress` option to indicate a threshold under which cache entries should not be compressed. This defaults to 16 kilobytes.
+* `:compress_threshold` - This options is used in conjunction with the `:compress` option to indicate a threshold under which cache entries should not be compressed. This defaults to 16 kibibytes.
 
 * `:expires_in` - This option sets an expiration time in seconds for the cache entry when it will be automatically removed from the cache.
 
@@ -337,7 +337,7 @@ There are some common options used by all cache implementations. These can be pa
 This cache store keeps entries in memory in the same Ruby process. The cache store has a bounded size specified by the `:size` options to the initializer (default is 32Mb). When the cache exceeds the allotted size, a cleanup will occur and the least recently used entries will be removed.
 
 ```ruby
-config.cache_store = :memory_store, { :size => 64.megabytes }
+config.cache_store = :memory_store, { :size => 64.mebibytes }
 ```
 
 If you're running multiple Ruby on Rails server processes (which is the case if you're using mongrel_cluster or Phusion Passenger), then your Rails server process instances won't be able to share cache data with each other. This cache store is not appropriate for large application deployments, but can work well for small, low traffic sites with only a couple of server processes or for development and test environments.


### PR DESCRIPTION
One of the greatest things about rails is that it is so standards-compliant,
no other framework that I have seen have complied to the
HTTP standard (think REST) in such a degree that Rails does. Kudos to
you all for that.

I think we (Rails community) should follow the line of standards
compliance and also
take it to the binary prefixes [1], i.e. kilobytes, megabytes,
etc. For more than half a decade SI units has been a standard
(occupying the prefixes kilo, mega, ...) Since the introduction of
computers the prefixes has been misused in the IT industry for powers
of 1024 but used correctly (for marketing reasons) by storage
manufacturers to mean powers of 1000.

In 1999 IEC published the new standard for powers of 1024 (known as
binary prefixes[1]). In 2008 this was harmonized with ISO standard in
ISO/IEC IEC 80000-13:2008

I think it is a good time (for Rails 4) for Rails to conform to these
standards. That means that every time a power of 1024 is used the IEC
prefixes kibi, mebi, and so on are used and vice versa. Further every
time a power of 1000 is used the SI prefixes are used, that is, kilo,
mega, and so on and vice versa.

I have created a pull request
(https://github.com/rails/rails/pull/7819) that implements two things
(in two separate commits):

1) Rename all use of 1024 to use IEC prefix names

   a) Rename of core extension: 2.kilobytes => 2.kibibyte  == 2*1024
   b) Rename all use of these helpers within the Rails project.
   c) Ensure that number the prefixes are KiB, MiB when dividing by
   powers of 1024, and using KB, MB when dividing by powers of 1000
   (that is when options[:prefix] => :si)

2) (Re)Introduced the posibility to use SI prefix names (meaning powers of 1000)
   Introduced SI prefix helpers 2.kilobytes == 2*1000

Impact on Rails itself:
None: All the useages has been renamed to use the semantically
equivalent method (that is IEC names).

Impact on Rails projects:
The use of core extensions 2.kilobytes, 2.megabytes will mean
something else; A power of 1000 in Rails4 as opposed to a power of
1024 in Rails3. But the old behaviour can still be achieved by using
IEC names instead such as 2.kibibytes or 2.mebibytes.

Footnotes:
[1]  http://en.wikipedia.org/wiki/Binary_prefix
