### PR TITLE
Fix missing spaces in method definitions

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -530,7 +530,7 @@ module ActionMailer
     # The resulting Mail::Message will have the following in its header:
     #
     #   X-Special-Domain-Specific-Header: SecretValue
-    def headers(args=nil)
+    def headers(args = nil)
       if args
         @_message.headers(args)
       else
@@ -660,7 +660,7 @@ module ActionMailer
     #     format.html
     #   end
     #
-    def mail(headers={}, &block)
+    def mail(headers = {}, &block)
       @_mail_was_called = true
       m = @_message
 

--- a/actionmailer/lib/action_mailer/collector.rb
+++ b/actionmailer/lib/action_mailer/collector.rb
@@ -20,7 +20,7 @@ module ActionMailer
     end
     alias :all :any
 
-    def custom(mime, options={})
+    def custom(mime, options = {})
       options.reverse_merge!(content_type: mime.to_s)
       @context.formats = [mime.to_sym]
       options[:body] = block_given? ? yield : @default_render.call


### PR DESCRIPTION
Hello,

A simple pull request. Pretty useless but it's horrible to see missing spaces when you read the code.

Have a nice day.
