### PR TITLE
Fixed style break when clicking "About your application’s environment" on no-root-route/welcome page

### DIFF
--- a/railties/lib/rails/templates/rails/welcome/index.html.erb
+++ b/railties/lib/rails/templates/rails/welcome/index.html.erb
@@ -181,8 +181,13 @@
           { xhr = new ActiveXObject("Microsoft.XMLHTTP"); }
         xhr.open("GET","rails/info/properties",false);
         xhr.send("");
-        info.innerHTML = xhr.responseText;
-        info.style.display = 'block'
+        
+        var doc = document.implementation.createHTMLDocument("about-app");
+        doc.documentElement.innerHTML = xhr.responseText;
+
+        info.innerHTML = doc.body.innerHTML;
+        info.style.display = 'block';
+        info.style.overflow = 'scroll';
       }
     </script>
   </head>


### PR DESCRIPTION
Fixed style break when clicking "About your application’s environment" on no-root-route/welcome page
