### PR TITLE
Backport multi_json dependency revert of #5861 to 3-1-stable

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Rails 3.1.11 ##
+
+*   Allow multi_json version >= 1.3, relaxing
+    back to semantic versioning 2.0.0 (revert of #5861)
+    Backport of #5896
+
 ## Rails 3.1.10 (Jan 8, 2012) ##
 
 *   Hash.from_xml raises when it encounters type="symbol" or type="yaml".

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
 
   s.rdoc_options.concat ['--encoding',  'UTF-8']
 
-  s.add_dependency('multi_json', '>= 1.0', '< 1.3')
+  s.add_dependency('multi_json', '~> 1.0')
 end


### PR DESCRIPTION
Revert #5861. Feature-detect which MultiJson API to use.
Conflicts:
    activesupport/activesupport.gemspec

This backports multi_json version depedency changes as applied.

Rationale: #5861

Patch by sferik (cherry-picked)
