### PR TITLE
[3.0] active_record: Quote numeric values compared to string columns.

### DIFF
--- a/activerecord/CHANGELOG
+++ b/activerecord/CHANGELOG
@@ -1,4 +1,14 @@
-## Rails 3.0.20 (unreleased)
+## Rails 3.0.21 (unreleased)
+
+* Quote numeric values being compared to non-numeric columns. Otherwise,
+  in some database, the string column values will be coerced to a numeric
+  allowing 0, 0.0 or false to match any string starting with a non-digit.
+
+  Example:
+
+    App.where(apikey: 0) # => SELECT * FROM users WHERE apikey = '0'
+
+## Rails 3.0.20 (Jan 28, 2013)
 
 ## Rails 3.0.19 (Jan 8, 2013)
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -21,11 +21,21 @@ module ActiveRecord
               "'#{quote_string(value)}'" # ' (for ruby-mode)
             end
           when NilClass                 then "NULL"
-          when TrueClass                then (column && column.type == :integer ? '1' : quoted_true)
-          when FalseClass               then (column && column.type == :integer ? '0' : quoted_false)
-          when Float, Fixnum, Bignum    then value.to_s
-          # BigDecimals need to be output in a non-normalized form and quoted.
-          when BigDecimal               then value.to_s('F')
+          when TrueClass, FalseClass
+            if column && column.type == :integer
+              value ? '1' : '0'
+            elsif column && [:text, :string, :binary].include?(column.type)
+              value ? "'1'" : "'0'"
+            else
+              value ? quoted_true : quoted_false
+            end
+          when Numeric, ActiveSupport::Duration
+            # BigDecimals need to be output in a non-normalized form and quoted.
+            value = BigDecimal === value ? value.to_s('F') : value.to_s
+            if column && ![:integer, :float, :decimal].include?(column.type)
+              value = "'#{value}'"
+            end
+            value
           when Symbol                   then "'#{quote_string(value.to_s)}'"
           else
             if value.acts_like?(:date) || value.acts_like?(:time)

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -191,8 +191,6 @@ module ActiveRecord
         if value.kind_of?(String) && column && column.type == :binary && column.class.respond_to?(:string_to_binary)
           s = column.class.string_to_binary(value).unpack("H*")[0]
           "x'#{s}'"
-        elsif value.kind_of?(BigDecimal)
-          value.to_s("F")
         else
           super
         end

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -40,6 +40,9 @@ module ActiveRecord
           when Class
             # FIXME: I think we need to deprecate this behavior
             attribute.eq(value.name)
+          when Integer, ActiveSupport::Duration
+            # Arel treats integers as literals, but they should be quoted when compared with strings
+            attribute.eq(Arel::Nodes::SqlLiteral.new(@engine.connection.quote(value, attribute.column)))
           else
             attribute.eq(value)
           end

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -35,5 +35,33 @@ module ActiveRecord
     def test_where_with_empty_hash_and_no_foreign_key
       assert_equal 0, Edge.where(:sink => {}).count
     end
+
+    def test_where_with_integer_for_string_column
+      count = Post.where(:title => 0).count
+      assert_equal 0, count
+    end
+
+    def test_where_with_float_for_string_column
+      count = Post.where(:title => 0.0).count
+      assert_equal 0, count
+    end
+
+    def test_where_with_boolean_for_string_column
+      count = Post.where(:title => false).count
+      assert_equal 0, count
+    end
+
+    def test_where_with_decimal_for_string_column
+      count = Post.where(:title => BigDecimal.new(0)).count
+      if count > 0 && current_adapter?(:Mysql2Adapter)
+        return skip("upstream bug in mysql2")
+      end
+      assert_equal 0, count
+    end
+
+    def test_where_with_duration_for_string_column
+      count = Post.where(:title => 0.seconds).count
+      assert_equal 0, count
+    end
   end
 end

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -53,9 +53,6 @@ module ActiveRecord
 
     def test_where_with_decimal_for_string_column
       count = Post.where(:title => BigDecimal.new(0)).count
-      if count > 0 && current_adapter?(:Mysql2Adapter)
-        return skip("upstream bug in mysql2")
-      end
       assert_equal 0, count
     end
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -444,6 +444,8 @@ ActiveRecord::Schema.define do
   create_table :price_estimates, :force => true do |t|
     t.string :estimate_of_type
     t.integer :estimate_of_id
+    t.string :thing_type
+    t.integer :thing_id
     t.integer :price
   end
 


### PR DESCRIPTION
This is a backport of pull #9207 to rails 3.0
