### PR TITLE
Charset should not be appended to image/* type

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Do not append `charset=` parameter when `head` is called with a
+    `:content_type` option.
+    Fix #8661.
+
+    *Yves Senn*
+
 *   Added `Mime::NullType` class. This  allows to use html?, xml?, json?..etc when
     the `format` of `request` is unknown, without raise an exception.
 

--- a/actionpack/lib/action_controller/metal/head.rb
+++ b/actionpack/lib/action_controller/metal/head.rb
@@ -31,6 +31,7 @@ module ActionController
 
       if include_content?(self.status)
         self.content_type = content_type || (Mime[formats.first] if formats)
+        self.response.charset = false if self.response
         self.response_body = " "
       else
         headers.delete('Content-Type')

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -260,12 +260,16 @@ module ActionDispatch # :nodoc:
       return if headers[CONTENT_TYPE].present?
 
       @content_type ||= Mime::HTML
-      @charset      ||= self.class.default_charset
+      @charset      ||= self.class.default_charset unless @charset == false
 
       type = @content_type.to_s.dup
-      type << "; charset=#{@charset}" unless @sending_file
+      type << "; charset=#{@charset}" if append_charset?
 
       headers[CONTENT_TYPE] = type
+    end
+
+    def append_charset?
+      !@sending_file && @charset != false
     end
 
     def rack_response(status, header)

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -531,6 +531,10 @@ class TestController < ActionController::Base
     head :created, :content_type => "application/json"
   end
 
+  def head_ok_with_image_png_content_type
+    head :ok, :content_type => "image/png"
+  end
+
   def head_with_location_header
     head :location => "/foo"
   end
@@ -1224,8 +1228,15 @@ class RenderTest < ActionController::TestCase
   def test_head_created_with_application_json_content_type
     post :head_created_with_application_json_content_type
     assert_blank @response.body
-    assert_equal "application/json", @response.content_type
+    assert_equal "application/json", @response.header["Content-Type"]
     assert_response :created
+  end
+
+  def test_head_ok_with_image_png_content_type
+    post :head_ok_with_image_png_content_type
+    assert_blank @response.body
+    assert_equal "image/png", @response.header["Content-Type"]
+    assert_response :ok
   end
 
   def test_head_with_location_header


### PR DESCRIPTION
WIP
the source issue is #8661.

I created a test case to illustrate the issue.

```
1) Failure:
    test_head_created_with_image_png_content_type(RenderTest) [test/controller/render_test.rb:1238]:
    Expected: "image/png"
      Actual: "image/png; charset=utf-8"
```

I'm not quite sure how to solve the problem. Currently the charset is only skipped when we are sending a file using `send_file` or `send_data`. I see the following options:
1. skip the charset for all responses generated with `head`
2. inspect the content-type and only append the charset if it's necessary. (This would need some kind of white/blacklist, which could be brittle)
