### PR TITLE
Allow specifying which MySQL Engine to Use, and store it in schema.rb

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -12,6 +12,10 @@ module ActiveRecord
         {}
       end
 
+      def table_options(table)
+        nil
+      end
+
       # Truncates a table alias according to the limits of the current adapter.
       def table_alias_for(table_name)
         table_name[0...table_alias_length].tr('.', '_')

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -442,7 +442,7 @@ module ActiveRecord
       end
 
       def create_table(table_name, options = {}) #:nodoc:
-        super(table_name, options.reverse_merge(:options => "ENGINE=InnoDB"))
+        super(table_name, options.with_indifferent_access.reverse_merge(:options => "ENGINE=InnoDB"))
       end
 
       def bulk_change_table(table_name, operations) #:nodoc:

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -242,6 +242,16 @@ module ActiveRecord
         @connection.last_id
       end
 
+      def table_options(table)
+        res = self.execute "SHOW TABLE STATUS LIKE '#{table}'"
+        engine = res.first[res.fields.index("Engine")]
+
+        options = ''
+        options = "ENGINE=#{engine}".inspect if engine
+      
+        options
+      end
+
       private
 
       def connect

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -297,6 +297,16 @@ module ActiveRecord
         @connection.insert_id
       end
 
+      def table_options(table)
+        res = self.exec_without_stmt "SHOW TABLE STATUS LIKE '#{table}'"
+        engine = res.first.to_hash.first['Engine']
+
+        options = ''
+        options = "ENGINE=#{engine}".inspect if engine
+      
+        options
+      end
+
       module Fields
         class Type
           def type; end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -101,6 +101,10 @@ HEADER
             tbl.print ", id: false"
           end
           tbl.print ", force: true"
+
+          options = @connection.table_options(table)
+          tbl.print ", options: #{options}" unless options.blank?
+
           tbl.puts " do |t|"
 
           # then dump all non-primary key columns

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -220,6 +220,11 @@ class SchemaDumperTest < ActiveRecord::TestCase
       assert_match %r{t.text\s+"medium_text",\s+limit: 16777215$}, output
       assert_match %r{t.text\s+"long_text",\s+limit: 2147483647$}, output
     end
+
+    def test_schema_dumps_engine 
+      output = standard_dump
+      assert_match %r{create_table "wheels", force: true, options: "ENGINE=InnoDB" do \|t\|$}, output
+    end
   end
 
   def test_schema_dump_includes_decimal_options


### PR DESCRIPTION
Support specifying the MySQL Engine when creating a table, and having it be maintained through `schema.rb`.

Also make `create_table`'s options parameter to allow strings or symbols for the keys, because the new hash syntax seems to be what the migrations and schema.rb are supposed to be by convention.

This is half of #8239 that I submitted earlier today.
