### PR TITLE
Adding suppport for conditional content_tag

### DIFF
--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -101,9 +101,9 @@ module ActionView
       # to +true+. Overwise only content will be returned
       #
       # ==== Examples
-      #   content_tag_if(true, "Hello world!", class: "strong")
+      #   content_tag_if(true, :div, "Hello world!", class: "strong")
       #    # => <div class="strong"><p>Hello world!</p></div>
-      #   content_tag_if(false, "Hello world!", class: "strong")
+      #   content_tag_if(false, :div, "Hello world!", class: "strong")
       #    # => Hello world!
       def content_tag_if(boolean, name, content_or_options_with_block = nil, options = nil, escape = true, &block)
         if boolean
@@ -118,9 +118,9 @@ module ActionView
       # Inverse of content_tag_if method.
       # 
       # ==== Examples
-      #   content_tag_unless(true, "Hello world!", class: "strong")
+      #   content_tag_unless(true, :div, "Hello world!", class: "strong")
       #    # => Hello world!
-      #   content_tag_unless(false, "Hello world!", class: "strong")
+      #   content_tag_unless(false, :div, "Hello world!", class: "strong")
       #    # => <div class="strong"><p>Hello world!</p></div>
       def content_tag_unless(boolean, name, content_or_options_with_block = nil, options = nil, escape = true, &block)
         content_tag_if(!boolean, name, content_or_options_with_block, options, escape, &block)

--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -118,9 +118,9 @@ module ActionView
       # Inverse of content_tag_if method.
       # 
       # ==== Examples
-      #   content_tag_if(true, "Hello world!", class: "strong")
+      #   content_tag_unless(true, "Hello world!", class: "strong")
       #    # => Hello world!
-      #   content_tag_if(false, "Hello world!", class: "strong")
+      #   content_tag_unless(false, "Hello world!", class: "strong")
       #    # => <div class="strong"><p>Hello world!</p></div>
       def content_tag_unless(boolean, name, content_or_options_with_block = nil, options = nil, escape = true, &block)
         content_tag_if(!boolean, name, content_or_options_with_block, options, escape, &block)

--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -96,6 +96,35 @@ module ActionView
           content_tag_string(name, content_or_options_with_block, options, escape)
         end
       end
+      
+      # Wrapper around content_tag method. Tag will be applied only if the boolean evaluates
+      # to +true+. Overwise only content will be returned
+      #
+      # ==== Examples
+      #   content_tag_if(true, "Hello world!", class: "strong")
+      #    # => <div class="strong"><p>Hello world!</p></div>
+      #   content_tag_if(false, "Hello world!", class: "strong")
+      #    # => Hello world!
+      def content_tag_if(boolean, name, content_or_options_with_block = nil, options = nil, escape = true, &block)
+        if boolean
+          content_tag(name, content_or_options_with_block, options, escape, &block)
+        elsif block_given?
+          capture(&block)
+        else
+          content_or_options_with_block
+        end
+      end
+      
+      # Inverse of content_tag_if method.
+      # 
+      # ==== Examples
+      #   content_tag_if(true, "Hello world!", class: "strong")
+      #    # => Hello world!
+      #   content_tag_if(false, "Hello world!", class: "strong")
+      #    # => <div class="strong"><p>Hello world!</p></div>
+      def content_tag_unless(boolean, name, content_or_options_with_block = nil, options = nil, escape = true, &block)
+        content_tag_if(!boolean, name, content_or_options_with_block, options, escape, &block)
+      end
 
       # Returns a CDATA section with the given +content+. CDATA sections
       # are used to escape blocks of text containing characters which would

--- a/actionpack/test/template/tag_helper_test.rb
+++ b/actionpack/test/template/tag_helper_test.rb
@@ -127,4 +127,30 @@ class TagHelperTest < ActionView::TestCase
         tag('a', { data => { a_float: 3.14, a_big_decimal: BigDecimal.new("-123.456"), a_number: 1, string: 'hello', symbol: :foo, array: [1, 2, 3], hash: { key: 'value'}, string_with_quotes: 'double"quote"party"' } })
     }
   end
+  
+  def test_content_tag_if_true
+    concat content_tag_if(true, :div, 'test', :class => 'test')
+    assert_equal "<div class=\"test\">test</div>", output_buffer
+  end
+  
+  def test_content_tag_if_false
+    concat content_tag_if(false, :div, 'test', :class => 'test')
+    assert_equal 'test', output_buffer
+  end
+  
+  def test_content_tag_if_with_block_if_true
+    concat(content_tag_if(true, :div, :class => 'test') { 'test' })
+    assert_equal "<div class=\"test\">test</div>", output_buffer
+  end
+  
+  def test_content_tag_if_with_block_if_false
+    concat(content_tag_if(false, :div, :class => 'test'){ 'test' })
+    assert_equal 'test', output_buffer
+  end
+  
+  def test_content_tag_unless
+    concat content_tag_unless(false, :div, 'test', :class => 'test')
+    assert_equal "<div class=\"test\">test</div>", output_buffer
+  end
+  
 end


### PR DESCRIPTION
This is an attempt to fix this very un-DRY pattern that happens a lot:

``` erb
<% if something == true %>
  <%= content_tag(:div, :class => 'wrapper') do %>
    Content
    # ... and more stuff
  <% end %>
<% else %>
  Content
  # ... and more of the same stuff as above
<% end %>
```

Now it's collapsible to this:

``` erb
<%= content_tag_if(something == true, :div, :class => 'wrapper') do %>
  Content
  # ... and more stuff
<% end %>
```

Also added `content_tag_unless` for convenience sake.
