### PR TITLE
recognize migrations, in folders containing numbers and 'rb'

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Recognize migrations placed in directories containing numbers and 'rb'.
+    Fix #8492
+
+    *Yves Senn*
+
 *   Add `ActiveRecord::Base.cache_timestamp_format` class attribute to control
     the format of the timestamp value in the cache key.
     This allows users to improve the precision of the cache key.

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -665,7 +665,7 @@ module ActiveRecord
         files = Dir[*paths.map { |p| "#{p}/**/[0-9]*_*.rb" }]
 
         migrations = files.map do |file|
-          version, name, scope = file.scan(/([0-9]+)_([_a-z0-9]*)\.?([_a-z0-9]*)?.rb/).first
+          version, name, scope = file.scan(/([0-9]+)_([_a-z0-9]*)\.?([_a-z0-9]*)?\.rb\z/).first
 
           raise IllegalMigrationNameError.new(file) unless version
           version = version.to_i

--- a/activerecord/test/cases/migrator_test.rb
+++ b/activerecord/test/cases/migrator_test.rb
@@ -84,6 +84,12 @@ module ActiveRecord
        end
     end
 
+    def test_finds_migrations_in_numbered_directory
+      migrations = ActiveRecord::Migrator.migrations [MIGRATIONS_ROOT + '/10_urban']
+      assert_equal 9, migrations[0].version
+      assert_equal 'AddExpressions', migrations[0].name
+    end
+
     def test_deprecated_constructor
       assert_deprecated do
         ActiveRecord::Migrator.new(:up, MIGRATIONS_ROOT + "/valid")

--- a/activerecord/test/migrations/10_urban/9_add_expressions.rb
+++ b/activerecord/test/migrations/10_urban/9_add_expressions.rb
@@ -1,0 +1,11 @@
+class AddExpressions < ActiveRecord::Migration
+  def self.up
+    create_table("expressions") do |t|
+      t.column :expression, :string
+    end
+  end
+
+  def self.down
+    drop_table "expressions"
+  end
+end


### PR DESCRIPTION
The Regexp was to wide and matched folders named with numbers and the text 'rb' as a migration. This led to problems when you have a migration inside a subdirectory named eg. "10_urban".

I added a test-case to reproduce the issue and made the Regexp more strict. I think this can be safely backported to `3-2-stable`.

Fixes #8492
