### PR TITLE
Set default value to ActiveModel::Validator initializer attribute

### DIFF
--- a/activemodel/lib/active_model/validator.rb
+++ b/activemodel/lib/active_model/validator.rb
@@ -103,7 +103,7 @@ module ActiveModel
     end
 
     # Accepts options that will be made available through the +options+ reader.
-    def initialize(options)
+    def initialize(options = {})
       @options = options.freeze
     end
 


### PR DESCRIPTION
Makes it easier to test its objects.

Don't think need any additional tests.
