### PR TITLE
Add .gemspec files to 2-3-stable to help Bundler

### DIFF
--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -1,0 +1,14 @@
+Gem::Specification.new do |s|
+  s.name = 'actionmailer'
+  s.version = '2.3.15'
+  s.summary = 'Service layer for easy email delivery and testing.'
+  s.description = 'Makes it trivial to test and deliver emails sent from a single service layer.'
+
+  s.author = 'David Heinemeier Hansson'
+  s.email = 'david@loudthinking.com'
+  s.homepage = 'http://www.rubyonrails.org'
+
+  s.require_path = 'lib'
+
+  s.add_dependency 'actionpack', '= 2.3.15'
+end

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -1,0 +1,15 @@
+Gem::Specification.new do |s|
+  s.name = 'actionpack'
+  s.version = '2.3.15'
+  s.summary = 'Web-flow and rendering framework putting the VC in MVC.'
+  s.description = 'Eases web-request routing, handling, and response as a half-way front, half-way page controller. Implemented with specific emphasis on enabling easy unit/integration testing that doesn\'t require a browser.'
+
+  s.author = 'David Heinemeier Hansson'
+  s.email = 'david@loudthinking.com'
+  s.homepage = 'http://www.rubyonrails.org'
+
+  s.require_path = 'lib'
+
+  s.add_dependency 'activesupport', '= 2.3.15'
+  s.add_dependency 'rack', '~> 1.1.0'
+end

--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -1,0 +1,17 @@
+Gem::Specification.new do |s|
+  s.name = 'activerecord'
+  s.version = '2.3.15'
+  s.summary = 'Implements the ActiveRecord pattern for ORM.'
+  s.description = 'Implements the ActiveRecord pattern (Fowler, PoEAA) for ORM. It ties database tables and classes together for business objects, like Customer or Subscription, that can find, save, and destroy themselves without resorting to manual SQL.'
+
+  s.author = 'David Heinemeier Hansson'
+  s.email = 'david@loudthinking.com'
+  s.homepage = 'http://www.rubyonrails.org'
+
+  s.require_path = 'lib'
+  s.files = ['README']
+  s.rdoc_options = ['--main', 'README']
+  s.extra_rdoc_files = ['README']
+
+  s.add_dependency 'activesupport', '= 2.3.15'
+end

--- a/activeresource/activeresource.gemspec
+++ b/activeresource/activeresource.gemspec
@@ -1,0 +1,17 @@
+Gem::Specification.new do |s|
+  s.name = 'activeresource'
+  s.version = '2.3.15'
+  s.summary = 'Think Active Record for web resources.'
+  s.description = 'Wraps web resources in model classes that can be manipulated through XML over REST.'
+
+  s.author = 'David Heinemeier Hansson'
+  s.email = 'david@loudthinking.com'
+  s.homepage = 'http://www.rubyonrails.org'
+
+  s.require_path = 'lib'
+  s.files = ['README']
+  s.rdoc_options = ['--main', 'README']
+  s.extra_rdoc_files = ['README']
+
+  s.add_dependency 'activesupport', '= 2.3.15'
+end

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -1,0 +1,12 @@
+Gem::Specification.new do |s|
+  s.name = 'activesupport'
+  s.version = '2.3.15'
+  s.summary = 'Support and utility classes used by the Rails framework.'
+  s.description = 'Utility library which carries commonly used classes and goodies from the Rails framework'
+
+  s.author = 'David Heinemeier Hansson'
+  s.email = 'david@loudthinking.com'
+  s.homepage = 'http://www.rubyonrails.org'
+
+  s.require_path = 'lib'
+end

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -1,0 +1,22 @@
+Gem::Specification.new do |s|
+  s.name = 'rails'
+  s.version = '2.3.15'
+  s.summary = 'Web-application framework with template engine, control-flow layer, and ORM.'
+  s.description = "Rails is a framework for building web-application using CGI, FCGI, mod_ruby, or WEBrick\non top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle with eRuby- or Builder-based templates."
+
+  s.author = 'David Heinemeier Hansson'
+  s.email = 'david@loudthinking.com'
+  s.homepage = 'http://www.rubyonrails.org'
+
+  s.require_path = 'lib'
+  s.files = ['bin/rails']
+  s.executables = ['rails']
+  s.rdoc_options = ['--exclude', '.']
+
+  s.add_dependency 'rake',           '>= 0.8.3'
+  s.add_dependency 'activesupport',  '= 2.3.15'
+  s.add_dependency 'activerecord',   '= 2.3.15'
+  s.add_dependency 'actionpack',     '= 2.3.15'
+  s.add_dependency 'actionmailer',   '= 2.3.15'
+  s.add_dependency 'activeresource', '= 2.3.15'
+end


### PR DESCRIPTION
Would you please consider including gemspec files in the 2-3-stable branch? This would help folks with ancient 2.3 apps by allowing them to use Bundler without requiring new official gem releases. 

Or, would it be better for folks to maintain a separate 2.3 fork?

This is related to [pull request 8948](https://github.com/rails/rails/pull/8948)
