### PR TITLE
`format: true` does not override existing format constraints.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `format: true` does not override existing format constraints.
+    Fixes #9466.
+
+    Example:
+
+        # this will force the .json extension
+        get '/json_only', to: ok, format: true, constraints: { format: /json/ }
+
+    *Yves Senn*
+
 *   Skip valid encoding checks for non-String parameters that come
     from the matched route's defaults.
     Fixes #9435.

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -129,7 +129,7 @@ module ActionDispatch
             end
 
             if options[:format] == true
-              @requirements[:format] = /.+/
+              @requirements[:format] ||= /.+/
             elsif Regexp === options[:format]
               @requirements[:format] = options[:format]
             elsif String === options[:format]

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3407,6 +3407,8 @@ class TestFormatConstraints < ActionDispatch::IntegrationTest
 
       get '/string', to: ok, constraints: { format: 'json'  }
       get '/regexp',  to: ok, constraints: { format: /json/ }
+      get '/json_only', to: ok, format: true, constraints: { format: /json/ }
+      get '/xml_only', to: ok, format: 'xml'
     end
   end
 
@@ -3432,6 +3434,28 @@ class TestFormatConstraints < ActionDispatch::IntegrationTest
     assert_response :success
 
     get 'http://www.example.com/regexp.html'
+    assert_response :not_found
+  end
+
+  def test_enforce_with_format_true_with_constraint
+    get 'http://www.example.com/json_only.json'
+    assert_response :success
+
+    get 'http://www.example.com/json_only.html'
+    assert_response :not_found
+
+    get 'http://www.example.com/json_only'
+    assert_response :not_found
+  end
+
+  def test_enforce_with_string
+    get 'http://www.example.com/xml_only.xml'
+    assert_response :success
+
+    get 'http://www.example.com/xml_only'
+    assert_response :success
+
+    get 'http://www.example.com/xml_only.json'
     assert_response :not_found
   end
 end


### PR DESCRIPTION
Closes #9466.

Passing `format: true` used to override the constraints: { format: /json/ }
with `/.+/`. This patch only sets the format if there is no constraint present.
