### PR TITLE
Support for sql options following column definitions in create_table

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -118,6 +118,8 @@ module ActiveRecord
       #   need to configure the primary key in the model via +self.primary_key=+.
       #   Models do NOT auto-detect the primary key from their table definition.
       #
+      # [<tt>:table_options</tt>]
+      #   Any extra options that you want appended after the set of column definitions.
       # [<tt>:options</tt>]
       #   Any extra options you want appended to the table definition.
       # [<tt>:temporary</tt>]
@@ -168,6 +170,7 @@ module ActiveRecord
         create_sql = "CREATE#{' TEMPORARY' if options[:temporary]} TABLE "
         create_sql << "#{quote_table_name(table_name)} ("
         create_sql << td.to_sql
+        create_sql << " #{options[:table_options]}" if options.has_key?(:table_options)
         create_sql << ") #{options[:options]}"
         execute create_sql
         td.indexes.each_pair { |c,o| add_index table_name, c, o }


### PR DESCRIPTION
This will allow definition with additional options inside the parenths per discussion and request on Rails core list, like:

```
create_table(:foos, table_options: "FOREIGN KEY(column2) REFERENCES table1(column1) DEFERRABLE, FOREIGN KEY(column3) REFERENCES table2(column2) DEFERRABLE")
```
