### PR TITLE
Fix #7619. 0x prefix must be added when assigning hexadecimal string into bit column in Postgresql, because solving ambiguity.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `0x` prefix must be added when assigning hexadecimal string into `bit` column in PostgreSQL.
+
+    *kennyj*
+
 *   Added Statement Cache to allow the caching of a single statement. The cache works by
     duping the relation returned from yielding a statement, which allows skipping the AST
     building phase for following executes. The cache returns results in array format.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -28,8 +28,10 @@ module ActiveRecord
 
         def string_to_bit(value)
           case value
-          when /^[01]*$/      then value             # Bit-string notation
-          when /^[0-9A-F]*$/i then value.hex.to_s(2) # Hexadecimal notation
+          when /^0x/i
+            value[2..-1].hex.to_s(2) # Hexadecimal notation
+          else
+            value                    # Bit-string notation
           end
         end
 

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -545,13 +545,19 @@ _SQL
 
   def test_update_bit_string
     new_bit_string = '11111111'
-    new_bit_string_varying = 'FF'
+    new_bit_string_varying = '0xFF'
     assert @first_bit_string.bit_string = new_bit_string
     assert @first_bit_string.bit_string_varying = new_bit_string_varying
     assert @first_bit_string.save
     assert @first_bit_string.reload
     assert_equal @first_bit_string.bit_string, new_bit_string
     assert_equal @first_bit_string.bit_string, @first_bit_string.bit_string_varying
+  end
+	
+  def test_invalid_hex_string
+    new_bit_string = 'FF'
+    @first_bit_string.bit_string = new_bit_string
+    assert_raise(ActiveRecord::StatementInvalid) { assert @first_bit_string.save }
   end
 
   def test_update_oid


### PR DESCRIPTION
According to https://github.com/rails/rails/blob/232d2223ebcfe5c9e0425c821f5d30a7d5968512/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb#L49 , hexadecimal data which has '0' and '1' character interpreted as binary data into bit column in PostgreSQL.

I try to fix this issue by behavior changing.

without this PR:
  "FF" # hex
  "1F" # hex
  "10" # binary !

with this PR:
  "FF" # invalid
  "0xFF" # hex
  "10" # binary

Please see #7619
