### PR TITLE
empty rails gem's require_paths

### DIFF
--- a/rails.gemspec
+++ b/rails.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   s.bindir      = 'bin'
   s.executables = []
+  s.require_paths = []
   s.files       = Dir['guides/**/*']
 
   s.add_dependency 'activesupport', version


### PR DESCRIPTION
I found that the Rails app's `$LOAD_PATH` includes `RAILS_GEM_DIRECTORY/lib`, despite rails gem actually has no `lib` directory.

Since the rails gem is a meta package, we'd better empty the `require_paths`, which will make every Rails app a bit faster.
