### PR TITLE
"head" renders valid JSON if response type is "application/json"

### DIFF
--- a/actionpack/lib/action_controller/metal/head.rb
+++ b/actionpack/lib/action_controller/metal/head.rb
@@ -31,7 +31,11 @@ module ActionController
 
       if include_content?(self.status)
         self.content_type = content_type || (Mime[formats.first] if formats)
-        self.response_body = " "
+        if self.content_type == "application/json"
+          self.response_body = "{}"
+        else
+          self.response_body = " "
+        end
       else
         headers.delete('Content-Type')
         headers.delete('Content-Length')

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -1219,7 +1219,7 @@ class RenderTest < ActionController::TestCase
 
   def test_head_created_with_application_json_content_type
     post :head_created_with_application_json_content_type
-    assert_blank @response.body
+    assert_nothing_raised { JSON.parse(@response.body) }
     assert_equal "application/json", @response.content_type
     assert_response :created
   end


### PR DESCRIPTION
I was getting javascript exceptions from jQuery using `$.post(...)` to an action that rendered using `head :ok` because head returns a blank response body (which is not valid JSON) even though $.post requested "application/json" and the response type was "application/json".

I went ahead and modified "head" put valid JSON in the response body if the response format is "application/json".

This may turn into a philosophical argument, but I would say that if the response claims that its content type is "application/json" that its body be valid for that type.
