### PR TITLE
active_record: Quote numeric values compared to string columns.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Quote numeric values being compared to non-numeric columns. Otherwise,
+    in some database, the string column values will be coerced to a numeric
+    allowing 0, 0.0 or false to match any string starting with a non-digit.
+
+    Example:
+
+        App.where(apikey: 0) # => SELECT * FROM users WHERE apikey = '0'
+
+    *Dylan Smith*
+
 *   Schema dumper supports dumping the enabled database extensions to `schema.rb`
     (currently only supported by postgresql).
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -212,8 +212,6 @@ module ActiveRecord
         if value.kind_of?(String) && column && column.type == :binary && column.class.respond_to?(:string_to_binary)
           s = column.class.string_to_binary(value).unpack("H*")[0]
           "x'#{s}'"
-        elsif value.kind_of?(BigDecimal)
-          value.to_s("F")
         else
           super
         end

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -98,6 +98,11 @@ module ActiveRecord
         when Class
           # FIXME: I think we need to deprecate this behavior
           attribute.eq(value.name)
+        when Integer, ActiveSupport::Duration
+          # Arel treats integers as literals, but they should be quoted when compared with strings
+          table = attribute.relation
+          column = table.engine.connection.schema_cache.columns_hash(table.name)[attribute.name.to_s]
+          attribute.eq(Arel::Nodes::SqlLiteral.new(table.engine.connection.quote(value, column)))
         else
           attribute.eq(value)
         end

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -122,35 +122,35 @@ module ActiveRecord
       def test_quote_float
         float = 1.2
         assert_equal float.to_s, @quoter.quote(float, nil)
-        assert_equal float.to_s, @quoter.quote(float, Object.new)
+        assert_equal float.to_s, @quoter.quote(float, FakeColumn.new(:float))
       end
 
       def test_quote_fixnum
         fixnum = 1
         assert_equal fixnum.to_s, @quoter.quote(fixnum, nil)
-        assert_equal fixnum.to_s, @quoter.quote(fixnum, Object.new)
+        assert_equal fixnum.to_s, @quoter.quote(fixnum, FakeColumn.new(:integer))
       end
 
       def test_quote_bignum
         bignum = 1 << 100
         assert_equal bignum.to_s, @quoter.quote(bignum, nil)
-        assert_equal bignum.to_s, @quoter.quote(bignum, Object.new)
+        assert_equal bignum.to_s, @quoter.quote(bignum, FakeColumn.new(:integer))
       end
 
       def test_quote_bigdecimal
         bigdec = BigDecimal.new((1 << 100).to_s)
         assert_equal bigdec.to_s('F'), @quoter.quote(bigdec, nil)
-        assert_equal bigdec.to_s('F'), @quoter.quote(bigdec, Object.new)
+        assert_equal bigdec.to_s('F'), @quoter.quote(bigdec, FakeColumn.new(:decimal))
       end
 
       def test_dates_and_times
         @quoter.extend(Module.new { def quoted_date(value) 'lol' end })
         assert_equal "'lol'", @quoter.quote(Date.today, nil)
-        assert_equal "'lol'", @quoter.quote(Date.today, Object.new)
+        assert_equal "'lol'", @quoter.quote(Date.today, FakeColumn.new(:date))
         assert_equal "'lol'", @quoter.quote(Time.now, nil)
-        assert_equal "'lol'", @quoter.quote(Time.now, Object.new)
+        assert_equal "'lol'", @quoter.quote(Time.now, FakeColumn.new(:time))
         assert_equal "'lol'", @quoter.quote(DateTime.now, nil)
-        assert_equal "'lol'", @quoter.quote(DateTime.now, Object.new)
+        assert_equal "'lol'", @quoter.quote(DateTime.now, FakeColumn.new(:datetime))
       end
 
       def test_crazy_object

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -108,5 +108,30 @@ module ActiveRecord
         assert_equal 4, Edge.where(blank).order("sink_id").to_a.size
       end
     end
+
+    def test_where_with_integer_for_string_column
+      count = Post.where(:title => 0).count
+      assert_equal 0, count
+    end
+
+    def test_where_with_float_for_string_column
+      count = Post.where(:title => 0.0).count
+      assert_equal 0, count
+    end
+
+    def test_where_with_boolean_for_string_column
+      count = Post.where(:title => false).count
+      assert_equal 0, count
+    end
+
+    def test_where_with_decimal_for_string_column
+      count = Post.where(:title => BigDecimal.new(0)).count
+      assert_equal 0, count
+    end
+
+    def test_where_with_duration_for_string_column
+      count = Post.where(:title => 0.seconds).count
+      assert_equal 0, count
+    end
   end
 end

--- a/activerecord/test/cases/relation_scoping_test.rb
+++ b/activerecord/test/cases/relation_scoping_test.rb
@@ -391,19 +391,19 @@ class DefaultScopingTest < ActiveRecord::TestCase
   def test_default_scope_with_inheritance
     wheres = InheritedPoorDeveloperCalledJamis.all.where_values_hash
     assert_equal "Jamis", wheres[:name]
-    assert_equal 50000,   wheres[:salary]
+    assert_equal Arel.sql("50000"), wheres[:salary]
   end
 
   def test_default_scope_with_module_includes
     wheres = ModuleIncludedPoorDeveloperCalledJamis.all.where_values_hash
     assert_equal "Jamis", wheres[:name]
-    assert_equal 50000,   wheres[:salary]
+    assert_equal Arel.sql("50000"), wheres[:salary]
   end
 
   def test_default_scope_with_multiple_calls
     wheres = MultiplePoorDeveloperCalledJamis.all.where_values_hash
     assert_equal "Jamis", wheres[:name]
-    assert_equal 50000,   wheres[:salary]
+    assert_equal Arel.sql("50000"), wheres[:salary]
   end
 
   def test_scope_overwrites_default

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -540,6 +540,8 @@ ActiveRecord::Schema.define do
   create_table :price_estimates, :force => true do |t|
     t.string :estimate_of_type
     t.integer :estimate_of_id
+    t.string :thing_type
+    t.integer :thing_id
     t.integer :price
   end
 


### PR DESCRIPTION
## Problem

The problem is described in [Potential Query Manipulation with Common Rails Practises](https://groups.google.com/forum/?hl=en&fromgroups=#!topic/rubyonrails-security/ZOdH5GH5jCU), which notes that "it is not possible for ActiveRecord to automatically protect against all instances of this attack".  However, it is possible to handle the case where the column type is known.

For example:

``` ruby
User.where(:login_token=>params[:token]).first
```

performs the query

``` sql
SELECT * FROM `users` WHERE `login_token` = 0 LIMIT 1;
```

where it will match any login_token that starts with a non-digit character.  But since active record can determine that login_token is a string type column, it can quote the integer it is being compared with as follows.

``` sql
SELECT * FROM `users` WHERE `login_token` = '0' LIMIT 1;
```

which will have the desired affect of only matching the exact string '0'.
## Solution

Modify the connection adapter's `quote` method to quote the numeric value as a SQL string if the column it is being compared with is known to be non-numeric.  Boolean values are represented as the integers 0 or 1 for some databases, so booleans are also quoted as SQL strings when comparing against a string type column.

The PredicateBuilder also needed to be modified to ensure that integers are quoted, since Arel treats them as literals.  Quoting the integer and passing it to Arel as a `Arel::Nodes::SqlLiteral` object will ensure that the value is not double quoted.
## Limitations

SQL fragments with quoted values have no information about the column type, so the following is still unsafe.

``` ruby
User.where("login_token = ?", params[:token])
```

The parameters to the SQL fragment should still be converted to the correct type before passing it to active record as follows.

``` ruby
User.where("login_token = ?", params[:token].to_s)
```
