### PR TITLE
Adds an :unknown column type.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -301,6 +301,8 @@ module ActiveRecord
             :string
           when /boolean/i
             :boolean
+          else
+            :unknown
           end
         end
     end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -411,6 +411,16 @@ class MigrationTest < ActiveRecord::TestCase
     Person.connection.drop_table :test_limits rescue nil
   end
 
+  def test_typo_in_column_type
+    assert_nothing_raised do
+      ActiveRecord::Migrator.up(MIGRATIONS_ROOT + "/type_typo")
+    end
+    
+    assert_nothing_raised do
+      ActiveRecord::Migrator.down(MIGRATIONS_ROOT + "/type_typo")
+    end
+  end
+
   protected
     def with_env_tz(new_tz = 'US/Eastern')
       old_tz, ENV['TZ'] = ENV['TZ'], new_tz

--- a/activerecord/test/migrations/type_typo/1_people_write_buggy_migrations.rb
+++ b/activerecord/test/migrations/type_typo/1_people_write_buggy_migrations.rb
@@ -1,0 +1,9 @@
+class PeopleWriteBuggyMigrations < ActiveRecord::Migration
+  def self.up
+    add_column "people", "type_typos", :bool
+  end
+
+  def self.down
+    remove_column "people", "type_typos"
+  end
+end


### PR DESCRIPTION
Trying to fix an "issue" where an unnoticed typo in the type parameter
of a migration could lead to data loss.

Using this example :

```
class PeopleWriteBuggyMigrations < ActiveRecord::Migration
  def self.up
    add_column "people", "type_typos", :bool
  end

  def self.down
    remove_column "people", "type_typos"
  end
end
```

This migration will run fine and without warning(s), but if you try to
remove this column later, active record would fail :
- SQLite cannot directly drop a column, so a temp table is used.
- AR then tries to create a temp table with the same structure.
- the #simplified_type method of the Column class is called at some point
- since the type doesn't exists it returns nil
- migration fails in a very ugly fashion.
- user has to fix it manually (dangerous and time comsuming) but will
  be tempted to fix the faulty migration, drop the db and migrate
  again.

This commit add tests for this issue and runs rake test_sqlite3 without error.

This is my first rails pull request, so i hope althought i read the guidelines i didn't make too big mistakes. I would really enjoy getting comments on this PR.

Thanks lovely community.
