### PR TITLE
Fixes #7950: Has many include for new records

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -137,6 +137,12 @@
 
     *Seamus Abshere*
 
+*   Calling `include?` on `has_many` associations on unsaved records no longer
+    returns `true` when passed a record with a `nil` foreign key.
+    Fixes #7950.
+
+    *George Brocklehurst*
+
 
 ## Rails 3.2.8 (Aug 9, 2012) ##
 

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -319,7 +319,7 @@ module ActiveRecord
 
       def include?(record)
         if record.is_a?(reflection.klass)
-          if record.new_record?
+          if record.new_record? || owner.new_record?
             include_in_memory?(record)
           else
             load_target if options[:finder_sql]

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1225,6 +1225,12 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert companies(:first_firm).clients.include?(Client.find(2))
   end
 
+  def test_included_in_collection_for_new_records
+    client = Client.create(:name => 'Persisted')
+    assert_nil client.client_of
+    assert !Firm.new.clients_of_firm.include?(client), 'includes not belonging client'
+  end
+
   def test_adding_array_and_collection
     assert_nothing_raised { Firm.find(:first).clients + Firm.find(:all).last.clients }
   end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1228,7 +1228,8 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_included_in_collection_for_new_records
     client = Client.create(:name => 'Persisted')
     assert_nil client.client_of
-    assert !Firm.new.clients_of_firm.include?(client), 'includes not belonging client'
+    assert !Firm.new.clients_of_firm.include?(client),
+           'includes a client that does not belong to any firm'
   end
 
   def test_adding_array_and_collection


### PR DESCRIPTION
Fixes incorrect behaviour of `#include?` on `has_many` associations for unsaved records.  See issue #7950 for code examples and a discussion of the bug.
