### PR TITLE
Added XX-Month format to month_name helper

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Added "XX - Month" format to month_name helper. Common format for expiration dates.
+
+    *An Yu*
+
 *   Fix `content_tag_for` with array html option.
     It would embed array as string instead of joining it like `content_tag` does:
 

--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -874,7 +874,6 @@ module ActionView
         #
         # If <tt>:add_two_digit_month_numbers</tt> option is passed
         #  month_name(1) => "01 - January"
-
         def month_name(number)
           if @options[:use_month_numbers]
             number

--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -560,12 +560,16 @@ module ActionView
 
       # Returns a select tag with options for each of the months January through December with the current month
       # selected. The month names are presented as keys (what's shown to the user) and the month numbers (1-12) are
-      # used as values (what's submitted to the server). It's also possible to use month numbers for the presentation
-      # instead of names -- set the <tt>:use_month_numbers</tt> key in +options+ to true for this to happen. If you
-      # want both numbers and names, set the <tt>:add_month_numbers</tt> key in +options+ to true. If you would prefer
-      # to show month names as abbreviations, set the <tt>:use_short_month</tt> key in +options+ to true. If you want
-      # to use your own month names, set the <tt>:use_month_names</tt> key in +options+ to an array of 12 month names.
-      # If you want to display months with a leading zero set the <tt>:use_two_digit_numbers</tt> key in +options+ to true.
+      # used as values (what's submitted to the server).
+      #
+      # To show month numbers instead of names, set the <tt>:use_month_numbers</tt> key in +options+ to true.
+      # To show both numbers and names, set the <tt>:add_month_numbers</tt> key in +options+ to true.
+      # To show month names as abbreviations, set the <tt>:use_short_month</tt> key in +options+ to true.
+      # To show your own month names, set the <tt>:use_month_names</tt> key in +options+ to an array of 12 month names.
+      # To display months with a leading zero, set the <tt>:use_two_digit_numbers</tt> key in +options+ to true.
+      # To display months with a leading zero AND use month names, set the <tt>:add_two_digit_month_numbers</tt>
+      # key in +options+ to true.
+      #
       # Override the field name using the <tt>:field_name</tt> option, 'month' by default.
       #
       #   # Generates a select field for months that defaults to the current month that
@@ -583,6 +587,10 @@ module ActionView
       #   # Generates a select field for months that defaults to the current month that
       #   # will use keys like "1 - January", "3 - March".
       #   select_month(Date.today, add_month_numbers: true)
+      #
+      #   # Generates a select field for months that defaults to the current month that
+      #   # will use keys like "01 - January", "03 - March".
+      #   select_month(Date.today, add_two_digit_month_numbers: true)
       #
       #   # Generates a select field for months that defaults to the current month that
       #   # will use keys like "Jan", "Mar".
@@ -863,6 +871,10 @@ module ActionView
         #
         # If <tt>:add_month_numbers</tt> option is passed
         #  month_name(1) => "1 - January"
+        #
+        # If <tt>:add_two_digit_month_numbers</tt> option is passed
+        #  month_name(1) => "01 - January"
+
         def month_name(number)
           if @options[:use_month_numbers]
             number
@@ -870,6 +882,8 @@ module ActionView
             sprintf "%02d", number
           elsif @options[:add_month_numbers]
             "#{number} - #{month_names[number]}"
+          elsif @options[:add_two_digit_month_numbers]
+            "#{sprintf "%02d", number} - #{month_names[number]}"
           else
             month_names[number]
           end

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -324,6 +324,15 @@ class DateHelperTest < ActionView::TestCase
     assert_dom_equal expected, select_month(8, :add_month_numbers => true)
   end
 
+  def test_select_month_with_two_digit_numbers_and_names
+    expected = %(<select id="date_month" name="date[month]">\n)
+    expected << %(<option value="1">01 - January</option>\n<option value="2">02 - February</option>\n<option value="3">03 - March</option>\n<option value="4">04 - April</option>\n<option value="5">05 - May</option>\n<option value="6">06 - June</option>\n<option value="7">07 - July</option>\n<option value="8" selected="selected">08 - August</option>\n<option value="9">09 - September</option>\n<option value="10">10 - October</option>\n<option value="11">11 - November</option>\n<option value="12">12 - December</option>\n)
+    expected << "</select>\n"
+
+    assert_dom_equal expected, select_month(Time.mktime(2003, 8, 16), :add_two_digit_month_numbers => true)
+    assert_dom_equal expected, select_month(8, :add_two_digit_month_numbers => true)
+  end
+
   def test_select_month_with_numbers_and_names_with_abbv
     expected = %(<select id="date_month" name="date[month]">\n)
     expected << %(<option value="1">1 - Jan</option>\n<option value="2">2 - Feb</option>\n<option value="3">3 - Mar</option>\n<option value="4">4 - Apr</option>\n<option value="5">5 - May</option>\n<option value="6">6 - Jun</option>\n<option value="7">7 - Jul</option>\n<option value="8" selected="selected">8 - Aug</option>\n<option value="9">9 - Sep</option>\n<option value="10">10 - Oct</option>\n<option value="11">11 - Nov</option>\n<option value="12">12 - Dec</option>\n)

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -329,8 +329,8 @@ class DateHelperTest < ActionView::TestCase
     expected << %(<option value="1">01 - January</option>\n<option value="2">02 - February</option>\n<option value="3">03 - March</option>\n<option value="4">04 - April</option>\n<option value="5">05 - May</option>\n<option value="6">06 - June</option>\n<option value="7">07 - July</option>\n<option value="8" selected="selected">08 - August</option>\n<option value="9">09 - September</option>\n<option value="10">10 - October</option>\n<option value="11">11 - November</option>\n<option value="12">12 - December</option>\n)
     expected << "</select>\n"
 
-    assert_dom_equal expected, select_month(Time.mktime(2003, 8, 16), :add_two_digit_month_numbers => true)
-    assert_dom_equal expected, select_month(8, :add_two_digit_month_numbers => true)
+    assert_dom_equal expected, select_month(Time.mktime(2003, 8, 16), add_two_digit_month_numbers: true)
+    assert_dom_equal expected, select_month(8, add_two_digit_month_numbers: true)
   end
 
   def test_select_month_with_numbers_and_names_with_abbv


### PR DESCRIPTION
Added another commonly used format to date_helper's month_name method.
"01 - January"

Added test + documentation.
