### PR TITLE
truncate debug.log on each test run

### DIFF
--- a/activerecord/test/support/connection.rb
+++ b/activerecord/test/support/connection.rb
@@ -13,7 +13,8 @@ module ARTest
 
   def self.connect
     puts "Using #{connection_name}"
-    ActiveRecord::Model.logger = ActiveSupport::Logger.new("debug.log")
+    file = File.open('debug.log', 'w')
+    ActiveRecord::Model.logger = ActiveSupport::Logger.new(file)
     ActiveRecord::Model.configurations = connection_config
     ActiveRecord::Model.establish_connection 'arunit'
     ARUnit2Model.establish_connection 'arunit2'


### PR DESCRIPTION
Yesterday, I found a big 1GB file called "debug.log" inside the activerecord/test directory. It's better if we truncate the log on each test run.
