### PR TITLE
Allow connection_handler to be overriden per-thread

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Allow ActiveRecord::Base.connection_handler to have thread affinity and be
+    settable, this effectively allows ActiveRecord to be used in a multi threaded
+    setup with multiple connections to multiple dbs.
+
+    *Sam Saffron*
+
 *   `rename_column` preserves auto_increment in mysql migrations.
     Fixes #3493.
 
@@ -8,7 +14,7 @@
 *   PostgreSQL geometric type point is supported by ActiveRecord. Fixes #7324.
 
     *Martin Schuerrer*
- 
+
 *   Add suport for concurrent indexing in PostgreSQL adapter via the
     `algorithm: :concurrently` option
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -77,8 +77,17 @@ module ActiveRecord
       mattr_accessor :disable_implicit_join_references, instance_writer: false
       self.disable_implicit_join_references = false
 
-      class_attribute :connection_handler, instance_writer: false
-      self.connection_handler = ConnectionAdapters::ConnectionHandler.new
+      class_attribute :default_connection_handler, instance_writer: false
+      
+      def self.connection_handler
+        Thread.current[:active_record_connection_handler] || self.default_connection_handler
+      end
+
+      def self.connection_handler=(handler)
+        Thread.current[:active_record_connection_handler] = handler
+      end
+
+      self.default_connection_handler = ConnectionAdapters::ConnectionHandler.new
     end
 
     module ClassMethods


### PR DESCRIPTION
This PR is in response to #8344, it introduces the ability to set a new connection_handler per thread while maintaining the current behavior. 

This can be used by applications that need multiple concurrent connections to different dbs. 

A typical use case may be for apps that serve multiple subdomains from a single rails app and need db isolation per subdomain.

cc @tenderlove
