### PR TITLE
Fix json params parsing regression for non-object JSON content.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fixed json params parsing regression for non-object JSON content.
+
+    *Dylan Smith*
+
 *   Extract `ActionDispatch::PerformanceTest` into https://github.com/rails/rails-perftest
     You can add the gem to your Gemfile to keep using performance tests.
 

--- a/actionpack/lib/action_dispatch/middleware/params_parser.rb
+++ b/actionpack/lib/action_dispatch/middleware/params_parser.rb
@@ -50,9 +50,9 @@ module ActionDispatch
           data = request.deep_munge(Hash.from_xml(request.body.read) || {})
           data.with_indifferent_access
         when :json
-          data = request.deep_munge ActiveSupport::JSON.decode(request.body)
+          data = ActiveSupport::JSON.decode(request.body)
           data = {:_json => data} unless data.is_a?(Hash)
-          data.with_indifferent_access
+          request.deep_munge(data).with_indifferent_access
         else
           false
         end

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -122,6 +122,13 @@ class RootLessJSONParamsParsingTest < ActionDispatch::IntegrationTest
     )
   end
 
+  test "parses json with non-object JSON content" do
+    assert_parses(
+      {"user" => {"_json" => "string content" }, "_json" => "string content" },
+      "\"string content\"", { 'CONTENT_TYPE' => 'application/json' }
+    )
+  end
+
   private
     def assert_parses(expected, actual, headers = {})
       with_test_routing(UsersController) do


### PR DESCRIPTION
Fixes #8845.

`request.deep_munge` requires a Hash to be passed to it, and the params_parser already wraps non-Hash objects, so it makes sense to just call deep_munge after wrapping the non-Hash object.
