### PR TITLE
Add `Relation#and` which is an alias of `#where`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add `Relation#and` which is an alias of `#where`, and it is to be used as
+    a syntatic sugar when you're chaining multiple #where clauses together.
+
+        # Before
+        User.where("created_at < ?", 1.week.ago).where(state: 'active')
+
+        # After
+        User.where("created_at < ?", 1.week.ago).and(state: 'active')
+
+    *Prem Sichanugrist*
+
 *   Fix `reset_counters` crashing on `has_many :through` associations.
     Fix #7822.
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -377,6 +377,16 @@ module ActiveRecord
       opts.blank? ? self : spawn.where!(opts, *rest)
     end
 
+    # This method is an alias of #where, and it is to be used as a syntatic sugar when you're
+    # chaining multiple #where clauses together.
+    #
+    #    # Before
+    #    User.where("created_at < ?", 1.week.ago).where(state: 'active')
+    #
+    #    # After
+    #    User.where("created_at < ?", 1.week.ago).and(state: 'active')
+    alias and where
+
     # #where! is identical to #where, except that instead of returning a new relation, it adds
     # the condition to the existing relation.
     def where!(opts, *rest)

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -85,5 +85,10 @@ module ActiveRecord
     def test_where_with_empty_hash_and_no_foreign_key
       assert_equal 0, Edge.where(:sink => {}).count
     end
+
+    def test_where_chaining_with_and
+      assert_equal Post.where('comments_count >= ?', 2).and(author_id: 1).to_a,
+       Post.where('comments_count >= ? AND author_id = ?', 2, 1).to_a
+    end
   end
 end

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -75,7 +75,7 @@ The methods are:
 * `reverse_order`
 * `select`
 * `uniq`
-* `where`
+* `where` (and its alias, `and`)
 
 All of the above methods return an instance of `ActiveRecord::Relation`.
 
@@ -503,6 +503,18 @@ This code will generate SQL like this:
 
 ```sql
 SELECT * FROM clients WHERE (clients.orders_count IN (1,3,5))
+```
+
+#### Chaining Conditions
+
+You can, of course, chaining conditions by calling `where` method multiple times. However, to make
+your syntax reads better, you can also use `and` method when you're intended to call `where` the
+second time.
+
+```ruby
+# These two will generate the same result:
+Client.where("created_at < ?", 1.week.ago).where(state: 'active')
+Client.where("created_at < ?", 1.week.ago).and(state: 'active')
 ```
 
 Ordering


### PR DESCRIPTION
This new method a syntatic sugar when you're chaining multiple #where clauses together.

``` ruby
# Before
User.where("created_at < ?", 1.week.ago).where(state: 'active')

# After
User.where("created_at < ?", 1.week.ago).and(state: 'active')
```
