### PR TITLE
Add a reread option to Cache.fetch to return response from cache

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -226,6 +226,12 @@ module ActiveSupport
       # new value. After that all the processes will start getting new value.
       # The key is to keep <tt>:race_condition_ttl</tt> small.
       #
+      # Setting <tt>:reread</tt> will ensure that in the case of a cache miss
+      # the object returned from this call will be one refetched out of the cache
+      # store after being written.  This is useful when working with raw data in
+      # memcached as it will ensure you always get a string response back from
+      # this call.
+      #
       # If the process regenerating the entry errors out, the entry will be
       # regenerated after the specified number of seconds. Also note that the
       # life of stale cache is extended only if it expired recently. Otherwise
@@ -302,7 +308,11 @@ module ActiveSupport
               yield(name)
             end
             write(name, result, options)
-            result
+            if options[:reread]
+              read(name, options)
+            else
+              result
+            end
           end
         else
           read(name, options)

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -820,6 +820,20 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     end
   end
 
+  def test_local_cache_fetch_with_refetch_should_return_object_from_memcached
+    cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, :raw => true)
+    cache.clear
+    assert_equal "1", cache.fetch("foo", :reread => true) { 1 }
+    assert_equal "1", cache.fetch("foo", :reread => true) { 1 }
+  end
+
+  def test_local_cache_fetch_without_refetch_should_return_block_response
+    cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, :raw => true)
+    cache.clear
+    assert_equal 1, cache.fetch("foo") { 1 }
+    assert_equal "1", cache.fetch("foo") { 1 }
+  end
+
   def test_read_should_return_a_different_object_id_each_time_it_is_called
     @cache.write('foo', 'bar')
     assert_not_equal @cache.read('foo').object_id, @cache.read('foo').object_id


### PR DESCRIPTION
When using memcached with the raw option, everything you push into cache will be stored as a string (and subsequently read back out as a string.)  This adds an option to fetch so that even when the block is executed and stored, the response is what came out of memcached instead of just returning the output of the block.
