### PR TITLE
Specified jbuilder version

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -10,7 +10,7 @@ source 'https://rubygems.org'
 <%= javascript_gemfile_entry -%>
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder'
+gem 'jbuilder', '~> 1.0.1'
 
 # To use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.0.0'


### PR DESCRIPTION
Jbuilder has scaffold override only since 1.0.0. Need to specify version so users won't get old version bundled with no json scaffolding.
