### PR TITLE
Fix reset_counters crashing on has_many :through associations (3-2-stable branch).

### DIFF
--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -19,12 +19,6 @@ module ActiveRecord
       counters.each do |association|
         has_many_association = reflect_on_association(association.to_sym)
 
-        if has_many_association.options[:as]
-          has_many_association.options[:as].to_s.classify
-        else
-          self.name
-        end
-
         if has_many_association.is_a? ActiveRecord::Reflection::ThroughReflection
           has_many_association = has_many_association.through_reflection
         end

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -16,6 +16,7 @@ require 'models/book'
 require 'models/universe'
 require 'models/galaxy'
 require 'models/star'
+require 'models/planet'
 
 class CounterCacheTest < ActiveRecord::TestCase
   fixtures :topics, :categories, :categorizations, :cars, :dogs, :dog_lovers, :people, :friendships, :subscribers, :subscriptions, :books
@@ -125,7 +126,7 @@ class CounterCacheTest < ActiveRecord::TestCase
     end
   end
 
-  test "reset counter of has_many :through medium association" do
+  test "reset counter of has_many :through (through association)" do
     subscriber = subscribers('second')
     Subscriber.reset_counters(subscriber.id, 'books')
     Subscriber.increment_counter('books_count', subscriber.id)
@@ -135,12 +136,21 @@ class CounterCacheTest < ActiveRecord::TestCase
     end
   end
 
-  test "reset counter of has_many :through target association" do
+  test "reset counter of has_many :through (source association)" do
     universe = Universe.create!
     Universe.increment_counter('stars_count', universe.id)
 
     assert_difference 'universe.reload.stars_count', -1 do
       Universe.reset_counters(universe.id, 'stars')
+    end
+  end
+
+  test "reset counter of deep has_many :through (source association)" do
+    universe = Universe.create!
+    Universe.increment_counter('planets_count', universe.id)
+
+    assert_difference 'universe.reload.planets_count', -1 do
+      Universe.reset_counters(universe.id, 'planets')
     end
   end
 end

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -13,6 +13,9 @@ require 'models/friendship'
 require 'models/subscriber'
 require 'models/subscription'
 require 'models/book'
+require 'models/universe'
+require 'models/galaxy'
+require 'models/star'
 
 class CounterCacheTest < ActiveRecord::TestCase
   fixtures :topics, :categories, :categorizations, :cars, :dogs, :dog_lovers, :people, :friendships, :subscribers, :subscriptions, :books
@@ -122,13 +125,22 @@ class CounterCacheTest < ActiveRecord::TestCase
     end
   end
 
-  test "reset counter of has_many :through association" do
+  test "reset counter of has_many :through medium association" do
     subscriber = subscribers('second')
     Subscriber.reset_counters(subscriber.id, 'books')
     Subscriber.increment_counter('books_count', subscriber.id)
 
     assert_difference 'subscriber.reload.books_count', -1 do
       Subscriber.reset_counters(subscriber.id, 'books')
+    end
+  end
+
+  test "reset counter of has_many :through target association" do
+    universe = Universe.create!
+    Universe.increment_counter('stars_count', universe.id)
+
+    assert_difference 'universe.reload.stars_count', -1 do
+      Universe.reset_counters(universe.id, 'stars')
     end
   end
 end

--- a/activerecord/test/models/galaxy.rb
+++ b/activerecord/test/models/galaxy.rb
@@ -1,0 +1,4 @@
+class Galaxy < ActiveRecord::Base
+  belongs_to :universe
+  has_many :stars
+end

--- a/activerecord/test/models/planet.rb
+++ b/activerecord/test/models/planet.rb
@@ -1,0 +1,3 @@
+class Planet < ActiveRecord::Base
+  belongs_to :universe, :counter_cache => true
+end

--- a/activerecord/test/models/star.rb
+++ b/activerecord/test/models/star.rb
@@ -1,0 +1,3 @@
+class Star < ActiveRecord::Base
+  belongs_to :universe, :counter_cache => true
+end

--- a/activerecord/test/models/star.rb
+++ b/activerecord/test/models/star.rb
@@ -1,3 +1,4 @@
 class Star < ActiveRecord::Base
   belongs_to :universe, :counter_cache => true
+  has_many :planets
 end

--- a/activerecord/test/models/universe.rb
+++ b/activerecord/test/models/universe.rb
@@ -1,0 +1,4 @@
+class Universe < ActiveRecord::Base
+  has_many :galaxies
+  has_many :stars, :through => :galaxies
+end

--- a/activerecord/test/models/universe.rb
+++ b/activerecord/test/models/universe.rb
@@ -1,4 +1,5 @@
 class Universe < ActiveRecord::Base
   has_many :galaxies
   has_many :stars, :through => :galaxies
+  has_many :planets, :through => :stars
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -759,6 +759,7 @@ ActiveRecord::Schema.define do
 
   create_table :universes, :force => true do |t|
     t.integer :stars_count, :default => 0
+    t.integer :planets_count, :default => 0
   end
 
   create_table :galaxies, :force => true do |t|
@@ -767,6 +768,10 @@ ActiveRecord::Schema.define do
 
   create_table :stars, :force => true do |t|
     t.integer :galaxy_id
+  end
+
+  create_table :planets, :force => true do |t|
+    t.integer :star_id
   end
 
   except 'SQLite' do

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -757,6 +757,18 @@ ActiveRecord::Schema.define do
     t.string 'a$b'
   end
 
+  create_table :universes, :force => true do |t|
+    t.integer :stars_count, :default => 0
+  end
+
+  create_table :galaxies, :force => true do |t|
+    t.integer :universe_id
+  end
+
+  create_table :stars, :force => true do |t|
+    t.integer :galaxy_id
+  end
+
   except 'SQLite' do
     # fk_test_has_fk should be before fk_test_has_pk
     create_table :fk_test_has_fk, :force => true do |t|


### PR DESCRIPTION
This seems to have been fixed in master ( https://github.com/rails/rails/pull/7822 ), but still is broken in current stable branch.
