### PR TITLE
Address test_create_when_database_exists_outputs_info_to_stderr failures

### DIFF
--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -3,6 +3,10 @@ require 'cases/helper'
 module ActiveRecord
   class MysqlDBCreateTest < ActiveRecord::TestCase
     def setup
+      unless current_adapter?(:MysqlAdapter, :Mysql2Adapter)
+        return skip("only tested on mysql or mysql2")
+      end
+
       @connection    = stub(:create_database => true)
       @configuration = {
         'adapter'  => 'mysql',


### PR DESCRIPTION
When tested with ruby-2.0.0-rc1 `rake test` executes this test even if the target adapter is not mysql nor mysql2.

``` ruby
$ for i in mysql mysql2 sqlite3 postgresql oracle;do echo $i; ARCONN=$i ruby -Itest test/cases/tasks/mysql_rake_test.rb;done
mysql
Using mysql
Run options: --seed 53784

# Running tests:

......................

Finished tests in 0.133132s, 165.2498 tests/s, 165.2498 assertions/s.

22 tests, 22 assertions, 0 failures, 0 errors, 0 skips
mysql2
Using mysql2
Run options: --seed 52428

# Running tests:

.........SSSSSS.......

Finished tests in 0.121255s, 181.4360 tests/s, 131.9535 assertions/s.

22 tests, 16 assertions, 0 failures, 0 errors, 6 skips
sqlite3
Using sqlite3
Run options: --seed 57010

# Running tests:

.........SSSSSSF......

Finished tests in 0.119009s, 184.8596 tests/s, 126.0406 assertions/s.

  1) Failure:
test_create_when_database_exists_outputs_info_to_stderr(ActiveRecord::MysqlDBCreateTest) [/home/yahonda/git/rails/activerecord/lib/active_record/tasks/database_tasks.rb:40]:
unexpected invocation: #<IO:0x1486178>.puts(#<TypeError:0x35a5e30>, '/home/yahonda/git/rails/activerecord/lib/active_record/tasks/mysql_database_tasks.rb:18:in `rescue in create'', '/home/yahonda/git/rails/activerecord/lib/active_record/tasks/mysql_database_tasks.rb:15:in `create'', '/home/yahonda/git/rails/activerecord/lib/active_record/tasks/database_tasks.rb:36:in `create'', 'test/cases/tasks/mysql_rake_test.rb:64:in `test_create_when_database_exists_outputs_info_to_stderr'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:1298:in `run'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:916:in `block in _run_suite'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:909:in `map'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:909:in `_run_suite'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:896:in `block in _run_suites'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:896:in `map'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:896:in `_run_suites'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:864:in `_run_anything'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:1057:in `run_tests'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:1044:in `block in _run'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:1043:in `each'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:1043:in `_run'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:1032:in `run'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:786:in `block in autorun'')
unsatisfied expectations:
- expected exactly once, not yet invoked: #<IO:0x1486178>.puts('my-app-db already exists')
satisfied expectations:
- allowed any number of times, invoked once: #<Mock:0x359b110>.create_database(any_parameters)
- allowed any number of times, not yet invoked: #<Mock:0x359b110>.create_database(any_parameters)
- allowed any number of times, invoked once: ActiveRecord::Base.establish_connection(any_parameters)
- allowed any number of times, invoked twice: ActiveRecord::Base.connection(any_parameters)


22 tests, 15 assertions, 1 failures, 0 errors, 6 skips
postgresql
Using postgresql
Run options: --seed 36889

# Running tests:

.........SSSSSSF......

Finished tests in 0.093439s, 235.4480 tests/s, 160.5327 assertions/s.

  1) Failure:
test_create_when_database_exists_outputs_info_to_stderr(ActiveRecord::MysqlDBCreateTest) [/home/yahonda/git/rails/activerecord/lib/active_record/tasks/database_tasks.rb:40]:
unexpected invocation: #<IO:0x1b52178>.puts(#<TypeError:0x3a46ea8>, '/home/yahonda/git/rails/activerecord/lib/active_record/tasks/mysql_database_tasks.rb:18:in `rescue in create'', '/home/yahonda/git/rails/activerecord/lib/active_record/tasks/mysql_database_tasks.rb:15:in `create'', '/home/yahonda/git/rails/activerecord/lib/active_record/tasks/database_tasks.rb:36:in `create'', 'test/cases/tasks/mysql_rake_test.rb:64:in `test_create_when_database_exists_outputs_info_to_stderr'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:1298:in `run'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:916:in `block in _run_suite'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:909:in `map'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:909:in `_run_suite'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:896:in `block in _run_suites'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:896:in `map'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:896:in `_run_suites'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:864:in `_run_anything'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:1057:in `run_tests'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:1044:in `block in _run'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:1043:in `each'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:1043:in `_run'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:1032:in `run'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:786:in `block in autorun'')
unsatisfied expectations:
- expected exactly once, not yet invoked: #<IO:0x1b52178>.puts('my-app-db already exists')
satisfied expectations:
- allowed any number of times, invoked once: #<Mock:0x3a38330>.create_database(any_parameters)
- allowed any number of times, not yet invoked: #<Mock:0x3a38330>.create_database(any_parameters)
- allowed any number of times, invoked once: ActiveRecord::Base.establish_connection(any_parameters)
- allowed any number of times, invoked twice: ActiveRecord::Base.connection(any_parameters)


22 tests, 15 assertions, 1 failures, 0 errors, 6 skips
oracle
Using oracle
Run options: --seed 61591

# Running tests:

.........SSSSSSF......

Finished tests in 0.130591s, 168.4654 tests/s, 114.8628 assertions/s.

  1) Failure:
test_create_when_database_exists_outputs_info_to_stderr(ActiveRecord::MysqlDBCreateTest) [/home/yahonda/git/rails/activerecord/lib/active_record/tasks/database_tasks.rb:40]:
unexpected invocation: #<IO:0x25c2158>.puts(#<TypeError:0x3f37e30>, '/home/yahonda/git/rails/activerecord/lib/active_record/tasks/mysql_database_tasks.rb:18:in `rescue in create'', '/home/yahonda/git/rails/activerecord/lib/active_record/tasks/mysql_database_tasks.rb:15:in `create'', '/home/yahonda/git/rails/activerecord/lib/active_record/tasks/database_tasks.rb:36:in `create'', 'test/cases/tasks/mysql_rake_test.rb:64:in `test_create_when_database_exists_outputs_info_to_stderr'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:1298:in `run'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:916:in `block in _run_suite'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:909:in `map'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:909:in `_run_suite'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:896:in `block in _run_suites'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:896:in `map'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:896:in `_run_suites'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:864:in `_run_anything'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:1057:in `run_tests'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:1044:in `block in _run'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:1043:in `each'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:1043:in `_run'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:1032:in `run'', '/home/yahonda/.rvm/gems/ruby-2.0.0-rc1@railsmaster/gems/minitest-4.4.0/lib/minitest/unit.rb:786:in `block in autorun'')
unsatisfied expectations:
- expected exactly once, not yet invoked: #<IO:0x25c2158>.puts('my-app-db already exists')
satisfied expectations:
- allowed any number of times, invoked once: #<Mock:0x3f164d8>.create_database(any_parameters)
- allowed any number of times, not yet invoked: #<Mock:0x3f164d8>.create_database(any_parameters)
- allowed any number of times, invoked once: ActiveRecord::Base.establish_connection(any_parameters)
- allowed any number of times, invoked twice: ActiveRecord::Base.connection(any_parameters)


22 tests, 15 assertions, 1 failures, 0 errors, 6 skips
$
```
