### PR TITLE
Fix for #9360 content_for regression

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -999,4 +999,6 @@
 *   `ActionView::Helpers::TextHelper#highlight` now defaults to the
     HTML5 `mark` element. *Brian Cardarella*
 
+*   Fixed `ActionView::Helpers::CaptureHelper#content_for` regression (described in #9360). *Nikolay Shebanov*
+
 Please check [3-2-stable](https://github.com/rails/rails/blob/3-2-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_view/helpers/capture_helper.rb
+++ b/actionpack/lib/action_view/helpers/capture_helper.rb
@@ -156,7 +156,7 @@ module ActionView
           end
           nil
         else
-          @view_flow.get(name)
+          @view_flow.get(name).presence
         end
       end
 

--- a/actionpack/test/template/capture_helper_test.rb
+++ b/actionpack/test/template/capture_helper_test.rb
@@ -137,6 +137,10 @@ class CaptureHelperTest < ActionView::TestCase
     assert_equal 'bar', content_for(:title)
   end
 
+  def test_content_for_returns_nil_when_content_missing
+    assert_equal nil, content_for(:some_missing_key)
+  end
+
   def test_content_for_question_mark
     assert ! content_for?(:title)
     content_for :title, 'title'


### PR DESCRIPTION
More info in #9360 bug report.
- Change @content hash default style
- Provide test
