### PR TITLE
Fix default output for postgres network address types

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -1,3 +1,5 @@
+require 'ipaddr'
+
 module ActiveRecord
   module ConnectionAdapters # :nodoc:
     # The goal of this module is to move Adapter specific column
@@ -50,6 +52,15 @@ module ActiveRecord
           when Range
             # infinity dumps as Infinity, which causes uninitialized constant error
             value.inspect.gsub('Infinity', '::Float::INFINITY')
+          when IPAddr
+            subnet_mask = value.instance_variable_get(:@mask_addr)
+
+            # If the subnet mask is equal to /32, don't output it
+            if subnet_mask == (2**32 - 1)
+              "\"#{value.to_s}\""
+            else
+              "\"#{value.to_s}/#{subnet_mask.to_s(2).count('1')}\""
+            end
           else
             value.inspect
           end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -261,22 +261,22 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
     def test_schema_dump_includes_inet_shorthand_definition
       output = standard_dump
-      if %r{create_table "postgresql_network_address"} =~ output
-        assert_match %r{t.inet "inet_address"}, output
+      if %r{create_table "postgresql_network_addresses"} =~ output
+        assert_match %r{t.inet\s+"inet_address",\s+default: "192.168.1.1"}, output
       end
     end
 
     def test_schema_dump_includes_cidr_shorthand_definition
       output = standard_dump
-      if %r{create_table "postgresql_network_address"} =~ output
-        assert_match %r{t.cidr "cidr_address"}, output
+      if %r{create_table "postgresql_network_addresses"} =~ output
+        assert_match %r{t.cidr\s+"cidr_address",\s+default: "192.168.1.0/24"}, output
       end
     end
 
     def test_schema_dump_includes_macaddr_shorthand_definition
       output = standard_dump
-      if %r{create_table "postgresql_network_address"} =~ output
-        assert_match %r{t.macaddr "macaddr_address"}, output
+      if %r{create_table "postgresql_network_addresses"} =~ output
+        assert_match %r{t.macaddr\s+"mac_address",\s+default: "ff:ff:ff:ff:ff:ff"}, output
       end
     end
 

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -145,9 +145,9 @@ _SQL
   execute <<_SQL
   CREATE TABLE postgresql_network_addresses (
     id SERIAL PRIMARY KEY,
-    cidr_address CIDR,
-    inet_address INET,
-    mac_address MACADDR
+    cidr_address CIDR default '192.168.1.0/24',
+    inet_address INET default '192.168.1.1',
+    mac_address MACADDR default 'ff:ff:ff:ff:ff:ff'
   );
 _SQL
 


### PR DESCRIPTION
On master, when a default value is given for a postgres network address type (inet, cidr, macaddr), the output of the schema.rb dump is incorrect:

``` ruby
t.inet     "dns_address",     default: #<IPAddr: IPv4:172.22.10.4/255.255.255.255>,   null: false
```

This patch fixes the issue, outputting them as strings. It also fixes the tests so that the network address tests actually run- previously the regexes didn't match and thus never asserted that the columns were in the schema dump at all.

A couple things that are suboptimal about this patch:
- The ipaddr stdlib is required now for all adapters, not just postgres. I don't think this is a serious issue in real-world deployments (actionpack requires it, for instance). The alternative would be to develop a postgres-specific implementation of ColumnDumper, and that seems difficult.
- We're now duplicating the logic for pulling a subnet mask out of an IPAddr in two places. We should probably monkey-patch IPAddr in activesupport. That's another patch, however.
