### PR TITLE
Fixed ActiveSupport inflector underscore regex

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -90,7 +90,7 @@ module ActiveSupport
     def underscore(camel_cased_word)
       word = camel_cased_word.to_s.dup
       word.gsub!('::', '/')
-      word.gsub!(/(?:([A-Za-z\d])|^)(#{inflections.acronym_regex})(?=\b|[^a-z])/) { "#{$1}#{$1 && '_'}#{$2.downcase}" }
+      word.gsub!(/(?:([A-Za-z\d])|^|(\/))(#{inflections.acronym_regex})(?=\b|[^a-z])/) { "#{$1}#{$1 && '_'}#{$2}#{$3.downcase}" }
       word.gsub!(/([A-Z\d]+)([A-Z][a-z])/,'\1_\2')
       word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
       word.tr!("-", "_")

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -124,6 +124,9 @@ class InflectorTest < ActiveSupport::TestCase
       ["PhDRequired",       "phd_required",       "PhD required",       "PhD Required"],
       ["IRoRU",             "i_ror_u",            "I RoR u",            "I RoR U"],
       ["RESTfulHTTPAPI",    "restful_http_api",   "RESTful HTTP API",   "RESTful HTTP API"],
+      ["HTTP::RESTful",     "http/restful",       "HTTP/RESTful",       "HTTP/RESTful"],
+      ["HTTP::RESTfulAPI",  "http/restful_api",   "HTTP/RESTful API",   "HTTP/RESTful API"],
+
 
       # misdirection
       ["Capistrano",        "capistrano",         "Capistrano",       "Capistrano"],
@@ -361,7 +364,7 @@ class InflectorTest < ActiveSupport::TestCase
 
       inflect.singular(/s$/, '')
       inflect.singular(/es$/, '')
-      
+
       inflect.irregular('el', 'los')
     end
 


### PR DESCRIPTION
The inflector underscore regex was not matching nested acronyms, which causes problems for mixed-case acronyms (i.e. calling `#underscore` on `"HTTP::RESTful"` with a `"RESTful"` acronym).
