### PR TITLE
Fix touching an invalid parent record for belongs_to

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Do not try to touch invalid (and thus not persisted) parent record
+    for a `belongs_to :parent, touch: true` association
+
+    *Olek Janiszewski*
+
 *   Fix when performing an ordered join query. The bug only
     affected queries where the order was given with a symbol.
     Fixes #9275.
@@ -12,7 +17,7 @@
 
 ## Rails 4.0.0.beta1 (February 25, 2013) ##
 
-*   Fix overriding of attributes by default_scope on `ActiveRecord::Base#dup`.
+*   Fix overriding of attributes by `default_scope` on `ActiveRecord::Base#dup`.
 
     *Hiroshige UMINO*
 

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -48,7 +48,7 @@ module ActiveRecord::Associations::Builder
         def belongs_to_touch_after_save_or_destroy_for_#{name}
           record = #{name}
 
-          unless record.nil?
+          unless record.nil? || record.new_record?
             record.touch #{options[:touch].inspect if options[:touch] != true}
           end
         end

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -113,6 +113,18 @@ class TimestampTest < ActiveRecord::TestCase
     assert_not_equal previously_owner_updated_at, pet.owner.updated_at
   end
 
+  def test_saving_a_new_record_belonging_to_invalid_parent_with_touch_should_not_raise_exception
+    klass = Class.new(Owner) do
+      def self.name; 'Owner'; end
+      validate { errors.add(:base, :invalid) }
+    end
+
+    pet = Pet.new(owner: klass.new)
+    pet.save!
+
+    assert pet.owner.new_record?
+  end
+
   def test_saving_a_record_with_a_belongs_to_that_specifies_touching_a_specific_attribute_the_parent_should_update_that_attribute
     klass = Class.new(ActiveRecord::Base) do
       def self.name; 'Pet'; end


### PR DESCRIPTION
If the parent of a `belongs_to` record fails to be saved due to
validation errors, `touch` will be called on a new record, which causes
an exception (see https://github.com/rails/rails/pull/9320).

Example:

``` ruby
class Owner < ActiveRecord::Base
  validates_presence_of :name
end

class Pet < ActiveRecord::Base
  belongs_to :owner, touch: true
end

pet = Pet.new(owner: Owner.new)

# Before, this line would raise ActiveRecord::ActiveRecordError
# "can not touch on a new record object"
pet.save
```
