### PR TITLE
No sort Hash options in #grouped_options_for_select

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   No sort Hash options in #grouped_options_for_select. *Sergey Kojin*
+
 *   Accept symbols as #send_data :disposition value *Elia Schito*
 
 *   Add i18n scope to distance_of_time_in_words. *Steve Klabnik*

--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -482,14 +482,14 @@ module ActionView
       #   grouped_options_for_select(grouped_options)
       #
       # Possible output:
+      #   <optgroup label="North America">
+      #     <option value="US">United States</option>
+      #     <option value="Canada">Canada</option>
+      #   </optgroup>
       #   <optgroup label="Europe">
       #     <option value="Denmark">Denmark</option>
       #     <option value="Germany">Germany</option>
       #     <option value="France">France</option>
-      #   </optgroup>
-      #   <optgroup label="North America">
-      #     <option value="US">United States</option>
-      #     <option value="Canada">Canada</option>
       #   </optgroup>
       #
       # Sample usage (divider):
@@ -529,8 +529,6 @@ module ActionView
         if prompt
           body.safe_concat content_tag(:option, prompt_text(prompt), :value => "")
         end
-
-        grouped_options = grouped_options.sort if grouped_options.is_a?(Hash)
 
         grouped_options.each do |container|
           if divider

--- a/actionpack/test/template/form_options_helper_test.rb
+++ b/actionpack/test/template/form_options_helper_test.rb
@@ -346,7 +346,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
   def test_optgroups_with_with_options_with_hash
     assert_dom_equal(
-       "<optgroup label=\"Europe\"><option value=\"Denmark\">Denmark</option>\n<option value=\"Germany\">Germany</option></optgroup><optgroup label=\"North America\"><option value=\"United States\">United States</option>\n<option value=\"Canada\">Canada</option></optgroup>",
+       "<optgroup label=\"North America\"><option value=\"United States\">United States</option>\n<option value=\"Canada\">Canada</option></optgroup><optgroup label=\"Europe\"><option value=\"Denmark\">Denmark</option>\n<option value=\"Germany\">Germany</option></optgroup>",
        grouped_options_for_select({'North America' => ['United States','Canada'], 'Europe' => ['Denmark','Germany']})
     )
   end


### PR DESCRIPTION
That's no make sense to sort Hash grouped_options. Possible that make sense in ruby 1.8 when Hash was unsorted. Now I expect to see options in same order like in Hash.

I checked, that hash.sort line is from first implementation https://github.com/evanfarrar/rails/commit/8761663a68bd7ddd918f78fb3def4697784024f2#L1R327
