### PR TITLE
Revert "Revert "Ignore /bin on new apps""

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/gitignore
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore
@@ -4,8 +4,9 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
-# Ignore bundler config
+# Ignore bundler related files.
 /.bundle
+/bin
 
 # Ignore the default SQLite database.
 /db/*.sqlite3


### PR DESCRIPTION
From the discussion and all the concerns on 61b91c4c55bcbd5a2ec85d6e1c67755150653dff, it seems like it's not a good idea to make people add `./bin` to their source control.

If we really would like to promote the usage of binstubs, we should instead coordinate with Bundler and find a better solution, such as a shared configuration that enable binstubs generation when user running `bundle install` locally, since it's now a de-facto that a developer would run `bundle install` after they clone a project.

This partially reverts commit 61b91c4c55bcbd5a2ec85d6e1c67755150653dff.
