### PR TITLE
3.2.12 More inclusive fix for regression in joins

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -53,7 +53,8 @@ module ActiveRecord
             attribute.eq(value.name)
           when Integer, ActiveSupport::Duration
             # Arel treats integers as literals, but they should be quoted when compared with strings
-            column = engine.connection.schema_cache.columns_hash[table.name][attribute.name.to_s]
+            schema_cache = table.engine.connection.schema_cache
+            column = schema_cache.table_exists?(table.name) ? schema_cache.columns_hash[table.name][attribute.name.to_s] : nil
             attribute.eq(Arel::Nodes::SqlLiteral.new(engine.connection.quote(value, column)))
           else
             attribute.eq(value)

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -53,6 +53,7 @@ module ActiveRecord
             attribute.eq(value.name)
           when Integer, ActiveSupport::Duration
             # Arel treats integers as literals, but they should be quoted when compared with strings
+            table = table.relation if table.is_a?(Arel::Nodes::TableAlias)
             schema_cache = table.engine.connection.schema_cache
             column = schema_cache.table_exists?(table.name) ? schema_cache.columns_hash[table.name][attribute.name.to_s] : nil
             attribute.eq(Arel::Nodes::SqlLiteral.new(engine.connection.quote(value, column)))

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -25,6 +25,13 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_construct_finder_sql_handles_integer_comparison_with_table_aliases
+    assert_nothing_raised do
+      sql = Person.joins(:agents).where('agents_people.followers_count' => 0).to_sql
+      assert_match(/agents_people/, sql)
+    end
+  end
+
   def test_construct_finder_sql_ignores_empty_joins_hash
     sql = Author.joins({}).to_sql
     assert_no_match(/JOIN/i, sql)

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -6,12 +6,13 @@ require 'models/essay'
 require 'models/category'
 require 'models/categorization'
 require 'models/person'
+require 'models/pet'
 require 'models/tagging'
 require 'models/tag'
 
 class InnerJoinAssociationTest < ActiveRecord::TestCase
   fixtures :authors, :essays, :posts, :comments, :categories, :categories_posts, :categorizations,
-           :taggings, :tags
+           :taggings, :tags, :pets
 
   def test_construct_finder_sql_applies_aliases_tables_on_association_conditions
     result = Author.joins(:thinking_posts, :welcome_posts).to_a
@@ -29,6 +30,12 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
     assert_nothing_raised do
       sql = Person.joins(:agents).where('agents_people.followers_count' => 0).to_sql
       assert_match(/agents_people/, sql)
+    end
+  end
+
+  def test_construct_finder_sql_handles_integer_comparison_with_arel_table_aliases
+    assert_nothing_raised do
+      Person.includes(:pets).where(:pets => {:created_at => Time.now}).length
     end
   end
 

--- a/activerecord/test/models/person.rb
+++ b/activerecord/test/models/person.rb
@@ -24,6 +24,7 @@ class Person < ActiveRecord::Base
   has_many :agents, :class_name => 'Person', :foreign_key => 'primary_contact_id'
   has_many :agents_of_agents, :through => :agents, :source => :agents
   belongs_to :number1_fan, :class_name => 'Person'
+  has_many :pets, :foreign_key => :owner_id, :conditions => {:owner_id => 1}
 
   has_many :agents_posts,         :through => :agents,       :source => :posts
   has_many :agents_posts_authors, :through => :agents_posts, :source => :author


### PR DESCRIPTION
This patch fixes an issue that #9262 did not solve for us.

In particular, it didn't resolve the case when not using an SQL table alias, but an Arel::TableAlias is present. See test case for an example.

(Addresses #9257, #9260.)
