### PR TITLE
Use secure default values for the session store.

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/session_store.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/session_store.rb.tt
@@ -1,3 +1,8 @@
 # Be sure to restart your server when you modify this file.
 
-<%= app_const %>.config.session_store :cookie_store, key: <%= "'_#{app_name}_session'" %>
+<%= app_const %>.config.session_store(
+  :cookie_store,
+  key: <%= "'_#{app_name}_session'" %>,
+  secure: <%= app_const %>.config.force_ssl,
+  httponly: true
+)


### PR DESCRIPTION
This improves security by complying with OWASP recommendations: https://www.owasp.org/index.php/Transport_Layer_Protection_Cheat_Sheet#Rule-Use.22Secure.22_Cookie_Flag

If administrators enable config.force_ssl this code automatically tells clients to only send cookies over SSL. If config.force_ssl is not set there will be no effect.

The problem this solves is that when you force SSL to be true you might forget to set your cookies to HTTPS only. If you forget to do this then your cookies are vulnerable when your users are on a unsafe connection, for example public wifi. This attack happens in the wild with Firesheep (http://codebutler.com/firesheep/). You can read more about this attack at http://en.wikipedia.org/wiki/HTTP_cookie#Cookie_theft_and_session_hijacking

Of course some people will remember and configure the cookie correctly to prevent this attack. However I feel it is important to be secure by default. Default in this case means when a user forces SSL, if that is not set this PR will not change anything.
