### PR TITLE
Add inequality methods gt, gte, lt, lte

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Allow `Relation#where` with no arguments to be chained with new inequality query methods
+    `greater_than`, `greater_than_or_equal`, `less_than`, and `less_than_or_equal`, also
+    aliased as `gt`, `gte`, `lt`, and `lte`.
+
+    Example:
+
+        Post.where.greater_than(comments_count: 1).where.lte(taggings_count: 3)
+
+    *claudiob*
+
 *   Allow `Relation#where` with no arguments to be chained with new query methods
     `not`, `like`, and `not_like`.
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -64,6 +64,62 @@ module ActiveRecord
         @scope.where_values += where_value
         @scope
       end
+
+      # Returns a new relation expressing WHERE + GREATER THAN condition
+      # according to the conditions provided as a hash in the arguments.
+      #
+      #    Post.where.greater_than(comments_count: 1)
+      #    # SELECT * FROM posts WHERE comments_count > 1
+      def greater_than(opts, *rest)
+        where_value = @scope.send(:build_where,  opts, rest).map do |rel|
+          Arel::Nodes::GreaterThan.new(rel.left, rel.right)
+        end
+        @scope.where_values += where_value
+        @scope
+      end
+      alias :gt :greater_than
+
+      # Returns a new relation expressing WHERE + GREATER THAN OR EQUAL condition
+      # according to the conditions provided as a hash in the arguments.
+      #
+      #    Post.where.greater_than_or_equal(comments_count: 1)
+      #    # SELECT * FROM posts WHERE comments_count >= 1
+      def greater_than_or_equal(opts, *rest)
+        where_value = @scope.send(:build_where,  opts, rest).map do |rel|
+          Arel::Nodes::GreaterThanOrEqual.new(rel.left, rel.right)
+        end
+        @scope.where_values += where_value
+        @scope
+      end
+      alias :gte :greater_than_or_equal
+
+      # Returns a new relation expressing WHERE + LESS THAN condition
+      # according to the conditions provided as a hash in the arguments.
+      #
+      #    Post.where.less_than(comments_count: 1)
+      #    # SELECT * FROM posts WHERE comments_count < 1
+      def less_than(opts, *rest)
+        where_value = @scope.send(:build_where,  opts, rest).map do |rel|
+          Arel::Nodes::LessThan.new(rel.left, rel.right)
+        end
+        @scope.where_values += where_value
+        @scope
+      end
+      alias :lt :less_than
+
+      # Returns a new relation expressing WHERE + LESS THAN OR EQUAL condition
+      # according to the conditions provided as a hash in the arguments.
+      #
+      #    Post.where.less_than_or_equal(comments_count: 1)
+      #    # SELECT * FROM posts WHERE comments_count <= 1
+      def less_than_or_equal(opts, *rest)
+        where_value = @scope.send(:build_where,  opts, rest).map do |rel|
+          Arel::Nodes::LessThanOrEqual.new(rel.left, rel.right)
+        end
+        @scope.where_values += where_value
+        @scope
+      end
+      alias :lte :less_than_or_equal
     end
 
     Relation::MULTI_VALUE_METHODS.each do |name|

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -62,6 +62,55 @@ module ActiveRecord
       assert_equal([expected], relation.where_values)
     end
 
+    def test_greater_than
+      expected = Arel::Nodes::GreaterThan.new(Post.arel_table[:comments_count], 1)
+      relation = Post.where.greater_than(comments_count: 1)
+      assert_equal([expected], relation.where_values)
+    end
+
+    def test_gt
+      expected = Arel::Nodes::GreaterThan.new(Post.arel_table[:comments_count], 1)
+      relation = Post.where.gt(comments_count: 1)
+      assert_equal([expected], relation.where_values)
+    end
+
+
+    def test_greater_than_or_equal
+      expected = Arel::Nodes::GreaterThanOrEqual.new(Post.arel_table[:comments_count], 1)
+      relation = Post.where.greater_than_or_equal(comments_count: 1)
+      assert_equal([expected], relation.where_values)
+    end
+
+    def test_gte
+      expected = Arel::Nodes::GreaterThanOrEqual.new(Post.arel_table[:comments_count], 1)
+      relation = Post.where.gte(comments_count: 1)
+      assert_equal([expected], relation.where_values)
+    end
+
+    def test_less_than
+      expected = Arel::Nodes::LessThan.new(Post.arel_table[:comments_count], 1)
+      relation = Post.where.less_than(comments_count: 1)
+      assert_equal([expected], relation.where_values)
+    end
+
+    def test_lt
+      expected = Arel::Nodes::LessThan.new(Post.arel_table[:comments_count], 1)
+      relation = Post.where.lt(comments_count: 1)
+      assert_equal([expected], relation.where_values)
+    end
+
+    def test_less_than_or_equal
+      expected = Arel::Nodes::LessThanOrEqual.new(Post.arel_table[:comments_count], 1)
+      relation = Post.where.less_than_or_equal(comments_count: 1)
+      assert_equal([expected], relation.where_values)
+    end
+
+    def test_lte
+      expected = Arel::Nodes::LessThanOrEqual.new(Post.arel_table[:comments_count], 1)
+      relation = Post.where.lte(comments_count: 1)
+      assert_equal([expected], relation.where_values)
+    end
+
     def test_chaining_multiple
       relation = Post.where.like(title: 'ruby on %').where.not(title: 'ruby on rails').where.not_like(title: '% ales')
 


### PR DESCRIPTION
This commit allows `Relation#where` with no arguments to be chained
with new inequality query methods `greater_than`, `greater_than_or_equal`,
`less_than`, and `less_than_or_equal`, also aliased as `gt`, `gte`, `lt`,
and `lte`.
