### PR TITLE
Backport: Fix pluck when columns/tables are reserved words.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 3.2.12 (unreleased) ##
 
+*   Fix `ActiveRecord::Relation#pluck` when columns or tables are reserved words.
+    Backport #7536.
+    Fix #8968.
+
+    *Ian Lesperance + Yves Senn + Kaspar Schiess*
+
 *   Don't run explain on slow queries for database adapters that don't support it.
     Backport #6197.
 

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -178,7 +178,7 @@ module ActiveRecord
     #
     def pluck(column_name)
       if column_name.is_a?(Symbol) && column_names.include?(column_name.to_s)
-        column_name = "#{table_name}.#{column_name}"
+        column_name = "#{connection.quote_table_name(table_name)}.#{connection.quote_column_name(column_name)}"
       else
         column_name = column_name.to_s
       end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -1,10 +1,11 @@
 require "cases/helper"
+require 'models/club'
 require 'models/company'
 require "models/contract"
-require 'models/topic'
 require 'models/edge'
-require 'models/club'
 require 'models/organization'
+require 'models/possession'
+require 'models/topic'
 
 Company.has_many :accounts
 
@@ -502,5 +503,11 @@ class CalculationsTest < ActiveRecord::TestCase
   def test_pluck_not_auto_table_name_prefix_if_column_joined
     Company.create!(:name => "test", :contracts => [Contract.new(:developer_id => 7)])
     assert_equal [7], Company.joins(:contracts).pluck(:developer_id).map(&:to_i)
+  end
+
+  def test_pluck_with_reserved_words
+    Possession.create!(:where => "Over There")
+
+    assert_equal ["Over There"], Possession.pluck(:where)
   end
 end

--- a/activerecord/test/models/possession.rb
+++ b/activerecord/test/models/possession.rb
@@ -1,0 +1,3 @@
+class Possession < ActiveRecord::Base
+  self.table_name = 'having'
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -281,6 +281,10 @@ ActiveRecord::Schema.define do
     t.string :info
   end
 
+  create_table :having, :force => true do |t|
+    t.string :where
+  end
+
   create_table :guids, :force => true do |t|
     t.column :key, :string
   end


### PR DESCRIPTION
Backport #7536 to fix #8968.

Conflicts:

```
activerecord/CHANGELOG.md
activerecord/lib/active_record/relation/calculations.rb
```

The code was slightly different than the one on master but I think its safe to apply this backport.
