### PR TITLE
Improved Error handling when parsing database.yaml, Fixes #8143

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -105,6 +105,10 @@ module Rails
       def database_configuration
         require 'erb'
         YAML.load ERB.new(IO.read(paths["config/database"].first)).result
+      rescue Psych::SyntaxError => e
+        raise "YAML syntax error occurred while parsing #{paths["config/database"].first}. " \
+              "Please note that YAML must be consistently indented using spaces. Tabs are not allowed. " \
+              "Error: #{e.message}"
       end
 
       def log_level


### PR DESCRIPTION
Provides better error message incase the database.yaml has some errors. fixes #8143

error message **before** the change, incase database.yml is invalid:

``` ruby
$ rails c
/home/gaurish/.rvm/rubies/ruby-1.9.3-p286-perf/lib/ruby/1.9.1/psych.rb:203:in `parse': (<unknown>): mapping values are not allowed in this context at line 2 column 10 (Psych::SyntaxError)     
```

Error message **AFTER** the change, incase database.yml is invalid:

``` ruby
$ rails c
/home/gaurish/code/repo/rails/railties/lib/rails/application/configuration.rb:112:in `rescue in database_configuration': YAML syntax error occurred while parsing /tmp/db/config/database.yml. Please note that YAML must be consistently indented using spaces. Tabs are not allowed Exact Error: (<unknown>): mapping values are not allowed in this context at line 2 column 10 (RuntimeError)

```

**cc**:  @carlosantoniodasilva, @steveklabnik
