### PR TITLE
require bundler groups to include rake-tasks in engines

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Engines with a dummy app include the rake tasks of dependencies in the app namespace.
+    Fix #8229
+
+    *Yves Senn*
+
 *   Add sqlserver.yml template file to satisfy '-d sqlserver' being passed to 'rails new'.
     Fix #6882
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Rails 4.0.0 (unreleased) ##
 
 *   Add sqlserver.yml template file to satisfy '-d sqlserver' being passed to 'rails new'.
-    Fix #6882 
-		
+    Fix #6882
+
 		*Robert Nesius*
 
 *   Rake test:uncommitted finds git directory in ancestors *Nicolas Despres*

--- a/railties/lib/rails/generators/rails/plugin_new/templates/rails/application.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/rails/application.rb
@@ -11,7 +11,7 @@ require "action_mailer/railtie"
 <%= comment_if :skip_test_unit %>require "rails/test_unit/railtie"
 <% end -%>
 
-Bundler.require
+Bundler.require(*Rails.groups)
 require "<%= name %>"
 
 <%= application_definition %>


### PR DESCRIPTION
If you generate a full engine, this will include rake tasks from
your gem under the `app` namespace. For example if you have a dependency
on `rspec-rails` in your engine's `gemspec`. You will get the task `app:spec`

This is a fix for #8229

Trailing whitespace snuck into the CHANGELOG. I removed it in a separate commit to make backporting easier.
