### PR TITLE
Fix #6951. Use query cache/uncache, when using not only database.yml but also DATABASE_URL.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Use query cache/uncache when using DATABASE_URL.
+    Fix #6951.
+
+    *kennyj*
+
 *   Added `#none!` method for mutating `ActiveRecord::Relation` objects to a NullRelation.
     It acts like `#none` but modifies relation in place.
 

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -5,19 +5,19 @@ module ActiveRecord
     module ClassMethods
       # Enable the query cache within the block if Active Record is configured.
       def cache(&block)
-        if ActiveRecord::Base.configurations.blank?
-          yield
-        else
+        if ActiveRecord::Base.connected?
           connection.cache(&block)
+        else
+          yield
         end
       end
 
       # Disable the query cache within the block if Active Record is configured.
       def uncached(&block)
-        if ActiveRecord::Base.configurations.blank?
-          yield
-        else
+        if ActiveRecord::Base.connected?
           connection.uncached(&block)
+        else
+          yield
         end
       end
     end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -184,6 +184,17 @@ class QueryCacheTest < ActiveRecord::TestCase
       assert_queries(2) { task.lock!; task.lock! }
     end
   end
+
+  def test_cache_is_available_when_connection_is_connected
+    conf = ActiveRecord::Base.configurations
+
+    ActiveRecord::Base.configurations = {}
+    Task.cache do
+      assert_queries(1) { Task.find(1); Task.find(1) }
+    end
+  ensure
+    ActiveRecord::Base.configurations = conf
+  end
 end
 
 class QueryCacheExpiryTest < ActiveRecord::TestCase


### PR DESCRIPTION
This PR closes #6951.

If we use `DATABASE_URL`, `ActiveRecord::Base.configurations` is not populated. Thus we can't use query cache with DATABASE_URL.

See https://github.com/rails/rails/blob/master/activerecord/lib/active_record/query_cache.rb#L7
