### PR TITLE
postgres timestamptz should return a ActiveSupport::TimeWithZone via OID::Timezone

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Postgresql timestamp with time zone (timestamptz) datatype now returns a
+    ActiveSupport::TimeWithZone instance instead of a string
+
+    *Troy Kruthoff*
+
 *   Added support for creating a table via Rails migration generator.
     For example, 
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -317,10 +317,6 @@ module ActiveRecord
         alias_type 'macaddr',  'text'
         alias_type 'uuid',     'text'
 
-        # FIXME: I don't think this is correct. We should probably be returning a parsed date,
-        # but the tests pass with a string returned.
-        register_type 'timestamptz', OID::Identity.new
-
         register_type 'money', OID::Money.new
         register_type 'bytea', OID::Bytea.new
         register_type 'bool', OID::Boolean.new
@@ -329,6 +325,7 @@ module ActiveRecord
         alias_type 'float8', 'float4'
 
         register_type 'timestamp', OID::Timestamp.new
+        register_type 'timestamptz', OID::Timestamp.new
         register_type 'date', OID::Date.new
         register_type 'time', OID::Time.new
 

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -573,6 +573,7 @@ _SQL
 
     @first_timestamp_with_zone = PostgresqlTimestampWithZone.find(1)
     assert_equal Time.utc(2010,1,1, 11,0,0), @first_timestamp_with_zone.time
+    assert_instance_of Time, @first_timestamp_with_zone.time
   ensure
     ActiveRecord::Base.default_timezone = old_default_tz
     ActiveRecord::Base.time_zone_aware_attributes = old_tz
@@ -590,6 +591,7 @@ _SQL
 
     @first_timestamp_with_zone = PostgresqlTimestampWithZone.find(1)
     assert_equal Time.utc(2010,1,1, 11,0,0), @first_timestamp_with_zone.time
+    assert_instance_of Time, @first_timestamp_with_zone.time
   ensure
     ActiveRecord::Base.default_timezone = old_default_tz
     ActiveRecord::Base.time_zone_aware_attributes = old_tz


### PR DESCRIPTION
Comments were correct, timestamptz should return a date.
