### PR TITLE
Added :prefix => :iec option

### DIFF
--- a/actionpack/test/template/number_helper_test.rb
+++ b/actionpack/test/template/number_helper_test.rb
@@ -186,15 +186,15 @@ class NumberHelperTest < ActionView::TestCase
     assert_equal '1.23 TB',    number_to_human_size(1234567890123, :prefix => :si)
   end
 
-  def test_number_to_human_size_with_iec_prefix
-    assert_equal '3 Bytes',    number_to_human_size(3.14159265, :prefix => :iec)
-    assert_equal '123 Bytes',  number_to_human_size(123.0, :prefix => :iec)
-    assert_equal '123 Bytes',  number_to_human_size(123, :prefix => :iec)
-    assert_equal '1.21 KiB',   number_to_human_size(1234, :prefix => :iec)
-    assert_equal '12.1 KiB',   number_to_human_size(12345, :prefix => :iec)
-    assert_equal '1.18 MiB',   number_to_human_size(1234567, :prefix => :iec)
-    assert_equal '1.15 GiB',   number_to_human_size(1234567890, :prefix => :iec)
-    assert_equal '1.12 TiB',   number_to_human_size(1234567890123, :prefix => :iec)
+  def test_number_to_human_size_with_iso_prefix
+    assert_equal '3 Bytes',    number_to_human_size(3.14159265, :prefix => :iso)
+    assert_equal '123 Bytes',  number_to_human_size(123.0, :prefix => :iso)
+    assert_equal '123 Bytes',  number_to_human_size(123, :prefix => :iso)
+    assert_equal '1.21 KiB',   number_to_human_size(1234, :prefix => :iso)
+    assert_equal '12.1 KiB',   number_to_human_size(12345, :prefix => :iso)
+    assert_equal '1.18 MiB',   number_to_human_size(1234567, :prefix => :iso)
+    assert_equal '1.15 GiB',   number_to_human_size(1234567890, :prefix => :iso)
+    assert_equal '1.12 TiB',   number_to_human_size(1234567890123, :prefix => :iso)
   end
 
   def test_number_to_human_size_with_options_hash

--- a/actionpack/test/template/number_helper_test.rb
+++ b/actionpack/test/template/number_helper_test.rb
@@ -179,22 +179,22 @@ class NumberHelperTest < ActionView::TestCase
     assert_equal '3 Bytes',    number_to_human_size(3.14159265, :prefix => :si)
     assert_equal '123 Bytes',  number_to_human_size(123.0, :prefix => :si)
     assert_equal '123 Bytes',  number_to_human_size(123, :prefix => :si)
-    assert_equal '1.23 kB',    number_to_human_size(1234, :prefix => :si)
-    assert_equal '12.3 kB',    number_to_human_size(12345, :prefix => :si)
+    assert_equal '1.23 kB',    number_to_human_size(1234, prefix: :si)
+    assert_equal '12.3 kB',    number_to_human_size(12345, prefix: :si)
     assert_equal '1.23 MB',    number_to_human_size(1234567, :prefix => :si)
     assert_equal '1.23 GB',    number_to_human_size(1234567890, :prefix => :si)
     assert_equal '1.23 TB',    number_to_human_size(1234567890123, :prefix => :si)
   end
 
   def test_number_to_human_size_with_iso_prefix
-    assert_equal '3 Bytes',    number_to_human_size(3.14159265, :prefix => :iso)
-    assert_equal '123 Bytes',  number_to_human_size(123.0, :prefix => :iso)
-    assert_equal '123 Bytes',  number_to_human_size(123, :prefix => :iso)
-    assert_equal '1.21 KiB',   number_to_human_size(1234, :prefix => :iso)
-    assert_equal '12.1 KiB',   number_to_human_size(12345, :prefix => :iso)
-    assert_equal '1.18 MiB',   number_to_human_size(1234567, :prefix => :iso)
-    assert_equal '1.15 GiB',   number_to_human_size(1234567890, :prefix => :iso)
-    assert_equal '1.12 TiB',   number_to_human_size(1234567890123, :prefix => :iso)
+    assert_equal '3 Bytes',    number_to_human_size(3.14159265, prefix: :iso)
+    assert_equal '123 Bytes',  number_to_human_size(123.0, prefix: :iso)
+    assert_equal '123 Bytes',  number_to_human_size(123, prefix: :iso)
+    assert_equal '1.21 KiB',   number_to_human_size(1234, prefix: :iso)
+    assert_equal '12.1 KiB',   number_to_human_size(12345, prefix: :iso)
+    assert_equal '1.18 MiB',   number_to_human_size(1234567, prefix: :iso)
+    assert_equal '1.15 GiB',   number_to_human_size(1234567890, prefix: :iso)
+    assert_equal '1.12 TiB',   number_to_human_size(1234567890123, prefix: :iso)
   end
 
   def test_number_to_human_size_with_options_hash

--- a/actionpack/test/template/number_helper_test.rb
+++ b/actionpack/test/template/number_helper_test.rb
@@ -179,11 +179,22 @@ class NumberHelperTest < ActionView::TestCase
     assert_equal '3 Bytes',    number_to_human_size(3.14159265, :prefix => :si)
     assert_equal '123 Bytes',  number_to_human_size(123.0, :prefix => :si)
     assert_equal '123 Bytes',  number_to_human_size(123, :prefix => :si)
-    assert_equal '1.23 KB',    number_to_human_size(1234, :prefix => :si)
-    assert_equal '12.3 KB',    number_to_human_size(12345, :prefix => :si)
+    assert_equal '1.23 kB',    number_to_human_size(1234, :prefix => :si)
+    assert_equal '12.3 kB',    number_to_human_size(12345, :prefix => :si)
     assert_equal '1.23 MB',    number_to_human_size(1234567, :prefix => :si)
     assert_equal '1.23 GB',    number_to_human_size(1234567890, :prefix => :si)
     assert_equal '1.23 TB',    number_to_human_size(1234567890123, :prefix => :si)
+  end
+
+  def test_number_to_human_size_with_iec_prefix
+    assert_equal '3 Bytes',    number_to_human_size(3.14159265, :prefix => :iec)
+    assert_equal '123 Bytes',  number_to_human_size(123.0, :prefix => :iec)
+    assert_equal '123 Bytes',  number_to_human_size(123, :prefix => :iec)
+    assert_equal '1.21 KiB',    number_to_human_size(1234, :prefix => :iec)
+    assert_equal '12.1 KiB',    number_to_human_size(12345, :prefix => :iec)
+    assert_equal '1.18 MiB',    number_to_human_size(1234567, :prefix => :iec)
+    assert_equal '1.15 GiB',    number_to_human_size(1234567890, :prefix => :iec)
+    assert_equal '1.12 TiB',    number_to_human_size(1234567890123, :prefix => :iec)
   end
 
   def test_number_to_human_size_with_options_hash

--- a/actionpack/test/template/number_helper_test.rb
+++ b/actionpack/test/template/number_helper_test.rb
@@ -190,11 +190,11 @@ class NumberHelperTest < ActionView::TestCase
     assert_equal '3 Bytes',    number_to_human_size(3.14159265, :prefix => :iec)
     assert_equal '123 Bytes',  number_to_human_size(123.0, :prefix => :iec)
     assert_equal '123 Bytes',  number_to_human_size(123, :prefix => :iec)
-    assert_equal '1.21 KiB',    number_to_human_size(1234, :prefix => :iec)
-    assert_equal '12.1 KiB',    number_to_human_size(12345, :prefix => :iec)
-    assert_equal '1.18 MiB',    number_to_human_size(1234567, :prefix => :iec)
-    assert_equal '1.15 GiB',    number_to_human_size(1234567890, :prefix => :iec)
-    assert_equal '1.12 TiB',    number_to_human_size(1234567890123, :prefix => :iec)
+    assert_equal '1.21 KiB',   number_to_human_size(1234, :prefix => :iec)
+    assert_equal '12.1 KiB',   number_to_human_size(12345, :prefix => :iec)
+    assert_equal '1.18 MiB',   number_to_human_size(1234567, :prefix => :iec)
+    assert_equal '1.15 GiB',   number_to_human_size(1234567890, :prefix => :iec)
+    assert_equal '1.12 TiB',   number_to_human_size(1234567890123, :prefix => :iec)
   end
 
   def test_number_to_human_size_with_options_hash

--- a/activesupport/lib/active_support/locale/en.yml
+++ b/activesupport/lib/active_support/locale/en.yml
@@ -106,6 +106,22 @@ en:
           mb: "MB"
           gb: "GB"
           tb: "TB"
+        si_units:
+          byte:
+            one:   "Byte"
+            other: "Bytes"
+          kb: "kB"
+          mb: "MB"
+          gb: "GB"
+          tb: "TB"
+        iec_units:
+          byte:
+            one:   "Byte"
+            other: "Bytes"
+          kb: "KiB"
+          mb: "MiB"
+          gb: "GiB"
+          tb: "TiB"
       # Used in NumberHelper.number_to_human()
       decimal_units:
         format: "%n %u"

--- a/activesupport/lib/active_support/locale/en.yml
+++ b/activesupport/lib/active_support/locale/en.yml
@@ -114,7 +114,7 @@ en:
           mb: "MB"
           gb: "GB"
           tb: "TB"
-        iec_units:
+        iso_units:
           byte:
             one:   "Byte"
             other: "Bytes"

--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -448,6 +448,7 @@ module ActiveSupport
 
       storage_units_format = translate_number_value_with_default('human.storage_units.format', :locale => options[:locale], :raise => true)
 
+      options[:prefix] ||= :binary
       case options[:prefix]
       when :si
         base = 1000
@@ -455,9 +456,11 @@ module ActiveSupport
       when :iec
         base = 1024
         system_key = "iec_units"
-      else #:binary
+      when :binary
         base = 1024
         system_key = "units"
+      else
+        raise ArgumentError, ":prefix must be :binary, :si, or :iec"
       end
 
       if number.to_i < base

--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -415,7 +415,7 @@ module ActiveSupport
     #   +true+)
     # * <tt>:prefix</tt> - If +:si+ formats the number using the SI
     #   prefix. If +:iec+ formats the numbers using the IEC prefix 
-    #   (defaults to :binary).
+    #   (defaults to :customary).
     #
     # ==== Examples
     #
@@ -448,7 +448,7 @@ module ActiveSupport
 
       storage_units_format = translate_number_value_with_default('human.storage_units.format', :locale => options[:locale], :raise => true)
 
-      options[:prefix] ||= :binary
+      options[:prefix] ||= :customary
       case options[:prefix]
       when :si
         base = 1000
@@ -456,11 +456,11 @@ module ActiveSupport
       when :iec
         base = 1024
         system_key = "iec_units"
-      when :binary
+      when :customary
         base = 1024
         system_key = "units"
       else
-        raise ArgumentError, ":prefix must be :binary, :si, or :iec"
+        raise ArgumentError, ":prefix must be :customary, :si, or :iec"
       end
 
       if number.to_i < base

--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 require 'active_support/core_ext/big_decimal/conversions'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/hash/keys'

--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -6,7 +6,7 @@ require 'active_support/i18n'
 module ActiveSupport
   class << self
     delegate :default_size_prefix, :default_size_prefix=,
-    :to => :'ActiveSupport::NumberHelper'
+    to: :'ActiveSupport::NumberHelper'
   end
 
   module NumberHelper
@@ -476,7 +476,7 @@ module ActiveSupport
       end
 
       if number.to_i < base
-        unit = translate_number_value_with_default("human.storage_units.#{system_key}.byte", :locale => options[:locale], :count => number.to_i, :raise => true)
+        unit = translate_number_value_with_default("human.storage_units.#{system_key}.byte", locale: options[:locale], count: number.to_i, raise: true)
         storage_units_format.gsub(/%n/, number.to_i.to_s).gsub(/%u/, unit)
       else
         max_exp  = STORAGE_UNITS.size - 1
@@ -485,7 +485,7 @@ module ActiveSupport
         number  /= base ** exponent
 
         unit_key = STORAGE_UNITS[exponent]
-        unit = translate_number_value_with_default("human.storage_units.#{system_key}.#{unit_key}", :locale => options[:locale], :count => number, :raise => true)
+        unit = translate_number_value_with_default("human.storage_units.#{system_key}.#{unit_key}", locale: options[:locale], count: number, raise: true)
 
         formatted_number = self.number_to_rounded(number, options)
         storage_units_format.gsub(/%n/, formatted_number).gsub(/%u/, unit)

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -351,15 +351,15 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
     assert_equal '1.23 TB',    1234567890123.to_s(:human_size, :prefix => :si)
   end
   
-  def test_to_s__human_size_with_iec_prefix
-    assert_equal '3 Bytes',    3.14159265.to_s(:human_size, :prefix => :iec)
-    assert_equal '123 Bytes',  123.0.to_s(:human_size, :prefix => :iec)
-    assert_equal '123 Bytes',  123.to_s(:human_size, :prefix => :iec)
-    assert_equal '1.21 KiB',   1234.to_s(:human_size, :prefix => :iec)
-    assert_equal '12.1 KiB',   12345.to_s(:human_size, :prefix => :iec)
-    assert_equal '1.18 MiB',   1234567.to_s(:human_size, :prefix => :iec)
-    assert_equal '1.15 GiB',   1234567890.to_s(:human_size, :prefix => :iec)
-    assert_equal '1.12 TiB',   1234567890123.to_s(:human_size, :prefix => :iec)
+  def test_to_s__human_size_with_iso_prefix
+    assert_equal '3 Bytes',    3.14159265.to_s(:human_size, :prefix => :iso)
+    assert_equal '123 Bytes',  123.0.to_s(:human_size, :prefix => :iso)
+    assert_equal '123 Bytes',  123.to_s(:human_size, :prefix => :iso)
+    assert_equal '1.21 KiB',   1234.to_s(:human_size, :prefix => :iso)
+    assert_equal '12.1 KiB',   12345.to_s(:human_size, :prefix => :iso)
+    assert_equal '1.18 MiB',   1234567.to_s(:human_size, :prefix => :iso)
+    assert_equal '1.15 GiB',   1234567890.to_s(:human_size, :prefix => :iso)
+    assert_equal '1.12 TiB',   1234567890123.to_s(:human_size, :prefix => :iso)
   end
   
   def test_to_s__human_size_with_options_hash

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -344,11 +344,22 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
     assert_equal '3 Bytes',    3.14159265.to_s(:human_size, :prefix => :si)
     assert_equal '123 Bytes',  123.0.to_s(:human_size, :prefix => :si)
     assert_equal '123 Bytes',  123.to_s(:human_size, :prefix => :si)
-    assert_equal '1.23 KB',    1234.to_s(:human_size, :prefix => :si)
-    assert_equal '12.3 KB',    12345.to_s(:human_size, :prefix => :si)
+    assert_equal '1.23 kB',    1234.to_s(:human_size, :prefix => :si)
+    assert_equal '12.3 kB',    12345.to_s(:human_size, :prefix => :si)
     assert_equal '1.23 MB',    1234567.to_s(:human_size, :prefix => :si)
     assert_equal '1.23 GB',    1234567890.to_s(:human_size, :prefix => :si)
     assert_equal '1.23 TB',    1234567890123.to_s(:human_size, :prefix => :si)
+  end
+  
+  def test_to_s__human_size_with_iec_prefix
+    assert_equal '3 Bytes',    3.14159265.to_s(:human_size, :prefix => :iec)
+    assert_equal '123 Bytes',  123.0.to_s(:human_size, :prefix => :iec)
+    assert_equal '123 Bytes',  123.to_s(:human_size, :prefix => :iec)
+    assert_equal '1.21 KiB',   1234.to_s(:human_size, :prefix => :iec)
+    assert_equal '12.1 KiB',   12345.to_s(:human_size, :prefix => :iec)
+    assert_equal '1.18 MiB',   1234567.to_s(:human_size, :prefix => :iec)
+    assert_equal '1.15 GiB',   1234567890.to_s(:human_size, :prefix => :iec)
+    assert_equal '1.12 TiB',   1234567890123.to_s(:human_size, :prefix => :iec)
   end
   
   def test_to_s__human_size_with_options_hash

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -344,22 +344,22 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
     assert_equal '3 Bytes',    3.14159265.to_s(:human_size, :prefix => :si)
     assert_equal '123 Bytes',  123.0.to_s(:human_size, :prefix => :si)
     assert_equal '123 Bytes',  123.to_s(:human_size, :prefix => :si)
-    assert_equal '1.23 kB',    1234.to_s(:human_size, :prefix => :si)
-    assert_equal '12.3 kB',    12345.to_s(:human_size, :prefix => :si)
+    assert_equal '1.23 kB',    1234.to_s(:human_size, prefix: :si)
+    assert_equal '12.3 kB',    12345.to_s(:human_size, prefix: :si)
     assert_equal '1.23 MB',    1234567.to_s(:human_size, :prefix => :si)
     assert_equal '1.23 GB',    1234567890.to_s(:human_size, :prefix => :si)
     assert_equal '1.23 TB',    1234567890123.to_s(:human_size, :prefix => :si)
   end
   
   def test_to_s__human_size_with_iso_prefix
-    assert_equal '3 Bytes',    3.14159265.to_s(:human_size, :prefix => :iso)
-    assert_equal '123 Bytes',  123.0.to_s(:human_size, :prefix => :iso)
-    assert_equal '123 Bytes',  123.to_s(:human_size, :prefix => :iso)
-    assert_equal '1.21 KiB',   1234.to_s(:human_size, :prefix => :iso)
-    assert_equal '12.1 KiB',   12345.to_s(:human_size, :prefix => :iso)
-    assert_equal '1.18 MiB',   1234567.to_s(:human_size, :prefix => :iso)
-    assert_equal '1.15 GiB',   1234567890.to_s(:human_size, :prefix => :iso)
-    assert_equal '1.12 TiB',   1234567890123.to_s(:human_size, :prefix => :iso)
+    assert_equal '3 Bytes',    3.14159265.to_s(:human_size, prefix: :iso)
+    assert_equal '123 Bytes',  123.0.to_s(:human_size, prefix: :iso)
+    assert_equal '123 Bytes',  123.to_s(:human_size, prefix: :iso)
+    assert_equal '1.21 KiB',   1234.to_s(:human_size, prefix: :iso)
+    assert_equal '12.1 KiB',   12345.to_s(:human_size, prefix: :iso)
+    assert_equal '1.18 MiB',   1234567.to_s(:human_size, prefix: :iso)
+    assert_equal '1.15 GiB',   1234567890.to_s(:human_size, prefix: :iso)
+    assert_equal '1.12 TiB',   1234567890123.to_s(:human_size, prefix: :iso)
   end
   
   def test_to_s__human_size_with_options_hash

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -222,11 +222,11 @@ module ActiveSupport
           assert_equal '3 Bytes',    number_helper.number_to_human_size(3.14159265, :prefix => :iec)
           assert_equal '123 Bytes',  number_helper.number_to_human_size(123.0, :prefix => :iec)
           assert_equal '123 Bytes',  number_helper.number_to_human_size(123, :prefix => :iec)
-          assert_equal '1.21 KiB',    number_helper.number_to_human_size(1234, :prefix => :iec)
-          assert_equal '12.1 KiB',    number_helper.number_to_human_size(12345, :prefix => :iec)
-          assert_equal '1.18 MiB',    number_helper.number_to_human_size(1234567, :prefix => :iec)
-          assert_equal '1.15 GiB',    number_helper.number_to_human_size(1234567890, :prefix => :iec)
-          assert_equal '1.12 TiB',    number_helper.number_to_human_size(1234567890123, :prefix => :iec)
+          assert_equal '1.21 KiB',   number_helper.number_to_human_size(1234, :prefix => :iec)
+          assert_equal '12.1 KiB',   number_helper.number_to_human_size(12345, :prefix => :iec)
+          assert_equal '1.18 MiB',   number_helper.number_to_human_size(1234567, :prefix => :iec)
+          assert_equal '1.15 GiB',   number_helper.number_to_human_size(1234567890, :prefix => :iec)
+          assert_equal '1.12 TiB',   number_helper.number_to_human_size(1234567890123, :prefix => :iec)
         end
       end
 

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -209,8 +209,8 @@ module ActiveSupport
           assert_equal '3 Bytes',    number_helper.number_to_human_size(3.14159265, :prefix => :si)
           assert_equal '123 Bytes',  number_helper.number_to_human_size(123.0, :prefix => :si)
           assert_equal '123 Bytes',  number_helper.number_to_human_size(123, :prefix => :si)
-          assert_equal '1.23 kB',    number_helper.number_to_human_size(1234, :prefix => :si)
-          assert_equal '12.3 kB',    number_helper.number_to_human_size(12345, :prefix => :si)
+          assert_equal '1.23 kB',    number_helper.number_to_human_size(1234, prefix: :si)
+          assert_equal '12.3 kB',    number_helper.number_to_human_size(12345, prefix: :si)
           assert_equal '1.23 MB',    number_helper.number_to_human_size(1234567, :prefix => :si)
           assert_equal '1.23 GB',    number_helper.number_to_human_size(1234567890, :prefix => :si)
           assert_equal '1.23 TB',    number_helper.number_to_human_size(1234567890123, :prefix => :si)
@@ -220,14 +220,14 @@ module ActiveSupport
       def test_number_to_human_size_with_iso_prefix
         [:iec, :iso].each do |prefix|
           [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
-            assert_equal '3 Bytes',    number_helper.number_to_human_size(3.14159265, :prefix => prefix)
-            assert_equal '123 Bytes',  number_helper.number_to_human_size(123.0, :prefix => prefix)
-            assert_equal '123 Bytes',  number_helper.number_to_human_size(123, :prefix => prefix)
-            assert_equal '1.21 KiB',   number_helper.number_to_human_size(1234, :prefix => prefix)
-            assert_equal '12.1 KiB',   number_helper.number_to_human_size(12345, :prefix => prefix)
-            assert_equal '1.18 MiB',   number_helper.number_to_human_size(1234567, :prefix => prefix)
-            assert_equal '1.15 GiB',   number_helper.number_to_human_size(1234567890, :prefix => prefix)
-            assert_equal '1.12 TiB',   number_helper.number_to_human_size(1234567890123, :prefix => prefix)
+            assert_equal '3 Bytes',    number_helper.number_to_human_size(3.14159265, prefix: prefix)
+            assert_equal '123 Bytes',  number_helper.number_to_human_size(123.0, prefix: prefix)
+            assert_equal '123 Bytes',  number_helper.number_to_human_size(123, prefix: prefix)
+            assert_equal '1.21 KiB',   number_helper.number_to_human_size(1234, prefix: prefix)
+            assert_equal '12.1 KiB',   number_helper.number_to_human_size(12345, prefix: prefix)
+            assert_equal '1.18 MiB',   number_helper.number_to_human_size(1234567, prefix: prefix)
+            assert_equal '1.15 GiB',   number_helper.number_to_human_size(1234567890, prefix: prefix)
+            assert_equal '1.12 TiB',   number_helper.number_to_human_size(1234567890123, prefix: prefix)
           end
         end
       end
@@ -239,7 +239,7 @@ module ActiveSupport
             assert_equal '1.12 TiB',   number_helper.number_to_human_size(1234567890123)
           end
           [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
-            assert_equal '1.12 TB',   number_helper.number_to_human_size(1234567890123, :prefix => :customary)
+            assert_equal '1.12 TB',   number_helper.number_to_human_size(1234567890123, prefix: :customary)
           end
         ensure
           ActiveSupport.default_size_prefix = :customary
@@ -249,7 +249,7 @@ module ActiveSupport
       def test_number_to_human_size_with_invalid_prefix
         [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
           assert_raise ArgumentError do
-            number_helper.number_to_human_size(1, :prefix => :unknown_prefix)
+            number_helper.number_to_human_size(1, prefix: :unknown_prefix)
           end
         end
       end

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -209,11 +209,24 @@ module ActiveSupport
           assert_equal '3 Bytes',    number_helper.number_to_human_size(3.14159265, :prefix => :si)
           assert_equal '123 Bytes',  number_helper.number_to_human_size(123.0, :prefix => :si)
           assert_equal '123 Bytes',  number_helper.number_to_human_size(123, :prefix => :si)
-          assert_equal '1.23 KB',    number_helper.number_to_human_size(1234, :prefix => :si)
-          assert_equal '12.3 KB',    number_helper.number_to_human_size(12345, :prefix => :si)
+          assert_equal '1.23 kB',    number_helper.number_to_human_size(1234, :prefix => :si)
+          assert_equal '12.3 kB',    number_helper.number_to_human_size(12345, :prefix => :si)
           assert_equal '1.23 MB',    number_helper.number_to_human_size(1234567, :prefix => :si)
           assert_equal '1.23 GB',    number_helper.number_to_human_size(1234567890, :prefix => :si)
           assert_equal '1.23 TB',    number_helper.number_to_human_size(1234567890123, :prefix => :si)
+        end
+      end
+
+      def test_number_to_human_size_with_iec_prefix
+        [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
+          assert_equal '3 Bytes',    number_helper.number_to_human_size(3.14159265, :prefix => :iec)
+          assert_equal '123 Bytes',  number_helper.number_to_human_size(123.0, :prefix => :iec)
+          assert_equal '123 Bytes',  number_helper.number_to_human_size(123, :prefix => :iec)
+          assert_equal '1.21 KiB',    number_helper.number_to_human_size(1234, :prefix => :iec)
+          assert_equal '12.1 KiB',    number_helper.number_to_human_size(12345, :prefix => :iec)
+          assert_equal '1.18 MiB',    number_helper.number_to_human_size(1234567, :prefix => :iec)
+          assert_equal '1.15 GiB',    number_helper.number_to_human_size(1234567890, :prefix => :iec)
+          assert_equal '1.12 TiB',    number_helper.number_to_human_size(1234567890123, :prefix => :iec)
         end
       end
 

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -230,6 +230,14 @@ module ActiveSupport
         end
       end
 
+      def test_number_to_human_size_with_invalid_prefix
+        [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
+          assert_raise ArgumentError do
+            number_helper.number_to_human_size(1, :prefix => :unknown_prefix)
+          end
+        end
+      end
+
       def test_number_to_human_size_with_options_hash
         [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
           assert_equal '1.2 MB',   number_helper.number_to_human_size(1234567, :precision => 2)

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -217,16 +217,32 @@ module ActiveSupport
         end
       end
 
-      def test_number_to_human_size_with_iec_prefix
-        [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
-          assert_equal '3 Bytes',    number_helper.number_to_human_size(3.14159265, :prefix => :iec)
-          assert_equal '123 Bytes',  number_helper.number_to_human_size(123.0, :prefix => :iec)
-          assert_equal '123 Bytes',  number_helper.number_to_human_size(123, :prefix => :iec)
-          assert_equal '1.21 KiB',   number_helper.number_to_human_size(1234, :prefix => :iec)
-          assert_equal '12.1 KiB',   number_helper.number_to_human_size(12345, :prefix => :iec)
-          assert_equal '1.18 MiB',   number_helper.number_to_human_size(1234567, :prefix => :iec)
-          assert_equal '1.15 GiB',   number_helper.number_to_human_size(1234567890, :prefix => :iec)
-          assert_equal '1.12 TiB',   number_helper.number_to_human_size(1234567890123, :prefix => :iec)
+      def test_number_to_human_size_with_iso_prefix
+        [:iec, :iso].each do |prefix|
+          [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
+            assert_equal '3 Bytes',    number_helper.number_to_human_size(3.14159265, :prefix => prefix)
+            assert_equal '123 Bytes',  number_helper.number_to_human_size(123.0, :prefix => prefix)
+            assert_equal '123 Bytes',  number_helper.number_to_human_size(123, :prefix => prefix)
+            assert_equal '1.21 KiB',   number_helper.number_to_human_size(1234, :prefix => prefix)
+            assert_equal '12.1 KiB',   number_helper.number_to_human_size(12345, :prefix => prefix)
+            assert_equal '1.18 MiB',   number_helper.number_to_human_size(1234567, :prefix => prefix)
+            assert_equal '1.15 GiB',   number_helper.number_to_human_size(1234567890, :prefix => prefix)
+            assert_equal '1.12 TiB',   number_helper.number_to_human_size(1234567890123, :prefix => prefix)
+          end
+        end
+      end
+
+      def test_number_to_human_size_using_active_support_default_size_prefix
+        begin
+          ActiveSupport.default_size_prefix = :iso
+          [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
+            assert_equal '1.12 TiB',   number_helper.number_to_human_size(1234567890123)
+          end
+          [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
+            assert_equal '1.12 TB',   number_helper.number_to_human_size(1234567890123, :prefix => :customary)
+          end
+        ensure
+          ActiveSupport.default_size_prefix = :customary
         end
       end
 


### PR DESCRIPTION
This will use base 1024 and the notation (KiB, MiB, GiB, etc.)

```
http://en.wikipedia.org/wiki/Binary_prefix
```

Also corrected the SI prefix for thousands, SI states lowercase "k" not capital letter "K"
