### PR TITLE
MySQL 5.6 and later supports microsecond precision in datetime.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -66,6 +66,14 @@ module ActiveRecord
         @connection.escape(string)
       end
 
+      def quoted_date(value)
+        if value.acts_like?(:time) && value.respond_to?(:usec)
+          "#{super}.#{sprintf("%06d", value.usec)}"
+        else
+          super
+        end
+      end
+
       # CONNECTION MANAGEMENT ====================================
 
       def active?


### PR DESCRIPTION
MySQL 5.6 supports microsecond fraction with datetime functions: http://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html

This patch allows saving microseconds to mysql's datetime columns such as`updated_at`. This is significant to take benefits from [cache_key second precision updated to nanoseconds](https://github.com/rails/rails/commit/900dbc54f17500e14e481eab2ebf88acfc5448aa).

You might want to branch it to include this only for 5.6, but passing these values to < 5.6 doesn't cause issues either, based on my experiment.

See also [a pull request on mysql2 gem](https://github.com/brianmario/mysql2/issues/324) that addresses retrieving microseconds _from_ mysql to inflate to Time with typecasting enabled.
