### PR TITLE
Raise an exception during development if an asset is missing from `config.assets.precompile`

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -69,6 +69,9 @@ module <%= app_const_base %>
 
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
+
+    # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
+    # config.assets.precompile += %w( search.js )
 <% end -%>
   end
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -37,5 +37,8 @@
 
   # Expands the lines which load the assets
   config.assets.debug = true
+
+  # Raises an exception if an included asset is not found in config.assets.precompile
+  config.assets.enforce_precompile = true
   <%- end -%>
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -47,11 +47,6 @@
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"
 
-  <%- unless options.skip_sprockets? -%>
-  # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
-  # config.assets.precompile += %w( search.js )
-  <%- end -%>
-
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false
 


### PR DESCRIPTION
This ensures that developers won't forget to add assets to `config.assets.precompile` while they are developing. It's currently possible to have a site that works fine in development, but raises `AssetNotPrecompiledError` in production because an asset hasn't been compiled. This has happened to me a few times. I think it would be much better if an exception could be raised when an included asset doesn't match a filter in `config.assets.precompile`. I have added a `config.assets.enforce_precompile` option that enables this behavior for `javascript_include_tag` and `stylesheet_link_tag`.

In order for this to work, `config.assets.precompile` has to be defined in `config/application.rb`, since it needs to be shared across development and production.

This pull request is a proof of concept, but please let me know if you think it's a good idea. Thanks!
