### PR TITLE
Simplify String#mb_chars and fix documentation.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   No longer proxy ActiveSupport::Multibyte#class. *Steve Klabnik*
+
 *   Deprecate `ActiveSupport::TestCase#pending` method, use `skip` from MiniTest instead. *Carlos Antonio da Silva*
 
 *   `XmlMini.with_backend` now may be safely used with threads:

--- a/activesupport/lib/active_support/core_ext/string/multibyte.rb
+++ b/activesupport/lib/active_support/core_ext/string/multibyte.rb
@@ -33,11 +33,7 @@ class String
   # For more information about the methods defined on the Chars proxy see ActiveSupport::Multibyte::Chars. For
   # information about how to change the default Multibyte behavior see ActiveSupport::Multibyte.
   def mb_chars
-    if ActiveSupport::Multibyte.proxy_class.consumes?(self)
-      ActiveSupport::Multibyte.proxy_class.new(self)
-    else
-      self
-    end
+    ActiveSupport::Multibyte.proxy_class.new(self)
   end
 
   def is_utf8?

--- a/activesupport/lib/active_support/core_ext/string/multibyte.rb
+++ b/activesupport/lib/active_support/core_ext/string/multibyte.rb
@@ -6,7 +6,7 @@ class String
   #
   # +mb_chars+ is a multibyte safe proxy for string methods.
   #
-  # In Ruby 1.8 and older it creates and returns an instance of the ActiveSupport::Multibyte::Chars class which
+  # It creates and returns an instance of the ActiveSupport::Multibyte::Chars class which
   # encapsulates the original string. A Unicode safe version of all the String methods are defined on this proxy
   # class. If the proxy class doesn't respond to a certain method, it's forwarded to the encapsulated string.
   #
@@ -16,9 +16,6 @@ class String
   #
   #   name.mb_chars.reverse.to_s # => "rellüM sualC"
   #   name.mb_chars.length       # => 12
-  #
-  # In Ruby 1.9 and newer +mb_chars+ returns +self+ because String is (mostly) encoding aware. This means that
-  # it becomes easy to run one version of your code on multiple Ruby versions.
   #
   # == Method chaining
   #

--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -47,7 +47,7 @@ class MultibyteCharsTest < ActiveSupport::TestCase
   end
 
   def test_methods_are_forwarded_to_wrapped_string_for_byte_strings
-    assert_equal BYTE_STRING.class, BYTE_STRING.mb_chars.class
+    assert_equal BYTE_STRING.length, BYTE_STRING.mb_chars.length
   end
 
   def test_forwarded_method_with_non_string_result_should_be_returned_vertabim
@@ -673,6 +673,9 @@ class MultibyteCharsExtrasTest < ActiveSupport::TestCase
     assert_equal "ð¥¤¤", chars(byte_string).tidy_bytes(true)
   end
 
+  def test_class_is_not_forwarded
+    assert_equal BYTE_STRING.dup.mb_chars.class, ActiveSupport::Multibyte::Chars
+  end
 
   private
 


### PR DESCRIPTION
Opened for feedback.

This came up due to #7798. I figured that if the if was a 1.8 to 1.9 difference, we should not just fix docs, but remove the if. Now one test fails:

```
  1) Failure:
test_methods_are_forwarded_to_wrapped_string_for_byte_strings(MultibyteCharsTest) [/Users/steve/src/rails/activesupport/test/multibyte_chars_test.rb:50]:
--- expected
+++ actual
@@ -1 +1 @@
-String
+ActiveSupport::Multibyte::Chars
```

I'm not sure this test is good, though: do we really want to proxy `.class`?
