### PR TITLE
active_model/validations requires necessary files to run

### DIFF
--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -3,6 +3,7 @@ require 'active_support/core_ext/hash/keys'
 require 'active_support/core_ext/hash/except'
 require 'active_model/errors'
 require 'active_model/validations/callbacks'
+require 'active_model/validator'
 
 module ActiveModel
 

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -233,7 +233,7 @@ module ActiveModel
     #
     #   person = Person.new
     #   person.valid? # => false
-    #   person.errors # => #<ActiveModel::Errors:0x007fe603816640 @messages={:name=>["can't be blank"]}>
+    #   person.errors # => #<ActiveModel::Errors:0x007fe603816640 @messages={:name=>["can't be blank"]}>
     def errors
       @errors ||= Errors.new(self)
     end
@@ -250,7 +250,7 @@ module ActiveModel
     #
     #   person = Person.new
     #   person.name = ''
-    #   person.valid? # => false
+    #   person.valid? # => false
     #   person.name = 'david'
     #   person.valid? # => true
     #
@@ -265,7 +265,7 @@ module ActiveModel
     #   end
     #
     #   person = Person.new
-    #   person.valid?       # => true
+    #   person.valid?       # => true
     #   person.valid?(:new) # => false
     def valid?(context = nil)
       current_context, self.validation_context = validation_context, context
@@ -287,7 +287,7 @@ module ActiveModel
     #
     #   person = Person.new
     #   person.name = ''
-    #   person.invalid? # => true
+    #   person.invalid? # => true
     #   person.name = 'david'
     #   person.invalid? # => false
     #
@@ -302,7 +302,7 @@ module ActiveModel
     #   end
     #
     #   person = Person.new
-    #   person.invalid?       # => false
+    #   person.invalid?       # => false
     #   person.invalid?(:new) # => true
     def invalid?(context = nil)
       !valid?(context)


### PR DESCRIPTION
While writing isolated unit-tests I noticed that `active_model/validations` does not require the necessary files to run.

``` shell
ruby -I activemodel/lib -I activesupport/lib -e "require 'active_support/all'; require 'active_model/validations'"
```

results in

```
/rails/activemodel/lib/active_model/validations/acceptance.rb:5:in `<module:Validations>': uninitialized constant ActiveModel::Validations::EachValidator (NameError)
```

I added the necessary require statement to get everything working.
