### PR TITLE
Attach ConfirmationValidator to proper attribute

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -68,7 +68,7 @@
 
 *   Passing false hash values to `validates` will no longer enable the corresponding validators *Steve Purcell*
 
-*   `ConfirmationValidator` error messages will attach to `:#{attribute}_confirmation` instead of `attribute` *Brian Cardarella*
+*   `ConfirmationValidator` will attach to `:#{attribute}_confirmation` instead of `attribute` *Brian Cardarella*
 
 *   Added ActiveModel::Model, a mixin to make Ruby objects work with AP out of box *Guillermo Iguaran*
 

--- a/activemodel/test/cases/validations/confirmation_validation_test.rb
+++ b/activemodel/test/cases/validations/confirmation_validation_test.rb
@@ -21,7 +21,7 @@ class ConfirmationValidationTest < ActiveModel::TestCase
 
     t.title_confirmation = nil
     t.title = "Parallel Lives"
-    assert t.valid?
+    assert t.invalid?
 
     t.title_confirmation = "Parallel Lives"
     assert t.valid?

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -51,9 +51,12 @@ Rails 4.0 has changed `serialized_attributes` and `attr_readonly` to class metho
 
 ### Active Model
 
-Rails 4.0 has changed how errors attach with the `ActiveModel::Validations::ConfirmationValidator`.
-Now when confirmation validations fail the error will be attached to
-`:#{attribute}_confirmation` instead of `attribute`.
+Rails 4.0 has changed which attribute `ActiveModel::Validations::ConfirmationValidator`
+attaches to. Now the validator will attach to
+`:#{attribute}_confirmation` instead of `attribute`. This was done
+to improve the usability of form errors. The error message for a failed
+confirmation will render on the confirmation field instead of the
+original attribute field.
 
 Rails 4.0 has changed `ActiveModel::Serializers::JSON.include_root_in_json` default
 value to `false`. Now, Active Model Serializers and Active Record objects have the


### PR DESCRIPTION
This is a follow up to fcc534e

This patch will attach the ConfirmationValidator to the _confirmation
attribute instead of the original attribute. I believe this should be
the preferred method instead of faking the desired behavior by just
rendering to the error message to the _confirmation attribute.
