### PR TITLE
Add a deprecation before removing ActiveRecord::Fixtures::find_table_name

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -381,6 +381,12 @@ module ActiveRecord
 
     @@all_cached_fixtures = Hash.new { |h,k| h[k] = {} }
 
+    def self.find_table_name(fixture_set_name) # :nodoc:
+      ActiveSupport::Deprecation.warn(
+        "ActiveRecord::Fixtures.find_table_name is deprecated and shall be removed from future releases.  Use ActiveRecord::Fixtures.default_fixture_model_name instead.")
+      default_fixture_model_name(fixture_set_name)
+    end
+
     def self.default_fixture_model_name(fixture_set_name) # :nodoc:
       ActiveRecord::Base.pluralize_table_names ?
         fixture_set_name.singularize.camelize :


### PR DESCRIPTION
The `ActiveRecord::Fixtures::find_table_name` method was removed from "master" 11 months ago, but it was never deprecated.  Here is a deprecated implementation, as suggested by @carlosantoniodasilva in the discussion of #4481.
