### PR TITLE
Decimal fields changed from zero to zero string marked as changed

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix zero-value decimal fields registering as changed when set to a zero-value
+    string (e.g. '0.0')
+
+    *Wesley Graybill*
+
 *   Quote numeric values being compared to non-numeric columns. Otherwise,
     in some database, the string column values will be coerced to a numeric
     allowing 0, 0.0 or false to match any string starting with a non-digit.

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -107,7 +107,11 @@ module ActiveRecord
 
       def changes_from_zero_to_string?(old, value)
         # For columns with old 0 and value non-empty string
-        old == 0 && value.is_a?(String) && value.present? && value != '0'
+        old == 0 && value.is_a?(String) && value.present? && !string_equal_to_zero?(value)
+      end
+
+      def string_equal_to_zero?(value)
+        Float(value) == 0 rescue false
       end
     end
   end

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -243,6 +243,27 @@ class DirtyTest < ActiveRecord::TestCase
     assert !pirate.changed?
   end
 
+  def test_decimal_zero_to_string_zero_not_marked_as_changed
+    numeric_data = NumericData.new
+    numeric_data.bank_balance = 0.0
+    assert numeric_data.save!
+
+    assert !numeric_data.changed?
+
+    numeric_data.bank_balance = '0.0'
+    assert !numeric_data.changed?
+  end
+
+  def test_decimal_zero_to_nonnumeric_string_marked_as_changed
+    numeric_data = NumericData.new
+    numeric_data.bank_balance = 0.0
+    assert numeric_data.save!
+
+    assert !numeric_data.changed?
+
+    numeric_data.bank_balance = 'arrr'
+    assert numeric_data.changed?
+  end
 
   def test_zero_to_blank_marked_as_changed
     pirate = Pirate.new


### PR DESCRIPTION
Decimal fields with an old value of 0.0 that are changed to a string representation of zero ('0.0', '0.000', etc.) are included in changed_attributes.

```
numeric_data = NumericData.new
numeric_data.bank_balance = 0.0
numeric_data.save!

numeric_data.bank_balance = '0.0'
numeric_data.changed_attributes # => {"bank_balance"=>#<BigDecimal:7f9f62ccefd0,'0.0',9(45)>}
```
