### PR TITLE
Require missing ActiveSupport files in abstract_adapter.rb

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -6,6 +6,8 @@ require 'active_record/connection_adapters/schema_cache'
 require 'active_record/connection_adapters/abstract/schema_dumper' 
 require 'monitor'
 require 'active_support/deprecation'
+require 'active_support/dependencies/autoload'
+require 'active_support/callbacks'
 
 module ActiveRecord
   module ConnectionAdapters # :nodoc:


### PR DESCRIPTION
When I was using the `activerecord-nulldb-adapter`, I got an error that `ActiveSupport::Autoload` and `ActiveSupport::Callbacks` were undefined, so I figured out that someone forgot to require them.
