### PR TITLE
ActiveModel::Errors spec fixes

### DIFF
--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -161,7 +161,7 @@ class ErrorsTest < ActiveModel::TestCase
     person = Person.new
     person.errors.add(:name, "can not be blank")
     person.errors.add(:name, "can not be nil")
-    assert_equal ["name can not be blank", "name can not be nil"], person.errors.to_a
+    assert_equal ["name can not be blank", "name can not be nil"], person.errors.full_messages
   end
 
   test 'full_message should return the given message if attribute equals :base' do
@@ -240,4 +240,3 @@ class ErrorsTest < ActiveModel::TestCase
     person.errors.add_on_blank :name, :message => 'custom'
   end
 end
-

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -116,7 +116,7 @@ class ErrorsTest < ActiveModel::TestCase
 
   test "added? should default message to :invalid" do
     person = Person.new
-    person.errors.add(:name, :invalid)
+    person.errors.add(:name)
     assert person.errors.added?(:name)
   end
 


### PR DESCRIPTION
Just small fixes in two tests for `ActiveModel::Errors`:
- `full_messages` test was calling `to_a`. The latter just calls the former, but since there are separate tests for each, they should call the right method.
- The test for `#add` defaulting to `:invalid` was actually passing `:invalid` as an argument, and so it was not actually  testing the default value.
