### PR TITLE
add origin type to error message

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -291,8 +291,11 @@ module ActiveModel
     #   # => NameIsInvalid: name is invalid
     #
     #   person.errors.messages # => {}
-    def add(attribute, message = nil, options = {})
-      message = normalize_message(attribute, message, options)
+    def add(attribute, type = nil, options = {})
+      message = normalize_message(attribute, type, options)
+      message.singleton_class.class_eval do
+        define_method :type do type end
+      end
       if exception = options[:strict]
         exception = ActiveModel::StrictValidationFailed if exception == true
         raise exception, full_message(attribute, message)


### PR DESCRIPTION
Normalize_message will return the localized string for input parameter, 
so the origin value will be lost. 
This patch will add the origin type to message object, then you can use 
type(more progrmability) to check validate result.
it will be used like this:

``` ruby
post = Post.create(params...)
if post.valid?
  status 200
  ......
elsif post.errors.values.flatten.map(&:type).include? :taken
  status 409
  ......
else
  status 400
end
```
