### PR TITLE
Use IN operator like Arel for empty hash in where clause

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -8,7 +8,7 @@ module ActiveRecord
 
         if value.is_a?(Hash)
           if value.empty?
-            queries << '1 = 2'
+            queries << '1=0'
           else
             table       = Arel::Table.new(column, default_table.engine)
             association = klass.reflect_on_association(column.to_sym)


### PR DESCRIPTION
Change for be more near to the sql generated by Arel, would be easier doing grep in the Rails logs when looking for suspect activity with this patch.

Currently rails is generating something like this

``` ruby
User.where(id: {})
User Load (0.1ms)  SELECT "users".* FROM "users" WHERE (1 = 2)
```

Arel use  '1=0' instead of '1=2' for User.where(id: [])  https://github.com/rails/arel/commit/d3a8fa952792c284eb63a91e36a593683ad76b93
