### PR TITLE
`ActiveRecord::Base.include_root_in_json` is `false` by default.

### DIFF
--- a/activerecord/lib/active_record/serialization.rb
+++ b/activerecord/lib/active_record/serialization.rb
@@ -5,7 +5,7 @@ module ActiveRecord #:nodoc:
     include ActiveModel::Serializers::JSON
 
     included do
-      self.include_root_in_json = true
+      self.include_root_in_json = false
     end
 
     def serializable_hash(options = nil)

--- a/activerecord/test/cases/serialization_test.rb
+++ b/activerecord/test/cases/serialization_test.rb
@@ -18,6 +18,10 @@ class SerializationTest < ActiveRecord::TestCase
     }
   end
 
+  def test_include_root_in_json_is_false_by_default
+    assert_equal false, ActiveRecord::Base.include_root_in_json, "include_root_in_json should be false by default but was not"
+  end
+
   def test_serialize_should_be_reversible
     FORMATS.each do |format|
       @serialized = Contact.new.send("to_#{format}")


### PR DESCRIPTION
Closes #9459.

The PR #6597 unified the configuration for `include_root_in_json`
in AM and AR to `false`.
Later on with the refactoring commit: e030f26 the value in AR was
set to `true` but I think this was not on purpose.

With this commit both AM and AR will have the same configuration
for `include_root_in_json`, which is `false`.
