### PR TITLE
AM::Translation extract I18n lookup defaults in separate method

### DIFF
--- a/activemodel/lib/active_model/translation.rb
+++ b/activemodel/lib/active_model/translation.rb
@@ -34,14 +34,8 @@ module ActiveModel
       self.ancestors.select { |x| x.respond_to?(:model_name) }
     end
 
-    # Transforms attribute names into a more human format, such as "First name"
-    # instead of "first_name".
-    #
-    #   Person.human_attribute_name("first_name") # => "First name"
-    #
-    # Specify +options+ with additional translating options.
-    def human_attribute_name(attribute, options = {})
-      options   = { :count => 1 }.merge!(options)
+    # Returns the default I18n lookup array for a specific attribute.
+    def human_attribute_lookup_defaults(attribute, options = {})
       parts     = attribute.to_s.split(".")
       attribute = parts.pop
       namespace = parts.join("/") unless parts.empty?
@@ -59,10 +53,21 @@ module ActiveModel
       end
 
       defaults << :"attributes.#{attribute}"
-      defaults << options.delete(:default) if options[:default]
+      defaults << options[:default] if options[:default]
       defaults << attribute.humanize
+    end
 
+    # Transforms attribute names into a more human format, such as "First name"
+    # instead of "first_name".
+    #
+    #   Person.human_attribute_name("first_name") # => "First name"
+    #
+    # Specify +options+ with additional translating options.
+    def human_attribute_name(attribute, options = {})
+      options = { :count => 1 }.merge!(options)
+      defaults = human_attribute_lookup_defaults(attribute, options)
       options[:default] = defaults
+
       I18n.translate(defaults.shift, options)
     end
   end

--- a/activemodel/test/cases/translation_test.rb
+++ b/activemodel/test/cases/translation_test.rb
@@ -7,6 +7,11 @@ class ActiveModelI18nTests < ActiveModel::TestCase
     I18n.backend = I18n::Backend::Simple.new
   end
 
+  def test_model_attribute_lookup_defaults
+    I18n.backend.store_translations 'en', :activemodel => {:attributes => {:person => {:name => 'person name attribute'} } }
+    assert_equal [:"activemodel.attributes.person.name", :"attributes.name", "Name"], Person.human_attribute_lookup_defaults('name')
+  end
+
   def test_translated_model_attributes
     I18n.backend.store_translations 'en', :activemodel => {:attributes => {:person => {:name => 'person name attribute'} } }
     assert_equal 'person name attribute', Person.human_attribute_name('name')


### PR DESCRIPTION
Many ActiveModel gems use human_attribute method for attribute localization.

Sometimes, I'd would like to retrieve the I18n default lookup array (ie. for debugging purpose in a console).

I think this process would be much easier if the lookup array generation is extracted in its own method...

```
Person.human_attribute_lookup_defaults('name')
# => [:"activemodel.attributes.person.name", :"attributes.name", "Name"]
```
