### PR TITLE
determine the match shorthand target early.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## unreleased ##
 
+*   Determine the controller#action from only the matched path when using the
+    shorthand syntax. Previously the complete path was used, which led
+    to problems with nesting (scopes and namespaces).
+    Fixes #7554.
+    Backport #9361.
+
+    Example:
+
+        # this will route to questions#new
+        scope ':locale' do
+          get 'questions/new'
+        end
+
+    *Yves Senn*
+
 *   Fix `assert_template` with `render :stream => true`.
     Fix #1743.
     Backport #5288.

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -517,6 +517,18 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
       end
 
       get 'search' => 'search'
+
+      scope ':locale' do
+        match 'questions/new', via: [:get]
+      end
+
+      namespace :api do
+        namespace :v3 do
+          scope ':locale' do
+            get "products/list"
+          end
+        end
+      end
     end
   end
 
@@ -1414,6 +1426,21 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
       assert_equal '/api/products/list', api_products_list_path
       get '/api/products/list'
       assert_equal 'api/products#list', @response.body
+    end
+  end
+
+  def test_match_shorthand_inside_scope_with_variables_with_controller
+    with_test_routes do
+      get '/de/questions/new'
+      assert_equal 'questions#new', @response.body
+      assert_equal 'de', @request.params[:locale]
+    end
+  end
+
+  def test_match_shorthand_inside_nested_namespaces_and_scopes_with_controller
+    with_test_routes do
+      get '/api/v3/en/products/list'
+      assert_equal 'api/v3/products#list', @response.body
     end
   end
 


### PR DESCRIPTION
This is a backport of #9361 to fix #7554.
