### PR TITLE
Use `Rails.env` instead of `ENV['RAILS_ENV']`

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -307,7 +307,7 @@ db_namespace = namespace :db do
 
     # desc "Recreate the databases from the structure.sql file"
     task :load => [:environment, :load_config] do
-      current_config = ActiveRecord::Tasks::DatabaseTasks.current_config(:env => (ENV['RAILS_ENV'] || 'test'))
+      current_config = ActiveRecord::Tasks::DatabaseTasks.current_config
       filename = ENV['DB_STRUCTURE'] || File.join(Rails.root, "db", "structure.sql")
       case current_config['adapter']
       when /mysql/, /postgresql/, /sqlite/


### PR DESCRIPTION
`ENV['RAILS_ENV']` is not defined unless explicitly specified on the
command line when running `rake db:structure:load`. This patch lets
the rake task retrieve the environment from `Rails.env` which defaults
to "development".
