### PR TITLE
rake railties:install:migrations respects the order of railties

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Rake task `railties:install:migrations` respects the order of railties.
+
+    *Slava Kravchenko*
+
 *   Remove support for parsing YAML parameters from request.
 
     *Aaron Patterson*

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -420,7 +420,7 @@ namespace :railties do
     task :migrations => :'db:load_config' do
       to_load = ENV['FROM'].blank? ? :all : ENV['FROM'].split(",").map {|n| n.strip }
       railties = {}
-      Rails.application.railties.each do |railtie|
+      Rails.application.ordered_railties.each do |railtie|
         next unless to_load == :all || to_load.include?(railtie.railtie_name)
 
         if railtie.respond_to?(:paths) && (path = railtie.paths['db/migrate'].first)


### PR DESCRIPTION
I have a couple of projects that make use of Rails' engines. There are two engines with migrations, where one engine depends on having a database table created in a migration in another engine. Unfortunately, "railties:install:migrations" task does not respect the order of engines that one can configure via "Rails.application.config.railties_order". This simple commit fixes that by using "ordered_railties" instead of "railties" (and thus the migration files are copied to the main application in the correct order).
