### PR TITLE
backport #8185, `#as_json` isolates options when encoding a hash.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 3.2.10 (unreleased)
 
+*   `#as_json` isolates options when encoding a hash. [Backport #8185]
+    Fix #8182
+
+    *Yves Senn*
+
 *   Handle the possible Permission Denied errors atomic.rb might trigger due to
     its chown and chmod calls. [Backport #8027]
 

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -61,7 +61,7 @@ module ActiveSupport
             # hashes and arrays need to get encoder in the options, so that they can detect circular references
             options.merge(:encoder => self)
           else
-            options
+            options.dup
           end
         end
 

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -22,6 +22,15 @@ class TestJSONEncoding < Test::Unit::TestCase
     end
   end
 
+  class CustomWithOptions
+    attr_accessor :foo, :bar
+
+    def as_json(options={})
+      options[:only] = %w(foo bar)
+      super(options)
+    end
+  end
+
   TrueTests     = [[ true,  %(true)  ]]
   FalseTests    = [[ false, %(false) ]]
   NilTests      = [[ nil,   %(null)  ]]
@@ -237,6 +246,15 @@ class TestJSONEncoding < Test::Unit::TestCase
     json = people.each.to_json :only => [:address, :city]
 
     assert_equal(%([{"address":{"city":"London"}},{"address":{"city":"Paris"}}]), json)
+  end
+
+  def test_to_json_should_not_keep_options_around
+    f = CustomWithOptions.new
+    f.foo = "hello"
+    f.bar = "world"
+
+    hash = {"foo" => f, "other_hash" => {"foo" => "other_foo", "test" => "other_test"}}
+    assert_equal(%({"foo":{"foo":"hello","bar":"world"},"other_hash":{"foo":"other_foo","test":"other_test"}}), hash.to_json)
   end
 
   def test_struct_encoding


### PR DESCRIPTION
This is a backport of #8185 to fix #8182
