### PR TITLE
Update activesupport/lib/active_support/json/backends/okjson.rb

### DIFF
--- a/activesupport/lib/active_support/json/backends/okjson.rb
+++ b/activesupport/lib/active_support/json/backends/okjson.rb
@@ -213,6 +213,7 @@ module ActiveSupport
       when ?t  then truetok(s)
       when ?f  then falsetok(s)
       when ?"  then strtok(s)
+      when ?'  then strtok_single_quotes(s)
       when Spc then [:space, s[0,1], s[0,1]]
       when ?\t then [:space, s[0,1], s[0,1]]
       when ?\n then [:space, s[0,1], s[0,1]]
@@ -245,6 +246,14 @@ module ActiveSupport
 
     def strtok(s)
       m = /"([^"\\]|\\["\/\\bfnrt]|\\u[0-9a-fA-F]{4})*"/.match(s)
+      if ! m
+        raise Error, "invalid string literal at #{abbrev(s)}"
+      end
+      [:str, m[0], unquote(m[0])]
+    end
+    
+    def strtok_single_quotes(s)
+      m = /'([^'\\]|\\['\/\\bfnrt]|\\u[0-9a-fA-F]{4})*'/.match(s)
       if ! m
         raise Error, "invalid string literal at #{abbrev(s)}"
       end


### PR DESCRIPTION
Okjson not parsing " ' " (single quote character). Writing a method and adding conditions for the same.
For example the following Json response will not be parsed properly : 
[{'key' : 'value'}]
but if the response uses double quotes(") instead of single quotes (') it will work properly.
This commit will also take care of responses returned with single quotes.
