### PR TITLE
Add alias to maintain coherence with other methods, in end_of_day

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -221,6 +221,7 @@ module ActiveSupport #:nodoc:
         def end_of_day
           change(:hour => 23, :min => 59, :sec => 59, :usec => 999999.999)
         end
+        alias :at_end_of_day, :end_of_day
 
         # Returns a new Time representing the start of the month (1st of the month, 0:00)
         def beginning_of_month


### PR DESCRIPTION
Just maintaining the coherence with other methods, since everything has "at_" as prefix.
