### PR TITLE
Add 'set_session:' param to database.yml for mysql and mysql2 adapters

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Session variables can be set for the `mysql`, `mysql2`, and `postgresql` adapters
+    in the `variables: <hash>` parameter in `database.yml`. The key-value pairs of this
+    hash will be sent in a `SET key = value` query on new database connections. See also:
+    http://dev.mysql.com/doc/refman/5.0/en/set-statement.html
+    http://www.postgresql.org/docs/8.3/static/sql-set.html
+
+    *Aaron Stone*
+
 *   Allow `Relation#where` with no arguments to be chained with new `not` query method.
 
     Example:

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -251,27 +251,7 @@ module ActiveRecord
 
       def configure_connection
         @connection.query_options.merge!(:as => :array)
-
-        # By default, MySQL 'where id is null' selects the last inserted id.
-        # Turn this off. http://dev.rubyonrails.org/ticket/6778
-        variable_assignments = ['SQL_AUTO_IS_NULL=0']
-
-        # Make MySQL reject illegal values rather than truncating or
-        # blanking them. See
-        # http://dev.mysql.com/doc/refman/5.5/en/server-sql-mode.html#sqlmode_strict_all_tables
-        variable_assignments << "SQL_MODE='STRICT_ALL_TABLES'" if strict_mode?
-
-        encoding = @config[:encoding]
-
-        # make sure we set the encoding
-        variable_assignments << "NAMES '#{encoding}'" if encoding
-
-        # increase timeout so mysql server doesn't disconnect us
-        wait_timeout = @config[:wait_timeout]
-        wait_timeout = 2147483 unless wait_timeout.is_a?(Fixnum)
-        variable_assignments << "@@wait_timeout = #{wait_timeout}"
-
-        execute("SET #{variable_assignments.join(', ')}", :skip_logging)
+        super
       end
 
       def version

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -51,7 +51,8 @@ module ActiveRecord
     # * <tt>:database</tt> - The name of the database. No default, must be provided.
     # * <tt>:encoding</tt> - (Optional) Sets the client encoding by executing "SET NAMES <encoding>" after connection.
     # * <tt>:reconnect</tt> - Defaults to false (See MySQL documentation: http://dev.mysql.com/doc/refman/5.0/en/auto-reconnect.html).
-    # * <tt>:strict</tt> - Defaults to true. Enable STRICT_ALL_TABLES. (See MySQL documentation: http://dev.mysql.com/doc/refman/5.5/en/server-sql-mode.html)
+    # * <tt>:strict</tt> - Defaults to true. Enable STRICT_ALL_TABLES. (See MySQL documentation: http://dev.mysql.com/doc/refman/5.0/en/server-sql-mode.html)
+    # * <tt>:variables</tt> - (Optional) A hash session variables to send as `SET @@SESSION.key = value` on each database connection. Use the value `:default` to set a variable to its DEFAULT value. (See MySQL documentation: http://dev.mysql.com/doc/refman/5.0/en/set-statement.html).
     # * <tt>:sslca</tt> - Necessary to use MySQL with an SSL connection.
     # * <tt>:sslkey</tt> - Necessary to use MySQL with an SSL connection.
     # * <tt>:sslcert</tt> - Necessary to use MySQL with an SSL connection.
@@ -535,18 +536,10 @@ module ActiveRecord
         configure_connection
       end
 
+      # Many Rails applications monkey-patch a replacement of the configure_connection method
+      # and don't call 'super', so leave this here even though it looks superfluous.
       def configure_connection
-        encoding = @config[:encoding]
-        execute("SET NAMES '#{encoding}'", :skip_logging) if encoding
-
-        # By default, MySQL 'where id is null' selects the last inserted id.
-        # Turn this off. http://dev.rubyonrails.org/ticket/6778
-        execute("SET SQL_AUTO_IS_NULL=0", :skip_logging)
-
-        # Make MySQL reject illegal values rather than truncating or
-        # blanking them. See
-        # http://dev.mysql.com/doc/refman/5.5/en/server-sql-mode.html#sqlmode_strict_all_tables
-        execute("SET SQL_MODE='STRICT_ALL_TABLES'", :skip_logging) if strict_mode?
+        super
       end
 
       def select(sql, name = nil, binds = [])

--- a/activerecord/test/cases/adapters/mysql/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql/connection_test.rb
@@ -137,6 +137,23 @@ class MysqlConnectionTest < ActiveRecord::TestCase
     end
   end
 
+  def test_mysql_set_session_variable
+    run_without_connection do |orig_connection|
+      ActiveRecord::Base.establish_connection(orig_connection.deep_merge({:variables => {:default_week_format => 3}}))
+      session_mode = ActiveRecord::Base.connection.exec_query "SELECT @@SESSION.DEFAULT_WEEK_FORMAT"
+      assert_equal 3, session_mode.rows.first.first.to_i
+    end
+  end
+
+  def test_mysql_set_session_variable_to_default
+    run_without_connection do |orig_connection|
+      ActiveRecord::Base.establish_connection(orig_connection.deep_merge({:variables => {:default_week_format => :default}}))
+      global_mode = ActiveRecord::Base.connection.exec_query "SELECT @@GLOBAL.DEFAULT_WEEK_FORMAT"
+      session_mode = ActiveRecord::Base.connection.exec_query "SELECT @@SESSION.DEFAULT_WEEK_FORMAT"
+      assert_equal global_mode.rows, session_mode.rows
+    end
+  end
+
   private
 
   def run_without_connection

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -53,6 +53,23 @@ class MysqlConnectionTest < ActiveRecord::TestCase
     end
   end
 
+  def test_mysql_set_session_variable
+    run_without_connection do |orig_connection|
+      ActiveRecord::Base.establish_connection(orig_connection.deep_merge({:variables => {:default_week_format => 3}}))
+      session_mode = ActiveRecord::Base.connection.exec_query "SELECT @@SESSION.DEFAULT_WEEK_FORMAT"
+      assert_equal 3, session_mode.rows.first.first.to_i
+    end
+  end
+
+  def test_mysql_set_session_variable_to_default
+    run_without_connection do |orig_connection|
+      ActiveRecord::Base.establish_connection(orig_connection.deep_merge({:variables => {:default_week_format => :default}}))
+      global_mode = ActiveRecord::Base.connection.exec_query "SELECT @@GLOBAL.DEFAULT_WEEK_FORMAT"
+      session_mode = ActiveRecord::Base.connection.exec_query "SELECT @@SESSION.DEFAULT_WEEK_FORMAT"
+      assert_equal global_mode.rows, session_mode.rows
+    end
+  end
+
   def test_logs_name_structure_dump
     @connection.structure_dump
     assert_equal "SCHEMA", @connection.logged[0][1]

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -154,5 +154,46 @@ module ActiveRecord
       end
     end
 
+    def test_set_session_variable_true
+      run_without_connection do |orig_connection|
+        ActiveRecord::Base.establish_connection(orig_connection.deep_merge({:variables => {:debug_print_plan => true}}))
+        set_true = ActiveRecord::Base.connection.exec_query "SHOW DEBUG_PRINT_PLAN"
+        assert_equal set_true.rows, [["on"]]
+      end
+    end
+
+    def test_set_session_variable_false
+      run_without_connection do |orig_connection|
+        ActiveRecord::Base.establish_connection(orig_connection.deep_merge({:variables => {:debug_print_plan => false}}))
+        set_false = ActiveRecord::Base.connection.exec_query "SHOW DEBUG_PRINT_PLAN"
+        assert_equal set_false.rows, [["off"]]
+      end
+    end
+
+    def test_set_session_variable_nil
+      run_without_connection do |orig_connection|
+        # This should be a no-op that does not raise an error
+        ActiveRecord::Base.establish_connection(orig_connection.deep_merge({:variables => {:debug_print_plan => nil}}))
+      end
+    end
+
+    def test_set_session_variable_default
+      run_without_connection do |orig_connection|
+        # This should execute a query that does not raise an error
+        ActiveRecord::Base.establish_connection(orig_connection.deep_merge({:variables => {:debug_print_plan => :default}}))
+      end
+    end
+
+    private
+
+    def run_without_connection
+      original_connection = ActiveRecord::Base.remove_connection
+      begin
+        yield original_connection
+      ensure
+        ActiveRecord::Base.establish_connection(original_connection)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
mysql and mysql2 session parameters can be set in the new 'set_session:' parameter in database.yml. The key-value pairs of this hash will be sent in a 'SET key = value, ...' query on new database connections.

Consolidated the configure_connection methods from mysql and mysql2 into the abstract_mysql base class.

Example use case, database.yml:

``` yaml
production:
  adapter: mysql2
  database: foo_prod
  user: foo
  set_session:
    sql_mode: traditional
    default_week_format: 1
```

See http://dev.mysql.com/doc/refman/5.0/en/set-statement.html and http://dev.mysql.com/doc/refman/5.0/en/server-system-variables.html

I originally wanted to remove the new 'strict: boolean' parameter, and run sql_mode just from the set_session section, but turns out that strict mode also cleans up some column value behavior within the mysql adapters. So the intersection of strict and set_session sql_mode is that when strict is true, you better not override sql_mode to a setting that is less-strict -- however you _can_ override it to a value that is more strict (e.g. TRADITIONAL includes strict-mode's STRICT_ALL_TABLES plus adds a few more strictness options that many people might like!).
