### PR TITLE
Update supported ruby versions error message in ruby_version_check.rb

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Rails 3.2.9 (unreleased)
+
+*   Update supported ruby versions error message in ruby_version_check.rb *Lihan Li*
+
 ## Rails 3.2.8 (Aug 9, 2012) ##
 
 *   ERB scaffold generator use the `:data => { :confirm => "Text" }` syntax instead of `:confirm`.

--- a/railties/lib/rails/ruby_version_check.rb
+++ b/railties/lib/rails/ruby_version_check.rb
@@ -2,7 +2,7 @@ if RUBY_VERSION < '1.8.7'
   desc = defined?(RUBY_DESCRIPTION) ? RUBY_DESCRIPTION : "ruby #{RUBY_VERSION} (#{RUBY_RELEASE_DATE})"
   abort <<-end_message
 
-    Rails 3 requires Ruby 1.8.7 or 1.9.2.
+    Rails 3 requires Ruby 1.8.7 or >= 1.9.2.
 
     You're running
       #{desc}
@@ -14,7 +14,7 @@ elsif RUBY_VERSION > '1.9' and RUBY_VERSION < '1.9.2'
   $stderr.puts <<-end_message
 
     Rails 3 doesn't officially support Ruby 1.9.1 since recent stable
-    releases have segfaulted the test suite. Please upgrade to Ruby 1.9.2.
+    releases have segfaulted the test suite. Please upgrade to Ruby 1.9.2 or later.
 
     You're running
       #{RUBY_DESCRIPTION}


### PR DESCRIPTION
I'm assuming Rails supports 1.9.3 because the official test box is using it.
