### PR TITLE
Save has_one associations only if record has changes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Only save has_one associations if record has changes.
+    Previously after save related callbacks, such as `#after_commit`, were triggered when the has_one
+    object did not get saved to the db.
+
+    *Alan Kennedy*
+
 *   ActiveRecord::Base#attribute_for_inspect now truncates long arrays (more than 10 elements)
 
     *Jan Bernacki*

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -377,14 +377,15 @@ module ActiveRecord
       def save_has_one_association(reflection)
         association = association_instance_get(reflection.name)
         record      = association && association.load_target
+
         if record && !record.destroyed?
           autosave = reflection.options[:autosave]
 
           if autosave && record.marked_for_destruction?
             record.destroy
-          else
+          elsif autosave != false
             key = reflection.options[:primary_key] ? send(reflection.options[:primary_key]) : id
-            if autosave != false && (autosave || new_record? || record_changed?(reflection, record, key))
+            if (autosave && record.changed_for_autosave?) || new_record? || record_changed?(reflection, record, key)
 
               unless reflection.through_reflection
                 record[reflection.foreign_key] = key

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -626,8 +626,23 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
       end
     end
 
+    @ship.pirate.catchphrase = "Changed Catchphrase"
+
     assert_raise(RuntimeError) { assert !@pirate.save }
     assert_not_nil @pirate.reload.ship
+  end
+
+  def test_should_save_changed_has_one_changed_object_if_child_is_saved
+    @pirate.ship.name = "NewName"
+    @pirate.ship.expects(:save).once.returns(true)
+
+    assert @pirate.save
+  end
+
+  def test_should_not_save_changed_has_one_unchanged_object_if_child_is_saved
+    @pirate.ship.expects(:save).never
+
+    assert @pirate.save
   end
 
   # belongs_to


### PR DESCRIPTION
Prevents save related callbacks such as `after_commit` being triggered when has_one objects are already persisted and have no changes.

Recently I found that `after_commit` callbacks were being triggered by the `autosave` behaviour on has_one records that had no changes.

For example, using the tests terminology, if a pirate has one ship, when the pirate is saved (with autosave enabled) then `after_commit` callbacks on ship are being triggered. I assume that other save
related callbacks are also being triggered which might be undesirable.

The same problem was fixed for belongs_to records in rails@658bb4f for an old lightouse ticket - https://rails.lighthouseapp.com/projects/8994/tickets/3353
