### PR TITLE
document the behavior of `ActionMailer::Base.delivieries` in tests

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -576,6 +576,8 @@ end
 
 In the test we send the email and store the returned object in the `email` variable. We then ensure that it was sent (the first assert), then, in the second batch of assertions, we ensure that the email does indeed contain what we expect.
 
+NOTE: The `ActionMailer::Base.deliveries` array is only reset automatically in `ActionMailer::TestCase` tests. If you want to have a clean slate outside Action Mailer tests, you can reset it manually with: `ActionMailer::Base.deliveries.clear`
+
 Intercepting Emails
 -------------------
 There are situations where you need to edit an email before it's delivered. Fortunately Action Mailer provides hooks to intercept every email. You can register an interceptor to make modifications to mail messages right before they are handed to the delivery agents.


### PR DESCRIPTION
While working on a project we noticed that the `deliveries` are only reset in AM test cases. The behavior is fine but I think we should document it to prevent confusion.

thanks @danielpuglisi
