### PR TITLE
Accept symbols as #send_data :disposition value

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Accept symbols as #send_data :disposition value *Elia Schito*
+
 *   Add i18n scope to distance_of_time_in_words. *Steve Klabnik*
 
 *   `assert_template`:

--- a/actionpack/lib/action_controller/metal/data_streaming.rb
+++ b/actionpack/lib/action_controller/metal/data_streaming.rb
@@ -150,6 +150,7 @@ module ActionController #:nodoc:
 
         disposition = options.fetch(:disposition, DEFAULT_SEND_FILE_DISPOSITION)
         unless disposition.nil?
+          disposition  = disposition.to_s
           disposition += %(; filename="#{options[:filename]}") if options[:filename]
           headers['Content-Disposition'] = disposition
         end

--- a/actionpack/test/controller/send_file_test.rb
+++ b/actionpack/test/controller/send_file_test.rb
@@ -114,6 +114,18 @@ class SendFileTest < ActionController::TestCase
     assert_equal 'private', h['Cache-Control']
   end
 
+  def test_send_file_headers_with_disposition_as_a_symbol
+    options = {
+      :type => Mime::PNG,
+      :disposition => :disposition,
+      :filename => 'filename'
+    }
+
+    @controller.headers = {}
+    @controller.send(:send_file_headers!, options)
+    assert_equal 'disposition; filename="filename"', @controller.headers['Content-Disposition']
+  end
+
   def test_send_file_headers_with_mime_lookup_with_symbol
     options = {
       :type => :png


### PR DESCRIPTION
Added a #to_s and the test

/cc @carlosantoniodasilva :)

(Previously #8327 which is a ready to serve port for rals/3-2-stable)
