### PR TITLE
Backport of #8500, recognize migrations, in folders containing numbers and 'rb'.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 3.2.10 (unreleased)
 
+*   Recognize migrations placed in directories containing numbers and 'rb'.
+    Fix #8492
+    Backport of #8500
+
+    *Yves Senn*
+
 *   Add `ActiveRecord::Base.cache_timestamp_format` class attribute to control
     the format of the timestamp value in the cache key.
     This allows users to improve the precision of the cache key.

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -627,7 +627,7 @@ module ActiveRecord
         seen = Hash.new false
 
         migrations = files.map do |file|
-          version, name, scope = file.scan(/([0-9]+)_([_a-z0-9]*)\.?([_a-z0-9]*)?.rb/).first
+          version, name, scope = file.scan(/([0-9]+)_([_a-z0-9]*)\.?([_a-z0-9]*)?\.rb\z/).first
 
           raise IllegalMigrationNameError.new(file) unless version
           version = version.to_i

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1430,6 +1430,12 @@ if ActiveRecord::Base.connection.supports_migrations?
       end
     end
 
+    def test_finds_migrations_in_numbered_directory
+      migrations = ActiveRecord::Migrator.migrations [MIGRATIONS_ROOT + '/10_urban']
+      assert_equal 9, migrations[0].version
+      assert_equal 'AddExpressions', migrations[0].name
+    end
+
     def test_dump_schema_information_outputs_lexically_ordered_versions
       migration_path = MIGRATIONS_ROOT + '/valid_with_timestamps'
       ActiveRecord::Migrator.run(:up, migration_path, 20100301010101)

--- a/activerecord/test/migrations/10_urban/9_add_expressions.rb
+++ b/activerecord/test/migrations/10_urban/9_add_expressions.rb
@@ -1,0 +1,11 @@
+class AddExpressions < ActiveRecord::Migration
+  def self.up
+    create_table("expressions") do |t|
+      t.column :expression, :string
+    end
+  end
+
+  def self.down
+    drop_table "expressions"
+  end
+end


### PR DESCRIPTION
Backport of #8500
Closes #8492

Conflicts:

```
activerecord/test/cases/migrator_test.rb
```

The `migrator_test.rb` does not exist on `rails/3-2-stable`. I incorporated the test-case into the `migrations_test.rb`
