### PR TITLE
assigning '0.0' to a nullable numeric column does not make it dirty

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Assigning "0.0" to a nullable numeric column does not make it dirty.
+    Fix #9034.
+
+    Example:
+
+        product = Product.create price: 0.0
+        product.price = '0.0'
+        product.changed? # => false (this used to return true)
+        product.changes # => {} (this used to return { price: [0.0, 0.0] })
+
+    *Yves Senn*
+
 *   Added functionality to unscope relations in a relations chain. For
     instance, if you are passed in a chain of relations as follows:
 

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -107,7 +107,11 @@ module ActiveRecord
 
       def changes_from_zero_to_string?(old, value)
         # For columns with old 0 and value non-empty string
-        old == 0 && value.is_a?(String) && value.present? && value != '0'
+        old == 0 && value.is_a?(String) && value.present? && non_zero?(value)
+      end
+
+      def non_zero?(value)
+        value !~ /\A0+(\.0+)?\z/
       end
     end
   end

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -243,6 +243,21 @@ class DirtyTest < ActiveRecord::TestCase
     assert !pirate.changed?
   end
 
+  def test_float_zero_to_string_zero_not_marked_as_changed
+    data = NumericData.new :temperature => 0.0
+    data.save!
+
+    assert_not data.changed?
+
+    data.temperature = '0'
+    assert_empty data.changes
+
+    data.temperature = '0.0'
+    assert_empty data.changes
+
+    data.temperature = '0.00'
+    assert_empty data.changes
+  end
 
   def test_zero_to_blank_marked_as_changed
     pirate = Pirate.new


### PR DESCRIPTION
This is a fix for the issue described in #9034

It treats `'0.0'` the same way as `'0'`. This makes sure that nullable numeric column don't get changed when you assign `'0.0'`.

If it's ok, I'll backport that change, since the behavior was reported from `3.2.x`
