### PR TITLE
Fix article for generator name

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -20,10 +20,10 @@ module Rails
 
       def self.add_shared_options_for(name)
         class_option :builder,            type: :string, aliases: '-b',
-                                          desc: "Path to a #{name} builder (can be a filesystem path or URL)"
+                                          desc: "Path to some #{name} builder (can be a filesystem path or URL)"
 
         class_option :template,           type: :string, aliases: '-m',
-                                          desc: "Path to an #{name} template (can be a filesystem path or URL)"
+                                          desc: "Path to some #{name} template (can be a filesystem path or URL)"
 
         class_option :skip_gemfile,       type: :boolean, default: false,
                                           desc: "Don't create a Gemfile"


### PR DESCRIPTION
The generator name should be checked whether
the beginning of the word is vowel or not.

I fixed the following:
- 'a application' -> 'an application'
- 'an plugin'     -> 'a plugin'
