### PR TITLE
Remove warning of intance variable not initialized

### DIFF
--- a/activesupport/lib/active_support/core_ext/thread.rb
+++ b/activesupport/lib/active_support/core_ext/thread.rb
@@ -65,6 +65,10 @@ class Thread
   private
 
   def locals
-    @locals || LOCK.synchronize { @locals ||= {} }
+    if defined?(@locals)
+      @locals
+    else
+      LOCK.synchronize { @locals ||= {} }
+    end
   end
 end unless Thread.instance_methods.include?(:thread_variable_set)


### PR DESCRIPTION
I'm not sure if this is the best fix.

@tenderlove chould you review this one?

```
activesupport/lib/active_support/core_ext/thread.rb:68: warning:
instance variable @locals not initialized
```
