### PR TITLE
ActiveSupport::BufferedLogger can be subclassed

### DIFF
--- a/activesupport/lib/active_support/buffered_logger.rb
+++ b/activesupport/lib/active_support/buffered_logger.rb
@@ -2,6 +2,10 @@ require 'active_support/deprecation'
 require 'active_support/logger'
 
 module ActiveSupport
-  BufferedLogger = ActiveSupport::Deprecation::DeprecatedConstantProxy.new(
-    'BufferedLogger', '::ActiveSupport::Logger')
+  class BufferedLogger < Logger
+    def self.inherited(*)
+      ::ActiveSupport::Deprecation.warn 'ActiveSupport::BufferedLogger is deprecated! Use ActiveSupport::Logger instead.'
+      super
+    end
+  end
 end

--- a/activesupport/test/deprecation/buffered_logger_test.rb
+++ b/activesupport/test/deprecation/buffered_logger_test.rb
@@ -1,0 +1,14 @@
+require 'abstract_unit'
+require 'active_support/buffered_logger'
+
+class BufferedLoggerTest < ActiveSupport::TestCase
+
+  def test_can_be_subclassed
+    warn = 'ActiveSupport::BufferedLogger is deprecated! Use ActiveSupport::Logger instead.'
+
+    ActiveSupport::Deprecation.expects(:warn).with(warn).once
+
+    Class.new(ActiveSupport::BufferedLogger)
+  end
+
+end


### PR DESCRIPTION
Since `ActiveSupport::BufferedLogger` was deprecated, it's not possible to subclass it anymore. Creating a subclass fails with the following exception:

```
test_can_be_subclassed(BufferedLoggerTest):
TypeError: superclass must be a Class (ActiveSupport::Deprecation::DeprecatedConstantProxy given)
    test/deprecation/buffered_logger_test.rb:11:in `initialize'
    test/deprecation/buffered_logger_test.rb:11:in `new'
    test/deprecation/buffered_logger_test.rb:11:in `test_can_be_subclassed'
```

This PR applies the same solution we used for `ActiveSupport::BasicObject` in #8518

There is a difference to `BasicObject`, which was only subclassed. There could be applications using BufferedLogger instances and I think this should also result in deprecation warnings. I'm not sure how `BufferedLogger` was used but I'll happily update the PR when we know what else we need to deprecate. 

This is a fix for #8576
