### PR TITLE
define Active Record Store accessors in a module

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Allow store accessors to be overrided like other attribute methods, e.g.:
+
+        class User < ActiveRecord::Base
+          store :settings, accessors: [ :color, :homepage ], coder: JSON
+
+          def color
+            super || 'red'
+          end
+        end
+
+    *Sergey Nartimov*
+
 *   Quote numeric values being compared to non-numeric columns. Otherwise,
     in some database, the string column values will be coerced to a numeric
     allowing 0, 0.0 or false to match any string starting with a non-digit.

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -42,21 +42,19 @@ module ActiveRecord
   #
   # All stored values are automatically available through accessors on the Active Record
   # object, but sometimes you want to specialize this behavior. This can be done by overwriting
-  # the default accessors (using the same name as the attribute) and calling
-  # <tt>read_store_attribute(store_attribute_name, attr_name)</tt> and
-  # <tt>write_store_attribute(store_attribute_name, attr_name, value)</tt> to actually
-  # change things.
+  # the default accessors (using the same name as the attribute) and calling <tt>super</tt>
+  # to actually change things.
   #
   #   class Song < ActiveRecord::Base
   #     # Uses a stored integer to hold the volume adjustment of the song
   #     store :settings, accessors: [:volume_adjustment]
   #
   #     def volume_adjustment=(decibels)
-  #       write_store_attribute(:settings, :volume_adjustment, decibels.to_i)
+  #       super(decibels.to_i)
   #     end
   #
   #     def volume_adjustment
-  #       read_store_attribute(:settings, :volume_adjustment).to_i
+  #       super.to_i
   #     end
   #   end
   module Store
@@ -75,18 +73,29 @@ module ActiveRecord
 
       def store_accessor(store_attribute, *keys)
         keys = keys.flatten
-        keys.each do |key|
-          define_method("#{key}=") do |value|
-            write_store_attribute(store_attribute, key, value)
-          end
 
-          define_method(key) do
-            read_store_attribute(store_attribute, key)
+        _store_accessors_module.module_eval do
+          keys.each do |key|
+            define_method("#{key}=") do |value|
+              write_store_attribute(store_attribute, key, value)
+            end
+
+            define_method(key) do
+              read_store_attribute(store_attribute, key)
+            end
           end
         end
 
         self.stored_attributes[store_attribute] ||= []
         self.stored_attributes[store_attribute] |= keys
+      end
+
+      def _store_accessors_module
+        @_store_accessors_module ||= begin
+          mod = Module.new
+          include mod
+          mod
+        end
       end
     end
 

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -35,6 +35,12 @@ class StoreTest < ActiveRecord::TestCase
     assert_equal '(123) 456-7890', @john.phone_number
   end
 
+  test "overriding a read accessor using super" do
+    @john.settings[:color] = nil
+
+    assert_equal 'red', @john.color
+  end
+
   test "updating the store will mark it as changed" do
     @john.color = 'red'
     assert @john.settings_changed?
@@ -64,6 +70,12 @@ class StoreTest < ActiveRecord::TestCase
     @john.phone_number = '(123) 456-7890'
 
     assert_equal '1234567890', @john.settings[:phone_number]
+  end
+
+  test "overriding a write accessor using super" do
+    @john.color = 'yellow'
+
+    assert_equal 'blue', @john.color
   end
 
   test "preserve store attributes data in HashWithIndifferentAccess format without any conversion" do

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -27,4 +27,13 @@ class Admin::User < ActiveRecord::Base
   def phone_number=(value)
     write_store_attribute(:settings, :phone_number, value && value.gsub(/[^\d]/,''))
   end
+
+  def color
+    super || 'red'
+  end
+
+  def color=(value)
+    value = 'blue' unless %w(black red green blue).include?(value)
+    super
+  end
 end


### PR DESCRIPTION
Allow store accessors to be overrided like other attribute methods,
e.g.:

```
class User < ActiveRecord::Base
  store :settings, accessors: [ :color, :homepage ], coder: JSON

  def color
    super || 'red'
  end
end
```
