### PR TITLE
Fixes improper database name when creating a new rails app with a '.' 

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fixes database.yml when creating a new rails application with '.'
+    Fix #8304
+
+    *Jeremy W. Rowe*
+
 *   Allow a `:dirs` key in the `SourceAnnotationExtractor.enumerate` options
     to explicitly set the directories to be traversed so it's easier to define
     custom rake tasks.

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -236,7 +236,7 @@ module Rails
       end
 
       def app_name
-        @app_name ||= defined_app_const_base? ? defined_app_name : File.basename(destination_root)
+        @app_name ||= (defined_app_const_base? ? defined_app_name : File.basename(destination_root)).tr(".", "_")
       end
 
       def defined_app_name

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -164,6 +164,11 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_config_database_app_name_with_period
+    run_generator [File.join(destination_root, "common.usage.com"), "-d", "postgresql"]
+    assert_file "common.usage.com/config/database.yml", /common_usage_com/
+  end
+
   def test_config_postgresql_database
     run_generator([destination_root, "-d", "postgresql"])
     assert_file "config/database.yml", /postgresql/


### PR DESCRIPTION
Fixes improper database name when a '.' is included while creating a new rails
application. EG: `rails new something.awesome.com`
