### PR TITLE
ActiveRecord: support for validates_uniqueness_of in PostgreSQL array columns

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Added support for `validates_uniqueness_of` in PostgreSQL array columns.
+    Fixes #8075.
+
+    *Pedro Padron*
+
 *   Added `#none!` method for mutating `ActiveRecord::Relation` objects to a NullRelation.
     It acts like `#none` but modifies relation in place.
 

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -71,8 +71,13 @@ module ActiveRecord
         end
 
         column = klass.columns_hash[attribute.to_s]
-        value = column.limit ? value.to_s[0, column.limit] : value.to_s if !value.nil? && column.text?
 
+        if !value.nil? && column.text? && column.limit
+          value = value.to_s[0, column.limit]
+        else
+          value = klass.connection.type_cast(value, column)
+        end
+        
         if !options[:case_sensitive] && value && column.text?
           # will use SQL LOWER function before comparison, unless it detects a case insensitive collation
           relation = klass.connection.case_insensitive_comparison(table, attribute, column, value)

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -360,13 +360,13 @@ class UniquenessValidationTest < ActiveRecord::TestCase
   end
 
   def test_validate_uniqueness_with_array_column
-    return skip "Uniqueness on arrays has only tested in PostgreSQL so far." if !current_adapter? :PostgreSQLAdapter
+    return skip "Uniqueness on arrays has only been tested in PostgreSQL so far." if !current_adapter? :PostgreSQLAdapter
 
     e1 = Employee.create("nicknames" => ["john", "johnny"], "commission_by_quarter" => [1000, 1200])
-    assert e1.valid?, "Saving e1"
+    assert e1.persisted?, "Saving e1"
 
     e2 = Employee.create("nicknames" => ["john", "johnny"], "commission_by_quarter" => [2200])
-    assert !e2.valid?, "e2 shouldn't be valid"
+    assert !e2.persisted?, "e2 shouldn't be valid"
     assert e2.errors[:nicknames].any?, "Should have errors for nicknames"
     assert_equal ["has already been taken"], e2.errors[:nicknames], "Should have uniqueness message for nicknames"
   end  


### PR DESCRIPTION
When setting an array column (or other PostgreSQL-specific data type) to be validated for uniqueness, the resulting SQL query is generated with syntax errors, like this:

SELECT  1 AS one FROM "postgresql_arrays"  WHERE "postgresql_arrays"."nicknames" = '["john", "johnny"]' LIMIT 1

This happens because Ruby Arrays must be type-casted to their PostgreSQL equivalent.  This small patch fixes this issue, calling the adapter's type_cast method.

I have added a test case for this, but since it's PostgreSQL-specific (it skips for other adapters), I'm not sure if it belongs in the validate_uniqueness_test.rb or if I should put it with other PostgreSQL tests.

Thanks,
