### PR TITLE
misleading error message that prompts non-existing command

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -175,7 +175,7 @@ task default: :test
                                                  "skip adding entry to Gemfile"
 
       def initialize(*args)
-        raise Error, "Options should be given after the plugin name. For details run: rails plugin --help" if args[0].blank?
+        raise Error, "Options should be given after the plugin name. For details run: rails plugin new --help" if args[0].blank?
 
         @dummy_path = nil
         super


### PR DESCRIPTION
```
% rails plugin new
Options should be given after the plugin name. For details run: rails plugin --help

% rails plugin --help
/Users/a_matsuda/src/rails/activesupport/lib/active_support/dependencies.rb:228:in `require': cannot load such file -- rails/commands/plugin (LoadError)
    from /Users/a_matsuda/src/rails/activesupport/lib/active_support/dependencies.rb:228:in `block in require'
    from /Users/a_matsuda/src/rails/activesupport/lib/active_support/dependencies.rb:213:in `load_dependency'
    from /Users/a_matsuda/src/rails/activesupport/lib/active_support/dependencies.rb:228:in `require'
    from /Users/a_matsuda/src/rails/railties/lib/rails/commands.rb:51:in `<top (required)>'
    from script/rails:6:in `require'
    from script/rails:6:in `<main>'

% rails plugin new --help
Usage:
  rails plugin new APP_PATH [options]

Options:
...
```
