### PR TITLE
Use pessimistic locking to prevent calling destroy callbacks

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -910,4 +910,10 @@
 
     *Aaron Patterson*
 
+*   Destroy callbacks are only called if the row to be deleted has not already
+    been deleted by another process. This feature is only available if the database
+    supports a pessimistic locking mechanism.
+
+   *Brian Durand*
+
 Please check [3-2-stable](https://github.com/rails/rails/blob/3-2-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -252,7 +252,16 @@ module ActiveRecord
     end
 
     def destroy #:nodoc:
-      run_callbacks(:destroy) { super }
+      # Select the row to delete using a database lock before running the callbacks so that callbacks
+      # won't be run if the row has already been deleted by another process.
+      klass = self.class
+      sql = klass.where(klass.primary_key => self.id).select(klass.primary_key).lock(true).to_sql
+      row_exists = !!klass.connection.select_one(sql)
+      if row_exists
+        run_callbacks(:destroy) { super }
+      else
+        super
+      end
     end
 
     def touch(*) #:nodoc:

--- a/activerecord/test/cases/associations/callbacks_test.rb
+++ b/activerecord/test/cases/associations/callbacks_test.rb
@@ -6,7 +6,7 @@ require 'models/developer'
 require 'models/company'
 
 class AssociationCallbacksTest < ActiveRecord::TestCase
-  fixtures :posts, :authors, :projects, :developers
+  fixtures :posts, :authors, :projects, :developers, :companies
 
   def setup
     @david = authors(:david)
@@ -164,5 +164,19 @@ class AssociationCallbacksTest < ActiveRecord::TestCase
     assert !@david.unchangable_posts.include?(@authorless)
     @david.reload
     assert !@david.unchangable_posts.include?(@authorless)
+  end
+
+  def test_call_destroy_callbacks_only_if_row_still_exists
+    client_1 = companies(:first_client)
+    client_2 = companies(:second_client)
+
+    # force raise error if callbacks called on client_1
+    client_1.raise_on_destroy = true
+    Client.delete_all(:id => client_1.id)
+    assert_nothing_raised{ client_1.destroy }
+    client_2.destroy
+
+    assert client_1.destroyed?
+    assert client_2.destroyed?
   end
 end


### PR DESCRIPTION
This change adds a pessimistic lock attempt before calling destroy callbacks on an ActiveRecord model. This is a work around for a race condition where a record is destroyed by concurrent processes. The record will only be deleted once, but the callbacks based on that deletion will be called multiple times. This can mess up logic like the association counter cache which is invoked by a callback.

The change adds a select call with lock => true before destroying so the database can lock the record (if it supports this mechanism). If the record no longer exists, then the callbacks are not called. The rest of the destroy chain is called so that the record will remain in a consistent state.
