### PR TITLE
Collection radio buttons and collection check boxes through FormBuilder render the provided block

### DIFF
--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -772,12 +772,12 @@ module ActionView
         @template.time_zone_select(@object_name, method, priority_zones, objectify_options(options), @default_options.merge(html_options))
       end
 
-      def collection_check_boxes(method, collection, value_method, text_method, options = {}, html_options = {})
-        @template.collection_check_boxes(@object_name, method, collection, value_method, text_method, objectify_options(options), @default_options.merge(html_options))
+      def collection_check_boxes(method, collection, value_method, text_method, options = {}, html_options = {}, &block)
+        @template.collection_check_boxes(@object_name, method, collection, value_method, text_method, objectify_options(options), @default_options.merge(html_options), &block)
       end
 
-      def collection_radio_buttons(method, collection, value_method, text_method, options = {}, html_options = {})
-        @template.collection_radio_buttons(@object_name, method, collection, value_method, text_method, objectify_options(options), @default_options.merge(html_options))
+      def collection_radio_buttons(method, collection, value_method, text_method, options = {}, html_options = {}, &block)
+        @template.collection_radio_buttons(@object_name, method, collection, value_method, text_method, objectify_options(options), @default_options.merge(html_options), &block)
       end
     end
   end

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -1120,6 +1120,28 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_form_for_with_collection_radio_buttons_with_custom_builder_block
+    post = Post.new
+    def post.active; false; end
+    form_for(post) do |f|
+      rendered_radio_buttons = f.collection_radio_buttons(:active, [true, false], :to_s, :to_s) do |b|
+        b.label { b.radio_button + b.text }
+      end
+      concat rendered_radio_buttons
+    end
+
+    expected = whole_form("/posts", "new_post" , "new_post") do
+      "<label for='post_active_true'>"+
+      "<input id='post_active_true' name='post[active]' type='radio' value='true' />" +
+      "true</label>" +
+      "<label for='post_active_false'>"+
+      "<input checked='checked' id='post_active_false' name='post[active]' type='radio' value='false' />" +
+      "false</label>"
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_form_for_with_collection_check_boxes
     post = Post.new
     def post.tag_ids; [1, 3]; end
@@ -1135,6 +1157,33 @@ class FormHelperTest < ActionView::TestCase
       "<label for='post_tag_ids_2'>Tag 2</label>" +
       "<input checked='checked' id='post_tag_ids_3' name='post[tag_ids][]' type='checkbox' value='3' />" +
       "<label for='post_tag_ids_3'>Tag 3</label>" +
+      "<input name='post[tag_ids][]' type='hidden' value='' />"
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_form_for_with_collection_check_boxes_with_custom_builder_block
+    post = Post.new
+    def post.tag_ids; [1, 3]; end
+    collection = (1..3).map{|i| [i, "Tag #{i}"] }
+    form_for(post) do |f|
+      rendered_check_boxes = f.collection_check_boxes(:tag_ids, collection, :first, :last) do |b|
+        b.label { b.check_box + b.text }
+      end
+      concat rendered_check_boxes
+    end
+
+    expected = whole_form("/posts", "new_post" , "new_post") do
+      "<label for='post_tag_ids_1'>" +
+      "<input checked='checked' id='post_tag_ids_1' name='post[tag_ids][]' type='checkbox' value='1' />" +
+      "Tag 1</label>" +
+      "<label for='post_tag_ids_2'>" +
+      "<input id='post_tag_ids_2' name='post[tag_ids][]' type='checkbox' value='2' />" +
+      "Tag 2</label>" +
+      "<label for='post_tag_ids_3'>" +
+      "<input checked='checked' id='post_tag_ids_3' name='post[tag_ids][]' type='checkbox' value='3' />" +
+      "Tag 3</label>" +
       "<input name='post[tag_ids][]' type='hidden' value='' />"
     end
 


### PR DESCRIPTION
In the case of having a `form_for` method being called, the block for each
collection would not be passed and thus the result expected was always the same.
This patch passes the block to the original method like it would be assumed.
