### PR TITLE
Include ActiveModel::Validations::Callbacks in ActiveModel::Model

### DIFF
--- a/activemodel/lib/active_model/model.rb
+++ b/activemodel/lib/active_model/model.rb
@@ -61,6 +61,7 @@ module ActiveModel
         extend  ActiveModel::Naming
         extend  ActiveModel::Translation
         include ActiveModel::Validations
+        include ActiveModel::Validations::Callbacks
         include ActiveModel::Conversion
       end
     end


### PR DESCRIPTION
`ActiveModel::Model` already includes `ActiveModel::Validations` and `ActiveModel::Callbacks`, but not `ActiveModel::Validations::Callbacks`. I think it would be handy to also include this module so methods like `before_validation` can be used. Thanks!
