### PR TITLE
Fix ActionView::Template#refresh when template has a different format to view context

### DIFF
--- a/actionpack/lib/action_view/template.rb
+++ b/actionpack/lib/action_view/template.rb
@@ -163,6 +163,7 @@ module ActionView
     def refresh(view)
       raise "A template needs to have a virtual path in order to be refreshed" unless @virtual_path
       lookup  = view.lookup_context
+      lookup.formats = self.formats
       pieces  = @virtual_path.split("/")
       name    = pieces.pop
       partial = !!name.sub!(/^_/, "")


### PR DESCRIPTION
I was getting a `ActionView::MissingTemplate` error when a `.json.rabl` template raised an exception inside an HTML template:

```
Missing template foo/bar with {:locale=>[:en], :formats=>[:html], :handlers=>[:erb, :builder, :coffee, :haml, :rabl]}
```

The error handling code was trying to refresh the template's source, but `:formats` should have been `[:json]` instead of `[:html]`. See [ActionView::Template#refresh](https://github.com/rails/rails/blob/3-2-stable/actionpack/lib/action_view/template.rb#L163), which is called by [handle_render_error](https://github.com/rails/rails/blob/3-2-stable/actionpack/lib/action_view/template.rb#L310).

When `refresh` is called, I'm setting `view.lookup_context.formats` to `self.formats` (from the template instance). Sorry I'm not familiar enough with ActionView to come up with a better solution. Also not sure how to write a test. Any help would be appreciated, and please let me know if you need any more details.
