### PR TITLE
Custom dependency trackers for the template digestor

### DIFF
--- a/actionpack/lib/action_view/dependency_tracker.rb
+++ b/actionpack/lib/action_view/dependency_tracker.rb
@@ -22,7 +22,7 @@ module ActionView
       @trackers.delete(handler)
     end
 
-    class ErbTracker
+    class ERBTracker
       EXPLICIT_DEPENDENCY = /# Template Dependency: (\S+)/
 
       # Matches:
@@ -81,6 +81,6 @@ module ActionView
         end
     end
 
-    register_tracker Template::Handlers::ERB, ErbTracker
+    register_tracker Template::Handlers::ERB, ERBTracker
   end
 end

--- a/actionpack/lib/action_view/dependency_tracker.rb
+++ b/actionpack/lib/action_view/dependency_tracker.rb
@@ -5,8 +5,13 @@ module ActionView
     @trackers = ThreadSafe::Cache.new
 
     def self.find_dependencies(name, template)
-      handler = template.handler
-      @trackers.fetch(handler).call(name, template)
+      tracker = @trackers[template.handler]
+
+      if tracker.present?
+        tracker.call(name, template)
+      else
+        []
+      end
     end
 
     def self.register_tracker(handler, tracker)

--- a/actionpack/lib/action_view/dependency_tracker.rb
+++ b/actionpack/lib/action_view/dependency_tracker.rb
@@ -1,6 +1,8 @@
+require 'thread_safe'
+
 module ActionView
   class DependencyTracker
-    @trackers = Hash.new
+    @trackers = ThreadSafe::Cache.new
 
     def self.find_dependencies(name, template)
       handler = template.handler

--- a/actionpack/lib/action_view/dependency_tracker.rb
+++ b/actionpack/lib/action_view/dependency_tracker.rb
@@ -1,0 +1,66 @@
+module ActionView
+  class DependencyTracker
+    def self.find_dependencies(name, template)
+      ErbTracker.call(name, template)
+    end
+
+    class ErbTracker
+      EXPLICIT_DEPENDENCY = /# Template Dependency: (\S+)/
+
+      # Matches:
+      #   render partial: "comments/comment", collection: commentable.comments
+      #   render "comments/comments"
+      #   render 'comments/comments'
+      #   render('comments/comments')
+      #
+      #   render(@topic)         => render("topics/topic")
+      #   render(topics)         => render("topics/topic")
+      #   render(message.topics) => render("topics/topic")
+      RENDER_DEPENDENCY = /
+        render\s*                     # render, followed by optional whitespace
+        \(?                           # start an optional parenthesis for the render call
+        (partial:|:partial\s+=>)?\s*  # naming the partial, used with collection -- 1st capture
+        ([@a-z"'][@a-z_\/\."']+)      # the template name itself -- 2nd capture
+      /x
+
+      def self.call(name, template)
+        new(name, template).call
+      end
+
+      def initialize(name, template)
+        @name, @template = name, template
+      end
+
+      def call
+        render_dependencies + explicit_dependencies
+      end
+
+      private
+        attr_reader :name, :template
+
+        def directory
+          name.split("/")[0..-2].join("/")
+        end
+
+        def render_dependencies
+          template.source.scan(RENDER_DEPENDENCY).
+            collect(&:second).uniq.
+
+            # render(@topic)         => render("topics/topic")
+            # render(topics)         => render("topics/topic")
+            # render(message.topics) => render("topics/topic")
+            collect { |name| name.sub(/\A@?([a-z]+\.)*([a-z_]+)\z/) { "#{$2.pluralize}/#{$2.singularize}" } }.
+
+            # render("headline") => render("message/headline")
+            collect { |name| name.include?("/") ? name : "#{directory}/#{name}" }.
+
+            # replace quotes from string renders
+            collect { |name| name.gsub(/["']/, "") }
+        end
+
+        def explicit_dependencies
+          template.source.scan(EXPLICIT_DEPENDENCY).flatten.uniq
+        end
+    end
+  end
+end

--- a/actionpack/lib/action_view/dependency_tracker.rb
+++ b/actionpack/lib/action_view/dependency_tracker.rb
@@ -1,7 +1,18 @@
 module ActionView
   class DependencyTracker
+    @trackers = Hash.new
+
     def self.find_dependencies(name, template)
-      ErbTracker.call(name, template)
+      handler = template.handler
+      @trackers.fetch(handler).call(name, template)
+    end
+
+    def self.register_tracker(handler, tracker)
+      @trackers[handler] = tracker
+    end
+
+    def self.remove_tracker(handler)
+      @trackers.delete(handler)
     end
 
     class ErbTracker
@@ -62,5 +73,7 @@ module ActionView
           template.source.scan(EXPLICIT_DEPENDENCY).flatten.uniq
         end
     end
+
+    register_tracker Template::Handlers::ERB, ErbTracker
   end
 end

--- a/actionpack/lib/action_view/digestor.rb
+++ b/actionpack/lib/action_view/digestor.rb
@@ -1,25 +1,8 @@
 require 'thread_safe'
+require 'action_view/dependency_tracker'
 
 module ActionView
   class Digestor
-    EXPLICIT_DEPENDENCY = /# Template Dependency: (\S+)/
-
-    # Matches:
-    #   render partial: "comments/comment", collection: commentable.comments
-    #   render "comments/comments"
-    #   render 'comments/comments'
-    #   render('comments/comments')
-    #
-    #   render(@topic)         => render("topics/topic")
-    #   render(topics)         => render("topics/topic")
-    #   render(message.topics) => render("topics/topic")
-    RENDER_DEPENDENCY = /
-      render\s*                     # render, followed by optional whitespace
-      \(?                           # start an optional parenthesis for the render call
-      (partial:|:partial\s+=>)?\s*  # naming the partial, used with collection -- 1st capture
-      ([@a-z"'][@a-z_\/\."']+)      # the template name itself -- 2nd capture
-    /x
-
     cattr_reader(:cache)
     @@cache = ThreadSafe::Cache.new
 
@@ -47,7 +30,7 @@ module ActionView
     end
 
     def dependencies
-      render_dependencies + explicit_dependencies
+      DependencyTracker.find_dependencies(name, template)
     rescue ActionView::MissingTemplate
       [] # File doesn't exist, so no dependencies
     end
@@ -69,16 +52,16 @@ module ActionView
         name.gsub(%r|/_|, "/")
       end
 
-      def directory
-        name.split("/")[0..-2].join("/")
-      end
-
       def partial?
         false
       end
 
+      def template
+        @template ||= finder.find(logical_name, [], partial?, formats: [ format ])
+      end
+
       def source
-        @source ||= finder.find(logical_name, [], partial?, formats: [ format ]).source
+        template.source
       end
 
       def dependency_digest
@@ -87,26 +70,6 @@ module ActionView
         end
 
         (template_digests + injected_dependencies).join("-")
-      end
-
-      def render_dependencies
-        source.scan(RENDER_DEPENDENCY).
-          collect(&:second).uniq.
-
-          # render(@topic)         => render("topics/topic")
-          # render(topics)         => render("topics/topic")
-          # render(message.topics) => render("topics/topic")
-          collect { |name| name.sub(/\A@?([a-z]+\.)*([a-z_]+)\z/) { "#{$2.pluralize}/#{$2.singularize}" } }.
-
-          # render("headline") => render("message/headline")
-          collect { |name| name.include?("/") ? name : "#{directory}/#{name}" }.
-
-          # replace quotes from string renders
-          collect { |name| name.gsub(/["']/, "") }
-      end
-
-      def explicit_dependencies
-        source.scan(EXPLICIT_DEPENDENCY).flatten.uniq
       end
 
       def injected_dependencies

--- a/actionpack/test/template/dependency_tracker_test.rb
+++ b/actionpack/test/template/dependency_tracker_test.rb
@@ -3,6 +3,7 @@ require 'action_view/dependency_tracker'
 
 class DependencyTrackerTest < ActionView::TestCase
   Neckbeard = Class.new
+  Bowtie = Class.new
 
   class NeckbeardTracker
     def self.call(name, template)
@@ -13,8 +14,8 @@ class DependencyTrackerTest < ActionView::TestCase
   class FakeTemplate
     attr_reader :source, :handler
 
-    def initialize(source)
-      @source, @handler = source, Neckbeard
+    def initialize(source, handler = Neckbeard)
+      @source, @handler = source, handler
     end
   end
 
@@ -34,5 +35,11 @@ class DependencyTrackerTest < ActionView::TestCase
     template = FakeTemplate.new("boo/hoo")
     dependencies = tracker.find_dependencies("boo/hoo", template)
     assert_equal ["foo/boo/hoo"], dependencies
+  end
+
+  def test_returns_empty_array_if_no_tracker_is_found
+    template = FakeTemplate.new("boo/hoo", Bowtie)
+    dependencies = tracker.find_dependencies("boo/hoo", template)
+    assert_equal [], dependencies
   end
 end

--- a/actionpack/test/template/dependency_tracker_test.rb
+++ b/actionpack/test/template/dependency_tracker_test.rb
@@ -2,8 +2,8 @@ require 'abstract_unit'
 require 'action_view/dependency_tracker'
 
 class DependencyTrackerTest < ActionView::TestCase
-  Neckbeard = Class.new
-  Bowtie = Class.new
+  Neckbeard = lambda {|template| template.source }
+  Bowtie = lambda {|template| template.source }
 
   class NeckbeardTracker
     def self.call(name, template)
@@ -24,11 +24,12 @@ class DependencyTrackerTest < ActionView::TestCase
   end
 
   def setup
-    tracker.register_tracker(Neckbeard, NeckbeardTracker)
+    ActionView::Template.register_template_handler :neckbeard, Neckbeard
+    tracker.register_tracker(:neckbeard, NeckbeardTracker)
   end
 
   def teardown
-    tracker.remove_tracker(Neckbeard)
+    tracker.remove_tracker(:neckbeard)
   end
 
   def test_finds_tracker_by_template_handler

--- a/actionpack/test/template/dependency_tracker_test.rb
+++ b/actionpack/test/template/dependency_tracker_test.rb
@@ -1,0 +1,38 @@
+require 'abstract_unit'
+require 'action_view/dependency_tracker'
+
+class DependencyTrackerTest < ActionView::TestCase
+  Neckbeard = Class.new
+
+  class NeckbeardTracker
+    def self.call(name, template)
+      ["foo/#{name}"]
+    end
+  end
+
+  class FakeTemplate
+    attr_reader :source, :handler
+
+    def initialize(source)
+      @source, @handler = source, Neckbeard
+    end
+  end
+
+  def tracker
+    ActionView::DependencyTracker
+  end
+
+  def setup
+    tracker.register_tracker(Neckbeard, NeckbeardTracker)
+  end
+
+  def teardown
+    tracker.remove_tracker(Neckbeard)
+  end
+
+  def test_finds_tracker_by_template_handler
+    template = FakeTemplate.new("boo/hoo")
+    dependencies = tracker.find_dependencies("boo/hoo", template)
+    assert_equal ["foo/boo/hoo"], dependencies
+  end
+end

--- a/actionpack/test/template/digestor_test.rb
+++ b/actionpack/test/template/digestor_test.rb
@@ -6,7 +6,7 @@ class FixtureTemplate
 
   def initialize(template_path)
     @source = File.read(template_path)
-    @handler = ActionView::Template::Handlers::ERB
+    @handler = ActionView::Template.handler_for_extension(:erb)
   rescue Errno::ENOENT
     raise ActionView::MissingTemplate.new([], "", [], true, [])
   end

--- a/actionpack/test/template/digestor_test.rb
+++ b/actionpack/test/template/digestor_test.rb
@@ -2,10 +2,11 @@ require 'abstract_unit'
 require 'fileutils'
 
 class FixtureTemplate
-  attr_reader :source
+  attr_reader :source, :handler
 
   def initialize(template_path)
     @source = File.read(template_path)
+    @handler = ActionView::Template::Handlers::ERB
   rescue Errno::ENOENT
     raise ActionView::MissingTemplate.new([], "", [], true, [])
   end


### PR DESCRIPTION
I'm working on a Liquid style templating system, and would like to take advantage of Action View's template digestor. However, there are no direct calls to `render` from within the template itself, but rather in an accompanying "presenter"/"view model"/whatever. Therefore, the approach currently taken by Digestor falls short of tracking the dependencies. Furthermore, since these templates would be user-supplied, I would rather avoid having to put in explicit dependency markers in the source itself, instead preferring to let the presenters do that.

I've refactored Digestor so that it is possible to register a custom dependency tracker. I'm not sure if the nomenclature is perfect, so I'm of course open for suggestions.

Currently, the tracker is chosen based on the template handler, which should roughly correspond to the template language. I'd like a better way of looking up trackers, e.g. by having each Template know its "language". That would be a bigger change than seems necessary right now, though.

Another question is whether the dependency tracker should default to the ErbTracker, which perhaps should be renamed. I'm not sure what level of support there is for non-Erb templating languages in Digestor right now.

Thanks for taking a look at this, I'd really love to be able to work with the new digest code :-)

Also: I've made a pull request to cache_digests that matches this one: rails/cache_digests#19.
