### PR TITLE
Add better_errors to the default Gemfile

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add `better_errors` and `binding_of_caller` to the default Gemfile.
+
+    *Charlie Somerville*
+
 *   The public/index.html is no longer generated for new projects. Page is replaced by internal welcome_controller inside of railties
 
     *Richard Schneeman*

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -9,6 +9,12 @@ source 'https://rubygems.org'
 <%= assets_gemfile_entry %>
 <%= javascript_gemfile_entry -%>
 
+# Use Better Errors for more advanced error pages in development
+group :development do
+  gem 'better_errors'
+  gem 'binding_of_caller', '>= 0.6.9'
+end
+
 # To use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.0.0'
 


### PR DESCRIPTION
Hi!

This pull request adds my [better_errors](https://github.com/charliesome/better_errors) gem and its optional dependency [binding_of_caller](https://github.com/banister/binding_of_caller) (now working on Ruby 2.0.0 thanks to the new debug_inspector API) to the default Rails 4 Gemfile.

Better Errors has been quite popular with Rails developers since release, so I figure it's a good fit for inclusion in the default set of gem dependencies.
