### PR TITLE
ParamsParser calls rewind on rack.input if needed

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/params_parser.rb
+++ b/actionpack/lib/action_dispatch/middleware/params_parser.rb
@@ -47,10 +47,11 @@ module ActionDispatch
         when Proc
           strategy.call(request.raw_post)
         when :xml_simple, :xml_node
-          data = request.deep_munge(Hash.from_xml(request.body.read) || {})
+          data = request.deep_munge(Hash.from_xml(request.raw_post) || {})
           data.with_indifferent_access
         when :json
           data = ActiveSupport::JSON.decode(request.body)
+          request.body.rewind if request.body.respond_to? :rewind
           data = {:_json => data} unless data.is_a?(Hash)
           request.deep_munge(data).with_indifferent_access
         else

--- a/actionpack/test/dispatch/request/rack_input_rewind_test.rb
+++ b/actionpack/test/dispatch/request/rack_input_rewind_test.rb
@@ -1,0 +1,25 @@
+require 'abstract_unit'
+
+class RackInputRewindTest < ActionDispatch::IntegrationTest
+  class InputReader
+    def call(env)
+      result = env['rack.input'].read
+      [200, {"Content-Type" => "text/plain"}, [result]]
+    end
+  end
+
+  test "request.body is rewound if while parsing XML parameters" do
+    req = Rack::MockRequest.new(ActionDispatch::ParamsParser.new(InputReader.new))
+    input = "<foo>bar</foo>"
+    resp = req.post('/', "CONTENT_TYPE" => "application/xml", :input => input)
+    assert !resp.body.empty?, "rack.input was not rewound properly by ParamsParser middleware"
+  end
+
+  test "request.body is rewound while parsing JSONparameters" do
+    req = Rack::MockRequest.new(ActionDispatch::ParamsParser.new(InputReader.new))
+    input = "{\"person\": {\"name\": \"David\"}}"
+    resp = req.post('/', "CONTENT_TYPE" => "application/json", :input => input )
+    assert !resp.body.empty?, "rack.input was not rewound properly by ParamsParser middleware"
+  end
+
+end


### PR DESCRIPTION
There was a lot of churn in the ParamsParser while fixing CVE-2013-0156
This attempts to restore intended functionality as faithfully as can be
from 3957d44 for JSON and e1a0d86 for XML.

Also added is a integration test RackInputRewindTest which checks to
make sure that ParamsParser rewinds rack.input for both cases.

In some cases request.body can be [rack.input](https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/http/request.rb#L226), so if ParamsParser doesn't rewind it unexpected things can happen. See rails#8490

I encountered this trying to get the better_errors gem working in Rails 4. 
I've created a test app here: https://github.com/ethansr/rack_input to show [better_errors](https://github.com/charliesome/better_errors/blob/master/lib/better_errors/middleware.rb#L113) failing because it expects the env['rack.input'] StringIO to be at its start.

If the app is working correctly a stack trace will appear on the right side. If it isn't then a strack trace similar to this: https://gist.github.com/4591803 will appear in the logs.

I realize this is sensitive file to touch right now and would appreciate any feedback. 
