### PR TITLE
fix guide with field_with_error proc example

### DIFF
--- a/guides/source/active_record_validations_callbacks.md
+++ b/guides/source/active_record_validations_callbacks.md
@@ -953,8 +953,12 @@ Below is a simple example where we change the Rails behavior to always display t
 
 ```ruby
 ActionView::Base.field_error_proc = Proc.new do |html_tag, instance|
-  errors = Array(instance.error_message).join(',')
-  %(#{html_tag}<span class="validation-error">&nbsp;#{errors}</span>).html_safe
+  if html_tag =~ /\<label/
+    html_tag
+  else
+    errors = Array(instance.error_message).join(',')
+    %(#{html_tag}<span class="validation-error">&nbsp;#{errors}</span>).html_safe
+  end
 end
 ```
 


### PR DESCRIPTION
The "Active Record Validations and Callbacks" guide section 9.3 "Customizing the Error Messages HTML" seems to indicate that

``` ruby
ActionView::Base.field_error_proc = Proc.new do |html_tag, instance|
  errors = Array(instance.error_message).join(',')
  %(#{html_tag}<span class="validation-error">&nbsp;#{errors}</span>).html_safe
end
```

Might be a suitable option to customizing a field with error. But in the most common case this would wrap around the `label` as well as inputs like `text_field` helpers, leading to the error beings displayed twice.

The suggested fix to the guide ensures that the error is not displayed in case of labels. I'm sorry, but I just cooked up the fix in a couple of minutes so feel free if you think the solution could be better.
