### PR TITLE
Added css code for mobile compatibility of Scaffolds

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb
@@ -16,7 +16,7 @@
     <%% @<%= plural_table_name %>.each do |<%= singular_table_name %>| %>
     <tr>
 <% attributes.each do |attribute| -%>
-      <td><%%= <%= singular_table_name %>.<%= attribute.name %> %></td>
+      <td class ="<%= attribute.human_name %>"><%%= <%= singular_table_name %>.<%= attribute.name %> %></td>
 <% end -%>
       <td><%%= link_to 'Show', <%= singular_table_name %> %></td>
       <td><%%= link_to 'Edit', edit_<%= singular_table_name %>_path(<%= singular_table_name %>) %></td>

--- a/railties/lib/rails/generators/rails/scaffold/templates/scaffold.css
+++ b/railties/lib/rails/generators/rails/scaffold/templates/scaffold.css
@@ -54,3 +54,45 @@ div.field, div.actions {
   font-size: 12px;
   list-style: square;
 }
+
+@media only screen and (max-width: 760px),
+(min-device-width: 768px) and (max-device-width: 1024px)  {
+
+  table, thead, tbody, th, td, tr {
+    display: block;
+  }
+
+  thead tr {
+    display:none;
+  }
+
+  tr {
+    border-top: 1px solid #ccc;
+    border-left: 1px solid #ccc;
+    border-right: 1px solid #ccc;
+  }
+
+  tr:last-child {
+    border-bottom: 1px solid #ccc;
+  }
+
+  td {
+    border: none;
+    border-bottom: 1px solid #eee;
+    position: relative;
+    padding-left: 50%;
+  }
+
+  td:before {
+    position: absolute;
+    top: 6px;
+    left: 6px;
+    width: 45%;
+    padding-right: 10px;
+    white-space: nowrap;
+  }
+
+  td:nth-child(n):before {
+    content: attr(class);
+  }
+}


### PR DESCRIPTION
Added:
  Css stuff to css scaffold template for the mobile compatibility.
  class named as attributes name to template index to get a pure css solution

Scaffolds are powerful to develop prototypes
with the evolution of mobile I think it makes sense to have
the possibility of making prototypes that are seen well on Mobile

![Schermata 01-2456307 alle 15 14 45](https://f.cloud.github.com/assets/46208/64652/f40a65aa-5e54-11e2-9b6c-278d5b050197.png)

![Schermata 01-2456303 alle 16 06 33](https://f.cloud.github.com/assets/46208/56989/5fa36b16-5b37-11e2-80c9-7cb58803ae15.png)
