### PR TITLE
test case for ActiveModel::Conversion#to_partial_path and namespaced models

### DIFF
--- a/activemodel/test/cases/conversion_test.rb
+++ b/activemodel/test/cases/conversion_test.rb
@@ -29,4 +29,8 @@ class ConversionTest < ActiveModel::TestCase
     assert_equal "helicopters/helicopter", Helicopter.new.to_partial_path,
       "ActiveModel::Conversion#to_partial_path caching should be class-specific"
   end
+
+  test "to_partial_path handles namespaced models" do
+    assert_equal "helicopter/comanches/comanche", Helicopter::Comanche.new.to_partial_path
+  end
 end

--- a/activemodel/test/models/helicopter.rb
+++ b/activemodel/test/models/helicopter.rb
@@ -1,3 +1,7 @@
 class Helicopter
   include ActiveModel::Conversion
 end
+
+class Helicopter::Comanche
+  include ActiveModel::Conversion
+end


### PR DESCRIPTION
stumbled across this code-path, which was not covered by tests. We had some nasty situations with AM and namespaces in the past. I added a test case to prevent regressions.
