### PR TITLE
fix testcase: ruby-2.0.0 warned unused variables

### DIFF
--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -1433,10 +1433,11 @@ class RenderTest < ActionController::TestCase
   end
 
   def test_locals_option_to_assert_template_is_not_supported
+    get :partial_collection_with_locals
+
     warning_buffer = StringIO.new
     $stderr = warning_buffer
 
-    get :partial_collection_with_locals
     assert_template partial: 'customer_greeting', locals: { greeting: 'Bonjour' }
     assert_equal "the :locals option to #assert_template is only supported in a ActionView::TestCase\n", warning_buffer.string
   ensure


### PR DESCRIPTION
ruby 2.0.0 (r38432) later warned unused variables. if you run `rake test`, some testcase is fail. because this testcase read $stderr with 2.0.0 warning messages.

I think this testcase is enough for confirmation of  display warning messages.
