### PR TITLE
Fix img width in guides

### DIFF
--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -83,6 +83,10 @@ table th {
   padding: 0.5em 1em;
 }
 
+img {
+  max-width: 100%;
+}
+
 
 /* Structure and Layout
 --------------------------------------- */


### PR DESCRIPTION
Currently, images in guides have no limits on their width, which leads to glitches like this:

![](http://cl.ly/image/2O0h2E310k1v/download)

This PR fixes that by setting `max-width` on images:

![](http://cl.ly/image/2x1b0j2N2l3X/download)
