### PR TITLE
Backport rails/rails-perftest#2 to fix rake test:benchmark

### DIFF
--- a/activesupport/lib/active_support/testing/performance.rb
+++ b/activesupport/lib/active_support/testing/performance.rb
@@ -23,7 +23,7 @@ module ActiveSupport
 
       # each implementation should define metrics and freeze the defaults
       DEFAULTS =
-        if ARGV.include?('--benchmark') # HAX for rake test
+        if ENV["BENCHMARK_TESTS"]
           { :runs => 4,
             :output => 'tmp/performance',
             :benchmark => true }

--- a/activesupport/lib/active_support/testing/performance/jruby.rb
+++ b/activesupport/lib/active_support/testing/performance/jruby.rb
@@ -6,7 +6,7 @@ module ActiveSupport
   module Testing
     module Performance
       DEFAULTS.merge!(
-        if ARGV.include?('--benchmark')
+        if ENV["BENCHMARK_TESTS"]
           {:metrics => [:wall_time, :user_time, :memory, :gc_runs, :gc_time]}
         else
           { :metrics => [:wall_time],

--- a/activesupport/lib/active_support/testing/performance/rubinius.rb
+++ b/activesupport/lib/active_support/testing/performance/rubinius.rb
@@ -4,7 +4,7 @@ module ActiveSupport
   module Testing
     module Performance
       DEFAULTS.merge!(
-        if ARGV.include?('--benchmark')
+        if ENV["BENCHMARK_TESTS"]
           {:metrics => [:wall_time, :memory, :objects, :gc_runs, :gc_time]}
         else
           { :metrics => [:wall_time],

--- a/activesupport/lib/active_support/testing/performance/ruby.rb
+++ b/activesupport/lib/active_support/testing/performance/ruby.rb
@@ -9,7 +9,7 @@ module ActiveSupport
   module Testing
     module Performance
       DEFAULTS.merge!(
-        if ARGV.include?('--benchmark')
+        if ENV["BENCHMARK_TESTS"]
           { :metrics => [:wall_time, :memory, :objects, :gc_runs, :gc_time] }
         else
           { :min_percent => 0.01,

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -21,6 +21,11 @@
 
 *   No changes.
 
+*   Fix launching performance tests through rake `test:benchmark`.
+    Fixes #4938.
+    Backport rails/rails-perftest#2.
+
+    *Dmitry Vorotilin + Yves Senn*
 
 ## Rails 3.2.11 (Jan 8, 2013) ##
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## unreleased ##
 
+*   Fix bugs that crashed `rake test:benchmark`, `rails profiler` and
+    `rails benchmarker`.
+    Fixes #4938.
+
+    *Yves Senn*
+
 *   Add support for runner hook.
 
     Backport #7695.

--- a/railties/lib/rails/commands/benchmarker.rb
+++ b/railties/lib/rails/commands/benchmarker.rb
@@ -2,9 +2,8 @@ require 'optparse'
 require 'rails/test_help'
 require 'rails/performance_test_help'
 
-ARGV.push('--benchmark') # HAX
+ENV["BENCHMARK_TESTS"] = '1'
 require 'active_support/testing/performance'
-ARGV.pop
 
 def options
   options = {}

--- a/railties/lib/rails/commands/benchmarker.rb
+++ b/railties/lib/rails/commands/benchmarker.rb
@@ -30,4 +30,5 @@ class BenchmarkerTest < ActionDispatch::PerformanceTest #:nodoc:
       end
     RUBY
   end
+  ARGV.clear
 end

--- a/railties/lib/rails/commands/profiler.rb
+++ b/railties/lib/rails/commands/profiler.rb
@@ -29,4 +29,5 @@ class ProfilerTest < ActionDispatch::PerformanceTest #:nodoc:
       end
     RUBY
   end
+  ARGV.clear
 end

--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -123,10 +123,13 @@ namespace :test do
     t.pattern = 'test/integration/**/*_test.rb'
   end
 
-  Rails::SubTestTask.new(:benchmark => 'test:prepare') do |t|
+  task 'test:benchmark_mode' do
+    ENV["BENCHMARK_TESTS"] = '1'
+  end
+
+  Rails::SubTestTask.new(:benchmark => ['test:prepare', 'test:benchmark_mode']) do |t|
     t.libs << 'test'
     t.pattern = 'test/performance/**/*_test.rb'
-    t.options = '-- --benchmark'
   end
 
   Rails::SubTestTask.new(:profile => 'test:prepare') do |t|


### PR DESCRIPTION
This is a backport of https://github.com/rails/rails-perftest/pull/2 to fix #4938.

The rake task does now work but while testing I got problems with the `rails benchmarker` and `rails profiler` commands:

```
local-3-2-stable » rails profiler '10.times{"a string"}'
/Users/senny/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/test/unit.rb:167:in `block in non_options': file not found: 10.times{"a string"} (ArgumentError)
    from /Users/senny/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/test/unit.rb:146:in `map!'
    from /Users/senny/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/test/unit.rb:146:in `non_options'
    from /Users/senny/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/test/unit.rb:207:in `non_options'
    from /Users/senny/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/test/unit.rb:52:in `process_args'
    from /Users/senny/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/minitest/unit.rb:891:in `_run'
    from /Users/senny/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/minitest/unit.rb:884:in `run'
    from /Users/senny/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/test/unit.rb:21:in `run'
    from /Users/senny/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/test/unit.rb:326:in `block (2 levels) in autorun'
    from /Users/senny/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/test/unit.rb:27:in `run_once'
    from /Users/senny/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/test/unit.rb:325:in `block in autorun'
```

I could fix this by clearing `ARGV` after the ["on-the-fly-test-case"](https://github.com/senny/rails/blob/backport_perftest_fix/railties/lib/rails/commands/benchmarker.rb#L32) is defined. This would be another hacky workaround though and I'm open for better ideas.
