### PR TITLE
Fix find_in_batches against string IDs when start option is not specified

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix `find_in_batches` crashing when IDs are strings and start option is not specified.
+
+    *Alexis Bernard*
+
 *   `AR::Base#attributes_before_type_cast` now returns unserialized values for serialized attributes.
 
     *Nikita Afanasenko*

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -62,11 +62,11 @@ module ActiveRecord
         ActiveRecord::Base.logger.warn("Scoped order and limit are ignored, it's forced to be batch order and batch size")
       end
 
-      start = options.delete(:start) || 0
+      start = options.delete(:start)
       batch_size = options.delete(:batch_size) || 1000
 
       relation = relation.reorder(batch_order).limit(batch_size)
-      records = relation.where(table[primary_key].gteq(start)).to_a
+      records = start ? relation.where(table[primary_key].gteq(start)).to_a : relation.to_a
 
       while records.any?
         records_size = records.size

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -136,4 +136,13 @@ class EachTest < ActiveRecord::TestCase
 
     assert_equal nick_order_subscribers[1..-1].map(&:id), subscribers.map(&:id)
   end
+
+  def test_find_in_batches_should_use_any_column_as_primary_key_when_start_is_not_specified
+    Subscriber.count('nick') # preheat arel's table cache
+    assert_queries(Subscriber.count + 1) do
+      Subscriber.find_each(:batch_size => 1) do |subscriber|
+        assert_kind_of Subscriber, subscriber
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hi,

Here is a fix for find_in_batches when Model#id is a string. In fact when calling find_in_batches (or find_each) without the start option it generates a wrong SQL statement:

```
Subscriber.find_each { |subscriber| ...  }
# Generates SQL:
# SELECT  "subscribers".* FROM "subscribers"  WHERE ("subscribers"."nick" >= 0) ...
```

That statement is invalid with strict databases such as PostgreSQL, because it tries to compare a string against an integer.

With more tolerant databases such as SQLite it's passing, but in fact it skips IDs starting with a lower character than '0'.

Once accepted and merged, I plan to backport that fix in pull request #7987 for rails 3.2.

cc @spastorino
