### PR TITLE
Added test case to prevent regression of chained, preloaded scopes.

### DIFF
--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -404,6 +404,13 @@ class RelationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_preload_applies_to_all_chained_preloaded_scopes
+    assert_queries(3) do
+      post = Post.with_comments.with_tags.first
+      assert post
+    end
+  end
+
   def test_find_with_included_associations
     assert_queries(2) do
       posts = Post.includes(:comments).order('posts.id')

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -29,6 +29,9 @@ class Post < ActiveRecord::Base
   scope :with_very_special_comments, -> { joins(:comments).where(:comments => {:type => 'VerySpecialComment'}) }
   scope :with_post, ->(post_id) { joins(:comments).where(:comments => { :post_id => post_id }) }
 
+  scope :with_comments, -> { preload(:comments) }
+  scope :with_tags, -> { preload(:taggings) }
+
   has_many   :comments do
     def find_most_recent
       order("id DESC").first


### PR DESCRIPTION
As discussed in #7792, this PR includes a test case that will prevent a regression of #7490 on master.
