### PR TITLE
Use File.join to better integrate fixture_path in fixture_file_upload.

### DIFF
--- a/actionpack/lib/action_dispatch/testing/test_process.rb
+++ b/actionpack/lib/action_dispatch/testing/test_process.rb
@@ -26,17 +26,19 @@ module ActionDispatch
       @response.redirect_url
     end
 
-    # Shortcut for <tt>Rack::Test::UploadedFile.new(ActionController::TestCase.fixture_path + path, type)</tt>:
+    # Shortcut for <tt>Rack::Test::UploadedFile.new(File.join(ActionController::TestCase.fixture_path, path), type)</tt>:
     #
-    #   post :change_avatar, avatar: fixture_file_upload('/files/spongebob.png', 'image/png')
+    #   post :change_avatar, avatar: fixture_file_upload('files/spongebob.png', 'image/png')
     #
     # To upload binary files on Windows, pass <tt>:binary</tt> as the last parameter.
     # This will not affect other platforms:
     #
-    #   post :change_avatar, avatar: fixture_file_upload('/files/spongebob.png', 'image/png', :binary)
+    #   post :change_avatar, avatar: fixture_file_upload('files/spongebob.png', 'image/png', :binary)
     def fixture_file_upload(path, mime_type = nil, binary = false)
-      fixture_path = self.class.fixture_path if self.class.respond_to?(:fixture_path)
-      Rack::Test::UploadedFile.new("#{fixture_path}#{path}", mime_type, binary)
+      if self.class.respond_to?(:fixture_path) && self.class.fixture_path
+        path = File.join(self.class.fixture_path, path)
+      end
+      Rack::Test::UploadedFile.new(path, mime_type, binary)
     end
   end
 end

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -818,6 +818,18 @@ XML
     assert_equal '159528', @response.body
   end
 
+  def test_fixture_file_upload_relative_to_fixture_path
+    TestCaseTest.stubs(:fixture_path).returns(FILES_DIR)
+    uploaded_file = fixture_file_upload("mona_lisa.jpg", "image/jpg")
+    assert_equal File.open("#{FILES_DIR}/mona_lisa.jpg", READ_PLAIN).read, uploaded_file.read
+  end
+
+  def test_fixture_file_upload_ignores_nil_fixture_path
+    TestCaseTest.stubs(:fixture_path).returns(nil)
+    uploaded_file = fixture_file_upload("#{FILES_DIR}/mona_lisa.jpg", "image/jpg")
+    assert_equal File.open("#{FILES_DIR}/mona_lisa.jpg", READ_PLAIN).read, uploaded_file.read
+  end
+
   def test_action_dispatch_uploaded_file_upload
     filename = 'mona_lisa.jpg'
     path = "#{FILES_DIR}/#{filename}"


### PR DESCRIPTION
In fixture_file_upload, File.join will do the right thing more consistently than appending fixture_path and path.
