### PR TITLE
Explain how to supersede the new dynamic welcome page

### DIFF
--- a/railties/lib/rails/templates/rails/welcome/index.html.erb
+++ b/railties/lib/rails/templates/rails/welcome/index.html.erb
@@ -223,6 +223,8 @@
             </li>
 
             <li>
+              <h2>Set up a root route to replace this page</h2>
+              <p>You're seeing this page because you're running in development mode and you haven't set a root route yet.</p>
               <p>Routes are set up in <span class="filename">config/routes.rb</span>.</p>
             </li>
 


### PR DESCRIPTION
The old, static welcome page instructed developers to delete the `public/index.html` file and set a root route.  The new, dynamic welcome page should tell developers:
- Why they're seeing it when it doesn't correspond to anything in the viewable app source
- That it can be superseded with a root route
