### PR TITLE
Locate `=require turbolinks` at the bottom of application.js

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/assets/javascripts/application.js.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/assets/javascripts/application.js.tt
@@ -13,6 +13,8 @@
 <% unless options[:skip_javascript] -%>
 //= require <%= options[:javascript] %>
 //= require <%= options[:javascript] %>_ujs
-//= require turbolinks
 <% end -%>
 //= require_tree .
+<% unless options[:skip_javascript] -%>
+//= require turbolinks
+<% end -%>


### PR DESCRIPTION
Turbolinks should be located at the bottom of application.js to detect assets change properly.
