### PR TITLE
backport #8662, charset should not be appended for `head` responses

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Rails 3.2.10 (unreleased) ##
 
+*   Do not append `charset=` parameter when `head` is called with a
+    `:content_type` option.
+    Fix #8661.
+    Backport #8662.
+
+    *Yves Senn*
+
 *   Clear url helper methods when routes are reloaded by removing the methods
     explicitly rather than just clearing the module because it didn't work
     properly and could be the source of a memory leak.

--- a/actionpack/lib/action_controller/metal/head.rb
+++ b/actionpack/lib/action_controller/metal/head.rb
@@ -29,6 +29,7 @@ module ActionController
       self.status = status
       self.location = url_for(location) if location
       self.content_type = content_type || (Mime[formats.first] if formats)
+      self.response.charset = false if self.response
       self.response_body = " "
     end
   end

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -56,7 +56,7 @@ module ActionDispatch # :nodoc:
     CONTENT_TYPE = "Content-Type".freeze
     SET_COOKIE   = "Set-Cookie".freeze
     LOCATION     = "Location".freeze
- 
+
     cattr_accessor(:default_charset) { "utf-8" }
 
     include Rack::Response::Helpers
@@ -195,12 +195,16 @@ module ActionDispatch # :nodoc:
       return if headers[CONTENT_TYPE].present?
 
       @content_type ||= Mime::HTML
-      @charset      ||= self.class.default_charset
+      @charset      ||= self.class.default_charset if !defined?(@charset) || @charset != false
 
       type = @content_type.to_s.dup
-      type << "; charset=#{@charset}" unless @sending_file
+      type << "; charset=#{@charset}" if append_charset?
 
       headers[CONTENT_TYPE] = type
+    end
+
+    def append_charset?
+      !@sending_file && @charset != false
     end
   end
 end

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -503,6 +503,10 @@ class TestController < ActionController::Base
     head :created, :content_type => "application/json"
   end
 
+  def head_ok_with_image_png_content_type
+    head :ok, :content_type => "image/png"
+  end
+
   def head_with_location_header
     head :location => "/foo"
   end
@@ -1197,8 +1201,15 @@ class RenderTest < ActionController::TestCase
   def test_head_created_with_application_json_content_type
     post :head_created_with_application_json_content_type
     assert_blank @response.body
-    assert_equal "application/json", @response.content_type
+    assert_equal "application/json", @response.header["Content-Type"]
     assert_response :created
+  end
+
+  def test_head_ok_with_image_png_content_type
+    post :head_ok_with_image_png_content_type
+    assert_blank @response.body
+    assert_equal "image/png", @response.header["Content-Type"]
+    assert_response :ok
   end
 
   def test_head_with_location_header


### PR DESCRIPTION
This is a backport of #8662 to fix #8661
