### PR TITLE
fix typo in button_to helper example

### DIFF
--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -239,6 +239,7 @@ this generates
 
 ```
 <form action="/posts/1" class="button_to" data-remote="true" method="post">
+  <div><input type="submit" value="A post"></div>
 </form>
 ```
 


### PR DESCRIPTION
As I understand, submit input was accidentally omitted.
