### PR TITLE
Strong parameters exception handling

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -373,12 +373,6 @@ module ActionController
     extend ActiveSupport::Concern
     include ActiveSupport::Rescuable
 
-    included do
-      rescue_from(ActionController::ParameterMissing) do |parameter_missing_exception|
-        render text: "Required parameter missing: #{parameter_missing_exception.param}", status: :bad_request
-      end
-    end
-
     # Returns a new ActionController::Parameters object that
     # has been instantiated with the <tt>request.parameters</tt>.
     def params

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -12,7 +12,8 @@ module ActionDispatch
       'ActionController::NotImplemented'           => :not_implemented,
       'ActionController::UnknownFormat'            => :not_acceptable,
       'ActionController::InvalidAuthenticityToken' => :unprocessable_entity,
-      'ActionController::BadRequest'               => :bad_request
+      'ActionController::BadRequest'               => :bad_request,
+      'ActionController::ParameterMissing'         => :bad_request
     )
 
     cattr_accessor :rescue_templates

--- a/actionpack/test/controller/required_params_test.rb
+++ b/actionpack/test/controller/required_params_test.rb
@@ -11,20 +11,17 @@ class ActionControllerRequiredParamsTest < ActionController::TestCase
   tests BooksController
 
   test "missing required parameters will raise exception" do
-    post :create, { magazine: { name: "Mjallo!" } }
-    assert_response :bad_request
+    assert_raise (ActionController::ParameterMissing) do
+      post :create, { magazine: { name: "Mjallo!" } }
+    end
 
-    post :create, { book: { title: "Mjallo!" } }
-    assert_response :bad_request
+    assert_raise (ActionController::ParameterMissing) do
+      post :create, { book: { title: "Mjallo!" } }
+    end
   end
 
   test "required parameters that are present will not raise" do
     post :create, { book: { name: "Mjallo!" } }
     assert_response :ok
-  end
-
-  test "missing parameters will be mentioned in the return" do
-    post :create, { magazine: { name: "Mjallo!" } }
-    assert_equal "Required parameter missing: book", response.body
   end
 end

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -39,6 +39,8 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
         raise ActionController::BadRequest
       when "/missing_keys"
         raise ActionController::UrlGenerationError, "No route matches"
+      when "/parameter_missing"
+        raise ActionController::ParameterMissing, :missing_param_key
       else
         raise "puke!"
       end
@@ -114,6 +116,10 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     get "/bad_request", {}, {'action_dispatch.show_exceptions' => true}
     assert_response 400
     assert_match(/ActionController::BadRequest/, body)
+
+    get "/parameter_missing", {}, {'action_dispatch.show_exceptions' => true}
+    assert_response 400
+    assert_match(/ActionController::ParameterMissing/, body)
   end
 
   test "does not show filtered parameters" do


### PR DESCRIPTION
When `ActionController::ParameterMissing` is raised, the following occurred before this pull-request:
- In development, the following error message is rendered to the response body: `"Required parameter missing: foo"`. But no backtrace is displayed in the browser or the logs.
- In production, the same error messages is rendered to the response body. This exposes the user to confusing developer-speak. Also, exception notifiers won't notify the developer of the issue since the exception is eaten by `rescue_from`.

After this pull-request, the following will occur:
- In development, the Rails exception page will be rendered, complete with backtrace and code snippet showing offending line.
- In production, the appropriate error page is rendered.

I didn't change the response code; it's still `400`. Since a default Rails app doesn't include a `400.html` file, an empty response body will be rendered by default in production.

Possibly we could change the response code to `422`? It seems like an appropriate code and Rails generates a `422.html` by default.

Thanks!
