### PR TITLE
Backported #7072 to 3-2-stable. Use database value for uniqueness validation scope

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## unreleased ##
+*   Fixes issue with overrding ActiveRecord reader methods with a
+    composed object and using that attribute as the scope of a
+    validates_uniqueness_of validation.
+    Backport of #7072
+
+    *Peter Brown*
 
 *   Sqlite now preserves custom primary keys when copying or altering tables.
     Fixes #9367.

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -26,7 +26,7 @@ module ActiveRecord
         relation = relation.and(table[finder_class.primary_key.to_sym].not_eq(record.send(:id))) if record.persisted?
 
         Array.wrap(options[:scope]).each do |scope_item|
-          scope_value = record.send(scope_item)
+          scope_value = record.read_attribute(scope_item)
           relation = relation.and(table[scope_item].eq(scope_value))
         end
 

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -22,6 +22,14 @@ end
 class Thaumaturgist < IneptWizard
 end
 
+class ReplyTitle; end
+
+class ReplyWithTitleObject < Reply
+  validates_uniqueness_of :content, :scope => :title
+
+  def title; ReplyTitle.new; end
+end
+
 class UniquenessValidationTest < ActiveRecord::TestCase
   fixtures :topics, 'warehouse-things', :developers
 
@@ -78,6 +86,14 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     t2 = Topic.create("title" => "I'm unique too!")
     r3 = t2.replies.create "title" => "r3", "content" => "hello world"
     assert r3.valid?, "Saving r3"
+  end
+
+  def test_validate_uniqueness_with_composed_attribute_scope
+    r1 = ReplyWithTitleObject.create "title" => "r1", "content" => "hello world"
+    assert r1.valid?, "Saving r1"
+
+    r2 = ReplyWithTitleObject.create "title" => "r1", "content" => "hello world"
+    assert !r2.valid?, "Saving r2 first time"
   end
 
   def test_validate_uniqueness_scoped_to_defining_class


### PR DESCRIPTION
I think #7072 is a bug. so it should be backported to 3-2-stable.
