### PR TITLE
Removed :if / :unless conditions to fragment cache in favour of *cache_i...

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -33,11 +33,23 @@
 
     *DHH*
 
-*   Add :if / :unless conditions to fragment cache:
+*   Add `cache_if` and `cache_unless` for conditional fragment caching:
 
-        <%= cache @model, if: some_condition(@model) do %>
+    Example:
 
-    *Stephen Ausman + Fabrizio Regini*
+        <%= cache_if condition, project do %>
+          <b>All the topics on this project</b>
+          <%= render project.topics %>
+        <% end %>
+
+        #and
+
+        <%= cache_unless condition, project do %>
+          <b>All the topics on this project</b>
+          <%= render project.topics %>
+        <% end %>
+ 
+    *Stephen Ausman + Fabrizio Regini + Angelo Capilleri*
 
 *   Add filter capability to ActionController logs for redirect locations:
 

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -46,20 +46,20 @@ module Another
       render :inline => "<%= cache('foo%bar'){ 'Contains % sign in key' } %>"
     end
 
-    def with_fragment_cache_and_if_true_condition
-      render :inline => "<%= cache('foo', :if => true) { 'bar' } %>"
+    def with_fragment_cache_if_with_true_condition
+      render :inline => "<%= cache_if(true, 'foo') { 'bar' } %>"
     end
 
-    def with_fragment_cache_and_if_false_condition
-      render :inline => "<%= cache('foo', :if => false) { 'bar' } %>"
+    def with_fragment_cache_if_with_false_condition
+      render :inline => "<%= cache_if(false, 'foo') { 'bar' } %>"
     end
 
-    def with_fragment_cache_and_unless_false_condition
-      render :inline => "<%= cache('foo', :unless => false) { 'bar' } %>"
+    def with_fragment_cache_unless_with_false_condition
+      render :inline => "<%= cache_unless(false, 'foo') { 'bar' } %>"
     end
 
-    def with_fragment_cache_and_unless_true_condition
-      render :inline => "<%= cache('foo', :unless => true) { 'bar' } %>"
+    def with_fragment_cache_unless_with_true_condition
+      render :inline => "<%= cache_unless(true, 'foo') { 'bar' } %>"
     end
 
     def with_exception
@@ -219,9 +219,9 @@ class ACLogSubscriberTest < ActionController::TestCase
     @controller.config.perform_caching = true
   end
 
-  def test_with_fragment_cache_and_if_true
+  def test_with_fragment_cache_if_with_true
     @controller.config.perform_caching = true
-    get :with_fragment_cache_and_if_true_condition
+    get :with_fragment_cache_if_with_true_condition
     wait
 
     assert_equal 4, logs.size
@@ -231,9 +231,9 @@ class ACLogSubscriberTest < ActionController::TestCase
     @controller.config.perform_caching = true
   end
 
-  def test_with_fragment_cache_and_if_false
+  def test_with_fragment_cache_if_with_false
     @controller.config.perform_caching = true
-    get :with_fragment_cache_and_if_false_condition
+    get :with_fragment_cache_if_with_false_condition
     wait
 
     assert_equal 2, logs.size
@@ -243,9 +243,9 @@ class ACLogSubscriberTest < ActionController::TestCase
     @controller.config.perform_caching = true
   end
 
-  def test_with_fragment_cache_and_unless_true
+  def test_with_fragment_cache_unless_with_true
     @controller.config.perform_caching = true
-    get :with_fragment_cache_and_unless_true_condition
+    get :with_fragment_cache_unless_with_true_condition
     wait
 
     assert_equal 2, logs.size
@@ -255,9 +255,9 @@ class ACLogSubscriberTest < ActionController::TestCase
     @controller.config.perform_caching = true
   end
 
-  def test_with_fragment_cache_and_unless_false
+  def test_with_fragment_cache_unless_with_false
     @controller.config.perform_caching = true
-    get :with_fragment_cache_and_unless_false_condition
+    get :with_fragment_cache_unless_with_false_condition
     wait
 
     assert_equal 4, logs.size


### PR DESCRIPTION
...f\* and _cache_unless_

cache_if(condition, option, &block) and cache_unless(condition, option, &block) are much concise and near to rails standard of view helpers
