### PR TITLE
[3.2] Fix test failure for ruby 1.8.

### DIFF
--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -52,7 +52,7 @@ module ActiveRecord
     end
 
     def test_where_with_decimal_for_string_column
-      count = Post.where(:title => BigDecimal.new(0)).count
+      count = Post.where(:title => BigDecimal.new('0')).count
       assert_equal 0, count
     end
 


### PR DESCRIPTION
BigDecimal.new needs to take a string rather than an integer in ruby 1.8.
