### PR TITLE
pg_namespace table isn't used.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -267,7 +267,6 @@ module ActiveRecord
             FROM pg_class      seq,
                  pg_attribute  attr,
                  pg_depend     dep,
-                 pg_namespace  name,
                  pg_constraint cons
             WHERE seq.oid           = dep.objid
               AND seq.relkind       = 'S'


### PR DESCRIPTION
When investigating #8414, I found a bit strange sql.
In this sql, pg_namespace (a.k.a. name) isn't joined other table.

If we want to use cross join, I'm wrong.
