### PR TITLE
Add source code left padding on error pages

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -99,6 +99,10 @@
       text-align: right;
     }
 
+    .line {
+      padding-left: 10px;
+    }
+
     .line:hover {
       background-color: #f6f6f6;
     }


### PR DESCRIPTION
Improves readability.

![](http://cl.ly/image/0A1E0r313O15/download)
