### PR TITLE
Additional tests and fixes for form helpers to support new CollectionProxy

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -421,9 +421,10 @@ module ActionView
           object_name = record
           object      = nil
         else
-          object      = record.is_a?(Array) ? record.last : record
+          object      = record.respond_to?(:to_ary) ? record.last : record
           raise ArgumentError, "First argument in form cannot contain nil or be empty" unless object
           object_name = options[:as] || model_name_from_record_or_class(object).param_key
+          record = record.respond_to?(:to_ary) ? record.to_ary : record
           apply_form_for_options!(record, object, options)
         end
 
@@ -1485,7 +1486,7 @@ module ActionView
             return fields_for_with_nested_attributes(record_name, record_object, fields_options, block)
           end
         else
-          record_object = record_name.is_a?(Array) ? record_name.last : record_name
+          record_object = record_name.respond_to?(:to_ary) ? record_name.last : record_name
           record_name   = model_name_from_record_or_class(record_object).param_key
         end
 

--- a/actionpack/test/activerecord/form_helper_activerecord_test.rb
+++ b/actionpack/test/activerecord/form_helper_activerecord_test.rb
@@ -41,6 +41,18 @@ class FormHelperActiveRecordTest < ActionView::TestCase
 
   include Routes.url_helpers
 
+  def test_form_for_with_collection
+    form_for(Developer.all) do |f|
+      concat f.text_field(:name)
+    end
+
+    expected = whole_form('/developers/123', 'edit_developer_123', 'edit_developer', :method => 'patch') do
+      '<input id="developer_name" name="developer[name]" type="text" value="developer #123" />'
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_nested_fields_for_with_child_index_option_override_on_a_nested_attributes_collection_association
     form_for(@developer) do |f|
       concat f.fields_for(:projects, @developer.projects.first, :child_index => 'abc') { |cf|
@@ -51,6 +63,20 @@ class FormHelperActiveRecordTest < ActionView::TestCase
     expected = whole_form('/developers/123', 'edit_developer_123', 'edit_developer', :method => 'patch') do
       '<input id="developer_projects_attributes_abc_name" name="developer[projects_attributes][abc][name]" type="text" value="project #321" />' +
           '<input id="developer_projects_attributes_abc_id" name="developer[projects_attributes][abc][id]" type="hidden" value="321" />'
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_nested_fields_for_with_collection_on_a_nested_attributes_collection_association
+    form_for(@developer) do |f|
+      concat f.fields_for(@developer.projects, @developer.projects.first) { |cf|
+        concat cf.text_field(:name)
+      }
+    end
+
+    expected = whole_form('/developers/123', 'edit_developer_123', 'edit_developer', :method => 'patch') do
+      '<input id="developer_project_name" name="developer[project][name]" type="text" value="project #321" />'
     end
 
     assert_dom_equal expected, output_buffer


### PR DESCRIPTION
Another pair of tests and fixes for form helpers to ensure they won't break on new CollectionProxy and behave the same way they did in Rails 3.
See #8623 and #9014
