### PR TITLE
Remove unnecessary always-nil var from #compact

### DIFF
--- a/activesupport/lib/active_support/dependencies/autoload.rb
+++ b/activesupport/lib/active_support/dependencies/autoload.rb
@@ -34,7 +34,7 @@ module ActiveSupport
 
     def autoload(const_name, path = @_at_path)
       unless path
-        full = [name, @_under_path, const_name.to_s, path].compact.join("::")
+        full = [name, @_under_path, const_name.to_s].compact.join("::")
         path = Inflector.underscore(full)
       end
 


### PR DESCRIPTION
`unless path` already proves `path` to be nil, so why insert it into an array and then compact? 

It also gotta be slightly faster, as `compact` has less items to iterate on. (Benchmark: https://gist.github.com/4428843)
