### PR TITLE
[Feature proposal] Add no-template option

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -25,6 +25,9 @@ module Rails
         class_option :template,           type: :string, aliases: '-m',
                                           desc: "Path to an #{name} template (can be a filesystem path or URL)"
 
+        class_option :no_template,        type: :boolean, aliases: '-M', default: false,
+                                          desc: "Don't use a template"
+
         class_option :skip_gemfile,       type: :boolean, default: false,
                                           desc: "Don't create a Gemfile"
 
@@ -119,7 +122,7 @@ module Rails
             File.expand_path(options[:template], Dir.pwd)
           else
             options[:template]
-        end
+        end unless options[:no_template]
       end
 
       def database_gemfile_entry

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -100,6 +100,15 @@ module SharedGeneratorTests
     assert_match(/It works!/, capture(:stdout) { generator.invoke_all })
   end
 
+  def test_template_is_never_executed_when_no_template_option_given
+    path = "https://gist.github.com/103208.txt"
+    template = %{ say "It works!" }
+    template.instance_eval "def read; self; end" # Make the string respond to read
+
+    generator([destination_root], template: path, no_template: true).expects(:open).never
+    assert_no_match(/It works!/, capture(:stdout) { generator.invoke_all })
+  end
+
   def test_dev_option
     generator([destination_root], dev: true).expects(:bundle_command).with('install').once
     quietly { generator.invoke_all }


### PR DESCRIPTION
I guess not so many people are using Application Template feature, but I like it.
I use with `.railsrc` which specifies the template path.

However, sometimes I would like to create bare rails with the command `rails new foo`,
but I can't overwrite or negate the template path, so rename `.railsrc` is pretty messy.

So this PR allows not to use template with the command `rails new foo -M`,
What do you guys think of it?

Thanks.
