### PR TITLE
descriptive error message when AR adapter was not found. Closes #7313

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Descriptive error message when the necessary AR adapter gem was not found.
+    Fix #7313
+
+    *Yves Senn*
+
 *   ActiveRecord now raises an error when blank arguments are passed to query
     methods for which blank arguments do not make sense. This also occurs for
     nil-like objects in arguments.
@@ -8,7 +13,7 @@
 
         Post.limit()     # => raises error
         Post.include([]) # => raises error
-    
+
     *John Wang*
 
 *   Simplified type casting code for timezone aware attributes to use the

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -51,10 +51,13 @@ module ActiveRecord
 
           raise(AdapterNotSpecified, "database configuration does not specify adapter") unless spec.key?(:adapter)
 
+          path_to_adapter = "active_record/connection_adapters/#{spec[:adapter]}_adapter"
           begin
-            require "active_record/connection_adapters/#{spec[:adapter]}_adapter"
+            require path_to_adapter
+          rescue Gem::LoadError => e
+            raise Gem::LoadError, "Specified '#{spec[:adapter]}' for database adapter, but the gem is not loaded. Add `gem '#{e.name}'` to your Gemfile."
           rescue LoadError => e
-            raise LoadError, "Please install the #{spec[:adapter]} adapter: `gem install activerecord-#{spec[:adapter]}-adapter` (#{e.message})", e.backtrace
+            raise LoadError, "Could not load '#{path_to_adapter}'. Make sure that the adapter in config/database.yml is valid. If you use an adapter other than 'mysql', 'mysql2', 'postgresql' or 'sqlite3' add the necessary adapter gem to the Gemfile.", e.backtrace
           end
 
           adapter_method = "#{spec[:adapter]}_connection"

--- a/activerecord/test/cases/connection_specification/resolver_test.rb
+++ b/activerecord/test/cases/connection_specification/resolver_test.rb
@@ -70,6 +70,15 @@ module ActiveRecord
           spec = resolve "abstract://foo:#{encoded_password}@localhost/bar"
           assert_equal password, spec[:password]
         end
+
+        def test_descriptive_error_message_when_adapter_is_missing
+          error = assert_raise(LoadError) do
+            resolve(adapter: 'non-existing')
+          end
+
+          assert_match "Could not load 'active_record/connection_adapters/non-existing_adapter'", error.message
+        end
+
       end
     end
   end


### PR DESCRIPTION
The error message currently looks like:

```
LoadError: could not load 'active_record/connection_adapters/non-existing_adapter'. Make sure to add the necessary adapter gem to your Gemfile:
    sqlite3:    gem 'sqlite3'
    postgres:   gem 'pg'
    mysql:      gem 'mysql2'
```

This is a fix for #7313
