### PR TITLE
another tiny update on generated README

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/README
+++ b/railties/lib/rails/generators/rails/app/templates/README
@@ -259,5 +259,5 @@ test
   directory.
 
 vendor
-  External libraries that the application depends on. If the app has frozen rails,
-  those gems also go here, under vendor/rails/. This directory is in the load path.
+  External libraries that the application depends on. This directory is in the
+  load path.


### PR DESCRIPTION
`rake rails:freeze` family had gone in 7204bb0feb6f6a76243749eef2c67b8265a6bba7
