### PR TITLE
Remove the sort in the serialization methods used by as_json

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -72,7 +72,7 @@ module ActiveModel
       only   = Array.wrap(options[:only]).map(&:to_s)
       except = Array.wrap(options[:except]).map(&:to_s)
 
-      attribute_names = attributes.keys.sort
+      attribute_names = attributes.keys
       if only.any?
         attribute_names &= only
       elsif except.any?

--- a/activemodel/test/cases/serializeration/json_serialization_test.rb
+++ b/activemodel/test/cases/serializeration/json_serialization_test.rb
@@ -135,6 +135,15 @@ class JsonSerializationTest < ActiveModel::TestCase
     end
   end
 
+  test "as_json should keep the default order in the hash" do
+    json = @contact.as_json
+
+    keys = json['contact'].keys
+    %w(name age created_at awesome preferences).each_with_index do |field, index|
+      assert_equal keys.index(field), index
+    end
+  end
+
   test "custom as_json should be honored when generating json" do
     def @contact.as_json(options); { :name => name, :created_at => created_at }; end
     json = @contact.to_json


### PR DESCRIPTION
- It's easier to order the keys afterwards than to unorder.
- Normally, we shouldn't waste some time to order the keys as it is a json object, the ordering doesn't matter.
