### PR TITLE
Do not overwrite manually built records during one-to-one nested attribute assignment

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Do not overwrite manually built records during one-to-one nested attribute assignment
+
+    For one-to-one nested associations, if you build the new (in-memory)
+    child object yourself before assignment, then the NestedAttributes
+    module will not overwrite it, e.g.:
+
+        class Member < ActiveRecord::Base
+          has_one :avatar
+          accepts_nested_attributes_for :avatar
+
+          def avatar
+            super || build_avatar(width: 200)
+          end
+        end
+
+        member = Member.new
+        member.avatar_attributes = {icon: 'sad'}
+        member.avatar.width # => 200
+
+    *Olek Janiszewski*
+
 *   fixes bug introduced by #3329.  Now, when autosaving associations,
     deletions happen before inserts and saves.  This prevents a 'duplicate
     unique value' database error that would occur if a record being created had

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -164,6 +164,13 @@ module ActiveRecord
         @reflection = @owner.class.reflect_on_association(reflection_name)
       end
 
+      def initialize_attributes(record) #:nodoc:
+        skip_assign = [reflection.foreign_key, reflection.type].compact
+        attributes = create_scope.except(*(record.changed - skip_assign))
+        record.assign_attributes(attributes)
+        set_inverse_instance(record)
+      end
+
       private
 
         def find_target?
@@ -233,10 +240,7 @@ module ActiveRecord
 
         def build_record(attributes)
           reflection.build_association(attributes) do |record|
-            skip_assign = [reflection.foreign_key, reflection.type].compact
-            attributes = create_scope.except(*(record.changed - skip_assign))
-            record.assign_attributes(attributes)
-            set_inverse_instance(record)
+            initialize_attributes(record)
           end
         end
     end

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -131,6 +131,20 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
     assert_equal 's1', ship.reload.name
   end
 
+  def test_reuse_already_built_new_record
+    pirate = Pirate.new
+    ship_built_first = pirate.build_ship
+    pirate.ship_attributes = { name: 'Ship 1' }
+    assert_equal ship_built_first.object_id, pirate.ship.object_id
+  end
+
+  def test_do_not_allow_assigning_foreign_key_when_reusing_existing_new_record
+    pirate = Pirate.create!(catchphrase: "Don' botharrr talkin' like one, savvy?")
+    pirate.build_ship
+    pirate.ship_attributes = { name: 'Ship 1', pirate_id: pirate.id + 1 }
+    assert_equal pirate.id, pirate.ship.pirate_id
+  end
+
   def test_reject_if_with_a_proc_which_returns_true_always_for_has_many
     Man.accepts_nested_attributes_for :interests, :reject_if => proc {|attributes| true }
     man = Man.create(name: "John")


### PR DESCRIPTION
For one-to-one nested associations, if you build the new (in-memory)
child object yourself before assignment, then the NestedAttributes
module will not overwrite it, e.g.:

``` ruby
class Member < ActiveRecord::Base
  has_one :avatar
  accepts_nested_attributes_for :avatar

  def avatar
    super || build_avatar(width: 200)
  end
end

member = Member.new
member.avatar_attributes = {icon: 'sad'}
member.avatar.width # => 200
```
