### PR TITLE
Add a regression test on #8195

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1442,6 +1442,13 @@ class BasicsTest < ActiveRecord::TestCase
     assert_match(/\/#{dev.id}$/, dev.cache_key)
   end
 
+  def test_cache_key_format_is_precise_enough
+    dev = Developer.first
+    key = dev.cache_key
+    dev.touch
+    assert_not_equal key, dev.cache_key
+  end
+
   def test_uniq_delegates_to_scoped
     scope = stub
     Bird.stubs(:all).returns(mock(:uniq => scope))


### PR DESCRIPTION
Issue #8195 was fixed in #6376. This test may be backported to `3-2-stable` as well as #6376.
