### PR TITLE
Fix rewinding in ActionDispatch::Request#raw_post

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix a bug in ActionDispatch::Request#raw_post that caused env['rack.input']
+    to be read but not rewound.
+
+    *Matt Venables*
+
 *   Prevent raising EOFError on multipart GET request (IE issue). *Adam Stankiewicz*
 
 *   Rename all action callbacks from *_filter to *_action to avoid the misconception that these

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -205,8 +205,9 @@ module ActionDispatch
     # work with raw requests directly.
     def raw_post
       unless @env.include? 'RAW_POST_DATA'
-        @env['RAW_POST_DATA'] = body.read(@env['CONTENT_LENGTH'].to_i)
-        body.rewind if body.respond_to?(:rewind)
+        raw_post_body = body
+        @env['RAW_POST_DATA'] = raw_post_body.read(@env['CONTENT_LENGTH'].to_i)
+        raw_post_body.rewind if raw_post_body.respond_to?(:rewind)
       end
       @env['RAW_POST_DATA']
     end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -650,6 +650,13 @@ class RequestTest < ActiveSupport::TestCase
     assert_equal Mime::XML, request.negotiate_mime([Mime::XML, Mime::CSV])
   end
 
+  test "raw_post rewinds rack.input if RAW_POST_DATA is nil" do
+    request = stub_request('rack.input' => StringIO.new("foo"),
+                           'CONTENT_LENGTH' => 3)
+    assert_equal "foo", request.raw_post
+    assert_equal "foo", request.env['rack.input'].read
+  end
+
   test "process parameter filter" do
     test_hashes = [
     [{'foo'=>'bar'},{'foo'=>'bar'},%w'food'],


### PR DESCRIPTION
There's a bug in `ActionDispatch::Request#raw_post`:

If `@env['RAW_POST_DATA']` is nil, `#raw_post` will attempt to set it to the result of `#body` (which will return `@env['rack.input']` if `@env['RAW_POST_DATA']` is nil). 

`#raw_post`will then attempt to rewind the result of another call to `#body`. Since `@env['RAW_POST_DATA']` has already been set, the result of `#body` is not `@env['rack.input']` anymore. 

This causes `@env['rack.input']` to never be rewound.

This is also an issue in 3.2 and earlier versions of Rails.
