### PR TITLE
don't cache invalid subsets when preloading hmt associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,27 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Preloading `has_many :through` associations with conditions won't
+    cache the `:through` association. This will prevent invalid
+    subsets to be cached.
+    Fixes #8423.
+
+    Example:
+
+        class User
+          has_many :posts
+          has_many :recent_comments, -> { where('created_at > ?', 1.week.ago) }, :through => :posts
+        end
+
+        a_user = User.includes(:recent_comments).first
+
+        # this is preloaded
+        a_user.recent_comments
+
+        # fetching the recent_comments through the posts association won't preload it.
+        a_user.posts
+
+    *Yves Senn*
+
 *   Don't run after_commit callback when creating through an association
     if saving the record fails.
 

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -31,7 +31,8 @@ module ActiveRecord
             through_records = Array.wrap(owner.send(through_reflection.name))
 
             # Dont cache the association - we would only be caching a subset
-            if reflection.options[:source_type] && through_reflection.collection?
+            if (through_scope != through_reflection.klass.unscoped) ||
+               (reflection.options[:source_type] && through_reflection.collection?)
               owner.association(through_reflection.name).reset
             end
 

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1162,4 +1162,10 @@ class EagerAssociationTest < ActiveRecord::TestCase
       Post.where('1 = 0').scoping { Comment.preload(:post).find(1).post }
     )
   end
+
+  test "preloading does not cache has many association subset when preloaded with a through association" do
+    author = Author.includes(:comments_with_order_and_conditions, :posts).first
+    assert_no_queries { assert_equal 2, author.comments_with_order_and_conditions.size }
+    assert_no_queries { assert_equal 5, author.posts.size, "should not cache a subset of the association" }
+  end
 end


### PR DESCRIPTION
this fixes #8423. The problematic area, was that the through_association-preloader eager-loaded the `has_many` association even when the there were additional conditions on the hmt association. This resulted that a subset of the `has_many` association was cached.

After the patch AR only caches the `has_many` association when there are no additional conditions on the `has_many :through` association.

If possible I'd like to submit a backport to `3-2-stable`.
