### PR TITLE
Fixes saving nil nested attributes in 3.0.19, 3.1.10, 3.2.11 (see #8832)

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -318,6 +318,7 @@ module ActiveRecord
     # then the existing record will be marked for destruction.
     def assign_nested_attributes_for_one_to_one_association(association_name, attributes)
       options = self.nested_attributes_options[association_name]
+      attributes ||= {}
       attributes = attributes.with_indifferent_access
 
       if (options[:update_only] || !attributes['id'].blank?) && (record = send(association_name)) &&
@@ -366,6 +367,7 @@ module ActiveRecord
     #   ])
     def assign_nested_attributes_for_collection_association(association_name, attributes_collection)
       options = self.nested_attributes_options[association_name]
+      attributes_collection ||= []
 
       unless attributes_collection.is_a?(Hash) || attributes_collection.is_a?(Array)
         raise ArgumentError, "Hash or Array expected, got #{attributes_collection.class.name} (#{attributes_collection.inspect})"

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -206,6 +206,17 @@ class TestNestedAttributesOnAHasOneAssociation < ActiveRecord::TestCase
     @ship = @pirate.create_ship(:name => 'Nights Dirty Lightning')
   end
 
+  def test_should_not_remove_associations_when_passed_nil_nested_attributes
+    original_ship = @pirate.ship
+
+    @pirate.update(ship_attributes: nil)
+    assert_equal @pirate.ship, original_ship
+  end
+
+  def test_should_accept_nil_attributes_for_nested_attributes
+    assert_nothing_raised{ @pirate.update(ship_attributes: nil) }
+  end
+
   def test_should_raise_argument_error_if_trying_to_build_polymorphic_belongs_to
     assert_raise_with_message ArgumentError, "Cannot build association `looter'. Are you trying to build a polymorphic one-to-one association?" do
       Treasure.new(:name => 'pearl', :looter_attributes => {:catchphrase => "Arrr"})
@@ -397,6 +408,10 @@ class TestNestedAttributesOnABelongsToAssociation < ActiveRecord::TestCase
     @ship.save!
   end
 
+  def test_should_accept_nil_attributes_for_nested_attributes
+    assert_nothing_raised { @ship.update(pirate_attributes:nil) }
+  end
+
   def test_should_define_an_attribute_writer_method_for_the_association
     assert_respond_to @ship, :pirate_attributes=
   end
@@ -562,10 +577,26 @@ class TestNestedAttributesOnABelongsToAssociation < ActiveRecord::TestCase
 
     Ship.accepts_nested_attributes_for :update_only_pirate, :update_only => true, :allow_destroy => false
   end
+
+  def test_should_replace_nil_nested_attributes_with_empty_collection
+    @ship = Ship.new
+    assert_nothing_raised { @ship.update(parts_attributes:nil) }
+
+  end
 end
 
 module NestedAttributesOnACollectionAssociationTests
   include AssertRaiseWithMessage
+
+  def test_should_not_remove_associations_when_passed_nil_nested_attributes
+    association_count = @pirate.send(@association_name).count
+    @pirate.update("#{@association_name}_attributes" => nil)
+    assert_equal @pirate.send(@association_name).count, association_count
+  end
+
+  def test_should_accept_nil_attributes_for_nested_attributes
+    assert_nothing_raised{ @pirate.update("#{@association_name}_attributes" => nil) }
+  end
 
   def test_should_define_an_attribute_writer_method_for_the_association
     assert_respond_to @pirate, association_setter
@@ -869,6 +900,7 @@ class TestNestedAttributesOnAHasAndBelongsToManyAssociation < ActiveRecord::Test
       }
     }
   end
+
 
   include NestedAttributesOnACollectionAssociationTests
 end


### PR DESCRIPTION
in ActionPack due to empty hashes and arrays in
params being replaced with nil.

Because actionpack now strips empty collections from
params, this causes NestedAttributes::assign_nested_attributes_for_collection_association to raise an ArgumentError.

This commit fixes that behavior by defaulting nil
collections to an empty hash.
