### PR TITLE
Do not render views when mail() isn't called. (NullMail refactoring)

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+* Do not render views when mail() isn't called.
+  Fix #7761
+
+  *Yves Senn*
+
 * Support `Mailer.deliver_foo(*args)` as a synonym for
   `Mailer.foo(*args).deliver`. This makes it easy to write e.g.
   `Mailer.expects(:deliver_foo)` when testing code that calls

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -510,7 +510,19 @@ module ActionMailer
 
     def process(*args) #:nodoc:
       lookup_context.skip_default_locale!
-      super
+
+      generated_mail = super
+      unless generated_mail
+        @_message = NullMail.new
+      end
+    end
+
+    class NullMail #:nodoc:
+      def body; '' end
+
+      def method_missing(*args)
+        nil
+      end
     end
 
     def mailer_name

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -499,6 +499,12 @@ class BaseTest < ActiveSupport::TestCase
     end
   end
 
+  test 'the view is not rendered when mail was never called' do
+    mail = BaseMailer.without_mail_call
+    assert_equal('', mail.body.to_s.strip)
+    mail.deliver
+  end
+
   # Before and After hooks
 
   class MyObserver

--- a/actionmailer/test/fixtures/base_mailer/without_mail_call.erb
+++ b/actionmailer/test/fixtures/base_mailer/without_mail_call.erb
@@ -1,0 +1,1 @@
+<% raise 'the template should not be rendered' %>

--- a/actionmailer/test/mailers/base_mailer.rb
+++ b/actionmailer/test/mailers/base_mailer.rb
@@ -115,4 +115,7 @@ class BaseMailer < ActionMailer::Base
   def email_with_translations
     mail body: render("email_with_translations", formats: [:html])
   end
+
+  def without_mail_call
+  end
 end


### PR DESCRIPTION
I introduced a `NullMail` class. When `mail()` is never called an instance of `NullMail` is returned in place of a regular `Mail`.

This refactoring fixes #7761
