### PR TITLE
Check joined table name by table_name

### DIFF
--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -25,33 +25,10 @@ module ActiveRecord::Associations::Builder
         })
       end
 
-      # TODO: These checks should probably be moved into the Reflection, and we should not be
-      #       redefining the options[:join_table] value - instead we should define a
-      #       reflection.join_table method.
       def check_validity(reflection)
         if reflection.association_foreign_key == reflection.foreign_key
           raise ActiveRecord::HasAndBelongsToManyAssociationForeignKeyNeeded.new(reflection)
         end
-
-        reflection.options[:join_table] ||= join_table_name(
-          model.send(:undecorated_table_name, model.to_s),
-          model.send(:undecorated_table_name, reflection.class_name)
-        )
-      end
-
-      # Generates a join table name from two provided table names.
-      # The names in the join table names end up in lexicographic order.
-      #
-      #   join_table_name("members", "clubs")         # => "clubs_members"
-      #   join_table_name("members", "special_clubs") # => "members_special_clubs"
-      def join_table_name(first_table_name, second_table_name)
-        if first_table_name < second_table_name
-          join_table = "#{first_table_name}_#{second_table_name}"
-        else
-          join_table = "#{second_table_name}_#{first_table_name}"
-        end
-
-        model.table_name_prefix + join_table + model.table_name_suffix
       end
   end
 end

--- a/activerecord/lib/active_record/associations/has_and_belongs_to_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_and_belongs_to_many_association.rb
@@ -5,7 +5,7 @@ module ActiveRecord
       attr_reader :join_table
 
       def initialize(owner, reflection)
-        @join_table = Arel::Table.new(reflection.options[:join_table])
+        @join_table = Arel::Table.new(reflection.join_table)
         super
       end
 

--- a/activerecord/lib/active_record/associations/join_helper.rb
+++ b/activerecord/lib/active_record/associations/join_helper.rb
@@ -19,7 +19,7 @@ module ActiveRecord
 
           if reflection.source_macro == :has_and_belongs_to_many
             tables << alias_tracker.aliased_table_for(
-              (reflection.source_reflection || reflection).options[:join_table],
+              (reflection.source_reflection || reflection).join_table,
               table_alias_for(reflection, true)
             )
           end

--- a/activerecord/lib/active_record/associations/preloader/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/preloader/has_and_belongs_to_many.rb
@@ -6,7 +6,7 @@ module ActiveRecord
 
         def initialize(klass, records, reflection, preload_options)
           super
-          @join_table = Arel::Table.new(options[:join_table]).alias('t0')
+          @join_table = Arel::Table.new(reflection.join_table).alias('t0')
         end
 
         # Unlike the other associations, we want to get a raw array of rows so that we can

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -622,7 +622,7 @@ module ActiveRecord
             when :has_and_belongs_to_many
               if (targets = row.delete(association.name.to_s))
                 targets = targets.is_a?(Array) ? targets : targets.split(/\s*,\s*/)
-                table_name = association.options[:join_table]
+                table_name = association.join_table
                 rows[table_name].concat targets.map { |target|
                   { association.foreign_key             => row[primary_key_name],
                     association.association_foreign_key => ActiveRecord::Fixtures.identify(target) }


### PR DESCRIPTION
In my app I use STI and overridden table_name but `habtm` in it doesn't work properly, and I have to set options on it forcibly. I'll show you example:

``` ruby
module Namespace
  class Base < ActiveRecord::Base
    self.table_name = 'tablename'
    has_and_belongs_to_many :somethings
  end
end

class Namespace::Child < Namespace::Base
end
```

It gives me advantage I can keep all these stuff inside `namespace` directory and it will be auto loaded by AS and it's still STI. But HABTM relies on classes when it calculates table names, so for join table it chooses `bases_somethings` instead of `tablename_somethings`. Of course I can set these options manually and it will work. I left comment in this PR and it has small refactoring proposed by @jonleighton in comment and actually this refactoring is the way to go if we want to use table_name.
