### PR TITLE
Parse '{"person":[]}' JSON/XML as {'person' => []}

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -253,9 +253,12 @@ module ActionDispatch
       hash.each do |k, v|
         case v
         when Array
+          if v.size > 0 && v.all?(&:nil?)
+            hash[k] = nil
+            next
+          end
           v.grep(Hash) { |x| deep_munge(x) }
           v.compact!
-          hash[k] = nil if v.empty?
         when Hash
           deep_munge(v)
         end

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -32,6 +32,10 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
 
   test "nils are stripped from collections" do
     assert_parses(
+      {"person" => []},
+      "{\"person\":[]}", { 'CONTENT_TYPE' => 'application/json' }
+    )
+    assert_parses(
       {"person" => nil},
       "{\"person\":[null]}", { 'CONTENT_TYPE' => 'application/json' }
     )

--- a/actionpack/test/dispatch/request/xml_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/xml_params_parsing_test.rb
@@ -43,6 +43,9 @@ class XmlParamsParsingTest < ActionDispatch::IntegrationTest
       {"hash" => { "person" => nil} },
       "<hash><person type=\"array\"><person nil=\"true\"/></person></hash>")
     assert_parses(
+      {"hash" => { "person" => []} },
+      "<hash><person type=\"array\"></person></hash>")
+    assert_parses(
       {"hash" => { "person" => ['foo']} },
       "<hash><person type=\"array\"><person>foo</person><person nil=\"true\"/></person>\n</hash>")
   end


### PR DESCRIPTION
We're also affected by #8832, so this is an attempt at solving that issue. Here's how JSON/XML will now be 'munged':

<table>
<tr><th>JSON</th><th>Hash</th></tr>
<tr><td>{"person":[]} </td><td> {'person' => []}</td></tr>
<tr><td> {"person":[null]} </td><td>{'person' => nil}</td></tr>
<tr><td> {"person":[null, null, ...]} </td><td> {'person' => nil}</td></tr>
<tr><td> {"person":["foo", null]} </td><td> {'person' => ["foo"]}</td></tr>
</table>


I know there must be a reason for replacing `[]` with `nil`, but I can't figure out how this would be a security risk. Could someone please help me understand the 'args injection' problem?

FWIW, the AR tests are still passing at https://github.com/rails/rails/commit/d5cd97baa44fa66dc681041a213092b45c57c32#L7R27.
