### PR TITLE
Revert "truncate debug.log on each test run"

### DIFF
--- a/activerecord/test/support/connection.rb
+++ b/activerecord/test/support/connection.rb
@@ -13,8 +13,7 @@ module ARTest
 
   def self.connect
     puts "Using #{connection_name}"
-    file = File.open('debug.log', 'w')
-    ActiveRecord::Model.logger = ActiveSupport::Logger.new(file)
+    ActiveRecord::Model.logger = ActiveSupport::Logger.new("debug.log")
     ActiveRecord::Model.configurations = connection_config
     ActiveRecord::Model.establish_connection 'arunit'
     ARUnit2Model.establish_connection 'arunit2'


### PR DESCRIPTION
This reverts commit 98043c689f945cabffc043f4bdc80ab2a7edc763. See #7994 .

Because if every time `debug.log` is truncated, developers have no way to see the previous ActiveRecord unit test results.

`debug.log` file size can be easily reduced by executing `$ touch /dev/null > debug.log` periodically.
