### PR TITLE
cache_key consults updated_on timestamp if present

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Expand `#cache_key` to consult all relevant updated timestamps.
+
+    Previously only `updated_at` column was checked, now it will
+    consult other columns that received updated timestamps on save,
+    such as `updated_on`.  When multiple columns are present it will
+    use the most recent timestamp.
+    Fixes #9033.
+
+    *Brendon Murphy*
+
 ## Rails 4.0.0.beta1 (February 25, 2013) ##
 
 *   Fix overriding of attributes by default_scope on `ActiveRecord::Base#dup`.

--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -49,7 +49,7 @@ module ActiveRecord
       case
       when new_record?
         "#{self.class.model_name.cache_key}/new"
-      when timestamp = self[:updated_at]
+      when timestamp = max_updated_column_timestamp
         timestamp = timestamp.utc.to_s(cache_timestamp_format)
         "#{self.class.model_name.cache_key}/#{id}-#{timestamp}"
       else

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -98,6 +98,12 @@ module ActiveRecord
       timestamp_attributes_for_create + timestamp_attributes_for_update
     end
 
+    def max_updated_column_timestamp
+      if (timestamps = timestamp_attributes_for_update.map { |attr| self[attr] }.compact).present?
+        timestamps.map { |ts| ts.to_time }.max
+      end
+    end
+
     def current_time_from_proper_timezone
       self.class.default_timezone == :utc ? Time.now.utc : Time.now
     end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1441,10 +1441,28 @@ class BasicsTest < ActiveRecord::TestCase
     assert_not_equal key, car.cache_key
   end
 
-  def test_cache_key_format_for_existing_record_with_nil_updated_at
+  def test_cache_key_format_for_existing_record_with_nil_updated_timestamps
     dev = Developer.first
-    dev.update_columns(updated_at: nil)
+    dev.update_columns(updated_at: nil, updated_on: nil)
     assert_match(/\/#{dev.id}$/, dev.cache_key)
+  end
+
+  def test_cache_key_for_updated_on
+    dev = Developer.first
+    dev.updated_at = nil
+    assert_equal "developers/#{dev.id}-#{dev.updated_on.utc.to_s(:nsec)}", dev.cache_key
+  end
+
+  def test_cache_key_for_newer_updated_at
+    dev = Developer.first
+    dev.updated_at += 3600
+    assert_equal "developers/#{dev.id}-#{dev.updated_at.utc.to_s(:nsec)}", dev.cache_key
+  end
+
+  def test_cache_key_for_newer_updated_on
+    dev = Developer.first
+    dev.updated_on += 3600
+    assert_equal "developers/#{dev.id}-#{dev.updated_on.utc.to_s(:nsec)}", dev.cache_key
   end
 
   def test_touch_should_raise_error_on_a_new_object

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -219,6 +219,8 @@ ActiveRecord::Schema.define do
     t.integer  :salary, :default => 70000
     t.datetime :created_at
     t.datetime :updated_at
+    t.datetime :created_on
+    t.datetime :updated_on
   end
 
   create_table :developers_projects, :force => true, :id => false do |t|


### PR DESCRIPTION
See gh-9033 for additional discussion.

I noticed that the cache_key is hardcoded to updated_at, and didn't consult updated_on which is a supported timestamp column.

I have 3 immediate concerns about this patch:
1.  Is it safe to cast all time/date possibilities with `#to_time` for the comparison
2.  It looks like an enumerable trainwreck
3.  Is the schema change safe?

/cc @senny
