### PR TITLE
Return false in toggle function on error pages

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.erb
@@ -1,6 +1,6 @@
 <% unless @exception.blamed_files.blank? %>
   <% if (hide = @exception.blamed_files.length > 8) %>
-    <a href="#" onclick="toggleTrace()">Toggle blamed files</a>
+    <a href="#" onclick="return toggleTrace()">Toggle blamed files</a>
   <% end %>
   <pre id="blame_trace" <%='style="display:none"' if hide %>><code><%= @exception.describe_blame %></code></pre>
 <% end %>
@@ -21,12 +21,12 @@
 <p><b>Parameters</b>:</p> <pre><%= request_dump %></pre>
 
 <div class="details">
-  <div class="summary"><a href="#" onclick="toggleSessionDump()">Toggle session dump</a></div>
+  <div class="summary"><a href="#" onclick="return toggleSessionDump()">Toggle session dump</a></div>
   <div id="session_dump" style="display:none"><pre><%= debug_hash @request.session %></pre></div>
 </div>
 
 <div class="details">
-  <div class="summary"><a href="#" onclick="toggleEnvDump()">Toggle env dump</a></div>
+  <div class="summary"><a href="#" onclick="return toggleEnvDump()">Toggle env dump</a></div>
   <div id="env_dump" style="display:none"><pre><%= debug_hash @request.env.slice(*@request.class::ENV_METHODS) %></pre></div>
 </div>
 

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -121,6 +121,7 @@
     var toggle = function(id) {
       var s = document.getElementById(id).style;
       s.display = s.display == 'none' ? 'block' : 'none';
+      return false;
     }
     var show = function(id) {
       document.getElementById(id).style.display = 'block';
@@ -129,13 +130,13 @@
       document.getElementById(id).style.display = 'none';
     }
     var toggleTrace = function() {
-      toggle('blame_trace');
+      return toggle('blame_trace');
     }
     var toggleSessionDump = function() {
-      toggle('session_dump');
+      return toggle('session_dump');
     }
     var toggleEnvDump = function() {
-      toggle('env_dump');
+      return toggle('env_dump');
     }
   </script>
 </head>


### PR DESCRIPTION
When you click on "Toggle env dump", "Toggle session dump" or "Toggle blamed files" on the error page anchor to '#' is invoked and page scrolls to the top.

I fixed this annoying thing by returning false from the toggle function.
