### PR TITLE
MemCacheStore's move to dalli as a backend broke :race_condition_ttl support

### DIFF
--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -132,6 +132,10 @@ module ActiveSupport
           method = options && options[:unless_exist] ? :add : :set
           value = options[:raw] ? entry.value.to_s : entry
           expires_in = options[:expires_in].to_i
+          if expires_in > 0 && !options[:raw]
+            # Set the memcache expire a few minutes in the future to support race condition ttls on read
+            expires_in += 5.minutes
+          end
           @data.send(method, escape_key(key), value, expires_in, options)
         rescue Dalli::DalliError => e
           logger.error("DalliError (#{e}): #{e.message}") if logger


### PR DESCRIPTION
Sending dalli an expires_in integer that matches the Entry instance's expires_at will invalidate the cached value in Memcache at the same time the Entry is expired.  This breaks the ability for Cache#fetch to determine if the :race_condition_ttl has occurred since the value will never make it back from Memcached.
