### PR TITLE
Point user to strong_parameters as the new protection model

### DIFF
--- a/activemodel/lib/active_model/deprecated_mass_assignment_security.rb
+++ b/activemodel/lib/active_model/deprecated_mass_assignment_security.rb
@@ -5,14 +5,16 @@ module ActiveModel
      module ClassMethods # :nodoc:
        def attr_protected(*args)
          raise "`attr_protected` is extracted out of Rails into a gem. " \
-           "Please use new recommended protection model for params " \
-           "or add `protected_attributes` to your Gemfile to use old one."
+           "Please use new recommended protection model for params" \
+           "(strong_parameters) or add `protected_attributes` to your " \
+           "Gemfile to use old one."
        end
 
        def attr_accessible(*args)
          raise "`attr_accessible` is extracted out of Rails into a gem. " \
-           "Please use new recommended protection model for params " \
-           "or add `protected_attributes` to your Gemfile to use old one."
+           "Please use new recommended protection model for params" \
+           "(strong_parameters) or add `protected_attributes` to your " \
+           "Gemfile to use old one."
        end
      end
   end


### PR DESCRIPTION
Hi,

this is a small deprecation notice improvement. I think we should give the user at least a keyword what to google for if he's unaware of strong_parameters.
