### PR TITLE
Prevent raising EOFError on multipart GET request.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -722,4 +722,6 @@
 *   `ActionView::Helpers::TextHelper#highlight` now defaults to the
     HTML5 `mark` element. *Brian Cardarella*
 
+*   Prevent raising EOFError on multipart GET request (IE issue). *Adam Stankiewicz*
+
 Please check [3-2-stable](https://github.com/rails/rails/blob/3-2-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -12,7 +12,11 @@ module ActionDispatch
       # Returns both GET and POST \parameters in a single hash.
       def parameters
         @env["action_dispatch.request.parameters"] ||= begin
-          params = request_parameters.merge(query_parameters)
+          params = begin
+            request_parameters.merge(query_parameters)
+          rescue EOFError
+            query_parameters.dup
+          end
           params.merge!(path_parameters)
           encode_params(params).with_indifferent_access
         end

--- a/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
@@ -123,6 +123,18 @@ class MultipartParamsParsingTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # This can happen in Internet Explorer when redirecting after multipart form submit.
+  test "does not raise EOFError on GET request with multipart content-type" do
+    with_routing do |set|
+      set.draw do
+        get ':action', to: 'multipart_params_parsing_test/test'
+      end
+      headers = { "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x" }
+      get "/parse", {}, headers
+      assert_response :ok
+    end
+  end
+
   private
     def fixture(name)
       File.open(File.join(FIXTURE_PATH, name), 'rb') do |file|


### PR DESCRIPTION
Such request can happen on Internet Explorer. When we redirect
after multipart form submission, the request type is changed
to GET, but Content-Type is preserved as multipart. GET request
cannot have multipart body and that caused Rails to fail.

It's similar fix to [Rack's one](https://github.com/chneukirchen/rack/blob/8025a4ae9477d1e6231344c2b7d795aa9b3717b6/lib/rack/request.rb#L224).

---

This need to be back ported to older Rails. How to do it?
