### PR TITLE
Add rename_index to change_table.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `rename_index` can be used inside a `change_table` block.
+
+        change_table :accounts do |t|
+          t.rename_index :user_id, :account_id
+        end
+
+    *Jarek Radosz*
+
 *   `#pluck` can be used on a relation with `select` clause. Fix #7551
 
     Example:

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -324,6 +324,7 @@ module ActiveRecord
     #   change_table :table do |t|
     #     t.column
     #     t.index
+    #     t.rename_index
     #     t.timestamps
     #     t.change
     #     t.change_default
@@ -384,6 +385,13 @@ module ActiveRecord
       # Checks to see if an index exists. See SchemaStatements#index_exists?
       def index_exists?(column_name, options = {})
         @base.index_exists?(@table_name, column_name, options)
+      end
+
+      # Renames the given index on the table.
+      #
+      #  t.rename_index(:user_id, :account_id)
+      def rename_index(index_name, new_index_name)
+        @base.rename_index(@table_name, index_name, new_index_name)
       end
 
       # Adds timestamps (+created_at+ and +updated_at+) columns to the table. See SchemaStatements#add_timestamps

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -164,6 +164,13 @@ module ActiveRecord
         end
       end
 
+      def test_rename_index_renames_index
+        with_change_table do |t|
+          @connection.expect :rename_index, nil, [:delete_me, :bar, :baz]
+          t.rename_index :bar, :baz
+        end
+      end
+
       def test_change_changes_column
         with_change_table do |t|
           @connection.expect :change_column, nil, [:delete_me, :bar, :string, {}]


### PR DESCRIPTION
With this change `rename_index` can be used inside a `change_table` block.
Example:

``` ruby
change_table :accounts do |t|
  t.rename_index :user_id, :account_id
end
```

I believe it was the only schema transforming method that wasn't available inside `change_table`.
