### PR TITLE
Update actionpack/lib/action_dispatch/routing/route_set.rb

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -662,7 +662,7 @@ module ActionDispatch
           keys -= options.keys if args.size < keys.size - 1 # take format into account
 
           # Tell url_for to skip default_url_options
-          options.merge!(Hash[args.zip(keys).map { |v, k| [k, v] }])
+          options.merge!(Hash[keys.zip(args)])
         end
 
     end


### PR DESCRIPTION
Use keys.zip(args) instead of args.zip(keys) as the latter one can sometimes lead to an options hash like:
{nil => Model}
which in turn will raise an exception when trying to convert to_param.
