### PR TITLE
Inflector irregular singularize rules

### DIFF
--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -132,6 +132,7 @@ module ActiveSupport
           plural(Regexp.new("(#{singular[0,1]})#{singular[1..-1]}$", "i"), '\1' + plural[1..-1])
           plural(Regexp.new("(#{plural[0,1]})#{plural[1..-1]}$", "i"), '\1' + plural[1..-1])
           singular(Regexp.new("(#{plural[0,1]})#{plural[1..-1]}$", "i"), '\1' + singular[1..-1])
+          singular(Regexp.new("(#{singular[0,1]})#{singular[1..-1]}$", "i"), '\1' + singular[1..-1])
         else
           plural(Regexp.new("#{singular[0,1].upcase}(?i)#{singular[1..-1]}$"), plural[0,1].upcase + plural[1..-1])
           plural(Regexp.new("#{singular[0,1].downcase}(?i)#{singular[1..-1]}$"), plural[0,1].downcase + plural[1..-1])
@@ -139,6 +140,8 @@ module ActiveSupport
           plural(Regexp.new("#{plural[0,1].downcase}(?i)#{plural[1..-1]}$"), plural[0,1].downcase + plural[1..-1])
           singular(Regexp.new("#{plural[0,1].upcase}(?i)#{plural[1..-1]}$"), singular[0,1].upcase + singular[1..-1])
           singular(Regexp.new("#{plural[0,1].downcase}(?i)#{plural[1..-1]}$"), singular[0,1].downcase + singular[1..-1])
+          singular(Regexp.new("#{singular[0,1].upcase}(?i)#{singular[1..-1]}$"), singular[0,1].upcase + singular[1..-1])
+          singular(Regexp.new("#{singular[0,1].downcase}(?i)#{singular[1..-1]}$"), singular[0,1].downcase + singular[1..-1])
         end
       end
 

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -310,5 +310,6 @@ module InflectorTestCases
     'move'   => 'moves',
     'cow'    => 'kine',
     'zombie' => 'zombies',
+    'genus'  => 'genera'
   }
 end


### PR DESCRIPTION
The rules to singularize the singular in Inflector's `irregular` method were missing. Without them the new test case added fails. 

This PR fix it adding the singular rules for irregular. And fixes #8605
