### PR TITLE
Adding a missing parenthesis in the doc of String#parameterize.

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -149,7 +149,7 @@ class String
   #   @person = Person.find(1)
   #   # => #<Person id: 1, name: "Donald E. Knuth">
   #
-  #   <%= link_to(@person.name, person_path %>
+  #   <%= link_to(@person.name, person_path) %>
   #   # => <a href="/person/1-donald-e-knuth">Donald E. Knuth</a>
   def parameterize(sep = '-')
     ActiveSupport::Inflector.parameterize(self, sep)


### PR DESCRIPTION
Before (penultimate line):

```
class Person
  def to_param
    "#{id}-#{name.parameterize}"
  end
end

@person = Person.find(1)
# => #<Person id: 1, name: "Donald E. Knuth">

<%= link_to(@person.name, person_path %>
# => <a href="/person/1-donald-e-knuth">Donald E. Knuth</a>
```

After (penultimate line):

```
class Person
  def to_param
    "#{id}-#{name.parameterize}"
  end
end

@person = Person.find(1)
# => #<Person id: 1, name: "Donald E. Knuth">

<%= link_to(@person.name, person_path) %>
# => <a href="/person/1-donald-e-knuth">Donald E. Knuth</a>
```
