### PR TITLE
Include command to create mysql user

### DIFF
--- a/guides/source/development_dependencies_install.md
+++ b/guides/source/development_dependencies_install.md
@@ -141,6 +141,9 @@ We need first to delete `.bundle/config` because Bundler remembers in that file 
 In order to be able to run the test suite against MySQL you need to create a user named `rails` with privileges on the test databases:
 
 ```bash
+$ mysql -uroot -p
+
+mysql> CREATE USER 'rails'@'localhost';
 mysql> GRANT ALL PRIVILEGES ON activerecord_unittest.*
        to 'rails'@'localhost';
 mysql> GRANT ALL PRIVILEGES ON activerecord_unittest2.*


### PR DESCRIPTION
The guide mentions that the 'rails' user is needed, but doesn't
explicitly include the command to do so.
