### PR TITLE
ruby constant syntax is not supported as routing `:controller` option.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   We don't support the `:controller` option for route definitions
+    with the ruby constant notation. This will now result in an
+    `ArgumentError`.
+
+    Example:
+            # This raises an ArgumentError:
+            resources :posts, :controller => "Admin::Posts"
+
+            # Use directory notation instead:
+            resources :posts, :controller => "admin/posts"
+
+    *Yves Senn*
+
 *   `assert_template` can be used to verify the locals of partials,
     which live inside a directory.
     Fixes #8516.

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -246,6 +246,12 @@ module ActionDispatch
                 raise ArgumentError, "missing :action"
               end
 
+              if controller.is_a?(String) && controller !~ /\A[a-z_\/]+\z/
+                message = "'#{controller}' is not a supported controller name. This can lead to potential routing problems."
+                message << " See http://guides.rubyonrails.org/routing.html#specifying-a-controller-to-use"
+                raise ArgumentError, message
+              end
+
               hash = {}
               hash[:controller] = controller unless controller.blank?
               hash[:action]     = action unless action.blank?

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -832,6 +832,19 @@ will recognize incoming paths beginning with `/photos` but route to the `Images`
 
 NOTE: Use `photos_path`, `new_photo_path`, etc. to generate paths for this resource.
 
+For namespaced controllers you can use the directory notation. For example:
+
+```ruby
+resources :user_permissions, controller: 'admin/user_permissions'
+```
+
+This will route to the `Admin::UserPermissions` controller.
+
+NOTE: Only the directory notation is supported. specifying the
+controller with ruby constant notation (eg. `:controller =>
+'Admin::UserPermissions'`) can lead to routing problems and results in
+a warning.
+
 ### Specifying Constraints
 
 You can use the `:constraints` option to specify a required format on the implicit `id`. For example:


### PR DESCRIPTION
The current implementation only works correctly if you supply the `:controller` with directory notation (eg. `:controller => 'admin/posts'`).

The ruby constant notation (eg. `:controller => 'Admin::Posts`) leads to unexpected problems with `url_for`.

This patch prints a warning for every non supported `:controller` option. I also added documentation how to work with namespaced controllers. The warning links to that documentation in the rails guide.
