### PR TITLE
Fix relative_url_root in integration tests (#8480)

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -61,6 +61,27 @@
 
     *Daniel Fox, Grant Hutchins & Trace Wax*
 
+*   Fixed integration tests so they respect RAILS_RELATIVE_URL_ROOT. Previously, url helpers
+    ignored this value, so even though the app worked, test code would not include the relative_url_root
+    in url helpers.
+
+    Before:
+        when running a test like this:
+            $ RAILS_RELATIVE_URL_ROOT='/context' rake test
+
+        tests with code like this:
+            assert_equal "http://relfoo.com/context/foo", rel_foos_url
+
+        would fail like this:
+            <"http://relbar.com/context/foo"> expected but was <"http://relbar.com/foo">.
+
+    After:
+        Tests pass, yay! :-)
+
+    Fix #8480
+
+    *Doug Smith, http://www.daveramsey.com*
+
 ## Rails 3.2.9 (Nov 12, 2012) ##
 
 *   Clear url helpers when reloading routes.

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -146,6 +146,10 @@ module ActionDispatch
       # The remote_addr used in the last request.
       attr_accessor :remote_addr
 
+      def script_name
+        @script_name ||= @app.config.relative_url_root if @app.respond_to?(:config)
+      end
+
       # The Accept header to send.
       attr_accessor :accept
 
@@ -194,7 +198,7 @@ module ActionDispatch
             url_options.reverse_merge!(@app.routes.default_url_options)
           end
 
-          url_options.reverse_merge!(:host => host, :protocol => https? ? "https" : "http")
+          url_options.reverse_merge!(:host => host, :protocol => https? ? "https" : "http", :script_name => script_name)
         end
       end
 

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -559,6 +559,7 @@ class ApplicationIntegrationTest < ActionDispatch::IntegrationTest
   end
 end
 
+# These tests are mirrored using a context root in actionpack/test/controller/url_options_with_relative_url_root_integration_test.rb
 class UrlOptionsIntegrationTest < ActionDispatch::IntegrationTest
   class FooController < ActionController::Base
     def index
@@ -624,12 +625,16 @@ class UrlOptionsIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "test can override default url options" do
+    # Setting default_url_options here bleeds over into other tests,
+    # so resetting to the original here.
+    orig_default_host = default_url_options[:host]
     default_url_options[:host] = "foobar.com"
     assert_equal "http://foobar.com/foo", foos_url
 
     get "/bar"
     assert_response :success
     assert_equal "http://foobar.com/foo", foos_url
+    orig_default_host.nil? ? default_url_options.delete(:host) : default_url_options[:host] = orig_default_host
   end
 
   test "current request path parameters are recalled" do

--- a/actionpack/test/controller/url_options_with_relative_url_root_integration_test.rb
+++ b/actionpack/test/controller/url_options_with_relative_url_root_integration_test.rb
@@ -1,0 +1,93 @@
+require 'abstract_unit'
+
+# Test classes copied and modified from actionpack/test/controller/integration_test.rb::UrlOptionsIntegrationTest
+class UrlOptionsWithRelativeUrlRootIntegrationTest < ActionDispatch::IntegrationTest
+  class FooController < ActionController::Base
+    def index
+      render :text => "foo#index"
+    end
+
+    def show
+      render :text => "foo#show"
+    end
+
+    def edit
+      render :text => "foo#show"
+    end
+  end
+
+  class BarController < ActionController::Base
+    def default_url_options
+      { :host => "relbar.com" }
+    end
+
+    def index
+      render :text => "foo#index"
+    end
+  end
+
+  def self.routes
+    @routes ||= ActionDispatch::Routing::RouteSet.new
+  end
+
+  def self.config
+    @config = ActiveSupport::InheritableOptions.new(ActionController::Base.config).tap do |config|
+      config.relative_url_root = '/context'
+      config
+    end
+  end
+
+  def self.call(env)
+    routes.call(env)
+  end
+
+  def app
+    self.class
+  end
+
+  routes.draw do
+    default_url_options :host => "relfoo.com"
+
+    scope :module => "url_options_with_relative_url_root_integration_test" do
+      get "/foo" => "foo#index", :as => :rel_foos
+      get "/foo/:id" => "foo#show", :as => :rel_foo
+      get "/foo/:id/edit" => "foo#edit", :as => :rel_edit_foo
+      get "/bar" => "bar#index", :as => :rel_bars
+    end
+  end
+
+  test "session uses default url options from routes with relative url root" do
+    assert_equal "http://relfoo.com/context/foo", rel_foos_url
+  end
+
+  test "current host overrides default url options from routes with relative url root" do
+    get "/foo"
+    assert_response :success
+    assert_equal "http://www.example.com/context/foo", rel_foos_url
+  end
+
+  test "controller can override default url options from request with relative url root" do
+    get "/bar"
+    assert_response :success
+    assert_equal "http://relbar.com/context/foo", rel_foos_url
+  end
+
+  test "test can override default url options with relative url root" do
+    # Setting default_url_options here bleeds over into other tests,
+    # so resetting to the original here.
+    orig_default_host = default_url_options[:host]
+    default_url_options[:host] = "relfoobar.com"
+    assert_equal "http://relfoobar.com/context/foo", rel_foos_url
+
+    get "/bar"
+    assert_response :success
+    assert_equal "http://relfoobar.com/context/foo", rel_foos_url
+    orig_default_host.nil? ? default_url_options.delete(:host) : default_url_options[:host] = orig_default_host
+  end
+
+  test "current request path parameters are recalled" do
+    get "/foo/1"
+    assert_response :success
+    assert_equal "/context/foo/1/edit", url_for(:action => 'edit', :only_path => true)
+  end
+end


### PR DESCRIPTION
Previously, url helpers in integration tests ignored RAILS_RELATIVE_URL_ROOT, so
even though the app worked, test code would not use the relative_url_root
in url helpers.

_Before:_
when running a test like this:
        `$ RAILS_RELATIVE_URL_ROOT='/context' rake test`

tests with code like this:
        `assert_equal "http://relfoo.com/context/foo", rel_foos_url`

would fail like this:
        `<"http://relbar.com/context/foo"> expected but was <"http://relbar.com/foo">.`

_After:_
    Tests pass, yay! :-)
