### PR TITLE
do not append a second slash when using `trailing_slash: true`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Do not append second slash to root_url when using `trailing_slash: true`
+    Fix #8700
+
+    Example:
+        # before
+        root_url # => http://test.host//
+
+        # after
+        root_url # => http://test.host/
+
+    *Yves Senn*
+
 *   Allow to toggle dumps on error pages.
 
     *Gosha Arinich*

--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -32,7 +32,11 @@ module ActionDispatch
           params.reject! { |_,v| v.to_param.nil? }
 
           result = build_host_url(options)
-          result << (options[:trailing_slash] ? path.sub(/\?|\z/) { "/" + $& } : path)
+          if options[:trailing_slash] && !path.ends_with?('/')
+            result << path.sub(/(\?|\z)/) { "/" + $& }
+          else
+            result << path
+          end
           result << "?#{params.to_query}" unless params.empty?
           result << "##{Journey::Router::Utils.escape_fragment(options[:anchor].to_param.to_s)}" if options[:anchor]
           result


### PR DESCRIPTION
The source issue is #8700

``` ruby
# before
root_url # => http://test.host//

# after
root_url # => http://test.host/
```

I changed the code to only append a "/" when the current path does not already end with "/". I added the test-case to routing_test instead of url_for_test to make sure, the right arguments are passed to `url_for` and end up in the right url.
