### PR TITLE
Backported #6755 to 3-2-stable. Don't read csv file during executing db:fixtures:load.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## unreleased ##
+*   Don't read csv file during executing db:fixtures:load.
+
+    *kennyj*
 
 *   Reverted 921a296a3390192a71abeec6d9a035cc6d1865c8, 'Quote numeric values
     compared to string columns.' This caused several regressions.

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -355,7 +355,7 @@ db_namespace = namespace :db do
       base_dir     = File.join [Rails.root, ENV['FIXTURES_PATH'] || %w{test fixtures}].flatten
       fixtures_dir = File.join [base_dir, ENV['FIXTURES_DIR']].compact
 
-      (ENV['FIXTURES'] ? ENV['FIXTURES'].split(/,/) : Dir["#{fixtures_dir}/**/*.{yml,csv}"].map {|f| f[(fixtures_dir.size + 1)..-5] }).each do |fixture_file|
+      (ENV['FIXTURES'] ? ENV['FIXTURES'].split(/,/) : Dir["#{fixtures_dir}/**/*.yml"].map {|f| f[(fixtures_dir.size + 1)..-5] }).each do |fixture_file|
         ActiveRecord::Fixtures.create_fixtures(fixtures_dir, fixture_file)
       end
     end

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -122,6 +122,18 @@ module ApplicationTests
       assert_equal 0, ::AppTemplate::Application::User.count
     end
 
+    def test_loading_only_yml_fixtures
+      Dir.chdir(app_path) do
+        `rake db:migrate`
+      end
+
+      app_file "test/fixtures/products.csv", ""
+
+      require "#{rails_root}/config/environment"
+      errormsg = Dir.chdir(app_path) { `rake db:fixtures:load` }
+      assert $?.success?, errormsg
+    end
+
     def test_scaffold_tests_pass_by_default
       content = Dir.chdir(app_path) do
         `rails generate scaffold user username:string password:string`


### PR DESCRIPTION
CSV fixture support was removed 1716da0720419.
So I think this should be backported :smiley: 
