### PR TITLE
Fix 3-2-stable to work with Mocha v0.13.0

### DIFF
--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -9,7 +9,9 @@ require 'active_support/testing/mochaing'
 require 'active_support/core_ext/kernel/reporting'
 
 module ActiveSupport
-  class TestCase < ::Test::Unit::TestCase
+  test_library = defined?(MiniTest) ? ::MiniTest : ::Test
+
+  class TestCase < test_library::Unit::TestCase
     if defined? MiniTest
       Assertion = MiniTest::Assertion
       alias_method :method_name, :name if method_defined? :name

--- a/activesupport/lib/active_support/testing/mochaing.rb
+++ b/activesupport/lib/active_support/testing/mochaing.rb
@@ -1,5 +1,5 @@
 begin
-  silence_warnings { require 'mocha' }
+  silence_warnings { require 'mocha/setup' }
 rescue LoadError
   # Fake Mocha::ExpectationError so we can rescue it in #run. Bleh.
   Object.const_set :Mocha, Module.new

--- a/activesupport/lib/active_support/testing/setup_and_teardown.rb
+++ b/activesupport/lib/active_support/testing/setup_and_teardown.rb
@@ -61,7 +61,7 @@ module ActiveSupport
         def run(result)
           return if @method_name.to_s == "default_test"
 
-          mocha_counter = retrieve_mocha_counter(result)
+          mocha_counter = retrieve_mocha_counter(self, result)
           yield(Test::Unit::TestCase::STARTED, name)
           @_result = result
 
@@ -102,14 +102,16 @@ module ActiveSupport
 
         protected
 
-        def retrieve_mocha_counter(result) #:nodoc:
+        def retrieve_mocha_counter(test_case, result) #:nodoc:
           if respond_to?(:mocha_verify) # using mocha
             if defined?(Mocha::TestCaseAdapter::AssertionCounter)
               Mocha::TestCaseAdapter::AssertionCounter.new(result)
             elsif defined?(Mocha::Integration::TestUnit::AssertionCounter)
               Mocha::Integration::TestUnit::AssertionCounter.new(result)
-            else
+            elsif defined?(Mocha::MonkeyPatching::TestUnit::AssertionCounter)
               Mocha::MonkeyPatching::TestUnit::AssertionCounter.new(result)
+            else
+              Mocha::Integration::AssertionCounter.new(test_case)
             end
           end
         end

--- a/activesupport/lib/active_support/testing/setup_and_teardown.rb
+++ b/activesupport/lib/active_support/testing/setup_and_teardown.rb
@@ -83,6 +83,8 @@ module ActiveSupport
               begin
                 teardown
                 run_callbacks :teardown
+              rescue Mocha::ExpectationError => e
+                add_failure(e.message, e.backtrace)
               rescue Test::Unit::AssertionFailedError => e
                 add_failure(e.message, e.backtrace)
               rescue Exception => e


### PR DESCRIPTION
Two commits (716bdfc01d45a61d211dbd766f494cb984fc9f9c & c3e186ec8dcb2ec26d5d56f3e89123b1350c4a6f) are fixes for problems that existed prior to the release of Mocha v0.13.0, but have remained unnoticed.

The other two commits (5573c1d29565f17aca48b6a320a676bf9f962f20 & 3791cac8747b5e36fe9619301a55d69f8feff982) fix Rails v3.2 to work with Mocha v0.13.0.
