### PR TITLE
test case to illustrate callbacks definitions and HABTM association are order dependent 

### DIFF
--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -38,6 +38,23 @@ class ProjectWithAfterCreateHook < ActiveRecord::Base
   end
 end
 
+class ProjectWithAfterCreateHookBeforeHABTM < ActiveRecord::Base
+  self.table_name = 'projects'
+
+  after_create :add_david
+
+  has_and_belongs_to_many :custom_developers,
+    :class_name => "DeveloperForProjectWithAfterCreateHook",
+    :join_table => "developers_projects",
+    :foreign_key => "project_id",
+    :association_foreign_key => "developer_id"
+
+  def add_david
+    david = DeveloperForProjectWithAfterCreateHook.find_by_name('David')
+    custom_developers << david
+   end
+end
+
 class DeveloperForProjectWithAfterCreateHook < ActiveRecord::Base
   self.table_name = 'developers'
   has_and_belongs_to_many :projects,
@@ -590,6 +607,13 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
 
     assert project.developers.include?(jamis)
     assert project.developers.include?(david)
+  end
+
+  def test_after_create_before_habtm_definition
+    project = ProjectWithAfterCreateHookBeforeHABTM.create! :name => 'Getting things done'
+    project.save!
+
+    assert_equal 1, project.custom_developers.count
   end
 
   def test_find_in_association_with_options


### PR DESCRIPTION
WIP

The source issue is: #8672

This PR is only a failing test case as I am not completely sure how to tackle the problem.

I investigated and can confirm that the order in which `after_create` and `has_and_belongs_to_many` associations are defined does impact the functionality.

If the callback is defined before the association every HABTM record created inside the callback will be inserted twice. The reason is `AutosaveAssociation#save_collection_association`. It will pick up the already created records and save them again. This happens because `@new_record_before_save` will be true and since it's an `after_create` callback, the associations are inserted directly with `<<`.

My test case results in the following failure:

```
  1) Failure:
test_after_create_before_habtm_definition(HasAndBelongsToManyAssociationsTest) [test/cases/associations/has_and_belongs_to_many_associations_test.rb:616]:
Expected: 1
  Actual: 2
```
