### PR TITLE
Fix #8832 - Parse '{"person":[]}' JSON/XML as {'person' => []}.

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -263,9 +263,12 @@ module ActionDispatch
       hash.each do |k, v|
         case v
         when Array
+          if v.size > 0 && v.all?(&:nil?)
+            hash[k] = nil
+            next
+          end
           v.grep(Hash) { |x| deep_munge(x) }
           v.compact!
-          hash[k] = nil if v.empty?
         when Hash
           deep_munge(v)
         end

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -32,6 +32,10 @@ class JsonParamsParsingTest < ActionController::IntegrationTest
 
   test "nils are stripped from collections" do
     assert_parses(
+      {"person" => []},
+      "{\"person\":[]}", { 'CONTENT_TYPE' => 'application/json' }
+    )
+    assert_parses(
       {"person" => nil},
       "{\"person\":[null]}", { 'CONTENT_TYPE' => 'application/json' }
     )

--- a/actionpack/test/dispatch/request/xml_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/xml_params_parsing_test.rb
@@ -42,6 +42,9 @@ class XmlParamsParsingTest < ActionController::IntegrationTest
       {"hash" => { "person" => nil} },
       "<hash><person type=\"array\"><person nil=\"true\"/></person></hash>")
     assert_parses(
+      {"hash" => { "person" => []} },
+      "<hash><person type=\"array\"></person></hash>")
+    assert_parses(
       {"hash" => { "person" => ['foo']} },
       "<hash><person type=\"array\"><person>foo</person><person nil=\"true\"/></person>\n</hash>")
   end


### PR DESCRIPTION
submitting @ndbroadbent 's patch for the 3.0 stable branch, as the bug introduced by the fix for CVE-2013-0155 applies to 3.0 as well

please see https://github.com/rails/rails/pull/8862 for details on the issue
