### PR TITLE
backport: active_model/validations requires necessary files to run

### DIFF
--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -5,6 +5,7 @@ require 'active_support/core_ext/hash/keys'
 require 'active_support/core_ext/hash/except'
 require 'active_model/errors'
 require 'active_model/validations/callbacks'
+require 'active_model/validator'
 
 module ActiveModel
 


### PR DESCRIPTION
this is a backport of #7969.
