### PR TITLE
ActiveModel SecurePassword cost factor for BCrypt

### DIFF
--- a/activemodel/lib/active_model/railtie.rb
+++ b/activemodel/lib/active_model/railtie.rb
@@ -5,8 +5,12 @@ module ActiveModel
   class Railtie < Rails::Railtie # :nodoc:
     config.eager_load_namespaces << ActiveModel
 
+    # Sets +ActiveModel::SecurePassword#cost+ to the minimum value allowed
+    # by the bcrypt-ruby gem when running tests.
     initializer "active_model.secure_password" do
-      ActiveModel::SecurePassword.min_cost = Rails.env.test?
+      if Rails.env.test?
+        ActiveModel::SecurePassword.cost = 1
+      end
     end
   end
 end

--- a/activemodel/test/cases/railtie_test.rb
+++ b/activemodel/test/cases/railtie_test.rb
@@ -13,17 +13,24 @@ class RailtieTest < ActiveModel::TestCase
     end
   end
 
-  test 'secure password min_cost is false in the development environment' do
+  test 'secure password is set to a default value in the development environment' do
     Rails.env = 'development'
     @app.initialize!
 
-    assert_equal false, ActiveModel::SecurePassword.min_cost
+    assert_equal 10, ActiveModel::SecurePassword.cost
   end
 
-  test 'secure password min_cost is true in the test environment' do
+  test 'secure password is set to a default value in the production environment' do
+    Rails.env = 'production'
+    @app.initialize!
+
+    assert_equal 10, ActiveModel::SecurePassword.cost
+  end
+
+  test 'secure password is set to the minimum cost allowed in the test environment' do
     Rails.env = 'test'
     @app.initialize!
 
-    assert_equal true, ActiveModel::SecurePassword.min_cost
+    assert_equal 1, ActiveModel::SecurePassword.cost
   end
 end

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -6,7 +6,7 @@ require 'models/administrator'
 
 class SecurePasswordTest < ActiveModel::TestCase
   setup do
-    ActiveModel::SecurePassword.min_cost = true
+    ActiveModel::SecurePassword.cost = 4
 
     @user = User.new
     @visitor = Visitor.new
@@ -14,7 +14,7 @@ class SecurePasswordTest < ActiveModel::TestCase
   end
 
   teardown do
-    ActiveModel::SecurePassword.min_cost = false
+    ActiveModel::SecurePassword.cost = 10
   end
 
   test "blank password" do
@@ -75,17 +75,24 @@ class SecurePasswordTest < ActiveModel::TestCase
     end
   end
 
-  test "Password digest cost defaults to bcrypt default cost when min_cost is false" do
-    ActiveModel::SecurePassword.min_cost = false
-
-    @user.password = "secret"
-    assert_equal BCrypt::Engine::DEFAULT_COST, @user.password_digest.cost
-  end
-
-  test "Password digest cost can be set to bcrypt min cost to speed up tests" do
-    ActiveModel::SecurePassword.min_cost = true
+  test "Password digest cost will be set to BCrypt's MIN_COST if the cost was set below MIN_COST in the User's model" do
+    ActiveModel::SecurePassword.cost = 1
 
     @user.password = "secret"
     assert_equal BCrypt::Engine::MIN_COST, @user.password_digest.cost
+  end
+
+  test "Password digest cost will be set to bcrypt default cost when cost is not set by User" do
+    ActiveModel::SecurePassword.cost = 10
+
+    @user.password = "secret"
+    assert_equal 10, @user.password_digest.cost
+  end
+
+  test "User should be able to set the Password digest cost" do
+    ActiveModel::SecurePassword.cost = 11
+
+    @user.password = "secret"
+    assert_equal 11, @user.password_digest.cost
   end
 end


### PR DESCRIPTION
ActiveModel::SecurePassword currently has a class method #min_cost that is used to set a boolean value to change the cost factor of bcrypt-ruby to either 4 (MIN_COST of bcrypt-ruby) or 10 (DEFAULT in bcrypt-ruby).

If you want to have more fine-grained control over the cost factor you need to override the #password= method of the SecurePassword module with your own model that is using has_secure_password. 

This PR removes the #min_cost class method and replaces it with a #cost class method which takes an integer.  A developer can then set this class method to a specific value is required by their application by doing:

``` ruby
  class User < ActiveRecord::Base
    has_secure_password
    ActiveModel::SecurePassword.cost = 15
  end
```
# cost maintains the same behavior of #min_cost where it is set to the MIN_COST during tests and defaults to bcrypt-ruby's DEFAULT value.

I personally like having a bit more control over the hash stretches for when I need it, in a simple class setter method instead of override an instance method. 

However, I feel like this is the middle of the road solution. I think a better implementation would be:

``` ruby
  class User < ActiveRecord::Base
    has_secure_password cost: 15
  end
```
# has_secure_password class method already has support for hash parameters (validations), so adding another key/value for cost is trivial.

Secondly, I think it would be better to set the min_cost and default_cost using bcrypt-ruby's constants instead of integers as I did in this implementation. 

I'm opening this PR to show what I've added and start the conversation on what I think would be the better implementation. I don't want to go too far down the road if the Core/Others feel this isn't the right direction.  Thanks! 
