### PR TITLE
Make AR::Relation include Enumerable

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -14,7 +14,7 @@ module ActiveRecord
 
     VALUE_METHODS = MULTI_VALUE_METHODS + SINGLE_VALUE_METHODS
 
-    include FinderMethods, Calculations, SpawnMethods, QueryMethods, Batches, Explain, Delegation
+    include FinderMethods, Calculations, SpawnMethods, QueryMethods, Batches, Explain, Delegation, ::Enumerable
 
     attr_reader :table, :klass, :loaded
     attr_accessor :default_scoped
@@ -198,10 +198,6 @@ module ActiveRecord
       @records
     end
 
-    def as_json(options = nil) #:nodoc:
-      to_a.as_json(options)
-    end
-
     # Returns size of the records.
     def size
       loaded? ? @records.length : count
@@ -218,7 +214,7 @@ module ActiveRecord
     # Returns true if there are any records.
     def any?
       if block_given?
-        to_a.any? { |*block_args| yield(*block_args) }
+        super
       else
         !empty?
       end
@@ -227,7 +223,7 @@ module ActiveRecord
     # Returns true if there is more than one record.
     def many?
       if block_given?
-        to_a.many? { |*block_args| yield(*block_args) }
+        super
       else
         limit_value ? to_a.many? : size > 1
       end

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -11,7 +11,7 @@ module ActiveRecord
     # may vary depending on the klass of a relation, so we create a subclass of Relation
     # for each different klass, and the delegations are compiled into that subclass only.
 
-    delegate :to_xml, :to_yaml, :length, :collect, :map, :each, :all?, :include?, :to_ary, :to => :to_a
+    delegate :to_xml, :to_yaml, :length, :each, :to_ary, :to => :to_a
     delegate :table_name, :quoted_table_name, :primary_key, :quoted_primary_key,
              :connection, :columns_hash, :auto_explain_threshold_in_seconds, :to => :klass
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -196,7 +196,7 @@ module ActiveRecord
     #   # => ActiveModel::MissingAttributeError: missing attribute: other_field
     def select(*fields)
       if block_given?
-        to_a.select { |*block_args| yield(*block_args) }
+        super
       else
         raise ArgumentError, 'Call this with at least one field' if fields.empty?
         spawn.select!(*fields)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1451,7 +1451,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_calling_many_on_loaded_association_should_not_use_query
     firm = companies(:first_firm)
-    firm.clients.collect  # force load
+    firm.clients.to_a  # force load
     assert_no_queries { assert firm.clients.many? }
   end
 

--- a/activerecord/test/cases/named_scope_test.rb
+++ b/activerecord/test/cases/named_scope_test.rb
@@ -22,8 +22,8 @@ class NamedScopeTest < ActiveRecord::TestCase
     all_posts = Topic.base
 
     assert_queries(1) do
-      all_posts.collect
-      all_posts.collect
+      all_posts.to_a
+      all_posts.to_a
     end
   end
 
@@ -192,7 +192,7 @@ class NamedScopeTest < ActiveRecord::TestCase
 
   def test_any_should_not_fire_query_if_scope_loaded
     topics = Topic.base
-    topics.collect # force load
+    topics.to_a # force load
     assert_no_queries { assert topics.any? }
   end
 
@@ -221,7 +221,7 @@ class NamedScopeTest < ActiveRecord::TestCase
 
   def test_many_should_not_fire_query_if_scope_loaded
     topics = Topic.base
-    topics.collect # force load
+    topics.to_a # force load
     assert_no_queries { assert topics.many? }
   end
 
@@ -445,5 +445,9 @@ class NamedScopeTest < ActiveRecord::TestCase
       klass.send(:default_scope, klass.where(:id => posts(:welcome).id))
     end
     assert_equal [posts(:welcome).title], klass.all.map(&:title)
+  end
+
+  def test_json_export
+    assert_equal '[{"comment":{"id":1,"post_id":1,"parent_id":null}}]', Comment.where(:id => 1).to_json(:only => [:id, :post_id, :parent_id])
   end
 end


### PR DESCRIPTION
In this way Relation will gain more Array  behaviors (like `as_json` method that is no longer required in Relation). 
Also it delegates every method to `to_a` without `method_missing` which is faster.

A few tests need a change because `collect` without a block doesn't load the relation anymore. This seems ok.
