### PR TITLE
memoize calculated ip without additional variable

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -63,9 +63,9 @@ module ActionDispatch
       }x
 
       def initialize(env, middleware)
-        @env           = env
-        @middleware    = middleware
-        @calculated_ip = false
+        @env        = env
+        @middleware = middleware
+        @ip         = nil
       end
 
       # Determines originating IP address. REMOTE_ADDR is the standard
@@ -100,9 +100,7 @@ module ActionDispatch
       end
 
       def to_s
-        return @ip if @calculated_ip
-        @calculated_ip = true
-        @ip = calculate_ip
+        @ip ||= calculate_ip
       end
 
       private


### PR DESCRIPTION
There is no need in additional `@calculated_ip` instance variable as we
can use `defined?` to check if `@ip` instance variable is already
assigned.
