### PR TITLE
Remove overmonkeypatching for Object#to_json

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/to_json.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_json.rb
@@ -9,12 +9,10 @@ end
 # otherwise they will always use to_json gem implementation, which is backwards incompatible in
 # several cases (for instance, the JSON implementation for Hash does not work) with inheritance
 # and consequently classes as ActiveSupport::OrderedHash cannot be serialized to json.
-[Object, Array, FalseClass, Float, Hash, Integer, NilClass, String, TrueClass].each do |klass|
-  klass.class_eval do
-    # Dumps object in JSON (JavaScript Object Notation). See www.json.org for more info.
-    def to_json(options = nil)
-      ActiveSupport::JSON.encode(self, options)
-    end
+class Object
+  # Dumps object in JSON (JavaScript Object Notation). See www.json.org for more info.
+  def to_json(options = nil)
+    ActiveSupport::JSON.encode(self, options)
   end
 end
 


### PR DESCRIPTION
All classes are inherited from Object.
No need to monkeypatch thme all.

Checked AM and AR tests - all pass.
