### PR TITLE
Initialize accessors to remove some warnings in Ruby 2.0

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -407,6 +407,8 @@ module Rails
       end
     end
 
+    self.isolated = false
+
     delegate :middleware, :root, :paths, to: :config
     delegate :engine_name, :isolated?, to: "self.class"
 


### PR DESCRIPTION
attr_accessor is here 

https://github.com/rails/rails/blob/master/railties/lib/rails/engine.rb#L341
