### PR TITLE
Add middleware initialisation points to app property information

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -82,6 +82,7 @@ module Rails
       @env_config       = nil
       @ordered_railties = nil
       @railties         = nil
+      @middleware_initialisation_points = nil
     end
 
     # Returns true if the application is initialized.
@@ -216,9 +217,29 @@ module Rails
     end
 
     def initializers #:nodoc:
-      Bootstrap.initializers_for(self) +
-      railties_initializers(super) +
-      Finisher.initializers_for(self)
+      bootstrap = Bootstrap.initializers_for(self) #BOOTSTRAP
+      railties = railties_initializers(super) #RAILTIES
+      finisher = Finisher.initializers_for(self) #FINISHER
+      @middleware_initialisation_points =
+        parse_middleware_initialisation_points(bootstrap, "#BOOTSTRAP") +
+        parse_middleware_initialisation_points(railties, "#RAILTIES") +
+        parse_middleware_initialisation_points(finisher, "#FINISHER")
+      bootstrap + railties + finisher
+    end
+
+    def parse_middleware_initialisation_points(initializers, stage) #:nodoc:
+      output = []
+      output << stage
+      initializers.each do |i|
+        output << i.name
+      end
+      output << "--------------"
+      output
+    end
+
+    # Returns middleware initialisation points
+    def middleware_initialisation_points
+      @middleware_initialisation_points
     end
 
     def config #:nodoc:

--- a/railties/lib/rails/info.rb
+++ b/railties/lib/rails/info.rb
@@ -94,6 +94,10 @@ module Rails
       Rails.configuration.middleware.map(&:inspect)
     end
 
+    property 'Middleware initialisation points' do
+      Rails.application.middleware_initialisation_points
+    end
+
     # The application's location on the filesystem.
     property 'Application root' do
       File.expand_path(Rails.root)


### PR DESCRIPTION
Details of the app's environment are updated to include initialisation points of the middleware stack as seen at `/rails/info/properties`.  This is particularly handy when developing engines etc.

Tested on a Rails 4.0.0.beta app.

![Screen Shot 2013-01-26 at 02 28 43](https://f.cloud.github.com/assets/368260/98802/1c0736d6-6734-11e2-8e8e-1181e997c69a.png)
