### PR TITLE
Clarify "config.action_mailer.raise_delivery_errors = true"

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -55,9 +55,8 @@
   # config.assets.precompile += %w( search.js )
   <%- end -%>
 
-  # Disable delivery errors, bad email addresses will be ignored.
-  # If set to true, delivery errors will not be raised unless your
-  # email server is configured properly.
+  # Ignore bad email addresses and do not raise email delivery errors.
+  # If set to true, delivery errors will be raised if the external email server is configured properly.
   # config.action_mailer.raise_delivery_errors = false
 
   # Enable threaded mode.

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -56,6 +56,8 @@
   <%- end -%>
 
   # Disable delivery errors, bad email addresses will be ignored.
+  # If set to true, delivery errors will not be raised unless your
+  # email server is configured properly.
   # config.action_mailer.raise_delivery_errors = false
 
   # Enable threaded mode.


### PR DESCRIPTION
...ents/production.rb.tt

Setting config.action_mailer.raise_delivery_errors = true only raises email delivery errors if the email server is configured a certain way. You will have to consult the documentation for your particular email server. Refer to discussion at https://github.com/rails/rails/issues/7473#issuecomment-8148695
