### PR TITLE
Do not log the binding values for binary columns.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Do not log the binding values for binary columns.
+
+    *Matthew M. Boedicker*
+
 *   Fix counter cache columns not updated when replacing `has_many :through`
     associations.
 

--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -20,6 +20,16 @@ module ActiveRecord
       @odd_or_even = false
     end
 
+    def render_bind(column, value)
+      if column.type == :binary
+        rendered_value = "<#{value.bytesize} bytes of binary data>"
+      else
+        rendered_value = value
+      end
+
+      [column.name, rendered_value]
+    end
+
     def sql(event)
       self.class.runtime += event.duration
       return unless logger.debug?
@@ -34,7 +44,7 @@ module ActiveRecord
 
       unless (payload[:binds] || []).empty?
         binds = "  " + payload[:binds].map { |col,v|
-          [col.name, v]
+          render_bind(col, v)
         }.inspect
       end
 

--- a/activerecord/test/cases/log_subscriber_test.rb
+++ b/activerecord/test/cases/log_subscriber_test.rb
@@ -1,4 +1,5 @@
 require "cases/helper"
+require "models/binary"
 require "models/developer"
 require "models/post"
 require "active_support/log_subscriber/test_helper"
@@ -99,5 +100,12 @@ class LogSubscriberTest < ActiveRecord::TestCase
 
   def test_initializes_runtime
     Thread.new { assert_equal 0, ActiveRecord::LogSubscriber.runtime }.join
+  end
+
+  def test_binary_data_is_not_logged
+    Binary.create(:data => 'some binary data')
+    wait
+    assert_equal 3, @logger.logged(:debug).size
+    assert_match(/<16 bytes of binary data>/, @logger.logged(:debug)[-2])
   end
 end


### PR DESCRIPTION
They tend to be large and not very useful in the log.
