### PR TITLE
Adding ability to specify association class as :class vs. :class_name

### DIFF
--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -4,7 +4,7 @@ module ActiveRecord::Associations::Builder
       attr_accessor :valid_options
     end
 
-    self.valid_options = [:class_name, :foreign_key, :validate]
+    self.valid_options = [:class, :class_name, :foreign_key, :validate]
 
     attr_reader :model, :name, :scope, :options, :reflection
 

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -118,7 +118,7 @@ module ActiveRecord
       # <tt>composed_of :balance, class_name: 'Money'</tt> returns the Money class
       # <tt>has_many :clients</tt> returns the Client class
       def klass
-        @klass ||= class_name.constantize
+        @klass ||= options[:class] || class_name.constantize
       end
 
       # Returns the class name for the macro.
@@ -126,7 +126,7 @@ module ActiveRecord
       # <tt>composed_of :balance, class_name: 'Money'</tt> returns <tt>'Money'</tt>
       # <tt>has_many :clients</tt> returns <tt>'Client'</tt>
       def class_name
-        @class_name ||= (options[:class_name] || derive_class_name).to_s
+        @class_name ||= (options[:class].try(:name) || options[:class_name] || derive_class_name).to_s
       end
 
       # Returns +true+ if +self+ and +other_aggregation+ have the same +name+ attribute, +active_record+ attribute,


### PR DESCRIPTION
To avoid having to type out class_name and a few quote characters for every non-standard class association, with these proposed changes can specify association with :class, e.g.:

```
belongs_to :employee, class: User
```

in addition to the old way:

```
belongs_to :employee, class_name: 'User'
```
