### PR TITLE
Make `rake stats` handle new test type names properly

### DIFF
--- a/railties/lib/rails/code_statistics.rb
+++ b/railties/lib/rails/code_statistics.rb
@@ -1,6 +1,10 @@
 class CodeStatistics #:nodoc:
 
-  TEST_TYPES = %w(Units Functionals Unit\ tests Functional\ tests Integration\ tests)
+  TEST_TYPES = ['Model tests',
+                'Controller tests',
+                'Unit tests (old)',
+                'Functional tests (old)',
+                'Integration tests']
 
   def initialize(*pairs)
     @pairs      = pairs


### PR DESCRIPTION
Since unit tests and functional tests are now being called model tests and controller tests, respectively, `rake stats` needs to be made to properly categorize lines of code in `test/models` and `test/controllers` as test lines of code.
