### PR TITLE
Deprecate Hash#diff.

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -1,5 +1,4 @@
 require 'uri'
-require 'active_support/core_ext/hash/diff'
 require 'active_support/core_ext/hash/indifferent_access'
 require 'action_controller/metal/exceptions'
 
@@ -44,9 +43,8 @@ module ActionDispatch
 
         expected_options.stringify_keys!
 
-        # FIXME: minitest does object diffs, do we need to have our own?
         message ||= sprintf("The recognized options <%s> did not match <%s>, difference: <%s>",
-            request.path_parameters, expected_options, expected_options.diff(request.path_parameters))
+            request.path_parameters, expected_options, diff(expected_options, request.path_parameters))
         assert_equal(expected_options, request.path_parameters, message)
       end
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
+
+*   Deprecate Hash#diff in favor of MiniTest's #diff. *Steve Klabnik*
+
 *   Kernel#capture can catch output from subprocesses *Dmitry Vorotilin*
 
 *   `to_xml` conversions now use builder's `tag!` method instead of explicit invocation of `method_missing`.

--- a/activesupport/lib/active_support/core_ext/hash/diff.rb
+++ b/activesupport/lib/active_support/core_ext/hash/diff.rb
@@ -6,6 +6,7 @@ class Hash
   #   {}.diff(1 => 2)               # => {1 => 2}
   #   {1 => 2, 3 => 4}.diff(1 => 2) # => {3 => 4}
   def diff(other)
+    ActiveSupport::Deprecation.warn "Hash#diff is no longer used inside of Rails, and is being deprecated with no replacement. If you're using it to compare hashes for the purpose of testing, please use MiniTest's diff instead."
     dup.
       delete_if { |k, v| other[k] == v }.
       merge!(other.dup.delete_if { |k, v| has_key?(k) })


### PR DESCRIPTION
It's no longer used in Rails any more.

See https://github.com/rails/rails/pull/8142\#issuecomment-10227297 for more.

I didn't add a CHANGELOG yet because I wanted to make sure the rest was okay. Let me know and I'll add it.
