### PR TITLE
make sure that individual parts `ActiveModel` can be required by itself

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Removed dispensable `require` statements. Make sure to require `active_model` before requiring
+    individual parts of the framework.
+
+    *Yves Senn*
+
 *   Use BCrypt's MIN_COST in the test environment for speedier tests when using `has_secure_pasword`.
 
     *Brian Cardarella + Jeremy Kemper + Trevor Turk*

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -8,7 +8,7 @@ module ActiveModel
   #
   #   user = User.first
   #   user.pets.select(:id).first.user_id
-  #   # => ActiveModel::MissingAttributeError: missing attribute: user_id
+  #   # => ActiveModel::MissingAttributeError: missing attribute: user_id
   class MissingAttributeError < NoMethodError
   end
   # == Active \Model Attribute Methods
@@ -202,7 +202,7 @@ module ActiveModel
       #   person.name            # => "Bob"
       #   person.nickname        # => "Bob"
       #   person.name_short?     # => true
-      #   person.nickname_short? # => true
+      #   person.nickname_short? # => true
       def alias_attribute(new_name, old_name)
         self.attribute_aliases = attribute_aliases.merge(new_name.to_s => old_name.to_s)
         attribute_method_matchers.each do |matcher|

--- a/activemodel/lib/active_model/callbacks.rb
+++ b/activemodel/lib/active_model/callbacks.rb
@@ -1,5 +1,3 @@
-require 'active_support/callbacks'
-
 module ActiveModel
   # == Active \Model \Callbacks
   #

--- a/activemodel/lib/active_model/conversion.rb
+++ b/activemodel/lib/active_model/conversion.rb
@@ -1,5 +1,3 @@
-require 'active_support/inflector'
-
 module ActiveModel
   # == Active \Model Conversions
   #

--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -1,4 +1,3 @@
-require 'active_model/attribute_methods'
 require 'active_support/hash_with_indifferent_access'
 require 'active_support/core_ext/object/duplicable'
 

--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -56,8 +56,8 @@ module ActiveModel
     #   end
     #
     #   BlogPost.model_name <=> 'BlogPost'  # => 0
-    #   BlogPost.model_name <=> 'Blog'      # => 1
-    #   BlogPost.model_name <=> 'BlogPosts' # => -1
+    #   BlogPost.model_name <=> 'Blog'      # => 1
+    #   BlogPost.model_name <=> 'BlogPosts' # => -1
 
     ##
     # :method: =~

--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -1,4 +1,3 @@
-require 'active_support/inflector'
 require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/module/introspection'
 

--- a/activemodel/lib/active_model/observing.rb
+++ b/activemodel/lib/active_model/observing.rb
@@ -5,7 +5,6 @@ require 'active_support/core_ext/module/remove_method'
 require 'active_support/core_ext/string/inflections'
 require 'active_support/core_ext/enumerable'
 require 'active_support/core_ext/object/try'
-require 'active_support/descendants_tracker'
 
 module ActiveModel
   # == Active \Model Observers Activation

--- a/activemodel/lib/active_model/observing.rb
+++ b/activemodel/lib/active_model/observing.rb
@@ -49,7 +49,7 @@ module ActiveModel
       #   end
       #
       #   ORM.observers = :cacher, :garbage_collector
-      #   ORM.observers       # => [:cacher, :garbage_collector]
+      #   ORM.observers       # => [:cacher, :garbage_collector]
       #   ORM.observers.class # => ActiveModel::ObserverArray
       def observers
         @observers ||= ObserverArray.new(self)
@@ -328,8 +328,8 @@ module ActiveModel
       # Returns the class observed by default. It's inferred from the observer's
       # class name.
       #
-      #   PersonObserver.observed_class  # => Person
-      #   AccountObserver.observed_class # => Account
+      #   PersonObserver.observed_class  # => Person
+      #   AccountObserver.observed_class # => Account
       def observed_class
         name[/(.*)Observer/, 1].try :constantize
       end

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -1,9 +1,6 @@
 require 'active_support/core_ext/array/extract_options'
 require 'active_support/core_ext/hash/keys'
 require 'active_support/core_ext/hash/except'
-require 'active_model/errors'
-require 'active_model/validations/callbacks'
-require 'active_model/validator'
 
 module ActiveModel
 

--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -1,5 +1,3 @@
-require 'active_support/callbacks'
-
 module ActiveModel
   module Validations
     # == Active \Model Validation Callbacks

--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -85,8 +85,8 @@ module ActiveModel
         #   person = Person.new
         #   person.name = ''
         #   person.valid? # => false
-        #   person.status # => false
-        #   person.name = 'bob'
+        #   person.status # => false
+        #   person.name = 'bob'
         #   person.valid? # => true
         #   person.status # => true
         def after_validation(*args, &block)


### PR DESCRIPTION
We do a lot of isolated tests. This process revelad that some modules of `ActiveModel` can not be required by itself. I created a test script to verify, that all the parts of `ActiveModel` can be loaded in isolation. The initial output of the script was:

```
verifying active_model/attribute_methods: FAILED (uninitialized constant ActiveModel::AttributeMethods::ActiveSupport)
verifying active_model/callbacks: DONE
verifying active_model/conversion: FAILED (uninitialized constant ActiveSupport::Concern)
verifying active_model/dirty: FAILED (uninitialized constant ActiveModel::AttributeMethods::ActiveSupport)
verifying active_model/errors: DONE
verifying active_model/model: DONE
verifying active_model/naming: FAILED (undefined method `delegate' for ActiveModel::Name:Class)
verifying active_model/observing: FAILED (uninitialized constant ActiveSupport::Concern)
verifying active_model/serialization: DONE
verifying active_model/translation: FAILED (uninitialized constant ActiveModel::Naming)
verifying active_model/validations: FAILED (undefined method `alias_method_chain' for Range:Class)
```

I added the necessary require statements to the `ActiveModel` parts to make every piece loadable.

I placed the script under `test/load_individual_parts.rb` but I was not sure how to integrate it into the test suite. Currently you can execute it using:

`bundle exec ruby test/load_individual_parts.rb`
#### cleanup
- There were some broken whitespace (non-breaking). I cleaned those up.
