### PR TITLE
Add has_#{association.pluralize}?

### DIFF
--- a/activerecord/lib/active_record/associations/builder/collection_association.rb
+++ b/activerecord/lib/active_record/associations/builder/collection_association.rb
@@ -73,6 +73,10 @@ module ActiveRecord::Associations::Builder
         def #{name.to_s.singularize}_ids
           association(:#{name}).ids_reader
         end
+
+        def has_#{name.to_s.pluralize}?
+          association(:#{name}).count != 0
+        end
       CODE
     end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1747,4 +1747,18 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     david.posts_with_special_categorizations = []
     assert_equal [], david.posts_with_special_categorizations
   end
+
+  test 'has_#{association}s? is true when association has rows' do
+    david = authors(:david)
+
+    assert david.has_posts?
+  end
+
+  test 'has_#{association}s? is false when association is empty' do
+    david = authors(:david)
+
+    david.posts.destroy_all
+
+    assert !david.has_posts?
+  end
 end


### PR DESCRIPTION
- Add has_assocations? reader method to collection assocations.
  
  For example, if Author has_many Posts, ActiveRecord::Associations will
  provide Author#has_posts?, which returns true if the posts association
  has at least one record and false otherwise.
