### PR TITLE
fix_for_reverse_order_with_functions

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -863,11 +863,13 @@ module ActiveRecord
       # values divided by coma without brackets OR with matching brackets included
       %r{
         (
-          [^\(\),]+ # value without brackets
+          (?:[^\(\),]+) # value without brackets
           |
-          [^,]*                         #
-          (\((?:(?>[^()]+)|\g<2>)*\))   # value with brackets
-          [^,]*                         #
+          (?:                             #
+            [^,]*?                        #
+            (\((?:(?>[^()]+)|\g<2>)*\))   # value with brackets
+            [^,]*?                        #
+          )                               #
         )
         (?:,|\s*\z) # coma or end of string
       }x

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -843,7 +843,7 @@ module ActiveRecord
         when Arel::Nodes::Ordering
           o.reverse
         when String
-          o.to_s.split(',').collect do |s|
+          o.to_s.scan(order_values_regexp).map(&:first).collect do |s|
             s.strip!
             s.gsub!(/\sasc\Z/i, ' DESC') || s.gsub!(/\sdesc\Z/i, ' ASC') || s.concat(' DESC')
           end
@@ -857,6 +857,20 @@ module ActiveRecord
           o
         end
       end
+    end
+
+    def order_values_regexp
+      # values divided by coma without brackets OR with matching brackets included
+      %r{
+        (
+          [^\(\),]+ # value without brackets
+          |
+          [^,]*                         #
+          (\((?:(?>[^()]+)|\g<2>)*\))   # value with brackets
+          [^,]*                         #
+        )
+        (?:,|\s*\z) # coma or end of string
+      }x
     end
 
     def array_of_strings?(o)

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1160,8 +1160,12 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_order_with_function_and_last
-    authors = Author.scoped
-    assert_equal authors(:bob), authors.order( "id asc, MAX( organization_id, owned_essay_id)" ).last
+    authors = Author.all
+    assert_equal authors(:bob), authors.order( "id asc, COALESCE(organization_id, owned_essay_id)" ).last
+  end
+
+  def test_reverse_order_with_nested_functions
+    assert_equal Author.all.send(:reverse_sql_order, ["id asc, COALESCE(IFNULL(1,0), owned_essay_id)"]), ["id DESC", "COALESCE(IFNULL(1,0), owned_essay_id) DESC"]
   end
 
   def test_unscoped_block_style

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1159,6 +1159,11 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal 'honda', car2.name
   end
 
+  def test_order_with_function_and_last
+    authors = Author.scoped
+    assert_equal authors(:bob), authors.order( "id asc, MAX( organization_id, owned_essay_id)" ).last
+  end
+
   def test_unscoped_block_style
     assert_equal 'honda', CoolCar.unscoped { CoolCar.order_using_new_style.limit(1).first.name}
     assert_equal 'honda', FastCar.unscoped { FastCar.order_using_new_style.limit(1).first.name}


### PR DESCRIPTION
fix for reverse_sql_order using regexp (for details of bug see pull request #8225)
