### PR TITLE
Deprecating update_attribute by cherry-picking b081f6b59fb3f15d12043072a...

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   AR::Base#update_attribute has been deprecated. Use `update_column` if
+    you want to bypass mass-assignment protection, validations, callbacks,
+    and touching of updated_at. Otherwise please use `update_attributes`.
+
 *   Rename related indexes on `rename_table` and `rename_column`. This
     does not affect indexes with custom names.
 

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -239,7 +239,7 @@ module ActiveRecord
   #       add_column :people, :salary, :integer
   #       Person.reset_column_information
   #       Person.all.each do |p|
-  #         p.update_attribute :salary, SalaryCalculator.compute(p)
+  #         p.update_column :salary, SalaryCalculator.compute(p)
   #       end
   #     end
   #   end
@@ -259,7 +259,7 @@ module ActiveRecord
   #     ...
   #     say_with_time "Updating salaries..." do
   #       Person.all.each do |p|
-  #         p.update_attribute :salary, SalaryCalculator.compute(p)
+  #         p.update_column :salary, SalaryCalculator.compute(p)
   #       end
   #     end
   #     ...

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -204,8 +204,12 @@ module ActiveRecord
     # * updated_at/updated_on column is updated if that column is available.
     # * Updates all the attributes that are dirty in this object.
     #
+    # This method has been deprecated in favor of <tt>update_column</tt> due to
+    # its similarity with <tt>update_attributes</tt>.
+    #
     def update_attribute(name, value)
       name = name.to_s
+      ActiveSupport::Deprecation.warn("update_attribute is deprecated and will be removed in Rails 4.1. Please use update_attributes or update_columns instead. Check their documentation for the implications.")
       verify_readonly_attribute(name)
       send("#{name}=", value)
       save(validate: false)
@@ -288,7 +292,7 @@ module ActiveRecord
     # Saving is not subjected to validation checks. Returns +true+ if the
     # record could be saved.
     def increment!(attribute, by = 1)
-      increment(attribute, by).update_attribute(attribute, self[attribute])
+      increment(attribute, by).update_column(attribute, self[attribute])
     end
 
     # Initializes +attribute+ to zero if +nil+ and subtracts the value passed as +by+ (default is 1).
@@ -305,7 +309,7 @@ module ActiveRecord
     # Saving is not subjected to validation checks. Returns +true+ if the
     # record could be saved.
     def decrement!(attribute, by = 1)
-      decrement(attribute, by).update_attribute(attribute, self[attribute])
+      decrement(attribute, by).update_column(attribute, self[attribute])
     end
 
     # Assigns to +attribute+ the boolean opposite of <tt>attribute?</tt>. So
@@ -322,7 +326,7 @@ module ActiveRecord
     # Saving is not subjected to validation checks. Returns +true+ if the
     # record could be saved.
     def toggle!(attribute)
-      toggle(attribute).update_attribute(attribute, self[attribute])
+      toggle(attribute).update_column(attribute, self[attribute])
     end
 
     # Reloads the attributes of this object from the database.

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -529,7 +529,7 @@ class DirtyTest < ActiveRecord::TestCase
     assert !pirate.previous_changes.key?('created_on')
 
     pirate = Pirate.find_by_catchphrase("Ahoy!")
-    pirate.update_attribute(:catchphrase, "Ninjas suck!")
+    pirate.update_attributes(catchphrase: "Ninjas suck!")
 
     assert_equal 2, pirate.previous_changes.size
     assert_equal ["Ahoy!", "Ninjas suck!"], pirate.previous_changes['catchphrase']

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -383,10 +383,17 @@ class PersistencesTest < ActiveRecord::TestCase
 
   def test_update_attribute
     assert !Topic.find(1).approved?
-    Topic.find(1).update_attribute("approved", true)
+
+    ActiveSupport::Deprecation.silence do
+      Topic.find(1).update_attribute("approved", true)
+    end
+
     assert Topic.find(1).approved?
 
-    Topic.find(1).update_attribute(:approved, false)
+    ActiveSupport::Deprecation.silence do
+      Topic.find(1).update_attribute(:approved, false)
+    end
+
     assert !Topic.find(1).approved?
   end
 
@@ -396,7 +403,10 @@ class PersistencesTest < ActiveRecord::TestCase
 
   def test_update_attribute_for_readonly_attribute
     minivan = Minivan.find('m1')
-    assert_raises(ActiveRecord::ActiveRecordError) { minivan.update_attribute(:color, 'black') }
+
+    ActiveSupport::Deprecation.silence do
+      assert_raises(ActiveRecord::ActiveRecordError) { minivan.update_attribute(:color, 'black') }
+    end
   end
 
   def test_string_ids
@@ -409,7 +419,11 @@ class PersistencesTest < ActiveRecord::TestCase
 
   def test_update_attribute_with_one_updated
     t = Topic.first
-    t.update_attribute(:title, 'super_title')
+
+    ActiveSupport::Deprecation.silence do
+      t.update_attribute(:title, 'super_title')
+    end
+
     assert_equal 'super_title', t.title
     assert !t.changed?, "topic should not have changed"
     assert !t.title_changed?, "title should not have changed"
@@ -423,10 +437,16 @@ class PersistencesTest < ActiveRecord::TestCase
     developer = Developer.find(1)
     prev_month = Time.now.prev_month
 
-    developer.update_attribute(:updated_at, prev_month)
+    ActiveSupport::Deprecation.silence do
+      developer.update_attribute(:updated_at, prev_month)
+    end
+
     assert_equal prev_month, developer.updated_at
 
-    developer.update_attribute(:salary, 80001)
+    ActiveSupport::Deprecation.silence do
+      developer.update_attribute(:salary, 80001)
+    end
+
     assert_not_equal prev_month, developer.updated_at
 
     developer.reload


### PR DESCRIPTION
Hello,

I believe the ActiveRecord::Base method update_attribute was intended to be deprecated in 4.0.  As you can see from the discussion here:

https://groups.google.com/forum/#!topic/rubyonrails-core/BWPUTK7WvYA/discussion
and
https://github.com/rails/rails/commit/b081f6b59fb3f15d12043072ad9b331ffd2bc56e

it was originally deprecated in 3.2 and removed in 4.0.  After that, I believe these changes were reverted so as to not deprecate functionality in patch releases:

https://github.com/rails/rails/commit/81542f95d25825a7d3eff87d6f706661bf553b18

However, I think the intent was still to have it deprecated in 4.0.

This pull request adds that deprecation.  Please let me know if this is indeed desired, and if so if any changes are needed.

Likely interested parties: @fxn and @steveklabnik

Thanks!
Andrew
