### PR TITLE
Revert "rails gem has no lib directory to require"

### DIFF
--- a/rails.gemspec
+++ b/rails.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
 
   s.bindir      = 'bin'
   s.executables = []
-  s.require_paths = []
   s.files       = Dir['guides/**/*']
 
   s.add_dependency 'activesupport', version


### PR DESCRIPTION
This reverts commit 6bcbd6046f82c5f0114249a6b725f9679a140b9a.

The default value for require_paths is ['lib'], and Rails does not
need to include any lib/ file to build the gem, so the previous
commit 'makes sense'. However, gems will not be built at all if
require_paths is empty (see https://gist.github.com/1065473), so
it's better to stick with the default, which does not have any
side-effects
