### PR TITLE
backport #8176, `#pluck` can be used on a relation with `select` clause.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Rails 3.2.10 (unreleased)
 
+*  `#pluck` can be used on a relation with `select` clause. [Backport #8176]
+   Fix #7551
+
+   Example:
+
+        Topic.select([:approved, :id]).order(:id).pluck(:id)
+
+   *Yves Senn*
+
 *   Do not create useless database transaction when building `has_one` association. [Backport #8154]
 
     Example:

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -178,7 +178,9 @@ module ActiveRecord
     #
     def pluck(column_name)
       column_name = column_name.to_s
-      klass.connection.select_all(select(column_name).arel).map! do |attributes|
+      relation = clone
+      relation.select_values = [column_name]
+      klass.connection.select_all(relation.arel).map! do |attributes|
         klass.type_cast_attribute(attributes.keys.first, klass.initialize_attributes(attributes))
       end
     end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -487,4 +487,10 @@ class CalculationsTest < ActiveRecord::TestCase
   def test_pluck_with_qualified_column_name
     assert_equal [1,2,3,4], Topic.order(:id).pluck("topics.id")
   end
+
+  def test_pluck_replaces_select_clause
+    taks_relation = Topic.select([:approved, :id]).order(:id)
+    assert_equal [1,2,3,4], taks_relation.pluck(:id)
+    assert_equal [false, true, true, true], taks_relation.pluck(:approved)
+  end
 end


### PR DESCRIPTION
This is a backport of #8176 to fix #7551

I had to modify the patch, since the code looks different on `3-2-stable` than on master. Effectively it does the exact same thing tough. Since `spawn` was not available I used `clone`. Also I had to use `pluck` with an Array (in the test case) because multiple arguments are not supported on `3-2-stable`
