### PR TITLE
Exception on unexpected params when enabled.

### DIFF
--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -21,21 +21,24 @@ module ActionController
 
     initializer "action_controller.parameters_config" do |app|
       ActionController::Parameters.permit_all_parameters = app.config.action_controller.delete(:permit_all_parameters) { false }
+      ActionController::Parameters.raise_on_unexpected = app.config.action_controller.raise_on_unexpected_params
     end
 
     initializer "action_controller.set_configs" do |app|
       paths   = app.config.paths
       options = app.config.action_controller
 
-      options.logger               ||= Rails.logger
-      options.cache_store          ||= Rails.cache
+      options.logger                      ||= Rails.logger
+      options.cache_store                 ||= Rails.cache
 
-      options.javascripts_dir      ||= paths["public/javascripts"].first
-      options.stylesheets_dir      ||= paths["public/stylesheets"].first
+      options.javascripts_dir             ||= paths["public/javascripts"].first
+      options.stylesheets_dir             ||= paths["public/stylesheets"].first
 
       # Ensure readers methods get compiled
-      options.asset_host           ||= app.config.asset_host
-      options.relative_url_root    ||= app.config.relative_url_root
+      options.asset_host                  ||= app.config.asset_host
+      options.relative_url_root           ||= app.config.relative_url_root
+
+      options.raise_on_unexpected_params  ||= (Rails.env.test? || Rails.env.development?)
 
       ActiveSupport.on_load(:action_controller) do
         include app.routes.mounted_helpers

--- a/actionpack/test/controller/parameters/raise_on_unpermitted_params_test.rb
+++ b/actionpack/test/controller/parameters/raise_on_unpermitted_params_test.rb
@@ -1,0 +1,33 @@
+require 'abstract_unit'
+require 'action_controller/metal/strong_parameters'
+
+class RaiseOnUnpermittedParamsTest < ActiveSupport::TestCase
+  def setup
+    ActionController::Parameters.raise_on_unexpected = true
+  end
+
+  def teardown
+    ActionController::Parameters.raise_on_unexpected = false
+  end
+
+  test "raises on unexpected params" do
+    params = ActionController::Parameters.new({
+      book: { pages: 65 },
+      fishing: "Turnips"
+    })
+
+    assert_raises(ActionController::UnexpectedParameters) do
+      params.permit(book: [:pages])
+    end
+  end
+
+  test "raises on unexpected nested params" do
+    params = ActionController::Parameters.new({
+      book: { pages: 65, title: "Green Cats and where to find then." }
+    })
+
+    assert_raises(ActionController::UnexpectedParameters) do
+      params.permit(book: [:pages])
+    end
+  end
+end


### PR DESCRIPTION
Added the ability for developers to enable reporting of unexpected parameters.

To enable add config.raise_on_unexpected_params = true to whatever environment file required.

Changes first proposed here: https://github.com/rails/strong_parameters/pull/75
