### PR TITLE
Remove Ruby 2.0 from allowed_failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,3 @@ notifications:
     rooms:
       - secure: "CGWvthGkBKNnTnk9YSmf9AXKoiRI33fCl5D3jU4nx3cOPu6kv2R9nMjt9EAo\nOuS4Q85qNSf4VNQ2cUPNiNYSWQ+XiTfivKvDUw/QW9r1FejYyeWarMsSBWA+\n0fADjF1M2dkDIVLgYPfwoXEv7l+j654F1KLKB69F0F/netwP9CQ="
 bundler_args: --path vendor/bundle
-matrix:
-  allow_failures:
-    - rvm: 2.0.0


### PR DESCRIPTION
This isn't ready to merge, as we're not totally fixed yet: https://travis-ci.org/rails/rails

But I was hopeful that we were, so I wrote it before the failures actually failed, and figured I'd get the PR in while I had the patch handy.
