### PR TITLE
Merge and add tests related to 5215

### DIFF
--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -799,12 +799,6 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 1, developer.projects.count
   end
 
-  def test_counting_should_not_fire_sql_if_parent_is_unsaved
-    assert_no_queries do
-      assert_equal 0, Developer.new.projects.count
-    end
-  end
-
   unless current_adapter?(:PostgreSQLAdapter)
     def test_count_with_finder_sql
       assert_equal 3, projects(:active_record).developers_with_finder_sql.count
@@ -862,4 +856,15 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     def klass.name; 'Foo'; end
     assert_deprecated { klass.has_and_belongs_to_many :posts, :delete_sql => 'lol' }
   end
+
+  test "has and belongs to many associations on new records use null relations" do
+    projects = Developer.new.projects
+    assert_no_queries do
+      assert_equal [], projects
+      assert_equal [], projects.where(title: 'omg')
+      assert_equal [], projects.pluck(:title)
+      assert_equal 0, projects.count
+    end
+  end
+
 end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -262,12 +262,6 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal firm.limited_clients.length, firm.limited_clients.count
   end
 
-  def test_counting_should_not_fire_sql_if_parent_is_unsaved
-    assert_no_queries do
-      assert_equal 0, Person.new.readers.count
-    end
-  end
-
   def test_finding
     assert_equal 2, Firm.all.merge!(:order => "id").first.clients.length
   end
@@ -1665,6 +1659,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
       assert_equal [], post.comments.where(body: 'omg')
       assert_equal [], post.comments.pluck(:body)
       assert_equal 0,  post.comments.sum(:id)
+      assert_equal 0,  post.comments.count
     end
   end
 end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -766,12 +766,6 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal 1, authors(:mary).categories.general.count
   end
 
-  def test_counting_should_not_fire_sql_if_parent_is_unsaved
-    assert_no_queries do
-      assert_equal 0, Person.new.posts.count
-    end
-  end
-
   def test_has_many_through_belongs_to_should_update_when_the_through_foreign_key_changes
     post = posts(:eager_other)
 
@@ -876,4 +870,17 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     post = tags(:general).tagged_posts.create! :title => "foo", :body => "bar"
     assert_equal [tags(:general)], post.reload.tags
   end
+
+  test "has many through associations on new records use null relations" do
+    person = Person.new
+
+    assert_no_queries do
+      assert_equal [], person.posts
+      assert_equal [], person.posts.where(body: 'omg')
+      assert_equal [], person.posts.pluck(:body)
+      assert_equal 0,  person.posts.sum(:tags_count)
+      assert_equal 0,  person.posts.count
+    end
+  end
+
 end


### PR DESCRIPTION
Merge redundant tests and add new ones to has_and_belongs_to_many and has_many_through associations for null relation usage on new records.
