### PR TITLE
Prevent relation builder from generating NULL for array of ranges

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -70,23 +70,25 @@ module ActiveRecord
           values = value.to_a.map {|x| x.is_a?(Base) ? x.id : x}
           ranges, values = values.partition {|v| v.is_a?(Range)}
 
-          values_predicate = if values.include?(nil)
-            values = values.compact
+          array_predicates = ranges.map { |range| attribute.in(range) }
 
-            case values.length
-            when 0
-              attribute.eq(nil)
-            when 1
-              attribute.eq(values.first).or(attribute.eq(nil))
+          if values.present?
+            array_predicates << if values.include?(nil)
+              values = values.compact
+
+              case values.length
+              when 0
+                attribute.eq(nil)
+              when 1
+                attribute.eq(values.first).or(attribute.eq(nil))
+              else
+                attribute.in(values).or(attribute.eq(nil))
+              end
             else
-              attribute.in(values).or(attribute.eq(nil))
+              attribute.in(values)
             end
-          else
-            attribute.in(values)
           end
 
-          array_predicates = ranges.map { |range| attribute.in(range) }
-          array_predicates << values_predicate
           array_predicates.inject { |composite, predicate| composite.or(predicate) }
         when ActiveRecord::Relation
           value = value.select(value.klass.arel_table[value.klass.primary_key]) if value.select_values.empty?

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -361,6 +361,14 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal [1,2,3,5,6,7,8,9], Comment.all.merge!(:where => {:id => [1..2, 3, 5, 6..8, 9]}).to_a.map(&:id).sort
   end
 
+  def test_find_on_hash_conditions_with_array_of_ranges
+    relation = Comment.where(:id => [1..2, 6..8])
+    assert_equal [1, 2, 6, 7, 8], relation.map(&:id).sort
+    sql = relation.to_sql
+    assert_no_match(/NULL/, sql)
+    assert_no_match(/1=0/, sql)
+  end
+
   def test_find_on_multiple_hash_conditions
     assert Topic.all.merge!(:where => { :author_name => "David", :title => "The First Topic", :replies_count => 1, :approved => false }).find(1)
     assert_raise(ActiveRecord::RecordNotFound) { Topic.all.merge!(:where => { :author_name => "David", :title => "The First Topic", :replies_count => 1, :approved => true }).find(1) }


### PR DESCRIPTION
Patch fixing issue #9171 on master
