### PR TITLE
javascript_include_tag does no longer sanitize the script url

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `javascript_include_tag` does not sanitize the url. This allows you to link to javascripts
+    with parameters in the query string
+    Fix #7931
+
+        javascript_include_tag('http://maps.googleapis.com/maps/api/js?key=KEY&sensor=true')
+
+    *Yves Senn*
+
 *   `date_select` helper accepts `with_css_classes: true` to add css classes similar with type
     of generated select tags.
 

--- a/actionpack/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helper.rb
@@ -51,6 +51,7 @@ module ActionView
       def javascript_include_tag(*sources)
         options = sources.extract_options!.stringify_keys
         sources.uniq.map { |source|
+          source = source.html_safe if source.respond_to?(:html_safe)
           tag_options = {
             "src" => path_to_javascript(source)
           }.merge(options)

--- a/actionpack/test/template/asset_tag_helper_test.rb
+++ b/actionpack/test/template/asset_tag_helper_test.rb
@@ -78,7 +78,9 @@ class AssetTagHelperTest < ActionView::TestCase
     %(javascript_path("xmlhr.js?123")) => %(/javascripts/xmlhr.js?123),
     %(javascript_path("xmlhr.js?body=1")) => %(/javascripts/xmlhr.js?body=1),
     %(javascript_path("xmlhr.js#hash")) => %(/javascripts/xmlhr.js#hash),
-    %(javascript_path("xmlhr.js?123#hash")) => %(/javascripts/xmlhr.js?123#hash)
+    %(javascript_path("xmlhr.js?123#hash")) => %(/javascripts/xmlhr.js?123#hash),
+
+    %(javascript_path("http://maps.googleapis.com/maps/api/js?key=KEY&sensor=true")) => %(http://maps.googleapis.com/maps/api/js?key=KEY&sensor=true)
   }
 
   PathToJavascriptToTag = {
@@ -107,6 +109,7 @@ class AssetTagHelperTest < ActionView::TestCase
     %(javascript_include_tag("http://example.com/all")) => %(<script src="http://example.com/all"></script>),
     %(javascript_include_tag("http://example.com/all.js")) => %(<script src="http://example.com/all.js"></script>),
     %(javascript_include_tag("//example.com/all.js")) => %(<script src="//example.com/all.js"></script>),
+    %(javascript_include_tag("http://maps.googleapis.com/maps/api/js?key=KEY&sensor=true")) => %(<script src="http://maps.googleapis.com/maps/api/js?key=KEY&sensor=true" ></script>)
   }
 
   StylePathToTag = {


### PR DESCRIPTION
This patch prevents `javascript_include_tag` from sanitizing the url to the script.
