### PR TITLE
3-0-stable: Fix JSON params parsing regression for non-object JSON content.

### DIFF
--- a/actionpack/CHANGELOG
+++ b/actionpack/CHANGELOG
@@ -1,5 +1,7 @@
 ## Rails 3.0.20 (unreleased)
 
+* Fixed JSON params parsing regression for non-object JSON content.
+
 ## Rails 3.0.19 (Jan 8, 2013)
 
 * Strip nils from collections on JSON and XML posts. [CVE-2013-0155]

--- a/actionpack/lib/action_dispatch/middleware/params_parser.rb
+++ b/actionpack/lib/action_dispatch/middleware/params_parser.rb
@@ -44,10 +44,10 @@ module ActionDispatch
         when :yaml
           YAML.load(request.raw_post)
         when :json
-          data = request.deep_munge ActiveSupport::JSON.decode(request.body)
+          data = ActiveSupport::JSON.decode(request.body)
           request.body.rewind if request.body.respond_to?(:rewind)
           data = {:_json => data} unless data.is_a?(Hash)
-          data.with_indifferent_access
+          request.deep_munge(data).with_indifferent_access
         else
           false
         end

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -60,6 +60,13 @@ class JsonParamsParsingTest < ActionController::IntegrationTest
     end
   end
 
+  test "parses json with non-object JSON content" do
+    assert_parses(
+      {"_json" => "string content" },
+      "\"string content\"", { 'CONTENT_TYPE' => 'application/json' }
+    )
+  end
+
   private
     def assert_parses(expected, actual, headers = {})
       with_test_routing do


### PR DESCRIPTION
Backports #8855.
