### PR TITLE
Fix Strong Parameters docs

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -70,8 +70,7 @@ module ActionController
     # Also, sets the +permitted+ attribute to the default value of
     # <tt>ActionController::Parameters.permit_all_parameters</tt>.
     #
-    #   class Person
-    #     include ActiveRecord::Base
+    #   class Person < ActiveRecord::Base
     #   end
     #
     #   params = ActionController::Parameters.new(name: 'Francesco')


### PR DESCRIPTION
It's only possible to inherit from ActiveRecord::Base and not include it.
