### PR TITLE
Address failure test_rename_column_with_multi_column_index with Oracle

### DIFF
--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -96,10 +96,18 @@ module ActiveRecord
         add_index "test_models", ["hat_style", "hat_size"], unique: true
 
         rename_column "test_models", "hat_size", 'size'
-        assert_equal ['index_test_models_on_hat_style_and_size'], connection.indexes('test_models').map(&:name)
+        if current_adapter? :OracleAdapter
+          assert_equal ['i_test_models_hat_style_size'], connection.indexes('test_models').map(&:name)
+        else
+          assert_equal ['index_test_models_on_hat_style_and_size'], connection.indexes('test_models').map(&:name)
+        end
 
         rename_column "test_models", "hat_style", 'style'
-        assert_equal ['index_test_models_on_style_and_size'], connection.indexes('test_models').map(&:name)
+        if current_adapter? :OracleAdapter
+          assert_equal ['i_test_models_style_size'], connection.indexes('test_models').map(&:name)
+        else
+          assert_equal ['index_test_models_on_style_and_size'], connection.indexes('test_models').map(&:name)
+        end
       end
 
       def test_rename_column_does_not_rename_custom_named_index


### PR DESCRIPTION
This pull request addresses this failure.

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/migration/columns_test.rb -n test_rename_column_with_multi_column_indexUsing oracle
Run options: -n test_rename_column_with_multi_column_index --seed 16961

# Running tests:

F

Finished tests in 3.336265s, 0.2997 tests/s, 0.2997 assertions/s.

  1) Failure:
test_rename_column_with_multi_column_index(ActiveRecord::Migration::ColumnsTest) [test/cases/migration/columns_test.rb:99]:
--- expected
+++ actual
@@ -1 +1 @@
-["index_test_models_on_hat_style_and_size"]
+["i_test_models_hat_style_size"]


1 tests, 1 assertions, 1 failures, 0 errors, 0 skips
```

Since #8645 has been merged, Oracle enhanced adapter supports its feature in rsim/oracle-enhanced#286. But because of its maximum index length is 30 bytes, Oracle enhanced adapter shortens its name if it is longer than 30 byte. 
