### PR TITLE
adding regression test in master for #8631

### DIFF
--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -462,6 +462,27 @@ class RequestTest < ActiveSupport::TestCase
     assert request.put?
   end
 
+  test "post uneffected by local inflections" do
+    existing_acrnoyms = ActiveSupport::Inflector.inflections.acronyms.dup
+    existing_acrnoym_regex = ActiveSupport::Inflector.inflections.acronym_regex.dup
+    begin
+      ActiveSupport::Inflector.inflections do |inflect|
+        inflect.acronym "POS"
+      end
+      assert_equal "pos_t", "POST".underscore
+      request = stub_request "REQUEST_METHOD" => "POST"
+      assert_equal :post, ActionDispatch::Request::HTTP_METHOD_LOOKUP["POST"]
+      assert_equal :post, request.method_symbol
+      assert request.post?
+    ensure
+      # Reset original acronym set
+      ActiveSupport::Inflector.inflections do |inflect|
+        inflect.send(:instance_variable_set,"@acronyms",existing_acrnoyms)
+        inflect.send(:instance_variable_set,"@acronym_regex",existing_acrnoym_regex)
+      end
+    end
+  end
+
   test "xml format" do
     request = stub_request
     request.expects(:parameters).at_least_once.returns({ :format => 'xml' })


### PR DESCRIPTION
As per comment by @pixeltrix on #8631 porting the regression test to master.

Tests that local inflections should not interfere with HTTP_METHOD_LOOKUP
