### PR TITLE
handle trailing slash with engines (test case for #7842)

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -491,9 +491,7 @@ module ActionDispatch
                 prefix_options = options.slice(*_route.segment_keys)
                 # we must actually delete prefix segment keys to avoid passing them to next url_for
                 _route.segment_keys.each { |k| options.delete(k) }
-                prefix = _routes.url_helpers.send("#{name}_path", prefix_options)
-                prefix = '' if prefix == '/'
-                prefix
+                _routes.url_helpers.send("#{name}_path", prefix_options)
               end
             end
           end

--- a/actionpack/test/dispatch/prefix_generation_test.rb
+++ b/actionpack/test/dispatch/prefix_generation_test.rb
@@ -241,6 +241,11 @@ module TestGenerationPrefix
       assert_equal "/something/", app_object.root_path
     end
 
+    test "[OBJECT] generating application's route includes default_url_options[:trailing_slash]" do
+      RailsApplication.routes.default_url_options[:trailing_slash] = true
+      assert_equal "/awesome/blog/posts", engine_object.posts_path
+    end
+
     test "[OBJECT] generating engine's route with url_for" do
       path = engine_object.url_for(:controller => "inside_engine_generating",
                                    :action => "show",


### PR DESCRIPTION
This PR adds a test case to make sure that we don't get any regressions on #7842. Also I removed obsolete code from the `_generate_prefix` method.

The issue described in #7842 has been fixed on master but is still present on `3-2-stable`. The attached test case will fail on `3-2-stable` and passes on master.
