### PR TITLE
Add missing CHANGELOG relating to addition of callbacks to mailers

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -27,4 +27,8 @@
 
 * Asynchronously send messages via the Rails Queue *Brian Cardarella*
 
+* Allow callbacks to be defined in mailers similar to `ActionController::Base`. You can configure default
+  settings, headers, attachments, delivery settings or change delivery using
+  `before_filter`, `after_filter` etc. *Justin S. Leitgeb*
+
 Please check [3-2-stable](https://github.com/rails/rails/blob/3-2-stable/actionmailer/CHANGELOG.md) for previous changes.

--- a/guides/source/4_0_release_notes.md
+++ b/guides/source/4_0_release_notes.md
@@ -141,6 +141,8 @@ Action Mailer
     end
     ```
 
+*   Allow for callbacks in mailers similar to ActionController::Base. You can now set up headers/attachments using `before_filter` or `after_filter`. You could also change delivery settings or prevent delivery in an after filter based on instance variables set in your mailer action. You have access to `ActionMailer::Base` instance methods like `message`, `attachments`, `headers`.
+
 Action Pack
 -----------
 


### PR DESCRIPTION
A few months ago, `AbstractController::Callbacks` were included in `ActionMailer::Base`. This commit cleans it up by including relevant changelog entries and updating the Rails 4.0 Release Notes.
