### PR TITLE
Changes encoding of JSON dictionaries and arrays to use UTF-8

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -14,6 +14,32 @@
 
     *Charles Jones*
 
+*   Defaults the resulting JSON output to UTF-8. This is for ruby 1.9.3
+(not 2.0.x) which doesn't default ruby files to UTF-8.
+
+    Before this change:
+
+        >> hash = {"foo" => "bar"}
+        => {"foo"=>"bar"}
+        >> hash.keys.first.encoding
+        => #<Encoding:UTF-8>
+        >> hash.values.first.encoding
+        => #<Encoding:UTF-8>
+        >> ActiveSupport::JSON.encode(hash).encoding
+        => #<Encoding:US-ASCII>
+
+    After this change:
+
+        >> hash = {"foo" => "bar"}
+        => {"foo"=>"bar"}
+        >> hash.keys.first.encoding
+        => #<Encoding:UTF-8>
+        >> hash.values.first.encoding
+        => #<Encoding:UTF-8>
+        >> ActiveSupport::JSON.encode(hash).encoding
+        => #<Encoding:UTF-8>
+
+    Zach Moazeni
 
 ## Rails 4.0.0.beta1 (February 25, 2013) ##
 

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'active_support/core_ext/object/to_json'
 require 'active_support/core_ext/module/delegation'
 require 'active_support/json/variable'

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -110,6 +110,13 @@ class TestJSONEncoding < ActiveSupport::TestCase
     assert_equal %({\"a\":\"b\",\"c\":\"d\"}), sorted_json(ActiveSupport::JSON.encode(:a => :b, :c => :d))
   end
 
+  def test_hash_utf8_encoding
+    hash = {"foo" => "bar"}
+    assert_equal Encoding::UTF_8, hash.keys.first.encoding
+    assert_equal Encoding::UTF_8, hash.values.first.encoding
+    assert_equal Encoding::UTF_8, ActiveSupport::JSON.encode(hash).encoding
+  end
+
   def test_utf8_string_encoded_properly
     result = ActiveSupport::JSON.encode('€2.99')
     assert_equal '"€2.99"', result


### PR DESCRIPTION
This makes sense considering strings are forced to UTF-8 encoding. This
eliminates rails code that looks like:

``` ruby
def show
  respond_to do |format|
    format.json do
      render :json => {"foo" => "bar"}.to_json.force_encoding("utf-8")
    end
  end
end
```
