### PR TITLE
Require ActiveSupport dependencies in ActionDispatch::Http::URL

### DIFF
--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -1,3 +1,6 @@
+require 'active_support/core_ext/module/attribute_accessors'
+require 'active_support/core_ext/hash/slice'
+
 module ActionDispatch
   module Http
     module URL


### PR DESCRIPTION
Makes it possible to use `url_for` and friends in isolation.

Before:

```
$ irb -Iactionpack/lib -raction_dispatch/http/url                                                                                                            
/Users/miha/.rbenv/versions/1.9.3-p327-perf/lib/ruby/gems/1.9.1/gems/actionpack-3.2.11/lib/action_dispatch/http/url.rb:4:in `<module:URL>': undefined method `mattr_accessor' for ActionDispatch::Http::URL:Module (NoMethodError)
```

After:

```
$ irb -Iactionpack/lib -raction_dispatch/http/url
irb(main):001:0> ActionDispatch::Http::URL
=> ActionDispatch::Http::URL
```

No tests since I wasn't sure how to approach this. If you have any pointers I'd love to give it a try.
