### PR TITLE
Removed useless "extend SanitizeHelper::ClassMethods"

### DIFF
--- a/actionpack/lib/action_view/helpers.rb
+++ b/actionpack/lib/action_view/helpers.rb
@@ -29,10 +29,6 @@ module ActionView #:nodoc:
 
     extend ActiveSupport::Concern
 
-    included do
-      extend SanitizeHelper::ClassMethods
-    end
-
     include ActiveModelHelper
     include AssetTagHelper
     include AssetUrlHelper


### PR DESCRIPTION
Since SanitizeHelper includes ActiveSupport::Concern,
extending of it ClassMethods is no needed.
