### PR TITLE
Add test to ensure preloading works as expected with "group", "select" and "includes".

### DIFF
--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1438,4 +1438,17 @@ class RelationTest < ActiveRecord::TestCase
     end
     assert_no_queries { relation.to_a }
   end
+
+  test 'group with select and includes' do
+    authors_count = Post.select('author_id, COUNT(author_id) AS num_posts').group('author_id').includes(:author).to_a
+
+    assert_no_queries do
+      result = authors_count.map do |post|
+        [post.num_posts, post.author.try(:name)]
+      end
+
+      expected = [[1, nil], [5, "David"], [3, "Mary"], [2, "Bob"]]
+      assert_equal expected, result
+    end
+  end
 end


### PR DESCRIPTION
Rebased and adapted #2303 onto master as requested buy @steveklabnik.

This test case failed with rails 3.1, but it works with 3.2 and current master. :beers: 
