### PR TITLE
check base64 decoded Authorization

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -90,7 +90,7 @@ module ActionController
       end
 
       def authenticate(request, &login_procedure)
-        unless request.authorization.blank?
+        unless request.authorization.blank? or decode_credentials(request).blank?
           login_procedure.call(*user_name_and_password(request))
         end
       end


### PR DESCRIPTION
For Authorization:3 header .blank? check will return false but Base64.decode will return empty string.
it will cause passing two nils into login_procedure block
we should check .blank? on decoded value too.
