### PR TITLE
fix #5523: postgresql adapter to disable user triggers in disable_referential_integrity

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add ability for postgresql adapter to disable user triggers in disable_referential_integrity.
+    Fix #5523
+
+    *Gary S. Weaver*
+
 *   Added support for `validates_uniqueness_of` in PostgreSQL array columns.
     Fixes #8075.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
@@ -7,13 +7,21 @@ module ActiveRecord
         end
 
         def disable_referential_integrity #:nodoc:
-          if supports_disable_referential_integrity? then
-            execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL" }.join(";"))
+          if supports_disable_referential_integrity?
+            begin
+              execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL" }.join(";"))
+            rescue
+              execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER USER" }.join(";"))
+            end
           end
           yield
         ensure
-          if supports_disable_referential_integrity? then
-            execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
+          if supports_disable_referential_integrity?
+            begin
+              execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
+            rescue
+              execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER USER" }.join(";"))
+            end
           end
         end
       end


### PR DESCRIPTION
Pull request to replace https://github.com/rails/rails/pull/8498

Fixes https://github.com/rails/rails/issues/5523

(Sorry for the duplicate. Had a rebasing migraine.)
