### PR TITLE
Add a method full_messages_for to the Errors class

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -364,6 +364,20 @@ module ActiveModel
     def full_messages
       map { |attribute, message| full_message(attribute, message) }
     end
+    
+    # Returns all the full error messages for a given attribute in an array.
+    #
+    #   class Person
+    #     validates_presence_of :name
+    #     validates_length_of :name, in: 5..30
+    #   end
+    #
+    #   person = Person.create()
+    #   person.errors.full_messages_for(:name)
+    #   # => ["Name is too short (minimum is 5 characters)", "Name can't be blank"]
+    def full_messages_for(attribute)
+      get(attribute).map { |message| full_message(attribute, message) }
+    end
 
     # Returns a full message for a given attribute.
     #


### PR DESCRIPTION
Which is pretty useful in the common case when you need to display 
the error messages for each attribute near it's field.
