### PR TITLE
backport #8616, quote column names in generated fixture files

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Rails 3.2.9 (Nov 12, 2012) ##
 
+*   Quote column names in generates fixture files. This prevents
+    conflicts with reserved YAML keywords such as 'yes' and 'no'
+    Fix #8612.
+    Backport #8616.
+
+    *Yves Senn*
+
 *   Engines with a dummy app include the rake tasks of dependencies in the app namespace. [Backport: #8262]
     Fix #8229
 

--- a/railties/lib/rails/generators/test_unit/model/model_generator.rb
+++ b/railties/lib/rails/generators/test_unit/model/model_generator.rb
@@ -3,6 +3,9 @@ require 'rails/generators/test_unit'
 module TestUnit
   module Generators
     class ModelGenerator < Base
+
+      RESERVED_YAML_KEYWORDS = %w(y yes n no true false on off null)
+
       argument :attributes, :type => :array, :default => [], :banner => "field:type field:type"
       class_option :fixture, :type => :boolean
 
@@ -19,6 +22,15 @@ module TestUnit
           template 'fixtures.yml', File.join('test/fixtures', class_path, "#{plural_file_name}.yml")
         end
       end
+
+      private
+        def yaml_key_value(key, value)
+          if RESERVED_YAML_KEYWORDS.include?(key.downcase)
+            "'#{key}': #{value}"
+          else
+            "#{key}: #{value}"
+          end
+        end
     end
   end
 end

--- a/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml
+++ b/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml
@@ -3,12 +3,12 @@
 <% unless attributes.empty? -%>
 one:
 <% attributes.each do |attribute| -%>
-  <%= attribute.name %>: <%= attribute.default %>
+  <%= yaml_key_value(attribute.name, attribute.default) %>
 <% end -%>
 
 two:
 <% attributes.each do |attribute| -%>
-  <%= attribute.name %>: <%= attribute.default %>
+  <%= yaml_key_value(attribute.name, attribute.default) %>
 <% end -%>
 <% else -%>
 # This model initially had no columns defined.  If you add columns to the


### PR DESCRIPTION
This is a fix for #8612

Conflicts:

```
railties/CHANGELOG.md
railties/lib/rails/generators/test_unit/model/model_generator.rb
railties/lib/rails/generators/test_unit/model/templates/fixtures.yml
railties/test/generators/model_generator_test.rb
```

There were some modifications on the fixture.yml that are not present on `3-2-stable`. Thats why most of the files had conflicts.
