### PR TITLE
Adding :in and :within options to `validates_numericality_of`

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,5 +1,24 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add `:in` and `:within` options to `ActiveModel::Validations::NumericalityValidator`
+    so that numbers can be validated using ranges rather than multiple options.
+
+        class Timer
+          include ActiveModel::Validations
+
+          attr_accessor :duration
+          validates_numericality_of :duration, in: 1..200
+        end
+
+        timer = Timer.new
+        timer.duration = 201
+        timer.valid?
+        # => false
+        timer.errors.messsages
+        # => {:duration=>["must be less than or equal to 200"]}
+
+    *Matt Bridges*
+
 *   Add `ActiveModel::Validations::AbsenceValidator`, a validator to check the
     absence of attributes.
 

--- a/activemodel/lib/active_model/validations/inclusion.rb
+++ b/activemodel/lib/active_model/validations/inclusion.rb
@@ -30,7 +30,7 @@ module ActiveModel
       #   supplied as a proc, lambda or symbol which returns an enumerable. If the
       #   enumerable is a range the test is performed with <tt>Range#cover?</tt>,
       #   otherwise with <tt>include?</tt>.
-      # * <tt>:within</tt> - A synonym(or alias) for <tt>:in</tt>
+      # * <tt>:within</tt> - A synonym (or alias) for <tt>:in</tt>
       # * <tt>:message</tt> - Specifies a custom error message (default is: "is
       #   not included in the list").
       # * <tt>:allow_nil</tt> - If set to +true+, skips this validation if the

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -8,6 +8,16 @@ module ActiveModel
 
       RESERVED_OPTIONS = CHECKS.keys + [:only_integer]
 
+      def initialize(options)
+        range = options.delete(:in) || options.delete(:within)
+        if range
+          raise ArgumentError, ":in and :within must be a Range" unless range.is_a?(Range)
+          options[:greater_than_or_equal_to], options[:less_than_or_equal_to] = range.min, range.max
+        end
+
+        super
+      end
+
       def check_validity!
         keys = CHECKS.keys - [:odd, :even]
         options.slice(*keys).each do |option, value|
@@ -108,6 +118,8 @@ module ActiveModel
       #   supplied value.
       # * <tt>:odd</tt> - Specifies the value must be an odd number.
       # * <tt>:even</tt> - Specifies the value must be an even number.
+      # * <tt>:in<tt> - Specifies the <tt>Range</tt> the value must be covered by.
+      # * <tt>:within<tt> - A synonym (or alias) for <tt>:in</tt>
       #
       # There is also a list of default options supported by every validator:
       # +:if+, +:unless+, +:on+ and +:strict+ .

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -30,84 +30,112 @@ class NumericalityValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_numericality_of_with_nil_allowed
-    Topic.validates_numericality_of :approved, :allow_nil => true
+    Topic.validates_numericality_of :approved, allow_nil: true
 
     invalid!(JUNK + BLANK)
     valid!(NIL + FLOATS + INTEGERS + BIGDECIMAL + INFINITY)
   end
 
   def test_validates_numericality_of_with_integer_only
-    Topic.validates_numericality_of :approved, :only_integer => true
+    Topic.validates_numericality_of :approved, only_integer: true
 
     invalid!(NIL + BLANK + JUNK + FLOATS + BIGDECIMAL + INFINITY)
     valid!(INTEGERS)
   end
 
+  def test_validates_numericality_with_in
+    Topic.validates_numericality_of :approved, in: 10..20
+
+    invalid!([-1] + NIL + BLANK + INFINITY + JUNK + BIGDECIMAL)
+    valid!([10, 11, 15, 20])
+  end
+
+  def test_validates_numericality_using_within
+    Topic.validates_numericality_of :approved, within: 10..20
+
+    invalid!([-1] + NIL + BLANK + INFINITY + JUNK + BIGDECIMAL)
+    valid!([10, 11, 15, 20])
+  end
+
+  def test_validates_numericality_raises_argument_error_when_using_in_without_range
+    assert_raise(ArgumentError) do
+      Topic.validates_numericality_of :approved, in: %w[1 2 3]
+    end
+  end
+
+  def test_validates_numericality_using_within_and_exclusive_range
+    Topic.validates_numericality_of :approved, in: 10...20
+
+    invalid!([-1, 20] + NIL + BLANK + INFINITY + JUNK + BIGDECIMAL)
+    valid!([10, 11, 15])
+  end
+
+
   def test_validates_numericality_of_with_integer_only_and_nil_allowed
-    Topic.validates_numericality_of :approved, :only_integer => true, :allow_nil => true
+    Topic.validates_numericality_of :approved, only_integer: true, allow_nil: true
 
     invalid!(JUNK + BLANK + FLOATS + BIGDECIMAL + INFINITY)
     valid!(NIL + INTEGERS)
   end
 
   def test_validates_numericality_with_greater_than
-    Topic.validates_numericality_of :approved, :greater_than => 10
+    Topic.validates_numericality_of :approved, greater_than: 10
 
     invalid!([-10, 10], 'must be greater than 10')
     valid!([11])
   end
 
   def test_validates_numericality_with_greater_than_or_equal
-    Topic.validates_numericality_of :approved, :greater_than_or_equal_to => 10
+    Topic.validates_numericality_of :approved, greater_than_or_equal_to: 10
 
     invalid!([-9, 9], 'must be greater than or equal to 10')
     valid!([10])
   end
 
   def test_validates_numericality_with_equal_to
-    Topic.validates_numericality_of :approved, :equal_to => 10
+    Topic.validates_numericality_of :approved, equal_to: 10
 
     invalid!([-10, 11] + INFINITY, 'must be equal to 10')
     valid!([10])
   end
 
   def test_validates_numericality_with_less_than
-    Topic.validates_numericality_of :approved, :less_than => 10
+    Topic.validates_numericality_of :approved, less_than: 10
 
     invalid!([10], 'must be less than 10')
     valid!([-9, 9])
   end
 
   def test_validates_numericality_with_less_than_or_equal_to
-    Topic.validates_numericality_of :approved, :less_than_or_equal_to => 10
+    Topic.validates_numericality_of :approved, less_than_or_equal_to: 10
 
     invalid!([11], 'must be less than or equal to 10')
     valid!([-10, 10])
   end
 
   def test_validates_numericality_with_odd
-    Topic.validates_numericality_of :approved, :odd => true
+    Topic.validates_numericality_of :approved, odd: true
 
     invalid!([-2, 2], 'must be odd')
     valid!([-1, 1])
   end
 
   def test_validates_numericality_with_even
-    Topic.validates_numericality_of :approved, :even => true
+    Topic.validates_numericality_of :approved, even: true
 
     invalid!([-1, 1], 'must be even')
     valid!([-2, 2])
   end
 
   def test_validates_numericality_with_greater_than_less_than_and_even
-    Topic.validates_numericality_of :approved, :greater_than => 1, :less_than => 4, :even => true
+    Topic.validates_numericality_of :approved, greater_than: 1, less_than: 4, even: true
 
     invalid!([1, 3, 4])
     valid!([2])
   end
 
   def test_validates_numericality_with_other_than
-    Topic.validates_numericality_of :approved, :other_than => 0
+    Topic.validates_numericality_of :approved, other_than: 0
 
     invalid!([0, 0.0])
     valid!([-1, 42])
@@ -115,7 +143,7 @@ class NumericalityValidationTest < ActiveModel::TestCase
 
   def test_validates_numericality_with_proc
     Topic.send(:define_method, :min_approved, lambda { 5 })
-    Topic.validates_numericality_of :approved, :greater_than_or_equal_to => Proc.new {|topic| topic.min_approved }
+    Topic.validates_numericality_of :approved, greater_than_or_equal_to: Proc.new {|topic| topic.min_approved }
 
     invalid!([3, 4])
     valid!([5, 6])
@@ -124,7 +152,7 @@ class NumericalityValidationTest < ActiveModel::TestCase
 
   def test_validates_numericality_with_symbol
     Topic.send(:define_method, :max_approved, lambda { 5 })
-    Topic.validates_numericality_of :approved, :less_than_or_equal_to => :max_approved
+    Topic.validates_numericality_of :approved, less_than_or_equal_to: :max_approved
 
     invalid!([6])
     valid!([4, 5])
@@ -132,13 +160,13 @@ class NumericalityValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_numericality_with_numeric_message
-    Topic.validates_numericality_of :approved, :less_than => 4, :message => "smaller than %{count}"
+    Topic.validates_numericality_of :approved, less_than: 4, message: "smaller than %{count}"
     topic = Topic.new("title" => "numeric test", "approved" => 10)
 
     assert !topic.valid?
     assert_equal ["smaller than 4"], topic.errors[:approved]
 
-    Topic.validates_numericality_of :approved, :greater_than => 4, :message => "greater than %{count}"
+    Topic.validates_numericality_of :approved, greater_than: 4, message: "greater than %{count}"
     topic = Topic.new("title" => "numeric test", "approved" => 1)
 
     assert !topic.valid?
@@ -146,7 +174,7 @@ class NumericalityValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_numericality_of_for_ruby_class
-    Person.validates_numericality_of :karma, :allow_nil => false
+    Person.validates_numericality_of :karma, allow_nil: false
 
     p = Person.new
     p.karma = "Pix"
@@ -161,11 +189,11 @@ class NumericalityValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_numericality_with_invalid_args
-    assert_raise(ArgumentError){ Topic.validates_numericality_of :approved, :greater_than_or_equal_to => "foo" }
-    assert_raise(ArgumentError){ Topic.validates_numericality_of :approved, :less_than_or_equal_to => "foo" }
-    assert_raise(ArgumentError){ Topic.validates_numericality_of :approved, :greater_than => "foo" }
-    assert_raise(ArgumentError){ Topic.validates_numericality_of :approved, :less_than => "foo" }
-    assert_raise(ArgumentError){ Topic.validates_numericality_of :approved, :equal_to => "foo" }
+    assert_raise(ArgumentError){ Topic.validates_numericality_of :approved, greater_than_or_equal_to: "foo" }
+    assert_raise(ArgumentError){ Topic.validates_numericality_of :approved, less_than_or_equal_to: "foo" }
+    assert_raise(ArgumentError){ Topic.validates_numericality_of :approved, greater_than: "foo" }
+    assert_raise(ArgumentError){ Topic.validates_numericality_of :approved, less_than: "foo" }
+    assert_raise(ArgumentError){ Topic.validates_numericality_of :approved, equal_to: "foo" }
   end
 
   private
@@ -185,7 +213,7 @@ class NumericalityValidationTest < ActiveModel::TestCase
   end
 
   def with_each_topic_approved_value(values)
-    topic = Topic.new(:title => "numeric test", :content => "whatever")
+    topic = Topic.new(title: "numeric test", content: "whatever")
     values.each do |value|
       topic.approved = value
       yield topic, value


### PR DESCRIPTION
Behaves similarly to length validation, except that it checks to see if the given value is covered by the given `Range`.

``` ruby
class Timer
  include ActiveModel::Validations

  attr_accessor :duration
  validates_numericality_of :duration, in: 1..200
end

timer = Timer.new
timer.duration = 201
timer.valid?
# => false
timer.errors.messsages
# => {:duration => ["must be less than or equal to 200"]}
```
