### PR TITLE
Postgresql doesn't accept limits on text columns.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 3.2.10 (unreleased)
 
+*   When running migrations on Postgresql, the `:limit` option for `binary` and `text` columns is silently dropped.
+    Previously, these migrations caused sql exceptions, because Postgresql doesn't support limits on these types.
+
+    *Victor Costan*
+
 *   Calling `include?` on `has_many` associations on unsaved records no longer
     returns `true` when passed a record with a `nil` foreign key.
     Fixes #7950.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1078,6 +1078,13 @@ module ActiveRecord
           when nil, 0..0x3fffffff; super(type)
           else raise(ActiveRecordError, "No binary type has byte size #{limit}.")
           end
+        when 'text'
+          # PostgreSQL doesn't support limits on text columns.
+          # The hard limit is 1Gb, according to section 8.3 in the manual.
+          case limit
+          when nil, 0..0x3fffffff; super(type)
+          else raise(ActiveRecordError, "The limit on text can be at most 1GB - 1byte.")
+          end
         when 'integer'
           return 'integer' unless limit
 

--- a/activerecord/test/cases/adapters/postgresql/sql_types_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/sql_types_test.rb
@@ -1,0 +1,18 @@
+require "cases/helper"
+
+class SqlTypesTest < ActiveRecord::TestCase
+  def test_binary_types
+    assert_equal 'bytea', type_to_sql(:binary, 100_000)
+    assert_raise ActiveRecord::ActiveRecordError do
+      type_to_sql :binary, 4294967295
+    end
+    assert_equal 'text', type_to_sql(:text, 100_000)
+    assert_raise ActiveRecord::ActiveRecordError do
+     type_to_sql :text, 4294967295
+    end
+  end
+
+  def type_to_sql(*args)
+    ActiveRecord::Base.connection.type_to_sql(*args)
+  end
+end

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -132,5 +132,10 @@ _SQL
 _SQL
 rescue #This version of PostgreSQL either has no XML support or is was not compiled with XML support: skipping table
   end
+
+  create_table :limitless_fields, force: true do |t|
+    t.binary :binary, limit: 100_000
+    t.text :text, limit: 100_000
+  end
 end
 


### PR DESCRIPTION
This is the diff in #8276, applied to 3-2-stable.
