### PR TITLE
Allow models to share a connection pool.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Rails 4.0.0 (unreleased) ##
 
+* `#share_connection` delegates the database connection pool of one model to
+  another model. This removes the necessity of creating an object hierarchy and
+  does not require establishing a new connection.
+
+  Example:
+
+      UserProfile.share_connection(User)
+
+  *Pan Thomakos*
+
 *  `#pluck` can be used on a relation with `select` clause
    Fix #7551
 

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -46,6 +46,35 @@ module ActiveRecord
       connection_handler.establish_connection self, spec
     end
 
+    # Allows one class to share the connection pool of another class without
+    # having to establish an object hierarchy. Accepts a class as the input
+    # where <tt>:klass</tt> must be the class with the connection pool to share.
+    #
+    # Example:
+    #
+    #   class User < ActiveRecord::Base; end
+    #   class Profile < ActiveRecord::Base; end
+    #
+    #   class RegularUser < User
+    #     establish_connection(:regular_user_db)
+    #   end
+    #
+    #   class SuperUser < User
+    #     establish_connection(:super_user_db)
+    #   end
+    #
+    #   class RegularProfile < Profile
+    #     share_connection(RegularUser)
+    #   end
+    #
+    #   class SuperProfile < Profile
+    #     share_connection(SuperUser)
+    #   end
+    def share_connection(klass = ActiveRecord::Base)
+      remove_connection
+      connection_handler.share_connection(self, klass)
+    end
+
     # Returns the connection currently associated with the class. This can
     # also be used to "borrow" the connection to do database work unrelated
     # to any of the specific Active Records.

--- a/activerecord/test/cases/connection_handling_test.rb
+++ b/activerecord/test/cases/connection_handling_test.rb
@@ -1,0 +1,17 @@
+require 'cases/helper'
+
+module ActiveRecord
+  class ConnectionHandlingTest < ActiveRecord::TestCase
+    def setup
+      @parent = Class.new(Base)
+      @child = Class.new(Base)
+
+      @child.share_connection(@parent)
+    end
+
+    def test_share_connection
+      assert_not_nil @parent.connection
+      assert_same @child.connection, @parent.connection
+    end
+  end
+end


### PR DESCRIPTION
This little feature arose from an actual application where an object hierarchy did not correspond to the database mapping. Instead of establishing a new connection in each model, and creating multiple connection pools and connections, this change allows one model to delegate its connection to another model.

Example:

```
class User < ActiveRecord::Base; end
class Profile < ActiveRecord::Base; end

class RegularUser < User
  establish_connection(:regular_db)
end

class SuperUser < User
  establish_connection(:super_db)
end

class RegularProfile < Profile
  share_connnection(RegularUser)
end

class SuperProfile < Profile
  share_connection(SuperUser)
end
```

In this example it does not make sense to create a superclass called `RegularDB` that both `RegularUser` and `RegularProfile` inherit from because that does not correspond at all with the object hierarchy. It's much more intuitive to have a top level `User` class, and then simply share the appropriate connection. This also enforces a separation between the database connection and the object hierarchy.
