### PR TITLE
fix for messages in invalid encoding from db-drivers

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -358,7 +358,11 @@ module ActiveRecord
           :statement_name => statement_name,
           :binds          => binds) { yield }
       rescue => e
-        message = "#{e.class.name}: #{e.message}: #{sql}"
+        begin
+          message = "#{e.class.name}: #{e.message}: #{sql}"
+        rescue Encoding::CompatibilityError
+          message = "#{e.class.name}: #{e.message.force_encoding sql.encoding}: #{sql}"
+        end
         @logger.error message if @logger
         exception = translate_exception(e, message)
         exception.set_backtrace e.backtrace

--- a/activerecord/test/cases/connection_adapters/abstract_adapter_test.rb
+++ b/activerecord/test/cases/connection_adapters/abstract_adapter_test.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require "cases/helper"
 
 module ActiveRecord
@@ -56,6 +57,14 @@ module ActiveRecord
         assert_not adapter.in_use?
 
         assert_equal adapter, pool.connection
+      end
+
+      def test_log_invalid_encoding
+        assert_raise ActiveRecord::StatementInvalid do
+          adapter.send :log, "SELECT 'ы' FROM DUAL" do
+            raise 'ы'.force_encoding(Encoding::ASCII_8BIT)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
When postgre query fails it gives sometimes error that could not be converted to utf and app fails with

```
activerecord (3.2.8) lib/active_record/connection_adapters/abstract_adapter.rb:282:in `rescue in log'
activerecord (3.2.8) lib/active_record/connection_adapters/abstract_adapter.rb:275:in `log'
activerecord (3.2.8) lib/active_record/connection_adapters/postgresql_adapter.rb:674:in `exec_delete'
activerecord (3.2.8) lib/active_record/connection_adapters/abstract/database_statements.rb:96:in `update'
activerecord (3.2.8) lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `update'
....
```

`e.message.encode('utf-8')` failed with

```
"\xD0" from ASCII-8BIT to UTF-8
```

I've added explicit `encode()` with `:replace` parameter.
