### PR TITLE
Unify routes output for console and web

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -560,7 +560,9 @@
 
     *Carlos Galdino + Rafael Mendonça França*
 
-*   Show routes in exception page while debugging a `RoutingError` in development. *Richard Schneeman and Mattt Thompson*
+*   Show routes in exception page while debugging a `RoutingError` in development.
+
+    *Richard Schneeman + Mattt Thompson + Yves Senn*
 
 *   Add `ActionController::Flash.add_flash_types` method to allow people to register their own flash types. e.g.:
 

--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -2,7 +2,6 @@ require 'action_dispatch/http/request'
 require 'action_dispatch/middleware/exception_wrapper'
 require 'action_dispatch/routing/inspector'
 
-
 module ActionDispatch
   # This middleware is responsible for logging exceptions and
   # showing a debugging page in case the request is local.
@@ -42,12 +41,11 @@ module ActionDispatch
           :application_trace => wrapper.application_trace,
           :framework_trace => wrapper.framework_trace,
           :full_trace => wrapper.full_trace,
-          :routes => formatted_routes(exception),
+          :routes_inspector => routes_inspector(exception),
           :source_extract => wrapper.source_extract,
           :line_number => wrapper.line_number,
           :file => wrapper.file
         )
-
         file = "rescues/#{wrapper.rescue_template}"
         body = template.render(:template => file, :layout => 'rescues/layout')
         render(wrapper.status_code, body)
@@ -85,11 +83,28 @@ module ActionDispatch
       @stderr_logger ||= ActiveSupport::Logger.new($stderr)
     end
 
-    def formatted_routes(exception)
+    def routes_inspector(exception)
       return false unless @routes_app.respond_to?(:routes)
       if exception.is_a?(ActionController::RoutingError) || exception.is_a?(ActionView::Template::Error)
-        inspector = ActionDispatch::Routing::RoutesInspector.new
-        inspector.collect_routes(@routes_app.routes.routes)
+        ActionDispatch::Routing::RoutesInspector.new(@routes_app.routes.routes)
+      end
+    end
+
+    class TableRoutesFormatter
+      def initialize(view)
+        @view = view
+        @buffer = []
+      end
+
+      def section(type, title, routes)
+        @buffer << %(<tr><th colspan="4">#{title}</th></tr>)
+        @buffer << @view.render(partial: "routes/route", collection: routes)
+      end
+
+      def result
+        @view.raw @view.render(layout: "routes/route_wrapper") {
+          @view.raw @buffer.join("\n")
+        }
       end
     end
   end

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/routing_error.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/routing_error.erb
@@ -15,6 +15,7 @@
   <% end %>
   <%= render template: "rescues/_trace" %>
 
+<% if @routes_inspector %>
   <h2>
     Routes
   </h2>
@@ -23,6 +24,5 @@
     Routes match in priority from top to bottom
   </p>
 
-<%= render layout: "routes/route_wrapper" do %>
-  <%= render partial: "routes/route", collection: @routes %>
+  <%= @routes_inspector.format(ActionDispatch::DebugExceptions::TableRoutesFormatter.new(self)) %>
 <% end %>

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -61,21 +61,33 @@ module ActionDispatch
 
     ##
     # This class is just used for displaying route information when someone
-    # executes `rake routes`.  People should not use this class.
+    # executes `rake routes` or looks at the RoutingError page.
+    # People should not use this class.
     class RoutesInspector # :nodoc:
-      def initialize
-        @engines = Hash.new
+      def initialize(routes)
+        @engines = {}
+        @routes = routes
       end
 
-      def format(all_routes, filter = nil)
-        if filter
-          all_routes = all_routes.select{ |route| route.defaults[:controller] == filter }
+      def format(formatter, filter = nil)
+        routes_to_display = filter_routes(filter)
+
+        routes = collect_routes(routes_to_display)
+        formatter.section :application, 'Application routes', routes
+
+        @engines.each do |name, routes|
+          formatter.section :engine, "Routes for #{name}", routes
         end
 
-        routes = collect_routes(all_routes)
+        formatter.result
+      end
 
-        formatted_routes(routes) +
-          formatted_routes_for_engines
+      def filter_routes(filter)
+        if filter
+          @routes.select { |route| route.defaults[:controller] == filter }
+        else
+          @routes
+        end
       end
 
       def collect_routes(routes)
@@ -100,22 +112,32 @@ module ActionDispatch
           @engines[name] = collect_routes(routes.routes)
         end
       end
+    end
 
-      def formatted_routes_for_engines
-        @engines.map do |name, routes|
-          ["\nRoutes for #{name}:"] + formatted_routes(routes)
-        end.flatten
+    class ConsoleFormatter
+      def initialize
+        @buffer = []
       end
 
-      def formatted_routes(routes)
-        name_width = routes.map{ |r| r[:name].length }.max
-        verb_width = routes.map{ |r| r[:verb].length }.max
-        path_width = routes.map{ |r| r[:path].length }.max
+      def result
+        @buffer.join("\n")
+      end
 
-        routes.map do |r|
-          "#{r[:name].rjust(name_width)} #{r[:verb].ljust(verb_width)} #{r[:path].ljust(path_width)} #{r[:reqs]}"
+      def section(type, title, routes)
+        @buffer << "\n#{title}:" unless type == :application
+        @buffer << draw_section(routes)
+      end
+
+      private
+        def draw_section(routes)
+          name_width = routes.map { |r| r[:name].length }.max
+          verb_width = routes.map { |r| r[:verb].length }.max
+          path_width = routes.map { |r| r[:path].length }.max
+
+          routes.map do |r|
+            "#{r[:name].rjust(name_width)} #{r[:verb].ljust(verb_width)} #{r[:path].ljust(path_width)} #{r[:reqs]}"
+          end
         end
-      end
     end
   end
 end

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -45,8 +45,17 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     end
   end
 
-  ProductionApp  = ActionDispatch::DebugExceptions.new(Boomer.new(false))
-  DevelopmentApp = ActionDispatch::DebugExceptions.new(Boomer.new(true))
+  def setup
+    app = ActiveSupport::OrderedOptions.new
+    app.config = ActiveSupport::OrderedOptions.new
+    app.config.assets = ActiveSupport::OrderedOptions.new
+    app.config.assets.prefix = '/sprockets'
+    Rails.stubs(:application).returns(app)
+  end
+
+  RoutesApp = Struct.new(:routes).new(SharedTestRoutes)
+  ProductionApp  = ActionDispatch::DebugExceptions.new(Boomer.new(false), RoutesApp)
+  DevelopmentApp = ActionDispatch::DebugExceptions.new(Boomer.new(true), RoutesApp)
 
   test 'skip diagnosis if not showing detailed exceptions' do
     @app = ProductionApp
@@ -76,6 +85,15 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
       get "/pass", {}, {'action_dispatch.show_exceptions' => true}
     end
     assert boomer.closed, "Expected to close the response body"
+  end
+
+  test 'displays routes in a table when a RoutingError occurs' do
+    @app = DevelopmentApp
+    get "/pass", {}, {'action_dispatch.show_exceptions' => true}
+    routing_table = body[/route_table.*<.table>/m]
+    assert_match '/:controller(/:action)(.:format)', routing_table
+    assert_match ':controller#:action', routing_table
+    assert_no_match '&lt;|&gt;', routing_table, "there should not be escaped html in the output"
   end
 
   test "rescue with diagnostics message" do

--- a/railties/lib/rails/tasks/routes.rake
+++ b/railties/lib/rails/tasks/routes.rake
@@ -2,6 +2,6 @@ desc 'Print out all defined routes in match order, with names. Target specific c
 task routes: :environment do
   all_routes = Rails.application.routes.routes
   require 'action_dispatch/routing/inspector'
-  inspector = ActionDispatch::Routing::RoutesInspector.new
-  puts inspector.format(all_routes, ENV['CONTROLLER']).join "\n"
+  inspector = ActionDispatch::Routing::RoutesInspector.new(all_routes)
+  puts inspector.format(ActionDispatch::Routing::ConsoleFormatter.new, ENV['CONTROLLER'])
 end


### PR DESCRIPTION
We have a class called `RoutesInspector`. It's purpose is to aggregate the routes so that they can be displayed in the console (`rake routes`). Recently a routes listing was added to the exception page. This listing used parts of `RoutesInspector` but since the class was intermingled with formatting logic for the console, only parts could be reused. This led to #8649.

To solve this I did:
1. split the formatting logic and `RoutesInspector`.
2. when formatting a filter can be applied. We did not have test coverage for the filter argument, so I added a small test case.
3. The `RoutesInspector` now holds the routes it operates on as an instance variable. This allows to instantiate the inspector but apply the formatting later (when we don't have access to the routes anymore).
4. use the same code path to aggregate routes for the console and the web (only the formatter is different).
5. I noticed that there was no test, that rendered the routes table on the exception page. This could lead to embarrassing errors. I added such a test to make sure we don't have any obvious errors. 

This fixes #8649
