### PR TITLE
rewrite order dependent test case

### DIFF
--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -276,7 +276,8 @@ class TestJSONEncoding < ActiveSupport::TestCase
     f.bar = "world"
 
     hash = {"foo" => f, "other_hash" => {"foo" => "other_foo", "test" => "other_test"}}
-    assert_equal(%({"foo":{"foo":"hello","bar":"world"},"other_hash":{"foo":"other_foo","test":"other_test"}}), hash.to_json)
+    assert_equal({"foo"=>{"foo"=>"hello","bar"=>"world"},
+                  "other_hash" => {"foo"=>"other_foo","test"=>"other_test"}}, JSON.parse(hash.to_json))
   end
 
   def test_struct_encoding


### PR DESCRIPTION
As reported (https://github.com/rails/rails/pull/8185#issuecomment-11702226) this test relied on the order a hash was serialized. Comparing the parsed hash makes the test no longer order dependent.
