### PR TITLE
set inverses correctly for first(n) and last(n)

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -571,7 +571,12 @@ module ActiveRecord
           args.shift if args.first.is_a?(Hash) && args.first.empty?
 
           collection = fetch_first_or_last_using_find?(args) ? scoped : load_target
-          collection.send(type, *args).tap {|it| set_inverse_instance it }
+          result = collection.send(type, *args)
+          if args.first.is_a?(Integer)
+            result.each { |it| set_inverse_instance it }
+          else
+            result.tap {|it| set_inverse_instance it }
+          end
         end
     end
   end

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -265,6 +265,12 @@ class InverseHasManyTests < ActiveRecord::TestCase
     assert man.interests.last.man.equal? man
   end
 
+  def test_parent_instance_should_be_shared_with_first_and_last_children
+    man = Man.first
+    assert man.interests.first(2).all? { |interest| interest.man.equal? man }
+    assert man.interests.last(2).all? { |interest| interest.man.equal? man }
+  end
+
   def test_trying_to_use_inverses_that_dont_exist_should_raise_an_error
     assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Man.find(:first).secret_interests }
   end


### PR DESCRIPTION
The code introduced in #7377 assumes that `first` and `last` always return a single record. This is incorrect for calling `first` with an integer argument.

The attached commit (against 3-2-stable) handles this case correctly and includes a test.

I'm not super-happy with the resulting code; there's way too much `is_a?` checking going on in `first_or_last`, but this will work for now to get 3.2.9 out.
