### PR TITLE
Bump Bundler dep to 1.3.0

### DIFF
--- a/rails.gemspec
+++ b/rails.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'actionmailer',  version
   s.add_dependency 'railties',      version
 
-  s.add_dependency 'bundler',         '>= 1.2.2', '< 2.0'
+  s.add_dependency 'bundler',         '>= 1.3.0', '< 2.0'
   s.add_dependency 'sprockets-rails', '~> 2.0.0.rc3'
 end


### PR DESCRIPTION
use bundler 1.3.0 for the binstub deploy story in Rails 4
