### PR TITLE
Fix decorate_columns for finding only non-serialized columns

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix decorating columns for serialized attributes. Fixes #8441
+
+    *itzki*
+
 *   Session variables can be set for the `mysql`, `mysql2`, and `postgresql` adapters
     in the `variables: <hash>` parameter in `database.yml`. The key-value pairs of this
     hash will be sent in a `SET key = value` query on new database connections. See also:

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -224,11 +224,10 @@ module ActiveRecord
       def decorate_columns(columns_hash) # :nodoc:
         return if columns_hash.empty?
 
-        serialized_attributes.each_key do |key|
-          columns_hash[key] = AttributeMethods::Serialization::Type.new(columns_hash[key])
-        end
-
         columns_hash.each do |name, col|
+          if serialized_attributes.key?(name)
+            columns_hash[name] = AttributeMethods::Serialization::Type.new(col)
+          end
           if create_time_zone_conversion_attribute?(name, col)
             columns_hash[name] = AttributeMethods::TimeZoneConversion::Type.new(col)
           end

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -212,4 +212,17 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     assert_kind_of BCrypt::Password, topic.content
     assert_equal(true, topic.content == password, 'password should equal')
   end
+
+  def test_serialize_attribute_via_select_method_when_time_zone_available
+    ActiveRecord::Base.time_zone_aware_attributes = true
+    Topic.serialize(:content, MyObject)
+
+    myobj = MyObject.new('value1', 'value2')
+    topic = Topic.create(content: myobj)
+
+    assert_equal(myobj, Topic.select(:content).find(topic.id).content)
+    assert_raise(ActiveModel::MissingAttributeError) { Topic.select(:id).find(topic.id).content }
+  ensure
+    ActiveRecord::Base.time_zone_aware_attributes = false
+  end
 end


### PR DESCRIPTION
steps to reproduce:

```
Topic.serialize(:content)
Topic.select(:id).last
```

> ```
> NoMethodError: undefined method `type' for nil:NilClass
> activerecord/lib/active_record/attribute_methods/serialization.rb:63:in `type'
> ```

conditions:
- PostgreSQL
- ActiveRecord::Base.time_zone_aware_attributes = true
