### PR TITLE
Methods that return nil should not be considered YAML

### DIFF
--- a/activemodel/CHANGELOG
+++ b/activemodel/CHANGELOG
@@ -1,3 +1,7 @@
+## Rails 3.0.20 (unreleased)
+
+* Fix XML serialization of methods that return nil to not be considered as YAML (GH #8853 and GH #492)
+
 ## Rails 3.0.18
 
 ## Rails 3.0.17 (Aug 9, 2012)

--- a/activemodel/lib/active_model/serializers/xml.rb
+++ b/activemodel/lib/active_model/serializers/xml.rb
@@ -33,6 +33,7 @@ module ActiveModel
         protected
 
           def compute_type
+            return if value.nil?
             type = ActiveSupport::XmlMini::TYPE_NAMES[value.class.name]
             type ||= :string if value.respond_to?(:to_str)
             type ||= :yaml

--- a/activemodel/test/cases/serializeration/xml_serialization_test.rb
+++ b/activemodel/test/cases/serializeration/xml_serialization_test.rb
@@ -86,6 +86,10 @@ class XmlSerializationTest < ActiveModel::TestCase
     assert_match %r{<name>aaron stack</name>}, @contact.to_xml
   end
 
+  test "should serialize nil" do
+    assert_match %r{<pseudonyms nil=\"true\"></pseudonyms>}, @contact.to_xml(:methods => :pseudonyms)
+  end
+
   test "should serialize integer" do
     assert_match %r{<age type="integer">25</age>}, @contact.to_xml
   end

--- a/activemodel/test/models/contact.rb
+++ b/activemodel/test/models/contact.rb
@@ -16,6 +16,10 @@ class Contact
     options.each { |name, value| send("#{name}=", value) }
   end
 
+  def pseudonyms
+    nil
+  end
+
   def persisted?
     id
   end

--- a/activerecord/test/cases/xml_serialization_test.rb
+++ b/activerecord/test/cases/xml_serialization_test.rb
@@ -143,10 +143,7 @@ class NilXmlSerializationTest < ActiveRecord::TestCase
   end
 
   def test_should_serialize_yaml
-    assert %r{<preferences(.*)></preferences>}.match(@xml)
-    attributes = $1
-    assert_match %r{type="yaml"}, attributes
-    assert_match %r{nil="true"}, attributes
+    assert_match %r{<preferences nil=\"true\"></preferences>}, @xml
   end
 end
 


### PR DESCRIPTION
This is a direct port of @jaw6's pull request
https://github.com/rails/rails/pull/492. His cleanly applied to Rails
v3.1 and v3.2, and this cleanly applies to v3.0.

With yesterday's security patches
http://weblog.rubyonrails.org/2013/1/8/Rails-3-2-11-3-1-10-3-0-19-and-2-3-15-have-been-released/
there is now an issue with Rails v3.0 serving XML to any of the latest
versions of ActiveResource.

Without this, Rails v3.0 can serve XML to ActiveResource consumers that
will see `Hash::DisallowedType: Disallowed type attribute: "yaml"`
