### PR TITLE
Move config.assets out into sprockets-rails plugin

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -66,7 +66,7 @@ module Rails
       end
     end
 
-    attr_accessor :assets, :sandbox, :queue_consumer
+    attr_accessor :sandbox, :queue_consumer
     alias_method :sandbox?, :sandbox
     attr_reader :reloaders
     attr_writer :queue

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -6,7 +6,7 @@ require 'rails/engine/configuration'
 module Rails
   class Application
     class Configuration < ::Rails::Engine::Configuration
-      attr_accessor :asset_host, :assets, :autoflush_log,
+      attr_accessor :asset_host, :autoflush_log,
                     :cache_classes, :cache_store, :consider_all_requests_local, :console,
                     :eager_load, :exceptions_app, :file_watcher, :filter_parameters,
                     :force_ssl, :helpers_paths, :logger, :log_formatter, :log_tags,
@@ -46,22 +46,6 @@ module Rails
         @queue                         = ActiveSupport::SynchronousQueue.new
         @queue_consumer                = nil
         @eager_load                    = nil
-
-        @assets = ActiveSupport::OrderedOptions.new
-        @assets.enabled                  = false
-        @assets.paths                    = []
-        @assets.precompile               = [ Proc.new { |path, fn| fn =~ /app\/assets/ && !%w(.js .css).include?(File.extname(path)) },
-                                             /(?:\/|\\|\A)application\.(css|js)$/ ]
-        @assets.prefix                   = "/assets"
-        @assets.version                  = ''
-        @assets.debug                    = false
-        @assets.compile                  = true
-        @assets.digest                   = false
-        @assets.cache_store              = [ :file_store, "#{root}/tmp/cache/assets/#{Rails.env}/" ]
-        @assets.js_compressor            = nil
-        @assets.css_compressor           = nil
-        @assets.initialize_on_precompile = true
-        @assets.logger                   = nil
       end
 
       def encoding=(value)

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -588,9 +588,11 @@ module Rails
     end
 
     initializer :append_assets_path, group: :all do |app|
-      app.config.assets.paths.unshift(*paths["vendor/assets"].existent_directories)
-      app.config.assets.paths.unshift(*paths["lib/assets"].existent_directories)
-      app.config.assets.paths.unshift(*paths["app/assets"].existent_directories)
+      if app.config.respond_to?(:assets)
+        app.config.assets.paths.unshift(*paths["vendor/assets"].existent_directories)
+        app.config.assets.paths.unshift(*paths["lib/assets"].existent_directories)
+        app.config.assets.paths.unshift(*paths["app/assets"].existent_directories)
+      end
     end
 
     initializer :prepend_helpers_path do |app|


### PR DESCRIPTION
Alright @rafaelfranca, got another thing.

It seems to work pretty good if the Sprockets Railtie just defines its own `config.assets` as an options set.

https://github.com/rails/sprockets-rails/blob/master/lib/sprockets/railtie.rb#L48-55
