### PR TITLE
Allow to override the value on date_select

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Allow value to be set on date_select tag helper.
+
+    *Colin Burn-Murdoch*
+
 *   Fixed json params parsing regression for non-object JSON content.
 
     *Dylan Smith*

--- a/actionpack/lib/action_view/helpers/tags/date_select.rb
+++ b/actionpack/lib/action_view/helpers/tags/date_select.rb
@@ -27,7 +27,7 @@ module ActionView
         end
 
         def datetime_selector(options, html_options)
-          datetime = value(object) || default_datetime(options)
+          datetime = options[:value] || value(object) || default_datetime(options)
           @auto_index ||= nil
 
           options = options.dup

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -1510,6 +1510,27 @@ class DateHelperTest < ActionView::TestCase
 
     assert_dom_equal expected, date_select("post", "written_on")
   end
+  
+  def test_date_select_with_value
+    @post = Post.new
+    @post.written_on = Date.new(2004, 6, 15)
+    
+    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}
+    expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option selected="selected" value="2004">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
+    expected << "</select>\n"
+    
+    expected << %{<select id="post_written_on_2i" name="post[written_on(2i)]">\n}
+    expected << %{<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7" selected="selected">July</option>\n<option value="8">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n}
+    expected << "</select>\n"
+    
+    expected << %{<select id="post_written_on_3i" name="post[written_on(3i)]">\n}
+    expected << %{<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10" selected="selected">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n}
+    
+    expected << "</select>\n"
+    
+    assert_dom_equal expected, date_select("post", "written_on", :value => '2004-07-10'.to_date)
+    
+  end
 
   def test_date_select_without_day
     @post = Post.new


### PR DESCRIPTION
With the text_field tag helper, you can pass an option of :value => 'whatever' to override the displayed value.

The date_select helper doesn't have the same option, but it can be easily enabled with attached change.
