### PR TITLE
counts.sum in alias_tracker.rb replaced by #inject

### DIFF
--- a/activerecord/lib/active_record/associations/alias_tracker.rb
+++ b/activerecord/lib/active_record/associations/alias_tracker.rb
@@ -65,7 +65,7 @@ module ActiveRecord
             end
           end
 
-          counts.sum
+          counts.inject(0, &:+)
         end
 
         def truncate(name)


### PR DESCRIPTION
in alias_tracker.rb (activerecord), line 68, #sum is used instead of #inject. This breaks if the #sum method is not present somehow - which can happen if plugins like composite_primary_keys are used.
