### PR TITLE
Don't discard cache during asset precompile

### DIFF
--- a/actionpack/lib/sprockets/assets.rake
+++ b/actionpack/lib/sprockets/assets.rake
@@ -66,11 +66,11 @@ namespace :assets do
       ruby_rake_task("assets:precompile:nondigest", false) if Rails.application.config.assets.digest
     end
 
-    task :primary => ["assets:environment", "tmp:cache:clear"] do
+    task :primary => ["assets:environment"] do
       internal_precompile
     end
 
-    task :nondigest => ["assets:environment", "tmp:cache:clear"] do
+    task :nondigest => ["assets:environment"] do
       internal_precompile(false)
     end
   end


### PR DESCRIPTION
A change was introduced in rails in 7f1a666d causing the whole application cache to be cleared everytime a precompile is run, but it is not neccesary and just slows down precompiling.

Secondary consequences are the clearing of the whole cache, which if using the default file cache could cause an application level performance hit.

The only benefit I can imagine is removing view fragments from the cache which may have old asset references, but this is really up to the application and how it is deployed.

This is already [fixed in sprockets-rails](https://github.com/rails/sprockets-rails/blob/22270f83fb63537cef8a638835363360f2fbaab4/lib/sprockets/rails/task.rb) for rails 4, but is a worthwhile point release patch for interim gains considering how much of a pain point this is for so many.

Here's the temporary solution we're now using in our app: https://gist.github.com/sj26/4728657
