### PR TITLE
Support cases where count equal zero

### DIFF
--- a/actionpack/lib/action_view/helpers/text_helper.rb
+++ b/actionpack/lib/action_view/helpers/text_helper.rb
@@ -188,7 +188,7 @@ module ActionView
       #   pluralize(0, 'person')
       #   # => 0 people
       def pluralize(count, singular, plural = nil)
-        word = if (count == 1 || count =~ /^1(\.0+)?$/)
+        word = if ([0, 1].include?(count) || count =~ /^1(\.0+)?$/)
           singular
         else
           plural || singular.pluralize


### PR DESCRIPTION
Hello,

Just a little pull request that makes the pluralize method return the singular version of the string when the `count` parameter equal zero.

Have a nice day.
