### PR TITLE
Fix find_in_batches with customized primary_key on 3-2-stable

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 3.2.9 (unreleased)
 
+*   Fix `find_in_batches` crashing when IDs are strings and start option is not specified.
+
+    *Alexis Bernard*
+
 *   Fix issue with collection associations calling first(n)/last(n) and attempting
     to set the inverse association when `:inverse_of` was used. Fixes #8087.
 

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -59,11 +59,11 @@ module ActiveRecord
         relation = apply_finder_options(finder_options)
       end
 
-      start = options.delete(:start) || 0
+      start = options.delete(:start)
       batch_size = options.delete(:batch_size) || 1000
 
       relation = relation.reorder(batch_order).limit(batch_size)
-      records = relation.where(table[primary_key].gteq(start)).all
+      records = start ? relation.where(table[primary_key].gteq(start)).to_a : relation.to_a
 
       while records.any?
         records_size = records.size

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -59,7 +59,7 @@ module ActiveRecord
         relation = apply_finder_options(finder_options)
       end
 
-      start = options.delete(:start).to_i
+      start = options.delete(:start) || 0
       batch_size = options.delete(:batch_size) || 1000
 
       relation = relation.reorder(batch_order).limit(batch_size)

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -148,4 +148,13 @@ class EachTest < ActiveRecord::TestCase
 
     assert_equal nick_order_subscribers[1..-1].map(&:id), subscribers.map(&:id)
   end
+
+  def test_find_in_batches_should_use_any_column_as_primary_key_when_start_is_not_specified
+    Subscriber.count('nick') # preheat arel's table cache
+    assert_queries(Subscriber.count + 1) do
+      Subscriber.find_each(:batch_size => 1) do |subscriber|
+        assert_kind_of Subscriber, subscriber
+      end
+    end
+  end
 end

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -1,8 +1,9 @@
 require 'cases/helper'
 require 'models/post'
+require 'models/subscriber'
 
 class EachTest < ActiveRecord::TestCase
-  fixtures :posts
+  fixtures :posts, :subscribers
 
   def setup
     @posts = Post.order("id asc")
@@ -137,18 +138,14 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_find_in_batches_should_use_any_column_as_primary_key
-    old_primary_key  = Post.primary_key
-    Post.primary_key = :title
-    title_order_posts = Post.order('title asc')
-    start_title = title_order_posts.second.title
+    nick_order_subscribers = Subscriber.order('nick asc')
+    start_nick = nick_order_subscribers.second.nick
 
-    posts = []
-    Post.find_in_batches(:batch_size => 1, :start => start_title) do |batch|
-      posts.concat(batch)
+    subscribers = []
+    Subscriber.find_in_batches(:batch_size => 1, :start => start_nick) do |batch|
+      subscribers.concat(batch)
     end
 
-    assert_equal title_order_posts[1..-1].map(&:id), posts.map(&:id)
-  ensure
-    Post.primary_key = old_primary_key
+    assert_equal nick_order_subscribers[1..-1].map(&:id), subscribers.map(&:id)
   end
 end

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -136,4 +136,19 @@ class EachTest < ActiveRecord::TestCase
     assert_equal special_posts_ids, posts.map(&:id)
   end
 
+  def test_find_in_batches_should_use_any_column_as_primary_key
+    old_primary_key  = Post.primary_key
+    Post.primary_key = :title
+    title_order_posts = Post.order('title asc')
+    start_title = title_order_posts.second.title
+
+    posts = []
+    Post.find_in_batches(:batch_size => 1, :start => start_title) do |batch|
+      posts.concat(batch)
+    end
+
+    assert_equal title_order_posts[1..-1].map(&:id), posts.map(&:id)
+  ensure
+    Post.primary_key = old_primary_key
+  end
 end


### PR DESCRIPTION
Back port @spastorino fix (https://github.com/rails/rails/pull/7652) from rails4 into 3.2.

I also noticed that find_in_batches is broken with string IDs when start option is not provided, but it works perfectly when start has been given. I fixed it with a test case in commit 827942195cdf4c6f09f540b60ee7c1b7a0d051b6. Maybe I went too far with that last commit?
