### PR TITLE
Replace comments' non-breaking spaces with spaces

### DIFF
--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -42,7 +42,7 @@ module ActionController
     # * <tt>:public</tt> By default the Cache-Control header is private, set this to
     #   +true+ if you want your application to be cachable by other devices (proxy caches).
     #
-    # === Example:
+    # === Example:
     #
     #   def show
     #     @article = Article.find(params[:id])

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -163,7 +163,7 @@ module ActionController
     #     }
     #   })
     #
-    #   permitted = params.permit(person: [ :name, { pets: :name } ])
+    #   permitted = params.permit(person: [ :name, { pets: :name } ])
     #   permitted.permitted?                    # => true
     #   permitted[:person][:name]               # => "Francesco"
     #   permitted[:person][:age]                # => nil
@@ -228,7 +228,7 @@ module ActionController
     # Returns a parameter for the given +key+. If not found,
     # returns +nil+.
     #
-    #   params = ActionController::Parameters.new(person: { name: 'Francesco' })
+    #   params = ActionController::Parameters.new(person: { name: 'Francesco' })
     #   params[:person] # => {"name"=>"Francesco"}
     #   params[:none]   # => nil
     def [](key)

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -122,7 +122,7 @@ module ActiveModel
     # Delete messages for +key+. Returns the deleted messages.
     #
     #   person.errors.get(:name)    # => ["can not be nil"]
-    #   person.errors.delete(:name) # => ["can not be nil"]
+    #   person.errors.delete(:name) # => ["can not be nil"]
     #   person.errors.get(:name)    # => nil
     def delete(key)
       messages.delete(key)
@@ -213,7 +213,7 @@ module ActiveModel
     # Returns +true+ if no errors are found, +false+ otherwise.
     # If the error message is a string it can be empty.
     #
-    #   person.errors.full_messages # => ["name can not be nil"]
+    #   person.errors.full_messages # => ["name can not be nil"]
     #   person.errors.empty?        # => false
     def empty?
       all? { |k, v| v && v.empty? && !v.is_a?(String) }
@@ -246,7 +246,7 @@ module ActiveModel
       to_hash(options && options[:full_messages])
     end
 
-    # Returns a Hash of attributes with their error messages. If +full_messages+
+    # Returns a Hash of attributes with their error messages. If +full_messages+
     # is +true+, it will contain full messages (see +full_message+).
     #
     #   person.to_hash       # => {:name=>["can not be nil"]}

--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -90,7 +90,7 @@ module ActiveModel
     #   person.name = 'bob'
     #   person.age  = 22
     #   person.serializable_hash                # => {"name"=>"bob", "age"=>22}
-    #   person.serializable_hash(only: :name)   # => {"name"=>"bob"}
+    #   person.serializable_hash(only: :name)   # => {"name"=>"bob"}
     #   person.serializable_hash(except: :name) # => {"age"=>22}
     #   person.serializable_hash(methods: :capitalized_name)
     #   # => {"name"=>"bob", "age"=>22, "capitalized_name"=>"Bob"}

--- a/activemodel/lib/active_model/validator.rb
+++ b/activemodel/lib/active_model/validator.rb
@@ -109,8 +109,8 @@ module ActiveModel
 
     # Return the kind for this validator.
     #
-    #   PresenceValidator.new.kind   # => :presence
-    #   UniquenessValidator.new.kind # => :uniqueness 
+    #   PresenceValidator.new.kind   # => :presence
+    #   UniquenessValidator.new.kind # => :uniqueness 
     def kind
       self.class.kind
     end

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -788,7 +788,7 @@
         end
 
         person.pets.delete("1") # => [#<Pet id: 1>]
-        person.pets.delete(2, 3) # => [#<Pet id: 2>, #<Pet id: 3>]
+        person.pets.delete(2, 3) # => [#<Pet id: 2>, #<Pet id: 3>]
 
     *Francesco Rodriguez*
 

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -101,7 +101,7 @@ module ActiveRecord
       #   #      #<Pet id: 3, name: "Choo-Choo", person_id: 1>
       #   #    ]
       #
-      #   person.pets.select(:name) { |pet| pet.name =~ /oo/ }
+      #   person.pets.select(:name) { |pet| pet.name =~ /oo/ }
       #   # => [
       #   #      #<Pet id: 2, name: "Spook">,
       #   #      #<Pet id: 3, name: "Choo-Choo">
@@ -824,7 +824,7 @@ module ActiveRecord
       #
       #   person.pets # => [#<Pet id: 20, name: "Snoop">]
       #
-      #   person.pets.include?(Pet.find(20)) # => true
+      #   person.pets.include?(Pet.find(20)) # => true
       #   person.pets.include?(Pet.find(21)) # => false
       def include?(record)
         @association.include?(record)
@@ -971,7 +971,7 @@ module ActiveRecord
       #   person.pets.reload # fetches pets from the database
       #   # => [#<Pet id: 1, name: "Snoop", group: "dogs", person_id: 1>]
       #
-      #   person.pets(true)  # fetches pets from the database
+      #   person.pets(true)  # fetches pets from the database
       #   # => [#<Pet id: 1, name: "Snoop", group: "dogs", person_id: 1>]
       def reload
         proxy_association.reload

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -116,7 +116,7 @@ module ActiveRecord
         # Scopes can also be used while creating/building a record.
         #
         #   class Article < ActiveRecord::Base
-        #     scope :published, -> { where(published: true) }
+        #     scope :published, -> { where(published: true) }
         #   end
         #
         #   Article.published.new.published    # => true
@@ -126,7 +126,7 @@ module ActiveRecord
         # on scopes. Assuming the following setup:
         #
         #   class Article < ActiveRecord::Base
-        #     scope :published, -> { where(published: true) }
+        #     scope :published, -> { where(published: true) }
         #     scope :featured, -> { where(featured: true) }
         #
         #     def self.latest_article

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -582,7 +582,7 @@ module ActiveSupport
       end
 
       # Returns the size of the cached value. This could be less than
-      # <tt>value.size</tt> if the data is compressed.
+      # <tt>value.size</tt> if the data is compressed.
       def size
         if defined?(@s)
           @s

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -14,7 +14,7 @@ module ActiveSupport
   # Mixing in this module allows you to define the events in the object's
   # lifecycle that will support callbacks (via +ClassMethods.define_callbacks+),
   # set the instance methods, procs, or callback objects to be called (via
-  # +ClassMethods.set_callback+), and run the installed callbacks at the
+  # +ClassMethods.set_callback+), and run the installed callbacks at the
   # appropriate times (via +run_callbacks+).
   #
   # Three kinds of callbacks are supported: before callbacks, run before a
@@ -382,7 +382,7 @@ module ActiveSupport
       #   set_callback :save, :before_meth
       #
       # The callback can specified as a symbol naming an instance method; as a
-      # proc, lambda, or block; as a string to be instance evaluated; or as an
+      # proc, lambda, or block; as a string to be instance evaluated; or as an
       # object that responds to a certain method determined by the <tt>:scope</tt>
       # argument to +define_callback+.
       #

--- a/activesupport/lib/active_support/configurable.rb
+++ b/activesupport/lib/active_support/configurable.rb
@@ -38,7 +38,7 @@ module ActiveSupport
       end
 
       # Allows you to add shortcut so that you don't have to refer to attribute
-      # through config. Also look at the example for config to contrast.
+      # through config. Also look at the example for config to contrast.
       #
       # Defines both class and instance config accessors.
       #
@@ -75,7 +75,7 @@ module ActiveSupport
       #   end
       #
       #   User.allowed_access = false
-      #   User.allowed_access # => false
+      #   User.allowed_access # => false
       #
       #   User.new.allowed_access = true # => NoMethodError
       #   User.new.allowed_access        # => NoMethodError
@@ -88,7 +88,7 @@ module ActiveSupport
       #   end
       #
       #   User.allowed_access = false
-      #   User.allowed_access # => false
+      #   User.allowed_access # => false
       #
       #   User.new.allowed_access = true # => NoMethodError
       #   User.new.allowed_access        # => NoMethodError

--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -26,7 +26,7 @@ class Array
   #
   #   [].to_sentence                      # => ""
   #   ['one'].to_sentence                 # => "one"
-  #   ['one', 'two'].to_sentence          # => "one and two"
+  #   ['one', 'two'].to_sentence          # => "one and two"
   #   ['one', 'two', 'three'].to_sentence # => "one, two, and three"
   #
   #   ['one', 'two'].to_sentence(passing: 'invalid option')
@@ -41,7 +41,7 @@ class Array
   # Examples using <tt>:locale</tt> option:
   #
   #   # Given this locale dictionary:
-  #   # 
+  #   # 
   #   #   es:
   #   #     support:
   #   #       array:
@@ -53,7 +53,7 @@ class Array
   #   # => "uno y dos"
   #
   #   ['uno', 'dos', 'tres'].to_sentence(locale: :es)
-  #   # => "uno o dos o al menos tres"
+  #   # => "uno o dos o al menos tres"
   def to_sentence(options = {})
     options.assert_valid_keys(:words_connector, :two_words_connector, :last_word_connector, :locale)
 

--- a/activesupport/lib/active_support/core_ext/class/subclasses.rb
+++ b/activesupport/lib/active_support/core_ext/class/subclasses.rb
@@ -31,7 +31,7 @@ class Class
   #   class Bar < Foo; end
   #   class Baz < Foo; end
   #
-  #   Foo.subclasses # => [Baz, Bar]
+  #   Foo.subclasses # => [Baz, Bar]
   def subclasses
     subclasses, chain = [], descendants
     chain.each do |k|

--- a/activesupport/lib/active_support/core_ext/hash/indifferent_access.rb
+++ b/activesupport/lib/active_support/core_ext/hash/indifferent_access.rb
@@ -16,7 +16,7 @@ class Hash
   # converting to an <tt>ActiveSupport::HashWithIndifferentAccess</tt> would not be
   # desirable.
   #
-  #   b = { b: 1 }
+  #   b = { b: 1 }
   #   { a: b }.with_indifferent_access['a'] # calls b.nested_under_indifferent_access
   alias nested_under_indifferent_access with_indifferent_access
 end

--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -24,7 +24,7 @@ class Hash
 
   # Return a new hash with all keys converted to strings.
   #
-  #   hash = { name: 'Rob', age: '28' }
+  #   hash = { name: 'Rob', age: '28' }
   #
   #   hash.stringify_keys
   #   #=> { "name" => "Rob", "age" => "28" }
@@ -44,7 +44,7 @@ class Hash
   #   hash = { 'name' => 'Rob', 'age' => '28' }
   #
   #   hash.symbolize_keys
-  #   #=> { name: "Rob", age: "28" }
+  #   #=> { name: "Rob", age: "28" }
   def symbolize_keys
     transform_keys{ |key| key.to_sym rescue key }
   end
@@ -102,7 +102,7 @@ class Hash
   # This includes the keys from the root hash and from all
   # nested hashes.
   #
-  #   hash = { person: { name: 'Rob', age: '28' } }
+  #   hash = { person: { name: 'Rob', age: '28' } }
   #
   #   hash.deep_stringify_keys
   #   # => { "person" => { "name" => "Rob", "age" => "28" } }
@@ -121,10 +121,10 @@ class Hash
   # they respond to +to_sym+. This includes the keys from the root hash
   # and from all nested hashes.
   #
-  #   hash = { 'person' => { 'name' => 'Rob', 'age' => '28' } }
+  #   hash = { 'person' => { 'name' => 'Rob', 'age' => '28' } }
   #
   #   hash.deep_symbolize_keys
-  #   # => { person: { name: "Rob", age: "28" } }
+  #   # => { person: { name: "Rob", age: "28" } }
   def deep_symbolize_keys
     deep_transform_keys{ |key| key.to_sym rescue key }
   end

--- a/activesupport/lib/active_support/core_ext/object/deep_dup.rb
+++ b/activesupport/lib/active_support/core_ext/object/deep_dup.rb
@@ -32,7 +32,7 @@ end
 class Hash
   # Returns a deep copy of hash.
   #
-  #   hash = { a: { b: 'b' } }
+  #   hash = { a: { b: 'b' } }
   #   dup  = hash.deep_dup
   #   dup[:a][:c] = 'c'
   #

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -44,7 +44,7 @@ module ActiveSupport #:nodoc:
     self.autoload_once_paths = []
 
     # An array of qualified constant names that have been loaded. Adding a name
-    # to this array will cause it to be unloaded the next time Dependencies are
+    # to this array will cause it to be unloaded the next time Dependencies are
     # cleared.
     mattr_accessor :autoloaded_constants
     self.autoloaded_constants = []
@@ -344,7 +344,7 @@ module ActiveSupport #:nodoc:
 
     # Given +path+, a filesystem path to a ruby file, return an array of
     # constant paths which would cause Dependencies to attempt to load this
-    # file.
+    # file.
     def loadable_constants_for_path(path, bases = autoload_paths)
       path = $` if path =~ /\.rb\z/
       expanded_path = File.expand_path(path)
@@ -394,7 +394,7 @@ module ActiveSupport #:nodoc:
     # Attempt to autoload the provided module name by searching for a directory
     # matching the expected path suffix. If found, the module is created and
     # assigned to +into+'s constants with the name +const_name+. Provided that
-    # the directory was loaded from a reloadable base path, it is added to the
+    # the directory was loaded from a reloadable base path, it is added to the
     # set of constants that are to be unloaded.
     def autoload_module!(into, const_name, qualified_name, path_suffix)
       return nil unless base_path = autoloadable_module?(path_suffix)

--- a/activesupport/lib/active_support/file_update_checker.rb
+++ b/activesupport/lib/active_support/file_update_checker.rb
@@ -68,7 +68,7 @@ module ActiveSupport
     end
 
     # Executes the given block and updates the latest watched files and
-    # timestamp.
+    # timestamp.
     def execute
       @last_watched   = watched
       @last_update_at = updated_at(@last_watched)

--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -36,7 +36,7 @@ module ActiveSupport
       end
 
       # Private, for the test suite.
-      def initialize_dup(orig) # :nodoc:
+      def initialize_dup(orig) # :nodoc:
         %w(plurals singulars uncountables humans acronyms acronym_regex).each do |scope|
           instance_variable_set("@#{scope}", orig.send(scope).dup)
         end
@@ -44,7 +44,7 @@ module ActiveSupport
 
       # Specifies a new acronym. An acronym must be specified as it will appear
       # in a camelized string. An underscore string that contains the acronym
-      # will retain the acronym when passed to +camelize+, +humanize+, or
+      # will retain the acronym when passed to +camelize+, +humanize+, or
       # +titleize+. A camelized string that contains the acronym will maintain
       # the acronym when titleized or humanized, and will convert the acronym
       # into a non-delimited single lowercase word when passed to +underscore+.
@@ -79,7 +79,7 @@ module ActiveSupport
       #
       # +acronym+ may be used to specify any word that contains an acronym or
       # otherwise needs to maintain a non-standard capitalization. The only
-      # restriction is that the word must begin with a capital letter.
+      # restriction is that the word must begin with a capital letter.
       #
       #   acronym 'RESTful'
       #   underscore 'RESTful'           #=> 'restful'
@@ -97,7 +97,7 @@ module ActiveSupport
       end
 
       # Specifies a new pluralization rule and its replacement. The rule can
-      # either be a string or a regular expression. The replacement should
+      # either be a string or a regular expression. The replacement should
       # always be a string that may include references to the matched data from
       # the rule.
       def plural(rule, replacement)

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -33,7 +33,7 @@ module ActiveSupport
     # the cipher key size. For the default 'aes-256-cbc' cipher, this is 256
     # bits. If you are using a user-entered secret, you can generate a suitable
     # key with <tt>OpenSSL::Digest::SHA256.new(user_secret).digest</tt> or
-    # similar.
+    # similar.
     #
     # Options:
     # * <tt>:cipher</tt>     - Cipher to use. Can be any cipher returned by
@@ -50,7 +50,7 @@ module ActiveSupport
     end
 
     # Encrypt and sign a message. We need to sign the message in order to avoid
-    # padding attacks. Reference: http://www.limited-entropy.com/padding-oracle-attacks.
+    # padding attacks. Reference: http://www.limited-entropy.com/padding-oracle-attacks.
     def encrypt_and_sign(value)
       verifier.generate(_encrypt(value))
     end

--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -6,7 +6,7 @@ module ActiveSupport
   # signed to prevent tampering.
   #
   # This is useful for cases like remember-me tokens and auto-unsubscribe links
-  # where the session store isn't suitable or available.
+  # where the session store isn't suitable or available.
   #
   # Remember Me:
   #   cookies[:remember_me] = @verifier.generate([@user.id, 2.weeks.from_now])

--- a/activesupport/lib/active_support/multibyte.rb
+++ b/activesupport/lib/active_support/multibyte.rb
@@ -5,7 +5,7 @@ module ActiveSupport #:nodoc:
 
     # The proxy class returned when calling mb_chars. You can use this accessor
     # to configure your own proxy class so you can support other encodings. See
-    # the ActiveSupport::Multibyte::Chars implementation for an example how to
+    # the ActiveSupport::Multibyte::Chars implementation for an example how to
     # do this.
     #
     #   ActiveSupport::Multibyte.proxy_class = CharsForUTF32

--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -11,7 +11,7 @@ module ActiveSupport
   #   logger.tagged('BCX') { logger.tagged('Jason') { logger.info 'Stuff' } } # Logs "[BCX] [Jason] Stuff"
   #
   # This is used by the default Rails.logger as configured by Railties to make
-  # it easy to stamp log lines with subdomains, request ids, and anything else
+  # it easy to stamp log lines with subdomains, request ids, and anything else
   # to aid debugging of multi-user production applications.
   module TaggedLogging
     module Formatter # :nodoc:

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -69,7 +69,7 @@ module ActiveSupport
     alias :assert_no_match :refute_match
     alias :assert_not_same :refute_same
 
-    # Fails if the block raises an exception.
+    # Fails if the block raises an exception.
     #
     #   assert_nothing_raised do
     #     ...

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -326,7 +326,7 @@ module ActiveSupport
     end
 
     # Available so that TimeZone instances respond like TZInfo::Timezone
-    # instances.
+    # instances.
     def period_for_utc(time)
       tzinfo.period_for_utc(time)
     end

--- a/railties/lib/rails/commands.rb
+++ b/railties/lib/rails/commands.rb
@@ -60,7 +60,7 @@ when 'console'
   require 'rails/commands/console'
   options = Rails::Console.parse_arguments(ARGV)
 
-  # RAILS_ENV needs to be set before config/application is required
+  # RAILS_ENV needs to be set before config/application is required
   ENV['RAILS_ENV'] = options[:environment] if options[:environment]
 
   # shift ARGV so IRB doesn't freak

--- a/railties/lib/rails/generators/rails/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/rails/scaffold/scaffold_generator.rb
@@ -2,7 +2,7 @@ require 'rails/generators/rails/resource/resource_generator'
 
 module Rails
   module Generators
-    class ScaffoldGenerator < ResourceGenerator # :nodoc:
+    class ScaffoldGenerator < ResourceGenerator # :nodoc:
       remove_hook_for :resource_controller
       remove_class_option :actions
 


### PR DESCRIPTION
Sometimes, on Mac OS X, programmers accidentally press Option+Space
rather than just Space and don’t see the difference. The problem is
that Option+Space writes a non-breaking space (0XA0) rather than a
normal space (0x20).

This commit removes all the non-breaking spaces inadvertently
introduced in the comments of the code.
