### PR TITLE
Fix handling of multiple cookies in rails 2.3

### DIFF
--- a/actionpack/CHANGELOG
+++ b/actionpack/CHANGELOG
@@ -1,3 +1,5 @@
+* Fixed handling of multiple cookies when cookie header is converted from a String to Array [Wesley Moore]
+
 *2.3.11 (February 9, 2011)*
 
 * Two security fixes. CVE-2011-0446, CVE-2011-0447

--- a/actionpack/lib/action_controller/response.rb
+++ b/actionpack/lib/action_controller/response.rb
@@ -230,7 +230,8 @@ module ActionController # :nodoc:
       end
 
       def convert_cookies!
-        cookies = Array(headers['Set-Cookie']).compact
+        cookies = headers['Set-Cookie']
+        cookies = (String === cookies ? cookies.split("\n") : Array(cookies)).compact
         headers['Set-Cookie'] = cookies unless cookies.empty?
       end
   end


### PR DESCRIPTION
Rails 2.3.15 increased the required rack version to 1.1.3, this brought
in [some changes to the way multiple cookies are handled](https://github.com/rack/rack/commit/7754cdb5f5fa937ed3e1a811680f349d0acba73d) in a response.
Previously they were stored as an Array but now they are stored as a
String.

As a result of this there is a failing test, test_multiple_cookies(CookieTest)
[actionpack/test/controller/cookie_test.rb:125]. This change fixes the
test and also resolves the original issue I encountered.

The original issue was failing integration tests (under ruby 1.8) due to
a stray new line being added to the cookie string. This in turn resulted
in an empty string being included in the cookies array when it was split
in [ActionController::Integration::Session](https://github.com/rails/rails/blob/2-3-stable/actionpack/lib/action_controller/integration.rb#L328).

For example a the cookie string would go from:

```
cookie1=aaa\ncookie2=bbb
```

to:

```
cookie1=aaa\n\ncookie2=bbb
```

resulting in `cookies` being set to `["cookie1=aaa", "", "cookie2=bbb"]`
in Integration::Session, which would subsequently cause an exception to
be raised when the empty [string was split on line 330](https://github.com/rails/rails/blob/2-3-stable/actionpack/lib/action_controller/integration.rb#L330).

The stray new line is introduced by convert_cookies! in
ActionController::Response. The use of Kernel#Array in ruby 1.8 was
splitting the string on new lines but does not consume the new line, so
when the array is eventually joined back into a string extra new lines
are present.

In ruby 1.9 Kernel#Array no longer splits, thus the test failed because
it was expecting multiple cookies but only getting one.
