### PR TITLE
Rake test:uncommitted finds git directory in ancestors.

### DIFF
--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -88,7 +88,7 @@ namespace :test do
     def t.file_list
       if File.directory?(".svn")
         changed_since_checkin = silence_stderr { `svn status` }.split.map { |path| path.chomp[7 .. -1] }
-      elsif File.directory?(".git")
+      elsif system "git rev-parse --git-dir 2>&1 >/dev/null"
         changed_since_checkin = silence_stderr { `git ls-files --modified --others --exclude-standard` }.split.map { |path| path.chomp }
       else
         abort "Not a Subversion or Git checkout."


### PR DESCRIPTION
Sometimes your git directory is an ancestor of your application root
directory.

For example:
 ./repo/.git/
 ./repo/app/Rakefile

In this case rake test:uncommitted will be unable to detect your SCM.

This patch fixes this and add a test.
