### PR TITLE
Updated DirtyModel's @changed_attributes hash to be symbol/string agnostic 

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Updated the DirtyModel *_changed? method to be indifferent between using 
+    symbols and strings as keys.
+
+    *William Myers*
+
 *   Add `ActiveModel::Validations::AbsenceValidator`, a validator to check the
     absence of attributes.
 

--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -139,7 +139,7 @@ module ActiveModel
     #   person.name = 'robert'
     #   person.changed_attributes # => {"name" => "bob"}
     def changed_attributes
-      @changed_attributes ||= {}
+      @changed_attributes ||= ActiveSupport::HashWithIndifferentAccess.new
     end
 
     private

--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -3,11 +3,12 @@ require "cases/helper"
 class DirtyTest < ActiveModel::TestCase
   class DirtyModel
     include ActiveModel::Dirty
-    define_attribute_methods :name, :color
+    define_attribute_methods :name, :color, :size
 
     def initialize
       @name = nil
       @color = nil
+      @size = nil
     end
 
     def name
@@ -26,6 +27,15 @@ class DirtyTest < ActiveModel::TestCase
     def color=(val)
       color_will_change! unless val == @color
       @color = val
+    end
+
+    def size
+      @size
+    end
+
+    def size=(val)
+      attribute_will_change!(:size) unless val == @size
+      @size = val
     end
 
     def save
@@ -113,5 +123,10 @@ class DirtyTest < ActiveModel::TestCase
     @model.name = "Mr. Manfredgensonton"
     assert_equal ["Otto", "Mr. Manfredgensonton"], @model.name_change
     assert_equal @model.name_was, "Otto"
+  end
+
+  test "using attribute_will_change! with a symbol" do
+    @model.size = 1
+    assert @model.size_changed?
   end
 end


### PR DESCRIPTION
DirtyModel uses a hash to keep track of any changes made to attributes
of an instance. When using the attribute_will_change! method, you must
supply is a string and not a symbol or the *_changed? method will break
(because it is looking for the attribute name as a string in the keys
of the underlying hash). To remedy this, I simply made the underlying
hash a HashWithIndifferentAccess so it won't matter if you supply
the attribute name as a symbol or string to attribute_will_change!.
