### PR TITLE
Clarify Dir.chdir definition

### DIFF
--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -55,8 +55,8 @@ module Rails
         add(path, with: value, glob: glob)
       end
 
-      def add(path, options={})
-        with = Array(options[:with] || path)
+      def add(path, options = {})
+        with = Array(options.fetch(:with, path))
         @root[path] = Path.new(self, path, with, options)
       end
 
@@ -189,9 +189,9 @@ module Rails
           path = File.expand_path(p, @root.path)
 
           if @glob && File.directory?(path)
-            result.concat Dir.chdir(path) {
-              Dir.glob(@glob).map { |file| File.join path, file }.sort
-            }
+            Dir.chdir(path) do
+              result.concat(Dir.glob(@glob).map { |file| File.join path, file }.sort)
+            end
           else
             result << path
           end


### PR DESCRIPTION
``` ruby
result.concat Dir.chdir(path) {
  # stuff to concat
}
```

This was a really confusing approach to look at. Performing the `Dir.chdir` before the `concat` is a little cleaner.

Also used `Hash#fetch` instead of `{}[:key] || :default` approach to simplify.
