### PR TITLE
Reduced memory leak problem in transactions by lazily updating AR objects

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,27 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fixing issue #776.
+
+    Memory bloat in transactions is handled by having the transaction hold only
+    the AR objects which it absolutely needs to know about. These are the AR
+    objects with callbacks (they need to be updated as soon as something in the
+    transaction occurs).
+
+    All other AR objects can be updated lazily by keeping a reference to a
+    TransactionState object. If an AR object gets inside a transaction, then
+    the transaction will add its TransactionState to the AR object. When the
+    user makes a call to some attribute on an AR object (which has no
+    callbacks) associated with a transaction, the AR object will call the
+    sync_with_transaction_state method and make sure it is up to date with the
+    transaction. After it has synced with the transaction state, the AR object
+    will return the attribute that was requested.
+
+    Most of the logic in the changes are used to handle multiple transactions,
+    in which case the AR object has to recursively follow parent pointers of
+    TransactionState objects.
+
+    *John Wang*
+
 *   Descriptive error message when the necessary AR adapter gem was not found.
     Fix #7313
 

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -8,27 +8,32 @@ module ActiveRecord
       # Returns this record's primary key value wrapped in an Array if one is
       # available.
       def to_key
+        sync_with_transaction_state
         key = self.id
         [key] if key
       end
 
       # Returns the primary key value.
       def id
+        sync_with_transaction_state
         read_attribute(self.class.primary_key)
       end
 
       # Sets the primary key value.
       def id=(value)
+        sync_with_transaction_state
         write_attribute(self.class.primary_key, value) if self.class.primary_key
       end
 
       # Queries the primary key value.
       def id?
+        sync_with_transaction_state
         query_attribute(self.class.primary_key)
       end
 
       # Returns the primary key value before type cast.
       def id_before_type_cast
+        sync_with_transaction_state
         read_attribute_before_type_cast(self.class.primary_key)
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -5,7 +5,7 @@ module ActiveRecord
 
       def initialize(connection)
         @connection = connection
-        @state = TransactionState.new 
+        @state = TransactionState.new
       end
 
       def state
@@ -14,11 +14,13 @@ module ActiveRecord
     end
 
     class TransactionState
+      attr_accessor :parent
 
       VALID_STATES = Set.new([:committed, :rolledback, nil])
 
       def initialize(state = nil)
         @state = state
+        @parent = nil
       end
 
       def committed?
@@ -116,7 +118,11 @@ module ActiveRecord
       end
 
       def add_record(record)
-        records << record
+        if record.has_transactional_callbacks?
+          records << record
+        else
+          record.set_transaction_state(@state)
+        end
       end
 
       def rollback_records
@@ -188,8 +194,9 @@ module ActiveRecord
       end
 
       def perform_commit
+        @state.set_state(:committed)
+        @state.parent = parent.state
         connection.release_savepoint
-        records.each { |r| parent.add_record(r) }
       end
     end
   end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -69,11 +69,13 @@ module ActiveRecord
     # Returns true if this object hasn't been saved yet -- that is, a record
     # for the object doesn't exist in the data store yet; otherwise, returns false.
     def new_record?
+      sync_with_transaction_state
       @new_record
     end
 
     # Returns true if this object has been destroyed, otherwise returns false.
     def destroyed?
+      sync_with_transaction_state
       @destroyed
     end
 

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -460,7 +460,7 @@ class TransactionTest < ActiveRecord::TestCase
     assert !transaction.state.committed?
 
     transaction.perform_rollback
-    
+
     assert transaction.state.rolledback?
     assert !transaction.state.committed?
   end
@@ -474,7 +474,7 @@ class TransactionTest < ActiveRecord::TestCase
     assert !transaction.state.committed?
 
     transaction.perform_commit
-    
+
     assert !transaction.state.rolledback?
     assert transaction.state.committed?
   end


### PR DESCRIPTION
This pull request concerns Issue https://github.com/rails/rails/issues/776. 

I handle memory bloat by having the transaction hold only the AR objects which it absolutely needs to know about. These are the AR objects with callbacks (they need to be updated as soon as something in the transaction occurs). 

All other AR objects can be updated lazily by keeping a reference to a TransactionState object. If an AR object is inside a transaction, then the transaction will add its TransactionState to the AR object. When the user makes a call to some attribute on an AR object (which has no callbacks) associated with a transaction, the AR object will call the sync_with_transaction_state method and make sure it is up to date with the transaction. After it has synced with the transaction state, the AR object will return the attribute that was requested.

Most of the logic in the changes are used to handle multiple transactions, in which case the AR object has to recursively follow parent pointers of TransactionState objects. 
