### PR TITLE
This commit fixes issue #8628

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -4,6 +4,13 @@
 
     *Jiri Pospisil*
 
+*   Environment name can be a start substring of the default environemnt names 
+    (production, development, test).
+    For example: tes, pro, prod, dev, devel.
+    Fix #8628
+
+    *Mykola Kyryk*
+
 *   Quote column names in generates fixture files. This prevents
     conflicts with reserved YAML keywords such as 'yes' and 'no'
     Fix #8612

--- a/railties/lib/rails/commands/console.rb
+++ b/railties/lib/rails/commands/console.rb
@@ -24,11 +24,20 @@ module Rails
 
         if arguments.first && arguments.first[0] != '-'
           env = arguments.first
-          options[:environment] = %w(production development test).detect {|e| e =~ /^#{env}/} || env
+          if available_environments.include? env
+            options[:environment] = env
+          else
+            options[:environment] = %w(production development test).detect {|e| e =~ /^#{env}/} || env
+          end
         end
 
         options
       end
+
+      private
+        def available_environments
+          Dir[Rails.root.join('config', 'environments', '*.rb')].map { |fname| File.basename(fname, '.*') }
+        end
     end
 
     attr_reader :options, :app, :console

--- a/railties/lib/rails/commands/dbconsole.rb
+++ b/railties/lib/rails/commands/dbconsole.rb
@@ -136,10 +136,18 @@ module Rails
 
       if arguments.first && arguments.first[0] != '-'
         env = arguments.first
-        options[:environment] = %w(production development test).detect {|e| e =~ /^#{env}/} || env
+        if self.class.available_environments.include? env
+          options[:environment] = env
+        else
+          options[:environment] = %w(production development test).detect {|e| e =~ /^#{env}/} || env
+        end
       end
 
       options
+    end
+
+    def self.available_environments
+      Dir[Rails.root.join('config', 'environments', '*.rb')].map { |fname| File.basename(fname, '.*') }
     end
 
     def find_cmd_and_exec(commands, *args)

--- a/railties/test/commands/console_test.rb
+++ b/railties/test/commands/console_test.rb
@@ -111,6 +111,12 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
     assert_match(/\sdevelopment\s/, output)
   end
 
+  def test_rails_env_is_dev_when_argument_is_dev_and_dev_env_is_present
+    Rails::Console.stubs(:available_environments).returns(['dev'])
+    options = Rails::Console.parse_arguments(['dev'])
+    assert_match('dev', options[:environment])
+  end
+
   private
 
   attr_reader :output

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -45,6 +45,18 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
     ENV['RAILS_ENV'] = "test"
   end
 
+  def test_rails_env_is_development_when_argument_is_dev
+    Rails::DBConsole.stubs(:available_environments).returns(['development', 'test'])
+    options = Rails::DBConsole.new.send(:parse_arguments, ['dev'])
+    assert_match('development', options[:environment])
+  end
+
+  def test_rails_env_is_dev_when_argument_is_dev_and_dev_env_is_present
+    Rails::DBConsole.stubs(:available_environments).returns(['dev'])
+    options = Rails::DBConsole.new.send(:parse_arguments, ['dev'])
+    assert_match('dev', options[:environment])
+  end
+
   def test_mysql
     dbconsole.expects(:find_cmd_and_exec).with(%w[mysql mysql5], 'db')
     start(adapter: 'mysql', database: 'db')


### PR DESCRIPTION
Allow environment name to start with a substring of the default
environment names.
For example: tes, pro, prod, dev, devel, etc.
