### PR TITLE
Support for PostgreSQL citext data type.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -19,6 +19,11 @@
 
     *Justin George*
 
+*   Support for Postgres citext data type enabling case-insensitive where 
+    values without needing to wrap in UPPER/LOWER sql functions
+
+    *Troy Kruthoff*
+
 *   The `DATABASE_URL` environment variable now converts ints, floats, and
     the strings true and false to Ruby types. For example, SQLite requires
     that the timeout value is an integer, and PostgreSQL requires that the

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Support for Postgres citext data type enabling case-insensitive where 
+    values without needing to wrap in UPPER/LOWER sql functions
+
+    *Troy Kruthoff*
+
 *   The `DATABASE_URL` environment variable now converts ints, floats, and
     the strings true and false to Ruby types. For example, SQLite requires
     that the timeout value is an integer, and PostgreSQL requires that the

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -337,6 +337,7 @@ module ActiveRecord
         register_type 'circle', OID::Identity.new
         register_type 'hstore', OID::Hstore.new
         register_type 'json', OID::Json.new
+        register_type 'citext', OID::Identity.new
         register_type 'ltree', OID::Identity.new
 
         register_type 'cidr', OID::Cidr.new

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -185,7 +185,7 @@ module ActiveRecord
           when 'macaddr'
             :macaddr
           # Character types
-          when /^(?:character varying|bpchar)(?:\(\d+\))?$/
+          when /^(?:character varying|bpchar|citext)(?:\(\d+\))?$/
             :string
           # Binary data types
           when 'bytea'
@@ -326,6 +326,10 @@ module ActiveRecord
           column(name, 'json', options)
         end
 
+        def citext(name, options = {})
+          column(name, 'citext', options)
+        end
+
         def column(name, type = nil, options = {})
           super
           column = self[name]
@@ -373,7 +377,8 @@ module ActiveRecord
         macaddr:     { name: "macaddr" },
         uuid:        { name: "uuid" },
         json:        { name: "json" },
-        ltree:       { name: "ltree" }
+        ltree:       { name: "ltree" },
+        citext:      { name: "citext" }
       }
 
       include Quoting

--- a/activerecord/test/cases/adapters/postgresql/citext_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/citext_test.rb
@@ -1,0 +1,67 @@
+# encoding: utf-8
+
+require "cases/helper"
+require 'active_record/base'
+require 'active_record/connection_adapters/postgresql_adapter'
+
+class PostgresqlHstoreTest < ActiveRecord::TestCase
+  class Citext < ActiveRecord::Base
+    self.table_name = 'citexts'
+  end
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+    unless @connection.extension_enabled?('citext')
+      @connection.enable_extension 'citext'
+      return skip "do not test on PG without citext"
+    end
+
+    @connection.transaction do
+      @connection.create_table('citexts') do |t|
+        t.citext 'cival'
+      end
+    end
+    @column = Citext.columns.find { |c| c.name == 'cival' }
+  end
+
+  def teardown
+    @connection.execute 'drop table if exists citexts'
+  end
+
+  def test_citext_enabled
+    assert @connection.extension_enabled?('citext')
+  end
+
+  def test_disable_hstore
+    if @connection.extension_enabled?('citext')
+      @connection.disable_extension 'citext'
+      assert_not @connection.extension_enabled?('citext')
+    end
+  end
+
+  def test_enable_hstore
+    if @connection.extension_enabled?('citext')
+      @connection.disable_extension 'citext'
+    end
+
+    assert_not @connection.extension_enabled?('citext')
+    @connection.enable_extension 'citext'
+    assert @connection.extension_enabled?('citext')
+  end
+
+  def test_column
+    assert_equal :string, @column.type
+  end
+
+  def test_write
+    x = Citext.new(cival: 'Some CI Text')
+    assert x.save!
+  end
+
+  def test_select
+    @connection.execute "insert into citexts (cival) values('text')"
+    x = Citext.first
+    assert_equal('text', x.cival)
+  end
+end
+

--- a/activerecord/test/cases/adapters/postgresql/citext_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/citext_test.rb
@@ -4,7 +4,7 @@ require "cases/helper"
 require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
-class PostgresqlHstoreTest < ActiveRecord::TestCase
+class PostgresqlCitextTest < ActiveRecord::TestCase
   class Citext < ActiveRecord::Base
     self.table_name = 'citexts'
   end
@@ -32,14 +32,14 @@ class PostgresqlHstoreTest < ActiveRecord::TestCase
     assert @connection.extension_enabled?('citext')
   end
 
-  def test_disable_hstore
+  def test_disable_citext
     if @connection.extension_enabled?('citext')
       @connection.disable_extension 'citext'
       assert_not @connection.extension_enabled?('citext')
     end
   end
 
-  def test_enable_hstore
+  def test_enable_citext
     if @connection.extension_enabled?('citext')
       @connection.disable_extension 'citext'
     end
@@ -58,10 +58,10 @@ class PostgresqlHstoreTest < ActiveRecord::TestCase
     assert x.save!
   end
 
-  def test_select
-    @connection.execute "insert into citexts (cival) values('text')"
-    x = Citext.first
-    assert_equal('text', x.cival)
+  def test_select_case_insensitive
+    @connection.execute "insert into citexts (cival) values('Cased Text')"
+    x = Citext.where(cival: 'cased text').first
+    assert_equal('Cased Text', x.cival)
   end
 end
 

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -36,6 +36,9 @@ end
 class PostgresqlLtree < ActiveRecord::Base
 end
 
+class PostgresqlCitext < ActiveRecord::Base
+end
+
 class PostgresqlDataTypeTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
 

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -1,7 +1,7 @@
 ActiveRecord::Schema.define do
 
   %w(postgresql_ranges postgresql_tsvectors postgresql_hstores postgresql_arrays postgresql_moneys postgresql_numbers postgresql_times postgresql_network_addresses postgresql_bit_strings postgresql_uuids postgresql_ltrees
-      postgresql_oids postgresql_xml_data_type defaults geometrics postgresql_timestamp_with_zones postgresql_partitioned_table postgresql_partitioned_table_parent postgresql_json_data_type).each do |table_name|
+      postgresql_oids postgresql_xml_data_type defaults geometrics postgresql_timestamp_with_zones postgresql_partitioned_table postgresql_partitioned_table_parent postgresql_json_data_type postgresql_citext).each do |table_name|
     execute "DROP TABLE IF EXISTS #{quote_table_name table_name}"
   end
 
@@ -106,6 +106,15 @@ _SQL
   CREATE TABLE postgresql_ltrees (
     id SERIAL PRIMARY KEY,
     path ltree
+  );
+_SQL
+  end
+
+  if 't' == select_value("select 'citext'=ANY(select typname from pg_type)")
+  execute <<_SQL
+  CREATE TABLE postgresql_citext (
+    id SERIAL PRIMARY KEY,
+    text_citext citext default ''::citext
   );
 _SQL
   end


### PR DESCRIPTION
citext makes it possible to use AR Hash finders for case-insensitive
matching as sql UPPER/LOWER functions are not needed.
