### PR TITLE
`assert_template("")` is returning true even if a template has been rendered.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `assert_template` is no more passing with empty string when some template has been rendered.
+
+    *Roberto Soares*
+
 *   Allow setting a symbol as path in scope on routes. This is now allowed:
 
         scope :api do

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Rails 4.0.0 (unreleased) ##
 
-*   `assert_template` is no more passing with empty string when some template has been rendered.
+*   `assert_template` is no more passing with empty string.
 
     *Roberto Soares*
 

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -94,10 +94,14 @@ module ActionController
         matches_template =
           case options
           when String
-            rendered.any? do |t, num|
-              options_splited = options.split(File::SEPARATOR)
-              t_splited = t.split(File::SEPARATOR)
-              t_splited.last(options_splited.size) == options_splited
+            if options.empty?
+              rendered.blank?
+            else
+              rendered.any? do |t, num|
+                options_splited = options.split(File::SEPARATOR)
+                t_splited = t.split(File::SEPARATOR)
+                t_splited.last(options_splited.size) == options_splited
+              end
             end
           when Regexp
             rendered.any? { |t,num| t.match(options) }

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -94,14 +94,10 @@ module ActionController
         matches_template =
           case options
           when String
-            if options.empty?
-              rendered.blank?
-            else
-              rendered.any? do |t, num|
-                options_splited = options.split(File::SEPARATOR)
-                t_splited = t.split(File::SEPARATOR)
-                t_splited.last(options_splited.size) == options_splited
-              end
+            !options.empty? && rendered.any? do |t, num|
+              options_splited = options.split(File::SEPARATOR)
+              t_splited = t.split(File::SEPARATOR)
+              t_splited.last(options_splited.size) == options_splited
             end
           when Regexp
             rendered.any? { |t,num| t.match(options) }

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -447,6 +447,13 @@ class AssertTemplateTest < ActionController::TestCase
     end
   end
 
+  def test_with_empty_string_fails_when_template_rendered
+    get :hello_world
+    assert_raise(ActiveSupport::TestCase::Assertion) do
+      assert_template ""
+    end
+  end
+
   def test_passes_with_correct_string
     get :hello_world
     assert_template 'hello_world'

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -454,6 +454,13 @@ class AssertTemplateTest < ActionController::TestCase
     end
   end
 
+  def test_with_empty_string_fails_when_no_template_rendered
+    get :nothing
+    assert_raise(ActiveSupport::TestCase::Assertion) do
+      assert_template ""
+    end
+  end
+
   def test_passes_with_correct_string
     get :hello_world
     assert_template 'hello_world'


### PR DESCRIPTION
After I got a false positive using a custom rspec matcher, I've figured out that `assert_template("")` was always returning true.

Example:

``` ruby
def index
  render :index
end
```

``` ruby
template = nil
get :index
assert_template("#{template}")
```

Change: `assert_template("")` fails if a template has been rendered, behaving like `assert_template(nil)`.
