### PR TITLE
Fix update_all() with default_scope with joins().where(condition_on_joined_table)

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -95,7 +95,7 @@ module ActiveRecord
             if method == :delete_all
               update_counter(-scope.delete_all)
             else
-              update_counter(-scope.update_all(reflection.foreign_key => nil))
+              update_counter(-scope.update_all("#{reflection.table_name}.#{reflection.foreign_key}" => nil))
             end
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -155,6 +155,18 @@ module ActiveRecord
         quote_column_name(name)
       end
 
+      # Override to return the quoted table name for assignment. Defaults to
+      # table quoting.
+      #
+      # This works for mysql and mysql2 where table.column can be used to
+      # resolve ambiguity.
+      #
+      # We override this in the sqlite and postgresql adaptors to use only
+      # the column name (as per syntax requirements).
+      def quote_table_name_for_assignment(name)
+        quote_table_name(name)
+      end
+
       # Returns a bind substitution value given a +column+ and list of current
       # +binds+
       def substitute_at(column, index)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -496,6 +496,10 @@ module ActiveRecord
         PGconn.quote_ident(name.to_s)
       end
 
+      def quote_table_name_for_assignment(name)
+        quote_column_name(name.to_s.gsub(/.*\./, ''))
+      end
+
       # Quote date/time values for use in SQL input. Includes microseconds
       # if the value is a Time responding to usec.
       def quoted_date(value) #:nodoc:

--- a/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
@@ -186,6 +186,10 @@ module ActiveRecord
         %Q("#{name.to_s.gsub('"', '""')}")
       end
 
+      def quote_table_name_for_assignment(name)
+        quote_column_name(name.to_s.gsub(/.*\./, ''))
+      end
+
       # Quote date/time values for use in SQL input. Includes microseconds
       # if the value is a Time responding to usec.
       def quoted_date(value) #:nodoc:

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -283,7 +283,7 @@ module ActiveRecord
         stmt.table(table)
         stmt.key = table[primary_key]
 
-        if joins_values.any?
+        if with_default_scope.joins_values.any?
           @klass.connection.join_to_update(stmt, arel)
         else
           stmt.take(arel.limit)
@@ -404,6 +404,7 @@ module ActiveRecord
     # +after_destroy+ callbacks, use the +destroy_all+ method instead.
     def delete_all(conditions = nil)
       raise ActiveRecordError.new("delete_all doesn't support limit scope") if self.limit_value
+      raise ActiveRecordError.new("delete_all doesn't support conditions on joined tables in delete statements.") if with_default_scope.joins_values.any?
 
       IdentityMap.repository[symbolized_base_class] = {} if IdentityMap.enabled?
       if conditions

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -102,7 +102,7 @@ module ActiveRecord
       #     # => "status = NULL , group_id = 1"
       def sanitize_sql_hash_for_assignment(attrs)
         attrs.map do |attr, value|
-          "#{connection.quote_column_name(attr)} = #{quote_bound_value(value)}"
+          "#{connection.quote_table_name_for_assignment(attr)} = #{quote_bound_value(value)}"
         end.join(', ')
       end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -8,6 +8,8 @@ require 'models/reply'
 require 'models/category'
 require 'models/post'
 require 'models/author'
+require 'models/book'
+require 'models/review'
 require 'models/essay'
 require 'models/comment'
 require 'models/person'
@@ -102,7 +104,8 @@ end
 class HasManyAssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :categories, :companies, :developers, :projects,
            :developers_projects, :topics, :authors, :comments,
-           :people, :posts, :readers, :taggings, :cars, :essays
+           :people, :posts, :readers, :taggings, :cars, :essays,
+           :books, :reviews
 
   def setup
     Client.destroyed_client_ids.clear
@@ -1748,5 +1751,11 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     result = car.bulbs.replace([bulb3, bulb1])
     assert_equal [bulb1, bulb3], car.bulbs
     assert_equal [bulb1, bulb3], result
+  end
+
+  def test_delete_records_with_complex_joins
+    david = authors(:david).becomes(AuthorWithPositiveReview)
+    david.books_with_positive_reviews = []
+    assert_equal [], david.books_with_positive_reviews
   end
 end

--- a/activerecord/test/cases/relation_scoping_test.rb
+++ b/activerecord/test/cases/relation_scoping_test.rb
@@ -163,20 +163,20 @@ class RelationScopingTest < ActiveRecord::TestCase
   end
 
   def test_default_scope_filters_on_joins
-      assert_equal 1, DeveloperFilteredOnJoins.all.count
-      assert_equal DeveloperFilteredOnJoins.all.first, developers(:david).becomes(DeveloperFilteredOnJoins)
+    assert_equal 1, DeveloperFilteredOnJoins.all.count
+    assert_equal DeveloperFilteredOnJoins.all.first, developers(:david).becomes(DeveloperFilteredOnJoins)
   end
 
   def test_update_all_default_scope_filters_on_joins
-      DeveloperFilteredOnJoins.update_all(:salary => 65000)
-      assert_equal 65000, Developer.find(developers(:david).id).salary
+    DeveloperFilteredOnJoins.update_all(:salary => 65000)
+    assert_equal 65000, Developer.find(developers(:david).id).salary
 
-      # has not changed jamis
-      assert_not_equal 65000, Developer.find(developers(:jamis).id).salary
+    # has not changed jamis
+    assert_not_equal 65000, Developer.find(developers(:jamis).id).salary
   end
 
   def test_delete_all_default_scope_filters_on_joins
-      assert_raise(ActiveRecord::ActiveRecordError) { DeveloperFilteredOnJoins.delete_all }
+    assert_raise(ActiveRecord::ActiveRecordError) { DeveloperFilteredOnJoins.delete_all }
   end
 end
 

--- a/activerecord/test/cases/relation_scoping_test.rb
+++ b/activerecord/test/cases/relation_scoping_test.rb
@@ -161,6 +161,23 @@ class RelationScopingTest < ActiveRecord::TestCase
 
     assert !Developer.scoped.where_values.include?("name = 'Jamis'")
   end
+
+  def test_default_scope_filters_on_joins
+      assert_equal 1, DeveloperFilteredOnJoins.all.count
+      assert_equal DeveloperFilteredOnJoins.all.first, developers(:david).becomes(DeveloperFilteredOnJoins)
+  end
+
+  def test_update_all_default_scope_filters_on_joins
+      DeveloperFilteredOnJoins.update_all(:salary => 65000)
+      assert_equal 65000, Developer.find(developers(:david).id).salary
+
+      # has not changed jamis
+      assert_not_equal 65000, Developer.find(developers(:jamis).id).salary
+  end
+
+  def test_delete_all_default_scope_filters_on_joins
+      assert_raise(ActiveRecord::ActiveRecordError) { DeveloperFilteredOnJoins.delete_all }
+  end
 end
 
 class NestedRelationScopingTest < ActiveRecord::TestCase

--- a/activerecord/test/fixtures/reviews.yml
+++ b/activerecord/test/fixtures/reviews.yml
@@ -1,0 +1,14 @@
+positive_review:
+  author_id: 2
+  book_id: 1
+  positive: true
+
+david_positive_review:
+  author_id: 1
+  book_id: 2
+  positive: true
+
+negative_review:
+  author_id: 3
+  book_id: 1
+  positive: false

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -104,6 +104,7 @@ class Author < ActiveRecord::Base
   has_many :tags_with_primary_key, :through => :posts
 
   has_many :books
+  has_many :books_with_positive_reviews, :class_name => 'BookPositiveReview'
   has_many :subscriptions,        :through => :books
   has_many :subscribers,          :through => :subscriptions, :order => "subscribers.nick" # through has_many :through (on through reflection)
   has_many :distinct_subscribers, :through => :subscriptions, :source => :subscriber, :select => "DISTINCT subscribers.*", :order => "subscribers.nick"
@@ -139,6 +140,8 @@ class Author < ActiveRecord::Base
 
   has_many :posts_with_default_include, :class_name => 'PostWithDefaultInclude'
   has_many :comments_on_posts_with_default_include, :through => :posts_with_default_include, :source => :comments
+
+  has_many :reviews
 
   scope :relation_include_posts, includes(:posts)
   scope :relation_include_tags, includes(:tags)
@@ -197,4 +200,10 @@ end
 class AuthorFavorite < ActiveRecord::Base
   belongs_to :author
   belongs_to :favorite_author, :class_name => "Author"
+end
+
+class AuthorWithPositiveReview < Author
+  def self.has_written_positive_reviews
+    joins(:reviews).where(:reviews => {:positive => true})
+  end
 end

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -204,6 +204,6 @@ end
 
 class AuthorWithPositiveReview < Author
   def self.has_written_positive_reviews
-    joins(:reviews).where(:reviews => {:positive => true})
+    joins(:reviews).where(:reviews => { :positive => true })
   end
 end

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -6,4 +6,14 @@ class Book < ActiveRecord::Base
 
   has_many :subscriptions
   has_many :subscribers, :through => :subscriptions
+
+  has_many :reviews
+end
+
+class BookPositiveReview < Book
+  default_scope { positive_reviews }
+
+  def self.positive_reviews
+    joins(:reviews).where(:reviews => {:positive => true})
+  end
 end

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -14,6 +14,6 @@ class BookPositiveReview < Book
   default_scope { positive_reviews }
 
   def self.positive_reviews
-    joins(:reviews).where(:reviews => {:positive => true})
+    joins(:reviews).where(:reviews => { :positive => true })
   end
 end

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -106,6 +106,15 @@ class DeveloperWithIncludes < ActiveRecord::Base
   default_scope includes(:audit_logs)
 end
 
+class DeveloperFilteredOnJoins < ActiveRecord::Base
+  self.table_name = 'developers'
+  has_and_belongs_to_many :projects, :foreign_key => 'developer_id', :join_table => 'developers_projects', :order => 'projects.id'
+
+  def self.default_scope
+    joins(:projects).where(:projects => { :name => 'Active Controller' })
+  end
+end
+
 class DeveloperOrderedBySalary < ActiveRecord::Base
   self.table_name = 'developers'
   default_scope :order => 'salary DESC'

--- a/activerecord/test/models/review.rb
+++ b/activerecord/test/models/review.rb
@@ -1,0 +1,4 @@
+class Review < ActiveRecord::Base
+    belongs_to :author
+    belongs_to :book
+end

--- a/activerecord/test/models/review.rb
+++ b/activerecord/test/models/review.rb
@@ -1,4 +1,4 @@
 class Review < ActiveRecord::Base
-    belongs_to :author
-    belongs_to :book
+  belongs_to :author
+  belongs_to :book
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -554,6 +554,12 @@ ActiveRecord::Schema.define do
     t.integer :lock_version, :default => 0
   end
 
+  create_table :reviews, :force => true do |t|
+    t.integer :author_id
+    t.integer :book_id
+    t.boolean :positive
+  end
+
   create_table :shape_expressions, :force => true do |t|
     t.string  :paint_type
     t.integer :paint_id


### PR DESCRIPTION
There was a bug where you could use `Model.joins(...).where(condition_on_joined_table).update_all(...)`, but the equivalent with a default scope didn't work. Basically, AR was using the where clause but not bothering to join the table, resulting in SQL errors.

After I fixed that, I found another bug where using `update_all()` on an ambiguous column name (in the mysql adaptor) resulted in more SQL errors. So I reproduced that in a test and fixed it too.

Feedback welcome. Let me know if it's unclear what I'm trying to do with the tests that I wrote.
