### PR TITLE
Make current_url? work with HEAD requests and remove caching_allowed? since it doesn't do anything

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix that CSRF protection and current_url? helper work with HEAD requests
+    now ActionDispatch::Head has been removed in favor of Rack::Head.
+
+    *Michiel Sikkes*
+
 *   Change asset_path to not include `SCRIPT_NAME` when it's used
     from a mounted engine (fixes #8119).
 

--- a/actionpack/lib/action_controller/caching.rb
+++ b/actionpack/lib/action_controller/caching.rb
@@ -82,10 +82,6 @@ module ActionController
       end
     end
 
-    def caching_allowed?
-      request.get? && response.status == 200
-    end
-
     def view_cache_dependencies
       self.class._view_cache_dependencies.map { |dep| instance_exec(&dep) }.compact
     end

--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -514,7 +514,7 @@ module ActionView
                 "in a #request method"
         end
 
-        return false unless request.get?
+        return false unless request.get? || request.head?
 
         url_string = url_for(options)
 

--- a/actionpack/test/template/url_helper_test.rb
+++ b/actionpack/test/template/url_helper_test.rb
@@ -437,6 +437,12 @@ class UrlHelperTest < ActiveSupport::TestCase
     ActionDispatch::Request.new(env)
   end
 
+  def test_current_page_with_http_head_method
+    @request = request_for_url("/", :method => :head)
+    assert current_page?(url_hash)
+    assert current_page?("http://www.example.com/")
+  end
+
   def test_current_page_with_simple_url
     @request = request_for_url("/")
     assert current_page?(url_hash)


### PR DESCRIPTION
Part 2 of this PR: https://github.com/rails/rails/pull/9032
