### PR TITLE
Bring back "database already exists" messages when running rake tasks

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -1,5 +1,7 @@
 module ActiveRecord
   module Tasks # :nodoc:
+    class DatabaseAlreadyExists < StandardError; end # :nodoc:
+
     module DatabaseTasks # :nodoc:
       extend self
 
@@ -32,6 +34,8 @@ module ActiveRecord
       def create(*arguments)
         configuration = arguments.first
         class_for_adapter(configuration['adapter']).new(*arguments).create
+      rescue DatabaseAlreadyExists
+        $stderr.puts "#{configuration['database']} already exists"
       rescue Exception => error
         $stderr.puts error, *(error.backtrace)
         $stderr.puts "Couldn't create database for #{configuration.inspect}"

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -18,6 +18,12 @@ module ActiveRecord
         connection.create_database configuration['database'],
           configuration.merge('encoding' => encoding)
         establish_connection configuration
+      rescue ActiveRecord::StatementInvalid => error
+        if /database .* already exists/ === error.message
+          raise DatabaseAlreadyExists
+        else
+          raise
+        end
       end
 
       def drop

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -9,10 +9,7 @@ module ActiveRecord
       end
 
       def create
-        if File.exist?(configuration['database'])
-          $stderr.puts "#{configuration['database']} already exists"
-          return
-        end
+        raise DatabaseAlreadyExists if File.exist?(configuration['database'])
 
         establish_connection configuration
         connection

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -11,10 +11,10 @@ module ActiveRecord
   end
 
   ADAPTERS_TASKS = {
-     :mysql      => :mysql_tasks,
-     :mysql2     => :mysql_tasks,
-     :postgresql => :postgresql_tasks,
-     :sqlite3    => :sqlite_tasks
+    mysql:      :mysql_tasks,
+    mysql2:     :mysql_tasks,
+    postgresql: :postgresql_tasks,
+    sqlite3:    :sqlite_tasks
   }
 
   class DatabaseTasksRegisterTask < ActiveRecord::TestCase
@@ -32,7 +32,7 @@ module ActiveRecord
       ActiveRecord::Tasks::DatabaseTasks.structure_dump({'adapter' => :foo}, "awesome-file.sql")
     end
   end
- 
+
   class DatabaseTasksCreateTest < ActiveRecord::TestCase
     include DatabaseTasksSetupper
 
@@ -258,7 +258,7 @@ module ActiveRecord
 
   class DatabaseTasksCharsetTest < ActiveRecord::TestCase
     include DatabaseTasksSetupper
- 
+
     ADAPTERS_TASKS.each do |k, v|
       define_method("test_#{k}_charset") do
         eval("@#{v}").expects(:charset)
@@ -269,7 +269,7 @@ module ActiveRecord
 
   class DatabaseTasksCollationTest < ActiveRecord::TestCase
     include DatabaseTasksSetupper
- 
+
     ADAPTERS_TASKS.each do |k, v|
       define_method("test_#{k}_collation") do
         eval("@#{v}").expects(:collation)

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -53,6 +53,16 @@ module ActiveRecord
 
       ActiveRecord::Tasks::DatabaseTasks.create @configuration
     end
+
+    def test_create_when_database_exists_outputs_info_to_stderr
+      $stderr.expects(:puts).with("my-app-db already exists").once
+
+      ActiveRecord::Base.connection.stubs(:create_database).raises(
+        ActiveRecord::StatementInvalid.new("Can't create database 'dev'; database exists:")
+      )
+
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration
+    end
   end
 
   class MysqlDBCreateAsRootTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -61,6 +61,16 @@ module ActiveRecord
 
       ActiveRecord::Tasks::DatabaseTasks.create @configuration
     end
+
+    def test_create_when_database_exists_outputs_info_to_stderr
+      $stderr.expects(:puts).with("my-app-db already exists").once
+
+      ActiveRecord::Base.connection.stubs(:create_database).raises(
+        ActiveRecord::StatementInvalid.new('database "my-app-db" already exists')
+      )
+
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration
+    end
   end
 
   class PostgreSQLDBDropTest < ActiveRecord::TestCase


### PR DESCRIPTION
When running tasks such "rake db:setup", instead of showing messages like
"db_development already exists", it was showing a big stack trace and a
message "Couldn't create database for ..." with the configuration options, a
very confusing message with a big trace.

This brings back the functionality present in 3-2, showing the same message.

Output of both mysql/postgresql:

``` shell
./master-app [1.9.3-p327-perf]
$ rake db:setup
masterapp_development already exists
masterapp_test already exists
-- initialize_schema_migrations_table()
...
```

And for sqlite3:

``` shell
./master-app [1.9.3-p327-perf]
$ rake db:setup
db/development.sqlite3 already exists
db/test.sqlite3 already exists
-- initialize_schema_migrations_table()
...
```

These changes should hopefully handle the issue @rubys has been seeing
on master related to the rake tasks.

I'm opening as a pull request to get some quick review before applying.
Let me know about any improvements.
