### PR TITLE
Apply `var` keyword to js at welcome#index

### DIFF
--- a/railties/lib/rails/templates/rails/welcome/index.html.erb
+++ b/railties/lib/rails/templates/rails/welcome/index.html.erb
@@ -173,7 +173,8 @@
     </style>
     <script>
       function about() {
-        info = document.getElementById('about-content');
+        var info = document.getElementById('about-content');
+        var xhr;
         if (window.XMLHttpRequest)
           { xhr = new XMLHttpRequest(); }
         else


### PR DESCRIPTION
I stopped global variable leaks.
