### PR TITLE
Creating validations for nested associations. 

### DIFF
--- a/activerecord/lib/active_record/validations/associated.rb
+++ b/activerecord/lib/active_record/validations/associated.rb
@@ -2,9 +2,78 @@ module ActiveRecord
   module Validations
     class AssociatedValidator < ActiveModel::EachValidator #:nodoc:
       def validate_each(record, attribute, value)
-        if Array.wrap(value).reject {|r| r.marked_for_destruction? || r.valid?(record.validation_context) }.any?
+        collection = Array.wrap(value)
+
+        # We must check 1) if the records pass validations individually and
+        # 2) that the records pass the uniqueness validations collectively.
+        # To accomplish 2), we need to call unique_for_nested_attributes.
+        if collection.reject { |r| r.marked_for_destruction? || r.valid?(record.validation_context) }.any? ||
+            !unique_for_nested_attributes?(collection)
           record.errors.add(attribute, :invalid, options.merge(:value => value))
         end
+      end
+
+    protected
+
+      # This method makes sure that the records in the collection satisfy the
+      # uniqueness validations.
+      def unique_for_nested_attributes?(collection)
+        return true if collection.empty?
+
+        uniqueness_validators = uniqueness_validators(collection.first)
+        return validate_uniqueness_of_collection(collection, uniqueness_validators)
+      end
+
+      # Takes an ActiveModel record, and finds all of the validators on it's class
+      # which are uniqueness validators.
+      def uniqueness_validators(record)
+        record.class.validators.grep(ActiveRecord::Validations::UniquenessValidator)
+      end
+
+      # Builds a hash for each validator from the uniqueness_validators collection.
+      # The hash will be of the following form:
+      #
+      #   [Sorted array of validator attributes] => Set()
+      #
+      # Most uniqueness validators will be a single attribute, so the key
+      # will be an array of length 1. But sometimes, uniqueness validators
+      # also have a scope. This means that a set of attributes must be unique
+      # so the key will be an array of length greater than 1. We sort the
+      # array so it is easy to find this key later on.
+      def attribute_uniquifiers_hash(uniqueness_validators)
+        attribute_uniquifiers = {}
+        uniqueness_validators.each do |validator|
+          validator_set = [validator.attributes, validator.options[:scope]].flatten.compact.sort
+          attribute_uniquifiers[validator_set] = Set.new()
+        end
+
+        attribute_uniquifiers
+      end
+
+      # This method discovers if no two records have the same set of attributes
+      # if those sets of attributes are supposed to be unique.
+      #
+      # This is done by keeping track of all the previous values from the
+      # records in the collection if the attributes are supposed to be unique.
+      # If two sets of values collide, then we know that we don't really have
+      # uniqueness and so we can return false. Otherwise, if no records collide
+      # then we do have uniqueness and we return true.
+      def validate_uniqueness_of_collection(collection, uniqueness_validators)
+        return true if uniqueness_validators.empty?
+        attribute_uniquifiers = attribute_uniquifiers_hash(uniqueness_validators)
+
+        collection.each do |record|
+          attribute_uniquifiers.each do |attribute_list, previous_combinations|
+            new_combination = attribute_list.map { |attribute| record.send(attribute) }
+            if previous_combinations.include?(new_combination)
+              return false
+            else
+              previous_combinations.add(new_combination)
+            end
+          end
+        end
+
+        return true
       end
     end
 

--- a/activerecord/test/cases/validations/association_validation_test.rb
+++ b/activerecord/test/cases/validations/association_validation_test.rb
@@ -135,4 +135,80 @@ class AssociationValidationTest < ActiveRecord::TestCase
     r.title = "Longer"
     assert t.valid?(:custom_context), "Should be valid if the associated object is not valid in the same context."
   end
+
+  def test_validates_associated_many_uniqueness
+    Topic.validates_associated(:replies)
+    Reply.validates_uniqueness_of(:title)
+
+    t = Topic.create("title" => "uhohuhoh", "content" => "whatever")
+    t.replies << [r = Reply.new("title" => "A reply"), r2 = Reply.new("title" => "Another reply"), r3 = Reply.new("title" => "Another reply")]
+
+    assert !t.valid?
+    assert t.errors[:replies].any?
+    assert_equal 0, r.errors.count  # make sure all associated objects have been validated
+    assert_equal 0, r2.errors.count
+    assert_equal 1, r3.errors.count
+
+    r3.title = "New reply"
+    assert t.valid?
+  end
+
+  def test_ignore_on_empty_validates_associated_nested_attributes_uniqueness
+    Topic.validates_associated(:replies)
+    Topic.accepts_nested_attributes_for(:replies)
+
+    t = Topic.create("title" => "uhohuhoh", "content" => "whatever")
+    t.replies_attributes = []
+
+    assert t.valid?
+    t.save!
+    assert_equal 0, t.replies.count
+  end
+
+  def test_ignore_validates_associated_nested_attributes_uniqueness
+    Topic.validates_associated(:replies)
+    Topic.accepts_nested_attributes_for(:replies)
+
+    # There is no uniquness on Reply, therefore it should allow duplicates.
+    t = Topic.create("title" => "uhohuhoh", "content" => "whatever")
+    t.replies_attributes = [{ "title" => "A reply" }, { "title" => "Another reply" }, { "title" => "Another reply" }]
+
+    assert t.valid?
+    t.save!
+    assert_equal 3, t.replies.count
+  end
+
+  def test_validates_associated_nested_attributes_uniqueness
+    Topic.validates_associated(:replies)
+    Topic.accepts_nested_attributes_for(:replies)
+    Reply.validates_uniqueness_of(:title)
+
+    t = Topic.create("title" => "My Title", "content" => "This is so boss.")
+    t.replies_attributes = [{ "title" => "A reply" }, { "title" => "Another reply" }, { "title" => "Another reply" }]
+    assert !t.valid?
+
+    new_t = Topic.create("title" => "My better title", "content" => "This is so boss.")
+    new_t.replies_attributes = [{ "title" => "A reply" }, { "title" => "It really isn't that boss." }, { "title" => "Actually, yes this is pretty boss." }]
+
+    assert new_t.valid?
+    new_t.save!
+    assert_equal 3, new_t.replies.size
+  end
+
+  def test_validates_associated_nested_attributes_uniqueness_with_scoping
+    Topic.validates_associated(:replies)
+    Topic.accepts_nested_attributes_for(:replies)
+    Reply.validates_uniqueness_of(:title, :scope => :content)
+
+    t = Topic.create("title" => "Brogramming", "content" => "Programming, for bros.")
+    t.replies_attributes = [{"title" => "Reply", "content" => "Some content"}, {"title" => "Reply", "content" => "Some content"}]
+    assert !t.valid?
+
+    new_t = Topic.create("title" => "Programming", "content" => "For the masses")
+    new_t.replies_attributes = [{"title" => "aa", "content" => "aa"}, {"title" => "a", :content => "aaa"}, {"title" => "Apple", :content => "Boy"}]
+
+    assert new_t.valid?
+    new_t.save!
+    assert_equal 3, new_t.replies.size
+  end
 end


### PR DESCRIPTION
I'm fixing issue https://github.com/rails/rails/issues/4568. I'm using the tests from the PR that @jeyb wrote in https://github.com/rails/rails/pull/8308. However, his solution is not quite correct because there are some edge cases which cause his solution to fail (in particular, uniqueness validations with scopes).
## The Problem:

The reason why this had to be solved with a bunch of code is because (at least to my knowledge) there's currently no way to check the uniqueness of a collection of new objects that have not yet been saved. 

The basic problem is that we have a bunch of new objects in our association, so when we check to see if they are valid one by one, each of the uniqueness validations pass. However, if two objects in the collection should fail a uniqueness validation (maybe two objects in the collection are exactly the same) we'd never know. We need to introduce some way to validate uniqueness across an unpersisted collection of records.
## My Solution:

My solution is to add a new method which checks uniqueness in a collection which has not yet been persisted. This only is called after all of the other validations are run and have passed (thus it is only called if records have not yet been persisted). 

I found all of the uniqueness validations associated with a particular collection of records, then made sure that the collection of records doesn't break any of these uniqueness validators.
