### PR TITLE
Ability to Retry code a given number of times

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -60,6 +60,34 @@ module Enumerable
   def exclude?(object)
     !include?(object)
   end
+
+  # Attempts to run code for every element, returns the first valid run.
+  # If code does not return, the original error will be raised.
+  #
+  # First run returns a `divided by 0` error, so the next result is returned.
+  #
+  #  [0, 1, 2].each.retry { |i| 1/i }
+  #  # => 1
+  #
+  # If there are no valid returns, the last error will be raised.
+  #
+  #  [0, 1, 2].each.retry { raise "bar" }
+  #  # => RuntimeError: bar
+  #
+  # By default only `StandardError` is caught, multiple error types can be
+  # specified.
+  #
+  #  array = [->{ raise Exception }, ->{ raise SignalException }, ->{ 1 }]
+  #  array.each.retry(Exception, SignalException) { |i| i.call }
+  #  # => 1
+  def retry(*exceptions, &block)
+    exceptions << StandardError if exceptions.empty?
+    enum       ||= self.to_enum
+    yield enum.next
+  rescue *exceptions => e
+    last_exception = e and retry unless e.is_a? StopIteration
+    raise last_exception unless last_exception.nil?
+  end
 end
 
 class Range #:nodoc:

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -122,4 +122,21 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_equal true,  GenericEnumerable.new([ 1 ]).exclude?(2)
     assert_equal false, GenericEnumerable.new([ 1 ]).exclude?(1)
   end
+
+  def test_retry
+    assert_equal 0.5, GenericEnumerable.new([ 2.0, 0 ]).retry { |i| 1/i }
+    assert_equal 1,   GenericEnumerable.new([ 0,   1 ]).retry { |i| 1/i }
+    assert_raise(ZeroDivisionError) {GenericEnumerable.new([0]).retry { |i| 1/i } }
+    result = GenericEnumerable.new([ Exception, 1 ]).retry(Exception) do |i|
+      raise i if i == Exception
+      i
+    end
+    assert_equal 1, result
+    result = GenericEnumerable.new([ Exception, SecurityError, 1 ]).retry(Exception, SecurityError) do |i|
+      raise i if i == Exception || i == SecurityError
+      i
+    end
+    assert_equal 1, result
+    GenericEnumerable.new([]).retry {} # ensure no errors
+  end
 end


### PR DESCRIPTION
Ruby gives us the ability to retry a piece of code, but the mechanisms to control or limit the number of times it is retried must be manually coded each time by a developer. This PR gives the ability to retry arbitrary code a maximum number of times based on an enumerator. If an exception is raised on every round of the enumerator, the last exception before StopIteration was be raised. 

This functionality is particularly useful for executing non-deterministic actions, such as networking code where one successful call is required, but an infinite number of retries is not desired since the endpoint may be permanently down.

```
3.times.retry do |i|
  puts "foo #{i}"
  raise "bar"
end
# foo 0
# foo 1
# foo 2
# RuntimeError: bar

3.times.retry do |i|
  puts "foo #{i}"
end
# foo 0
#  => nil
```

WDYT?
