### PR TITLE
Do not override attributes on `dup` by default scopes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## unreleased ##
 
+*   Fix overriding of attributes by default_scope on `ActiveRecord::Base#dup`.
+
+    *Hiroshige UMINO*
+
 *   Sqlite now preserves custom primary keys when copying or altering tables.
     Fixes #9367.
     Backport #2312.

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -553,7 +553,6 @@ module ActiveRecord #:nodoc:
         @new_record  = true
 
         ensure_proper_type
-        populate_with_current_scope_attributes
         super
       end
 

--- a/activerecord/test/cases/dup_test.rb
+++ b/activerecord/test/cases/dup_test.rb
@@ -113,5 +113,14 @@ module ActiveRecord
       assert topic.invalid?
       assert duped.valid?
     end
+
+    def test_dup_with_default_scope
+      prev_default_scopes = Topic.default_scopes
+      Topic.default_scopes = [Topic.where(:approved => true)]
+      topic = Topic.new(:approved => false)
+      assert !topic.dup.approved?, "should not be overriden by default scopes"
+    ensure
+      Topic.default_scopes = prev_default_scopes
+    end
   end
 end


### PR DESCRIPTION
This is to backport #9197.
