### PR TITLE
Fixes issue when calling 'xls'.classify

### DIFF
--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -23,6 +23,7 @@ module ActiveSupport
     inflect.plural(/^(ox)$/i, '\1en')
     inflect.plural(/^(oxen)$/i, '\1')
     inflect.plural(/(quiz)$/i, '\1zes')
+    inflect.plural(/(xls)$/i, '\1')
 
     inflect.singular(/s$/i, '')
     inflect.singular(/(ss)$/i, '\1')
@@ -51,6 +52,7 @@ module ActiveSupport
     inflect.singular(/(matr)ices$/i, '\1ix')
     inflect.singular(/(quiz)zes$/i, '\1')
     inflect.singular(/(database)s$/i, '\1')
+    inflect.singular(/(xls)$/i, '\1')
 
     inflect.irregular('person', 'people')
     inflect.irregular('man', 'men')

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -67,6 +67,8 @@ module InflectorTestCases
 
     "quiz"        => "quizzes",
 
+    "xls"         => "xls",
+
     "perspective" => "perspectives",
 
     "ox"          => "oxen",


### PR DESCRIPTION
If I have a class called XlsParser and try to instantiate
that class dinamically using something like:
`
  type_name = "xls"
  class_name = "#{type_name.classify}Parser"
`
the classify method will return "Xl" instead of "Xls"
