### PR TITLE
Removing JSON for other ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,6 @@ platforms :mri do
 end
 
 platforms :ruby do
-  gem 'json'
   gem 'yajl-ruby'
   gem 'nokogiri', '>= 1.4.5'
 


### PR DESCRIPTION
It's only required for 1.8 and for JRuby!
I was fixing a bug with JSON pure on 1.8.7
and I found that we have included json for other
1.8 > rubies also.
