### PR TITLE
Use the index name explicitly provided in a migration when reverting.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   When `:name` option is provided to `remove_index`, use it if there is no index by the conventional name.
+
+    For example, previously if an index was removed like so
+    `remove_index :values, column: :value, name: 'a_different_name'`
+    the generated SQL would not contain the specified index name,
+    and hence the migration would fail.
+    Fixes #8858.
+
+    *Ezekiel Smithburg*
+
 *   Expand `#cache_key` to consult all relevant updated timestamps.
 
     Previously only `updated_at` column was checked, now it will

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -687,6 +687,12 @@ module ActiveRecord
           index_name = index_name(table_name, options)
 
           unless index_name_exists?(table_name, index_name, true)
+            if options.has_key? :name
+              options_without_column = options.dup
+              options_without_column.delete :column
+              index_name_without_column = index_name(table_name, options_without_column)
+              return index_name_without_column if index_name_exists?(table_name, index_name_without_column, false)
+            end
             raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' does not exist"
           end
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -462,6 +462,22 @@ class ReservedWordsMigrationTest < ActiveRecord::TestCase
   end
 end
 
+class ExplicitlyNamedIndexMigrationTest < ActiveRecord::TestCase
+  def test_drop_index_by_name
+    connection = Person.connection
+    connection.create_table :values, force: true do |t|
+      t.integer :value
+    end
+
+    assert_nothing_raised ArgumentError do
+      connection.add_index :values, :value, name: 'a_different_name'
+      connection.remove_index :values, column: :value, name: 'a_different_name'
+    end
+
+    connection.drop_table :values rescue nil
+  end
+end
+
 if ActiveRecord::Base.connection.supports_bulk_alter?
   class BulkAlterTableMigrationsTest < ActiveRecord::TestCase
     def setup


### PR DESCRIPTION
schema_statements uses the column name by default to construct the index name, and then raises an exception if it doesn't exist, even if the name option is specified, which causes #8858.  this commit makes index_name_for_remove fall back to constructing the index name to remove based on the name option.
