### PR TITLE
Raise or log unpermitted params.

### DIFF
--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -21,21 +21,24 @@ module ActionController
 
     initializer "action_controller.parameters_config" do |app|
       ActionController::Parameters.permit_all_parameters = app.config.action_controller.delete(:permit_all_parameters) { false }
+      ActionController::Parameters.action_on_unpermitted = app.config.action_controller.action_on_unpermitted_params
     end
 
     initializer "action_controller.set_configs" do |app|
       paths   = app.config.paths
       options = app.config.action_controller
 
-      options.logger               ||= Rails.logger
-      options.cache_store          ||= Rails.cache
+      options.logger                        ||= Rails.logger
+      options.cache_store                   ||= Rails.cache
 
-      options.javascripts_dir      ||= paths["public/javascripts"].first
-      options.stylesheets_dir      ||= paths["public/stylesheets"].first
+      options.javascripts_dir               ||= paths["public/javascripts"].first
+      options.stylesheets_dir               ||= paths["public/stylesheets"].first
 
       # Ensure readers methods get compiled
-      options.asset_host           ||= app.config.asset_host
-      options.relative_url_root    ||= app.config.relative_url_root
+      options.asset_host                    ||= app.config.asset_host
+      options.relative_url_root             ||= app.config.relative_url_root
+
+      options.action_on_unpermitted_params  ||= (Rails.env.test? || Rails.env.development?) ? :log : false
 
       ActiveSupport.on_load(:action_controller) do
         include app.routes.mounted_helpers

--- a/actionpack/test/controller/parameters/log_on_unpermitted_params_test.rb
+++ b/actionpack/test/controller/parameters/log_on_unpermitted_params_test.rb
@@ -1,0 +1,50 @@
+require 'abstract_unit'
+require 'action_controller/metal/strong_parameters'
+
+class LogOnUnpermittedParamsTest < ActiveSupport::TestCase
+  def setup
+    ActionController::Parameters.action_on_unpermitted = :log
+  end
+
+  def teardown
+    ActionController::Parameters.action_on_unpermitted = false
+  end
+
+  test "logs on unexpected params" do
+    params = ActionController::Parameters.new({
+      book: { pages: 65 },
+      fishing: "Turnips"
+    })
+
+    assert_logged("Unpermitted parameters: fishing") do
+      params.permit(book: [:pages])
+    end
+  end
+
+  test "logs on unexpected nested params" do
+    params = ActionController::Parameters.new({
+      book: { pages: 65, title: "Green Cats and where to find then." }
+    })
+
+    assert_logged("Unpermitted parameters: title") do
+      params.permit(book: [:pages])
+    end
+  end
+
+  private
+
+  def assert_logged(message)
+    old_logger = ActionController::Base.logger
+    log = StringIO.new
+    ActionController::Base.logger = Logger.new(log)
+
+    begin
+      yield
+
+      log.rewind
+      assert_match message, log.read
+    ensure
+      ActionController::Base.logger = old_logger
+    end
+  end
+end

--- a/actionpack/test/controller/parameters/raise_on_unpermitted_params_test.rb
+++ b/actionpack/test/controller/parameters/raise_on_unpermitted_params_test.rb
@@ -1,0 +1,33 @@
+require 'abstract_unit'
+require 'action_controller/metal/strong_parameters'
+
+class RaiseOnUnpermittedParamsTest < ActiveSupport::TestCase
+  def setup
+    ActionController::Parameters.action_on_unpermitted = :raise
+  end
+
+  def teardown
+    ActionController::Parameters.action_on_unpermitted = false
+  end
+
+  test "raises on unexpected params" do
+    params = ActionController::Parameters.new({
+      book: { pages: 65 },
+      fishing: "Turnips"
+    })
+
+    assert_raises(ActionController::UnexpectedParameters) do
+      params.permit(book: [:pages])
+    end
+  end
+
+  test "raises on unexpected nested params" do
+    params = ActionController::Parameters.new({
+      book: { pages: 65, title: "Green Cats and where to find then." }
+    })
+
+    assert_raises(ActionController::UnexpectedParameters) do
+      params.permit(book: [:pages])
+    end
+  end
+end


### PR DESCRIPTION
For context see: https://github.com/rails/strong_parameters/pull/75#issuecomment-12255994
- Developers can choose to log or raise on unpermitted parameters.
- Default is to log in test and development, otherwise do nothing.

To enable the exception:

``` ruby
config.action_controller.action_on_unpermitted_params = :raise
```

This is ultimately in response to: https://github.com/rails/strong_parameters/issues/66

I will port this work over to https://github.com/rails/strong_parameters once discussion here is complete.
