### PR TITLE
CacheDigests: Support templates in directories several levels deep

### DIFF
--- a/actionpack/lib/action_view/digestor.rb
+++ b/actionpack/lib/action_view/digestor.rb
@@ -64,7 +64,7 @@ module ActionView
       end
 
       def directory
-        name.split("/").first
+        name.split("/")[0..-2].join("/")
       end
 
       def partial?

--- a/actionpack/test/fixtures/digestor/level/below/index.html.erb
+++ b/actionpack/test/fixtures/digestor/level/below/index.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "header" %>

--- a/actionpack/test/template/digestor_test.rb
+++ b/actionpack/test/template/digestor_test.rb
@@ -59,6 +59,12 @@ class TemplateDigestorTest < ActionView::TestCase
       change_template("comments/_comment")
     end
   end
+  
+  def test_directory_depth_dependency
+    assert_digest_difference("level/below/index") do
+      change_template("level/below/_header")
+    end
+  end
 
   def test_logging_of_missing_template
     assert_logged "Couldn't find template for digesting: messages/something_missing.html" do


### PR DESCRIPTION
Per the [PR](https://github.com/rails/cache_digests/pull/6) in `cache_digests`.

I have a view template structure in my Rails app that goes several directories deep.

To support that with cache_digests, this patch alters the #directory method in ActionView::Digestor to pop the template name off the end of the path and return the full view directory structure instead of taking just the first directory.

This was accepted into `cache_digests` gem, and is replicated here for rails per @dhh request.
