### PR TITLE
Fix ORA-00972 error at test_rename_table_with_prefix_and_suffix

### DIFF
--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -61,7 +61,7 @@ if ActiveRecord::Base.connection.supports_migrations?
       ActiveRecord::Base.connection.initialize_schema_migrations_table
       ActiveRecord::Base.connection.execute "DELETE FROM #{ActiveRecord::Migrator.schema_migrations_table_name}"
 
-      %w(things awesome_things prefix_things_suffix prefix_awesome_things_suffix).each do |table|
+      %w(things awesome_things prefix_things_suffix p_awesome_things_s).each do |table|
         Thing.connection.drop_table(table) rescue nil
       end
       Thing.reset_column_information
@@ -1647,8 +1647,8 @@ if ActiveRecord::Base.connection.supports_migrations?
 
     def test_rename_table_with_prefix_and_suffix
       assert !Thing.table_exists?
-      ActiveRecord::Base.table_name_prefix = 'prefix_'
-      ActiveRecord::Base.table_name_suffix = '_suffix'
+      ActiveRecord::Base.table_name_prefix = 'p_'
+      ActiveRecord::Base.table_name_suffix = '_s'
       Thing.reset_table_name
       Thing.reset_sequence_name
       WeNeedThings.up
@@ -1657,7 +1657,7 @@ if ActiveRecord::Base.connection.supports_migrations?
       assert_equal "hello world", Thing.find(:first).content
 
       RenameThings.up
-      Thing.table_name = "prefix_awesome_things_suffix"
+      Thing.table_name = "p_awesome_things_s"
 
       assert_equal "hello world", Thing.find(:first).content
     ensure


### PR DESCRIPTION
This pull request backports pull request #5837 to 3-2-stable to fix this error.

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/migration_test.rb -n 'test_rename_table_with_prefix_and_suffix'
Using oracle with Identity Map off
Run options: -n test_rename_table_with_prefix_and_suffix

# Running tests:

E

Finished tests in 0.184196s, 5.4290 tests/s, 16.2870 assertions/s.

  1) Error:
test_rename_table_with_prefix_and_suffix(MigrationTest):
ArgumentError: New sequence name 'prefix_awesome_things_suffix_seq' is too long; the limit is 30 characters
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:105:in `rename_table'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:466:in `block in method_missing'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:438:in `block in say_with_time'

1 tests, 3 assertions, 0 failures, 1 errors, 0 skips
$
```

We are going to release new version of Oracle enhanced adapter, I need to test them with the latest 3-2-stable branch.
