### PR TITLE
Worker and consumer logs failed jobs instead of raising an exception

### DIFF
--- a/activesupport/test/queueing/synchronous_queue_test.rb
+++ b/activesupport/test/queueing/synchronous_queue_test.rb
@@ -16,12 +16,17 @@ class SynchronousQueueTest < ActiveSupport::TestCase
   end
 
   def test_runs_jobs_immediately
-    job = Job.new
-    @queue.push job
-    assert job.ran
+    begin
+      $stderr, old_stderr = StringIO.new, $stderr
 
-    assert_raises RuntimeError do
+      job = Job.new
+      @queue.push job
+      assert job.ran
+
       @queue.push ExceptionRaisingJob.new
+      assert_match 'Job Error', $stderr.string
+    ensure
+      $stderr = old_stderr
     end
   end
 end

--- a/activesupport/test/queueing/test_queue_test.rb
+++ b/activesupport/test/queueing/test_queue_test.rb
@@ -12,9 +12,16 @@ class TestQueueTest < ActiveSupport::TestCase
     end
   end
 
-  def test_drain_raises_exceptions_from_running_jobs
-    @queue.push ExceptionRaisingJob.new
-    assert_raises(RuntimeError) { @queue.drain }
+  def test_drain_logs_exceptions_from_running_jobs
+    begin
+      $stderr, old_stderr = StringIO.new, $stderr
+
+      @queue.push ExceptionRaisingJob.new
+      @queue.drain
+      assert_match 'Job Error', $stderr.string
+    ensure
+      $stderr = old_stderr
+    end
   end
 
   def test_jobs


### PR DESCRIPTION
This fixes activesupport tests.
