### PR TITLE
Revert "Strip nils from collections on JSON and XML posts dealing with empty hashes"

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -284,14 +284,15 @@ module ActionDispatch
       LOCALHOST =~ remote_addr && LOCALHOST =~ remote_ip
     end
 
+    protected
+
     # Remove nils from the params hash
     def deep_munge(hash)
-      hash.each do |k, v|
+      hash.each_value do |v|
         case v
         when Array
           v.grep(Hash) { |x| deep_munge(x) }
           v.compact!
-          hash[k] = nil if v.empty?
         when Hash
           deep_munge(v)
         end
@@ -299,8 +300,6 @@ module ActionDispatch
 
       hash
     end
-
-    protected
 
     def parse_query(qs)
       deep_munge(super)

--- a/actionpack/lib/action_dispatch/middleware/params_parser.rb
+++ b/actionpack/lib/action_dispatch/middleware/params_parser.rb
@@ -47,10 +47,10 @@ module ActionDispatch
         when Proc
           strategy.call(request.raw_post)
         when :xml_simple, :xml_node
-          data = request.deep_munge(Hash.from_xml(request.body.read) || {})
+          data = Hash.from_xml(request.raw_post) || {}
           data.with_indifferent_access
         when :json
-          data = request.deep_munge ActiveSupport::JSON.decode(request.body)
+          data = ActiveSupport::JSON.decode(request.raw_post)
           data = {:_json => data} unless data.is_a?(Hash)
           data.with_indifferent_access
         else

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -30,21 +30,6 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
     )
   end
 
-  test "nils are stripped from collections" do
-    assert_parses(
-      {"person" => nil},
-      "{\"person\":[null]}", { 'CONTENT_TYPE' => 'application/json' }
-    )
-    assert_parses(
-      {"person" => ['foo']},
-      "{\"person\":[\"foo\",null]}", { 'CONTENT_TYPE' => 'application/json' }
-    )
-    assert_parses(
-      {"person" => nil},
-      "{\"person\":[null, null]}", { 'CONTENT_TYPE' => 'application/json' }
-    )
-  end
-
   test "logs error if parsing unsuccessful" do
     with_test_routing do
       output = StringIO.new

--- a/actionpack/test/dispatch/request/xml_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/xml_params_parsing_test.rb
@@ -30,23 +30,6 @@ class XmlParamsParsingTest < ActionDispatch::IntegrationTest
     assert_equal "<ok>bar</ok>", resp.body
   end
 
-  def assert_parses(expected, xml)
-    with_test_routing do
-      post "/parse", xml, default_headers
-      assert_response :ok
-      assert_equal(expected, TestController.last_request_parameters)
-    end
-  end
-
-  test "nils are stripped from collections" do
-    assert_parses(
-      {"hash" => { "person" => nil} },
-      "<hash><person type=\"array\"><person nil=\"true\"/></person></hash>")
-    assert_parses(
-      {"hash" => { "person" => ['foo']} },
-      "<hash><person type=\"array\"><person>foo</person><person nil=\"true\"/></person>\n</hash>")
-  end
-
   test "parses hash params" do
     with_test_routing do
       xml = "<person><name>David</name></person>"


### PR DESCRIPTION
This change was considered as fix for [CVE-2013-0155](https://groups.google.com/forum/?fromgroups#!topic/rubyonrails-security/t1WFuuQyavI) but is completely wrong solution for this problem.

**Rationale:**
- #8831 - incorrect delivering valid JSON that contains nils in array(a lot of APIs are using that)
- #8832 - error in `accepts_nested_attributes_for` with valid attributes
- #8845 - regression with non-object JSON content
- incorrect handling of `serialize` method([waiting for bug report](https://github.com/rails/rails/issues/8832#issuecomment-12091767))

This is not partially bypassing bug like #8862, but the only valid and working solution - allow nils in arrays as JSON specification is saying.

We should work to fix design flaw in AR instead of breaking working standards.
