### PR TITLE
Added foreign_key option

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -40,6 +40,8 @@ module ActiveRecord
       class_attribute :pluralize_table_names, instance_writer: false
       self.pluralize_table_names = true
 
+      class_attribute :foreign_key, instance_writer: false
+
       self.inheritance_column = 'type'
     end
 

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -370,7 +370,9 @@ module ActiveRecord
         end
 
         def derive_foreign_key
-          if belongs_to?
+          if active_record.foreign_key?
+            active_record.foreign_key
+          elsif belongs_to?
             "#{name}_id"
           elsif options[:as]
             "#{options[:as]}_id"


### PR DESCRIPTION
After discussion on #8630 I've checked HABTM against master and derivation of join table name works properly. But there's another thing here, if we change table name we'll want to see that foreign key will be changed too.

``` ruby
module Namespace
  class Base < ActiveRecord::Base
    self.table_name = 'tablename'
    has_and_belongs_to_many :somethings
  end
end
```

In case above foreign_key for HABTM will be `base_id`, and for all associations we have to set it manually. I decided to add new option for it, this way we can set it for the whole class and descendants. Any other suggestions? /cc @pixeltrix
