### PR TITLE
spelling correction for Action Mailer interceptors

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -588,7 +588,7 @@ class SandboxEmailInterceptor
 end
 ```
 
-Before the Interceptor can do it's job you need to register it with the Action Mailer framework. You can do this in an initializer file `config/initializers/sandbox_email_interceptor.rb`
+Before the interceptor can do it's job you need to register it with the Action Mailer framework. You can do this in an initializer file `config/initializers/sandbox_email_interceptor.rb`
 
 ```ruby
 ActionMailer::Base.register_interceptor(SandboxEmailInterceptor) if Rails.env.staging?


### PR DESCRIPTION
A small spelling correction for the Action Mailer interceptor documentation. This was pointed out by @fxn in #8967
