### PR TITLE
Add Hash#extract as an alternative to #extract!

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/slice.rb
+++ b/activesupport/lib/active_support/core_ext/hash/slice.rb
@@ -30,6 +30,16 @@ class Hash
     omit
   end
 
+  # Returns the key/value pairs matching the given keys, but keeps
+  # the original hash intact
+  #
+  #   a = { b: 1, c: 2 }
+  #   a.extract(:b) # => { c: 2 }
+  #   a # => { b: 1, c: 2 }
+  def extract(*keys)
+    dup.extract!(*keys)
+  end
+
   # Removes and returns the key/value pairs matching the given keys.
   #
   #   { a: 1, b: 2, c: 3, d: 4 }.extract!(:a, :b) # => {:a=>1, :b=>2}

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -738,6 +738,15 @@ class HashExtTest < ActiveSupport::TestCase
   def test_extract
     original = {:a => 1, :b => 2, :c => 3, :d => 4}
     expected = {:a => 1, :b => 2}
+    remaining = original.dup
+
+    assert_equal expected, original.extract(:a, :b, :x)
+    assert_equal remaining, original
+  end
+
+  def test_extract_bang
+    original = {:a => 1, :b => 2, :c => 3, :d => 4}
+    expected = {:a => 1, :b => 2}
     remaining = {:c => 3, :d => 4}
 
     assert_equal expected, original.extract!(:a, :b, :x)


### PR DESCRIPTION
Sometimes it is desirable to extract some keys from a hash, while leaving the original one intact.

This is basically the opposite of `Hash#except`.
