### PR TITLE
Remove variables when determining the controller for match shorthand routes

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Remove variables when determining the controller for match shorthand routes.
+    Fix #7554
+
+    *Yves Senn*
+
 *   `date_select` helper accepts `with_css_classes: true` to add css classes similar with type
     of generated select tags.
 
@@ -18,7 +23,7 @@
 
     *Josh Peek*
 
-*   `assert_template` can be used to assert on the same template with different locals
+*   `assert_template` can be used to assert on the same template with different locals.
     Fix #3675
 
     *Yves Senn*

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -84,7 +84,7 @@ module ActionDispatch
 
             if using_match_shorthand?(path_without_format, @options)
               to_shorthand    = @options[:to].blank?
-              @options[:to] ||= path_without_format.gsub(/\(.*\)/, "")[1..-1].sub(%r{/([^/]*)$}, '#\1')
+              @options[:to] ||= path_without_format.gsub(/\(.*\)/, "").gsub(/\/:[^\/]+/, '')[1..-1].sub(%r{/([^/]*)$}, '#\1')
             end
 
             @options.merge!(default_controller_and_action(to_shorthand))

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -347,6 +347,10 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
         root :to => 'projects#index'
       end
 
+      scope ':locale' do
+        match 'questions/new', via: [:get]
+      end
+
       scope :only => [:index, :show] do
         resources :products, :constraints => { :id => /\d{4}/ } do
           root :to => "products#root"
@@ -1409,6 +1413,12 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
     get '/en/registrations/new'
     assert_equal 'en', @request.params[:locale]
+  end
+
+  def test_match_within_scope
+    get '/de/questions/new'
+    assert_equal 'questions#new', @response.body
+    assert_equal 'de', @request.params[:locale]
   end
 
   def test_default_params


### PR DESCRIPTION
When match is used inside a scope that contains path variables, the logic to determine the controller will return unusable results.

This patch removes the path variables from the segment, before determining the controller.
