### PR TITLE
Fix has_many assocation w/select load after create

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 3.2.9 (unreleased)
 
+*   Fix deprecation notice when loading a collection association that
+    selects columns from other tables, if a new record was previously
+    built using that association.
+
+    *Ernie Miller*
+
 *   The postgres adapter now supports tables with capital letters.
     Fix #5920
 

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -409,7 +409,7 @@ module ActiveRecord
             if mem_index
               mem_record = memory.delete_at(mem_index)
 
-              (record.attribute_names - mem_record.changes.keys).each do |name|
+              ((record.attribute_names & mem_record.attribute_names) - mem_record.changes.keys).each do |name|
                 mem_record[name] = record[name]
               end
 

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -236,6 +236,14 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     assert_equal "2", categories(:sti_test).authors_with_select.first.post_id.to_s
   end
 
+  def test_create_through_has_many_with_piggyback
+    category = categories(:sti_test)
+    ernie = category.authors_with_select.create(:name => 'Ernie')
+    assert_not_deprecated do
+      assert_equal ernie, category.authors_with_select.detect {|a| a.name == 'Ernie'}
+    end
+  end
+
   def test_include_has_many_through
     posts              = Post.find(:all, :order => 'posts.id')
     posts_with_authors = Post.find(:all, :include => :authors, :order => 'posts.id')


### PR DESCRIPTION
Backported from master, per #7859

If you create a new record via a collection association proxy that has
not loaded its target, and which selects additional attributes through
the association, then when the proxy loads its target, it will
inadvertently trigger a deprecation notice during attribute writing when
CollectionAssociation#merge_target_lists attempts to do its thing, since
the newly loaded records will possess attributes the created record does
not.
