### PR TITLE
Fix asset_path in mounted engine

### DIFF
--- a/actionpack/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionpack/lib/action_view/helpers/asset_url_helper.rb
@@ -132,8 +132,7 @@ module ActionView
           source = compute_asset_path(source, options)
         end
 
-        relative_url_root = (defined?(config.relative_url_root) && config.relative_url_root) ||
-          (respond_to?(:request) && request.try(:script_name))
+        relative_url_root = defined?(config.relative_url_root) && config.relative_url_root
         if relative_url_root
           source = "#{relative_url_root}#{source}" unless source.starts_with?("#{relative_url_root}/")
         end

--- a/railties/test/railties/mounted_engine_test.rb
+++ b/railties/test/railties/mounted_engine_test.rb
@@ -89,6 +89,7 @@ module ApplicationTests
           get '/generate_application_route', to: 'posts#generate_application_route'
           get '/application_route_in_view', to: 'posts#application_route_in_view'
           get '/engine_polymorphic_path', to: 'posts#engine_polymorphic_path'
+          get '/engine_asset_path', to: 'posts#engine_asset_path'
         end
       RUBY
 
@@ -112,6 +113,10 @@ module ApplicationTests
 
             def engine_polymorphic_path
               render text: polymorphic_path(Post.new)
+            end
+
+            def engine_asset_path
+              render inline: "<%= asset_path 'images/foo.png' %>"
             end
           end
         end
@@ -211,6 +216,10 @@ module ApplicationTests
       # and in an application
       get "/application_polymorphic_path"
       assert_equal "/posts/44", last_response.body
+
+      # test that asset path will not get script_name when generated in the engine
+      get "/someone/blog/engine_asset_path"
+      assert_equal "/images/foo.png", last_response.body
     end
 
     test "route path for controller action when engine is mounted at root" do


### PR DESCRIPTION
This is my solution for #8119, more in commit message:

```
Historically serving assets from a mountable engine could be achieved by
running ActionDispatch::Static as a part of engine middleware stack or
to copy assets prefixed with an engine name. After introduction of
assets pipeline this is not needed as all of the assets are served or
compiled into main application's assets.

This commit removes the obsolete line making asset_path always generate
paths relative to the root or config.relative_url_root if it's set.

(closes #8119)
```
