### PR TITLE
Use Rails to Render Default Index Page

### DIFF
--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -51,7 +51,7 @@ module ActionDispatch
       end
 
       def internal?
-        path =~ %r{/rails/info.*|^#{Rails.application.config.assets.prefix}}
+        controller =~ %r{^rails/info|^rails/welcome} || path =~ %r{^#{Rails.application.config.assets.prefix}}
       end
 
       def engine?

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -215,11 +215,7 @@ Open the `app/views/welcome/index.html.erb` file in your text editor and edit it
 
 ### Setting the Application Home Page
 
-Now that we have made the controller and view, we need to tell Rails when we want Hello Rails! to show up. In our case, we want it to show up when we navigate to the root URL of our site, <http://localhost:3000>. At the moment, however, the "Welcome Aboard" smoke test is occupying that spot.
-
-To fix this, delete the `index.html` file located inside the `public` directory of the application.
-
-You need to do this because Rails will serve any static file in the `public` directory that matches a route in preference to any dynamic content you generate from the controllers. The `index.html` file is special: it will be served if a request comes in at the root route, e.g. <http://localhost:3000>. If another request such as <http://localhost:3000/welcome> happened, a static file at `public/welcome.html` would be served first, but only if it existed.
+Now that we have made the controller and view, we need to tell Rails when we want Hello Rails! to show up. In our case, we want it to show up when we navigate to the root URL of our site, <http://localhost:3000>. At the moment, "Welcome Aboard" is occupying that spot.
 
 Next, you have to tell Rails where your actual home page is located.
 
@@ -233,7 +229,6 @@ Blog::Application.routes.draw do
   # first created -> highest priority.
   # ...
   # You can have the root of your site routed with "root"
-  # just remember to delete public/index.html.
   # root to: "welcome#index"
 ```
 
@@ -558,7 +553,7 @@ parameter, which in our case will be the id of the post. Note that this
 time we had to specify the actual mapping, `posts#show` because
 otherwise Rails would not know which action to render.
 
-As we did before, we need to add the `show` action in 
+As we did before, we need to add the `show` action in
 `app/controllers/posts_controller.rb` and its respective view.
 
 ```ruby

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,9 +1,13 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   The public/index.html is no longer generated for new projects. Page is replaced by internal welcome_controller inside of railties
+
+    *Richard Schneeman*
+
 *   Add ENV['RACK_ENV'] support to `rails runner/console/server`.
 
     *kennyj*
- 
+
 *   Add `db` to list of folders included by `rake notes` and `rake notes:custom`. *Antonio Cangiano*
 
 *   Engines with a dummy app include the rake tasks of dependencies in the app namespace.

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -21,7 +21,8 @@ end
 
 module Rails
   autoload :Info, 'rails/info'
-  autoload :InfoController, 'rails/info_controller'
+  autoload :InfoController,    'rails/info_controller'
+  autoload :WelcomeController, 'rails/welcome_controller'
 
   class << self
     attr_accessor :application, :cache, :logger

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -25,6 +25,7 @@ module Rails
             get '/rails/info/properties' => "rails/info#properties"
             get '/rails/info/routes'     => "rails/info#routes"
             get '/rails/info'            => "rails/info#index"
+            get '/'                      => "rails/welcome#index"
           end
         end
       end

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -52,9 +52,6 @@ module Rails
         class_option :skip_javascript,    type: :boolean, aliases: '-J', default: false,
                                           desc: 'Skip JavaScript files'
 
-        class_option :skip_index_html,    type: :boolean, aliases: '-I', default: false,
-                                          desc: 'Skip public/index.html and app/assets/images/rails.png files'
-
         class_option :dev,                type: :boolean, default: false,
                                           desc: "Setup the #{name} with Gemfile pointing to your Rails checkout"
 

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -97,11 +97,6 @@ module Rails
 
     def public_directory
       directory "public", "public", recursive: false
-      if options[:skip_index_html]
-        remove_file "public/index.html"
-        remove_file 'app/assets/images/rails.png'
-        keep_file 'app/assets/images'
-      end
     end
 
     def script

--- a/railties/lib/rails/generators/rails/app/templates/config/routes.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/routes.rb
@@ -2,7 +2,7 @@
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 
-  # You can have the root of your site routed with "root" just remember to delete public/index.html.
+  # You can have the root of your site routed with "root"
   # root to: 'welcome#index'
 
   # Example of regular route:

--- a/railties/lib/rails/templates/rails/welcome/index.html.erb
+++ b/railties/lib/rails/templates/rails/welcome/index.html.erb
@@ -223,7 +223,6 @@
             </li>
 
             <li>
-              <h2>Set up a default route and remove <span class="filename">public/index.html</span></h2>
               <p>Routes are set up in <span class="filename">config/routes.rb</span>.</p>
             </li>
 

--- a/railties/lib/rails/welcome_controller.rb
+++ b/railties/lib/rails/welcome_controller.rb
@@ -1,0 +1,7 @@
+class Rails::WelcomeController < ActionController::Base # :nodoc:
+  self.view_paths = File.expand_path('../templates', __FILE__)
+  layout nil
+
+  def index
+  end
+end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -55,7 +55,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "app/views/layouts/application.html.erb", /javascript_include_tag\s+"application"/
     assert_file "app/assets/stylesheets/application.css"
     assert_file "config/application.rb", /config\.assets\.enabled = true/
-    assert_file "public/index.html", /url\("assets\/rails.png"\);/
   end
 
   def test_invalid_application_name_raises_an_error
@@ -249,13 +248,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     else
       assert_file "Gemfile", /# gem\s+["']therubyracer["']+, platforms: :ruby$/
     end
-  end
-
-  def test_generator_if_skip_index_html_is_given
-    run_generator [destination_root, '--skip-index-html']
-    assert_no_file 'public/index.html'
-    assert_no_file 'app/assets/images/rails.png'
-    assert_file 'app/assets/images/.keep'
   end
 
   def test_creation_of_a_test_directory


### PR DESCRIPTION
This is an alternative implementation to #7771 thanks to the advice of @spastorino

Rails is a dynamic framework that serves a static index.html by default. One of my first questions ever on IRC was solved by simply deleting my public/index.html file. This file is a source of confusion when starting as it over-rides any set "root" in the routes yet it itself is not listed in the routes. By making the page dynamic by default we can eliminate this confusion.

This PR moves the static index page to an internal controller/route/view similar to `rails/info`. When someone starts a rails server, if no root is defined, this route will take over and the "dynamic" index page from rails/welcome_controller will be rendered. These routes are only added in development. If a developer defines a root in their routes, it automatically takes precedence over this route and will be rendered, with no deleting of files required. 

In addition to removing this source of confusion for new devs, we can now use Rails view helpers to build and render this page. While not the primary intent, the added value of "dogfooding" should not be under-estimated.

The prior PR #7771 had push-back since it introduced developer facing files. This PR solves all of the same problems, but does not have any new developer facing files (it actually removes one). 

cc/ @wsouto, @dickeyxxx, @tyre, @ryanb, @josevalim, @maxim, @subdigital, @steveklabnik

ATP Railties and Actionpack.
