### PR TITLE
include_root_in_json attribute allows inheritance.

### DIFF
--- a/activerecord/lib/active_record/serialization.rb
+++ b/activerecord/lib/active_record/serialization.rb
@@ -5,7 +5,6 @@ module ActiveRecord #:nodoc:
     include ActiveModel::Serializers::JSON
 
     included do
-      mattr_accessor :include_root_in_json, instance_accessor: false
       self.include_root_in_json = true
     end
 

--- a/activerecord/test/cases/serialization_test.rb
+++ b/activerecord/test/cases/serialization_test.rb
@@ -45,4 +45,20 @@ class SerializationTest < ActiveRecord::TestCase
       assert_equal @contact_attributes[:awesome], contact.awesome, "For #{format}"
     end
   end
+
+  def test_include_root_in_json_allows_inheritance
+    original_root_in_json = ActiveRecord::Base.include_root_in_json
+    ActiveRecord::Base.include_root_in_json = true
+
+    klazz = Class.new(ActiveRecord::Base)
+    klazz.table_name = 'topics'
+    assert klazz.include_root_in_json
+
+    klazz.include_root_in_json = false
+    assert ActiveRecord::Base.include_root_in_json
+    assert !klazz.include_root_in_json
+    assert !klazz.new.include_root_in_json
+  ensure
+    ActiveRecord::Base.include_root_in_json = original_root_in_json
+  end
 end


### PR DESCRIPTION
When I executed rails's testcases, I found the following warnings. And I wanted to fix this.

```
activesupport/lib/active_support/core_ext/module/attribute_accessors.rb:11: warning: method redefined; discarding old include_root_in_json
activesupport/lib/active_support/core_ext/class/attribute.rb:83: warning: previous definition of include_root_in_json was here
activesupport/lib/active_support/core_ext/module/attribute_accessors.rb:31: warning: method redefined; discarding old include_root_in_json=
activesupport/lib/active_support/core_ext/class/attribute.rb:80: warning: previous definition of include_root_in_json= was here
```

But I thought `include_root_in_json` should be `class_attribute` (inheritance-able attribute), and my testcase was not passed.
