### PR TITLE
removes request.script_name being prepended to asset urls

### DIFF
--- a/actionpack/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionpack/lib/action_view/helpers/asset_url_helper.rb
@@ -132,9 +132,7 @@ module ActionView
           source = compute_asset_path(source, options)
         end
 
-        relative_url_root = (defined?(config.relative_url_root) && config.relative_url_root) ||
-          (respond_to?(:request) && request.try(:script_name))
-        if relative_url_root
+        if relative_url_root = defined?(config.relative_url_root) && config.relative_url_root
           source = "#{relative_url_root}#{source}" unless source.starts_with?("#{relative_url_root}/")
         end
 

--- a/actionpack/test/template/asset_tag_helper_test.rb
+++ b/actionpack/test/template/asset_tag_helper_test.rb
@@ -684,11 +684,11 @@ class AssetUrlHelperControllerTest < ActionView::TestCase
     @controller.extend ActionView::Helpers::AssetUrlHelper
 
     @request = Class.new do
-      attr_accessor :script_name
       def protocol() 'http://' end
       def ssl?() false end
       def host_with_port() 'www.example.com' end
       def base_url() 'http://www.example.com' end
+      def script_name() '/script_name' end
     end.new
 
     @controller.request = @request


### PR DESCRIPTION
- fixes an issue where asset paths from within an engine are prepended with where the engine was mounted
- issue documented at https://github.com/jejacks0n/sprockets_engine
- clarification pending at https://github.com/rails/rails/commit/e6451a5599e92fa07e7c39562bacfd1824d199f8

I initially created an issue on rails/sprockets-rails, but identified the cause by digging into _why_ it's happening.
