### PR TITLE
backport: handle trailing slash with engines

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 3.2.10 (unreleased) ##
 
+*   prevent double slashes in engine urls when `Rails.application.default_url_options[:trailing_slash] = true` is set
+    Fix #7842
+
+    *Yves Senn*
+
 *   Fix input name when `:multiple => true` and `:index` are set.
 
     Before:

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -451,7 +451,7 @@ module ActionDispatch
                 # we must actually delete prefix segment keys to avoid passing them to next url_for
                 _route.segment_keys.each { |k| options.delete(k) }
                 prefix = _routes.url_helpers.send("#{name}_path", prefix_options)
-                prefix = '' if prefix == '/'
+                prefix = prefix.gsub(%r{/\z}, '')
                 prefix
               end
             end

--- a/actionpack/test/dispatch/prefix_generation_test.rb
+++ b/actionpack/test/dispatch/prefix_generation_test.rb
@@ -248,6 +248,11 @@ module TestGenerationPrefix
       assert_equal "/something/", app_object.root_path
     end
 
+    test "[OBJECT] generating application's route includes default_url_options[:trailing_slash]" do
+      RailsApplication.routes.default_url_options[:trailing_slash] = true
+      assert_equal "/awesome/blog/posts", engine_object.posts_path
+    end
+
     test "[OBJECT] generating engine's route with url_for" do
       path = engine_object.url_for(:controller => "inside_engine_generating",
                                    :action => "show",


### PR DESCRIPTION
this is a backport of #8115 to fix #7842

The problem was already fixed in master, the solution used for `3-2-stable` is different.
