### PR TITLE
More descriptive error when rendering a partial with `:layout => true`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   More descriptive error messages when calling `render :partial` with
+    an invalid `:layout` argument.
+    #8376
+
+        render :partial => 'partial', :layout => true
+
+        # results in ActionView::MissingTemplate: Missing partial /true
+
+    *Yves Senn*
+
 *   Sweepers was extracted from Action Controller as `rails-observers` gem.
 
     *Rafael Mendonça França*

--- a/actionpack/lib/action_view/renderer/partial_renderer.rb
+++ b/actionpack/lib/action_view/renderer/partial_renderer.rb
@@ -293,7 +293,7 @@ module ActionView
       object, as = @object, @variable
 
       if !block && (layout = @options[:layout])
-        layout = find_template(layout, @template_keys)
+        layout = find_template(layout.to_s, @template_keys)
       end
 
       object ||= locals[as]

--- a/actionpack/test/template/render_test.rb
+++ b/actionpack/test/template/render_test.rb
@@ -437,6 +437,11 @@ module RenderTestCases
       @view.render(:partial => 'test/partial_with_layout_block_content', :layout => 'test/layout_for_partial', :locals => { :name => 'Foo!'})
   end
 
+  def test_render_partial_with_layout_raises_descriptive_error
+    e = assert_raises(ActionView::MissingTemplate) { @view.render(partial: 'test/partial', layout: true) }
+    assert_match "Missing partial /true with", e.message
+  end
+
   def test_render_with_nested_layout
     assert_equal %(<title>title</title>\n\n<div id="column">column</div>\n<div id="content">content</div>\n),
       @view.render(:file => "test/nested_layout", :layout => "layouts/yield")


### PR DESCRIPTION
This change was motivated by the stack trace from #8376. The error describes the problem poorly. Since calling `render` with `:layout => true` is valid for templates, I can see beginners making the mistake to make such a call to render a partial.

Since the `:layout` argument for partials must be a string, I made this explicit in the code. This raises more descriptive error messages when invalid arguments like `:layout => true` are passed.
