### PR TITLE
Address test_find_by_id_with_hash failure with Oracle

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -101,7 +101,11 @@ module ActiveRecord
         when Integer, ActiveSupport::Duration
           # Arel treats integers as literals, but they should be quoted when compared with strings
           table = attribute.relation
-          column = table.engine.connection.schema_cache.columns_hash(table.name)[attribute.name.to_s]
+          begin
+            column = table.engine.connection.schema_cache.columns_hash(table.name)[attribute.name.to_s]
+          rescue
+            attribute.eq(value)
+          end
           attribute.eq(Arel::Nodes::SqlLiteral.new(table.engine.connection.quote(value, column)))
         else
           attribute.eq(value)


### PR DESCRIPTION
This pull request address these 3 failures not catching `ActiveRecord::StatementInvalid` exceptions with Oracle.

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/relation/where_test.rb -n test_where_error
Using oracle
Run options: -n test_where_error --seed 37633

# Running tests:

F

Finished tests in 1.690807s, 0.5914 tests/s, 0.5914 assertions/s.

  1) Failure:
test_where_error(ActiveRecord::WhereTest) [test/cases/relation/where_test.rb:84]:
[ActiveRecord::StatementInvalid] exception expected, not
Class: <ActiveRecord::ConnectionAdapters::OracleEnhancedConnectionException>
Message: <"\"DESC id\" failed; does it exist?">
---Backtrace---
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_connection.rb:76:in `describe'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:213:in `rescue in describe'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:208:in `describe'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1105:in `columns_without_cache'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1096:in `columns'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:86:in `block in prepare_default_proc'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:90:in `yield'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:90:in `default'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:90:in `block in prepare_default_proc'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:46:in `yield'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:46:in `default'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:46:in `columns_hash'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/predicate_builder.rb:104:in `build'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/predicate_builder.rb:51:in `expand'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/predicate_builder.rb:17:in `block (2 levels) in build_from_hash'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/predicate_builder.rb:16:in `each'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/predicate_builder.rb:16:in `block in build_from_hash'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/predicate_builder.rb:6:in `each'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/predicate_builder.rb:6:in `build_from_hash'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/query_methods.rb:772:in `build_where'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/query_methods.rb:450:in `where!'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/query_methods.rb:438:in `where'
/home/yahonda/git/rails/activerecord/lib/active_record/querying.rb:9:in `where'
test/cases/relation/where_test.rb:85:in `block in test_where_error'
---------------

1 tests, 1 assertions, 1 failures, 0 errors, 0 skips
```

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/finder_test.rb -n /test_find_by/
Using oracle
Run options: -n /test_find_by/ --seed 760

# Running tests:

....F.................F....

Finished tests in 4.946353s, 5.4586 tests/s, 9.2998 assertions/s.

  1) Failure:
test_find_by_id_with_hash(FinderTest) [test/cases/finder_test.rb:19]:
[ActiveRecord::StatementInvalid] exception expected, not
Class: <ActiveRecord::ConnectionAdapters::OracleEnhancedConnectionException>
Message: <"\"DESC id\" failed; does it exist?">
---Backtrace---
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_connection.rb:76:in `describe'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:213:in `rescue in describe'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:208:in `describe'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1105:in `columns_without_cache'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1096:in `columns'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:86:in `block in prepare_default_proc'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:90:in `yield'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:90:in `default'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:90:in `block in prepare_default_proc'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:46:in `yield'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:46:in `default'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:46:in `columns_hash'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/predicate_builder.rb:104:in `build'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/predicate_builder.rb:51:in `expand'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/predicate_builder.rb:17:in `block (2 levels) in build_from_hash'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/predicate_builder.rb:16:in `each'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/predicate_builder.rb:16:in `block in build_from_hash'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/predicate_builder.rb:6:in `each'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/predicate_builder.rb:6:in `build_from_hash'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/query_methods.rb:772:in `build_where'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/query_methods.rb:450:in `where!'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/query_methods.rb:438:in `where'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/finder_methods.rb:48:in `find_by'
/home/yahonda/git/rails/activerecord/lib/active_record/dynamic_matchers.rb:76:in `find_by_id'
/home/yahonda/git/rails/activerecord/lib/active_record/dynamic_matchers.rb:20:in `method_missing'
test/cases/finder_test.rb:20:in `block in test_find_by_id_with_hash'
---------------

  2) Failure:
test_find_by_title_and_id_with_hash(FinderTest) [test/cases/finder_test.rb:25]:
[ActiveRecord::StatementInvalid] exception expected, not
Class: <ActiveRecord::ConnectionAdapters::OracleEnhancedConnectionException>
Message: <"\"DESC id\" failed; does it exist?">
---Backtrace---
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_connection.rb:76:in `describe'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:213:in `rescue in describe'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:208:in `describe'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1105:in `columns_without_cache'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1096:in `columns'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:86:in `block in prepare_default_proc'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:90:in `yield'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:90:in `default'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:90:in `block in prepare_default_proc'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:46:in `yield'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:46:in `default'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:46:in `columns_hash'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/predicate_builder.rb:104:in `build'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/predicate_builder.rb:51:in `expand'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/predicate_builder.rb:17:in `block (2 levels) in build_from_hash'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/predicate_builder.rb:16:in `each'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/predicate_builder.rb:16:in `block in build_from_hash'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/predicate_builder.rb:6:in `each'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/predicate_builder.rb:6:in `build_from_hash'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/query_methods.rb:772:in `build_where'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/query_methods.rb:450:in `where!'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/query_methods.rb:438:in `where'
/home/yahonda/git/rails/activerecord/lib/active_record/relation/finder_methods.rb:48:in `find_by'
/home/yahonda/git/rails/activerecord/lib/active_record/dynamic_matchers.rb:76:in `find_by_title_and_id'
/home/yahonda/git/rails/activerecord/lib/active_record/dynamic_matchers.rb:20:in `method_missing'
test/cases/finder_test.rb:26:in `block in test_find_by_title_and_id_with_hash'
---------------

27 tests, 46 assertions, 2 failures, 0 errors, 0 skips
$
```

For other database adapters, this test already passes but expected `ActiveRecord::StatementInvalid` exception occurs within ActiveRecord::PredicateBuilder, not at genereated statements.

Here is the example.
- test code

``` ruby
    def test_where_error
      assert_raises(ActiveRecord::StatementInvalid) do
        Post.where(:id => { 'posts.author_id' => 10 }).first
      end
    end
```
- Tested with sqlite3 adapter current master branch

``` ruby
$ ARCONN=sqlite3 ruby -Itest test/cases/relation/where_test.rb -n test_where_error
Using sqlite3
Run options: -n test_where_error --seed 44190

# Running tests:

[82, 91] in test/cases/relation/where_test.rb
   82  
   83      def test_where_error
   84        assert_raises(ActiveRecord::StatementInvalid) do
   85          require 'debugger'
   86          debugger
=> 87          Post.where(:id => { 'posts.author_id' => 10 }).first
   88        end
   89      end
   90  
   91      def test_where_with_table_name
test/cases/relation/where_test.rb:87
Post.where(:id => { 'posts.author_id' => 10 }).first
(rdb:1) puts Post.where(:id => { 'posts.author_id' => 10 }).first.sql
ActiveRecord::StatementInvalid Exception: Could not find table 'id'
(rdb:1) ^C.
```
- Tested with sqlite3 adapter with this fix

``` ruby
$ ARCONN=sqlite3 ruby -Itest test/cases/relation/where_test.rb -n test_where_error
Using sqlite3
Run options: -n test_where_error --seed 40443

# Running tests:

[82, 91] in test/cases/relation/where_test.rb
   82  
   83      def test_where_error
   84        assert_raises(ActiveRecord::StatementInvalid) do
   85          require 'debugger'
   86          debugger
=> 87          Post.where(:id => { 'posts.author_id' => 10 }).first
   88        end
   89      end
   90  
   91      def test_where_with_table_name
test/cases/relation/where_test.rb:87
Post.where(:id => { 'posts.author_id' => 10 }).first
(rdb:1) puts Post.where(:id => { 'posts.author_id' => 10 }).first.sql
ActiveRecord::StatementInvalid Exception: SQLite3::SQLException: no such column: id.posts.author_id: SELECT  "posts".* FROM "posts"  WHERE "id"."posts.author_id" = 10  ORDER BY "posts"."id" ASC LIMIT 1
(rdb:1) ^C.
```
