### PR TITLE
Fix guides' warning bottom padding

### DIFF
--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -573,7 +573,7 @@ h6 {
 #mainCol div.warning, #subCol dd.warning {
   background: #f9d9d8 url(../images/tab_red.gif) no-repeat left top;
   border: none;
-  padding: 1.25em 1.25em 1.25em 48px;
+  padding: 1.25em 1.25em 0.25em 48px;
   margin-left: 0;
   margin-top: 0.25em;
 }


### PR DESCRIPTION
Currently, there is inconsistency between how notes/info and warnings look like:

![](http://cl.ly/image/0l2E2s1q242T/download)

This huge warning bottom padding is neither consistent nor good-looking. This PR makes it look as follows:

![](http://cl.ly/image/250A1o3S370G/download)
