### PR TITLE
Access an instance's connection via its class, rather than via #connection

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `connection` is deprecated as an instance method.
+    This allows end-users to have a `connection` method on their models
+    without clashing with ActiveRecord internals.
+
+    *Ben Moss*
+
 *   When copying migrations, preserve their magic comments and content encoding.
 
     *OZAWA Sakuro*

--- a/activerecord/lib/active_record/associations/has_and_belongs_to_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_and_belongs_to_many_association.rb
@@ -26,7 +26,7 @@ module ActiveRecord
             join_table[reflection.association_foreign_key] => record.id
           )
 
-          owner.connection.insert stmt
+          owner.class.connection.insert stmt
         end
 
         record
@@ -41,7 +41,7 @@ module ActiveRecord
         def delete_records(records, method)
           if sql = options[:delete_sql]
             records = load_target if records == :all
-            records.each { |record| owner.connection.delete(interpolate(sql, record)) }
+            records.each { |record| owner.class.connection.delete(interpolate(sql, record)) }
           else
             relation  = join_table
             condition = relation[reflection.foreign_key].eq(owner.id)
@@ -53,7 +53,7 @@ module ActiveRecord
               )
             end
 
-            owner.connection.delete(relation.where(condition).compile_delete)
+            owner.class.connection.delete(relation.where(condition).compile_delete)
           end
         end
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -324,6 +324,7 @@ module ActiveRecord
     # also be used to "borrow" the connection to do database work that isn't
     # easily done without going straight to SQL.
     def connection
+      ActiveSupport::Deprecation.warn("#connection is deprecated in favour of accessing it via the class")
       self.class.connection
     end
 

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -86,7 +86,7 @@ module ActiveRecord
               )
             ).arel.compile_update(arel_attributes_with_values_for_update(attribute_names))
 
-            affected_rows = connection.update stmt
+            affected_rows = self.class.connection.update stmt
 
             unless affected_rows == 1
               raise ActiveRecord::StaleObjectError.new(self, "update")
@@ -117,7 +117,7 @@ module ActiveRecord
           if locking_enabled?
             column_name = self.class.locking_column
             column      = self.class.columns_hash[column_name]
-            substitute  = connection.substitute_at(column, relation.bind_values.length)
+            substitute  = self.class.connection.substitute_at(column, relation.bind_values.length)
 
             relation = relation.where(self.class.arel_table[column_name].eq(substitute))
             relation.bind_values << [column, self[column_name].to_i]

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -410,7 +410,7 @@ module ActiveRecord
     def relation_for_destroy
       pk         = self.class.primary_key
       column     = self.class.columns_hash[pk]
-      substitute = connection.substitute_at(column, 0)
+      substitute = self.class.connection.substitute_at(column, 0)
 
       relation = self.class.unscoped.where(
         self.class.arel_table[pk].eq(substitute))

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -477,9 +477,8 @@ class CustomConnectionFixturesTest < ActiveRecord::TestCase
   fixtures :courses
   self.use_transactional_fixtures = false
 
-  def test_connection
-    assert_kind_of Course, courses(:ruby)
-    assert_equal Course.connection, courses(:ruby).connection
+  def test_connection_instance_method_deprecation
+    assert_deprecated { courses(:ruby).connection }
   end
 
   def test_leaky_destroy

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -182,9 +182,9 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
   end
 
   def test_call_after_rollback_when_commit_fails
-    @first.connection.class.send(:alias_method, :real_method_commit_db_transaction, :commit_db_transaction)
+    @first.class.connection.class.send(:alias_method, :real_method_commit_db_transaction, :commit_db_transaction)
     begin
-      @first.connection.class.class_eval do
+      @first.class.connection.class.class_eval do
         def commit_db_transaction; raise "boom!"; end
       end
 
@@ -194,8 +194,8 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
       assert !@first.save rescue nil
       assert_equal [:after_rollback], @first.history
     ensure
-      @first.connection.class.send(:remove_method, :commit_db_transaction)
-      @first.connection.class.send(:alias_method, :commit_db_transaction, :real_method_commit_db_transaction)
+      @first.class.connection.class.send(:remove_method, :commit_db_transaction)
+      @first.class.connection.class.send(:alias_method, :commit_db_transaction, :real_method_commit_db_transaction)
     end
   end
 


### PR DESCRIPTION
Had a problem today where we had a `belongs_to :connection` on our model. Hadn't occurred to me that this might be a problem, but when we ran our tests we were getting an obscure `undefined method substitute_at for nil:NilClass` exception whenever an instance of this class was being destroyed.

Discovered the root cause was this method, which was attempting to call `connection` on the instance, which in turn [delegates to the class](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/core.rb#L328). This seems like a pretty safe change to make, I can't think of any possible repercussions. I wasn't sure if this warranted a regression test, but I'd be happy to provide one if it's required.
