### PR TITLE
Updated dependency on bundler to ~> 1.2.2

### DIFF
--- a/rails.gemspec
+++ b/rails.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'actionmailer',  version
   s.add_dependency 'railties',      version
 
-  s.add_dependency 'bundler',         '~> 1.2.2'
+  s.add_dependency 'bundler',         '>= 1.2.2', '< 2.0'
   s.add_dependency 'sprockets-rails', '~> 2.0.0.rc1'
 end

--- a/rails.gemspec
+++ b/rails.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'actionmailer',  version
   s.add_dependency 'railties',      version
 
-  s.add_dependency 'bundler',         '~> 1.2'
+  s.add_dependency 'bundler',         '~> 1.2.2'
   s.add_dependency 'sprockets-rails', '~> 2.0.0.rc1'
 end


### PR DESCRIPTION
Bundler <= 1.2.1 and Ruby 2.0.0 can raise an error since the commit below (incompatible change was added to Error class):

https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/37292

It's been now fixed in bundler 1.2.2. I think it's better for Rails 4 to update the dependency on bundler to `~> 1.2.2` toward the next coming Ruby 2.0.0, in advance.
