### PR TITLE
Prompt to run rake when accidentally typed rails

### DIFF
--- a/railties/lib/rails/commands.rb
+++ b/railties/lib/rails/commands.rb
@@ -9,6 +9,30 @@ aliases = {
   "r"  => "runner"
 }
 
+help_message = <<-EOT
+Usage: rails COMMAND [ARGS]
+
+The most common rails commands are:
+ generate    Generate new code (short-cut alias: "g")
+ console     Start the Rails console (short-cut alias: "c")
+ server      Start the Rails server (short-cut alias: "s")
+ dbconsole   Start a console for the database specified in config/database.yml
+             (short-cut alias: "db")
+ new         Create a new Rails application. "rails new my_app" creates a
+             new application called MyApp in "./my_app"
+
+In addition to those, there are:
+ application  Generate the Rails application code
+ destroy      Undo code generated with "generate" (short-cut alias: "d")
+ benchmarker  See how fast a piece of code runs
+ profiler     Get profile information from a piece of code
+ plugin new   Generates skeleton for developing a Rails plugin
+ runner       Run a piece of code in the application environment (short-cut alias: "r")
+
+All commands can be run with -h (or --help) for more information.
+EOT
+
+
 command = ARGV.shift
 command = aliases[command] || command
 
@@ -81,29 +105,14 @@ when '--version', '-v'
   ARGV.unshift '--version'
   require 'rails/commands/application'
 
+when '-h', '--help'
+  puts help_message
+
 else
-  puts "Error: Command not recognized" unless %w(-h --help).include?(command)
-  puts <<-EOT
-Usage: rails COMMAND [ARGS]
-
-The most common rails commands are:
- generate    Generate new code (short-cut alias: "g")
- console     Start the Rails console (short-cut alias: "c")
- server      Start the Rails server (short-cut alias: "s")
- dbconsole   Start a console for the database specified in config/database.yml
-             (short-cut alias: "db")
- new         Create a new Rails application. "rails new my_app" creates a
-             new application called MyApp in "./my_app"
-
-In addition to those, there are:
- application  Generate the Rails application code
- destroy      Undo code generated with "generate" (short-cut alias: "d")
- benchmarker  See how fast a piece of code runs
- profiler     Get profile information from a piece of code
- plugin new   Generates skeleton for developing a Rails plugin
- runner       Run a piece of code in the application environment (short-cut alias: "r")
-
-All commands can be run with -h (or --help) for more information.
-  EOT
+  puts "Error: Command '#{command}' not recognized"
+  if %x{rake #{command} --dry-run 2>&1 } && $?.success?
+    puts "Did you mean: `$ rake #{command}` ?\n\n"
+  end
+  puts help_message
   exit(1)
 end


### PR DESCRIPTION
Developers from all levels will accidentally run rake tasks using the `rails` keyword when they meant to use `rake`. Often times beginners struggle with the difference between the tools. The most common example would be `$ rails db:migrate`

Rather than telling the developer simply that they did not use a valid rails command, we can see if it was a valid rake command first. If it is a valid rake command we can auto execute it giving the user a period of time to cancel if that isn't what they intended.

Here is what `rake db:migrate` would look like if you cancel the command:

``` sh
$ rails db:migrate
Assuming you meant: $ rake db:migrate 
press any key to cancel in 3 seconds
> 
command terminated ...
```

Here is what it looks like if you don't cancel the command:

``` sh
$ rails db:migrate
Assuming you meant: $ rake db:migrate 
press any key to cancel in 3 seconds
> 
Running: $ rake db:migrate 
==  Foo: migrating ============================================================
==  Foo: migrated (0.0000s) ===================================================
```
