### PR TITLE
Pass :full_messages option from Responder to AM::Errors

### DIFF
--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -259,7 +259,7 @@ module ActionController #:nodoc:
     # * for other requests - i.e. data formats such as xml, json, csv etc, if
     #   the resource passed to +respond_with+ responds to <code>to_<format></code>,
     #   the method attempts to render the resource in the requested format
-    #   directly, e.g. for an xml request, the response is equivalent to calling 
+    #   directly, e.g. for an xml request, the response is equivalent to calling
     #   <code>render :xml => resource</code>.
     #
     # === Nested resources
@@ -314,11 +314,13 @@ module ActionController #:nodoc:
     # to save a resource, e.g. when automatically rendering <tt>:new</tt>
     # after a post request.
     #
-    # Two additional options are relevant specifically to +respond_with+ -
+    # Three additional options are relevant specifically to +respond_with+ -
     # 1. <tt>:location</tt> - overwrites the default redirect location used after
     #    a successful html +post+ request.
     # 2. <tt>:action</tt> - overwrites the default render action used after an
     #    unsuccessful html +post+ request.
+    # 3. <tt>:full_messages</tt> - if set to true, validation error messages after
+    #    an unsuccessful json +post+ request will contain full messages.
     def respond_with(*resources, &block)
       raise "In order to use respond_with, first you need to declare the formats your " <<
             "controller responds to in the class level" if self.class.mimes_for_respond_to.empty?

--- a/actionpack/lib/action_controller/metal/responder.rb
+++ b/actionpack/lib/action_controller/metal/responder.rb
@@ -277,7 +277,7 @@ module ActionController #:nodoc:
     end
 
     def json_resource_errors
-      {:errors => resource.errors}
+      {:errors => resource.errors.as_json(full_messages: options[:full_messages])}
     end
 
     def response_overridden?

--- a/actionpack/lib/action_controller/metal/responder.rb
+++ b/actionpack/lib/action_controller/metal/responder.rb
@@ -277,7 +277,7 @@ module ActionController #:nodoc:
     end
 
     def json_resource_errors
-      {:errors => resource.errors.as_json(full_messages: options[:full_messages])}
+      {errors: resource.errors.as_json(full_messages: options[:full_messages])}
     end
 
     def response_overridden?

--- a/actionpack/test/controller/mime_responds_test.rb
+++ b/actionpack/test/controller/mime_responds_test.rb
@@ -569,7 +569,7 @@ class RespondWithController < ActionController::Base
   end
 
   def using_full_messages_with_invalid_resource
-    respond_with(resource, :full_messages => true)
+    respond_with(resource, full_messages: true)
   end
 
 protected
@@ -1123,22 +1123,22 @@ class RespondWithControllerTest < ActionController::TestCase
   end
 
   def test_full_messages_with_using_invalid
-    errors = { :name => :invalid }
-    errors_with_full_messages = { :name => 'name is invalid' }
+    errors = { name: :invalid }
+    errors_with_full_messages = { name: 'name is invalid' }
     errors.stubs(:as_json).returns(errors)
-    errors.stubs(:as_json).with(has_entries(:full_messages => true)).returns(errors_with_full_messages)
+    errors.stubs(:as_json).with(has_entries(full_messages: true)).returns(errors_with_full_messages)
 
     Customer.any_instance.stubs(:errors).returns(errors)
 
     @request.accept = "application/json"
 
     post :using_full_messages_with_invalid_resource
-    assert_equal({ :errors => errors_with_full_messages }.to_json, @response.body)
+    assert_equal({ errors: errors_with_full_messages }.to_json, @response.body)
     assert_equal 422, @response.status
     assert_equal nil, @response.location
 
     put :using_full_messages_with_invalid_resource
-    assert_equal({ :errors => errors_with_full_messages }.to_json, @response.body)
+    assert_equal({ errors: errors_with_full_messages }.to_json, @response.body)
     assert_equal 422, @response.status
     assert_equal nil, @response.location
   end


### PR DESCRIPTION
PR #5075 added a nice feature to provider client-side with full error messages arranged by model fields. With this patch, it's now possible to provide that option directly to `respond_with`, e.g.:

``` ruby
respond_to :json

def update
  @user.update_attributes(params[:user])
  respond_with(@user, full_messages: true)
end
```

To achieve the following output:

``` json
{ "errors": {
    "name": "Name cannot be blank." } }
```
