### PR TITLE
Credit for previous commit

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -76,6 +76,6 @@
 
 *   Trim down Active Model API by removing `valid?` and `errors.full_messages` *José Valim*
 
-*   When `^` or `$` are used in the regular expression provided to `validates_format_of` and the :multiline option is not set to true, an exception will be raised. This is to prevent security vulnerabilities when using `validates_format_of`. The problem is described in detail in the Rails security guide.
+*   When `^` or `$` are used in the regular expression provided to `validates_format_of` and the :multiline option is not set to true, an exception will be raised. This is to prevent security vulnerabilities when using `validates_format_of`. The problem is described in detail in the Rails security guide *Jan Berdajs + Egor Homakov*
 
 Please check [3-2-stable](https://github.com/rails/rails/blob/3-2-stable/activemodel/CHANGELOG.md) for previous changes.


### PR DESCRIPTION
Hey,

in my pull request that was already commited https://github.com/rails/rails/pull/6671
I forgot to include credit in the changelog (by the way, is it customary to put credit in any other place as well?). Since I see all the other changes have credit attributed I would like to include credit to myself and Egor Homakov who described the issue.
I'm not sure what the best way to do this is, so that it would not be a single commit just for this, perhaps the next time the ActiveModel changelog is changed?
Just in case I am attaching a pull request.

I'm sorry for the trouble :S

Thanks,
Jan
