### PR TITLE
use respond_with to DRY scaffold generator output

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Scaffold generator now uses respond_with by default.
+
+    *Jordi Polo*
+
 *   Quote column names in generates fixture files. This prevents
     conflicts with reserved YAML keywords such as 'yes' and 'no'
     Fix #8612

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
@@ -5,29 +5,24 @@ require_dependency "<%= namespaced_file_path %>/application_controller"
 <% module_namespacing do -%>
 class <%= controller_class_name %>Controller < ApplicationController
   before_action :set_<%= singular_table_name %>, only: [:show, :edit, :update, :destroy]
+  <%- if options[:html] -%>
+    respond_to :html, :json
+  <%- else -%>
+    respond_to :json
+  <%- end -%>
+  
 
   # GET <%= route_url %>
   # GET <%= route_url %>.json
   def index
     @<%= plural_table_name %> = <%= orm_class.all(class_name) %>
-
-    respond_to do |format|
-      <%- if options[:html] -%>
-      format.html # index.html.erb
-      <%- end -%>
-      format.json { render json: <%= "@#{plural_table_name}" %> }
-    end
+    respond_with @<%= plural_table_name %>
   end
 
   # GET <%= route_url %>/1
   # GET <%= route_url %>/1.json
   def show
-    respond_to do |format|
-      <%- if options[:html] -%>
-      format.html # show.html.erb
-      <%- end -%>
-      format.json { render json: <%= "@#{singular_table_name}" %> }
-    end
+    respond_with @<%= singular_table_name %> 
   end
 
   <%- if options[:html] -%>
@@ -35,11 +30,7 @@ class <%= controller_class_name %>Controller < ApplicationController
   # GET <%= route_url %>/new.json
   def new
     @<%= singular_table_name %> = <%= orm_class.build(class_name) %>
-
-    respond_to do |format|
-      format.html # new.html.erb
-      format.json { render json: <%= "@#{singular_table_name}" %> }
-    end
+    respond_with @<%= singular_table_name %>
   end
 
   # GET <%= route_url %>/1/edit
@@ -51,46 +42,26 @@ class <%= controller_class_name %>Controller < ApplicationController
   # POST <%= route_url %>.json
   def create
     @<%= singular_table_name %> = <%= orm_class.build(class_name, "#{singular_table_name}_params") %>
-
-    respond_to do |format|
-      if @<%= orm_instance.save %>
-        <%- if options[:html] -%>
-        format.html { redirect_to @<%= singular_table_name %>, notice: <%= "'#{human_name} was successfully created.'" %> }
-        <%- end -%>
-        format.json { render json: <%= "@#{singular_table_name}" %>, status: :created, location: <%= "@#{singular_table_name}" %> }
-      else
-        <%- if options[:html] -%>
-        format.html { render action: "new" }
-        <%- end -%>
-        format.json { render json: <%= "@#{orm_instance.errors}" %>, status: :unprocessable_entity }
-      end
+    if @<%= orm_instance.save %>
+      flash[:notice] = <%= "'#{human_name} was successfully created.'" %>
     end
+    respond_with @<%= singular_table_name %>
   end
 
   # PATCH/PUT <%= route_url %>/1
   # PATCH/PUT <%= route_url %>/1.json
   def update
-    respond_to do |format|
-      if @<%= orm_instance.update_attributes("#{singular_table_name}_params") %>
-        <%- if options[:html] -%>
-        format.html { redirect_to @<%= singular_table_name %>, notice: <%= "'#{human_name} was successfully updated.'" %> }
-        <%- end -%>
-        format.json { head :no_content }
-      else
-        <%- if options[:html] -%>
-        format.html { render action: "edit" }
-        <%- end -%>
-        format.json { render json: <%= "@#{orm_instance.errors}" %>, status: :unprocessable_entity }
-      end
+    if @<%= orm_instance.update_attributes("#{singular_table_name}_params") %>
+      flash[:notice] = <%= "'#{human_name} was successfully updated.'" %>
     end
+    respond_with @<%= singular_table_name %>
   end
 
   # DELETE <%= route_url %>/1
   # DELETE <%= route_url %>/1.json
   def destroy
     @<%= orm_instance.destroy %>
-
-    respond_to do |format|
+    respond_with @<%= singular_table_name %> do |format|
       <%- if options[:html] -%>
       format.html { redirect_to <%= index_helper %>_url }
       <%- end -%>

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -31,12 +31,10 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       assert_instance_method :create, content do |m|
         assert_match(/@user = User\.new\(user_params\)/, m)
         assert_match(/@user\.save/, m)
-        assert_match(/@user\.errors/, m)
       end
 
       assert_instance_method :update, content do |m|
         assert_match(/@user\.update_attributes\(user_params\)/, m)
-        assert_match(/@user\.errors/, m)
       end
 
       assert_instance_method :destroy, content do |m|
@@ -136,6 +134,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       assert_no_match(/format\.html/, content)
       assert_no_match(/def edit/, content)
       assert_no_match(/def new/, content)
+      assert_no_match(/respond_to :html/, content)
     end
   end
 
@@ -173,10 +172,12 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
     Unknown::Generators.send :remove_const, :ActiveModel
   end
 
-  def test_new_hash_style
+  def test_respond_with_responses
     run_generator
     assert_file "app/controllers/users_controller.rb" do |content|
-      assert_match(/\{ render action: "new" \}/, content)
+      assert_match(/respond_to :html, :json/, content)
+      assert_match(/respond_with @users/, content)
+      assert_match(/respond_with @user/, content)
     end
   end
 end

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -41,12 +41,10 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       assert_instance_method :create, content do |m|
         assert_match(/@product_line = ProductLine\.new\(product_line_params\)/, m)
         assert_match(/@product_line\.save/, m)
-        assert_match(/@product_line\.errors/, m)
       end
 
       assert_instance_method :update, content do |m|
         assert_match(/@product_line\.update_attributes\(product_line_params\)/, m)
-        assert_match(/@product_line\.errors/, m)
       end
 
       assert_instance_method :destroy, content do |m|
@@ -158,12 +156,10 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       assert_instance_method :create, content do |m|
         assert_match(/@admin_role = Admin::Role\.new\(admin_role_params\)/, m)
         assert_match(/@admin_role\.save/, m)
-        assert_match(/@admin_role\.errors/, m)
       end
 
       assert_instance_method :update, content do |m|
         assert_match(/@admin_role\.update_attributes\(admin_role_params\)/, m)
-        assert_match(/@admin_role\.errors/, m)
       end
 
       assert_instance_method :destroy, content do |m|


### PR DESCRIPTION
respond_with has been around for some time and it really helps to keep the controller DRY.  If you see the file before and after I think you will agree is an improvement.
I think making the generator to use respond_with by default Rails will promote its use. 
In my experience many Rails developers still do not know about it.

This is my first contribution to Rails, if I may have overlooked something and something is lacking in the PR, please point it to me and I'll work on the details.   
