### PR TITLE
Remove unused error class

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -409,8 +409,7 @@ module ActionDispatch
         if encrypted_message = @parent_jar[key]
           @encryptor.decrypt_and_verify(encrypted_message)
         end
-      rescue ActiveSupport::MessageVerifier::InvalidSignature,
-             ActiveSupport::MessageVerifier::InvalidMessage
+      rescue ActiveSupport::MessageVerifier::InvalidSignature
         nil
       end
 


### PR DESCRIPTION
InvalidMessage doesn't appear to be used anywhere and when using the
encrypted_cookie_store on jruby, this line raises `NameError:
uninitialized constant ActiveSupport::MessageVerifier::InvalidMessage`.
