### PR TITLE
Don't rely on Hash key's ordering to configure default options

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -7,13 +7,15 @@ module ActiveRecord
   module ConnectionHandling
     # Establishes a connection to the database that's used by all Active Record objects.
     def mysql2_connection(config)
+      config = config.symbolize_keys
+
       config[:username] = 'root' if config[:username].nil?
 
       if Mysql2::Client.const_defined? :FOUND_ROWS
         config[:flags] = Mysql2::Client::FOUND_ROWS
       end
 
-      client = Mysql2::Client.new(config.symbolize_keys)
+      client = Mysql2::Client.new(config)
       options = [config[:host], config[:username], config[:password], config[:database], config[:port], config[:socket], 0]
       ConnectionAdapters::Mysql2Adapter.new(client, logger, options, config)
     end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -18,9 +18,9 @@ module ActiveRecord
         #   create_database config[:database], config
         #   create_database 'foo_development', encoding: 'unicode'
         def create_database(name, options = {})
-          options = options.reverse_merge(:encoding => "utf8")
+          options = { encoding: 'utf8' }.merge!(options.symbolize_keys)
 
-          option_string = options.symbolize_keys.sum do |key, value|
+          option_string = options.sum do |key, value|
             case key
             when :owner
               " OWNER = \"#{value}\""

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -16,6 +16,7 @@ class PostgresqlActiveSchemaTest < ActiveRecord::TestCase
   def test_create_database_with_encoding
     assert_equal %(CREATE DATABASE "matt" ENCODING = 'utf8'), create_database(:matt)
     assert_equal %(CREATE DATABASE "aimonetti" ENCODING = 'latin1'), create_database(:aimonetti, :encoding => :latin1)
+    assert_equal %(CREATE DATABASE "aimonetti" ENCODING = 'latin1'), create_database(:aimonetti, 'encoding' => :latin1)
   end
 
   def test_create_database_with_collation_and_ctype


### PR DESCRIPTION
(I've talked with @rafaelfranca about it)

If we set encoding latin1 for a PostgreSQL database, it calls
PostgreSQLAdapter::create_database with options that have,
among other things:

  { 'encoding' => 'latin1' }

Then, we use reverse_merge(:encoding => "utf8") to setup the default
encoding. In the end, the hash looks like:

  { :encoding => 'utf8', 'encoding' => 'latin1' }

The call to options.symbolize_keys calls to_sym on each_key of this
Hash. It usually means that the encoding passed overwrites the default
utf8, but it's not guaranteed. So, we shouldn't rely on it.

The same was happening in ActiveRecord::ConnectionHandling.
