### PR TITLE
Backport #8522, Keep index names when using  with sqlite3

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 3.2.10 (unreleased)
 
+*   Keep index names when using `alter_table` with sqlite3.
+    Fix #3489
+    Backport #8522
+
+    *Yves Senn*
+
 *   Recognize migrations placed in directories containing numbers and 'rb'.
     Fix #8492
     Backport of #8500

--- a/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite_adapter.rb
@@ -530,7 +530,7 @@ module ActiveRecord
 
             unless columns.empty?
               # index name can't be the same
-              opts = { :name => name.gsub(/_(#{from})_/, "_#{to}_") }
+              opts = { :name => name.gsub(/(^|_)(#{from})_/, "\\1#{to}_") }
               opts[:unique] = true if index.unique
               add_index(to, columns, opts)
             end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1051,6 +1051,18 @@ if ActiveRecord::Base.connection.supports_migrations?
       Person.connection.remove_column("people", "administrator") rescue nil
     end
 
+    def test_change_column_with_custom_index_name
+      Person.connection.add_column "people", "category", :string, :default => 'human'
+      Person.connection.add_index :people, :category, :name => 'people_categories_idx'
+
+      assert_equal ['people_categories_idx'], Person.connection.indexes('people').map(&:name)
+      Person.connection.change_column "people", "category", :string, :null => false, :default => 'article'
+
+      assert_equal ['people_categories_idx'], Person.connection.indexes('people').map(&:name)
+    ensure
+      Person.connection.remove_column("people", "category") rescue nil
+    end
+
     def test_change_column_default
       Person.connection.change_column_default "people", "first_name", "Tester"
       Person.reset_column_information


### PR DESCRIPTION
This is a backport of #8522 to fix #3489

Conflicts:

```
activerecord/CHANGELOG.md
activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
activerecord/test/cases/migration/rename_column_test.rb
```

The files looked quite different on `rails/3-2-stable` but the affected line is exactly the same. Also the tests have a different format.
