### PR TITLE
Rename ActiveSupport::BasicObject to ActiveSupport::ProxyObject

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Deprecate `ActiveSupport::BasicObject` in favor of `ActiveSupport::ProxyObject`.
+    This class is used for proxy classes. It avoids confusion with Ruby's BasicObject
+    class.
+
+    *Francesco Rodriguez*
+
 *   Patched Marshal#load to work with constant autoloading.
     Fixes autoloading with cache stores that relay on Marshal(MemCacheStore and FileStore). [fixes #8167]
 

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -40,6 +40,7 @@ module ActiveSupport
   eager_autoload do
     autoload :BacktraceCleaner
     autoload :BasicObject
+    autoload :ProxyObject
     autoload :Benchmarkable
     autoload :Cache
     autoload :Callbacks

--- a/activesupport/lib/active_support/basic_object.rb
+++ b/activesupport/lib/active_support/basic_object.rb
@@ -1,13 +1,7 @@
-module ActiveSupport
-  # A class with no predefined methods that behaves similarly to Builder's
-  # BlankSlate. Used for proxy classes.
-  class BasicObject < ::BasicObject
-    undef_method :==
-    undef_method :equal?
+require 'active_support/deprecation'
 
-    # Let ActiveSupport::BasicObject at least raise exceptions.
-    def raise(*args)
-      ::Object.send(:raise, *args)
-    end
-  end
+module ActiveSupport
+  # :nodoc:
+  # Deprecated in favor of ActiveSupport::ProxyObject
+  BasicObject = Deprecation::DeprecatedConstantProxy.new('ActiveSupport::BasicObject', 'ActiveSupport::ProxyObject')
 end

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -1,4 +1,4 @@
-require 'active_support/basic_object'
+require 'active_support/proxy_object'
 require 'active_support/core_ext/array/conversions'
 require 'active_support/core_ext/object/acts_like'
 
@@ -7,7 +7,7 @@ module ActiveSupport
   # Time#advance, respectively. It mainly supports the methods on Numeric.
   #
   #   1.month.ago       # equivalent to Time.now.advance(months: -1)
-  class Duration < BasicObject
+  class Duration < ProxyObject
     attr_accessor :value, :parts
 
     def initialize(value, parts) #:nodoc:

--- a/activesupport/lib/active_support/proxy_object.rb
+++ b/activesupport/lib/active_support/proxy_object.rb
@@ -1,0 +1,13 @@
+module ActiveSupport
+  # A class with no predefined methods that behaves similarly to Builder's
+  # BlankSlate. Used for proxy classes.
+  class ProxyObject < ::BasicObject
+    undef_method :==
+    undef_method :equal?
+
+    # Let ActiveSupport::BasicObject at least raise exceptions.
+    def raise(*args)
+      ::Object.send(:raise, *args)
+    end
+  end
+end

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -21,7 +21,7 @@ class DurationTest < ActiveSupport::TestCase
     assert ActiveSupport::Duration === 1.day
     assert !(ActiveSupport::Duration === 1.day.to_i)
     assert !(ActiveSupport::Duration === 'foo')
-    assert !(ActiveSupport::Duration === ActiveSupport::BasicObject.new)
+    assert !(ActiveSupport::Duration === ActiveSupport::ProxyObject.new)
   end
 
   def test_equals
@@ -131,7 +131,7 @@ class DurationTest < ActiveSupport::TestCase
       assert_equal Time.local(2009,3,29,0,0,0) + 1.day, Time.local(2009,3,30,0,0,0)
     end
   end
-  
+
   def test_delegation_with_block_works
     counter = 0
     assert_nothing_raised do


### PR DESCRIPTION
AS::BasicObject is used for proxy classes. I'm concerned about the name.

Also, it avoids the confusion with Ruby's BasicObject.
