### PR TITLE
Symbol case for #check_box_checked? helper

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -1033,6 +1033,8 @@ module ActionView
             value != 0
           when String
             value == checked_value
+          when Symbol
+            checked_value.is_a?(Symbol) ? (value == checked_value) : (value.to_s == checked_value)
           when Array
             value.include?(checked_value)
           else


### PR DESCRIPTION
Symbol is not currently a case. The else statement calls #to_i on value and in Ruby 1.9.3, Symbol has no #to_i method.

Also, please close https://github.com/rails/rails/pull/8991, I accidentally sent the first version of this pull request to master instead of 3-0-stable
