### PR TITLE
Fix TaggedLogging to allow loggers to be instantiated multiple times without having to share the stack of tags

### DIFF
--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -42,7 +42,9 @@ module ActiveSupport
       end
 
       def current_tags
-        Thread.current[:activesupport_tagged_logging_tags] ||= []
+        # We use our object ID here to void conflicting with other instances
+        thread_key = @thread_key ||= "activesupport_tagged_logging_tags:#{object_id}".freeze
+        Thread.current[thread_key] ||= []
       end
 
       private

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -79,6 +79,19 @@ class TaggedLoggingTest < ActiveSupport::TestCase
     assert_equal "[OMG] Cool story bro\n[BCX] Funky time\n", @output.string
   end
 
+  test "keeps each tag in their own instance" do
+    @other_output = StringIO.new
+    @other_logger = ActiveSupport::TaggedLogging.new(MyLogger.new(@other_output))
+    @logger.tagged("OMG") do
+      @other_logger.tagged("BCX") do
+        @logger.info "Cool story bro"
+        @other_logger.info "Funky time"
+      end
+    end
+    assert_equal "[OMG] Cool story bro\n", @output.string
+    assert_equal "[BCX] Funky time\n", @other_output.string
+  end
+
   test "cleans up the taggings on flush" do
     @logger.tagged("BCX") do
       Thread.new do


### PR DESCRIPTION
This is accomplished by using a unique key for the thread-local tag list. Fixes #9064.
