### PR TITLE
set 'alt' attribute for image_submit_tag

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `image_submit_tag` will set `alt` attribute from image source if not
+    specified.
+
+    *Nihad Abbasov*
+
 *   Do not generate local variables for partials without object or collection.
     Previously rendering a partial without giving `:object` or `:collection`
     would generate a local variable with the partial name by default.

--- a/actionpack/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_tag_helper.rb
@@ -526,19 +526,19 @@ module ActionView
       #
       # ==== Examples
       #   image_submit_tag("login.png")
-      #   # => <input src="/images/login.png" type="image" />
+      #   # => <input alt="Login" src="/images/login.png" type="image" />
       #
       #   image_submit_tag("purchase.png", disabled: true)
-      #   # => <input disabled="disabled" src="/images/purchase.png" type="image" />
+      #   # => <input alt="Purchase" disabled="disabled" src="/images/purchase.png" type="image" />
       #
-      #   image_submit_tag("search.png", class: 'search_button')
-      #   # => <input class="search_button" src="/images/search.png" type="image" />
+      #   image_submit_tag("search.png", class: 'search_button', alt: 'Find')
+      #   # => <input alt="Find" class="search_button" src="/images/search.png" type="image" />
       #
       #   image_submit_tag("agree.png", disabled: true, class: "agree_disagree_button")
-      #   # => <input class="agree_disagree_button" disabled="disabled" src="/images/agree.png" type="image" />
+      #   # => <input alt="Agree" class="agree_disagree_button" disabled="disabled" src="/images/agree.png" type="image" />
       #
       #   image_submit_tag("save.png", data: { confirm: "Are you sure?" })
-      #   # => <input src="/images/save.png" data-confirm="Are you sure?" type="image" />
+      #   # => <input alt="Save" src="/images/save.png" data-confirm="Are you sure?" type="image" />
       def image_submit_tag(source, options = {})
         options = options.stringify_keys
 
@@ -550,7 +550,7 @@ module ActionView
           options["data-confirm"] = confirm
         end
 
-        tag :input, { "type" => "image", "src" => path_to_image(source) }.update(options)
+        tag :input, { "alt" => image_alt(source), "type" => "image", "src" => path_to_image(source) }.update(options)
       end
 
       # Creates a field set for grouping HTML form elements.

--- a/actionpack/test/template/form_tag_helper_test.rb
+++ b/actionpack/test/template/form_tag_helper_test.rb
@@ -488,7 +488,7 @@ class FormTagHelperTest < ActionView::TestCase
 
   def test_image_submit_tag_with_confirmation
     assert_dom_equal(
-      %(<input type="image" src="/images/save.gif" data-confirm="Are you sure?" />),
+      %(<input alt="Save" type="image" src="/images/save.gif" data-confirm="Are you sure?" />),
       image_submit_tag("save.gif", :data => { :confirm => "Are you sure?" })
     )
   end
@@ -496,7 +496,7 @@ class FormTagHelperTest < ActionView::TestCase
   def test_image_submit_tag_with_deprecated_confirmation
     assert_deprecated ":confirm option is deprecated and will be removed from Rails 4.1. Use 'data: { confirm: \'Text\' }' instead" do
       assert_dom_equal(
-        %(<input type="image" src="/images/save.gif" data-confirm="Are you sure?" />),
+        %(<input alt="Save" type="image" src="/images/save.gif" data-confirm="Are you sure?" />),
         image_submit_tag("save.gif", :confirm => "Are you sure?")
       )
     end


### PR DESCRIPTION
According to [html5 spec](http://www.w3.org/html/wg/drafts/html/master/forms.html#image-button-state-%28type=image%29):

> The alt attribute must be present, and must contain a non-empty string.
