### PR TITLE
Fix #9127, Extract PostgreSQL array column defaults more reliable.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Extract PostgreSQL array column defaults more reliable.
+
+    Fix #9127
+
+    *Tawan Sierek*
+
 *   Previously, the `has_one` macro incorrectly accepted the `counter_cache`
     option, but never actually supported it. Now it will raise an `ArgumentError`
     when using `has_one` with `counter_cache`.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -117,6 +117,8 @@ module ActiveRecord
           # Arrays
           when /\A'(.*)'::"?\D+"?\[\]\z/
             $1
+          when /\AARRAY\[(.*)\](::\D+)?\z/
+            "{#{$1.gsub(/'(.*?)'::[a-z]+(,)?\s?/, '\1\2')}}"
           # Hstore
           when /\A'(.*)'::hstore\z/
             $1

--- a/activerecord/test/cases/column_definition_test.rb
+++ b/activerecord/test/cases/column_definition_test.rb
@@ -137,6 +137,25 @@ module ActiveRecord
           smallint_column = PostgreSQLColumn.new('number', nil, oid, "smallint")
           assert_equal :integer, smallint_column.type
         end
+
+        def test_array_column_should_extract_default
+          oid = PostgreSQLAdapter::OID::Identity.new
+          array_column = PostgreSQLColumn.new('array', "'{1,2,3}'::integer[]", oid, "integer[]")
+          assert_equal '{1,2,3}', array_column.default
+
+          array_column = PostgreSQLColumn.new('array', "ARRAY[1,2,3]", oid, "integer[]")
+          assert_equal '{1,2,3}', array_column.default
+
+          array_column = PostgreSQLColumn.new('array', "ARRAY[]::integer", oid, "integer[]")
+          assert_equal '{}', array_column.default
+
+          array_column = PostgreSQLColumn.new('array', "ARRAY['a'::text, 'b'::text]", oid, "character(1)[]")
+          assert_equal '{a,b}', array_column.default
+
+          raw_default = "ARRAY['Diana''s Horse'::text, 'b'::text]"
+          array_column = PostgreSQLColumn.new('array', raw_default, oid, "character(1)[]")
+          assert_equal "{Diana''s Horse,b}", array_column.default
+        end
       end
     end
   end


### PR DESCRIPTION
As described in #9127 defaults of PostgreSQL columns of array types
are not extracted when the ARRAY constructor expression was used since
only the curly braces notation is expected.
This can lead to the situation that new instances of
activerecord models don't prefill the relating attribute with the
default value as usual and set them to `nil` instead.

Nonetheless it is completely valid to define a default value for a
column with the ARRAY constructor expression.
