### PR TITLE
`#pluck` can be used on a relation with `select` clause (#7551)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*  `#pluck` can be used on a relation with `select` clause
+   Fix #7551
+
+   Example:
+
+        Topic.select([:approved, :id]).order(:id).pluck(:id)
+
+   *Yves Senn*
+
 *   Do not create useless database transaction when building `has_one` association.
 
     Example:

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
 *   Do not create useless database transaction when building `has_one` association.
-    
+
     Example:
 
         User.has_one :profile

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -165,7 +165,9 @@ module ActiveRecord
       if has_include?(column_names.first)
         construct_relation_for_association_calculations.pluck(*column_names)
       else
-        result  = klass.connection.select_all(select(column_names).arel, nil, bind_values)
+        relation = spawn
+        relation.select_values = column_names
+        result = klass.connection.select_all(relation.arel, nil, bind_values)
         columns = result.columns.map do |key|
           klass.column_types.fetch(key) {
             result.column_types.fetch(key) {

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -580,4 +580,10 @@ class CalculationsTest < ActiveRecord::TestCase
 
     assert_equal ["Over There"], Possession.pluck(:where)
   end
+
+  def test_pluck_replaces_select_clause
+    taks_relation = Topic.select(:approved, :id).order(:id)
+    assert_equal [1,2,3,4], taks_relation.pluck(:id)
+    assert_equal [false, true, true, true], taks_relation.pluck(:approved)
+  end
 end


### PR DESCRIPTION
I changed `#pluck` to spawn a new relation and then modify the `select_values` directly to ignore previously present `select` clauses. This patch simply ignores present `select` clauses.

There was also trailing whitespace in the `CHANGELOG.md` (created a separate commit to remove it, so that it's easier to backport)

This is a fix for #7551

The `ActiveRecord::Calculations` module has a couple of methods, which modify the `select_values` of a relation directly. I thought about a small refactoring to expose a method on `ActiveRecord::QueryMethods` to assign fields directly to `select_values` instead of concatenate them as `select` does. This could be named something like `#select_only` or `#force_select` (could also be implemented with a parameter to `select` like `:force => true` or `:override => true`.
I wanted to submit this PR first though to ask wether this is necessary or not.
