### PR TITLE
Modify TimeWithZone#as_json to return 3DP of sub-second accuracy.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Modify `TimeWithZone#as_json` to include 3 decimal places of sub-second accuracy
+    by default, which is optional as per the ISO8601 spec, but extremely useful. Also
+    the default behaviour of Date#toJSON() in recent versions of Chrome, Safari and
+    Firefox.
+
 *   Improve `String#squish` to handle Unicode whitespace. *Antoine Lyset*
 
 *   Standardise on `to_time` returning an instance of `Time` in the local system timezone

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -154,7 +154,7 @@ module ActiveSupport
     #   # => "2005/02/01 15:15:10 +0000"
     def as_json(options = nil)
       if ActiveSupport::JSON::Encoding.use_standard_json_time_format
-        xmlschema
+        xmlschema(3)
       else
         %(#{time.strftime("%Y/%m/%d %H:%M:%S")} #{formatted_offset(false)})
       end

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -75,7 +75,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
 
   def test_to_json_with_use_standard_json_time_format_config_set_to_true
     old, ActiveSupport.use_standard_json_time_format = ActiveSupport.use_standard_json_time_format, true
-    assert_equal "\"1999-12-31T19:00:00-05:00\"", ActiveSupport::JSON.encode(@twz)
+    assert_equal "\"1999-12-31T19:00:00.000-05:00\"", ActiveSupport::JSON.encode(@twz)
   ensure
     ActiveSupport.use_standard_json_time_format = old
   end


### PR DESCRIPTION
The ISO8601 spec says that decimal fractions may be added for the seconds (actually any) value. The default in recent versions of Firefox, Chrome and Safari (that I have tested) all return 3 decimal places of accuracy for seconds for their default serialisation:

``` javascript
(new Date()).toJSON()
"2013-01-31T01:15:22.236Z"
```

I ran into this in an app using rails-api/active_model_serializers, and initially intended to submit a PR there, but soon discovered that it uses ActiveSupport's default JSON encodings.

It's a very simple change, so I've updated the one test for this method and added a changelog entry.  Tests pass on my machine.  Please let me know if there's anything I've missed and I'll clean it up immediately.
