### PR TITLE
Fix info page style

### DIFF
--- a/railties/lib/rails/info_controller.rb
+++ b/railties/lib/rails/info_controller.rb
@@ -3,7 +3,7 @@ require 'action_dispatch/routing/inspector'
 class Rails::InfoController < ActionController::Base # :nodoc:
   self.view_paths = File.expand_path('../templates', __FILE__)
   prepend_view_path ActionDispatch::DebugExceptions::RESCUES_TEMPLATE_PATH
-  layout 'application'
+  layout -> { request.xhr? ? nil : 'application' }
 
   before_filter :require_local!
 

--- a/railties/lib/rails/templates/rails/welcome/index.html.erb
+++ b/railties/lib/rails/templates/rails/welcome/index.html.erb
@@ -174,8 +174,9 @@
     <script>
       function about() {
         var info = document.getElementById('about-content'),
-             xhr = new XMLHttpRequest();
-        xhr.open("GET","rails/info/properties",false);
+            xhr = new XMLHttpRequest();
+        xhr.open("GET", "rails/info/properties", false);
+        xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
         xhr.send("");
         info.innerHTML = xhr.responseText;
         info.style.display = 'block'


### PR DESCRIPTION
When I click link "About your application's environment" at welcome page, the page style (such as font, background color etc) are broken. (see the following images.)

This cause is that the partial page loaded by xhr contains their own css.

So I stop containing css in loaded page.

---

Before click:
![ 2013-01-04 15 51 05](https://f.cloud.github.com/assets/290782/42622/33f23390-563b-11e2-80c4-87c596d6f301.png)

After click:
![ 2013-01-04 15 51 17](https://f.cloud.github.com/assets/290782/42621/33c2d00a-563b-11e2-9ae6-f24e4ae31590.png)
