### PR TITLE
quote column names in generated fixture files

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Quote column names in generates fixture files. This prevents
+    conflicts with reserved YAML keywords such as 'yes' and 'no'
+    Fix #8612
+
+    *Yves Senn*
+
 *   Explicit options have precedence over `~/.railsrc` on the `rails new` command.
 
     *Rafael Mendonça França*

--- a/railties/lib/rails/generators/test_unit/model/model_generator.rb
+++ b/railties/lib/rails/generators/test_unit/model/model_generator.rb
@@ -3,6 +3,9 @@ require 'rails/generators/test_unit'
 module TestUnit # :nodoc:
   module Generators # :nodoc:
     class ModelGenerator < Base # :nodoc:
+
+      RESERVED_YAML_KEYWORDS = %w(y yes n no true false on off null)
+
       argument :attributes, type: :array, default: [], banner: "field:type field:type"
       class_option :fixture, type: :boolean
 
@@ -19,6 +22,15 @@ module TestUnit # :nodoc:
           template 'fixtures.yml', File.join('test/fixtures', class_path, "#{plural_file_name}.yml")
         end
       end
+
+      private
+        def yaml_key_value(key, value)
+          if RESERVED_YAML_KEYWORDS.include?(key.downcase)
+            "'#{key}': #{value}"
+          else
+            "#{key}: #{value}"
+          end
+        end
     end
   end
 end

--- a/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml
+++ b/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml
@@ -3,17 +3,17 @@
 <% unless attributes.empty? -%>
 one:
 <% attributes.each do |attribute| -%>
-  <%= attribute.column_name %>: <%= attribute.default %>
+  <%= yaml_key_value(attribute.column_name, attribute.default) %>
   <%- if attribute.polymorphic? -%>
-  <%= "#{attribute.name}_type: #{attribute.human_name}" %>
+  <%= yaml_key_value("#{attribute.name}_type", attribute.human_name) %>
   <%- end -%>
 <% end -%>
 
 two:
 <% attributes.each do |attribute| -%>
-  <%= attribute.column_name %>: <%= attribute.default %>
+  <%= yaml_key_value(attribute.column_name, attribute.default) %>
   <%- if attribute.polymorphic? -%>
-  <%= "#{attribute.name}_type: #{attribute.human_name}" %>
+  <%= yaml_key_value("#{attribute.name}_type", attribute.human_name) %>
   <%- end -%>
 <% end -%>
 <% else -%>

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -270,17 +270,34 @@ class ModelGeneratorTest < Rails::Generators::TestCase
   def test_invokes_default_test_framework
     run_generator
     assert_file "test/models/account_test.rb", /class AccountTest < ActiveSupport::TestCase/
-    assert_file "test/fixtures/accounts.yml", /name: MyString/, /age: 1/
+
+    assert_file 'test/fixtures/accounts.yml', /name: MyString/, /age: 1/
+    assert_generated_fixture('test/fixtures/accounts.yml',
+                             {'one'=>{'name'=>'MyString', 'age'=>1}, 'two'=>{'name'=>'MyString', 'age'=>1}})
   end
 
   def test_fixtures_use_the_references_ids
     run_generator ["LineItem", "product:references", "cart:belongs_to"]
-    assert_file "test/fixtures/line_items.yml", /product_id: \n  cart_id: /
+
+    assert_file 'test/fixtures/line_items.yml', /product_id: \n  cart_id: /
+    assert_generated_fixture('test/fixtures/line_items.yml',
+                             {"one"=>{"product_id"=>nil, "cart_id"=>nil}, "two"=>{"product_id"=>nil, "cart_id"=>nil}})
   end
 
   def test_fixtures_use_the_references_ids_and_type
     run_generator ["LineItem", "product:references{polymorphic}", "cart:belongs_to"]
-    assert_file "test/fixtures/line_items.yml", /product_id: \n  product_type: Product\n  cart_id: /
+
+    assert_file 'test/fixtures/line_items.yml', /product_id: \n  product_type: Product\n  cart_id: /
+    assert_generated_fixture('test/fixtures/line_items.yml',
+                             {"one"=>{"product_id"=>nil, "product_type"=>"Product", "cart_id"=>nil},
+                              "two"=>{"product_id"=>nil, "product_type"=>"Product", "cart_id"=>nil}})
+  end
+
+  def test_fixtures_respect_reserved_yml_keywords
+    run_generator ["LineItem", "no:integer", "Off:boolean", 'ON:boolean']
+
+    assert_generated_fixture('test/fixtures/line_items.yml',
+                             {"one"=>{"no"=>1, "Off"=>false, "ON"=>false}, "two"=>{"no"=>1, "Off"=>false, "ON"=>false}})
   end
 
   def test_fixture_is_skipped
@@ -338,4 +355,10 @@ class ModelGeneratorTest < Rails::Generators::TestCase
       end
     end
   end
+
+  private
+    def assert_generated_fixture(path, parsed_contents)
+      fixture_file = File.new File.expand_path(path, destination_root)
+      assert_equal(parsed_contents, YAML.load(fixture_file))
+    end
 end


### PR DESCRIPTION
When fixture files are generated the column names can cause conflicts with reserved YAML keywords such as "yes" and "no".  This patch quotes all columns in generated fixture files.

I also rewrote the fixture tests to match against the parsed content. This makes them less brittle and verifies if they actually work.

This is a fix for #8612
