### PR TITLE
Make Rails.public_path return a Pathname

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `Rails.public_path` now returns a Pathname object. *Prem Sichanugrist*
+
 *   Remove highly uncommon `config.assets.manifest` option for moving the manifest path.
     This option is now unsupported in sprockets-rails. 
 

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -127,7 +127,7 @@ module Rails
     end
 
     def public_path
-      application && application.paths["public"].first
+      application && Pathname.new(application.paths["public"].first)
     end
   end
 end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -139,6 +139,14 @@ module ApplicationTests
       assert_instance_of Pathname, Rails.root
     end
 
+    test "Rails.public_path should be a Pathname" do
+      add_to_config <<-RUBY
+        config.paths["public"] = "somewhere"
+      RUBY
+      require "#{app_path}/config/environment"
+      assert_instance_of Pathname, Rails.public_path
+    end
+
     test "initialize an eager loaded, cache classes app" do
       add_to_config <<-RUBY
         config.eager_load = true
@@ -227,7 +235,7 @@ module ApplicationTests
       RUBY
 
       require "#{app_path}/config/application"
-      assert_equal File.join(app_path, "somewhere"), Rails.public_path
+      assert_equal Pathname.new(app_path).join("somewhere"), Rails.public_path
     end
 
     test "config.secret_token is sent in env" do


### PR DESCRIPTION
I've discussed with @tenderlove earlier, and it seems like it make sense to make `Rails.public_path` a Pathname, so you can call Pathname methods on it, such as `.join`. I think this is a useful addition to this method.
