### PR TITLE
Backport #8701, do not append a second slash with `trailing_slash: true`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Rails 3.2.11 (unreleased) ##
 
+*   Do not append second slash to root_url when using `trailing_slash: true`
+    Fix #8700.
+    Backport #8701.
+
+    Example:
+        # before
+        root_url # => http://test.host//
+
+        # after
+        root_url # => http://test.host/
+
+    *Yves Senn*
+
 *   Fix a bug in `content_tag_for` that prevents it for work without a block.
 
     *Jasl*

--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -43,7 +43,11 @@ module ActionDispatch
           params = options[:params] || {}
           params.reject! {|k,v| v.to_param.nil? }
 
-          rewritten_url << (options[:trailing_slash] ? path.sub(/\?|\z/) { "/" + $& } : path)
+          if options[:trailing_slash] && !path.ends_with?('/')
+            rewritten_url << path.sub(/(\?|\z)/) { "/" + $& }
+          else
+            rewritten_url << path
+          end
           rewritten_url << "?#{params.to_query}" unless params.empty?
           rewritten_url << "##{Journey::Router::Utils.escape_fragment(options[:anchor].to_param.to_s)}" if options[:anchor]
           rewritten_url


### PR DESCRIPTION
Backport of #8701 to fix #8700
