### PR TITLE
Fix #7127. Don't call after_* callbacks when around_* callbacks returns false.

### DIFF
--- a/activemodel/test/cases/callbacks_test.rb
+++ b/activemodel/test/cases/callbacks_test.rb
@@ -111,4 +111,18 @@ class CallbacksTest < ActiveModel::TestCase
     assert_equal ["callback1", "callback2"], Violin2.new.create.history
   end
 
+  class Saxophone
+    attr_reader :called
+    extend ActiveModel::Callbacks
+    define_model_callbacks :create
+    def create; run_callbacks(:create) {}; end
+    around_create { false }
+    after_create  { @called = true }
+  end
+
+  test "don't call after_create if around_create returns false" do
+    sax = Saxophone.new
+    sax.create
+    assert !sax.called
+  end
 end

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -172,10 +172,13 @@ module ActiveSupport
         when :around
           name = define_conditional_callback
           <<-RUBY_EVAL
-          #{name}(halted) do
+          called = false
+          result = #{name}(halted) do
             #{code}
+            called = true
             value
           end
+          value = result unless called
           RUBY_EVAL
         end
       end


### PR DESCRIPTION
Please see #7127.

According to https://github.com/rails/rails/blob/master/activesupport/lib/active_support/callbacks.rb#L173-L179 and https://github.com/rails/rails/blob/master/activesupport/lib/active_support/callbacks.rb#L320, if we don't call a block, `value` is not assigned  (nil) . 

Thus I guess we call after_\* callbacks incorrectly in the case.
