### PR TITLE
unused scope in AR test model

### DIFF
--- a/activerecord/test/models/reply.rb
+++ b/activerecord/test/models/reply.rb
@@ -1,8 +1,6 @@
 require 'models/topic'
 
 class Reply < Topic
-  scope :base, -> { scoped }
-
   belongs_to :topic, :foreign_key => "parent_id", :counter_cache => true
   belongs_to :topic_with_primary_key, :class_name => "Topic", :primary_key => "title", :foreign_key => "parent_title", :counter_cache => "replies_count"
   has_many :replies, :class_name => "SillyReply", :dependent => :destroy, :foreign_key => "parent_id"


### PR DESCRIPTION
- executing this scope should warn because it calls deprecated `scoped` method inside, but we see no warning when running `rake test`
- `rake test` still passes without this line
