### PR TITLE
improved `assert_template` when matching :locals

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `assert_template` can be used to verify the locals of partials,
+    which live inside a directory.
+    Fixes #8516.
+
+        # Prefixed partials inside directories worked and still work.
+        assert_template partial: 'directory/_partial', locals: {name: 'John'}
+
+        # This did not work but does now.
+        assert_template partial: 'directory/partial', locals: {name: 'John'}
+
+    *Yves Senn*
+
 *   Fix `content_tag_for` with array html option.
     It would embed array as string instead of joining it like `content_tag` does:
 
@@ -248,7 +260,7 @@
 
 *   More descriptive error messages when calling `render :partial` with
     an invalid `:layout` argument.
-    
+
     Fixes #8376.
 
         render partial: 'partial', layout: true

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -126,7 +126,8 @@ module ActionController
         if expected_partial = options[:partial]
           if expected_locals = options[:locals]
             if defined?(@_rendered_views)
-              view = expected_partial.to_s.sub(/^_/,'')
+              view = expected_partial.to_s.sub(/^_/, '').sub(/\/_(?=[^\/]+\z)/, '/')
+
               partial_was_not_rendered_msg = "expected %s to be rendered but it was not." % view
               assert_includes @_rendered_views.rendered_views, view, partial_was_not_rendered_msg
 

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -127,6 +127,9 @@ module ActionController
           if expected_locals = options[:locals]
             if defined?(@_rendered_views)
               view = expected_partial.to_s.sub(/^_/,'')
+              partial_was_not_rendered_msg = "expected %s to be rendered but it was not." % view
+              assert_includes @_rendered_views.rendered_views, view, partial_was_not_rendered_msg
+
               msg = 'expecting %s to be rendered with %s but was with %s' % [expected_partial,
                                                                              expected_locals,
                                                                              @_rendered_views.locals_for(view)]

--- a/actionpack/lib/action_view/test_case.rb
+++ b/actionpack/lib/action_view/test_case.rb
@@ -122,7 +122,7 @@ module ActionView
 
       class RenderedViewsCollection
         def initialize
-          @rendered_views ||= {}
+          @rendered_views ||= Hash.new { |hash, key| hash[key] = [] }
         end
 
         def add(view, locals)

--- a/actionpack/lib/action_view/test_case.rb
+++ b/actionpack/lib/action_view/test_case.rb
@@ -134,6 +134,10 @@ module ActionView
           @rendered_views[view]
         end
 
+        def rendered_views
+          @rendered_views.keys
+        end
+
         def view_rendered?(view, expected_locals)
           locals_for(view).any? do |actual_locals|
             expected_locals.all? {|key, value| value == actual_locals[key] }

--- a/actionpack/test/fixtures/test/_directory/_partial_with_locales.html.erb
+++ b/actionpack/test/fixtures/test/_directory/_partial_with_locales.html.erb
@@ -1,0 +1,1 @@
+Hello <%= name %>

--- a/actionpack/test/fixtures/test/render_partial_inside_directory.html.erb
+++ b/actionpack/test/fixtures/test/render_partial_inside_directory.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'test/_directory/partial_with_locales', locals: {'name' => 'Jane'} %>

--- a/actionpack/test/template/test_case_test.rb
+++ b/actionpack/test/template/test_case_test.rb
@@ -338,6 +338,18 @@ module ActionView
       assert_match "i_was_never_rendered to be rendered but it was not.", e.message
       assert_match 'Expected ["/test/partial"] to include "i_was_never_rendered"', e.message
     end
+
+    test 'specifying locals works when the partial is inside a directory with underline prefix' do
+      controller.controller_path = "test"
+      render(template: 'test/render_partial_inside_directory')
+      assert_template partial: 'test/_directory/_partial_with_locales', locals: { 'name' => 'Jane' }
+    end
+
+    test 'specifying locals works when the partial is inside a directory without underline prefix' do
+      controller.controller_path = "test"
+      render(template: 'test/render_partial_inside_directory')
+      assert_template partial: 'test/_directory/partial_with_locales', locals: { 'name' => 'Jane' }
+    end
   end
 
   module AHelperWithInitialize

--- a/actionpack/test/template/test_case_test.rb
+++ b/actionpack/test/template/test_case_test.rb
@@ -329,6 +329,15 @@ module ActionView
       assert_template partial: '_partial', locals: { 'second' => '2' }
     end
 
+    test 'raises descriptive error message when template was not rendered' do
+      controller.controller_path = "test"
+      render(template: "test/hello_world_with_partial")
+      e = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_template partial: 'i_was_never_rendered', locals: { 'did_not' => 'happen' }
+      end
+      assert_match "i_was_never_rendered to be rendered but it was not.", e.message
+      assert_match 'Expected ["/test/partial"] to include "i_was_never_rendered"', e.message
+    end
   end
 
   module AHelperWithInitialize


### PR DESCRIPTION
This PR improves two aspects of `assert_template` when used with the :locals option.
### 1. descriptive error message when the partial wasn't rendered

When `assert_template` is used with the :locals option, and the partial was not rendered, a method_missing error was raised. This changes first checks, if the partial actually was rendered and raises a descriptive error.
### 2. recognize partial inside a directory

previously when a partial was placed inside a directory (eg. '/dir/_partial'), `assert_template` did not replace the '_' prefix when looking through rendered tempaltes, which resulted in an error.

I modified it to replace both, the leading '_' and the last '_' after a '/'.

This is a fix for #8516
