### PR TITLE
Fix #8080 (wrong #respond_to? value for AR::Delegation).

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix the case when `AR::Relation#respond_to?` always return `true` for the methods
+    delegated to `AR::Base` instance without checking in this instance.
+
+    Before:
+
+      Topic.all.by_lifo              #=> Creates the scoped method on ActiveRecord::Delegation module
+      Post.all.respond_to?(:by_lifo) #=> true
+      Post.all.by_lifo               #=> NoMethodError
+
+    After:
+
+      Topic.all.by_lifo              #=> Creates the scoped method on ActiveRecord::Delegation module
+      Post.all.respond_to?(:by_lifo) #=> false
+
+    *Nikita Afanasenko*
+
 *   `AR::Delegation.delegate_to_scoped_klass` is now private.
 
     *Nikita Afanasenko*

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `AR::Delegation.delegate_to_scoped_klass` is now private.
+
+    *Nikita Afanasenko*
+
 *   Fix postgresql adapter to handle BC timestamps correctly
 
         HistoryEvent.create!(:name => "something", :occured_at => Date.new(0) - 5.years)

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -1,14 +1,22 @@
 module ActiveRecord
   module Delegation # :nodoc:
     # Set up common delegations for performance (avoids method_missing)
-    delegate :to_xml, :to_yaml, :length, :collect, :map, :each, :all?, :include?, :to_ary, :to => :to_a
+    delegate :to_xml, :to_yaml, :length, :collect, :map, :each, :all?, :include?, :to_ary, to: :to_a
     delegate :table_name, :quoted_table_name, :primary_key, :quoted_primary_key,
-             :connection, :columns_hash, :auto_explain_threshold_in_seconds, :to => :klass
+             :connection, :columns_hash, :auto_explain_threshold_in_seconds, to: :klass
 
+    @@compiled_delegators = Set.new
     @@delegation_mutex = Mutex.new
 
     def respond_to?(method, include_private = false)
-      super || Array.method_defined?(method) ||
+      # Check if `super` respond but the method is not in @@compiled_delegators,
+      # because for @@compiled_delegators, `super` always return `true`, but
+      # `method` itself sometimes returns `NoMethodError`.
+      super_respond = super && @@delegation_mutex.synchronize do
+        not @@compiled_delegators.include?(method)
+      end
+      super_respond ||
+        Array.method_defined?(method) ||
         @klass.respond_to?(method, include_private) ||
         arel.respond_to?(method, include_private)
     end
@@ -27,7 +35,7 @@ module ActiveRecord
       elsif Array.method_defined?(method)
         @@delegation_mutex.synchronize do
           unless ::ActiveRecord::Delegation.method_defined?(method)
-            ::ActiveRecord::Delegation.delegate method, :to => :to_a
+            ::ActiveRecord::Delegation.delegate method, to: :to_a
           end
         end
 
@@ -35,7 +43,7 @@ module ActiveRecord
       elsif arel.respond_to?(method)
         @@delegation_mutex.synchronize do
           unless ::ActiveRecord::Delegation.method_defined?(method)
-            ::ActiveRecord::Delegation.delegate method, :to => :arel
+            ::ActiveRecord::Delegation.delegate method, to: :arel
           end
         end
 
@@ -49,16 +57,38 @@ module ActiveRecord
       private
 
         def delegate_to_scoped_klass(method)
+          # Keep `@@compiled_delegators` updating and method definition in the same
+          # critical region to prevent inconsistency (when `@@compiled_delegators`
+          # includes `:foo`, but `:foo` has not yet been defined).
+
+          @@compiled_delegators << method
+
           if method.to_s =~ /\A[a-zA-Z_]\w*[!?]?\z/
             module_eval <<-RUBY, __FILE__, __LINE__ + 1
               def #{method}(*args, &block)
-                scoping { @klass.#{method}(*args, &block) }
+                if @klass.respond_to?(#{method.inspect})
+                  scoping { @klass.#{method}(*args, &block) }
+                elsif Array.method_defined?(#{method.inspect})
+                  to_a.#{method}(*args, &block)
+                elsif arel.respond_to?(#{method.inspect})
+                  arel.#{method}(*args, &block)
+                else
+                  raise NoMethodError, "undefined method `#{method}` for \#{@klass}"
+                end
               end
             RUBY
           else
             module_eval <<-RUBY, __FILE__, __LINE__ + 1
               def #{method}(*args, &block)
-                scoping { @klass.send(#{method.inspect}, *args, &block) }
+                if @klass.respond_to?(#{method.inspect})
+                  scoping { @klass.send(#{method.inspect}, *args, &block) }
+                elsif Array.method_defined?(#{method.inspect})
+                  to_a.send(#{method.inspect}, *args, &block)
+                elsif arel.respond_to?(#{method.inspect})
+                  arel.send(#{method.inspect}, *args, &block)
+                else
+                  raise NoMethodError, "undefined method `#{method}` for \#{@klass}"
+                end
               end
             RUBY
           end

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -1,0 +1,47 @@
+require "cases/helper"
+require "models/topic"
+require "models/post"
+
+module ActiveRecord
+  class RelationTest < ActiveRecord::TestCase
+    def test_scoped_responds_to_delegated_methods
+      relation = Topic.all
+
+      ["map", "uniq", "sort", "insert", "delete", "update"].each do |method|
+        assert_respond_to relation, method, "Topic.all should respond to #{method.inspect}"
+      end
+    end
+
+    def test_respond_to_delegates_to_relation
+      relation = Topic.all
+      fake_arel = Struct.new(:responds) {
+        def respond_to? method, access = false
+          responds << [method, access]
+        end
+      }.new []
+
+      relation.extend(Module.new { attr_accessor :arel })
+      relation.arel = fake_arel
+
+      relation.respond_to?(:matching_attributes)
+      assert_equal [:matching_attributes, false], fake_arel.responds.first
+
+      fake_arel.responds = []
+      relation.respond_to?(:matching_attributes, true)
+      assert_equal [:matching_attributes, true], fake_arel.responds.first
+    end
+
+    def test_respond_to_dynamic_finders
+      relation = Topic.all
+
+      ["find_by_title", "find_by_title_and_author_name", "find_or_create_by_title", "find_or_initialize_by_title_and_author_name"].each do |method|
+        assert_respond_to relation, method, "Topic.all should respond to #{method.inspect}"
+      end
+    end
+
+    def test_respond_to_class_methods_and_scopes
+      assert Topic.all.respond_to?(:by_lifo)
+    end
+
+  end
+end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -321,45 +321,6 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal 1, person_with_reader_and_post.size
   end
 
-  def test_scoped_responds_to_delegated_methods
-    relation = Topic.all
-
-    ["map", "uniq", "sort", "insert", "delete", "update"].each do |method|
-      assert_respond_to relation, method, "Topic.all should respond to #{method.inspect}"
-    end
-  end
-
-  def test_respond_to_delegates_to_relation
-    relation = Topic.all
-    fake_arel = Struct.new(:responds) {
-      def respond_to? method, access = false
-        responds << [method, access]
-      end
-    }.new []
-
-    relation.extend(Module.new { attr_accessor :arel })
-    relation.arel = fake_arel
-
-    relation.respond_to?(:matching_attributes)
-    assert_equal [:matching_attributes, false], fake_arel.responds.first
-
-    fake_arel.responds = []
-    relation.respond_to?(:matching_attributes, true)
-    assert_equal [:matching_attributes, true], fake_arel.responds.first
-  end
-
-  def test_respond_to_dynamic_finders
-    relation = Topic.all
-
-    ["find_by_title", "find_by_title_and_author_name", "find_or_create_by_title", "find_or_initialize_by_title_and_author_name"].each do |method|
-      assert_respond_to relation, method, "Topic.all should respond to #{method.inspect}"
-    end
-  end
-
-  def test_respond_to_class_methods_and_scopes
-    assert Topic.all.respond_to?(:by_lifo)
-  end
-
   def test_find_with_readonly_option
     Developer.all.each { |d| assert !d.readonly? }
     Developer.all.readonly.each { |d| assert d.readonly? }


### PR DESCRIPTION
Fix the case when `Relation#respond_to?` always return `true` for the methods delegated to `@klass` without checking for this method in `@klass`. (#8080)

Before patch:

``` ruby
Topic.all.by_lifo              #=> Creates the scoped method on ActiveRecord::Delegation module
Post.all.respond_to?(:by_lifo) #=> true
Post.all.by_lifo               #=> NoMethodError
```

After patch:

``` ruby
Topic.all.by_lifo              #=> Creates the scoped method on ActiveRecord::Delegation module
Post.all.respond_to?(:by_lifo) #=> false
```

Also moved delegation tests to the separate case and fixed some hashes to 1.9-style.
