### PR TITLE
backport #8291, prevent mass assignment of polymorphic type with `build`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 3.2.10 (unreleased)
 
+*   Prevent mass assignment to the type column of polymorphic associations when using `build` [Backport #8291]
+    Fix #8265
+
+    *Yves Senn*
+
 *   When running migrations on Postgresql, the `:limit` option for `binary` and `text` columns is silently dropped.
     Previously, these migrations caused sql exceptions, because Postgresql doesn't support limits on these types.
 

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -231,7 +231,8 @@ module ActiveRecord
 
         def build_record(attributes, options)
           reflection.build_association(attributes, options) do |record|
-            attributes = create_scope.except(*(record.changed - [reflection.foreign_key]))
+            skip_assign = [reflection.foreign_key, reflection.type].compact
+            attributes = create_scope.except(*(record.changed - skip_assign))
             record.assign_attributes(attributes, :without_protection => true)
           end
         end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1704,6 +1704,14 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal [tagging], post.taggings
   end
 
+  def test_build_with_polymotphic_has_many_does_not_allow_to_override_type_and_id
+    welcome = posts(:welcome)
+    tagging = welcome.taggings.build(:taggable_id => 99, :taggable_type => 'ShouldNotChange')
+
+    assert_equal welcome.id, tagging.taggable_id
+    assert_equal 'Post', tagging.taggable_type
+  end
+
   def test_dont_call_save_callbacks_twice_on_has_many
     firm = companies(:first_firm)
     contract = firm.contracts.create!


### PR DESCRIPTION
This is a backport of #8291

Closes #8265

Conflicts:

```
activerecord/CHANGELOG.md
activerecord/lib/active_record/associations/association.rb
```
