### PR TITLE
Fix a number of validation/style errors

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.erb
@@ -18,17 +18,17 @@
 %>
 
 <h2 style="margin-top: 30px">Request</h2>
-<p><b>Parameters</b>: <pre><%=h request_dump %></pre></p>
+<p><b>Parameters</b>:<p> <pre><%=h request_dump %></pre>
 
 <div class="details">
   <div class="summary"><a href="#" onclick="s = document.getElementById('session_dump').style; s.display = s.display == 'none' ? 'block' : 'none'; return false;">Toggle session dump</a></div>
-  <div id="session_dump" style="display:none"><p><pre><%= debug_hash @request.session %></pre></p></div>
+  <div id="session_dump" style="display:none"><pre><%= debug_hash @request.session %></pre></div>
 </div>
 
 <div class="details">
   <div class="summary"><a href="#" onclick="s = document.getElementById('env_dump').style; s.display=='block' ? s.display = s.display == 'none' ? 'block' : 'none'; return false;">Toggle env dump</a></div>
-  <div id="env_dump" style="display:none"><p><pre><%= debug_hash @request.env.slice(*@request.class::ENV_METHODS) %></pre></p></div>
+  <div id="env_dump" style="display:none"><pre><%= debug_hash @request.env.slice(*@request.class::ENV_METHODS) %></pre></div>
 </div>
 
 <h2 style="margin-top: 30px">Response</h2>
-<p><b>Headers</b>: <pre><%=h defined?(@response) ? @response.headers.inspect.gsub(',', ",\n") : 'None' %></pre></p>
+<p><b>Headers</b>:</p> <pre><%=h defined?(@response) ? @response.headers.inspect.gsub(',', ",\n") : 'None' %></pre>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/template_error.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/template_error.erb
@@ -9,12 +9,12 @@
 <div id="container">
   <p>
     Showing <i><%=h @exception.file_name %></i> where line <b>#<%=h @exception.line_number %></b> raised:
-    <pre><code><%=h @exception.message %></code></pre>
-    </p>
+  </p>
+  <pre><code><%=h @exception.message %></code></pre>
 
   <div class="source">
     <div class="info">
-      <p>Extracted source (around line <strong>#<%=h @exception.line_number %></strong>):
+      <p>Extracted source (around line <strong>#<%=h @exception.line_number %></strong>):</p>
     </div>
     <div class="data">
     <table cellpadding="0" cellspacing="0" class="lines">
@@ -40,5 +40,4 @@
 
   <%= render template: "rescues/_trace" %>
   <%= render template: "rescues/_request_and_response" %>
-  </div>
 </div>


### PR DESCRIPTION
- `<pre>` is not allowed to be nested inside of `<p>` elements in HTML
- Indentation of `</p>` doesn't match corresponding `<p>`
- `<p>` element not explicitly closed
- One more `</div>` than `<div>`

In each case, the template was fixed to match how a HTML5 parser would "see" the resulting page.
