### PR TITLE
test case to prevent duplicated associations with custom PK.

### DIFF
--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -20,6 +20,8 @@ require 'models/car'
 require 'models/bulb'
 require 'models/engine'
 require 'models/categorization'
+require 'models/minivan'
+require 'models/speedometer'
 
 class HasManyAssociationsTestForCountWithFinderSql < ActiveRecord::TestCase
   class Invoice < ActiveRecord::Base
@@ -1746,5 +1748,13 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_not_equal [], david.posts_with_special_categorizations
     david.posts_with_special_categorizations = []
     assert_equal [], david.posts_with_special_categorizations
+  end
+
+  test "does not duplicate associations when used with natural primary keys" do
+    speedometer = Speedometer.create!(id: '4')
+    minivan = speedometer.minivans.create!(minivan_id: 'a-van-red' ,name: 'a van', color: 'red')
+
+    assert_equal 1, speedometer.minivans.to_a.size, "Only one association should be present:\n#{speedometer.minivans.to_a}"
+    assert_equal 1, speedometer.reload.minivans.to_a.size
   end
 end

--- a/activerecord/test/models/speedometer.rb
+++ b/activerecord/test/models/speedometer.rb
@@ -1,4 +1,6 @@
 class Speedometer < ActiveRecord::Base
   self.primary_key = :speedometer_id
   belongs_to :dashboard
+
+  has_many :minivans
 end


### PR DESCRIPTION
This is only a test-case to prevent regressions for the issue #9201. I think we should include it in rails master where it's already fixed to make sure we don't run into the same problem again.

I would be willing to backport the fix to 3-2-stable but I have no idea what commit actually fixed it. I tried to bisect but was with no luck because I could not get bundle to work on most commits (renamed gems, missing gems, etc...).
