### PR TITLE
Add a method full_messages_for to the Errors class

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add ActiveModel::Errors#full_messages_for, a method that returns all the error
+    messages for a given attribute.
+
+    *Volodymyr Shatsky*
+
 *   Added a method so that validations can be easily cleared on a model.
     For example:
 

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -352,6 +352,20 @@ module ActiveModel
       map { |attribute, message| full_message(attribute, message) }
     end
 
+    # Returns all the full error messages for a given attribute in an array.
+    #
+    #   class Person
+    #     validates_presence_of :name, :email
+    #     validates_length_of :name, in: 5..30
+    #   end
+    #
+    #   person = Person.create()
+    #   person.errors.full_messages_for(:name)
+    #   # => ["Name is too short (minimum is 5 characters)", "Name can't be blank"]
+    def full_messages_for(attribute)
+      (get(attribute) || []).map { |message| full_message(attribute, message) }
+    end
+
     # Returns a full message for a given attribute.
     #
     #   person.errors.full_message(:name, 'is invalid') # => "Name is invalid"

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -216,6 +216,26 @@ class ErrorsTest < ActiveModel::TestCase
     person.errors.add(:name, "can not be nil")
     assert_equal ["name can not be blank", "name can not be nil"], person.errors.full_messages
   end
+  
+  test 'full_messages_for should contain all the messages for a given attribute' do
+    person = Person.new
+    person.errors.add(:name, "can not be blank")
+    person.errors.add(:name, "can not be nil")
+    assert_equal ["name can not be blank", "name can not be nil"], person.errors.full_messages_for(:name)
+  end
+
+  test 'full_messages_for should not contain messages for another attributes' do
+    person = Person.new
+    person.errors.add(:name, "can not be blank")
+    person.errors.add(:email, "can not be blank")
+    assert_equal ["name can not be blank"], person.errors.full_messages_for(:name)
+  end
+
+  test "full_messages_for should return an empty array in case if errors hash doesn't contain a given attribute" do
+    person = Person.new
+    person.errors.add(:name, "can not be blank")
+    assert_equal [], person.errors.full_messages_for(:email)
+  end
 
   test 'full_message should return the given message if attribute equals :base' do
     person = Person.new


### PR DESCRIPTION
Which is pretty useful in the common case when you need to display the error messages for each attribute near it's field.
