### PR TITLE
Treat IPv4 and IPv6 the same when dumping the schema for Postgresql

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -55,8 +55,8 @@ module ActiveRecord
           when IPAddr
             subnet_mask = value.instance_variable_get(:@mask_addr)
 
-            # If the subnet mask is equal to /32, don't output it
-            if subnet_mask == (2**32 - 1)
+            # If the subnet mask is equal to /32 for IPv4 or /128 for IPv6, don't output it
+            if (value.ipv4? && subnet_mask == IPAddr::IN4MASK) || subnet_mask == IPAddr::IN6MASK
               "\"#{value.to_s}\""
             else
               "\"#{value.to_s}/#{subnet_mask.to_s(2).count('1')}\""

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -262,7 +262,8 @@ class SchemaDumperTest < ActiveRecord::TestCase
     def test_schema_dump_includes_inet_shorthand_definition
       output = standard_dump
       if %r{create_table "postgresql_network_addresses"} =~ output
-        assert_match %r{t.inet\s+"inet_address",\s+default: "192.168.1.1"}, output
+        assert_match %r{t.inet\s+"inet_address_v4",\s+default: "192.168.1.1"}, output
+        assert_match %r{t.inet\s+"inet_address_v6",\s+default: "2001:db8:85a3::8a2e:370:7334"}, output
       end
     end
 

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -146,7 +146,8 @@ _SQL
   CREATE TABLE postgresql_network_addresses (
     id SERIAL PRIMARY KEY,
     cidr_address CIDR default '192.168.1.0/24',
-    inet_address INET default '192.168.1.1',
+    inet_address_v4 INET default '192.168.1.1',
+    inet_address_v6 INET default '2001:0db8:85a3:0000:0000:8a2e:0370:7334/128',
     mac_address MACADDR default 'ff:ff:ff:ff:ff:ff'
   );
 _SQL


### PR DESCRIPTION
ffeb7ddcf from #8010 doesn't include the "/32" when dumping inet/IPAddr IPv4 values, but still includes "/128" on IPv6 values. This patch changes that behavior, and also changes a comparison to use constants.. though IPAddr::IN4MASK is probably just about as meaningful as 2**32-1
