### PR TITLE
Fixed #7245 Inconsistent output from ActiveSupport::TimeZone.all

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -360,10 +360,7 @@ module ActiveSupport
 
       def zones_map
         @zones_map ||= begin
-          new_zones_names = MAPPING.keys - lazy_zones_map.keys
-          new_zones       = Hash[new_zones_names.map { |place| [place, create(place)] }]
-
-          lazy_zones_map.merge(new_zones)
+          new_zones = Hash[MAPPING.keys.map { |place| [place, create(place)] }]
         end
       end
 


### PR DESCRIPTION
Now this is not given any inconsistent out.

ActiveSupport::TimeZone.all
chicago = ActiveSupport::TimeZone['America/Chicago']
ActiveSupport::TimeZone.all.include?(chicago)
=> false

chicago = ActiveSupport::TimeZone['America/Chicago']
ActiveSupport::TimeZone.all.include?(chicago)
=> false

This fixes #7245 
