### PR TITLE
keep index names when using `alter_table` with sqlite3

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Keep index names when using `alter_table` with sqlite3.
+    Fix #3489
+
+    *Yves Senn*
+
 *   Add ability for postgresql adapter to disable user triggers in disable_referential_integrity.
     Fix #5523
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -537,7 +537,6 @@ module ActiveRecord
             end
             yield @definition if block_given?
           end
-
           copy_table_indexes(from, to, options[:rename] || {})
           copy_table_contents(from, to,
             @definition.columns.map {|column| column.name},
@@ -560,7 +559,7 @@ module ActiveRecord
 
             unless columns.empty?
               # index name can't be the same
-              opts = { :name => name.gsub(/_(#{from})_/, "_#{to}_") }
+              opts = { name: name.gsub(/(^|_)(#{from})_/, "\\1#{to}_") }
               opts[:unique] = true if index.unique
               add_index(to, columns, opts)
             end

--- a/activerecord/test/cases/migration/rename_column_test.rb
+++ b/activerecord/test/cases/migration/rename_column_test.rb
@@ -173,6 +173,16 @@ module ActiveRecord
         refute TestModel.new.administrator?
       end
 
+      def test_change_column_with_custom_index_name
+        add_column "test_models", "category", :string
+        add_index :test_models, :category, name: 'test_models_categories_idx'
+
+        assert_equal ['test_models_categories_idx'], connection.indexes('test_models').map(&:name)
+        change_column "test_models", "category", :string, null: false, default: 'article'
+
+        assert_equal ['test_models_categories_idx'], connection.indexes('test_models').map(&:name)
+      end
+
       def test_change_column_default
         add_column "test_models", "first_name", :string
         connection.change_column_default "test_models", "first_name", "Tester"


### PR DESCRIPTION
The code in `SQLite3Adapter#copy_table_indexes` wrongly renamed indexes when using `alter_table`. This only happened for indexes, which begin with the table name. As soon as they had a prefix it worked.

This patch makes `#copy_table_indexes` aware that no prefix is required. It is a fix for #3489
