### PR TITLE
3.2 escape_once isn't escaping single quotes and is double-escaping hex-encoded entites

### DIFF
--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -122,7 +122,7 @@ module ActionView
       #   escape_once("&lt;&lt; Accept & Checkout")
       #   # => "&lt;&lt; Accept &amp; Checkout"
       def escape_once(html)
-        ActiveSupport::Multibyte.clean(html.to_s).gsub(/[\"><]|&(?!([a-zA-Z]+|(#\d+));)/) { |special| ERB::Util::HTML_ESCAPE[special] }
+        ActiveSupport::Multibyte.clean(html.to_s).gsub(/["><']|&(?!([a-zA-Z]+|(#\d+)|(#[xX][\dA-Fa-f]{1,4}));)/) { |special| ERB::Util::HTML_ESCAPE[special] }
       end
 
       private

--- a/actionpack/test/template/tag_helper_test.rb
+++ b/actionpack/test/template/tag_helper_test.rb
@@ -93,6 +93,7 @@ class TagHelperTest < ActionView::TestCase
 
   def test_escape_once
     assert_equal '1 &lt; 2 &amp; 3', escape_once('1 < 2 &amp; 3')
+    assert_equal " &#X27; &#x27; &#x03BB; &#X03bb; &quot; &#x27; &lt; &gt; ", escape_once(" &#X27; &#x27; &#x03BB; &#X03bb; \" ' < > ")
   end
 
   def test_tag_honors_html_safe_for_param_values


### PR DESCRIPTION
Related to #9088
