### PR TITLE
:counter_cache option for  to support custom named counter caches

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   :counter_cache option for `has_many` associations to support custom named counter caches.
+    Fix #7993
+
+    *Yves Senn*
+
 *   Deprecate the possibility to pass a string as third argument of `add_index`.
     Pass `unique: true` instead.
 

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1122,6 +1122,9 @@ module ActiveRecord
       #   If using with the <tt>:through</tt> option, the association on the join model must be
       #   a +belongs_to+, and the records which get deleted are the join records, rather than
       #   the associated records.
+      # [:counter_cache]
+      #   This option can be used to configure a custom named <tt>:counter_cache.</tt> You only need this option,
+      #   when you customized the name of your <tt>:counter_cache</tt> on the <tt>belongs_to</tt> association.
       # [:as]
       #   Specifies a polymorphic interface (See <tt>belongs_to</tt>).
       # [:through]

--- a/activerecord/lib/active_record/associations/builder/has_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_many.rb
@@ -5,7 +5,7 @@ module ActiveRecord::Associations::Builder
     end
 
     def valid_options
-      super + [:primary_key, :dependent, :as, :through, :source, :source_type, :inverse_of]
+      super + [:primary_key, :dependent, :as, :through, :source, :source_type, :inverse_of, :counter_cache]
     end
 
     def valid_dependent_options

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -76,7 +76,7 @@ module ActiveRecord
         end
 
         def cached_counter_attribute_name(reflection = reflection)
-          "#{reflection.name}_count"
+          options[:counter_cache] || "#{reflection.name}_count"
         end
 
         def update_counter(difference, reflection = reflection)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -754,6 +754,14 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_custom_named_counter_cache
+    topic = topics(:first)
+
+    assert_difference "topic.reload.replies_count", -1 do
+      topic.approved_replies.clear
+    end
+  end
+
   def test_deleting_a_collection
     force_signal37_to_load_all_clients_of_firm
     companies(:first_firm).clients_of_firm.create("name" => "Another Client")

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -33,6 +33,7 @@ class Topic < ActiveRecord::Base
   end
 
   has_many :replies, :dependent => :destroy, :foreign_key => "parent_id"
+  has_many :approved_replies, -> { approved }, class_name: 'Reply', foreign_key: "parent_id", counter_cache: 'replies_count'
   has_many :replies_with_primary_key, :class_name => "Reply", :dependent => :destroy, :primary_key => "title", :foreign_key => "parent_title"
 
   has_many :unique_replies, :dependent => :destroy, :foreign_key => "parent_id"


### PR DESCRIPTION
This is a fix for #7993. I introduced a `counter_cache` option for `has_many` associations. This option is only necessary, when the name of the counter cache was customized on the `belongs_to` association.

I updated the `CHANGELOG` and provided documentation for the `:counter_cache` option. I'm not sure if the wording is good enough though.
