### PR TITLE
Fix behavior of `rake db:structure:load` for 3.2.8

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -412,7 +412,7 @@ db_namespace = namespace :db do
 
     # desc "Recreate the databases from the structure.sql file"
     task :load => [:environment, :load_config] do
-      env = ENV['RAILS_ENV'] || 'test'
+      env = Rails.env
 
       abcs = ActiveRecord::Base.configurations
       filename = ENV['DB_STRUCTURE'] || File.join(Rails.root, "db", "structure.sql")


### PR DESCRIPTION
This patch fixes issue rails/rails#7951 for 3.2.8. I created a blank app and can confirm that this change restores the desired behavior to `rake db:structure:load`.

(Sorry for the messed up pull request earlier)
