### PR TITLE
Handle arrays with inclusion/exclusion validation.

### DIFF
--- a/activemodel/lib/active_model/locale/en.yml
+++ b/activemodel/lib/active_model/locale/en.yml
@@ -6,8 +6,8 @@ en:
     # The values :model, :attribute and :value are always available for interpolation
     # The value :count is available when applicable. Can be used for pluralization.
     messages:
-      inclusion: "is not included in the list"
-      exclusion: "is reserved"
+      inclusion: "is not (or does not include) a value in the list"
+      exclusion: "is (or has a value that is) reserved"
       invalid: "is invalid"
       confirmation: "doesn't match %{attribute}"
       accepted: "must be accepted"

--- a/activemodel/lib/active_model/validations/clusivity.rb
+++ b/activemodel/lib/active_model/validations/clusivity.rb
@@ -23,7 +23,9 @@ module ActiveModel
                        delimiter
                      end
 
-        exclusions.send(inclusion_method(exclusions), value)
+        Array(value).any? do |val|
+          exclusions.send(inclusion_method(exclusions), val)
+        end
       end
 
       def delimiter

--- a/activemodel/test/cases/validations/exclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/exclusion_validation_test.rb
@@ -10,6 +10,34 @@ class ExclusionValidationTest < ActiveModel::TestCase
     Topic.reset_callbacks(:validate)
   end
 
+  def test_validates_exclusion_of_range_on_array_attribute
+    Topic.validates_exclusion_of(:aliases, :in => 1...3)
+    assert Topic.new("aliases" => [ 1 ]).invalid?
+    assert Topic.new("aliases" => [ 1, 5, 9 ]).invalid?
+    assert Topic.new("aliases" => [ 4, 5, 9 ]).valid?
+  end
+
+  def test_validates_exclusion_of_values_on_array_attribute
+    Topic.validates_exclusion_of(:aliases, :in => [ 1, 2, 3 ])
+    assert Topic.new("aliases" => [ 1 ]).invalid?
+    assert Topic.new("aliases" => [ 1, 5, 9 ]).invalid?
+    assert Topic.new("aliases" => [ 4, 5, 9 ]).valid?
+  end
+
+  def test_validates_exclusion_of_array_attribute_with_allow_nil
+    Topic.validates_exclusion_of(:aliases, :in => [ 1, 2, 3 ], :allow_nil => true)
+    assert Topic.new("aliases" => [ 1 ]).invalid?
+    assert Topic.new("aliases" => [ 4, 5, 9 ]).valid?
+    assert Topic.new.valid?
+  end
+
+  def test_validates_exclusion_of_array_attribute_with_allow_blank
+    Topic.validates_exclusion_of(:aliases, :in => [ 1, 2, 3 ], :allow_blank => true)
+    assert Topic.new("aliases" => [ 1 ]).invalid?
+    assert Topic.new("aliases" => [ 4, 5, 9 ]).valid?
+    assert Topic.new("aliases" => []).valid?
+  end
+
   def test_validates_exclusion_of
     Topic.validates_exclusion_of( :title, :in => %w( abe monkey ) )
 
@@ -45,7 +73,7 @@ class ExclusionValidationTest < ActiveModel::TestCase
     p.karma = "abe"
     assert p.invalid?
 
-    assert_equal ["is reserved"], p.errors[:karma]
+    assert_equal ["is (or has a value that is) reserved"], p.errors[:karma]
 
     p.karma = "Lifo"
     assert p.valid?
@@ -76,7 +104,7 @@ class ExclusionValidationTest < ActiveModel::TestCase
     end
 
     assert p.invalid?
-    assert_equal ["is reserved"], p.errors[:karma]
+    assert_equal ["is (or has a value that is) reserved"], p.errors[:karma]
 
     p = Person.new
     p.karma = "abe"

--- a/activemodel/test/cases/validations/i18n_generate_message_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_generate_message_validation_test.rb
@@ -10,7 +10,7 @@ class I18nGenerateMessageValidationTest < ActiveModel::TestCase
 
   # validates_inclusion_of: generate_message(attr_name, :inclusion, message: custom_message, value: value)
   def test_generate_message_inclusion_with_default_message
-    assert_equal 'is not included in the list', @person.errors.generate_message(:title, :inclusion, :value => 'title')
+    assert_equal 'is not (or does not include) a value in the list', @person.errors.generate_message(:title, :inclusion, :value => 'title')
   end
 
   def test_generate_message_inclusion_with_custom_message
@@ -19,7 +19,7 @@ class I18nGenerateMessageValidationTest < ActiveModel::TestCase
 
   # validates_exclusion_of: generate_message(attr_name, :exclusion, message: custom_message, value: value)
   def test_generate_message_exclusion_with_default_message
-    assert_equal 'is reserved', @person.errors.generate_message(:title, :exclusion, :value => 'title')
+    assert_equal 'is (or has a value that is) reserved', @person.errors.generate_message(:title, :exclusion, :value => 'title')
   end
 
   def test_generate_message_exclusion_with_custom_message

--- a/activemodel/test/cases/validations/inclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/inclusion_validation_test.rb
@@ -10,6 +10,38 @@ class InclusionValidationTest < ActiveModel::TestCase
     Topic.reset_callbacks(:validate)
   end
 
+  def test_validates_inclusion_of_range_on_array_attribute
+    Topic.validates_inclusion_of(:aliases, :in => 1...3)
+    assert Topic.new("aliases" => [ 1 ]).valid?
+    assert Topic.new("aliases" => [ 1, 2 ]).valid?
+    assert Topic.new("aliases" => [ 1, 2, 3 ]).valid?
+    assert Topic.new("aliases" => [ 1, 5, 9 ]).valid?
+    assert Topic.new("aliases" => [ 4, 5, 9 ]).invalid?
+  end
+
+  def test_validates_inclusion_of_values_on_array_attribute
+    Topic.validates_inclusion_of(:aliases, :in => [ 1, 2, 3 ])
+    assert Topic.new("aliases" => [ 1 ]).valid?
+    assert Topic.new("aliases" => [ 1, 2 ]).valid?
+    assert Topic.new("aliases" => [ 1, 2, 3 ]).valid?
+    assert Topic.new("aliases" => [ 1, 5, 9 ]).valid?
+    assert Topic.new("aliases" => [ 4, 5, 9 ]).invalid?
+  end
+
+  def test_validates_inclusion_of_array_attribute_with_allow_nil
+    Topic.validates_inclusion_of(:aliases, :in => [ 1, 2, 3 ], :allow_nil => true)
+    assert Topic.new("aliases" => [ 1 ]).valid?
+    assert Topic.new("aliases" => [ 4, 5, 9 ]).invalid?
+    assert Topic.new.valid?
+  end
+
+  def test_validates_inclusion_of_array_attribute_with_allow_blank
+    Topic.validates_inclusion_of(:aliases, :in => [ 1, 2, 3 ], :allow_blank => true)
+    assert Topic.new("aliases" => [ 1 ]).valid?
+    assert Topic.new("aliases" => [ 4, 5, 9 ]).invalid?
+    assert Topic.new("aliases" => []).valid?
+  end
+
   def test_validates_inclusion_of_range
     Topic.validates_inclusion_of( :title, :in => 'aaa'..'bbb' )
     assert Topic.new("title" => "bbc", "content" => "abc").invalid?
@@ -31,7 +63,7 @@ class InclusionValidationTest < ActiveModel::TestCase
     t.title = "uhoh"
     assert t.invalid?
     assert t.errors[:title].any?
-    assert_equal ["is not included in the list"], t.errors[:title]
+    assert_equal ["is not (or does not include) a value in the list"], t.errors[:title]
 
     assert_raise(ArgumentError) { Topic.validates_inclusion_of( :title, :in => nil ) }
     assert_raise(ArgumentError) { Topic.validates_inclusion_of( :title, :in => 0) }
@@ -77,7 +109,7 @@ class InclusionValidationTest < ActiveModel::TestCase
     p.karma = "Lifo"
     assert p.invalid?
 
-    assert_equal ["is not included in the list"], p.errors[:karma]
+    assert_equal ["is not (or does not include) a value in the list"], p.errors[:karma]
 
     p.karma = "monkey"
     assert p.valid?
@@ -108,7 +140,7 @@ class InclusionValidationTest < ActiveModel::TestCase
     end
 
     assert p.invalid?
-    assert_equal ["is not included in the list"], p.errors[:karma]
+    assert_equal ["is not (or does not include) a value in the list"], p.errors[:karma]
 
     p = Person.new
     p.karma = "Lifo"

--- a/activemodel/test/cases/validations/validates_test.rb
+++ b/activemodel/test/cases/validations/validates_test.rb
@@ -100,7 +100,7 @@ class ValidatesTest < ActiveModel::TestCase
     Person.validates :gender, :inclusion => %w(m f)
     person = Person.new
     assert person.invalid?
-    assert_equal ['is not included in the list'], person.errors[:gender]
+    assert_equal ['is not (or does not include) a value in the list'], person.errors[:gender]
     person.gender = "m"
     assert person.valid?
   end

--- a/activemodel/test/models/topic.rb
+++ b/activemodel/test/models/topic.rb
@@ -6,7 +6,7 @@ class Topic
     super | [ :message ]
   end
 
-  attr_accessor :title, :author_name, :content, :approved
+  attr_accessor :title, :author_name, :content, :approved, :aliases
   attr_accessor :after_validation_performed
 
   after_validation :perform_after_validation


### PR DESCRIPTION
There are cases where applications or frameworks that use Active Model would like to validate that members of array fields include or exclude specific values. This is natural given the language used in these validations, but the current implementation is only one-sided:

_"Validate that the attribute is any of these values (includes) or none of these values (excludes)."_

What this pull request does is expand this language to include:

_"Validate that the attribute is any of or contains any of these values (includes) or is not or does not include any of these values (excludes)."_

The added test cases show the expectations of what this means, but I will also put examples here. First a model for the examples.

``` ruby
class Code
  include ActiveModel::Validations
  include ActiveModel::Validations::Callbacks

  attr_accessor :letters, :numbers

  def initialize(attributes)
    attributes.each do |key, value|
      send "#{key}=", value
    end
  end

  # Validate that letters contains any of the values a, b, or c.
  validates_inclusion_of :letters, :in => [ "a", "b", "c" ]

  # Validate that numbers contains none of the values 1, 2, or 3.
  validates_exclusion_of :numbers, :in => [ 1, 2, 3 ]
end
```

Expectations:

``` ruby
Code.new(:letters => [ "a" ]).valid? #=> true
Code.new(:letters => [ "a", "b" ]).valid? #=> true
Code.new(:letters => [ "a", "c" ]).valid? #=> true
Code.new(:letters => [ "z", "d" ]).valid? #=> false

Code.new(:numbers => [ 1 ]).valid? #=> false
Code.new(:numbers => [ 1, 3 ]).valid? #=> false
Code.new(:numbers => [ 5, 6 ]).valid? #=> true
```

Both the `allow_nil` and `allow_blank` options would function as normal here as well. 

Let me know what you think - I would love to have this functionality in core Active Model for Rails 4 in of course you think it makes sense. Otherwise perhaps a discussion around this would be lovely as well. :)

For the tests I followed the conventions of the existing tests for those two classes.
