### PR TITLE
don't eagerload paths that have been flagged as eager_load => false

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -436,7 +436,7 @@ module Rails
       config.eager_load_paths.each do |load_path|
         matcher = /\A#{Regexp.escape(load_path)}\/(.*)\.rb\Z/
         Dir.glob("#{load_path}/**/*.rb").sort.each do |file|
-          require_dependency file.sub(matcher, '\1')
+          require_dependency file.sub(matcher, '\1') unless config.paths.skip_eager_load.any?{|path| file.match(path)}
         end
       end
     end

--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -72,6 +72,10 @@ module Rails
         filter_by(:autoload_once?)
       end
 
+      def skip_eager_load
+        @skip_eager_load ||= all_paths.select{|path| !path.eager_load?}.flatten
+      end
+
       def eager_load
         filter_by(:eager_load?)
       end


### PR DESCRIPTION
Hey @spastorino,

This has created a regression in how paths are eager loaded:

https://github.com/rails/rails/commit/53778ec2d716f860646fd43957fd53c8db4da2fe

However, I don't think there's anything wrong with this commit.... I'll explain more:

Before the above commit:

 ?> pp Rails.configuration.paths.eager_load
["/home/jsharpe/project/app/assets",
 "/home/jsharpe/project/app/controllers",
 "/home/jsharpe/project/app/helpers",
 "/home/jsharpe/project/app/models",
 "/home/jsharpe/project/app/modules",
 "/home/jsharpe/project/app/structs",
 "/home/jsharpe/project/app/workers"]

After the commit:

?> pp Rails.configuration.paths.eager_load
 ["/home/jsharpe/project/app/controllers",
  "/home/jsharpe/project/app/helpers",
  "/home/jsharpe/project/app/models",
  "/home/jsharpe/project/app/modules",
  "/home/jsharpe/project/app/structs",
  "/home/jsharpe/project/app/workers",
  "/home/jsharpe/project/app"]

Note that /assets is now missing from #eager_load - which was the intent of the patch.  However, /app is now included when it wasn't before.

I'm pretty sure that it was a bug before the commit that /app was missing.  It is set to be eager_load => true here:

https://github.com/rails/rails/blob/3-2-rel/railties/lib/rails/engine/configuration.rb#L42

Now that /app is (correctly) part of eager_load, it now automatically loads anything inside of /app - including things that are specifically intended not be loaded.

For example, if I do this in config/ application.rb:

config.paths.add('app/manifests', :eager_load => false)

then files located in app/manifests are loaded - and that I believe is a regression.  The attached patch fixes that.

I'm trying to set up the rails test suite up and running, but I wanted to at least start this conversation.

Thanks!
