### PR TITLE
Avoid using Integer#/, as it is redefined by the 'mathn' stdlib

### DIFF
--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -129,7 +129,7 @@ module ActionView
                 minutes_with_offset = distance_in_minutes
               end
               remainder                   = (minutes_with_offset % 525600)
-              distance_in_years           = (minutes_with_offset / 525600)
+              distance_in_years           = (minutes_with_offset.div 525600)
               if remainder < 131400
                 locale.t(:about_x_years,  :count => distance_in_years)
               elsif remainder < 394200

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -19,6 +19,8 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def assert_distance_of_time_in_words(from, to=nil)
+    Fixnum.send :private, :/  # test we avoid Integer#/ (redefined by mathn)
+
     to ||= from
 
     # 0..1 minute with :include_seconds => true
@@ -121,6 +123,9 @@ class DateHelperTest < ActionView::TestCase
     assert_equal "about 4 hours", distance_of_time_in_words(from + 4.hours, to)
     assert_equal "less than 20 seconds", distance_of_time_in_words(from + 19.seconds, to, :include_seconds => true)
     assert_equal "less than a minute", distance_of_time_in_words(from + 19.seconds, to, :include_seconds => false)
+
+  ensure
+    Fixnum.send :public, :/
   end
 
   def test_distance_in_words


### PR DESCRIPTION
Avoid using `Integer#/`, as it is redefined by the 'mathn' stdlib to return rationals.

Otherwise the methods gives a strange result.

Note that `Integer#div` is more clear in its intent anyways.

I didn't use Integer#divmod because it is less efficient than a separate `div` and `%` (because of the intermediate array :-( )
