### PR TITLE
Add cache_if and cache_unless two methods to skip fragment cache.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add `cache_if` and `cache_unless` two methods to skip fragment cache. *jjyr*
+
 *   Accept :remote as symbolic option for `link_to` helper. *Riley Lynch*
 
 *   Warn when the `:locals` option is passed to `assert_template` outside of a view test case

--- a/actionpack/lib/action_view/helpers/cache_helper.rb
+++ b/actionpack/lib/action_view/helpers/cache_helper.rb
@@ -113,6 +113,40 @@ module ActionView
         nil
       end
 
+      # Caching fragments of a view if condition is true.
+      #
+      # === Examples
+      #
+      #   <% cache_if session[:user_id].blank? do %>
+      #     Something...
+      #   <% end %>
+      #
+      # See cache method for details.
+      def cache_if(condition, name = {}, options = nil, &block)
+        if condition
+          cache(name, options, &block)
+        else
+          yield
+        end
+      end
+
+      # Caching fragments of a view unless condition is true.
+      #
+      # === Examples
+      #
+      #   <% cache_unless current_user.admin? do %>
+      #     Something...
+      #   <% end %>
+      #
+      # See cache method for details.
+      def cache_unless(condition, name = {}, options = nil, &block)
+        unless condition
+          cache(name, options, &block)
+        else
+          yield
+        end
+      end
+
       def fragment_name_with_digest(name) #:nodoc:
         if @virtual_path
           [

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -42,6 +42,14 @@ module Another
       render :inline => "<%= cache('foo%bar'){ 'Contains % sign in key' } %>"
     end
 
+    def with_fragment_cache_with_option_if
+      render :inline => "<%= cache_if(false,'foo'){ 'bar' } %>"
+    end
+
+    def with_fragment_cache_with_option_unless
+      render :inline => "<%= cache_unless(false,'foo'){ 'bar' } %>"
+    end
+
     def with_exception
       raise Exception
     end
@@ -189,6 +197,28 @@ class ACLogSubscriberTest < ActionController::TestCase
     assert_equal 4, logs.size
     assert_match(/Read fragment views\/foo/, logs[1])
     assert_match(/Write fragment views\/foo/, logs[2])
+  ensure
+    @controller.config.perform_caching = true
+  end
+
+  def test_with_fragment_cache_with_option_unless
+    @controller.config.perform_caching = true
+    get :with_fragment_cache_with_option_unless
+    wait
+
+    assert_equal 4, logs.size
+    assert_match(/Read fragment views\/foo/, logs[1])
+    assert_match(/Write fragment views\/foo/, logs[2])
+  ensure
+    @controller.config.perform_caching = true
+  end
+
+  def test_with_fragment_cache_with_option_if
+    @controller.config.perform_caching = true
+    get :with_fragment_cache_with_option_if
+    wait
+
+    assert_not_equal 4, logs.size
   ensure
     @controller.config.perform_caching = true
   end


### PR DESCRIPTION
Sometimes you don't want cache to all user.
you can

```
<%cache_if session[:user_id].blank?,'xxx' do%>
  something..
<%end%>
```

or

```
<%cache_unless current_user.admin?, 'xxx' do%>
  something..
<%end%>
```
