### PR TITLE
`CollectionAssociation#empty?` respects newly builded records

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Collection associations `#empty?` always respects builded records.
+    Fix #8879.
+
+    Example:
+
+        widget = Widget.new
+        widget.things.build
+        widget.things.empty? # => false
+
+    *Yves Senn*
+
 *   Remove support for parsing YAML parameters from request.
 
     *Aaron Patterson*

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -273,7 +273,7 @@ module ActiveRecord
         if loaded? || options[:counter_sql]
           size.zero?
         else
-          !scope.exists?
+          @target.blank? && !scope.exists?
         end
       end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -625,6 +625,13 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 3, company.clients_of_firm.size
   end
 
+  def test_collection_not_empty_after_building
+    company = companies(:first_firm)
+    assert_predicate company.contracts, :empty?
+    company.contracts.build
+    assert_not_predicate company.contracts, :empty?
+  end
+
   def test_collection_size_twice_for_regressions
     post = posts(:thinking)
     assert_equal 0, post.readers.size


### PR DESCRIPTION
This is a fix for #8879

My solution is quite hacky, I did not want to mess with the `loading` internals of the association though. I wrote up a test-case to lock the behavior. If someone with more insight about the internals good a better fix, I'm happy to adjust.
