### PR TITLE
Allow setting a symbol as path in scope on routes

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,27 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Allow setting a symbol as path in scope on routes. This is now allowed:
+
+      scope :api do
+        resources :users
+      end
+
+    also is possible pass multiple symbols to scope to shorten multiple nested scopes:
+
+      scope :api do
+        scope :v1 do
+          resources :users
+        end
+      end
+
+    can be rewritten as:
+
+      scope :api, :v1 do
+        resources :users
+      end
+
+    *Guillermo Iguaran*
+
 *   Fix error when using a non-hash query argument named "params" in `url_for`.
 
     Before:

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -644,7 +644,7 @@ module ActionDispatch
           options = args.extract_options!
           options = options.dup
 
-          options[:path] = args.first if args.first.is_a?(String)
+          options[:path] = args.flatten.join('/') if args.any?
           recover = {}
 
           options[:constraints] ||= {}

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -370,6 +370,14 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
       scope :path => 'api' do
         resource :me
         get '/' => 'mes#index'
+        scope :v2 do
+          resource :me, as: 'v2_me'
+          get '/' => 'mes#index'
+        end
+
+        scope :v3, :admin do
+          resource :me, as: 'v3_me'
+        end
       end
 
       get "(/:username)/followers" => "followers#index"
@@ -1465,6 +1473,18 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
     get '/api'
     assert_equal 'mes#index', @response.body
+  end
+
+  def test_symbol_scope
+    get '/api/v2/me'
+    assert_equal 'mes#show', @response.body
+    assert_equal '/api/v2/me', v2_me_path
+
+    get '/api/v2'
+    assert_equal 'mes#index', @response.body
+
+    get '/api/v3/admin/me'
+    assert_equal 'mes#show', @response.body
   end
 
   def test_url_generator_for_generic_route


### PR DESCRIPTION
Was surprising found that this example doesn't work:

``` ruby
scope :api do
  resources :users
end
```

and the right form to use it is:

``` ruby
scope 'api' do
  resources :users
end
```

I think this should work similary as `namespace` where both are allowed.
These two are equivalent:

``` ruby
namespace :api do
  resources :users
end
```

``` ruby
namespace 'api' do
  resources :users
end
```
