### PR TITLE
move config.assets.precompile into config/application.rb

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   The configuration option `config.assets.precompile` is no longer
+    in `config/environments/production.rb` but in
+    `config/application.rb`.
+
+    *Yves Senn*
+
 *   Add notice message for destroy action in scaffold generator.
 
     *Rahul P. Chaudhari*

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -31,6 +31,10 @@ module <%= app_const_base %>
 
     # Disable the asset pipeline.
     config.assets.enabled = false
+<% else %>
+  # Precompile additional assets.
+  # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
+  # config.assets.precompile += %w( search.js )
 <% end -%>
   end
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -59,12 +59,6 @@
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = "http://assets.example.com"
 
-  <%- unless options.skip_sprockets? -%>
-  # Precompile additional assets.
-  # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-  # config.assets.precompile += %w( search.js )
-  <%- end -%>
-
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
Since `rake assets:precompile` is no longer executed in production it makes no sense to have the option `config.assets.precompile` in `config/environments/production.rb`. I moved it into `config/application.rb` since it makes more sense to configure what to precompile for the whole application than for different environments.

I'm not sure if this is the only option that needs to move. I already talked with @guilleiguaran about that change, so if further things come up, let me know.
