### PR TITLE
CHANGELOG for 78d5d6f

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   SQLite adapter no longer corrupts binary data if the data contains '%00'
+    *Chris Feist*
+
 *   Add migration history to schema.rb dump.
     Loading schema.rb with full migration history
     restores the exact list of migrations that created


### PR DESCRIPTION
It was pointed out by @giner that the CHANGELOG entry for https://github.com/rails/rails/commit/78d5d6f8688bb7c45ba9a3ef893682231130da3f
wasn't included. Here it is.
