### PR TITLE
ActiveSupport: Added `each_with_hash` to Enumerable

### DIFF
--- a/actionpack/lib/action_dispatch/request/session.rb
+++ b/actionpack/lib/action_dispatch/request/session.rb
@@ -168,7 +168,7 @@ module ActionDispatch
       end
 
       def stringify_keys(other)
-        other.each_with_object({}) { |(key, value), hash|
+        other.each_with_hash { |(key, value), hash|
           hash[key.to_s] = value
         }
       end

--- a/actionpack/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionpack/lib/action_view/renderer/abstract_renderer.rb
@@ -13,7 +13,7 @@ module ActionView
     protected
 
     def extract_details(options)
-      @lookup_context.registered_details.each_with_object({}) do |key, details|
+      @lookup_context.registered_details.each_with_hash do |key, details|
         next unless value = options[key]
         details[key] = Array(value)
       end

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -201,7 +201,7 @@ module ActiveRecord
     #   person.attributes
     #   # => {"id"=>3, "created_at"=>Sun, 21 Oct 2012 04:53:04, "updated_at"=>Sun, 21 Oct 2012 04:53:04, "name"=>"Francesco", "age"=>22}
     def attributes
-      attribute_names.each_with_object({}) { |name, attrs|
+      attribute_names.each_with_hash { |name, attrs|
         attrs[name] = read_attribute(name)
       }
     end

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -258,7 +258,7 @@ module ActiveRecord
       # and true as the value. This makes it possible to do O(1) lookups in respond_to? to check if a given method for attribute
       # is available.
       def column_methods_hash #:nodoc:
-        @dynamic_methods_hash ||= column_names.each_with_object(Hash.new(false)) do |attr, methods|
+        @dynamic_methods_hash ||= column_names.each_with_hash(false) do |attr, methods|
           attr_name = attr.to_s
           methods[attr.to_sym]       = attr_name
           methods["#{attr}=".to_sym] = attr_name

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -808,7 +808,7 @@ module ActiveRecord
         when Symbol
           { o => :desc }
         when Hash
-          o.each_with_object({}) do |(field, dir), memo|
+          o.each_with_hash do |(field, dir), memo|
             memo[field] = (dir == :asc ? :desc : :asc )
           end
         else

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -39,6 +39,40 @@ module Enumerable
     end
   end
 
+  # Convert an enumerable to a hash, with the same block syntax as <tt>each_with_object</tt>.
+  # Allows a default value or proc to be given. If <tt>set_default_on_lookup</tt> is <tt>true</tt>,
+  # the default value will be converted to a proc that sets the Hash key when looked up.
+  # This is ignored if default is already a proc.
+  #
+  # [1,3,5].each_with_hash {|i, h| h[i] = i ** 2 }
+  #   => {1=>1, 3=>9, 5=>25}
+  #
+  # [3,4,5,4].each_with_hash(0) {|i, h| h[i] += i }
+  #   => {3=>3, 4=>8, 5=>5}
+  #
+  # ['red', 'blue'].each_with_hash(-> h, k { h[k] = k.upcase }) {|c, h| h[c] << '!' }
+  #   => {'red'=>'RED!', 'blue'=>'BLUE!'}
+  #
+  # [1,2,3,2,1].each_with_hash([], true) {|i, h| h[i] << i * 2 }
+  #   => {1=>[2, 2], 2=>[4, 4], 3=>[3]}
+  def each_with_hash(default = nil, set_default_on_lookup = false)
+    if block_given?
+      hash = if Proc === default
+        Hash.new &default
+      else
+        if set_default_on_lookup
+          Hash.new &-> hash, key { hash[key] = default.dup }
+        else
+          Hash.new default
+        end
+      end
+      self.each { |el| yield el, hash }
+      hash
+    else
+      to_enum :each_with_hash, default, set_default_on_lookup
+    end
+  end
+
   # Returns +true+ if the enumerable has more than 1 element. Functionally
   # equivalent to <tt>enum.to_a.size > 1</tt>. Can be called with a block too,
   # much like any?, so <tt>people.many? { |p| p.age > 26 }</tt> returns +true+


### PR DESCRIPTION
This is in response to the discussion at https://bugs.ruby-lang.org/issues/7241

I think an `each_with_hash` method would be a very useful addition. It provides a nice shortcut for the common `each_with_object({})`, but it also supports setting a default value or proc for the Hash. It also provides a shortcut for a common use of `Hash.new( <proc> )`, which is setting the default value on a hash key when it is looked up. Here's an example of how you could write less code using that feature:

``` ruby
# using each_with_object:

[1,2,3,2].each_with_object(Hash.new(&-> hash, key { hash[key] = [] })) {|el, hash| hash[el] << el ** 2 }
#=> {1=>[1], 2=>[4, 4], 3=>[9]}

# using each_with_hash:

[1,2,3,2].each_with_hash([], true) {|hash, el| hash[el] << el ** 2}
#=> {1=>[1], 2=>[4, 4], 3=>[9]}
```

I would love to be able to easily use `<<` with arrays, instead of having to write `hash[el] += [el ** 2]`.

If this gets merged, it would be awesome if it could also be included in `3-2-stable`.

Thanks!
