### PR TITLE
Fix content_tag_for with array :class option

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -8,12 +8,12 @@
 
     Before:
 
-        content_tag_for(:td, item, class: ["foo", "bar"]){}
+        content_tag_for(:td, item, class: ["foo", "bar"])
         #=> '<td class="item [&quot;foo&quot;, &quot;bar&quot;]" id="item_1"></td>'
 
     After:
 
-        content_tag_for(:td, item, class: ["foo", "bar"]){}
+        content_tag_for(:td, item, class: ["foo", "bar"])
         #=> '<td class="item foo bar" id="item_1"></td>'
 
     *Semyon Perepelitsa*

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,23 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix `content_tag_for` with array html option.
+    It would embed array as string instead of joining it like `content_tag` does:
+
+        content_tag(:td, class: ["foo", "bar"]){}
+        #=> '<td class="foo bar"></td>'
+
+    Before:
+
+        content_tag_for(:td, item, class: ["foo", "bar"]){}
+        #=> '<td class="item [&quot;foo&quot;, &quot;bar&quot;]" id="item_1"></td>'
+
+    After:
+
+        content_tag_for(:td, item, class: ["foo", "bar"]){}
+        #=> '<td class="item foo bar" id="item_1"></td>'
+
+    *Semyon Perepelitsa*
+
 *   Change asset_path to not include `SCRIPT_NAME` when it's used
     from a mounted engine (fixes #8119).
 

--- a/actionpack/lib/action_view/helpers/record_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/record_tag_helper.rb
@@ -92,7 +92,7 @@ module ActionView
         # for each record.
         def content_tag_for_single_record(tag_name, record, prefix, options, &block)
           options = options ? options.dup : {}
-          options[:class] = "#{dom_class(record, prefix)} #{options[:class]}".rstrip
+          options[:class] = [ dom_class(record, prefix), options[:class] ].compact
           options[:id]    = dom_id(record, prefix)
 
           if block_given?

--- a/actionpack/test/template/record_tag_helper_test.rb
+++ b/actionpack/test/template/record_tag_helper_test.rb
@@ -41,6 +41,12 @@ class RecordTagHelperTest < ActionView::TestCase
     assert_dom_equal expected, actual
   end
 
+  def test_content_tag_for_with_array_css_class
+    expected = %(<tr class="record_tag_post special odd" id="record_tag_post_45"></tr>)
+    actual = content_tag_for(:tr, @post, class: ["special", "odd"])
+    assert_dom_equal expected, actual
+  end
+
   def test_content_tag_for_with_prefix_and_extra_html_options
     expected = %(<tr class="archived_record_tag_post special" id="archived_record_tag_post_45" style='background-color: #f0f0f0'></tr>)
     actual = content_tag_for(:tr, @post, :archived, class: "special", style: "background-color: #f0f0f0")


### PR DESCRIPTION
It would embed array as string instead of joining it like content_tag does:

``` ruby
>> helper.content_tag(:td, class: ["foo", "bar"]){}
=> "<td class=\"foo bar\"></td>"
>> helper.content_tag_for(:td, item, class: ["foo", "bar"]){}
=> "<td class=\"item [&quot;foo&quot;, &quot;bar&quot;]\" id=\"item_1\"></td>"
=> "<td class=\"item foo bar\" id=\"item_1\"></td>"
```

Issue #9047
