### PR TITLE
backport #8139, `plugin new` adds dummy app tasks when necessary

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 3.2.9 (Nov 12, 2012) ##
 
+*   Add dummy app Rake tasks when --skip-test-unit and --dummy-path is passed to the plugin generator. [Backport #8139]
+    Fix #8121
+
+    *Yves Senn*
+
 *   Update supported ruby versions error message in ruby_version_check.rb *Lihan Li*
 
 ## Rails 3.2.8 (Aug 9, 2012) ##

--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -282,7 +282,7 @@ task :default => :test
           dummy_application_path = File.expand_path("#{dummy_path}/config/application.rb", destination_root)
           unless options[:pretend] || !File.exists?(dummy_application_path)
             contents = File.read(dummy_application_path)
-            contents[(contents.index("module Dummy"))..-1]
+            contents[(contents.index(/module ([\w]+)\n(.*)class Application/m))..-1]
           end
         end
       end

--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -204,7 +204,7 @@ task :default => :test
       end
 
       def create_test_dummy_files
-        return if options[:skip_test_unit] && options[:dummy_path] == 'test/dummy'
+        return unless with_dummy_app?
         create_dummy_app
       end
 
@@ -240,6 +240,10 @@ task :default => :test
 
       def mountable?
         options[:mountable]
+      end
+
+      def with_dummy_app?
+        options[:skip_test_unit].blank? || options[:dummy_path] != 'test/dummy'
       end
 
       def self.banner

--- a/railties/lib/rails/generators/rails/plugin_new/templates/Rakefile
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/Rakefile
@@ -20,7 +20,7 @@ RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_files.include('lib/**/*.rb')
 end
 
-<% if full? && !options[:skip_active_record] && !options[:skip_test_unit] -%>
+<% if full? && !options[:skip_active_record] && with_dummy_app? -%>
 APP_RAKEFILE = File.expand_path("../<%= dummy_path -%>/Rakefile", __FILE__)
 load 'rails/tasks/engine.rake'
 <% end %>

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -65,6 +65,12 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
     assert_no_match(/APP_RAKEFILE/, File.read(File.join(destination_root, "Rakefile")))
   end
 
+  def test_generating_adds_dummy_app_rake_tasks_without_unit_test_files
+    run_generator [destination_root, "-T", "--mountable", '--dummy-path', 'my_dummy_app']
+
+    assert_match(/APP_RAKEFILE/, File.read(File.join(destination_root, "Rakefile")))
+  end
+
   def test_ensure_that_plugin_options_are_not_passed_to_app_generator
     FileUtils.cd(Rails.root)
     assert_no_match(/It works from file!.*It works_from_file/, run_generator([destination_root, "-m", "lib/template.rb"]))


### PR DESCRIPTION
The `plugin new` generator always adds the dummy app rake tasks,
when a dummy app was created.

Closes #8224

I had to backport the commit 00fbee5bbf7896d38ccf3a26d4b6f36f9a63f358 also. Otherwise the error from #6251 would popup.
