### PR TITLE
Rename update_attributes method to update

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -41,7 +41,7 @@ module ActionController
   #   permitted.class      # => ActionController::Parameters
   #   permitted.permitted? # => true
   #
-  #   Person.first.update_attributes!(permitted)
+  #   Person.first.update!(permitted)
   #   # => #<Person id: 1, name: "Francesco", age: 22, role: "user">
   #
   # It provides a +permit_all_parameters+ option that controls the top-level
@@ -329,7 +329,7 @@ module ActionController
   #     # into a 400 Bad Request reply.
   #     def update
   #       redirect_to current_account.people.find(params[:id]).tap { |person|
-  #         person.update_attributes!(person_params)
+  #         person.update!(person_params)
   #       }
   #     end
   #

--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -101,9 +101,9 @@ module ActionView
     # and generate HTML accordingly.
     #
     # The controller would receive the form data again in <tt>params[:person]</tt>, ready to be
-    # passed to <tt>Person#update_attributes</tt>:
+    # passed to <tt>Person#update</tt>:
     #
-    #   if @person.update_attributes(params[:person])
+    #   if @person.update(params[:person])
     #     # success
     #   else
     #     # error handling
@@ -897,7 +897,7 @@ module ActionView
       # invoice the user unchecks its check box, no +paid+ parameter is sent. So,
       # any mass-assignment idiom like
       #
-      #   @invoice.update_attributes(params[:invoice])
+      #   @invoice.update(params[:invoice])
       #
       # wouldn't update the flag.
       #
@@ -1569,7 +1569,7 @@ module ActionView
       # invoice the user unchecks its check box, no +paid+ parameter is sent. So,
       # any mass-assignment idiom like
       #
-      #   @invoice.update_attributes(params[:invoice])
+      #   @invoice.update(params[:invoice])
       #
       # wouldn't update the flag.
       #

--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -130,7 +130,7 @@ module ActionView
       # the user deselects all roles from +role_ids+ multiple select box, no +role_ids+ parameter is sent. So,
       # any mass-assignment idiom like
       #
-      #   @user.update_attributes(params[:user])
+      #   @user.update(params[:user])
       #
       # wouldn't update roles.
       #

--- a/actionpack/lib/action_view/record_identifier.rb
+++ b/actionpack/lib/action_view/record_identifier.rb
@@ -17,7 +17,7 @@ module ActionView
   #   # controller
   #   def update
   #     post = Post.find(params[:id])
-  #     post.update_attributes(params[:post])
+  #     post.update(params[:post])
   #
   #     redirect_to(post) # Calls polymorphic_url(post) which in turn calls post_url(post)
   #   end

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Rename `update_attributes` to `update`, keep `update_attributes` as an alias for `update` method. 
+    This is a soft-deprecation for `update_attributes`, although it will still work without any
+    deprecation message in 4.0 is recommended to start using `update` since `update_attributes` will be
+    deprecated and removed in future versions of Rails.
+    
+    *Amparo Luna + Guillermo Iguaran*
+
 *   `after_commit` and `after_rollback` now validate the `:on` option and raise an `ArgumentError`
     if it is not one of `:create`, `:destroy` or ``:update`
 

--- a/activerecord/examples/performance.rb
+++ b/activerecord/examples/performance.rb
@@ -143,7 +143,7 @@ Benchmark.ips(TIME) do |x|
   end
 
   x.report 'Resource#update' do
-    Exhibit.first.update_attributes(:name => 'bob')
+    Exhibit.first.update(name: 'bob')
   end
 
   x.report 'Resource#destroy' do

--- a/activerecord/lib/active_record/associations/has_one_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_through_association.rb
@@ -23,7 +23,7 @@ module ActiveRecord
             attributes = construct_join_attributes(record)
 
             if through_record
-              through_record.update_attributes(attributes)
+              through_record.update(attributes)
             elsif owner.new_record?
               through_proxy.build(attributes)
             else

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -71,11 +71,11 @@ module ActiveRecord
         super(attr, value)
       end
 
-      def update(*)
+      def update_record(*)
         partial_writes? ? super(keys_for_partial_write) : super
       end
 
-      def create(*)
+      def create_record(*)
         partial_writes? ? super(keys_for_partial_write) : super
       end
 

--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -299,11 +299,11 @@ module ActiveRecord
       run_callbacks(:save) { super }
     end
 
-    def create #:nodoc:
+    def create_record #:nodoc:
       run_callbacks(:create) { super }
     end
 
-    def update(*) #:nodoc:
+    def update_record(*) #:nodoc:
       run_callbacks(:update) { super }
     end
   end

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -66,7 +66,7 @@ module ActiveRecord
           send(lock_col + '=', previous_lock_value + 1)
         end
 
-        def update(attribute_names = @attributes.keys) #:nodoc:
+        def update_record(attribute_names = @attributes.keys) #:nodoc:
           return super unless locking_enabled?
           return 0 if attribute_names.empty?
 

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -58,7 +58,7 @@ module ActiveRecord
     # It also allows you to update the avatar through the member:
     #
     #   params = { member: { avatar_attributes: { id: '2', icon: 'sad' } } }
-    #   member.update_attributes params[:member]
+    #   member.update params[:member]
     #   member.avatar.icon # => 'sad'
     #
     # By default you will only be able to set and update attributes on the

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -223,7 +223,7 @@ module ActiveRecord
     
     alias update_attributes update
 
-    # Updates its receiver just like +update_attributes+ but calls <tt>save!</tt> instead
+    # Updates its receiver just like +update+ but calls <tt>save!</tt> instead
     # of +save+, so an exception is raised if the record is invalid.
     def update!(attributes)
       # The following transaction covers any possible database side-effects of the

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -212,7 +212,7 @@ module ActiveRecord
     # Updates the attributes of the model from the passed-in hash and saves the
     # record, all wrapped in a transaction. If the object is invalid, the saving
     # will fail and false will be returned.
-    def update_attributes(attributes)
+    def update(attributes)
       # The following transaction covers any possible database side-effects of the
       # attributes assignment. For example, setting the IDs of a child collection.
       with_transaction_returning_status do
@@ -220,10 +220,12 @@ module ActiveRecord
         save
       end
     end
+    
+    alias update_attributes update
 
     # Updates its receiver just like +update_attributes+ but calls <tt>save!</tt> instead
     # of +save+, so an exception is raised if the record is invalid.
-    def update_attributes!(attributes)
+    def update!(attributes)
       # The following transaction covers any possible database side-effects of the
       # attributes assignment. For example, setting the IDs of a child collection.
       with_transaction_returning_status do
@@ -231,6 +233,8 @@ module ActiveRecord
         save!
       end
     end
+    
+    alias update_attributes! update!
 
     # Updates a single attribute of an object, without having to explicitly call save on that object.
     #
@@ -406,13 +410,13 @@ module ActiveRecord
 
     def create_or_update
       raise ReadOnlyRecord if readonly?
-      result = new_record? ? create : update
+      result = new_record? ? create_record : update_record
       result != false
     end
 
     # Updates the associated record with values matching those of the instance attributes.
     # Returns the number of affected rows.
-    def update(attribute_names = @attributes.keys)
+    def update_record(attribute_names = @attributes.keys)
       attributes_with_values = arel_attributes_with_values_for_update(attribute_names)
 
       if attributes_with_values.empty?
@@ -426,7 +430,7 @@ module ActiveRecord
 
     # Creates a record with values matching those of the instance attributes
     # and returns its id.
-    def create(attribute_names = @attributes.keys)
+    def create_record(attribute_names = @attributes.keys)
       attributes_values = arel_attributes_with_values_for_create(attribute_names)
 
       new_id = self.class.unscoped.insert attributes_values

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -308,7 +308,7 @@ module ActiveRecord
         id.map.with_index { |one_id, idx| update(one_id, attributes[idx]) }
       else
         object = find(id)
-        object.update_attributes(attributes)
+        object.update(attributes)
         object
       end
     end

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -43,7 +43,7 @@ module ActiveRecord
 
   private
 
-    def create
+    def create_record
       if self.record_timestamps
         current_time = current_time_from_proper_timezone
 
@@ -57,7 +57,7 @@ module ActiveRecord
       super
     end
 
-    def update(*args)
+    def update_record(*args)
       if should_record_timestamps?
         current_time = current_time_from_proper_timezone
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -317,12 +317,12 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal 1, Topic.find(topic.id)[:replies_count]
   end
 
-  def test_belongs_to_counter_after_update_attributes
-    topic = Topic.create!(:title => "37s")
-    topic.replies.create!(:title => "re: 37s", :content => "rails")
+  def test_belongs_to_counter_after_update
+    topic = Topic.create!(title: "37s")
+    topic.replies.create!(title: "re: 37s", content: "rails")
     assert_equal 1, Topic.find(topic.id)[:replies_count]
 
-    topic.update_attributes(:title => "37signals")
+    topic.update(title: "37signals")
     assert_equal 1, Topic.find(topic.id)[:replies_count]
   end
 

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -212,8 +212,9 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_finding_with_includes_on_null_belongs_to_association_with_same_include_includes_only_once
     post = posts(:welcome)
-    post.update_attributes!(:author => nil)
-    post = assert_queries(1) { Post.all.merge!(:includes => {:author_with_address => :author_address}).find(post.id) } # find the post, then find the author which is null so no query for the author or address
+    post.update!(author: nil)
+    post = assert_queries(1) { Post.all.merge!(includes: {author_with_address: :author_address}).find(post.id) } 
+    # find the post, then find the author which is null so no query for the author or address
     assert_no_queries do
       assert_equal nil, post.author_with_address
     end
@@ -221,7 +222,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_finding_with_includes_on_null_belongs_to_polymorphic_association
     sponsor = sponsors(:moustache_club_sponsor_for_groucho)
-    sponsor.update_attributes!(:sponsorable => nil)
+    sponsor.update!(sponsorable: nil)
     sponsor = assert_queries(1) { Sponsor.all.merge!(:includes => :sponsorable).find(sponsor.id) }
     assert_no_queries do
       assert_equal nil, sponsor.sponsorable

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -706,7 +706,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_can_update_through_association
     assert_nothing_raised do
-      people(:michael).posts.first.update_attributes!(:title => "Can write")
+      people(:michael).posts.first.update!(title: "Can write")
     end
   end
 

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -161,16 +161,16 @@ class TestDefaultAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCas
   end
 
   def test_callbacks_firing_order_on_update
-    eye = Eye.create(:iris_attributes => {:color => 'honey'})
-    eye.update_attributes(:iris_attributes => {:color => 'green'})
+    eye = Eye.create(iris_attributes: {color: 'honey'})
+    eye.update(iris_attributes: {color: 'green'})
     assert_equal [true, false], eye.after_update_callbacks_stack
   end
 
   def test_callbacks_firing_order_on_save
-    eye = Eye.create(:iris_attributes => {:color => 'honey'})
+    eye = Eye.create(iris_attributes: {color: 'honey'})
     assert_equal [false, false], eye.after_save_callbacks_stack
 
-    eye.update_attributes(:iris_attributes => {:color => 'blue'})
+    eye.update(iris_attributes: {color: 'blue'})
     assert_equal [false, false, false, false], eye.after_save_callbacks_stack
   end
 end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -593,7 +593,7 @@ class BasicsTest < ActiveRecord::TestCase
     post.reload
     assert_equal "cannot change this", post.title
 
-    post.update_attributes(:title => "try to change", :body => "changed")
+    post.update(title: "try to change", body: "changed")
     post.reload
     assert_equal "cannot change this", post.title
     assert_equal "changed", post.body
@@ -1001,7 +1001,7 @@ class BasicsTest < ActiveRecord::TestCase
 
   def test_reload_with_exclusive_scope
     dev = DeveloperCalledDavid.first
-    dev.update_attributes!( :name => "NotDavid" )
+    dev.update!(name: "NotDavid" )
     assert_equal dev, dev.reload
   end
 

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -517,7 +517,7 @@ class DirtyTest < ActiveRecord::TestCase
     assert !pirate.previous_changes.key?('created_on')
 
     pirate = Pirate.find_by_catchphrase("Thar She Blows!")
-    pirate.update_attributes(:catchphrase => "Ahoy!")
+    pirate.update(catchphrase: "Ahoy!")
 
     assert_equal 2, pirate.previous_changes.size
     assert_equal ["Thar She Blows!", "Ahoy!"], pirate.previous_changes['catchphrase']

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -207,7 +207,7 @@ class OptimisticLockingTest < ActiveRecord::TestCase
     s.reload
     assert_equal "unchangeable name", s.name
 
-    s.update_attributes(:name => "changed name")
+    s.update(name: "changed name")
     s.reload
     assert_equal "unchangeable name", s.name
   end

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -79,10 +79,10 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
   def test_should_disable_allow_destroy_by_default
     Pirate.accepts_nested_attributes_for :ship
 
-    pirate = Pirate.create!(:catchphrase => "Don' botharrr talkin' like one, savvy?")
-    ship = pirate.create_ship(:name => 'Nights Dirty Lightning')
+    pirate = Pirate.create!(catchphrase: "Don' botharrr talkin' like one, savvy?")
+    ship = pirate.create_ship(name: 'Nights Dirty Lightning')
 
-    pirate.update_attributes(:ship_attributes => { '_destroy' => true, :id => ship.id })
+    pirate.update(ship_attributes: { '_destroy' => true, :id => ship.id })
 
     assert_nothing_raised(ActiveRecord::RecordNotFound) { pirate.ship.reload }
   end
@@ -125,33 +125,33 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
 
   def test_reject_if_with_a_proc_which_returns_true_always_for_has_one
     Pirate.accepts_nested_attributes_for :ship, :reject_if => proc {|attributes| true }
-    pirate = Pirate.new(:catchphrase => "Stop wastin' me time")
-    ship = pirate.create_ship(:name => 's1')
-    pirate.update_attributes({:ship_attributes => { :name => 's2', :id => ship.id } })
+    pirate = Pirate.new(catchphrase: "Stop wastin' me time")
+    ship = pirate.create_ship(name: 's1')
+    pirate.update({ship_attributes: { name: 's2', id: ship.id } })
     assert_equal 's1', ship.reload.name
   end
 
   def test_reject_if_with_a_proc_which_returns_true_always_for_has_many
     Man.accepts_nested_attributes_for :interests, :reject_if => proc {|attributes| true }
-    man = Man.create(:name => "John")
-    interest = man.interests.create(:topic => 'photography')
-    man.update_attributes({:interests_attributes => { :topic => 'gardening', :id => interest.id } })
+    man = Man.create(name: "John")
+    interest = man.interests.create(topic: 'photography')
+    man.update({interests_attributes: { topic: 'gardening', id: interest.id } })
     assert_equal 'photography', interest.reload.topic
   end
 
   def test_destroy_works_independent_of_reject_if
     Man.accepts_nested_attributes_for :interests, :reject_if => proc {|attributes| true }, :allow_destroy => true
-    man = Man.create(:name => "Jon")
-    interest = man.interests.create(:topic => 'the ladies')
-    man.update_attributes({:interests_attributes => { :_destroy => "1", :id => interest.id } })
+    man = Man.create(name: "Jon")
+    interest = man.interests.create(topic: 'the ladies')
+    man.update({interests_attributes: { _destroy: "1", id: interest.id } })
     assert man.reload.interests.empty?
   end
 
   def test_has_many_association_updating_a_single_record
     Man.accepts_nested_attributes_for(:interests)
-    man = Man.create(:name => 'John')
-    interest = man.interests.create(:topic => 'photography')
-    man.update_attributes({:interests_attributes => {:topic => 'gardening', :id => interest.id}})
+    man = Man.create(name: 'John')
+    interest = man.interests.create(topic: 'photography')
+    man.update({interests_attributes: {topic: 'gardening', id: interest.id}})
     assert_equal 'gardening', interest.reload.topic
   end
 
@@ -284,8 +284,8 @@ class TestNestedAttributesOnAHasOneAssociation < ActiveRecord::TestCase
     @pirate.ship.destroy
 
     [1, '1', true, 'true'].each do |truth|
-      ship = @pirate.reload.create_ship(:name => 'Mister Pablo')
-      @pirate.update_attributes(:ship_attributes => { :id => ship.id, :_destroy => truth })
+      ship = @pirate.reload.create_ship(name: 'Mister Pablo')
+      @pirate.update(ship_attributes: { id: ship.id, _destroy: truth })
 
       assert_nil @pirate.reload.ship
       assert_raise(ActiveRecord::RecordNotFound) { Ship.find(ship.id) }
@@ -294,7 +294,7 @@ class TestNestedAttributesOnAHasOneAssociation < ActiveRecord::TestCase
 
   def test_should_not_destroy_an_existing_record_if_destroy_is_not_truthy
     [nil, '0', 0, 'false', false].each do |not_truth|
-      @pirate.update_attributes(:ship_attributes => { :id => @pirate.ship.id, :_destroy => not_truth })
+      @pirate.update(ship_attributes: { id: @pirate.ship.id, _destroy: not_truth })
 
       assert_equal @ship, @pirate.reload.ship
     end
@@ -303,7 +303,7 @@ class TestNestedAttributesOnAHasOneAssociation < ActiveRecord::TestCase
   def test_should_not_destroy_an_existing_record_if_allow_destroy_is_false
     Pirate.accepts_nested_attributes_for :ship, :allow_destroy => false, :reject_if => proc { |attributes| attributes.empty? }
 
-    @pirate.update_attributes(:ship_attributes => { :id => @pirate.ship.id, :_destroy => '1' })
+    @pirate.update(ship_attributes: { id: @pirate.ship.id, _destroy: '1' })
 
     assert_equal @ship, @pirate.reload.ship
 
@@ -317,8 +317,8 @@ class TestNestedAttributesOnAHasOneAssociation < ActiveRecord::TestCase
     assert_equal 'Davy Jones Gold Dagger', @pirate.ship.name
   end
 
-  def test_should_work_with_update_attributes_as_well
-    @pirate.update_attributes({ :catchphrase => 'Arr', :ship_attributes => { :id => @ship.id, :name => 'Mister Pablo' } })
+  def test_should_work_with_update_as_well
+    @pirate.update({ catchphrase: 'Arr', ship_attributes: { id: @ship.id, name: 'Mister Pablo' } })
     @pirate.reload
 
     assert_equal 'Arr', @pirate.catchphrase
@@ -342,22 +342,22 @@ class TestNestedAttributesOnAHasOneAssociation < ActiveRecord::TestCase
   end
 
   def test_should_accept_update_only_option
-    @pirate.update_attributes(:update_only_ship_attributes => { :id => @pirate.ship.id, :name => 'Mayflower' })
+    @pirate.update(update_only_ship_attributes: { id: @pirate.ship.id, name: 'Mayflower' })
   end
 
   def test_should_create_new_model_when_nothing_is_there_and_update_only_is_true
     @ship.delete
 
-    @pirate.reload.update_attributes(:update_only_ship_attributes => { :name => 'Mayflower' })
+    @pirate.reload.update(update_only_ship_attributes: { name: 'Mayflower' })
 
     assert_not_nil @pirate.ship
   end
 
   def test_should_update_existing_when_update_only_is_true_and_no_id_is_given
     @ship.delete
-    @ship = @pirate.create_update_only_ship(:name => 'Nights Dirty Lightning')
+    @ship = @pirate.create_update_only_ship(name: 'Nights Dirty Lightning')
 
-    @pirate.update_attributes(:update_only_ship_attributes => { :name => 'Mayflower' })
+    @pirate.update(update_only_ship_attributes: { name: 'Mayflower' })
 
     assert_equal 'Mayflower', @ship.reload.name
     assert_equal @ship, @pirate.reload.ship
@@ -365,9 +365,9 @@ class TestNestedAttributesOnAHasOneAssociation < ActiveRecord::TestCase
 
   def test_should_update_existing_when_update_only_is_true_and_id_is_given
     @ship.delete
-    @ship = @pirate.create_update_only_ship(:name => 'Nights Dirty Lightning')
+    @ship = @pirate.create_update_only_ship(name: 'Nights Dirty Lightning')
 
-    @pirate.update_attributes(:update_only_ship_attributes => { :name => 'Mayflower', :id => @ship.id })
+    @pirate.update(update_only_ship_attributes: { name: 'Mayflower', id: @ship.id })
 
     assert_equal 'Mayflower', @ship.reload.name
     assert_equal @ship, @pirate.reload.ship
@@ -376,9 +376,9 @@ class TestNestedAttributesOnAHasOneAssociation < ActiveRecord::TestCase
   def test_should_destroy_existing_when_update_only_is_true_and_id_is_given_and_is_marked_for_destruction
     Pirate.accepts_nested_attributes_for :update_only_ship, :update_only => true, :allow_destroy => true
     @ship.delete
-    @ship = @pirate.create_update_only_ship(:name => 'Nights Dirty Lightning')
+    @ship = @pirate.create_update_only_ship(name: 'Nights Dirty Lightning')
 
-    @pirate.update_attributes(:update_only_ship_attributes => { :name => 'Mayflower', :id => @ship.id, :_destroy => true })
+    @pirate.update(update_only_ship_attributes: { name: 'Mayflower', id: @ship.id, _destroy: true })
 
     assert_nil @pirate.reload.ship
     assert_raise(ActiveRecord::RecordNotFound) { Ship.find(@ship.id) }
@@ -468,15 +468,15 @@ class TestNestedAttributesOnABelongsToAssociation < ActiveRecord::TestCase
   def test_should_destroy_an_existing_record_if_there_is_a_matching_id_and_destroy_is_truthy
     @ship.pirate.destroy
     [1, '1', true, 'true'].each do |truth|
-      pirate = @ship.reload.create_pirate(:catchphrase => 'Arr')
-      @ship.update_attributes(:pirate_attributes => { :id => pirate.id, :_destroy => truth })
+      pirate = @ship.reload.create_pirate(catchphrase: 'Arr')
+      @ship.update(pirate_attributes: { id: pirate.id, _destroy: truth })
       assert_raise(ActiveRecord::RecordNotFound) { pirate.reload }
     end
   end
 
   def test_should_unset_association_when_an_existing_record_is_destroyed
     original_pirate_id = @ship.pirate.id
-    @ship.update_attributes! pirate_attributes: { id: @ship.pirate.id, _destroy: true }
+    @ship.update! pirate_attributes: { id: @ship.pirate.id, _destroy: true }
 
     assert_empty Pirate.where(id: original_pirate_id)
     assert_nil @ship.pirate_id
@@ -490,7 +490,7 @@ class TestNestedAttributesOnABelongsToAssociation < ActiveRecord::TestCase
 
   def test_should_not_destroy_an_existing_record_if_destroy_is_not_truthy
     [nil, '0', 0, 'false', false].each do |not_truth|
-      @ship.update_attributes(:pirate_attributes => { :id => @ship.pirate.id, :_destroy => not_truth })
+      @ship.update(pirate_attributes: { id: @ship.pirate.id, _destroy: not_truth })
       assert_nothing_raised(ActiveRecord::RecordNotFound) { @ship.pirate.reload }
     end
   end
@@ -498,14 +498,14 @@ class TestNestedAttributesOnABelongsToAssociation < ActiveRecord::TestCase
   def test_should_not_destroy_an_existing_record_if_allow_destroy_is_false
     Ship.accepts_nested_attributes_for :pirate, :allow_destroy => false, :reject_if => proc { |attributes| attributes.empty? }
 
-    @ship.update_attributes(:pirate_attributes => { :id => @ship.pirate.id, :_destroy => '1' })
+    @ship.update(pirate_attributes: { id: @ship.pirate.id, _destroy: '1' })
     assert_nothing_raised(ActiveRecord::RecordNotFound) { @ship.pirate.reload }
   ensure
     Ship.accepts_nested_attributes_for :pirate, :allow_destroy => true, :reject_if => proc { |attributes| attributes.empty? }
   end
 
-  def test_should_work_with_update_attributes_as_well
-    @ship.update_attributes({ :name => 'Mister Pablo', :pirate_attributes => { :catchphrase => 'Arr' } })
+  def test_should_work_with_update_as_well
+    @ship.update({ name: 'Mister Pablo', pirate_attributes: { catchphrase: 'Arr' } })
     @ship.reload
 
     assert_equal 'Mister Pablo', @ship.name
@@ -534,18 +534,18 @@ class TestNestedAttributesOnABelongsToAssociation < ActiveRecord::TestCase
 
   def test_should_update_existing_when_update_only_is_true_and_no_id_is_given
     @pirate.delete
-    @pirate = @ship.create_update_only_pirate(:catchphrase => 'Aye')
+    @pirate = @ship.create_update_only_pirate(catchphrase: 'Aye')
 
-    @ship.update_attributes(:update_only_pirate_attributes => { :catchphrase => 'Arr' })
+    @ship.update(update_only_pirate_attributes: { catchphrase: 'Arr' })
     assert_equal 'Arr', @pirate.reload.catchphrase
     assert_equal @pirate, @ship.reload.update_only_pirate
   end
 
   def test_should_update_existing_when_update_only_is_true_and_id_is_given
     @pirate.delete
-    @pirate = @ship.create_update_only_pirate(:catchphrase => 'Aye')
+    @pirate = @ship.create_update_only_pirate(catchphrase: 'Aye')
 
-    @ship.update_attributes(:update_only_pirate_attributes => { :catchphrase => 'Arr', :id => @pirate.id })
+    @ship.update(update_only_pirate_attributes: { catchphrase: 'Arr', id: @pirate.id })
 
     assert_equal 'Arr', @pirate.reload.catchphrase
     assert_equal @pirate, @ship.reload.update_only_pirate
@@ -554,9 +554,9 @@ class TestNestedAttributesOnABelongsToAssociation < ActiveRecord::TestCase
   def test_should_destroy_existing_when_update_only_is_true_and_id_is_given_and_is_marked_for_destruction
     Ship.accepts_nested_attributes_for :update_only_pirate, :update_only => true, :allow_destroy => true
     @pirate.delete
-    @pirate = @ship.create_update_only_pirate(:catchphrase => 'Aye')
+    @pirate = @ship.create_update_only_pirate(catchphrase: 'Aye')
 
-    @ship.update_attributes(:update_only_pirate_attributes => { :catchphrase => 'Arr', :id => @pirate.id, :_destroy => true })
+    @ship.update(update_only_pirate_attributes: { catchphrase: 'Arr', id: @pirate.id, _destroy: true })
 
     assert_raise(ActiveRecord::RecordNotFound) { @pirate.reload }
 
@@ -582,7 +582,7 @@ module NestedAttributesOnACollectionAssociationTests
 
   def test_should_take_a_hash_with_string_keys_and_assign_the_attributes_to_the_associated_models
     @alternate_params[association_getter].stringify_keys!
-    @pirate.update_attributes @alternate_params
+    @pirate.update @alternate_params
     assert_equal ['Grace OMalley', 'Privateers Greed'], [@child_1.reload.name, @child_2.reload.name]
   end
 
@@ -628,10 +628,10 @@ module NestedAttributesOnACollectionAssociationTests
 
   def test_should_refresh_saved_records_when_not_overwriting_unsaved_updates
     @pirate.reload
-    record = @pirate.class.reflect_on_association(@association_name).klass.new(:name => 'Grace OMalley')
+    record = @pirate.class.reflect_on_association(@association_name).klass.new(name: 'Grace OMalley')
     @pirate.send(@association_name) << record
     record.save!
-    @pirate.send(@association_name).last.update_attributes!(:name => 'Polly')
+    @pirate.send(@association_name).last.update!(name: 'Polly')
     assert_equal 'Polly', @pirate.send(@association_name).send(:load_target).last.name
   end
 
@@ -718,17 +718,17 @@ module NestedAttributesOnACollectionAssociationTests
     end
   end
 
-  def test_should_work_with_update_attributes_as_well
-    @pirate.update_attributes(:catchphrase => 'Arr',
+  def test_should_work_with_update_as_well
+    @pirate.update(catchphrase: 'Arr',
       association_getter => { 'foo' => { :id => @child_1.id, :name => 'Grace OMalley' }})
 
     assert_equal 'Grace OMalley', @child_1.reload.name
   end
 
   def test_should_update_existing_records_and_add_new_ones_that_have_no_id
-    @alternate_params[association_getter]['baz'] = { :name => 'Buccaneers Servant' }
+    @alternate_params[association_getter]['baz'] = { name: 'Buccaneers Servant' }
     assert_difference('@pirate.send(@association_name).count', +1) do
-      @pirate.update_attributes @alternate_params
+      @pirate.update @alternate_params
     end
     assert_equal ['Grace OMalley', 'Privateers Greed', 'Buccaneers Servant'].to_set, @pirate.reload.send(@association_name).map(&:name).to_set
   end
@@ -750,7 +750,7 @@ module NestedAttributesOnACollectionAssociationTests
     [nil, '', '0', 0, 'false', false].each do |false_variable|
       @alternate_params[association_getter]['foo']['_destroy'] = false_variable
       assert_no_difference('@pirate.send(@association_name).count') do
-        @pirate.update_attributes(@alternate_params)
+        @pirate.update(@alternate_params)
       end
     end
   end
@@ -814,7 +814,7 @@ module NestedAttributesOnACollectionAssociationTests
       man = Man.create(name: 'John')
       interest = man.interests.create(topic: 'bar', zine_id: 0)
       assert interest.save
-      assert !man.update_attributes({interests_attributes: { id: interest.id, zine_id: 'foo' }})
+      assert !man.update({interests_attributes: { id: interest.id, zine_id: 'foo' }})
     end
   end
 
@@ -945,18 +945,18 @@ class TestNestedAttributesWithNonStandardPrimaryKeys < ActiveRecord::TestCase
   end
 
   def test_should_update_existing_records_with_non_standard_primary_key
-    @owner.update_attributes(@params)
+    @owner.update(@params)
     assert_equal ['Foo', 'Bar'], @owner.pets.map(&:name)
   end
 
-  def test_attr_accessor_of_child_should_be_value_provided_during_update_attributes
+  def test_attr_accessor_of_child_should_be_value_provided_during_update
     @owner = owners(:ashley)
     @pet1 = pets(:chew)
     attributes = {:pets_attributes => { "1"=> { :id => @pet1.id,
                                                 :name => "Foo2",
                                                 :current_user => "John",
                                                 :_destroy=>true }}}
-    @owner.update_attributes(attributes)
+    @owner.update(attributes)
     assert_equal 'John', Pet.after_destroy_output
   end
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -391,7 +391,7 @@ class PersistencesTest < ActiveRecord::TestCase
   end
 
   def test_update_attribute_does_not_choke_on_nil
-    assert Topic.find(1).update_attributes(nil)
+    assert Topic.find(1).update(nil)
   end
 
   def test_update_attribute_for_readonly_attribute
@@ -547,7 +547,7 @@ class PersistencesTest < ActiveRecord::TestCase
 
   def test_update_columns_should_not_leave_the_object_dirty
     topic = Topic.find(1)
-    topic.update_attributes({ "content" => "Have a nice day", :author_name => "Jose" })
+    topic.update({ "content" => "Have a nice day", :author_name => "Jose" })
 
     topic.reload
     topic.update_columns({ content: "You too", "author_name" => "Sebastian" })
@@ -631,6 +631,22 @@ class PersistencesTest < ActiveRecord::TestCase
     assert developer.update_columns(name: 'Will'), 'did not update record due to default scope'
   end
 
+  def test_update
+    topic = Topic.find(1)
+    assert !topic.approved?
+    assert_equal "The First Topic", topic.title
+
+    topic.update("approved" => true, "title" => "The First Topic Updated")
+    topic.reload
+    assert topic.approved?
+    assert_equal "The First Topic Updated", topic.title
+
+    topic.update(approved: false, title: "The First Topic")
+    topic.reload
+    assert !topic.approved?
+    assert_equal "The First Topic", topic.title
+  end
+  
   def test_update_attributes
     topic = Topic.find(1)
     assert !topic.approved?
@@ -641,10 +657,31 @@ class PersistencesTest < ActiveRecord::TestCase
     assert topic.approved?
     assert_equal "The First Topic Updated", topic.title
 
-    topic.update_attributes(:approved => false, :title => "The First Topic")
+    topic.update_attributes(approved: false, title: "The First Topic")
     topic.reload
     assert !topic.approved?
     assert_equal "The First Topic", topic.title
+  end
+
+  def test_update!
+    Reply.validates_presence_of(:title)
+    reply = Reply.find(2)
+    assert_equal "The Second Topic of the day", reply.title
+    assert_equal "Have a nice day", reply.content
+
+    reply.update!("title" => "The Second Topic of the day updated", "content" => "Have a nice evening")
+    reply.reload
+    assert_equal "The Second Topic of the day updated", reply.title
+    assert_equal "Have a nice evening", reply.content
+
+    reply.update!(title: "The Second Topic of the day", content: "Have a nice day")
+    reply.reload
+    assert_equal "The Second Topic of the day", reply.title
+    assert_equal "Have a nice day", reply.content
+
+    assert_raise(ActiveRecord::RecordInvalid) { reply.update!(title: nil, content: "Have a nice evening") }
+  ensure
+    Reply.reset_callbacks(:validate)
   end
 
   def test_update_attributes!
@@ -658,12 +695,12 @@ class PersistencesTest < ActiveRecord::TestCase
     assert_equal "The Second Topic of the day updated", reply.title
     assert_equal "Have a nice evening", reply.content
 
-    reply.update_attributes!(:title => "The Second Topic of the day", :content => "Have a nice day")
+    reply.update_attributes!(title: "The Second Topic of the day", content: "Have a nice day")
     reply.reload
     assert_equal "The Second Topic of the day", reply.title
     assert_equal "Have a nice day", reply.content
 
-    assert_raise(ActiveRecord::RecordInvalid) { reply.update_attributes!(:title => nil, :content => "Have a nice evening") }
+    assert_raise(ActiveRecord::RecordInvalid) { reply.update_attributes!(title: nil, content: "Have a nice evening") }
   ensure
     Reply.reset_callbacks(:validate)
   end

--- a/activerecord/test/cases/transaction_isolation_test.rb
+++ b/activerecord/test/cases/transaction_isolation_test.rb
@@ -77,7 +77,7 @@ class TransactionIsolationTest < ActiveRecord::TestCase
 
     Tag.transaction(isolation: :repeatable_read) do
       tag.reload
-      Tag2.find(tag.id).update_attributes(name: 'emily')
+      Tag2.find(tag.id).update(name: 'emily')
 
       tag.reload
       assert_equal 'jon', tag.name

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -117,21 +117,21 @@ class TransactionTest < ActiveRecord::TestCase
     assert !Topic.find(1).approved?
   end
 
-  def test_update_attributes_should_rollback_on_failure
+  def test_update_should_rollback_on_failure
     author = Author.find(1)
     posts_count = author.posts.size
     assert posts_count > 0
-    status = author.update_attributes(:name => nil, :post_ids => [])
+    status = author.update(name: nil, post_ids: [])
     assert !status
     assert_equal posts_count, author.posts(true).size
   end
 
-  def test_update_attributes_should_rollback_on_failure!
+  def test_update_should_rollback_on_failure!
     author = Author.find(1)
     posts_count = author.posts.size
     assert posts_count > 0
     assert_raise(ActiveRecord::RecordInvalid) do
-      author.update_attributes!(:name => nil, :post_ids => [])
+      author.update!(name: nil, post_ids: [])
     end
     assert_equal posts_count, author.posts(true).size
   end

--- a/activerecord/test/models/reference.rb
+++ b/activerecord/test/models/reference.rb
@@ -11,7 +11,7 @@ class Reference < ActiveRecord::Base
 
   def make_comments
     if self.class.make_comments
-      person.update_attributes :comments => "Reference destroyed"
+      person.update comments: "Reference destroyed"
     end
   end
 end

--- a/activesupport/lib/active_support/core_ext/hash/except.rb
+++ b/activesupport/lib/active_support/core_ext/hash/except.rb
@@ -2,7 +2,7 @@ class Hash
   # Return a hash that includes everything but the given keys. This is useful for
   # limiting a set of parameters to everything but a few known toggles:
   #
-  #   @person.update_attributes(params[:person].except(:admin))
+  #   @person.update(params[:person].except(:admin))
   def except(*keys)
     dup.except!(*keys)
   end

--- a/guides/code/getting_started/app/controllers/posts_controller.rb
+++ b/guides/code/getting_started/app/controllers/posts_controller.rb
@@ -31,7 +31,7 @@ class PostsController < ApplicationController
   def update
     @post = Post.find(params[:id])
 
-    if @post.update_attributes(params[:post])
+    if @post.update(params[:post])
       redirect_to :action => :show, :id => @post.id
     else
       render 'edit'

--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -277,7 +277,7 @@ value, like so:
 
 ```ruby
 user = User.find_by_name('David')
-user.update_attributes(name: 'Dave')
+user.update(name: 'Dave')
 ```
 
 This is most useful when updating several attributes at once. If, on the other 
@@ -307,10 +307,10 @@ models and validate that an attribute value is not empty, is unique and not
 already in the database, follows a specific format and many more.
 
 Validation is a very important issue to consider when persisting to database, so 
-the methods `create`, `save` and `update_attributes` take it into account when 
+the methods `create`, `save` and `update` take it into account when 
 running: they return `false` when validation fails and they didn't actually 
 perform any operation on database. All of these have a bang counterpart (that 
-is, `create!`, `save!` and `update_attributes!`), which are stricter in that 
+is, `create!`, `save!` and `update!`), which are stricter in that 
 they raise the exception `ActiveRecord::RecordInvalid` if validation fails. 
 A quick example to illustrate:
 

--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -159,8 +159,8 @@ The following methods trigger callbacks:
 * `toggle!`
 * `update`
 * `update_attribute`
-* `update_attributes`
-* `update_attributes!`
+* `update`
+* `update!`
 * `valid?`
 
 Additionally, the `after_find` callback is triggered by the following finder methods:

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -117,11 +117,11 @@ database only if the object is valid:
 * `save`
 * `save!`
 * `update`
-* `update_attributes`
-* `update_attributes!`
+* `update`
+* `update!`
 
 The bang versions (e.g. `save!`) raise an exception if the record is invalid.
-The non-bang versions don't: `save` and `update_attributes` return `false`,
+The non-bang versions don't: `save` and `update` return `false`,
 `create` and `update` just return the objects.
 
 ### Skipping Validations

--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -217,7 +217,7 @@ will produce output similar to
 <input id="person_name" name="person[name]" type="text" value="Henry"/>
 ```
 
-Upon form submission the value entered by the user will be stored in `params[:person][:name]`. The `params[:person]` hash is suitable for passing to `Person.new` or, if `@person` is an instance of Person, `@person.update_attributes`. While the name of an attribute is the most common second parameter to these helpers this is not compulsory. In the example above, as long as person objects have a `name` and a `name=` method Rails will be happy.
+Upon form submission the value entered by the user will be stored in `params[:person][:name]`. The `params[:person]` hash is suitable for passing to `Person.new` or, if `@person` is an instance of Person, `@person.update`. While the name of an attribute is the most common second parameter to these helpers this is not compulsory. In the example above, as long as person objects have a `name` and a `name=` method Rails will be happy.
 
 WARNING: You must pass the name of an instance variable, i.e. `:person` or `"person"`, not an actual instance of your model object.
 
@@ -460,7 +460,7 @@ As with other helpers, if you were to use the `select` helper on a form builder 
 <%= f.select(:city_id, ...) %>
 ```
 
-WARNING: If you are using `select` (or similar helpers such as `collection_select`, `select_tag`) to set a `belongs_to` association you must pass the name of the foreign key (in the example above `city_id`), not the name of association itself. If you specify `city` instead of `city_id` Active Record will raise an error along the lines of ` ActiveRecord::AssociationTypeMismatch: City(#17815740) expected, got String(#1138750) ` when you pass the `params` hash to `Person.new` or `update_attributes`. Another way of looking at this is that form helpers only edit attributes. You should also be aware of the potential security ramifications of allowing users to edit foreign keys directly.
+WARNING: If you are using `select` (or similar helpers such as `collection_select`, `select_tag`) to set a `belongs_to` association you must pass the name of the foreign key (in the example above `city_id`), not the name of association itself. If you specify `city` instead of `city_id` Active Record will raise an error along the lines of ` ActiveRecord::AssociationTypeMismatch: City(#17815740) expected, got String(#1138750) ` when you pass the `params` hash to `Person.new` or `update`. Another way of looking at this is that form helpers only edit attributes. You should also be aware of the potential security ramifications of allowing users to edit foreign keys directly.
 
 ### Option Tags from a Collection of Arbitrary Objects
 
@@ -556,7 +556,7 @@ which results in a `params` hash like
 {:person => {'birth_date(1i)' => '2008', 'birth_date(2i)' => '11', 'birth_date(3i)' => '22'}}
 ```
 
-When this is passed to `Person.new` (or `update_attributes`), Active Record spots that these parameters should all be used to construct the `birth_date` attribute and uses the suffixed information to determine in which order it should pass these parameters to functions such as `Date.civil`.
+When this is passed to `Person.new` (or `update`), Active Record spots that these parameters should all be used to construct the `birth_date` attribute and uses the suffixed information to determine in which order it should pass these parameters to functions such as `Date.civil`.
 
 ### Common Options
 

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -882,7 +882,7 @@ And then create the `update` action in `app/controllers/posts_controller.rb`:
 def update
   @post = Post.find(params[:id])
 
-  if @post.update_attributes(params[:post])
+  if @post.update(params[:post])
     redirect_to action: :show, id: @post.id
   else
     render 'edit'
@@ -890,13 +890,13 @@ def update
 end
 ```
 
-The new method, `update_attributes`, is used when you want to update a record
+The new method, `update`, is used when you want to update a record
 that already exists, and it accepts a hash containing the attributes
 that you want to update. As before, if there was an error updating the
 post we want to show the form back to the user.
 
-TIP: You don't need to pass all attributes to `update_attributes`. For
-example, if you'd call `@post.update_attributes(title: 'A new title')`
+TIP: You don't need to pass all attributes to `update`. For
+example, if you'd call `@post.update(title: 'A new title')`
 Rails would only update the `title` attribute, leaving all other
 attributes untouched.
 

--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -137,7 +137,7 @@ If you want to render the view that corresponds to a different template within t
 ```ruby
 def update
   @book = Book.find(params[:id])
-  if @book.update_attributes(params[:book])
+  if @book.update(params[:book])
     redirect_to(@book)
   else
     render "edit"
@@ -145,14 +145,14 @@ def update
 end
 ```
 
-If the call to `update_attributes` fails, calling the `update` action in this controller will render the `edit.html.erb` template belonging to the same controller.
+If the call to `update` fails, calling the `update` action in this controller will render the `edit.html.erb` template belonging to the same controller.
 
 If you prefer, you can use a symbol instead of a string to specify the action to render:
 
 ```ruby
 def update
   @book = Book.find(params[:id])
-  if @book.update_attributes(params[:book])
+  if @book.update(params[:book])
     redirect_to(@book)
   else
     render :edit

--- a/railties/lib/rails/generators/active_model.rb
+++ b/railties/lib/rails/generators/active_model.rb
@@ -59,8 +59,8 @@ module Rails
       end
 
       # PATCH/PUT update
-      def update_attributes(params=nil)
-        "#{name}.update_attributes(#{params})"
+      def update(params=nil)
+        "#{name}.update(#{params})"
       end
 
       # POST create

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
@@ -71,7 +71,7 @@ class <%= controller_class_name %>Controller < ApplicationController
   # PATCH/PUT <%= route_url %>/1.json
   def update
     respond_to do |format|
-      if @<%= orm_instance.update_attributes("#{singular_table_name}_params") %>
+      if @<%= orm_instance.update("#{singular_table_name}_params") %>
         <%- if options[:html] -%>
         format.html { redirect_to @<%= singular_table_name %>, notice: <%= "'#{human_name} was successfully updated.'" %> }
         <%- end -%>

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -35,7 +35,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       end
 
       assert_instance_method :update, content do |m|
-        assert_match(/@user\.update_attributes\(user_params\)/, m)
+        assert_match(/@user\.update\(user_params\)/, m)
         assert_match(/@user\.errors/, m)
       end
 

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -45,7 +45,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       end
 
       assert_instance_method :update, content do |m|
-        assert_match(/@product_line\.update_attributes\(product_line_params\)/, m)
+        assert_match(/@product_line\.update\(product_line_params\)/, m)
         assert_match(/@product_line\.errors/, m)
       end
 
@@ -162,7 +162,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       end
 
       assert_instance_method :update, content do |m|
-        assert_match(/@admin_role\.update_attributes\(admin_role_params\)/, m)
+        assert_match(/@admin_role\.update\(admin_role_params\)/, m)
         assert_match(/@admin_role\.errors/, m)
       end
 


### PR DESCRIPTION
Rename update_attributes to update, keep update_attributes as an alias for update method. This is a soft-deprecation for update_attributes, although it will still work without any deprecation message in 4.0 is recommended to start using update since update_attributes will be deprecated and removed in future versions of Rails.
