### PR TITLE
if format is unknown NullMimeTypeObject is returned

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Added `NullMimeTypeObject` class. This  allows to use html?, xml?, json?..etc when
+    the `format` of `request` is unknown.
+   
+    *Angelo  Capilleri*
+
 *   `date_select` helper accepts `with_css_classes: true` to add css classes similar with type
     of generated select tags.
 

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -153,7 +153,7 @@ module Mime
       end
 
       def lookup_by_extension(extension)
-        EXTENSION_LOOKUP[extension.to_s]
+        EXTENSION_LOOKUP[extension.to_s] || NullMimeTypeObject.new
       end
 
       # Registers an alias that's not used on mime type lookup, but can be referenced directly. Especially useful for
@@ -300,6 +300,17 @@ module Mime
       def respond_to_missing?(method, include_private = false) #:nodoc:
         method.to_s.ends_with? '?'
       end
+  end
+
+  class NullMimeTypeObject
+    private
+    def method_missing(method, *args)
+      if method.to_s.ends_with? '?'
+        false
+      else
+        super
+      end
+    end
   end
 end
 

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -590,7 +590,17 @@ class RequestTest < ActiveSupport::TestCase
 
     request = stub_request
     request.expects(:parameters).at_least_once.returns({ :format => :unknown })
-    assert request.formats.empty?
+    assert_instance_of Mime::NullMimeTypeObject , request.format
+  end
+
+
+  test "format is not nil with unknown format" do
+    request = stub_request
+    request.expects(:parameters).at_least_once.returns({ format: :hello })
+    assert_equal request.format.html?, false
+    assert_equal request.format.xml?, false
+    assert_equal request.format.json?, false
+    assert !request.format.html?
   end
 
   test "formats with xhr request" do


### PR DESCRIPTION
If a unknown format is passed in a request, the methods html?, xml?, json? ...etc
Nil Exception.

This patch add a class NullMimeTypeObject, that is returned when  request.format is unknown
and it responds false to the methods that ends with '?'.

It refers to #7837, not fixes because it's not considered a improvement not a bug.
