### PR TITLE
Detect asset changes by saving source_digests in manifest.yml, and speed up non-digest assets

### DIFF
--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -10,7 +10,7 @@ module Sprockets
         @asset_paths ||= begin
           paths = RailsHelper::AssetPaths.new(config, controller)
           paths.asset_environment = asset_environment
-          paths.asset_digests     = asset_digests
+          paths.digests      = digests
           paths.compile_assets    = compile_assets?
           paths.digest_assets     = digest_assets?
           paths
@@ -95,7 +95,7 @@ module Sprockets
         Rails.application.config.assets.prefix
       end
 
-      def asset_digests
+      def digests
         Rails.application.config.assets.digests
       end
 
@@ -115,7 +115,7 @@ module Sprockets
       end
 
       class AssetPaths < ::ActionView::AssetPaths #:nodoc:
-        attr_accessor :asset_environment, :asset_prefix, :asset_digests, :compile_assets, :digest_assets
+        attr_accessor :asset_environment, :asset_prefix, :digests, :compile_assets, :digest_assets
 
         class AssetNotPrecompiledError < StandardError; end
 
@@ -129,7 +129,7 @@ module Sprockets
         end
 
         def digest_for(logical_path)
-          if digest_assets && asset_digests && (digest = asset_digests[logical_path])
+          if digest_assets && digests && (digest = digests[logical_path])
             return digest
           end
 

--- a/actionpack/lib/sprockets/railtie.rb
+++ b/actionpack/lib/sprockets/railtie.rb
@@ -7,6 +7,7 @@ module Sprockets
   autoload :LazyCompressor, "sprockets/compressors"
   autoload :NullCompressor, "sprockets/compressors"
   autoload :StaticCompiler, "sprockets/static_compiler"
+  autoload :StaticNonDigestGenerator, "sprockets/static_non_digest_generator"
 
   # TODO: Get rid of config.assets.enabled
   class Railtie < ::Rails::Railtie
@@ -32,15 +33,11 @@ module Sprockets
         end
       end
 
-      if config.assets.manifest
-        path = File.join(config.assets.manifest, "manifest.yml")
-      else
-        path = File.join(Rails.public_path, config.assets.prefix, "manifest.yml")
-      end
-
-      if File.exist?(path)
-        config.assets.digests = YAML.load_file(path)
-      end
+      manifest_dir = config.assets.manifest || File.join(Rails.public_path, config.assets.prefix)
+      digests_manifest = File.join(manifest_dir, "manifest.yml")
+      sources_manifest = File.join(manifest_dir, "sources_manifest.yml")
+      config.assets.digests        = (File.exist?(digests_manifest) && YAML.load_file(digests_manifest)) || {}
+      config.assets.source_digests = (File.exist?(sources_manifest) && YAML.load_file(sources_manifest)) || {}
 
       ActiveSupport.on_load(:action_view) do
         include ::Sprockets::Helpers::RailsHelper

--- a/actionpack/lib/sprockets/static_compiler.rb
+++ b/actionpack/lib/sprockets/static_compiler.rb
@@ -8,27 +8,82 @@ module Sprockets
       @env = env
       @target = target
       @paths = paths
-      @digest = options.key?(:digest) ? options.delete(:digest) : true
-      @manifest = options.key?(:manifest) ? options.delete(:manifest) : true
+      @digest = options.fetch(:digest, true)
+      @manifest = options.fetch(:manifest, true)
       @manifest_path = options.delete(:manifest_path) || target
+
+      @current_source_digests = options.fetch(:source_digests, {})
+      @current_digests   = options.fetch(:digests,   {})
+
+      @digests = {}
+      @source_digests = {}
     end
 
     def compile
-      manifest = {}
-      env.each_logical_path(paths) do |logical_path|
-        if asset = env.find_asset(logical_path)
-          digest_path = write_asset(asset)
-          manifest[asset.logical_path] = digest_path
-          manifest[aliased_path_for(asset.logical_path)] = digest_path
-        end
+      start_time = Time.now.to_f
+
+      # Run asset compilation
+      process_assets
+
+      # Encode all filenames & digests as UTF-8 for Ruby 1.9,
+      # otherwise YAML dumps other string encodings as !binary
+      if RUBY_VERSION.to_f >= 1.9
+        @source_digests = encode_hash_as_utf8 @source_digests
+        @digests = encode_hash_as_utf8 @digests
       end
-      write_manifest(manifest) if @manifest
+
+      if @manifest
+        write_manifest(@digests, @source_digests)
+      end
+
+      # Store digests in Rails config. (Important if non-digest is run after primary)
+      config = ::Rails.application.config
+      config.assets.digests = @digests
+      config.assets.source_digests = @source_digests
+
+      elapsed_time = ((Time.now.to_f - start_time) * 1000).to_i
+      env.logger.debug "Processed #{'non-' unless @digest}digest assets in #{elapsed_time}ms"
     end
 
-    def write_manifest(manifest)
+    # Compiles assets if their source digests haven't changed
+    def process_assets
+      env.each_logical_path(paths) do |logical_path|
+        # Fetch asset without any processing or compression,
+        # to calculate a digest of the concatenated source files
+        asset = env.find_asset(logical_path, :process => false)
+
+        @source_digests[logical_path] = asset.digest
+
+        # Recompile if digest has changed or compiled digest file is missing
+        current_digest_file = @current_digests[logical_path]
+
+        if @source_digests[logical_path] != @current_source_digests[logical_path] ||
+           !(current_digest_file && File.exists?("#{@target}/#{current_digest_file}"))
+
+          if asset = env.find_asset(logical_path)
+            digest_path = write_asset(asset)
+            @digests[asset.logical_path] = digest_path
+            @digests[aliased_path_for(asset.logical_path)] = digest_path
+          end
+        else
+          # Set asset file from manifest.yml
+          digest_path = @current_digests[logical_path]
+          @digests[logical_path] = digest_path
+          @digests[aliased_path_for(logical_path)] = digest_path
+
+          env.logger.debug "Not compiling #{logical_path}, sources digest has not changed " <<
+                           "(#{@source_digests[logical_path][0...7]})"
+        end
+      end
+    end
+
+    def write_manifest(digests, source_digests)
       FileUtils.mkdir_p(@manifest_path)
       File.open("#{@manifest_path}/manifest.yml", 'wb') do |f|
-        YAML.dump(manifest, f)
+        YAML.dump(digests, f)
+      end
+      File.open("#{@manifest_path}/sources_manifest.yml", 'wb') do |f|
+        YAML.dump(source_digests, f)
       end
     end
 
@@ -41,8 +96,13 @@ module Sprockets
       end
     end
 
+
     def path_for(asset)
       @digest ? asset.digest_path : asset.logical_path
+    end
+
+    def encode_hash_as_utf8(hash)
+      Hash[*hash.map {|k,v| [k.encode("UTF-8"), v.encode("UTF-8")] }.flatten]
     end
 
     def aliased_path_for(logical_path)

--- a/actionpack/lib/sprockets/static_non_digest_generator.rb
+++ b/actionpack/lib/sprockets/static_non_digest_generator.rb
@@ -1,0 +1,100 @@
+require 'fileutils'
+
+module Sprockets
+  class StaticNonDigestGenerator
+
+    DIGEST_REGEX = /-([0-9a-f]{32})\./
+
+    attr_accessor :env, :target, :paths
+
+    def initialize(env, target, paths, options = {})
+      @env = env
+      @target = target
+      @paths = paths
+      @digests = options.fetch(:digests, {})
+
+      # Parse digests from digests hash
+      @asset_digests = Hash[*@digests.map {|file, digest_file|
+        [file, digest_file[DIGEST_REGEX, 1]]
+      }.flatten]
+    end
+
+
+    # Generate non-digest assets by making a copy of the digest asset,
+    # with digests stripped from js and css. The new files are also gzipped.
+    # Other assets are copied verbatim.
+    def generate
+      start_time = Time.now.to_f
+
+      env.each_logical_path(paths) do |logical_path|
+        digest_path      = @digests[logical_path]
+        abs_digest_path  = "#{@target}/#{digest_path}"
+        abs_logical_path = "#{@target}/#{logical_path}"
+
+        mtime = File.mtime(abs_digest_path)
+
+        # Remove known digests from css & js
+        if abs_digest_path.match(/\.(?:js|css)$/)
+          asset_body = File.read(abs_digest_path)
+
+          # Find all hashes in the asset body with a leading '-'
+          asset_body.gsub!(DIGEST_REGEX) do |match|
+            # Only remove if known digest
+            $1.in?(@asset_digests.values) ? '.' : match
+          end
+
+          # Write non-digest file
+          File.open abs_logical_path, 'w' do |f|
+            f.write asset_body
+          end
+          # Set modification and access times
+          File.utime(File.atime(abs_digest_path), mtime, abs_logical_path)
+
+          # Also write gzipped asset
+          File.open("#{abs_logical_path}.gz", 'wb') do |f|
+            gz = Zlib::GzipWriter.new(f, Zlib::BEST_COMPRESSION)
+            gz.mtime = mtime.to_i
+            gz.write asset_body
+            gz.close
+          end
+
+          env.logger.debug "Stripped digests, copied to #{logical_path}, and created gzipped asset"
+
+        else
+          # Otherwise, treat file as binary and copy it.
+          # Ignore paths that have no digests, such as READMEs
+          unless abs_digest_path == abs_logical_path
+            FileUtils.cp_r abs_digest_path, abs_logical_path, :remove_destination => true
+            env.logger.debug "Copied binary asset to #{logical_path}"
+
+            # Copy gzipped asset if exists
+            if File.exist? "#{abs_digest_path}.gz"
+              FileUtils.cp_r "#{abs_digest_path}.gz", "#{abs_logical_path}.gz", :remove_destination => true
+              env.logger.debug "Copied gzipped asset to #{logical_path}.gz"
+            end
+          end
+        end
+      end
+
+
+      elapsed_time = ((Time.now.to_f - start_time) * 1000).to_i
+      env.logger.debug "Generated non-digest assets in #{elapsed_time}ms"
+    end
+
+    private
+
+    def compile_path?(logical_path)
+      paths.each do |path|
+        case path
+        when Regexp
+          return true if path.match(logical_path)
+        when Proc
+          return true if path.call(logical_path)
+        else
+          return true if File.fnmatch(path.to_s, logical_path)
+        end
+      end
+      false
+    end
+  end
+end


### PR DESCRIPTION
Please see the Rails 4 pull request on sprockets-rails for more information: https://github.com/rails/sprockets-rails/pull/21

This is a backport of the work for Rails 3.2. Please note that a new version of sprockets will need to be released with this commit: https://github.com/ndbroadbent/sprockets/commit/82cc1de7e2164c8e96052c612179bb397ccd9a39 (from my [rails3_assets_speedup](https://github.com/ndbroadbent/sprockets/tree/rails3_assets_speedup) branch)

These changes have already been released as a gem called [turbo-sprockets-rails3](https://github.com/ndbroadbent/turbo-sprockets-rails3), and it's working well for many applications.
