### PR TITLE
Add ENV['RACK_ENV'] support to rake runner/console/server.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add ENV['RACK_ENV'] support to `rails runner/console/server`.
+
+    *kennyj*
+ 
 *   Add `db` to list of folders included by `rake notes` and `rake notes:custom`. *Antonio Cangiano*
 
 *   Engines with a dummy app include the rake tasks of dependencies in the app namespace.

--- a/railties/lib/rails/commands/console.rb
+++ b/railties/lib/rails/commands/console.rb
@@ -45,7 +45,7 @@ module Rails
     end
 
     def environment
-      options[:environment] ||= ENV['RAILS_ENV'] || 'development'
+      options[:environment] ||= ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
     end
 
     def environment?

--- a/railties/lib/rails/commands/runner.rb
+++ b/railties/lib/rails/commands/runner.rb
@@ -1,7 +1,7 @@
 require 'optparse'
 require 'rbconfig'
 
-options = { environment: (ENV['RAILS_ENV'] || "development").dup }
+options = { environment: (ENV['RAILS_ENV'] || ENV['RACK_ENV'] || "development").dup }
 code_or_file = nil
 
 if ARGV.first.nil?

--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -108,7 +108,7 @@ module Rails
       super.merge({
         Port:         3000,
         DoNotReverseLookup:  true,
-        environment:  (ENV['RAILS_ENV'] || "development").dup,
+        environment:  (ENV['RAILS_ENV'] || ENV['RACK_ENV'] || "development").dup,
         daemonize:    false,
         debugger:     false,
         pid:          File.expand_path("tmp/pids/server.pid"),

--- a/railties/test/application/runner_test.rb
+++ b/railties/test/application/runner_test.rb
@@ -67,5 +67,28 @@ module ApplicationTests
 
       assert_match "true", Dir.chdir(app_path) { `bundle exec rails runner "puts Rails.application.config.ran"` }
     end
+
+    def test_default_environment
+      assert_match "development", Dir.chdir(app_path) { `bundle exec rails runner "puts Rails.env"` }
+    end
+
+    def test_environment_with_rails_env
+      orig = ENV['RAILS_ENV']
+      ENV['RAILS_ENV'] = "production"
+      assert_match "production", Dir.chdir(app_path) { `bundle exec rails runner "puts Rails.env"` }
+    ensure
+      ENV['RAILS_ENV'] = orig
+    end
+
+    def test_environment_with_rails_env
+      rack, rails = ENV['RACK_ENV'], ENV['RAILS_ENV']
+      ENV['RACK_ENV'] = "production"
+      ENV['RAILS_ENV'] = nil
+      assert_match "production", Dir.chdir(app_path) { `bundle exec rails runner "puts Rails.env"` }
+    ensure
+      ENV['RAILS_ENV'] = rails
+      ENV['RACK_ENV'] = rack
+    end
+
   end
 end

--- a/railties/test/commands/console_test.rb
+++ b/railties/test/commands/console_test.rb
@@ -78,6 +78,13 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
       assert_match(/\sspecial-production\s/, output)
     end
   end
+
+  def test_default_environment_with_rack_env
+    with_rack_env 'production' do
+      start
+      assert_match(/\sproduction\s/, output)
+    end
+  end
   
   def test_e_option
     start ['-e', 'special-production']
@@ -128,10 +135,18 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
   end
 
   def with_rails_env(env)
-    original_rails_env = ENV['RAILS_ENV']
+    rails = ENV['RAILS_ENV']
     ENV['RAILS_ENV'] = env
     yield
   ensure
-    ENV['RAILS_ENV'] = original_rails_env
+    ENV['RAILS_ENV'] = rails
+  end
+
+  def with_rack_env(env)
+    rack = ENV['RACK_ENV']
+    ENV['RACK_ENV'] = env
+    with_rails_env(nil) { yield }
+  ensure
+    ENV['RACK_ENV'] = rack
   end
 end

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -23,4 +23,24 @@ class Rails::ServerTest < ActiveSupport::TestCase
     assert_nil options[:environment]
     assert_equal 'thin', options[:server]
   end
+
+  def test_environment_with_rails_env
+    rails = ENV['RAILS_ENV']
+    ENV['RAILS_ENV'] = 'production'
+    server = Rails::Server.new
+    assert_equal 'production', server.options[:environment]
+  ensure
+    ENV['RAILS_ENV'] = rails
+  end
+
+  def test_environment_with_rack_env
+    rack, rails = ENV['RACK_ENV'], ENV['RAILS_ENV']
+    ENV['RAILS_ENV'] = nil
+    ENV['RACK_ENV'] = 'production'
+    server = Rails::Server.new
+    assert_equal 'production', server.options[:environment]
+  ensure
+    ENV['RACK_ENV'] = rack
+    ENV['RAILS_ENV'] = rails
+  end
 end


### PR DESCRIPTION
`rake dbconsole` support ENV['RACK_ENV']. And `railties/lib/rails.rb` also support one.

``` ruby
 87     def env
 88       @_env ||= begin
 89         ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
 90         ActiveSupport::StringInquirer.new(ENV["RAILS_ENV"])
 91       end
 92     end
```

I thinks we should use RACK_ENV  for usefulness and consistency.
