### PR TITLE
avoid using alias in generators

### DIFF
--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -28,7 +28,10 @@ module Rails
 
       protected
         attr_reader :file_name
-        alias :singular_name :file_name
+
+        def singular_name
+          file_name
+        end
 
         # Wrap block with namespace of current application
         # if namespace exists and is not skipped


### PR DESCRIPTION
Ruby's alias produces public methods, causing a spurious Thor task
to be created.  For example, this is the reason MigrationGenerator
currently has two tasks:

```
> ActiveRecord::Generators::MigrationGenerator.all_tasks.keys
=> ["singular_name", "create_migration_file"]
```

singular_name was meant to be an attribute, not a task.  Because it's
public, it gets called as a task every time the generator is invoked.

The fix is to ensure all generator methods have the correct
visibility.
