### PR TITLE
Remove unnecessary require

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/bundle
+++ b/railties/lib/rails/generators/rails/app/templates/bin/bundle
@@ -1,3 +1,2 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
-require 'rubygems'
 load Gem.bin_path('bundler', 'bundle')


### PR DESCRIPTION
`require 'rubygems'` is already required in Ruby 1.9 or later.
