### PR TITLE
Removed extra call to #diff in #assert_recognizes

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -36,16 +36,19 @@ module ActionDispatch
       #
       #   # Test a custom route
       #   assert_recognizes({controller: 'items', action: 'show', id: '1'}, 'view/item1')
-      def assert_recognizes(expected_options, path, extras={}, message=nil)
+      def assert_recognizes(expected_options, path, extras={}, msg=nil)
         request = recognized_request_for(path, extras)
 
         expected_options = expected_options.clone
 
         expected_options.stringify_keys!
 
-        message ||= sprintf("The recognized options <%s> did not match <%s>, difference: <%s>",
-            request.path_parameters, expected_options, diff(expected_options, request.path_parameters))
-        assert_equal(expected_options, request.path_parameters, message)
+        msg = message(msg, "") {
+          sprintf("The recognized options <%s> did not match <%s>, difference:",
+                  request.path_parameters, expected_options)
+        }
+
+        assert_equal(expected_options, request.path_parameters, msg)
       end
 
       # Asserts that the provided options can be used to generate the provided path. This is the inverse of +assert_recognizes+.

--- a/activesupport/lib/active_support/core_ext/hash/diff.rb
+++ b/activesupport/lib/active_support/core_ext/hash/diff.rb
@@ -6,7 +6,7 @@ class Hash
   #   {}.diff(1 => 2)               # => {1 => 2}
   #   {1 => 2, 3 => 4}.diff(1 => 2) # => {3 => 4}
   def diff(other)
-    ActiveSupport::Deprecation.warn "Hash#diff is no longer used inside of Rails, and is being deprecated with no replacement. If you're using it to compare hashes for the purpose of testing, please use MiniTest's diff instead."
+    ActiveSupport::Deprecation.warn "Hash#diff is no longer used inside of Rails, and is being deprecated with no replacement. If you're using it to compare hashes for the purpose of testing, please use MiniTest's assert_equal instead."
     dup.
       delete_if { |k, v| other[k] == v }.
       merge!(other.dup.delete_if { |k, v| has_key?(k) })


### PR DESCRIPTION
this is in response to http://twitter.com/alindeman/status/269595485692624896 -- basically, you shouldn't use diff, and if you do, you **really** shouldn't use it building up the message raw. That means you're spending the cost whether your assertion passes or fails. I'll poke and look for others.
