### PR TITLE
fixing issue 8931

### DIFF
--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -367,4 +367,12 @@ class LengthValidationTest < ActiveModel::TestCase
   ensure
     Person.reset_callbacks(:validate)
   end
+
+  def test_validates_with_diff_in_option
+    Topic.validates_length_of( :title, :is => 5)
+    Topic.validates_length_of( :title, :is => 5, :if => Proc.new { false } )
+
+    assert Topic.new("title" => "david").valid?
+    assert Topic.new("title" => "david2").invalid?
+  end
 end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -4,6 +4,15 @@
 
     *Dan Kubb*
 
+*   Prevent `Callbacks#set_callback` from setting the same callback twice.
+
+        before_save :foo, :bar, :foo
+
+    will at first call `bar`, then `foo`. `foo` will no more be called
+    twice.
+
+    *Dmitriy Kiriyenko*
+
 *   Remove surrogate unicode character encoding from ActiveSupport::JSON.encode
     The encoding scheme was broken for unicode characters outside the basic
     multilingual plane; since json is assumed to be UTF-8, and we already force the

--- a/activesupport/test/test_test.rb
+++ b/activesupport/test/test_test.rb
@@ -131,12 +131,12 @@ end
 # Setup and teardown callbacks.
 class SetupAndTeardownTest < ActiveSupport::TestCase
   setup :reset_callback_record, :foo
-  teardown :foo, :sentinel, :foo
+  teardown :foo, :sentinel
 
   def test_inherited_setup_callbacks
     assert_equal [:reset_callback_record, :foo], self.class._setup_callbacks.map(&:raw_filter)
     assert_equal [:foo], @called_back
-    assert_equal [:foo, :sentinel, :foo], self.class._teardown_callbacks.map(&:raw_filter)
+    assert_equal [:foo, :sentinel], self.class._teardown_callbacks.map(&:raw_filter)
   end
 
   def setup
@@ -156,7 +156,7 @@ class SetupAndTeardownTest < ActiveSupport::TestCase
     end
 
     def sentinel
-      assert_equal [:foo, :foo], @called_back
+      assert_equal [:foo], @called_back
     end
 end
 
@@ -168,7 +168,7 @@ class SubclassSetupAndTeardownTest < SetupAndTeardownTest
   def test_inherited_setup_callbacks
     assert_equal [:reset_callback_record, :foo, :bar], self.class._setup_callbacks.map(&:raw_filter)
     assert_equal [:foo, :bar], @called_back
-    assert_equal [:foo, :sentinel, :foo, :bar], self.class._teardown_callbacks.map(&:raw_filter)
+    assert_equal [:foo, :sentinel, :bar], self.class._teardown_callbacks.map(&:raw_filter)
   end
 
   protected
@@ -177,6 +177,6 @@ class SubclassSetupAndTeardownTest < SetupAndTeardownTest
     end
 
     def sentinel
-      assert_equal [:foo, :bar, :bar, :foo], @called_back
+      assert_equal [:foo, :bar, :bar], @called_back
     end
 end


### PR DESCRIPTION
this fix issue #8931.

When you add one callack in two separate `set_callback` calls - it is
only called once.

When you do it in one `set_callback` call - it is called twice.

This violates the principle of least astonishment for me. Duplicating
callback is usually an error. There is a correct and obvious way to do
anything without this "feature".

If you want to do

``` ruby
    before_save :clear_balance, :calculate_tax, :clear_balance
```

or whatever, you should better do

``` ruby
    before_save :carefully_calculate_tax

    def carefully_calculate_tax
      clear_balance
      calculate_tax
      clear_balance
    end
```

And this even opens gates for some advanced refactorings, unlike the
first approach.

My assumptions are:
- Principle of least astonishment is violated, when callbacks are either
  prevented from duplication, or not.
- Duplicating callbacks is usually an error. When it is intentional -
  it's a smell of a bad design and can be approached without abusing
  this "feature".

My suggestion is: do not allow duplicating callbacks in one callback
call, like it is not allowed in separate callbacks call.

Conflicts:
    activesupport/CHANGELOG.md
    activesupport/lib/active_support/callbacks.rb
    activesupport/test/callbacks_test.rb
