### PR TITLE
Fix deletion of empty directories

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0.beta1 (February 25, 2013) ##
 
+*   Fix deletion of empty directories in ActiveSupport::Cache::FileStore. *Charles Jones*
+
 *   Prevent `DateTime#change` from truncating the second fraction, when seconds
     do not need to be changed.
 

--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -150,9 +150,9 @@ module ActiveSupport
 
         # Delete empty directories in the cache.
         def delete_empty_directories(dir)
-          return if dir == cache_path
+          return if File.realpath(dir) == File.realpath(cache_path)
           if Dir.entries(dir).reject {|f| EXCLUDED_DIRS.include?(f)}.empty?
-            File.delete(dir) rescue nil
+            Dir.delete(dir) rescue nil
             delete_empty_directories(File.dirname(dir))
           end
         end

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -672,6 +672,18 @@ class FileStoreTest < ActiveSupport::TestCase
     end
   end
 
+  def test_delete_does_not_delete_empty_parent_dir
+    sub_cache_dir = File.join(cache_dir, 'subdir/')
+    sub_cache_store = ActiveSupport::Cache::FileStore.new(sub_cache_dir)
+    assert_nothing_raised(Exception) do
+      assert sub_cache_store.write('foo', 'bar')
+      assert sub_cache_store.delete('foo')
+    end
+    assert File.exist?(cache_dir), "Parent of top level cache dir was deleted!"
+    assert File.exist?(sub_cache_dir), "Top level cache dir was deleted!"
+    assert Dir.entries(sub_cache_dir).reject {|f| ActiveSupport::Cache::FileStore::EXCLUDED_DIRS.include?(f)}.empty?
+  end
+
   def test_log_exception_when_cache_read_fails
     File.expects(:exist?).raises(StandardError, "failed")
     @cache.send(:read_entry, "winston", {})


### PR DESCRIPTION
1. When comparing the directory to delete against the top level
   cache_path, use File.realpath to make sure we aren't comparing two
   unequal strings that point to the same path. This occurs, for
   example, when cache_path has a trailing slash, which it does in the
   default Rails configuration. Since the input to
   delete_empty_directories never has a trailing slash, the comparison
   will never be true and the top level cache directory (and above) may
   be deleted. However…
2. File.delete raises EPERM when trying to delete a directory, so no
   directories have ever been deleted. Changing the code to Dir.delete
   fixes that.
