### PR TITLE
Print message on stderr when no routes are defined.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add a message when you have no routes defined to both `rake routes` and
+    GET "/rails/info/routes" that lets you know you have none defined and links
+    to the Rails Guide on the topic.
+
+    *Steve Klabnik*
+
 *   Change `image_alt` method to replace underscores/hyphens to spaces in filenames.
 
     Previously, underscored filenames became `alt="A_long_file_name_with_underscores"`

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -91,6 +91,11 @@ module ActionDispatch
 
         routes = collect_routes(routes_to_display)
 
+        if routes.none?
+          formatter.no_routes
+          return formatter.result
+        end
+
         formatter.header routes
         formatter.section routes
 
@@ -161,6 +166,16 @@ module ActionDispatch
         @buffer << draw_header(routes)
       end
 
+      def no_routes
+        @buffer << <<-MESSAGE
+You don't have any routes defined!
+
+Please add some routes in config/routes.rb.
+
+For more information about routes, see the Rails Guide: http://guides.rubyonrails.org/routing.html .
+MESSAGE
+      end
+
       private
         def draw_section(routes)
           name_width, verb_width, path_width = widths(routes)
@@ -195,6 +210,16 @@ module ActionDispatch
 
       def section(routes)
         @buffer << @view.render(partial: "routes/route", collection: routes)
+      end
+
+      def no_routes
+        @buffer << <<-MESSAGE
+<p>You don't have any routes defined!</p>
+<ul>
+<li>Please add some routes in config/routes.rb.</li>
+<li>For more information about routes, please <a href="http://guides.rubyonrails.org/routing.html">see the Rails Guide</a>.</li>
+</ul>
+MESSAGE
       end
 
       def result

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -143,6 +143,21 @@ module ApplicationTests
       assert_equal "cart GET /cart(.:format) cart#show\n", Dir.chdir(app_path){ `rake routes` }
     end
 
+    def test_rake_routes_displays_message_when_no_routes_are_defined
+      app_file "config/routes.rb", <<-RUBY
+        AppTemplate::Application.routes.draw do
+        end
+      RUBY
+
+      assert_equal <<-MESSAGE, Dir.chdir(app_path){ `rake routes` }
+You don't have any routes defined!
+
+Please add some routes in config/routes.rb.
+
+For more information about routes, see the Rails Guide: http://guides.rubyonrails.org/routing.html .
+MESSAGE
+    end
+
     def test_logger_is_flushed_when_exiting_production_rake_tasks
       add_to_config <<-RUBY
         rake_tasks do


### PR DESCRIPTION
Newbies get confused when they run 'rake routes' and no routes are defined. Let's
point them to some documentation.

Thanks to @burtlo for the suggestion.

```
$ rake routes
You don't have any routes defined!
Please add some routes in config/routes.rb.
For more information about routes, see the Rails Guide: http://guides.rubyonrails.org/routing.html
```

![routes](https://f.cloud.github.com/assets/27786/168732/18a92f1e-7a06-11e2-9a54-1689d14dad2a.png)
