### PR TITLE
can't pass :locals to #assert_template without a view test case (#3415)

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
-*   The `Rack::Cache` middleware is now disabled by default. To enable it, 
+*   Warn when the `:locals` option is passed to `assert_template` outside of a view test case
+    Fix #3415
+
+    *Yves Senn*
+
+*   The `Rack::Cache` middleware is now disabled by default. To enable it,
     set `config.action_dispatch.rack_cache = true` and add `gem rack-cache` to your Gemfile.
 
     *Guillermo Iguaran*

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -123,9 +123,13 @@ module ActionController
 
         if expected_partial = options[:partial]
           if expected_locals = options[:locals]
-            actual_locals = @locals[expected_partial.to_s.sub(/^_/,'')]
-            expected_locals.each_pair do |k,v|
-              assert_equal(v, actual_locals[k])
+            if defined?(@locals)
+              actual_locals = @locals[expected_partial.to_s.sub(/^_/,'')]
+              expected_locals.each_pair do |k,v|
+                assert_equal(v, actual_locals[k])
+              end
+            else
+              warn "the :locals option to #assert_template is only supported in a ActionView::TestCase"
             end
           elsif expected_count = options[:count]
             actual_count = @_partials[expected_partial]

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -1428,6 +1428,17 @@ class RenderTest < ActionController::TestCase
     assert_equal "Bonjour: davidBonjour: mary", @response.body
   end
 
+  def test_locals_option_to_assert_template_is_not_supported
+    warning_buffer = StringIO.new
+    $stderr = warning_buffer
+
+    get :partial_collection_with_locals
+    assert_template partial: 'customer_greeting', locals: { greeting: 'Bonjour' }
+    assert_equal "the :locals option to #assert_template is only supported in a ActionView::TestCase\n", warning_buffer.string
+  ensure
+    $stderr = STDERR
+  end
+
   def test_partial_collection_with_spacer
     get :partial_collection_with_spacer
     assert_equal "Hello: davidonly partialHello: mary", @response.body


### PR DESCRIPTION
the documentation on #assert_template states that the :locals option is only available in view test cases:

```
# In a view test case, you can also assert that specific locals are passed
# to partials:
```

I added a warning when it's passed in an inapropriate context to prevent a NoMethodError.

I also changed the code to simply ignore the :locals option if @locals is not set. This way the users will get a warning but the tests don't fail.
