### PR TITLE
the `:controller` option for routes can contain numbers. closes #9231.

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -246,7 +246,7 @@ module ActionDispatch
                 raise ArgumentError, "missing :action"
               end
 
-              if controller.is_a?(String) && controller !~ /\A[a-z_\/]+\z/
+              if controller.is_a?(String) && controller !~ /\A[a-z_0-9\/]*\z/
                 message = "'#{controller}' is not a supported controller name. This can lead to potential routing problems."
                 message << " See http://guides.rubyonrails.org/routing.html#specifying-a-controller-to-use"
                 raise ArgumentError, message

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1031,6 +1031,18 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal 'users/home#index', @response.body
   end
 
+  def test_namespace_containing_numbers
+    draw do
+      namespace :v2 do
+        resources :subscriptions
+      end
+    end
+
+    get '/v2/subscriptions'
+    assert_equal 'v2/subscriptions#index', @response.body
+    assert_equal '/v2/subscriptions', v2_subscriptions_path
+  end
+
   def test_articles_with_id
     draw do
       controller :articles do


### PR DESCRIPTION
this is a fix for #9231 and a follow up of #9039. The regular expression I used did not allow numbers in the `:controller` option. I modified the expression to also allow numbers.

Do we need to take other edge-cases into account? For example unicode characters?
