### PR TITLE
Backport #8078: Fix `attributes_before_type_cast` for serialised attributes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 3.2.10 (unreleased)
 
+*   `AR::Base#attributes_before_type_cast` now returns unserialized values for serialized attributes.
+
+    *Nikita Afanasenko*
+
 *   Fix issue that raises `NameError` when overriding the `accepts_nested_attributes` in child classes.
 
     Before:

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -97,6 +97,16 @@ module ActiveRecord
           super
         end
       end
+
+      def attributes_before_type_cast
+        super.dup.tap do |attributes|
+          self.class.serialized_attributes.each_key do |key|
+            if attributes.key?(key)
+              attributes[key] = attributes[key].unserialized_value
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1293,6 +1293,16 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal({ :foo => :bar }, t.content_before_type_cast)
   end
 
+  def test_serialized_attributes_before_type_cast_returns_unserialized_value
+    Topic.serialize :content, Hash
+
+    t = Topic.new(:content => { :foo => :bar })
+    assert_equal({ :foo => :bar }, t.attributes_before_type_cast["content"])
+    t.save!
+    t.reload
+    assert_equal({ :foo => :bar }, t.attributes_before_type_cast["content"])
+  end
+
   def test_serialized_attribute_calling_dup_method
     klass = Class.new(ActiveRecord::Base)
     klass.table_name = "topics"


### PR DESCRIPTION
Public method attributes_before_type_cast used to return internal AR structure (ActiveRecord::AttributeMethods::Serialization::Attribute), patch fixes this. Now behaves like read_attribute_before_type_cast and returns unserialised values.
