### PR TITLE
Fixing #8196, Http auth token breaks with equals sign

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix #8196, correctly handle '=' characters with token based http authentication
+
+    Kalvir Sandhu
+
 *   Fix input name when `:multiple => true` and `:index` are set.
 
     Before:

--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -434,9 +434,9 @@ module ActionController
         if request.authorization.to_s[/^Token (.*)/]
           values = Hash[$1.split(',').map do |value|
             value.strip!                      # remove any spaces between commas and values
-            key, value = value.split(/\=\"?/) # split key=value pairs
+            key, value = value.split(/(.*?)\=(.*)/)[1,2] # split key=value pairs
             if value
-              value.chomp!('"')                 # chomp trailing " in value
+              value.gsub!(/^\"|\"$/,'')         # remove trailing and starting " in value
               value.gsub!(/\\\"/, '"')          # unescape remaining quotes
               [key, value]
             end


### PR DESCRIPTION
Changed the regex to split the key value pairs from the
relevant header so that it doesn't break when the value contains '='
characters
