### PR TITLE
db:migrate:down, db:migrate:up & db:migrate:redo doesn't support transactions

### DIFF
--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1420,6 +1420,19 @@ if ActiveRecord::Base.connection.supports_migrations?
         Person.reset_column_information
         assert !Person.column_methods_hash.include?(:last_name)
       end
+
+      def test_migrator_one_up_with_exception_and_rollback_using_run
+        assert !Person.column_methods_hash.include?(:last_name)
+
+        e = assert_raise(StandardError) do
+          ActiveRecord::Migrator.run(:up, MIGRATIONS_ROOT + "/broken", 100)
+        end
+
+        assert_equal "An error has occurred, the migration canceled:\n\nSomething broke", e.message
+
+        Person.reset_column_information
+        assert !Person.column_methods_hash.include?(:last_name)
+      end
     end
 
     def test_finds_migrations


### PR DESCRIPTION
If you are using these rakes while developing migrations you have a risk to put a database in invalid state, even if the database supports ddl transactions. Surprising, Migrator.migrate, used in db:migrate, supports transactions, but in same time Migrator.run doesn't.
This pull requests makes things more similar. Its not so DRY as may be, but provides fix what can prevent some hard-to-find problems.
