### PR TITLE
Fixed issue where routes with globs caused constraints to be ignored

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## Rails 3.2.9 (unreleased) ##
+*   Fixed issue where routes with globs caused constraints on that glob to be ignored. A regular
+    expression constraint gets overwritten when the routes.rb file is processed. Changed the
+    overwriting to an ||= instead of an = assignment. GH#7924
+
+    *Maura Fitzgerald*
 
 *   Accept :remote as symbolic option for `link_to` helper. *Riley Lynch*
 

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -142,7 +142,7 @@ module ActionDispatch
           def requirements
             @requirements ||= (@options[:constraints].is_a?(Hash) ? @options[:constraints] : {}).tap do |requirements|
               requirements.reverse_merge!(@scope[:constraints]) if @scope[:constraints]
-              @options.each { |k, v| requirements[k] = v if v.is_a?(Regexp) }
+              @options.each { |k, v| requirements[k] ||= v if v.is_a?(Regexp) }
             end
           end
 


### PR DESCRIPTION
Fixed issue where routes with globs caused constraints on that glob to
be ignored. A regular expression constraint gets overwritten when the
routes.rb file is processed. Changed the overwriting to an ||= instead
of an = assignment.
