### PR TITLE
Support Different Engines for Different Tables; Support MyISAM FULLTEXT indexes

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -8,7 +8,7 @@ module ActiveRecord
     # Abstract representation of an index definition on a table. Instances of
     # this type are typically created and returned by methods in database
     # adapters. e.g. ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#indexes
-    class IndexDefinition < Struct.new(:table, :name, :unique, :columns, :lengths, :orders, :where) #:nodoc:
+    class IndexDefinition < Struct.new(:table, :name, :unique, :columns, :lengths, :orders, :where, :options) #:nodoc:
     end
 
     # Abstract representation of a column definition. Instances of this type

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -620,10 +620,13 @@ module ActiveRecord
           index_name   = index_name(table_name, column: column_names)
 
           if Hash === options # legacy support, since this param was a string
-            options.assert_valid_keys(:unique, :order, :name, :where, :length)
+            raise ArgumentError, "Only fulltext or unique is allowed" if options[:unique] && options[:fulltext]
+
+            options.assert_valid_keys(:unique, :order, :name, :where, :length, :fulltext)
 
             index_type = options[:unique] ? "UNIQUE" : ""
             index_name = options[:name].to_s if options.key?(:name)
+            index_type = "FULLTEXT" if options[:fulltext]
 
             if supports_partial_index?
               index_options = options[:where] ? " WHERE #{options[:where]}" : ""

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -425,6 +425,12 @@ module ActiveRecord
 
             indexes.last.columns << row[:Column_name]
             indexes.last.lengths << row[:Sub_part]
+
+            if row[:Index_type] == 'FULLTEXT'
+              indexes.last.options ||= Hash.new
+              indexes.last.options.merge!(:fulltext => true)
+            end
+            
           end
         end
 

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -101,6 +101,14 @@ HEADER
             tbl.print ", id: false"
           end
           tbl.print ", force: true"
+
+
+          # Add table engine
+          res = @connection.execute "SHOW TABLE STATUS LIKE '#{table}'"
+          engine = res.first[res.fields.index("Engine")] rescue nil
+          tbl.print ", :options => 'ENGINE=#{engine}'" if engine
+          res = nil # Free the result 
+
           tbl.puts " do |t|"
 
           # then dump all non-primary key columns
@@ -171,6 +179,10 @@ HEADER
             statement_parts << ('order: ' + index.orders.inspect) unless index_orders.empty?
 
             statement_parts << ('where: ' + index.where.inspect) if index.where
+
+            if index.options && index.options[:fulltext]
+              statement_parts << ('fulltext: true')
+            end
 
             '  ' + statement_parts.join(', ')
           end


### PR DESCRIPTION
Add support for different MySQL engines for different tables; Add support for MyISAM fulltext indexes in migrations, and schema.rb.

In a project I was working on we wanted to use MyISAM fulltext indexes for a single table, but continue to use InnoDB for the remaining tables.  This patch adds support for that.  Without this patch it's impossible to use the [full-text search query syntax](http://dev.mysql.com/doc/refman/5.5/en//fulltext-search.html), because in the test database it would continue to use the default engine for all, and not add the fulltext option to the index that is create (just a standard key would be created, which isn't what we needed).
- When dumping the schema to schema.rb, include engine information, and add a flag for fulltext indexes.
- When engine and fulltext index flags are in the migration, create the index as a fulltext one.

**Sources:**

Integrated: [multiple engine support from this gist](https://gist.github.com/1374003)
