### PR TITLE
Postgresql doesn't accepts limits on text columns

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   When running migrations on Postgresql, the `:limit` option for `binary` and `text` columns is silently dropped.
+    Previously, these migrations caused sql exceptions, because Postgresql doesn't support limits on these types.
+
+    *Victor Costan*
+
 *   Don't change STI type when calling `ActiveRecord::Base#becomes`.
     Add `ActiveRecord::Base#becomes!` with the previous behavior.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -396,6 +396,13 @@ module ActiveRecord
             when nil, 0..0x3fffffff; super(type)
             else raise(ActiveRecordError, "No binary type has byte size #{limit}.")
             end
+          when 'text'
+            # PostgreSQL doesn't support limits on text columns.
+            # The hard limit is 1Gb, according to section 8.3 in the manual.
+            case limit
+            when nil, 0..0x3fffffff; super(type)
+            else raise(ActiveRecordError, "The limit on text can be at most 1GB - 1byte.")
+            end
           when 'integer'
             return 'integer' unless limit
 

--- a/activerecord/test/cases/adapters/postgresql/sql_types_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/sql_types_test.rb
@@ -1,0 +1,18 @@
+require "cases/helper"
+
+class SqlTypesTest < ActiveRecord::TestCase
+  def test_binary_types
+    assert_equal 'bytea', type_to_sql(:binary, 100_000)
+    assert_raise ActiveRecord::ActiveRecordError do
+      type_to_sql :binary, 4294967295
+    end
+    assert_equal 'text', type_to_sql(:text, 100_000)
+    assert_raise ActiveRecord::ActiveRecordError do
+      type_to_sql :text, 4294967295
+    end
+  end
+
+  def type_to_sql(*args)
+    ActiveRecord::Base.connection.type_to_sql(*args)
+  end
+end

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -192,5 +192,10 @@ end
 _SQL
 rescue #This version of PostgreSQL either has no XML support or is was not compiled with XML support: skipping table
   end
+
+  create_table :limitless_fields, force: true do |t|
+    t.binary :binary, limit: 100_000
+    t.text :text, limit: 100_000
+  end
 end
 


### PR DESCRIPTION
TL;DR similar to accepted pull request #6328, but this time targeting text columns
https://github.com/rails/rails/pull/6238

The long story: PostgreSQL doesn't take a limit for "text" columns so developers must choose between removing :limit from their binary column definitions, and not being able to target pgsql.

This change drops :limit specifications, when migrations are applied against a pgsql database. It's not ideal, because the limit information is lost. However, the mysql adapters do something similar, so I hope the approach is OK.

A better long-term solution might be to map :text columns without :limit to "text", and :text columns with :limit to "character varying(xxx)". However, that requires changes in the code that maps postgresql types back into Rails types, and this change seems like a smaller step in the same direction.

Testing: I added a table to postgresql_specific_schema that uses :limit on :text and :binary columns. Setting up this table fails without the patch in this pull request. I also added a couple of unit tests to a new sql_types_test file, which follows the convention in the MySQL adapter tests.

Please let me know if this patch needs more work, and thank you very much for Rails!
