### PR TITLE
backport 4f0f1b5 into 3-2-stable. because 1.9.3-p362 warned unused vari...

### DIFF
--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -1406,10 +1406,11 @@ class RenderTest < ActionController::TestCase
   end
 
   def test_locals_option_to_assert_template_is_not_supported
+    get :partial_collection_with_locals
+
     warning_buffer = StringIO.new
     $stderr = warning_buffer
 
-    get :partial_collection_with_locals
     assert_template :partial => 'customer_greeting', :locals => { :greeting => 'Bonjour' }
     assert_equal "the :locals option to #assert_template is only supported in a ActionView::TestCase\n", warning_buffer.string
   ensure


### PR DESCRIPTION
backport 4f0f1b5.

1.9.3-p362 warned unused variables. this test failed because of this warning.
