### PR TITLE
Evaluate view_cache_dependencies at the instance level

### DIFF
--- a/actionpack/lib/action_controller/caching.rb
+++ b/actionpack/lib/action_controller/caching.rb
@@ -80,10 +80,6 @@ module ActionController
       def view_cache_dependency(&dependency)
         self._view_cache_dependencies += [dependency]
       end
-
-      def view_cache_dependencies
-        _view_cache_dependencies.map { |dep| instance_exec &dep }.compact
-      end
     end
 
     def caching_allowed?
@@ -91,7 +87,7 @@ module ActionController
     end
 
     def view_cache_dependencies
-      self.class.view_cache_dependencies
+      self.class._view_cache_dependencies.map { |dep| instance_exec &dep }.compact
     end
 
     protected

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -306,11 +306,11 @@ class ViewCacheDependencyTest < ActionController::TestCase
   end
 
   def test_view_cache_dependencies_are_empty_by_default
-    assert NoDependenciesController.view_cache_dependencies.empty?
+    assert NoDependenciesController.new.view_cache_dependencies.empty?
   end
 
   def test_view_cache_dependencies_are_listed_in_declaration_order
-    assert_equal %w(trombone flute), HasDependenciesController.view_cache_dependencies
+    assert_equal %w(trombone flute), HasDependenciesController.new.view_cache_dependencies
   end
 end
 


### PR DESCRIPTION
A poorly considered refactoring resulted in the view_cache_dependencies being evaluated at the class level, instead of the instance level. This patch fixes that.
