### PR TITLE
Actionize2

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -19,7 +19,7 @@ module ActionController #:nodoc:
   #
   #   class ApplicationController < ActionController::Base
   #     protect_from_forgery
-  #     skip_before_filter :verify_authenticity_token, if: :json_request?
+  #     skip_before_action :verify_authenticity_token, if: :json_request?
   #
   #     protected
   #
@@ -66,15 +66,15 @@ module ActionController #:nodoc:
       #
       # You can disable csrf protection on controller-by-controller basis:
       #
-      #   skip_before_filter :verify_authenticity_token
+      #   skip_before_action :verify_authenticity_token
       #
       # It can also be disabled for specific controller actions:
       #
-      #   skip_before_filter :verify_authenticity_token, except: [:create]
+      #   skip_before_action :verify_authenticity_token, except: [:create]
       #
       # Valid Options:
       #
-      # * <tt>:only/:except</tt> - Passed to the <tt>before_filter</tt> call. Set which actions are verified.
+      # * <tt>:only/:except</tt> - Passed to the <tt>before_action</tt> call. Set which actions are verified.
       # * <tt>:with</tt> - Set the method to handle unverified request.
       #
       # Valid unverified request handling methods are:
@@ -84,7 +84,7 @@ module ActionController #:nodoc:
       def protect_from_forgery(options = {})
         include protection_method_module(options[:with] || :null_session)
         self.request_forgery_protection_token ||= :authenticity_token
-        prepend_before_filter :verify_authenticity_token, options
+        prepend_before_action :verify_authenticity_token, options
       end
 
       private
@@ -152,7 +152,7 @@ module ActionController #:nodoc:
     end
 
     protected
-      # The actual before_filter that is used. Modify this to change how you handle unverified requests.
+      # The actual before_action that is used. Modify this to change how you handle unverified requests.
       def verify_authenticity_token
         unless verified_request?
           logger.warn "Can't verify CSRF token authenticity" if logger

--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -68,7 +68,7 @@ module ActionDispatch
       # that are not controlled by the extension.
       #
       #   class ApplicationController < ActionController::Base
-      #     before_filter :adjust_format_for_iphone
+      #     before_action :adjust_format_for_iphone
       #
       #     private
       #       def adjust_format_for_iphone
@@ -87,7 +87,7 @@ module ActionDispatch
       # to the :html format.
       #
       #   class ApplicationController < ActionController::Base
-      #     before_filter :adjust_format_for_iphone_with_html_fallback
+      #     before_action :adjust_format_for_iphone_with_html_fallback
       #
       #     private
       #       def adjust_format_for_iphone_with_html_fallback

--- a/actionpack/test/abstract/callbacks_test.rb
+++ b/actionpack/test/abstract/callbacks_test.rb
@@ -265,5 +265,51 @@ module AbstractController
         assert_equal "Hello world Howdy!", controller.response_body
       end
     end
+
+    class AliasedCallbacks < ControllerWithCallbacks
+      before_filter :first
+      after_filter :second
+      around_filter :aroundz
+
+      def first
+        @text = "Hello world"
+      end
+
+      def second
+        @second = "Goodbye"
+      end
+
+      def aroundz
+        @aroundz = "FIRST"
+        yield
+        @aroundz << "SECOND"
+      end
+
+      def index
+        @text ||= nil
+        self.response_body = @text.to_s
+      end
+    end
+
+    class TestAliasedCallbacks < ActiveSupport::TestCase
+      def setup
+        @controller = AliasedCallbacks.new
+      end
+
+      test "before_filter works" do
+        @controller.process(:index)
+        assert_equal "Hello world", @controller.response_body
+      end
+
+      test "after_filter works" do
+        @controller.process(:index)
+        assert_equal "Goodbye", @controller.instance_variable_get("@second")
+      end
+
+      test "around_filter works" do
+        @controller.process(:index)
+        assert_equal "FIRSTSECOND", @controller.instance_variable_get("@aroundz")
+      end
+    end
   end
 end

--- a/actionpack/test/abstract/callbacks_test.rb
+++ b/actionpack/test/abstract/callbacks_test.rb
@@ -28,9 +28,9 @@ module AbstractController
     end
 
     class Callback2 < ControllerWithCallbacks
-      before_filter :first
-      after_filter :second
-      around_filter :aroundz
+      before_action :first
+      after_action :second
+      around_action :aroundz
 
       def first
         @text = "Hello world"
@@ -53,7 +53,7 @@ module AbstractController
     end
 
     class Callback2Overwrite < Callback2
-      before_filter :first, :except => :index
+      before_action :first, except: :index
     end
 
     class TestCallbacks2 < ActiveSupport::TestCase
@@ -61,22 +61,22 @@ module AbstractController
         @controller = Callback2.new
       end
 
-      test "before_filter works" do
+      test "before_action works" do
         @controller.process(:index)
         assert_equal "Hello world", @controller.response_body
       end
 
-      test "after_filter works" do
+      test "after_action works" do
         @controller.process(:index)
         assert_equal "Goodbye", @controller.instance_variable_get("@second")
       end
 
-      test "around_filter works" do
+      test "around_action works" do
         @controller.process(:index)
         assert_equal "FIRSTSECOND", @controller.instance_variable_get("@aroundz")
       end
 
-      test "before_filter with overwritten condition" do
+      test "before_action with overwritten condition" do
         @controller = Callback2Overwrite.new
         @controller.process(:index)
         assert_equal "", @controller.response_body
@@ -102,12 +102,12 @@ module AbstractController
         @controller = Callback3.new
       end
 
-      test "before_filter works with procs" do
+      test "before_action works with procs" do
         @controller.process(:index)
         assert_equal "Hello world", @controller.response_body
       end
 
-      test "after_filter works with procs" do
+      test "after_action works with procs" do
         @controller.process(:index)
         assert_equal "Goodbye", @controller.instance_variable_get("@second")
       end
@@ -141,25 +141,25 @@ module AbstractController
         @controller = CallbacksWithConditions.new
       end
 
-      test "when :only is specified, a before filter is triggered on that action" do
+      test "when :only is specified, a before action is triggered on that action" do
         @controller.process(:index)
         assert_equal "Hello, World", @controller.response_body
       end
 
-      test "when :only is specified, a before filter is not triggered on other actions" do
+      test "when :only is specified, a before action is not triggered on other actions" do
         @controller.process(:sekrit_data)
         assert_equal "true", @controller.response_body
       end
 
-      test "when :except is specified, an after filter is not triggered on that action" do
+      test "when :except is specified, an after action is not triggered on that action" do
         @controller.process(:index)
         assert !@controller.instance_variable_defined?("@authenticated")
       end
     end
 
     class CallbacksWithArrayConditions < ControllerWithCallbacks
-      before_filter :list, :only => [:index, :listy]
-      before_filter :authenticate, :except => [:index, :listy]
+      before_action :list, only: [:index, :listy]
+      before_action :authenticate, except: [:index, :listy]
 
       def index
         self.response_body = @list.join(", ")
@@ -185,17 +185,17 @@ module AbstractController
         @controller = CallbacksWithArrayConditions.new
       end
 
-      test "when :only is specified with an array, a before filter is triggered on that action" do
+      test "when :only is specified with an array, a before action is triggered on that action" do
         @controller.process(:index)
         assert_equal "Hello, World", @controller.response_body
       end
 
-      test "when :only is specified with an array, a before filter is not triggered on other actions" do
+      test "when :only is specified with an array, a before action is not triggered on other actions" do
         @controller.process(:sekrit_data)
         assert_equal "true", @controller.response_body
       end
 
-      test "when :except is specified with an array, an after filter is not triggered on that action" do
+      test "when :except is specified with an array, an after action is not triggered on that action" do
         @controller.process(:index)
         assert !@controller.instance_variable_defined?("@authenticated")
       end
@@ -227,7 +227,7 @@ module AbstractController
     end
 
     class SetsResponseBody < ControllerWithCallbacks
-      before_filter :set_body
+      before_action :set_body
 
       def index
         self.response_body = "Fail"
@@ -265,7 +265,5 @@ module AbstractController
         assert_equal "Hello world Howdy!", controller.response_body
       end
     end
-
-
   end
 end

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -53,8 +53,8 @@ class FlashTest < ActionController::TestCase
       render :inline => "hello"
     end
 
-    # methods for test_sweep_after_halted_filter_chain
-    before_filter :halt_and_redir, :only => "filter_halting_action"
+    # methods for test_sweep_after_halted_action_chain
+    before_action :halt_and_redir, only: 'filter_halting_action'
 
     def std_action
       @flash_copy = {}.update(flash)
@@ -159,7 +159,7 @@ class FlashTest < ActionController::TestCase
     assert_nil session["flash"]
   end
 
-  def test_sweep_after_halted_filter_chain
+  def test_sweep_after_halted_action_chain
     get :std_action
     assert_nil assigns["flash_copy"]["foo"]
     get :filter_halting_action

--- a/actionpack/test/controller/rescue_test.rb
+++ b/actionpack/test/controller/rescue_test.rb
@@ -68,9 +68,9 @@ class RescueController < ActionController::Base
     render :text => 'io error'
   end
 
-  before_action(only: :before_filter_raises) { raise 'umm nice' }
+  before_action(only: :before_action_raises) { raise 'umm nice' }
 
-  def before_filter_raises
+  def before_action_raises
   end
 
   def raises


### PR DESCRIPTION
- use `_action` instead of `_filter` callbacks
- add tests to the aliased _filter callbacks
