### PR TITLE
Fix typo in inet and cidr saving

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -90,7 +90,7 @@ module ActiveRecord
             else super(value, column)
             end
           when IPAddr
-            return super(value, column) unless ['inet','cidr'].includes? column.sql_type
+            return super(value, column) unless ['inet','cidr'].include? column.sql_type
             PostgreSQLColumn.cidr_to_string(value)
           else
             super(value, column)

--- a/activerecord/test/cases/adapters/postgresql/quoting_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/quoting_test.rb
@@ -1,4 +1,5 @@
 require "cases/helper"
+require 'ipaddr'
 
 module ActiveRecord
   module ConnectionAdapters
@@ -18,6 +19,18 @@ module ActiveRecord
           c = Column.new(nil, 1, 'boolean')
           assert_equal 'f', @conn.type_cast(false, nil)
           assert_equal 'f', @conn.type_cast(false, c)
+        end
+
+        def test_type_cast_cidr
+          ip = IPAddr.new('255.0.0.0/8')
+          c = Column.new(nil, ip, 'cidr')
+          assert_equal ip, @conn.type_cast(ip, c)
+        end
+
+        def test_type_cast_inet
+          ip = IPAddr.new('255.1.0.0/8')
+          c = Column.new(nil, ip, 'inet')
+          assert_equal ip, @conn.type_cast(ip, c)
         end
 
         def test_quote_float_nan


### PR DESCRIPTION
Before this commit when saving or creating a model with an inet or cidr attribute I got the error:

``` ruby
NoMethodError: undefined method `includes?' for ["inet", "cidr"]:Array
```
