### PR TITLE
Addresses undefined local variable or method `connection' error

### DIFF
--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -757,9 +757,11 @@ class CopyMigrationsTest < ActiveRecord::TestCase
   end
 
   def test_create_join_table_with_symbol_and_string
-    connection.create_join_table :artists, 'musics'
+    ActiveRecord::Base.connection.create_join_table :artists, 'musics'
 
-    assert_equal %w(artist_id music_id), connection.columns(:artists_musics).map(&:name).sort
+    assert_equal %w(artist_id music_id), ActiveRecord::Base.connection.columns(:artists_musics).map(&:name).sort
+  ensure
+    ActiveRecord::Base.connection.drop_table :artists_musics rescue nil
   end
 
 end


### PR DESCRIPTION
This commit addresses following error since 48a035712e9a4478ff248fd51ff43505d2aa2ddb merged.

```
  1) Error:
test_create_join_table_with_symbol_and_string(CopyMigrationsTest):
NameError: undefined local variable or method `connection' for #<CopyMigrationsTest:0x00000003df56a8>
    test/cases/migration_test.rb:760:in `test_create_join_table_with_symbol_and_string'
```
