### PR TITLE
More helpful error message if `thread_safe` is not available

### DIFF
--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -1,4 +1,11 @@
-require 'thread_safe'
+begin
+  require 'thread_safe'
+rescue LoadError
+  puts "The `thread_safe` gem is not available.\nIf you ran this command " \
+       "from a git checkout of Rails, please make sure it is installed,\n" \
+       "and run this command as `ruby #{$0} #{(ARGV | ['--dev']).join(" ")}`"
+  exit
+end
 require 'active_support/core_ext/array/prepend_and_append'
 require 'active_support/i18n'
 


### PR DESCRIPTION
 Hi everyone,
I tried to create a new Rails project with edge rails and it responded with a not very helpful Error Message. The reason for that was, that `thread_safe` was required but was not available. 
So i added a more helpful message, and oriented on [this message](https://github.com/rails/rails/blob/master/railties/lib/rails/generators/base.rb#l4-6) which solves the same problem with `thor`.

`rails/railties/bin/rails new testapp --edge --dev`
## Before

```
/home/crunch/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- thread_safe (LoadError) from /home/crunch/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /home/crunch/Code/rails/edge/rails-dev-box/rails/activesupport/lib/active_support/inflector/inflections.rb:1:in `<top (required)>'
    from /home/crunch/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /home/crunch/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /home/crunch/Code/rails/edge/rails-dev-box/rails/activesupport/lib/active_support/inflector/methods.rb:3:in `<top (required)>'
    from /home/crunch/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /home/crunch/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /home/crunch/Code/rails/edge/rails-dev-box/rails/activesupport/lib/active_support/dependencies/autoload.rb:1:in `<top (required)>'
    from /home/crunch/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /home/crunch/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /home/crunch/Code/rails/edge/rails-dev-box/rails/activesupport/lib/active_support.rb:25:in `<top (required)>'
    from /home/crunch/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /home/crunch/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /home/crunch/Code/rails/edge/rails-dev-box/rails/railties/lib/rails/generators.rb:4:in `<top (required)>'
    from /home/crunch/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /home/crunch/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /home/crunch/Code/rails/edge/rails-dev-box/rails/railties/lib/rails/commands/application.rb:22:in `<top (required)>'
    from /home/crunch/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /home/crunch/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /home/crunch/Code/rails/edge/rails-dev-box/rails/railties/lib/rails/cli.rb:15:in `<top (required)>'
    from /home/crunch/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /home/crunch/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from rails/railties/bin/rails:7:in `<main>'
```
## After

```
The `thread_safe` gem is not available.
If you ran this command from a git checkout of Rails, please make sure it is installed,
and run this command as `ruby rails/railties/bin/rails testapp --edge --dev`
```
