### PR TITLE
Extending Notifications to know about File System Changes

### DIFF
--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -36,6 +36,7 @@ module ActiveSupport
   autoload :FileUpdateChecker
   autoload :LogSubscriber
   autoload :Notifications
+  autoload :FileSystemChanges
 
   eager_autoload do
     autoload :BacktraceCleaner

--- a/activesupport/lib/active_support/file_system_changes.rb
+++ b/activesupport/lib/active_support/file_system_changes.rb
@@ -1,0 +1,121 @@
+module ActiveSupport
+  module FileSystemChanges
+    class ChangedFile
+      attr_accessor :path, :time, :type
+
+      VALID_CHANGE_TYPES = [:modified, :added, :removed]
+
+      def initialize(path, type)
+        check_change_type(type)
+
+        @path = path
+        @type = type
+        @time = Time.now
+      end
+
+      private
+
+      def check_change_type(type)
+        if !VALID_CHANGE_TYPES.include?(type)
+          raise ArgumentError, "Change type #{type} is invalid. Valid change types are :#{VALID_CHANGE_TYPES.join(', :')}"
+        end
+      end
+    end
+
+    class FileSystemListener
+      attr_accessor :changed_files
+
+      def initialize(initial_paths=[], opts={})
+        @paths = Array(initial_paths)
+        @opts = opts
+
+        @file_change_times = Hash.new(Time.now)
+        @changed_files = Queue.new
+      end
+
+      def start_listening
+        @continue_listening = true
+        while @continue_listening
+          listen_for_changes
+        end
+      end
+
+      def stop_listening
+        @continue_listening = false
+      end
+
+      private
+
+      def listen_for_changes
+        @files_alive = Set.new([])
+
+        directories = handle_paths(@paths)
+        find_changed_files(directories)
+
+        deleted_files = @file_change_times.delete_if do |key, _|
+          !@files_alive.include?(key)
+        end
+        deleted_files.each do |filename|
+          @changed_files.push(ChangedFile.new(filename, :deleted))
+        end
+      end
+
+      def find_changed_files(directories)
+        new_directory_paths = []
+
+        directories.each do |directory_path|
+          expanded_filepaths = Dir.foreach(directory_path)
+            .select { |path| valid_path?(path) }
+            .map { |path| "#{directory_path}/#{path}" }
+
+          new_directory_paths += handle_paths(expanded_filepaths)
+        end
+
+        find_changed_files(new_directory_paths) if new_directory_paths.any?
+      end
+
+      def valid_path?(path)
+        # FIXME: Hacks to get around the up and down directories
+        if path == ".." || path == "."
+          return false
+        end
+
+        validations = []
+        if @opts[:filter]
+          validations << (path =~ @opts[:filter])
+        end
+        if @opts[:ignore]
+          validations << !(path =~ @opts[:ignore])
+        end
+
+        validations.all?
+      end
+
+      def handle_paths(expanded_filepaths)
+        new_directory_paths = []
+
+        expanded_filepaths.each do |expanded_filepath|
+          if File.file?(expanded_filepath)
+            check_file_for_changes(expanded_filepath)
+          elsif File.directory?(expanded_filepath)
+            new_directory_paths << expanded_filepath
+          end
+        end
+
+        new_directory_paths
+      end
+
+      def check_file_for_changes(filepath)
+        last_modified = File.mtime(filepath)
+
+        if @file_change_times[filepath] < last_modified
+          change_type = (@file_change_times[filepath] == @file_change_times.default ? :added : :modified)
+          @changed_files.push(ChangedFile.new(filepath, change_type))
+          @files_alive.add(filepath)
+        end
+
+        @file_change_times[filepath] = last_modified
+      end
+    end
+  end
+end


### PR DESCRIPTION
There is now functionality which allows a user to get notifications about file system changes. The majority of this pull request creates a module which queries for file system changes using the Ruby IO classes (note that it doesn't require any C or operating system specific extensions).

I've added the capability to listen for file additions, modifications, and deletions and send these on to a new notification queue. Subscribing to this queue will allow you to receive file system updates.

The Notifications module is also changed because of this. There is now a notion of the type of Notification one is subscribing to. The regular notifications are the canonical notifications that one could subscribe to in the previous code. However, there is now a filesystem notification that one can subscribe to. There is a completely separate notification queue for each type of notification.

I kept the previous methods for the regular notifications intact for backwards compatibility, but I also included methods such as "subscribe_with_type" or "publish_with_type" which allows you do deal with notifications of a particular type.

The code is still in its infancy and looks pretty raw, so I'm looking forward to comments. 
