### PR TITLE
Accept :remote as symbol in link_to options (backport)

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 3.2.9 (unreleased) ##
 
+*   Accept :remote as symbolic option for `link_to` helper. *Riley Lynch*
+
 *   Warn when the `:locals` option is passed to `assert_template` outside of a view test case
     Fix #3415
 

--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -633,7 +633,9 @@ module ActionView
         end
 
         def link_to_remote_options?(options)
-          options.is_a?(Hash) && options.key?('remote') && options.delete('remote')
+          if options.is_a?(Hash)
+            options.delete('remote') || options.delete(:remote)
+          end
         end
 
         def add_method_to_attributes!(html_options, method)

--- a/actionpack/test/template/url_helper_test.rb
+++ b/actionpack/test/template/url_helper_test.rb
@@ -227,6 +227,13 @@ class UrlHelperTest < ActiveSupport::TestCase
     )
   end
 
+  def test_link_to_with_symbolic_remote_in_non_html_options
+    assert_dom_equal(
+      "<a href=\"/\" data-remote=\"true\">Hello</a>",
+      link_to("Hello", hash_for([:remote, true]), {})
+    )
+  end
+
   def test_link_tag_using_post_javascript
     assert_dom_equal(
       "<a href='http://www.example.com' data-method=\"post\" rel=\"nofollow\">Hello</a>",


### PR DESCRIPTION
This is a backport of pull request #7864
