### PR TITLE
`#as_json` isolates options when encoding a hash. Closes #8182

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `#as_json` isolates options when encoding a hash.
+    Fix #8182
+
+    *Yves Senn*
+
 *   Deprecate Hash#diff in favor of MiniTest's #diff. *Steve Klabnik*
 
 *   Kernel#capture can catch output from subprocesses *Dmitry Vorotilin*

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -65,7 +65,7 @@ module ActiveSupport
             # they can detect circular references.
             options.merge(:encoder => self)
           else
-            options
+            options.dup
           end
         end
 

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -22,6 +22,15 @@ class TestJSONEncoding < ActiveSupport::TestCase
     end
   end
 
+  class CustomWithOptions
+    attr_accessor :foo, :bar
+
+    def as_json(options={})
+      options[:only] = %w(foo bar)
+      super(options)
+    end
+  end
+
   TrueTests     = [[ true,  %(true)  ]]
   FalseTests    = [[ false, %(false) ]]
   NilTests      = [[ nil,   %(null)  ]]
@@ -246,6 +255,15 @@ class TestJSONEncoding < ActiveSupport::TestCase
     json = people.each.to_json :only => [:address, :city]
 
     assert_equal(%([{"address":{"city":"London"}},{"address":{"city":"Paris"}}]), json)
+  end
+
+  def test_to_json_should_not_keep_options_around
+    f = CustomWithOptions.new
+    f.foo = "hello"
+    f.bar = "world"
+
+    hash = {"foo" => f, "other_hash" => {"foo" => "other_foo", "test" => "other_test"}}
+    assert_equal(%({"foo":{"foo":"hello","bar":"world"},"other_hash":{"foo":"other_foo","test":"other_test"}}), hash.to_json)
   end
 
   def test_struct_encoding


### PR DESCRIPTION
I modified the `Encoder` so that duplicates of the original `options` hash are passed around. I'm not sure if there are cases where we actually wan't the side effects but all the tests passed.

This is a fix #8182
