### PR TITLE
rake railties:install:migrations now respects ordered_railties.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Rake task `railties:install:migrations` respects the order of railties.
+
+    *Slava Kravchenko* and *Philip Arndt*
+
 *   Ambiguous reflections are on :through relationships are no longer supported.
     For example, you need to change this:
 
@@ -5,12 +9,12 @@
         has_many :posts
         has_many :taggings, :through => :posts
       end
-      
+
       class Post < ActiveRecord::Base
         has_one :tagging
         has_many :taggings
       end
-      
+
       class Tagging < ActiveRecord::Base
       end
 
@@ -20,12 +24,12 @@
         has_many :posts
         has_many :taggings, :through => :posts, :source => :tagging
       end
-      
+
       class Post < ActiveRecord::Base
         has_one :tagging
         has_many :taggings
       end
-      
+
       class Tagging < ActiveRecord::Base
       end
 

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -374,7 +374,7 @@ namespace :railties do
     task :migrations => :'db:load_config' do
       to_load = ENV['FROM'].blank? ? :all : ENV['FROM'].split(",").map {|n| n.strip }
       railties = {}
-      Rails.application.railties.each do |railtie|
+      (Rails.application.ordered_railties & Rails.application.railties).reverse_each do |railtie|
         next unless to_load == :all || to_load.include?(railtie.railtie_name)
 
         if railtie.respond_to?(:paths) && (path = railtie.paths['db/migrate'].first)

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -235,6 +235,34 @@ module Rails
       config.helpers_paths
     end
 
+    def railties #:nodoc:
+      @railties ||= Rails::Railtie.subclasses.map(&:instance) +
+        Rails::Engine.subclasses.map(&:instance)
+    end
+
+    # Returns the ordered railties for this application considering railties_order.
+    def ordered_railties #:nodoc:
+      @ordered_railties ||= begin
+        order = config.railties_order.map do |railtie|
+          if railtie == :main_app
+            self
+          elsif railtie.respond_to?(:instance)
+            railtie.instance
+          else
+            railtie
+          end
+        end
+
+        all = (railties - order)
+        all.push(self)   unless (all + order).include?(self)
+        order.push(:all) unless order.include?(:all)
+
+        index = order.index(:all)
+        order[index] = all
+        order.reverse.flatten
+      end
+    end
+
   protected
 
     alias :build_middleware_stack :app
@@ -263,29 +291,6 @@ module Rails
     def run_console_blocks(app) #:nodoc:
       railties.each { |r| r.run_console_blocks(app) }
       super
-    end
-
-    # Returns the ordered railties for this application considering railties_order.
-    def ordered_railties #:nodoc:
-      @ordered_railties ||= begin
-        order = config.railties_order.map do |railtie|
-          if railtie == :main_app
-            self
-          elsif railtie.respond_to?(:instance)
-            railtie.instance
-          else
-            railtie
-          end
-        end
-
-        all = (railties - order)
-        all.push(self)   unless (all + order).include?(self)
-        order.push(:all) unless order.include?(:all)
-
-        index = order.index(:all)
-        order[index] = all
-        order.reverse.flatten
-      end
     end
 
     def railties_initializers(current) #:nodoc:


### PR DESCRIPTION
This replaces #8930 and has the previously failing tests now passing for me.
