### PR TITLE
Rails 3.2.x is now compatible with Ruby 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ env:
   - "GEM=ar:mysql2"
   - "GEM=ar:sqlite3"
   - "GEM=ar:postgresql"
-matrix:
-  allow_failures:
-    - rvm: 2.0.0
 notifications:
   email: false
   irc:

--- a/actionpack/lib/action_controller/metal/compatibility.rb
+++ b/actionpack/lib/action_controller/metal/compatibility.rb
@@ -58,7 +58,8 @@ module ActionController
     end
 
     def method_for_action(action_name)
-      super || (respond_to?(:method_missing) && "_handle_method_missing")
+      super || ((self.class.public_method_defined?(:method_missing) ||
+        self.class.protected_method_defined?(:method_missing)) && "_handle_method_missing")
     end
   end
 end

--- a/actionpack/lib/action_controller/metal/hide_actions.rb
+++ b/actionpack/lib/action_controller/metal/hide_actions.rb
@@ -27,20 +27,14 @@ module ActionController
         self.hidden_actions = hidden_actions.dup.merge(args.map(&:to_s)).freeze
       end
 
-      def inherited(klass)
-        klass.class_eval { @visible_actions = {} }
-        super
-      end
-
       def visible_action?(action_name)
-        return @visible_actions[action_name] if @visible_actions.key?(action_name)
-        @visible_actions[action_name] = !hidden_actions.include?(action_name)
+        action_methods.include?(action_name)
       end
 
       # Overrides AbstractController::Base#action_methods to remove any methods
       # that are listed as hidden methods.
       def action_methods
-        @action_methods ||= Set.new(super.reject { |name| hidden_actions.include?(name) })
+        @action_methods ||= Set.new(super.reject { |name| hidden_actions.include?(name) }).freeze
       end
     end
   end

--- a/actionpack/test/template/html-scanner/sanitizer_test.rb
+++ b/actionpack/test/template/html-scanner/sanitizer_test.rb
@@ -210,7 +210,7 @@ class SanitizerTest < ActionController::TestCase
 
   # TODO: Clean up
   def test_should_sanitize_attributes
-    assert_sanitized %(<SPAN title="'><script>alert()</script>">blah</SPAN>), %(<span title="'&gt;&lt;script&gt;alert()&lt;/script&gt;">blah</span>)
+    assert_sanitized %(<SPAN title="'><script>alert()</script>">blah</SPAN>), %(<span title="#{CGI.escapeHTML "'><script>alert()</script>"}">blah</span>)
   end
 
   def test_should_sanitize_illegal_style_properties

--- a/actionpack/test/template/template_test.rb
+++ b/actionpack/test/template/template_test.rb
@@ -1,3 +1,4 @@
+# encoding: US-ASCII
 require "abstract_unit"
 require "logger"
 

--- a/activesupport/lib/active_support/core_ext/hash/indifferent_access.rb
+++ b/activesupport/lib/active_support/core_ext/hash/indifferent_access.rb
@@ -1,7 +1,6 @@
 require 'active_support/hash_with_indifferent_access'
 
 class Hash
-
   # Returns an <tt>ActiveSupport::HashWithIndifferentAccess</tt> out of its receiver:
   #
   #   {:a => 1}.with_indifferent_access["a"] # => 1

--- a/activesupport/lib/active_support/core_ext/hash/slice.rb
+++ b/activesupport/lib/active_support/core_ext/hash/slice.rb
@@ -13,7 +13,7 @@ class Hash
   #   valid_keys = [:mass, :velocity, :time]
   #   search(options.slice(*valid_keys))
   def slice(*keys)
-    keys = keys.map! { |key| convert_key(key) } if respond_to?(:convert_key)
+    keys = keys.map! { |key| convert_key(key) } if respond_to?(:convert_key, true)
     hash = self.class.new
     keys.each { |k| hash[k] = self[k] if has_key?(k) }
     hash
@@ -23,7 +23,7 @@ class Hash
   # Returns a hash contained the removed key/value pairs
   #   {:a => 1, :b => 2, :c => 3, :d => 4}.slice!(:a, :b) # => {:c => 3, :d => 4}
   def slice!(*keys)
-    keys = keys.map! { |key| convert_key(key) } if respond_to?(:convert_key)
+    keys = keys.map! { |key| convert_key(key) } if respond_to?(:convert_key, true)
     omit = slice(*self.keys - keys)
     hash = slice(*keys)
     replace(hash)

--- a/activesupport/lib/active_support/core_ext/kernel/reporting.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/reporting.rb
@@ -1,4 +1,6 @@
 require 'rbconfig'
+require 'stringio'
+
 module Kernel
   # Sets $VERBOSE to nil for the duration of the block and back to its original value afterwards.
   #

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -6,7 +6,7 @@ require 'active_support/core_ext/hash/keys'
 
 module ActiveSupport
   class HashWithIndifferentAccess < Hash
-    
+
     # Always returns true, so that <tt>Array#extract_options!</tt> finds members of this class.
     def extractable_options?
       true

--- a/activesupport/lib/active_support/testing/isolation.rb
+++ b/activesupport/lib/active_support/testing/isolation.rb
@@ -12,8 +12,8 @@ module ActiveSupport
     end
 
     class ProxyTestResult
-      def initialize
-        @calls = []
+      def initialize(calls = [])
+        @calls = calls
       end
 
       def add_error(e)
@@ -25,6 +25,14 @@ module ActiveSupport
         @calls.each do |name, args|
           result.send(name, *args)
         end
+      end
+
+      def marshal_dump
+        @calls
+      end
+
+      def marshal_load(calls)
+        initialize(calls)
       end
 
       def method_missing(name, *args)

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -690,7 +690,6 @@ uses_memcached 'memcached backed store' do
       @data = @cache.instance_variable_get(:@data)
       @cache.clear
       @cache.silence!
-      @cache.logger = Logger.new("/dev/null")
     end
 
     include CacheStoreBehavior

--- a/activesupport/test/ordered_hash_test.rb
+++ b/activesupport/test/ordered_hash_test.rb
@@ -221,7 +221,6 @@ class OrderedHashTest < Test::Unit::TestCase
     alternate = ActiveSupport::OrderedHash[ [
       [1, 2],
       [3, 4],
-      "bad key value pair",
       [ 'missing value' ]
     ]]
 

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -16,6 +16,9 @@ module ActiveSupport
       def options
         nil
       end
+
+      def record(*args)
+      end
     end
 
     if defined?(MiniTest::Assertions) && TestCase < MiniTest::Assertions

--- a/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin_new/plugin_new_generator.rb
@@ -214,6 +214,18 @@ task :default => :test
 
       public_task :apply_rails_template, :run_bundle
 
+      def name
+        @name ||= begin
+          # same as ActiveSupport::Inflector#underscore except not replacing '-'
+          underscored = original_name.dup
+          underscored.gsub!(/([A-Z]+)([A-Z][a-z])/,'\1_\2')
+          underscored.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
+          underscored.downcase!
+
+          underscored
+        end
+      end
+
     protected
 
       def app_templates_dir
@@ -252,18 +264,6 @@ task :default => :test
 
       def original_name
         @original_name ||= File.basename(destination_root)
-      end
-
-      def name
-        @name ||= begin
-          # same as ActiveSupport::Inflector#underscore except not replacing '-'
-          underscored = original_name.dup
-          underscored.gsub!(/([A-Z]+)([A-Z][a-z])/,'\1_\2')
-          underscored.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
-          underscored.downcase!
-
-          underscored
-        end
       end
 
       def camelized

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -2,6 +2,7 @@
 require 'isolation/abstract_unit'
 require 'active_support/core_ext/kernel/reporting'
 require 'rack/test'
+require 'yaml'
 
 module ApplicationTests
   class AssetsTest < Test::Unit::TestCase

--- a/railties/test/application/route_inspect_test.rb
+++ b/railties/test/application/route_inspect_test.rb
@@ -18,7 +18,7 @@ module ApplicationTests
 
     def test_displaying_routes_for_engines
       engine = Class.new(Rails::Engine) do
-        def self.to_s
+        def self.inspect
           "Blog::Engine"
         end
       end
@@ -136,7 +136,7 @@ module ApplicationTests
 
     def test_rake_routes_shows_route_with_rack_app_nested_with_dynamic_constraints
       constraint = Class.new do
-        def to_s
+        def inspect
           "( my custom constraint )"
         end
       end


### PR DESCRIPTION
This PR is pretty much a bunch of backport commits since we already fixed a lot of stuff in `master`. This will making sure that you'll be able to use your Rails 3.2.x project with Ruby 2.0.0 that just came out today.

All tests are green: https://travis-ci.org/rails/rails/builds/5027376

And yes, happy 20th birthday Ruby!

![credit: http://clintandelyse.blogspot.com/2009/09/happy-birthday-ruby.html](https://lh3.ggpht.com/_kYHP9FOYrMk/Sqki2JlGBaI/AAAAAAAAAiw/nPPkrFqylAQ/s400/IMG_1772.JPG)
