### PR TITLE
Provide a call stack for deprecation warnings where needed.

### DIFF
--- a/actionpack/lib/action_controller/record_identifier.rb
+++ b/actionpack/lib/action_controller/record_identifier.rb
@@ -8,12 +8,12 @@ module ActionController
               'ActionView::RecodIdentifier module.'
 
     def dom_id(record, prefix = nil)
-      ActiveSupport::Deprecation.warn 'dom_id ' + MESSAGE
+      ActiveSupport::Deprecation.warn('dom_id ' + MESSAGE, caller)
       ActionView::RecordIdentifier.dom_id(record, prefix)
     end
 
     def dom_class(record, prefix = nil)
-      ActiveSupport::Deprecation.warn 'dom_class ' + MESSAGE
+      ActiveSupport::Deprecation.warn('dom_class ' + MESSAGE, caller)
       ActionView::RecordIdentifier.dom_class(record, prefix)
     end
   end

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -476,7 +476,7 @@ module ActionController
 
       def process(action, http_method = 'GET', *args)
         check_required_ivars
-        http_method, args = handle_old_process_api(http_method, args)
+        http_method, args = handle_old_process_api(http_method, args, caller)
 
         if args.first.is_a?(String) && http_method != 'HEAD'
           @request.env['RAW_POST_DATA'] = args.shift
@@ -579,10 +579,10 @@ module ActionController
         end
       end
 
-      def handle_old_process_api(http_method, args)
+      def handle_old_process_api(http_method, args, callstack)
         # 4.0: Remove this method.
         if http_method.is_a?(Hash)
-          ActiveSupport::Deprecation.warn("TestCase#process now expects the HTTP method as second argument: process(action, http_method, params, session, flash)")
+          ActiveSupport::Deprecation.warn("TestCase#process now expects the HTTP method as second argument: process(action, http_method, params, session, flash)", callstack)
           args.unshift(http_method)
           http_method = args.last.is_a?(String) ? args.last : "GET"
         end

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -275,12 +275,12 @@ module Mime
     # Returns true if Action Pack should check requests using this Mime Type for possible request forgery. See
     # ActionController::RequestForgeryProtection.
     def verify_request?
-      ActiveSupport::Deprecation.warn "Mime::Type#verify_request? is deprecated and will be removed in Rails 4.1"
+      ActiveSupport::Deprecation.warn("Mime::Type#verify_request? is deprecated and will be removed in Rails 4.1", caller)
       @@browser_generated_types.include?(to_sym)
     end
 
     def self.browser_generated_types
-      ActiveSupport::Deprecation.warn "Mime::Type.browser_generated_types is deprecated and will be removed in Rails 4.1"
+      ActiveSupport::Deprecation.warn("Mime::Type.browser_generated_types is deprecated and will be removed in Rails 4.1", caller)
       @@browser_generated_types
     end
 

--- a/actionpack/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helper.rb
@@ -125,7 +125,7 @@ module ActionView
                     "the :type option key. This behavior is deprecated and will be remove in Rails 4.1. You should pass " +
                     ":type option explicitly if you want to use other types, for example: " +
                     "auto_discovery_link_tag(:xml, '/feed.xml', :type => 'application/xml')"
-          ActiveSupport::Deprecation.warn message
+          ActiveSupport::Deprecation.warn(message, caller)
         end
 
         tag(

--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -1181,8 +1181,8 @@ module ActionView
 
       def initialize(object_name, object, template, options, block=nil)
         if block
-          ActiveSupport::Deprecation.warn(
-            "Giving a block to FormBuilder is deprecated and has no effect anymore.")
+          message = "Giving a block to FormBuilder is deprecated and has no effect anymore."
+          ActiveSupport::Deprecation.warn(message, caller)
         end
 
         @nested_child_index = {}

--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -519,7 +519,9 @@ module ActionView
         else
           prompt  = options
           options = {}
-          ActiveSupport::Deprecation.warn "Passing the prompt to grouped_options_for_select as an argument is deprecated. Please use an options hash like `{ prompt: #{prompt.inspect} }`."
+          message = "Passing the prompt to grouped_options_for_select as an argument is deprecated. " /
+                    "Please use an options hash like `{ prompt: #{prompt.inspect} }`."
+          ActiveSupport::Deprecation.warn(message, caller)
         end
 
         body = "".html_safe

--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -425,13 +425,17 @@ module ActionView
         options = options.stringify_keys
 
         if disable_with = options.delete("disable_with")
-          ActiveSupport::Deprecation.warn ":disable_with option is deprecated and will be removed from Rails 4.1. Use ':data => { :disable_with => \'Text\' }' instead"
+          message = ":disable_with option is deprecated and will be removed from Rails 4.1. " /
+                    "Use ':data => { :disable_with => \'Text\' }' instead."
+          ActiveSupport::Deprecation.warn(message, caller)
 
           options["data-disable-with"] = disable_with
         end
 
         if confirm = options.delete("confirm")
-          ActiveSupport::Deprecation.warn ":confirm option is deprecated and will be removed from Rails 4.1. Use ':data => { :confirm => \'Text\' }' instead'"
+          message = ":confirm option is deprecated and will be removed from Rails 4.1. " /
+                    "Use ':data => { :confirm => \'Text\' }' instead'."
+          ActiveSupport::Deprecation.warn(message, caller)
 
           options["data-confirm"] = confirm
         end
@@ -483,13 +487,17 @@ module ActionView
         options = options.stringify_keys
 
         if disable_with = options.delete("disable_with")
-          ActiveSupport::Deprecation.warn ":disable_with option is deprecated and will be removed from Rails 4.1. Use ':data => { :disable_with => \'Text\' }' instead"
+          message = ":disable_with option is deprecated and will be removed from Rails 4.1. " /
+                    "Use ':data => { :disable_with => \'Text\' }' instead."
+          ActiveSupport::Deprecation.warn(message, caller)
 
           options["data-disable-with"] = disable_with
         end
 
         if confirm = options.delete("confirm")
-          ActiveSupport::Deprecation.warn ":confirm option is deprecated and will be removed from Rails 4.1. Use ':data => { :confirm => \'Text\' }' instead'"
+          message = ":confirm option is deprecated and will be removed from Rails 4.1. " /
+                    "Use ':data => { :confirm => \'Text\' }' instead'."
+          ActiveSupport::Deprecation.warn(message, caller)
 
           options["data-confirm"] = confirm
         end
@@ -533,7 +541,9 @@ module ActionView
         options = options.stringify_keys
 
         if confirm = options.delete("confirm")
-          ActiveSupport::Deprecation.warn ":confirm option is deprecated and will be removed from Rails 4.1. Use ':data => { :confirm => \'Text\' }' instead'"
+          message = ":confirm option is deprecated and will be removed from Rails 4.1. " /
+                    "Use ':data => { :confirm => \'Text\' }' instead'."
+          ActiveSupport::Deprecation.warn(message, caller)
 
           options["data-confirm"] = confirm
         end

--- a/actionpack/lib/action_view/helpers/javascript_helper.rb
+++ b/actionpack/lib/action_view/helpers/javascript_helper.rb
@@ -80,7 +80,7 @@ module ActionView
       def button_to_function(name, function=nil, html_options={})
         message = "button_to_function is deprecated and will be removed from Rails 4.1. We recomend to use Unobtrusive JavaScript instead. " +
           "See http://guides.rubyonrails.org/working_with_javascript_in_rails.html#unobtrusive-javascript"
-        ActiveSupport::Deprecation.warn message
+        ActiveSupport::Deprecation.warn(message, caller)
 
         onclick = "#{"#{html_options[:onclick]}; " if html_options[:onclick]}#{function};"
 
@@ -102,7 +102,7 @@ module ActionView
       def link_to_function(name, function, html_options={})
         message = "link_to_function is deprecated and will be removed from Rails 4.1. We recomend to use Unobtrusive JavaScript instead. " +
           "See http://guides.rubyonrails.org/working_with_javascript_in_rails.html#unobtrusive-javascript"
-        ActiveSupport::Deprecation.warn message
+        ActiveSupport::Deprecation.warn(message, caller)
 
         onclick = "#{"#{html_options[:onclick]}; " if html_options[:onclick]}#{function}; return false;"
         href = html_options[:href] || '#'

--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -577,7 +577,9 @@ module ActionView
             method  = html_options.delete('method')
 
             if confirm
-              ActiveSupport::Deprecation.warn ":confirm option is deprecated and will be removed from Rails 4.1. Use ':data => { :confirm => \'Text\' }' instead"
+              message = ":confirm option is deprecated and will be removed from Rails 4.1. " /
+                        "Use ':data => { :confirm => \'Text\' }' instead."
+              ActiveSupport::Deprecation.warn(message, caller)
 
               html_options["data-confirm"] = confirm
             end
@@ -585,7 +587,9 @@ module ActionView
             add_method_to_attributes!(html_options, method) if method
 
             if disable_with
-              ActiveSupport::Deprecation.warn ":disable_with option is deprecated and will be removed from Rails 4.1. Use ':data => { :disable_with => \'Text\' }' instead"
+              message = ":disable_with option is deprecated and will be removed from Rails 4.1. " /
+                        "Use ':data => { :disable_with => \'Text\' }' instead."
+              ActiveSupport::Deprecation.warn(message, caller)
 
               html_options["data-disable-with"] = disable_with
             end

--- a/actionpack/lib/action_view/template.rb
+++ b/actionpack/lib/action_view/template.rb
@@ -149,7 +149,8 @@ module ActionView
     end
 
     def mime_type
-      ActiveSupport::Deprecation.warn 'Template#mime_type is deprecated and will be removed in Rails 4.1. Please use type method instead.'
+      message = 'Template#mime_type is deprecated and will be removed in Rails 4.1. Please use type method instead.'
+      ActiveSupport::Deprecation.warn(message, caller)
       @mime_type ||= Mime::Type.lookup_by_extension(@formats.first.to_s) if @formats.first
     end
 

--- a/actionpack/lib/action_view/template/resolver.rb
+++ b/actionpack/lib/action_view/template/resolver.rb
@@ -232,8 +232,14 @@ module ActionView
     def extract_handler_and_format(path, default_formats)
       pieces = File.basename(path).split(".")
       pieces.shift
+
       extension = pieces.pop
-      ActiveSupport::Deprecation.warn "The file #{path} did not specify a template handler. The default is currently ERB, but will change to RAW in the future." unless extension
+      unless extension
+        message = "The file #{path} did not specify a template handler. The default is currently ERB, " /
+                  "but will change to RAW in the future."
+        ActiveSupport::Deprecation.warn(message, caller)
+      end
+
       handler = Template.handler_for_extension(extension)
       format  = pieces.last && Template::Types[pieces.last]
       [handler, format]

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -383,12 +383,11 @@ module ActiveModel
 
           def initialize(options = {})
             if options[:prefix] == '' || options[:suffix] == ''
-              ActiveSupport::Deprecation.warn(
-                "Specifying an empty prefix/suffix for an attribute method is no longer " \
-                "necessary. If the un-prefixed/suffixed version of the method has not been " \
-                "defined when `define_attribute_methods` is called, it will be defined " \
-                "automatically."
-              )
+              message = "Specifying an empty prefix/suffix for an attribute method is no longer " \
+                        "necessary. If the un-prefixed/suffixed version of the method has not been " \
+                        "defined when `define_attribute_methods` is called, it will be defined " \
+                        "automatically."
+              ActiveSupport::Deprecation.warn(message, caller)
             end
 
             @prefix, @suffix = options.fetch(:prefix, ''), options.fetch(:suffix, '')

--- a/activemodel/lib/active_model/observing.rb
+++ b/activemodel/lib/active_model/observing.rb
@@ -172,7 +172,7 @@ module ActiveModel
       # <tt>count_observers</tt> is deprecated. Use #observers_count.
       def count_observers
         msg = "count_observers is deprecated in favor of observers_count"
-        ActiveSupport::Deprecation.warn(msg)
+        ActiveSupport::Deprecation.warn(msg, caller)
         observers_count
       end
 

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -85,7 +85,7 @@ module ActiveRecord
       end
 
       def scoped
-        ActiveSupport::Deprecation.warn("#scoped is deprecated. use #scope instead.")
+        ActiveSupport::Deprecation.warn("#scoped is deprecated. use #scope instead.", caller)
         scope
       end
 

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -45,7 +45,8 @@ module ActiveRecord
       end
 
       def serialized_attributes
-        ActiveSupport::Deprecation.warn("Instance level serialized_attributes method is deprecated, please use class level method.")
+        message = "Instance level serialized_attributes method is deprecated, please use class level method."
+        ActiveSupport::Deprecation.warn(message, caller)
         defined?(@serialized_attributes) ? @serialized_attributes : self.class.serialized_attributes
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -255,15 +255,16 @@ module ActiveRecord
       end
 
       def increment_open_transactions
-        ActiveSupport::Deprecation.warn "#increment_open_transactions is deprecated and has no effect"
+        ActiveSupport::Deprecation.warn("#increment_open_transactions is deprecated and has no effect", caller)
       end
 
       def decrement_open_transactions
-        ActiveSupport::Deprecation.warn "#decrement_open_transactions is deprecated and has no effect"
+        ActiveSupport::Deprecation.warn("#decrement_open_transactions is deprecated and has no effect", caller)
       end
 
       def transaction_joinable=(joinable)
-        ActiveSupport::Deprecation.warn "#transaction_joinable= is deprecated. Please pass the :joinable option to #begin_transaction instead."
+        message = "#transaction_joinable= is deprecated. Please pass the :joinable option to #begin_transaction instead."
+        ActiveSupport::Deprecation.warn(message, caller)
         @transaction.joinable = joinable
       end
 

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -107,8 +107,9 @@ module ActiveRecord
       end
 
       def type_cast_code(var_name)
-        ActiveSupport::Deprecation.warn("Column#type_cast_code is deprecated in favor of" \
-          "using Column#type_cast only, and it is going to be removed in future Rails versions.")
+        message = "Column#type_cast_code is deprecated in favor of using Column#type_cast only, " \
+                  "and it is going to be removed in future Rails versions."
+        ActiveSupport::Deprecation.warn(message, caller)
 
         klass = self.class.name
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -221,10 +221,9 @@ module ActiveRecord
         end
 
         def outside_transaction?
-          ActiveSupport::Deprecation.warn(
-            "#outside_transaction? is deprecated. This method was only really used " \
-            "internally, but you can use #transaction_open? instead."
-          )
+          message = "#outside_transaction? is deprecated. This method was only really used " \
+                    "internally, but you can use #transaction_open? instead."
+          ActiveSupport::Deprecation.warn(message, caller)
           @connection.transaction_status == PGconn::PQTRANS_IDLE
         end
 

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -732,9 +732,8 @@ module ActiveRecord
       running = runnable
 
       if block_given?
-        ActiveSupport::Deprecation.warn(<<-eomsg)
-block argument to migrate is deprecated, please filter migrations before constructing the migrator
-        eomsg
+        message = "block argument to migrate is deprecated, please filter migrations before constructing the migrator"
+        ActiveSupport::Deprecation.warn(message, caller)
         running.select! { |m| yield m }
       end
 

--- a/activerecord/lib/active_record/readonly_attributes.rb
+++ b/activerecord/lib/active_record/readonly_attributes.rb
@@ -22,7 +22,8 @@ module ActiveRecord
     end
 
     def _attr_readonly
-      ActiveSupport::Deprecation.warn("Instance level _attr_readonly method is deprecated, please use class level method.")
+      message = "Instance level _attr_readonly method is deprecated, please use class level method."
+      ActiveSupport::Deprecation.warn(message, caller)
       defined?(@_attr_readonly) ? @_attr_readonly : self.class._attr_readonly
     end
   end

--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -95,7 +95,8 @@ module ActiveRecord
               "Calling #default_scope without a block is deprecated. For example instead " \
               "of `default_scope where(color: 'red')`, please use " \
               "`default_scope { where(color: 'red') }`. (Alternatively you can just redefine " \
-              "self.default_scope.)"
+              "self.default_scope.)",
+              caller
             )
           end
 

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -156,7 +156,8 @@ module ActiveRecord
               "`scope :red, -> { where(color: 'red') }`. There are numerous gotchas " \
               "in the former usage and it makes the implementation more complicated " \
               "and buggy. (If you prefer, you can just define a class method named " \
-              "`self.red`.)"
+              "`self.red`.)",
+              caller
             )
           end
 

--- a/activesupport/lib/active_support/benchmarkable.rb
+++ b/activesupport/lib/active_support/benchmarkable.rb
@@ -48,7 +48,8 @@ module ActiveSupport
 
     # Silence the logger during the execution of the block.
     def silence
-      ActiveSupport::Deprecation.warn "ActiveSupport::Benchmarkable#silence is deprecated. It will be removed from Rails 4.1."
+      message = "ActiveSupport::Benchmarkable#silence is deprecated. It will be removed from Rails 4.1."
+      ActiveSupport::Deprecation.warn(message, caller)
       old_logger_level, logger.level = logger.level, ::Logger::ERROR if logger
       yield
     ensure

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -282,12 +282,15 @@ module ActiveSupport
 
       def _normalize_legacy_filter(kind, filter)
         if !filter.respond_to?(kind) && filter.respond_to?(:filter)
-          ActiveSupport::Deprecation.warn("Filter object with #filter method is deprecated. Define method corresponding to filter type (#before, #after or #around).")
+          message = "Filter object with #filter method is deprecated. Define method corresponding " \
+                    "to filter type (#before, #after or #around)."
+          ActiveSupport::Deprecation.warn(message, caller)
           filter.singleton_class.class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
             def #{kind}(context, &block) filter(context, &block) end
           RUBY_EVAL
         elsif filter.respond_to?(:before) && filter.respond_to?(:after) && kind == :around && !filter.respond_to?(:around)
-          ActiveSupport::Deprecation.warn("Filter object with #before and #after methods is deprecated. Define #around method instead.")
+          message = "Filter object with #before and #after methods is deprecated. Define #around method instead."
+          ActiveSupport::Deprecation.warn(message, caller)
           def filter.around(context)
             should_continue = before(context)
             yield if should_continue

--- a/activesupport/lib/active_support/json/variable.rb
+++ b/activesupport/lib/active_support/json/variable.rb
@@ -5,8 +5,9 @@ module ActiveSupport
     # Deprecated: A string that returns itself as its JSON-encoded form.
     class Variable < String
       def initialize(*args)
-        ActiveSupport::Deprecation.warn 'ActiveSupport::JSON::Variable is deprecated and will be removed in Rails 4.1. ' \
-                                        'For your own custom JSON literals, define #as_json and #encode_json yourself.'
+        message = 'ActiveSupport::JSON::Variable is deprecated and will be removed in Rails 4.1. ' \
+                  'For your own custom JSON literals, define #as_json and #encode_json yourself.'
+        ActiveSupport::Deprecation.warn(message, caller)
         super
       end
 

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -43,7 +43,8 @@ module ActiveSupport
       if block_given?
         super
       else
-        ActiveSupport::Deprecation.warn("`describe` without a block is deprecated, please switch to: `def self.name; #{text.inspect}; end`\n")
+        message = "`describe` without a block is deprecated, please switch to: `def self.name; #{text.inspect}; end`\n"
+        ActiveSupport::Deprecation.warn(message, caller)
 
         class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
           def self.name

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -88,9 +88,10 @@ module Rails
       end
 
       def threadsafe!
-        ActiveSupport::Deprecation.warn "config.threadsafe! is deprecated. Rails applications " \
-          "behave by default as thread safe in production as long as config.cache_classes and " \
-          "config.eager_load are set to true"
+        message = "config.threadsafe! is deprecated. Rails applications " \
+                  "behave by default as thread safe in production as long as config.cache_classes and " \
+                  "config.eager_load are set to true"
+        ActiveSupport::Deprecation.warn(message, caller)
         @cache_classes = true
         @eager_load = true
         self


### PR DESCRIPTION
It's sometimes hard to quickly find where deprecated call was performed, especially in case of migrating between Rails versions. So this is an attempt to improve the call stack part of the warning message by providing caller explicitly.
