### PR TITLE
Use model connection for fixtures

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -461,7 +461,7 @@ module ActiveRecord
             fixtures_map[fs_name] = new( # ActiveRecord::FixtureSet.new
               connection,
               fs_name,
-              class_names[fs_name] || default_fixture_model_name(fs_name),
+              (class_names[fs_name] || default_fixture_model_name(fs_name)).constantize,
               ::File.join(fixtures_directory, fs_name))
           end
 


### PR DESCRIPTION
This change fixes a problem where fixtures in multiple databases didn't work due to everything using ActiveRecord::Base.connection.
With this change, that now uses the connection of the model class.

If a class is passed to Fixture.new, it will inherit the table name and database connection from that class.

This functionality already existed, but wasn't being used because the model class was always being passed in as a string.
