### PR TITLE
replace regexp global in #url_for

### DIFF
--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -32,8 +32,12 @@ module ActionDispatch
           params.reject! { |_,v| v.to_param.nil? }
 
           result = build_host_url(options)
-          if options[:trailing_slash] && !path.ends_with?('/')
-            result << path.sub(/(\?|\z)/) { "/" + $& }
+          if options[:trailing_slash]
+            if path.include?('?')
+              result << path.sub(/\?/, '/\&')
+            else
+              result << path.sub(/[^\/]\z|\A\z/, '\&/')
+            end
           else
             result << path
           end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -13,6 +13,9 @@ class RequestTest < ActiveSupport::TestCase
 
     assert_equal '/books', url_for(:only_path => true, :path => '/books')
 
+    assert_equal 'http://www.example.com/books/?q=code', url_for(trailing_slash: true, path: '/books?q=code')
+    assert_equal 'http://www.example.com/books/?spareslashes=////', url_for(trailing_slash: true, path: '/books?spareslashes=////')
+
     assert_equal 'http://www.example.com',  url_for
     assert_equal 'http://api.example.com',  url_for(:subdomain => 'api')
     assert_equal 'http://example.com',      url_for(:subdomain => false)


### PR DESCRIPTION
WIP:

I replaced `$&` with `"\&"` in the `sub` expression.

We don't have any test-coverage for this case though. (everything passes without the reference to the match). I think we should add coverage to see what it actually does :smile: 
