### PR TITLE
Glob Constraint Fix 

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
+*   Fixed issue where routes with globs caused constraints on that glob to be ignored. A regular
+    expression constraint gets overwritten when the routes.rb file is processed. Changed the
+    overwriting to an ||= instead of an = assignment. Added a regression test. GH#7924
+
+    *Maura Fitzgerald*
 
 *   `date_select` helper accepts `with_css_classes: true` to add css classes similar with type
     of generated select tags.
@@ -106,7 +111,7 @@
     *Nihad Abbasov*
 
 *   Deprecate Mime::Type#verify_request? and Mime::Type.browser_generated_types,
-    since they are no longer used inside of Rails, they will be removed in Rails 4.1
+    since they are no longer used inside of Rals, they will be removed in Rails 4.1
 
     *Michael Grosser*
 

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -158,7 +158,7 @@ module ActionDispatch
           def requirements
             @requirements ||= (@options[:constraints].is_a?(Hash) ? @options[:constraints] : {}).tap do |requirements|
               requirements.reverse_merge!(@scope[:constraints]) if @scope[:constraints]
-              @options.each { |k, v| requirements[k] = v if v.is_a?(Regexp) }
+              @options.each { |k, v| requirements[k] ||= v if v.is_a?(Regexp) }
             end
           end
 

--- a/actionpack/test/dispatch/glob_routing_test.rb
+++ b/actionpack/test/dispatch/glob_routing_test.rb
@@ -1,0 +1,20 @@
+require 'abstract_unit'
+
+
+class TestGlobRoutingMapper < ActionDispatch::IntegrationTest
+  stub_controllers do |routes|
+    Routes = routes
+    Routes.draw do
+      get "/*id" => redirect("/not_cars"), :constraints => {id: /dummy/}
+      resource :cars
+    end
+  end
+
+  include Routes.url_helpers
+  def app; Routes end
+
+  def test_glob_constraints
+    get "/cars"
+    assert_equal "200", @response.code
+  end
+end


### PR DESCRIPTION
Fixed issue where routes with globs caused constraints on that glob to be ignored. A regular expression constraint gets overwritten when the routes.rb file is processed. Changed the overwriting to an ||= instead of an = assignment. Added a regression test.
