### PR TITLE
Reset attributes should not report changes.

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `[attribute]_changed?` now returns `false` after a call to `reset_[attribute]!`
+
+    *Renato Mascarenhas*
+
 *   Observers was extracted from Active Model as `rails-observers` gem.
 
     *Rafael Mendonça França*

--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -174,7 +174,10 @@ module ActiveModel
 
       # Handle <tt>reset_*!</tt> for +method_missing+.
       def reset_attribute!(attr)
-        __send__("#{attr}=", changed_attributes[attr]) if attribute_changed?(attr)
+        if attribute_changed?(attr)
+          __send__("#{attr}=", changed_attributes[attr])
+          changed_attributes.delete(attr)
+        end
       end
   end
 end

--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -78,7 +78,7 @@ class DirtyTest < ActiveModel::TestCase
     @model.name = "Bob"
     @model.reset_name!
     assert_nil @model.name
-    #assert !@model.name_changed #Doesn't work yet
+    assert !@model.name_changed?
   end
 
   test "setting color to same value should not result in change being recorded" do
@@ -114,5 +114,4 @@ class DirtyTest < ActiveModel::TestCase
     assert_equal ["Otto", "Mr. Manfredgensonton"], @model.name_change
     assert_equal @model.name_was, "Otto"
   end
-
 end


### PR DESCRIPTION
This fixes the following behavior:

``` ruby
model.name = "Bob"
model.reset_name!
model.name_changed? #=> true
```
