### PR TITLE
[3.2] active_record: Quote numeric values compared to string columns.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Rails 3.2.12 (unreleased) ##
 
+*   Quote numeric values being compared to non-numeric columns. Otherwise,
+    in some database, the string column values will be coerced to a numeric
+    allowing 0, 0.0 or false to match any string starting with a non-digit.
+
+    Example:
+
+        App.where(apikey: 0) # => SELECT * FROM users WHERE apikey = '0'
+
+    *Dylan Smith*
+
 *   Don't update `column_defaults` when calling destructive methods on column with default value.
     Backport c517602.
     Fix #6115.

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -25,13 +25,19 @@ module ActiveRecord
         when true, false
           if column && column.type == :integer
             value ? '1' : '0'
+          elsif column && [:text, :string, :binary].include?(column.type)
+            value ? "'1'" : "'0'"
           else
             value ? quoted_true : quoted_false
           end
           # BigDecimals need to be put in a non-normalized form and quoted.
         when nil        then "NULL"
-        when BigDecimal then value.to_s('F')
-        when Numeric    then value.to_s
+        when Numeric, ActiveSupport::Duration
+          value = BigDecimal === value ? value.to_s('F') : value.to_s
+          if column && ![:integer, :float, :decimal].include?(column.type)
+            value = "'#{value}'"
+          end
+          value
         when Date, Time then "'#{quoted_date(value)}'"
         when Symbol     then "'#{quote_string(value.to_s)}'"
         else

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -199,8 +199,6 @@ module ActiveRecord
         if value.kind_of?(String) && column && column.type == :binary && column.class.respond_to?(:string_to_binary)
           s = column.class.string_to_binary(value).unpack("H*")[0]
           "x'#{s}'"
-        elsif value.kind_of?(BigDecimal)
-          value.to_s("F")
         else
           super
         end

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -51,6 +51,10 @@ module ActiveRecord
           when Class
             # FIXME: I think we need to deprecate this behavior
             attribute.eq(value.name)
+          when Integer, ActiveSupport::Duration
+            # Arel treats integers as literals, but they should be quoted when compared with strings
+            column = engine.connection.schema_cache.columns_hash(table.name)[attribute.name.to_s]
+            attribute.eq(Arel::Nodes::SqlLiteral.new(engine.connection.quote(value, column)))
           else
             attribute.eq(value)
           end

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -122,35 +122,35 @@ module ActiveRecord
       def test_quote_float
         float = 1.2
         assert_equal float.to_s, @quoter.quote(float, nil)
-        assert_equal float.to_s, @quoter.quote(float, Object.new)
+        assert_equal float.to_s, @quoter.quote(float, FakeColumn.new(:float))
       end
 
       def test_quote_fixnum
         fixnum = 1
         assert_equal fixnum.to_s, @quoter.quote(fixnum, nil)
-        assert_equal fixnum.to_s, @quoter.quote(fixnum, Object.new)
+        assert_equal fixnum.to_s, @quoter.quote(fixnum, FakeColumn.new(:integer))
       end
 
       def test_quote_bignum
         bignum = 1 << 100
         assert_equal bignum.to_s, @quoter.quote(bignum, nil)
-        assert_equal bignum.to_s, @quoter.quote(bignum, Object.new)
+        assert_equal bignum.to_s, @quoter.quote(bignum, FakeColumn.new(:integer))
       end
 
       def test_quote_bigdecimal
         bigdec = BigDecimal.new((1 << 100).to_s)
         assert_equal bigdec.to_s('F'), @quoter.quote(bigdec, nil)
-        assert_equal bigdec.to_s('F'), @quoter.quote(bigdec, Object.new)
+        assert_equal bigdec.to_s('F'), @quoter.quote(bigdec, FakeColumn.new(:decimal))
       end
 
       def test_dates_and_times
         @quoter.extend(Module.new { def quoted_date(value) 'lol' end })
         assert_equal "'lol'", @quoter.quote(Date.today, nil)
-        assert_equal "'lol'", @quoter.quote(Date.today, Object.new)
+        assert_equal "'lol'", @quoter.quote(Date.today, FakeColumn.new(:date))
         assert_equal "'lol'", @quoter.quote(Time.now, nil)
-        assert_equal "'lol'", @quoter.quote(Time.now, Object.new)
+        assert_equal "'lol'", @quoter.quote(Time.now, FakeColumn.new(:time))
         assert_equal "'lol'", @quoter.quote(DateTime.now, nil)
-        assert_equal "'lol'", @quoter.quote(DateTime.now, Object.new)
+        assert_equal "'lol'", @quoter.quote(DateTime.now, FakeColumn.new(:datetime))
       end
 
       def test_crazy_object

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -35,5 +35,30 @@ module ActiveRecord
     def test_where_with_empty_hash_and_no_foreign_key
       assert_equal 0, Edge.where(:sink => {}).count
     end
+
+    def test_where_with_integer_for_string_column
+      count = Post.where(:title => 0).count
+      assert_equal 0, count
+    end
+
+    def test_where_with_float_for_string_column
+      count = Post.where(:title => 0.0).count
+      assert_equal 0, count
+    end
+
+    def test_where_with_boolean_for_string_column
+      count = Post.where(:title => false).count
+      assert_equal 0, count
+    end
+
+    def test_where_with_decimal_for_string_column
+      count = Post.where(:title => BigDecimal.new(0)).count
+      assert_equal 0, count
+    end
+
+    def test_where_with_duration_for_string_column
+      count = Post.where(:title => 0.seconds).count
+      assert_equal 0, count
+    end
   end
 end

--- a/activerecord/test/cases/relation_scoping_test.rb
+++ b/activerecord/test/cases/relation_scoping_test.rb
@@ -380,19 +380,19 @@ class DefaultScopingTest < ActiveRecord::TestCase
   def test_default_scope_with_inheritance
     wheres = InheritedPoorDeveloperCalledJamis.scoped.where_values_hash
     assert_equal "Jamis", wheres[:name]
-    assert_equal 50000,   wheres[:salary]
+    assert_equal Arel.sql("50000"), wheres[:salary]
   end
 
   def test_default_scope_with_module_includes
     wheres = ModuleIncludedPoorDeveloperCalledJamis.scoped.where_values_hash
     assert_equal "Jamis", wheres[:name]
-    assert_equal 50000,   wheres[:salary]
+    assert_equal Arel.sql("50000"), wheres[:salary]
   end
 
   def test_default_scope_with_multiple_calls
     wheres = MultiplePoorDeveloperCalledJamis.scoped.where_values_hash
     assert_equal "Jamis", wheres[:name]
-    assert_equal 50000,   wheres[:salary]
+    assert_equal Arel.sql("50000"), wheres[:salary]
   end
 
   def test_method_scope

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -530,6 +530,8 @@ ActiveRecord::Schema.define do
   create_table :price_estimates, :force => true do |t|
     t.string :estimate_of_type
     t.integer :estimate_of_id
+    t.string :thing_type
+    t.integer :thing_id
     t.integer :price
   end
 


### PR DESCRIPTION
This is a backport of pull #9207 to rails 3.2
