### PR TITLE
Replace flow-control exception with explicit test.

### DIFF
--- a/activesupport/lib/active_support/core_ext/file/atomic.rb
+++ b/activesupport/lib/active_support/core_ext/file/atomic.rb
@@ -23,10 +23,10 @@ class File
     yield temp_file
     temp_file.close
 
-    begin
+    if File.exists?(file_name)
       # Get original file permissions
       old_stat = stat(file_name)
-    rescue Errno::ENOENT
+    else
       # If not possible, probe which are the default permissions in the
       # destination directory.
       old_stat = probe_stat_in(dirname(file_name))


### PR DESCRIPTION
It was noticed while profiling 'assets:precompile' in JRuby that
exception creation was consuming a large portion of time, and
some of that was due to File.atomic_write.

Testing first with File.exists? eliminates the need for an exception
which should be a performance improvement on both JRuby and MRI.
In this case, the stat() isn't even extra overhead, since it is always
called anyway.

See some [benchmarks on exception vs stat overhead](http://polycrystal.org/2012/10/25/comparing_ruby_exceptions_to_additional_stat_test.html).
