### PR TITLE
ignored performance test when not loading ruby-prof

### DIFF
--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -75,7 +75,7 @@ module ApplicationTests
       RUBY
 
       run_test_file 'performance/posts_test.rb'
-    end
+    end if defined?(RubyProf)
 
     private
       def run_test_file(name)


### PR DESCRIPTION
Rails edge ignored ruby-prof when running with ruby-2.0.0 now. but test of performance test in railties is running and it always failed.

I ignored this test of performance test. if ruby-prof support ruby-2.0.0 and we added it to Gemfile. this test is enabled.

I think this problem is last fails of rails edge with ruby-2.0.0. 
