### PR TITLE
Unbreak update_column/update_columns for the primary key attribute.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix bug where `update_columns` and `update_column` would not let you update the primary key column.
+
+    *Henrik Nyh*
+
 *   The `create_table` method raises an `ArgumentError` when the primary key column is redefined.
     Fix #6378
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -224,11 +224,13 @@ module ActiveRecord
         verify_readonly_attribute(key.to_s)
       end
 
+      updated_count = self.class.where(self.class.primary_key => id).update_all(attributes)
+
       attributes.each do |k,v|
         raw_write_attribute(k,v)
       end
 
-      self.class.where(self.class.primary_key => id).update_all(attributes) == 1
+      updated_count == 1
     end
 
     # Initializes +attribute+ to zero if +nil+ and adds the value passed as +by+ (default is 1).

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -592,6 +592,19 @@ class PersistencesTest < ActiveRecord::TestCase
     assert_equal 'super_title', t.title
   end
 
+  def test_update_columns_changing_id
+    topic = Topic.find(1)
+    topic.update_columns(id: 123)
+    assert_equal 123, topic.id
+    topic.reload
+    assert_equal 123, topic.id
+  end
+
+  def test_update_columns_returns_boolean
+    topic = Topic.find(1)
+    assert_equal true, topic.update_columns(title: "New title")
+  end
+
   def test_update_attributes
     topic = Topic.find(1)
     assert !topic.approved?


### PR DESCRIPTION
Didn't work before because it updated the model-in-memory first, so the DB query couldn't find the record.
