### PR TITLE
Add `rails test` command to run the test suite

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1,8 +1,7 @@
 A Guide to Testing Rails Applications
 =====================================
 
-This guide covers built-in mechanisms offered by Rails to test your
-application.
+This guide covers built-in mechanisms in Rails for testing your application.
 
 After reading this guide, you will know:
 
@@ -234,7 +233,7 @@ Finished tests in 0.009262s, 107.9680 tests/s, 107.9680 assertions/s.
 1 tests, 1 assertions, 0 failures, 0 errors, 0 skips
 ```
 
-You can also run a particular test method from the test case by running the test and use the `-n` switch with the `test method name`.
+You can also run a particular test method from the test case by running the test and using `-n` switch with the `test method name`.
 
 ```bash
 $ rails test test/models/post_test.rb -n test_the_truth
@@ -245,7 +244,7 @@ Finished tests in 0.009064s, 110.3266 tests/s, 110.3266 assertions/s.
 1 tests, 1 assertions, 0 failures, 0 errors, 0 skips
 ```
 
-This will run all the test methods from the test case. Note that `test_helper.rb` is in the `test` directory, hence this directory needs to be added to the load path using the `-I` switch.
+This will run all test methods from the test case. Note that `test_helper.rb` is in the `test` directory, hence this directory needs to be added to the load path using the `-I` switch.
 
 The `.` (dot) above indicates a passing test. When a test fails you see an `F`; when a test throws an error you see an `E` in its place. The last line of the output is the summary.
 

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -38,7 +38,6 @@ Rails creates a `test` folder for you as soon as you create a Rails project usin
 
 ```bash
 $ ls -F test
-
 controllers/    helpers/        mailers/        test_helper.rb
 fixtures/       integration/    models/
 ```
@@ -235,13 +234,10 @@ Finished tests in 0.009262s, 107.9680 tests/s, 107.9680 assertions/s.
 1 tests, 1 assertions, 0 failures, 0 errors, 0 skips
 ```
 
-You can also run a particular test method from the test case by running the test using Ruby and use the `-n` switch with the `test method name`.
+You can also run a particular test method from the test case by running the test and use the `-n` switch with the `test method name`.
 
 ```bash
-Run options: -n test_the_truth --seed 23064
-
-# Running tests:
-
+$ rails test test/models/post_test.rb -n test_the_truth
 .
 
 Finished tests in 0.009064s, 110.3266 tests/s, 110.3266 assertions/s.
@@ -265,10 +261,7 @@ end
 Let us run this newly added test.
 
 ```bash
-Run options: -n test_should_not_save_post_without_title --seed 38984
-
-# Running tests:
-
+$ rails test test/models/post_test.rb -n test_should_not_save_post_without_title
 F
 
 Finished tests in 0.044632s, 22.4054 tests/s, 22.4054 assertions/s.
@@ -308,11 +301,7 @@ end
 Now the test should pass. Let us verify by running the test again:
 
 ```bash
-$ ruby -Itest test/models/post_test.rb -n test_should_not_save_post_without_title
-Run options: -n test_should_not_save_post_without_title --seed 62114
-
-# Running tests:
-
+$ rails test test/models/post_test.rb -n test_should_not_save_post_without_title
 .
 
 Finished tests in 0.047721s, 20.9551 tests/s, 20.9551 assertions/s.
@@ -337,11 +326,7 @@ end
 Now you can see even more output in the console from running the tests:
 
 ```bash
-$ ruby -Itest test/models/post_test.rb -n test_should_report_error
-Run options: -n test_should_report_error --seed 22995
-
-# Running tests:
-
+$ rails test test/models/post_test.rb -n test_should_report_error
 E
 
 Finished tests in 0.030974s, 32.2851 tests/s, 0.0000 assertions/s.

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -39,10 +39,11 @@ Rails creates a `test` folder for you as soon as you create a Rails project usin
 ```bash
 $ ls -F test
 
-fixtures/  functional/  integration/  test_helper.rb  unit/
+controllers/    helpers/        mailers/        test_helper.rb
+fixtures/       integration/    models/
 ```
 
-The `unit` directory is meant to hold tests for your models, the `functional` directory is meant to hold tests for your controllers and the `integration` directory is meant to hold tests that involve any number of controllers interacting.
+The `models` directory is meant to hold tests for your models, the `controllers` directory is meant to hold tests for your controllers and the `integration` directory is meant to hold tests that involve any number of controllers interacting.
 
 Fixtures are a way of organizing test data; they reside in the `fixtures` folder.
 
@@ -140,10 +141,9 @@ The default test stub in `test/models/post_test.rb` looks like this:
 require 'test_helper'
 
 class PostTest < ActiveSupport::TestCase
-  # Replace this with your real tests.
-  test "the truth" do
-    assert true
-  end
+  # test "the truth" do
+  #   assert true
+  # end
 end
 ```
 
@@ -224,33 +224,32 @@ TIP: You can see all these rake tasks and their descriptions by running `rake --
 
 ### Running Tests
 
-Running a test is as simple as invoking the file containing the test cases through Ruby:
+Running a test is as simple as invoking the file containing the test cases through `rails test` command.
 
 ```bash
-$ ruby -Itest test/models/post_test.rb
-
-Loaded suite models/post_test
-Started
+$ rails test test/models/post_test.rb
 .
-Finished in 0.023513 seconds.
 
-1 tests, 1 assertions, 0 failures, 0 errors
+Finished tests in 0.009262s, 107.9680 tests/s, 107.9680 assertions/s.
+
+1 tests, 1 assertions, 0 failures, 0 errors, 0 skips
+```
+
+You can also run a particular test method from the test case by running the test using Ruby and use the `-n` switch with the `test method name`.
+
+```bash
+Run options: -n test_the_truth --seed 23064
+
+# Running tests:
+
+.
+
+Finished tests in 0.009064s, 110.3266 tests/s, 110.3266 assertions/s.
+
+1 tests, 1 assertions, 0 failures, 0 errors, 0 skips
 ```
 
 This will run all the test methods from the test case. Note that `test_helper.rb` is in the `test` directory, hence this directory needs to be added to the load path using the `-I` switch.
-
-You can also run a particular test method from the test case by using the `-n` switch with the `test method name`.
-
-```bash
-$ ruby -Itest test/models/post_test.rb -n test_the_truth
-
-Loaded suite models/post_test
-Started
-.
-Finished in 0.023513 seconds.
-
-1 tests, 1 assertions, 0 failures, 0 errors
-```
 
 The `.` (dot) above indicates a passing test. When a test fails you see an `F`; when a test throws an error you see an `E` in its place. The last line of the output is the summary.
 
@@ -266,17 +265,19 @@ end
 Let us run this newly added test.
 
 ```bash
-$ ruby unit/post_test.rb -n test_should_not_save_post_without_title
-Loaded suite -e
-Started
+Run options: -n test_should_not_save_post_without_title --seed 38984
+
+# Running tests:
+
 F
-Finished in 0.102072 seconds.
+
+Finished tests in 0.044632s, 22.4054 tests/s, 22.4054 assertions/s.
 
   1) Failure:
-test_should_not_save_post_without_title(PostTest) [/test/models/post_test.rb:6]:
-<false> is not true.
+test_should_not_save_post_without_title(PostTest) [test/models/post_test.rb:6]:
+Failed assertion, no message given.
 
-1 tests, 1 assertions, 1 failures, 0 errors
+1 tests, 1 assertions, 1 failures, 0 errors, 0 skips
 ```
 
 In the output, `F` denotes a failure. You can see the corresponding trace shown under `1)` along with the name of the failing test. The next few lines contain the stack trace followed by a message which mentions the actual value and the expected value by the assertion. The default assertion messages provide just enough information to help pinpoint the error. To make the assertion failure message more readable, every assertion provides an optional message parameter, as shown here:
@@ -292,9 +293,8 @@ Running this test shows the friendlier assertion message:
 
 ```bash
   1) Failure:
-test_should_not_save_post_without_title(PostTest) [/test/models/post_test.rb:6]:
-Saved the post without a title.
-<false> is not true.
+test_should_not_save_post_without_title(PostTest) [test/models/post_test.rb:6]:
+Saved the post without a title
 ```
 
 Now to get this test to pass we can add a model level validation for the _title_ field.
@@ -308,13 +308,16 @@ end
 Now the test should pass. Let us verify by running the test again:
 
 ```bash
-$ ruby unit/post_test.rb -n test_should_not_save_post_without_title
-Loaded suite unit/post_test
-Started
-.
-Finished in 0.193608 seconds.
+$ ruby -Itest test/models/post_test.rb -n test_should_not_save_post_without_title
+Run options: -n test_should_not_save_post_without_title --seed 62114
 
-1 tests, 1 assertions, 0 failures, 0 errors
+# Running tests:
+
+.
+
+Finished tests in 0.047721s, 20.9551 tests/s, 20.9551 assertions/s.
+
+1 tests, 1 assertions, 0 failures, 0 errors, 0 skips
 ```
 
 Now, if you noticed, we first wrote a test which fails for a desired functionality, then we wrote some code which adds the functionality and finally we ensured that our test passes. This approach to software development is referred to as _Test-Driven Development_ (TDD).
@@ -334,18 +337,21 @@ end
 Now you can see even more output in the console from running the tests:
 
 ```bash
-$ ruby unit/post_test.rb -n test_should_report_error
-Loaded suite -e
-Started
+$ ruby -Itest test/models/post_test.rb -n test_should_report_error
+Run options: -n test_should_report_error --seed 22995
+
+# Running tests:
+
 E
-Finished in 0.082603 seconds.
+
+Finished tests in 0.030974s, 32.2851 tests/s, 0.0000 assertions/s.
 
   1) Error:
 test_should_report_error(PostTest):
-NameError: undefined local variable or method `some_undefined_variable' for #<PostTest:0x249d354>
-    /test/models/post_test.rb:6:in `test_should_report_error'
+NameError: undefined local variable or method `some_undefined_variable' for #<PostTest:0x007fe32e24afe0>
+    test/models/post_test.rb:10:in `block in <class:PostTest>'
 
-1 tests, 0 assertions, 0 failures, 1 errors
+1 tests, 0 assertions, 0 failures, 1 errors, 0 skips
 ```
 
 Notice the 'E' in the output. It denotes a test with error.
@@ -642,12 +648,9 @@ Here's what a freshly-generated integration test looks like:
 require 'test_helper'
 
 class UserFlowsTest < ActionDispatch::IntegrationTest
-  fixtures :all
-
-  # Replace this with your real tests.
-  test "the truth" do
-    assert true
-  end
+  # test "the truth" do
+  #   assert true
+  # end
 end
 ```
 
@@ -755,23 +758,28 @@ end
 Rake Tasks for Running your Tests
 ---------------------------------
 
-You don't need to set up and run your tests by hand on a test-by-test basis. Rails comes with a number of rake tasks to help in testing. The table below lists all rake tasks that come along in the default Rakefile when you initiate a Rails project.
+You don't need to set up and run your tests by hand on a test-by-test basis. Rails comes with a number of commands to help in testing. The table below lists all commands that come along in the default Rakefile when you initiate a Rails project.
 
-| Tasks                           | Description |
-| ------------------------------- | ----------- |
-| `rake test`                     | Runs all unit, functional and integration tests. You can also simply run `rake` as the _test_ target is the default.|
-| `rake test:controllers`         | Runs all the controller tests from `test/controllers`|
-| `rake test:functionals`         | Runs all the functional tests from `test/controllers`, `test/mailers`, and `test/functional`|
-| `rake test:helpers`             | Runs all the helper tests from `test/helpers`|
-| `rake test:integration`         | Runs all the integration tests from `test/integration`|
-| `rake test:mailers`             | Runs all the mailer tests from `test/mailers`|
-| `rake test:models`              | Runs all the model tests from `test/models`|
-| `rake test:recent`              | Tests recent changes|
-| `rake test:uncommitted`         | Runs all the tests which are uncommitted. Supports Subversion and Git|
-| `rake test:units`               | Runs all the unit tests from `test/models`, `test/helpers`, and `test/unit`|
+| Tasks                    | Description |
+| ------------------------ | ----------- |
+| `rails test`             | Runs all unit, functional and integration tests. You can also simply run `rails test` as Rails will run all the tests by default|
+| `rails test controllers` | Runs all the controller tests from `test/controllers`|
+| `rails test functionals` | Runs all the functional tests from `test/controllers`, `test/mailers`, and `test/functional`|
+| `rails test helpers`     | Runs all the helper tests from `test/helpers`|
+| `rails test integration` | Runs all the integration tests from `test/integration`|
+| `rails test mailers`     | Runs all the mailer tests from `test/mailers`|
+| `rails test models`      | Runs all the model tests from `test/models`|
+| `rails test units`       | Runs all the unit tests from `test/models`, `test/helpers`, and `test/unit`|
 
+There're also some test commands which you can initiate by running rake tasks:
 
-Brief Note About `Test::Unit`
+| Tasks                    | Description |
+| ------------------------ | ----------- |
+| `rake test`              | Runs all unit, functional and integration tests. You can also simply run `rake` as the _test_ target is the default.|
+| `rake test:recent`       | Tests recent changes|
+| `rake test:uncommitted`  | Runs all the tests which are uncommitted. Supports Subversion and Git|
+
+Brief Note About `MiniTest`
 -----------------------------
 
 Ruby ships with a boat load of libraries. Ruby 1.8 provides `Test::Unit`, a framework for unit testing in Ruby. All the basic assertions discussed above are actually defined in `Test::Unit::Assertions`. The class `ActiveSupport::TestCase` which we have been using in our unit and functional tests extends `Test::Unit::TestCase`, allowing

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -19,6 +19,27 @@
 
     *Terence Lee*
 
+*   Add `rails test` command to run the test suite
+
+    To run the whole test suite:
+
+        $ rails test
+
+    To run the test file(s):
+
+        $ rails test test/unit/foo_test.rb [test/unit/bar_test.rb ...]
+
+    To run the test suite
+
+        $ rails test [models,helpers,units,controllers,mailers,...]
+
+    For more information, see `rails test --help`.
+
+    This command will eventually replacing `rake test:*`, and `rake test`
+    command will actually invoking `rails test` instead.
+
+    *Prem Sichanugrist and Chris Toomey*
+
 *   Add notice message for destroy action in scaffold generator.
 
     *Rahul P. Chaudhari*

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -19,6 +19,14 @@
 
     *Terence Lee*
 
+*   Rails now generate a `test/test_helper.rb` file with `fixtures :all` commented out by default,
+    since we don't want to force loading all fixtures for user when a single test is run. However,
+    fixtures are still going to be loaded automatically for test suites.
+
+    To force all fixtures to be create in your database, use `rails test -f` to run your test.
+
+    *Prem Sichanugrist*
+
 *   Add `rails test` command to run the test suite
 
     To run the whole test suite:

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -19,7 +19,7 @@
 
     *Terence Lee*
 
-*   Rails now generate a `test/test_helper.rb` file with `fixtures :all` commented out by default,
+*   Rails now generates a `test/test_helper.rb` file with `fixtures :all` commented out by default,
     since we don't want to force loading all fixtures for user when a single test is run. However,
     fixtures are still going to be loaded automatically for test suites.
 
@@ -27,24 +27,27 @@
 
     *Prem Sichanugrist*
 
-*   Add `rails test` command to run the test suite
+*   Add `rails test` command for running tests
 
-    To run the whole test suite:
+    To run all tests:
 
         $ rails test
 
-    To run the test file(s):
-
-        $ rails test test/unit/foo_test.rb [test/unit/bar_test.rb ...]
-
-    To run the test suite
+    To run a test suite
 
         $ rails test [models,helpers,units,controllers,mailers,...]
 
+    To run a selected test file(s):
+
+        $ rails test test/unit/foo_test.rb [test/unit/bar_test.rb ...]
+
+    To run a single test from a test file
+
+        $ rails test test/unit/foo_test.rb -n test_the_truth
+
     For more information, see `rails test --help`.
 
-    This command will eventually replacing `rake test:*`, and `rake test`
-    command will actually invoking `rails test` instead.
+    This command will eventually replace `rake test:*` and `rake test` tasks
 
     *Prem Sichanugrist and Chris Toomey*
 

--- a/railties/lib/rails/commands.rb
+++ b/railties/lib/rails/commands.rb
@@ -5,6 +5,7 @@ aliases = {
   "d"  => "destroy",
   "c"  => "console",
   "s"  => "server",
+  "t"  => "test",
   "db" => "dbconsole",
   "r"  => "runner"
 }
@@ -16,6 +17,7 @@ The most common rails commands are:
  generate    Generate new code (short-cut alias: "g")
  console     Start the Rails console (short-cut alias: "c")
  server      Start the Rails server (short-cut alias: "s")
+ test        Running the test file (short-cut alias: "t")
  dbconsole   Start a console for the database specified in config/database.yml
              (short-cut alias: "db")
  new         Create a new Rails application. "rails new my_app" creates a
@@ -76,6 +78,19 @@ when 'server'
     require APP_PATH
     Dir.chdir(Rails.application.root)
     server.start
+  end
+
+when 'test'
+  $LOAD_PATH.unshift("./test")
+  require 'rails/commands/test_runner'
+  if ["-h", "--help"].include?(ARGV.first)
+    Rails::TestRunner.help_message
+    exit
+  else
+    require APP_PATH
+    Rails.application.require_environment!
+    Rails.application.load_tasks
+    Rails::TestRunner.start(ARGV)
   end
 
 when 'dbconsole'

--- a/railties/lib/rails/commands.rb
+++ b/railties/lib/rails/commands.rb
@@ -83,15 +83,12 @@ when 'server'
 when 'test'
   $LOAD_PATH.unshift("./test")
   require 'rails/commands/test_runner'
-  if ["-h", "--help"].include?(ARGV.first)
-    Rails::TestRunner.help_message
-    exit
-  else
-    require APP_PATH
-    Rails.application.require_environment!
-    Rails.application.load_tasks
-    Rails::TestRunner.start(ARGV)
-  end
+  options = Rails::TestRunner.parse_arguments(ARGV)
+
+  require APP_PATH
+  Rails.application.require_environment!
+  Rails.application.load_tasks
+  Rails::TestRunner.start(ARGV, options)
 
 when 'dbconsole'
   require 'rails/commands/dbconsole'

--- a/railties/lib/rails/commands.rb
+++ b/railties/lib/rails/commands.rb
@@ -84,10 +84,9 @@ when 'test'
   $LOAD_PATH.unshift("./test")
   require 'rails/commands/test_runner'
   options = Rails::TestRunner.parse_arguments(ARGV)
+  ENV['RAILS_ENV'] ||= options[:environment] || 'test'
 
   require APP_PATH
-  Rails.application.require_environment!
-  Rails.application.load_tasks
   Rails::TestRunner.start(ARGV, options)
 
 when 'dbconsole'

--- a/railties/lib/rails/commands/test_runner.rb
+++ b/railties/lib/rails/commands/test_runner.rb
@@ -1,0 +1,92 @@
+require 'optparse'
+require 'minitest/unit'
+
+module Rails
+  # Handling the all the logic behind +rails test+ command.
+  class TestRunner
+    class << self
+      # Parse the test suite name from the arguments array and pass in a list
+      # of file to a new +TestRunner+ object, then invoke the evaluation. If
+      # the argument is not a test suite name, it will be treated as a file
+      # name and passed to the +TestRunner+ instance right away.
+      def start(arguments)
+        case arguments.first
+        when nil
+          new(Dir['test/**/*_test.rb']).run
+        when 'models'
+          new(Dir['test/models/**/*_test.rb']).run
+        when 'helpers'
+          new(Dir['test/helpers/**/*_test.rb']).run
+        when 'units'
+          new(Dir['test/{models,helpers,unit}/**/*_test.rb']).run
+        when 'controllers'
+          new(Dir['test/controllers/**/*_test.rb']).run
+        when 'mailers'
+          new(Dir['test/mailers/**/*_test.rb']).run
+        when 'functionals'
+          new(Dir['test/{controllers,mailers,functional}/**/*_test.rb']).run
+        when 'integration'
+          new(Dir['test/integration/**/*_test.rb']).run
+        else
+          new(arguments).run
+        end
+      end
+
+      # Print out the help message which listed all of the test suite names.
+      def help_message
+        puts "Usage: rails test [path to test file(s) or test suite type]"
+        puts ""
+        puts "Run single test file, or a test suite, under Rails'"
+        puts "environment. If the file name(s) or suit name is omitted,"
+        puts "Rails will run all the test suites."
+        puts ""
+        puts "Support types of test suites:"
+        puts "-------------------------------------------------------------"
+        puts "* models (test/models/**/*)"
+        puts "* helpers (test/helpers/**/*)"
+        puts "* units (test/{models,helpers,unit}/**/*"
+        puts "* controllers (test/controllers/**/*)"
+        puts "* mailers (test/mailers/**/*)"
+        puts "* functionals (test/{controllers,mailers,functional}/**/*)"
+        puts "* integration (test/integration/**/*)"
+        puts "-------------------------------------------------------------"
+      end
+    end
+
+    # Create a new +TestRunner+ object with a list of test file paths.
+    def initialize(files)
+      @files = files
+      Rake::Task['test:prepare'].invoke
+      MiniTest::Unit.output = SilentUntilSyncStream.new(MiniTest::Unit.output)
+    end
+
+    # Run the test files by evaluate each of them.
+    def run
+      @files.each { |filename| load(filename) }
+    end
+
+    # A null stream object which ignores everything until +sync+ has been set
+    # to true. This is only to be used to silence unnecessary output from
+    # MiniTest, as MiniTest calls +output.sync = true+ right before output the
+    # first test result.
+    class SilentUntilSyncStream < File
+      # Create a +SilentUntilSyncStream+ object by given a stream object that
+      # this stream should set +MiniTest::Unit.output+ to after +sync+ has been
+      # set to true.
+      def initialize(target_stream)
+        @target_stream = target_stream
+        super(File::NULL, 'w')
+      end
+
+      # Swap +MiniTest::Unit.output+ to another stream when +sync+ is true.
+      def sync=(sync)
+        if sync
+          @target_stream.sync = true
+          MiniTest::Unit.output = @target_stream
+        end
+
+        super
+      end
+    end
+  end
+end

--- a/railties/lib/rails/commands/test_runner.rb
+++ b/railties/lib/rails/commands/test_runner.rb
@@ -2,13 +2,13 @@ require 'optparse'
 require 'minitest/unit'
 
 module Rails
-  # Handling the all the logic behind +rails test+ command.
+  # Handles all logic behind +rails test+ command.
   class TestRunner
     class << self
-      # Parse the test suite name from the arguments array and pass in a list
-      # of file to a new +TestRunner+ object, then invoke the evaluation. If
-      # the argument is not a test suite name, it will be treated as a file
-      # name and passed to the +TestRunner+ instance right away.
+      # Creates a new +TestRunner+ object with an array of test files to run
+      # based on the arguments. When no arguments are provided, it runs all test
+      # files. When a suite argument is provided, it runs only the test files in
+      # that suite. Otherwise, it runs the specified test file(s).
       def start(files, options = {})
         original_fixtures_options = options.delete(:fixtures)
         options[:fixtures] = true
@@ -36,18 +36,18 @@ module Rails
         end
       end
 
-      # Parse arguments and set them as option flags
+      # Parses arguments and sets them as option flags
       def parse_arguments(arguments)
         options = {}
         orig_arguments = arguments.dup
 
         OptionParser.new do |opts|
-          opts.banner = "Usage: rails test [path to test file(s) or test suite type]"
+          opts.banner = "Usage: rails test [path to test file(s) or test suite]"
 
           opts.separator ""
-          opts.separator "Run single test file, or a test suite, under Rails'"
+          opts.separator "Run a specific test file(s) or a test suite, under Rails'"
           opts.separator "environment. If the file name(s) or suit name is omitted,"
-          opts.separator "Rails will run all the test suites."
+          opts.separator "Rails will run all tests."
           opts.separator ""
           opts.separator "Specific options:"
 
@@ -91,7 +91,7 @@ module Rails
       end
     end
 
-    # Create a new +TestRunner+ object with a list of test file paths.
+    # Creates a new +TestRunner+ object with a list of test file paths.
     def initialize(files, options)
       @files = files
       Rake::Task['test:prepare'].invoke
@@ -108,25 +108,25 @@ module Rails
       MiniTest::Unit.output = SilentUntilSyncStream.new(MiniTest::Unit.output)
     end
 
-    # Run the test files by evaluate each of them.
+    # Runs test files by evaluating each of them.
     def run
       @files.each { |filename| load(filename) }
     end
 
     # A null stream object which ignores everything until +sync+ has been set
-    # to true. This is only to be used to silence unnecessary output from
-    # MiniTest, as MiniTest calls +output.sync = true+ right before output the
-    # first test result.
+    # to true. This is only used to silence unnecessary output from MiniTest,
+    # as MiniTest calls +output.sync = true+ right before it outputs the first
+    # test result.
     class SilentUntilSyncStream < File
-      # Create a +SilentUntilSyncStream+ object by given a stream object that
-      # this stream should set +MiniTest::Unit.output+ to after +sync+ has been
+      # Creates a +SilentUntilSyncStream+ object by giving it a target stream
+      # object that will be assigned to +MiniTest::Unit.output+ after +sync+ is
       # set to true.
       def initialize(target_stream)
         @target_stream = target_stream
         super(File::NULL, 'w')
       end
 
-      # Swap +MiniTest::Unit.output+ to another stream when +sync+ is true.
+      # Swaps +MiniTest::Unit.output+ to another stream when +sync+ is true.
       def sync=(sync)
         if sync
           @target_stream.sync = true

--- a/railties/lib/rails/commands/test_runner.rb
+++ b/railties/lib/rails/commands/test_runner.rb
@@ -56,6 +56,10 @@ module Rails
             exit
           end
 
+          opts.on '-e', '--environment NAME', String, 'Specifies the environment to run this test under' do |e|
+            options[:environment] = e
+          end
+
           opts.on '-f', '--fixtures', 'Load fixtures in test/fixtures/ before running the tests' do
             options[:fixtures] = true
           end
@@ -68,8 +72,8 @@ module Rails
             options[:verbose] = true
           end
 
-          opts.on '-n', '--name PATTERN', "Filter test names on pattern (e.g. /foo/)" do |a|
-            options[:filter] = a
+          opts.on '-n', '--name PATTERN', "Filter test names on pattern (e.g. /foo/)" do |n|
+            options[:filter] = n
           end
 
           opts.separator ""
@@ -94,7 +98,9 @@ module Rails
     # Creates a new +TestRunner+ object with a list of test file paths.
     def initialize(files, options)
       @files = files
-      Rake::Task['test:prepare'].invoke
+
+      Rails.application.load_tasks
+      Rake::Task['db:test:load'].invoke
 
       if options.delete(:fixtures)
         if defined?(ActiveRecord::Base)

--- a/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb
+++ b/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb
@@ -6,8 +6,8 @@ class ActiveSupport::TestCase
 <% unless options[:skip_active_record] -%>
   ActiveRecord::Migration.check_pending!
 
-  # Uncomment the `fixtures` line below to setup all fixtures in test/fixtures/*.yml for all tests
-  # in alphabetical order.
+  # Uncomment the `fixtures :all` line below to setup all fixtures in test/fixtures/*.yml
+  # for all tests in alphabetical order.
   #
   # Note: You'll currently still have to declare fixtures explicitly in integration tests
   # -- they do not yet inherit this setting

--- a/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb
+++ b/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb
@@ -6,11 +6,12 @@ class ActiveSupport::TestCase
 <% unless options[:skip_active_record] -%>
   ActiveRecord::Migration.check_pending!
 
-  # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
+  # Uncomment the `fixtures` line below to setup all fixtures in test/fixtures/*.yml for all tests
+  # in alphabetical order.
   #
   # Note: You'll currently still have to declare fixtures explicitly in integration tests
   # -- they do not yet inherit this setting
-  fixtures :all
+  # fixtures :all
 
 <% end -%>
   # Add more helper methods to be used by all tests here...

--- a/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb
+++ b/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb
@@ -1,4 +1,4 @@
-ENV["RAILS_ENV"] = "test"
+ENV["RAILS_ENV"] ||= "test"
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -149,6 +149,27 @@ module ApplicationTests
       end
     end
 
+    def test_run_named_test
+      app_file 'test/unit/chu_2_koi_test.rb', <<-RUBY
+        require 'test_helper'
+
+        class Chu2KoiTest < ActiveSupport::TestCase
+          def test_rikka
+            puts 'Rikka'
+          end
+
+          def test_sanae
+            puts 'Sanae'
+          end
+        end
+      RUBY
+
+      run_test_command('test/unit/chu_2_koi_test.rb -n test_rikka').tap do |output|
+        assert_match /Rikka/, output
+        assert_no_match /Sanae/, output
+      end
+    end
+
     private
       def run_test_command(arguments = 'test/unit/test_test.rb')
         Dir.chdir(app_path) { `bundle exec rails test #{arguments}` }

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -141,11 +141,11 @@ module ApplicationTests
       end
     end
 
-    def test_run_whole_suite
-      types = [:models, :helpers, :unit, :controllers, :mailers, :functional, :integration]
-      types.each { |type| create_test_file type, "foo_#{type}" }
+    def test_run_all_suites
+      suites = [:models, :helpers, :unit, :controllers, :mailers, :functional, :integration]
+      suites.each { |suite| create_test_file suite, "foo_#{suite}" }
       run_test_command('') .tap do |output|
-        types.each { |type| assert_match /Foo#{type.to_s.camelize}Test/, output }
+        suites.each { |suite| assert_match /Foo#{suite.to_s.camelize}Test/, output }
         assert_match /7 tests, 7 assertions, 0 failures/, output
       end
     end
@@ -180,13 +180,13 @@ module ApplicationTests
 
     def test_load_fixtures_when_running_test_suites
       create_model_with_fixture
-      types = [:models, :helpers, [:units, :unit], :controllers, :mailers,
+      suites = [:models, :helpers, [:units, :unit], :controllers, :mailers,
         [:functionals, :functional], :integration]
 
-      types.each do |type, directory|
-        directory ||= type
+      suites.each do |suite, directory|
+        directory ||= suite
         create_fixture_test directory
-        assert_match /3 users/, run_test_command(type)
+        assert_match /3 users/, run_test_command(suite)
         Dir.chdir(app_path) { FileUtils.rm_f "test/#{directory}" }
       end
     end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -1,0 +1,183 @@
+require 'isolation/abstract_unit'
+
+module ApplicationTests
+  class TestRunnerTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+
+    def setup
+      build_app
+      create_schema
+    end
+
+    def teardown
+      teardown_app
+    end
+
+    def test_should_not_display_heading
+      create_test_file
+      run_test_command.tap do |output|
+        assert_no_match /Run options:/, output
+        assert_no_match /Running tests:/, output
+      end
+    end
+
+    def test_run_shortcut
+      create_test_file :models, 'foo'
+      output = Dir.chdir(app_path) { `bundle exec rails t test/models/foo_test.rb` }
+      assert_match /1 tests, 1 assertions, 0 failures/, output
+    end
+
+    def test_run_single_file
+      create_test_file :models, 'foo'
+      assert_match /1 tests, 1 assertions, 0 failures/, run_test_command("test/models/foo_test.rb")
+    end
+
+    def test_run_multiple_files
+      create_test_file :models,  'foo'
+      create_test_file :models,  'bar'
+      assert_match /2 tests, 2 assertions, 0 failures/, run_test_command("test/models/foo_test.rb test/models/bar_test.rb")
+    end
+
+    def test_run_file_with_syntax_error
+      app_file 'test/models/error_test.rb', <<-RUBY
+        require 'test_helper'
+        def; end
+      RUBY
+
+      error_stream = Tempfile.new('error')
+      redirect_stderr(error_stream) { run_test_command('test/models/error_test.rb') }
+      assert_match /SyntaxError/, error_stream.read
+    end
+
+    def test_invoke_rake_test_prepare
+      app_file "lib/tasks/test.rake", <<-RUBY
+        namespace :test do
+          task :prepare do
+            puts "Hello World"
+          end
+        end
+      RUBY
+      create_test_file
+      assert_match /Hello World/, run_test_command
+    end
+
+    def test_run_models
+      create_test_file :models, 'foo'
+      create_test_file :models, 'bar'
+      create_test_file :controllers, 'foobar_controller'
+      run_test_command("models").tap do |output|
+        assert_match /FooTest/, output
+        assert_match /BarTest/, output
+        assert_match /2 tests, 2 assertions, 0 failures/, output
+      end
+    end
+
+    def test_run_helpers
+      create_test_file :helpers, 'foo_helper'
+      create_test_file :helpers, 'bar_helper'
+      create_test_file :controllers, 'foobar_controller'
+      run_test_command('helpers').tap do |output|
+        assert_match /FooHelperTest/, output
+        assert_match /BarHelperTest/, output
+        assert_match /2 tests, 2 assertions, 0 failures/, output
+      end
+    end
+
+    def test_run_units
+      create_test_file :models, 'foo'
+      create_test_file :helpers, 'bar_helper'
+      create_test_file :unit, 'baz_unit'
+      create_test_file :controllers, 'foobar_controller'
+      run_test_command('units').tap do |output|
+        assert_match /FooTest/, output
+        assert_match /BarHelperTest/, output
+        assert_match /BazUnitTest/, output
+        assert_match /3 tests, 3 assertions, 0 failures/, output
+      end
+    end
+
+    def test_run_controllers
+      create_test_file :controllers, 'foo_controller'
+      create_test_file :controllers, 'bar_controller'
+      create_test_file :models, 'foo'
+      run_test_command('controllers').tap do |output|
+        assert_match /FooControllerTest/, output
+        assert_match /BarControllerTest/, output
+        assert_match /2 tests, 2 assertions, 0 failures/, output
+      end
+    end
+
+    def test_run_mailers
+      create_test_file :mailers, 'foo_mailer'
+      create_test_file :mailers, 'bar_mailer'
+      create_test_file :models, 'foo'
+      run_test_command('mailers').tap do |output|
+        assert_match /FooMailerTest/, output
+        assert_match /BarMailerTest/, output
+        assert_match /2 tests, 2 assertions, 0 failures/, output
+      end
+    end
+
+    def test_run_functionals
+      create_test_file :mailers, 'foo_mailer'
+      create_test_file :controllers, 'bar_controller'
+      create_test_file :functional, 'baz_functional'
+      create_test_file :models, 'foo'
+      run_test_command('functionals').tap do |output|
+        assert_match /FooMailerTest/, output
+        assert_match /BarControllerTest/, output
+        assert_match /BazFunctionalTest/, output
+        assert_match /3 tests, 3 assertions, 0 failures/, output
+      end
+    end
+
+    def test_run_integration
+      create_test_file :integration, 'foo_integration'
+      create_test_file :models, 'foo'
+      run_test_command('integration').tap do |output|
+        assert_match /FooIntegration/, output
+        assert_match /1 tests, 1 assertions, 0 failures/, output
+      end
+    end
+
+    def test_run_whole_suite
+      types = [:models, :helpers, :unit, :controllers, :mailers, :functional, :integration]
+      types.each { |type| create_test_file type, "foo_#{type}" }
+      run_test_command('') .tap do |output|
+        types.each { |type| assert_match /Foo#{type.to_s.camelize}Test/, output }
+        assert_match /7 tests, 7 assertions, 0 failures/, output
+      end
+    end
+
+    private
+      def run_test_command(arguments = 'test/unit/test_test.rb')
+        Dir.chdir(app_path) { `bundle exec rails test #{arguments}` }
+      end
+
+      def create_schema
+        app_file 'db/schema.rb', ''
+      end
+
+      def redirect_stderr(target_stream)
+        previous_stderr = STDERR.dup
+        $stderr.reopen(target_stream)
+        yield
+        target_stream.rewind
+      ensure
+        $stderr = previous_stderr
+      end
+
+      def create_test_file(path = :unit, name = 'test')
+        app_file "test/#{path}/#{name}_test.rb", <<-RUBY
+          require 'test_helper'
+
+          class #{name.camelize}Test < ActiveSupport::TestCase
+            def test_truth
+              puts "#{name.camelize}Test"
+              assert true
+            end
+          end
+        RUBY
+      end
+  end
+end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -191,6 +191,39 @@ module ApplicationTests
       end
     end
 
+    def test_run_different_environment_using_env_var
+      app_file 'test/unit/env_test.rb', <<-RUBY
+        require 'test_helper'
+
+        class EnvTest < ActiveSupport::TestCase
+          def test_env
+            puts Rails.env
+          end
+        end
+      RUBY
+
+      assert_match /development/, Dir.chdir(app_path) { `RAILS_ENV=development bundle exec rails test test/unit/env_test.rb` }
+    end
+
+    def test_run_different_environment_using_e_tag
+      app_file 'test/unit/env_test.rb', <<-RUBY
+        require 'test_helper'
+
+        class EnvTest < ActiveSupport::TestCase
+          def test_env
+            puts Rails.env
+          end
+        end
+      RUBY
+
+      assert_match /development/, run_test_command('-e development test/unit/env_test.rb')
+    end
+
+    def test_generated_scaffold_works_with_rails_test
+      create_scaffold
+      assert_match /0 failures, 0 errors, 0 skips/, run_test_command('')
+    end
+
     private
       def run_test_command(arguments = 'test/unit/test_test.rb')
         Dir.chdir(app_path) { `bundle exec rails test #{arguments}` }
@@ -211,7 +244,7 @@ module ApplicationTests
             name: Tsubasa Hanekawa
         YAML
 
-        Dir.chdir(app_path) { `bundle exec rake db:migrate` }
+        run_migration
       end
 
       def create_fixture_test(path = :unit, name = 'test')
@@ -250,6 +283,16 @@ module ApplicationTests
             end
           end
         RUBY
+      end
+
+      def create_scaffold
+        script 'generate scaffold user name:string'
+        Dir.chdir(app_path) { File.exist?('app/models/user.rb') }
+        run_migration
+      end
+
+      def run_migration
+        Dir.chdir(app_path) { `bundle exec rake db:migrate` }
       end
   end
 end


### PR DESCRIPTION
To run the whole test suite:

```
$ rails test
```

To run the test file(s):

```
$ rails test test/unit/foo_test.rb [test/unit/bar_test.rb ...]
```

To run the test suite

```
$ rails test [models,helpers,units,controllers,mailers,...]
```

For more information, see `rails test --help`.

This command will eventually replacing `rake test:*`, and `rake test`
command will actually invoking `rails test` instead.

---

After this got merged, there'll be several things that need to be done:
- [x] Update guides to cover this :sparkles:new:sparkles: feature.
- [x] Decide whether we should show a deprecation warning if user run `rake test:*` (but if you run `rake` or `rake test`, there will no deprecation warning.
- [x] <del>Add a notification for `test:prepare` event, so that we can drop `Rake::Task['test:prepare'].invoke` line.</del>
- [x] <del>Add back `uncommitted` and `recent` suites.</del>
- [x] Add support for `-n` to specify the test name.
