### PR TITLE
Add NumberHelper missing dependency

### DIFF
--- a/actionpack/lib/action_view/helpers/number_helper.rb
+++ b/actionpack/lib/action_view/helpers/number_helper.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+require 'active_support/core_ext/hash/keys'
 require 'active_support/core_ext/big_decimal/conversions'
 require 'active_support/core_ext/float/rounding'
 require 'active_support/core_ext/object/blank'


### PR DESCRIPTION
`symbolize_keys` depends on hash/keys `ActiveSupport` core extension.

My unit tests were failing due to this dependency missing in 3.2 branch.

This is already fixed on master but maybe you could fix that on next 3.2 release.
