### PR TITLE
Add explicit opt-out for fragment cache digesting

### DIFF
--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -164,6 +164,9 @@ class FunctionalCachingController < CachingController
       format.xml
     end
   end
+
+  def fragment_cached_without_digest
+  end
 end
 
 class FunctionalFragmentCachingTest < ActionController::TestCase
@@ -198,6 +201,15 @@ CACHED
 
     assert_match("Old fragment caching in a partial",
       @store.read("views/test.host/functional_caching/html_fragment_cached_with_partial/#{template_digest("functional_caching/_partial", "html")}"))
+  end
+
+  def test_skipping_fragment_cache_digesting
+    get :fragment_cached_without_digest, :format => "html"
+    assert_response :success
+    expected_body = "<body>\n<p>ERB</p>\n</body>\n"
+
+    assert_equal expected_body, @response.body
+    assert_equal "<p>ERB</p>", @store.read("views/nodigest")
   end
 
   def test_render_inline_before_fragment_caching

--- a/actionpack/test/fixtures/functional_caching/fragment_cached_without_digest.html.erb
+++ b/actionpack/test/fixtures/functional_caching/fragment_cached_without_digest.html.erb
@@ -1,0 +1,3 @@
+<body>
+<%= cache 'nodigest', skip_digest: true do %><p>ERB</p><% end %>
+</body>


### PR DESCRIPTION
This add support for sending an explicit opt-out of the "Russian-doll" cache digest feature on a case-by-case basis. This is useful when cache-expiration needs to be performed manually and it would be otherwise difficult to know the exact name of a digested cache key.

@dhh requested I submit this PR, more information can be found here: https://github.com/rails/cache_digests/pull/16

Note that the cache_digests gem also checks to see if a cache fragment is explicitly versioned using the following heuristic:
1. The cache key is an array
2. The first item in that array is in the format of "v{digits}" (e.g. ["v2",project] would be considered explicitly versioned)

I have **not** added support for this feature in this PR but I can add it fairly easily if you would like it. Adding the "explicitly versioned key" check would bring the rails master functionality in-line with gem's behavior.
