### PR TITLE
Convert int, float, and bools from ENV['DATABASE_URL'] query args

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   The DATABASE_URL environment variable now converts ints, floats, and
+    the strings true and false to Ruby types. For example, SQLite requires
+    that the timeout value is an integer, and PostgreSQL requires that the
+    prepared_statements option is a boolean. These now work as expected:
+
+    Example:
+
+        DATABASE_URL=sqlite3://localhost/test_db?timeout=500
+        DATABASE_URL=postgresql://localhost/test_db?prepared_statements=false
+
+    *Aaron Stone*
+
 *   Relation#merge now only overwrites where values on the LHS of the
     merge. Consider:
 

--- a/activerecord/test/cases/connection_specification/resolver_test.rb
+++ b/activerecord/test/cases/connection_specification/resolver_test.rb
@@ -8,40 +8,66 @@ module ActiveRecord
           Resolver.new(spec, {}).spec.config
         end
 
+        def test_url_invalid_adapter
+          assert_raises(LoadError) do
+            resolve 'ridiculous://foo?encoding=utf8'
+          end
+        end
+
+        # The abstract adapter is used simply to bypass the bit of code that
+        # checks that the adapter file can be required in.
+
         def test_url_host_no_db
-          skip "only if mysql is available" unless current_adapter?(:MysqlAdapter, :Mysql2Adapter)
-          spec = resolve 'mysql://foo?encoding=utf8'
+          spec = resolve 'abstract://foo?encoding=utf8'
           assert_equal({
-            :adapter  => "mysql",
+            :adapter  => "abstract",
             :host     => "foo",
             :encoding => "utf8" }, spec)
         end
 
         def test_url_host_db
-          skip "only if mysql is available" unless current_adapter?(:MysqlAdapter, :Mysql2Adapter)
-          spec = resolve 'mysql://foo/bar?encoding=utf8'
+          spec = resolve 'abstract://foo/bar?encoding=utf8'
           assert_equal({
-            :adapter  => "mysql",
+            :adapter  => "abstract",
             :database => "bar",
             :host     => "foo",
             :encoding => "utf8" }, spec)
         end
 
         def test_url_port
-          skip "only if mysql is available" unless current_adapter?(:MysqlAdapter, :Mysql2Adapter)
-          spec = resolve 'mysql://foo:123?encoding=utf8'
+          spec = resolve 'abstract://foo:123?encoding=utf8'
           assert_equal({
-            :adapter  => "mysql",
+            :adapter  => "abstract",
             :port     => 123,
             :host     => "foo",
             :encoding => "utf8" }, spec)
         end
 
+        def test_url_query_numeric
+          spec = resolve 'abstract://foo:123?encoding=utf8&int=500&float=10.9'
+          assert_equal({
+            :adapter  => "abstract",
+            :port     => 123,
+            :int      => 500,
+            :float    => 10.9,
+            :host     => "foo",
+            :encoding => "utf8" }, spec)
+        end
+
+        def test_url_query_boolean
+          spec = resolve 'abstract://foo:123?true=true&false=false'
+          assert_equal({
+            :adapter  => "abstract",
+            :port     => 123,
+            :true     => true,
+            :false    => false,
+            :host     => "foo" }, spec)
+        end
+
         def test_encoded_password
-          skip "only if mysql is available" unless current_adapter?(:MysqlAdapter, :Mysql2Adapter)
           password = 'am@z1ng_p@ssw0rd#!'
           encoded_password = URI.encode_www_form_component(password)
-          spec = resolve "mysql://foo:#{encoded_password}@localhost/bar"
+          spec = resolve "abstract://foo:#{encoded_password}@localhost/bar"
           assert_equal password, spec[:password]
         end
       end


### PR DESCRIPTION
Previous title: SQLite3 busy_timeout function requires an int argument

This resolves an exception seen when calling `rake db:create` with a DATABASE_URL and a timeout argument:

``` shell
DATABASE_URL="sqlite3://localhost/db/test.sqlite3?timeout=500&pool=5" bundle exec rake db:create
can't convert String into Integer
gems/activerecord-3.2.9/lib/active_record/connection_adapters/sqlite3_adapter.rb:31:in `busy_timeout'
...
Couldn't create database for {"adapter"=>"sqlite3", "timeout"=>"500", "database"=>"db/test.sqlite3", "host"=>"localhost", "pool"=>"5"}
```
