### PR TITLE
Attempt to convert `as_json` options to a Hash

### DIFF
--- a/activemodel/lib/active_model/serializers/json.rb
+++ b/activemodel/lib/active_model/serializers/json.rb
@@ -86,6 +86,7 @@ module ActiveModel
       #   #                   { "comments" => [ { "body" => "Don't think too hard" } ],
       #   #                     "title" => "So I was thinking" } ] }
       def as_json(options = nil)
+        options = options.to_h if options.respond_to?(:to_h)
         root = if options && options.key?(:root)
           options[:root]
         else

--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -3,6 +3,8 @@ require 'models/contact'
 require 'models/automobile'
 require 'active_support/core_ext/object/instance_variables'
 
+JsonOptions = Struct.new(:only)
+
 class Contact
   include ActiveModel::Serializers::JSON
   include ActiveModel::Validations
@@ -207,6 +209,16 @@ class JsonSerializationTest < ActiveModel::TestCase
   test "custom as_json options should be extendible" do
     def @contact.as_json(options = {}); super(options.merge(only: [:name])); end
     json = @contact.to_json
+
+    assert_match %r{"name":"Konata Izumi"}, json
+    assert_no_match %r{"created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))}}, json
+    assert_no_match %r{"awesome":}, json
+    assert_no_match %r{"preferences":}, json
+  end
+
+  test "as_json options should work with objects that implement to_h" do
+    options = JsonOptions.new([:name])
+    json = @contact.to_json(options)
 
     assert_match %r{"name":"Konata Izumi"}, json
     assert_no_match %r{"created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))}}, json


### PR DESCRIPTION
This avoid errors when serializing models with `JSON.generate`,
where the given option isn't a Hash but a State object, where
a `NoMethodError: undefined method 'key?' for JSON::Ext::Generator::State`
error would appear.

/cc @rafaelfranca
