### PR TITLE
Revert turbolinks load order requirement

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/assets/javascripts/application.js.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/assets/javascripts/application.js.tt
@@ -13,8 +13,6 @@
 <% unless options[:skip_javascript] -%>
 //= require <%= options[:javascript] %>
 //= require <%= options[:javascript] %>_ujs
-<% end -%>
-//= require_tree .
-<% unless options[:skip_javascript] -%>
 //= require turbolinks
 <% end -%>
+//= require_tree .


### PR DESCRIPTION
As of Turbolinks 0.6.1, the turbolinks script doesn't need to be last in the manifest.  

Reverts the change made in #8411.
