### PR TITLE
3-2-stable: Fix JSON params parsing regression for non-object JSON content.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 3.2.12 (unreleased) ##
 
+*   Fixed JSON params parsing regression for non-object JSON content.
+
+    *Dylan Smith*
+
 *   Prevent unnecessary asset compilation when using `javascript_include_tag` on
     files with non-standard extensions.
 

--- a/actionpack/lib/action_dispatch/middleware/params_parser.rb
+++ b/actionpack/lib/action_dispatch/middleware/params_parser.rb
@@ -44,10 +44,10 @@ module ActionDispatch
         when :yaml
           YAML.load(request.raw_post)
         when :json
-          data = request.deep_munge ActiveSupport::JSON.decode(request.body)
+          data = ActiveSupport::JSON.decode(request.body)
           request.body.rewind if request.body.respond_to?(:rewind)
           data = {:_json => data} unless data.is_a?(Hash)
-          data.with_indifferent_access
+          request.deep_munge(data).with_indifferent_access
         else
           false
         end

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -120,6 +120,13 @@ class RootLessJSONParamsParsingTest < ActionDispatch::IntegrationTest
     )
   end
 
+  test "parses json with non-object JSON content" do
+    assert_parses(
+      {"user" => {"_json" => "string content" }, "_json" => "string content" },
+      "\"string content\"", { 'CONTENT_TYPE' => 'application/json' }
+    )
+  end
+
   private
     def assert_parses(expected, actual, headers = {})
       with_test_routing(UsersController) do


### PR DESCRIPTION
Backports #8855.
