### PR TITLE
update_attribute, update_column and update_columns should not update readonly attributes

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -175,7 +175,6 @@ module ActiveRecord
     #
     def update_attribute(name, value)
       name = name.to_s
-      verify_readonly_attribute(name)
       send("#{name}=", value)
       save(:validate => false)
     end
@@ -230,10 +229,6 @@ module ActiveRecord
     # one of the attributes is marked as readonly.
     def update_columns(attributes)
       raise ActiveRecordError, "can not update on a new record object" unless persisted?
-
-      attributes.each_key do |key|
-        verify_readonly_attribute(key.to_s)
-      end
 
       attributes.each do |k,v|
         raw_write_attribute(k,v)
@@ -404,10 +399,6 @@ module ActiveRecord
 
       @new_record = false
       id
-    end
-
-    def verify_readonly_attribute(name)
-      raise ActiveRecordError, "#{name} is marked as readonly" if self.class.readonly_attributes.include?(name)
     end
   end
 end

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -386,7 +386,7 @@ class PersistencesTest < ActiveRecord::TestCase
 
   def test_update_attribute_for_readonly_attribute
     minivan = Minivan.find('m1')
-    assert_raises(ActiveRecord::ActiveRecordError) { minivan.update_attribute(:color, 'black') }
+    assert minivan.update_attribute(:color, 'black'), "update_attribute doesn't do any validation"
   end
 
   def test_update_attribute_with_one_updated
@@ -467,9 +467,7 @@ class PersistencesTest < ActiveRecord::TestCase
 
   def test_update_column_for_readonly_attribute
     minivan = Minivan.find('m1')
-    prev_color = minivan.color
-    assert_raises(ActiveRecord::ActiveRecordError) { minivan.update_column(:color, 'black') }
-    assert_equal prev_color, minivan.color
+    assert minivan.update_column(:color, 'black'), "update_column doesn't do any validation"
   end
 
   def test_update_column_should_not_modify_updated_at
@@ -550,15 +548,8 @@ class PersistencesTest < ActiveRecord::TestCase
 
   def test_update_columns_with_one_readonly_attribute
     minivan = Minivan.find('m1')
-    prev_color = minivan.color
-    prev_name = minivan.name
-    assert_raises(ActiveRecord::ActiveRecordError) { minivan.update_columns({ name: "My old minivan", color: 'black' }) }
-    assert_equal prev_color, minivan.color
-    assert_equal prev_name, minivan.name
-
-    minivan.reload
-    assert_equal prev_color, minivan.color
-    assert_equal prev_name, minivan.name
+    assert minivan.update_columns({ name: 'My old minivan', color: 'black' }),
+      "update_columns doesn't do any validation"
   end
 
   def test_update_columns_should_not_modify_updated_at


### PR DESCRIPTION
_This is a new version of broken #7688_

It was decided two year ago in c96a505391 that "update_attribute should not update readonly attributes". I believe it's missleading and should be changed.

I wrote an issue asking whether it's normal or not: rails/rails/issues/7679. As you can see, it was recommended to me to try sending pull request.

Reasons I believe `update_attribute`, `update_column` and `update_columns` should update readonly attributes:
1. All validations are skipped in this methods. Readonly check really looks like validation.
2. `update_attribute` is kind of more 'raw' version of `=` operator, but in this case I can do
   
   ``` ruby
   minivan.color = 'new_color'
   minivan.save
   ```
   
   without getting exceptions, but can't do
   
   ``` ruby
   minivan.update_attribute :color, 'new_color'
   ```
   
   It's pretty weird, in this case `=` behaves more raw than `update_attribute`.
3. Readonly control is relatively low-level:
   
   ``` ruby
   # Filters the primary keys and readonly attributes from the attribute names.
   def attributes_for_update(attribute_names)
    attribute_names.select do |name|
      column_for_attribute(name) && !pk_attribute?(name) && !readonly_attribute?(name)
    end
   end
   ```
   
   And here is one more oddity: we don't raise exception for `pk_attribute`, but do for `readonly_attribute` in `update_attribute`, `update_column` and `update_columns`.

I'm open for discussion. Please, let me know where I'm wrong :)
