### PR TITLE
refactor the naming within plugin new generator

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -53,13 +53,11 @@ module Rails
       template "lib/%name%.rb"
       template "lib/tasks/%name%_tasks.rake"
       template "lib/%name%/version.rb"
-      if full?
-        template "lib/%name%/engine.rb"
-      end
+      template "lib/%name%/engine.rb" if engine?
     end
 
     def config
-      template "config/routes.rb" if full?
+      template "config/routes.rb" if engine?
     end
 
     def test
@@ -70,7 +68,7 @@ module Rails
 
 task default: :test
       EOF
-      if full?
+      if engine?
         template "test/integration/navigation_test.rb"
       end
     end
@@ -133,7 +131,7 @@ task default: :test
     end
 
     def script(force = false)
-      return unless full?
+      return unless engine?
 
       directory "script", force: force do |content|
         "#{shebang}\n" + content
@@ -271,8 +269,12 @@ task default: :test
         end
       end
 
+      def engine?
+        full? || mountable?
+      end
+
       def full?
-        options[:full] || options[:mountable]
+        options[:full]
       end
 
       def mountable?

--- a/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 <% end -%>
 
   <%= '# ' if options.dev? || options.edge? -%>s.add_dependency "rails", "~> <%= Rails::VERSION::STRING %>"
-<% if full? && !options[:skip_javascript] -%>
+<% if engine? && !options[:skip_javascript] -%>
   # s.add_dependency "<%= "#{options[:javascript]}-rails" %>"
 <% end -%>
 <% unless options[:skip_active_record] -%>

--- a/railties/lib/rails/generators/rails/plugin_new/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/Gemfile
@@ -2,7 +2,7 @@ source "http://rubygems.org"
 
 <% if options[:skip_gemspec] -%>
 <%= '# ' if options.dev? || options.edge? -%>gem "rails", "~> <%= Rails::VERSION::STRING %>"
-<% if full? && !options[:skip_javascript] -%>
+<% if engine? && !options[:skip_javascript] -%>
 # gem "<%= "#{options[:javascript]}-rails" %>"
 <% end -%>
 <% else -%>

--- a/railties/lib/rails/generators/rails/plugin_new/templates/Rakefile
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/Rakefile
@@ -14,7 +14,7 @@ RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_files.include('lib/**/*.rb')
 end
 
-<% if full? && !options[:skip_active_record] && with_dummy_app? -%>
+<% if engine? && !options[:skip_active_record] && with_dummy_app? -%>
 APP_RAKEFILE = File.expand_path("../<%= dummy_path -%>/Rakefile", __FILE__)
 load 'rails/tasks/engine.rake'
 <% end %>

--- a/railties/lib/rails/generators/rails/plugin_new/templates/lib/%name%.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/lib/%name%.rb
@@ -1,4 +1,4 @@
-<% if full? -%>
+<% if engine? -%>
 require "<%= name %>/engine"
 
 <% end -%>


### PR DESCRIPTION
Having a method called `full?`, which checks on :full and :mountable
is very confusing. I renamed `full?` to `engine?` and created a `full?`
method that only checks the `:full` option.

I started this work from the discussion on #8192.
