### PR TITLE
Eliminate Rack::File headers deprecation warning

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -6,7 +6,7 @@ module ActionDispatch
     def initialize(root, cache_control)
       @root          = root.chomp('/')
       @compiled_root = /^#{Regexp.escape(root)}/
-      @file_server   = ::Rack::File.new(@root, cache_control)
+      @file_server   = ::Rack::File.new(@root, 'Cache-Control' => cache_control)
     end
 
     def match?(path)


### PR DESCRIPTION
See http://intertwingly.net/projects/AWDwR4/checkdepot/section-6.1.html
rake test produces:
   "Rack::File headers parameter replaces cache_control after Rack 1.5."

Despite what the message says, it appears that the hearders parameter change
will be effective as of Rack 1.5:

https://github.com/rack/rack/blob/rack-1.4/lib/rack/file.rb#L24
https://github.com/rack/rack/blob/master/lib/rack/file.rb#L24
