### PR TITLE
Adding unscope to WhereChain

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Added functionality to unscope relations in a relations chain. For
+    instance, if you are passed in a chain of relations as follows:
+
+        Posts.select(:name => "John").order('id DESC') 
+
+    but you want to get rid of order, then this feature allows you to do:
+
+        Posts.select(:name => "John").order("id DESC").unscope(:order)
+            == Posts.select(:name => "John")
+
+    The .unscope() function is more general than the .except() method because
+    .except() only works on the relation it is acting on. However, .unscope()
+    works for any relation in the entire relation chain.
+
+    *John Wang*
+
 *   Postgresql timestamp with time zone (timestamptz) datatype now returns a
     ActiveSupport::TimeWithZone instance instead of a string
 

--- a/activerecord/test/cases/relation_scoping_test.rb
+++ b/activerecord/test/cases/relation_scoping_test.rb
@@ -424,6 +424,150 @@ class DefaultScopingTest < ActiveRecord::TestCase
     assert_equal expected, received
   end
 
+  def test_unscope_overrides_default_scope
+    expected = Developer.all.collect { |dev| [dev.name, dev.id] }
+    received = Developer.order('name ASC, id DESC').unscope(:order).collect { |dev| [dev.name, dev.id] }
+    assert_equal expected, received
+  end
+
+  def test_unscope_after_reordering_and_combining
+    expected = Developer.order('id DESC, name DESC').collect { |dev| [dev.name, dev.id] }
+    received = DeveloperOrderedBySalary.reorder('name DESC').unscope(:order).order('id DESC, name DESC').collect { |dev| [dev.name, dev.id] }
+    assert_equal expected, received
+
+    expected_2 = Developer.all.collect { |dev| [dev.name, dev.id] }
+    received_2 = Developer.order('id DESC, name DESC').unscope(:order).collect { |dev| [dev.name, dev.id] }
+    assert_equal expected_2, received_2
+
+    expected_3 = Developer.all.collect { |dev| [dev.name, dev.id] }
+    received_3 = Developer.reorder('name DESC').unscope(:order).collect { |dev| [dev.name, dev.id] }
+    assert_equal expected_3, received_3
+  end
+
+  def test_unscope_with_where_attributes
+    expected = Developer.order('salary DESC').collect { |dev| dev.name }
+    received = DeveloperOrderedBySalary.where(name: 'David').unscope(where: :name).collect { |dev| dev.name }
+    assert_equal expected, received
+
+    expected_2 = Developer.order('salary DESC').collect { |dev| dev.name }
+    received_2 = DeveloperOrderedBySalary.select("id").where("name" => "Jamis").unscope({:where => :name}, :select).collect { |dev| dev.name }
+    assert_equal expected_2, received_2
+
+    expected_3 = Developer.order('salary DESC').collect { |dev| dev.name }
+    received_3 = DeveloperOrderedBySalary.select("id").where("name" => "Jamis").unscope(:select, :where).collect { |dev| dev.name }
+    assert_equal expected_3, received_3
+  end
+
+  def test_unscope_multiple_where_clauses
+    expected = Developer.order('salary DESC').collect { |dev| dev.name }
+    received = DeveloperOrderedBySalary.where(name: 'Jamis').where(id: 1).unscope(where: [:name, :id]).collect { |dev| dev.name }
+    assert_equal expected, received
+  end
+
+  def test_unscope_with_grouping_attributes
+    expected = Developer.order('salary DESC').collect { |dev| dev.name }
+    received = DeveloperOrderedBySalary.group(:name).unscope(:group).collect { |dev| dev.name }
+    assert_equal expected, received
+
+    expected_2 = Developer.order('salary DESC').collect { |dev| dev.name }
+    received_2 = DeveloperOrderedBySalary.group("name").unscope(:group).collect { |dev| dev.name }
+    assert_equal expected_2, received_2
+  end
+
+  def test_unscope_with_limit_in_query
+    expected = Developer.order('salary DESC').collect { |dev| dev.name }
+    received = DeveloperOrderedBySalary.limit(1).unscope(:limit).collect { |dev| dev.name }
+    assert_equal expected, received
+  end
+
+  def test_order_to_unscope_reordering
+    expected = DeveloperOrderedBySalary.all.collect { |dev| [dev.name, dev.id] }
+    received = DeveloperOrderedBySalary.order('salary DESC, name ASC').reverse_order.unscope(:order).collect { |dev| [dev.name, dev.id] }
+    assert_equal expected, received
+  end
+
+  def test_unscope_reverse_order
+    expected = Developer.all.collect { |dev| dev.name }
+    received = Developer.order('salary DESC').reverse_order.unscope(:order).collect { |dev| dev.name }
+    assert_equal expected, received
+  end
+
+  def test_unscope_select
+    expected = Developer.order('salary ASC').collect { |dev| dev.name }
+    received = Developer.order('salary DESC').reverse_order.select(:name => "Jamis").unscope(:select).collect { |dev| dev.name }
+    assert_equal expected, received
+
+    expected_2 = Developer.all.collect { |dev| dev.id }
+    received_2 = Developer.select(:name).unscope(:select).collect { |dev| dev.id }
+    assert_equal expected_2, received_2
+  end
+
+  def test_unscope_offset
+    expected = Developer.all.collect { |dev| dev.name }
+    received = Developer.offset(5).unscope(:offset).collect { |dev| dev.name }
+    assert_equal expected, received
+  end
+
+  def test_unscope_joins_and_select_on_developers_projects
+    expected = Developer.all.collect { |dev| dev.name }
+    received = Developer.joins('JOIN developers_projects ON id = developer_id').select(:id).unscope(:joins, :select).collect { |dev| dev.name }
+    assert_equal expected, received
+  end
+
+  def test_unscope_includes
+    expected = Developer.all.collect { |dev| dev.name }
+    received = Developer.includes(:projects).select(:id).unscope(:includes, :select).collect { |dev| dev.name }
+    assert_equal expected, received
+  end
+
+  def test_unscope_having
+    expected = DeveloperOrderedBySalary.all.collect { |dev| dev.name }
+    received = DeveloperOrderedBySalary.having("name IN ('Jamis', 'David')").unscope(:having).collect { |dev| dev.name }
+    assert_equal expected, received
+  end
+
+  def test_unscope_errors_with_invalid_value
+    assert_raises(ArgumentError) do
+      Developer.includes(:projects).where(name: "Jamis").unscope(:stupidly_incorrect_value)
+    end
+
+    assert_raises(ArgumentError) do
+      Developer.all.unscope(:includes, :select, :some_broken_value)
+    end
+
+    assert_raises(ArgumentError) do
+      Developer.order('name DESC').reverse_order.unscope(:reverse_order)
+    end
+
+    assert_raises(ArgumentError) do
+      Developer.order('name DESC').where(name: "Jamis").unscope()
+    end
+  end
+
+  def test_unscope_errors_with_non_where_hash_keys
+    assert_raises(ArgumentError) do
+      Developer.where(name: "Jamis").limit(4).unscope(limit: 4)
+    end
+
+    assert_raises(ArgumentError) do
+      Developer.where(name: "Jamis").unscope("where" => :name)
+    end
+  end
+
+  def test_unscope_errors_with_non_symbol_or_hash_arguments
+    assert_raises(ArgumentError) do
+      Developer.where(name: "Jamis").limit(3).unscope("limit")
+    end
+
+    assert_raises(ArgumentError) do
+      Developer.select("id").unscope("select")
+    end
+
+    assert_raises(ArgumentError) do 
+      Developer.select("id").unscope(5)
+    end
+  end
+
   def test_order_in_default_scope_should_not_prevail
     expected = Developer.all.merge!(:order => 'salary').to_a.collect { |dev| dev.salary }
     received = DeveloperOrderedBySalary.all.merge!(:order => 'salary').to_a.collect { |dev| dev.salary }

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -692,6 +692,27 @@ The SQL that would be executed:
 SELECT * FROM posts WHERE id > 10 LIMIT 20
 ```
 
+### `unscope`
+
+The `except` method does not work when the relation is merged. For example:
+
+```ruby
+Post.comments.except(:order)
+```
+
+will still have an order if the order comes from a default scope on Comment. In order to remove all ordering, even from relations which are merged in, use unscope as follows:
+
+```ruby
+Post.order('id DESC').limit(20).unscope(:order) = Post.limit(20)
+Post.order('id DESC').limit(20).unscope(:order, :limit) = Post.all
+```
+
+You can additionally unscope specific where clauses. For example:
+
+```ruby
+Post.where(:id => 10).limit(1).unscope(:where => :id, :limit).order('id DESC') = Post.order('id DESC')
+```
+
 ### `only`
 
 You can also override conditions using the `only` method. For example:


### PR DESCRIPTION
This pull request adds functionality so that you can unscope something in a where chain. For instance, if you are passed in a WhereChain as follows: Posts.select(:name => "John").order('id DESC') but you want to get rid of order, then this feature allows you to do:

Posts.select(:name => "John").order("id DESC").unscope(:order) == Posts.select(:name => "John")

This is implemented for all methods in the ActiveRecord query interface such as:

where
select
group
order
reorder
reverse_order
limit
offset
joins
includes
lock
readonly
from
having

Currently, joins, includes, lock, readonly, from, and having have not yet been tested.
