### PR TITLE
Reformat gemspec

### DIFF
--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -1,4 +1,4 @@
-version = File.read(File.expand_path("../../RAILS_VERSION", __FILE__)).strip
+version = File.read(File.expand_path('../../RAILS_VERSION', __FILE__)).strip
 
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
@@ -6,17 +6,20 @@ Gem::Specification.new do |s|
   s.version     = version
   s.summary     = 'Email composition, delivery, and receiving framework (part of Rails).'
   s.description = 'Email on Rails. Compose, deliver, receive, and test emails using the familiar controller/view pattern. First-class support for multipart email and attachments.'
-  s.required_ruby_version = '>= 1.9.3'
-  s.license     = 'MIT'
 
-  s.author            = 'David Heinemeier Hansson'
-  s.email             = 'david@loudthinking.com'
-  s.homepage          = 'http://www.rubyonrails.org'
+  s.required_ruby_version = '>= 1.9.3'
+
+  s.license = 'MIT'
+
+  s.author   = 'David Heinemeier Hansson'
+  s.email    = 'david@loudthinking.com'
+  s.homepage = 'http://www.rubyonrails.org'
 
   s.files        = Dir['CHANGELOG.md', 'README.rdoc', 'MIT-LICENSE', 'lib/**/*']
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency('actionpack',  version)
-  s.add_dependency('mail',        '~> 2.4.4')
+  s.add_dependency 'actionpack', version
+
+  s.add_dependency 'mail', '~> 2.4.4'
 end

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -1,4 +1,4 @@
-version = File.read(File.expand_path("../../RAILS_VERSION", __FILE__)).strip
+version = File.read(File.expand_path('../../RAILS_VERSION', __FILE__)).strip
 
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
@@ -6,24 +6,26 @@ Gem::Specification.new do |s|
   s.version     = version
   s.summary     = 'Web-flow and rendering framework putting the VC in MVC (part of Rails).'
   s.description = 'Web apps on Rails. Simple, battle-tested conventions for building and testing MVC web applications. Works with any Rack-compatible server.'
-  s.required_ruby_version = '>= 1.9.3'
-  s.license     = 'MIT'
 
-  s.author            = 'David Heinemeier Hansson'
-  s.email             = 'david@loudthinking.com'
-  s.homepage          = 'http://www.rubyonrails.org'
+  s.required_ruby_version = '>= 1.9.3'
+
+  s.license = 'MIT'
+
+  s.author   = 'David Heinemeier Hansson'
+  s.email    = 'david@loudthinking.com'
+  s.homepage = 'http://www.rubyonrails.org'
 
   s.files        = Dir['CHANGELOG.md', 'README.rdoc', 'MIT-LICENSE', 'lib/**/*']
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency('activesupport', version)
-  s.add_dependency('builder',       '~> 3.1.0')
-  s.add_dependency('rack',          '~> 1.4.1')
-  s.add_dependency('rack-test',     '~> 0.6.1')
-  s.add_dependency('journey',       '~> 2.0.0')
-  s.add_dependency('erubis',        '~> 2.7.0')
+  s.add_dependency 'activesupport', version
+  s.add_dependency 'builder',       '~> 3.1.0'
+  s.add_dependency 'rack',          '~> 1.4.1'
+  s.add_dependency 'rack-test',     '~> 0.6.1'
+  s.add_dependency 'journey',       '~> 2.0.0'
+  s.add_dependency 'erubis',        '~> 2.7.0'
 
-  s.add_development_dependency('activemodel', version)
-  s.add_development_dependency('tzinfo', '~> 0.3.33')
+  s.add_development_dependency 'activemodel', version
+  s.add_development_dependency 'tzinfo',      '~> 0.3.33'
 end

--- a/activemodel/activemodel.gemspec
+++ b/activemodel/activemodel.gemspec
@@ -8,15 +8,17 @@ Gem::Specification.new do |s|
   s.description = 'A toolkit for building modeling frameworks like Active Record. Rich support for attributes, callbacks, validations, observers, serialization, internationalization, and testing.'
 
   s.required_ruby_version = '>= 1.9.3'
-  s.license     = 'MIT'
 
-  s.author            = 'David Heinemeier Hansson'
-  s.email             = 'david@loudthinking.com'
-  s.homepage          = 'http://www.rubyonrails.org'
+  s.license = 'MIT'
+
+  s.author   = 'David Heinemeier Hansson'
+  s.email    = 'david@loudthinking.com'
+  s.homepage = 'http://www.rubyonrails.org'
 
   s.files        = Dir['CHANGELOG.md', 'MIT-LICENSE', 'README.rdoc', 'lib/**/*']
   s.require_path = 'lib'
 
-  s.add_dependency('activesupport', version)
-  s.add_dependency('builder',       '~> 3.1.0')
+  s.add_dependency 'activesupport', version
+
+  s.add_dependency 'builder', '~> 3.1.0'
 end

--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -1,4 +1,4 @@
-version = File.read(File.expand_path("../../RAILS_VERSION", __FILE__)).strip
+version = File.read(File.expand_path('../../RAILS_VERSION', __FILE__)).strip
 
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
@@ -8,21 +8,22 @@ Gem::Specification.new do |s|
   s.description = 'Databases on Rails. Build a persistent domain model by mapping database tables to Ruby classes. Strong conventions for associations, validations, aggregations, migrations, and testing come baked-in.'
 
   s.required_ruby_version = '>= 1.9.3'
-  s.license     = 'MIT'
 
-  s.author            = 'David Heinemeier Hansson'
-  s.email             = 'david@loudthinking.com'
-  s.homepage          = 'http://www.rubyonrails.org'
+  s.license = 'MIT'
+
+  s.author   = 'David Heinemeier Hansson'
+  s.email    = 'david@loudthinking.com'
+  s.homepage = 'http://www.rubyonrails.org'
 
   s.files        = Dir['CHANGELOG.md', 'MIT-LICENSE', 'README.rdoc', 'examples/**/*', 'lib/**/*']
   s.require_path = 'lib'
 
-  s.extra_rdoc_files = %w( README.rdoc )
+  s.extra_rdoc_files = %w(README.rdoc)
   s.rdoc_options.concat ['--main',  'README.rdoc']
 
-  s.add_dependency('activesupport', version)
-  s.add_dependency('activemodel',   version)
-  s.add_dependency('arel',          '~> 3.0.2')
+  s.add_dependency 'activesupport', version
+  s.add_dependency 'activemodel',   version
 
-  s.add_dependency('activerecord-deprecated_finders', '0.0.1')
+  s.add_dependency 'arel',                            '~> 3.0.2'
+  s.add_dependency 'activerecord-deprecated_finders', '0.0.1'
 end

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -1,4 +1,4 @@
-version = File.read(File.expand_path("../../RAILS_VERSION", __FILE__)).strip
+version = File.read(File.expand_path('../../RAILS_VERSION', __FILE__)).strip
 
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
@@ -8,19 +8,20 @@ Gem::Specification.new do |s|
   s.description = 'A toolkit of support libraries and Ruby core extensions extracted from the Rails framework. Rich support for multibyte strings, internationalization, time zones, and testing.'
 
   s.required_ruby_version = '>= 1.9.3'
-  s.license     = 'MIT'
 
-  s.author       = 'David Heinemeier Hansson'
-  s.email        = 'david@loudthinking.com'
-  s.homepage     = 'http://www.rubyonrails.org'
+  s.license = 'MIT'
+
+  s.author   = 'David Heinemeier Hansson'
+  s.email    = 'david@loudthinking.com'
+  s.homepage = 'http://www.rubyonrails.org'
 
   s.files        = Dir['CHANGELOG.md', 'MIT-LICENSE', 'README.rdoc', 'lib/**/*']
   s.require_path = 'lib'
 
   s.rdoc_options.concat ['--encoding',  'UTF-8']
 
-  s.add_dependency('i18n',       '~> 0.6')
-  s.add_dependency('multi_json', '~> 1.3')
-  s.add_dependency('tzinfo',     '~> 0.3.33')
-  s.add_dependency('minitest',   '~> 4.1')
+  s.add_dependency 'i18n',       '~> 0.6'
+  s.add_dependency 'multi_json', '~> 1.3'
+  s.add_dependency 'tzinfo',     '~> 0.3.33'
+  s.add_dependency 'minitest',   '~> 4.1'
 end

--- a/rails.gemspec
+++ b/rails.gemspec
@@ -1,4 +1,4 @@
-version = File.read(File.expand_path("../RAILS_VERSION",__FILE__)).strip
+version = File.read(File.expand_path('../RAILS_VERSION', __FILE__)).strip
 
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
@@ -8,8 +8,9 @@ Gem::Specification.new do |s|
   s.description = 'Ruby on Rails is a full-stack web framework optimized for programmer happiness and sustainable productivity. It encourages beautiful code by favoring convention over configuration.'
 
   s.required_ruby_version     = '>= 1.9.3'
-  s.required_rubygems_version = ">= 1.8.11"
-  s.license     = 'MIT'
+  s.required_rubygems_version = '>= 1.8.11'
+
+  s.license = 'MIT'
 
   s.author   = 'David Heinemeier Hansson'
   s.email    = 'david@loudthinking.com'
@@ -19,11 +20,12 @@ Gem::Specification.new do |s|
   s.executables = []
   s.files       = Dir['guides/**/*']
 
-  s.add_dependency('activesupport',   version)
-  s.add_dependency('actionpack',      version)
-  s.add_dependency('activerecord',    version)
-  s.add_dependency('actionmailer',    version)
-  s.add_dependency('railties',        version)
-  s.add_dependency('bundler',         '~> 1.2')
-  s.add_dependency('sprockets-rails', '~> 2.0.0.rc1')
+  s.add_dependency 'activesupport', version
+  s.add_dependency 'actionpack',    version
+  s.add_dependency 'activerecord',  version
+  s.add_dependency 'actionmailer',  version
+  s.add_dependency 'railties',      version
+
+  s.add_dependency 'bundler',         '~> 1.2'
+  s.add_dependency 'sprockets-rails', '~> 2.0.0.rc1'
 end

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -1,4 +1,4 @@
-version = File.read(File.expand_path("../../RAILS_VERSION", __FILE__)).strip
+version = File.read(File.expand_path('../../RAILS_VERSION', __FILE__)).strip
 
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
@@ -6,24 +6,27 @@ Gem::Specification.new do |s|
   s.version     = version
   s.summary     = 'Tools for creating, working with, and running Rails applications.'
   s.description = 'Rails internals: application bootup, plugins, generators, and rake tasks.'
+
   s.required_ruby_version = '>= 1.9.3'
-  s.license     = 'MIT'
 
-  s.author            = 'David Heinemeier Hansson'
-  s.email             = 'david@loudthinking.com'
-  s.homepage          = 'http://www.rubyonrails.org'
+  s.license = 'MIT'
 
-  s.files              = Dir['CHANGELOG.md', 'README.rdoc', 'bin/**/*', 'lib/**/{*,.[a-z]*}']
-  s.require_path       = 'lib'
+  s.author   = 'David Heinemeier Hansson'
+  s.email    = 'david@loudthinking.com'
+  s.homepage = 'http://www.rubyonrails.org'
 
-  s.bindir             = 'bin'
-  s.executables        = ['rails']
+  s.files        = Dir['CHANGELOG.md', 'README.rdoc', 'bin/**/*', 'lib/**/{*,.[a-z]*}']
+  s.require_path = 'lib'
+
+  s.bindir      = 'bin'
+  s.executables = ['rails']
 
   s.rdoc_options << '--exclude' << '.'
 
-  s.add_dependency('rake',          '>= 0.8.7')
-  s.add_dependency('thor',          '>= 0.15.4', '< 2.0')
-  s.add_dependency('rdoc',          '~> 3.4')
-  s.add_dependency('activesupport', version)
-  s.add_dependency('actionpack',    version)
+  s.add_dependency 'activesupport', version
+  s.add_dependency 'actionpack',    version
+
+  s.add_dependency 'rake', '>= 0.8.7'
+  s.add_dependency 'thor', '>= 0.15.4', '< 2.0'
+  s.add_dependency 'rdoc', '~> 3.4'
 end


### PR DESCRIPTION
DRYed up and organized the gemspec file a bit.
- Made quotes more consistent (single quotes dominated, so I used
  that).
- Moved license line down a line, separating it logically, and removed
  the extra whitespace before its = operator.
- Used a loop to add dependencies for all Rails components that use the
  same version.
- Minor whitespace fixes such as padding the comma on the first line.
