### PR TITLE
Improve a way to handle errors for collection nested attributes

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -357,7 +357,8 @@ module ActiveModel
     #   person.errors.full_message(:name, 'is invalid') # => "Name is invalid"
     def full_message(attribute, message)
       return message if attribute == :base
-      attr_name = attribute.to_s.tr('.', '_').humanize
+      attribute = attribute.to_s.gsub(/\[\d+\]/, "")
+      attr_name = attribute.tr('.', '_').humanize
       attr_name = @base.class.human_attribute_name(attribute, :default => attr_name)
       I18n.t(:"errors.format", {
         :default   => "%{attribute} %{message}",

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -31,7 +31,7 @@ class I18nValidationTest < ActiveModel::TestCase
 
   def test_errors_full_messages_translates_human_attribute_name_for_model_attributes
     @person.errors.add(:name, 'not found')
-    Person.expects(:human_attribute_name).with(:name, :default => 'Name').returns("Person's name")
+    Person.expects(:human_attribute_name).with("name", :default => 'Name').returns("Person's name")
     assert_equal ["Person's name not found"], @person.errors.full_messages
   end
 

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -275,7 +275,9 @@ module ActiveRecord
     def validate_collection_association(reflection)
       if association = association_instance_get(reflection.name)
         if records = associated_records_to_validate_or_save(association, new_record?, reflection.options[:autosave])
-          records.each { |record| association_valid?(reflection, record) }
+          records.each_with_index do |record, index|
+            association_valid?(reflection, record, index)
+          end
         end
       end
     end
@@ -283,13 +285,15 @@ module ActiveRecord
     # Returns whether or not the association is valid and applies any errors to
     # the parent, <tt>self</tt>, if it wasn't. Skips any <tt>:autosave</tt>
     # enabled records if they're marked_for_destruction? or destroyed.
-    def association_valid?(reflection, record)
+    def association_valid?(reflection, record, index = nil)
       return true if record.destroyed? || record.marked_for_destruction?
 
       unless valid = record.valid?(validation_context)
         if reflection.options[:autosave]
+          attribute_prefix = reflection.name.to_s
+          attribute_prefix += "[#{index}]" if index
           record.errors.each do |attribute, message|
-            attribute = "#{reflection.name}.#{attribute}"
+            attribute = "#{attribute_prefix}.#{attribute}"
             errors[attribute] << message
             errors[attribute].uniq!
           end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1140,7 +1140,7 @@ module AutosaveAssociationOnACollectionAssociationTests
     @pirate.send(@association_name).each { |child| child.name = '' }
 
     assert !@pirate.valid?
-    assert_equal ["can't be blank"], @pirate.errors["#{@association_name}.name"]
+    assert_equal ["can't be blank"], @pirate.errors["#{@association_name}[0].name"]
     assert @pirate.errors[@association_name].empty?
   end
 
@@ -1148,7 +1148,7 @@ module AutosaveAssociationOnACollectionAssociationTests
     @pirate.send(@association_name).build(:name => '')
 
     assert !@pirate.valid?
-    assert_equal ["can't be blank"], @pirate.errors["#{@association_name}.name"]
+    assert_equal ["can't be blank"], @pirate.errors["#{@association_name}[0].name"]
     assert @pirate.errors[@association_name].empty?
   end
 
@@ -1160,7 +1160,7 @@ module AutosaveAssociationOnACollectionAssociationTests
     @pirate.send(@association_name).build(:name => '')
 
     assert !@pirate.valid?
-    assert_equal ["cannot be blank"], @pirate.errors["#{@association_name}.name"]
+    assert_equal ["cannot be blank"], @pirate.errors["#{@association_name}[0].name"]
     assert_equal ["#{@association_name.to_s.titleize} name cannot be blank"], @pirate.errors.full_messages
     assert @pirate.errors[@association_name].empty?
   ensure
@@ -1172,7 +1172,7 @@ module AutosaveAssociationOnACollectionAssociationTests
     @pirate.catchphrase = nil
 
     assert !@pirate.valid?
-    assert_equal ["can't be blank"], @pirate.errors["#{@association_name}.name"]
+    assert_equal ["can't be blank"], @pirate.errors["#{@association_name}[0].name"]
     assert @pirate.errors[:catchphrase].any?
   end
 

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -793,7 +793,8 @@ module NestedAttributesOnACollectionAssociationTests
       assert_no_difference ['Man.count', 'Interest.count'] do
         man = Man.create(:name => 'John',
                          :interests_attributes => [{:topic=>'Cars'}, {:topic=>'Sports'}])
-        assert !man.errors[:"interests.man"].empty?
+        assert !man.errors[:"interests[0].man"].empty?
+        assert !man.errors[:"interests[1].man"].empty?
       end
     end
   ensure


### PR DESCRIPTION
Example:

``` ruby
    Employment.validates :company, :presence => true
    Developer.has_many :employments
    Developer.accepts_nested_attributes_for :employments
    d = Developer.new
    2.times { d.employments.build }
    d.valid?
    d.errors.messages
```

Old result:

``` ruby
    {
      :"employments.company"=>["can't be blank"],
      :email=>["can't be blank"],
      :password=>["can't be blank"]
    }

```

See that it is impossible to detect which `Employment` object is error related to.
In order to fix that propose to use an index(as Employment could be new - we can not use an id).
Only applied to collection associations.

New result

``` ruby
    {
      :"employments[0].company"=>["can't be blank"],
      :"employments[1].company"=>["can't be blank"],
      :email=>["can't be blank"],
      :password=>["can't be blank"]
    }

```

Live demo:
http://rails-ajax-validation.herokuapp.com
