### PR TITLE
Place article name in the beginning of guides page title

### DIFF
--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'redcarpet'
 require 'nokogiri'
 require 'rails_guides/markdown/renderer'
@@ -129,7 +131,7 @@ module RailsGuides
 
       def generate_title
         if heading = Nokogiri::HTML(@header).at(:h2)
-          @title = "Ruby on Rails Guides: #{heading.text}".html_safe
+          @title = "#{heading.text} — Ruby on Rails Guides".html_safe
         else
           @title = "Ruby on Rails Guides"
         end


### PR DESCRIPTION
The motivation of this is that when page title is too long to fit in tab's title, usually, only the beginning of it is rendered. Placing actual article name in the beginning is better for users navigating between many tabs, for example. So that they see what's the article about, not that it is "Ruby on Rails Guides".

Having article name in front on the search engine results page also allows to easily understand what the guide is about.
