### PR TITLE
fix rake db:migrate when used with ENV['DATABASE_URL']

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -38,7 +38,7 @@ module ActiveRecord
         private
         def resolve_string_connection(spec) # :nodoc:
           hash = configurations.fetch(spec) do |k|
-            connection_url_to_hash(k)
+            self.class.connection_url_to_hash(k)
           end
 
           raise(AdapterNotSpecified, "#{spec} database is not configured") unless hash
@@ -69,7 +69,7 @@ module ActiveRecord
         SIMPLE_INT = /\A\d+\z/
         SIMPLE_FLOAT = /\A\d+\.\d+\z/
 
-        def connection_url_to_hash(url) # :nodoc:
+        def self.connection_url_to_hash(url) # :nodoc:
           config = URI.parse url
           adapter = config.scheme
           adapter = "postgresql" if adapter == "postgres"

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -141,9 +141,7 @@ module ActiveRecord
     # and then establishes the connection.
     initializer "active_record.initialize_database" do |app|
       ActiveSupport.on_load(:active_record) do
-        unless ENV['DATABASE_URL']
-          self.configurations = app.config.database_configuration
-        end
+        self.configurations = app.config.database_configuration
         establish_connection
       end
     end

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
+*   fix rake db:* tasks to work with DATABASE_URL and without config/database.yml
+
+    *Terence Lee*
 
 *   Add notice message for destroy action in scaffold generator.
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -101,8 +101,12 @@ module Rails
       # contents of the file are processed via ERB before being sent through
       # YAML::load.
       def database_configuration
-        require 'erb'
-        YAML.load ERB.new(IO.read(paths["config/database"].first)).result
+        if ENV['DATABASE_URL']
+          {Rails.env => ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.connection_url_to_hash(ENV['DATABASE_URL']).stringify_keys}
+        else
+          require 'erb'
+          YAML.load ERB.new(IO.read(paths["config/database"].first)).result
+        end
       rescue Psych::SyntaxError => e
         raise "YAML syntax error occurred while parsing #{paths["config/database"].first}. " \
               "Please note that YAML must be consistently indented using spaces. Tabs are not allowed. " \

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -168,9 +168,16 @@ module ApplicationTests
       end
 
       test 'db:test:load_structure with database_url' do
-        require "#{app_path}/config/environment"
-        set_database_url
-        db_test_load_structure
+        old_rails_env = ENV["RAILS_ENV"]
+        ENV["RAILS_ENV"] = 'test'
+
+        begin
+          require "#{app_path}/config/environment"
+          set_database_url
+          db_test_load_structure
+        ensure
+          ENV["RAILS_ENV"] = old_rails_env
+        end
       end
     end
   end

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -21,6 +21,8 @@ module ApplicationTests
 
       def set_database_url
         ENV['DATABASE_URL'] = "sqlite3://:@localhost/#{database_url_db_name}"
+        # ensure it's using the DATABASE_URL
+        FileUtils.rm_rf("#{app_path}/config/database.yml")
       end
 
       def expected


### PR DESCRIPTION
`rake db:migrate` currently expects `config/database.yml`. This patch allows the use of `ENV['DATABASE_URL']`. This is the current error I'm seeing:

```
$ foreman run bin/rake db:migrate
rake aborted!
No such file or directory - /tmp/rails4/config/database.yml
/home/hone/Projects/heroku_work/rails/railties/lib/rails/application/configuration.rb:108:in `read'
/home/hone/Projects/heroku_work/rails/railties/lib/rails/application/configuration.rb:108:in `database_configuration'
/home/hone/Projects/heroku_work/rails/activerecord/lib/active_record/railties/databases.rake:5:in `block (2 levels) in <top (required)>'
Tasks: TOP => db:migrate => db:load_config
(See full trace by running task with --trace)
```
