### PR TITLE
Cleanup the CSS on the new error page.

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -4,7 +4,11 @@
   <meta charset="utf-8" />
   <title>Action Controller: Exception caught</title>
   <style>
-    body { background-color: #fff; color: #333; margin: 0px}
+    body {
+      background-color: #FFF;
+      color: #333;
+      margin: 0px;
+    }
 
     body, p, ol, ul, td {
       font-family: helvetica, verdana, arial, sans-serif;
@@ -18,18 +22,17 @@
     }
 
     pre.box {
-      border: #eee solid 1px;
+      border: 1px solid #EEE;
       padding: 10px;
       margin: 0px;
       width: 958px;
     }
 
     header {
-      background: whiteSmoke;
-      filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0,startColorstr='#980905',endColorstr='#c52f24');
-      background: -webkit-gradient(linear,0% 0,0% 100%,from(#980905),to(#C52F24));
-      background: -moz-linear-gradient(270deg,#980905,#C52F24);
-      color: #fff;
+      background: #980905;
+      background: -webkit-linear-gradient(270deg, #980905, #C52F24);
+      background: linear-gradient(270deg, #980905, #C52F24);
+      color: #FFF;
       padding: 0.5em;
     }
 
@@ -41,8 +44,6 @@
 
     .details {
       border: 1px solid #E5E5E5;
-      -webkit-border-radius: 4px;
-      -moz-border-radius: 4px;
       border-radius: 4px;
       margin: 1em 0px;
       display: block;
@@ -84,7 +85,7 @@
     .source .data {
       font-size: 80%;
       overflow: auto;
-      background-color: #fff;
+      background-color: #FFF;
     }
 
     .info {
@@ -104,7 +105,7 @@
     }
 
     .line:hover {
-      background-color: #f6f6f6;
+      background-color: #F6F6F6;
     }
 
     .line.active {
@@ -113,7 +114,7 @@
 
     a { color: #980905; }
     a:visited { color: #666; }
-    a:hover { color: #C52F24;}
+    a:hover { color: #C52F24; }
   </style>
 </head>
 <body>


### PR DESCRIPTION
I've removed some old vendor prefixed properties, like the old `webkit-gradient` and the prefixed border radius, also the proprietary `filter` used by oldIE. Also reformatted some lines to match the overall styles of the rest of the CSS on this file.
