### PR TITLE
schema dumper tests now conducted by ActiveRecord::Base.Connection

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -314,6 +314,10 @@ module ActiveRecord
         # override in derived class
         ActiveRecord::StatementInvalid.new(message)
       end
+
+      def valid_types?(type)
+        true
+      end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -750,6 +750,9 @@ module ActiveRecord
         execute("SET #{encoding} #{variable_assignments}", :skip_logging)
       end
 
+      def valid_type?(type)
+        !native_database_types[type].nil?
+      end  
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -820,6 +820,10 @@ module ActiveRecord
         def table_definition
           TableDefinition.new(self)
         end
+
+        def valid_type?(type)
+          !native_database_types[type].nil?
+        end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -599,6 +599,10 @@ module ActiveRecord
           end
         end
 
+        def valid_type?(type)
+          true
+        end
+
     end
   end
 end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -105,7 +105,7 @@ HEADER
 
           # then dump all non-primary key columns
           column_specs = columns.map do |column|
-            raise StandardError, "Unknown type '#{column.sql_type}' for column '#{column.name}'" if @types[column.type].nil?
+            raise StandardError, "Unknown type '#{column.sql_type}' for column '#{column.name}'" unless @connection.valid_type?(column.type)
             next if column.name == pk
             @connection.column_spec(column, @types)
           end.compact

--- a/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
@@ -16,6 +16,15 @@ module ActiveRecord
         eosql
       end
 
+      def test_valid_column
+        column = @conn.column('ex').find { |col| col.name == 'id' }
+        assert @conn.valid_type?(column.type)
+      end
+
+      def test_invalid_column
+        assert !@conn.valid_type?(:foobar)
+      end
+
       def test_client_encoding
         assert_equal Encoding::UTF_8, @conn.client_encoding
       end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -10,6 +10,15 @@ module ActiveRecord
         @connection.exec_query('create table ex(id serial primary key, number integer, data character varying(255))')
       end
 
+      def test_valid_column
+        column = @connection.column('ex').find { |col| col.name == 'id' }
+        assert @connection.valid_type?(column.type)
+      end
+
+      def test_invalid_column
+        assert !@connection.valid_type?(:foobar)
+      end
+
       def test_primary_key
         assert_equal 'id', @connection.primary_key('ex')
       end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -25,6 +25,15 @@ module ActiveRecord
         @conn.intercepted = true
       end
 
+      def test_valid_column
+        column = @conn.column('items').find { |col| col.name == 'id' }
+        assert @conn.valid_type?(column.type)
+      end
+
+      def test_invalid_column
+        assert @conn.valid_type?(:foobar)
+      end
+
       def teardown
         @conn.intercepted = false
         @conn.logged = []


### PR DESCRIPTION
We abstracted the test for valid data types from databases from the schema dumper to Connection. We set it so that sqlite would approve all values. However, you can not create arbitrary types in sqlite as it still checks against its native_database_types.
