### PR TITLE
[Plugin template] Instead of $:.push  use $LOAD_PATH in Gemspec template

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
@@ -1,4 +1,4 @@
-$:.push File.expand_path("../lib", __FILE__)
+$LOAD_PATH << File.expand_path("../lib", __FILE__)
 
 # Maintain your gem's version:
 require "<%= name %>/version"


### PR DESCRIPTION
Following change in Gemspec template:

**Before**
`$:.push File.expand_path("../lib", __FILE__)`

**After**
`$LOAD_PATH << File.expand_path("../lib", __FILE__)`

`$LOAD_PATH << File.expand_path ...` does the same thing as `$:.push` and looks a bit less obfuscated & the intent is more clear, IMHO.
