### PR TITLE
Fix 3-1-stable to work with Mocha >= v0.13.0

### DIFF
--- a/activesupport/lib/active_support/testing/mochaing.rb
+++ b/activesupport/lib/active_support/testing/mochaing.rb
@@ -1,5 +1,5 @@
 begin
-  silence_warnings { require 'mocha' }
+  silence_warnings { require 'mocha/setup' }
 rescue LoadError
   # Fake Mocha::ExpectationError so we can rescue it in #run. Bleh.
   Object.const_set :Mocha, Module.new

--- a/activesupport/lib/active_support/testing/setup_and_teardown.rb
+++ b/activesupport/lib/active_support/testing/setup_and_teardown.rb
@@ -61,7 +61,7 @@ module ActiveSupport
         def run(result)
           return if @method_name.to_s == "default_test"
 
-          mocha_counter = retrieve_mocha_counter(result)
+          mocha_counter = retrieve_mocha_counter(self, result)
           yield(Test::Unit::TestCase::STARTED, name)
           @_result = result
 
@@ -83,6 +83,8 @@ module ActiveSupport
               begin
                 teardown
                 run_callbacks :teardown
+              rescue Mocha::ExpectationError => e
+                add_failure(e.message, e.backtrace)
               rescue Test::Unit::AssertionFailedError => e
                 add_failure(e.message, e.backtrace)
               rescue Exception => e
@@ -100,12 +102,14 @@ module ActiveSupport
 
         protected
 
-        def retrieve_mocha_counter(result) #:nodoc:
+        def retrieve_mocha_counter(test_case, result) #:nodoc:
           if respond_to?(:mocha_verify) # using mocha
             if defined?(Mocha::TestCaseAdapter::AssertionCounter)
               Mocha::TestCaseAdapter::AssertionCounter.new(result)
-            else
+            elsif defined?(Mocha::Integration::TestUnit::AssertionCounter)
               Mocha::Integration::TestUnit::AssertionCounter.new(result)
+            else
+              Mocha::Integration::AssertionCounter.new(test_case)
             end
           end
         end


### PR DESCRIPTION
Backport of #8200. The equivalent of 17ccefc4360caea1a80eada324513dc6cb809c75 by @carlosantoniodasilva would fix Mocha deprecation warnings in Rails tests.
