### PR TITLE
Fixture loading does not respect table_name_prefix when loading

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -507,7 +507,7 @@ module ActiveRecord
             # Cap primary key sequences to max(pk).
             if connection.respond_to?(:reset_pk_sequence!)
               table_names.each do |table_name|
-                connection.reset_pk_sequence!(table_name.tr('/', '_'))
+                connection.reset_pk_sequence!("#{ActiveRecord::Base.table_name_prefix}#{table_name.tr('/', '_')}#{ActiveRecord::Base.table_name_suffix}")
               end
             end
           end


### PR DESCRIPTION
When using ActiveRecord::Base.table_name_prefix, fixtures fail to load. This is because a step in the fixture load process does not reference the prefixed table, but the table without a prefix. This causes silent database errors, which in turn fails to load the fixtures in the transaction, which means that tested apps get a weird "Cannot find where id=?".

This looks like it was fixed in the master branch (along with others), but this patch provides a basic update that fixes this particular error for 3.2.
