### PR TITLE
Organize README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -6,29 +6,29 @@ database-backed web applications according to the {Model-View-Controller (MVC)}[
 Understanding the MVC pattern is key to understanding Rails. MVC divides your application
 into three layers, each with a specific responsibility.
 
-The View layer is composed of "templates" that are responsible for providing 
+The View layer is composed of "templates" that are responsible for providing
 appropriate representations of your application's resources. Templates
 can come in a variety of formats, but most view templates are \HTML with embedded Ruby
-code (.erb files). 
+code (.erb files).
 
-The Model layer represents your domain model (such as Account, Product, Person, Post) 
-and encapsulates the business logic that is specific to your application. In Rails, 
+The Model layer represents your domain model (such as Account, Product, Person, Post)
+and encapsulates the business logic that is specific to your application. In Rails,
 database-backed model classes are derived from ActiveRecord::Base. Active Record allows
-you to present the data from database rows as objects and embellish these data objects 
-with business logic methods. Although most Rails models are backed by a database, models 
+you to present the data from database rows as objects and embellish these data objects
+with business logic methods. Although most Rails models are backed by a database, models
 can also be ordinary Ruby classes, or Ruby classes that implement a set of interfaces as
 provided by the ActiveModel module. You can read more about Active Record in its
 {README}[link:/rails/rails/blob/master/activerecord/README.rdoc].
 
-The Controller layer is responsible for handling incoming HTTP requests and providing a 
+The Controller layer is responsible for handling incoming HTTP requests and providing a
 suitable response. Usually this means returning \HTML, but Rails controllers can also
-generate XML, JSON, PDFs, mobile-specific views, and more. Controllers manipulate models 
+generate XML, JSON, PDFs, mobile-specific views, and more. Controllers manipulate models
 and render view templates in order to generate the appropriate HTTP response.
 
 In Rails, the Controller and View layers are handled together by Action Pack.
-These two layers are bundled in a single package due to their heavy interdependence. 
+These two layers are bundled in a single package due to their heavy interdependence.
 This is unlike the relationship between Active Record and Action Pack which are
-independent. Each of these packages can be used independently outside of Rails. You 
+independent. Each of these packages can be used independently outside of Rails. You
 can read more about Action Pack in its {README}[link:/rails/rails/blob/master/actionpack/README.rdoc].
 
 == Getting Started
@@ -67,12 +67,11 @@ We encourage you to contribute to Ruby on Rails! Please check out the {Contribut
 guide}[http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html] for guidelines about how
 to proceed. {Join us}[http://contributors.rubyonrails.org]!
 
-== Build Status {<img src="https://secure.travis-ci.org/rails/rails.png"/>}[http://travis-ci.org/rails/rails]
+== Code Status
 
-== Dependency Status {<img src="https://gemnasium.com/rails/rails.png?travis"/>}[https://gemnasium.com/rails/rails]
+* {<img src="https://secure.travis-ci.org/rails/rails.png"/>}[http://travis-ci.org/rails/rails]
+* {<img src="https://gemnasium.com/rails/rails.png?travis"/>}[https://gemnasium.com/rails/rails]
 
 == License
 
-Ruby on Rails is released under the MIT license:
-
-* http://www.opensource.org/licenses/MIT
+Ruby on Rails is released under the {MIT License}[http://www.opensource.org/licenses/MIT].

--- a/Rakefile
+++ b/Rakefile
@@ -75,10 +75,10 @@ RDoc::Task.new do |rdoc|
     rdoc_main.gsub!(/^(?=\S).*?\b(?=Rails)\b/) { "#$&\\" }
     rdoc_main.gsub!(%r{link:/rails/rails/blob/master/(\w+)/README\.rdoc}, "link:files/\\1/README_rdoc.html")
 
-    # Remove Travis and Gemnasium status images from API pages. Only GitHub
-    # README page gets these images. Travis' https build image is used to avoid
-    # GitHub caching: http://about.travis-ci.org/docs/user/status-images
-    rdoc_main.gsub!(%r{^== (Build|Dependency) Status.*}, '')
+    # Remove Travis and Gemnasium status images from API pages. Only the GitHub
+    # README page gets these images. Travis's HTTPS build image is used to
+    # avoid GitHub caching: http://about.travis-ci.org/docs/user/status-images
+    rdoc_main.gsub!(/^== Code Status(\n(?!==).*)*/, '')
 
     File.open(RDOC_MAIN, 'w') do |f|
       f.write(rdoc_main)


### PR DESCRIPTION
- Organized code status badges into a "Code Status" section.
- Moved the OSI MIT License link inline (bullets are for unordered
  lists).
