### PR TITLE
AR supporting new int4range and int8range data type on PostgreSQL >= 9.2. Fix #8528 pull request

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -97,8 +97,7 @@ module ActiveRecord
             nil
           elsif "empty" == string
             (nil..nil)
-          elsif String === string
-            matches = /^(\(|\[)([0-9]+),(\s?)([0-9]+)(\)|\])$/i.match(string)
+          elsif String === string && (matches = /^(\(|\[)([0-9]+),(\s?)([0-9]+)(\)|\])$/i.match(string))
             lower_bound = ("(" == matches[1] ? (matches[2].to_i + 1) : matches[2].to_i)
             upper_bound = (")" == matches[5] ? (matches[4].to_i - 1) : matches[4].to_i)
             (lower_bound..upper_bound)
@@ -108,8 +107,16 @@ module ActiveRecord
         end
 
         def intrange_to_string(object)
-          if Range === object
-            "[#{object.first},#{object.exclude_end? ? object.last : object.last.to_i + 1})"
+          if object.nil?
+            nil
+          elsif Range === object
+            if [object.first, object.last].all? { |el| Integer === el }
+              "[#{object.first.to_i},#{object.exclude_end? ? object.last.to_i : object.last.to_i + 1})"
+            elsif [object.first, object.last].all? { |el| NilClass === el }
+              "empty"
+            else
+              nil
+            end
           else
             object
           end

--- a/activerecord/test/cases/adapters/postgresql/intrange_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/intrange_test.rb
@@ -84,4 +84,21 @@ class PostgresqlIntrangesTest < ActiveRecord::TestCase
     assert_equal(nil, x.int_range)
   end
 
+  def test_invalid_intrange
+    assert IntRangeDataType.create!(int_range: ('a'..'d'))
+    x = IntRangeDataType.first
+    assert_equal(nil, x.int_range)
+  end
+
+  def test_save_empty_range
+    assert IntRangeDataType.create!(int_range: (nil..nil))
+    x = IntRangeDataType.first
+    assert_equal((nil..nil), x.int_range)
+  end
+
+  def test_save_invalid_data
+    assert_raises(ActiveRecord::StatementInvalid) do
+      IntRangeDataType.create!(int_range: "empty1")
+    end
+  end
 end


### PR DESCRIPTION
This is fix for [#8528](https://github.com/rails/rails/pull/8528) pull request. I just add tests for all possible variants (with invalid data).
