### PR TITLE
Fix for inflector's incorrect camelCase replacement for acronyms

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Rails 3.2.10 (unreleased)
+*   Fixed a bug in Inflector#underscore where acroynms are incorrectly parsed as camelCases. *Fred Wu*
 
 *   Handle the possible Permission Denied errors atomic.rb might trigger due to
     its chown and chmod calls. [Backport #8027]

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -78,7 +78,7 @@ module ActiveSupport
       word = camel_cased_word.to_s.dup
       word.gsub!(/::/, '/')
       word.gsub!(/(?:([A-Za-z\d])|^)(#{inflections.acronym_regex})(?=\b|[^a-z])/) { "#{$1}#{$1 && '_'}#{$2.downcase}" }
-      word.gsub!(/([A-Z\d]+)([A-Z][a-z])/,'\1_\2')
+      word.gsub!(/(?!#{inflections.acronym_regex})\b([A-Z\d]+)([A-Z][a-z])/,'\1_\2')
       word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
       word.tr!("-", "_")
       word.downcase!

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -164,11 +164,13 @@ class InflectorTest < Test::Unit::TestCase
   def test_underscore_acronym_sequence
     ActiveSupport::Inflector.inflections do |inflect|
       inflect.acronym("API")
+      inflect.acronym("APIs")
       inflect.acronym("HTML5")
       inflect.acronym("HTML")
     end
 
     assert_equal("html5_html_api", ActiveSupport::Inflector.underscore("HTML5HTMLAPI"))
+    assert_equal("namespaced/apis", ActiveSupport::Inflector.underscore("Namespaced::APIs"))
   end
 
   def test_underscore
@@ -295,7 +297,7 @@ class InflectorTest < Test::Unit::TestCase
       ActiveSupport::Inflector.constantize(string)
     end
   end
-  
+
   def test_safe_constantize
     run_safe_constantize_tests_on do |string|
       ActiveSupport::Inflector.safe_constantize(string)


### PR DESCRIPTION
Description of this bug: https://github.com/rails/rails/issues/8015
