### PR TITLE
Add more documentation for create_join_table.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -195,10 +195,10 @@ module ActiveRecord
       # Note that +create_join_table+ does not create any indices by default; you can use
       # its block form to do so yourself:
       #
-      #  create_join_table :products, :categories do |t|
-      #    t.index :products
-      #    t.index :categories
-      #  end
+      #   create_join_table :products, :categories do |t|
+      #     t.index :products
+      #     t.index :categories
+      #   end
       #
       # ====== Add a backend specific option to the generated SQL (MySQL)
       #  create_join_table(:assemblies, :parts, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8')

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -192,6 +192,14 @@ module ActiveRecord
       #   Set to true to drop the table before creating it.
       #   Defaults to false.
       #
+      # Note that +create_join_table+ does not create any indices by default; you can use
+      # its block form to do so yourself:
+      #
+      #  create_join_table :products, :categories do |t|
+      #    t.index :products
+      #    t.index :categories
+      #  end
+      #
       # ====== Add a backend specific option to the generated SQL (MySQL)
       #  create_join_table(:assemblies, :parts, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8')
       # generates:

--- a/guides/source/migrations.md
+++ b/guides/source/migrations.md
@@ -344,6 +344,16 @@ create_join_table :products, :categories, column_options: {null: true}
 will create the `product_id` and `category_id` with the `:null` option as
 `true`.
 
+`create_join_table` also accepts a block, which you can use to add indices
+(which are not created by default) or additional columns:
+
+```ruby
+create_join_table :products, :categories do |t|
+  t.index :products
+  t.index :categories
+end
+```
+
 ### Changing Tables
 
 A close cousin of `create_table` is `change_table`, used for changing existing


### PR DESCRIPTION
Explain that it doesn't create indices by default and that it also has a block form.
