### PR TITLE
Optimistic locking destroy bug

### DIFF
--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -11,6 +11,8 @@ require 'models/car'
 require 'models/engine'
 require 'models/wheel'
 require 'models/treasure'
+require 'models/invoice'
+require 'models/line_item'
 
 class LockWithoutDefault < ActiveRecord::Base; end
 
@@ -162,6 +164,13 @@ class OptimisticLockingTest < ActiveRecord::TestCase
 
     p1.touch
     assert_equal 1, p1.lock_version
+  end
+  
+  def test_touch_related_model_updates_lock_in_memory
+    p = Person.find(1)
+    lock_version = p.lock_version
+    p.references.first.touch
+    assert_equal lock_version + 1, p.lock_version
   end
 
   def test_lock_column_name_existing

--- a/activerecord/test/models/reference.rb
+++ b/activerecord/test/models/reference.rb
@@ -1,5 +1,5 @@
 class Reference < ActiveRecord::Base
-  belongs_to :person
+  belongs_to :person, :touch => true
   belongs_to :job
 
   has_many :agents_posts_authors, :through => :person


### PR DESCRIPTION
This PR is only meant as a discussion point at this time.  I do not
currently have a fix here.

There seems to be a problem when using optimistic locking with
:dependent => :destroy and :touch => true.  This pull request
attempts to expose the error although I do not yet have a
fix.  Please see the new test in locking_test and note that
it fails.  This failure means that when attempting to destroy
a model object with :dependent => :destroy on a realtionship
where the inverse has :touch => true results in:

ActiveRecord::StaleObjectError: Attempted to destroy a stale object

If in the new test we attempted to do `p.destroy` we would trigger the
StaleObjectError.  This is because the lock_version of the Person in
the database gets updated when the :reference is destroyed due to
:touch => true but the in-memory lock_version on the person object,
p, is NOT updated so when the destroy is attempted it thinks it is
stale.

Any advice on how to fix this in AR without breaking anything else
would be appreciated.
