### PR TITLE
if force_ssl filters a non html request, the url of redirection loses

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+* force_ssl adds the format of request to redirected url
+
+  *Angelo Capilleri*
+
 *   Fix incorrectly appended square brackets to a multiple select box
     if an explicit name has been given and it already ends with "[]"
 

--- a/actionpack/lib/action_controller/metal/force_ssl.rb
+++ b/actionpack/lib/action_controller/metal/force_ssl.rb
@@ -53,10 +53,19 @@ module ActionController
       unless request.ssl?
         redirect_options = {:protocol => 'https://', :status => :moved_permanently}
         redirect_options.merge!(:host => host) if host
+        redirect_options.merge!(:format => request.params['format']) if request_path_has_format?
         redirect_options.merge!(:params => request.query_parameters)
         flash.keep if respond_to?(:flash)
         redirect_to redirect_options
       end
     end
+
+    private
+
+      def request_path_has_format?
+        format = request.params['format']
+        Mime::Type.lookup_by_extension(format) &&
+        request.path =~ /\.#{format}/ && request.format.send("#{format}?")
+      end
   end
 end

--- a/actionpack/test/controller/force_ssl_test.rb
+++ b/actionpack/test/controller/force_ssl_test.rb
@@ -78,6 +78,25 @@ class ForceSSLControllerLevelTest < ActionController::TestCase
     assert_response 301
     assert_equal "https://test.host/force_ssl_controller_level/cheeseburger", redirect_to_url
   end
+
+  def test_cheeseburger_redirects_to_https_with_extra_format
+    get :cheeseburger, format: :json
+    assert_response 301
+    assert_equal "https://test.host/force_ssl_controller_level/cheeseburger.json", redirect_to_url
+  end
+
+  def test_cheeseburger_redirects_to_https_with_extra_invalid_format
+    get :cheeseburger, format: :rise
+    assert_response 301
+    assert_equal "https://test.host/force_ssl_controller_level/cheeseburger", redirect_to_url
+  end
+
+  def test_cheeseburger_redirects_to_https_with_html_format_on_url
+     get :cheeseburger, format: :html
+     assert_response 301
+     assert_equal "https://test.host/force_ssl_controller_level/cheeseburger.html", redirect_to_url
+   end
+
 end
 
 class ForceSSLCustomDomainTest < ActionController::TestCase


### PR DESCRIPTION
the format.

It happens because the format is not added to redirect_options.
This PR tests if the request is not a html request and than
looks up the format inside Mime::Type.
fixes #9061
