### PR TITLE
3-2-stable ActiveSupport::TaggedLogging logging progname issue

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -15,6 +15,10 @@
     Fixes #9678.
 
     *Andrew White*
+    
+*   Fix `ActiveSupport::TaggedLogging` incorrectly providing program name the same as log message even when block is not provided.
+
+    *Carson Reinke*
 
 
 ## Rails 3.2.13 (Mar 18, 2013) ##

--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -44,7 +44,14 @@ module ActiveSupport
     deprecate :silence
 
     def add(severity, message = nil, progname = nil, &block)
-      message = (block_given? ? block.call : progname) if message.nil?
+      if message.nil?
+        if block_given?
+          message = block.call
+        else
+          message = progname
+          progname = nil #No instance variable for this like Logger
+        end
+      end
       @logger.add(severity, "#{tags_text}#{message}", progname)
     end
 

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -4,14 +4,24 @@ require 'active_support/tagged_logging'
 
 class TaggedLoggingTest < ActiveSupport::TestCase
   class MyLogger < ::Logger
+    attr_accessor :last_message
+    attr_accessor :last_progname
+    
     def flush(*)
       info "[FLUSHED]"
+    end
+    
+    def add(severity, message = nil, progname = nil, &block)
+      @last_message = message
+      @last_progname = progname
+      super(severity, message, progname, &block)
     end
   end
 
   setup do
     @output = StringIO.new
-    @logger = ActiveSupport::TaggedLogging.new(MyLogger.new(@output))
+    @my_logger = MyLogger.new(@output)
+    @logger = ActiveSupport::TaggedLogging.new(@my_logger)
   end
 
   test "tagged once" do


### PR DESCRIPTION
Prog name was always matching message even when not using a block.  This allows for progname to be nil, as this is the default.  Does not apply to master branch.
