### PR TITLE
Removed :if / :unless conditions to fragment cache in favour of

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Removed :if / :unless conditions to fragment cache in favour of
+    `cache_if` and `cache_unless`
+    *Angelo Capilleri*
+
 *   Fix a bug in ActionDispatch::Request#raw_post that caused env['rack.input']
     to be read but not rewound.
 

--- a/actionpack/lib/action_view/helpers/cache_helper.rb
+++ b/actionpack/lib/action_view/helpers/cache_helper.rb
@@ -113,18 +113,42 @@ module ActionView
       #
       # ==== Conditional caching
       #
-      # You can pass :if and :unless options, to conditionally perform or skip the cache.
+      # For conditional cache you can use:
       #
-      #   <%= cache @model, if: some_condition(@model) do %>
+      #   <%= cache_if condition, project do %>
+      #     <b>All the topics on this project</b>
+      #     <%= render project.topics %>
+      #   <% end %>
+      #
+      #    or
+      #
+      #   <%= cache_unless condition, project do %>
+      #     <b>All the topics on this project</b>
+      #     <%= render project.topics %>
+      #   <% end %>
       #
       def cache(name = {}, options = nil, &block)
-        if controller.perform_caching && conditions_match?(options)
+        if controller.perform_caching
           safe_concat(fragment_for(cache_fragment_name(name, options), options, &block))
         else
           yield
         end
 
         nil
+      end
+
+      def cache_if(condition, name = {}, options = nil, &block)
+        if condition
+          cache(name, options, &block)
+        else
+          yield
+        end
+
+        nil
+      end
+
+      def cache_unless(condition, name = {}, options = nil, &block)
+        cache_if !condition, name, options = nil, &block
       end
 
       # This helper returns the name of a cache key for a given fragment cache
@@ -143,10 +167,6 @@ module ActionView
       end
 
     private
-
-      def conditions_match?(options)
-        !(options && (!options.fetch(:if, true) || options.fetch(:unless, false)))
-      end
 
       def fragment_name_with_digest(name) #:nodoc:
         if @virtual_path

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -46,20 +46,20 @@ module Another
       render :inline => "<%= cache('foo%bar'){ 'Contains % sign in key' } %>"
     end
 
-    def with_fragment_cache_and_if_true_condition
-      render :inline => "<%= cache('foo', :if => true) { 'bar' } %>"
+    def with_fragment_cache_if_with_true_condition
+      render :inline => "<%= cache_if(true, 'foo') { 'bar' } %>"
     end
 
-    def with_fragment_cache_and_if_false_condition
-      render :inline => "<%= cache('foo', :if => false) { 'bar' } %>"
+    def with_fragment_cache_if_with_false_condition
+      render :inline => "<%= cache_if(false, 'foo') { 'bar' } %>"
     end
 
-    def with_fragment_cache_and_unless_false_condition
-      render :inline => "<%= cache('foo', :unless => false) { 'bar' } %>"
+    def with_fragment_cache_unless_with_false_condition
+      render :inline => "<%= cache_unless(false, 'foo') { 'bar' } %>"
     end
 
-    def with_fragment_cache_and_unless_true_condition
-      render :inline => "<%= cache('foo', :unless => true) { 'bar' } %>"
+    def with_fragment_cache_unless_with_true_condition
+      render :inline => "<%= cache_unless(true, 'foo') { 'bar' } %>"
     end
 
     def with_exception
@@ -219,9 +219,9 @@ class ACLogSubscriberTest < ActionController::TestCase
     @controller.config.perform_caching = true
   end
 
-  def test_with_fragment_cache_and_if_true
+  def test_with_fragment_cache_if_with_true
     @controller.config.perform_caching = true
-    get :with_fragment_cache_and_if_true_condition
+    get :with_fragment_cache_if_with_true_condition
     wait
 
     assert_equal 4, logs.size
@@ -231,9 +231,9 @@ class ACLogSubscriberTest < ActionController::TestCase
     @controller.config.perform_caching = true
   end
 
-  def test_with_fragment_cache_and_if_false
+  def test_with_fragment_cache_if_with_false
     @controller.config.perform_caching = true
-    get :with_fragment_cache_and_if_false_condition
+    get :with_fragment_cache_if_with_false_condition
     wait
 
     assert_equal 2, logs.size
@@ -243,9 +243,9 @@ class ACLogSubscriberTest < ActionController::TestCase
     @controller.config.perform_caching = true
   end
 
-  def test_with_fragment_cache_and_unless_true
+  def test_with_fragment_cache_unless_with_true
     @controller.config.perform_caching = true
-    get :with_fragment_cache_and_unless_true_condition
+    get :with_fragment_cache_unless_with_true_condition
     wait
 
     assert_equal 2, logs.size
@@ -255,9 +255,9 @@ class ACLogSubscriberTest < ActionController::TestCase
     @controller.config.perform_caching = true
   end
 
-  def test_with_fragment_cache_and_unless_false
+  def test_with_fragment_cache_unless_with_false
     @controller.config.perform_caching = true
-    get :with_fragment_cache_and_unless_false_condition
+    get :with_fragment_cache_unless_with_false_condition
     wait
 
     assert_equal 4, logs.size


### PR DESCRIPTION
_cache_if_ and _cache_unless_
cache_if(condition, option, &block) and cache_unless(condition, option, &block) are much concise and near to rails standard of view helpers
