### PR TITLE
Add an if statement to not raise an exception when the user can't use the debugger gem

### DIFF
--- a/railties/lib/rails/commands/console.rb
+++ b/railties/lib/rails/commands/console.rb
@@ -79,12 +79,14 @@ module Rails
     end
 
     def require_debugger
-      begin
-        require 'debugger'
-        puts "=> Debugger enabled"
-      rescue Exception
-        puts "You're missing the 'debugger' gem. Add it to your Gemfile, bundle, and try again."
-        exit
+      if RUBY_VERSION < "2.0" && RUBY_PATCHLEVEL < 286
+        begin
+          require 'debugger'
+          puts "=> Debugger enabled"
+        rescue Exception
+          puts "You're missing the 'debugger' gem. Add it to your Gemfile, bundle, and try again."
+          exit
+        end
       end
     end
   end


### PR DESCRIPTION
Hi,

Just a little pull request thanks to @jeremy, just a little fix to ensure users can load the debugger gem if they have a version which allows him to load it.

Have a nice day.
