### PR TITLE
Remove warning in Ruby2.0

### DIFF
--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -90,4 +90,9 @@ module Rails
       application && Pathname.new(application.paths["public"].first)
     end
   end
+
+  self.application = nil
+  self.cache = nil
+  self.logger = nil
+
 end


### PR DESCRIPTION
- warning: instance variable @application not initialized
- warning: instance variable @logger not initialized
- warning: instance variable @cache not initialized
