### PR TITLE
Raise an exception with a useful message if a rake task is requested for an unknown adapter

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -1,6 +1,7 @@
 module ActiveRecord
   module Tasks # :nodoc:
     class DatabaseAlreadyExists < StandardError; end # :nodoc:
+    class DatabaseNotSupported < StandardError; end # :nodoc:
 
     module DatabaseTasks # :nodoc:
       extend self
@@ -121,6 +122,9 @@ module ActiveRecord
 
       def class_for_adapter(adapter)
         key = @tasks.keys.detect { |pattern| adapter[pattern] }
+        unless key
+          raise DatabaseNotSupported, "Rake tasks not supported by '#{adapter}' adapter"
+        end
         @tasks[key]
       end
 

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -31,6 +31,12 @@ module ActiveRecord
       ActiveRecord::Tasks::DatabaseTasks.register_task(/foo/, klazz)
       ActiveRecord::Tasks::DatabaseTasks.structure_dump({'adapter' => :foo}, "awesome-file.sql")
     end
+
+    def test_unregistered_task
+      assert_raise(ActiveRecord::Tasks::DatabaseNotSupported) do
+        ActiveRecord::Tasks::DatabaseTasks.structure_dump({'adapter' => :bar}, "awesome-file.sql")
+      end
+    end
   end
 
   class DatabaseTasksCreateTest < ActiveRecord::TestCase


### PR DESCRIPTION
Currently, if one of the ActiveRecord::Tasks::DatabaseTasks entry points is run using a connection adapter that doesn't provide an implementation for DatabaseTasks, Rails raises a NoMethodError due to calling new on a nil class. (Because it fails to find a corresponding implementation, and then tries to instantiate it.) This is not a very helpful exception for this case.

This is a small change that provides a "default" DatabaseTasks implementation. This default implementation merely raises a more useful exception when invoked. We may decide, in the future, to provide true default implementations of some rake tasks.

Test case provided.
