### PR TITLE
Use `silence` instead of `quietly` to silence the `CheckPending` middleware.

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -342,7 +342,7 @@ module ActiveRecord
       end
 
       def call(env)
-        ActiveRecord::Base.logger.quietly do
+        ActiveRecord::Base.logger.silence do
           ActiveRecord::Migration.check_pending!
         end
         @app.call(env)


### PR DESCRIPTION
`Kernel.quietly` silences `STDOUT` and `STDERR`, which is useless if
the logger is writing to a file, while `AS::Logger#silence` swaps the
logger level to `ERROR`.

Related to #8820 and #8052.
