### PR TITLE
Update test names and locations

### DIFF
--- a/actionmailer/lib/rails/generators/mailer/USAGE
+++ b/actionmailer/lib/rails/generators/mailer/USAGE
@@ -13,6 +13,6 @@ Example:
     creates a Notifications mailer class, views, test, and fixtures:
         Mailer:     app/mailers/notifications.rb
         Views:      app/views/notifications/signup.erb [...]
-        Test:       test/functional/notifications_test.rb
+        Test:       test/mailers/notifications_test.rb
         Fixtures:   test/fixtures/notifications/signup [...]
 

--- a/guides/CHANGELOG.md
+++ b/guides/CHANGELOG.md
@@ -1,3 +1,5 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Guides updated to reflect new test locations. *Mike Moore*
+
 *   Guides have a responsive design. *Joe Fiorini*

--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -27,7 +27,7 @@ create  app/mailers/user_mailer.rb
 invoke  erb
 create    app/views/user_mailer
 invoke  test_unit
-create    test/functional/user_mailer_test.rb
+create    test/mailers/user_mailer_test.rb
 ```
 
 So we got the mailer, the views, and the tests.

--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -134,10 +134,10 @@ Example:
     `rails generate controller CreditCard open debit credit close`
 
     Credit card controller with URLs like /credit_card/debit.
-        Controller:      app/controllers/credit_card_controller.rb
-        Functional Test: test/functional/credit_card_controller_test.rb
-        Views:           app/views/credit_card/debit.html.erb [...]
-        Helper:          app/helpers/credit_card_helper.rb
+        Controller: app/controllers/credit_card_controller.rb
+        Test:       test/controllers/credit_card_controller_test.rb
+        Views:      app/views/credit_card/debit.html.erb [...]
+        Helper:     app/helpers/credit_card_helper.rb
 ```
 
 The controller generator is expecting parameters in the form of `generate controller ControllerName action1 action2`. Let's make a `Greetings` controller with an action of **hello**, which will say something nice to us.
@@ -150,11 +150,11 @@ $ rails generate controller Greetings hello
      create    app/views/greetings
      create    app/views/greetings/hello.html.erb
      invoke  test_unit
-     create    test/functional/greetings_controller_test.rb
+     create    test/controllers/greetings_controller_test.rb
      invoke  helper
      create    app/helpers/greetings_helper.rb
      invoke    test_unit
-     create      test/unit/helpers/greetings_helper_test.rb
+     create      test/helpers/greetings_helper_test.rb
      invoke  assets
      invoke    coffee
      create      app/assets/javascripts/greetings.js.coffee
@@ -223,7 +223,7 @@ $ rails generate scaffold HighScore game:string score:integer
     create    db/migrate/20120528060026_create_high_scores.rb
     create    app/models/high_score.rb
     invoke    test_unit
-    create      test/unit/high_score_test.rb
+    create      test/models/high_score_test.rb
     create      test/fixtures/high_scores.yml
      route  resources :high_scores
     invoke  scaffold_controller
@@ -236,11 +236,11 @@ $ rails generate scaffold HighScore game:string score:integer
     create      app/views/high_scores/new.html.erb
     create      app/views/high_scores/_form.html.erb
     invoke    test_unit
-    create      test/functional/high_scores_controller_test.rb
+    create      test/controllers/high_scores_controller_test.rb
     invoke    helper
     create      app/helpers/high_scores_helper.rb
     invoke      test_unit
-    create        test/unit/helpers/high_scores_helper_test.rb
+    create        test/helpers/high_scores_helper_test.rb
     invoke  assets
     invoke    coffee
     create      app/assets/javascripts/high_scores.js.coffee
@@ -327,7 +327,7 @@ $ rails generate model Oops
       create    db/migrate/20120528062523_create_oops.rb
       create    app/models/oops.rb
       invoke    test_unit
-      create      test/unit/oops_test.rb
+      create      test/models/oops_test.rb
       create      test/fixtures/oops.yml
 ```
 ```bash
@@ -336,7 +336,7 @@ $ rails destroy model Oops
       remove    db/migrate/20120528062523_create_oops.rb
       remove    app/models/oops.rb
       invoke    test_unit
-      remove      test/unit/oops_test.rb
+      remove      test/models/oops_test.rb
       remove      test/fixtures/oops.yml
 ```
 

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -130,7 +130,7 @@ end
 
 This line mounts the engine at the path `/blorgh`, which will make it accessible through the application only at that path.
 
-Also in the test directory is the `test/integration` directory, where integration tests for the engine should be placed. Other directories can be created in the `test` directory also. For example, you may wish to create a `test/unit` directory for your unit tests.
+Also in the test directory is the `test/integration` directory, where integration tests for the engine should be placed. Other directories can be created in the `test` directory also. For example, you may wish to create a `test/models` directory for your models tests.
 
 Providing engine functionality
 ------------------------------
@@ -152,7 +152,7 @@ invoke  active_record
 create    db/migrate/[timestamp]_create_blorgh_posts.rb
 create    app/models/blorgh/post.rb
 invoke    test_unit
-create      test/unit/blorgh/post_test.rb
+create      test/models/blorgh/post_test.rb
 create      test/fixtures/blorgh/posts.yml
  route  resources :posts
 invoke  scaffold_controller
@@ -165,11 +165,11 @@ create      app/views/blorgh/posts/show.html.erb
 create      app/views/blorgh/posts/new.html.erb
 create      app/views/blorgh/posts/_form.html.erb
 invoke    test_unit
-create      test/functional/blorgh/posts_controller_test.rb
+create      test/controllers/blorgh/posts_controller_test.rb
 invoke    helper
 create      app/helpers/blorgh/posts_helper.rb
 invoke      test_unit
-create        test/unit/helpers/blorgh/posts_helper_test.rb
+create        test/helpers/blorgh/posts_helper_test.rb
 invoke  assets
 invoke    js
 create      app/assets/javascripts/blorgh/posts.js
@@ -181,7 +181,7 @@ create    app/assets/stylesheets/scaffold.css
 
 The first thing that the scaffold generator does is invoke the `active_record` generator, which generates a migration and a model for the resource. Note here, however, that the migration is called `create_blorgh_posts` rather than the usual `create_posts`. This is due to the `isolate_namespace` method called in the `Blorgh::Engine` class's definition. The model here is also namespaced, being placed at `app/models/blorgh/post.rb` rather than `app/models/post.rb` due to the `isolate_namespace` call within the `Engine` class.
 
-Next, the `test_unit` generator is invoked for this model, generating a unit test at `test/unit/blorgh/post_test.rb` (rather than `test/unit/post_test.rb`) and a fixture at `test/fixtures/blorgh/posts.yml` (rather than `test/fixtures/posts.yml`).
+Next, the `test_unit` generator is invoked for this model, generating a model test at `test/models/blorgh/post_test.rb` (rather than `test/models/post_test.rb`) and a fixture at `test/fixtures/blorgh/posts.yml` (rather than `test/fixtures/posts.yml`).
 
 After that, a line for the resource is inserted into the `config/routes.rb` file for the engine. This line is simply `resources :posts`, turning the `config/routes.rb` file for the engine into this:
 
@@ -193,7 +193,7 @@ end
 
 Note here that the routes are drawn upon the `Blorgh::Engine` object rather than the `YourApp::Application` class. This is so that the engine routes are confined to the engine itself and can be mounted at a specific point as shown in the [test directory](#test-directory) section. This is also what causes the engine's routes to be isolated from those routes that are within the application. This is discussed further in the [Routes](#routes) section of this guide.
 
-Next, the `scaffold_controller` generator is invoked, generating a controller called `Blorgh::PostsController` (at `app/controllers/blorgh/posts_controller.rb`) and its related views at `app/views/blorgh/posts`. This generator also generates a functional test for the controller (`test/functional/blorgh/posts_controller_test.rb`) and a helper (`app/helpers/blorgh/posts_controller.rb`).
+Next, the `scaffold_controller` generator is invoked, generating a controller called `Blorgh::PostsController` (at `app/controllers/blorgh/posts_controller.rb`) and its related views at `app/views/blorgh/posts`. This generator also generates a test for the controller (`test/controllers/blorgh/posts_controller_test.rb`) and a helper (`app/helpers/blorgh/posts_controller.rb`).
 
 Everything this generator has created is neatly namespaced. The controller's class is defined within the `Blorgh` module:
 
@@ -261,7 +261,7 @@ invoke  active_record
 create    db/migrate/[timestamp]_create_blorgh_comments.rb
 create    app/models/blorgh/comment.rb
 invoke    test_unit
-create      test/unit/blorgh/comment_test.rb
+create      test/models/blorgh/comment_test.rb
 create      test/fixtures/blorgh/comments.yml
 ```
 
@@ -334,11 +334,11 @@ create  app/controllers/blorgh/comments_controller.rb
 invoke  erb
  exist    app/views/blorgh/comments
 invoke  test_unit
-create    test/functional/blorgh/comments_controller_test.rb
+create    test/controllers/blorgh/comments_controller_test.rb
 invoke  helper
 create    app/helpers/blorgh/comments_helper.rb
 invoke    test_unit
-create      test/unit/helpers/blorgh/comments_helper_test.rb
+create      test/helpers/blorgh/comments_helper_test.rb
 invoke  assets
 invoke    js
 create      app/assets/javascripts/blorgh/comments.js

--- a/guides/source/generators.md
+++ b/guides/source/generators.md
@@ -176,7 +176,7 @@ $ rails generate scaffold User name:string
       create    db/migrate/20091120125558_create_users.rb
       create    app/models/user.rb
       invoke    test_unit
-      create      test/unit/user_test.rb
+      create      test/models/user_test.rb
       create      test/fixtures/users.yml
        route  resources :users
       invoke  scaffold_controller
@@ -189,11 +189,11 @@ $ rails generate scaffold User name:string
       create      app/views/users/new.html.erb
       create      app/views/users/_form.html.erb
       invoke    test_unit
-      create      test/functional/users_controller_test.rb
+      create      test/controllers/users_controller_test.rb
       invoke    helper
       create      app/helpers/users_helper.rb
       invoke      test_unit
-      create        test/unit/helpers/users_helper_test.rb
+      create        test/helpers/users_helper_test.rb
       invoke  stylesheets
       create    app/assets/stylesheets/scaffold.css
 ```
@@ -350,7 +350,7 @@ $ rails generate scaffold Comment body:text
       create    db/migrate/20091120151323_create_comments.rb
       create    app/models/comment.rb
       invoke    shoulda
-      create      test/unit/comment_test.rb
+      create      test/models/comment_test.rb
       create      test/fixtures/comments.yml
        route    resources :comments
       invoke  scaffold_controller
@@ -364,11 +364,11 @@ $ rails generate scaffold Comment body:text
       create      app/views/comments/_form.html.erb
       create      app/views/layouts/comments.html.erb
       invoke    shoulda
-      create      test/functional/comments_controller_test.rb
+      create      test/controllers/comments_controller_test.rb
       invoke    my_helper
       create      app/helpers/comments_helper.rb
       invoke      shoulda
-      create        test/unit/helpers/comments_helper_test.rb
+      create        test/helpers/comments_helper_test.rb
 ```
 
 Fallbacks allow your generators to have a single responsibility, increasing code reuse and reducing the amount of duplication.

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -185,11 +185,11 @@ invoke  erb
 create    app/views/welcome
 create    app/views/welcome/index.html.erb
 invoke  test_unit
-create    test/functional/welcome_controller_test.rb
+create    test/controllers/welcome_controller_test.rb
 invoke  helper
 create    app/helpers/welcome_helper.rb
 invoke    test_unit
-create      test/unit/helpers/welcome_helper_test.rb
+create      test/helpers/welcome_helper_test.rb
 invoke  assets
 invoke    coffee
 create      app/assets/javascripts/welcome.js.coffee
@@ -1239,7 +1239,7 @@ This command will generate four files:
 | -------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | db/migrate/20100207235629_create_comments.rb | Migration to create the comments table in your database (your name will include a different timestamp) |
 | app/models/comment.rb                        | The Comment model                                                                                      |
-| test/unit/comment_test.rb                    | Unit testing harness for the comments model                                                            |
+| test/models/comment_test.rb                  | Testing harness for the comments model                                                                 |
 | test/fixtures/comments.yml                   | Sample comments for use in testing                                                                     |
 
 First, take a look at `comment.rb`:
@@ -1360,15 +1360,15 @@ $ rails generate controller Comments
 
 This creates six files and one empty directory:
 
-| File/Directory                              | Purpose                                  |
-| ------------------------------------------- | ---------------------------------------- |
-| app/controllers/comments_controller.rb      | The Comments controller                  |
-| app/views/comments/                         | Views of the controller are stored here  |
-| test/functional/comments_controller_test.rb | The functional tests for the controller  |
-| app/helpers/comments_helper.rb              | A view helper file                       |
-| test/unit/helpers/comments_helper_test.rb   | The unit tests for the helper            |
-| app/assets/javascripts/comment.js.coffee    | CoffeeScript for the controller          |
-| app/assets/stylesheets/comment.css.scss     | Cascading style sheet for the controller |
+| File/Directory                               | Purpose                                  |
+| -------------------------------------------- | ---------------------------------------- |
+| app/controllers/comments_controller.rb       | The Comments controller                  |
+| app/views/comments/                          | Views of the controller are stored here  |
+| test/controllers/comments_controller_test.rb | The test for the controller              |
+| app/helpers/comments_helper.rb               | A view helper file                       |
+| test/helpers/comments_helper_test.rb         | The test for the helper                  |
+| app/assets/javascripts/comment.js.coffee     | CoffeeScript for the controller          |
+| app/assets/stylesheets/comment.css.scss      | Cascading style sheet for the controller |
 
 Like with any blog, our readers will create their comments directly after
 reading the post, and once they have added their comment, will be sent back to

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -121,18 +121,18 @@ For this guide we will be using Rails _scaffolding_. It will create the model, a
 
 NOTE: For more information on Rails <i>scaffolding</i>, refer to [Getting Started with Rails](getting_started.html)
 
-When you use `rails generate scaffold`, for a resource among other things it creates a test stub in the `test/unit` folder:
+When you use `rails generate scaffold`, for a resource among other things it creates a test stub in the `test/models` folder:
 
 ```bash
 $ rails generate scaffold post title:string body:text
 ...
 create  app/models/post.rb
-create  test/unit/post_test.rb
+create  test/models/post_test.rb
 create  test/fixtures/posts.yml
 ...
 ```
 
-The default test stub in `test/unit/post_test.rb` looks like this:
+The default test stub in `test/models/post_test.rb` looks like this:
 
 ```ruby
 require 'test_helper'
@@ -225,9 +225,9 @@ TIP: You can see all these rake tasks and their descriptions by running `rake --
 Running a test is as simple as invoking the file containing the test cases through Ruby:
 
 ```bash
-$ ruby -Itest test/unit/post_test.rb
+$ ruby -Itest test/models/post_test.rb
 
-Loaded suite unit/post_test
+Loaded suite models/post_test
 Started
 .
 Finished in 0.023513 seconds.
@@ -240,9 +240,9 @@ This will run all the test methods from the test case. Note that `test_helper.rb
 You can also run a particular test method from the test case by using the `-n` switch with the `test method name`.
 
 ```bash
-$ ruby -Itest test/unit/post_test.rb -n test_the_truth
+$ ruby -Itest test/models/post_test.rb -n test_the_truth
 
-Loaded suite unit/post_test
+Loaded suite models/post_test
 Started
 .
 Finished in 0.023513 seconds.
@@ -271,7 +271,7 @@ F
 Finished in 0.102072 seconds.
 
   1) Failure:
-test_should_not_save_post_without_title(PostTest) [/test/unit/post_test.rb:6]:
+test_should_not_save_post_without_title(PostTest) [/test/models/post_test.rb:6]:
 <false> is not true.
 
 1 tests, 1 assertions, 1 failures, 0 errors
@@ -290,7 +290,7 @@ Running this test shows the friendlier assertion message:
 
 ```bash
   1) Failure:
-test_should_not_save_post_without_title(PostTest) [/test/unit/post_test.rb:6]:
+test_should_not_save_post_without_title(PostTest) [/test/models/post_test.rb:6]:
 Saved the post without a title.
 <false> is not true.
 ```
@@ -341,7 +341,7 @@ Finished in 0.082603 seconds.
   1) Error:
 test_should_report_error(PostTest):
 NameError: undefined local variable or method `some_undefined_variable' for #<PostTest:0x249d354>
-    /test/unit/post_test.rb:6:in `test_should_report_error'
+    /test/models/post_test.rb:6:in `test_should_report_error'
 
 1 tests, 0 assertions, 0 failures, 1 errors
 ```
@@ -420,7 +420,7 @@ You should test for things such as:
 * was the correct object stored in the response template?
 * was the appropriate message displayed to the user in the view?
 
-Now that we have used Rails scaffold generator for our `Post` resource, it has already created the controller code and functional tests. You can take look at the file `posts_controller_test.rb` in the `test/functional` directory.
+Now that we have used Rails scaffold generator for our `Post` resource, it has already created the controller code and tests. You can take look at the file `posts_controller_test.rb` in the `test/controllers` directory.
 
 Let me take you through one such test, `test_should_get_index` from the file `posts_controller_test.rb`.
 
@@ -762,12 +762,16 @@ You don't need to set up and run your tests by hand on a test-by-test basis. Rai
 | ------------------------------- | ----------- |
 | `rake test`                     | Runs all unit, functional and integration tests. You can also simply run `rake` as the _test_ target is the default.|
 | `rake test:benchmark`           | Benchmark the performance tests|
-| `rake test:functionals`         | Runs all the functional tests from `test/functional`|
+| `rake test:controllers`         | Runs all the controller tests from `test/controllers`|
+| `rake test:functionals`         | Runs all the functional tests from `test/controllers`, `test/mailers`, and `test/functional`|
+| `rake test:helpers`             | Runs all the helper tests from `test/helpers`|
 | `rake test:integration`         | Runs all the integration tests from `test/integration`|
+| `rake test:mailers`             | Runs all the mailer tests from `test/mailers`|
+| `rake test:models`              | Runs all the model tests from `test/models`|
 | `rake test:profile`             | Profile the performance tests|
 | `rake test:recent`              | Tests recent changes|
 | `rake test:uncommitted`         | Runs all the tests which are uncommitted. Supports Subversion and Git|
-| `rake test:units`               | Runs all the unit tests from `test/unit`|
+| `rake test:units`               | Runs all the unit tests from `test/models`, `test/helpers`, and `test/unit`|
 
 
 Brief Note About `Test::Unit`

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   New test locations `test/models`, `test/helpers`, `test/controllers`, and
+    `test/mailers`. Corresponding rake tasks added as well. *Mike Moore*
+
 *   Set a different cache per environment for assets pipeline 
     through `config.assets.cache`.
 

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -113,9 +113,11 @@ module Rails
 
     def test
       empty_directory_with_keep_file 'test/fixtures'
-      empty_directory_with_keep_file 'test/functional'
+      empty_directory_with_keep_file 'test/controllers'
+      empty_directory_with_keep_file 'test/mailers'
+      empty_directory_with_keep_file 'test/models'
+      empty_directory_with_keep_file 'test/helpers'
       empty_directory_with_keep_file 'test/integration'
-      empty_directory_with_keep_file 'test/unit'
 
       template 'test/performance/browsing_test.rb'
       template 'test/test_helper.rb'

--- a/railties/lib/rails/generators/rails/controller/USAGE
+++ b/railties/lib/rails/generators/rails/controller/USAGE
@@ -12,7 +12,7 @@ Example:
     `rails generate controller CreditCards open debit credit close`
 
     CreditCards controller with URLs like /credit_cards/debit.
-        Controller:      app/controllers/credit_cards_controller.rb
-        Functional Test: test/functional/credit_cards_controller_test.rb
-        Views:           app/views/credit_cards/debit.html.erb [...]
-        Helper:          app/helpers/credit_cards_helper.rb
+        Controller: app/controllers/credit_cards_controller.rb
+        Test:       test/controllers/credit_cards_controller_test.rb
+        Views:      app/views/credit_cards/debit.html.erb [...]
+        Helper:     app/helpers/credit_cards_helper.rb

--- a/railties/lib/rails/generators/rails/helper/USAGE
+++ b/railties/lib/rails/generators/rails/helper/USAGE
@@ -13,5 +13,5 @@ Example:
 
     Credit card helper.
         Helper:     app/helpers/credit_card_helper.rb
-        Test:       test/unit/helpers/credit_card_helper_test.rb
+        Test:       test/helpers/credit_card_helper_test.rb
 

--- a/railties/lib/rails/generators/rails/model/USAGE
+++ b/railties/lib/rails/generators/rails/model/USAGE
@@ -74,7 +74,7 @@ Examples:
         For ActiveRecord and TestUnit it creates:
 
             Model:      app/models/account.rb
-            Test:       test/unit/account_test.rb
+            Test:       test/models/account_test.rb
             Fixtures:   test/fixtures/accounts.yml
             Migration:  db/migrate/XXX_add_accounts.rb
 
@@ -88,7 +88,7 @@ Examples:
 
             Module:     app/models/admin.rb
             Model:      app/models/admin/account.rb
-            Test:       test/unit/admin/account_test.rb
+            Test:       test/models/admin/account_test.rb
             Fixtures:   test/fixtures/admin/accounts.yml
             Migration:  db/migrate/XXX_add_admin_accounts.rb
 

--- a/railties/lib/rails/generators/rails/observer/USAGE
+++ b/railties/lib/rails/generators/rails/observer/USAGE
@@ -9,4 +9,4 @@ Example:
 
     For ActiveRecord and TestUnit it creates:
         Observer:   app/models/account_observer.rb
-        TestUnit:   test/unit/account_observer_test.rb
+        TestUnit:   test/models/account_observer_test.rb

--- a/railties/lib/rails/generators/rails/scaffold_controller/USAGE
+++ b/railties/lib/rails/generators/rails/scaffold_controller/USAGE
@@ -13,7 +13,7 @@ Example:
     `rails generate scaffold_controller CreditCard`
 
     Credit card controller with URLs like /credit_card/debit.
-        Controller:      app/controllers/credit_cards_controller.rb
-        Functional Test: test/functional/credit_cards_controller_test.rb
-        Views:           app/views/credit_cards/index.html.erb [...]
-        Helper:          app/helpers/credit_cards_helper.rb
+        Controller: app/controllers/credit_cards_controller.rb
+        Test:       test/controllers/credit_cards_controller_test.rb
+        Views:      app/views/credit_cards/index.html.erb [...]
+        Helper:     app/helpers/credit_cards_helper.rb

--- a/railties/lib/rails/generators/test_unit/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/test_unit/controller/controller_generator.rb
@@ -8,7 +8,7 @@ module TestUnit
 
       def create_test_files
         template 'functional_test.rb',
-                 File.join('test/functional', class_path, "#{file_name}_controller_test.rb")
+                 File.join('test/controllers', class_path, "#{file_name}_controller_test.rb")
       end
     end
   end

--- a/railties/lib/rails/generators/test_unit/helper/helper_generator.rb
+++ b/railties/lib/rails/generators/test_unit/helper/helper_generator.rb
@@ -6,7 +6,7 @@ module TestUnit
       check_class_collision :suffix => "HelperTest"
 
       def create_helper_files
-        template 'helper_test.rb', File.join('test/unit/helpers', class_path, "#{file_name}_helper_test.rb")
+        template 'helper_test.rb', File.join('test/helpers', class_path, "#{file_name}_helper_test.rb")
       end
     end
   end

--- a/railties/lib/rails/generators/test_unit/mailer/mailer_generator.rb
+++ b/railties/lib/rails/generators/test_unit/mailer/mailer_generator.rb
@@ -7,7 +7,7 @@ module TestUnit
       check_class_collision :suffix => "Test"
 
       def create_test_files
-        template "functional_test.rb", File.join('test/functional', class_path, "#{file_name}_test.rb")
+        template "functional_test.rb", File.join('test/mailers', class_path, "#{file_name}_test.rb")
       end
     end
   end

--- a/railties/lib/rails/generators/test_unit/model/model_generator.rb
+++ b/railties/lib/rails/generators/test_unit/model/model_generator.rb
@@ -9,7 +9,7 @@ module TestUnit
       check_class_collision :suffix => "Test"
 
       def create_test_file
-        template 'unit_test.rb', File.join('test/unit', class_path, "#{file_name}_test.rb")
+        template 'unit_test.rb', File.join('test/models', class_path, "#{file_name}_test.rb")
       end
 
       hook_for :fixture_replacement

--- a/railties/lib/rails/generators/test_unit/observer/observer_generator.rb
+++ b/railties/lib/rails/generators/test_unit/observer/observer_generator.rb
@@ -6,7 +6,7 @@ module TestUnit
       check_class_collision :suffix => "ObserverTest"
 
       def create_test_files
-        template 'unit_test.rb',  File.join('test/unit', class_path, "#{file_name}_observer_test.rb")
+        template 'unit_test.rb',  File.join('test/models', class_path, "#{file_name}_observer_test.rb")
       end
     end
   end

--- a/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
@@ -12,7 +12,7 @@ module TestUnit
 
       def create_test_files
         template "functional_test.rb",
-                 File.join("test/functional", controller_class_path, "#{controller_file_name}_controller_test.rb")
+                 File.join("test/controllers", controller_class_path, "#{controller_file_name}_controller_test.rb")
       end
 
       private

--- a/railties/lib/rails/tasks/statistics.rake
+++ b/railties/lib/rails/tasks/statistics.rake
@@ -6,9 +6,13 @@ STATS_DIRECTORIES = [
   %w(Javascripts        app/assets/javascripts),
   %w(Libraries          lib/),
   %w(APIs               app/apis),
+  %w(Controller\ tests  test/controllers),
+  %w(Helper\ tests      test/helpers),
+  %w(Model\ tests       test/models),
+  %w(Mailer\ tests      test/mailers),
   %w(Integration\ tests test/integration),
-  %w(Functional\ tests  test/functional),
-  %w(Unit\ tests        test/unit)
+  %w(Functional\ tests\ (old)  test/functional),
+  %w(Unit\ tests \ (old)       test/unit)
 ].collect { |name, dir| [ name, "#{Rails.root}/#{dir}" ] }.select { |name, dir| File.directory?(dir) }
 
 desc "Report code statistics (KLOCs, etc) from the application"

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -86,12 +86,12 @@ module ApplicationTests
     def test_rake_test_error_output
       Dir.chdir(app_path){ `rake db:migrate` }
 
-      app_file "test/unit/one_unit_test.rb", <<-RUBY
-        raise 'unit'
+      app_file "test/models/one_model_test.rb", <<-RUBY
+        raise 'models'
       RUBY
 
-      app_file "test/functional/one_functional_test.rb", <<-RUBY
-        raise 'functional'
+      app_file "test/controllers/one_controller_test.rb", <<-RUBY
+        raise 'controllers'
       RUBY
 
       app_file "test/integration/one_integration_test.rb", <<-RUBY
@@ -100,8 +100,8 @@ module ApplicationTests
 
       silence_stderr do
         output = Dir.chdir(app_path) { `rake test 2>&1` }
-        assert_match 'unit', output
-        assert_match 'functional', output
+        assert_match 'models', output
+        assert_match 'controllers', output
         assert_match 'integration', output
       end
     end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -26,10 +26,12 @@ DEFAULT_APP_FILES = %w(
   log
   script/rails
   test/fixtures
-  test/functional
+  test/controllers
+  test/models
+  test/helpers
+  test/mailers
   test/integration
   test/performance
-  test/unit
   vendor
   vendor/assets
   tmp/cache

--- a/railties/test/generators/controller_generator_test.rb
+++ b/railties/test/generators/controller_generator_test.rb
@@ -28,13 +28,13 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
   def test_invokes_helper
     run_generator
     assert_file "app/helpers/account_helper.rb"
-    assert_file "test/unit/helpers/account_helper_test.rb"
+    assert_file "test/helpers/account_helper_test.rb"
   end
 
   def test_does_not_invoke_helper_if_required
     run_generator ["account", "--skip-helper"]
     assert_no_file "app/helpers/account_helper.rb"
-    assert_no_file "test/unit/helpers/account_helper_test.rb"
+    assert_no_file "test/helpers/account_helper_test.rb"
   end
 
   def test_invokes_assets
@@ -45,12 +45,12 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
 
   def test_invokes_default_test_framework
     run_generator
-    assert_file "test/functional/account_controller_test.rb"
+    assert_file "test/controllers/account_controller_test.rb"
   end
 
   def test_does_not_invoke_test_framework_if_required
     run_generator ["account", "--no-test-framework"]
-    assert_no_file "test/functional/account_controller_test.rb"
+    assert_no_file "test/controllers/account_controller_test.rb"
   end
 
   def test_invokes_default_template_engine

--- a/railties/test/generators/helper_generator_test.rb
+++ b/railties/test/generators/helper_generator_test.rb
@@ -15,7 +15,7 @@ class HelperGeneratorTest < Rails::Generators::TestCase
 
   def test_invokes_default_test_framework
     run_generator
-    assert_file "test/unit/helpers/admin_helper_test.rb", /class AdminHelperTest < ActionView::TestCase/
+    assert_file "test/helpers/admin_helper_test.rb", /class AdminHelperTest < ActionView::TestCase/
   end
 
   def test_logs_if_the_test_framework_cannot_be_found

--- a/railties/test/generators/mailer_generator_test.rb
+++ b/railties/test/generators/mailer_generator_test.rb
@@ -29,7 +29,7 @@ class MailerGeneratorTest < Rails::Generators::TestCase
 
   def test_invokes_default_test_framework
     run_generator
-    assert_file "test/functional/notifier_test.rb" do |test|
+    assert_file "test/mailers/notifier_test.rb" do |test|
       assert_match(/class NotifierTest < ActionMailer::TestCase/, test)
       assert_match(/test "foo"/, test)
       assert_match(/test "bar"/, test)

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -157,7 +157,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
         assert_match(/create_table :products/, up)
         assert_match(/t\.string :name/, up)
         assert_match(/t\.integer :supplier_id/, up)
-        
+
         assert_match(/add_index :products, :name/, up)
         assert_match(/add_index :products, :supplier_id/, up)
         assert_no_match(/add_index :products, :year/, up)
@@ -181,7 +181,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
       assert_match(/add_index :products, :discount, unique: true/, content)
     end
   end
-  
+
   def test_migration_without_timestamps
     ActiveRecord::Base.timestamped_migrations = false
     run_generator ["account"]
@@ -269,7 +269,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
 
   def test_invokes_default_test_framework
     run_generator
-    assert_file "test/unit/account_test.rb", /class AccountTest < ActiveSupport::TestCase/
+    assert_file "test/models/account_test.rb", /class AccountTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/accounts.yml", /name: MyString/, /age: 1/
   end
 

--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -25,7 +25,7 @@ class NamespacedControllerGeneratorTest < NamespacedGeneratorTestCase
                 /module TestApp/,
                 /  class AccountController < ApplicationController/
 
-    assert_file "test/functional/test_app/account_controller_test.rb",
+    assert_file "test/controllers/test_app/account_controller_test.rb",
                 /module TestApp/,
                 /  class AccountControllerTest/
   end
@@ -46,12 +46,12 @@ class NamespacedControllerGeneratorTest < NamespacedGeneratorTestCase
   def test_helpr_is_also_namespaced
     run_generator
     assert_file "app/helpers/test_app/account_helper.rb", /module TestApp/, /  module AccountHelper/
-    assert_file "test/unit/helpers/test_app/account_helper_test.rb", /module TestApp/, /  class AccountHelperTest/
+    assert_file "test/helpers/test_app/account_helper_test.rb", /module TestApp/, /  class AccountHelperTest/
   end
 
   def test_invokes_default_test_framework
     run_generator
-    assert_file "test/functional/test_app/account_controller_test.rb"
+    assert_file "test/controllers/test_app/account_controller_test.rb"
   end
 
   def test_invokes_default_template_engine
@@ -136,7 +136,7 @@ class NamespacedModelGeneratorTest < NamespacedGeneratorTestCase
 
   def test_invokes_default_test_framework
     run_generator
-    assert_file "test/unit/test_app/account_test.rb", /module TestApp/, /class AccountTest < ActiveSupport::TestCase/
+    assert_file "test/models/test_app/account_test.rb", /module TestApp/, /class AccountTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/accounts.yml", /name: MyString/, /age: 1/
   end
 end
@@ -158,7 +158,7 @@ class NamespacedObserverGeneratorTest < NamespacedGeneratorTestCase
 
   def test_invokes_default_test_framework
     run_generator
-    assert_file "test/unit/test_app/account_observer_test.rb", /module TestApp/, /  class AccountObserverTest < ActiveSupport::TestCase/
+    assert_file "test/models/test_app/account_observer_test.rb", /module TestApp/, /  class AccountObserverTest < ActiveSupport::TestCase/
   end
 end
 
@@ -186,7 +186,7 @@ class NamespacedMailerGeneratorTest < NamespacedGeneratorTestCase
 
   def test_invokes_default_test_framework
     run_generator
-    assert_file "test/functional/test_app/notifier_test.rb" do |test|
+    assert_file "test/mailers/test_app/notifier_test.rb" do |test|
       assert_match(/module TestApp/, test)
       assert_match(/class NotifierTest < ActionMailer::TestCase/, test)
       assert_match(/test "foo"/, test)
@@ -225,7 +225,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Model
     assert_file "app/models/test_app/product_line.rb", /module TestApp\n  class ProductLine < ActiveRecord::Base/
-    assert_file "test/unit/test_app/product_line_test.rb", /module TestApp\n  class ProductLineTest < ActiveSupport::TestCase/
+    assert_file "test/models/test_app/product_line_test.rb", /module TestApp\n  class ProductLineTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/product_lines.yml"
     assert_migration "db/migrate/create_test_app_product_lines.rb"
 
@@ -240,7 +240,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
                 /module TestApp/,
                 /class ProductLinesController < ApplicationController/
 
-    assert_file "test/functional/test_app/product_lines_controller_test.rb",
+    assert_file "test/controllers/test_app/product_lines_controller_test.rb",
                 /module TestApp\n  class ProductLinesControllerTest < ActionController::TestCase/
 
     # Views
@@ -255,7 +255,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Helpers
     assert_file "app/helpers/test_app/product_lines_helper.rb"
-    assert_file "test/unit/helpers/test_app/product_lines_helper_test.rb"
+    assert_file "test/helpers/test_app/product_lines_helper_test.rb"
 
     # Stylesheets
     assert_file "app/assets/stylesheets/scaffold.css"
@@ -267,7 +267,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Model
     assert_no_file "app/models/test_app/product_line.rb"
-    assert_no_file "test/unit/test_app/product_line_test.rb"
+    assert_no_file "test/models/test_app/product_line_test.rb"
     assert_no_file "test/fixtures/test_app/product_lines.yml"
     assert_no_migration "db/migrate/create_test_app_product_lines.rb"
 
@@ -278,7 +278,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Controller
     assert_no_file "app/controllers/test_app/product_lines_controller.rb"
-    assert_no_file "test/functional/test_app/product_lines_controller_test.rb"
+    assert_no_file "test/controllers/test_app/product_lines_controller_test.rb"
 
     # Views
     assert_no_file "app/views/test_app/product_lines"
@@ -286,7 +286,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Helpers
     assert_no_file "app/helpers/test_app/product_lines_helper.rb"
-    assert_no_file "test/unit/helpers/test_app/product_lines_helper_test.rb"
+    assert_no_file "test/helpers/test_app/product_lines_helper_test.rb"
 
     # Stylesheets (should not be removed)
     assert_file "app/assets/stylesheets/scaffold.css"
@@ -298,7 +298,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
     # Model
     assert_file "app/models/test_app/admin.rb", /module TestApp\n  module Admin/
     assert_file "app/models/test_app/admin/role.rb", /module TestApp\n  class Admin::Role < ActiveRecord::Base/
-    assert_file "test/unit/test_app/admin/role_test.rb", /module TestApp\n  class Admin::RoleTest < ActiveSupport::TestCase/
+    assert_file "test/models/test_app/admin/role_test.rb", /module TestApp\n  class Admin::RoleTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/admin/roles.yml"
     assert_migration "db/migrate/create_test_app_admin_roles.rb"
 
@@ -312,7 +312,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
       assert_match(/module TestApp\n  class Admin::RolesController < ApplicationController/, content)
     end
 
-    assert_file "test/functional/test_app/admin/roles_controller_test.rb",
+    assert_file "test/controllers/test_app/admin/roles_controller_test.rb",
                 /module TestApp\n  class Admin::RolesControllerTest < ActionController::TestCase/
 
     # Views
@@ -327,7 +327,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Helpers
     assert_file "app/helpers/test_app/admin/roles_helper.rb"
-    assert_file "test/unit/helpers/test_app/admin/roles_helper_test.rb"
+    assert_file "test/helpers/test_app/admin/roles_helper_test.rb"
 
     # Stylesheets
     assert_file "app/assets/stylesheets/scaffold.css"
@@ -340,7 +340,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
     # Model
     assert_file "app/models/test_app/admin.rb"	# ( should not be remove )
     assert_no_file "app/models/test_app/admin/role.rb"
-    assert_no_file "test/unit/test_app/admin/role_test.rb"
+    assert_no_file "test/models/test_app/admin/role_test.rb"
     assert_no_file "test/fixtures/test_app/admin/roles.yml"
     assert_no_migration "db/migrate/create_test_app_admin_roles.rb"
 
@@ -351,7 +351,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Controller
     assert_no_file "app/controllers/test_app/admin/roles_controller.rb"
-    assert_no_file "test/functional/test_app/admin/roles_controller_test.rb"
+    assert_no_file "test/controllers/test_app/admin/roles_controller_test.rb"
 
     # Views
     assert_no_file "app/views/test_app/admin/roles"
@@ -359,19 +359,19 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Helpers
     assert_no_file "app/helpers/test_app/admin/roles_helper.rb"
-    assert_no_file "test/unit/helpers/test_app/admin/roles_helper_test.rb"
+    assert_no_file "test/helpers/test_app/admin/roles_helper_test.rb"
 
     # Stylesheets (should not be removed)
     assert_file "app/assets/stylesheets/scaffold.css"
   end
-  
+
   def test_scaffold_with_nested_namespace_on_invoke
     run_generator [ "admin/user/special/role", "name:string", "description:string" ]
 
     # Model
     assert_file "app/models/test_app/admin/user/special.rb", /module TestApp\n  module Admin/
     assert_file "app/models/test_app/admin/user/special/role.rb", /module TestApp\n  class Admin::User::Special::Role < ActiveRecord::Base/
-    assert_file "test/unit/test_app/admin/user/special/role_test.rb", /module TestApp\n  class Admin::User::Special::RoleTest < ActiveSupport::TestCase/
+    assert_file "test/models/test_app/admin/user/special/role_test.rb", /module TestApp\n  class Admin::User::Special::RoleTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/admin/user/special/roles.yml"
     assert_migration "db/migrate/create_test_app_admin_user_special_roles.rb"
 
@@ -385,7 +385,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
       assert_match(/module TestApp\n  class Admin::User::Special::RolesController < ApplicationController/, content)
     end
 
-    assert_file "test/functional/test_app/admin/user/special/roles_controller_test.rb",
+    assert_file "test/controllers/test_app/admin/user/special/roles_controller_test.rb",
                 /module TestApp\n  class Admin::User::Special::RolesControllerTest < ActionController::TestCase/
 
     # Views
@@ -400,7 +400,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Helpers
     assert_file "app/helpers/test_app/admin/user/special/roles_helper.rb"
-    assert_file "test/unit/helpers/test_app/admin/user/special/roles_helper_test.rb"
+    assert_file "test/helpers/test_app/admin/user/special/roles_helper_test.rb"
 
     # Stylesheets
     assert_file "app/assets/stylesheets/scaffold.css"
@@ -413,7 +413,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
     # Model
     assert_file "app/models/test_app/admin/user/special.rb"	# ( should not be remove )
     assert_no_file "app/models/test_app/admin/user/special/role.rb"
-    assert_no_file "test/unit/test_app/admin/user/special/role_test.rb"
+    assert_no_file "test/models/test_app/admin/user/special/role_test.rb"
     assert_no_file "test/fixtures/test_app/admin/user/special/roles.yml"
     assert_no_migration "db/migrate/create_test_app_admin_user_special_roles.rb"
 
@@ -424,14 +424,14 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Controller
     assert_no_file "app/controllers/test_app/admin/user/special/roles_controller.rb"
-    assert_no_file "test/functional/test_app/admin/user/special/roles_controller_test.rb"
+    assert_no_file "test/controllers/test_app/admin/user/special/roles_controller_test.rb"
 
     # Views
     assert_no_file "app/views/test_app/admin/user/special/roles"
 
     # Helpers
     assert_no_file "app/helpers/test_app/admin/user/special/roles_helper.rb"
-    assert_no_file "test/unit/helpers/test_app/admin/user/special/roles_helper_test.rb"
+    assert_no_file "test/helpers/test_app/admin/user/special/roles_helper_test.rb"
 
     # Stylesheets (should not be removed)
     assert_file "app/assets/stylesheets/scaffold.css"

--- a/railties/test/generators/observer_generator_test.rb
+++ b/railties/test/generators/observer_generator_test.rb
@@ -17,7 +17,7 @@ class ObserverGeneratorTest < Rails::Generators::TestCase
 
   def test_invokes_default_test_framework
     run_generator
-    assert_file "test/unit/account_observer_test.rb", /class AccountObserverTest < ActiveSupport::TestCase/
+    assert_file "test/models/account_observer_test.rb", /class AccountObserverTest < ActiveSupport::TestCase/
   end
 
   def test_logs_if_the_test_framework_cannot_be_found

--- a/railties/test/generators/resource_generator_test.rb
+++ b/railties/test/generators/resource_generator_test.rb
@@ -18,7 +18,7 @@ class ResourceGeneratorTest < Rails::Generators::TestCase
 
     %w(
       app/models/account.rb
-      test/unit/account_test.rb
+      test/models/account_test.rb
       test/fixtures/accounts.yml
     ).each { |path| assert_file path }
 
@@ -33,10 +33,10 @@ class ResourceGeneratorTest < Rails::Generators::TestCase
   def test_resource_controller_with_pluralized_class_name
     run_generator
     assert_file "app/controllers/accounts_controller.rb", /class AccountsController < ApplicationController/
-    assert_file "test/functional/accounts_controller_test.rb", /class AccountsControllerTest < ActionController::TestCase/
+    assert_file "test/controllers/accounts_controller_test.rb", /class AccountsControllerTest < ActionController::TestCase/
 
     assert_file "app/helpers/accounts_helper.rb", /module AccountsHelper/
-    assert_file "test/unit/helpers/accounts_helper_test.rb", /class AccountsHelperTest < ActionView::TestCase/
+    assert_file "test/helpers/accounts_helper_test.rb", /class AccountsHelperTest < ActionView::TestCase/
   end
 
   def test_resource_controller_with_actions
@@ -62,14 +62,14 @@ class ResourceGeneratorTest < Rails::Generators::TestCase
   def test_plural_names_are_singularized
     content = run_generator ["accounts".freeze]
     assert_file "app/models/account.rb", /class Account < ActiveRecord::Base/
-    assert_file "test/unit/account_test.rb", /class AccountTest/
+    assert_file "test/models/account_test.rb", /class AccountTest/
     assert_match(/Plural version of the model detected, using singularized version. Override with --force-plural./, content)
   end
 
   def test_plural_names_can_be_forced
     content = run_generator ["accounts", "--force-plural"]
     assert_file "app/models/accounts.rb", /class Accounts < ActiveRecord::Base/
-    assert_file "test/unit/accounts_test.rb", /class AccountsTest/
+    assert_file "test/models/accounts_test.rb", /class AccountsTest/
     assert_no_match(/Plural version of the model detected/, content)
   end
 

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -57,7 +57,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
   def test_helper_are_invoked_with_a_pluralized_name
     run_generator
     assert_file "app/helpers/users_helper.rb", /module UsersHelper/
-    assert_file "test/unit/helpers/users_helper_test.rb", /class UsersHelperTest < ActionView::TestCase/
+    assert_file "test/helpers/users_helper_test.rb", /class UsersHelperTest < ActionView::TestCase/
   end
 
   def test_views_are_generated
@@ -75,7 +75,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
   def test_functional_tests
     run_generator
 
-    assert_file "test/functional/users_controller_test.rb" do |content|
+    assert_file "test/controllers/users_controller_test.rb" do |content|
       assert_match(/class UsersControllerTest < ActionController::TestCase/, content)
       assert_match(/test "should get index"/, content)
       assert_match(/post :create, user: \{ age: @user.age, name: @user.name \}/, content)
@@ -86,7 +86,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
   def test_functional_tests_without_attributes
     run_generator ["User"]
 
-    assert_file "test/functional/users_controller_test.rb" do |content|
+    assert_file "test/controllers/users_controller_test.rb" do |content|
       assert_match(/class UsersControllerTest < ActionController::TestCase/, content)
       assert_match(/test "should get index"/, content)
       assert_match(/post :create, user: \{  \}/, content)
@@ -97,7 +97,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
   def test_skip_helper_if_required
     run_generator ["User", "name:string", "age:integer", "--no-helper"]
     assert_no_file "app/helpers/users_helper.rb"
-    assert_no_file "test/unit/helpers/users_helper_test.rb"
+    assert_no_file "test/helpers/users_helper_test.rb"
   end
 
   def test_skip_layout_if_required

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -12,7 +12,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     # Model
     assert_file "app/models/product_line.rb", /class ProductLine < ActiveRecord::Base/
-    assert_file "test/unit/product_line_test.rb", /class ProductLineTest < ActiveSupport::TestCase/
+    assert_file "test/models/product_line_test.rb", /class ProductLineTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/product_lines.yml"
     assert_migration "db/migrate/create_product_lines.rb", /belongs_to :product, index: true/
     assert_migration "db/migrate/create_product_lines.rb", /references :user, index: true/
@@ -60,7 +60,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       end
     end
 
-    assert_file "test/functional/product_lines_controller_test.rb" do |test|
+    assert_file "test/controllers/product_lines_controller_test.rb" do |test|
       assert_match(/class ProductLinesControllerTest < ActionController::TestCase/, test)
       assert_match(/post :create, product_line: \{ title: @product_line.title \}/, test)
       assert_match(/put :update, id: @product_line, product_line: \{ title: @product_line.title \}/, test)
@@ -78,7 +78,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     # Helpers
     assert_file "app/helpers/product_lines_helper.rb"
-    assert_file "test/unit/helpers/product_lines_helper_test.rb"
+    assert_file "test/helpers/product_lines_helper_test.rb"
 
     # Assets
     assert_file "app/assets/stylesheets/scaffold.css"
@@ -89,7 +89,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
   def test_functional_tests_without_attributes
     run_generator ["product_line"]
 
-    assert_file "test/functional/product_lines_controller_test.rb" do |content|
+    assert_file "test/controllers/product_lines_controller_test.rb" do |content|
       assert_match(/class ProductLinesControllerTest < ActionController::TestCase/, content)
       assert_match(/test "should get index"/, content)
       assert_match(/post :create, product_line: \{  \}/, content)
@@ -103,7 +103,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     # Model
     assert_no_file "app/models/product_line.rb"
-    assert_no_file "test/unit/product_line_test.rb"
+    assert_no_file "test/models/product_line_test.rb"
     assert_no_file "test/fixtures/product_lines.yml"
     assert_no_migration "db/migrate/create_product_lines.rb"
 
@@ -114,7 +114,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     # Controller
     assert_no_file "app/controllers/product_lines_controller.rb"
-    assert_no_file "test/functional/product_lines_controller_test.rb"
+    assert_no_file "test/controllers/product_lines_controller_test.rb"
 
     # Views
     assert_no_file "app/views/product_lines"
@@ -122,7 +122,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     # Helpers
     assert_no_file "app/helpers/product_lines_helper.rb"
-    assert_no_file "test/unit/helpers/product_lines_helper_test.rb"
+    assert_no_file "test/helpers/product_lines_helper_test.rb"
 
     # Assets
     assert_file "app/assets/stylesheets/scaffold.css", /:visited/
@@ -136,7 +136,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     # Model
     assert_file "app/models/admin.rb", /module Admin/
     assert_file "app/models/admin/role.rb", /class Admin::Role < ActiveRecord::Base/
-    assert_file "test/unit/admin/role_test.rb", /class Admin::RoleTest < ActiveSupport::TestCase/
+    assert_file "test/models/admin/role_test.rb", /class Admin::RoleTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/admin/roles.yml"
     assert_migration "db/migrate/create_admin_roles.rb"
 
@@ -183,7 +183,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       end
     end
 
-    assert_file "test/functional/admin/roles_controller_test.rb",
+    assert_file "test/controllers/admin/roles_controller_test.rb",
                 /class Admin::RolesControllerTest < ActionController::TestCase/
 
     # Views
@@ -198,7 +198,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     # Helpers
     assert_file "app/helpers/admin/roles_helper.rb"
-    assert_file "test/unit/helpers/admin/roles_helper_test.rb"
+    assert_file "test/helpers/admin/roles_helper_test.rb"
 
     # Assets
     assert_file "app/assets/stylesheets/scaffold.css", /:visited/
@@ -213,7 +213,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     # Model
     assert_file "app/models/admin.rb"	# ( should not be remove )
     assert_no_file "app/models/admin/role.rb"
-    assert_no_file "test/unit/admin/role_test.rb"
+    assert_no_file "test/models/admin/role_test.rb"
     assert_no_file "test/fixtures/admin/roles.yml"
     assert_no_migration "db/migrate/create_admin_roles.rb"
 
@@ -224,7 +224,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     # Controller
     assert_no_file "app/controllers/admin/roles_controller.rb"
-    assert_no_file "test/functional/admin/roles_controller_test.rb"
+    assert_no_file "test/controllers/admin/roles_controller_test.rb"
 
     # Views
     assert_no_file "app/views/admin/roles"
@@ -232,7 +232,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     # Helpers
     assert_no_file "app/helpers/admin/roles_helper.rb"
-    assert_no_file "test/unit/helpers/admin/roles_helper_test.rb"
+    assert_no_file "test/helpers/admin/roles_helper_test.rb"
 
     # Assets
     assert_file "app/assets/stylesheets/scaffold.css"


### PR DESCRIPTION
As discussed on the [rubyonrails-core mailing list](https://groups.google.com/forum/#!topic/rubyonrails-core/pwQSx3rpVow), this request changes the default test locations as follows:

```
test/units          -> test/models
test/units/helpers  -> test/helpers
test/functional     -> test/controllers
test/functional     -> test/mailers
test/integration    -> test/acceptance
```

The existing rake tasks are backwards compatible, and will run tests in the old and new locations. New rake tasks were added that only runs the tests in the new locations. The new tasks are `test:models`, `test:helpers`, `test:controllers`, `test:mailers`, and `test:acceptance`.

attn: @spastorino and @tenderlove
