### PR TITLE
Warn on dangerous column names

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -66,6 +66,10 @@ module ActiveRecord
       # that have been defined.
       attr_accessor :columns, :indexes
 
+      # a list of column names which, if used, may cause other ActiveRecord 
+      # classes to behave in a non-intuitive way
+      DANGEROUS_COLUMN_NAMES = [:attributes]
+
       def initialize(base)
         @columns = []
         @columns_hash = {}
@@ -237,6 +241,10 @@ module ActiveRecord
         if primary_key_column_name == name
           raise ArgumentError, "you can't redefine the primary key column '#{name}'. To define a custom primary key, pass { id: false } to create_table."
         end
+
+        if DANGEROUS_COLUMN_NAMES.include? name 
+          ActiveRecord::Base.logger.warn "'#{name}' specified as column name. This name is already in use by ActiveRecord. If you plan to access the table via ActiveRecord, it is strongly advised to select a different name for the column."
+        end 
 
         column = self[name] || new_column_definition(@base, name, type)
 


### PR DESCRIPTION
Print a warning when migrating with a column name that may conflict
with reserved words

In relation to https://github.com/rails/rails/issues/4238

I wanted to get feedback on this before I go any further. The idea would be to grow this list to cover any column which would have its accessors hidden by built in methods.
