### PR TITLE
Update documentation for yml usage of reserved words

### DIFF
--- a/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml
+++ b/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml
@@ -1,4 +1,5 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/Fixtures.html
+# Column names which resemble YAML keywords such as 'yes' and 'no' are quoted so that YAML Parser correctly interprets them.
 
 <% unless attributes.empty? -%>
 one:


### PR DESCRIPTION
#8612 fixed. updating documentation to clarify why some columns are quoted while others are not

Also, addition to this https://github.com/rails/rails/pull/8616
