### PR TITLE
Add i18n scope to disance_of_time_in_words.

### DIFF
--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -65,6 +65,10 @@ module ActionView
       #   distance_of_time_in_words(to_time, from_time, :include_seconds => true)                     # => about 6 years
       #   distance_of_time_in_words(Time.now, Time.now)                                               # => less than a minute
       def distance_of_time_in_words(from_time, to_time = 0, include_seconds_or_options = {}, options = {})
+        options = {
+          :scope => :'datetime.distance_in_words',
+        }.merge(options)
+
         if include_seconds_or_options.is_a?(Hash)
           options = include_seconds_or_options
         else
@@ -79,7 +83,7 @@ module ActionView
         distance_in_minutes = ((to_time - from_time)/60.0).round
         distance_in_seconds = (to_time - from_time).round
 
-        I18n.with_options :locale => options[:locale], :scope => :'datetime.distance_in_words' do |locale|
+        I18n.with_options :locale => options[:locale], :scope => options[:scope] do |locale|
           case distance_in_minutes
             when 0..1
               return distance_in_minutes == 0 ?
@@ -153,9 +157,9 @@ module ActionView
       #
       # Note that you cannot pass a <tt>Numeric</tt> value to <tt>time_ago_in_words</tt>.
       #
-      def time_ago_in_words(from_time, include_seconds_or_options = {})
-        distance_of_time_in_words(from_time, Time.now, include_seconds_or_options)
-      end
+      def time_ago_in_words(from_time, include_seconds = false, options = {})
+        distance_of_time_in_words(from_time, Time.now, include_seconds, options)
+       end
 
       alias_method :distance_of_time_in_words_to_now, :time_ago_in_words
 

--- a/actionpack/test/template/date_helper_i18n_test.rb
+++ b/actionpack/test/template/date_helper_i18n_test.rb
@@ -36,16 +36,26 @@ class DateHelperDistanceOfTimeInWordsI18nTests < ActiveSupport::TestCase
     end
   end
 
-  def assert_distance_of_time_in_words_translates_key(passed, expected)
+  def test_distance_of_time_in_words_calls_i18n_with_custom_scope
+    { 
+      [30.days,             false] => [:'about_x_months',      1],
+      [60.days,             false] => [:'x_months',            2],
+    }.each do |passed, expected|
+      assert_distance_of_time_in_words_translates_key(passed, expected, {:scope => :'datetime.distance_in_words_ago'})
+    end
+  end
+
+  def assert_distance_of_time_in_words_translates_key(passed, expected, options = {})
+    
     diff, passed_options = *passed
     key, count = *expected
     to = @from + diff
 
-    options = {:locale => 'en', :scope => :'datetime.distance_in_words'}
+    options = {:locale => 'en', :scope => :'datetime.distance_in_words'}.merge(options)
     options[:count] = count if count
 
     I18n.expects(:t).with(key, options)
-    distance_of_time_in_words(@from, to, passed_options.merge(:locale => 'en'))
+    distance_of_time_in_words(@from, to, options)
   end
 
   def test_time_ago_in_words_passes_locale


### PR DESCRIPTION
This fixes #733.

Because of the spotty wifi in RubyConfAR, I couldn't get `bundle` going, and so I couldn't run the tests. I wanted to get this up here, though, and @clemenshelm says that it works fine in their application.
