### PR TITLE
Address a failure test_remove_column_with_multi_column_index with Oracle

### DIFF
--- a/activerecord/test/cases/migration/rename_column_test.rb
+++ b/activerecord/test/cases/migration/rename_column_test.rb
@@ -107,8 +107,9 @@ module ActiveRecord
         assert_equal 1, connection.indexes('test_models').size
         remove_column("test_models", "hat_size")
 
-        # FIXME: should all adapters behave the same?
-        if current_adapter?(:PostgreSQLAdapter)
+        # Every database and/or database adapter has their own behavior 
+        # if it drops the multi-column index when any of the indexed columns dropped by remove_column.
+        if current_adapter?(:PostgreSQLAdapter, :OracleAdapter)
           assert_equal [], connection.indexes('test_models').map(&:name)
         else
           assert_equal ['index_test_models_on_hat_style_and_hat_size'], connection.indexes('test_models').map(&:name)


### PR DESCRIPTION
This pull request addresses the following failure.

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/migration/rename_column_test.rb -n test_remove_column_with_multi_column_index
Using oracle
Run options: -n test_remove_column_with_multi_column_index --seed 24358

# Running tests:

F

Finished tests in 4.192528s, 0.2385 tests/s, 0.4770 assertions/s.

  1) Failure:
test_remove_column_with_multi_column_index(ActiveRecord::Migration::RenameColumnTest) [test/cases/migration/rename_column_test.rb:114]:
--- expected
+++ actual
@@ -1 +1 @@
-["index_test_models_on_hat_style_and_hat_size"]
+[]


1 tests, 2 assertions, 1 failures, 0 errors, 0 skips
$
```

Not only PostgreSQL, Oracle database adapter drops the multi-column index if any of the indexed columns are dropped by remove_column.
