### PR TITLE
Separate titleize and titlecase behavior

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -100,14 +100,18 @@ class String
   # a nicer looking title. +titleize+ is meant for creating pretty output. It is not
   # used in the Rails internals.
   #
-  # +titleize+ is also aliased as +titlecase+.
-  #
   #   'man from the boondocks'.titleize # => "Man From The Boondocks"
   #   'x-men: the last stand'.titleize  # => "X Men: The Last Stand"
   def titleize
     ActiveSupport::Inflector.titleize(self)
   end
-  alias_method :titlecase, :titleize
+
+  # Capitalizes all the words (segments separated by whitespace)
+  #   'active record' # => 'Active Record'
+  #   'laissez-faire' # => 'Laissez-faire'
+  def titlecase
+    ActiveSupport::Inflector.titlecase(self)
+  end
 
   # The reverse of +camelize+. Makes an underscored, lowercase form from the expression in the string.
   #

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -118,14 +118,21 @@ module ActiveSupport
     # create a nicer looking title. +titleize+ is meant for creating pretty
     # output. It is not used in the Rails internals.
     #
-    # +titleize+ is also aliased as +titlecase+.
-    #
     #   'man from the boondocks'.titleize   # => "Man From The Boondocks"
     #   'x-men: the last stand'.titleize    # => "X Men: The Last Stand"
     #   'TheManWithoutAPast'.titleize       # => "The Man Without A Past"
     #   'raiders_of_the_lost_ark'.titleize  # => "Raiders Of The Lost Ark"
     def titleize(word)
       humanize(underscore(word)).gsub(/\b(?<!['’`])[a-z]/) { $&.capitalize }
+    end
+
+    # Capitalizes all the words where words are defined as separated by whitespace
+    #
+    #   'man from the boondocks'.titlecase   # => "Man From The Boondocks"
+    #   'TheManWithoutAPast'.titlecase       # => "TheManWithoutAPast"
+    #   'ActiveSupport::Cache'.titlecase     # => "ActiveSupport::Cache"
+    def titlecase(word)
+      word.gsub(/\s(\w)/) { $&.upcase }.gsub(/^\W*\w/) { $&.upcase }
     end
 
     # Create the name of a table like Rails does for models to table names. This

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -72,8 +72,14 @@ class StringInflectionsTest < ActiveSupport::TestCase
   end
 
   def test_titleize
-    MixtureToTitleCase.each do |before, titleized|
+    MixtureToTitleize.each do |before, titleized|
       assert_equal(titleized, before.titleize)
+    end
+  end
+
+  def test_titlecase
+    MixtureToTitleCase.each do |before, titlecased|
+      assert_equal(titlecased, before.titlecase)
     end
   end
 

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -78,9 +78,15 @@ class InflectorTest < ActiveSupport::TestCase
     ActiveSupport::Inflector.inflections.uncountable "series" # Return to normal
   end
 
-  MixtureToTitleCase.each do |before, titleized|
+  MixtureToTitleize.each do |before, titleized|
     define_method "test_titleize_#{before}" do
       assert_equal(titleized, ActiveSupport::Inflector.titleize(before))
+    end
+  end
+
+  MixtureToTitleCase.each do |before, titlecased|
+    define_method "test_titlecase_#{before}" do
+      assert_equal(titlecased, ActiveSupport::Inflector.titlecase(before))
     end
   end
 

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -213,7 +213,7 @@ module InflectorTestCases
     "underground"     => "Underground"
   }
 
-  MixtureToTitleCase = {
+  MixtureToTitleize = {
     'active_record'         => 'Active Record',
     'ActiveRecord'          => 'Active Record',
     'action web service'    => 'Action Web Service',
@@ -229,7 +229,30 @@ module InflectorTestCases
     "maybe you'll be there" => "Maybe You'll Be There",
     "¿por qué?"             => '¿Por Qué?',
     "Fred’s"                => "Fred’s",
-    "Fred`s"                => "Fred`s"
+    "Fred`s"                => "Fred`s",
+    'ActiveSupport::Cache'  => 'Active Support/Cache',
+    'laissez-faire'         => 'Laissez Faire'
+  }
+
+  MixtureToTitleCase = {
+    'active_record'        => 'Active_record',
+    'active record'        => 'Active Record',
+    'action web service'    => 'Action Web Service',
+    'Action Web Service'    => 'Action Web Service',
+    'Action web service'    => 'Action Web Service',
+    'actionwebservice'      => 'Actionwebservice',
+    'Actionwebservice'      => 'Actionwebservice',
+    "david's code"          => "David's Code",
+    "David's code"          => "David's Code",
+    "david's Code"          => "David's Code",
+    "sgt. pepper's"         => "Sgt. Pepper's",
+    "i've just seen a face" => "I've Just Seen A Face",
+    "maybe you'll be there" => "Maybe You'll Be There",
+    "¿por qué?"             => '¿Por Qué?',
+    "Fred’s"                => "Fred’s",
+    "Fred`s"                => "Fred`s",
+    'ActiveSupport::Cache'  => 'ActiveSupport::Cache',
+    'laissez-faire'         => 'Laissez-faire'
   }
 
   OrdinalNumbers = {


### PR DESCRIPTION
This commit addresses #3662
- Titlecase falls in line with ruby's upcase and downcase. It
  capitalizes each word in the string.
- Titleize retains the old behavior. It removes punctuation, replaces
  e.g :: with /, _ with ' ', etc.

One doubt I have is whether "MAN WITHOUT A PAST" should be titlecased to "Man Without A Past" or should be left as it is. I lean to the first version (transforming it) but wanted to hear some feedback first. It is not yet implemented so it should be an extra commit.
