### PR TITLE
add ActiveModel::Errors#to_s

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -366,6 +366,13 @@ module ActiveModel
       })
     end
 
+    # Returns all the full messages as string.
+    #
+    #   person.errors.to_s # => "Name is invalid, Name is to short (minimun is 5 characters)"
+    def to_s
+      full_messages.join(', ')
+    end
+
     # Translates an error message in its default scope
     # (<tt>activemodel.errors.messages</tt>).
     #

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -164,6 +164,13 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal ["name can not be blank", "name can not be nil"], person.errors.to_a
   end
 
+  test 'to_s should return a joined full_messages with ", "' do
+    person = Person.new
+    person.errors.add(:name, "can not be blank")
+    person.errors.add(:name, "can not be nil")
+    assert_equal "name can not be blank, name can not be nil", person.errors.to_s
+  end
+
   test 'full_message should return the given message if attribute equals :base' do
     person = Person.new
     assert_equal "press the button", person.errors.full_message(:base, "press the button")


### PR DESCRIPTION
It's a helper method for `full_messages.join(', ')`.

Very useful in this case: `redirect_to some_path, alert: @model.errors`
