### PR TITLE
Use the MySQL varbinary type when appropriate in migrations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Small binary fields use the `VARBINARY` MySQL type, instead of `TINYBLOB`.
+
+    *Victor Costan*
+
 *   Decode URI encoded attributes on database connection URLs.
 
     *Shawn Veader*

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -498,6 +498,13 @@ module ActiveRecord
       # Maps logical Rails types to MySQL-specific data types.
       def type_to_sql(type, limit = nil, precision = nil, scale = nil)
         case type.to_s
+        when 'binary'
+          case limit
+          when 0..0xfff;           "varbinary(#{limit})"
+          when nil;                "blob"
+          when 0x1000..0xffffffff; "blob(#{limit})"
+          else raise(ActiveRecordError, "No binary type has character length #{limit}")
+          end
         when 'integer'
           case limit
           when 1; 'tinyint'

--- a/activerecord/test/cases/adapters/mysql/sql_types_test.rb
+++ b/activerecord/test/cases/adapters/mysql/sql_types_test.rb
@@ -1,0 +1,14 @@
+require "cases/helper"
+
+class SqlTypesTest < ActiveRecord::TestCase
+  def test_binary_types
+    assert_equal 'varbinary(64)', type_to_sql(:binary, 64)
+    assert_equal 'varbinary(4095)', type_to_sql(:binary, 4095)
+    assert_equal 'blob(4096)', type_to_sql(:binary, 4096)
+    assert_equal 'blob', type_to_sql(:binary)
+  end
+
+  def type_to_sql(*args)
+    ActiveRecord::Base.connection.type_to_sql(*args)
+  end
+end

--- a/activerecord/test/cases/adapters/mysql2/sql_types_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/sql_types_test.rb
@@ -1,0 +1,14 @@
+require "cases/helper"
+
+class SqlTypesTest < ActiveRecord::TestCase
+  def test_binary_types
+    assert_equal 'varbinary(64)', type_to_sql(:binary, 64)
+    assert_equal 'varbinary(4095)', type_to_sql(:binary, 4095)
+    assert_equal 'blob(4096)', type_to_sql(:binary, 4096)
+    assert_equal 'blob', type_to_sql(:binary)
+  end
+
+  def type_to_sql(*args)
+    ActiveRecord::Base.connection.type_to_sql(*args)
+  end
+end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -203,6 +203,12 @@ class SchemaDumperTest < ActiveRecord::TestCase
       assert_match %r{t.text\s+"body",\s+null: false$}, output
     end
 
+    def test_schema_dump_includes_length_for_mysql_binary_fields
+      output = standard_dump
+      assert_match %r{t.binary\s+"var_binary",\s+limit: 255$}, output
+      assert_match %r{t.binary\s+"var_binary_large",\s+limit: 4095$}, output
+    end
+
     def test_schema_dump_includes_length_for_mysql_blob_and_text_fields
       output = standard_dump
       assert_match %r{t.binary\s+"tiny_blob",\s+limit: 255$}, output

--- a/activerecord/test/schema/mysql2_specific_schema.rb
+++ b/activerecord/test/schema/mysql2_specific_schema.rb
@@ -1,14 +1,18 @@
 ActiveRecord::Schema.define do
-  create_table :binary_fields, :force => true do |t|
-    t.binary :tiny_blob,   :limit => 255
-    t.binary :normal_blob, :limit => 65535
-    t.binary :medium_blob, :limit => 16777215
-    t.binary :long_blob,   :limit => 2147483647
-    t.text   :tiny_text,   :limit => 255
-    t.text   :normal_text, :limit => 65535
-    t.text   :medium_text, :limit => 16777215
-    t.text   :long_text,   :limit => 2147483647
+  create_table :binary_fields, force: true do |t|
+    t.binary :var_binary, limit: 255
+    t.binary :var_binary_large, limit: 4095
+    t.column :tiny_blob, 'tinyblob', limit: 255
+    t.binary :normal_blob, limit: 65535
+    t.binary :medium_blob, limit: 16777215
+    t.binary :long_blob, limit: 2147483647
+    t.text   :tiny_text, limit: 255
+    t.text   :normal_text, limit: 65535
+    t.text   :medium_text, limit: 16777215
+    t.text   :long_text, limit: 2147483647
   end
+
+  add_index :binary_fields, :var_binary
 
   ActiveRecord::Base.connection.execute <<-SQL
 DROP PROCEDURE IF EXISTS ten;

--- a/activerecord/test/schema/mysql_specific_schema.rb
+++ b/activerecord/test/schema/mysql_specific_schema.rb
@@ -1,14 +1,18 @@
 ActiveRecord::Schema.define do
-  create_table :binary_fields, :force => true do |t|
-    t.binary :tiny_blob,   :limit => 255
-    t.binary :normal_blob, :limit => 65535
-    t.binary :medium_blob, :limit => 16777215
-    t.binary :long_blob,   :limit => 2147483647
-    t.text   :tiny_text,   :limit => 255
-    t.text   :normal_text, :limit => 65535
-    t.text   :medium_text, :limit => 16777215
-    t.text   :long_text,   :limit => 2147483647
+  create_table :binary_fields, force: true do |t|
+    t.binary :var_binary, limit: 255
+    t.binary :var_binary_large, limit: 4095
+    t.column :tiny_blob, 'tinyblob', limit: 255
+    t.binary :normal_blob, limit: 65535
+    t.binary :medium_blob, limit: 16777215
+    t.binary :long_blob, limit: 2147483647
+    t.text   :tiny_text, limit: 255
+    t.text   :normal_text, limit: 65535
+    t.text   :medium_text, limit: 16777215
+    t.text   :long_text, limit: 2147483647
   end
+
+  add_index :binary_fields, :var_binary
 
   ActiveRecord::Base.connection.execute <<-SQL
 DROP PROCEDURE IF EXISTS ten;


### PR DESCRIPTION
Currently, the mysql adapters use blob types for all `binary` columns. Blobs require extra care when used as keys in indexes, and have some performance caveats [1].

This change uses `varbinary` for `binary` columns that specify a `limit` <= 255 bytes. The test changes indirectly verify the code, as the `add_index` statement fails if the `tiny_blob` column uses a blob type. I can add a direct test if that is desirable.

Thank you for considering this pull request!

[1] http://dev.mysql.com/doc/refman/5.5/en/blob.html 
