### PR TITLE
Address edge case for number_to_human with units option.

### DIFF
--- a/actionpack/test/template/number_helper_test.rb
+++ b/actionpack/test/template/number_helper_test.rb
@@ -266,6 +266,11 @@ class NumberHelperTest < ActionView::TestCase
     assert_equal '100&lt;script&gt;&lt;/script&gt;000 Quadrillion', number_to_human(10**20, :delimiter => "<script></script>")
   end
 
+  def test_number_to_human_with_custom_units_that_are_missing_the_needed_key
+    assert_equal '123', number_to_human(123, :units => {:thousand => 'k'})
+    assert_equal '123', number_to_human(123, :units => {})
+  end
+
   def test_number_to_human_with_custom_format
     assert_equal '123 times Thousand', number_to_human(123456, :format => "%n times %u")
     volume = {:unit => "ml", :thousand => "lt", :million => "m3"}

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `ActiveSupport::NumberHelper#number_to_human` returns the number unaltered when
+    the units hash does not contain the needed key, e.g. when the number provided is less
+    than the largest key proivided.
+
+    Examples:
+
+        number_to_human(123, :units => {}) # => 123
+        number_to_human(123, :units => {:thousand => 'k'}) # => 123
+
+    Fixes #9269.
+
+    *Michael Hoffman*
+
 *   Added beginning_of_minute support to core_ext calculations for Time and DateTime
 
     *Gagan Awhad*

--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -580,7 +580,7 @@ module ActiveSupport
 
       unit = case units
       when Hash
-        units[DECIMAL_UNITS[display_exponent]]
+        units[DECIMAL_UNITS[display_exponent]] || ''
       when String, Symbol
         I18n.translate(:"#{units}.#{DECIMAL_UNITS[display_exponent]}", :locale => options[:locale], :count => number.to_i)
       else


### PR DESCRIPTION
`ActiveSupport::NumberHelper#number_to_human` now returns the number unaltered when
the units hash does not contain the needed key, e.g. when the number provided is less
than the largest key provided.

Examples:

```
number_to_human(123, :units => {}) # => 123
number_to_human(123, :units => {:thousand => 'k'}) # => 123
```

Fixes #9269.

_Note: This pull request is a recision of #9311, which I abandoned due to source control problems._
