### PR TITLE
Suggested comment in database.yml about adding to .gitignore

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/databases/frontbase.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/frontbase.yml
@@ -29,3 +29,11 @@ production:
   database: <%= app_name %>_production
   username: <%= app_name %>
   password: ''
+#
+# Security Concern: Although it is very convenient to commit database.yml to source control and deploy
+# it with the rest of the app, if you ever open-source your project then your database passwords
+# will be open as well. Adding config/database.yml to your .gitignore file keep it from being in
+# your deployed repository but will require you to SCP it to your server.
+#
+# See https://groups.google.com/forum/?fromgroups=#!topic/rubyonrails-core/7HB0wdRzfVE for more info.
+#

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/ibm_db.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/ibm_db.yml
@@ -83,4 +83,13 @@ production:
   #security: SSL
   #timeout: 10
   #authentication: SERVER
-  #parameterized: false
+  #parameterized: false# Security Note: Although its very convenient to commit database.yml to source control and deploy
+#
+# Security Concern: Although it is very convenient to commit database.yml to source control and deploy
+# it with the rest of the app, if you ever open-source your project then your database passwords
+# will be open as well. Adding config/database.yml to your .gitignore file keep it from being in
+# your deployed repository but will require you to SCP it to your server.
+#
+# See https://groups.google.com/forum/?fromgroups=#!topic/rubyonrails-core/7HB0wdRzfVE for more info.
+#
+

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml
@@ -60,3 +60,11 @@ production:
   password:
   driver:
   url: jdbc:db://localhost/<%= app_name %>_production
+#
+# Security Concern: Although it is very convenient to commit database.yml to source control and deploy
+# it with the rest of the app, if you ever open-source your project then your database passwords
+# will be open as well. Adding config/database.yml to your .gitignore file keep it from being in
+# your deployed repository but will require you to SCP it to your server.
+#
+# See https://groups.google.com/forum/?fromgroups=#!topic/rubyonrails-core/7HB0wdRzfVE for more info.
+#

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml
@@ -31,3 +31,11 @@ production:
   username: root
   password:
   host: localhost
+#
+# Security Concern: Although it is very convenient to commit database.yml to source control and deploy
+# it with the rest of the app, if you ever open-source your project then your database passwords
+# will be open as well. Adding config/database.yml to your .gitignore file keep it from being in
+# your deployed repository but will require you to SCP it to your server.
+#
+# See https://groups.google.com/forum/?fromgroups=#!topic/rubyonrails-core/7HB0wdRzfVE for more info.
+#

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
@@ -41,3 +41,11 @@ production:
   database: <%= app_name %>_production
   username: <%= app_name %>
   password:
+#
+# Security Concern: Although it is very convenient to commit database.yml to source control and deploy
+# it with the rest of the app, if you ever open-source your project then your database passwords
+# will be open as well. Adding config/database.yml to your .gitignore file keep it from being in
+# your deployed repository but will require you to SCP it to your server.
+#
+# See https://groups.google.com/forum/?fromgroups=#!topic/rubyonrails-core/7HB0wdRzfVE for more info.
+#

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml
@@ -18,3 +18,11 @@ test:
 production:
   adapter: sqlite3
   database: db/production.sqlite3
+#
+# Security Concern: Although it is very convenient to commit database.yml to source control and deploy
+# it with the rest of the app, if you ever open-source your project then your database passwords
+# will be open as well. Adding config/database.yml to your .gitignore file keep it from being in
+# your deployed repository but will require you to SCP it to your server.
+#
+# See https://groups.google.com/forum/?fromgroups=#!topic/rubyonrails-core/7HB0wdRzfVE for more info.
+#

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml
@@ -49,3 +49,11 @@ production:
 <% else -%>
   host: localhost
 <% end -%>
+#
+# Security Concern: Although it is very convenient to commit database.yml to source control and deploy
+# it with the rest of the app, if you ever open-source your project then your database passwords
+# will be open as well. Adding config/database.yml to your .gitignore file keep it from being in
+# your deployed repository but will require you to SCP it to your server.
+#
+# See https://groups.google.com/forum/?fromgroups=#!topic/rubyonrails-core/7HB0wdRzfVE for more info.
+#

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml
@@ -37,3 +37,11 @@ production:
   database: <%= app_name %>_production
   username: <%= app_name %>
   password:
+#
+# Security Concern: Although it is very convenient to commit database.yml to source control and deploy
+# it with the rest of the app, if you ever open-source your project then your database passwords
+# will be open as well. Adding config/database.yml to your .gitignore file keep it from being in
+# your deployed repository but will require you to SCP it to your server.
+#
+# See https://groups.google.com/forum/?fromgroups=#!topic/rubyonrails-core/7HB0wdRzfVE for more info.
+#

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml
@@ -56,3 +56,11 @@ production:
   pool: 5
   username: <%= app_name %>
   password:
+#
+# Security Concern: Although it is very convenient to commit database.yml to source control and deploy
+# it with the rest of the app, if you ever open-source your project then your database passwords
+# will be open as well. Adding config/database.yml to your .gitignore file keep it from being in
+# your deployed repository but will require you to SCP it to your server.
+#
+# See https://groups.google.com/forum/?fromgroups=#!topic/rubyonrails-core/7HB0wdRzfVE for more info.
+#

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml
@@ -23,3 +23,11 @@ production:
   database: db/production.sqlite3
   pool: 5
   timeout: 5000
+#
+# Security Concern: Although it is very convenient to commit database.yml to source control and deploy
+# it with the rest of the app, if you ever open-source your project then your database passwords
+# will be open as well. Adding config/database.yml to your .gitignore file keep it from being in
+# your deployed repository but will require you to SCP it to your server.
+#
+# See https://groups.google.com/forum/?fromgroups=#!topic/rubyonrails-core/7HB0wdRzfVE for more info.
+#


### PR DESCRIPTION
Added this comment to all the database-specific versions of database.yml, as suggested at
https://groups.google.com/forum/?fromgroups=#!topic/rubyonrails-core/7HB0wdRzfVE

``` ruby
# Security Concern: Although it is very convenient to commit database.yml to source control and deploy
# it with the rest of the app, if you ever open-source your project then your database passwords
# will be open as well. Adding config/database.yml to your .gitignore file keep it from being in
# your deployed repository but will require you to SCP it to your server.
#
# See <URL above> for more info.
```
