### PR TITLE
Small change to active_record/locale/en.yml

### DIFF
--- a/activerecord/lib/active_record/locale/en.yml
+++ b/activerecord/lib/active_record/locale/en.yml
@@ -4,11 +4,15 @@ en:
     #created_at: "Created at"
     #updated_at: "Updated at"
 
+  # Default error messages
+  errors:
+    messages:
+      taken: "has already been taken"
+
   # Active Record models configuration
   activerecord:
     errors:
       messages:
-        taken: "has already been taken"
         record_invalid: "Validation failed: %{errors}"
         restrict_dependent_destroy:
           one: "Cannot delete record because a dependent %{record} exists"

--- a/activerecord/test/cases/validations/i18n_generate_message_validation_test.rb
+++ b/activerecord/test/cases/validations/i18n_generate_message_validation_test.rb
@@ -54,4 +54,9 @@ class I18nGenerateMessageValidationTest < ActiveRecord::TestCase
     end
   end
 
+  test "translation for 'taken' can be overridden" do
+    I18n.backend.store_translations "en", {errors: {attributes: {title: {taken: "Custom taken message" }}}}
+    assert_equal "Custom taken message", @topic.errors.generate_message(:title, :taken, :value => 'title')
+  end
+
 end


### PR DESCRIPTION
Moved "activerecord.errors.messages.taken" to "errors.messages.taken so that translations" for, e.g., "errors.attributes.email.taken" don't get overridden. This also makes the 'taken' message consistent with the other error messages which are defined in "errors.messages".
