### PR TITLE
Make YAML.dump work with ActiveSupport::TimeWithZone (under both Ruby 1.8/1.9)

### DIFF
--- a/activesupport/lib/active_support/core_ext/load_error.rb
+++ b/activesupport/lib/active_support/core_ext/load_error.rb
@@ -20,7 +20,8 @@ class MissingSourceFile < LoadError #:nodoc:
   REGEXPS = [
     [/^no such file to load -- (.+)$/i, 1],
     [/^Missing \w+ (file\s*)?([^\s]+.rb)$/i, 2],
-    [/^Missing API definition file in (.+)$/i, 1]
+    [/^Missing API definition file in (.+)$/i, 1],
+    [/^cannot load such file -- (.+)$/i, 1]
   ] unless defined?(REGEXPS)
 end
 

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -129,11 +129,19 @@ module ActiveSupport
       end
     end
 
+    def encode_with(coder)
+      if coder.respond_to?(:represent_object)
+        coder.represent_object(nil, utc)
+       else
+        coder.represent_scalar(nil, utc.strftime("%Y-%m-%d %H:%M:%S.%9NZ"))
+      end
+    end
+
     def to_yaml(options = {})
       if options.kind_of?(YAML::Emitter)
         utc.to_yaml(options)
       else
-        time.to_yaml(options).gsub('Z', formatted_offset(true, 'Z'))
+        time.to_yaml(options).to_s.gsub('Z', formatted_offset(true, 'Z'))
       end
     end
 

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -97,11 +97,17 @@ class TimeWithZoneTest < Test::Unit::TestCase
   end
 
   def test_to_yaml
-    assert_equal "--- 1999-12-31 19:00:00 -05:00\n", @twz.to_yaml
+    # Should use same format as underlying Ruby implementation's Time#to_yaml
+    #   (which varies between different implementations)
+    assert_equal @twz.time.to_yaml.gsub('Z', '-05:00'), @twz.to_yaml
   end
 
   def test_ruby_to_yaml
-    assert_equal "--- \n:twz: 2000-01-01 00:00:00 Z\n", {:twz => @twz}.to_yaml
+    assert_equal({:twz => @twz.utc}.to_yaml, {:twz => @twz}.to_yaml)
+  end
+
+  def test_yaml_serialization_and_deserialization
+    assert_equal @twz, YAML.load(YAML.dump(@twz))
   end
 
   def test_httpdate

--- a/activesupport/test/i18n_test.rb
+++ b/activesupport/test/i18n_test.rb
@@ -7,8 +7,8 @@ class I18nTest < Test::Unit::TestCase
   end
   
   def test_time_zone_localization_with_default_format
-    Time.zone.stubs(:now).returns Time.local(2000)
-    assert_equal Time.zone.now.strftime("%a, %d %b %Y %H:%M:%S %z"), I18n.localize(Time.zone.now)
+    time = Time.local(2000)
+    assert_equal time.strftime("%a, %d %b %Y %H:%M:%S %z"), I18n.localize(time)
   end
   
   def test_date_localization_should_use_default_format


### PR DESCRIPTION
Just ran into this one while working on a legacy Rails 2.3 site.

Try `YAML.load(YAML.dump(t))` where `t` is an instance of `ActiveSupport::TimeWithZone`. Under Ruby 1.9.3, this fails with the following message:

```
NoMethodError: undefined method `period_for_utc' for nil:NilClass
    from /home/alex/Programming/Ruby/rails/activesupport/lib/active_support/time_with_zone.rb:58:in `period'
    from /home/alex/Programming/Ruby/rails/activesupport/lib/active_support/time_with_zone.rb:44:in `time'
    from /home/alex/Programming/Ruby/rails/activesupport/lib/active_support/time_with_zone.rb:304:in `respond_to?'
    from /home/alex/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:284:in `init_with'
```

The solution is to backport `TimeWithZone#encode_with` from Rails 3.

Under Ruby 1.8.7, `YAML.dump` also fails, with a different message:

```
NoMethodError: private method `gsub' called for #<StringIO:0x7f16d2215a08>
    from ./activesupport/lib/active_support/time_with_zone.rb:145:in `to_yaml'
```

Under Syck, `YAML.dump` passes a `StringIO` to `to_yaml` (rather than the "options" Hash which the author of `TimeWithZone#to_yaml` seemed to expect). Naturally, `gsub` fails on the `StringIO` object. The solution is simply to convert it to a String first.
