### PR TITLE
Better error message for String#to_date

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Change String#to_date to use Date.parse. This gives more consistant error
+    messages and allows the use of partial dates.
+
+        "gibberish".to_date => Argument Error: invalid date
+        "3rd Feb".to_date => Sun, 03 Feb 2013
+
+    *Kelly Stannard*
+
 *   It's now possible to compare Date, DateTime, Time and TimeWithZone with Infinity
     This allows to create date/time ranges with one infinite bound.
     Example:

--- a/activesupport/lib/active_support/core_ext/string/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/string/conversions.rb
@@ -32,11 +32,7 @@ class String
   #   "2012-12-13".to_date #=> Thu, 13 Dec 2012
   #   "12/13/2012".to_date #=> ArgumentError: invalid date
   def to_date
-    unless blank?
-      date_values = ::Date._parse(self, false).values_at(:year, :mon, :mday)
-
-      ::Date.new(*date_values)
-    end
+    ::Date.parse(self, false) unless blank?
   end
 
   # Converts a string to a DateTime value.

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -307,6 +307,7 @@ class StringConversionsTest < ActiveSupport::TestCase
   def test_string_to_date
     assert_equal Date.new(2005, 2, 27), "2005-02-27".to_date
     assert_nil "".to_date
+    assert_equal Date.new(Date.today.year, 2, 3), "Feb 3rd".to_date
   end
 end
 


### PR DESCRIPTION
The main change of this PR is that passing in an invalid date will return "Argument Error: invalid date" instead of "NoMethodError: undefined method `div' for nil:NilClass".

I did this because the original error is unhelpful if you do not pass in a correct date. In the process I think this cleans up the code nicely.

Benchmark
https://gist.github.com/4440875
