### PR TITLE
Revert "move config.assets.precompile into config/application.rb"

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -3,12 +3,6 @@
 
     *Terence Lee*
 
-*   The configuration option `config.assets.precompile` is no longer
-    in `config/environments/production.rb` but in
-    `config/application.rb`.
-
-    *Yves Senn*
-
 *   Add notice message for destroy action in scaffold generator.
 
     *Rahul P. Chaudhari*

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -31,10 +31,6 @@ module <%= app_const_base %>
 
     # Disable the asset pipeline.
     config.assets.enabled = false
-<% else %>
-  # Precompile additional assets.
-  # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-  # config.assets.precompile += %w( search.js )
 <% end -%>
   end
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -59,6 +59,12 @@
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = "http://assets.example.com"
 
+  <%- unless options.skip_sprockets? -%>
+  # Precompile additional assets.
+  # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
+  # config.assets.precompile += %w( search.js )
+  <%- end -%>
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
This reverts commit 304f4d4c25ccabdbf97d37dd7a92a54d0b63a9c9.

As it turns out everything should behave as it did and we don't
need to move this configuration option.
