### PR TITLE
Use div

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/grouping.rb
+++ b/activesupport/lib/active_support/core_ext/array/grouping.rb
@@ -58,7 +58,7 @@ class Array
     # size / number gives minor group size;
     # size % number gives how many objects need extra accommodation;
     # each group hold either division or division + 1 items.
-    division = size / number
+    division = size.div number
     modulo = size % number
 
     # create a new array avoiding dup

--- a/activesupport/lib/active_support/core_ext/array/grouping.rb
+++ b/activesupport/lib/active_support/core_ext/array/grouping.rb
@@ -67,9 +67,9 @@ class Array
 
     number.times do |index|
       length = division + (modulo > 0 && modulo > index ? 1 : 0)
-      padding = fill_with != false &&
-        modulo > 0 && length == division ? 1 : 0
-      groups << slice(start, length).concat([fill_with] * padding)
+      groups << last_group = slice(start, length)
+      last_group << fill_with if fill_with != false &&
+        modulo > 0 && length == division
       start += length
     end
 

--- a/activesupport/test/core_ext/array_ext_test.rb
+++ b/activesupport/test/core_ext/array_ext_test.rb
@@ -112,6 +112,14 @@ class ArrayExtToSTests < ActiveSupport::TestCase
 end
 
 class ArrayExtGroupingTests < ActiveSupport::TestCase
+  def setup
+    Fixnum.send :private, :/  # test we avoid Integer#/ (redefined by mathn)
+  end
+
+  def teardown
+    Fixnum.send :public, :/
+  end
+
   def test_in_groups_of_with_perfect_fit
     groups = []
     ('a'..'i').to_a.in_groups_of(3) do |group|


### PR DESCRIPTION
Avoid using `Integer#/`, as it is redefined by the 'mathn' stdlib to return rationals.

Otherwise the methods gives a strange result.

Note that `Integer#div` is more clear in its intent anyways.

I didn't use Integer#divmod because it is less efficient than a separate `div` and `%` (because of the intermediate array :-( )

I couldn't resist simplifying slightly the method (and making it slightly faster too).

Fixes #7087
