### PR TITLE
Ignore asset url query string or anchor when generating path

### DIFF
--- a/actionpack/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionpack/lib/action_view/helpers/asset_url_helper.rb
@@ -122,6 +122,8 @@ module ActionView
         return "" unless source.present?
         return source if source =~ URI_REGEXP
 
+        tail, source = source[/([\?#].+)$/], source.sub(/([\?#].+)$/, '')
+
         if extname = compute_asset_extname(source, options)
           source = "#{source}#{extname}"
         end
@@ -140,7 +142,7 @@ module ActionView
           source = "#{host}#{source}"
         end
 
-        source
+        "#{source}#{tail}"
       end
       alias_method :path_to_asset, :asset_path # aliased to avoid conflicts with a asset_path named route
 

--- a/actionpack/test/template/asset_tag_helper_test.rb
+++ b/actionpack/test/template/asset_tag_helper_test.rb
@@ -73,7 +73,12 @@ class AssetTagHelperTest < ActionView::TestCase
     %(javascript_path("super/xmlhr")) => %(/javascripts/super/xmlhr.js),
     %(javascript_path("/super/xmlhr.js")) => %(/super/xmlhr.js),
     %(javascript_path("xmlhr.min")) => %(/javascripts/xmlhr.min.js),
-    %(javascript_path("xmlhr.min.js")) => %(/javascripts/xmlhr.min.js)
+    %(javascript_path("xmlhr.min.js")) => %(/javascripts/xmlhr.min.js),
+
+    %(javascript_path("xmlhr.js?123")) => %(/javascripts/xmlhr.js?123),
+    %(javascript_path("xmlhr.js?body=1")) => %(/javascripts/xmlhr.js?body=1),
+    %(javascript_path("xmlhr.js#hash")) => %(/javascripts/xmlhr.js#hash),
+    %(javascript_path("xmlhr.js?123#hash")) => %(/javascripts/xmlhr.js?123#hash)
   }
 
   PathToJavascriptToTag = {
@@ -285,6 +290,14 @@ class AssetTagHelperTest < ActionView::TestCase
     %(audio_tag(["audio.mp3", "audio.ogg"], :autobuffer => true, :controls => true)) => %(<audio autobuffer="autobuffer" controls="controls"><source src="/audios/audio.mp3" /><source src="/audios/audio.ogg" /></audio>)
   }
 
+  FontPathToTag = {
+    %(font_path("font.eot")) => %(/fonts/font.eot),
+    %(font_path("font.eot#iefix")) => %(/fonts/font.eot#iefix),
+    %(font_path("font.woff")) => %(/fonts/font.woff),
+    %(font_path("font.ttf")) => %(/fonts/font.ttf),
+    %(font_path("font.ttf?123")) => %(/fonts/font.ttf?123)
+  }
+
   def test_autodiscovery_link_tag_deprecated_types
     result = nil
     assert_deprecated do
@@ -464,6 +477,10 @@ class AssetTagHelperTest < ActionView::TestCase
 
   def test_audio_tag
     AudioLinkToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
+  end
+
+  def test_font_path
+    FontPathToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
   end
 
   def test_video_audio_tag_does_not_modify_options


### PR DESCRIPTION
This one's pretty straight forward.

``` ruby
javascript_path "foo.js?body=1"

# common font-face icon hack
font_path "octicons.eot#iefix"
```

/cc @rafaelfranca
