### PR TITLE
Remove header bloat introduced by BestStandardsSupport middleware

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `BestStandardsSupport` no longer duplicates `X-UA-Compatible` values on
+    each request to prevent header size from blowing up.
+
+    *Edward Anderson*
+
 *   Change the behavior of route defaults so that explicit defaults are no longer
     required where the key is not part of the path. For example:
 

--- a/actionpack/lib/action_dispatch/middleware/best_standards_support.rb
+++ b/actionpack/lib/action_dispatch/middleware/best_standards_support.rb
@@ -17,7 +17,9 @@ module ActionDispatch
       status, headers, body = @app.call(env)
 
       if headers["X-UA-Compatible"] && @header
-        headers["X-UA-Compatible"] << "," << @header.to_s
+        unless headers["X-UA-Compatible"][@header]
+          headers["X-UA-Compatible"] << "," << @header.to_s
+        end
       else
         headers["X-UA-Compatible"] = @header
       end

--- a/actionpack/test/dispatch/best_standards_support_test.rb
+++ b/actionpack/test/dispatch/best_standards_support_test.rb
@@ -16,8 +16,9 @@ class BestStandardsSupportTest < ActiveSupport::TestCase
     assert_equal nil, headers["X-UA-Compatible"]
   end
 
-  def test_appends_to_app_headers
+  def test_appends_to_app_headers_without_duplication_after_multiple_requests
     app_headers = { "X-UA-Compatible" => "requiresActiveX=true" }
+    _, headers, _ = app(true, app_headers).call({})
     _, headers, _ = app(true, app_headers).call({})
 
     expects = "requiresActiveX=true,IE=Edge,chrome=1"


### PR DESCRIPTION
After the Rails server ran for long enough, Chome started returning a `net::ERR_RESPONSE_HEADERS_TOO_BIG` error on every page load, and curl would error with `curl: (27) Avoided giant realloc for header (max is 102400)!`. A server restart would reset the headers and made the problem temporarily go away.

Investigating showed that the same `IE=Edge,` headers were being appended on every request until finally the header size exceeded the 100k limit that browsers impose. 

This patch ensures that the IE=Edge and other header variables only get appended to the X-UA-Compatible header if they are not there already, and it makes the test pass that I modified to catch the problem.

The commit that introduced this problem (d8c1404107501e131e4c7c653794768f5c461793, @nikitug) was applied to both master and 3-2-stable, so this fix should be backported to 3-2-stable as well.
