### PR TITLE
Update CSRF docs to better explain API usage scenarios

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -9,13 +9,11 @@ module ActionController #:nodoc:
   # by including a token in the rendered html for your application. This token is
   # stored as a random string in the session, to which an attacker does not have
   # access. When a request reaches your application, \Rails verifies the received
-  # token with the token in the session. Only HTML and JavaScript requests are checked,
-  # so this will not protect your XML API (presumably you'll have a different
-  # authentication scheme there anyway). Also, GET requests are not protected as these
+  # token with the token in the session. GET requests are not protected as these
   # should be idempotent.
   #
   # It's important to remember that XML or JSON requests are also affected and if
-  # you're building an API you'll need something like:
+  # you're building an API you may want to skip CSRF protection with something like:
   #
   #   class ApplicationController < ActionController::Base
   #     protect_from_forgery
@@ -27,6 +25,10 @@ module ActionController #:nodoc:
   #       request.format.json?
   #     end
   #   end
+  #
+  # Though even for API requests it is a good practice to use CSRF protection.
+  # API clients can send the CSRF token in a header property called
+  # X-CSRF-Token which Rails checks for.
   #
   # CSRF protection is turned on with the <tt>protect_from_forgery</tt> method,
   # which checks the token and resets the session if it doesn't match what was expected.

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -26,9 +26,8 @@ module ActionController #:nodoc:
   #     end
   #   end
   #
-  # Though even for API requests it is a good practice to use CSRF protection.
-  # API clients can send the CSRF token in a header property called
-  # X-CSRF-Token which Rails checks for.
+  # Even for API requests you may want to use CSRF protection. API clients can send 
+  # the CSRF token in a header property called X-CSRF-Token which Rails checks for.
   #
   # CSRF protection is turned on with the <tt>protect_from_forgery</tt> method,
   # which checks the token and resets the session if it doesn't match what was expected.


### PR DESCRIPTION
- CSRF protection does not only apply to HTML/JS requests anymore (as
  far as I can tell)
- CSRF protection is still fine to use with API requests and Rails
  supports this scenario through the X-CSRF-Token header. Updated the
  docs to reflect and explain this.

I was going through the API docs for this while configuring Rails to
work with AngularJS and noticed that they suggest Rails ignores CSRF
tokens on non HTML/JS requests. This does not appear to be the case
anymore.

Also while I understand the reasons why CSRF is not really an issue for
API requests, it does technically rely on secure implementations of the
browsers (and possibly their plugins) to ensure that a site can't make
XSS requests via AJAX. Since Rails easily supports submitting the CSRF
token via a header I thought it might be worth adding that API
developers can do that if they prefer.
