### PR TITLE
guides/rails_guides moved up and out of the railties directory 

### DIFF
--- a/railties/lib/rails/tasks/documentation.rake
+++ b/railties/lib/rails/tasks/documentation.rake
@@ -102,7 +102,7 @@ namespace :doc do
   # desc "Generate Rails Guides"
   task :guides do
     # FIXME: Reaching outside lib directory is a bad idea
-    require File.expand_path('../../../../guides/rails_guides', __FILE__)
+    require File.expand_path('../../../../../guides/rails_guides', __FILE__)
     RailsGuides::Generator.new(Rails.root.join("doc/guides")).generate
   end
 end


### PR DESCRIPTION
Needed to make 'rake doc:rails' work
