### PR TITLE
keep the build :green_heart:, #first on 1.8.7 and pg is different

### DIFF
--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1114,7 +1114,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   test "preloading does not cache has many association subset when preloaded with a through association" do
-    author = Author.includes(:comments_with_order_and_conditions, :posts).first
+    author = Author.where(:id => 1).includes(:comments_with_order_and_conditions, :posts).first
     assert_no_queries { assert_equal 2, author.comments_with_order_and_conditions.size }
     assert_no_queries { assert_equal 5, author.posts.size, "should not cache a subset of the association" }
   end


### PR DESCRIPTION
The build only failed for ruby-1.8.7 and pg. The problem was that the statement:

``` ruby
author = Author.includes(:comments_with_order_and_conditions, :posts).first
```

resulted in Author with ID 2 where on all other rubies / db-engines Author with ID 1
was retunred. Of course this breaks the assertions.
