### PR TITLE
assert_template works when the same partial was rendered multiple times

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `assert_template` can be used to assert on the same template with different locals
+    Fix #3675
+
+    *Yves Senn*
+
 *   Remove old asset tag concatenation (no longer needed now that we have the asset pipeline). *Josh Peek*
 
 *   Accept :remote as symbolic option for `link_to` helper. *Riley Lynch*

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -123,11 +123,17 @@ module ActionController
 
         if expected_partial = options[:partial]
           if expected_locals = options[:locals]
-            if defined?(@locals)
-              actual_locals = @locals[expected_partial.to_s.sub(/^_/,'')]
-              expected_locals.each_pair do |k,v|
-                assert_equal(v, actual_locals[k])
+            if defined?(@_locals)
+              actual_locals_collection = @_locals[expected_partial.to_s.sub(/^_/,'')]
+              result = actual_locals_collection.any? do |actual_locals|
+                expected_locals.each_pair.all? do |k,v|
+                  v == actual_locals[k]
+                end
               end
+              msg = 'expecting %s to be rendered with %s but was with %s' % [expected_partial,
+                                                                             expected_locals,
+                                                                             actual_locals_collection]
+              assert(result, msg)
             else
               warn "the :locals option to #assert_template is only supported in a ActionView::TestCase"
             end

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -123,17 +123,12 @@ module ActionController
 
         if expected_partial = options[:partial]
           if expected_locals = options[:locals]
-            if defined?(@_locals)
-              actual_locals_collection = @_locals[expected_partial.to_s.sub(/^_/,'')]
-              result = actual_locals_collection.any? do |actual_locals|
-                expected_locals.each_pair.all? do |k,v|
-                  v == actual_locals[k]
-                end
-              end
+            if defined?(@_rendered_views)
+              view = expected_partial.to_s.sub(/^_/,'')
               msg = 'expecting %s to be rendered with %s but was with %s' % [expected_partial,
                                                                              expected_locals,
-                                                                             actual_locals_collection]
-              assert(result, msg)
+                                                                             @_rendered_views.locals_for(view)]
+              assert(@_rendered_views.view_rendered?(view, options[:locals]), msg)
             else
               warn "the :locals option to #assert_template is only supported in a ActionView::TestCase"
             end

--- a/actionpack/lib/action_view/test_case.rb
+++ b/actionpack/lib/action_view/test_case.rb
@@ -119,8 +119,29 @@ module ActionView
         output
       end
 
-      def locals
-        @_locals ||= {}
+      def rendered_views
+        @_rendered_views ||= RenderedViewsCollection.new
+      end
+
+      class RenderedViewsCollection
+        def initialize
+          @rendered_views ||= {}
+        end
+
+        def add(view, locals)
+          @rendered_views[view] ||= []
+          @rendered_views[view] << locals
+        end
+
+        def locals_for(view)
+          @rendered_views[view]
+        end
+
+        def view_rendered?(view, expected_locals)
+          locals_for(view).any? do |actual_locals|
+            expected_locals.all? {|key, value| value == actual_locals[key] }
+          end
+        end
       end
 
       included do
@@ -156,21 +177,18 @@ module ActionView
       end
 
       module Locals
-        attr_accessor :locals
+        attr_accessor :rendered_views
 
         def render(options = {}, local_assigns = {})
           case options
           when Hash
             if block_given?
-              locals[options[:layout]] ||= []
-              locals[options[:layout]] << options[:locals]
+              rendered_views.add options[:layout], options[:locals]
             elsif options.key?(:partial)
-              locals[options[:partial]] ||= []
-              locals[options[:partial]] << options[:locals]
+              rendered_views.add options[:partial], options[:locals]
             end
           else
-            locals[options] ||= []
-            locals[options] << local_assigns
+            rendered_views.add options, local_assigns
           end
 
           super
@@ -183,7 +201,7 @@ module ActionView
           view = @controller.view_context
           view.singleton_class.send :include, _helpers
           view.extend(Locals)
-          view.locals = self.locals
+          view.rendered_views = self.rendered_views
           view.output_buffer = self.output_buffer
           view
         end
@@ -200,7 +218,7 @@ module ActionView
         :@_routes,
         :@controller,
         :@_layouts,
-        :@_locals,
+        :@_rendered_views,
         :@method_name,
         :@output_buffer,
         :@_partials,

--- a/actionpack/lib/action_view/test_case.rb
+++ b/actionpack/lib/action_view/test_case.rb
@@ -120,7 +120,7 @@ module ActionView
       end
 
       def locals
-        @locals ||= {}
+        @_locals ||= {}
       end
 
       included do
@@ -162,12 +162,15 @@ module ActionView
           case options
           when Hash
             if block_given?
-              locals[options[:layout]] = options[:locals]
+              locals[options[:layout]] ||= []
+              locals[options[:layout]] << options[:locals]
             elsif options.key?(:partial)
-              locals[options[:partial]] = options[:locals]
+              locals[options[:partial]] ||= []
+              locals[options[:partial]] << options[:locals]
             end
           else
-            locals[options] = local_assigns
+            locals[options] ||= []
+            locals[options] << local_assigns
           end
 
           super
@@ -197,7 +200,7 @@ module ActionView
         :@_routes,
         :@controller,
         :@_layouts,
-        :@locals,
+        :@_locals,
         :@method_name,
         :@output_buffer,
         :@_partials,

--- a/actionpack/test/fixtures/test/render_two_partials.html.erb
+++ b/actionpack/test/fixtures/test/render_two_partials.html.erb
@@ -1,0 +1,2 @@
+<%= render :partial => 'partial', :locals => {'first' => '1'} %>
+<%= render :partial => 'partial', :locals => {'second' => '2'} %>

--- a/actionpack/test/template/test_case_test.rb
+++ b/actionpack/test/template/test_case_test.rb
@@ -321,6 +321,14 @@ module ActionView
         assert_template :partial => "_partial_for_use_in_layout", :locals => { :name => "Somebody Else" }
       end
     end
+
+    test 'supports different locals on the same partial' do
+      controller.controller_path = "test"
+      render(:template => "test/render_two_partials")
+      assert_template partial: '_partial', locals: { 'first' => '1' }
+      assert_template partial: '_partial', locals: { 'second' => '2' }
+    end
+
   end
 
   module AHelperWithInitialize


### PR DESCRIPTION
This is a fix for #3675.

I also refactored the `ActionView::TestCase` internals, so that a separate object keeps track of rendered views and their locals. The internal instance variable `@locals` does no longer exist.
