### PR TITLE
backport #8403, no intermediate AR objects when eager loading.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Rails 3.2.10 (unreleased)
 
+*   Do not instantiate intermediate Active Record objects when eager loading.
+    These records caused `after_find` to run more than expected.
+    Fix #3313
+    Backport of #8403
+
+    *Yves Senn*
+
 *   Fix `pluck` to work with joins. Backport of #4942.
 
     *Carlos Antonio da Silva*

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -253,9 +253,11 @@ module ActiveRecord
       orders = relation.order_values.map { |val| val.presence }.compact
       values = @klass.connection.distinct("#{@klass.connection.quote_table_name table_name}.#{primary_key}", orders)
 
-      relation = relation.dup
+      relation = relation.dup.select(values)
 
-      ids_array = relation.select(values).collect {|row| row[primary_key]}
+      id_rows = @klass.connection.select_all(relation.arel, 'SQL', relation.bind_values)
+      ids_array = id_rows.map {|row| row[primary_key]}
+
       ids_array.empty? ? raise(ThrowResult) : table[primary_key].in(ids_array)
     end
 

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -916,6 +916,12 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal 3, Developer.find(:all, :include => 'projects', :conditions => 'developers_projects.access_level = 1', :limit => 5).size
   end
 
+  def test_dont_create_temporary_active_record_instances
+    Developer.instance_count = 0
+    developers = Developer.find(:all, :include => 'projects', :conditions => 'developers_projects.access_level = 1', :limit => 5).to_a
+    assert_equal developers.count, Developer.instance_count
+  end
+
   def test_order_on_join_table_with_include_and_limit
     assert_equal 5, Developer.find(:all, :include => 'projects', :order => 'developers_projects.joined_on DESC', :limit => 5).size
   end

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -63,6 +63,15 @@ class Developer < ActiveRecord::Base
       self.all
     end
   end
+
+  after_find :track_instance_count
+  cattr_accessor :instance_count
+
+  def track_instance_count
+    self.class.instance_count ||= 0
+    self.class.instance_count += 1
+  end
+  private :track_instance_count
 end
 
 class AuditLog < ActiveRecord::Base


### PR DESCRIPTION
This is a backport of #8403.
It fixes the issue described in #3313

Conflicts:

```
activerecord/CHANGELOG.md
activerecord/test/models/developer.rb
```

I had to make some modifications to the spec because the API changed in 4.0.
