### PR TITLE
9253: Before writing a numeric attribute value, ActiveRecord does an imp...

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -74,12 +74,13 @@ module ActiveRecord
       def type_cast_for_write(value)
         return value unless number?
 
-        if value == false
+        case value
+        when FalseClass
           0
-        elsif value == true
+        when TrueClass
           1
-        elsif value.is_a?(String) && value.blank?
-          nil
+        when String
+          value.presence
         else
           value
         end


### PR DESCRIPTION
Before writing a numeric attribute value, ActiveRecord does an implicit conversion (in activerecord/lib/active_record/connection_adapters/column.rb) of boolean types (true => 1 and false => 0). If the numeric value being assigned is a BigDecimal, then ActiveRecord compares a BigDecimal to true and false. This is known to be very slow in Ruby 1.9.3 (see http://www.ruby-forum.com/topic/4409452 and https://bugs.ruby-lang.org/issues/7645#change-35188). The Ruby core team has implemented a fix for this issue that will be included in Ruby 2, but they appear to have no intention of back-porting this fix to Ruby 1.9.3. In my case, the performance impact of this issue was enormous (200% - 300% performance hit) for some of the pages in my application.
