### PR TITLE
assert_template: validating option keys

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Rails 4.0.0 (unreleased) ##
 
-*   `assert_template` is no more passing with empty string.
+*   `assert_template`:
+    - is no more passing with empty string.
+    - is now validating option keys. It accepts: `:layout`, `:partial`, `:locals` and `:count`.
 
     *Roberto Soares*
 

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -106,6 +106,8 @@ module ActionController
           end
         assert matches_template, msg
       when Hash
+        options.assert_valid_keys(:layout, :partial, :locals, :count)
+
         if options.key?(:layout)
           expected_layout = options[:layout]
           msg = message || sprintf("expecting layout <%s> but action rendered <%s>",

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -430,6 +430,12 @@ end
 class AssertTemplateTest < ActionController::TestCase
   tests ActionPackAssertionsController
 
+  def test_with_invalid_hash_keys_raises_argument_error
+    assert_raise(ArgumentError) do
+      assert_template foo: "bar"
+    end
+  end
+
   def test_with_partial
     get :partial
     assert_template :partial => '_partial'


### PR DESCRIPTION
`assert_template` is only handling the keys locals, partial, layout and count(thx @carlosantoniodasilva) , anything else never fails or passes, giving false positives. 

``` ruby
assert_template(foo: "bar") # it isn't raising anything and "passes"
assert_template(leiaute: "test") # misspelled option, same issue
```

Change: I've added `assert_valid_keys` to raise ArgumentError in those cases.

``` ruby
assert_template(foo: "bar") # raises ArgumentError
assert_template(leiaute: "test") # raises ArgumentError
```

Thanks!
