### PR TITLE
Correct source for in_clause_length for eager loading (Fix for #8474)

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Eager loading made to use relation's in_clause_length instead of host's one.
+    Fix #8474
+
+    *Boris Staal*
+
 *   Explicit multipart messages no longer set the order of the MIME parts.
     *Nate Berkopec*
 

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -76,7 +76,7 @@ module ActiveRecord
           else
             # Some databases impose a limit on the number of ids in a list (in Oracle it's 1000)
             # Make several smaller queries if necessary or make one query if the adapter supports it
-            sliced  = owner_keys.each_slice(model.connection.in_clause_length || owner_keys.size)
+            sliced  = owner_keys.each_slice(klass.connection.in_clause_length || owner_keys.size)
             records = sliced.map { |slice| records_for(slice).to_a }.flatten
           end
 

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -93,31 +93,31 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_preloading_has_many_in_multiple_queries_with_more_ids_than_database_can_handle
-    Post.connection.expects(:in_clause_length).at_least_once.returns(5)
+    Comment.connection.expects(:in_clause_length).at_least_once.returns(5)
     posts = Post.all.merge!(:includes=>:comments).to_a
     assert_equal 11, posts.size
   end
 
   def test_preloading_has_many_in_one_queries_when_database_has_no_limit_on_ids_it_can_handle
-    Post.connection.expects(:in_clause_length).at_least_once.returns(nil)
+    Comment.connection.expects(:in_clause_length).at_least_once.returns(nil)
     posts = Post.all.merge!(:includes=>:comments).to_a
     assert_equal 11, posts.size
   end
 
   def test_preloading_habtm_in_multiple_queries_with_more_ids_than_database_can_handle
-    Post.connection.expects(:in_clause_length).at_least_once.returns(5)
+    Comment.connection.expects(:in_clause_length).at_least_once.returns(5)
     posts = Post.all.merge!(:includes=>:categories).to_a
     assert_equal 11, posts.size
   end
 
   def test_preloading_habtm_in_one_queries_when_database_has_no_limit_on_ids_it_can_handle
-    Post.connection.expects(:in_clause_length).at_least_once.returns(nil)
+    Comment.connection.expects(:in_clause_length).at_least_once.returns(nil)
     posts = Post.all.merge!(:includes=>:categories).to_a
     assert_equal 11, posts.size
   end
 
   def test_load_associated_records_in_one_query_when_adapter_has_no_limit
-    Post.connection.expects(:in_clause_length).at_least_once.returns(nil)
+    Comment.connection.expects(:in_clause_length).at_least_once.returns(nil)
 
     post = posts(:welcome)
     assert_queries(2) do
@@ -126,7 +126,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_load_associated_records_in_several_queries_when_many_ids_passed
-    Post.connection.expects(:in_clause_length).at_least_once.returns(1)
+    Comment.connection.expects(:in_clause_length).at_least_once.returns(1)
 
     post1, post2 = posts(:welcome), posts(:thinking)
     assert_queries(3) do
@@ -135,7 +135,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_load_associated_records_in_one_query_when_a_few_ids_passed
-    Post.connection.expects(:in_clause_length).at_least_once.returns(3)
+    Comment.connection.expects(:in_clause_length).at_least_once.returns(3)
 
     post = posts(:welcome)
     assert_queries(2) do


### PR DESCRIPTION
#8474 issue source links are a bit outdated yet the bug still persists. This PR makes eager loading seek for the `in_clause_length` option at the relation klass instead of the host model. Tests are also fixed.

/cc @tenderlove
