### PR TITLE
Raising an ActiveRecordError when one tries to use touch on a new record object

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fixing issue #8345. Now throwing an error when one attempts to touch a
+    new object that has not yet been persisted. For instance:
+
+      ball = Ball.new
+      ball.touch :updated_at   # => raises error
+
+    It is not until the ball object has been persisted that it can be touched.
+    This follows the behavior of update_column.
+
+    *John Wang*
+
 *   Preloading ordered `has_many :through` associations no longer applies
     invalid ordering to the `:through` association.
     Fixes #8663.

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -368,6 +368,8 @@ module ActiveRecord
     #   # triggers @brake.car.touch and @brake.car.corporation.touch
     #   @brake.touch
     def touch(name = nil)
+      raise ActiveRecordError, "can not touch on a new record object" unless persisted?
+
       attributes = timestamp_attributes_for_update_in_model
       attributes << name if name
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1447,6 +1447,13 @@ class BasicsTest < ActiveRecord::TestCase
     assert_match(/\/#{dev.id}$/, dev.cache_key)
   end
 
+  def test_touch_should_raise_error_on_a_new_object
+    company = Company.new(:rating => 1, :name => "37signals", :firm_name => "37signals")
+    assert_raises(ActiveRecord::ActiveRecordError) do
+      company.touch :updated_at
+    end
+  end
+
   def test_cache_key_format_is_precise_enough
     dev = Developer.first
     key = dev.cache_key


### PR DESCRIPTION
This is in response to https://github.com/rails/rails/issues/8345. It seems like the best course of action is to throw an error when one attempts to touch a new object that has not yet been persisted. For instance: 

ball = Ball.new
ball.touch :updated_at

Should not trigger a DB statement at all, but should probably throw an error until the ball object has been persisted. This PR takes care of that (in the same manner that it is done for update_column) and adds a test.
