### PR TITLE
Permitted should be sticky on #slice

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -259,7 +259,9 @@ module ActionController
     #   params.slice(:a, :b) # => {"a"=>1, "b"=>2}
     #   params.slice(:d)     # => {}
     def slice(*keys)
-      self.class.new(super)
+      self.class.new(super).tap do |new_instance|
+        new_instance.instance_variable_set :@permitted, @permitted
+      end
     end
 
     # Returns an exact copy of the <tt>ActionController::Parameters</tt>

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -32,13 +32,37 @@ class ParametersPermitTest < ActiveSupport::TestCase
     assert !@params.values_at(:person).first.permitted?
   end
 
+  test "permitted is sticky on accessors" do
+    @params.permit!
+    assert @params.slice(:person).permitted?
+    assert @params[:person][:name].permitted?
+    assert @params[:person].except(:name).permitted?
+
+    @params.each { |key, value| assert(value.permitted?) if key == "person" }
+
+    assert @params.fetch(:person).permitted?
+
+    assert @params.values_at(:person).first.permitted?
+  end
+
   test "not permitted is sticky on mutators" do
     assert !@params.delete_if { |k| k == "person" }.permitted?
     assert !@params.keep_if { |k,v| k == "person" }.permitted?
   end
 
+  test "permitted is sticky on mutators" do
+    @params.permit!
+    assert @params.delete_if { |k| k == "person" }.permitted?
+    assert @params.keep_if { |k,v| k == "person" }.permitted?
+  end
+
   test "not permitted is sticky beyond merges" do
     assert !@params.merge(a: "b").permitted?
+  end
+
+  test "permitted is sticky beyond merges" do
+    @params.permit!
+    assert @params.merge(a: "b").permitted?
   end
 
   test "modifying the parameters" do

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -23,6 +23,7 @@ class ParametersPermitTest < ActiveSupport::TestCase
   test "not permitted is sticky on accessors" do
     assert !@params.slice(:person).permitted?
     assert !@params[:person][:name].permitted?
+    assert !@params[:person].except(:name).permitted?
 
     @params.each { |key, value| assert(!value.permitted?) if key == "person" }
 

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -20,7 +20,7 @@ class ParametersPermitTest < ActiveSupport::TestCase
     assert_equal "monkey", @params.fetch(:foo) { "monkey" }
   end
 
-  test "permitted is sticky on accessors" do
+  test "not permitted is sticky on accessors" do
     assert !@params.slice(:person).permitted?
     assert !@params[:person][:name].permitted?
 
@@ -31,12 +31,12 @@ class ParametersPermitTest < ActiveSupport::TestCase
     assert !@params.values_at(:person).first.permitted?
   end
 
-  test "permitted is sticky on mutators" do
+  test "not permitted is sticky on mutators" do
     assert !@params.delete_if { |k| k == "person" }.permitted?
     assert !@params.keep_if { |k,v| k == "person" }.permitted?
   end
 
-  test "permitted is sticky beyond merges" do
+  test "not permitted is sticky beyond merges" do
     assert !@params.merge(a: "b").permitted?
   end
 

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -24,7 +24,7 @@ class ParametersPermitTest < ActiveSupport::TestCase
     assert !@params.slice(:person).permitted?
     assert !@params[:person][:name].permitted?
 
-    @params.each { |key, value| assert(value.permitted?) if key == :person }
+    @params.each { |key, value| assert(!value.permitted?) if key == "person" }
 
     assert !@params.fetch(:person).permitted?
 
@@ -32,8 +32,8 @@ class ParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "permitted is sticky on mutators" do
-    assert !@params.delete_if { |k| k == :person }.permitted?
-    assert !@params.keep_if { |k,v| k == :person }.permitted?
+    assert !@params.delete_if { |k| k == "person" }.permitted?
+    assert !@params.keep_if { |k,v| k == "person" }.permitted?
   end
 
   test "permitted is sticky beyond merges" do
@@ -77,7 +77,7 @@ class ParametersPermitTest < ActiveSupport::TestCase
       ActionController::Parameters.permit_all_parameters = false
     end
   end
-  
+
   test "permitting parameters as an array" do
     assert_equal "32", @params[:person].permit([ :age ])[:age]
   end


### PR DESCRIPTION
In rails/strong_parameters#57, I filed a bug report:

---
#### #permitted? survives :except, but not :slice

I would expect that calling `:slice` on a permitted Parameters hash would return another permitted hash, just as `:except` does. But no:

```
> params = ActionController::Parameters.new(:foo => 42, :bar => 1337).permit(:foo, :bar)
 => {"foo"=>42, "bar"=>1337}
> params.except(:bar).permitted?
 => true
> params.slice(:foo).permitted?
 => false
```

Is this a feature, or is it a bug?

---

DHH et al confirmed that it's a bug. I made a pull request rails/strong_parameters#58, which got merged in, and @rafaelfranca asked me to open a pull request for Rails core as well. Here is the description of the original pull request (with SHAs changed to match the current pull request):

---
#### Permitted should be sticky when calling slice

This pull request solves 3 different things:
1. Some of the parameters_taint tests were broken. Fixed in 5b3b9b0ebcbe35038adaf7b1636032e6f436ed1c
2. The "permitted is sticky" tests are actually testing that "tainted is sticky". "Tainted" seems to not be used anymore, so I changed their titles to "not permitted is sticky" in 93eaffe59b713e94424212540a8788f0b273f8eb – and added a test for #except in 1a0f14e0453d3a36f134989752721292aed54892
3. I made a set of new "permitted is sticky" tests, basically inverted copies of the existing tests, only testing on a `permitted` object: 478d80fd5788a4b3e7c8482bfd3713eef7d00884 – with the #slice bug fixed in 344364990436d9fcb7e77d5deb1beeb9c34a2b85

---
