### PR TITLE
default source in Gemfiles to :rubygems rather than hardcoding the URL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source :rubygems
 
 gemspec
 

--- a/guides/code/getting_started/Gemfile
+++ b/guides/code/getting_started/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source :rubygems
 
 gem 'rails', '3.2.3'
 

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source :rubygems
 
 <%= rails_gemfile_entry -%>
 

--- a/railties/lib/rails/generators/rails/plugin_new/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source :rubygems
 
 <% if options[:skip_gemspec] -%>
 <%= '# ' if options.dev? || options.edge? -%>gem "rails", "~> <%= Rails::VERSION::STRING %>"


### PR DESCRIPTION
- I guess this would be the preferrable default for Bundler
- current version of Bundler converts :rubygems into 'http://rubygems.org', not https://,
  and that will help those who are working on a very poor network environment that doesn't allow SSL
