### PR TITLE
Fix DateTime comparison with DateTime::Infinity object

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -19,6 +19,9 @@
 
     *Daniele Sluijters*
 
+*   Fix DateTime comparison with DateTime::Infinity object.
+
+    *Dan Kubb*
 
 ## Rails 3.2.11 (Jan 8, 2012) ##
 

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -138,6 +138,6 @@ class DateTime
 
   # Layers additional behavior on DateTime#<=> so that Time and ActiveSupport::TimeWithZone instances can be compared with a DateTime
   def <=>(other)
-    super other.to_datetime
+    super other.kind_of?(Infinity) ? other : other.to_datetime
   end
 end

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -12,6 +12,12 @@ class RangeTest < Test::Unit::TestCase
     date_range = Time.utc(2005, 12, 10, 15, 30)..Time.utc(2005, 12, 10, 17, 30)
     assert_equal "BETWEEN '2005-12-10 15:30:00' AND '2005-12-10 17:30:00'", date_range.to_s(:db)
   end
+  
+  def test_date_range
+    assert_instance_of Range, DateTime.new..DateTime.new
+    assert_instance_of Range, DateTime::Infinity.new..DateTime::Infinity.new
+    assert_instance_of Range, DateTime.new..DateTime::Infinity.new
+  end
 
   def test_overlaps_last_inclusive
     assert((1..5).overlaps?(5..10))


### PR DESCRIPTION
This fix allows a `Range` to include `DateTime` and `DateTime::Infinity` objects.

Closes #8178
