### PR TITLE
Add another NumberHelper missing dependency

### DIFF
--- a/actionpack/lib/action_view/helpers/number_helper.rb
+++ b/actionpack/lib/action_view/helpers/number_helper.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'active_support/core_ext/hash/keys'
+require 'active_support/core_ext/hash/reverse_merge'
 require 'active_support/core_ext/big_decimal/conversions'
 require 'active_support/core_ext/float/rounding'
 require 'active_support/core_ext/object/blank'


### PR DESCRIPTION
Another missing dependency, now affecting NumberHelper#number_to_percentage.

It depends on reverse_merge.
