### PR TITLE
Improve String#squish whitespaces matching

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -399,4 +399,6 @@
 
 *   Optimize log subscribers to check log level before doing any processing. *Brian Durand*
 
+*   Improve String#squish to handle Unicode whitespace. *Antoine Lyset*
+
 Please check [3-2-stable](https://github.com/rails/rails/blob/3-2-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support/core_ext/string/filters.rb
+++ b/activesupport/lib/active_support/core_ext/string/filters.rb
@@ -3,6 +3,8 @@ class String
   # the string, and then changing remaining consecutive whitespace
   # groups into one space each.
   #
+  # Note that it handles both ASCII and Unicode whitespace like mongolian vowel separator (U+180E).
+  #
   #   %{ Multi-line
   #      string }.squish                   # => "Multi-line string"
   #   " foo   bar    \n   \t   boo".squish # => "foo bar boo"
@@ -12,8 +14,9 @@ class String
 
   # Performs a destructive squish. See String#squish.
   def squish!
-    strip!
-    gsub!(/\s+/, ' ')
+    gsub!(/\A[[:space:]]+/, '')
+    gsub!(/[[:space:]]+\Z/, '')
+    gsub!(/[[:space:]]+/, ' ')
     self
   end
 

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -223,10 +223,11 @@ class StringInflectionsTest < ActiveSupport::TestCase
   end
 
   def test_string_squish
-    original = %{ A string with tabs(\t\t), newlines(\n\n), and
-                  many spaces(  ). }
+    original = %{\u180E\u180E A string surrounded by unicode mongolian vowel separators,
+      with tabs(\t\t), newlines(\n\n), unicode nextlines(\u0085\u0085) and many spaces(  ). \u180E\u180E}
 
-    expected = "A string with tabs( ), newlines( ), and many spaces( )."
+    expected = "A string surrounded by unicode mongolian vowel separators, " +
+      "with tabs( ), newlines( ), unicode nextlines( ) and many spaces( )."
 
     # Make sure squish returns what we expect:
     assert_equal original.squish,  expected

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -1233,6 +1233,8 @@ The method `squish` strips leading and trailing whitespace, and substitutes runs
 
 There's also the destructive version `String#squish!`.
 
+Note that it handles both ASCII and Unicode whitespace like mongolian vowel separator (U+180E).
+
 NOTE: Defined in `active_support/core_ext/string/filters.rb`.
 
 ### `truncate`


### PR DESCRIPTION
Hi,

My first PR :).
This is a simple improvement of the regex detecting the whitespaces in String#squish. 
The actual regex is an "ASCII version" and my PR replaces it with a more UTF-8 compliant.

More infos on UTF-8 whitespaces : [http://en.wikipedia.org/wiki/Unicode_character_property#Whitespace](http://en.wikipedia.org/wiki/Unicode_character_property#Whitespace)
