### PR TITLE
Fixed the repair_validations helper method.

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,5 +1,26 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Added a method so that validations can be easily cleared on a model.
+    For example:
+
+      class Person
+        include ActiveModel::Validations
+
+        validates_uniqueness_of :first_name
+        validate :cannot_be_robot
+
+        def cannot_be_robot
+          errors.add(:base, 'A person cannot be a robot') if person_is_robot
+        end
+      end
+
+    Now, if someone runs `Person.clear_validators!`, then the following occurs:
+
+      Person.validators                  # => []
+      Person._validate_callbacks.empty?  # => true
+
+    *John Wang*
+
 *   `has_secure_password` does not fail the confirmation validation
     when assigning empty String to `password` and `password_confirmation`.
 

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -169,6 +169,49 @@ module ActiveModel
         _validators.values.flatten.uniq
       end
 
+      # Clears all of the validators and validations.
+      #
+      # Note that this will clear anything that is being used to validate
+      # the model for both the +validates_with+ and +validate+ methods.
+      # It clears the validators that are created with an invocation of
+      # +validates_with+ and the callbacks that are set by an invocation
+      # of +validate+.
+      #
+      #   class Person
+      #     include ActiveModel::Validations
+      #
+      #     validates_with MyValidator
+      #     validates_with OtherValidator, on: :create
+      #     validates_with StrictValidator, strict: true
+      #     validate :cannot_be_robot
+      #
+      #     def cannot_be_robot
+      #       errors.add(:base, 'A person cannot be a robot') if person_is_robot
+      #     end
+      #   end
+      #
+      #   Person.validators
+      #   # => [
+      #   #      #<MyValidator:0x007fbff403e808 @options={}>,
+      #   #      #<OtherValidator:0x007fbff403d930 @options={on: :create}>,
+      #   #      #<StrictValidator:0x007fbff3204a30 @options={strict:true}>
+      #   #    ]
+      #
+      # If one runs Person.clear_validators! and then checks to see what
+      # validators this class has, you would obtain:
+      #
+      #   Person.validators # => []
+      #
+      # Also, the callback set by +validate :cannot_be_robot+ will be erased
+      # so that:
+      #
+      #   Person._validate_callbacks.empty?  # => true
+      #
+      def clear_validators!
+        reset_callbacks(:validate)
+        _validators.clear
+      end
+
       # List all validators that are being used to validate a specific attribute.
       #
       #   class Person

--- a/activerecord/test/cases/validations_repair_helper.rb
+++ b/activerecord/test/cases/validations_repair_helper.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       def repair_validations(*model_classes)
         teardown do
           model_classes.each do |k|
-            k.reset_callbacks(:validate)
+            k.clear_validators!
           end
         end
       end
@@ -16,7 +16,7 @@ module ActiveRecord
       yield
     ensure
       model_classes.each do |k|
-        k.reset_callbacks(:validate)
+        k.clear_validators!
       end
     end
   end


### PR DESCRIPTION
The repair_validations helper was not working correctly before because it only cleared the validations that created :validate callbacks. This didn't include the validations created by validates_with, so I've added a method to clear these validations as well.

The validates_with associations are all associations that are created using: validates_uniqueness_of(), validates_presence_of(), etc. and other custom validations.

Thankfully, the fixing the repair infrastructure didn't make any of the tests fail.
