### PR TITLE
AS::BasicObject cannot be inherited from

### DIFF
--- a/activesupport/lib/active_support/basic_object.rb
+++ b/activesupport/lib/active_support/basic_object.rb
@@ -1,7 +1,12 @@
 require 'active_support/deprecation'
+require 'active_support/proxy_object'
 
 module ActiveSupport
   # :nodoc:
-  # Deprecated in favor of ActiveSupport::ProxyObject
-  BasicObject = Deprecation::DeprecatedConstantProxy.new('ActiveSupport::BasicObject', 'ActiveSupport::ProxyObject')
+  class BasicObject < ProxyObject
+    def self.inherited(*)
+      ::ActiveSupport::Deprecation.warn 'ActiveSupport::BasicObject is deprecated! Use ActiveSupport::ProxyObject instead.'
+      super
+    end
+  end
 end

--- a/activesupport/test/deprecation/basic_object_test.rb
+++ b/activesupport/test/deprecation/basic_object_test.rb
@@ -1,0 +1,12 @@
+require 'abstract_unit'
+require 'active_support/deprecation'
+require 'active_support/basic_object'
+
+
+class BasicObjectTest < ActiveSupport::TestCase
+  test 'BasicObject warns about deprecation when inherited from' do
+    warn = 'ActiveSupport::BasicObject is deprecated! Use ActiveSupport::ProxyObject instead.'
+    ActiveSupport::Deprecation.expects(:warn).with(warn).once
+    Class.new(ActiveSupport::BasicObject)
+  end
+end


### PR DESCRIPTION
In #8454 `ActiveSupport::BasicObject` was deprecated. And this broke the inheritance.

AFIK, the class was made mainly to be inherited from. Now if you try doing something like this:

``` ruby
class Foo < ActiveSupport::BasicObject
end
```

you'll get this error:

```
wrong argument type ActiveSupport::Deprecation::DeprecatedConstantProxy (expected Class) (TypeError)
```

which I believe is not a good way to deprecate a class, 99% of usage for is to be inherited from.

Since the class itself does not contain any methods, there is no point of using `DeprecatedConstantProxy` to deprecate it.
