### PR TITLE
[ActiveSupport] [Cache] Inconsistent behavior in namespaced_key

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -494,11 +494,7 @@ module ActiveSupport
 
           case key
           when Array
-            if key.size > 1
-              key = key.collect{|element| expanded_key(element)}
-            else
-              key = key.first
-            end
+            key = key.collect{|element| expanded_key(element)}
           when Hash
             key = key.sort_by { |k,_| k.to_s }.collect{|k,v| "#{k}=#{v}"}
           end

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -295,6 +295,29 @@ module CacheStoreBehavior
     assert_equal "bar", @cache.read("fu/foo")
   end
 
+  def test_array_as_cache_key_with_one_element_that_responds_to_cache_key
+    obj = Object.new
+    def obj.cache_key
+      :foo
+    end
+    @cache.write([obj], "bar")
+    assert_equal "bar", @cache.read("foo")
+  end
+
+  def test_array_as_cache_key_with_n_elements_that_respond_to_cache_key
+    obj1 = Object.new
+    def obj1.cache_key
+      :foo1
+    end
+    obj2 = Object.new
+    def obj2.cache_key
+      :foo2
+    end
+
+    @cache.write([obj1, obj2], "bar")
+    assert_equal "bar", @cache.read("foo1/foo2")
+  end
+
   def test_hash_as_cache_key
     @cache.write({:foo => 1, :fu => 2}, "bar")
     assert_equal "bar", @cache.read("foo=1/fu=2")


### PR DESCRIPTION
fix for #8614

``` bash

>  Rails.cache.send(:namespaced_key, User.first, {})
 => "users/508fefdb54ca455644000003-20121226093034" 
> Rails.cache.send(:namespaced_key, [User.first, User.last], {})
 => "users/508fefdb54ca455644000003-20121226093034/users/50b7832354ca45f043000011-20121129154539" 
> Rails.cache.send(:namespaced_key, [User.first], {})
 => "508fefdb54ca455644000003" 

# yurk, should probably be "users/508fefdb54ca455644000003-20121226093034" instead
```

Also this is inconsistent with the (internally used) ActiveSupport::Cache.expand_cache_key

``` bash

> ActiveSupport::Cache.expand_cache_key User.first
 => "users/508fefdb54ca455644000003-20121226093034" 
> ActiveSupport::Cache.expand_cache_key [User.first, User.last]
 => "users/508fefdb54ca455644000003-20121226093034/users/50b7832354ca45f043000011-20121129154539" 
>   ActiveSupport::Cache.expand_cache_key [User.first]
 => "users/508fefdb54ca455644000003-20121226093034" 

```
