### PR TITLE
Handle aliased attributes in AR::Relation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,27 @@
+*   Handle aliased attributes in ActiveRecord::Relation.
+
+    When using symbol keys, ActiveRecord will now translate aliased attribute names to the actual column name used in the database:
+
+    With the model
+
+        class Topic
+          alias_attribute :heading, :title
+        end
+
+    The call
+
+        Topic.where(heading: 'The First Topic')
+
+    should yield the same result as
+
+        Topic.where(title: 'The First Topic')
+
+    This also applies to ActiveRecord::Relation::Calculations calls such as `Model.sum(:aliased)` and `Model.pluck(:aliased)`.
+
+    This will not work with SQL fragment strings like `Model.sum('DISTINCT aliased')`.
+
+    *Godfrey Chan*
+
 *   Mute `psql` output when running rake db:schema:load.
 
     *Godfrey Chan*

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -6,6 +6,10 @@ module ActiveRecord
       attributes.each do |column, value|
         table = default_table
 
+        if column.is_a?(Symbol) && klass.attribute_aliases.key?(column.to_s)
+          column = klass.attribute_aliases[column.to_s]
+        end
+
         if value.is_a?(Hash)
           if value.empty?
             queries << '1=0'

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -28,6 +28,10 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 53.0, value
   end
 
+  def test_should_resolve_aliased_attributes
+    assert_equal 318, Account.sum(:available_credit)
+  end
+
   def test_should_return_decimal_average_of_integer_field
     value = Account.average(:id)
     assert_equal 3.5, value
@@ -352,6 +356,10 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 4, Account.select(:credit_limit).uniq.count
   end
 
+  def test_count_with_aliased_attribute
+    assert_equal 6, Account.count(:available_credit)
+  end
+
   def test_count_with_column_and_options_parameter
     assert_equal 2, Account.where("credit_limit = 50 AND firm_id IS NOT NULL").count(:firm_id)
   end
@@ -486,6 +494,10 @@ class CalculationsTest < ActiveRecord::TestCase
     company = Company.first
     contract = company.contracts.create!
     assert_equal [contract.id], company.contracts.pluck(:id)
+  end
+
+  def test_pluck_on_aliased_attribute
+    assert_equal 'The First Topic', Topic.order(:id).pluck(:heading).first
   end
 
   def test_pluck_with_serialization

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -47,7 +47,8 @@ class FinderTest < ActiveRecord::TestCase
   def test_exists
     assert Topic.exists?(1)
     assert Topic.exists?("1")
-    assert Topic.exists?(:author_name => "David")
+    assert Topic.exists?(title: "The First Topic")
+    assert Topic.exists?(heading: "The First Topic")
     assert Topic.exists?(:author_name => "Mary", :approved => true)
     assert Topic.exists?(["parent_id = ?", 1])
     assert !Topic.exists?(45)

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -5,6 +5,7 @@ require 'models/treasure'
 require 'models/post'
 require 'models/comment'
 require 'models/edge'
+require 'models/topic'
 
 module ActiveRecord
   class WhereTest < ActiveRecord::TestCase
@@ -76,6 +77,13 @@ module ActiveRecord
 
       expected = Treasure.where(price_estimates: { estimate_of_type: 'Treasure', estimate_of_id: 1 }).joins(:price_estimates)
       actual   = Treasure.where(price_estimates: { estimate_of: treasure }).joins(:price_estimates)
+
+      assert_equal expected.to_sql, actual.to_sql
+    end
+
+    def test_aliased_attribute
+      expected = Topic.where(heading: 'The First Topic')
+      actual   = Topic.where(title: 'The First Topic')
 
       assert_equal expected.to_sql, actual.to_sql
     end

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -206,6 +206,8 @@ class Account < ActiveRecord::Base
   belongs_to :firm, :class_name => 'Company'
   belongs_to :unautosaved_firm, :foreign_key => "firm_id", :class_name => "Firm", :autosave => false
 
+  alias_attribute :available_credit, :credit_limit
+
   def self.destroyed_account_ids
     @destroyed_account_ids ||= Hash.new { |h,k| h[k] = [] }
   end


### PR DESCRIPTION
I started experimenting with `alias_attribute` in my STI models and got quite frustrated by the second-class support for attributes aliasing. Ideally if you aliased an attribute all the AR methods should be able to resolve the real column name automatically, just like if you have set `self.table_name = ...` then all of AR (associations, etc) will be made aware of that and do the right thing.

This commit added support for aliased attributes in the finders, calculation methods, counting and pluck. This doesn't cover everything, but I believe it's a step in the right direction, and fixed this in places where it matters the most (finders).

@jonleighton and @rafaelfranca can you take a look? (This basically builds on top of #6800)
