### PR TITLE
convert non-string default params to strings in the router.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Skip valid encoding checks for non-String parameters that come
+    from the matched route's defaults.
+    Fixes #9435.
+
+    Example:
+
+        root to: 'main#posts', page: 1
+
+    *Yves Senn*
+
 *   Don't verify Regexp requirements for non-Regexp `:constraints`.
     Fixes #9432.
 

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -31,6 +31,8 @@ module ActionDispatch
           # If any of the path parameters has a invalid encoding then
           # raise since it's likely to trigger errors further on.
           params.each do |key, value|
+            next unless value.respond_to?(:valid_encoding?)
+
             unless value.valid_encoding?
               raise ActionController::BadRequest, "Invalid parameter: #{key} => #{value}"
             end

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1346,7 +1346,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal 'en', @request.params[:locale]
   end
 
-  def test_default_params
+  def test_default_string_params
     draw do
       get 'inline_pages/(:id)', :to => 'pages#show', :id => 'home'
       get 'default_pages/(:id)', :to => 'pages#show', :defaults => { :id => 'home' }
@@ -1364,6 +1364,26 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
     get '/scoped_pages'
     assert_equal 'home', @request.params[:id]
+  end
+
+  def test_default_integer_params
+    draw do
+      get 'inline_pages/(:page)', to: 'pages#show', page: 1
+      get 'default_pages/(:page)', to: 'pages#show', defaults: { page: 1 }
+
+      defaults page: 1 do
+        get 'scoped_pages/(:page)', to: 'pages#show'
+      end
+    end
+
+    get '/inline_pages'
+    assert_equal 1, @request.params[:page]
+
+    get '/default_pages'
+    assert_equal 1, @request.params[:page]
+
+    get '/scoped_pages'
+    assert_equal 1, @request.params[:page]
   end
 
   def test_resource_constraints


### PR DESCRIPTION
Closes #9435.

Since Rails 4.0.0.beta1 Rails raises an exception when non-string default params
are provided in the router (eg. `root to: 'main#posts', page: 1`).

I see sevaral options to fix this:
1. issue a deprecation warning when non-string defaults are used.
2. convert all default params to strings.
3. get the router to work with non-string params (implemented by this patch).

I chose 3. becuase it's the only option, which is backwards compatible.
With 3.2.x the router happily accepted non-string default params.
