### PR TITLE
Edge guides don't properly link to the current GitHub tree

### DIFF
--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -85,6 +85,7 @@ module RailsGuides
       @all      = ENV['ALL']      == '1'
       @kindle   = ENV['KINDLE']   == '1'
       @version  = ENV['RAILS_VERSION'] || `git rev-parse --short HEAD`.chomp
+      @full_version = ENV['RAILS_VERSION'] || `git rev-parse HEAD`.chomp
       @lang     = ENV['GUIDES_LANGUAGE']
     end
 

--- a/guides/source/_welcome.html.erb
+++ b/guides/source/_welcome.html.erb
@@ -10,7 +10,7 @@
 </p>
 <% else %>
 <p>
-  These are the new guides for Rails 3.2 based on <a href="https://github.com/rails/rails/tree/<%= @version %>"><%= @version %></a>.
+  These are the new guides for Rails 3.2 based on <a href="https://github.com/rails/rails/tree/<%= @full_version %>"><%= @version %></a>.
   These guides are designed to make you immediately productive with Rails, and to help you understand how all of the pieces fit together.
 </p>
 <% end %>


### PR DESCRIPTION
WIthout the full commit hash, GitHub responds with a 404 when clicking the edge guides "master branch" link. I would have committed this directly to lifo/docrails, but it does include code-related changes in generator.rb, so I thought it was warranted to put it here first.
