### PR TITLE
unshift html-scanner into $LOAD_PATH rather than append

### DIFF
--- a/actionpack/lib/action_view/vendor/html-scanner.rb
+++ b/actionpack/lib/action_view/vendor/html-scanner.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH << "#{File.dirname(__FILE__)}/html-scanner"
+$LOAD_PATH.unshift "#{File.dirname(__FILE__)}/html-scanner"
 
 module HTML
   extend ActiveSupport::Autoload


### PR DESCRIPTION
I noticed there's always `actionpack/lib/action_view/vendor/html-scanner` at the bottom of my apps' `$LOAD_PATH`.

This patch moves it :arrow_up: to the top.
