### PR TITLE
Should not eager_load app/assets

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 3.2.9 (unreleased)
 
+*   Don't eager-load app/assets and app/views *Elia Schito*
+
 *   Update supported ruby versions error message in ruby_version_check.rb *Lihan Li*
 
 ## Rails 3.2.8 (Aug 9, 2012) ##

--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -87,14 +87,15 @@ module Rails
     protected
 
       def filter_by(constraint)
-        all = []
+        yes = []
+        no  = []
+
         all_paths.each do |path|
-          if path.send(constraint)
-            paths  = path.existent
-            paths -= path.children.map { |p| p.send(constraint) ? [] : p.existent }.flatten
-            all.concat(paths)
-          end
+          paths = path.existent + path.existent_base_paths
+          path.send(constraint) ? yes.concat(paths) : no.concat(paths)
         end
+
+        all = yes - no
         all.uniq!
         all
       end
@@ -192,6 +193,10 @@ module Rails
 
       def existent_directories
         expanded.select { |d| File.directory?(d) }
+      end
+
+      def existent_base_paths
+        map { |p| File.expand_path(p, @root.path) }.select{ |f| File.exist? f }
       end
 
       alias to_a expanded

--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -124,6 +124,7 @@ module Rails
         keys.delete(@current)
         @root.values_at(*keys.sort)
       end
+      deprecate :children
 
       def first
         expanded.first

--- a/railties/test/application/paths_test.rb
+++ b/railties/test/application/paths_test.rb
@@ -61,6 +61,8 @@ module ApplicationTests
       assert eager_load.include?(root("app/controllers"))
       assert eager_load.include?(root("app/helpers"))
       assert eager_load.include?(root("app/models"))
+      assert !eager_load.include?(root("app/views")), "expected to not be in the eager_load_path"
+      assert !eager_load.include?(root("app/assets")), "expected to not be in the eager_load_path"
     end
 
     test "environments has a glob equal to the current environment" do
@@ -75,6 +77,7 @@ module ApplicationTests
       assert_in_load_path "vendor"
 
       assert_not_in_load_path "app", "views"
+      assert_not_in_load_path "app", "assets"
       assert_not_in_load_path "config"
       assert_not_in_load_path "config", "locales"
       assert_not_in_load_path "config", "environments"


### PR DESCRIPTION
If I happen to use a `.rb` file inside `app/assets` it can get automatically loaded, this probably holds true for `app/views`.

I think this is not the intended behavior, [railties has](https://github.com/rails/rails/blob/master/railties/lib/rails/engine/configuration.rb#L38):

``` ruby
paths.add "app",                 :eager_load => true, :glob => "*"
paths.add "app/assets",          :glob => "*"
paths.add "app/controllers",     :eager_load => true
paths.add "app/helpers",         :eager_load => true
paths.add "app/models",          :eager_load => true
paths.add "app/mailers",         :eager_load => true
paths.add "app/views"
```

seems quite clear that the first line refers to all non-specified paths

Of course I can fix this per application by adding to `application.rb`:

``` ruby
    config.before_initialize do
      config.eager_load_paths = config.eager_load_paths.dup - Dir["#{Rails.root}/app/{assets,views}"]
    end
```
