### PR TITLE
Make ThreadedQueueConsumer abort on exception and set a thread name.

### DIFF
--- a/activesupport/lib/active_support/queueing.rb
+++ b/activesupport/lib/active_support/queueing.rb
@@ -70,7 +70,14 @@ module ActiveSupport
     end
 
     def start
-      @thread = Thread.new { consume }
+      @thread = Thread.new do
+        # Set this just in case an exception is thrown outside the
+        # rescue block. We don't want the code to fail silently.
+        Thread.current.abort_on_exception = true
+        # For Phusion Passenger backtrace reports.
+        Thread.current[:name] = "Rails ThreadedQueueConsumer"
+        consume
+      end
       self
     end
 


### PR DESCRIPTION
The abort on exception flag makes sure that exceptions outside the begin..rescue block have effect. Otherwise the thread would just die without an error message.

The thread name makes it easier to see what the thread is for in Phusion Passenger thread backtraces.
