### PR TITLE
Update #where rdoc to match 6ba0f97

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -432,9 +432,9 @@ module ActiveRecord
     #    User.joins(:posts).where({ "posts.published" => true })
     #    User.joins(:posts).where({ posts: { published: true } })
     #
-    # === no argument or nil
+    # === no argument or :chain
     #
-    # If no argument or nil is passed, #where returns a new instance of WhereChain which, when
+    # If no argument or :chain is passed, #where returns a new instance of WhereChain which, when
     # chained with either #not, #like, or #not_like, returns a new relation.
     #
     #    User.where.not(name: "Jon")
@@ -448,9 +448,9 @@ module ActiveRecord
     #
     # See WhereChain for more details on #not, #like, and #not_like.
     #
-    # === empty condition
+    # === blank condition
     #
-    # If the condition is any other blank-ish object than nil, then where is a # no-op and returns
+    # If the condition is any blank-ish object, then #where is a no-op and returns
     # the current relation.
     def where(opts = :chain, *rest)
       if opts == :chain


### PR DESCRIPTION
This commit updates the rdoc of AR#where to match the changes applied
in https://github.com/rails/rails/commit/6ba0f97 that is:
- `where(nil)` has the same effect of `where('')`: a no op
- `where` (no args) has the same effect of `where(:chain)`: to create a WhereChain
