### PR TITLE
Adding sqlserver.yml template to satisfy "-d sqlserver" 

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add sqlserver.yml template file to satisfy '-d sqlserver' being passed to 'rails new'.
+    Fix #6882 
+		
+		*Robert Nesius*
+
 *   Rake test:uncommitted finds git directory in ancestors *Nicolas Despres*
 
 *   Add dummy app Rake tasks when --skip-test-unit and --dummy-path is passed to the plugin generator.

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlserver.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlserver.yml
@@ -1,0 +1,57 @@
+# SQL Server (2005 or higher recommended)
+# 
+# Install the adapters and driver
+#   gem install tiny_tds
+#   gem install activerecord-sqlserver-adapter
+#
+# Ensure the activerecord adapter and db driver gems are defined in your Gemfile
+# 	gem 'tiny_tds'
+# 	gem 'activerecord-sqlserver-adapter'
+#
+# You should make sure freetds is configured correctly first.  
+# freetds.conf contains host/port/protocol_versions settings.  
+# http://freetds.schemamania.org/userguide/freetdsconf.htm
+#
+# A typical Microsoft server
+# 	[mssql]
+#   host = mssqlserver.yourdomain.com
+#		port = 1433
+#		tds version = 7.1
+
+# If you can connect with "tsql -S servername", your basic FreeTDS installation is working.
+# 'man tsql' for more info
+# Set timeout to a larger number if valid queries against a live db fail
+
+development:
+  adapter: sqlserver
+  encoding: utf8
+  reconnect: false
+  database: <%= app_name %>_development
+  username: <%= app_name %>
+  password:
+  timeout: 25
+  dataserver: from_freetds.conf
+
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  adapter: sqlserver
+  encoding: utf8
+  reconnect: false
+  database: <%= app_name %>_test
+  username: <%= app_name %>
+  password:
+  timeout: 25
+  dataserver: from_freetds.conf
+
+production:
+  adapter: sqlserver
+  encoding: utf8
+  reconnect: false
+  database: <%= app_name %>_production
+  username: <%= app_name %>
+  password:
+  timeout: 25
+  dataserver: from_freetds.conf


### PR DESCRIPTION
Adding sqlserver.yml template to satisfy "-d sqlserver" being passed to invocations of "rails new".  Fixes issue #6882.  
