### PR TITLE
Add a failing test case for subqueries on scoped relations

### DIFF
--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -583,6 +583,15 @@ class RelationTest < ActiveRecord::TestCase
     }
   end
 
+  def test_find_all_using_where_with_scoped_relations_to_build_subquery
+    david = authors(:david)
+    relation = Post.where(:id => david.posts.scoped)
+    posts = nil
+    assert_nothing_raised {
+      posts = relation.all
+    }
+    assert_equal david.posts, posts
+  end
 
   def test_find_all_using_where_with_relation_with_select_to_build_subquery
     david = authors(:david)


### PR DESCRIPTION
Hi, I ran into a problem upgrading to recent versions of 3-2-stable...

When doing subqueries with assocations - eg `Post.where(id: author.posts)` [1] - it used to be possible to call `scoped` on the association and use the return value from that - eg `Post.where(id: author.posts.scoped)` [2].

As of a3cf03ef99b2cfd811e0ca5cd31ef57976a9408b (/cc @tenderlove), that causes an error.  The exception varies from adapter to adapter, but mysql2 produces this : 

```
NoMethodError: undefined method `reverse' for nil:NilClass
    RAILS/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:9:in `block in to_sql'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/bind_visitor.rb:17:in `call'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/bind_visitor.rb:17:in `visit_Arel_Nodes_BindParam'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/visitor.rb:19:in `visit'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/to_sql.rb:341:in `visit_Arel_Nodes_Equality'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/visitor.rb:19:in `visit'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/to_sql.rb:323:in `block in visit_Arel_Nodes_And'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/to_sql.rb:323:in `map'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/to_sql.rb:323:in `visit_Arel_Nodes_And'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/visitor.rb:19:in `visit'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/to_sql.rb:136:in `block in visit_Arel_Nodes_SelectCore'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/to_sql.rb:136:in `map'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/to_sql.rb:136:in `visit_Arel_Nodes_SelectCore'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/mysql.rb:41:in `visit_Arel_Nodes_SelectCore'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/to_sql.rb:121:in `block in visit_Arel_Nodes_SelectStatement'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/to_sql.rb:121:in `map'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/to_sql.rb:121:in `visit_Arel_Nodes_SelectStatement'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/mysql.rb:36:in `visit_Arel_Nodes_SelectStatement'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/visitor.rb:19:in `visit'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/to_sql.rb:315:in `visit_Arel_Nodes_In'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/visitor.rb:19:in `visit'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/to_sql.rb:323:in `block in visit_Arel_Nodes_And'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/to_sql.rb:323:in `map'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/to_sql.rb:323:in `visit_Arel_Nodes_And'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/visitor.rb:19:in `visit'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/to_sql.rb:136:in `block in visit_Arel_Nodes_SelectCore'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/to_sql.rb:136:in `map'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/to_sql.rb:136:in `visit_Arel_Nodes_SelectCore'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/mysql.rb:41:in `visit_Arel_Nodes_SelectCore'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/to_sql.rb:121:in `block in visit_Arel_Nodes_SelectStatement'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/to_sql.rb:121:in `map'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/to_sql.rb:121:in `visit_Arel_Nodes_SelectStatement'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/mysql.rb:36:in `visit_Arel_Nodes_SelectStatement'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/visitor.rb:19:in `visit'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/visitor.rb:5:in `accept'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/to_sql.rb:19:in `accept'
    GEM_HOME/arel-3.0.2/lib/arel/visitors/bind_visitor.rb:11:in `accept'
    RAILS/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:8:in `to_sql'
    RAILS/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:19:in `select_all'
    RAILS/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:63:in `select_all'
    RAILS/activerecord/lib/active_record/querying.rb:38:in `block in find_by_sql'
    RAILS/activerecord/lib/active_record/explain.rb:40:in `logging_query_plan'
    RAILS/activerecord/lib/active_record/querying.rb:37:in `find_by_sql'
    RAILS/activerecord/lib/active_record/relation.rb:171:in `exec_queries'
    RAILS/activerecord/lib/active_record/relation.rb:160:in `block in to_a'
    RAILS/activerecord/lib/active_record/explain.rb:40:in `logging_query_plan'
    RAILS/activerecord/lib/active_record/relation.rb:159:in `to_a'
    RAILS/activerecord/lib/active_record/relation/finder_methods.rb:159:in `all'
```

I don't think I'm smart enough to actually fix it, but a failing test case is attached.  Is it fixable, or am I doing it wrong?

---

[1]: Yes, this could be written more sensibly as just `author.posts`, which would avoid the subquery.  It's simplified to make a point.
[2]: Again, this is a simplified version.  In my case, I've got an object which might be an AR::Base model, or it might be an AR::Relation, and I'm calling `scoped` to ensure it's definitely an `AR::Relation`.
