### PR TITLE
Remove sprockets-rails from the Gemfile generator

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -196,7 +196,6 @@ module Rails
             # Gems used only for assets and not required
             # in production environments by default.
             group :assets do
-              gem 'sprockets-rails', '~> 2.0.0.rc3'
               gem 'sass-rails',   '~> 4.0.0.beta'
               gem 'coffee-rails', '~> 4.0.0.beta'
 


### PR DESCRIPTION
sprockets 2.0.0.rc3 is already added in the  rails gemspec 40111c5c8afdcc
