### PR TITLE
use :only instead of :except callback option in the controller template

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
@@ -4,8 +4,8 @@ require_dependency "<%= namespaced_file_path %>/application_controller"
 <% end -%>
 <% module_namespacing do -%>
 class <%= controller_class_name %>Controller < ApplicationController
-  before_action :set_<%= singular_table_name %>, except: [ :index, :new, :create ]
-  
+  before_action :set_<%= singular_table_name %>, only: [ :show, :edit, :update, :destroy ]
+
   # GET <%= route_url %>
   # GET <%= route_url %>.json
   def index
@@ -81,7 +81,6 @@ class <%= controller_class_name %>Controller < ApplicationController
       format.json { head :no_content }
     end
   end
-
 
   private
     # Use callbacks to share common setup or constraints between actions.

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -30,17 +30,13 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
         assert_match(/@product_lines = ProductLine\.all/, m)
       end
 
-      assert_instance_method :show, content do |m|
-        assert_match(/@product_line = ProductLine\.find\(params\[:id\]\)/, m)
-      end
+      assert_instance_method :show, content
 
       assert_instance_method :new, content do |m|
         assert_match(/@product_line = ProductLine\.new/, m)
       end
 
-      assert_instance_method :edit, content do |m|
-        assert_match(/@product_line = ProductLine\.find\(params\[:id\]\)/, m)
-      end
+      assert_instance_method :edit, content
 
       assert_instance_method :create, content do |m|
         assert_match(/@product_line = ProductLine\.new\(product_line_params\)/, m)
@@ -49,14 +45,16 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       end
 
       assert_instance_method :update, content do |m|
-        assert_match(/@product_line = ProductLine\.find\(params\[:id\]\)/, m)
         assert_match(/@product_line\.update_attributes\(product_line_params\)/, m)
         assert_match(/@product_line\.errors/, m)
       end
 
       assert_instance_method :destroy, content do |m|
-        assert_match(/@product_line = ProductLine\.find\(params\[:id\]\)/, m)
         assert_match(/@product_line\.destroy/, m)
+      end
+
+      assert_instance_method :set_product_line, content do |m|
+        assert_match(/@product_line = ProductLine\.find\(params\[:id\]\)/, m)
       end
     end
 
@@ -149,17 +147,13 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
         assert_match(/@admin_roles = Admin::Role\.all/, m)
       end
 
-      assert_instance_method :show, content do |m|
-        assert_match(/@admin_role = Admin::Role\.find\(params\[:id\]\)/, m)
-      end
+      assert_instance_method :show, content
 
       assert_instance_method :new, content do |m|
         assert_match(/@admin_role = Admin::Role\.new/, m)
       end
 
-      assert_instance_method :edit, content do |m|
-        assert_match(/@admin_role = Admin::Role\.find\(params\[:id\]\)/, m)
-      end
+      assert_instance_method :edit, content
 
       assert_instance_method :create, content do |m|
         assert_match(/@admin_role = Admin::Role\.new\(admin_role_params\)/, m)
@@ -168,14 +162,16 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       end
 
       assert_instance_method :update, content do |m|
-        assert_match(/@admin_role = Admin::Role\.find\(params\[:id\]\)/, m)
         assert_match(/@admin_role\.update_attributes\(admin_role_params\)/, m)
         assert_match(/@admin_role\.errors/, m)
       end
 
       assert_instance_method :destroy, content do |m|
-        assert_match(/@admin_role = Admin::Role\.find\(params\[:id\]\)/, m)
         assert_match(/@admin_role\.destroy/, m)
+      end
+
+      assert_instance_method :set_admin_role, content do |m|
+        assert_match(/@admin_role = Admin::Role\.find\(params\[:id\]\)/, m)
       end
     end
 


### PR DESCRIPTION
As [Security Guide](http://edgeguides.rubyonrails.org/security.html#whitelists-versus-blacklists) says, it's better to use `before_filter only: []` instead of `except: []` so we don't forget to turn the filter off for newly added actions.
