### PR TITLE
Remove i18n symbol dependency

### DIFF
--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -880,6 +880,7 @@ module ActionView
 
         def translated_date_order
           date_order = I18n.translate(:'date.order', :locale => @options[:locale], :default => [])
+          date_order.map! { |element| element.to_sym }
 
           forbidden_elements = date_order - [:year, :month, :day]
           if forbidden_elements.any?

--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -880,7 +880,7 @@ module ActionView
 
         def translated_date_order
           date_order = I18n.translate(:'date.order', :locale => @options[:locale], :default => [])
-          date_order.map! { |element| element.to_sym }
+          date_order = date_order.map { |element| element.to_sym }
 
           forbidden_elements = date_order - [:year, :month, :day]
           if forbidden_elements.any?

--- a/actionpack/test/template/date_helper_i18n_test.rb
+++ b/actionpack/test/template/date_helper_i18n_test.rb
@@ -117,7 +117,7 @@ class DateHelperSelectTagsI18nTests < ActiveSupport::TestCase
       I18n.expects(:translate).with(('datetime.prompts.' + key.to_s).to_sym, :locale => 'en').returns prompt
     end
 
-    I18n.expects(:translate).with(:'date.order', :locale => 'en', :default => []).returns [:year, :month, :day]
+    I18n.expects(:translate).with(:'date.order', :locale => 'en', :default => []).returns %w(year month day)
     datetime_select('post', 'updated_at', :locale => 'en', :include_seconds => true, :prompt => true)
   end
 
@@ -129,15 +129,20 @@ class DateHelperSelectTagsI18nTests < ActiveSupport::TestCase
   end
 
   def test_date_or_time_select_given_no_order_options_translates_order
-    I18n.expects(:translate).with(:'date.order', :locale => 'en', :default => []).returns [:year, :month, :day]
+    I18n.expects(:translate).with(:'date.order', :locale => 'en', :default => []).returns %w(year month day)
     datetime_select('post', 'updated_at', :locale => 'en')
   end
 
   def test_date_or_time_select_given_invalid_order
-    I18n.expects(:translate).with(:'date.order', :locale => 'en', :default => []).returns [:invalid, :month, :day]
+    I18n.expects(:translate).with(:'date.order', :locale => 'en', :default => []).returns %w(invalid month day)
 
     assert_raise StandardError do
       datetime_select('post', 'updated_at', :locale => 'en')
     end
+  end
+
+  def test_date_or_time_select_given_symbol_keys
+    I18n.expects(:translate).with(:'date.order', :locale => 'en', :default => []).returns [:year, :month, :day]
+    datetime_select('post', 'updated_at', :locale => 'en')
   end
 end

--- a/activesupport/lib/active_support/locale/en.yml
+++ b/activesupport/lib/active_support/locale/en.yml
@@ -16,9 +16,9 @@ en:
     abbr_month_names: [~, Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec]
     # Used in date_select and datetime_select.
     order:
-      - :year
-      - :month
-      - :day
+      - year
+      - month
+      - day
 
   time:
     formats:


### PR DESCRIPTION
date.order is the only key in rails i18n that is required to be a
symbol. This patch allows for symbols or strings which means:
- No requirement for symbol type in .yml files. A future
  YAML.safe_load wouldn't need to load symbols
- Rails could actually use json rather than yml as the backend
