### PR TITLE
Fixed a method redefine warning 

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/deep_merge.rb
+++ b/activesupport/lib/active_support/core_ext/hash/deep_merge.rb
@@ -1,4 +1,5 @@
 class Hash
+  undef :deep_merge! if instance_methods.include?(:deep_merge!)
   # Returns a new hash with +self+ and +other_hash+ merged recursively.
   #
   #   h1 = { x: { y: [4,5,6] }, z: [7,8,9] }


### PR DESCRIPTION
While running the tests in activemodel  the below warning  is fixed. 

/rails/activesupport/lib/active_support/core_ext/hash/deep_merge.rb:16: warning: method redefined; discarding old deep_merge!

I am not sure if using  `undef` in the source is fine. 
