### PR TITLE
Adding reference a few Time and Date aliases in Rails 4.0 release notes

### DIFF
--- a/guides/source/4_0_release_notes.md
+++ b/guides/source/4_0_release_notes.md
@@ -810,6 +810,10 @@ Active Support
 
 *   Add `Time#prev_quarter` and `Time#next_quarter` short-hands for `months_ago(3)` and `months_since(3)`.
 
+*   Add `Time#last_week`, `Time#last_month`, `Time#last_year` as aliases for `Time#prev_week`, `Time#prev_month`, and `Time#prev_year`.
+
+*   Add `Date#last_week`, `Date#last_month`, `Date#last_year` as aliases for `Date#prev_week`, `Date#prev_month`, and `Date#prev_year`.
+
 *   Remove obsolete and unused `require_association` method from dependencies.
 
 *   Add `:instance_accessor` option for `config_accessor`.


### PR DESCRIPTION
I originally contributed these aliases 10 months ago and just never got it added to the Rails 4.0 release notes. Here they are.
