### PR TITLE
Remove test for XML YAML parsing

### DIFF
--- a/activeresource/test/cases/base_test.rb
+++ b/activeresource/test/cases/base_test.rb
@@ -53,25 +53,11 @@ class BaseTest < Test::Unit::TestCase
                                            :children => [{:name => 'Natacha'}]},
                                           {:name => 'Milena',
                                            :children => []}]}]}.to_xml(:root => 'customer')
-    # - resource with yaml array of strings; for ARs using serialize :bar, Array
-    @marty = <<-eof.strip
-      <?xml version=\"1.0\" encoding=\"UTF-8\"?>
-      <person>
-        <id type=\"integer\">5</id>
-        <name>Marty</name>
-        <colors type=\"yaml\">---
-      - \"red\"
-      - \"green\"
-      - \"blue\"
-      </colors>
-      </person>
-    eof
 
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get    "/people/1.xml",                {}, @matz
       mock.get    "/people/2.xml",                {}, @david
       mock.get    "/people/6.json",               {}, @joe
-      mock.get    "/people/5.xml",                {}, @marty
       mock.get    "/people/Greg.xml",             {}, @greg
       mock.get    "/people/4.xml",                {'key' => 'value'}, nil, 404
       mock.put    "/people/1.xml",                {}, nil, 204
@@ -1106,16 +1092,6 @@ class BaseTest < Test::Unit::TestCase
         brother.children.each do |child|
           assert_kind_of Customer::Friend::Brother::Child, child
         end
-      end
-    end
-  end
-
-  def test_load_yaml_array
-    assert_nothing_raised do
-      marty = Person.find(5)
-      assert_equal 3, marty.colors.size
-      marty.colors.each do |color|
-        assert_kind_of String, color
       end
     end
   end

--- a/activeresource/test/cases/finder_test.rb
+++ b/activeresource/test/cases/finder_test.rb
@@ -50,24 +50,10 @@ class FinderTest < Test::Unit::TestCase
                                            :children => [{:name => 'Natacha'}]},
                                           {:name => 'Milena',
                                            :children => []}]}]}.to_xml(:root => 'customer')
-    # - resource with yaml array of strings; for ARs using serialize :bar, Array
-    @marty = <<-eof.strip
-      <?xml version=\"1.0\" encoding=\"UTF-8\"?>
-      <person>
-        <id type=\"integer\">5</id>
-        <name>Marty</name>
-        <colors type=\"yaml\">---
-      - \"red\"
-      - \"green\"
-      - \"blue\"
-      </colors>
-      </person>
-    eof
 
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get    "/people/1.xml",                {}, @matz
       mock.get    "/people/2.xml",                {}, @david
-      mock.get    "/people/5.xml",                {}, @marty
       mock.get    "/people/Greg.xml",             {}, @greg
       mock.get    "/people/4.xml",                {'key' => 'value'}, nil, 404
       mock.put    "/people/1.xml",                {}, nil, 204


### PR DESCRIPTION
The support for YAML parsing in XML has been removed from Active Support
since it introduced an security risk. See a494824 for more detail.

This is for `3-0-stable`.
