### PR TITLE
Write config.threasafe! deprecated waning in config/environments/production.rb

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -66,6 +66,9 @@
   # config.action_mailer.raise_delivery_errors = false
 
   # Enable threaded mode.
+  # config.threadsafe! is deprecated. Rails application behave
+  # by default as thread safe in production as long as config.cache_classes and
+  # config.eager_load are set to true.
   # config.threadsafe!
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to


### PR DESCRIPTION
Since Rails 4.0 config.threadsafe! is enabled by default.
I think we have to strongly warn users about it by not only showing deprecated warnings when
user use this option, but also writing deprecated warnings in config file.
