### PR TITLE
Digestor explicit dependency should not contain trailing whitespace

### DIFF
--- a/actionpack/lib/action_view/digestor.rb
+++ b/actionpack/lib/action_view/digestor.rb
@@ -2,7 +2,7 @@ require 'thread_safe'
 
 module ActionView
   class Digestor
-    EXPLICIT_DEPENDENCY = /# Template Dependency: ([^ ]+)/
+    EXPLICIT_DEPENDENCY = /# Template Dependency: (\S+)/
 
     # Matches:
     #   render partial: "comments/comment", collection: commentable.comments

--- a/actionpack/test/fixtures/digestor/messages/show.html.erb
+++ b/actionpack/test/fixtures/digestor/messages/show.html.erb
@@ -7,3 +7,7 @@
 <%= render @message.history.events %>
 
 <%# render "something_missing"  %>
+
+<%
+  # Template Dependency: messages/form
+%>

--- a/actionpack/test/template/digestor_test.rb
+++ b/actionpack/test/template/digestor_test.rb
@@ -46,6 +46,12 @@ class TemplateDigestorTest < ActionView::TestCase
     end
   end
 
+  def test_explicit_dependency_in_multiline_erb_tag
+    assert_digest_difference("messages/show") do
+      change_template("messages/_form")
+    end
+  end
+
   def test_second_level_dependency
     assert_digest_difference("messages/show") do
       change_template("comments/_comments")


### PR DESCRIPTION
This is an extremely simple and low impact change in the regex used to find explicit template dependencies. This allows `Digestor` to be used with HAML. Please see https://github.com/rails/cache_digests/pull/21 for details.
