### PR TITLE
postgres, quote table names when fetching the primary key (#5920)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   The postgres adapter now supports tables with capital letters.
+    Fix #5920
+
+    *Yves Senn*
+
 *   `CollectionAssociation#count` returns `0` without querying if the
     parent record is not persisted.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -314,7 +314,7 @@ module ActiveRecord
             INNER JOIN pg_depend dep ON attr.attrelid = dep.refobjid AND attr.attnum = dep.refobjsubid
             INNER JOIN pg_constraint cons ON attr.attrelid = cons.conrelid AND attr.attnum = cons.conkey[1]
             WHERE cons.contype = 'p'
-              AND dep.refobjid = '#{table}'::regclass
+              AND dep.refobjid = '#{quote_table_name(table)}'::regclass
           end_sql
 
           row && row.first

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -14,6 +14,10 @@ module ActiveRecord
         assert_equal 'id', @connection.primary_key('ex')
       end
 
+      def test_primary_key_works_tables_containing_capital_letters
+        assert_equal 'id', @connection.primary_key('CamelCase')
+      end
+
       def test_non_standard_primary_key
         @connection.exec_query('drop table if exists ex')
         @connection.exec_query('create table ex(data character varying(255) primary key)')


### PR DESCRIPTION
quote the table name when fetching the primary key information for a postgres table.
