### PR TITLE
removed dangling whitespace in generated database yml

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml
@@ -26,7 +26,7 @@ development:
   # domain socket that doesn't need configuration. Windows does not have
   # domain sockets, so uncomment these lines.
   #host: localhost
-  
+
   # The TCP port the server listens on. Defaults to 5432.
   # If your server runs on a different port number, change accordingly.
   #port: 5432

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlserver.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlserver.yml
@@ -1,5 +1,5 @@
 # SQL Server (2005 or higher recommended)
-# 
+#
 # Install the adapters and driver
 #   gem install tiny_tds
 #   gem install activerecord-sqlserver-adapter
@@ -8,8 +8,8 @@
 # 	gem 'tiny_tds'
 # 	gem 'activerecord-sqlserver-adapter'
 #
-# You should make sure freetds is configured correctly first.  
-# freetds.conf contains host/port/protocol_versions settings.  
+# You should make sure freetds is configured correctly first.
+# freetds.conf contains host/port/protocol_versions settings.
 # http://freetds.schemamania.org/userguide/freetdsconf.htm
 #
 # A typical Microsoft server


### PR DESCRIPTION
Removed some ugly dangling white space in generated database.yml in a new project for postgres and sqlserver databases.
