### PR TITLE
Remove suggestion that Procs can be used as session secrets.

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
@@ -21,15 +21,12 @@ module ActionDispatch
     #
     # Session options:
     #
-    # * <tt>:secret</tt>: An application-wide key string or block returning a
-    #   string called per generated digest. The block is called with the
-    #   CGI::Session instance as an argument. It's important that the secret
-    #   is not vulnerable to a dictionary attack. Therefore, you should choose
-    #   a secret consisting of random numbers and letters and more than 30
-    #   characters.
+    # * <tt>:secret</tt>: An application-wide key string. It's important that
+    #   the secret is not vulnerable to a dictionary attack. Therefore, you
+    #   should choose a secret consisting of random numbers and letters and
+    #   more than 30 characters.
     #
     #     secret: '449fe2e7daee471bffae2fd8dc02313d'
-    #     secret: Proc.new { User.current_user.secret_key }
     #
     # * <tt>:digest</tt>: The message digest algorithm used to verify session
     #   integrity defaults to 'SHA1' but may be any digest provided by OpenSSL,


### PR DESCRIPTION
The docs suggest you can use a `Proc` as a session-signing key, and does not seem to be true from spelunking the code and setting up a minimal app using just the `Cookie` middlewares.

It also promotes a dangerous practise: using the current user to pick a signing token means you need to unmarshal the session and send part of it to the database, _before_ you've verified the session cookie's authenticity.
