### PR TITLE
Support :multiple option on input tags that also have :index

### DIFF
--- a/actionpack/lib/action_view/helpers/tags/base.rb
+++ b/actionpack/lib/action_view/helpers/tags/base.rb
@@ -80,18 +80,16 @@ module ActionView
             options["name"] ||= options.fetch("name"){ tag_name_with_index(@auto_index) }
             options["id"] = options.fetch("id"){ tag_id_with_index(@auto_index) }
           else
-            options["name"] ||= options.fetch("name"){ options['multiple'] ? tag_name_multiple : tag_name }
+            options["name"] ||= options.fetch("name"){ tag_name }
             options["id"] = options.fetch("id"){ tag_id }
           end
+
+          options["name"] += "[]" if options["multiple"]
           options["id"] = [options.delete('namespace'), options["id"]].compact.join("_").presence
         end
 
         def tag_name
           "#{@object_name}[#{sanitized_method_name}]"
-        end
-
-        def tag_name_multiple
-          "#{tag_name}[]"
         end
 
         def tag_name_with_index(index)

--- a/actionpack/lib/action_view/helpers/tags/collection_check_boxes.rb
+++ b/actionpack/lib/action_view/helpers/tags/collection_check_boxes.rb
@@ -27,7 +27,7 @@ module ActionView
 
           # Append a hidden field to make sure something will be sent back to the
           # server if all check boxes are unchecked.
-          hidden = @template_object.hidden_field_tag(tag_name_multiple, "", :id => nil)
+          hidden = @template_object.hidden_field_tag("#{tag_name}[]", "", :id => nil)
 
           rendered_collection + hidden
         end

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -525,6 +525,19 @@ class FormHelperTest < ActionView::TestCase
     )
   end
 
+  def test_check_box_with_multiple_behavior_and_index
+    @post.comment_ids = [2,3]
+    assert_dom_equal(
+      '<input name="post[foo][comment_ids][]" type="hidden" value="0" /><input id="post_foo_comment_ids_1" name="post[foo][comment_ids][]" type="checkbox" value="1" />',
+      check_box("post", "comment_ids", { :multiple => true, :index => "foo" }, 1)
+    )
+    assert_dom_equal(
+      '<input name="post[bar][comment_ids][]" type="hidden" value="0" /><input checked="checked" id="post_bar_comment_ids_3" name="post[bar][comment_ids][]" type="checkbox" value="3" />',
+      check_box("post", "comment_ids", { :multiple => true, :index => "bar" }, 3)
+    )
+
+  end
+
   def test_checkbox_disabled_disables_hidden_field
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" disabled="disabled"/><input checked="checked" disabled="disabled" id="post_secret" name="post[secret]" type="checkbox" value="1" />',


### PR DESCRIPTION
When you have an explicit index set, then when you build an input tag with :multiple => true, it doesn't add [] to the end of its name, although it should.
