### PR TITLE
Revert "Skip test_remove_column_with_array_as_an_argument_is_deprecated ...

### DIFF
--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -874,8 +874,6 @@ if ActiveRecord::Base.connection.supports_migrations?
     end
 
     def test_remove_column_with_array_as_an_argument_is_deprecated
-      return skip "remove_column with array as argument is not supported with OracleAdapter" if current_adapter? :OracleAdapter
-
       ActiveRecord::Base.connection.create_table(:hats) do |table|
         table.column :hat_name, :string, :limit => 100
         table.column :hat_size, :integer
@@ -886,7 +884,7 @@ if ActiveRecord::Base.connection.supports_migrations?
         Person.connection.remove_column("hats", ["hat_name", "hat_size"])
       end
     ensure
-      ActiveRecord::Base.connection.drop_table(:hats) rescue nil
+      ActiveRecord::Base.connection.drop_table(:hats)
     end
 
     def test_removing_and_renaming_column_preserves_custom_primary_key


### PR DESCRIPTION
This reverts commit 7544c7a9f290a3ea25099ae38d52795458391785 made #6593

This pull request reverts "Skip test_remove_column_with_array_as_an_argument_is_deprecated with Oracle adapter." because Oracle enhanced adapter is supporting remove_column with Array. 

When this pull request merged, it should work as follows.

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/migration_test.rb -n test_remove_column_with_array_as_an_argument_is_deprecated
Using oracle with Identity Map off
Run options: -n test_remove_column_with_array_as_an_argument_is_deprecated

# Running tests:

.

Finished tests in 0.191176s, 5.2308 tests/s, 10.4615 assertions/s.

1 tests, 2 assertions, 0 failures, 0 errors, 0 skips
$
```
