### PR TITLE
Adding Back Rails::Engine::Railties#engines

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Restore Rails::Engine::Railties#engines with deprecation to ensure
+    compatibility with gems such as Thinking Sphinx
+    Fix #8551
+
+    *Tim Raymond*
+
 *   Add `-B` alias for `--skip-bundle` option in the rails new generators.
 
     *Jiri Pospisil*

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -55,6 +55,7 @@ module Rails
     autoload :Bootstrap,      'rails/application/bootstrap'
     autoload :Configuration,  'rails/application/configuration'
     autoload :Finisher,       'rails/application/finisher'
+    autoload :Railties,       'rails/engine/railties'
     autoload :RoutesReloader, 'rails/application/routes_reloader'
 
     class << self
@@ -230,11 +231,6 @@ module Rails
 
     def helpers_paths #:nodoc:
       config.helpers_paths
-    end
-
-    def railties #:nodoc:
-      @railties ||= Rails::Railtie.subclasses.map(&:instance) +
-        Rails::Engine.subclasses.map(&:instance)
     end
 
   protected

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -468,6 +468,10 @@ module Rails
       end
     end
 
+    def railties
+      @railties ||= self.class::Railties.new
+    end
+
     # Returns a module with all the helpers defined for the engine.
     def helpers
       @helpers ||= begin

--- a/railties/lib/rails/engine/railties.rb
+++ b/railties/lib/rails/engine/railties.rb
@@ -1,0 +1,29 @@
+module Rails
+  class Engine < Railtie
+    class Railties
+      include Enumerable
+      attr_reader :_all
+
+      def initialize
+        @_all ||= ::Rails::Railtie.subclasses.map(&:instance) +
+          ::Rails::Engine.subclasses.map(&:instance)
+      end
+
+      def self.engines
+        @engines ||= ::Rails::Engine.subclasses.map(&:instance)
+      end
+
+      def each(*args, &block)
+        _all.each(*args, &block)
+      end
+
+      def -(others)
+        _all - others
+      end
+
+      delegate :engines, to: "self.class"
+    end
+  end
+end
+
+ActiveSupport::Deprecation.deprecate_methods(Rails::Engine::Railties, :engines)

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -1241,6 +1241,12 @@ YAML
       assert_equal '/foo/bukkits/bukkit', last_response.body
     end
 
+    test "engines method is properly deprecated" do
+      boot_rails
+
+      assert_deprecated { app.railties.engines }
+    end
+
   private
     def app
       Rails.application


### PR DESCRIPTION
First PR for me, so please let me know if I've done something horribly wrong :-P

Removing Rails::Engine::Railties#engines breaks functionality with gems such as Thinking Sphinx.
This restores it with a deprecation warning. See #8551
