### PR TITLE
Add #seconds_until_end_of_day to DateTime and Time

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add `DateTime#seconds_until_end_of_day` and `Time#seconds_until_end_of_day`
+    as a complement for `seconds_from_midnight`; useful when setting expiration
+    times for caches, e.g.:
+
+        <% cache('dashboard', expires_in: Date.current.seconds_until_end_of_day) do %>
+          ...
+
+    *Olek Janiszewski*
+
 *   No longer proxy ActiveSupport::Multibyte#class. *Steve Klabnik*
 
 *   Deprecate `ActiveSupport::TestCase#pending` method, use `skip` from MiniTest instead. *Carlos Antonio da Silva*
@@ -65,7 +74,7 @@
 
     *Jeremy Kemper*
 
-*   Add logger.push_tags and .pop_tags to complement logger.tagged:
+*   Add `logger.push_tags` and `.pop_tags` to complement logger.tagged:
 
         class Job
           def before

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -32,6 +32,15 @@ class DateTime
     sec + (min * 60) + (hour * 3600)
   end
 
+  # Returns the number of seconds until 23:59:59.
+  #
+  #   DateTime.new(2012, 8, 29,  0,  0,  0).seconds_until_end_of_day # => 86399
+  #   DateTime.new(2012, 8, 29, 12, 34, 56).seconds_until_end_of_day # => 41103
+  #   DateTime.new(2012, 8, 29, 23, 59, 59).seconds_until_end_of_day # => 0
+  def seconds_until_end_of_day
+    end_of_day.to_i - to_i
+  end
+
   # Returns a new DateTime where one or more of the elements have been changed
   # according to the +options+ parameter. The time options (<tt>:hour</tt>,
   # <tt>:minute</tt>, <tt>:sec</tt>) reset cascadingly, so if only the hour is

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -62,6 +62,15 @@ class Time
     to_i - change(:hour => 0).to_i + (usec / 1.0e+6)
   end
 
+  # Returns the number of seconds until 23:59:59.
+  #
+  #   Time.new(2012, 8, 29,  0,  0,  0).seconds_until_end_of_day # => 86399
+  #   Time.new(2012, 8, 29, 12, 34, 56).seconds_until_end_of_day # => 41103
+  #   Time.new(2012, 8, 29, 23, 59, 59).seconds_until_end_of_day # => 0
+  def seconds_until_end_of_day
+    end_of_day.to_i - to_i
+  end
+
   # Returns a new Time where one or more of the elements have been changed according
   # to the +options+ parameter. The time options (<tt>:hour</tt>, <tt>:min</tt>,
   # <tt>:sec</tt>, <tt>:usec</tt>) reset cascadingly, so if only the hour is passed,

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -61,6 +61,14 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal 86399,DateTime.civil(2005,1,1,23,59,59).seconds_since_midnight
   end
 
+  def test_seconds_until_end_of_day
+    assert_equal 0, DateTime.civil(2005,1,1,23,59,59).seconds_until_end_of_day
+    assert_equal 1, DateTime.civil(2005,1,1,23,59,58).seconds_until_end_of_day
+    assert_equal 60, DateTime.civil(2005,1,1,23,58,59).seconds_until_end_of_day
+    assert_equal 3660, DateTime.civil(2005,1,1,22,58,59).seconds_until_end_of_day
+    assert_equal 86399, DateTime.civil(2005,1,1,0,0,0).seconds_until_end_of_day
+  end
+
   def test_beginning_of_day
     assert_equal DateTime.civil(2005,2,4,0,0,0), DateTime.civil(2005,2,4,10,10,10).beginning_of_day
   end

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -57,6 +57,54 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_seconds_until_end_of_day
+    assert_equal 0, Time.local(2005,1,1,23,59,59).seconds_until_end_of_day
+    assert_equal 1, Time.local(2005,1,1,23,59,58).seconds_until_end_of_day
+    assert_equal 60, Time.local(2005,1,1,23,58,59).seconds_until_end_of_day
+    assert_equal 3660, Time.local(2005,1,1,22,58,59).seconds_until_end_of_day
+    assert_equal 86399, Time.local(2005,1,1,0,0,0).seconds_until_end_of_day
+  end
+
+  def test_seconds_until_end_of_day_at_daylight_savings_time_start
+    with_env_tz 'US/Eastern' do
+      # dt: US: 2005 April 3rd 2:00am ST => April 3rd 3:00am DT
+      assert_equal 21*3600, Time.local(2005,4,3,1,59,59).seconds_until_end_of_day, 'just before DST start'
+      assert_equal 21*3600-2, Time.local(2005,4,3,3,0,1).seconds_until_end_of_day, 'just after DST start'
+    end
+
+    with_env_tz 'NZ' do
+      # dt: New Zealand: 2006 October 1st 2:00am ST => October 1st 3:00am DT
+      assert_equal 21*3600, Time.local(2006,10,1,1,59,59).seconds_until_end_of_day, 'just before DST start'
+      assert_equal 21*3600-2, Time.local(2006,10,1,3,0,1).seconds_until_end_of_day, 'just after DST start'
+    end
+  end
+
+  def test_seconds_until_end_of_day_at_daylight_savings_time_end
+    with_env_tz 'US/Eastern' do
+      # st: US: 2005 October 30th 2:00am DT => October 30th 1:00am ST
+      # avoid setting a time between 1:00 and 2:00 since that requires specifying whether DST is active
+      assert_equal 24*3600, Time.local(2005,10,30,0,59,59).seconds_until_end_of_day, 'just before DST end'
+      assert_equal 22*3600-2, Time.local(2005,10,30,2,0,1).seconds_until_end_of_day, 'just after DST end'
+
+      # now set a time between 1:00 and 2:00 by specifying whether DST is active
+      # uses: Time.local( sec, min, hour, day, month, year, wday, yday, isdst, tz )
+      assert_equal 24*3600-30*60-1, Time.local(0,30,1,30,10,2005,0,0,true,ENV['TZ']).seconds_until_end_of_day, 'before DST end'
+      assert_equal 23*3600-30*60-1, Time.local(0,30,1,30,10,2005,0,0,false,ENV['TZ']).seconds_until_end_of_day, 'after DST end'
+    end
+
+    with_env_tz 'NZ' do
+      # st: New Zealand: 2006 March 19th 3:00am DT => March 19th 2:00am ST
+      # avoid setting a time between 2:00 and 3:00 since that requires specifying whether DST is active
+      assert_equal 23*3600, Time.local(2006,3,19,1,59,59).seconds_until_end_of_day, 'just before DST end'
+      assert_equal 21*3600-2, Time.local(2006,3,19,3,0,1).seconds_until_end_of_day, 'just after DST end'
+
+      # now set a time between 2:00 and 3:00 by specifying whether DST is active
+      # uses: Time.local( sec, min, hour, day, month, year, wday, yday, isdst, tz )
+      assert_equal 23*3600-30*60-1, Time.local(0,30,2,19,3,2006,0,0,true, ENV['TZ']).seconds_until_end_of_day, 'before DST end'
+      assert_equal 22*3600-30*60-1, Time.local(0,30,2,19,3,2006,0,0,false,ENV['TZ']).seconds_until_end_of_day, 'after DST end'
+    end
+  end
+
   def test_beginning_of_day
     assert_equal Time.local(2005,2,4,0,0,0), Time.local(2005,2,4,10,10,10).beginning_of_day
     with_env_tz 'US/Eastern' do


### PR DESCRIPTION
Add `DateTime#seconds_until_end_of_day` and `Time#seconds_until_end_of_day`
as a complement for `seconds_from_midnight`; useful when setting expiration
times for caches, e.g.:

``` erb
<% cache('dashboard', expires_in: Date.current.seconds_until_end_of_day) do %>
  ...
```
