### PR TITLE
Review, please: Capture block so content won't leak.

### DIFF
--- a/actionpack/lib/action_view/helpers/tags/collection_radio_buttons.rb
+++ b/actionpack/lib/action_view/helpers/tags/collection_radio_buttons.rb
@@ -13,12 +13,12 @@ module ActionView
           end
         end
 
-        def render
+        def render &block
           render_collection do |item, value, text, default_html_options|
             builder = instantiate_builder(RadioButtonBuilder, item, value, text, default_html_options)
 
             if block_given?
-              yield builder
+              capture builder, &block
             else
               render_component(builder)
             end


### PR DESCRIPTION
**Beware: tests are red.**

The [following pull request](https://github.com/rails/rails/pull/8916) fixed
the block being passed to the appropriate helper method. However, the content
being passed into the block is generating repeated markup on the page due to
some weird ERb evaluation.

This commit tries to capture the block's generated output so the page isn't
flooded with markup, but I'm not able to make the tests pass due to a missing
output buffer. Please help me review this behavior.
### Example 1 - it leaks markup to the page.

``` erb
<%= f.collection_radio_buttons :category, Category.all, :id, :name do |b|%>
  <%= b.label { b.radio_button + b.text } %>
<%- end%>
```
### Example 2 - doesn't leak

``` erb
<%= f.collection_radio_buttons :category, Category.all, :id, :name do |b| b.label { b.radio_button + b.text }; end %>
```
