### PR TITLE
[3.2] active_record: Fix regression in predicate builder for join aliases.

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -53,7 +53,8 @@ module ActiveRecord
             attribute.eq(value.name)
           when Integer, ActiveSupport::Duration
             # Arel treats integers as literals, but they should be quoted when compared with strings
-            column = engine.connection.schema_cache.columns_hash[table.name][attribute.name.to_s]
+            schema_cache = table.engine.connection.schema_cache
+            column = schema_cache.table_exists?(table.name) ? schema_cache.columns_hash[table.name][attribute.name.to_s] : nil
             attribute.eq(Arel::Nodes::SqlLiteral.new(engine.connection.quote(value, column)))
           else
             attribute.eq(value)

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -25,6 +25,13 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_construct_finder_sql_handles_integer_comparison_with_table_aliases
+    assert_nothing_raised do
+      sql = Person.joins(:agents).where('agents_people.followers_count' => 0).to_sql
+      assert_match(/agents_people/, sql)
+    end
+  end
+
   def test_construct_finder_sql_ignores_empty_joins_hash
     sql = Author.joins({}).to_sql
     assert_no_match(/JOIN/i, sql)


### PR DESCRIPTION
Fixes #9257

Backports pull #9262.
