### PR TITLE
Now mysql gem can be built on ruby 2.0.0-preview1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ platforms :ruby do
 
   group :db do
     gem 'pg', '>= 0.11.0'
-    gem 'mysql', '>= 2.8.1' if RUBY_VERSION < '2.0.0'
+    gem 'mysql', '>= 2.8.1'
     gem 'mysql2', '>= 0.3.10'
   end
 end


### PR DESCRIPTION
This pull request reverts commit 8d8fd13179cacd86f307e87396474bdfab9f3462
because Now mysql gem can be built on ruby 2.0.0-preview1.
- ruby 2.0.0-preview1 used

``` ruby
$ ruby -v
ruby 2.0.0dev (2012-11-01 trunk 37411) [x86_64-linux]
```
-  MySQL 5.6.8 rc

``` ruby
$ mysql -V
mysql  Ver 14.14 Distrib 5.6.8-rc, for Linux (x86_64) using  EditLine wrapper
```
- bundler 1.2.2 required to execute bundler successfully.

``` ruby
$ cd activerecord
$ gem update
Updating installed gems
Updating bundler
Fetching: bundler-1.2.2.gem (100%)
Successfully installed bundler-1.2.2
Updating rake
Fetching: rake-10.0.1.gem (100%)
Successfully installed rake-10.0.1
Gems updated: bundler, rake
Installing ri documentation for bundler-1.2.2...
Installing ri documentation for rake-10.0.1...
Installing RDoc documentation for bundler-1.2.2...
Installing RDoc documentation for rake-10.0.1...
```
- mysql gem can be installed

``` ruby
$ gem install mysql
Fetching: mysql-2.8.1.gem (100%)
Building native extensions.  This could take a while...
Successfully installed mysql-2.8.1
1 gem installed
Installing ri documentation for mysql-2.8.1...
Installing RDoc documentation for mysql-2.8.1...
```
- rake test_mysql finishes successfully without any failures/errors

```
$ bundle update
... snip ...
Your bundle is updated! Use `bundle show [gemname]` to see where a bundled gem is installed.

$ rake test_mysql
... snip ...
3477 tests, 10113 assertions, 0 failures, 0 errors, 7 skips
$
```
