### PR TITLE
Incorrect SQL generated for .last when ordering uses an SQL function

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1226,4 +1226,11 @@
 
     *Aaron Patterson*
 
+*   Fix for reverting sorting order when SQL function is used in order clause
+    This was causing incorrect SQL generation when order is not just a simple
+    column name, i.e.
+        Job.order("COALESCE(jobs.field1, jobs.field2)").last
+    
+    *Ivan Vanyak*
+
 Please check [3-2-stable](https://github.com/rails/rails/blob/3-2-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -843,7 +843,7 @@ module ActiveRecord
         when Arel::Nodes::Ordering
           o.reverse
         when String
-          o.to_s.split(',').collect do |s|
+          o.to_s.split(/,(?=(?:[^)]|\([^)]*\))*$)/).collect do |s|
             s.strip!
             s.gsub!(/\sasc\Z/i, ' DESC') || s.gsub!(/\sdesc\Z/i, ' ASC') || s.concat(' DESC')
           end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1141,6 +1141,11 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal last, Developer.all.merge!(:order => 'developers.salary ASC').to_a.last
   end
 
+  def test_find_ordered_with_sql_function_last
+    last  = Developer.all.merge!(:order => 'COALESCE(developers.name, CAST(developers.salary as CHAR)) ASC, id ASC').last
+    assert_equal last, Developer.all.merge!(:order => 'COALESCE(developers.name, CAST(developers.salary as CHAR)) ASC, id ASC').to_a.last
+  end
+
   def test_find_reverse_ordered_last
     last  = Developer.all.merge!(:order => 'developers.salary DESC').last
     assert_equal last, Developer.all.merge!(:order => 'developers.salary DESC').to_a.last
@@ -1149,6 +1154,11 @@ class BasicsTest < ActiveRecord::TestCase
   def test_find_multiple_ordered_last
     last  = Developer.all.merge!(:order => 'developers.name, developers.salary DESC').last
     assert_equal last, Developer.all.merge!(:order => 'developers.name, developers.salary DESC').to_a.last
+  end
+
+  def test_find_multiple_ordered_last_with_use_of_sql_function
+    last  = Developer.all.merge!(:order => 'COALESCE(developers.name, CAST(developers.salary as CHAR)) DESC, id DESC').last
+    assert_equal last, Developer.all.merge!(:order => 'COALESCE(developers.name, CAST(developers.salary as CHAR)) DESC, id DESC').to_a.last
   end
 
   def test_find_keeps_multiple_order_values


### PR DESCRIPTION
I bumped into a problem with using COALESCE in sorting but it's relevant to any function like min or max.

When I have an order defined as `COALESCE(t.field1, t.field2)`, all works great until .last is used. ActiveRecord was generating invalid SQL `select whatever from t ORDER BY COALESCE(t.field1 DESC, t.field2 DESC) LIMIT 1`.
