### PR TITLE
Revert locale

### DIFF
--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -13,6 +13,20 @@ module ActiveSupport
       end
     end
 
+    # Sets the default value for Time.zone
+    # If assigned value cannot be matched to a TimeZone, an exception will be raised.
+    initializer "active_support.initialize_time_zone" do |app|
+      require 'active_support/core_ext/time/zones'
+      zone_default = Time.find_zone!(app.config.time_zone)
+
+      unless zone_default
+        raise 'Value assigned to config.time_zone not recognized. ' \
+          'Run "rake -D time" for a list of tasks for finding appropriate time zone names.'
+      end
+
+      Time.zone_default = zone_default
+    end
+
     # Sets the default week start
     # If assigned value is not a valid day symbol (e.g. :sunday, :monday, ...), an exception will be raised.
     initializer "active_support.initialize_beginning_of_week" do |app|
@@ -28,21 +42,5 @@ module ActiveSupport
         ActiveSupport.send(k, v) if ActiveSupport.respond_to? k
       end
     end
-
-    # Sets the default value for Time.zone after initialization since the default configuration
-    # lives in application initializers.
-    # If assigned value cannot be matched to a TimeZone, an exception will be raised.
-    config.after_initialize do |app|
-      require 'active_support/core_ext/time/zones'
-      zone_default = Time.find_zone!(app.config.time_zone)
-
-      unless zone_default
-        raise 'Value assigned to config.time_zone not recognized. ' \
-          'Run "rake -D time" for a list of tasks for finding appropriate time zone names.'
-      end
-
-      Time.zone_default = zone_default
-    end
-
   end
 end

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -102,7 +102,7 @@ The **translations load path** (`I18n.load_path`) is just a Ruby Array of paths 
 
 NOTE: The backend will lazy-load these translations when a translation is looked up for the first time. This makes it possible to just swap the backend with something else even after translations have already been announced.
 
-The default initializer `locale.rb` file has instructions on how to add locales from another directory and how to set a different default locale. Just uncomment and edit the specific lines.
+The default `application.rb` files has instructions on how to add locales from another directory and how to set a different default locale. Just uncomment and edit the specific lines.
 
 ```ruby
 # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -22,6 +22,14 @@ module <%= app_const_base %>
 
     # Custom directories with classes and modules you want to be autoloadable.
     # config.autoload_paths += %W(#{config.root}/extras)
+
+    # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
+    # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
+    # config.time_zone = 'Central Time (US & Canada)'
+
+    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
+    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
+    # config.i18n.default_locale = :de
 <% if options.skip_sprockets? -%>
 
     # Disable the asset pipeline.

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/locale.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/locale.rb
@@ -1,9 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
-# Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-# Rails.application.config.time_zone = 'Central Time (US & Canada)'
-
-# The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-# Rails.application.config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-# Rails.application.config.i18n.default_locale = :de

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -417,17 +417,7 @@ module ApplicationTests
 
       require "#{app_path}/config/environment"
 
-      assert_equal Time.find_zone!("Wellington"), Time.zone_default
-    end
-
-    test "timezone can be set on initializers" do
-      app_file "config/initializers/locale.rb", <<-RUBY
-        Rails.application.config.time_zone = "Central Time (US & Canada)"
-      RUBY
-
-      require "#{app_path}/config/environment"
-
-      assert_equal Time.find_zone!("Central Time (US & Canada)"), Time.zone_default
+      assert_equal "Wellington", Rails.application.config.time_zone
     end
 
     test "raises when an invalid timezone is defined in the config" do


### PR DESCRIPTION
Setting the `Time.zone` in an `after_initialize` block can become a problem for people upgrading, since it's not going to be available when `config/initializers` run, and people might be relying on it.

An example that I noticed was with the [Chronic gem](https://github.com/mojombo/chronic), for date/time parsing. It requires us [to configure the time class to be Time.zone](https://github.com/mojombo/chronic#time-zones), and doing that in an initializer no longer worked with these changes.

Example code in `config/initializers/chronic.rb`:

``` ruby
Chronic.time_class = Time.zone
```

I had to change to this to make it work with the locale change:

``` ruby
Rails.configuration.after_initialize do
  Chronic.time_class = Time.zone
end
```

Even though I think it'd be good to move the locale options, I don't think this change should affect people relying on the current behavior, so it seems safer to revert now.

_I'm sending as a pull request to get some feedback from @steveklabnik and @rafaelfranca, to check if I'm not forgetting to revert anything else_.
