### PR TITLE
making secure_compare 40-50 times faster

### DIFF
--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -49,15 +49,9 @@ module ActiveSupport
     end
 
     private
-      # constant-time comparison algorithm to prevent timing attacks
+      # hash-based comparison algorithm to prevent timing attacks
       def secure_compare(a, b)
-        return false unless a.bytesize == b.bytesize
-
-        l = a.unpack "C#{a.bytesize}"
-
-        res = 0
-        b.each_byte { |byte| res |= byte ^ l.shift }
-        res == 0
+        a.hash == b.hash && a == b
       end
 
       def generate_digest(data)


### PR DESCRIPTION
https://gist.github.com/homakov/4745028

how it works: we use .hash which is super fast, so we know that strings are different super fast too.
Even if strings hashes are just collisions we compare using ==, which is also much faster than current ruby iteration.
timing attack makes no sense for hash based comparison.
