### PR TITLE
don't apply invalid ordering when preloading hmt associations.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Preloading ordered `has_many :through` associations does no longer
+    apply invalid ordering to the `:through` association.
+    Fixes #8663.
+
+    *Yves Senn*
+
 *   The auto explain feature has been removed. This feature was
     activated by configuring `config.active_record.auto_explain_threshold_in_seconds`.
     The configuration option was deprecated and has no more effect.

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -47,12 +47,12 @@ module ActiveRecord
             through_scope.where! reflection.foreign_type => options[:source_type]
           else
             unless reflection_scope.where_values.empty?
-              through_scope.includes_values = reflection_scope.values[:includes] || options[:source]
+              through_scope.includes_values = Array(reflection_scope.values[:includes] || options[:source])
               through_scope.where_values    = reflection_scope.values[:where]
             end
 
-            through_scope.order!      reflection_scope.values[:order]
             through_scope.references! reflection_scope.values[:references]
+            through_scope.order! reflection_scope.values[:order] if through_scope.eager_loading?
           end
 
           through_scope

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -73,6 +73,11 @@ class EagerAssociationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_has_many_through_with_order
+    authors = Author.includes(:favorite_authors).to_a
+    assert_no_queries { authors.map(&:favorite_authors) }
+  end
+
   def test_with_two_tables_in_from_without_getting_double_quoted
     posts = Post.select("posts.*").from("authors, posts").eager_load(:comments).where("posts.author_id = authors.id").order("posts.id").to_a
     assert_equal 2, posts.first.comments.size


### PR DESCRIPTION
closes #8663.

When preloading a hmt association there two possible scenarios:

1.) preload with 2 queries: first hm association, then hmt with id IN ()
2.) preload with join: hmt association is loaded with a join on the hm association

The bug was happening in scenario 1.) with a normal order clause on the hmt association.
The ordering was also applied when loading the hm association, which resulted in the error.

This patch only applies the ordering the the hm-relation if we are performing a join (2).
Otherwise the order will only appear in the second query (1).
