### PR TITLE
if format is unknown NullMimeTypeObject is returned

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Added `Mime::NullType` class. This  allows to use html?, xml?, json?..etc when
+    the `format` of `request` is unknown, without raise an exception.
+    
+    *Angelo Capilleri*
+
 *   Integrate the Journey gem into Action Dispatch so that the global namespace
     is not polluted with names that may be used as models.
 

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -27,7 +27,7 @@ module Mime
   class << self
     def [](type)
       return type if type.is_a?(Type)
-      Type.lookup_by_extension(type)
+      Type.lookup_by_extension(type) || NullType.new
     end
 
     def fetch(type)
@@ -304,6 +304,17 @@ module Mime
 
     def respond_to_missing?(method, include_private = false) #:nodoc:
       method.to_s.ends_with? '?'
+    end
+  end
+  
+  class NullType
+    def nil?
+      true
+    end
+
+    private
+    def method_missing(method, *args)
+      false if method.to_s.ends_with? '?'
     end
   end
 end

--- a/actionpack/test/controller/send_file_test.rb
+++ b/actionpack/test/controller/send_file_test.rb
@@ -144,7 +144,7 @@ class SendFileTest < ActionController::TestCase
     }
 
     @controller.headers = {}
-    assert_raise(ArgumentError){ @controller.send(:send_file_headers!, options) }
+    assert !@controller.send(:send_file_headers!, options)
   end
 
   def test_send_file_headers_guess_type_from_extension

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -591,9 +591,18 @@ class RequestTest < ActiveSupport::TestCase
 
     request = stub_request
     request.expects(:parameters).at_least_once.returns({ :format => :unknown })
-    assert request.formats.empty?
+    assert_instance_of Mime::NullType, request.format
   end
 
+  test "format is not nil with unknown format" do
+    request = stub_request
+    request.expects(:parameters).at_least_once.returns({ format: :hello })
+    assert_equal request.format.nil?, true
+    assert_equal request.format.html?, false
+    assert_equal request.format.xml?, false
+    assert_equal request.format.json?, false
+  end
+  
   test "formats with xhr request" do
     request = stub_request 'HTTP_X_REQUESTED_WITH' => "XMLHttpRequest"
     request.expects(:parameters).at_least_once.returns({})


### PR DESCRIPTION
If a unknown format is passed in a request, the methods html?, xml?, json? ...etc
Nil Exception.

This patch add a class NullMimeTypeObject, that is returned when  request.format is unknown
and it responds false to the methods that ends with '?'.

It refers to #7837, it's considered a improvement not a bug.
