### PR TITLE
Implement HashWithIndifferentAccess#replace so key? works correctly.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Implement HashWithIndifferentAccess#replace so key? works correctly. *David Graham*
+
 *   Hash#extract! returns only those keys that present in the receiver.
 
         {:a => 1, :b => 2}.extract!(:a, :x) # => {:a => 1}

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -204,6 +204,14 @@ module ActiveSupport
       replace(reverse_merge( other_hash ))
     end
 
+    # Replaces the contents of this hash with other_hash.
+    #
+    #   h = { "a" => 100, "b" => 200 }
+    #   h.replace({ "c" => 300, "d" => 400 }) #=> {"c"=>300, "d"=>400}
+    def replace(other_hash)
+      super(self.class.new_from_hash_copying_default(other_hash))
+    end
+
     # Removes the specified key from the hash.
     def delete(key)
       super(convert_key(key))

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -428,6 +428,18 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal 2, hash['b']
   end
 
+  def test_indifferent_replace
+    hash = HashWithIndifferentAccess.new
+    hash[:a] = 42
+
+    replaced = hash.replace(b: 12)
+
+    assert hash.key?('b')
+    assert !hash.key?(:a)
+    assert_equal 12, hash[:b]
+    assert_same hash, replaced
+  end
+
   def test_indifferent_merging_with_block
     hash = HashWithIndifferentAccess.new
     hash[:a] = 1


### PR DESCRIPTION
After calling `replace` all calls to `key?` return false.

``` ruby
hash = HashWithIndifferentAccess.new(a: 42)
hash.key?('a')      #=> true
hash.replace(b: 12) #=> {b: 12}
hash.key?('b')      #=> false
hash.key?(:b)       #=> false
```

This branch adds a simple implementation of replace so key? will work.
