### PR TITLE
When serialising a class, specify the type of any singular associations,...

### DIFF
--- a/activemodel/lib/active_model/serializers/xml.rb
+++ b/activemodel/lib/active_model/serializers/xml.rb
@@ -140,7 +140,9 @@ module ActiveModel
             end
           else
             merged_options[:root] = association.to_s
-            records.to_xml(merged_options)
+            association_name = association.to_s.tableize.singularize
+            record_type = { :type => ((records.class.to_s.underscore == association_name) ? nil : records.class.name) }
+            records.to_xml merged_options.merge(record_type)
           end
         end
 

--- a/activemodel/test/cases/serializers/xml_serialization_test.rb
+++ b/activemodel/test/cases/serializers/xml_serialization_test.rb
@@ -7,12 +7,12 @@ class Contact
   extend ActiveModel::Naming
   include ActiveModel::Serializers::Xml
 
-  attr_accessor :address, :friends
+  attr_accessor :address, :friends, :contact
 
   remove_method :attributes if method_defined?(:attributes)
 
   def attributes
-    instance_values.except("address", "friends")
+    instance_values.except("address", "friends", "contact")
   end
 end
 
@@ -57,6 +57,9 @@ class XmlSerializationTest < ActiveModel::TestCase
     @contact.address.state = "CA"
     @contact.address.zip = 11111
     @contact.friends = [Contact.new, Contact.new]
+    @related_contact = SerializableContact.new
+    @related_contact.name = "related"
+    @contact.contact = @related_contact
   end
 
   test "should serialize default root" do
@@ -204,5 +207,10 @@ class XmlSerializationTest < ActiveModel::TestCase
     xml = @contact.to_xml :include => :friends, :indent => 0, :skip_types => true
     assert_match %r{<friends>}, xml
     assert_match %r{<friend>}, xml
+  end
+
+  test "association with sti" do
+    xml = @contact.to_xml(:include => :contact)
+    assert xml.include?(%(<contact type="SerializableContact">))
   end
 end


### PR DESCRIPTION
When serialising a class, specify the type of any singular associations, if necessary. Rails already correctly specifies the :type of any enumerable association (e.g. a has_many association), but made no attempt to do so for non-enumerables (e.g. a has_one association).

We must specify the :type of any polymorphic association. A has_one association to a class which uses single-table inheritance is an example of a polymorphic association.

Fixes #7471
