### PR TITLE
Fix: Overriding attributes on `dup` by default scopes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -181,6 +181,10 @@
 
     *Justin George*
 
+*   Fix overriding of attributes by default_scope on `ActiveRecord::Base#dup`.
+
+    *Hiroshige UMINO*
+
 *   The database adpters now converts the options passed thought `DATABASE_URL`
     environment variable to the proper Ruby types before using. For example, SQLite requires
     that the timeout value is an integer, and PostgreSQL requires that the

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -249,7 +249,6 @@ module ActiveRecord
       @new_record  = true
 
       ensure_proper_type
-      populate_with_current_scope_attributes
       super
     end
 

--- a/activerecord/test/cases/dup_test.rb
+++ b/activerecord/test/cases/dup_test.rb
@@ -123,5 +123,14 @@ module ActiveRecord
         assert duped.valid?
       end
     end
+
+    def test_dup_with_default_scope
+      prev_default_scopes = Topic.default_scopes
+      Topic.default_scopes = [Topic.where(:approved => true)]
+      topic = Topic.new(:approved => false)
+      assert !topic.dup.approved?, "should not be overriden by default scopes"
+    ensure
+      Topic.default_scopes = prev_default_scopes
+    end
   end
 end


### PR DESCRIPTION
Unexpecting overriding occurs like this: 

```
class Topic < ActiveRecord::Base
  default_scope { where(:private => false) }
end
Topic.new(:private => true).dup.private # => false
```
