### PR TITLE
Fix #8414. Performance problem with postgresql adapter primary_key function.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix performance problem with primary_key method in PostgreSQL adapter when having many schemas.
+    Uses pg_constraint table instead of pg_depend table which has many records in general.
+    Fix #8414
+
+    *kennyj*
+
 *   Do not instantiate intermediate Active Record objects when eager loading.
     These records caused `after_find` to run more than expected.
     Fix #3313

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -305,12 +305,11 @@ module ActiveRecord
         # Returns just a table's primary key
         def primary_key(table)
           row = exec_query(<<-end_sql, 'SCHEMA').rows.first
-            SELECT DISTINCT(attr.attname)
+            SELECT attr.attname
             FROM pg_attribute attr
-            INNER JOIN pg_depend dep ON attr.attrelid = dep.refobjid AND attr.attnum = dep.refobjsubid
             INNER JOIN pg_constraint cons ON attr.attrelid = cons.conrelid AND attr.attnum = cons.conkey[1]
             WHERE cons.contype = 'p'
-              AND dep.refobjid = '#{quote_table_name(table)}'::regclass
+              AND cons.conrelid = '#{quote_table_name(table)}'::regclass
           end_sql
 
           row && row.first


### PR DESCRIPTION
According to @mccuskk, primary_key method in PostgreSQLAdapter execute slow query when we have many schemas. And if we use pg_constraint , we haven't to use pg_depend table to filter with table name.

Please see #8414.
