### PR TITLE
Added extra comment when a migration already exists of the same name

### DIFF
--- a/railties/lib/rails/generators/migration.rb
+++ b/railties/lib/rails/generators/migration.rb
@@ -52,7 +52,7 @@ module Rails
           if destination && options.force?
             remove_file(destination)
           elsif destination
-            raise Error, "Another migration is already named #{@migration_file_name}: #{destination}"
+            raise Error, "Another migration is already named #{@migration_file_name}: #{destination}. Use --force to remove the old migration file and replace it."
           end
           destination = File.join(migration_dir, "#{@migration_number}_#{@migration_file_name}.rb")
         end


### PR DESCRIPTION
User should know that they can overwrite the previous migration. This
comes in handy especially when generating models which were previously
created then removed.
