### PR TITLE
added marshal_load and marshal_dump for ProxyTestResult. Behavior of met...

### DIFF
--- a/activesupport/lib/active_support/testing/isolation.rb
+++ b/activesupport/lib/active_support/testing/isolation.rb
@@ -12,8 +12,8 @@ module ActiveSupport
     end
 
     class ProxyTestResult
-      def initialize
-        @calls = []
+      def initialize(calls = [])
+        @calls = calls
       end
 
       def add_error(e)
@@ -25,6 +25,14 @@ module ActiveSupport
         @calls.each do |name, args|
           result.send(name, *args)
         end
+      end
+
+      def marshal_dump
+        @calls
+      end
+
+      def marshal_load(calls)
+        initialize(calls)
       end
 
       def method_missing(name, *args)


### PR DESCRIPTION
Ruby-2.0.0 later changed behaivior of method_missing. method_missing of any Object repond to marshal_dump and marshal_load when call with Marshal.dump and Marshal.load.

details of this behaivior discussion:
- http://bugs.ruby-lang.org/issues/7564
- http://bugs.ruby-lang.org/issues/7638

I think this problem is that ProxyTestResult calling marshal_load and marshal_dump but don't have these methods. I added it.

@tenderlove How do you think about this problem?
