### PR TITLE
Use separate Relation subclasses for each AR class

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -34,7 +34,7 @@ module ActiveRecord
           reload
         end
 
-        CollectionProxy.new(self)
+        CollectionProxy.new(klass, self)
       end
 
       # Implements the writer method, e.g. foo.items= for Foo.has_many :items

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -30,9 +30,9 @@ module ActiveRecord
     class CollectionProxy < Relation
       delegate(*(ActiveRecord::Calculations.public_instance_methods - [:count]), to: :scope)
 
-      def initialize(association) #:nodoc:
+      def initialize(klass, association) #:nodoc:
         @association = association
-        super association.klass, association.klass.arel_table
+        super klass, klass.arel_table
         merge! association.scope(nullify: false)
       end
 

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -1,27 +1,107 @@
-require 'thread'
+require 'active_support/concern'
 
 module ActiveRecord
   module Delegation # :nodoc:
-    # Set up common delegations for performance (avoids method_missing)
+    extend ActiveSupport::Concern
+
     delegate :to_xml, :to_yaml, :length, :collect, :map, :each, :all?, :include?, :to_ary, :to => :to_a
     delegate :table_name, :quoted_table_name, :primary_key, :quoted_primary_key,
              :connection, :columns_hash, :auto_explain_threshold_in_seconds, :to => :klass
 
-    @@delegation_mutex = Mutex.new
+    module ClassSpecificRelation
+      extend ActiveSupport::Concern
 
-    def self.delegate_to_scoped_klass(method)
-      if method.to_s =~ /\A[a-zA-Z_]\w*[!?]?\z/
-        module_eval <<-RUBY, __FILE__, __LINE__ + 1
-          def #{method}(*args, &block)
-            scoping { @klass.#{method}(*args, &block) }
+      included do
+        @delegation_mutex = Mutex.new
+      end
+
+      module ClassMethods
+        def name
+          superclass.name
+        end
+
+        def delegate_to_scoped_klass(method)
+          @delegation_mutex.synchronize do
+            return if method_defined?(method)
+
+            if method.to_s =~ /\A[a-zA-Z_]\w*[!?]?\z/
+              module_eval <<-RUBY, __FILE__, __LINE__ + 1
+                def #{method}(*args, &block)
+                  scoping { @klass.#{method}(*args, &block) }
+                end
+              RUBY
+            else
+              module_eval <<-RUBY, __FILE__, __LINE__ + 1
+                def #{method}(*args, &block)
+                  scoping { @klass.send(#{method.inspect}, *args, &block) }
+                end
+              RUBY
+            end
           end
-        RUBY
-      else
-        module_eval <<-RUBY, __FILE__, __LINE__ + 1
-          def #{method}(*args, &block)
-            scoping { @klass.send(#{method.inspect}, *args, &block) }
+        end
+
+        def delegate(method, opts = {})
+          @delegation_mutex.synchronize do
+            return if method_defined?(method)
+            super
           end
-        RUBY
+        end
+      end
+
+      protected
+
+      def method_missing(method, *args, &block)
+        if @klass.respond_to?(method)
+          self.class.delegate_to_scoped_klass(method)
+          scoping { @klass.send(method, *args, &block) }
+        elsif Array.method_defined?(method)
+          self.class.delegate method, :to => :to_a
+          to_a.send(method, *args, &block)
+        elsif arel.respond_to?(method)
+          self.class.delegate method, :to => :arel
+          arel.send(method, *args, &block)
+        else
+          super
+        end
+      end
+    end
+
+    module ClassMethods
+      @@mutex      = Mutex.new
+      @@subclasses = Hash.new { |h, k| h[k] = {} }
+
+      def new(klass, *args)
+        relation = relation_class_for(klass).allocate
+        relation.__send__(:initialize, klass, *args)
+        relation
+      end
+
+      # Cache the constants in @@subclasses because looking them up via const_get
+      # make instantiation significantly slower.
+      def relation_class_for(klass)
+        if klass && klass.name
+          if subclass = @@mutex.synchronize { @@subclasses[self][klass] }
+            subclass
+          else
+            subclass = const_get("#{name.gsub('::', '_')}_#{klass.name.gsub('::', '_')}", false)
+            @@mutex.synchronize { @@subclasses[self][klass] = subclass }
+            subclass
+          end
+        else
+          ActiveRecord::Relation
+        end
+      end
+
+      # Check const_defined? in case another thread has already defined the constant
+      # I am not sure whether this is strictly necessary.
+      def const_missing(name)
+        @@mutex.synchronize {
+          if const_defined?(name)
+            const_get(name)
+          else
+            const_set(name, Class.new(self) { include ClassSpecificRelation })
+          end
+        }
       end
     end
 
@@ -35,28 +115,10 @@ module ActiveRecord
 
     def method_missing(method, *args, &block)
       if @klass.respond_to?(method)
-        @@delegation_mutex.synchronize do
-          unless ::ActiveRecord::Delegation.method_defined?(method)
-            ::ActiveRecord::Delegation.delegate_to_scoped_klass(method)
-          end
-        end
-
         scoping { @klass.send(method, *args, &block) }
       elsif Array.method_defined?(method)
-        @@delegation_mutex.synchronize do
-          unless ::ActiveRecord::Delegation.method_defined?(method)
-            ::ActiveRecord::Delegation.delegate method, :to => :to_a
-          end
-        end
-
         to_a.send(method, *args, &block)
       elsif arel.respond_to?(method)
-        @@delegation_mutex.synchronize do
-          unless ::ActiveRecord::Delegation.method_defined?(method)
-            ::ActiveRecord::Delegation.delegate method, :to => :arel
-          end
-        end
-
         arel.send(method, *args, &block)
       else
         super


### PR DESCRIPTION
Dear @tenderlove and @josevalim, I would like your opinions on this before I merge it in. I'm not sure if it's a good solution, and I'd be happy to hear alternative proposals. (Other people's opinions are also welcome :)

There are currently 3 broken tests that require changes in activerecord-deprecated_finders in order to pass. I'll do that if we decide to pull this in.

Commit message below:

---

At present, ActiveRecord::Delegation compiles delegation methods on a
global basis. The compiled methods apply to all subsequent Relation
instances. This creates several problems:

1) After Post.all.recent has been called, User.all.respond_to?(:recent)
   will be true, even if User.all.recent will actually raise an error due
   to no User.recent method existing. (See #8080.)

2) Depending on the AR class, the delegation should do different things.
   For example, if a Post.zip method exists, then Post.all.zip should call
   it. But this will then result in User.zip being called by a subsequent
   User.all.zip, even if User.zip does not exist, when in fact
   User.all.zip should call User.all.to_a.zip. (There are various
   variants of this problem.)

We are creating these compiled delegations in order to avoid method
missing and to avoid repeating logic on each invocation.

One way of handling these issues is to add additional checks in various
places to ensure we're doing the "right thing". However, this makes the
compiled methods signficantly slower. In which case, there's almost no
point in avoiding method_missing at all. (See #8127 for a proposed
solution which takes this approach.)

This is an alternative approach which involves creating a subclass of
ActiveRecord::Relation for each AR class represented. So, with this
patch, Post.all.class != User.all.class. This means that the delegations
are compiled for and only apply to a single AR class. A compiled method
for Post.all will not be invoked from User.all.

This solves the above issues without incurring significant performance
penalties. It's designed to be relatively seamless, however the downside
is a bit of complexity and potentially confusion for a user who thinks
that Post.all and User.all should be instances of the same class.
## Benchmark

``` ruby
require 'active_record'
require 'benchmark/ips'

class Post < ActiveRecord::Base
  establish_connection adapter: 'sqlite3', database: ':memory:'
  connection.create_table :posts

  def self.omg
    :omg
  end
end

relation = Post.all

Benchmark.ips do |r|
  r.report('delegation')   { relation.omg }
  r.report('constructing') { Post.all }
end
```
## Before

```
Calculating -------------------------------------
          delegation      4392 i/100ms
        constructing      4780 i/100ms
-------------------------------------------------
          delegation   144235.9 (±27.7%) i/s -     663192 in   5.038075s
        constructing   182015.5 (±21.2%) i/s -     850840 in   5.005364s
```
## After

```
Calculating -------------------------------------
          delegation      6677 i/100ms
        constructing      6260 i/100ms
-------------------------------------------------
          delegation   166828.2 (±34.2%) i/s -     754501 in   5.001430s
        constructing   116575.5 (±18.6%) i/s -     563400 in   5.036690s
```
## Comments

Bear in mind that the standard deviations in the above are huge, so we
can't compare the numbers too directly. However, we can conclude that
Relation construction has become a little slower (as we'd expect), but
not by a huge huge amount, and we can still construct a large number of
Relations quite quickly.
