### PR TITLE
Remove references to AR::Observer from docs

### DIFF
--- a/activerecord/README.rdoc
+++ b/activerecord/README.rdoc
@@ -80,17 +80,6 @@ A short rundown of some of the major features:
   {Learn more}[link:classes/ActiveRecord/Callbacks.html]
 
 
-* Observers that react to changes in a model.
-
-   class CommentObserver < ActiveRecord::Observer
-     def after_create(comment) # is called just after Comment#save
-       CommentMailer.new_comment_email('david@loudthinking.com', comment).deliver
-     end
-   end
-
-  {Learn more}[link:classes/ActiveRecord/Observer.html]
-
-
 * Inheritance hierarchies.
 
    class Company < ActiveRecord::Base; end

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2067,14 +2067,6 @@ The sum of an empty receiver can be customized in this form as well:
 [].sum(1) {|n| n**3} # => 1
 ```
 
-The method `ActiveRecord::Observer#observed_subclasses` for example is implemented this way:
-
-```ruby
-def observed_subclasses
-  observed_classes.sum([]) { |klass| klass.send(:subclasses) }
-end
-```
-
 NOTE: Defined in `active_support/core_ext/enumerable.rb`.
 
 ### `index_by`


### PR DESCRIPTION
ActiveRecord::Observer was extracted into a separate gem so it
should not be referenced anymore (see https://github.com/rails/rails/commit/ccecab3).
@rafaelfranca Do you agree?
