### PR TITLE
check_box value can be not only an object of Array class

### DIFF
--- a/actionpack/lib/action_view/helpers/tags/check_box.rb
+++ b/actionpack/lib/action_view/helpers/tags/check_box.rb
@@ -46,10 +46,12 @@ module ActionView
             false
           when String
             value == @checked_value
-          when Array
-            value.include?(@checked_value)
           else
-            value.to_i == @checked_value.to_i
+            if value.respond_to?(:include?)
+              value.include?(@checked_value)
+            else
+              value.to_i == @checked_value.to_i
+            end
           end
         end
 

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -400,6 +400,12 @@ class FormHelperTest < ActionView::TestCase
       '<input name="post[secret]" type="hidden" value="0" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
       check_box("post", "secret")
     )
+
+    @post.secret = Set.new(['1'])
+    assert_dom_equal(
+      '<input name="post[secret]" type="hidden" value="0" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      check_box("post", "secret")
+    )
   end
 
   def test_check_box_with_include_hidden_false


### PR DESCRIPTION
there is a chance that `value` is a Set or an object that reponses to `include?` method so let's handle this case
