### PR TITLE
Remove unnecessary #dup

### DIFF
--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -37,8 +37,7 @@ module ActionDispatch
       private
 
         def extract_parameterized_parts(route, options, recall, parameterize = nil)
-          constraints = recall.merge(options)
-          data = constraints.dup
+          data = recall.merge(options)
 
           keys_to_keep = route.parts.reverse.drop_while { |part|
             !options.key?(part) || (options[part] || recall[part]).nil?


### PR DESCRIPTION
`constraints` is never referenced in `extract_parameterized_parts`, makes no sense to assign anything to it and then `dup`.
