### PR TITLE
Support another file type .rake in `rake notes`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add `.rake` to list of file extensions included by `rake notes` and `rake notes:custom`. *Brent J. Nordquist*
+
 *   New test locations `test/models`, `test/helpers`, `test/controllers`, and
     `test/mailers`. Corresponding rake tasks added as well. *Mike Moore*
 

--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -32,9 +32,9 @@ class SourceAnnotationExtractor
   end
 
   # Prints all annotations with tag +tag+ under the root directories +app+, +config+, +lib+,
-  # +script+, and +test+ (recursively). Only filenames with extension 
-  # +.builder+, +.rb+, +.erb+, +.haml+, +.slim+, +.css+, +.scss+, +.js+, and
-  # +.coffee+ are taken into account. The +options+ hash is passed to each
+  # +script+, and +test+ (recursively). Filenames with extension 
+  # +.builder+, +.rb+, +.erb+, +.haml+, +.slim+, +.css+, +.scss+, +.js+,
+  # +.coffee+, and +.rake+ are taken into account. The +options+ hash is passed to each
   # annotation's +to_s+.
   #
   # This class method is the single entry point for the rake tasks.
@@ -56,9 +56,9 @@ class SourceAnnotationExtractor
   end
 
   # Returns a hash that maps filenames under +dir+ (recursively) to arrays
-  # with their annotations. Only files with annotations are included, and only
-  # those with extension +.builder+, +.rb+, +.erb+, +.haml+, +.slim+, +.css+,
-  # +.scss+, +.js+, and +.coffee+
+  # with their annotations. Only files with annotations are included. Files
+  # with extension +.builder+, +.rb+, +.erb+, +.haml+, +.slim+, +.css+,
+  # +.scss+, +.js+, +.coffee+, and +.rake+
   # are taken into account.
   def find_in(dir)
     results = {}
@@ -68,7 +68,7 @@ class SourceAnnotationExtractor
 
       if File.directory?(item)
         results.update(find_in(item))
-      elsif item =~ /\.(builder|rb|coffee)$/
+      elsif item =~ /\.(builder|rb|coffee|rake)$/
         results.update(extract_annotations_from(item, /#\s*(#{tag}):?\s*(.*)$/))
       elsif item =~ /\.(css|scss|js)$/
         results.update(extract_annotations_from(item, /\/\/\s*(#{tag}):?\s*(.*)$/))

--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -25,6 +25,7 @@ module ApplicationTests
         app_file "app/assets/stylesheets/application.css", "// TODO: note in css"
         app_file "app/assets/stylesheets/application.css.scss", "// TODO: note in scss"
         app_file "app/controllers/application_controller.rb", 1000.times.map { "" }.join("\n") << "# TODO: note in ruby"
+        app_file "lib/tasks/task.rake", "# TODO: note in rake"
 
         boot_rails
         require 'rake'
@@ -45,8 +46,9 @@ module ApplicationTests
           assert_match(/note in js/, output)
           assert_match(/note in css/, output)
           assert_match(/note in scss/, output)
+          assert_match(/note in rake/, output)
 
-          assert_equal 8, lines.size
+          assert_equal 9, lines.size
 
           lines.each do |line|
             assert_equal 4, line[0].size


### PR DESCRIPTION
Similar to commit 55ceced1 which added support for .css .scss and .js, this commit adds .rake files to the list of files scanned by the `rake notes` and `rake notes:custom` tasks. These tasks will now pick up FIXME and TODO in lib/tasks/*.rake custom rake tasks.
