### PR TITLE
Allow Relation.where with no arguments to be chained with new query methods `not`, `like`, and `not_like`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Allow Relation.where with no arguments to be chained with new query methods 
+    `not`, `like`, and `not_like`.
+
+    Example:
+
+        User.where.not(name: "Akira").where.not_like(name: "claudio%")
+
+    *Akira Matsuda* and *claudiob*
+
 *   Add STI support to init and building associations.
     Allows you to do BaseClass.new(:type => "SubClass") as well as
     parent.children.build(:type => "SubClass") or parent.build_child

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -299,7 +299,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_find_with_blank_conditions
-    [[], {}, nil, ""].each do |blank|
+    [[], {}, ""].each do |blank|
       assert_equal 2, Firm.all.merge!(:order => "id").first.clients.where(blank).to_a.size
     end
   end

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -1,0 +1,78 @@
+require 'cases/helper'
+require 'models/post'
+require 'models/comment'
+
+module ActiveRecord
+  class WhereChainTest < ActiveRecord::TestCase
+    fixtures :posts
+
+    def test_not_eq
+      expected = Arel::Nodes::NotEqual.new(Post.arel_table[:title], 'hello')
+      relation = Post.where.not(title: 'hello')
+      assert_equal([expected], relation.where_values)
+    end
+
+    def test_not_null
+      expected = Arel::Nodes::NotEqual.new(Post.arel_table[:title], nil)
+      relation = Post.where.not(title: nil)
+      assert_equal([expected], relation.where_values)
+    end
+
+    def test_not_in
+      expected = Arel::Nodes::NotEqual.new(Post.arel_table[:title], %w[hello goodbye])
+      relation = Post.where.not(title: %w[hello goodbye])
+      assert_equal([expected], relation.where_values)
+    end
+
+    def test_association_not_eq
+      expected = Arel::Nodes::NotEqual.new(Comment.arel_table[:title], 'hello')
+      relation = Post.joins(:comments).where.not(comments: {title: 'hello'})
+      assert_equal(expected.to_sql, relation.where_values.first.to_sql)
+    end
+
+    def test_not_eq_with_preceding_where
+      relation = Post.where(:title => 'hello').where.not(:title => 'world')
+
+      expected = Arel::Nodes::Equality.new(Post.arel_table[:title], 'hello')
+      assert_equal(expected, relation.where_values.first)
+
+      expected = Arel::Nodes::NotEqual.new(Post.arel_table[:title], 'world')
+      assert_equal(expected, relation.where_values.last)
+    end
+
+    def test_not_eq_with_succeeding_where
+      relation = Post.where.not(:title => 'hello').where(:title => 'world')
+
+      expected = Arel::Nodes::NotEqual.new(Post.arel_table[:title], 'hello')
+      assert_equal(expected, relation.where_values.first)
+
+      expected = Arel::Nodes::Equality.new(Post.arel_table[:title], 'world')
+      assert_equal(expected, relation.where_values.last)
+    end
+
+    def test_like
+      expected = Arel::Nodes::Matches.new(Post.arel_table[:title], 'a%')
+      relation = Post.where.like(title: 'a%')
+      assert_equal([expected], relation.where_values)
+    end
+
+    def test_not_like
+      expected = Arel::Nodes::DoesNotMatch.new(Post.arel_table[:title], 'a%')
+      relation = Post.where.not_like(title: 'a%')
+      assert_equal([expected], relation.where_values)
+    end
+
+    def test_chaining_multiple
+      relation = Post.where.like(:title => 'ruby on %').where.not(:title => 'ruby on rails').where.not_like(:title => '% ales')
+
+      expected = Arel::Nodes::Matches.new(Post.arel_table[:title], 'ruby on %')
+      assert_equal(expected, relation.where_values[0])
+
+      expected = Arel::Nodes::NotEqual.new(Post.arel_table[:title], 'ruby on rails')
+      assert_equal(expected, relation.where_values[1])
+
+      expected = Arel::Nodes::DoesNotMatch.new(Post.arel_table[:title], '% ales')
+      assert_equal(expected, relation.where_values[2])
+    end
+  end
+end

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -31,7 +31,7 @@ module ActiveRecord
     end
 
     def test_not_eq_with_preceding_where
-      relation = Post.where(:title => 'hello').where.not(:title => 'world')
+      relation = Post.where(title: 'hello').where.not(title: 'world')
 
       expected = Arel::Nodes::Equality.new(Post.arel_table[:title], 'hello')
       assert_equal(expected, relation.where_values.first)
@@ -41,7 +41,7 @@ module ActiveRecord
     end
 
     def test_not_eq_with_succeeding_where
-      relation = Post.where.not(:title => 'hello').where(:title => 'world')
+      relation = Post.where.not(title: 'hello').where(title: 'world')
 
       expected = Arel::Nodes::NotEqual.new(Post.arel_table[:title], 'hello')
       assert_equal(expected, relation.where_values.first)
@@ -63,7 +63,7 @@ module ActiveRecord
     end
 
     def test_chaining_multiple
-      relation = Post.where.like(:title => 'ruby on %').where.not(:title => 'ruby on rails').where.not_like(:title => '% ales')
+      relation = Post.where.like(title: 'ruby on %').where.not(title: 'ruby on rails').where.not_like(title: '% ales')
 
       expected = Arel::Nodes::Matches.new(Post.arel_table[:title], 'ruby on %')
       assert_equal(expected, relation.where_values[0])

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -85,5 +85,12 @@ module ActiveRecord
     def test_where_with_empty_hash_and_no_foreign_key
       assert_equal 0, Edge.where(:sink => {}).count
     end
+
+    def test_where_with_blank_condition
+      expected = Post.all
+      actual   = Post.where('')
+
+      assert_equal expected.to_sql, actual.to_sql
+    end
   end
 end


### PR DESCRIPTION
Similarly to https://github.com/rails/rails/pull/8332 this commit closes #5950 by making available three new methods `not`, `like`, and `not_like` that can be chained with a Relation.where with no (or nil) arguments.

The difference is that this commit follows the suggestion by José Valim https://github.com/rails/rails/pull/8332#issuecomment-10754953 to use a class and a builder, rather than a mixin, to implement WhereChain.
