### PR TITLE
Ignore .ruby-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 debug.log
 .Gemfile
 /.bundle
+/.ruby-version
 /.rbenv-version
 /.rvmrc
 /Gemfile.lock


### PR DESCRIPTION
Both rbenv and RVM prefer `.ruby-version` now.
See: https://gist.github.com/fnichol/1912050
