### PR TITLE
ActionView::Template#refresh fails to reload the template to render the error

### DIFF
--- a/actionpack/lib/action_view/lookup_context.rb
+++ b/actionpack/lib/action_view/lookup_context.rb
@@ -144,7 +144,7 @@ module ActionView
       def detail_args_for(options)
         return @details, details_key if options.empty? # most common path.
         user_details = @details.merge(options)
-        [user_details, DetailsKey.get(user_details)]
+        [user_details, @cache ? DetailsKey.get(user_details) : nil]
       end
 
       # Support legacy foo.erb names even though we now ignore .erb

--- a/actionpack/lib/action_view/template.rb
+++ b/actionpack/lib/action_view/template.rb
@@ -115,6 +115,7 @@ module ActionView
     def initialize(source, identifier, handler, details)
       format = details[:format] || (handler.default_format if handler.respond_to?(:default_format))
 
+      @details           = details
       @source            = source
       @identifier        = identifier
       @handler           = handler
@@ -166,8 +167,9 @@ module ActionView
       pieces  = @virtual_path.split("/")
       name    = pieces.pop
       partial = !!name.sub!(/^_/, "")
+      options = @details.slice(:locale, :formats, :handlers)
       lookup.disable_cache do
-        lookup.find_template(name, [ pieces.join('/') ], partial, @locals)
+        lookup.find_template(name, [ pieces.join('/') ], partial, @locals, options)
       end
     end
 

--- a/actionpack/lib/action_view/template/resolver.rb
+++ b/actionpack/lib/action_view/template/resolver.rb
@@ -132,10 +132,10 @@ module ActionView
         handler, format = extract_handler_and_format(template, formats)
         contents = File.binread template
 
-        Template.new(contents, File.expand_path(template), handler,
+        Template.new(contents, File.expand_path(template), handler, details.merge(
           :virtual_path => path.virtual,
           :format       => format,
-          :updated_at   => mtime(template))
+          :updated_at   => mtime(template)))
       }
     end
 

--- a/actionpack/test/template/lookup_context_test.rb
+++ b/actionpack/test/template/lookup_context_test.rb
@@ -102,6 +102,17 @@ class LookupContextTest < ActiveSupport::TestCase
     end
   end
 
+  test "does not generate details key if caching is disabled" do
+    details = { :handlers => [:foo], :formats => [:bar], :locale => [:ru] }
+    @lookup_context.view_paths.expects(:find).with("bar", %w(test/foo), false, details, nil, [:key]).returns("template")
+
+    template = @lookup_context.disable_cache do
+      @lookup_context.find("bar", %w(test/foo), false, [:key], details)
+    end
+
+    assert_equal template, "template"
+  end
+
   test "generates a new details key for each details hash" do
     keys = []
     keys << @lookup_context.details_key
@@ -169,7 +180,7 @@ class LookupContextTest < ActiveSupport::TestCase
 
     assert_not_equal template, old_template
   end
-  
+
   test "responds to #prefixes" do
     assert_equal [], @lookup_context.prefixes
     @lookup_context.prefixes = ["foo"]
@@ -247,6 +258,6 @@ class TestMissingTemplate < ActiveSupport::TestCase
       @lookup_context.view_paths.find("foo", "parent", true, details)
     end
     assert_match %r{Missing partial parent/foo with .* Searched in:\n  \* "/Path/to/views"\n}, e.message
-  end 
-  
+  end
+
 end

--- a/actionpack/test/template/template_test.rb
+++ b/actionpack/test/template/template_test.rb
@@ -112,15 +112,22 @@ class TestERBTemplate < ActiveSupport::TestCase
   def test_refresh_with_templates
     @template = new_template("Hello", :virtual_path => "test/foo/bar")
     @template.locals = [:key]
-    @context.lookup_context.expects(:find_template).with("bar", %w(test/foo), false, [:key]).returns("template")
+    @context.lookup_context.expects(:find_template).with("bar", %w(test/foo), false, [:key], {}).returns("template")
     assert_equal "template", @template.refresh(@context)
   end
 
   def test_refresh_with_partials
     @template = new_template("Hello", :virtual_path => "test/_foo")
     @template.locals = [:key]
-    @context.lookup_context.expects(:find_template).with("foo", %w(test), true, [:key]).returns("partial")
+    @context.lookup_context.expects(:find_template).with("foo", %w(test), true, [:key], {}).returns("partial")
     assert_equal "partial", @template.refresh(@context)
+  end
+
+  def test_refresh_template_uses_details
+    @template = new_template("Hello", :virtual_path => "test/foo/bar", :handlers => [:foo], :formats => [:bar])
+    @template.locals = [:key]
+    @context.lookup_context.expects(:find_template).with("bar", %w(test/foo), false, [:key], :handlers => [:foo], :formats => [:bar]).returns("template")
+    assert_equal "template", @template.refresh(@context)
   end
 
   def test_refresh_raises_an_error_without_virtual_path


### PR DESCRIPTION
Sorry, I messed up with previous issue (#8383) by submitting pull-request on the wrong base :(

I'm trying to render a json/jbuilder template inside of a regular html template. Here is the code of the helper I'm using

``` ruby
def get_some_json_stuff
   render partial: 'my_json_partial', handler: [:jbuilder], formats: [:json], locals: { foo: @bar }
end
```

Everything goes fine in most cases, the template renders and I'm getting a string of json — exactly what I want.

But when there is an exception in the json template, funny things start to happen. Basically, I'm seeing this description: 

```
Missing partial /my_json_partial with {:locale=>[:en], :formats=>[:html], :handlers=>[:erb, :builder, :jbuilder, :coffee]}. Searched in:
  * "/my/app/views"
```

I've looked into actionpack in attempt to understand what's going on and here's what I've found.

The code goes into [render method](https://github.com/rails/rails/blob/v3.2.9/actionpack/lib/action_view/template.rb#L142) then the error actually happens and gets rescued by [handle_render_error ](https://github.com/rails/rails/blob/v3.2.9/actionpack/lib/action_view/template.rb#L310) method.

And then it comes to [refresh](https://github.com/rails/rails/blob/v3.2.9/actionpack/lib/action_view/template.rb#L163) method that actually tries to reload the broken template. Doing so, it completely ignores original template format and handler, trying to use view's defaults, therefore failing and showing completely unrelevant exception.
