### PR TITLE
Make tests for the presence of MiniTest consistent

### DIFF
--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -10,7 +10,7 @@ require 'active_support/core_ext/kernel/reporting'
 
 module ActiveSupport
   class TestCase < ::Test::Unit::TestCase
-    if defined? MiniTest
+    if defined?(MiniTest::Assertions) && TestCase < MiniTest::Assertions
       Assertion = MiniTest::Assertion
       alias_method :method_name, :name if method_defined? :name
       alias_method :method_name, :__name__ if method_defined? :__name__


### PR DESCRIPTION
There is an inconsistency between the conditional logic in
the definition of ActiveSupport::TestCase and the conditional logic in
ActiveSupport::Testing::SetupAndTeardown [1].

In some circumstances, it's possible for MiniTest to be defined, but
for ActiveSupport::TestCase _not_ to have MiniTest::Unit::TestCase or
MiniTest::Assertions in its ancestor chain. e.g. in Ruby 1.8 with the
minitest gem included in the bundle. In this case, the
Test::Unit/MiniTest shim/wrapper is not present and so
Test::Unit::TestCase (and therefore ActiveSupport::TestCase) is
completely independent of MiniTest::Unit::TestCase.

The conditional logic in the definition of ActiveSupport::TestCase does
not take this scenario into account, whereas the logic in
ActiveSupport::Testing::SetupAndTeardown does take it into account.

The changes in this commit are an alternative to the change in [2] which
was reverted in [3].

Similar conditional logic exists in ActiveSupport::Testing::Isolation
[4], ActiveSupport::Testing::Pending [5],
ActiveSupport::Testing::Performance [6], and in their respective tests.
I have not addressed these, because I know less about what's going on
there, but it would be worth bringing them all into line too.

[1]
https://github.com/rails/rails/blob/3-2-stable/activesupport/lib/active_support/testing/setup_and_teardown.rb#L13
[2]
https://github.com/rails/rails/commit/c3e186ec8dcb2ec26d5d56f3e89123b1350c4a6f
[3]
https://github.com/rails/rails/commit/267fb61277ac960ad443d239febcb3136a007d24
[4]
https://github.com/rails/rails/blob/3-2-stable/activesupport/lib/active_support/testing/isolation.rb#L41
[5]
https://github.com/rails/rails/blob/3-2-stable/activesupport/lib/active_support/testing/pending.rb#L14
[6]
https://github.com/rails/rails/blob/3-2-stable/activesupport/lib/active_support/testing/performance.rb#L17
