### PR TITLE
Add app Rake tasks when -T and --dummy-path is passed to `plugin new`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add dummy app Rake tasks when --skip-test-unit and --dummy-path is passed to the plugin generator.
+    Fix #8121
+
+    *Yves Senn*
+
 *   Ensure that RAILS_ENV is set when accessing Rails.env *Steve Klabnik*
 
 *   Don't eager-load app/assets and app/views *Elia Schito*
@@ -9,7 +14,7 @@
 *   New test locations `test/models`, `test/helpers`, `test/controllers`, and
     `test/mailers`. Corresponding rake tasks added as well. *Mike Moore*
 
-*   Set a different cache per environment for assets pipeline 
+*   Set a different cache per environment for assets pipeline
     through `config.assets.cache`.
 
     *Guillermo Iguaran*

--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -225,7 +225,7 @@ task default: :test
       end
 
       def create_test_dummy_files
-        return if options[:skip_test_unit] && options[:dummy_path] == 'test/dummy'
+        return unless with_dummy_app?
         create_dummy_app
       end
 
@@ -277,6 +277,10 @@ task default: :test
 
       def mountable?
         options[:mountable]
+      end
+
+      def with_dummy_app?
+        options[:skip_test_unit].blank? || options[:dummy_path] != 'test/dummy'
       end
 
       def self.banner

--- a/railties/lib/rails/generators/rails/plugin_new/templates/Rakefile
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/Rakefile
@@ -14,7 +14,7 @@ RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_files.include('lib/**/*.rb')
 end
 
-<% if full? && !options[:skip_active_record] && !options[:skip_test_unit] -%>
+<% if full? && !options[:skip_active_record] && with_dummy_app? -%>
 APP_RAKEFILE = File.expand_path("../<%= dummy_path -%>/Rakefile", __FILE__)
 load 'rails/tasks/engine.rake'
 <% end %>

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -66,6 +66,12 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
     assert_no_match(/APP_RAKEFILE/, File.read(File.join(destination_root, "Rakefile")))
   end
 
+  def test_generating_adds_dummy_app_rake_tasks_without_unit_test_files
+    run_generator [destination_root, "-T", "--mountable", '--dummy-path', 'my_dummy_app']
+
+    assert_match(/APP_RAKEFILE/, File.read(File.join(destination_root, "Rakefile")))
+  end
+
   def test_ensure_that_plugin_options_are_not_passed_to_app_generator
     FileUtils.cd(Rails.root)
     assert_no_match(/It works from file!.*It works_from_file/, run_generator([destination_root, "-m", "lib/template.rb"]))


### PR DESCRIPTION
This patch adds the dummy app Rake tasks to the Rakefile template when `rails plugin new` is called with `--skip-test-unit` and `--dummy-path`. Since `--dummy-path` generates the dummy app even when test unit is skipped I think it's ok to also add in the Rake tasks.

I added a CHANGELOG entry and also created the `with_dummy_app?` method to reuse the condition.

This is a fix for #8121
