### PR TITLE
Don't HTML escape ActionMailer plaintext templates

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -23,6 +23,13 @@
 
     *Josh Peek*
 
+*   Introduce ActionView::Template::Handlers::ERB.escape_whitelist. Contains a list
+    of mime types where text is not html escaped by default. Prevents `Jack & Joe`
+    from rendering as `Jack &amp; Joe` in plain text emails. The default whitelist
+    contains text/plain and text/rtf. Fix #7976
+
+    *Joost Baaij*
+
 *   `assert_template` can be used to assert on the same template with different locals
     Fix #3675
 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -13,6 +13,13 @@
 
     *Josh Peek*
 
+*   Introduce ActionView::Template::Handlers::ERB.escape_whitelist. Contains a list
+    of mime types where text is not html escaped by default. Prevents `Jack & Joe`
+    from rendering as `Jack &amp; Joe` in plain text emails. The default whitelist
+    contains text/plain and text/rtf. Fix #7976
+
+    *Joost Baaij*
+
 *   `assert_template` can be used to assert on the same template with different locals
     Fix #3675
 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Introduce ActionView::Template::Handlers::ERB.escape_whitelist. Contains a list
+    of mime types where text is not html escaped by default. Prevents `Jack & Joe`
+    from rendering as `Jack &amp; Joe` in plain text emails. The default whitelist
+    contains text/plain and text/rtf. Fix #7976
+
+    *Joost Baaij*
+
 *   `assert_template` can be used to assert on the same template with different locals
     Fix #3675
 

--- a/actionpack/lib/action_view/template/handlers/erb.rb
+++ b/actionpack/lib/action_view/template/handlers/erb.rb
@@ -47,6 +47,10 @@ module ActionView
         class_attribute :erb_implementation
         self.erb_implementation = Erubis
 
+        # Do not escape templates of these mime types.
+        class_attribute :escape_whitelist
+        self.escape_whitelist = ["text/plain", "text/rtf"]
+
         ENCODING_TAG = Regexp.new("\\A(<%#{ENCODING_FLAG}-?%>)[ \\t]*")
 
         def self.call(template)
@@ -78,6 +82,7 @@ module ActionView
 
           self.class.erb_implementation.new(
             erb,
+            :escape => (self.class.escape_whitelist.include? template.type),
             :trim => (self.class.erb_trim_mode == "-")
           ).src
         end

--- a/actionpack/lib/action_view/template/handlers/erb.rb
+++ b/actionpack/lib/action_view/template/handlers/erb.rb
@@ -49,7 +49,7 @@ module ActionView
 
         # Do not escape templates of these mime types.
         class_attribute :escape_whitelist
-        self.escape_whitelist = ["text/plain", "text/rtf"]
+        self.escape_whitelist = ["text/plain"]
 
         ENCODING_TAG = Regexp.new("\\A(<%#{ENCODING_FLAG}-?%>)[ \\t]*")
 

--- a/actionpack/test/template/template_test.rb
+++ b/actionpack/test/template/template_test.rb
@@ -51,7 +51,7 @@ class TestERBTemplate < ActiveSupport::TestCase
     end
   end
 
-  def new_template(body = "<%= hello %>", details = {:format => :html})
+  def new_template(body = "<%= hello %>", details = {format: html})
     ActionView::Template.new(body, "hello template", details.fetch(:handler) { ERBHandler }, {:virtual_path => "hello"}.merge!(details))
   end
 
@@ -81,7 +81,7 @@ class TestERBTemplate < ActiveSupport::TestCase
   end
 
   def test_text_template_does_not_html_escape
-    @template = new_template("<%= apostrophe %>", :format => :text)
+    @template = new_template("<%= apostrophe %>", format: text)
     assert_equal "l'apostrophe", render
   end
 

--- a/actionpack/test/template/template_test.rb
+++ b/actionpack/test/template/template_test.rb
@@ -25,6 +25,10 @@ class TestERBTemplate < ActiveSupport::TestCase
       "Hello"
     end
 
+    def apostrophe
+      "l'apostrophe"
+    end
+
     def partial
       ActionView::Template.new(
         "<%= @virtual_path %>",
@@ -47,7 +51,7 @@ class TestERBTemplate < ActiveSupport::TestCase
     end
   end
 
-  def new_template(body = "<%= hello %>", details = {})
+  def new_template(body = "<%= hello %>", details = {:format => :html})
     ActionView::Template.new(body, "hello template", details.fetch(:handler) { ERBHandler }, {:virtual_path => "hello"}.merge!(details))
   end
 
@@ -69,6 +73,16 @@ class TestERBTemplate < ActiveSupport::TestCase
   def test_basic_template
     @template = new_template
     assert_equal "Hello", render
+  end
+
+  def test_basic_template_does_html_escape
+    @template = new_template("<%= apostrophe %>")
+    assert_equal "l&#39;apostrophe", render
+  end
+
+  def test_text_template_does_not_html_escape
+    @template = new_template("<%= apostrophe %>", :format => :text)
+    assert_equal "l'apostrophe", render
   end
 
   def test_raw_template


### PR DESCRIPTION
Continuation of https://github.com/rails/rails/pull/6943
