### PR TITLE
Fixed misleading Error message while creating new rails application.

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -150,7 +150,7 @@ module Rails
                              desc: "Show Rails version number and quit"
 
       def initialize(*args)
-        raise Error, "Options should be given after the application name. For details run: rails --help" if args[0].blank?
+        raise Error, "APP_PATH should be given. For details run: rails --help" if args[0].blank?
 
         super
 


### PR DESCRIPTION
APP_PATH is the only required argument for creating new rails
application using `rails new` command. All other arguments are
optional. But the Error is raised with the message 'Options should
be given after the application name' which is misleading.
