### PR TITLE
Allow to setup default config option using block

### DIFF
--- a/actionpack/lib/action_dispatch/routing/redirection.rb
+++ b/actionpack/lib/action_dispatch/routing/redirection.rb
@@ -30,7 +30,7 @@ module ActionDispatch
       end
 
       def path(params, request)
-        block.call params, request
+        URI.escape(block.call params, request)
       end
     end
 

--- a/activesupport/lib/active_support/configurable.rb
+++ b/activesupport/lib/active_support/configurable.rb
@@ -49,7 +49,21 @@ module ActiveSupport
       #   user.allowed_access = true
       #   user.allowed_access # => true
       #
-      def config_accessor(*names)
+      # You can pass a block to set up the attribute with a default value.
+      #
+      #   class User
+      #     include ActiveSupport::Configurable
+      #     config_accessor :hair_color do
+      #       :red
+      #     end
+      #   end
+      #
+      #   user = User.new
+      #   user.hair_color # => :red
+      #   user.hair_color = :brown
+      #   user.hair_color # => :brown
+      #
+      def config_accessor(*names, &block)
         options = names.extract_options!
 
         names.each do |name|
@@ -60,6 +74,8 @@ module ActiveSupport
           singleton_class.class_eval writer, __FILE__, line
           class_eval reader, __FILE__, line unless options[:instance_reader] == false
           class_eval writer, __FILE__, line unless options[:instance_writer] == false
+
+          send("#{name}=", yield) if block_given?
         end
       end
     end

--- a/activesupport/test/configurable_test.rb
+++ b/activesupport/test/configurable_test.rb
@@ -71,6 +71,17 @@ class ConfigurableActiveSupport < ActiveSupport::TestCase
     assert_method_defined child.new.config, :bar
   end
 
+  test "configuration can take defaults" do
+    parent = Class.new do
+      include ActiveSupport::Configurable
+      config_accessor :foo, :bar do
+        'bar'
+      end
+    end
+    assert_equal parent.config.foo, 'bar'
+    assert_equal parent.config.bar, 'bar'
+   end
+
   def assert_method_defined(object, method)
     methods = object.public_methods.map(&:to_s)
     assert methods.include?(method.to_s), "Expected #{methods.inspect} to include #{method.to_s.inspect}"


### PR DESCRIPTION
It works the same way as `cattr_accessor`

``` ruby
         class User
           include ActiveSupport::Configurable
           config_accessor :hair_color do
             :red
           end
         end

         user = User.new
         user.hair_color # => :red
```
