### PR TITLE
Address test_binary_data_is_not_logged with Oracle database

### DIFF
--- a/activerecord/test/cases/log_subscriber_test.rb
+++ b/activerecord/test/cases/log_subscriber_test.rb
@@ -107,7 +107,6 @@ class LogSubscriberTest < ActiveRecord::TestCase
 
     Binary.create(:data => 'some binary data')
     wait
-    assert_equal 3, @logger.logged(:debug).size
-    assert_match(/<16 bytes of binary data>/, @logger.logged(:debug)[-2])
+    assert_match(/<16 bytes of binary data>/, @logger.logged(:debug).join)
   end
 end


### PR DESCRIPTION
This pull request addresses the following failure.

``` ruby
$ cd activerecord
$ ARCONN=oracle  ruby -Itest test/cases/log_subscriber_test.rb -n test_binary_data_is_not_logged
Using oracle
Run options: -n test_binary_data_is_not_logged --seed 33899

# Running tests:

F

Finished tests in 1.068614s, 0.9358 tests/s, 0.9358 assertions/s.

  1) Failure:
test_binary_data_is_not_logged(LogSubscriberTest) [test/cases/log_subscriber_test.rb:110]:
Expected: 3
  Actual: 6

1 tests, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

The number of sql statement logged depends on each database adapter implementation.
Also, this test does not depends on how many sql statement executed.
