### PR TITLE
Fixe  #reverse_order incorrect behavior 

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,4 +1,12 @@
 ## Rails 4.0.0 (unreleased) ##
+*  Fixed #reverse_order incorect behavior
+   in situations when the string containing function comes in method order.
+
+    Post.order('SUBSTR(name, 1, 10)').reverse_order.to_sql
+     expected: #=> "SELECT \"posts\".* FROM \"posts\"   ORDER BY SUBSTR(name, 1, 10) DESC"
+     got:      #=> "SELECT \"posts\".* FROM \"posts\"   ORDER BY SUBSTR(name DESC, 1 DESC, 10) DESC"
+
+   Shemerey Anton
 
 *  `#pluck` can be used on a relation with `select` clause
    Fix #7551

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -791,6 +791,26 @@ module ActiveRecord
       end
     end
 
+    def split_order_expressions(str)
+      return str.split(',') unless str =~ /[)(]/
+
+      depth, index, expressions = 0, 0, []
+      current = expressions[index] = ''
+
+      str.each_char do |char|
+        depth += 1 if char == '('
+        depth -= 1 if char == ')'
+        if depth == 0 && char == ','
+          index += 1
+          current = expressions[index] = ''
+        else
+          current << char
+        end
+      end
+
+      expressions
+    end
+
     def reverse_sql_order(order_query)
       order_query = ["#{quoted_table_name}.#{quoted_primary_key} ASC"] if order_query.empty?
 
@@ -799,7 +819,7 @@ module ActiveRecord
         when Arel::Nodes::Ordering
           o.reverse
         when String
-          o.to_s.split(',').collect do |s|
+          split_order_expressions(o.to_s).collect do |s|
             s.strip!
             s.gsub!(/\sasc\Z/i, ' DESC') || s.gsub!(/\sdesc\Z/i, ' ASC') || s.concat(' DESC')
           end

--- a/activerecord/test/cases/relation_scoping_test.rb
+++ b/activerecord/test/cases/relation_scoping_test.rb
@@ -31,6 +31,10 @@ class RelationScopingTest < ActiveRecord::TestCase
     assert_equal Developer.order("name DESC"), Developer.order("name DESC").reverse_order.reverse_order
   end
 
+  def test_reverse_order_with_function_in_order
+    assert_equal Developer.order('SUBSTR(name, 1, 100)').to_a, Developer.order("substr(name, 1, 100) DESC").reverse_order
+  end
+
   def test_scoped_find
     Developer.where("name = 'David'").scoping do
       assert_nothing_raised { Developer.find(1) }


### PR DESCRIPTION
Fixed incorrect behavior in situations when the string containing function comes in method order. for example SUBSTR()

```
  Sybase:     SUBSTR(field, 1, 10)
  MySql:      SUBSTR(field, 1, 10)
  Postgresql: SUBSTR(field, 1, 10)
  Sqlite:     SUBSTR(field, 1, 10)
  Oracle:     SUBSTR(field, 1, 10)
  DB2:        SUBSTR(field, 1, 10)
```

  “,” was used as means for dividing fields where sorting takes place, as a result of that invalid sql was generated, example:

`Post.order('SUBSTR(name, 1, 10)').reverse_order.to_sql`
#### expected:

`SELECT "posts".* FROM "posts"   ORDER BY SUBSTR(name, 1, 10) DESC`
#### got

`SELECT "posts".* FROM "posts"   ORDER BY SUBSTR(name DESC, 1 DESC, 10) DESC`

This fixes the incorrect behavior. for that purpose i added private method (#split_order_expressions) that split only by expected ","  Other behavior was not affected.
