### PR TITLE
Active Record: Change behaviour with empty hash in where clause

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Raise ArgumentError instead of generate invalid SQL when empty hash is used in where clause value
+
+    Roberto Miranda
+
 *   Quote numeric values being compared to non-numeric columns. Otherwise,
     in some database, the string column values will be coerced to a numeric
     allowing 0, 0.0 or false to match any string starting with a non-digit.

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -8,7 +8,7 @@ module ActiveRecord
 
         if value.is_a?(Hash)
           if value.empty?
-            queries << '1 = 2'
+            raise ArgumentError, "Condition value in SQL clause can't be an empty hash"
           else
             table       = Arel::Table.new(column, default_table.engine)
             association = klass.reflect_on_association(column.to_sym)

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -92,7 +92,9 @@ module ActiveRecord
     end
 
     def test_where_with_table_name_and_empty_hash
-      assert_equal 0, Post.where(:posts => {}).count
+      assert_raises(ArgumentError) do
+        Post.where(:posts => {})
+      end
     end
 
     def test_where_with_table_name_and_empty_array
@@ -100,7 +102,9 @@ module ActiveRecord
     end
 
     def test_where_with_empty_hash_and_no_foreign_key
-      assert_equal 0, Edge.where(:sink => {}).count
+      assert_raises(ArgumentError) do
+        Edge.where(:sink => {}).count
+      end
     end
 
     def test_where_with_blank_conditions


### PR DESCRIPTION
Raise ArgumentError instead of generate invalid SQL when empty hash is used in where clause value

For Example:

``` ruby
Post.where(id: {})
=> SELECT "posts".* FROM "posts" WHERE (1 = 2)
```
