### PR TITLE
remove trailing whitespace within actionpack

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -51,7 +51,7 @@ module AbstractController
         @view_context_class ||= begin
           routes = respond_to?(:_routes) && _routes
           helpers = respond_to?(:_helpers) && _helpers
-          
+
           Class.new(ActionView::Base) do
             if routes
               include routes.url_helpers

--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -259,7 +259,7 @@ module ActionController #:nodoc:
     # * for other requests - i.e. data formats such as xml, json, csv etc, if
     #   the resource passed to +respond_with+ responds to <code>to_<format></code>,
     #   the method attempts to render the resource in the requested format
-    #   directly, e.g. for an xml request, the response is equivalent to calling 
+    #   directly, e.g. for an xml request, the response is equivalent to calling
     #   <code>render :xml => resource</code>.
     #
     # === Nested resources

--- a/actionpack/test/activerecord/controller_runtime_test.rb
+++ b/actionpack/test/activerecord/controller_runtime_test.rb
@@ -15,7 +15,7 @@ class ControllerRuntimeLogSubscriberTest < ActionController::TestCase
     def zero
       render :inline => "Zero DB runtime"
     end
-    
+
     def redirect
       Project.all
       redirect_to :action => 'show'
@@ -63,18 +63,18 @@ class ControllerRuntimeLogSubscriberTest < ActionController::TestCase
     assert_equal 2, @logger.logged(:info).size
     assert_match(/\(Views: [\d.]+ms \| ActiveRecord: 0.0ms\)/, @logger.logged(:info)[1])
   end
-  
+
   def test_log_with_active_record_when_redirecting
     get :redirect
     wait
     assert_equal 3, @logger.logged(:info).size
     assert_match(/\(ActiveRecord: [\d.]+ms\)/, @logger.logged(:info)[2])
   end
-  
+
   def test_include_time_query_time_after_rendering
     get :db_after_render
     wait
-    
+
     assert_equal 2, @logger.logged(:info).size
     assert_match(/\(Views: [\d.]+ms \| ActiveRecord: ([1-9][\d.]+)ms\)/, @logger.logged(:info)[1])
   end

--- a/actionpack/test/controller/default_url_options_with_filter_test.rb
+++ b/actionpack/test/controller/default_url_options_with_filter_test.rb
@@ -16,7 +16,7 @@ class ControllerWithBeforeFilterAndDefaultUrlOptions < ActionController::Base
 
   def default_url_options
     {:locale => "de"}
-  end 
+  end
 end
 
 class ControllerWithBeforeFilterAndDefaultUrlOptionsTest < ActionController::TestCase

--- a/actionpack/test/controller/http_basic_authentication_test.rb
+++ b/actionpack/test/controller/http_basic_authentication_test.rb
@@ -19,7 +19,7 @@ class HttpBasicAuthenticationTest < ActionController::TestCase
     def show
       render :text => 'Only for loooooong credentials'
     end
-    
+
     def search
       render :text => 'All inline'
     end
@@ -118,7 +118,7 @@ class HttpBasicAuthenticationTest < ActionController::TestCase
     assert assigns(:logged_in)
     assert_equal 'Definitely Maybe', @response.body
   end
-  
+
   test "authenticate with class method" do
     @request.env['HTTP_AUTHORIZATION'] = encode_credentials('David', 'Goliath')
     get :search

--- a/actionpack/test/controller/mime_responds_test.rb
+++ b/actionpack/test/controller/mime_responds_test.rb
@@ -240,7 +240,7 @@ class RespondToControllerTest < ActionController::TestCase
     assert_equal 'HTML', @response.body
 
     @request.accept = "text/javascript, text/html"
-    
+
     assert_raises(ActionController::UnknownFormat) do
       xhr :get, :just_xml
     end

--- a/actionpack/test/controller/new_base/middleware_test.rb
+++ b/actionpack/test/controller/new_base/middleware_test.rb
@@ -25,14 +25,14 @@ module MiddlewareTest
       result
     end
   end
-  
+
   class BlockMiddleware
     attr_accessor :configurable_message
     def initialize(app, &block)
       @app = app
       yield(self) if block_given?
     end
-    
+
     def call(env)
       result = @app.call(env)
       result[1]["Configurable-Message"] = configurable_message

--- a/actionpack/test/controller/new_base/render_partial_test.rb
+++ b/actionpack/test/controller/new_base/render_partial_test.rb
@@ -28,7 +28,7 @@ module RenderPartial
       @test_unchanged = 'hello'
     end
   end
-  
+
   class ChildController < BasicController; end
 
   class TestPartial < Rack::TestCase

--- a/actionpack/test/controller/send_file_test.rb
+++ b/actionpack/test/controller/send_file_test.rb
@@ -134,7 +134,7 @@ class SendFileTest < ActionController::TestCase
     @controller.headers = {}
     assert_raise(ArgumentError){ @controller.send(:send_file_headers!, options) }
   end
-  
+
   def test_send_file_headers_guess_type_from_extension
     {
       'image.png' => 'image/png',

--- a/actionpack/test/template/digestor_test.rb
+++ b/actionpack/test/template/digestor_test.rb
@@ -63,7 +63,7 @@ class TemplateDigestorTest < ActionView::TestCase
       change_template("comments/_comment")
     end
   end
-  
+
   def test_directory_depth_dependency
     assert_digest_difference("level/below/index") do
       change_template("level/below/_header")

--- a/actionpack/test/template/render_test.rb
+++ b/actionpack/test/template/render_test.rb
@@ -451,12 +451,12 @@ module RenderTestCases
     assert_equal %(<title>David</title>),
       @view.render(:file => "test/layout_render_object")
   end
-  
+
   def test_render_with_passing_couple_extensions_to_one_register_template_handler_function_call
     ActionView::Template.register_template_handler :foo1, :foo2, CustomHandler
     assert_equal @view.render(:inline => "Hello, World!", :type => :foo1), @view.render(:inline => "Hello, World!", :type => :foo2)
   end
-  
+
   def test_render_throws_exception_when_no_extensions_passed_to_register_template_handler_function_call
     assert_raises(ArgumentError) { ActionView::Template.register_template_handler CustomHandler }
   end


### PR DESCRIPTION
I've been browsing the actionpack source lately and submitted a few patches.
There were occasions of trailing whitespace and to keep the commit diffs clean,
I removed them all in one go.
