### PR TITLE
Remove invalid query example from ActiveRecord changelog.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1110,6 +1110,13 @@
             .where("comments.name = 'foo'")
             .references(:comments)
 
+    Note that you do not need to explicitly specify references in the
+    following cases, as they can be automatically inferred:
+
+        Post.includes(:comments).where(comments: { name: 'foo' })
+        Post.includes(:comments).where('comments.name' => 'foo')
+        Post.includes(:comments).order('comments.name')
+
     You do not need to worry about this unless you are doing eager
     loading. Basically, don't worry unless you see a deprecation warning
     or (in future releases) an SQL error due to a missing JOIN.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1110,14 +1110,7 @@
             .where("comments.name = 'foo'")
             .references(:comments)
 
-    Note that you do not need to explicitly specify references in the
-    following cases, as they can be automatically inferred:
-
-        Post.where(comments: { name: 'foo' })
-        Post.where('comments.name' => 'foo')
-        Post.order('comments.name')
-
-    You also do not need to worry about this unless you are doing eager
+    You do not need to worry about this unless you are doing eager
     loading. Basically, don't worry unless you see a deprecation warning
     or (in future releases) an SQL error due to a missing JOIN.
 


### PR DESCRIPTION
These queries don't seem to work without explicitly informing
the join table, like:

  Post.where(comments: { name: 'foo' }).joins(:comments)

Which also reflects what tests in test/cases/relation/where_test.rb
currently look like.
