### PR TITLE
AR::Base#becomes should change errors base to new object

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -179,6 +179,7 @@ module ActiveRecord
       became.instance_variable_set("@new_record", new_record?)
       became.instance_variable_set("@destroyed", destroyed?)
       became.instance_variable_set("@errors", errors)
+      became.errors.instance_variable_set("@base", became)
       became
     end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1268,6 +1268,13 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal "The First Topic", topics(:first).becomes(Reply).title
   end
 
+  def test_becomes_changes_active_model_errors_base
+    company = Company.new(:name => "MyCompany")
+    account_client = company.becomes(AccountClient)
+    assert !account_client.valid?
+    assert_equal account_client.errors.instance_variable_get("@base"), account_client
+  end
+
   def test_becomes_includes_errors
     company = Company.new(:name => nil)
     assert !company.valid?

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -202,6 +202,10 @@ end
 class VerySpecialClient < SpecialClient
 end
 
+class AccountClient < Client
+  validates_presence_of :account
+end
+
 class Account < ActiveRecord::Base
   belongs_to :firm, :class_name => 'Company'
   belongs_to :unautosaved_firm, :foreign_key => "firm_id", :class_name => "Firm", :autosave => false


### PR DESCRIPTION
The current implementation of AR::Base#becomes throws an exception, whenever the new class validates something, the super class doesn't 'know' e.g. the presence of an associated object.

``` ruby
class Company < ActiveRecord::Base
end

class Client < Company
  belongs_to :account
  validates_presence_of :account
end

company = Company.new
client = company.becomes(Client)
client.valid?

=> NoMethodError: undefined method `account' for #<Company:0x0000010383acd0>

```

This happens because since https://github.com/rails/rails/pull/3438 AR::Base#becomes copies the errors information, but doesn't change the base instance variable of the related ActiveModel::Errors object to the transformed object.

In my opinion, there are two alternatives:
1. Fix the bug: I attached a pull request with a failing test and bugfix
2. Revert https://github.com/rails/rails/pull/3438 . The whole behaviour could be misleading, because your errors object could contain messages of validations, which were overwritten by the new class.
