### PR TITLE
Supress warning about method redifinition

### DIFF
--- a/activesupport/lib/active_support/i18n.rb
+++ b/activesupport/lib/active_support/i18n.rb
@@ -1,5 +1,7 @@
 begin
   require 'active_support/core_ext/hash/deep_merge'
+  require 'active_support/core_ext/hash/except'
+  require 'active_support/core_ext/hash/slice'
   require 'i18n'
   require 'active_support/lazy_load_hooks'
 rescue LoadError => e


### PR DESCRIPTION
In i18n gem, the following methods are defined.
- `Hash#except`
- `Hash#slice`

But if there are defined already, i18n skips these definitions.
So these definition by `active_support` are required before `require 'i18n'`.
