### PR TITLE
Refactored class_attribute.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -311,4 +311,6 @@
 
 *   Optimize log subscribers to check log level before doing any processing. *Brian Durand*
 
+*   Refactored class_attribute, also now accepts an option of persist_when_inherited: true/false. *Jason Waldrip*
+
 Please check [3-2-stable](https://github.com/rails/rails/blob/3-2-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -68,6 +68,8 @@ class Class
   #   object.setting = false  # => NoMethodError
   #
   # To opt out of both instance methods, pass <tt>instance_accessor: false</tt>.
+  #
+  # To opt out of values being passed on inheritance, pass <tt>persist_when_inherited: false</tt>.
 
   def class_attribute(*attrs)
     options = attrs.extract_options!

--- a/activesupport/test/core_ext/class/attribute_test.rb
+++ b/activesupport/test/core_ext/class/attribute_test.rb
@@ -73,6 +73,13 @@ class ClassAttributeTest < ActiveSupport::TestCase
     assert_raise(NoMethodError) { object.setting = 'boom' }
   end
 
+  test 'disabling inherited persistence' do
+    base_class = Class.new { class_attribute :setting, :persist_when_inherited => false ; self.setting = "value" }
+    inherited_class = Class.new(base_class)
+    assert_equal "value", base_class.setting
+    assert_equal nil, inherited_class.setting
+  end
+
   test 'works well with singleton classes' do
     object = @klass.new
     object.singleton_class.setting = 'foo'


### PR DESCRIPTION
class_attribute now uses ruby instance vars rather than redefining the value as a method. Also added a new option allowing for the value to not be persisted on inheritance, that option defaults to true (does persist).
