### PR TITLE
Filter redirects

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
+*   Add filter capability to ActionController logs for redirect locations:
+
+        config.filter_redirect << 'http://please.hide.it/'
+
+    *Fabrizio Regini*
+
 *   Fixed a bug that ignores constraints on a glob route. This was caused because the constraint
     regular expression is overwritten when the `routes.rb` file is processed. Fixes #7924
 

--- a/actionpack/lib/action_controller/metal/instrumentation.rb
+++ b/actionpack/lib/action_controller/metal/instrumentation.rb
@@ -60,7 +60,7 @@ module ActionController
       ActiveSupport::Notifications.instrument("redirect_to.action_controller") do |payload|
         result = super
         payload[:status]   = response.status
-        payload[:location] = response.location
+        payload[:location] = response.filtered_location
         result
       end
     end

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -75,6 +75,7 @@ module ActionDispatch
     autoload :Parameters
     autoload :ParameterFilter
     autoload :FilterParameters
+    autoload :FilterRedirect
     autoload :Upload
     autoload :UploadedFile, 'action_dispatch/http/upload'
     autoload :URL

--- a/actionpack/lib/action_dispatch/http/filter_redirect.rb
+++ b/actionpack/lib/action_dispatch/http/filter_redirect.rb
@@ -1,0 +1,37 @@
+module ActionDispatch
+  module Http
+    module FilterRedirect
+
+      FILTERED = '[FILTERED]'.freeze # :nodoc:
+
+      def filtered_location
+        if !location_filter.empty? && location_filter_match?
+          FILTERED
+        else
+          location
+        end
+      end
+
+    private
+
+      def location_filter
+        if request.present?
+          request.env['action_dispatch.redirect_filter'] || []
+        else
+          []
+        end
+      end
+
+      def location_filter_match?
+        location_filter.any? do |filter|
+          if String === filter
+            location.include?(filter)
+          elsif Regexp === filter
+            location.match(filter)
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -61,6 +61,7 @@ module ActionDispatch # :nodoc:
     cattr_accessor(:default_headers)
 
     include Rack::Response::Helpers
+    include ActionDispatch::Http::FilterRedirect
     include ActionDispatch::Http::Cache::Response
     include MonitorMixin
 

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -26,6 +26,10 @@ module Another
       redirect_to "http://foo.bar/"
     end
 
+    def filterable_redirector
+      redirect_to "http://secret.foo.bar/"
+    end
+
     def data_sender
       send_data "cool data", :filename => "file.txt"
     end
@@ -150,6 +154,24 @@ class ACLogSubscriberTest < ActionController::TestCase
 
     assert_equal 3, logs.size
     assert_equal "Redirected to http://foo.bar/", logs[1]
+  end
+
+  def test_filter_redirect_url_by_string
+    @request.env['action_dispatch.redirect_filter'] = ['secret']
+    get :filterable_redirector
+    wait
+
+    assert_equal 3, logs.size
+    assert_equal "Redirected to [FILTERED]", logs[1]
+  end
+
+  def test_filter_redirect_url_by_regexp
+    @request.env['action_dispatch.redirect_filter'] = [/secret\.foo.+/]
+    get :filterable_redirector
+    wait
+
+    assert_equal 3, logs.size
+    assert_equal "Redirected to [FILTERED]", logs[1]
   end
 
   def test_send_data

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -751,14 +751,35 @@ Now the user can request to get a PDF version of a client just by adding ".pdf" 
 GET /clients/1.pdf
 ```
 
-Parameter Filtering
--------------------
+Log Filtering
+-------------
 
-Rails keeps a log file for each environment in the `log` folder. These are extremely useful when debugging what's actually going on in your application, but in a live application you may not want every bit of information to be stored in the log file. You can filter certain request parameters from your log files by appending them to `config.filter_parameters` in the application configuration. These parameters will be marked [FILTERED] in the log.
+Rails keeps a log file for each environment in the `log` folder. These are extremely useful when debugging what's actually going on in your application, but in a live application you may not want every bit of information to be stored in the log file.
+
+### Parameters Filtering
+
+You can filter certain request parameters from your log files by appending them to `config.filter_parameters` in the application configuration. These parameters will be marked [FILTERED] in the log.
 
 ```ruby
 config.filter_parameters << :password
 ```
+
+### Redirects Filtering
+
+Sometimes it's desirable to filter out from log files some sensible locations your application is redirecting to.
+You can do that by using the `config.filter_redirect` configuration option:
+
+```ruby
+config.filter_redirect << 's3.amazonaws.com'
+```
+
+You can set it to a String, a Regexp, or an array of both.
+
+```ruby
+config.filter_redirect.concat ['s3.amazonaws.com', /private_path/]
+```
+
+Matching URLs will be marked as '[FILTERED]'.
 
 Rescue
 ------

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -123,6 +123,7 @@ module Rails
     # Currently stores:
     #
     #   * "action_dispatch.parameter_filter"             => config.filter_parameters
+    #   * "action_dispatch.redirect_filter"              => config.filter_redirect
     #   * "action_dispatch.secret_token"                 => config.secret_token,
     #   * "action_dispatch.show_exceptions"              => config.action_dispatch.show_exceptions
     #   * "action_dispatch.show_detailed_exceptions"     => config.consider_all_requests_local
@@ -149,6 +150,7 @@ module Rails
 
         super.merge({
           "action_dispatch.parameter_filter" => config.filter_parameters,
+          "action_dispatch.redirect_filter" => config.filter_redirect,
           "action_dispatch.secret_token" => config.secret_token,
           "action_dispatch.show_exceptions" => config.action_dispatch.show_exceptions,
           "action_dispatch.show_detailed_exceptions" => config.consider_all_requests_local,

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -13,7 +13,7 @@ module Rails
                     :railties_order, :relative_url_root, :secret_key_base, :secret_token,
                     :serve_static_assets, :ssl_options, :static_cache_control, :session_options,
                     :time_zone, :reload_classes_only_on_change,
-                    :queue, :queue_consumer, :beginning_of_week
+                    :queue, :queue_consumer, :beginning_of_week, :filter_redirect
 
       attr_writer :log_level
       attr_reader :encoding
@@ -23,6 +23,7 @@ module Rails
         self.encoding = "utf-8"
         @consider_all_requests_local   = false
         @filter_parameters             = []
+        @filter_redirect               = []
         @helpers_paths                 = []
         @serve_static_assets           = true
         @static_cache_control          = nil


### PR DESCRIPTION
Given the latest discussion on rails-core google group, rather than just discussing this one I'm providing working code. I think Rails is missing a way to filter redirect logs. It makes sense to me, given redirect logs could hold sensible informations the same way POST params do. 
The typical example is when you redirect to S3 signed URLs, which is my case. People is sending out logs to third party services for analysis, this feature will at least give them a way to have more control over what they send.

I was thinking about a way to make a gem out of it, but I seems that the current implementation does not leave room for anything to plug other than a monkeypatch. Advices on how to make a gem for this are of welcome of course.
