### PR TITLE
use html key as html_options in form helpers

### DIFF
--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -678,7 +678,7 @@ module ActionView
 
       def initialize(datetime, options = {}, html_options = {})
         @options      = options.dup
-        @html_options = html_options.dup
+        @html_options = (@options.delete(:html) || {}).merge html_options
         @datetime     = datetime
         @options[:datetime_separator] ||= ' &mdash; '
         @options[:time_separator]     ||= ' : '

--- a/actionpack/lib/action_view/helpers/tags/collection_helpers.rb
+++ b/actionpack/lib/action_view/helpers/tags/collection_helpers.rb
@@ -26,7 +26,7 @@ module ActionView
           @collection   = collection
           @value_method = value_method
           @text_method  = text_method
-          @html_options = html_options
+          @html_options = (options.delete(:html) || {}).merge html_options
 
           super(object_name, method_name, template_object, options)
         end

--- a/actionpack/lib/action_view/helpers/tags/collection_select.rb
+++ b/actionpack/lib/action_view/helpers/tags/collection_select.rb
@@ -6,7 +6,7 @@ module ActionView
           @collection   = collection
           @value_method = value_method
           @text_method  = text_method
-          @html_options = html_options
+          @html_options = (options.delete(:html) || {}).merge html_options
 
           super(object_name, method_name, template_object, options)
         end

--- a/actionpack/lib/action_view/helpers/tags/date_select.rb
+++ b/actionpack/lib/action_view/helpers/tags/date_select.rb
@@ -5,7 +5,7 @@ module ActionView
     module Tags
       class DateSelect < Base #:nodoc:
         def initialize(object_name, method_name, template_object, options, html_options)
-          @html_options = html_options
+          @html_options = (options.delete(:html) || {}).merge html_options
 
           super(object_name, method_name, template_object, options)
         end

--- a/actionpack/lib/action_view/helpers/tags/grouped_collection_select.rb
+++ b/actionpack/lib/action_view/helpers/tags/grouped_collection_select.rb
@@ -8,7 +8,7 @@ module ActionView
           @group_label_method  = group_label_method
           @option_key_method   = option_key_method
           @option_value_method = option_value_method
-          @html_options        = html_options
+          @html_options        = (options.delete(:html) || {}).merge html_options
 
           super(object_name, method_name, template_object, options)
         end

--- a/actionpack/lib/action_view/helpers/tags/select.rb
+++ b/actionpack/lib/action_view/helpers/tags/select.rb
@@ -5,7 +5,7 @@ module ActionView
         def initialize(object_name, method_name, template_object, choices, options, html_options)
           @choices = choices
           @choices = @choices.to_a if @choices.is_a?(Range)
-          @html_options = html_options
+          @html_options = (options.delete(:html) || {}).merge html_options
 
           super(object_name, method_name, template_object, options)
         end

--- a/actionpack/lib/action_view/helpers/tags/time_zone_select.rb
+++ b/actionpack/lib/action_view/helpers/tags/time_zone_select.rb
@@ -4,7 +4,7 @@ module ActionView
       class TimeZoneSelect < Base #:nodoc:
         def initialize(object_name, method_name, template_object, priority_zones, options, html_options)
           @priority_zones = priority_zones
-          @html_options   = html_options
+          @html_options   = (options.delete(:html) || {}).merge html_options
 
           super(object_name, method_name, template_object, options)
         end


### PR DESCRIPTION
Before

``` erb
<%= form_for @user, html: { class: 'form-class' } do |f| %>
  ...
  <%= f.select :roles, [['Regular', 1], ['Admin', 2]], { include_blank: true }, multiple: true %>

  <%= f.select :sub_roles, [['Regular', 1], ['Admin', 2]], {}, multiple: true %>
  ...
```

After

``` erb
<%= form_for @user, html: { class: 'form-class' } do |f| %>
  ...
  <%= f.select :roles, [['Regular', 1], ['Admin', 2]], include_blank: true, html: { multiple: true } %>

  <%= f.select :sub_roles, [['Regular', 1], ['Admin', 2]], html: { multiple: true } %>
  ...
```

I think it will make it more readable
Also make it similar to `form_for`
