### PR TITLE
Added documentation to touch throwing an error

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -367,6 +367,13 @@ module ActiveRecord
     #
     #   # triggers @brake.car.touch and @brake.car.corporation.touch
     #   @brake.touch
+    #
+    # Note that +touch+ must be used on a persisted object, or else an
+    # ActiveRecordError will be thrown. For example:
+    #
+    #   ball = Ball.new
+    #   ball.touch(:updated_at)   # => raises ActiveRecordError
+    #
     def touch(name = nil)
       raise ActiveRecordError, "can not touch on a new record object" unless persisted?
 


### PR DESCRIPTION
A recent change in the touch method introduced in https://github.com/rails/rails/pull/9320 now raises an error whenever touch is called on an unpersisted object.

This PR adds some documentation about the new behavior.
