### PR TITLE
Use define_method when method name contains weird characters.

### DIFF
--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -37,11 +37,9 @@ module ActiveRecord
                 end
               RUBY
             else
-              module_eval <<-RUBY, __FILE__, __LINE__ + 1
-                def #{method}(*args, &block)
-                  scoping { @klass.send(#{method.inspect}, *args, &block) }
-                end
-              RUBY
+              define_method method do |*args, &block|
+                scoping { @klass.send(method, *args, &block) }
+              end
             end
           end
         end

--- a/activerecord/test/cases/named_scope_test.rb
+++ b/activerecord/test/cases/named_scope_test.rb
@@ -271,6 +271,20 @@ class NamedScopeTest < ActiveRecord::TestCase
     assert_equal 'lifo', topic.author_name
   end
 
+  # Method delegation for scope names which look like /\A[a-zA-Z_]\w*[!?]?\z/
+  # has been done by evaluating a string with a plain def statement. For scope
+  # names which contain spaces this approach doesn't work.
+  def test_spaces_in_scope_names
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "topics"
+      scope :"title containing space", -> { where("title LIKE '% %'") }
+      scope :approved, -> { where(:approved => true) }
+    end
+    assert_equal klass.send(:"title containing space"), klass.where("title LIKE '% %'")
+    assert_equal klass.approved.send(:"title containing space"), klass.approved.where("title LIKE '% %'")
+    end
+  end
+
   def test_find_all_should_behave_like_select
     assert_equal Topic.base.to_a.select(&:approved), Topic.base.to_a.find_all(&:approved)
   end


### PR DESCRIPTION
In delegate_to_scoped_klass method in ActiveRecord, plain def was used when defining methods with weird characters in names, which resulted in syntax errors. I've changed it to use define_method instead and added a regression test for scope names with spaces.

This could be also rewritten to use a block instead of a string in module_eval, but in pull request #9206 I've read that it may impose some performance penalty, so I didn't change it as I don't know how important it is.
