### PR TITLE
attempt to fix slow runner name method

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -1,3 +1,4 @@
+require 'thread_safe'
 require 'active_support/concern'
 require 'active_support/descendants_tracker'
 require 'active_support/core_ext/class/attribute'
@@ -351,8 +352,16 @@ module ActiveSupport
         undef_method(name) if method_defined?(name)
       end
 
-      def __callback_runner_name(kind)
+      def __callback_runner_name_cache
+        @__callback_runner_name_cache ||= ThreadSafe::Cache.new {|cache, kind| cache[kind] = __generate_callback_runner_name(kind) }
+      end
+
+      def __generate_callback_runner_name(kind)
         "_run__#{self.name.hash.abs}__#{kind}__callbacks"
+      end
+
+      def __callback_runner_name(kind)
+        __callback_runner_name_cache[kind]
       end
 
       # This is used internally to append, prepend and skip callbacks to the


### PR DESCRIPTION
Replacement for https://github.com/rails/rails/pull/8486

Updated to use ThreadSafe::Cache

Using https://gist.github.com/2710476

``` ruby
Running benchmark with current working tree
Checkout HEAD^
Running benchmark with HEAD^
Checkout to previous HEAD again

                    user     system      total        real
-----------------------------------------------set_callback
After patch:    0.030000   0.000000   0.030000 (  0.028368)
Before patch:   0.050000   0.010000   0.060000 (  0.045907)
Improvement: 38%

-------------------------------------------define_callbacks
After patch:    0.030000   0.000000   0.030000 (  0.036034)
Before patch:   0.030000   0.000000   0.030000 (  0.035713)

----------------------------------------------run_callbacks
After patch:    0.010000   0.000000   0.010000 (  0.007374)
Before patch:   0.010000   0.000000   0.010000 (  0.011215)
Improvement: 34%

----------------------------------------------skip_callback
After patch:    0.040000   0.000000   0.040000 (  0.044974)
Before patch:   0.050000   0.000000   0.050000 (  0.052612)
Improvement: 15%
```
