### PR TITLE
Add db to the list of default annotation folders

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add `db` to list of folders included by `rake notes` and `rake notes:custom`. *Antonio Cangiano*
+
 *   Engines with a dummy app include the rake tasks of dependencies in the app namespace.
     Fix #8229
 

--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -15,7 +15,7 @@
 class SourceAnnotationExtractor
   class Annotation < Struct.new(:line, :tag, :text)
     def self.directories
-      @@directories ||= %w(app config lib script test) + (ENV['SOURCE_ANNOTATION_DIRECTORIES'] || '').split(',')
+      @@directories ||= %w(app config db lib script test) + (ENV['SOURCE_ANNOTATION_DIRECTORIES'] || '').split(',')
     end
 
     # Returns a representation of the annotation that looks like this:

--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -60,6 +60,7 @@ module ApplicationTests
       test 'notes finds notes in default directories' do
         app_file "app/controllers/some_controller.rb", "# TODO: note in app directory"
         app_file "config/initializers/some_initializer.rb", "# TODO: note in config directory"
+        app_file "db/some_seeds.rb", "# TODO: note in db directory"
         app_file "lib/some_file.rb", "# TODO: note in lib directory"
         app_file "script/run_something.rb", "# TODO: note in script directory"
         app_file "test/some_test.rb", 1000.times.map { "" }.join("\n") << "# TODO: note in test directory"
@@ -80,6 +81,7 @@ module ApplicationTests
 
           assert_match(/note in app directory/, output)
           assert_match(/note in config directory/, output)
+          assert_match(/note in db directory/, output)
           assert_match(/note in lib directory/, output)
           assert_match(/note in script directory/, output)
           assert_match(/note in test directory/, output)
@@ -96,6 +98,7 @@ module ApplicationTests
       test 'notes finds notes in custom directories' do
         app_file "app/controllers/some_controller.rb", "# TODO: note in app directory"
         app_file "config/initializers/some_initializer.rb", "# TODO: note in config directory"
+        app_file "db/some_seeds.rb", "# TODO: note in db directory"
         app_file "lib/some_file.rb", "# TODO: note in lib directory"
         app_file "script/run_something.rb", "# TODO: note in script directory"
         app_file "test/some_test.rb", 1000.times.map { "" }.join("\n") << "# TODO: note in test directory"
@@ -116,6 +119,7 @@ module ApplicationTests
 
           assert_match(/note in app directory/, output)
           assert_match(/note in config directory/, output)
+          assert_match(/note in db directory/, output)
           assert_match(/note in lib directory/, output)
           assert_match(/note in script directory/, output)
           assert_match(/note in test directory/, output)


### PR DESCRIPTION
`rake notes` and `rake notes:custom` do not currently search the `db` folder of a Rails project by default. This means that your `# TODO:` and other annotations in files such as `db/seeds.rb` are ignored unless this folder is included explicitly via the `SOURCE_ANNOTATION_DIRECTORIES` environment variable. I believe `db` should instead be included by default.

This pull request includes `db` in the default list of annotation folders.
