### PR TITLE
Fix error raised when assigning NaN to an integer column

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -4,10 +4,11 @@
 
     *Rob Worley*
 
-*   Fix undefined method `to_i` when calling `new` on a scope that uses an Array.
-    Fixes #8718, #8734.
+*   Fix undefined method `to_i` when calling `new` on a scope that uses an 
+    Array; Fix FloatDomainError when setting integer column to NaN.
+    Fixes #8718, #8734, #8757.
 
-    *Jason Stirk*
+    *Jason Stirk + Tristan Harward*
 
 *   Rename `update_attributes` to `update`, keep `update_attributes` as an alias for `update` method.
     This is a soft-deprecation for `update_attributes`, although it will still work without any
@@ -17,7 +18,7 @@
     *Amparo Luna + Guillermo Iguaran*
 
 *   `after_commit` and `after_rollback` now validate the `:on` option and raise an `ArgumentError`
-    if it is not one of `:create`, `:destroy` or ``:update`
+    if it is not one of `:create`, `:destroy` or `:update`
 
     *Pascal Friederich*
 

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -206,11 +206,7 @@ module ActiveRecord
           when TrueClass, FalseClass
             value ? 1 : 0
           else
-            if value.respond_to?(:to_i)
-              value.to_i
-            else
-              nil
-            end
+            value.to_i rescue nil
           end
         end
 

--- a/activerecord/test/cases/column_test.rb
+++ b/activerecord/test/cases/column_test.rb
@@ -57,6 +57,12 @@ module ActiveRecord
         assert_nil column.type_cast(Object.new)
       end
 
+      def test_type_cast_nan_and_infinity_to_integer
+        column = Column.new("field", nil, "integer")
+        assert_nil column.type_cast(Float::NAN)
+        assert_nil column.type_cast(1.0/0.0)
+      end
+
       def test_type_cast_time
         column = Column.new("field", nil, "time")
         assert_equal nil, column.type_cast('')


### PR DESCRIPTION
This makes integer casting cover any non-castable case by returning `nil`, which is in-line with the intention of the former implementation in 3525a9b5, but covers the odd cases which respond to `to_i` but raise an error when it's called, such as `NaN`, `Infinity` and `-Infinity`. 

Those are the only ones I know of, but it's possible other objects could raise errors on `to_i`, which is the reason for the generic rescue. (Note that this generic rescue was also the behavior pre-3.2.8, except that the value was interpreted as a boolean instead—fixed in 96a13fc7—after this pull it will be more correctly and consistently interpreted as `nil`).

Fixes #8757 (see that issue for full description)
