### PR TITLE
document :hidden_field_id option for fields_for

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -702,6 +702,11 @@ module ActionView
       #     <% end %>
       #     ...
       #   <% end %>
+      #
+      # Note that fields_for will automatically generate a hidden field
+      # to store the ID of the record. There are circumstances where this
+      # hidden field is not needed and you can pass <tt>hidden_field_id: false</tt>
+      # to prevent fields_for from rendering it automatically.
       def fields_for(record_name, record_object = nil, options = {}, &block)
         builder = instantiate_builder(record_name, record_object, options)
         output = capture(builder, &block)


### PR DESCRIPTION
I once submitted a patch to prevent `fields_for` from rendering hidden fields for the ID automatically. I just noticed that I forgot to document said option.

This patch adds the necessary documentation.
