### PR TITLE
Specify type of singular assication during serialization

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Specify type of singular association during serialization *Steve Klabnik*
+
 *   Fixed length validator to correctly handle nil values. Fixes #7180.
 
     *Michal Zima*

--- a/activemodel/lib/active_model/serializers/xml.rb
+++ b/activemodel/lib/active_model/serializers/xml.rb
@@ -149,7 +149,12 @@ module ActiveModel
             end
           else
             merged_options[:root] = association.to_s
-            records.to_xml(merged_options)
+
+            unless records.class.to_s.underscore == association.to_s
+              merged_options[:type] = records.class.name
+            end
+
+            records.to_xml merged_options
           end
         end
 

--- a/activemodel/test/cases/serializers/xml_serialization_test.rb
+++ b/activemodel/test/cases/serializers/xml_serialization_test.rb
@@ -6,12 +6,12 @@ require 'ostruct'
 class Contact
   include ActiveModel::Serializers::Xml
 
-  attr_accessor :address, :friends
+  attr_accessor :address, :friends, :contact
 
   remove_method :attributes if method_defined?(:attributes)
 
   def attributes
-    instance_values.except("address", "friends")
+    instance_values.except("address", "friends", "contact")
   end
 end
 
@@ -56,6 +56,9 @@ class XmlSerializationTest < ActiveModel::TestCase
     @contact.address.zip = 11111
     @contact.address.apt_number = 35
     @contact.friends = [Contact.new, Contact.new]
+    @related_contact = SerializableContact.new
+    @related_contact.name = "related"
+    @contact.contact = @related_contact
   end
 
   test "should serialize default root" do
@@ -255,5 +258,10 @@ class XmlSerializationTest < ActiveModel::TestCase
     xml = @contact.to_xml :dasherize => false, :include => { :address => { :dasherize => true } }, :indent => 0
     assert_match %r{<address>}, xml
     assert_match %r{<apt-number type="integer">}, xml
+  end
+
+  test "association with sti" do
+    xml = @contact.to_xml(include: :contact)
+    assert xml.include?(%(<contact type="SerializableContact">))
   end
 end


### PR DESCRIPTION
When serialising a class, specify the type of any singular associations, if
necessary. Rails already correctly specifies the :type of any enumerable
association (e.g. a has_many association), but made no attempt to do so for
non-enumerables (e.g. a has_one association).
We must specify the :type of any STI association. A has_one
association to a class which uses single-table inheritance is an example of
this type of association.

Fixes #7471
