### PR TITLE
Only compile non-js/css under app/assets by default

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -50,7 +50,7 @@ module Rails
         @assets = ActiveSupport::OrderedOptions.new
         @assets.enabled                  = false
         @assets.paths                    = []
-        @assets.precompile               = [ Proc.new { |path| !%w(.js .css).include?(File.extname(path)) },
+        @assets.precompile               = [ Proc.new { |path, fn| fn =~ /app\/assets/ && !%w(.js .css).include?(File.extname(path)) },
                                              /(?:\/|\\|\A)application\.(css|js)$/ ]
         @assets.prefix                   = "/assets"
         @assets.version                  = ''


### PR DESCRIPTION
This has been bugging me forever.

I have a few packaged asset gems that have other loose files under their load path like README.mds. Those get copied over and digested to `public/assets`. This happens more often with bower packages.

The other thing is that these libraries have many optional parts. You don't always want all the images and other stuff copied over unless you say so.

I'm suggesting that we only auto compile "loose" files under `app/asset` paths. This would include railtie gems. So if you do `app/assets` in your gem, those are auto included. `lib/assets` and `vendor/assets` are by hand. I think that this models Rails' default autoloading strategy of `app/` is autoloaded and autorequired, while `lib/` and `vendor/` have to be explicit.

Depends on #7964 being merged first.

/cc @dhh 
