### PR TITLE
Backport: Duplicate column_defaults properly

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 3.2.12 (unreleased) ##
 
+*   Don't update `column_defaults` when calling destructive methods on column with default value.
+    Backport c517602.
+    Fix #6115.
+
+    *Piotr Sarnacki + Aleksey Magusev + Alan Daud*
+
 *   When `#count` is used in conjunction with `#uniq` we perform `count(:distinct => true)`.
     Fix #6865.
 

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -479,7 +479,8 @@ module ActiveRecord #:nodoc:
       #   # Instantiates a single new object bypassing mass-assignment security
       #   User.new({ :first_name => 'Jamie', :is_admin => true }, :without_protection => true)
       def initialize(attributes = nil, options = {})
-        @attributes = self.class.initialize_attributes(self.class.column_defaults.dup)
+        defaults = Hash[self.class.column_defaults.map { |k, v| [k, v.duplicable? ? v.dup : v] }]
+        @attributes = self.class.initialize_attributes(defaults)
         @association_cache = {}
         @aggregation_cache = {}
         @attributes_cache = {}

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -325,6 +325,12 @@ class BasicsTest < ActiveRecord::TestCase
     assert parrot.valid?
   end
 
+  def test_default_values_are_deeply_dupped
+    company = Company.new
+    company.description << "foo"
+    assert_equal "", Company.new.description
+  end
+
   def test_load
     topics = Topic.find(:all, :order => 'id')
     assert_equal(4, topics.size)
@@ -2148,7 +2154,7 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_attribute_names
-    assert_equal ["id", "type", "ruby_type", "firm_id", "firm_name", "name", "client_of", "rating", "account_id"],
+    assert_equal ["id", "type", "ruby_type", "firm_id", "firm_name", "name", "client_of", "rating", "account_id", "description"],
                  Company.attribute_names
   end
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -176,7 +176,7 @@ ActiveRecord::Schema.define do
     t.integer :client_of
     t.integer :rating, :default => 1
     t.integer :account_id
-    t.string :description, :null => false, :default => ""
+    t.string :description, :default => ""
   end
 
   add_index :companies, [:firm_id, :type, :rating, :ruby_type], :name => "company_index"

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -176,6 +176,7 @@ ActiveRecord::Schema.define do
     t.integer :client_of
     t.integer :rating, :default => 1
     t.integer :account_id
+    t.string :description, :null => false, :default => ""
   end
 
   add_index :companies, [:firm_id, :type, :rating, :ruby_type], :name => "company_index"


### PR DESCRIPTION
Backport c5176023a0585278c533610daf1eaf6ba7d19cd8 to fix #6115

Deleted:

```
activerecord/lib/active_record/core.rb
```

Conflicts:

```
activerecord/test/cases/base_test.rb
```
