### PR TITLE
Fix ActionView::TestCase::TestController threadsafe issue

### DIFF
--- a/actionpack/lib/action_view/test_case.rb
+++ b/actionpack/lib/action_view/test_case.rb
@@ -30,6 +30,14 @@ module ActionView
         @request.env.delete('PATH_INFO')
         @params = {}
       end
+
+      if defined?(Rails.application) && Rails.application
+        define_method :_routes do
+          Rails.application.routes
+        end
+
+        helper Rails.application.routes.url_helpers
+      end
     end
 
     module Behavior


### PR DESCRIPTION
Using rspec, when enabling threadsafe mode in the test environment, all of my helper tests that use url_helpers fail. I get the following error:

> In order to use #url_for, you must include routing helpers explicitly. For instance, `include > Rails.application.routes.url_helpers`

I tried rails 4.0 and my helper tests all pass fine. Both 3.2.11 and the 3-2-stable branch cause the tests to fail. 

This issue was originally reported to rspec-rails here: https://github.com/rspec/rspec-rails/issues/476

This patch adds url_helpers to the `ActionView::TestCase::TestController` class. I ran the actionpack tests, they all seem to pass fine.

I would add some tests to cover this functionality but i'm not too sure what's required, if you could let me know, that would be tops.
