### PR TITLE
`Hash#deep_diff`, the recursive difference between two hashes

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Implement `Hash#deep_diff`, the recursive difference between two hashes.
+
+      { a: { b: 1 }}.deep_diff(a: { b: 1 })        # => {}
+      { a: { b: 1, c: 2 } }.deep_diff(a: { b: 1 }) # => { a: { c: 2 } }
+      { a: { b: 1 } }.deep_diff(a: { b: 1, c: 2 }) # => { a: { c: 2 } }
+
+    *Nikita Afanasenko*
+
 *   `to_xml` conversions now use builder's `tag!` method instead of explicit invocation of `method_missing`.
 
     *Nikita Afanasenko*

--- a/activesupport/lib/active_support/core_ext/hash/diff.rb
+++ b/activesupport/lib/active_support/core_ext/hash/diff.rb
@@ -1,13 +1,35 @@
 class Hash
   # Returns a hash that represents the difference between two hashes.
   #
-  #   {1 => 2}.diff(1 => 2)         # => {}
-  #   {1 => 2}.diff(1 => 3)         # => {1 => 2}
-  #   {}.diff(1 => 2)               # => {1 => 2}
-  #   {1 => 2, 3 => 4}.diff(1 => 2) # => {3 => 4}
+  #   { 1 => 2 }.diff(1 => 2)         # => {}
+  #   { 1 => 2 }.diff(1 => 3)         # => { 1 => 2 }
+  #   {}.diff(1 => 2)                 # => { 1 => 2 }
+  #   { 1 => 2, 3 => 4 }.diff(1 => 2) # => { 3 => 4 }
   def diff(other)
     dup.
       delete_if { |k, v| other[k] == v }.
       merge!(other.dup.delete_if { |k, v| has_key?(k) })
+  end
+
+  # Returns a hash that represents the recursive difference between two hashes.
+  #
+  #   { a: { b: 1 } }.deep_diff(a: { b: 1 })       # => {}
+  #   { a: { b: 1, c: 2 } }.deep_diff(a: { b: 1 }) # => { a: { c: 2 } }
+  #   { a: { b: 1 } }.deep_diff(a: { b: 1, c: 2 }) # => { a: { c: 2 } }
+  def deep_diff(other)
+    diff = {}
+    other_diff = other.dup
+
+    each_pair do |k,v|
+      if v.is_a?(Hash) && other[k].is_a?(Hash)
+        h = v.deep_diff(other[k])
+        diff[k] = h unless h.empty?
+      elsif v != other[k]
+        diff[k] = v
+      end
+      other_diff.delete(k)
+    end
+
+    diff.merge!(other_diff)
   end
 end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -656,7 +656,14 @@ class HashExtTest < ActiveSupport::TestCase
   end
 
   def test_diff
-    assert_equal({ :a => 2 }, { :a => 2, :b => 5 }.diff({ :a => 1, :b => 5 }))
+    assert_equal({ a: 2 }, { a: 2, b: 5 }.diff({ a: 1, b: 5 }))
+  end
+
+  def test_deep_diff
+    assert_equal({ a: 2 }, { a: 2, b: 5 }.deep_diff({ a: 1, b: 5 }))
+    assert_equal({}, { a: { b: 1 } }.deep_diff(a: { b: 1 }))
+    assert_equal({ a: { c: 2 } }, { a: { b: 1, c: 2 } }.deep_diff(a: { b: 1 }))
+    assert_equal({ a: { c: 2 } }, { a: { b: 1 } }.deep_diff(a: { b: 1, c: 2 }))
   end
 
   def test_slice


### PR DESCRIPTION
### `diff` vs `deep_diff` vs `MiniTest#diff`

Here is `deep_diff` usage example:

``` ruby
{ a: { b: 1 }}.deep_diff(a: { b: 1 })        # => {}
{ a: { b: 1, c: 2 } }.deep_diff(a: { b: 1 }) # => { a: { c: 2 } }
{ a: { b: 1 } }.deep_diff(a: { b: 1, c: 2 }) # => { a: { c: 2 } }
```

---

`diff` was introduced in @891a962a1 to improve failed assertion message. So `deep_diff` will be more useful when you need descriptive messages. So I'm wondering are there any such cases when `diff` is a better choice than `deep_diff`?

Also here is a couple of strings from Rails using `diff`:

``` ruby
# FIXME: minitest does object diffs, do we need to have our own?
message ||= sprintf("The recognized options <%s> did not match <%s>, difference: <%s>",
  request.path_parameters, expected_options, expected_options.diff(request.path_parameters))
assert_equal(expected_options, request.path_parameters, message)
```

`FIXME` says that there is a `MiniTest` alternative which is way less descriptive:

``` shell
[15] pry(main)> diff({a: 1, b: 2}, {b: 2})
=> "Expected: {:a=>1, :b=>2}\n  Actual: {:b=>2}"
```

So WDYT is the best way we should act here?
