### PR TITLE
Add a `:subject_interpolations` option to `ActionMailer::Base#mail`

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,6 +1,23 @@
 ## Rails 4.0.0 (unreleased) ##
 
-*   Eager loading made to use relation's in_clause_length instead of host's one.
+*   Allow passing interpolations to `#default_i18n_subject`, e.g.:
+
+        # config/locales/en.yml
+        en:
+          user_mailer:
+            welcome:
+              subject: 'Hello, %{username}'
+
+        # app/mailers/user_mailer.rb
+        class UserMailer < ActionMailer::Base
+          def welcome(user)
+            mail(subject: default_i18n_subject(username: user.name))
+          end
+        end
+
+    *Olek Janiszewski*
+
+*   Eager loading made to use relation's `in_clause_length` instead of host's one.
     Fix #8474
 
     *Boris Staal*

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -726,9 +726,10 @@ module ActionMailer
     # Translates the +subject+ using Rails I18n class under <tt>[mailer_scope, action_name]</tt> scope.
     # If it does not find a translation for the +subject+ under the specified scope it will default to a
     # humanized version of the <tt>action_name</tt>.
-    def default_i18n_subject #:nodoc:
+    # If the subject has interpolations, you can pass them through the +interpolations+ parameter.
+    def default_i18n_subject(interpolations = {})
       mailer_scope = self.class.mailer_name.tr('/', '.')
-      I18n.t(:subject, scope: [mailer_scope, action_name], default: action_name.humanize)
+      I18n.t(:subject, interpolations.merge(scope: [mailer_scope, action_name], default: action_name.humanize))
     end
 
     def collect_responses(headers) #:nodoc:

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -209,6 +209,12 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal "New Subject!", email.subject
   end
 
+  test 'default subject can have interpolations' do
+    I18n.backend.store_translations('en', base_mailer: {with_subject_interpolations: {subject: 'Will the real %{rapper_or_impersonator} please stand up?'}})
+    email = BaseMailer.with_subject_interpolations
+    assert_equal 'Will the real Slim Shady please stand up?', email.subject
+  end
+
   test "translations are scoped properly" do
     I18n.backend.store_translations('en', base_mailer: {email_with_translations: {greet_user: "Hello %{name}!"}})
     email = BaseMailer.email_with_translations

--- a/actionmailer/test/mailers/base_mailer.rb
+++ b/actionmailer/test/mailers/base_mailer.rb
@@ -123,4 +123,8 @@ class BaseMailer < ActionMailer::Base
     mail(:template_name => "welcome")
     nil
   end
+
+  def with_subject_interpolations
+    mail(subject: default_i18n_subject(rapper_or_impersonator: 'Slim Shady'), body: '')
+  end
 end


### PR DESCRIPTION
It allows to have a properly scoped default I18n subject, but with interpolations, which
will be populated from the `:subject_interpolations` hash, e.g.:

```
# config/locales/en.yml
en:
  user_mailer:
    welcome:
      subject: 'Hello, %{username}'

# app/mailers/user_mailer.rb
class UserMailer < ActionMailer::Base
  def welcome(user)
    mail(subject_interpolations: {username: user.name})
  end
end
```

I was also thinking of not introducing a new option, but use the `:subject` option, but detect if it's a Hash, and if so, pass it as interpolations to the default i18n subject.

As usual, open for feedback.
