### PR TITLE
ignore .ruby-version instead of tool specifc config on 3-2-stable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,7 @@
 debug.log
 .Gemfile
 /.bundle
-/.rbenv-version
-/.rvmrc
+/.ruby-version
 /Gemfile.lock
 /pkg
 /dist


### PR DESCRIPTION
It's not very practical to have different ignores for ruby-version configuration files on master and 3-2-stable. I suggest we also ignore `.ruby-version` on `3-2-stable` as we did on master.

This is a combined backport of 36acc0a and 99bb2fd
