### PR TITLE
Ensure assets aren't duplicated when using sprockets require.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -5,6 +5,9 @@
     *Sam Ruby + Carlos Antonio da Silva*
 
 *   Do not append second slash to `root_url` when using `trailing_slash: true`
+
+*   Do not append second slash to root_url when using `trailing_slash: true`
+
     Fix #8700.
     Backport #8701.
 
@@ -16,6 +19,10 @@
         root_url # => http://test.host/
 
     *Yves Senn*
+
+*   Fixes issue where duplicate assets can be required with sprockets.
+
+    *Jeremy Jackson*
 
 *   Fix a bug in `content_tag_for` that prevents it for work without a block.
 

--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -31,7 +31,7 @@ module Sprockets
           else
             super(source.to_s, { :src => path_to_asset(source, :ext => 'js', :body => body, :digest => digest) }.merge!(options))
           end
-        end.uniq.join("\n").html_safe
+        end.flatten.uniq.join("\n").html_safe
       end
 
       def stylesheet_link_tag(*sources)
@@ -48,7 +48,7 @@ module Sprockets
           else
             super(source.to_s, { :href => path_to_asset(source, :ext => 'css', :body => body, :protocol => :request, :digest => digest) }.merge!(options))
           end
-        end.uniq.join("\n").html_safe
+        end.flatten.uniq.join("\n").html_safe
       end
 
       def asset_path(source, options = {})

--- a/actionpack/test/fixtures/sprockets/app/javascripts/extra.js
+++ b/actionpack/test/fixtures/sprockets/app/javascripts/extra.js
@@ -1,0 +1,1 @@
+//= require xmlhr

--- a/actionpack/test/fixtures/sprockets/app/stylesheets/extra.css
+++ b/actionpack/test/fixtures/sprockets/app/stylesheets/extra.css
@@ -1,0 +1,1 @@
+/*= require style */

--- a/actionpack/test/template/sprockets_helper_test.rb
+++ b/actionpack/test/template/sprockets_helper_test.rb
@@ -266,6 +266,8 @@ class SprocketsHelperTest < ActionView::TestCase
       javascript_include_tag('/javascripts/application')
     assert_match %r{<script src="/assets/xmlhr-[0-9a-f]+.js\?body=1" type="text/javascript"></script>\n<script src="/assets/application-[0-9a-f]+.js\?body=1" type="text/javascript"></script>},
       javascript_include_tag(:application)
+    assert_match %r{<script src="/assets/xmlhr-[0-9a-f]+.js\?body=1" type="text/javascript"></script>\n<script src="/assets/application-[0-9a-f]+.js\?body=1" type="text/javascript"></script>\n<script src="/assets/extra-[0-9a-f]+.js\?body=1" type="text/javascript"></script>},
+      javascript_include_tag(:application, :extra)
   end
 
   test "stylesheet path through asset_path" do
@@ -323,6 +325,9 @@ class SprocketsHelperTest < ActionView::TestCase
 
     assert_match %r{<link href="/assets/style-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />\n<link href="/assets/application-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />},
       stylesheet_link_tag(:application)
+
+    assert_match %r{<link href="/assets/style-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />\n<link href="/assets/application-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />\n<link href="/assets/extra-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" type="text/css" />},
+      stylesheet_link_tag(:application, :extra)
 
     assert_match %r{<link href="/assets/style-[0-9a-f]+.css\?body=1" media="print" rel="stylesheet" type="text/css" />\n<link href="/assets/application-[0-9a-f]+.css\?body=1" media="print" rel="stylesheet" type="text/css" />},
       stylesheet_link_tag(:application, :media => "print")


### PR DESCRIPTION
Addresses the problem by calling flatten on asset array before calling uniq.

I've created a separate pull request on rails/sprockets-rails that addresses the issue for Rails 4.

https://github.com/rails/sprockets-rails/pull/33
