### PR TITLE
fix a typo on the engine guide

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -395,7 +395,7 @@ def create
   @post = Post.find(params[:post_id])
   @comment = @post.comments.create(params[:comment])
   flash[:notice] = "Comment has been created!"
-  redirect_to post_path
+  redirect_to posts_path
 end
 ```
 


### PR DESCRIPTION
I noticed a typo on the engine guide... I'm pretty sure that the correct on the create action is is posts_path, instead of post_path.
