### PR TITLE
Fix #assert_instance_method to also assert indented methods

### DIFF
--- a/railties/lib/rails/generators/test_case.rb
+++ b/railties/lib/rails/generators/test_case.rb
@@ -163,7 +163,7 @@ module Rails
       #     end
       #   end
       def assert_instance_method(method, content)
-        assert content =~ /def #{method}(\(.+\))?(.*?)\n  end/m, "Expected to have method #{method}"
+        assert content =~ /def #{method}(\(.+\))?(.*?)\n\s+end/m, "Expected to have method #{method}"
         yield $2.strip if block_given?
       end
       alias :assert_method :assert_instance_method


### PR DESCRIPTION
Now we can assert if private methods (Rails style) exists in the generated templates:

```
class ProductController < ActionController::Base
  ...
  private

    def set_product
      ...
    end
end

assert_file "app/controllers/products_controller.rb" do |controller|
  assert_instance_method :set_product, controller
end
```
