### PR TITLE
the return value of mailer methods should not be relevant

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Explicit multipart messages no longer set the order of the MIME parts.
   *Nate Berkopec*
-  
+
 * Do not render views when mail() isn't called.
   Fix #7761
 

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -501,6 +501,7 @@ module ActionMailer
     # method, for instance).
     def initialize(method_name=nil, *args)
       super()
+      @_mail_was_called = false
       @_message = Mail.new
       process(method_name, *args) if method_name
     end
@@ -508,7 +509,8 @@ module ActionMailer
     def process(*args) #:nodoc:
       lookup_context.skip_default_locale!
 
-      @_message = NullMail.new unless super
+      super
+      @_message = NullMail.new unless @_mail_was_called
     end
 
     class NullMail #:nodoc:
@@ -668,6 +670,7 @@ module ActionMailer
     #   end
     #
     def mail(headers={}, &block)
+      @_mail_was_called = true
       m = @_message
 
       # At the beginning, do not consider class default for parts order neither content_type

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -505,6 +505,12 @@ class BaseTest < ActiveSupport::TestCase
     mail.deliver
   end
 
+  test 'the return value of mailer methods is not relevant' do
+    mail = BaseMailer.with_nil_as_return_value
+    assert_equal('Welcome', mail.body.to_s.strip)
+    mail.deliver
+  end
+
   # Before and After hooks
 
   class MyObserver

--- a/actionmailer/test/mailers/base_mailer.rb
+++ b/actionmailer/test/mailers/base_mailer.rb
@@ -118,4 +118,9 @@ class BaseMailer < ActionMailer::Base
 
   def without_mail_call
   end
+
+  def with_nil_as_return_value(hash = {})
+    mail(:template_name => "welcome")
+    nil
+  end
 end


### PR DESCRIPTION
This issue was raised in #8448 and caused by an earlier PR #8048. Previously the return value form the mailer methods was used to determine if `mail()` was called. This led to bugs when `mail()` was not the last call in the mailer method.

I re-introduced the `@mail_was_called` flag to check wether `mail()` was actually called. The return value of the mailer method is ignored.

This needs a backport to `3-2-stable` where the flag `@mail_was_called` is already present.
