### PR TITLE
Atomic.rb assumes it may chown/chmod a file but doesn't handle the EPERM error.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 *   Implement HashWithIndifferentAccess#replace so key? works correctly. *David Graham*
 
+*   Handle the possible Permission Denied errors atomic.rb might trigger due to its chown and chmod calls. *Daniele Sluijters*
+
 *   Hash#extract! returns only those keys that present in the receiver.
 
         {:a => 1, :b => 2}.extract!(:a, :x) # => {:a => 1}

--- a/activesupport/lib/active_support/core_ext/file/atomic.rb
+++ b/activesupport/lib/active_support/core_ext/file/atomic.rb
@@ -36,8 +36,13 @@ class File
     FileUtils.mv(temp_file.path, file_name)
 
     # Set correct permissions on new file
-    chown(old_stat.uid, old_stat.gid, file_name)
-    chmod(old_stat.mode, file_name)
+    begin
+      chown(old_stat.uid, old_stat.gid, file_name)
+      # This operation will affect filesystem ACL's
+      chmod(old_stat.mode, file_name)
+    rescue Errno::EPERM
+      # Changing file ownership failed, moving on.
+    end
   end
 
   # Private utility method.

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -3716,7 +3716,9 @@ File.atomic_write(joined_asset_path) do |cache|
 end
 ```
 
-To accomplish this `atomic_write` creates a temporary file. That's the file the code in the block actually writes to. On completion, the temporary file is renamed, which is an atomic operation on POSIX systems. If the target file exists `atomic_write` overwrites it and keeps owners and permissions.
+To accomplish this `atomic_write` creates a temporary file. That's the file the code in the block actually writes to. On completion, the temporary file is renamed, which is an atomic operation on POSIX systems. If the target file exists `atomic_write` overwrites it and keeps owners and permissions. However there are a few cases where `atomic_write` cannot change the file ownership or permissions, this error is caught and skipped over trusting in the user/filesystem to ensure the file is accessible to the processes that need it.
+
+NOTE. Due to the chmod operation `atomic_write` performs, if the target file has an ACL set on it this ACL will be recalculated/modified.
 
 WARNING. Note you can't append with `atomic_write`.
 


### PR DESCRIPTION
Previously this code just assumed it is capable of changing the file
ownership, both user and group. This will fail in a lot of scenario's
unless:
- The process is run as a superuser (root);
- The owning user and group are already set to the user and group we're
  trying to chown to;
- The user chown'ing only changes the group to another group it is a
  member of.
  If either of those conditions are not met the filesystem will simply
  deny the operation throwing an error.

It is also not always possible to do a chmod, there might be a SELinux
policy or another limitation preventing the user to change the file
mode. To this end the chmod call has also been added to the rescue
block.

I've also added a little comment above the chmod command that doing a
chmod on a file which has an ACL set will cause the ACL to be
recalculated / modified.
