### PR TITLE
give a Hash Object to static_cache_control instead of a String Object

### DIFF
--- a/guides/code/getting_started/config/environments/test.rb
+++ b/guides/code/getting_started/config/environments/test.rb
@@ -9,7 +9,7 @@ Blog::Application.configure do
 
   # Configure static asset server for tests with Cache-Control for performance.
   config.serve_static_assets = true
-  config.static_cache_control = "public, max-age=3600"
+  config.static_cache_control = { 'Cache-Control' => 'public, max-age=3600' }
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -224,7 +224,7 @@ You can help test performance with these additions to your test environment:
 ```ruby
 # Configure static asset server for tests with Cache-Control for performance
 config.serve_static_assets = true
-config.static_cache_control = "public, max-age=3600"
+config.static_cache_control = { 'Cache-Control' => 'public, max-age=3600' }
 ```
 
 ### config/initializers/wrap_parameters.rb

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -14,7 +14,7 @@
 
   # Configure static asset server for tests with Cache-Control for performance.
   config.serve_static_assets = true
-  config.static_cache_control = "public, max-age=3600"
+  config.static_cache_control = { 'Cache-Control' => 'public, max-age=3600' }
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true


### PR DESCRIPTION
rack shows a warning message if we give a String Object as of the
version 1.4.3.

https://github.com/chneukirchen/rack/commit/40cb556422d15f6011e86435135298085bf8443c

Warning will not appear in this fix.
