### PR TITLE
2.3.16 Including fix for CVE-2013-0155

### DIFF
--- a/actionmailer/Rakefile
+++ b/actionmailer/Rakefile
@@ -54,7 +54,7 @@ spec = Gem::Specification.new do |s|
   s.rubyforge_project = "actionmailer"
   s.homepage = "http://www.rubyonrails.org"
 
-  s.add_dependency('actionpack', '= 2.3.15' + PKG_BUILD)
+  s.add_dependency('actionpack', '= 2.3.16' + PKG_BUILD)
 
   s.requirements << 'none'
   s.require_path = 'lib'

--- a/actionmailer/lib/action_mailer/version.rb
+++ b/actionmailer/lib/action_mailer/version.rb
@@ -2,7 +2,7 @@ module ActionMailer
   module VERSION #:nodoc:
     MAJOR = 2
     MINOR = 3
-    TINY  = 15
+    TINY  = 16
 
     STRING = [MAJOR, MINOR, TINY].join('.')
   end

--- a/actionpack/Rakefile
+++ b/actionpack/Rakefile
@@ -78,7 +78,7 @@ spec = Gem::Specification.new do |s|
 
   s.requirements << 'none'
 
-  s.add_dependency('activesupport', '= 2.3.15' + PKG_BUILD)
+  s.add_dependency('activesupport', '= 2.3.16' + PKG_BUILD)
   s.add_dependency('rack', '~> 1.1.3')
 
   s.require_path = 'lib'

--- a/actionpack/lib/action_pack/version.rb
+++ b/actionpack/lib/action_pack/version.rb
@@ -2,7 +2,7 @@ module ActionPack #:nodoc:
   module VERSION #:nodoc:
     MAJOR = 2
     MINOR = 3
-    TINY  = 15
+    TINY  = 16
 
     STRING = [MAJOR, MINOR, TINY].join('.')
   end

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -192,7 +192,7 @@ spec = Gem::Specification.new do |s|
     s.files = s.files + Dir.glob( "#{dir}/**/*" ).delete_if { |item| item.include?( "\.svn" ) }
   end
 
-  s.add_dependency('activesupport', '= 2.3.15' + PKG_BUILD)
+  s.add_dependency('activesupport', '= 2.3.16' + PKG_BUILD)
 
   s.files.delete FIXTURES_ROOT + "/fixture_database.sqlite"
   s.files.delete FIXTURES_ROOT + "/fixture_database_2.sqlite"

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -2340,6 +2340,8 @@ module ActiveRecord #:nodoc:
         def sanitize_sql_hash_for_conditions(attrs, default_table_name = quoted_table_name, top_level = true)
           attrs = expand_hash_conditions_for_aggregates(attrs)
 
+          return '1 = 2' if !top_level && attrs.is_a?(Hash) && attrs.empty?
+
           conditions = attrs.map do |attr, value|
             table_name = default_table_name
 

--- a/activerecord/lib/active_record/version.rb
+++ b/activerecord/lib/active_record/version.rb
@@ -2,7 +2,7 @@ module ActiveRecord
   module VERSION #:nodoc:
     MAJOR = 2
     MINOR = 3
-    TINY  = 15
+    TINY  = 16
 
     STRING = [MAJOR, MINOR, TINY].join('.')
   end

--- a/activeresource/Rakefile
+++ b/activeresource/Rakefile
@@ -65,8 +65,8 @@ spec = Gem::Specification.new do |s|
   dist_dirs.each do |dir|
     s.files = s.files + Dir.glob( "#{dir}/**/*" ).delete_if { |item| item.include?( "\.svn" ) }
   end
-  
-  s.add_dependency('activesupport', '= 2.3.15' + PKG_BUILD)
+
+  s.add_dependency('activesupport', '= 2.3.16' + PKG_BUILD)
 
   s.require_path = 'lib'
 

--- a/activeresource/lib/active_resource/version.rb
+++ b/activeresource/lib/active_resource/version.rb
@@ -2,7 +2,7 @@ module ActiveResource
   module VERSION #:nodoc:
     MAJOR = 2
     MINOR = 3
-    TINY  = 15
+    TINY  = 16
 
     STRING = [MAJOR, MINOR, TINY].join('.')
   end

--- a/activesupport/CHANGELOG
+++ b/activesupport/CHANGELOG
@@ -1,3 +1,7 @@
+## Rails 2.3.16 (Jan 15, 2013) ##
+
+* Fix for CVE-2013-0155 (Ernie Miller)
+
 ## Rails 2.3.15 (Jan 8, 2012) ##
 
 * Hash.from_xml raises when it encounters type="symbol" or type="yaml". Use Hash.from_trusted_xml to parse this XML. CVE-2013-0156 [Jeremy Kemper]

--- a/activesupport/lib/active_support/version.rb
+++ b/activesupport/lib/active_support/version.rb
@@ -2,7 +2,7 @@ module ActiveSupport
   module VERSION #:nodoc:
     MAJOR = 2
     MINOR = 3
-    TINY  = 15
+    TINY  = 16
 
     STRING = [MAJOR, MINOR, TINY].join('.')
   end

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -313,11 +313,11 @@ spec = Gem::Specification.new do |s|
   EOF
 
   s.add_dependency('rake', '>= 0.8.3')
-  s.add_dependency('activesupport',    '= 2.3.15' + PKG_BUILD)
-  s.add_dependency('activerecord',     '= 2.3.15' + PKG_BUILD)
-  s.add_dependency('actionpack',       '= 2.3.15' + PKG_BUILD)
-  s.add_dependency('actionmailer',     '= 2.3.15' + PKG_BUILD)
-  s.add_dependency('activeresource',   '= 2.3.15' + PKG_BUILD)
+  s.add_dependency('activesupport',    '= 2.3.16' + PKG_BUILD)
+  s.add_dependency('activerecord',     '= 2.3.16' + PKG_BUILD)
+  s.add_dependency('actionpack',       '= 2.3.16' + PKG_BUILD)
+  s.add_dependency('actionmailer',     '= 2.3.16' + PKG_BUILD)
+  s.add_dependency('activeresource',   '= 2.3.16' + PKG_BUILD)
 
   s.rdoc_options << '--exclude' << '.'
 

--- a/railties/lib/rails/version.rb
+++ b/railties/lib/rails/version.rb
@@ -2,7 +2,7 @@ module Rails
   module VERSION #:nodoc:
     MAJOR = 2
     MINOR = 3
-    TINY  = 15
+    TINY  = 16
 
     STRING = [MAJOR, MINOR, TINY].join('.')
   end


### PR DESCRIPTION
In response to this announcement: https://groups.google.com/group/rubyonrails-security/browse_thread/thread/73b8d3f8478df5e2

It's hard to tell whether or not the fix is legitimate:
- There's no updated gem (for 2.3)
- The commit doesn't exist on GitHub
- There's no tag
- The vulnerability is not addressed on the blog
- There's no test
- The code fix looks... strange
- The email is not signed

If this problem is legitimate, and the patch fixes it, we would immensely appreciate an updated Rails 2 gem. Especially since last week's issue in fact did result in a new 2.3 gem.

This PR makes all the necessary preparations, all you need to do is build and push.
