### PR TITLE
Revert hm:t on unsaved collection for 3.2

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 3.2.12 (unreleased) ##
 
+*   Revert creation of through association models when using `collection=[]`
+    on a `has_many :through` association from an unsaved model.
+    Fix #7661, #8269.
+
+    *Ernie Miller*
+
 *   Fix undefined method `to_i` when calling `new` on a scope that uses an
     Array; Fix FloatDomainError when setting integer column to NaN.
     Fixes #8718, #8734, #8757.

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -38,20 +38,6 @@ module ActiveRecord
         super
       end
 
-      def concat_records(records)
-        ensure_not_nested
-
-        records = super
-
-        if owner.new_record? && records
-          records.flatten.each do |record|
-            build_through_record(record)
-          end
-        end
-
-        records
-      end
-
       def insert_record(record, validate = true, raise = false)
         ensure_not_nested
 

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -851,11 +851,6 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     end
   end
 
-  def test_assign_array_to_new_record_builds_join_records
-    c = Category.new(:name => 'Fishing', :authors => [Author.first])
-    assert_equal 1, c.categorizations.size
-  end
-
   def test_create_bang_should_raise_exception_when_join_record_has_errors
     repair_validations(Categorization) do
       Categorization.validate { |r| r.errors[:base] << 'Invalid Categorization' }


### PR DESCRIPTION
It would appear that #7661 had unintended consequences for the documented API. Until
we can sort those out, this should not be in 3.2.x, and wait for 4.0.0. To be clear, I still think it's "the right thing" but it wasn't really a point-release kind of right thing.

@steveklabnik, do you agree?
