### PR TITLE
Fix #8086 (BestStandardsSupport rewrites app X-UA-Compatible header)

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `BestStandardsSupport` middleware now appends it's `X-UA-Compatible` value to app's
+    returned value if any. Fix #8086
+
+    *Nikita Afanasenko*
+
 *   `date_select` helper accepts `with_css_classes: true` to add css classes similar with type
     of generated select tags.
 

--- a/actionpack/lib/action_dispatch/middleware/best_standards_support.rb
+++ b/actionpack/lib/action_dispatch/middleware/best_standards_support.rb
@@ -15,7 +15,13 @@ module ActionDispatch
 
     def call(env)
       status, headers, body = @app.call(env)
-      headers["X-UA-Compatible"] = @header
+
+      if headers["X-UA-Compatible"] && @header
+        headers["X-UA-Compatible"] << "," << @header.to_s
+      else
+        headers["X-UA-Compatible"] = @header
+      end
+
       [status, headers, body]
     end
   end

--- a/actionpack/test/dispatch/best_standards_support_test.rb
+++ b/actionpack/test/dispatch/best_standards_support_test.rb
@@ -1,0 +1,34 @@
+require 'abstract_unit'
+
+class BestStandardsSupportTest < ActiveSupport::TestCase
+  def test_with_best_standards_support
+    _, headers, _ = app(true, {}).call({})
+    assert_equal "IE=Edge,chrome=1", headers["X-UA-Compatible"]
+  end
+
+  def test_with_builtin_best_standards_support
+    _, headers, _ = app(:builtin, {}).call({})
+    assert_equal "IE=Edge", headers["X-UA-Compatible"]
+  end
+
+  def test_without_best_standards_support
+    _, headers, _ = app(false, {}).call({})
+    assert_equal nil, headers["X-UA-Compatible"]
+  end
+
+  def test_appends_to_app_headers
+    app_headers = { "X-UA-Compatible" => "requiresActiveX=true" }
+    _, headers, _ = app(true, app_headers).call({})
+
+    expects = "requiresActiveX=true,IE=Edge,chrome=1"
+    assert_equal expects, headers["X-UA-Compatible"]
+  end
+
+  private
+
+    def app(type, headers)
+      app = proc { [200, headers, "response"] }
+      ActionDispatch::BestStandardsSupport.new(app, type)
+    end
+
+end


### PR DESCRIPTION
Now `BestStandardsSupport` middleware appends it's `X-UA-Compatible` value to app's value.
Also test for `BestStandardsSupport` middleware added.
