### PR TITLE
Change default root route helper

### DIFF
--- a/guides/code/getting_started/config/routes.rb
+++ b/guides/code/getting_started/config/routes.rb
@@ -2,6 +2,6 @@ Blog::Application.routes.draw do
   resources :posts do
     resources :comments
   end
- 
-  root to: "welcome#index"
+
+  root "welcome#index"
 end

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -215,7 +215,7 @@ module Rails
 
       # Make an entry in Rails routing file config/routes.rb
       #
-      #   route "root :to => 'welcome#index'"
+      #   route "root 'welcome#index'"
       def route(routing_code)
         log :route, routing_code
         sentinel = /\.routes\.draw do\s*$/

--- a/railties/lib/rails/generators/rails/app/templates/config/routes.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/routes.rb
@@ -3,7 +3,7 @@
   # See how all your routes lay out with "rake routes".
 
   # You can have the root of your site routed with "root"
-  # root to: 'welcome#index'
+  # root 'welcome#index'
 
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'


### PR DESCRIPTION
Since this commit (https://github.com/rails/rails/commit/2ee4dd856d47113625589bc5410b5a6669ea02d5), it is allowed to use this root route syntax.

```
 root "welcome#index"
```

What about using this syntax as default in a simple and consistent way?
