### PR TITLE
Docs: Fixed bad exists? documentation.

### DIFF
--- a/railties/guides/source/active_record_querying.textile
+++ b/railties/guides/source/active_record_querying.textile
@@ -867,10 +867,11 @@ Client.exists?(1,2,3)
 Client.exists?([1,2,3])
 </ruby>
 
-Further more, +exists+ takes a +conditions+ option much like find:
+Further more, +exists+ takes a hash or array like what you would pass into a +conditions+ option:
 
 <ruby>
-Client.exists?(:conditions => "first_name = 'Ryan'")
+Client.exists?(:first_name => 'Ryan')
+Client.exists?(['first_name = ?', 'Ryan'])
 </ruby>
 
 It's even possible to use +exists?+ without any arguments:


### PR DESCRIPTION
First I want to say, I am not sure of the best way of fixing 2.3 docs, since docrails only has the one branch. If this isn't the right way I can ammend this. Thanks.

Base#exists? does not actually take options like finder methods. Trying
to use what the documentation suggests will return a PG error because it
will look for a column named 'conditions'.

I changed the documentation to reflect how the exists? method actually
works in 2-3.
