### PR TITLE
Instance eval in migrations

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -276,13 +276,13 @@ module ActiveRecord
       #
       # See also Table for details on
       # all of the various column transformation
-      def change_table(table_name, options = {})
+      def change_table(table_name, options = {}, &block)
         if supports_bulk_alter? && options[:bulk]
           recorder = ActiveRecord::Migration::CommandRecorder.new(self)
-          yield Table.new(table_name, recorder)
+          eval_block Table.new(table_name, recorder)
           bulk_change_table(table_name, recorder.commands)
         else
-          yield Table.new(table_name, self)
+          eval_block Table.new(table_name, self)
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -155,11 +155,17 @@ module ActiveRecord
       #  )
       #
       # See also TableDefinition#column for details on how to create columns.
-      def create_table(table_name, options = {})
+      def create_table(table_name, options = {}, &block)
         td = table_definition
         td.primary_key(options[:primary_key] || Base.get_primary_key(table_name.to_s.singularize)) unless options[:id] == false
 
-        yield td if block_given?
+        if block_given?
+          if block.arity == 1
+            yield td
+          else
+            td.instance_exec &block
+          end
+        end
 
         if options[:force] && table_exists?(table_name)
           drop_table(table_name, options)

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -38,6 +38,14 @@ module ActiveRecord
         assert_equal %w(foo id), connection.columns(:testings).map(&:name).sort
       end
 
+      def test_create_table_with_instance_eval
+        connection.create_table :testings do
+          column :foo, :string
+        end
+
+        assert_equal %w(foo id), connection.columns(:testings).map(&:name).sort
+      end
+
       def test_create_table_with_not_null_column
         connection.create_table :testings do |t|
           t.column :foo, :string, :null => false

--- a/activerecord/test/cases/migration/create_join_table_test.rb
+++ b/activerecord/test/cases/migration/create_join_table_test.rb
@@ -72,6 +72,14 @@ module ActiveRecord
 
         assert_equal [%w(artist_id music_id)], connection.indexes(:artists_musics).map(&:columns)
       end
+
+      def test_create_join_table_with_index_and_instance_eval
+        connection.create_join_table :artists, :musics do
+          index [:artist_id, :music_id]
+        end
+
+        assert_equal [%w(artist_id music_id)], connection.indexes(:artists_musics).map(&:columns)
+      end
     end
   end
 end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -459,6 +459,14 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
       assert_equal 0, column(:age).default
     end
 
+    def test_bulk_change_with_instance_eval
+      with_bulk_change_table do
+        string :qualification
+      end
+
+      assert column(:qualification)
+    end
+
     def test_removing_columns
       with_bulk_change_table do |t|
         t.string :qualification, :experience
@@ -547,13 +555,11 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
 
     protected
 
-    def with_bulk_change_table
+    def with_bulk_change_table(&block)
       # Reset columns/indexes cache as we're changing the table
       @columns = @indexes = nil
 
-      Person.connection.change_table(:delete_me, :bulk => true) do |t|
-        yield t
-      end
+      Person.connection.change_table :delete_me, :bulk => true, &block
     end
 
     def column(name)


### PR DESCRIPTION
Since pretty much in most of Rails we use `instance_eval`. I think it will be good to have it in the migrations. 

``` ruby

create_table :user do |t|
  t.string :email, :name
  t.timestamps
end

# changes to:

create_table :user do
  string :email, :name
  timestamps
end

```

This pull request contains the code to do this. It aslo includes the same behaviour for `create_join_table` and `change_table`.

I still have to:
- Describe it in the rdocs
- Possibly use this in the schema.rb generation
- Change the tests and internal usage of the `do |t|` pattern
- Deprecation ?
- Update CHANGELOG

But first, I want to know if such feature will be accepted.
