### PR TITLE
Fix debug helper not inspecting when it can't convert to YAML

### DIFF
--- a/actionpack/lib/action_view/helpers/debug_helper.rb
+++ b/actionpack/lib/action_view/helpers/debug_helper.rb
@@ -32,7 +32,7 @@ module ActionView
         content_tag(:pre, object, :class => "debug_dump")
       rescue Exception  # errors from Marshal or YAML
         # Object couldn't be dumped, perhaps because of singleton methods -- this is the fallback
-        content_tag(:code, object.to_yaml, :class => "debug_dump")
+        content_tag(:code, object.inspect, :class => "debug_dump")
       end
     end
   end


### PR DESCRIPTION
The debug helper should inspect the object when it can't be converted to YAML, this behavior was changed in 8f8d8eb1465069e2ed9b6f2404aa9d02e785f534

According to the documentation the helper should call inspect when converting to YAML fails.
