### PR TITLE
Allow use of assert_template with the :file option.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -16,6 +16,12 @@
 
     *Yves Senn*
 
+*   Fixed regression when using `assert_template` to verify files sent using
+    `render file: 'README.md'`.
+    Fixes #9464.
+
+    *Justin Coyne*
+
 *   Skip valid encoding checks for non-String parameters that come
     from the matched route's defaults.
     Fixes #9435.

--- a/actionpack/lib/action_view/template.rb
+++ b/actionpack/lib/action_view/template.rb
@@ -138,7 +138,7 @@ module ActionView
     # we use a bang in this instrumentation because you don't want to
     # consume this in production. This is only slow if it's being listened to.
     def render(view, locals, buffer=nil, &block)
-      ActiveSupport::Notifications.instrument("!render_template.action_view", :virtual_path => @virtual_path) do
+      ActiveSupport::Notifications.instrument("!render_template.action_view", :virtual_path => @virtual_path, :identifier=>@identifier) do
         compile!(view)
         view.send(method_name, locals, buffer, &block)
       end

--- a/actionpack/lib/action_view/test_case.rb
+++ b/actionpack/lib/action_view/test_case.rb
@@ -219,6 +219,7 @@ module ActionView
         :@_routes,
         :@controller,
         :@_layouts,
+        :@_files,
         :@_rendered_views,
         :@method_name,
         :@output_buffer,

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -96,6 +96,14 @@ class ActionPackAssertionsController < ActionController::Base
     raise "post" if request.post?
     render :text => "request method: #{request.env['REQUEST_METHOD']}"
   end
+
+  def render_file_absolute_path
+    render :file => File.expand_path('../../../README.rdoc', __FILE__)
+  end
+
+  def render_file_relative_path
+    render :file => 'README.rdoc'
+  end
 end
 
 # Used to test that assert_response includes the exception message
@@ -140,6 +148,16 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
   def test_assert_tag_and_url_for
     get :render_url
     assert_tag :content => "/action_pack_assertions/flash_me"
+  end
+
+  def test_render_file_absolute_path
+    get :render_file_absolute_path
+    assert_match /\A= Action Pack/, @response.body
+  end
+
+  def test_render_file_relative_path
+    get :render_file_relative_path
+    assert_match /\A= Action Pack/, @response.body
   end
 
   def test_get_request
@@ -439,6 +457,23 @@ class AssertTemplateTest < ActionController::TestCase
   def test_with_partial
     get :partial
     assert_template :partial => '_partial'
+  end
+
+  def test_file_with_absolute_path_success
+    get :render_file_absolute_path
+    assert_template :file => File.expand_path('../../../README.rdoc', __FILE__)
+  end
+
+  def test_file_with_relative_path_success
+    get :render_file_relative_path
+    assert_template :file => 'README.rdoc'
+  end
+
+  def test_with_file_failure
+    get :render_file_absolute_path
+    assert_raise(ActiveSupport::TestCase::Assertion) do
+      assert_template :file => 'test/hello_world'
+    end
   end
 
   def test_with_nil_passes_when_no_template_rendered


### PR DESCRIPTION
This worked in Rails 3.2, but was a regression in 4.0.0.beta1
