### PR TITLE
fix block.arity will raise nil error

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 3.2.10 (unreleased) ##
 
+*   Fix a bug in `ActionView::Helpers::RecordTagHelper::content_tag_for`
+    raise `nil:NilClass` without given a block.
+    
+    *Jasl*
+
 *   Clear url helper methods when routes are reloaded by removing the methods
     explicitly rather than just clearing the module because it didn't work
     properly and could be the source of a memory leak.

--- a/actionpack/lib/action_view/helpers/record_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/record_tag_helper.rb
@@ -98,7 +98,9 @@ module ActionView
           options, prefix = prefix, nil if prefix.is_a?(Hash)
           options = options ? options.dup : {}
           options.merge!(:class => "#{dom_class(record, prefix)} #{options[:class]}".strip, :id => dom_id(record, prefix))
-          if block.arity == 0
+          if !block_given?
+            content_tag(tag_name, "", options)
+          elsif block.arity == 0
             content_tag(tag_name, capture(&block), options)
           else
             content_tag(tag_name, capture(record, &block), options)

--- a/actionpack/test/template/record_tag_helper_test.rb
+++ b/actionpack/test/template/record_tag_helper_test.rb
@@ -81,6 +81,14 @@ class RecordTagHelperTest < ActionView::TestCase
     assert_dom_equal expected, actual
   end
 
+  def test_content_tag_for_collection_without_given_block
+    post_1 = RecordTagPost.new.tap { |post| post.id = 101; post.body = "Hello!"; post.persisted = true }
+    post_2 = RecordTagPost.new.tap { |post| post.id = 102; post.body = "World!"; post.persisted = true }
+    expected = %(<li class="record_tag_post" id="record_tag_post_101"></li>\n<li class="record_tag_post" id="record_tag_post_102"></li>)
+    actual = content_tag_for(:li, [post_1, post_2])
+    assert_dom_equal expected, actual
+  end
+
   def test_div_for_collection
     post_1 = RecordTagPost.new.tap { |post| post.id = 101; post.body = "Hello!"; post.persisted = true }
     post_2 = RecordTagPost.new.tap { |post| post.id = 102; post.body = "World!"; post.persisted = true }


### PR DESCRIPTION
`content_tag_for` will raise `nil:NilClass` when not given a block, cause `content_tag_for_single_record` will check `block.arity == 0` but in this case "block" should be `nil` obviously.
