### PR TITLE
Don't require 'turn' from rails/test_help

### DIFF
--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -11,14 +11,11 @@ require 'action_dispatch/testing/integration'
 require 'rails/backtrace_cleaner'
 MiniTest.backtrace_filter = Rails.backtrace_cleaner
 
-# Enable turn if it is available
-begin
-  require 'turn'
-
+# Configure turn if it is available
+if defined?(Turn)
   Turn.config do |c|
     c.natural = true
   end
-rescue LoadError
 end
 
 if defined?(ActiveRecord::Base)


### PR DESCRIPTION
If 'turn' is in the Gemfile with `:require => nil`, Rails should
respect that.

This supports the case where 'turn' may or may not be required
depending on different developers' preference or environment. E.g., you
require turn for local testing, but not on your CI server by putting
this in `test/test_helper.rb`:

```
require 'turn' if ENV['TURN']
```
