### PR TITLE
Write timestamps only if there are timestamps columns

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Do not try to write timestamps when a table has no timestamps columns.
+
+    Fixes #8813.
+
+    *Sergey Potapov*
+
 *   Properly detect if a connection is still active before using it
     in multi-threaded environments.
 

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -48,7 +48,7 @@ module ActiveRecord
         current_time = current_time_from_proper_timezone
 
         all_timestamp_attributes.each do |column|
-          if respond_to?(column) && respond_to?("#{column}=") && self.send(column).nil?
+          if attributes.has_key?(column.to_s) && self.send(column).nil?
             write_attribute(column.to_s, current_time)
           end
         end


### PR DESCRIPTION
Lets say we have a model:

``` ruby
# Has no timestamps columns in DB but has accessor methods
class Model < ActiveRecord::Base
  attr_accessor :created_at, :updated_at
end
```

On save in will produce deprecation warning:

```
DEPRECATION WARNING: You're trying to create an attribute `created_at'. Writing arbitrary attributes on a model is deprecated. Please just use `attr_writer` etc

DEPRECATION WARNING: You're trying to create an attribute `updated_at'. Writing arbitrary attributes on a model is deprecated. Please just use `attr_writer` etc
```

So Rails tries to use `write_attribute` to assign this values. But there is no such attribute. So I think it should depend on real `attributes`, then just result of `resond_to?`.

Or at least it should use `send("#{attribute_name}=", value)` if it's depends on `respond_to` method.

Thanks.
