### PR TITLE
make ActionMailer::QueuedMessage autoloadable

### DIFF
--- a/actionmailer/lib/action_mailer.rb
+++ b/actionmailer/lib/action_mailer.rb
@@ -44,4 +44,5 @@ module ActionMailer
   autoload :MailHelper
   autoload :TestCase
   autoload :TestHelper
+  autoload :QueuedMessage
 end


### PR DESCRIPTION
I'm implementing the Rails 4 Queue API for queue_classic. I use `constantize` on the job name to trigger the rails autoloading before I unmarshal the job object. AM adds the following job when sending an email asynchronously: `ActionMailer::QueuedMessage::DeliveryJob`

calling `constantize` on this class results in a `#<NameError: uninitialized constant ActionMailer::QueuedMessage>`

I added the necessary `autoload` statement to `ActionMailer` to get it working.
