### PR TITLE
Don't call will_change! for datetime nil->"".

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix dirty attribute checks for TimeZoneConversion with nil and blank
+    datetime attributes. Setting a nil datetime to a blank string should not
+    result in a change being flagged. Fix #8310
+
+    *Alisdair McDiarmid*
+
 *   Prevent mass assignment to the type column of polymorphic associations when using `build`
     Fix #8265
 

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -34,6 +34,7 @@ module ActiveRecord
           if create_time_zone_conversion_attribute?(attr_name, columns_hash[attr_name])
             method_body, line = <<-EOV, __LINE__ + 1
               def #{attr_name}=(original_time)
+                original_time = nil if original_time.blank?
                 time = original_time
                 unless time.acts_like?(:time)
                   time = time.is_a?(String) ? Time.zone.parse(time) : time.to_time rescue time

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -203,6 +203,20 @@ class DirtyTest < ActiveRecord::TestCase
     end
   end
 
+  def test_nullable_datetime_not_marked_as_changed_if_new_value_is_blank
+    in_time_zone 'Edinburgh' do
+      target = Class.new(ActiveRecord::Base)
+      target.table_name = 'topics'
+
+      topic = target.create
+      assert_equal nil, topic.written_on
+
+      topic.written_on = ""
+      assert_equal nil, topic.written_on
+      assert !topic.written_on_changed?
+    end
+  end
+
   def test_integer_zero_to_string_zero_not_marked_as_changed
     pirate = Pirate.new
     pirate.parrot_id = 0


### PR DESCRIPTION
Setting a nil datetime attribute to a blank string should not cause the
attribute to be dirty.

Fix #8310
