### PR TITLE
Correct singularization for words like 'reserves' and 'nerves'

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Inflector no longer singularizes words like 'reserves' and 'nerves' to 'reserfs' and 'nerfs' *Mart Karu*
+
 *   Patched Marshal#load to work with constant autoloading.
     Fixes autoloading with cache stores that relay on Marshal(MemCacheStore and FileStore). [fixes #8167]
 

--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -34,6 +34,7 @@ module ActiveSupport
     inflect.singular(/(hive)s$/i, '\1')
     inflect.singular(/(tive)s$/i, '\1')
     inflect.singular(/([lr])ves$/i, '\1f')
+    inflect.singular(/(erve)s$/i, '\1')
     inflect.singular(/([^aeiouy]|qu)ies$/i, '\1y')
     inflect.singular(/(s)eries$/i, '\1eries')
     inflect.singular(/(m)ovies$/i, '\1ovie')

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -75,6 +75,7 @@ module InflectorTestCases
     "tomato"      => "tomatoes",
     "dwarf"       => "dwarves",
     "elf"         => "elves",
+    "reserve"     => "reserves",
     "information" => "information",
     "equipment"   => "equipment",
     "bus"         => "buses",


### PR DESCRIPTION
Inflector no longer singularizes words like 'reserves' and 'nerves' to 'reserfs' and 'nerfs'.
