### PR TITLE
AR integration tests for form helpers

### DIFF
--- a/actionpack/test/activerecord/form_helper_activerecord_test.rb
+++ b/actionpack/test/activerecord/form_helper_activerecord_test.rb
@@ -1,0 +1,91 @@
+require 'active_record_unit'
+require 'fixtures/project'
+require 'fixtures/developer'
+
+class FormHelperActiveRecordTest < ActionView::TestCase
+  tests ActionView::Helpers::FormHelper
+
+  def form_for(*)
+    @output_buffer = super
+  end
+
+  def setup
+    @developer = Developer.new
+    @developer.id   = 123
+    @developer.name = "developer #123"
+
+    @project = Project.new
+    @project.id   = 321
+    @project.name = "project #321"
+    @project.save
+
+    @developer.projects << @project
+    @developer.save
+  end
+
+  def teardown
+    Project.delete(321)
+    Developer.delete(123)
+  end
+
+  Routes = ActionDispatch::Routing::RouteSet.new
+  Routes.draw do
+    resources :developers do
+      resources :projects
+    end
+  end
+
+  def _routes
+    Routes
+  end
+
+  include Routes.url_helpers
+
+  def test_nested_fields_for_with_child_index_option_override_on_a_nested_attributes_collection_association
+    form_for(@developer) do |f|
+      concat f.fields_for(:projects, @developer.projects.first, :child_index => 'abc') { |cf|
+        concat cf.text_field(:name)
+      }
+    end
+
+    expected = whole_form('/developers/123', 'edit_developer_123', 'edit_developer', :method => 'patch') do
+      '<input id="developer_projects_attributes_abc_name" name="developer[projects_attributes][abc][name]" type="text" value="project #321" />' +
+          '<input id="developer_projects_attributes_abc_id" name="developer[projects_attributes][abc][id]" type="hidden" value="321" />'
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  protected
+
+  def hidden_fields(method = nil)
+    txt =  %{<div style="margin:0;padding:0;display:inline">}
+    txt << %{<input name="utf8" type="hidden" value="&#x2713;" />}
+    if method && !%w(get post).include?(method.to_s)
+      txt << %{<input name="_method" type="hidden" value="#{method}" />}
+    end
+    txt << %{</div>}
+  end
+
+  def form_text(action = "/", id = nil, html_class = nil, remote = nil, multipart = nil, method = nil)
+    txt =  %{<form accept-charset="UTF-8" action="#{action}"}
+    txt << %{ enctype="multipart/form-data"} if multipart
+    txt << %{ data-remote="true"} if remote
+    txt << %{ class="#{html_class}"} if html_class
+    txt << %{ id="#{id}"} if id
+    method = method.to_s == "get" ? "get" : "post"
+    txt << %{ method="#{method}">}
+  end
+
+  def whole_form(action = "/", id = nil, html_class = nil, options = nil)
+    contents = block_given? ? yield : ""
+
+    if options.is_a?(Hash)
+      method, remote, multipart = options.values_at(:method, :remote, :multipart)
+    else
+      method = options
+    end
+
+    form_text(action, id, html_class, remote, multipart, method) + hidden_fields(method) + contents + "</form>"
+  end
+end

--- a/actionpack/test/fixtures/developer.rb
+++ b/actionpack/test/fixtures/developer.rb
@@ -2,6 +2,7 @@ class Developer < ActiveRecord::Base
   has_and_belongs_to_many :projects
   has_many :replies
   has_many :topics, :through => :replies
+  accepts_nested_attributes_for :projects
 end
 
 class DeVeLoPeR < ActiveRecord::Base


### PR DESCRIPTION
As suggested in #8623, I'm adding AR integration tests for form helpers. This will ensure they won't break if the AR interface is updated later.
Please review the code. If it's alright, I'll add a few more tests and fixes to the pull request.
