### PR TITLE
Don't allow confirmation to pass if confirmation value is nil and doesn't match value

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix bug where confirmation validator was not triggering if
+    `_confirmation` attribute is `nil` *Brian Cardarella*
+
 *   Add `ActiveModel::ForbiddenAttributesProtection`, a simple module to
     protect attributes from mass assignment when non-permitted attributes are passed.
 
@@ -77,5 +80,5 @@
 *   Trim down Active Model API by removing `valid?` and `errors.full_messages` *José Valim*
 
 *   When `^` or `$` are used in the regular expression provided to `validates_format_of` and the :multiline option is not set to true, an exception will be raised. This is to prevent security vulnerabilities when using `validates_format_of`. The problem is described in detail in the Rails security guide *Jan Berdajs + Egor Homakov*
-
+    
 Please check [3-2-stable](https://github.com/rails/rails/blob/3-2-stable/activemodel/CHANGELOG.md) for previous changes.

--- a/activemodel/lib/active_model/validations/confirmation.rb
+++ b/activemodel/lib/active_model/validations/confirmation.rb
@@ -3,7 +3,8 @@ module ActiveModel
   module Validations
     class ConfirmationValidator < EachValidator # :nodoc:
       def validate_each(record, attribute, value)
-        if (confirmed = record.send("#{attribute}_confirmation")) && (value != confirmed)
+        confirmed = record.send("#{attribute}_confirmation")
+        if value != confirmed
           human_attribute_name = record.class.human_attribute_name(attribute)
           record.errors.add(:"#{attribute}_confirmation", :confirmation, options.merge(:attribute => human_attribute_name))
         end

--- a/activemodel/test/cases/validations/confirmation_validation_test.rb
+++ b/activemodel/test/cases/validations/confirmation_validation_test.rb
@@ -21,7 +21,7 @@ class ConfirmationValidationTest < ActiveModel::TestCase
 
     t.title_confirmation = nil
     t.title = "Parallel Lives"
-    assert t.valid?
+    assert t.invalid?
 
     t.title_confirmation = "Parallel Lives"
     assert t.valid?


### PR DESCRIPTION
Now that the validator has been put on the confirmation attribute there is the possibility of the confirmation validator passing when it shouldn't.

This fix resolves the following usecase:

``` ruby
class User < ActiveRecord::Base
  attr_accessor :password
  validates :password => { :confirmation => true }
end

u = User.new(:password => 'test')
u.valid?
# => true
```

The logic in the validator would skip if `password_confirmation` evaluates to `nil` which is very likely for many cases.
