### PR TITLE
the router allows String contraints.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,9 +1,17 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Don't verify Regexp requirements for non-Regexp `:constraints`.
+    Fixes #9432.
+
+    Example:
+
+        get '/photos.:format' => 'feeds#photos', constraints: {format: 'xml'}
+
+    *Yves Senn*
+
 *   Make `ActionDispatch::Journey::Path::Pattern#new` raise more meaningful exception message.
 
     *Thierry Zires*
-
 
 ## Rails 4.0.0.beta1 (February 25, 2013) ##
 

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -124,15 +124,7 @@ module ActionDispatch
           def normalize_requirements!
             constraints.each do |key, requirement|
               next unless segment_keys.include?(key) || key == :controller
-
-              if requirement.source =~ ANCHOR_CHARACTERS_REGEX
-                raise ArgumentError, "Regexp anchor characters are not allowed in routing requirements: #{requirement.inspect}"
-              end
-
-              if requirement.multiline?
-                raise ArgumentError, "Regexp multiline option is not allowed in routing requirements: #{requirement.inspect}"
-              end
-
+              verify_regexp_requirement(requirement) if requirement.is_a?(Regexp)
               @requirements[key] = requirement
             end
 
@@ -142,6 +134,16 @@ module ActionDispatch
               @requirements[:format] = options[:format]
             elsif String === options[:format]
               @requirements[:format] = Regexp.compile(options[:format])
+            end
+          end
+
+          def verify_regexp_requirement(requirement)
+            if requirement.source =~ ANCHOR_CHARACTERS_REGEX
+              raise ArgumentError, "Regexp anchor characters are not allowed in routing requirements: #{requirement.inspect}"
+            end
+
+            if requirement.multiline?
+              raise ArgumentError, "Regexp multiline option is not allowed in routing requirements: #{requirement.inspect}"
             end
           end
 
@@ -425,10 +427,14 @@ module ActionDispatch
         #      end
         #
         # [:constraints]
-        #   Constrains parameters with a hash of regular expressions or an
-        #   object that responds to <tt>matches?</tt>
+        #   Constrains parameters with a hash of regular expressions
+        #   or an object that responds to <tt>matches?</tt>. In addition, constraints
+        #   other than path can also be specified with any object
+        #   that responds to <tt>===</tt> (eg. String, Array, Range, etc.).
         #
         #     match 'path/:id', constraints: { id: /[A-Z]\d{5}/ }
+        #
+        #     match 'json_only', constraints: { format: 'json' }
         #
         #     class Blacklist
         #       def matches?(request) request.remote_ip == '1.2.3.4' end

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3380,6 +3380,42 @@ class TestPortConstraints < ActionDispatch::IntegrationTest
   end
 end
 
+class TestFormatConstraints < ActionDispatch::IntegrationTest
+  Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
+    app.draw do
+      ok = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, []] }
+
+      get '/string', to: ok, constraints: { format: 'json'  }
+      get '/regexp',  to: ok, constraints: { format: /json/ }
+    end
+  end
+
+  include Routes.url_helpers
+  def app; Routes end
+
+  def test_string_format_constraints
+    get 'http://www.example.com/string'
+    assert_response :success
+
+    get 'http://www.example.com/string.json'
+    assert_response :success
+
+    get 'http://www.example.com/string.html'
+    assert_response :not_found
+  end
+
+  def test_regexp_format_constraints
+    get 'http://www.example.com/regexp'
+    assert_response :success
+
+    get 'http://www.example.com/regexp.json'
+    assert_response :success
+
+    get 'http://www.example.com/regexp.html'
+    assert_response :not_found
+  end
+end
+
 class TestRouteDefaults < ActionDispatch::IntegrationTest
   stub_controllers do |routes|
     Routes = routes


### PR DESCRIPTION
Closes #9432.

This patch only applies the sanity checks to Rexep Contraints. This gets string contraints working again. I also modified the documentation to reflect that Strings are valid inside the :constraints hash.
