### PR TITLE
Match the controller and path names defensively.

### DIFF
--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -51,7 +51,7 @@ module ActionDispatch
       end
 
       def internal?
-        controller =~ %r{^rails/info|^rails/welcome} || path =~ %r{^#{Rails.application.config.assets.prefix}}
+        controller =~ %r{\Arails/(info|welcome)} || path =~ %r{\A#{Rails.application.config.assets.prefix}}
       end
 
       def engine?


### PR DESCRIPTION
Use `\A` instead of `^`, and make the alteration shorter.

This improves upon #8468.

Thanks for your consideration.
