### PR TITLE
Use #flat_map instead of .map { foo }.flatten

### DIFF
--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -110,7 +110,7 @@ module ActiveRecord
       def preload_hash(association)
         association.each do |parent, child|
           Preloader.new(records, parent, preload_scope).run
-          Preloader.new(records.map { |record| record.send(parent) }.flatten, child).run
+          Preloader.new(records.flat_map { |record| record.send(parent) }, child).run
         end
       end
 

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -77,7 +77,7 @@ module ActiveRecord
             # Some databases impose a limit on the number of ids in a list (in Oracle it's 1000)
             # Make several smaller queries if necessary or make one query if the adapter supports it
             sliced  = owner_keys.each_slice(model.connection.in_clause_length || owner_keys.size)
-            records = sliced.map { |slice| records_for(slice).to_a }.flatten
+            records = sliced.flat_map { |slice| records_for(slice).to_a }
           end
 
           # Each record may have multiple owners, and vice-versa

--- a/guides/rails_guides/helpers.rb
+++ b/guides/rails_guides/helpers.rb
@@ -17,7 +17,7 @@ module RailsGuides
     end
 
     def documents_flat
-      documents_by_section.map {|section| section['documents']}.flatten
+      documents_by_section.flat_map { |section| section['documents'] }
     end
 
     def finished_documents(documents)

--- a/railties/lib/rails/commands/application.rb
+++ b/railties/lib/rails/commands/application.rb
@@ -12,7 +12,7 @@ else
   railsrc = File.join(File.expand_path("~"), ".railsrc")
   if File.exist?(railsrc)
     extra_args_string = File.open(railsrc).read
-    extra_args = extra_args_string.split(/\n+/).map {|l| l.split}.flatten
+    extra_args = extra_args_string.split(/\n+/).flat_map { |l| l.split }
     puts "Using #{extra_args.join(" ")} from #{railsrc}"
     ARGV << extra_args
     ARGV.flatten!

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -184,7 +184,7 @@ module Rails
       #   generate(:authenticated, "user session")
       def generate(what, *args)
         log :generate, what
-        argument = args.map {|arg| arg.to_s }.flatten.join(" ")
+        argument = args.flat_map { |arg| arg.to_s }.join(" ")
 
         in_root { run_ruby_script("script/rails generate #{what} #{argument}", verbose: false) }
       end

--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -32,7 +32,7 @@ class SourceAnnotationExtractor
   end
 
   # Prints all annotations with tag +tag+ under the root directories +app+, +config+, +lib+,
-  # +script+, and +test+ (recursively). Filenames with extension 
+  # +script+, and +test+ (recursively). Filenames with extension
   # +.builder+, +.rb+, +.erb+, +.haml+, +.slim+, +.css+, +.scss+, +.js+,
   # +.coffee+, and +.rake+ are taken into account. The +options+ hash is passed to each
   # annotation's +to_s+.
@@ -100,7 +100,7 @@ class SourceAnnotationExtractor
   # Prints the mapping from filenames to annotations in +results+ ordered by filename.
   # The +options+ hash is passed to each annotation's +to_s+.
   def display(results, options={})
-    options[:indent] = results.map { |f, a| a.map(&:line) }.flatten.max.to_s.size
+    options[:indent] = results.flat_map { |f, a| a.map(&:line) }.max.to_s.size
     results.keys.sort.each do |file|
       puts "#{file}:"
       results[file].each do |note|


### PR DESCRIPTION
I was discussing this matter on #ruby, and we eventually got curious as to whether or not it made any difference in performance- surprisingly, benchmarks showed that `#flap_map` was twice as fast as calling `#map`, then `#flatten` on that result. Modern Ruby code should definitely be using this method.

With this PR there are, to my knowledge, no more occurrences of the old way of flattening a `#map`.
