### PR TITLE
Explicit multipart messages respect :parts_order

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Rails 4.0.0 (unreleased) ##
 
+* Explicit multipart messages no longer set the order of the MIME parts.
+  *Nate Berkopec*
+  
 * Do not render views when mail() isn't called.
   Fix #7761
 

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -322,19 +322,6 @@ class BaseTest < ActiveSupport::TestCase
     assert_not_nil(mail.content_type_parameters[:boundary])
   end
 
-  test "explicit multipart does not sort order" do
-    order = ["text/html", "text/plain"]
-    with_default BaseMailer, parts_order: order do
-      email = BaseMailer.explicit_multipart
-      assert_equal("text/plain", email.parts[0].mime_type)
-      assert_equal("text/html",  email.parts[1].mime_type)
-
-      email = BaseMailer.explicit_multipart(parts_order: order.reverse)
-      assert_equal("text/plain", email.parts[0].mime_type)
-      assert_equal("text/html",  email.parts[1].mime_type)
-    end
-  end
-
   test "explicit multipart with attachments creates nested parts" do
     email = BaseMailer.explicit_multipart(attachments: true)
     assert_equal("application/pdf", email.parts[0].mime_type)
@@ -349,10 +336,10 @@ class BaseTest < ActiveSupport::TestCase
     email = BaseMailer.explicit_multipart_templates
     assert_equal(2, email.parts.size)
     assert_equal("multipart/alternative", email.mime_type)
-    assert_equal("text/html", email.parts[0].mime_type)
-    assert_equal("HTML Explicit Multipart Templates", email.parts[0].body.encoded)
-    assert_equal("text/plain", email.parts[1].mime_type)
-    assert_equal("TEXT Explicit Multipart Templates", email.parts[1].body.encoded)
+    assert_equal("text/plain", email.parts[0].mime_type)
+    assert_equal("TEXT Explicit Multipart Templates", email.parts[0].body.encoded)
+    assert_equal("text/html", email.parts[1].mime_type)
+    assert_equal("HTML Explicit Multipart Templates", email.parts[1].body.encoded)
   end
 
   test "explicit multipart with format.any" do
@@ -387,10 +374,23 @@ class BaseTest < ActiveSupport::TestCase
     email = BaseMailer.explicit_multipart_with_one_template
     assert_equal(2, email.parts.size)
     assert_equal("multipart/alternative", email.mime_type)
-    assert_equal("text/html", email.parts[0].mime_type)
-    assert_equal("[:html]", email.parts[0].body.encoded)
-    assert_equal("text/plain", email.parts[1].mime_type)
-    assert_equal("[:text]", email.parts[1].body.encoded)
+    assert_equal("text/plain", email.parts[0].mime_type)
+    assert_equal("[:text]", email.parts[0].body.encoded)
+    assert_equal("text/html", email.parts[1].mime_type)
+    assert_equal("[:html]", email.parts[1].body.encoded)
+  end
+
+  test "explicit multipart with sort order" do
+    order = ["text/html", "text/plain"]
+    with_default BaseMailer, parts_order: order do
+      email = BaseMailer.explicit_multipart
+      assert_equal("text/html",  email.parts[0].mime_type)
+      assert_equal("text/plain", email.parts[1].mime_type)
+
+      email = BaseMailer.explicit_multipart(parts_order: order.reverse)
+      assert_equal("text/plain", email.parts[0].mime_type)
+      assert_equal("text/html",  email.parts[1].mime_type)
+    end
   end
 
   # Class level API with method missing

--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -377,23 +377,7 @@ If you use this setting, you should pass the `only_path: false` option when usin
 
 Action Mailer will automatically send multipart emails if you have different templates for the same action. So, for our UserMailer example, if you have `welcome_email.text.erb` and `welcome_email.html.erb` in `app/views/user_mailer`, Action Mailer will automatically send a multipart email with the HTML and text versions setup as different parts.
 
-The order of the parts getting inserted is determined by the `:parts_order` inside of the `ActionMailer::Base.default` method. If you want to explicitly alter the order, you can either change the `:parts_order` or explicitly render the parts in a different order:
-
-```ruby
-class UserMailer < ActionMailer::Base
-  def welcome_email(user)
-    @user = user
-    @url  = user_url(@user)
-    mail(to: user.email,
-         subject: 'Welcome to My Awesome Site') do |format|
-      format.html
-      format.text
-    end
-  end
-end
-```
-
-Will put the HTML part first, and the plain text part second.
+The order of the parts getting inserted is determined by the `:parts_order` inside of the `ActionMailer::Base.default` method.
 
 ### Sending Emails with Attachments
 


### PR DESCRIPTION
My original issue was #7978. Our app's emails were showing up in Gmail as plain text only, and I couldn't figure out why. I checked the raw text being sent, and confirmed both HTML and plaintext parts were in there. 

However, what I wasn't aware of was this little line in [RFC 2046](http://www.ietf.org/rfc/rfc2046.txt):

> In general, user agents that compose "multipart/alternative" entities
>    must place the body parts in increasing order of preference, that is,
>    with the preferred format last.  [..] Receiving user agents should pick and display the last format
>    they are capable of displaying.

Aha! So I checked the order of my mime parts, and, lo and behold, the plaintext part was being sent last! So Gmail was following the spec correctly - it was displaying the last format it was capable of displaying. (Side note: other mail clients seem to display HTML regardless).

Now, what the heck was actually setting this order? I read through the ActionMailer documentation and discovered the `[:parts_order]` option. Great! All I have to do is set this and it'll work fine. Nope. After about a day worth of digging and frustration, I discovered that passing a block to `mail` sets the parts order to the same order as the block!

This pull request changes `mail` to respect `:parts_order` regardless of the order of any block passed into `mail`. I decided this change, rather than just clarifying the documentation, was appropriate for several reasons:
- It wasn't clear what should happen when `:parts_order` and the order of the block conflicted. Which should take precedence?
- Setting the mime part order in two places seemed unnecessarily confusing.
- When an email is multipart, I can think of few reasons why html would _not_ be the preferred format. It seems too easy to accidentally send an email you _think_ will show up as HTML but actually will be plaintext (this is what happened to me). `:parts_order` already sets a sensible default (html last), so let's make it difficult to unintentionally mess up this setting.
- In ActionController, the convention when writing an explicit block is put `format.html` first in the order of possible formats. This is how most examples/documentation is written. In ActionMailer, in order for HTML to actually display in an end user's mail client, you have to do the opposite. Flipping this convention in ActionMailer seems unneccessary.

Thanks for considering this change. I lost about a day or two figuring this one out, just want to prevent anyone from having the same issue.
