### PR TITLE
Require 'active_support/core_ext/module/aliasing' in the infinite_comparable module

### DIFF
--- a/activesupport/lib/active_support/core_ext/infinite_comparable.rb
+++ b/activesupport/lib/active_support/core_ext/infinite_comparable.rb
@@ -1,4 +1,5 @@
 require 'active_support/concern'
+require 'active_support/core_ext/module/aliasing'
 require 'active_support/core_ext/object/try'
 
 module InfiniteComparable


### PR DESCRIPTION
Hi, I'm getting the following error when requiring 'active_support/core_ext':

```
~/.rvm/gems/ruby-1.9.3-p327/bundler/gems/rails-15971c3d51f5/activesupport/lib/active_support/core_ext/infinite_comparable.rb:8:in `block in <module:InfiniteComparable>': undefined method `alias_method_chain' for Date:Class (NoMethodError)
  from ~/.rvm/gems/ruby-1.9.3-p327/bundler/gems/rails-15971c3d51f5/activesupport/lib/active_support/concern.rb:114:in `class_eval'
  from ~/.rvm/gems/ruby-1.9.3-p327/bundler/gems/rails-15971c3d51f5/activesupport/lib/active_support/concern.rb:114:in `append_features'
  from ~/.rvm/gems/ruby-1.9.3-p327/bundler/gems/rails-15971c3d51f5/activesupport/lib/active_support/core_ext/date/infinite_comparable.rb:4:in `include'
  from ~/.rvm/gems/ruby-1.9.3-p327/bundler/gems/rails-15971c3d51f5/activesupport/lib/active_support/core_ext/date/infinite_comparable.rb:4:in `<class:Date>'
  from ~/.rvm/gems/ruby-1.9.3-p327/bundler/gems/rails-15971c3d51f5/activesupport/lib/active_support/core_ext/date/infinite_comparable.rb:3:in `<top (required)>'
  from ~/.rvm/gems/ruby-1.9.3-p327/bundler/gems/rails-15971c3d51f5/activesupport/lib/active_support/core_ext/date.rb:5:in `require'
  from ~/.rvm/gems/ruby-1.9.3-p327/bundler/gems/rails-15971c3d51f5/activesupport/lib/active_support/core_ext/date.rb:5:in `<top (required)>'
  from ~/.rvm/gems/ruby-1.9.3-p327/bundler/gems/rails-15971c3d51f5/activesupport/lib/active_support/core_ext.rb:3:in `require'
  from ~/.rvm/gems/ruby-1.9.3-p327/bundler/gems/rails-15971c3d51f5/activesupport/lib/active_support/core_ext.rb:3:in `block in <top (required)>'
  from ~/.rvm/gems/ruby-1.9.3-p327/bundler/gems/rails-15971c3d51f5/activesupport/lib/active_support/core_ext.rb:1:in `each'
  from ~/.rvm/gems/ruby-1.9.3-p327/bundler/gems/rails-15971c3d51f5/activesupport/lib/active_support/core_ext.rb:1:in `<top (required)>'
  from error.rb:1:in `require'
  from error.rb:1:in `<main>'
```
## Simulating the problem

To simulate the problem is very simple, just create a script that requires core_ext:

**error.rb**

```
require 'active_support/core_ext'
```

**Gemfile**

```
source 'http://rubygems.org'
gem 'rails', github: 'rails/rails'
```

**Command**

```
bundle exec ruby error.rb
```
## Solution

As you can see in the commit, the solution is to require 'active_support/core_ext/module/aliasing' in the 'infinite_comparable' module.
