### PR TITLE
Make HEAD work / convert to GET once more

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -162,11 +162,11 @@ module ActionController #:nodoc:
 
       # Returns true or false if a request is verified. Checks:
       #
-      # * is it a GET request?  Gets should be safe and idempotent
+      # * is it a GET or HEAD request?  Gets should be safe and idempotent
       # * Does the form_authenticity_token match the given token value from the params?
       # * Does the X-CSRF-Token header match the form_authenticity_token
       def verified_request?
-        !protect_against_forgery? || request.get? ||
+        !protect_against_forgery? || request.get? || request.head? ||
           form_authenticity_token == params[request_forgery_protection_token] ||
           form_authenticity_token == request.headers['X-CSRF-Token']
       end

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -170,6 +170,10 @@ module RequestForgeryProtectionTests
     assert_not_blocked { get :index }
   end
 
+  def test_should_allow_head
+    assert_not_blocked { head :index }
+  end
+
   def test_should_allow_post_without_token_on_unsafe_action
     assert_not_blocked { post :unsafe }
   end


### PR DESCRIPTION
While testing a Rails 4 app in semi-production, I noticed that CSRF protection threw exceptions on HEAD requests by crawler bots.

TL;DR: Shall I make a pull request that adds support for a HEAD request in the csrf protection code? Should we find a way to convert HEAD -> GET just like in Rails <4.

After discovering, I read in the CHANGELOG that `ActionDispatch::Head` was replaced in favor of `Rack::Head` by  Santiago Pastorino. `ActionDispatch::Head` converted a HEAD to a GET request like so:

``` ruby
    def call(env)
      if env["REQUEST_METHOD"] == "HEAD"
        env["REQUEST_METHOD"] = "GET"
        env["rack.methodoverride.original_method"] = "HEAD"
        status, headers, _ = @app.call(env)
        [status, headers, []]
      else
        @app.call(env)
      end
    end
```

However. `Rack::Head` middleware does not do this HEAD -> GET conversion in https://github.com/rack/rack/blob/master/lib/rack/head.rb.

``` ruby
    if env["REQUEST_METHOD"] == "HEAD"
      body.close if body.respond_to? :close
      [status, headers, []]
    else
      [status, headers, body]
    end
```

We could easily add a `request.head?` in `valid_request?` to support this. But somehow I feel there are more reasons and code that depends on HEAD requests being converted to GETs.

Added a failing test for now.
