### PR TITLE
Don't call after_commit when creating through an association and save fails, fixes #5802

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Don't run after_commit callback when creating through an association
+    if saving the record fails.
+
+    *James Miller *
+
 *   Allow store accessors to be overrided like other attribute methods, e.g.:
 
         class User < ActiveRecord::Base

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -286,8 +286,11 @@ module ActiveRecord
     end
 
     # Call the after_commit callbacks
+    #
+    # Ensure that it is not called if the object was never persisted (failed create),
+    # but call it after the commit of a destroyed object
     def committed! #:nodoc:
-      run_callbacks :commit
+      run_callbacks :commit if destroyed? || persisted?
     ensure
       clear_transaction_record_state
     end


### PR DESCRIPTION
As described in #5802, when creating through an association using a non-bang `create`, if the create fails for some reason, `after_commit` is still called.
