### PR TITLE
Add asset pipeline guides section on implementing & registering own engines

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -720,7 +720,31 @@ A good example of this is the `jquery-rails` gem which comes with Rails as the s
 Making Your Library or Gem a Pre-Processor
 ------------------------------------------
 
-TODO: Registering gems on [Tilt](https://github.com/rtomayko/tilt) enabling Sprockets to find them.
+As Sprockets uses [Tilt](https://github.com/rtomayko/tilt) as a generic
+interface to different templating engines, your gem should just
+implement the Tilt template protocol. Normally, you would subclass
+`Tilt::Template` and reimplement `evaluate` method to return final
+output. Template source is stored at `@code`. Have a look at
+[`Tilt::Template`](https://github.com/rtomayko/tilt/blob/master/lib/tilt/template.rb)
+sources to learn more.
+
+```ruby
+module BangBang
+  class Template < ::Tilt::Template
+    # Adds a "!" to original template.
+    def evaluate(scope, locals, &block)
+      "#{@code}!"
+    end
+  end
+end
+```
+
+Now that you have a `Template` class, it's time to associate it with an
+extenstion for template files:
+
+```ruby
+Sprockets.register_engine '.bang', BangBang::Template
+```
 
 Upgrading from Old Versions of Rails
 ------------------------------------


### PR DESCRIPTION
Added a brief section on registering own gems with Sprockets.

As it is my first writing contribution, I would love any sort of feedback, so I am submitting it via a PR and not pushing directly to lifo/docrails.
