### PR TITLE
Mention performance test extraction in 4.0 guide

### DIFF
--- a/guides/source/4_0_release_notes.md
+++ b/guides/source/4_0_release_notes.md
@@ -68,6 +68,7 @@ In Rails 4.0, several features have been extracted into gems. You can simply add
 * Action Caching ([Github](https://github.com/rails/actionpack-action_caching), [Pull Request](https://github.com/rails/rails/pull/7833))
 * Page Caching ([Github](https://github.com/rails/actionpack-page_caching), [Pull Request](https://github.com/rails/rails/pull/7833))
 * Sprockets ([Github](https://github.com/rails/sprockets-rails))
+* Performance tests ([Github](https://github.com/rails/rails-perftest), [Pull Request](https://github.com/rails/rails/pull/8876))
 
 Documentation
 -------------


### PR DESCRIPTION
I forgot to add the extraction of the performance tests to the Rails 4.0 guide.
