### PR TITLE
more descriptive return parameters

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -16,15 +16,14 @@ module ActionDispatch
 
     def call(env)
       begin
-        response = @app.call(env)
+        response = (_, headers, body = @app.call(env))
 
-        if response[1]['X-Cascade'] == 'pass'
-          body = response[2]
+        if headers['X-Cascade'] == 'pass'
           body.close if body.respond_to?(:close)
           raise ActionController::RoutingError, "No route matches [#{env['REQUEST_METHOD']}] #{env['PATH_INFO'].inspect}"
         end
       rescue Exception => exception
-        raise exception if env['action_dispatch.show_exceptions'] == false
+        raise exception unless env['action_dispatch.show_exceptions']
       end
 
       exception ? render_exception(env, exception) : response


### PR DESCRIPTION
Let's use `headers` and `body` instead of `response[1]` and `response[2]`.
