### PR TITLE
Add headings to rake routes table

### DIFF
--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -90,6 +90,8 @@ module ActionDispatch
         routes_to_display = filter_routes(filter)
 
         routes = collect_routes(routes_to_display)
+
+        formatter.header routes
         formatter.section routes
 
         @engines.each do |name, engine_routes|
@@ -155,15 +157,29 @@ module ActionDispatch
         @buffer << draw_section(routes)
       end
 
+      def header(routes)
+        @buffer << draw_header(routes)
+      end
+
       private
         def draw_section(routes)
-          name_width = routes.map { |r| r[:name].length }.max
-          verb_width = routes.map { |r| r[:verb].length }.max
-          path_width = routes.map { |r| r[:path].length }.max
+          name_width, verb_width, path_width = widths(routes)
 
           routes.map do |r|
             "#{r[:name].rjust(name_width)} #{r[:verb].ljust(verb_width)} #{r[:path].ljust(path_width)} #{r[:reqs]}"
           end
+        end
+
+        def draw_header(routes)
+          name_width, verb_width, path_width = widths(routes)
+
+          "#{"Prefix".rjust(name_width)} #{"Verb".ljust(verb_width)} #{"URI Pattern".ljust(path_width)} Controller#Action"
+        end
+
+        def widths(routes)
+          [routes.map { |r| r[:name].length }.max,
+           routes.map { |r| r[:verb].length }.max,
+           routes.map { |r| r[:path].length }.max]
         end
     end
 


### PR DESCRIPTION
Another "get some feedback on this idea" PR. Thanks @burtlo!

It's easy to forget what the order of things are in the routing table, especially if you're new. The HTML view has headings, but the console does not. They're a little different at the moment due to space, but I can change them to be as close to possible once we determine this is a good idea.

```
$ rake routes
  Prefix Verb   URI Pattern              Controller#Action
    foos GET    /foos(.:format)          foos#index
         POST   /foos(.:format)          foos#create
 new_foo GET    /foos/new(.:format)      foos#new
edit_foo GET    /foos/:id/edit(.:format) foos#edit
     foo GET    /foos/:id(.:format)      foos#show
         PATCH  /foos/:id(.:format)      foos#update
         PUT    /foos/:id(.:format)      foos#update
         DELETE /foos/:id(.:format)      foos#destroy
```

One other thing I'd like to implement, but haven't: test if we're running in a shell or not. If we're not, then we shouldn't print the headings. If you're writing scripts that rely on the output of the task, no headings is way better.
