### PR TITLE
ActiveModel::Serializers::Xml should extend ActiveModel::Naming

### DIFF
--- a/activemodel/lib/active_model/serializers/xml.rb
+++ b/activemodel/lib/active_model/serializers/xml.rb
@@ -10,6 +10,10 @@ module ActiveModel
       extend ActiveSupport::Concern
       include ActiveModel::Serialization
 
+      included do
+        extend ActiveModel::Naming
+      end
+
       class Serializer #:nodoc:
         class Attribute #:nodoc:
           attr_reader :name, :value, :type


### PR DESCRIPTION
Assuming a native Ruby class named `Foo` which includes only the following module `ActiveModel::Serializers::Xml`. If we call `#to_xml` on an instance of `Foo` we would get the following exception `NoMethodError (undefined method 'model_name'...`

One way to solve this issue would be to also make sure `Foo` also extend `ActiveModel::Naming`. Another way, which appear to be more robust, and more importantly, consistent with the rest of the codebase (i.e. already used in `ActiveModel::Serializers::JSON`) would be extend `ActiveModel::Naming` the moment `ActiveModel::Serializers::Xml` is included. 
