### PR TITLE
Undefined abcs variable inside structure:dump task.

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -433,11 +433,11 @@ db_namespace = namespace :db do
       when 'sqlserver'
         `smoscript -s #{config['host']} -d #{config['database']} -u #{config['username']} -p #{config['password']} -f #{filename} -A -U`
       when "firebird"
-        set_firebird_env(abcs[Rails.env])
-        db_string = firebird_db_string(abcs[Rails.env])
+        set_firebird_env(config)
+        db_string = firebird_db_string(config)
         sh "isql -a #{db_string} > #{filename}"
       else
-        raise "Task not supported by '#{abcs[Rails.env]["adapter"]}'"
+        raise "Task not supported by '#{config['adapter']}'"
       end
 
       if ActiveRecord::Base.connection.supports_migrations?


### PR DESCRIPTION
By some reason inside `case firebird` and `else` blocks `abcs` variable is used. However this variable isn't defined anywhere inside this task. This variable was removed in this commit: https://github.com/rails/rails/commit/e7a6b92959012ffde730b2daa38ecd006570779c#L2L380
