### PR TITLE
Update current_page? view helper method

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Made it possible to do `current_page?(controller: 'shop')` *Takehiro Adachi*
+
 *   Accept symbols as #send_data :disposition value *Elia Schito*
 
 *   Add i18n scope to distance_of_time_in_words. *Steve Klabnik*

--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -509,6 +509,9 @@ module ActionView
       #   current_page?(controller: 'shop', action: 'checkout', order: 'asc')
       #   # => false
       #
+      #   current_page?(controller: 'shop')
+      #   # => true
+      #
       #   current_page?(action: 'checkout')
       #   # => true
       #
@@ -531,6 +534,9 @@ module ActionView
       #
       #   current_page?(controller: 'shop', action: 'checkout', order: 'desc')
       #   # => false
+      #
+      #   current_page?(controller: 'shop')
+      #   # => true
       #
       #   current_page?(action: 'checkout')
       #   # => true
@@ -561,6 +567,12 @@ module ActionView
 
         if url_string =~ /^\w+:\/\//
           url_string == "#{request.protocol}#{request.host_with_port}#{request_uri}"
+
+        # If the action isn't passed into options, url_string will be
+        # generated untill the controllers path.
+        # This allows current_page?(controller: 'shop') to be true
+        elsif Hash === options && !options.has_key?(:action)
+          url_string.match(request_uri) ? true : false         
         else
           url_string == request_uri
         end


### PR DESCRIPTION
Made it possible to use the method only with `controller:` option, like below.

``` ruby
# in "/shop/checkout"

current_page?(controller: 'shop')
# => true
```

Since we are able to do `current_page?(action: 'checkout')`, I think we should be able to do this as well.

Sorry for the typo on my topic branch :P realized it now.
