### PR TITLE
Active Record 3.0: Change behaviour with empty hash in where clause

### DIFF
--- a/activerecord/CHANGELOG
+++ b/activerecord/CHANGELOG
@@ -1,5 +1,8 @@
 ## Rails 3.0.21 (unreleased)
 
+* Raise `ArgumentError` instead of generating invalid SQL when empty hash is
+	used in where clause value.
+
 * Quote numeric values being compared to non-numeric columns. Otherwise,
   in some database, the string column values will be coerced to a numeric
   allowing 0, 0.0 or false to match any string starting with a non-digit.

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -13,7 +13,7 @@ module ActiveRecord
           table = Arel::Table.new(column, :engine => @engine)
 
           if value.empty?
-            '1 = 2'
+            raise ArgumentError, "Condition value in SQL clause can't be an empty hash"
           else
             build_from_hash(value, table, false)
           end

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -25,7 +25,9 @@ module ActiveRecord
     end
 
     def test_where_with_table_name_and_empty_hash
-      assert_equal 0, Post.where(:posts => {}).count
+      assert_raises(ArgumentError) do
+        Post.where(:posts => {})
+      end
     end
 
     def test_where_with_table_name_and_empty_array
@@ -33,7 +35,9 @@ module ActiveRecord
     end
 
     def test_where_with_empty_hash_and_no_foreign_key
-      assert_equal 0, Edge.where(:sink => {}).count
+      assert_raises(ArgumentError) do
+        Edge.where(:sink => {})
+      end
     end
 
     def test_where_with_integer_for_string_column


### PR DESCRIPTION
This is a backport of pull #9220 to rails 3.0
