### PR TITLE
Backport #8074 to 3-2-stable. Use query cache/uncache, when using not only database.yml but also DATABASE_URL.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 3.2.10 (unreleased)
 
+*   Use query cache/uncache when using ENV["DATABASE_URL"].
+    Fixes #6951. [Backport #8074]
+
+    *kennyj*
+
 *   Do not create useless database transaction when building `has_one` association. [Backport #8154]
 
     Example:

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -6,19 +6,19 @@ module ActiveRecord
     module ClassMethods
       # Enable the query cache within the block if Active Record is configured.
       def cache(&block)
-        if ActiveRecord::Base.configurations.blank?
-          yield
-        else
+        if ActiveRecord::Base.connected?
           connection.cache(&block)
+        else
+          yield
         end
       end
 
       # Disable the query cache within the block if Active Record is configured.
       def uncached(&block)
-        if ActiveRecord::Base.configurations.blank?
-          yield
-        else
+        if ActiveRecord::Base.connected?
           connection.uncached(&block)
+        else
+          yield
         end
       end
     end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -173,6 +173,17 @@ class QueryCacheTest < ActiveRecord::TestCase
       assert_queries(2) { task.lock!; task.lock! }
     end
   end
+
+  def test_cache_is_available_when_connection_is_connected
+    conf = ActiveRecord::Base.configurations
+
+    ActiveRecord::Base.configurations = {}
+    Task.cache do
+      assert_queries(1) { Task.find(1); Task.find(1) }
+    end
+  ensure
+    ActiveRecord::Base.configurations = conf
+  end
 end
 
 class QueryCacheExpiryTest < ActiveRecord::TestCase


### PR DESCRIPTION
This is backport #8074.
I send this PR, because 3.2.9 was released.

Please see  #6951 for more details.

/cc @rafaelfranca
