### PR TITLE
active_record: Fix regression in predicate builder for join aliases.

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -101,7 +101,8 @@ module ActiveRecord
         when Integer, ActiveSupport::Duration
           # Arel treats integers as literals, but they should be quoted when compared with strings
           table = attribute.relation
-          column = table.engine.connection.schema_cache.columns_hash(table.name)[attribute.name.to_s]
+          schema_cache = table.engine.connection.schema_cache
+          column = schema_cache.table_exists?(table.name) ? schema_cache.columns_hash(table.name)[attribute.name.to_s] : nil
           attribute.eq(Arel::Nodes::SqlLiteral.new(table.engine.connection.quote(value, column)))
         else
           attribute.eq(value)

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -25,6 +25,13 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_construct_finder_sql_handles_integer_comparison_with_table_aliases
+    assert_nothing_raised do
+      sql = Person.joins(:agents).where('agents_people.followers_count' => 0).to_sql
+      assert_match(/agents_people/, sql)
+    end
+  end
+
   def test_construct_finder_sql_ignores_empty_joins_hash
     sql = Author.joins({}).to_sql
     assert_no_match(/JOIN/i, sql)


### PR DESCRIPTION
## Problem

Pull #9207 introduced a regression where the predicate builder causes an exception to be raised when trying to get the column for quoting integers when compared to an attribute on an aliased table.
## Solution

Takes the same approach as Arel, checking if the table exists, and otherwise passing a nil column to quote.

Relevant Arel code: https://github.com/rails/arel/blob/master/lib/arel/visitors/to_sql.rb#L144
