### PR TITLE
Fix has_many assocation w/select load after create

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -414,7 +414,7 @@ module ActiveRecord
           persisted.map! do |record|
             if mem_record = memory.delete(record)
 
-              (record.attribute_names - mem_record.changes.keys).each do |name|
+              ((record.attribute_names & mem_record.attribute_names) - mem_record.changes.keys).each do |name|
                 mem_record[name] = record[name]
               end
 

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -231,6 +231,14 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     assert_equal "2", categories(:sti_test).authors_with_select.first.post_id.to_s
   end
 
+  def test_create_through_has_many_with_piggyback
+    category = categories(:sti_test)
+    ernie = category.authors_with_select.create(:name => 'Ernie')
+    assert_nothing_raised do
+      assert_equal ernie, category.authors_with_select.detect {|a| a.name == 'Ernie'}
+    end
+  end
+
   def test_include_has_many_through
     posts              = Post.all.merge!(:order => 'posts.id').to_a
     posts_with_authors = Post.all.merge!(:includes => :authors, :order => 'posts.id').to_a


### PR DESCRIPTION
If you create a new record via a collection association proxy that has
not loaded its target, and which selects additional attributes through
the association, then when the proxy loads its target, it will
inadvertently trigger an ActiveModel::MissingAttributeError during
attribute writing when CollectionAssociation#merge_target_lists attempts
to do its thing, since the newly loaded records will possess attributes
the created record does not.

This error also raises a bogus/confusing deprecation warning when
accessing the association in Rails 3.2.x, so cherry-pick would be
appreciated!
