### PR TITLE
log output from activemodel's railtie_test directly to STDOUT

### DIFF
--- a/activemodel/test/cases/railtie_test.rb
+++ b/activemodel/test/cases/railtie_test.rb
@@ -9,6 +9,7 @@ class RailtieTest < ActiveModel::TestCase
 
     @app ||= Class.new(::Rails::Application).tap do |app|
       app.config.eager_load = false
+      app.config.logger = Logger.new(STDOUT)
     end
   end
 


### PR DESCRIPTION
after this patch, running the tests in activemodel will no longer
create an untracked log/ folder inside of activemodel
