### PR TITLE
2.3: escape_once isn't escaping single quotes and is double-escaping hex-encoded entites

### DIFF
--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -104,7 +104,7 @@ module ActionView
       #   escape_once("&lt;&lt; Accept & Checkout")
       #   # => "&lt;&lt; Accept &amp; Checkout"
       def escape_once(html)
-        ActiveSupport::Multibyte.clean(html.to_s).gsub(/[\"><]|&(?!([a-zA-Z]+|(#\d+));)/) { |special| ERB::Util::HTML_ESCAPE[special] }
+        ActiveSupport::Multibyte.clean(html.to_s).gsub(/["><']|&(?!([a-zA-Z]+|(#\d+)|(#[xX][\dA-Fa-f]{1,4}));)/) { |special| ERB::Util::HTML_ESCAPE[special] }
       end
 
       private

--- a/actionpack/test/template/tag_helper_test.rb
+++ b/actionpack/test/template/tag_helper_test.rb
@@ -78,6 +78,7 @@ class TagHelperTest < ActionView::TestCase
   
   def test_escape_once
     assert_equal '1 &lt; 2 &amp; 3', escape_once('1 < 2 &amp; 3')
+    assert_equal " &#X27; &#x27; &#x03BB; &#X03bb; &quot; &#x27; &lt; &gt; ", escape_once(" &#X27; &#x27; &#x03BB; &#X03bb; \" ' < > ")
   end
   
   def test_double_escaping_attributes


### PR DESCRIPTION
@tenderlove recently committed d549df7133f2b0bad8112890d478c33e990e12bc, which escapes single quotes :smile: :+1: , but escape_once still leaves them unescaped. And escape_once couldn't handle the hex-encoded entity, which caused it to be double-escaped.

i.e. `escape_once("&#x27;") was returning "&amp;#x27;"`
and `escape_once("'") was returning "'"`

Formtastic uses escape_once on field values, so it was causing text inputs containing single quotes to be double-escaped. So if the user submitted the form, it would be saved to the database escaped instead of raw.
