### PR TITLE
Add missing requires to core_ext/integer/time

### DIFF
--- a/activesupport/lib/active_support/core_ext/integer/time.rb
+++ b/activesupport/lib/active_support/core_ext/integer/time.rb
@@ -1,3 +1,6 @@
+require 'active_support/duration'
+require 'active_support/core_ext/numeric/time'
+
 class Integer
   # Enables the use of time calculations and declarations, like <tt>45.minutes +
   # 2.hours + 4.years</tt>.


### PR DESCRIPTION
Fixes this:

``` ruby
[1] pry(main)> require 'active_support/core_ext/integer/time'
=> true
[2] pry(main)> 3.months
NameError: uninitialized constant Integer::ActiveSupport
```

Reported in #8531
