### PR TITLE
Don't detect counter_caches by attribute name

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Depreciate automatic detection of counter cache columns for has_many associations
+    based on attribute names.
+
+    Fixes #8446 #3903
+
+    *Matthew Robertson*
+
 *   If a model was instantiated from the database using `select`, `respond_to?`
     returns false for non-selected attributes. For example:
 

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -1,4 +1,3 @@
-
 module ActiveRecord
   # = Active Record Has Many Through Association
   module Associations

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -303,17 +303,17 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     post = posts(:welcome)
     tag  = post.tags.create!(:name => 'doomed')
 
-    assert_difference ['post.reload.taggings_count', 'post.reload.tags_count'], -1 do
+    assert_difference ['post.reload.taggings_count', 'post.reload.taggings.count'], -1 do
       posts(:welcome).tags.delete(tag)
     end
+
   end
 
   def test_update_counter_caches_on_delete_with_dependent_destroy
     post = posts(:welcome)
     tag  = post.tags.create!(:name => 'doomed')
-    post.update_columns(tags_with_destroy_count: post.tags.count)
 
-    assert_difference ['post.reload.taggings_count', 'post.reload.tags_with_destroy_count'], -1 do
+    assert_difference ['post.reload.taggings_count', 'post.reload.taggings.count'], -1 do
       posts(:welcome).tags_with_destroy.delete(tag)
     end
   end
@@ -321,12 +321,9 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   def test_update_counter_caches_on_delete_with_dependent_nullify
     post = posts(:welcome)
     tag  = post.tags.create!(:name => 'doomed')
-    post.update_columns(tags_with_nullify_count: post.tags.count)
 
-    assert_no_difference 'post.reload.taggings_count' do
-      assert_difference 'post.reload.tags_with_nullify_count', -1 do
-        posts(:welcome).tags_with_nullify.delete(tag)
-      end
+    assert_no_difference ['post.reload.taggings_count', 'post.reload.taggings.count'] do
+      posts(:welcome).tags_with_nullify.delete(tag)
     end
   end
 

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -522,11 +522,16 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     assert !author.comments.loaded?
   end
 
-  def test_has_many_through_collection_size_uses_counter_cache_if_it_exists
+  def test_has_many_does_not_detect_false_positive_counter_caches
     c = categories(:general)
-    c.categorizations_count = 100
-    assert_equal 100, c.categorizations.size
-    assert !c.categorizations.loaded?
+    c.categorizations_count = c.categorizations.count + 1
+    assert_equal c.categorizations.count, c.categorizations.size
+  end
+
+  def test_has_many_through_collection_size_does_not_infer_counter_caches
+    post = posts(:thinking)
+    post.tags_count = post.tags.count + 1
+    assert_equal post.tags.count, post.tags.size
   end
 
   def test_adding_junk_to_has_many_through_should_raise_type_mismatch


### PR DESCRIPTION
This commit fixes issues ##3903 and #8446 in which false positive detection of counter_cache columns based on column name causes inconsistent behaviour.

The approach used here is to query the `belongs_to` side of an association to discover if the `counter_cache` option is set, which is the only documented way to create cached counters
