### PR TITLE
Removes empty string from ActiveModel::MassAssignmentSecurity::WhiteList set

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -60,7 +60,7 @@ module ActiveRecord
     initializer "active_record.set_configs" do |app|
       ActiveSupport.on_load(:active_record) do
         if app.config.active_record.delete(:whitelist_attributes)
-          attr_accessible(nil)
+          attr_accessible
         end
         app.config.active_record.each do |k,v|
           send "#{k}=", v

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -303,7 +303,7 @@ module ApplicationTests
 
       assert_equal ActiveModel::MassAssignmentSecurity::WhiteList,
                    ActiveRecord::Base.active_authorizers[:default].class
-      assert_equal [""], ActiveRecord::Base.active_authorizers[:default].to_a
+      assert_equal [], ActiveRecord::Base.active_authorizers[:default].to_a
     end
 
     test "registers interceptors with ActionMailer" do


### PR DESCRIPTION
Given:

``` ruby
# config/application.rb
config.active_record.whitelist_attributes = true

# app/models/user.rb
class User < ActiveRecord::Base
  attr_accessible :name
end
```

As of today for 3-2-stable:

``` ruby
User.accessible_attributes # => #<ActiveModel::MassAssignmentSecurity::WhiteList: { "", "name" }>
```

With the proposed change:

``` ruby
User.accessible_attributes # => #<ActiveModel::MassAssignmentSecurity::WhiteList: { "name" }>
```
