### PR TITLE
Use \A in Regexps

### DIFF
--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -88,7 +88,7 @@ module ActionController
         # letters, digits, and the plus ("+"), period ("."), or hyphen ("-")
         # characters; and is terminated by a colon (":").
         # The protocol relative scheme starts with a double slash "//"
-        when %r{^(\w[\w+.-]*:|//).*}
+        when %r{\A(\w[\w+.-]*:|//).*}
           options
         when String
           request.protocol + request.host_with_port + options


### PR DESCRIPTION
So, if there is redirect_to params[:q]
i can send ?q=javascript:asdf()%0A/localpath
Or something more nasty, so please use \A
