### PR TITLE
Add AR::Base#valid! method

### DIFF
--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -54,7 +54,7 @@ module ActiveRecord
     # Attempts to save the record just like Base#save but will raise a +RecordInvalid+
     # exception instead of returning +false+ if the record is not valid.
     def save!(options={})
-      perform_validations(options) ? super : raise(RecordInvalid.new(self))
+      perform_validations(options) ? super : raise_record_invalid
     end
 
     # Runs all the validations within the specified context. Returns +true+ if
@@ -75,7 +75,23 @@ module ActiveRecord
 
     alias_method :validate, :valid?
 
+    # Runs all the validations within the specified context. Returns +true+ if
+    # no errors are found, raises +RecordInvalid+ otherwise.
+    #
+    # If the argument is +false+ (default is +nil+), the context is set to <tt>:create</tt> if
+    # <tt>new_record?</tt> is +true+, and to <tt>:update</tt> if it is not.
+    #
+    # Validations with no <tt>:on</tt> option will run no matter the context. Validations with
+    # some <tt>:on</tt> option will only run in the specified context.
+    def validate!(context = nil)
+      valid?(context) || raise_record_invalid
+    end
+
   protected
+
+    def raise_record_invalid
+      raise(RecordInvalid.new(self))
+    end
 
     def perform_validations(options={}) # :nodoc:
       options[:validate] == false || valid?(options[:context])

--- a/activerecord/test/cases/validations_test.rb
+++ b/activerecord/test/cases/validations_test.rb
@@ -78,6 +78,20 @@ class ValidationsTest < ActiveRecord::TestCase
     assert_equal r, invalid.record
   end
 
+  def test_validate_with_bang
+    assert_raise(ActiveRecord::RecordInvalid) do
+      WrongReply.new.validate!
+    end
+  end
+
+  def test_validate_with_bang_and_context
+    assert_raise(ActiveRecord::RecordInvalid) do
+      WrongReply.new.validate!(:special_case)
+    end
+    r = WrongReply.new(:title => "Valid title", :author_name => "secret", :content => "Good")
+    assert r.validate!(:special_case)
+  end
+
   def test_exception_on_create_bang_many
     assert_raise(ActiveRecord::RecordInvalid) do
       WrongReply.create!([ { "title" => "OK" }, { "title" => "Wrong Create" }])


### PR DESCRIPTION
This is helper method in case when some operations should be done on a record before saving. But they doesn't make sence if record is invalid.

``` ruby
def create_developer_from_linkedin(parameters)
  d = Developer.new(parameters)
  d.valid!
  d.import_linkedin_profile
  d.save!
end
```
