### PR TITLE
Mocha fixes

### DIFF
--- a/activesupport/lib/active_support/testing/mocha_module.rb
+++ b/activesupport/lib/active_support/testing/mocha_module.rb
@@ -3,7 +3,14 @@ module ActiveSupport
     module MochaModule
       begin
         require 'mocha/api'
+        require 'mocha/expectation_error_factory'
+        require 'minitest/unit'
+
         include Mocha::API
+
+        def self.included(mod)
+          Mocha::ExpectationErrorFactory.exception_class = ::MiniTest::Assertion
+        end
 
         def before_setup
           mocha_setup

--- a/activesupport/lib/active_support/testing/mocha_module.rb
+++ b/activesupport/lib/active_support/testing/mocha_module.rb
@@ -2,12 +2,19 @@ module ActiveSupport
   module Testing
     module MochaModule
       begin
-        require 'mocha/api'
-        begin
-          silence_warnings { require 'mocha/expectation_error_factory' }
-        rescue LoadError => e
+        silence_warnings do
+          require 'mocha/version'
+          version = Gem::Version.new(Mocha::VERSION)
+          if Gem::Requirement.new('>= 0.13.0').satisfied_by?(version)
+            require 'mocha/api'
+          else
+            require 'mocha_standalone'
+          end
+          if Gem::Requirement.new('>= 0.12.2').satisfied_by?(version)
+            require 'mocha/expectation_error_factory'
+            require 'minitest/unit'
+          end
         end
-        require 'minitest/unit'
 
         include Mocha::API
 

--- a/activesupport/lib/active_support/testing/mocha_module.rb
+++ b/activesupport/lib/active_support/testing/mocha_module.rb
@@ -3,13 +3,18 @@ module ActiveSupport
     module MochaModule
       begin
         require 'mocha/api'
-        require 'mocha/expectation_error_factory'
+        begin
+          silence_warnings { require 'mocha/expectation_error_factory' }
+        rescue LoadError => e
+        end
         require 'minitest/unit'
 
         include Mocha::API
 
         def self.included(mod)
-          Mocha::ExpectationErrorFactory.exception_class = ::MiniTest::Assertion
+          if defined?(Mocha::ExpectationErrorFactory)
+            Mocha::ExpectationErrorFactory.exception_class = ::MiniTest::Assertion
+          end
         end
 
         class AssertionCounter

--- a/activesupport/lib/active_support/testing/mocha_module.rb
+++ b/activesupport/lib/active_support/testing/mocha_module.rb
@@ -17,9 +17,15 @@ module ActiveSupport
           super
         end
 
+        def before_teardown
+          return unless passed?
+          mocha_verify
+        ensure
+          super
+        end
+
         def after_teardown
           super
-          mocha_verify
           mocha_teardown
         end
       rescue LoadError

--- a/activesupport/lib/active_support/testing/mocha_module.rb
+++ b/activesupport/lib/active_support/testing/mocha_module.rb
@@ -12,6 +12,16 @@ module ActiveSupport
           Mocha::ExpectationErrorFactory.exception_class = ::MiniTest::Assertion
         end
 
+        class AssertionCounter
+          def initialize(test_case)
+            @test_case = test_case
+          end
+
+          def increment
+            @test_case.assert(true)
+          end
+        end
+
         def before_setup
           mocha_setup
           super
@@ -19,7 +29,8 @@ module ActiveSupport
 
         def before_teardown
           return unless passed?
-          mocha_verify
+          assertion_counter = AssertionCounter.new(self)
+          mocha_verify(assertion_counter)
         ensure
           super
         end


### PR DESCRIPTION
These commits fix a number of subtle mocha-related bugs that have been present for a while :-
- Mocha was raising a `MiniTest::Assertion` instead of a
  `Mocha::ExpectationError` as intended. The latter is not recognized by
  MiniTest as an assertion failure and so it is recorded as a test
  _error_, not a test _failure_ as it ought to. This leads to
  potentially confusing output in the test results.
- Mocha verification should happen as part of the test. The verification
  of expectations is equivalent to a set of assertions. These assertions
  should happen as _part of_ the test so that they have a chance to
  cause the test to fail, and not just as part of the teardown. Also if
  an assertion fails during the test, then there is no need to verify
  expectations, because only the first assertion failure is normally
  reported and all subsequent bets are off.
- Expectation verification should be counted as an assertion. Mocha
  cannot record each expectation verification as an assertion, because
  we weren't passing in an assertion counter to `#mocha_verify`.

The code has unfortunately become relatively complicated to support different versions of mocha. If it is acceptable to only support the latest version of mocha (v0.13.0) onwards, I'd suggest it would be preferable to accept [this other pull request](https://github.com/rails/rails/pull/8180) which simplifies the code considerably.

I'd be more than happy to provide back-ported fixes to 3-x-stable branches if these would be useful.
