### PR TITLE
also rename the test-case class inside columns_test.rb

### DIFF
--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -2,7 +2,7 @@ require "cases/migration/helper"
 
 module ActiveRecord
   class Migration
-    class RenameColumnTest < ActiveRecord::TestCase
+    class ColumnsTest < ActiveRecord::TestCase
       include ActiveRecord::Migration::TestHelper
 
       self.use_transactional_fixtures = false


### PR DESCRIPTION
With d03928c81a3a12b92ee6db4caf27f1e1643ca2a7 the test case was renamed to `columns_test.rb` and I forgot to rename the test-case class itself...

Thanks @lexmag for pointing it out.
