### PR TITLE
Add support for action arguments

### DIFF
--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -194,7 +194,9 @@ module AbstractController
       # not to add additional behavior around it. For example, you would
       # override #send_action if you want to inject arguments into the
       # method.
-      alias send_action send
+      def send_action(*args, &block)
+        send(*args, &block)
+      end
 
       # If the action name was not found, but a method called "action_missing"
       # was found, #method_for_action will return "_handle_action_missing".

--- a/actionpack/lib/action_controller.rb
+++ b/actionpack/lib/action_controller.rb
@@ -13,6 +13,7 @@ module ActionController
   autoload :Middleware
 
   autoload_under "metal" do
+    autoload :ActionArgs
     autoload :Compatibility
     autoload :ConditionalGet
     autoload :Cookies

--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -216,6 +216,7 @@ module ActionController
       MimeResponds,
       ImplicitRender,
       StrongParameters,
+      ActionArgs,
 
       Cookies,
       Flash,

--- a/actionpack/lib/action_controller/metal/action_args.rb
+++ b/actionpack/lib/action_controller/metal/action_args.rb
@@ -1,0 +1,95 @@
+module ActionController
+  # == Action Controller Arguments
+  #
+  # You can specify Ruby arguments to your actions, and they
+  # will automatically be populated with the same-named
+  # parameters from the `params` hash.
+  #
+  #   class PostsController < ActionController::Base
+  #     def index(query)
+  #       # query is the same as params[:query]
+  #     end
+  #   end
+  #
+  # Action arguments work well with strong parameters. Any
+  # arguments specified in your action are automatically
+  # `required`, so Rails will automatically return a 400
+  # Bad Request if the parameter was not present.
+  #
+  # You can also specify a list of attributes of the main
+  # resource to permit by default.
+  #
+  #   class PostsController < ActionController::Base
+  #     permits :title, :body
+  #
+  #     def create(post)
+  #       # post is params[:post].permit(:title, :body)
+  #     end
+  #   end
+  module ActionArgs
+    extend ActiveSupport::Concern
+
+    include ActionController::StrongParameters
+
+    def send_action(method_name, *args, &block)
+      return super if args.present?
+
+      parameters = method(method_name).parameters.reject { |type, _| type == :block }
+
+      values, _ = process_parameters(parameters)
+
+      super method_name, *values, &block
+    end
+
+    module ClassMethods
+      # Specifies a list of attributes of the main parameters hash
+      # to be whitelisted.
+      #
+      #   class PostsController < ApplicationController
+      #     permits :title, :body
+      #
+      #     def create(post)
+      #       # post == params[:post].permit(:title, :body)
+      #     end
+      #   end
+      #
+      # The attributes apply to the sub-hash in `params` corresponding
+      # to the singularized form of the controller name. In this
+      # example, since the controller name was `posts`, the attributes
+      # apply to `params[:post]`.
+      def permits(*attributes)
+        @_permitted_attributes = attributes
+      end
+
+      attr_reader :_permitted_attributes
+    end
+
+    private
+      def process_parameters(parameters)
+        return if self.class.anonymous?
+
+        model_name = controller_name.singularize.to_sym
+        permitted_attributes = self.class._permitted_attributes
+
+        values, keywords = [], {}
+
+        parameters.map do |type, key|
+          params.require(key) if type == :req
+
+          if (key == model_name) && permitted_attributes && params[key]
+            value = params[key].try(:permit, *permitted_attributes)
+          else
+            value = params[key]
+          end
+
+          if type == :req
+            values << value
+          elsif type == :key
+            keywords[key] = value
+          end
+        end
+
+        [ values, keywords ]
+      end
+  end
+end

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -273,7 +273,7 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
       render :text => "Created", :status => 201
     end
 
-    def method
+    def get_method
       render :text => "method: #{request.method.downcase}"
     end
 
@@ -452,11 +452,11 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
       assert_equal 201, status
       assert_equal "", body
 
-      get '/get/method'
+      get '/get/get_method'
       assert_equal 200, status
       assert_equal "method: get", body
 
-      head '/get/method'
+      head '/get/get_method'
       assert_equal 200, status
       assert_equal "", body
     end

--- a/actionpack/test/controller/parameters/action_args_test.rb
+++ b/actionpack/test/controller/parameters/action_args_test.rb
@@ -1,0 +1,77 @@
+require 'abstract_unit'
+
+module ActionArgsTest
+  class ActionArgsController < ActionController::Metal
+    include ActionController::ActionArgs
+    include ActionController::Rendering
+
+    permits :title, :body
+
+    def get(name, address)
+      render text: "Name: #{name}, Address: #{address}"
+    end
+
+    def show(name, action_arg)
+      render text: "Name: #{name}, Title: #{action_arg[:title]}, Body: #{action_arg[:body]}#{action_arg[:admin]}"
+    end
+
+    #if RUBY_VERSION >= "2.0"
+      #class_eval <<-RUBY, __FILE__, __LINE__ + 1
+        #def keywords(action_arg, address: 'Unknown')
+          #render text: "Address: \#{address}, Title: \#{action_arg[:title]}, Body: \#{action_arg[:body]}\#{action_arg[:admin]}"
+        #end
+      #RUBY
+    #end
+  end
+
+  class Simple < Rack::TestCase
+    def app
+      ActionArgsController.action(:get)
+    end
+
+    def test_simple_args
+      get "/action_args/get", { name: 'Erik', address: 'San Francisco' }
+      assert_body "Name: Erik, Address: San Francisco"
+    end
+
+    def test_inadequate_args
+      assert_raises(ActionController::ParameterMissing) do
+        get "/action_args/get"
+      end
+    end
+  end
+
+  class Nested < Rack::TestCase
+    def app
+      ActionArgsController.action(:show)
+    end
+
+    def test_nested
+      get "/action_args/show", { name: 'David', action_arg: { title: "First Post", body: "This is the first post" } }
+      assert_body "Name: David, Title: First Post, Body: This is the first post"
+    end
+
+    def test_invalid_param
+      get "/action_args/show", { name: 'David', action_arg: { title: "First Post", body: "This is the first post", admin: 'haha' } }
+      assert_body "Name: David, Title: First Post, Body: This is the first post"
+    end
+  end
+
+  #if RUBY_VERSION >= "2"
+    #class KeywordArgs < Rack::TestCase
+      #def app
+        #ActionArgsController.action(:keywords)
+      #end
+
+      #def test_nested
+        #get "/action_args/show", { action_arg: { title: "First Post", body: "This is the first post" } }
+        #assert_body "Address: Unknown, Title: First Post, Body: This is the first post"
+      #end
+
+      #def test_invalid_param
+        #get "/action_args/show", { address: 'San Francisco', action_arg: { title: "First Post", body: "This is the first post", admin: 'haha' } }
+        #assert_body "Address: San Francisco, Title: First Post, Body: This is the first post"
+      #end
+    #end
+  #end
+end


### PR DESCRIPTION
On this Festivus day—the fourth anniversary of [the announcement of the merger of Merb into Rails](http://weblog.rubyonrails.org/2008/12/23/merb-gets-merged-into-rails-3/)—I'd like to reintroduce one of my favorite features from Merb that never made it into Rails 3: action arguments. This feature gives users the ability to define controller actions with parameters that take the values of keys in the `params` hash of the same name. For example:

``` ruby
class PostsController < ApplicationController

  # Without action arguments
  def destroy
    @post = Post.find(params[:id])
    @post.destroy
  end

  # With action arguments
  def destroy(id)
    @post = Post.find(id)
    @post.destroy
  end

end
```

In my opinion, this syntax is more concise, more Ruby-like, and more explicit than fetching values out of a big `params` hash (of course, `params` is still there for users who need it…as is the whole `request` object).

I believe this feature pairs particularly nicely with the introduction of strong parameters in Rails 4, since specifying an action argument is also a shorthand for specifying a required parameter.

In Merb, which supported Ruby 1.8, the implementation of this feature required some black magic. Today, this feature can be implemented cleanly using the `Method#parameters`, which was added to Ruby 1.9 for just this purpose.

:santa::christmas_tree::gift:
