### PR TITLE
Removed an old require of an MD5 digest which is no longer used.

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -1,4 +1,3 @@
-require 'digest/md5'
 require 'active_support/core_ext/class/attribute_accessors'
 require 'monitor'
 


### PR DESCRIPTION
Inside of ActionDispatch module, there is an extra require which should be removed. The original require was included by dhh back in 2005, but the code has since involved to no longer require an MD5 hash.
