### PR TITLE
Query methods allowed for include option for collections.

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -154,10 +154,15 @@ module ActiveModel
         end
 
         includes.each do |association, opts|
-          if records = send(association)
+          if records = fetch_query_methods(send(association), opts)
             yield association, records, opts
           end
         end
+      end
+
+      # Dummy method. Should be redefined in active_record serialization
+      def fetch_query_methods(records, opts)
+        records
       end
   end
 end

--- a/activerecord/lib/active_record/serialization.rb
+++ b/activerecord/lib/active_record/serialization.rb
@@ -24,6 +24,23 @@ module ActiveRecord #:nodoc:
 
       super(options)
     end
+
+    private
+      # Additional options can be provided for associations specified via the <tt>:include</tt> option.
+      #
+      # You can respond with included collections like this:
+      #
+      #   respond_with @authors, include: [books: { order: "price ASC", limit: 5, where: ["price < ?", 5] }]
+      def fetch_query_methods(records, opts)
+        limit = opts.fetch(:limit, nil)
+        order = opts.fetch(:order, nil)
+        where = opts.fetch(:where, nil)
+
+        records = records.limit(limit) if limit && records.respond_to?(:limit)
+        records = records.order(order) if order && records.respond_to?(:order)
+        records = records.where(where) if where && records.respond_to?(:where)
+        records
+      end
   end
 end
 


### PR DESCRIPTION
Now you can do things like this:
respond_with @authors, include: [books: { order: "price ASC", limit: 5, where: ["price < ?", 5] }]
or just
@authors.to_xml(include: [books: { order: "price ASC", limit: 5, where: ["price < ?", 5] }])
