### PR TITLE
fix remove_constant

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -640,6 +640,7 @@ module ActiveSupport #:nodoc:
     end
 
     def remove_constant(const) #:nodoc:
+      return false unless qualified_const_defined? const
       # Normalize ::Foo, ::Object::Foo, Object::Foo, Object::Object::Foo, etc. as Foo.
       normalized = const.to_s.sub(/\A::/, '')
       normalized.sub!(/\A(Object::)+/, '')


### PR DESCRIPTION
I'm developing an app in edge rails and recently I've been getting the exceptions "A copy of Cms has been removed from the module tree but is still active!" and "Circular dependency detected while autoloading constant Cms::BaseController" whenever I made code changes (Cms is my controller namespace). I tracked the problem down to bff4d8d165486797227c5933e93a62e7f2c15d98 where a particular line of code was removed. Restoring this line fixes my issue.

As you can probably tell I know very little about the internals of rails, so I don't know if restoring this line causes problems elsewhere.
