### PR TITLE
Fix undefined method `to_i' introduced since 3.2.8

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 3.2.11 (unreleased)
 
+*   Fix undefined method `to_i` when calling `new` on a scope that uses an Array.
+    Fixes #8718.
+
+    *Jason Stirk*
+
 *   Serialized attributes can be serialized in integer columns.
     Fix #8575.
 

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -175,7 +175,11 @@ module ActiveRecord
           when TrueClass, FalseClass
             value ? 1 : 0
           else
-            value.to_i
+            if value.respond_to?(:to_i)
+              value.to_i
+            else
+              nil
+            end
           end
         end
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -66,7 +66,8 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
   def test_id_assignment
     apple = Firm.create("name" => "Apple")
     citibank = Account.create("credit_limit" => 10)
-    assert_raise(NoMethodError) { citibank.firm_id = apple }
+    citibank.firm_id = apple
+    assert_nil citibank.firm_id
   end
 
   def test_natural_assignment_with_primary_key
@@ -542,6 +543,11 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
   def test_attributes_are_being_set_when_initialized_from_belongs_to_association_with_where_clause
     new_firm = accounts(:signals37).build_firm(:name => 'Apple')
     assert_equal new_firm.name, "Apple"
+  end
+
+  def test_attributes_are_set_without_error_when_initialized_from_belongs_to_association_with_array_in_where_clause
+    new_account = Account.where(:credit_limit => [ 50, 60 ]).new
+    assert_nil new_account.credit_limit
   end
 
   def test_reassigning_the_parent_id_updates_the_object

--- a/activerecord/test/cases/column_test.rb
+++ b/activerecord/test/cases/column_test.rb
@@ -1,4 +1,5 @@
 require "cases/helper"
+require 'models/company'
 
 module ActiveRecord
   module ConnectionAdapters
@@ -40,13 +41,20 @@ module ActiveRecord
 
       def test_type_cast_non_integer_to_integer
         column = Column.new("field", nil, "integer")
-        assert_raises(NoMethodError) do
-          column.type_cast([])
-        end
+        assert_nil column.type_cast([1,2])
+        assert_nil column.type_cast({1 => 2})
+        assert_nil column.type_cast((1..2))
+      end
 
-        assert_raises(NoMethodError) do
-          column.type_cast(Object.new)
-        end
+      def test_type_cast_activerecord_to_integer
+        column = Column.new("field", nil, "integer")
+        firm = Firm.create(:name => 'Apple')
+        assert_nil column.type_cast(firm)
+      end
+
+      def test_type_cast_object_without_to_i_to_integer
+        column = Column.new("field", nil, "integer")
+        assert_nil column.type_cast(Object.new)
       end
     end
   end


### PR DESCRIPTION
This commit fixes a bug introduced in 96a13fc7 which breaks behaviour of
integer fields in 3.2.8.

In 3.2.8, setting the value of an integer field to a non-integer (eg.
Array, Hash, etc.) would use the first value in the array :

```
#3.2.8
p = Post.new
p.category_id = [ 1, 2 ]
p.category_id # => 1
p.category_id = { 1 => 2 }
p.category_id # => 1
```

In 3.2.9 and above, this will raise a NoMethodError :

```
#3.2.9
p = Post.new
p.category_id = [ 1, 2 ]

NoMethodError: undefined method `to_i' for [1, 2]:Array
```

Whilst at first blush this appear to be sensible, it combines in bad
ways with scoping.

For example, it is common to use scopes to control access to data :

```
@collection = Posts.where(:category_id => [ 1,2 ])
@new_post = @collection.new
```

In 3.2.8, this would work as expected, creating a new Post object
(albeit with `@new_post.category_id = 1`). However, in 3.2.9 this will
cause the NoMethodError to be raised as above.

It is difficult to avoid triggering this error without descoping before
calling `.new`, breaking any apps running on 3.2.8 that rely on this
behaviour.

This patch deviates from 3.2.8 in that it does not retain the somewhat
spurious behaviour of setting the attribute to the first element or key.
Instead, it explicitly sets these invalid values to nil :

```
p = Post.new
p.category_id = [ 1, 2 ]
p.category_id # => nil
```

This also fixes the situation where a scope using an array will
"pollute" any newly instantiated records.

```
@new_post = @collection.new
@new_post.category_id # => nil
```

Finally, 3.2.8 exhibited a behaviour where setting an object to an
integer field caused it to be coerced to "1". This has not been
retained, as it is spurious and surprising in the same way that setting
Arrays and Hashes was :

```
c = Category.find(6)
p = Post.new

#3.2.8
p.category_id = c
p.category_id # => 1

# This patch
p.category_id = c
p.category_id # => nil
```
