### PR TITLE
backport #8262, require bundler groups to include rake-tasks in engines

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 3.2.9 (Nov 12, 2012) ##
 
+*   Engines with a dummy app include the rake tasks of dependencies in the app namespace. [Backport: #8262]
+    Fix #8229
+
+    *Yves Senn*
+
 *   Add dummy app Rake tasks when --skip-test-unit and --dummy-path is passed to the plugin generator. [Backport #8139]
     Fix #8121
 

--- a/railties/lib/rails/generators/rails/plugin_new/templates/rails/application.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/rails/application.rb
@@ -12,7 +12,7 @@ require "active_resource/railtie"
 <%= comment_if :skip_test_unit %>require "rails/test_unit/railtie"
 <% end -%>
 
-Bundler.require
+Bundler.require(*Rails.groups)
 require "<%= name %>"
 
 <%= application_definition %>


### PR DESCRIPTION
If you generate a full engine, this will include rake tasks from
your gem under the `app` namespace. For example if you have a dependency
on `rspec-rails` in your engine's `gemspec`. You will get the task `app:spec`

Closes #8229

Conflicts:

```
railties/CHANGELOG.md
```
