### PR TITLE
Update RUBY_VERSION check for performance testing to handle 2.0.0

### DIFF
--- a/activesupport/lib/active_support/testing/performance/ruby.rb
+++ b/activesupport/lib/active_support/testing/performance/ruby.rb
@@ -142,7 +142,7 @@ module ActiveSupport
   end
 end
 
-if RUBY_VERSION.between?('1.9.2', '2.0')
+if RUBY_VERSION.between?('1.9.2', '2.0.0')
   require 'active_support/testing/performance/ruby/yarv'
 elsif RUBY_VERSION.between?('1.8.6', '1.9')
   require 'active_support/testing/performance/ruby/mri'


### PR DESCRIPTION
Presently, I am unable to run performance tests and am getting the `$stderr` message.

This is because `RUBY_VERSION` is returning `"2.0.0"` for me and the `between?` check failing. 
