### PR TITLE
Clear specific logs when using `rake log:clear`

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -355,7 +355,7 @@ rake assets:clean       # Remove compiled assets
 rake assets:precompile  # Compile all the assets named in config.assets.precompile
 rake db:create          # Create the database from config/database.yml for the current Rails.env
 ...
-rake log:clear          # Truncates all *.log files in log/ to zero bytes
+rake log:clear          # Truncates all *.log files in log/ to zero bytes (specify which logs with LOGS=test,development)
 rake middleware         # Prints out your Rack middleware stack
 ...
 rake tmp:clear          # Clear session, cache, and socket files from tmp/ (narrow w/ tmp:sessions:clear, tmp:cache:clear, tmp:sockets:clear)

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Specify which logs to clear when using the `rake log:clear` task.
+    (e.g. rake log:clear LOGS=test,staging)
+
+    *Matt Bridges*
+
 *   Allow a `:dirs` key in the `SourceAnnotationExtractor.enumerate` options
     to explicitly set the directories to be traversed so it's easier to define
     custom rake tasks.

--- a/railties/lib/rails/tasks/log.rake
+++ b/railties/lib/rails/tasks/log.rake
@@ -1,9 +1,23 @@
 namespace :log do
-  desc "Truncates all *.log files in log/ to zero bytes"
+  desc "Truncates all *.log files in log/ to zero bytes (specify which logs with LOGS=test,development)"
   task :clear do
-    FileList["log/*.log"].each do |log_file|
-      f = File.open(log_file, "w")
-      f.close
+    log_files.each do |file|
+      clear_log_file(file)
     end
+  end
+
+  def log_files
+    if ENV['LOGS']
+      ENV['LOGS'].split(',')
+                  .map    { |file| "log/#{file.strip}.log" }
+                  .select { |file| File.exists?(file) }
+    else
+      FileList["log/*.log"]
+    end
+  end
+
+  def clear_log_file(file)
+    f = File.open(file, "w")
+    f.close
   end
 end


### PR DESCRIPTION
There are times when I want to clear only one of the logs or just two of the logs rather than all of the logs. You can now accomplish this with:

```
$ LOGS=test rake log:clear
```

Or multiple:

```
$ LOGS=test,staging rake log:clear
```

Wasn't sure the best way to test this. I couldn't find any tests for it, so if there are any suggestions, I am more than willing to add them or provide a sample app with this successfully running in it.
