### PR TITLE
Make rake task for code statistics handle new test locations properly

### DIFF
--- a/railties/lib/rails/code_statistics.rb
+++ b/railties/lib/rails/code_statistics.rb
@@ -1,6 +1,12 @@
 class CodeStatistics #:nodoc:
 
-  TEST_TYPES = %w(Units Functionals Unit\ tests Functional\ tests Integration\ tests)
+  TEST_TYPES = ['Controller tests',
+                'Helper tests',
+                'Model tests',
+                'Mailer tests',
+                'Integration tests',
+                'Functional tests (old)',
+                'Unit tests (old)']
 
   def initialize(*pairs)
     @pairs      = pairs


### PR DESCRIPTION
As of 2a68f68aead9fd65ecac8062ca8efc15f5bab418:
- Unit tests are now in test/models, instead of test/units
- Functional tests are now in test/controllers, instead of
  test/functional
- Helper tests are now in test/helpers, instead of test/units/helpers
- Mailer tests are now in test/mailers, instead of test/functional

Update the rake task for code statistics (`rake stats`) so that it recognizes files in the above locations as tests, and accurately calculates statistics such as "Test LOC" and "Code to Test Ratio."  Safely handle Rails apps that still have tests in the old locations.

In a Rails 4 app running master, with one model and two corresponding model tests in the new location, the output of `rake stats` is as follows:

```
+----------------------+-------+-------+---------+---------+-----+-------+
| Name                 | Lines |   LOC | Classes | Methods | M/C | LOC/M |
+----------------------+-------+-------+---------+---------+-----+-------+
| Controllers          |     5 |     3 |       1 |       0 |   0 |     0 |
| Helpers              |     2 |     2 |       0 |       0 |   0 |     0 |
| Models               |    17 |    13 |       1 |       2 |   2 |     4 |
| Mailers              |     0 |     0 |       0 |       0 |   0 |     0 |
| Javascripts          |    16 |     0 |       0 |       0 |   0 |     0 |
| Libraries            |     0 |     0 |       0 |       0 |   0 |     0 |
| Controller tests     |     0 |     0 |       0 |       0 |   0 |     0 |
| Helper tests         |     0 |     0 |       0 |       0 |   0 |     0 |
| Model tests          |    15 |    11 |       1 |       0 |   0 |     0 |
| Mailer tests         |     0 |     0 |       0 |       0 |   0 |     0 |
| Integration tests    |     0 |     0 |       0 |       0 |   0 |     0 |
+----------------------+-------+-------+---------+---------+-----+-------+
| Total                |    55 |    29 |       3 |       2 |   0 |    12 |
+----------------------+-------+-------+---------+---------+-----+-------+
  Code LOC: 29     Test LOC: 0     Code to Test Ratio: 1:0.0
```

Note that Test LOC is incorrectly reported as 0 and Code-to-Test Ratio is incorrectly reported as 1:0.0.

In the same Rails 4 app running with my `rake stats` updates:

```
+----------------------+-------+-------+---------+---------+-----+-------+
| Name                 | Lines |   LOC | Classes | Methods | M/C | LOC/M |
+----------------------+-------+-------+---------+---------+-----+-------+
| Controllers          |     5 |     3 |       1 |       0 |   0 |     0 |
| Helpers              |     2 |     2 |       0 |       0 |   0 |     0 |
| Models               |    17 |    13 |       1 |       2 |   2 |     4 |
| Mailers              |     0 |     0 |       0 |       0 |   0 |     0 |
| Javascripts          |    16 |     0 |       0 |       0 |   0 |     0 |
| Libraries            |     0 |     0 |       0 |       0 |   0 |     0 |
| Controller tests     |     0 |     0 |       0 |       0 |   0 |     0 |
| Helper tests         |     0 |     0 |       0 |       0 |   0 |     0 |
| Model tests          |    15 |    11 |       1 |       0 |   0 |     0 |
| Mailer tests         |     0 |     0 |       0 |       0 |   0 |     0 |
| Integration tests    |     0 |     0 |       0 |       0 |   0 |     0 |
+----------------------+-------+-------+---------+---------+-----+-------+
| Total                |    55 |    29 |       3 |       2 |   0 |    12 |
+----------------------+-------+-------+---------+---------+-----+-------+
  Code LOC: 18     Test LOC: 11     Code to Test Ratio: 1:0.6
```

Test LOC is now correctly reported as 11 and Code-to-Test Ratio is correctly reported as 1:0.6.

/cc @carlosantoniodasilva
