### PR TITLE
Don't rescue unrelated NameErrors when looking up types in ActiveRecord::Inheritance.compute_type.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   ActiveRecord::Inheritance.compute_type now only ignores NameErrors in
+    which the missing constant was the candidate itself.
+
+    This prevents us from improperly rescuing errors when the module
+    being looked up exists but includes a bad reference in its
+    definition. In those cases it is better to fail noisily with the
+    actual bad reference, than to silently rescue the bad reference error.
+
+    *Ben Woosley*
+
 *   Enable support for materialized views on PostgreSQL >= 9.3.
 
     *Dave Lee*

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -123,10 +123,13 @@ module ActiveRecord
             begin
               constant = ActiveSupport::Dependencies.constantize(candidate)
               return constant if candidate == constant.to_s
-            # We don't want to swallow NoMethodError < NameError errors
-            rescue NoMethodError
-              raise
-            rescue NameError
+            rescue NameError => e
+              # swallow error if the candidate or a parent of the candidate was missing
+              missing_name = e.missing_name
+              candidate_is_missing = missing_name && (
+                candidate == missing_name || candidate.starts_with?("#{missing_name}::")
+              )
+              raise unless candidate_is_missing
             end
           end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1310,8 +1310,35 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal 'ActiveRecord::Base::NonexistentModel', e.name
   end
 
+  def test_compute_type_references_nonexistent_constant
+    error_message = "uninitialized constant WithInvalidReference::NonexistentModel"
+    ActiveSupport::Dependencies.stubs(:constantize).raises(NameError, error_message)
+    e = assert_raises NameError do
+      ActiveRecord::Base.send :compute_type, 'WithInvalidReference'
+    end
+    assert_equal error_message, e.message
+  end
+
+  def test_compute_type_parent_references_nonexistent_constant
+    error_message = "uninitialized constant ParentWithInvalidReference::NonexistentModel"
+    ActiveSupport::Dependencies.stubs(:constantize).raises(NameError, error_message)
+    e = assert_raises NameError do
+      ActiveRecord::Base.send :compute_type, 'HasParentWithInvalidReference'
+    end
+    assert_equal error_message, e.message
+  end
+
+  def test_compute_type_undefined_local_method_error
+    error_message = "undefined local variable or method `missing' for main:Object"
+    ActiveSupport::Dependencies.stubs(:constantize).raises(NameError, error_message)
+    e = assert_raises NameError do
+      ActiveRecord::Base.send :compute_type, 'InvalidModel'
+    end
+    assert_equal error_message, e.message
+  end
+
   def test_compute_type_no_method_error
-    ActiveSupport::Dependencies.stubs(:constantize).raises(NoMethodError)
+    ActiveSupport::Dependencies.stubs(:constantize).raises(NoMethodError, "undefined method `InvalidModel' for main:Object")
     assert_raises NoMethodError do
       ActiveRecord::Base.send :compute_type, 'InvalidModel'
     end


### PR DESCRIPTION
This fix prevents us from improperly rescuing errors when the module
being looked up exists but includes an bad reference in its
definition. In those cases it is better to fail noisily with the
actual bad reference than to rescue the error.
