### PR TITLE
Remove extra line in Gemfile generated

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -7,7 +7,7 @@ source 'https://rubygems.org'
 <%= "gem 'jruby-openssl'\n" if defined?(JRUBY_VERSION) -%>
 
 <%= assets_gemfile_entry %>
-<%= javascript_gemfile_entry %>
+<%= javascript_gemfile_entry -%>
 
 # To use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.0.0'


### PR DESCRIPTION
Actually we have two lines under the turbo links.

So my commit permits to have only one line.

Before:

```
gem 'jquery-rails'

# Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
gem 'turbolinks'


# To use ActiveModel has_secure_password
# gem 'bcrypt-ruby', '~> 3.0.0'
```

After:

```
gem 'jquery-rails'

# Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
gem 'turbolinks'

# To use ActiveModel has_secure_password
# gem 'bcrypt-ruby', '~> 3.0.0'
```
