### PR TITLE
Adding a usage message to install.rb script

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -1,5 +1,10 @@
 version = ARGV.pop
 
+if version.nil?
+  puts "Usage: ruby install.rb version"
+  exit(64)
+end
+
 %w( activesupport activemodel activerecord actionpack actionmailer railties ).each do |framework|
   puts "Installing #{framework}..."
   `cd #{framework} && gem build #{framework}.gemspec && gem install #{framework}-#{version}.gem --local --no-ri --no-rdoc && rm #{framework}-#{version}.gem`


### PR DESCRIPTION
Previously, invoking the install.rb script with zero arguments
caused it to attempt to install all gems without a version
suffix, which would fail spectacularly. Failing gracefully with
a usage message is more helpful to a first-time user.

This was a small pain point for me as I attempted to build
master for the first time on my local machine. Hope this helps
out other first-time contributors.
