### PR TITLE
Debug TZInfo zones in time_zone_options_for_select

### DIFF
--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -564,6 +564,17 @@ module ActionView
         zone_options = "".html_safe
 
         zones = model.all
+        # If +selected+ is specified as a TZInfo identifier, this block ensures
+        # that it gets add to ::TimeZone.all, and an option tag is generated.
+        # This is mostly for debugging purposes, so you remember to convert your
+        # TZInfo identifiers to friendlier Rails equivalents (specified in
+        # active_support/values/time_zone.rb) in views.
+        if selected_zone = ActiveSupport::TimeZone[selected]
+          if !zones.include?(selected_zone)
+            zones << selected_zone
+          end
+        end
+
         convert_zones = lambda { |list| list.map { |z| [ z.to_s, z.name ] } }
 
         if priority_zones

--- a/actionpack/test/template/form_options_helper_test.rb
+++ b/actionpack/test/template/form_options_helper_test.rb
@@ -381,6 +381,15 @@ class FormOptionsHelperTest < ActionView::TestCase
                  opts
   end
 
+  def test_time_zone_options_with_tzinfo_zone_identifiers
+    rails_zone = stub(:name => 'Central Time (US & Canada)', :to_s => '(GMT-06:00) Central Time (US & Canada)')
+    ActiveSupport::TimeZone.stubs(:all).returns([rails_zone])
+    opts = time_zone_options_for_select('America/Chicago')
+    assert_dom_equal "<option selected=\"selected\" value=\"America/Chicago\">America/Chicago</option>",
+                 opts
+    ActiveSupport::TimeZone.stubs(:all).returns(@fake_timezones)
+  end
+
   def test_time_zone_options_with_priority_zones
     zones = [ ActiveSupport::TimeZone.new( "B" ), ActiveSupport::TimeZone.new( "E" ) ]
     opts = time_zone_options_for_select( nil, zones )


### PR DESCRIPTION
Fixes issue #7245

time_zone_options_for_select only generates option tags for Rails zone
identifiers. TZInfo identifiers were getting ignored invisibly, if passed as
the +selected+ arg.

This change generates option tags for all identifiers recognized
by ActiveSupport::TimeZone, so TZInfo identifiers can be preselected too.
