### PR TITLE
The SQLite3 Adapter mutates arguments

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -251,7 +251,7 @@ module ActiveRecord
         value = super
         if column.type == :string && value.encoding == Encoding::ASCII_8BIT
           logger.error "Binary data inserted for `string` type on column `#{column.name}`" if logger
-          value.encode! 'utf-8'
+          value = value.encode Encoding::UTF_8
         end
         value
       end


### PR DESCRIPTION
I'd like to add a test, but I'm a bit lost on where it'd belong within all those tests :-/
So if somebody can tell me where to add it, I'll gladly amend this pull request with a matching test.

For now, an example to reproduce the problem:

```
ActiveRecord::Migration.create_table :foos do |t| t.string :demo end
class Foo < ActiveRecord::Base; attr_accessible :demo; end
demo = "foo".force_encoding('binary')
p before: demo.encoding # => binary
Foo.create(demo: demo)
p after: demo.encoding # => utf-8

# worse, it crashes on frozen strings:
Foo.create(demo: "demo".force_encoding('binary').freeze)
#!> ActiveRecord::StatementInvalid: RuntimeError: can't modify frozen String: INSERT INTO "foos" ("demo") VALUES (?)
#!>   from /…/gems/ruby-1.9.3-p194/gems/activerecord-3.2.8/lib/active_record/connection_adapters/sqlite_adapter.rb:208:in `encode!'
```

A method should never mutate its arguments.
In this specific case, after reading the code, I also think it'd be even better to raise an exception right away, stating the two options (provide a utf-8 string or use a binary type column). A warning in the log like this is IMO mostly useless.
