### PR TITLE
Allow passing options to source elements within video/audio tags.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -8,6 +8,7 @@
     pass an array of hashes with the options you want to use.
 
     Example:
+    
         video_tag([{ src: 'trailer.ogg', type: 'video/ogg'}])
         # => <video><source src="/videos/trailer.ogg" type="video/ogg" /></video>
 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Change `multiple_sources_tag` private method in asset_tag_helper.rb to
+    allow for options to be passed to the source tags.
+
+    Previously, in order to add type or media attributes to source tags you
+    would have had to construct the video/audio tag yourself. Now you can just
+    pass an array of hashes with the options you want to use.
+
+    Example:
+        video_tag([{ src: 'trailer.ogg', type: 'video/ogg'}])
+        # => <video><source src="/videos/trailer.ogg" type="video/ogg" /></video>
+
+    *Phil Nash*
+
 *   Fix `respond_to` not using formats that have no block if all is present. *Michael Grosser*
 
 *   New applications use an encrypted session store by default.

--- a/actionpack/test/template/asset_tag_helper_test.rb
+++ b/actionpack/test/template/asset_tag_helper_test.rb
@@ -249,7 +249,8 @@ class AssetTagHelperTest < ActionView::TestCase
     %(video_tag("//media.rubyonrails.org/video/rails_blog_2.mov")) => %(<video src="//media.rubyonrails.org/video/rails_blog_2.mov"></video>),
     %(video_tag("multiple.ogg", "multiple.avi")) => %(<video><source src="/videos/multiple.ogg" /><source src="/videos/multiple.avi" /></video>),
     %(video_tag(["multiple.ogg", "multiple.avi"])) => %(<video><source src="/videos/multiple.ogg" /><source src="/videos/multiple.avi" /></video>),
-    %(video_tag(["multiple.ogg", "multiple.avi"], :size => "160x120", :controls => true)) => %(<video controls="controls" height="120" width="160"><source src="/videos/multiple.ogg" /><source src="/videos/multiple.avi" /></video>)
+    %(video_tag(["multiple.ogg", "multiple.avi"], :size => "160x120", :controls => true)) => %(<video controls="controls" height="120" width="160"><source src="/videos/multiple.ogg" /><source src="/videos/multiple.avi" /></video>),
+    %(video_tag([{:src => "multiple.ogg", :type => "video/ogg; codecs=theora,vorbis" }, "multiple.avi"])) => %(<video><source src="/videos/multiple.ogg" type="video/ogg; codecs=theora,vorbis" /><source src="/videos/multiple.avi" /></video>)
   }
 
   AudioPathToTag = {
@@ -287,7 +288,8 @@ class AssetTagHelperTest < ActionView::TestCase
     %(audio_tag("//media.rubyonrails.org/audio/rails_blog_2.mov")) => %(<audio src="//media.rubyonrails.org/audio/rails_blog_2.mov"></audio>),
     %(audio_tag("audio.mp3", "audio.ogg")) => %(<audio><source src="/audios/audio.mp3" /><source src="/audios/audio.ogg" /></audio>),
     %(audio_tag(["audio.mp3", "audio.ogg"])) => %(<audio><source src="/audios/audio.mp3" /><source src="/audios/audio.ogg" /></audio>),
-    %(audio_tag(["audio.mp3", "audio.ogg"], :autobuffer => true, :controls => true)) => %(<audio autobuffer="autobuffer" controls="controls"><source src="/audios/audio.mp3" /><source src="/audios/audio.ogg" /></audio>)
+    %(audio_tag(["audio.mp3", "audio.ogg"], :autobuffer => true, :controls => true)) => %(<audio autobuffer="autobuffer" controls="controls"><source src="/audios/audio.mp3" /><source src="/audios/audio.ogg" /></audio>),
+    %(audio_tag([{:src => "audio.mp3", :type => "audio/mpeg"}, "audio.ogg"])) => %(<audio><source src="/audios/audio.mp3" type="audio/mpeg" /><source src="/audios/audio.ogg" /></audio>)
   }
 
   FontPathToTag = {
@@ -443,8 +445,8 @@ class AssetTagHelperTest < ActionView::TestCase
     [nil, '/', '/foo/bar/', 'foo/bar/'].each do |prefix|
       assert_equal 'Rails', image_alt("#{prefix}rails.png")
       assert_equal 'Rails', image_alt("#{prefix}rails-9c0a079bdd7701d7e729bd956823d153.png")
-      assert_equal 'Long file name with hyphens', image_alt("#{prefix}long-file-name-with-hyphens.png") 
-      assert_equal 'Long file name with underscores', image_alt("#{prefix}long_file_name_with_underscores.png")  
+      assert_equal 'Long file name with hyphens', image_alt("#{prefix}long-file-name-with-hyphens.png")
+      assert_equal 'Long file name with underscores', image_alt("#{prefix}long_file_name_with_underscores.png")
     end
   end
 


### PR DESCRIPTION
Previously, in order to add type or media attributes to source tags you
would have had to construct the video/audio tag yourself. Now you can just
pass an array of hashes with the options you want to use.

Example:

```
video_tag([{ src: 'trailer.ogg', type: 'video/ogg'}])
# => <video><source src="/videos/trailer.ogg" type="video/ogg" /></video>
```
