### PR TITLE
Use `tag!` instead of `method_missing` in `to_xml` conversions.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `to_xml` conversions now use builder's `tag!` method instead of explicit invocation of `method_missing`.
+
+    *Nikita Afanasenko*
+
 *   Fixed timezone mapping of the Solomon Islands. *Steve Klabnik*
 
 *   Make callstack attribute optional in

--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -194,7 +194,7 @@ class Array
 
     options = options.dup
     options[:indent]  ||= 2
-    options[:builder] ||= Builder::XmlMarkup.new(:indent => options[:indent])
+    options[:builder] ||= Builder::XmlMarkup.new(indent: options[:indent])
     options[:root]    ||= \
       if first.class != Hash && all? { |e| e.is_a?(first.class) }
         underscored = ActiveSupport::Inflector.underscore(first.class.name)
@@ -208,12 +208,12 @@ class Array
 
     root = ActiveSupport::XmlMini.rename_key(options[:root].to_s, options)
     children = options.delete(:children) || root.singularize
-    attributes = options[:skip_types] ? {} : {:type => 'array'}
+    attributes = options[:skip_types] ? {} : { type: 'array' }
 
     if empty?
       builder.tag!(root, attributes)
     else
-      builder.__send__(:method_missing, root, attributes) do
+      builder.tag!(root, attributes) do
         each { |value| ActiveSupport::XmlMini.to_tag(children, value, options) }
         yield builder if block_given?
       end

--- a/activesupport/lib/active_support/core_ext/hash/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/hash/conversions.rb
@@ -74,14 +74,14 @@ class Hash
     options = options.dup
     options[:indent]  ||= 2
     options[:root]    ||= 'hash'
-    options[:builder] ||= Builder::XmlMarkup.new(:indent => options[:indent])
+    options[:builder] ||= Builder::XmlMarkup.new(indent: options[:indent])
 
     builder = options[:builder]
     builder.instruct! unless options.delete(:skip_instruct)
 
     root = ActiveSupport::XmlMini.rename_key(options[:root].to_s, options)
 
-    builder.__send__(:method_missing, root) do
+    builder.tag!(root) do
       each { |key, value| ActiveSupport::XmlMini.to_tag(key, value, options) }
       yield builder if block_given?
     end


### PR DESCRIPTION
Since version `3.0.x` `Builder` caches method passed to `method_missing` each time. This commit replaces `method_missing` call with `tag!` call to prevent method redefinition on each `to_xml` call with the same builder.
