### PR TITLE
Fix time_zone_options_for_select to not mutate TimeZones array

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix `time_zone_options_for_select` to call `dup` on the returned TimeZone array.
+    
+    Previously if you supplied :priority_zones options to `time_zone_options_for_select`
+    the memoized ActiveSupport::TimeZone.all array would be mutated.  Calling
+    `dup` prevents mutation of the main TimeZones array.
+    
+    *Brian McManus*
+    
 *   Remove support for parsing YAML parameters from request.
 
     *Aaron Patterson*

--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -560,7 +560,7 @@ module ActionView
       def time_zone_options_for_select(selected = nil, priority_zones = nil, model = ::ActiveSupport::TimeZone)
         zone_options = "".html_safe
 
-        zones = model.all
+        zones = model.all.dup
         convert_zones = lambda { |list| list.map { |z| [ z.to_s, z.name ] } }
 
         if priority_zones

--- a/actionpack/test/template/form_options_helper_test.rb
+++ b/actionpack/test/template/form_options_helper_test.rb
@@ -416,6 +416,13 @@ class FormOptionsHelperTest < ActionView::TestCase
                  "<option value=\"D\">D</option>",
                  opts
   end
+  
+  def test_time_zone_options_with_priority_zones_does_not_mutate_time_zones
+    original_zones = ActiveSupport::TimeZone.all.dup
+    zones = [ ActiveSupport::TimeZone.new( "B" ), ActiveSupport::TimeZone.new( "E" ) ]
+    opts = time_zone_options_for_select( nil, zones )
+    assert_equal original_zones, ActiveSupport::TimeZone.all
+  end
 
   def test_time_zone_options_returns_html_safe_string
     assert time_zone_options_for_select.html_safe?


### PR DESCRIPTION
Previous implementation of time_zone_options_for_select did not dup the
ActiveSupport::TimeZone.all array.  When :priority_zones were provided
the method would reject! the zones from the memoized TimeZones array
thus affecting future requests to the server.  Essentially whatever
zones were specified as :priority_zones would show up for the first
request but then disappear from the time zone options on future
requests.
