### PR TITLE
Keep the code related to serialization in Serialization module.

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -369,14 +369,10 @@ module ActiveRecord
     end
 
     def typecasted_attribute_value(name)
-      if self.class.serialized_attributes.include?(name)
-        @attributes[name].serialized_value
-      else
-        # FIXME: we need @attributes to be used consistently.
-        # If the values stored in @attributes were already typecasted, this code
-        # could be simplified
-        read_attribute(name)
-      end
+      # FIXME: we need @attributes to be used consistently.
+      # If the values stored in @attributes were already typecasted, this code
+      # could be simplified
+      read_attribute(name)
     end
   end
 end

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -5,7 +5,7 @@ module ActiveRecord
 
       included do
         # Returns a hash of all the attributes that have been specified for
-        # serialization as keys and their class restriction as values.
+        # serialization as keys and their class restriction as values.
         class_attribute :serialized_attributes, instance_accessor: false
         self.serialized_attributes = {}
       end
@@ -127,6 +127,14 @@ module ActiveRecord
                 attributes[key] = attributes[key].unserialized_value
               end
             end
+          end
+        end
+
+        def typecasted_attribute_value(name)
+          if self.class.serialized_attributes.include?(name)
+            @attributes[name].serialized_value
+          else
+            super
           end
         end
       end


### PR DESCRIPTION
We should not need any `serialized_attributes` checks outside `ActiveRecord::AttributeMethods::Serialization` module.
