### PR TITLE
attempt to fix slow  runner name method

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -351,8 +351,16 @@ module ActiveSupport
         undef_method(name) if method_defined?(name)
       end
 
-      def __callback_runner_name(kind)
+      def __callback_runner_name_cache
+        @__callback_runner_name_cache ||= Hash.new {|hash, kind| hash[kind] = __generate_callback_runner_name(kind) }
+      end
+
+      def __generate_callback_runner_name(kind)
         "_run__#{self.name.hash.abs}__#{kind}__callbacks"
+      end
+
+      def __callback_runner_name(kind)
+        __callback_runner_name_cache[kind]
       end
 
       # This is used internally to append, prepend and skip callbacks to the


### PR DESCRIPTION
From http://gusiev.com/slides/rails_contribution/static/#29

Attempt to solve the https://github.com/rails/rails/pull/6351#commitcomment-1404989

Using https://gist.github.com/2710476

``` ruby
Running benchmark with current working tree
Checkout HEAD^
Running benchmark with HEAD^
Checkout to previous HEAD again

                    user     system      total        real
-----------------------------------------------set_callback
After patch:    0.030000   0.010000   0.040000 (  0.028517)
Before patch:   0.040000   0.000000   0.040000 (  0.046620)
Improvement: 39%

-------------------------------------------define_callbacks
After patch:    0.030000   0.000000   0.030000 (  0.036352)
Before patch:   0.030000   0.000000   0.030000 (  0.036225)

----------------------------------------------run_callbacks
After patch:    0.010000   0.000000   0.010000 (  0.006695)
Before patch:   0.010000   0.000000   0.010000 (  0.011243)
Improvement: 40%

----------------------------------------------skip_callback
After patch:    0.040000   0.000000   0.040000 (  0.045709)
Before patch:   0.060000   0.000000   0.060000 (  0.054022)
Improvement: 15%
```
