### PR TITLE
deprecation warning when BufferedLogger is instantiated

### DIFF
--- a/activesupport/lib/active_support/buffered_logger.rb
+++ b/activesupport/lib/active_support/buffered_logger.rb
@@ -3,9 +3,19 @@ require 'active_support/logger'
 
 module ActiveSupport
   class BufferedLogger < Logger
-    def self.inherited(*)
-      ::ActiveSupport::Deprecation.warn 'ActiveSupport::BufferedLogger is deprecated! Use ActiveSupport::Logger instead.'
+
+    def initialize(*args)
+      self.class._deprecation_warning
       super
+    end
+
+    def self.inherited(*)
+      _deprecation_warning
+      super
+    end
+
+    def self._deprecation_warning
+      ::ActiveSupport::Deprecation.warn 'ActiveSupport::BufferedLogger is deprecated! Use ActiveSupport::Logger instead.'
     end
   end
 end

--- a/activesupport/test/deprecation/buffered_logger_test.rb
+++ b/activesupport/test/deprecation/buffered_logger_test.rb
@@ -11,4 +11,12 @@ class BufferedLoggerTest < ActiveSupport::TestCase
     Class.new(ActiveSupport::BufferedLogger)
   end
 
+  def test_issues_deprecation_when_instantiated
+    warn = 'ActiveSupport::BufferedLogger is deprecated! Use ActiveSupport::Logger instead.'
+
+    ActiveSupport::Deprecation.expects(:warn).with(warn).once
+
+    ActiveSupport::BufferedLogger.new(STDOUT)
+  end
+
 end


### PR DESCRIPTION
This commit belongs to a previously merged PR #8607

`ActiveSupport::BufferedLogger` is not only subclassed but also instantiated. This patch adds the deprecation warning when a new `BufferedLogger` is instantiated.

I think this should be enough to show the user every use of the `BufferedLogger`. At some point there must be an instantiation or a subclass definition. This is when a deprecation warning will be shown and these are the places that need modification.

I did not add deprecation warnings to every instance method because I think this would pollute the log and would not help to track down the problematic areas.
