### PR TITLE
Fix typo in deprecation warning

### DIFF
--- a/actionpack/lib/action_controller/record_identifier.rb
+++ b/actionpack/lib/action_controller/record_identifier.rb
@@ -4,7 +4,7 @@ module ActionController
   module RecordIdentifier
     MESSAGE = 'method will no longer be included by default in controllers since Rails 4.1. ' +
               'If you would like to use it in controllers, please include ' +
-              'ActionView::RecodIdentifier module.'
+              'ActionView::RecordIdentifier module.'
 
     def dom_id(record, prefix = nil)
       ActiveSupport::Deprecation.warn('dom_id ' + MESSAGE)


### PR DESCRIPTION
Fix typo in ActionController::RecordIdentifier deprecation warning, references non-existant `RecorIdentifier`
