### PR TITLE
Keep second fraction when DateTime#change is called.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Prevent `DateTime#change` from truncating the second fraction, when seconds
+    do not need to be changed.
+
+    *Chris Baynes*
+
 *   Added `ActiveSupport::TimeWithZone#to_r` for `Time#at` compatibility.
 
     Before this change:

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -59,7 +59,7 @@ class DateTime
       options.fetch(:day, day),
       options.fetch(:hour, hour),
       options.fetch(:min, options[:hour] ? 0 : min),
-      options.fetch(:sec, (options[:hour] || options[:min]) ? 0 : sec),
+      options.fetch(:sec, (options[:hour] || options[:min]) ? 0 : sec + sec_fraction),
       options.fetch(:offset, offset),
       options.fetch(:start, start)
     )

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -129,6 +129,9 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal DateTime.civil(2005,2,22,16),       DateTime.civil(2005,2,22,15,15,10).change(:hour => 16)
     assert_equal DateTime.civil(2005,2,22,16,45),    DateTime.civil(2005,2,22,15,15,10).change(:hour => 16, :min => 45)
     assert_equal DateTime.civil(2005,2,22,15,45),    DateTime.civil(2005,2,22,15,15,10).change(:min => 45)
+
+    # datetime with fractions of a second
+    assert_equal DateTime.civil(2005,2,1,15,15,10.7), DateTime.civil(2005,2,22,15,15,10.7).change(:day => 1)
   end
 
   def test_advance


### PR DESCRIPTION
Using `change` on a `DateTime` having fractional seconds produces unexpected results if compared to the original.

For example:

``` ruby
t = DateTime.new(2012, 1, 1, 2, 5, 12.7)
t.change(day: 2) - t # returns: (863993/864000), expected: (1/1)

# also affects higher level functionality like:
(t..t+1.day).count # returns: 1, expected: 2
```

The reason I think this is important is not in the case where a `DateTime` is created manually as above, rather when `DateTime.current` is used which always contains fractions of a second.
