### PR TITLE
Extended FileUpdateChecker so it can detect file changes in subdirectories.

### DIFF
--- a/activesupport/lib/active_support/file_update_checker.rb
+++ b/activesupport/lib/active_support/file_update_checker.rb
@@ -143,7 +143,7 @@ module ActiveSupport
     # changed since the object was created.
     #
     # If the object was previously stopped, and start_listening is called
-    # again, then all of the file changes since the last stop was called will
+    # again, then all of the file changes since the last stop which was called will
     # be pushed to the changed_files queue. The files which were created and
     # deleted between the stop and start of the method will be ignored.
     def start_listening
@@ -223,16 +223,15 @@ module ActiveSupport
     # Does a BFS on the set of starting directories and recursively calls
     # itself until there are no more files left.
     #
-    # Each path that is found in the directory is passed through valid_path?
-    # to look for new paths that are relevant. Paths are then parsed by
-    # handle_paths. New directories that are found form the BFS frontier
-    # and update_changed_files is called on these new directories.
+    # Paths are then parsed by handle_paths. New directories that are found
+    # form the BFS frontier and update_changed_files is called on these new
+    # directories.
     def update_changed_files(directories)
       new_directory_paths = []
 
       directories.each do |directory_path|
         expanded_filepaths = Dir.foreach(directory_path)
-        .select { |path| valid_path?(path) }
+        .reject { |path| path == ".." || path == "." }  # reject up and self directories on UNIX
         .map { |path| "#{directory_path}/#{path}" }
 
         new_directory_paths += handle_paths(expanded_filepaths)
@@ -245,12 +244,8 @@ module ActiveSupport
     # that were passed in as options on object initialization.
     #
     # The method also removes .. and . as valid paths since they lead
-    # to up and down directories.
+    # to previous and current directories.
     def valid_path?(path)
-      if path == ".." || path == "."
-        return false
-      end
-
       validations = []
       if @opts[:filter]
         validations << (path =~ @opts[:filter])
@@ -273,8 +268,10 @@ module ActiveSupport
       files, new_directories = expanded_filepaths.partition { |fp| File.file?(fp) }
 
       files.each do |filepath|
-        @files_alive << filepath
-        check_file_for_changes(filepath)
+        if valid_path?(filepath)
+          @files_alive << filepath
+          check_file_for_changes(filepath)
+        end
       end
 
       new_directories

--- a/activesupport/lib/active_support/file_update_checker.rb
+++ b/activesupport/lib/active_support/file_update_checker.rb
@@ -1,4 +1,33 @@
+require 'digest/md5'
+
 module ActiveSupport
+  # The ChangedFile class provides a means of accessing information about
+  # a file which has recently been changed. The class provides information
+  # about the time of the change, the path for the file which was changed
+  # and the type of change (whether the file was modified, added, or
+  # removed).
+  class ChangedFile
+    attr_accessor :path, :time, :type
+
+    VALID_CHANGE_TYPES = [:modified, :added, :removed]
+
+    def initialize(path, type)
+      check_change_type(type)
+
+      @path = path
+      @type = type
+      @time = Time.now
+    end
+
+    private
+
+    def check_change_type(type)
+      if !VALID_CHANGE_TYPES.include?(type)
+        raise ArgumentError, "Change type #{type} is invalid. Valid change types are :#{VALID_CHANGE_TYPES.join(', :')}"
+      end
+    end
+  end
+
   # FileUpdateChecker specifies the API used by Rails to watch files
   # and control reloading. The API depends on four methods:
   #
@@ -26,56 +55,133 @@ module ActiveSupport
   #   ActionDispatch::Reloader.to_prepare do
   #     i18n_reloader.execute_if_updated
   #   end
+  #
+  # One can use regex to filter or ignore particular files through the options
+  # hash. For example, one could use:
+  #
+  #   opts = {:filter => /Gemfile/}
+  #   listener = FileChangeListener.new(["/home/john/rails"], {}, opts)
+  #   Thread.new do
+  #     listener.start_listening
+  #   end
+  #
+  # This would look at all of the files inside the "/home/john/rails" directory
+  # and keep track of all the files that have been changed. To access the
+  # changed files, one can read from the changed_files queue like so:
+  #
+  #   changed_file = listener.changed_files.pop()
+  #
+  # An alternative to creating a queue of changed files, one can elect to send
+  # notifications to a particular notification group. The changed_files queue
+  # will always stay empty, but the ChangedFile objects will be sent through
+  # the ActiveSupport::Notifications framework. To do this, one needs to set
+  # opts[:notifications] to the name of the notification group. For example:
+  #
+  #   opts = {:notifications => "filesystem_changes"}
+  #   listener = FileChangeListener.new(["/home/john/rails"], {}, opts)
+  #   Thread.new do
+  #     listener.start_listening
+  #   end
+  #
+  # In the above example, one would recieve the changed files in the
+  # /home/john/rails directory if they subscribed to notifications as follows:
+  #
+  #   changed_files = []
+  #   ActiveSupport::Notifications.subscribe("filesystem_changed") { |*args| changed_files << [*args] }
+  #
+  # Note that the start_listening method will continue infinitely, so it is
+  # best called from within a new thread.
   class FileUpdateChecker
+    attr_accessor :changed_files
+
     # It accepts two parameters on initialization. The first is an array
     # of files and the second is an optional hash of directories. The hash must
     # have directories as keys and the value is an array of extensions to be
     # watched under that directory.
     #
-    # This method must also receive a block that will be called once a path
-    # changes. The array of files and list of directories cannot be changed
-    # after FileUpdateChecker has been initialized.
-    def initialize(files, dirs={}, &block)
-      @files = files.freeze
-      @glob  = compile_glob(dirs)
+    # This method may also receive a block that will be called once a path
+    # changes and execute or execute_if_updated is called. The array of files
+    # and list of directories cannot be changed after FileUpdateChecker 
+    # has been initialized.
+    #
+    # The options one can specify are the following:
+    #
+    #   :filter -> Only chooses paths matching the regex
+    #
+    #   :ignore -> Ignores all paths matching the regex
+    #
+    #   :cache_type -> Determines the type of file_cache used. Options are
+    #   either :time or :checksum. If :time is chosen, then file changes are
+    #   determined via the system time (note that changes which happen within
+    #   a second of another change will not be noticed). If :checksum is
+    #   chosen then an MD5 hash is computed over the file and the hash is
+    #   checked for changes. Using :checksum will detect changes better than
+    #   :time, but :time has significant performance advantages. The default
+    #   :cache_type is :time.
+    #
+    #   :notifications -> Give the name of the group of the notifications
+    #   which you would like to call upon file change. If this field is
+    #   not nil, then the changed_files queue will always be empty and changed
+    #   files will be sent via the appropriate notifications. The value of
+    #   this field is notifications group name to which file change
+    #   notifications are sent.
+    #
+    #   :recurse -> If true, then all of the subdirectories of the original
+    #   paths will be searched recursively in a BFS fashion. All file changes
+    #   will be detected, such as additions, deletions, and modifications. 
+    def initialize(paths, dirs={}, opts={}, &block)
+      @paths = paths
+      @dirs = dirs
+      @opts = opts
       @block = block
 
-      @watched    = nil
-      @updated_at = nil
+      @start_time = Time.now
+      @file_cache = ThreadSafe::Cache.new
+      @changed_files = Queue.new
+      @semaphore = Mutex.new
 
-      @last_watched   = watched
-      @last_update_at = updated_at(@last_watched)
+      listen_for_changes
     end
 
-    # Check if any of the entries were updated. If so, the watched and/or
-    # updated_at values are cached until the block is executed via +execute+
-    # or +execute_if_updated+.
-    def updated?
-      current_watched = watched
-      if @last_watched.size != current_watched.size
-        @watched = current_watched
-        true
-      else
-        current_updated_at = updated_at(current_watched)
-        if @last_update_at < current_updated_at
-          @watched    = current_watched
-          @updated_at = current_updated_at
-          true
-        else
-          false
+    # Starts listening to changes in the filesystem. This method is
+    # synchronized until the stop_listening method is called. Once the object
+    # starts listening, it goes through and checks all files that have been
+    # changed since the object was created.
+    #
+    # If the object was previously stopped, and start_listening is called
+    # again, then all of the file changes since the last stop was called will
+    # be pushed to the changed_files queue. The files which were created and
+    # deleted between the stop and start of the method will be ignored.
+    def start_listening
+      Thread.new do
+        @continue_listening = true
+        while @continue_listening
+          listen_for_changes
         end
       end
+    end
+
+    # Stops listening to changes in the filesystem. When this method is called
+    # the FileChangeListener object will finish its last pass of the
+    # filesystem and stop.
+    def stop_listening
+      @continue_listening = false
+    end
+
+    # Check if any of the entries were updated.
+    def updated?
+      @changed_files.clear()
+      start_size = @file_cache.size
+      listen_for_changes
+      end_size = @file_cache.size
+      start_size != end_size || !@changed_files.empty?
     end
 
     # Executes the given block and updates the latest watched files and
     # timestamp.
     def execute
-      @last_watched   = watched
-      @last_update_at = updated_at(@last_watched)
+      listen_for_changes
       @block.call
-    ensure
-      @watched = nil
-      @updated_at = nil
     end
 
     # Execute the block given if updated.
@@ -90,28 +196,138 @@ module ActiveSupport
 
     private
 
-    def watched
-      @watched || begin
-        all = @files.select { |f| File.exists?(f) }
-        all.concat(Dir[@glob]) if @glob
-        all
+    # Method which listens for changes in the file system. This method
+    # delegates work to all the helper methods.
+    #
+    # Looks for files which have been added or modified by checking the
+    # @file_cache and seeing if files have been changed since the last
+    # pass. It also keeps track of @files_alive which are the files which
+    # are still around in the directory. If the @file_cache has a filepath
+    # which does not show up in @files_alive, that file is considered deleted.
+    #
+    # Note that this file is synchronized so that only a single BFS can be run
+    # over the file system at a single time.
+    def listen_for_changes
+      @semaphore.synchronize do
+        @files_alive = []
+
+        paths = initialize_paths(@paths, @dirs)
+        directories = handle_paths(paths)
+        if @opts[:recurse]
+          update_changed_files(directories)
+        end
+
+        deleted_files = @file_cache.keys - @files_alive.uniq
+        deleted_files.each do |filename|
+          @file_cache.delete(filename)
+          @changed_files.push(ChangedFile.new(filename, :removed))
+        end
       end
     end
 
-    def updated_at(paths)
-      @updated_at || max_mtime(paths) || Time.at(0)
+    # Takes a set of directories and looks for new files in those directories.
+    # Does a BFS on the set of starting directories and recursively calls
+    # itself until there are no more files left.
+    #
+    # Each path that is found in the directory is passed through valid_path?
+    # to look for new paths that are relevant. Paths are then parsed by
+    # handle_paths. New directories that are found form the BFS frontier
+    # and update_changed_files is called on these new directories.
+    def update_changed_files(directories)
+      new_directory_paths = []
+
+      directories.each do |directory_path|
+        expanded_filepaths = Dir.foreach(directory_path)
+        .select { |path| valid_path?(path) }
+        .map { |path| "#{directory_path}/#{path}" }
+
+        new_directory_paths += handle_paths(expanded_filepaths)
+      end
+
+      update_changed_files(new_directory_paths) if new_directory_paths.any?
     end
 
-    # This method returns the maximum mtime of the files in +paths+, or +nil+
-    # if the array is empty.
+    # Checks whether the path is valid based on the filters and ignores
+    # that were passed in as options on object initialization.
     #
-    # Files with a mtime in the future are ignored. Such abnormal situation
-    # can happen for example if the user changes the clock by hand. It is
-    # healthy to consider this edge case because with mtimes in the future
-    # reloading is not triggered.
-    def max_mtime(paths)
-      time_now = Time.now
-      paths.map {|path| File.mtime(path)}.reject {|mtime| time_now < mtime}.max
+    # The method also removes .. and . as valid paths since they lead
+    # to up and down directories.
+    def valid_path?(path)
+      if path == ".." || path == "."
+        return false
+      end
+
+      validations = []
+      if @opts[:filter]
+        validations << (path =~ @opts[:filter])
+      end
+      if @opts[:ignore]
+        validations << !(path =~ @opts[:ignore])
+      end
+
+      validations.all?
+    end
+
+    # Requires an array of filepaths. The filepaths must be valid objects
+    # in the filesystem.
+    #
+    # This method checks to see whether each filepath is a directory or
+    # whether it is a file. If it is a file, then it checks for changes
+    # using the check_file_for_changes submethod. If it is a directory,
+    # the method appends the filepath to a list and returns that list.
+    def handle_paths(expanded_filepaths)
+      new_directory_paths = []
+
+      expanded_filepaths.each do |expanded_filepath|
+        if File.file?(expanded_filepath)
+          @files_alive << expanded_filepath
+          check_file_for_changes(expanded_filepath)
+        elsif File.directory?(expanded_filepath)
+          new_directory_paths << expanded_filepath
+        end
+      end
+
+      new_directory_paths
+    end
+
+    # Requires a filepath, and checks to see whether that file has been
+    # changed since the last pass.
+    #
+    # There are two ways for which this is done. If the cache_type is not
+    # set or is set to :time, then the last time the file was modified is
+    # placed into the cache. Each pass then checks if the modified time
+    # is greater than it was previously.
+    #
+    # If the cache_type option is set to :checksum, then an MD5 checksum
+    # is computed for each file. Each pass checks to see if the checksum
+    # has changed at all from the previous pass.
+    #
+    # If the method detects a change, then a ChangedFile object is created
+    # with the path to the file and the type of change it was. The object
+    # is then pushed onto the @changed_files queue.
+    def check_file_for_changes(filepath)
+      last_modified = File.mtime(filepath)
+
+      case @opts[:cache_type]
+      when nil, :time
+        new_filepath_value = last_modified
+      when :checksum
+        new_filepath_value = Digest::MD5.hexdigest(File.read(filepath))
+      else
+        raise "Cache type #{@opts[:cache_type]} is an invalid option."
+      end
+
+      if @file_cache[filepath] != new_filepath_value && @start_time <= last_modified
+        change_type = (@file_cache[filepath] ? :modified : :added)
+        changed_file = ChangedFile.new(filepath, change_type)
+        if @opts[:notifications]
+          ActiveSupport::Notifications.instrument(@opts[:notifications], {:changed_file => changed_file})
+        else
+          @changed_files.push(changed_file)
+        end
+      end
+
+      @file_cache[filepath] = new_filepath_value
     end
 
     def compile_glob(hash)
@@ -132,6 +348,11 @@ module ActiveSupport
       array = Array(array)
       return if array.empty?
       ".{#{array.join(",")}}"
+    end
+
+    def initialize_paths(paths, dirs)
+      glob = compile_glob(dirs)
+      glob ? Array(paths) + Dir[glob] : Array(paths)
     end
   end
 end

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -47,11 +47,11 @@ module Notifications
         sleep(0.05)
       end
       assert !filesystem_events.empty?, "Filesystem change was not detected."
-      changed_file = filesystem_events[0][4][:changed_file]
+      changed_file_hash = filesystem_events[0][4]
 
       assert_equal "test_filesystem_notification", filesystem_events[0][0], "Incorrect notifications group name."
-      assert_equal filename, changed_file.path, "Incorrect path was detected for the filesystem change."
-      assert_equal :added, changed_file.type, "Incorrect type of filesystem change detected."
+      assert_equal filename, changed_file_hash[:path], "Incorrect path was detected for the filesystem change."
+      assert_equal :added, changed_file_hash[:type], "Incorrect type of filesystem change detected."
     ensure
       ActiveSupport::Notifications.unpublish_file_changes
       File.delete(filename)


### PR DESCRIPTION
FileUpdateChecker now has the ability to pinpoint the files that have been changed within the directories that it watches. All files which are children of the watched subdirectories will be found (recursively using a BFS search on the file system).

The class now can expose a queue of changed files, and there is also functionality in ActiveSupport::Notifications to listen to filesystem changes.

The idea behind this change is so that rails will eventually have a message bus system in development mode--i.e. that pages will automatically refresh when the developer saves or modifies a file, and that these file changes will be pushed to the browser so that the developer does not have to manually hit refresh. This is the first step to a larger change.
