### PR TITLE
determine the match shorthand target early.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Determine the controller#action from only the matched path when using the
+    shorthand syntax. Previously the complete path was used, which led
+    to problems with nesting (scopes and namespaces).
+    Fixes #7554.
+
+    Example:
+
+        # this will route to questions#new
+        scope ':locale' do
+          get 'questions/new'
+        end
+
+    *Yves Senn*
+
 *   Remove support for parsing XML parameters from request. If you still want to parse XML
     parameters, please install `actionpack-xml_parser' gem.
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1146,6 +1146,33 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal 'api/products#list', @response.body
   end
 
+  def test_match_shorthand_inside_scope_with_variables_with_controller
+    draw do
+      scope ':locale' do
+        match 'questions/new', via: [:get]
+      end
+    end
+
+    get '/de/questions/new'
+    assert_equal 'questions#new', @response.body
+    assert_equal 'de', @request.params[:locale]
+  end
+
+  def test_match_shorthand_inside_nested_namespaces_and_scopes_with_controller
+    draw do
+      namespace :api do
+        namespace :v3 do
+          scope ':locale' do
+            get "products/list"
+          end
+        end
+      end
+    end
+
+    get '/api/v3/en/products/list'
+    assert_equal 'api/v3/products#list', @response.body
+  end
+
   def test_dynamically_generated_helpers_on_collection_do_not_clobber_resources_url_helper
     draw do
       resources :replies do


### PR DESCRIPTION
Closes #7554.

This patch determines the `controller#action` directly in the `match` method when the shorthand syntax is used. this prevents problems with namespaces and scopes.
