### PR TITLE
Remove unnecessary `ERB::Util::h`

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.erb
@@ -2,7 +2,7 @@
   <% if (hide = @exception.blamed_files.length > 8) %>
     <a href="#" onclick="toggleTrace()">Toggle blamed files</a>
   <% end %>
-  <pre id="blame_trace" <%='style="display:none"' if hide %>><code><%=h @exception.describe_blame %></code></pre>
+  <pre id="blame_trace" <%='style="display:none"' if hide %>><code><%= @exception.describe_blame %></code></pre>
 <% end %>
 
 <%
@@ -18,7 +18,7 @@
 %>
 
 <h2 style="margin-top: 30px">Request</h2>
-<p><b>Parameters</b>:</p> <pre><%=h request_dump %></pre>
+<p><b>Parameters</b>:</p> <pre><%= request_dump %></pre>
 
 <div class="details">
   <div class="summary"><a href="#" onclick="toggleSessionDump()">Toggle session dump</a></div>
@@ -31,4 +31,4 @@
 </div>
 
 <h2 style="margin-top: 30px">Response</h2>
-<p><b>Headers</b>:</p> <pre><%=h defined?(@response) ? @response.headers.inspect.gsub(',', ",\n") : 'None' %></pre>
+<p><b>Headers</b>:</p> <pre><%= defined?(@response) ? @response.headers.inspect.gsub(',', ",\n") : 'None' %></pre>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_trace.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_trace.erb
@@ -20,7 +20,7 @@
 
   <% traces.each do |name, trace| %>
     <div id="<%= name.gsub(/\s/, '-') %>" style="display: <%= (name == "Application Trace") ? 'block' : 'none' %>;">
-      <pre><code><%=h trace.join "\n" %></code></pre>
+      <pre><code><%= trace.join "\n" %></code></pre>
     </div>
   <% end %>
 </div>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.erb
@@ -1,14 +1,14 @@
 <header>
   <h1>
-    <%=h @exception.class.to_s %>
+    <%= @exception.class.to_s %>
     <% if @request.parameters['controller'] %>
-      in <%=h @request.parameters['controller'].camelize %>Controller<% if @request.parameters['action'] %>#<%=h @request.parameters['action'] %><% end %>
+      in <%= @request.parameters['controller'].camelize %>Controller<% if @request.parameters['action'] %>#<%= @request.parameters['action'] %><% end %>
     <% end %>
   </h1>
 </header>
 
 <div id="container">
-  <h2><%=h @exception.message %></h2>
+  <h2><%= @exception.message %></h2>
 
   <%= render template: "rescues/_source" %>
   <%= render template: "rescues/_trace" %>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_template.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_template.erb
@@ -3,5 +3,5 @@
 </header>
 
 <div id="container">
-  <h2><%=h @exception.message %></h2>
+  <h2><%= @exception.message %></h2>
 </div>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/routing_error.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/routing_error.erb
@@ -2,13 +2,13 @@
   <h1>Routing Error</h1>
 </header>
 <div id="container">
-  <h2><%=h @exception.message %></h2>
+  <h2><%= @exception.message %></h2>
   <% unless @exception.failures.empty? %>
     <p>
       <h2>Failure reasons:</h2>
       <ol>
       <% @exception.failures.each do |route, reason| %>
-        <li><code><%=h route.inspect.gsub('\\', '') %></code> failed because <%=h reason.downcase %></li>
+        <li><code><%= route.inspect.gsub('\\', '') %></code> failed because <%= reason.downcase %></li>
       <% end %>
       </ol>
     </p>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/template_error.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/template_error.erb
@@ -1,20 +1,20 @@
 <% @source_extract = @exception.source_extract(0, :html) %>
 <header>
   <h1>
-    <%=h @exception.original_exception.class.to_s %> in
-    <%=h @request.parameters["controller"].capitalize if @request.parameters["controller"]%>#<%=h @request.parameters["action"] %>
+    <%= @exception.original_exception.class.to_s %> in
+    <%= @request.parameters["controller"].capitalize if @request.parameters["controller"]%>#<%= @request.parameters["action"] %>
   </h1>
 </header>
 
 <div id="container">
   <p>
-    Showing <i><%=h @exception.file_name %></i> where line <b>#<%=h @exception.line_number %></b> raised:
+    Showing <i><%= @exception.file_name %></i> where line <b>#<%= @exception.line_number %></b> raised:
   </p>
-  <pre><code><%=h @exception.message %></code></pre>
+  <pre><code><%= @exception.message %></code></pre>
 
   <div class="source">
     <div class="info">
-      <p>Extracted source (around line <strong>#<%=h @exception.line_number %></strong>):</p>
+      <p>Extracted source (around line <strong>#<%= @exception.line_number %></strong>):</p>
     </div>
     <div class="data">
     <table cellpadding="0" cellspacing="0" class="lines">
@@ -36,7 +36,7 @@
 </div>
 </div>
 
-  <p><%=h @exception.sub_template_message %></p>
+  <p><%= @exception.sub_template_message %></p>
 
   <%= render template: "rescues/_trace" %>
   <%= render template: "rescues/_request_and_response" %>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/unknown_action.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/unknown_action.erb
@@ -2,5 +2,5 @@
   <h1>Unknown action</h1>
 </header>
 <div id="container">
-  <h2><%=h @exception.message %></h2>
+  <h2><%= @exception.message %></h2>
 </div>


### PR DESCRIPTION
It is automatically applied when strings is unsafe for html.
