### PR TITLE
Add release date of Rails 3.2.9 to documentation

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Rails 3.2.9 (unreleased) ##
+## Rails 3.2.9 (Nov 12, 2012) ##
 
 * Do not render views when mail() isn't called.
   Fix #7761

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -26,7 +26,7 @@
 
     *Daniel Fox, Grant Hutchins & Trace Wax*
 
-## Rails 3.2.9 (unreleased) ##
+## Rails 3.2.9 (Nov 12, 2012) ##
 
 *   Clear url helpers when reloading routes.
 

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Rails 3.2.9 (unreleased)
+## Rails 3.2.9 (Nov 12, 2012) ##
 
 *   Due to a change in builder, nil values and empty strings now generates
     closed tags, so instead of this:

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -40,7 +40,7 @@
     *Gabriel Sobrinho, Ricardo Henrique*
 
 
-## Rails 3.2.9 (unreleased)
+## Rails 3.2.9 (Nov 12, 2012) ##
 
 *   Fix `find_in_batches` crashing when IDs are strings and start option is not specified.
 

--- a/activeresource/CHANGELOG.md
+++ b/activeresource/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Rails 3.2.9 (unreleased) ##
+## Rails 3.2.9 (Nov 12, 2012) ##
 
 *   No changes.
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -5,7 +5,7 @@
 
     *Daniele Sluijters*
 
-## Rails 3.2.9 (unreleased)
+## Rails 3.2.9 (Nov 12, 2012) ##
 
 *   Add logger.push_tags and .pop_tags to complement logger.tagged:
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Rails 3.2.9 (unreleased)
+## Rails 3.2.9 (Nov 12, 2012) ##
 
 *   Update supported ruby versions error message in ruby_version_check.rb *Lihan Li*
 


### PR DESCRIPTION
Change 

```
Rails 3.2.9 (unreleased)
```

to  

```
Rails 3.2.9 (Nov 12, 2012)
```
