### PR TITLE
ignore other warnings in test assertion. Ruby 2.0

### DIFF
--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -1438,7 +1438,7 @@ class RenderTest < ActionController::TestCase
 
     get :partial_collection_with_locals
     assert_template partial: 'customer_greeting', locals: { greeting: 'Bonjour' }
-    assert_equal "the :locals option to #assert_template is only supported in a ActionView::TestCase\n", warning_buffer.string
+    assert_match /the :locals option to #assert_template is only supported in a ActionView::TestCase/, warning_buffer.string
   ensure
     $stderr = STDERR
   end


### PR DESCRIPTION
Using Ruby 2.0 we get a failing test in actionpack:

```
  1) Failure:
test_locals_option_to_assert_template_is_not_supported(RenderTest) [/Users/senny/Projects/rails/actionpack/test/controller/render_test.rb:1441]:
--- expected
+++ actual
@@ -1,2 +1,3 @@
-"the :locals option to #assert_template is only supported in a ActionView::TestCase
+"/Users/senny/Projects/rails/actionpack/test/fixtures/test/_customer_greeting.erb:1: warning: assigned but unused variable - customer_greeting_counter
+the :locals option to #assert_template is only supported in a ActionView::TestCase
 "
```

This is because there are tons of warnings emitted and the test makes a hard match against the warning buffer.

I'm sure we will get rid of the warnings with Ruby 2.0 but there is no reason this test should fail.
