### PR TITLE
No need to test for rack-cache present in gem file

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -302,11 +302,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "Gemfile", /# gem 'debugger'/
   end
 
-  def test_inclusion_of_rack_cache
-    run_generator
-    assert_file "Gemfile", /gem 'rack-cache'/
-  end
-
   def test_template_from_dir_pwd
     FileUtils.cd(Rails.root)
     assert_match(/It works from file!/, run_generator([destination_root, "-m", "lib/template.rb"]))


### PR DESCRIPTION
as it's removed here 
1fc795468525d8622cdca474a54c8310a514aa46
