### PR TITLE
delete duplicated tests in AR base_test.rb

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -327,29 +327,6 @@ class BasicsTest < ActiveRecord::TestCase
     assert !cbs[1].frickinawesome
   end
 
-  def test_first_or_create
-    parrot = Bird.first_or_create(:color => 'green', :name => 'parrot')
-    assert parrot.persisted?
-    the_same_parrot = Bird.first_or_create(:color => 'yellow', :name => 'macaw')
-    assert_equal parrot, the_same_parrot
-  end
-
-  def test_first_or_create_bang
-    assert_raises(ActiveRecord::RecordInvalid) { Bird.first_or_create! }
-    parrot = Bird.first_or_create!(:color => 'green', :name => 'parrot')
-    assert parrot.persisted?
-    the_same_parrot = Bird.first_or_create!(:color => 'yellow', :name => 'macaw')
-    assert_equal parrot, the_same_parrot
-  end
-
-  def test_first_or_initialize
-    parrot = Bird.first_or_initialize(:color => 'green', :name => 'parrot')
-    assert_kind_of Bird, parrot
-    assert !parrot.persisted?
-    assert parrot.new_record?
-    assert parrot.valid?
-  end
-
   def test_load
     topics = Topic.all.merge!(:order => 'id').to_a
     assert_equal(4, topics.size)


### PR DESCRIPTION
After I opened #9312, I realized that these tests are unnecessary.

These are duplicated with the tests which are in
- <del>[persistence_test.rb](https://github.com/rails/rails/blob/master/activerecord/test/cases/persistence_test.rb#L167) ( test_create_~ </del>
- [relations_test.rb](https://github.com/rails/rails/blob/master/activerecord/test/cases/relations_test.rb#L946) ( test_first_or_~

Thx
