### PR TITLE
Do not instantiate intermediate AR objects when eager loading.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Do not instantiate intermediate Active Record objects when eager loading.
+    These records caused `after_find` to run more than expected.
+    Fix #3313
+
+    *Yves Senn*
+
 *   Add STI support to init and building associations.
     Allows you to do BaseClass.new(:type => "SubClass") as well as
     parent.children.build(:type => "SubClass") or parent.build_child

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -225,9 +225,11 @@ module ActiveRecord
       orders = relation.order_values.map { |val| val.presence }.compact
       values = @klass.connection.distinct("#{quoted_table_name}.#{primary_key}", orders)
 
-      relation = relation.dup
+      relation = relation.dup.select(values)
 
-      ids_array = relation.select(values).collect {|row| row[primary_key]}
+      id_rows = @klass.connection.select_all(relation.arel, 'SQL', relation.bind_values)
+      ids_array = id_rows.map {|row| row[primary_key]}
+
       ids_array.empty? ? raise(ThrowResult) : table[primary_key].in(ids_array)
     end
 

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -944,6 +944,12 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal 3, Developer.all.merge!(:includes => 'projects', :where => { 'developers_projects.access_level' => 1 }, :limit => 5).to_a.size
   end
 
+  def test_dont_create_temporary_active_record_instances
+    Developer.instance_count = 0
+    developers = Developer.all.merge!(:includes => 'projects', :where => { 'developers_projects.access_level' => 1 }, :limit => 5).to_a
+    assert_equal developers.count, Developer.instance_count
+  end
+
   def test_order_on_join_table_with_include_and_limit
     assert_equal 5, Developer.all.merge!(:includes => 'projects', :order => 'developers_projects.joined_on DESC', :limit => 5).to_a.size
   end

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -57,6 +57,16 @@ class Developer < ActiveRecord::Base
   def log=(message)
     audit_logs.build :message => message
   end
+
+  after_find :track_instance_count
+  cattr_accessor :instance_count
+
+  def track_instance_count
+    self.class.instance_count ||= 0
+    self.class.instance_count += 1
+  end
+  private :track_instance_count
+
 end
 
 class AuditLog < ActiveRecord::Base


### PR DESCRIPTION
There are eager-loading queries that Active Record performs in two steps.
1. Fetch the ID of the relevant records
2. Perform the actual select to instantiate AR objects

Currently step one also instantiated intermediate ActiveRecord objects just to pick the ID from them. This changes fetches the IDs using `select_all`, which does not instante objects.

The intermediate objects were a problem because the `after_find` callback was triggered twice. Also I think it does not make sense to instantiate objects that we don't actually need.

This is a fix for #3313

I'm not sure if my test-case is very helpful. It was the best I could come up with to illustrate the problem.
