### PR TITLE
Relax Rack dependency

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activesupport', version
   s.add_dependency 'builder',       '~> 3.1.0'
-  s.add_dependency 'rack',          '~> 1.5.2'
+  s.add_dependency 'rack',          '>= 1.5.2'
   s.add_dependency 'rack-test',     '~> 0.6.2'
   s.add_dependency 'erubis',        '~> 2.7.0'
 


### PR DESCRIPTION
Not sure why Rack is so tight specified. I guess the are not going to happen major changes in minor releases.
