### PR TITLE
after_remove callbacks only run if record was removed.

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -468,9 +468,10 @@ module ActiveRecord
           records.each { |record| callback(:before_remove, record) }
 
           delete_records(existing_records, method) if existing_records.any?
-          records.each { |record| target.delete(record) }
-
-          records.each { |record| callback(:after_remove, record) }
+          records.each do |record| 
+              deleted = target.delete(record) 
+              callback(:after_remove, record) if deleted
+          end
         end
 
         # Delete the given records from the association, using one of the methods :destroy,

--- a/activerecord/test/cases/associations/callbacks_test.rb
+++ b/activerecord/test/cases/associations/callbacks_test.rb
@@ -42,11 +42,12 @@ class AssociationCallbacksTest < ActiveRecord::TestCase
 
   def test_removing_with_proc_callbacks
     first_post, second_post = @david.posts_with_callbacks[0, 2]
+    @david.posts_with_proc_callbacks << first_post
     @david.posts_with_proc_callbacks.delete(first_post)
-    assert_equal ["before_removing#{first_post.id}", "after_removing#{first_post.id}"], @david.post_log
+    assert_equal ["before_adding#{first_post.id}", "after_adding#{first_post.id}", "before_removing#{first_post.id}", "after_removing#{first_post.id}"], @david.post_log
     @david.posts_with_proc_callbacks.delete(second_post)
-    assert_equal ["before_removing#{first_post.id}", "after_removing#{first_post.id}", "before_removing#{second_post.id}",
-                  "after_removing#{second_post.id}"], @david.post_log
+
+    assert_equal ["before_adding#{first_post.id}", "after_adding#{first_post.id}", "before_removing#{first_post.id}", "after_removing#{first_post.id}", "before_removing#{second_post.id}"], @david.post_log
   end
 
   def test_multiple_callbacks
@@ -121,12 +122,12 @@ class AssociationCallbacksTest < ActiveRecord::TestCase
     jamis = developers(:jamis)
     activerecord = projects(:active_record)
     assert activerecord.developers_log.empty?
+    activerecord.developers_with_callbacks << david
     activerecord.developers_with_callbacks.delete(david)
-    assert_equal ["before_removing#{david.id}", "after_removing#{david.id}"], activerecord.developers_log
+    assert_equal ["before_adding#{david.id}", "after_adding#{david.id}", "before_removing#{david.id}", "after_removing#{david.id}"], activerecord.developers_log
 
     activerecord.developers_with_callbacks.delete(jamis)
-    assert_equal ["before_removing#{david.id}", "after_removing#{david.id}", "before_removing#{jamis.id}",
-                  "after_removing#{jamis.id}"], activerecord.developers_log
+    assert_equal ["before_adding#{david.id}", "after_adding#{david.id}", "before_removing#{david.id}", "after_removing#{david.id}", "before_removing#{jamis.id}"], activerecord.developers_log
   end
 
   def test_has_and_belongs_to_many_remove_callback_on_clear


### PR DESCRIPTION
If a record that does not belong to a HABTM collection is passed in to a collection to be deleted, the after_remove callback is run even though the record was not actually removed. This can cause unexpected behaviour, such as incorrectly decrementing a counter.

The new behaviour still has before_remove called, but after_remove called only if the record was actually removed from the collection.

Example of unexpected behaviour:

``` ruby
class Post < ActiveRecord::Base
  has_and_belongs_to_many :post_collections
end

class PostCollection < ActiveRecord::Base
  has_and_belongs_to_many :posts, after_remove: :decrememnt_posts_count

  def decrement_posts_count
     PostCollection.decrement_counter :posts_count, self.id
  end
end

post = Post.new
post_collection = PostCollection.new
post_collection.posts.delete(post)

# post_collection.posts_count is now -1
```

Addendum:
The pull request fixes behaviour that may or may not have been what was originally intended. If after_remove is to be called regardless of what happens to the data, this will invalidate the pull request. It seems intuitive however that the after_remove callback should only be run if the record was actually removed from the collection.
