### PR TITLE
fix typo in "The Rails Initialization Process"

### DIFF
--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -367,7 +367,7 @@ on your needs.
 
 ### `Rails::Server#start`
 
-After `congif/application` is loaded, `server.start` is called. This method is defined like this:
+After `config/application` is loaded, `server.start` is called. This method is defined like this:
 
 ```ruby
 def start


### PR DESCRIPTION
Guess it's typo in Rails Guides
