### PR TITLE
Allow the `:location` option to `respond_with` to accept a proc

### DIFF
--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -62,6 +62,7 @@ module ActionController
     # Process controller specific options, as status, content-type and location.
     def _process_options(options) #:nodoc:
       status, content_type, location = options.values_at(:status, :content_type, :location)
+      location = location.call if location.respond_to?(:call)
 
       self.status = status if status
       self.content_type = content_type if content_type

--- a/actionpack/test/controller/mime_responds_test.rb
+++ b/actionpack/test/controller/mime_responds_test.rb
@@ -541,6 +541,16 @@ class RespondWithController < ActionController::Base
     respond_with(resource, :location => "http://test.host/", :status => :created)
   end
 
+  def using_resource_with_location_proc
+    @customer = Customer.new("david", 13)
+    respond_with(@customer, :location => proc { "http://test.host/customers/#{@customer.id}" })
+  end
+
+  def using_resource_with_bad_location_proc
+    @customer = Customer.new("david", 13)
+    respond_with(@customer, :location => proc { raise "bad" })
+  end
+
   def using_invalid_resource_with_template
     respond_with(resource)
   end
@@ -1063,6 +1073,24 @@ class RespondWithControllerTest < ActionController::TestCase
     put :using_resource_with_status_and_location
     assert_equal errors.to_xml, @response.body
     assert_equal 422, @response.status
+    assert_equal nil, @response.location
+  end
+
+  def test_using_resource_with_location_proc
+    @request.accept = "text/html"
+    post :using_resource_with_location_proc
+
+    assert @response.redirect?
+    assert_equal "http://test.host/customers/13", @response.location
+  end
+
+  def test_using_resource_with_bad_location_proc
+    errors = { :name => :invalid }
+    Customer.any_instance.stubs(:errors).returns(errors)
+
+    @request.accept = "text/xml"
+    post :using_resource_with_bad_location_proc
+
     assert_equal nil, @response.location
   end
 


### PR DESCRIPTION
This allows `respond_with` to accept a `:location` option with a value that might fail if the resource in question could not be saved. Some named route methods might raise an error if the resource isn't persisted and consequently has no ID. Passing a proc allows execution to be delayed until such time as the Location header is needed (if it's needed).
