### PR TITLE
Remove test for XML YAML parsing

### DIFF
--- a/activeresource/test/abstract_unit.rb
+++ b/activeresource/test/abstract_unit.rb
@@ -77,19 +77,6 @@ def setup_response
       }]
     }
   }.to_json
-  # - resource with yaml array of strings; for ARs using serialize :bar, Array
-  @marty = <<-eof.strip
-    <?xml version=\"1.0\" encoding=\"UTF-8\"?>
-    <person>
-      <id type=\"integer\">5</id>
-      <name>Marty</name>
-      <colors type=\"yaml\">---
-    - \"red\"
-    - \"green\"
-    - \"blue\"
-    </colors>
-    </person>
-  eof
 
   @startup_sound = {
     :sound => {
@@ -101,7 +88,6 @@ def setup_response
     mock.get    "/people/1.json",               {}, @matz
     mock.get    "/people/1.xml",                {}, @matz_xml
     mock.get    "/people/2.xml",                {}, @david
-    mock.get    "/people/5.xml",                {}, @marty
     mock.get    "/people/Greg.json",            {}, @greg
     mock.get    "/people/6.json",               {}, @joe
     mock.get    "/people/4.json",               { 'key' => 'value' }, nil, 404

--- a/activeresource/test/cases/base_test.rb
+++ b/activeresource/test/cases/base_test.rb
@@ -1077,19 +1077,6 @@ class BaseTest < Test::Unit::TestCase
     end
   end
 
-  def test_load_yaml_array
-    assert_nothing_raised do
-      Person.format = :xml
-      marty = Person.find(5)
-      assert_equal 3, marty.colors.size
-      marty.colors.each do |color|
-        assert_kind_of String, color
-      end
-    end
-  ensure
-    Person.format = :json
-  end
-
   def test_with_custom_formatter
     addresses = [{ :id => "1", :street => "1 Infinite Loop", :city => "Cupertino", :state => "CA" }].to_xml(:root => :addresses)
 


### PR DESCRIPTION
The support for YAML parsing in XML has been removed from Active Support
since it introduced an security risk. See 43109ec for more detail.

This is for `3-2-stable`
