### PR TITLE
Lock sprockets to 2.2.x

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency('rack',          '~> 1.4.0')
   s.add_dependency('rack-test',     '~> 0.6.1')
   s.add_dependency('journey',       '~> 1.0.4')
-  s.add_dependency('sprockets',     '~> 2.2')
+  s.add_dependency('sprockets',     '~> 2.2.1')
   s.add_dependency('erubis',        '~> 2.7.0')
 
   s.add_development_dependency('tzinfo', '~> 0.3.29')


### PR DESCRIPTION
Rails is failing with sprockets >= 2.3, see #8099 for reference and discussion.

I think we should address the issue anyway and relax the dependency again later but right now this is being a blocker for 3.2.9 release since last week.

We isolated the problem to sass-rails but we don't have much idea right now about how to fix it
