### PR TITLE
update directory tree in the generated README in Rails 3.2

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/README
+++ b/railties/lib/rails/generators/rails/app/templates/README
@@ -157,9 +157,9 @@ The default directory structure of a generated Ruby on Rails application:
 
   |-- app
   |   |-- assets
-  |       |-- images
-  |       |-- javascripts
-  |       `-- stylesheets
+  |   |   |-- images
+  |   |   |-- javascripts
+  |   |   `-- stylesheets
   |   |-- controllers
   |   |-- helpers
   |   |-- mailers
@@ -173,6 +173,7 @@ The default directory structure of a generated Ruby on Rails application:
   |-- db
   |-- doc
   |-- lib
+  |   |-- assets
   |   `-- tasks
   |-- log
   |-- public
@@ -184,13 +185,12 @@ The default directory structure of a generated Ruby on Rails application:
   |   |-- performance
   |   `-- unit
   |-- tmp
-  |   |-- cache
-  |   |-- pids
-  |   |-- sessions
-  |   `-- sockets
+  |   `-- cache
+  |       `-- assets
   `-- vendor
       |-- assets
-          `-- stylesheets
+      |   |-- javascripts
+      |   `-- stylesheets
       `-- plugins
 
 app


### PR DESCRIPTION
This is Rails 3.2 version of #8731

I think generating inaccurate documentation in users' app is a bug, so it's better to be fixed also in the stable branch.
