### PR TITLE
Fix bug with presence validation of associations.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix bug with presence validation of associations. Would incorrectly add duplicated errors 
+    when the association was blank. Bug introduced in 1fab518c6a75dac5773654646eb724a59741bc13.
+
+    *Scott Willson*
+
 *   Fix bug where sum(expression) returns string '0' for no matching records
     Fixes #7439
 

--- a/activerecord/lib/active_record/validations/presence.rb
+++ b/activerecord/lib/active_record/validations/presence.rb
@@ -5,8 +5,10 @@ module ActiveRecord
         super
         attributes.each do |attribute|
           next unless record.class.reflect_on_association(attribute)
-          value = record.send(attribute)
-          if Array(value).all? { |r| r.marked_for_destruction? }
+          associated_records = Array(record.send(attribute))
+
+          # Superclass validates presence. Ensure present records aren't about to be destroyed.
+          if associated_records.present? && associated_records.all? { |r| r.marked_for_destruction? }
             record.errors.add(attribute, :blank, options)
           end
         end

--- a/activerecord/test/cases/validations/presence_validation_test.rb
+++ b/activerecord/test/cases/validations/presence_validation_test.rb
@@ -18,6 +18,13 @@ class PresenceValidationTest < ActiveRecord::TestCase
     assert b.valid?
   end
 
+  def test_validates_presence_of_has_one
+    Boy.validates_presence_of(:face)
+    b = Boy.new
+    assert b.invalid?, "should not be valid if has_one association missing"
+    assert_equal 1, b.errors[:face].size, "validates_presence_of should only add one error"
+  end
+
   def test_validates_presence_of_has_one_marked_for_destruction
     Boy.validates_presence_of(:face)
     b = Boy.new


### PR DESCRIPTION
A recent commit to edge Rails rails/rails@1fab518
correctly considers marked for destruction associations as blank, but
incorrectly adds a duplicate error for blank has_one and belongs_to associations.

This pull request fixes this.

Example:
Boy.validates_presence_of(:face)
b = Boy.new
b.errors.full_messages

["Face can't be blank", "Face can't be blank"]

Fumbled the git squash so opened a second pull request.
