### PR TITLE
changed test case name

### DIFF
--- a/railties/test/generators/task_generator_test.rb
+++ b/railties/test/generators/task_generator_test.rb
@@ -5,7 +5,7 @@ class TaskGeneratorTest < Rails::Generators::TestCase
   include GeneratorsTestHelper
   arguments %w(feeds foo bar)
 
-  def test_controller_skeleton_is_created
+  def test_task_is_created
     run_generator
     assert_file "lib/tasks/feeds.rake", /namespace :feeds/
   end


### PR DESCRIPTION
I think this name was copy pasted from [here](https://github.com/rails/rails/blob/v3.2.8.rc2/railties/test/generators/controller_generator_test.rb#L15)
