### PR TITLE
belongs_to :touch should touch old record when transitioning.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -447,6 +447,28 @@
     *Aaron Stone + Rafael Mendonça França*
 
 *   `Relation#merge` now only overwrites where values on the LHS of the
+=======
+*   Belongs_to :touch behavior now touches old association when
+    transitioning to new association
+
+        class Passenger < ActiveRecord::Base
+           belongs_to :car, touch: true
+        end
+
+        car_1 = Car.create
+        car_2 = Car.create
+
+        passenger = Passenger.create :car => car_1
+
+        passenger.car = car_2
+        passenger.save
+
+    Previously only car_2 would be touched. Now both car_1 and car_2
+    will be touched.
+
+    *Adam Gamble*
+
+*   Relation#merge now only overwrites where values on the LHS of the
     merge. Consider:
 
         left  = Person.where(age: [13, 14, 15])

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -48,6 +48,16 @@ module ActiveRecord::Associations::Builder
         def belongs_to_touch_after_save_or_destroy_for_#{name}
           record = #{name}
 
+          foreign_key_field   = #{reflection.foreign_key}
+          if changed_attributes.key?(foreign_key_field)
+            reflection_klass  = #{reflection.klass}
+            old_foreign_id    = changed_attributes[foreign_key_field]
+            old_record        = reflection_klass.where(foreign_key_field.to_sym => old_foreign_id).first
+            if old_record
+              old_record.touch #{options[:touch].inspect if options[:touch] != true}
+            end
+          end
+
           unless record.nil? || record.new_record?
             record.touch #{options[:touch].inspect if options[:touch] != true}
           end

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -176,6 +176,40 @@ class TimestampTest < ActiveRecord::TestCase
     assert_not_equal time, owner.updated_at
   end
 
+  def test_changing_parent_of_a_record_touches_both_new_and_old_parent_record_and_grandparent_record
+    klass = Class.new(ActiveRecord::Base) do
+      def self.name; 'Toy'; end
+      belongs_to :pet, touch: true
+    end
+
+    toy1 = klass.find(1)
+    old_pet = toy1.pet
+    old_owner = old_pet.owner
+
+    toy2 = klass.find(2)
+    new_pet = toy2.pet
+    new_owner = new_pet.owner
+    time = 3.days.ago
+
+    old_pet.update_columns(updated_at: time)
+    old_owner.update_columns(updated_at: time)
+    new_pet.update_columns(updated_at: time)
+    new_owner.update_columns(updated_at: time)
+
+    toy1.pet = new_pet
+    toy1.save!
+
+    old_pet.reload
+    old_owner.reload
+    new_pet.reload
+    new_owner.reload
+
+    assert_not_equal time, old_pet.updated_at
+    assert_not_equal time, old_owner.updated_at
+    assert_not_equal time, new_pet.updated_at
+    assert_not_equal time, new_owner.updated_at
+  end
+
   def test_timestamp_attributes_for_create
     toy = Toy.first
     assert_equal toy.send(:timestamp_attributes_for_create), [:created_at, :created_on]

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -176,7 +176,7 @@ class TimestampTest < ActiveRecord::TestCase
     assert_not_equal time, owner.updated_at
   end
 
-  def test_changing_parent_of_a_record_touches_both_new_and_old_parent_record_and_grandparent_record
+  def test_changing_parent_of_a_record_touches_both_new_and_old_parent_record
     klass = Class.new(ActiveRecord::Base) do
       def self.name; 'Toy'; end
       belongs_to :pet, touch: true
@@ -184,30 +184,22 @@ class TimestampTest < ActiveRecord::TestCase
 
     toy1 = klass.find(1)
     old_pet = toy1.pet
-    old_owner = old_pet.owner
 
     toy2 = klass.find(2)
     new_pet = toy2.pet
-    new_owner = new_pet.owner
     time = 3.days.ago
 
     old_pet.update_columns(updated_at: time)
-    old_owner.update_columns(updated_at: time)
     new_pet.update_columns(updated_at: time)
-    new_owner.update_columns(updated_at: time)
 
     toy1.pet = new_pet
     toy1.save!
 
     old_pet.reload
-    old_owner.reload
     new_pet.reload
-    new_owner.reload
 
-    assert_not_equal time, old_pet.updated_at
-    assert_not_equal time, old_owner.updated_at
     assert_not_equal time, new_pet.updated_at
-    assert_not_equal time, new_owner.updated_at
+    assert_not_equal time, old_pet.updated_at
   end
 
   def test_timestamp_attributes_for_create

--- a/activerecord/test/fixtures/toys.yml
+++ b/activerecord/test/fixtures/toys.yml
@@ -2,3 +2,7 @@ bone:
   toy_id: 1
   name: Bone
   pet_id: 1
+doll:
+  toy_id: 2
+  name: Doll
+  pet_id: 2


### PR DESCRIPTION
In testing the new cache_digest functionality of Rails 4 I ran across something that might not be a bug, but to me is unexpected behavior. Assume we have a model named Person that belongs to car with the touch functionality enabled.

```
car_1 = Car.create
car_2 = Car.create

person = Person.create :car_id => car_1.id
```

At this point car_1 gets touched as expected.

```
person.car = car_2
person.save
```

At this point car_2 gets touched as expected, but car_1 is not touched. This leads to a situation where car_1's cache will not be busted. I submit that it should.

Basically when an object that belongs_to another object had a previous relationship. I think both should be touched.

I don't mind writing the code for this behavior, but I wanted to get some feedback from everyone else to see if there was a reason this wasn't ever implemented, or something i'm not thinking of.

Thanks
