### PR TITLE
A small fix for an AR test case

### DIFF
--- a/activerecord/test/cases/explain_test.rb
+++ b/activerecord/test/cases/explain_test.rb
@@ -122,7 +122,7 @@ if ActiveRecord::Base.connection.supports_explain?
       base.expects(:collecting_sqls_for_explain).never
       base.logger.expects(:warn).never
       base.silence_auto_explain do
-        with_threshold(0) { Car.all }
+        with_threshold(0) { Car.all.to_a }
       end
     end
 


### PR DESCRIPTION
`Car.all` here needs a `to_a` to execute SQL because `Car.all` alone just returns a Relation.

Actually, the test passes without `base.silence_auto_explain do` block if not `to_a`'ed.
