### PR TITLE
Provides standard layout lookup behavior for method and proc cases

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,25 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Ensure consistent fallback to the default layout lookup for layouts set
+    using symbols or procs that return nil.
+
+    All of the following layouts will result in the default layout lookup:
+
+        layout nil
+
+        layout proc { |c| nil }
+
+        layout :returns_nil
+
+        def returns_nil
+          nil
+        end
+
+    Previously symbols and procs which returned nil resulted in no layout which
+    differed from the `layout nil` behavior.
+
+    *Chris Nicola*
+
 *   Fix `respond_to` not using formats that have no block if all is present. *Michael Grosser*
 
 *   New applications use an encrypted session store by default.

--- a/actionpack/test/abstract/layouts_test.rb
+++ b/actionpack/test/abstract/layouts_test.rb
@@ -79,6 +79,14 @@ module AbstractControllerTests
       end
     end
 
+    class WithProcReturningNil < Base
+      layout proc { |c| nil }
+
+      def index
+        render template: ActionView::Template::Text.new("Hello nil!")
+      end
+    end
+
     class WithZeroArityProc < Base
       layout proc { "overwrite" }
 
@@ -247,6 +255,12 @@ module AbstractControllerTests
         controller = WithProc.new
         controller.process(:index)
         assert_equal "Overwrite Hello proc!", controller.response_body
+      end
+
+      test "when layout is specified as a proc and the proc retuns nil, don't use a layout" do
+        controller = WithProcReturningNil.new
+        controller.process(:index)
+        assert_equal "Hello nil!", controller.response_body
       end
 
       test "when layout is specified as a proc without parameters it works just the same" do

--- a/actionpack/test/controller/layout_test.rb
+++ b/actionpack/test/controller/layout_test.rb
@@ -94,6 +94,18 @@ class HasOwnLayoutController < LayoutTest
   layout 'item'
 end
 
+class HasNilLayoutSymbol < LayoutTest
+  layout :nilz
+
+  def nilz
+    nil
+  end
+end
+
+class HasNilLayoutProc < LayoutTest
+  layout proc { |c| nil }
+end
+
 class PrependsViewPathController < LayoutTest
   def hello
     prepend_view_path File.dirname(__FILE__) + '/../fixtures/layout_tests/alt/'
@@ -140,6 +152,18 @@ class LayoutSetInResponseTest < ActionController::TestCase
     @controller = HasOwnLayoutController.new
     get :hello
     assert_template :layout => "layouts/item"
+  end
+
+  def test_layout_symbol_set_in_controller_returning_nil_falls_back_to_default
+    @controller = HasNilLayoutSymbol.new
+    get :hello
+    assert_template layout: "layouts/layout_test"
+  end
+
+  def test_layout_proc_set_in_controller_returning_nil_falls_back_to_default
+    @controller = HasNilLayoutProc.new
+    get :hello
+    assert_template layout: "layouts/layout_test"
   end
 
   def test_layout_only_exception_when_included


### PR DESCRIPTION
When setting the layout either by referencing a method with a symbol or supplying a Proc there is no way to fall back to the default lookup behavior if desired instead returning nil will render no template.

This patch changes this behavior so that returning nil from either a method or a proc will result in the default template lookup.
