### PR TITLE
Make `.validators_on` accept `:kind` option

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `ActiveModel::Validators#validators_on` now accepts a `:kind` option which will filter out the
+    validators on a particular attribute based on its kind.
+
+        Person.validators_on(:name)
+        # => [#<ActiveModel::Validations::PresenceValidator:0x007fe604914e60 @attributes=[:name], @options={}>,
+        # #<ActiveModel::Validations::InclusionValidator:0x007fe603bb8780 @attributes=[:age], @options={:in=>0..99}>]
+
+        Person.validators_on(:name, kind: :presence)
+        # => [#<ActiveModel::Validations::PresenceValidator:0x007fe604914e60 @attributes=[:name], @options={}>]
+
 *   Add `ActiveModel::ForbiddenAttributesProtection`, a simple module to
     protect attributes from mass assignment when non-permitted attributes are passed.
 

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -187,10 +187,21 @@ module ActiveModel
       #   #       #<ActiveModel::Validations::PresenceValidator:0x007fe604914e60 @attributes=[:name], @options={}>,
       #   #       #<ActiveModel::Validations::InclusionValidator:0x007fe603bb8780 @attributes=[:age], @options={:in=>0..99}>
       #   #    ]
+      #
+      # You can also pass a +:kind+ option to filter the validators based on their kind.
+      #
+      #   Person.validators_on(:name, kind: :presence)
+      #   # => [#<ActiveModel::Validations::PresenceValidator:0x007fe604914e60 @attributes=[:name], @options={}>]
       def validators_on(*attributes)
+        options = attributes.extract_options!
+
         attributes.map do |attribute|
           _validators[attribute.to_sym]
-        end.flatten
+        end.flatten.tap do |validators|
+          if options[:kind]
+            validators.select! { |validator| validator.kind == options[:kind] }
+          end
+        end
       end
 
       # Returns +true+ if +attribute+ is an attribute method, +false+ otherwise.

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -287,6 +287,14 @@ class ValidationsTest < ActiveModel::TestCase
     assert_equal [], Topic.validators_on(:author_name)
   end
 
+  def test_list_of_validators_on_an_attribute_based_on_kind
+    Topic.validates_presence_of :title, :content
+    Topic.validates_length_of :title, :minimum => 2
+
+    assert_equal Topic.validators_on(:title).select { |v| v.kind == :presence },
+      Topic.validators_on(:title, kind: :presence)
+  end
+
   def test_validations_on_the_instance_level
     auto = Automobile.new
 


### PR DESCRIPTION
Making `ActiveModel::Validators#validators_on` to accept a `:kind` option which will filter out the validators on a particular attribute based on its kind.

``` ruby
Person.validators_on(:name)
# => [#<ActiveModel::Validations::PresenceValidator:0x007fe604914e60 @attributes=[:name], @options={}>,
# #<ActiveModel::Validations::InclusionValidator:0x007fe603bb8780 @attributes=[:age], @options={:in=>0..99}>]

Person.validators_on(:name, :presence)
# => [#<ActiveModel::Validations::PresenceValidator:0x007fe604914e60 @attributes=[:name], @options={}>]
```
