### PR TITLE
Add #to_s method to VERSION modules

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -141,7 +141,7 @@ task :update_versions do
   require File.dirname(__FILE__) + "/version"
 
   File.open("RAILS_VERSION", "w") do |f|
-    f.write Rails::VERSION::STRING + "\n"
+    f.puts Rails.version
   end
 
   constants = {

--- a/actionmailer/lib/action_mailer/version.rb
+++ b/actionmailer/lib/action_mailer/version.rb
@@ -1,10 +1,11 @@
 module ActionMailer
-  module VERSION #:nodoc:
-    MAJOR = 4
-    MINOR = 0
-    TINY  = 0
-    PRE   = "beta1"
+  # Returns the version of the currently loaded ActionMailer as a Gem::Version
+  def self.version
+    Gem::Version.new "4.0.0.beta1"
+  end
 
-    STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
+  module VERSION #:nodoc:
+    MAJOR, MINOR, TINY, PRE = ActionMailer.version.segments
+    STRING = ActionMailer.version.to_s
   end
 end

--- a/actionpack/lib/action_pack/version.rb
+++ b/actionpack/lib/action_pack/version.rb
@@ -1,10 +1,11 @@
 module ActionPack
-  module VERSION #:nodoc:
-    MAJOR = 4
-    MINOR = 0
-    TINY  = 0
-    PRE   = "beta1"
+  # Returns the version of the currently loaded ActionPack as a Gem::Version
+  def self.version
+    Gem::Version.new "4.0.0.beta1"
+  end
 
-    STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
+  module VERSION #:nodoc:
+    MAJOR, MINOR, TINY, PRE = ActionPack.version.segments
+    STRING = ActionPack.version.to_s
   end
 end

--- a/activemodel/lib/active_model/version.rb
+++ b/activemodel/lib/active_model/version.rb
@@ -1,10 +1,11 @@
 module ActiveModel
-  module VERSION #:nodoc:
-    MAJOR = 4
-    MINOR = 0
-    TINY  = 0
-    PRE   = "beta1"
+  # Returns the version of the currently loaded ActiveModel as a Gem::Version
+  def self.version
+    Gem::Version.new "4.0.0.beta1"
+  end
 
-    STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
+  module VERSION #:nodoc:
+    MAJOR, MINOR, TINY, PRE = ActiveModel.version.segments
+    STRING = ActiveModel.version.to_s
   end
 end

--- a/activerecord/lib/active_record/version.rb
+++ b/activerecord/lib/active_record/version.rb
@@ -1,10 +1,11 @@
 module ActiveRecord
-  module VERSION #:nodoc:
-    MAJOR = 4
-    MINOR = 0
-    TINY  = 0
-    PRE   = "beta1"
+  # Returns the version of the currently loaded ActiveRecord as a Gem::Version
+  def self.version
+    Gem::Version.new "4.0.0.beta1"
+  end
 
-    STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
+  module VERSION #:nodoc:
+    MAJOR, MINOR, TINY, PRE = ActiveRecord.version.segments
+    STRING = ActiveRecord.version.to_s
   end
 end

--- a/activesupport/lib/active_support/version.rb
+++ b/activesupport/lib/active_support/version.rb
@@ -1,10 +1,11 @@
 module ActiveSupport
-  module VERSION #:nodoc:
-    MAJOR = 4
-    MINOR = 0
-    TINY  = 0
-    PRE   = "beta1"
+  # Returns the version of the currently loaded ActiveSupport as a Gem::Version
+  def self.version
+    Gem::Version.new "4.0.0.beta1"
+  end
 
-    STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
+  module VERSION #:nodoc:
+    MAJOR, MINOR, TINY, PRE = ActiveSupport.version.segments
+    STRING = ActiveSupport.version.to_s
   end
 end

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `Rails.version` now returns an instance of `Gem::Version`
+
+    *Charlie Somerville*
+
 *   Don't generate a scaffold.css when --no-assets is specified
 
     *Kevin Glowacz*

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -82,10 +82,6 @@ module Rails
       groups
     end
 
-    def version
-      VERSION::STRING
-    end
-
     def public_path
       application && Pathname.new(application.paths["public"].first)
     end

--- a/railties/lib/rails/commands/application.rb
+++ b/railties/lib/rails/commands/application.rb
@@ -1,7 +1,7 @@
 require 'rails/version'
 
 if ['--version', '-v'].include?(ARGV.first)
-  puts "Rails #{Rails::VERSION::STRING}"
+  puts "Rails #{Rails.version}"
   exit(0)
 end
 

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -1,7 +1,7 @@
 require 'digest/md5'
 require 'securerandom'
 require 'active_support/core_ext/string/strip'
-require 'rails/version' unless defined?(Rails::VERSION)
+require 'rails/version' unless defined?(Rails.version)
 require 'rbconfig'
 require 'open-uri'
 require 'uri'
@@ -142,7 +142,7 @@ module Rails
         else
           <<-GEMFILE.strip_heredoc
             # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-            gem 'rails', '#{Rails::VERSION::STRING}'
+            gem 'rails', '#{Rails.version}'
           GEMFILE
         end
       end

--- a/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 <% end -%>
 
-  <%= '# ' if options.dev? || options.edge? -%>s.add_dependency "rails", "~> <%= Rails::VERSION::STRING %>"
+  <%= '# ' if options.dev? || options.edge? -%>s.add_dependency "rails", "~> <%= Rails.version %>"
 <% unless options[:skip_active_record] -%>
 
   s.add_development_dependency "<%= gem_for_database %>"

--- a/railties/lib/rails/generators/rails/plugin_new/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 <% if options[:skip_gemspec] -%>
-<%= '# ' if options.dev? || options.edge? -%>gem "rails", "~> <%= Rails::VERSION::STRING %>"
+<%= '# ' if options.dev? || options.edge? -%>gem "rails", "~> <%= Rails.version %>"
 <% else -%>
 # Declare your gem's dependencies in <%= name %>.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and

--- a/railties/lib/rails/info.rb
+++ b/railties/lib/rails/info.rb
@@ -29,7 +29,7 @@ module Rails
       def framework_version(framework)
         if Object.const_defined?(framework.classify)
           require "#{framework}/version"
-          "#{framework.classify}::VERSION::STRING".constantize
+          framework.classify.constantize.version.to_s
         end
       end
 
@@ -75,7 +75,7 @@ module Rails
 
     # The Rails version.
     property 'Rails version' do
-      Rails::VERSION::STRING
+      Rails.version.to_s
     end
 
     property 'JavaScript Runtime' do

--- a/railties/lib/rails/version.rb
+++ b/railties/lib/rails/version.rb
@@ -1,10 +1,11 @@
 module Rails
-  module VERSION #:nodoc:
-    MAJOR = 4
-    MINOR = 0
-    TINY  = 0
-    PRE   = "beta1"
+  # Returns the version of the currently loaded Rails as a Gem::Version
+  def self.version
+    Gem::Version.new "4.0.0.beta1"
+  end
 
-    STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
+  module VERSION #:nodoc:
+    MAJOR, MINOR, TINY, PRE = Rails.version.segments
+    STRING = Rails.version.to_s
   end
 end

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -292,7 +292,7 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
     assert_no_file "bukkits.gemspec"
     assert_file "Gemfile" do |contents|
       assert_no_match('gemspec', contents)
-      assert_match(/gem "rails", "~> #{Rails::VERSION::STRING}"/, contents)
+      assert_match(/gem "rails", "~> #{Rails.version}"/, contents)
       assert_match(/group :development do\n  gem "sqlite3"\nend/, contents)
       assert_no_match(/# gem "jquery-rails"/, contents)
     end
@@ -303,7 +303,7 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
     assert_no_file "bukkits.gemspec"
     assert_file "Gemfile" do |contents|
       assert_no_match('gemspec', contents)
-      assert_match(/gem "rails", "~> #{Rails::VERSION::STRING}"/, contents)
+      assert_match(/gem "rails", "~> #{Rails.version}"/, contents)
       assert_match(/group :development do\n  gem "sqlite3"\nend/, contents)
     end
   end

--- a/railties/test/rails_info_test.rb
+++ b/railties/test/rails_info_test.rb
@@ -38,7 +38,7 @@ class InfoTest < ActiveSupport::TestCase
   end
 
   def test_framework_version
-    assert_property 'Active Support version', ActiveSupport::VERSION::STRING
+    assert_property 'Active Support version', ActiveSupport.version
   end
 
   def test_frameworks_exist

--- a/version.rb
+++ b/version.rb
@@ -1,10 +1,10 @@
 module Rails
-  module VERSION #:nodoc:
-    MAJOR = 4
-    MINOR = 0
-    TINY  = 0
-    PRE   = "beta1"
+  def self.version
+    Gem::Version.new "4.0.0.beta1"
+  end
 
-    STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
+  module VERSION #:nodoc:
+    MAJOR, MINOR, TINY, PRE = Rails.version.segments
+    STRING = Rails.version.to_s
   end
 end


### PR DESCRIPTION
IMO this is pretty useless behaviour:

``` ruby
>> Rails::VERSION
=> Rails::VERSION
>> ActiveSupport::VERSION
=> ActiveSupport::VERSION
```

This patch adds a `#to_s` method so that accessing `*::VERSION` gives useful output in REPLs, etc:

``` ruby
>> Rails::VERSION
=> 4.0.0.beta
>> ActiveSupport::VERSION
=> 4.0.0.beta
```
