### PR TITLE
Support PostgreSQL specific column types when using `change_table`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Support PostgreSQL specific column types when using `change_table`.
+    Fixes #9480.
+
+    Example:
+
+        change_table :authors do |t|
+          t.hstore :books
+          t.json :metadata
+        end
+
+    *Yves Senn*
+
 *   Revert 408227d9c5ed7d, 'quote numeric'. This introduced some regressions.
 
     *Steve Klabnik*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -44,8 +44,8 @@ module ActiveRecord
     # Represents the schema of an SQL table in an abstract way. This class
     # provides methods for manipulating the schema representation.
     #
-    # Inside migration files, the +t+ object in +create_table+ and
-    # +change_table+ is actually of this type:
+    # Inside migration files, the +t+ object in +create_table+
+    # is actually of this type:
     #
     #   class SomeMigration < ActiveRecord::Migration
     #     def up
@@ -489,7 +489,7 @@ module ActiveRecord
           args.each do |name|
             @base.add_column(@table_name, name, column_type, options)
           end
-        end  
+        end
       end
 
       private

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -156,7 +156,7 @@ module ActiveRecord
       #
       # See also TableDefinition#column for details on how to create columns.
       def create_table(table_name, options = {})
-        td = table_definition
+        td = create_table_definition
         td.primary_key(options[:primary_key] || Base.get_primary_key(table_name.to_s.singularize)) unless options[:id] == false
 
         yield td if block_given?
@@ -298,10 +298,10 @@ module ActiveRecord
       def change_table(table_name, options = {})
         if supports_bulk_alter? && options[:bulk]
           recorder = ActiveRecord::Migration::CommandRecorder.new(self)
-          yield Table.new(table_name, recorder)
+          yield update_table_definition(table_name, recorder)
           bulk_change_table(table_name, recorder.commands)
         else
-          yield Table.new(table_name, self)
+          yield update_table_definition(table_name, self)
         end
       end
 
@@ -727,8 +727,12 @@ module ActiveRecord
         end
 
       private
-      def table_definition
+      def create_table_definition
         TableDefinition.new(self)
+      end
+
+      def update_table_definition(table_name, base)
+        Table.new(table_name, base)
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -263,7 +263,7 @@ module ActiveRecord
         attr_accessor :array
       end
 
-      class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
+      module ColumnMethods
         def xml(*args)
           options = args.extract_options!
           column(args[0], 'xml', options)
@@ -325,6 +325,10 @@ module ActiveRecord
         def json(name, options = {})
           column(name, 'json', options)
         end
+      end
+
+      class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
+        include ColumnMethods
 
         def column(name, type = nil, options = {})
           super
@@ -342,6 +346,10 @@ module ActiveRecord
           @columns_hash[name] = definition
           definition
         end
+      end
+
+      class Table < ActiveRecord::ConnectionAdapters::Table
+        include ColumnMethods
       end
 
       ADAPTER_NAME = 'PostgreSQL'
@@ -884,8 +892,12 @@ module ActiveRecord
           $1.strip if $1
         end
 
-        def table_definition
+        def create_table_definition
           TableDefinition.new(self)
+        end
+
+        def update_table_definition(table_name, base)
+          Table.new(table_name, base)
         end
     end
   end

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -65,6 +65,21 @@ class PostgresqlHstoreTest < ActiveRecord::TestCase
     assert_equal :hstore, @column.type
   end
 
+  def test_change_table_supports_hstore
+    @connection.transaction do
+      @connection.change_table('hstores') do |t|
+        t.hstore 'users', default: ''
+      end
+      Hstore.reset_column_information
+      column = Hstore.columns.find { |c| c.name == 'users' }
+      assert_equal :hstore, column.type
+
+      raise ActiveRecord::Rollback # reset the schema change
+    end
+  ensure
+    Hstore.reset_column_information
+  end
+
   def test_type_cast_hstore
     assert @column
 

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -31,6 +31,21 @@ class PostgresqlJSONTest < ActiveRecord::TestCase
     assert_equal :json, @column.type
   end
 
+  def test_change_table_supports_json
+    @connection.transaction do
+      @connection.change_table('json_data_type') do |t|
+        t.json 'users', default: '{}'
+      end
+      JsonDataType.reset_column_information
+      column = JsonDataType.columns.find { |c| c.name == 'users' }
+      assert_equal :json, column.type
+
+      raise ActiveRecord::Rollback # reset the schema change
+    end
+  ensure
+    JsonDataType.reset_column_information
+  end
+
   def test_type_cast_json
     assert @column
 


### PR DESCRIPTION
Closes #9480.

We use `TableDefinition` for `#create_table` and `Table` for `#change_table`. The PostgreSQL sepcifc types were only defined on `TableDefinition` so I also added them to `Table`.
