### PR TITLE
Fix javascript_include_tag when no js runtime is available

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 3.2.11 (unreleased) ##
 
+*   Prevent unnecessary asset compilation when using javascript_include_tag on
+    files with non-standard extensions.
+
+    *Noah Silas*
+
 *   Do not append second slash to root_url when using `trailing_slash: true`
     Fix #8700.
     Backport #8701.

--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -157,17 +157,24 @@ module Sprockets
         end
 
         def rewrite_extension(source, dir, ext)
-          source_ext = File.extname(source)
-          if ext && source_ext != ".#{ext}"
-            if !source_ext.empty? && (asset = asset_environment[source]) &&
-                  asset.pathname.to_s =~ /#{source}\Z/
-              source
-            else
-              "#{source}.#{ext}"
-            end
-          else
+          source_ext = File.extname(source)[1..-1]
+
+          if !ext || ext == source_ext
             source
+          elsif source_ext.blank?
+            "#{source}.#{ext}"
+          elsif exact_match_present?(source)
+            source
+          else
+            "#{source}.#{ext}"
           end
+        end
+
+        def exact_match_present?(source)
+          pathname = asset_environment.resolve(source)
+          pathname.to_s =~ /#{Regexp.escape(source)}\Z/
+        rescue Sprockets::FileNotFound
+          false
         end
       end
     end

--- a/actionpack/test/template/sprockets_helper_test.rb
+++ b/actionpack/test/template/sprockets_helper_test.rb
@@ -268,6 +268,13 @@ class SprocketsHelperTest < ActionView::TestCase
       javascript_include_tag(:application)
   end
 
+  test "precompiled assets with an extension when no JS runtime is available" do
+    @config.assets.compile = false
+    @config.assets.digests = {'foo.min.js' => 'foo.min-f00.js'}
+    Sprockets::Index.any_instance.stubs(:build_asset).raises
+    assert_nothing_raised { javascript_include_tag('foo.min') }
+  end
+
   test "stylesheet path through asset_path" do
     assert_match %r{/assets/application-[0-9a-f]+.css}, asset_path(:application, :ext => "css")
 


### PR DESCRIPTION
In a production environment where the assets have been precompiled, we
don't want an assets compile step to happen on the application server at
all. To ensure this, a js runtime may not be available on the app
servers. In this environment, pages using javascript_include_tag for
assets with non-standard or chained extensions were throwing 500 errors.
For instance, `javascript_include_tag('jquery.min')` would blow up.

Sprockets was attempting to build the assets being included during the
rewrite_extension step (responsible for appending a '.js' extension to
assets being included by the basename rather than a fully qualified
name). This was happening as a step to resolve #6310, which required
checking for the presence of an asset with a non-standard extension
before appending the extension.

We can check for the presence of an asset without invoking the asset
build step by using Sprockets' resolve method, which will search for the
base file without building it (and is the method that find_asset uses
internally to get the path to the asset before attempting to build it).

When rewriting the extension on an asset, these are the steps:
- If the source does not have an extension, assume that the default
  extension is desired and append it.
- If there is an extension and it doesn't match the default extension,
  check to see if a file with the precise name specified exists amongst
  the assets; if it is present, do not append the default extension.
  (This is the step that resolves #6310).

---

This is a new pull of #6729 after github was confused post-rebase.
