### PR TITLE
Pass key to block in cache.fetch on miss

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -182,10 +182,10 @@ module ActiveSupport
       # the cache with the given key, then that data is returned.
       #
       # If there is no such data in the cache (a cache miss), then +nil+ will be
-      # returned. However, if a block has been passed, that block will be run
-      # in the event of a cache miss. The return value of the block will be
-      # written to the cache under the given cache key, and that return value
-      # will be returned.
+      # returned. However, if a block has been passed, that block will be passed
+      # the key and executed in the event of a cache miss. The return value of the
+      # block will be written to the cache under the given cache key, and that
+      # return value will be returned.
       #
       #   cache.write('today', 'Monday')
       #   cache.fetch('today')  # => "Monday"
@@ -300,7 +300,7 @@ module ActiveSupport
             entry.value
           else
             result = instrument(:generate, name, options) do |payload|
-              yield
+              yield(name)
             end
             write(name, result, options)
             result

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -83,7 +83,7 @@ class CacheKeyTest < ActiveSupport::TestCase
   def test_expand_cache_key_of_true
     assert_equal 'true', ActiveSupport::Cache.expand_cache_key(true)
   end
-  
+
   def test_expand_cache_key_of_array_like_object
     assert_equal 'foo/bar/baz', ActiveSupport::Cache.expand_cache_key(%w{foo bar baz}.to_enum)
   end
@@ -195,6 +195,11 @@ module CacheStoreBehavior
   def test_fetch_with_cache_miss
     @cache.expects(:write).with('foo', 'baz', @cache.options)
     assert_equal 'baz', @cache.fetch('foo') { 'baz' }
+  end
+
+  def test_fetch_with_cache_miss_passes_key_to_block
+    @cache.expects(:write).with('foo', 3, @cache.options)
+    assert_equal 3, @cache.fetch('foo') { |key| key.length }
   end
 
   def test_fetch_with_forced_cache_miss
@@ -594,7 +599,7 @@ class FileStoreTest < ActiveSupport::TestCase
     assert_equal "views/index?id=1", @cache_with_pathname.send(:file_path_key, key)
   end
 
-  # Test that generated cache keys are short enough to have Tempfile stuff added to them and 
+  # Test that generated cache keys are short enough to have Tempfile stuff added to them and
   # remain valid
   def test_filename_max_size
     key = "#{'A' * ActiveSupport::Cache::FileStore::FILENAME_MAX_SIZE}"

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -198,8 +198,13 @@ module CacheStoreBehavior
   end
 
   def test_fetch_with_cache_miss_passes_key_to_block
-    @cache.expects(:write).with('foo', 3, @cache.options)
-    assert_equal 3, @cache.fetch('foo') { |key| key.length }
+    cache_miss = false
+    assert_equal 3, @cache.fetch('foo') { |key| cache_miss = true; key.length }
+    assert cache_miss
+
+    cache_miss = false
+    assert_equal 3, @cache.fetch('foo') { |key| cache_miss = true; key.length }
+    assert !cache_miss
   end
 
   def test_fetch_with_forced_cache_miss


### PR DESCRIPTION
It would be convient to pass the key to the block on `cache.fetch` when their is a miss. When I use `cache.fetch` I always have to store the key I'm attempting to write away to pass to the computation function:

``` ruby
query = complex_calculation(params[:q])

Rails.cache.fetch(query) do
  ExpensiveOperation.execute(query)
end
```

vs. after my commit:

``` ruby
Rails.cache.fetch(complex_calculation(params[:q])) do |query|
  ExpensiveOperation.execute(query)
end
```

This is low-risk, medium-reward commit. Existing code will _just work_ if the block doesn't receive a variable and future code will be cleaner in this very common pattern.
