### PR TITLE
Ignore binds payload with nil column in AR log subscriber

### DIFF
--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -32,7 +32,11 @@ module ActiveRecord
 
       unless (payload[:binds] || []).empty?
         binds = "  " + payload[:binds].map { |col,v|
-          [col.name, v]
+          if col
+            [col.name, v]
+          else
+            [nil, v]
+          end
         }.inspect
       end
 


### PR DESCRIPTION
This pull request backports commit 77516a7 to `3-2-stable` branch.

Conflict resolution:
- Revert ruby 1.9 style hash to support ruby 1.8
- Do not include 8f59ffce into 3-2-stable

This commit works with `ruby-1.9.3-p362` without any regressions.
But it causes two `RuntimeError: ActiveRecord::Associations::Association` errors at `test_sqlite3` when tested with `ruby-1.8.7-p371`. 
- The full output https://gist.github.com/4490252. 
- A minimum testcase is https://gist.github.com/4490257

It's strange for me, Tested `3-2-stable` branch without my fix, a minimum testcase causes the same `RuntimeError: ActiveRecord::Associations::Association`.  
