### PR TITLE
Add 'mixed_options_for_select' helper to generate combined bare option and optgroup tags from nested array

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -583,4 +583,19 @@
 *   `ActionView::Helpers::TextHelper#highlight` now defaults to the
     HTML5 `mark` element. *Brian Cardarella*
 
+*   Add `mixed_options_for_select` form options helper to generate a combination of `option`
+    and `optgroup` tags, similar to `options_for_select` and `grouped_options_for_select`,
+    based on the array passed.
+
+        mixed_options_for_select([["Pop"], ["Rock", [["Alternative Rock"], ["Hard Rock"]]], ["Country"]])
+        # Optputs:
+        <option value="Pop">Pop</option>
+        <optgroup label="Rock">
+            <option value="Alternative Rock">Alternative Rock</option>
+            <option value="Hard Rock">Hard Rock</option>
+        </optgroup>
+        <option value="Country">Country</option>
+
+    Takes an options hash and parses HTML attributes from hashes in array elements. *Chatura Atapattu*
+
 Please check [3-2-stable](https://github.com/rails/rails/blob/3-2-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -542,6 +542,73 @@ module ActionView
         body
       end
 
+      # Accepts an array and returns a string of option and optgroup tags based on the array structure. Given an array
+      # where the elements respond to first and last (such as a two-element array), the "lasts" serve as option values
+      # and the "firsts" as option text. For each element, any hashes will be parsed into HTML attributes. An optional
+      # options hash allows selected and disabled options to be set, as well as a divider and prompt.
+      #
+      # Parameters:
+      # * +mixed_options+ - Accepts an array in which for each element, if the last part is an array, the element
+      #   represents an optgroup, otherwise an option. If the element is an option, it will be processed as it would in
+      #   <tt>options_for_select</tt>. If the element is an optgroup, the first part is the optgroup label (unless a
+      #   divider is defined) and the last part will be processed as options by <tt>options_for_select</tt>. Any
+      #   included hashes in the element will be processed as HTML attributes.
+      #    Ex. ["Pop"], ["Rock", [["Alternative Rock"], ["Hard Rock"]]], ["Country"]
+      #
+      # Options:
+      # * <tt>:selected</tt> - array of values to be selected when using a multiple select.
+      # * <tt>:disabled</tt> - array of values to be disabled.
+      # * <tt>:prompt</tt> - set to true or a prompt string. When the select element doesn't have a value yet, this
+      #   prepends an option with a generic prompt - "Please select" - or the given prompt string.
+      # * <tt>:divider</tt> - the divider for the options groups.
+      #
+      # Examples:
+      #   mixed_options_for_select([["Pop"], ["Rock", [["Alternative Rock"], ["Hard Rock"]]], ["Country"]], selected:
+      #     "Pop", disabled: "Hard Rock", prompt: "Choose a genre...", divider: "----------")
+      #   # <option value="">Choose a genre...</option>
+      #   # <option value="Pop" selected="selected">Pop</option>
+      #   # <optgroup label="----------">
+      #   #   <option value="Alternative Rock">Alternative Rock</option>
+      #   #   <option value="Hard Rock" disabled="disabled">Hard Rock</option>
+      #   # </optgroup>
+      #   # <option value="Country">Country</option>
+      #
+      #   mixed_options_for_select([["Pop", { class: "popular" }], ["R&B", "R_and_B"], ["Rock", { class: "bold" },
+      #     [["Alternative Rock", "Alternative Rock"], ["Hard Rock", { class: "dark" }], ["Rock 'N' Roll",
+      #     "rock_n_roll"]]], ["Country", "Country"]]
+      #   # <option value="Pop" class="popular">Pop</option>
+      #   # <option value="R_and_B">R&B</option>
+      #   # <optgroup class="bold" label="Rock">
+      #   #   <option value="Alternative Rock">Alternative Rock</option>
+      #   #   <option value="Hard Rock" class="dark">Hard Rock</option>
+      #   #   <option value="rock_n_roll">Rock 'N' Roll</option>
+      #   # </optgroup>
+      #   # <option value="Country">Country</option>
+      def mixed_options_for_select(mixed_options, options = {})
+        if options.is_a?(Hash)
+          prompt  = options[:prompt]
+          divider = options[:divider]
+          selected = options[:selected]
+          disabled = options[:disabled]
+        end
+
+        body = "".html_safe
+
+        body.safe_concat content_tag(:option, prompt_text(prompt), :value => "") if prompt
+
+        mixed_options.each do |option|
+          if option.last.is_a?(Array)
+            html_attributes = option_html_attributes(option)
+            html_attributes[:label] = divider ? divider : option.first
+            body.safe_concat content_tag(:optgroup, options_for_select(option.last, { selected: selected, disabled: disabled }), html_attributes)
+          else
+            body.safe_concat options_for_select([option], { selected: selected, disabled: disabled })
+          end
+        end
+
+        body
+      end
+
       # Returns a string of option tags for pretty much any time zone in the
       # world. Supply a ActiveSupport::TimeZone name as +selected+ to have it
       # marked as the selected option tag. You can also supply an array of

--- a/actionpack/test/template/form_options_helper_test.rb
+++ b/actionpack/test/template/form_options_helper_test.rb
@@ -344,6 +344,73 @@ class FormOptionsHelperTest < ActionView::TestCase
       grouped_options_for_select([["Hats", ["Baseball Cap","Cowboy Hat"]]], nil, prompt: '<Choose One>'))
   end
 
+  def test_mixed_options_for_select_with_array
+    assert_dom_equal(
+      "<option value=\"Pop\">Pop</option><optgroup label=\"Rock\"><option value=\"Alternative Rock\">Alternative Rock</option>\n<option value=\"Hard Rock\">Hard Rock</option></optgroup><option value=\"Country\">Country</option>",
+      mixed_options_for_select([
+        ["Pop"],
+        ["Rock", [
+          ["Alternative Rock"],
+          ["Hard Rock"]
+        ]],
+        ["Country"]
+      ])
+    )
+  end
+
+  def test_mixed_options_for_select_with_optional_divider
+    assert_dom_equal(
+      "<option value=\"Pop\">Pop</option><optgroup label=\"----------\"><option value=\"Alternative Rock\">Alternative Rock</option>\n<option value=\"Hard Rock\">Hard Rock</option></optgroup><option value=\"Country\">Country</option>",
+      mixed_options_for_select([["Pop"], ["Rock", [["Alternative Rock"], ["Hard Rock"]]], ["Country"]], divider: "----------")
+    )
+  end
+
+  def test_mixed_options_for_select_with_selected_and_prompt
+    assert_dom_equal(
+      "<option value=\"\">Choose a genre...</option><option value=\"Pop\" selected=\"selected\">Pop</option><optgroup label=\"Rock\"><option value=\"Alternative Rock\">Alternative Rock</option>\n<option value=\"Hard Rock\">Hard Rock</option></optgroup><option value=\"Country\">Country</option>",
+      mixed_options_for_select([["Pop"], ["Rock", [["Alternative Rock"], ["Hard Rock"]]], ["Country"]], selected: "Pop", prompt: "Choose a genre...")
+    )
+  end
+
+  def test_mixed_options_for_select_with_selected_and_prompt_true
+    assert_dom_equal(
+      "<option value=\"\">Please select</option><option value=\"Pop\" selected=\"selected\">Pop</option><optgroup label=\"Rock\"><option value=\"Alternative Rock\">Alternative Rock</option>\n<option value=\"Hard Rock\">Hard Rock</option></optgroup><option value=\"Country\">Country</option>",
+      mixed_options_for_select([["Pop"], ["Rock", [["Alternative Rock"], ["Hard Rock"]]], ["Country"]], selected: "Pop", prompt: true)
+    )
+  end
+
+  def test_mixed_options_for_select_returns_html_safe_string
+    assert mixed_options_for_select([["Pop"], ["Rock", [["Alternative Rock"], ["Hard Rock"]]], ["Country"]]).html_safe?
+  end
+
+  def test_mixed_options_for_select_returns_html_escaped_string
+    assert_dom_equal(
+      "<option value=\"Pop\">Pop</option><option value=\"Rap\">Rap</option><option value=\"R&amp;B\">R&amp;B</option><optgroup label=\"Rock\"><option value=\"Alternative Rock\">Alternative Rock</option>\n<option value=\"Hard Rock\">Hard Rock</option>\n<option value=\"Rock &#39;N&#39; Roll\">Rock &#39;N&#39; Roll</option></optgroup><option value=\"Country\">Country</option>",
+      mixed_options_for_select([["Pop"], ["Rap"], ["R&B"], ["Rock", [["Alternative Rock"], ["Hard Rock"], ["Rock 'N' Roll"]]], ["Country"]])
+    )
+  end
+
+  def test_mixed_options_for_select_with_prompt_returns_html_escaped_string
+    assert_dom_equal(
+      "<option value=\"\">&lt;Choose One&gt;</option><option value=\"Pop\">Pop</option><optgroup label=\"Rock\"><option value=\"Alternative Rock\">Alternative Rock</option>\n<option value=\"Hard Rock\">Hard Rock</option></optgroup><option value=\"Country\">Country</option>",
+      mixed_options_for_select([["Pop"], ["Rock", [["Alternative Rock"], ["Hard Rock"]]], ["Country"]], prompt: "<Choose One>")
+    )
+  end
+
+  def test_mixed_options_for_select_with_disabled
+    assert_dom_equal(
+      "<option value=\"Pop\">Pop</option><optgroup label=\"Rock\"><option value=\"Alternative Rock\">Alternative Rock</option>\n<option value=\"Hard Rock\" disabled=\"disabled\">Hard Rock</option></optgroup><option value=\"Country\">Country</option>",
+      mixed_options_for_select([["Pop"], ["Rock", [["Alternative Rock"], ["Hard Rock"]]], ["Country"]], disabled: "Hard Rock")
+    )
+  end
+
+  def test_mixed_options_for_select_with_attributes_and_values
+    assert_dom_equal(
+      "<option value=\"Pop\" class=\"popular\">Pop</option><option value=\"Rap\">Rap</option><option value=\"R&amp;B\">R&amp;B</option><optgroup class=\"bold\" label=\"Rock\"><option value=\"Alternative Rock\">Alternative Rock</option>\n<option value=\"Hard Rock\" class=\"dark\">Hard Rock</option>\n<option value=\"rock_n_roll\">Rock &#39;N&#39; Roll</option></optgroup><option value=\"Country\">Country</option>",
+      mixed_options_for_select([["Pop", { class: "popular" }], ["Rap"], ["R&B"], ["Rock", { class: "bold" }, [["Alternative Rock", "Alternative Rock"], ["Hard Rock", { class: "dark" }], ["Rock 'N' Roll", "rock_n_roll"]]], ["Country", "Country"]])
+    )
+  end
+
   def test_optgroups_with_with_options_with_hash
     assert_dom_equal(
        "<optgroup label=\"Europe\"><option value=\"Denmark\">Denmark</option>\n<option value=\"Germany\">Germany</option></optgroup><optgroup label=\"North America\"><option value=\"United States\">United States</option>\n<option value=\"Canada\">Canada</option></optgroup>",


### PR DESCRIPTION
``` ruby
mixed_options_for_select([["Pop"], ["Rock", [["Alternative Rock"], ["Hard Rock"]]], ["Country"]])
```

``` html
<option value="Pop">Pop</option>
<optgroup label="Rock">
  <option value="Alternative Rock">Alternative Rock</option>
  <option value="Hard Rock">Hard Rock</option>
</optgroup>
<option value="Country">Country</option>
```

Currently not possible.
