### PR TITLE
Added javascript helpers which add event listeners to an EventSource.

### DIFF
--- a/actionpack/lib/action_view/helpers/javascript_helper.rb
+++ b/actionpack/lib/action_view/helpers/javascript_helper.rb
@@ -71,6 +71,113 @@ module ActionView
         "\n//#{cdata_section("\n#{content}\n//")}\n".html_safe
       end
 
+
+      # Creates a javascript tag that adds event listeners to an EventSource.
+      # +source_name+ is the URI that should be initialized in a new EventSource
+      # object. For example: setting +source_name = "message_server"+ will
+      # create javascript code like:
+      #
+      #   var eventStream = new EventSource("message_server");
+      #
+      # +event_callbacks+ is a hash of event names to javascript functions
+      # (both of which are strings). The javascript functions will be called
+      # whenever the event they are keyed on occurs. For example:
+      #
+      #   event_callbacks = {
+      #     "message" => "function(e) { console.log(e.data) }",
+      #     "error" => "function(e) { console.log("ERROR") }"
+      #   }
+      #
+      # This will create javascript like the following:
+      #
+      #   eventStream.addEventListener("message", function(e) { console.log(e.data) }, false);
+      #   eventStream.addEventListener("error", function(e) { console.log("ERROR") }, false);
+      #
+      # The +html_options+ may be a hash of attributes for the
+      # <tt>\<script></tt> tag. It uses the same syntax as +javascript_tag+.
+      #
+      def event_source_tag(source_name, event_callbacks = {}, html_options = {})
+        javascript = event_stream_subscription("eventStream", source_name, event_callbacks)
+        javascript_tag(javascript, html_options)
+      end
+
+      # Returns a string of javscript which creates an EventSource variable
+      # and adds listeners to it.
+      #
+      # The newly created EventSource variable will be named
+      # +event_source_variable+. The +source_name+ variable gives the URI
+      # of the EventSource variable that is created. For example, if
+      # +event_source_variable = "eventSource"+ and +source_name = "sse_server"+,
+      # then the following code will initialize an EventSource:
+      #
+      #   var eventSource = new EventSource('sse_server');
+      #
+      # +event_callbacks+ is a hash which has event names as keys and
+      # strings of javascript functions as values. The values correspond
+      # to the callback that will be run each time an event is sent which
+      # corresponds to the key. For example:
+      #
+      #   message_callback = "function(e) { console.log(e.data) }"
+      #   event_callbacks = {"message" => message_callback}
+      #
+      # In the above, the +message_callback+ function will be called whenever
+      # whenever a "message" event occurs.
+      #
+      # Here is a full example:
+      #
+      #   event_source_variable = "eventSource"
+      #   source_name = "sse_server"
+      #   event_callbacks = {"message" => "function(e) { console.log(e.data) }"}
+      # 
+      #   event_source_subscription(event_source_variable, source_name, event_callbacks)
+      #
+      #   # =>
+      #   #
+      #   # "if (!!window.EventSource) {
+      #   #   var eventSource = new EventSource('sse_server');
+      #   #   eventSource.addEventListener('message', function(e) { console.log(e.data) }, false);
+      #   # }"
+      #   #
+      def event_source_subscription(event_source_variable, source_name, event_callbacks = {})
+        listeners = event_callbacks.map { |event_name, function|
+          event_stream_subscription_javascript(event_source_variable, event_name, function)
+        }.join("")
+
+        %{if (!!window.EventSource) {
+            var #{event_source_variable} = new EventSource('#{source_name}');
+            #{listeners}
+          }}
+      end
+
+      # Returns a string which is javascript code that adds an EventListener
+      # to a variable.
+      #
+      # The event_source_variable a variable holding an EventSource object.
+      # For instance, one could use "source" as the event_source_variable 
+      # when in javascript "source" is defined as:
+      #
+      #   var source = new EventSource("stream_name");
+      #
+      # The event_name is the event to listen to from the EventSource, and
+      # the function should be some javascript function to run as a callback
+      # whenever such an event is received from the stream.
+      #
+      # For example:
+      #
+      #   event_source_variable = "source"
+      #   event_name = "message"
+      #   function = "function(e) { console.log(e.data) }"
+      #
+      #   event_stream_subscription_javascript(event_source_variable,
+      #       event_name, function)
+      #
+      #   # =>
+      #   #  "source.addEventListener('message', function(e) { console.log(e.data) }, false);"
+      #   #
+      def event_stream_subscription_javascript(event_source_variable, event_name, function)
+        "#{event_source_variable}.addEventListener('#{event_name}', #{function}, false);"
+      end
+
       # Returns a button whose +onclick+ handler triggers the passed JavaScript.
       #
       # The helper receives a name, JavaScript code, and an optional hash of HTML options. The


### PR DESCRIPTION
This pull request adds an easy way to create a javascript tag that listens to an EventSource. I have also added methods to create strings containing javascript for adding event listeners to a source.

This helps for adding streaming SSEs to a rails app. You can now call the `event_source_tag` function and create javascript. For example:

``` ruby
event_source_tag("sse_server", {"message" => "function(e) { console.log(e.data) }"})
```

will create a javascript tag with the following javascript code:

``` javascript
if (!!window.EventSource){
  var eventStream = new EventSource("sse_server");
  eventStream.addListener('message', function(e) { console.log(e.data) }, false);
}
```
