### PR TITLE
Fix ActiveRecord locking column defaults not getting persisted

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -176,6 +176,7 @@ module ActiveRecord
       @columns_hash = self.class.column_types.dup
 
       init_internals
+      init_changed_attributes
       ensure_proper_type
       populate_with_current_scope_attributes
 
@@ -246,9 +247,7 @@ module ActiveRecord
       run_callbacks(:initialize) unless _initialize_callbacks.empty?
 
       @changed_attributes = {}
-      self.class.column_defaults.each do |attr, orig_value|
-        @changed_attributes[attr] = orig_value if _field_changed?(attr, orig_value, @attributes[attr])
-      end
+      init_changed_attributes
 
       @aggregation_cache = {}
       @association_cache = {}
@@ -432,6 +431,15 @@ module ActiveRecord
       @_start_transaction_state = {}
       @transaction_state        = nil
       @reflects_state           = [false]
+    end
+
+    def init_changed_attributes
+      # Intentionally avoid using #column_defaults since overriden defaults (as is done in
+      # optimistic locking) won't get written unless they get marked as changed
+      self.class.columns.each do |c|
+        attr, orig_value = c.name, c.default
+        @changed_attributes[attr] = orig_value if _field_changed?(attr, orig_value, @attributes[attr])
+      end
     end
   end
 end

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -193,10 +193,18 @@ class OptimisticLockingTest < ActiveRecord::TestCase
   def test_lock_without_default_sets_version_to_zero
     t1 = LockWithoutDefault.new
     assert_equal 0, t1.lock_version
+
+    t1.save
+    t1 = LockWithoutDefault.find(t1.id)
+    assert_equal 0, t1.lock_version
   end
 
   def test_lock_with_custom_column_without_default_sets_version_to_zero
     t1 = LockWithCustomColumnWithoutDefault.new
+    assert_equal 0, t1.custom_lock_version
+
+    t1.save
+    t1 = LockWithCustomColumnWithoutDefault.find(t1.id)
     assert_equal 0, t1.custom_lock_version
   end
 


### PR DESCRIPTION
TL;DR; Overridden column defaults do not get marked as changed for new records, causing the locking column default to not get saved

**Premise**: In `ActiveRecord::Locking::Optimistic#column_defaults` we set the default value for the locking column to `0` if it's not already set by the database.

**Problem**: Due to the introduction of partial inserts @ 144e8691cbfb8bba77f18cfe68d5e7fd48887f5e, this overridden default will get ignored and never persisted to the database.  This results in the locking column having a `nil` value for new records.  The reason this happens is because `ActiveRecord::AttributeMethods::Dirty#keys_for_partial_write` will skip writing attributes that are not marked as changed.  When a new record's default attributes are set, the list of changed attributes is always assumed to be empty -- we don't actually check to verify that.

**Solution**: When a new record's default attributes are set, _also_ initialize the list of changed attributes by comparing current values against what's stored as the column defaults.  This initialization step intentionally does not use the `#column_defaults` helper since that's what's used by `ActiveRecord::Locking::Optimistic` to set the overridden default in the first place.

**Verification**: Two existing locking tests have been modified to verify that they're locking column defaults are persisted to the database.  These tests were failing prior to this change.

This change will also fix other libraries that have been relying on this behavior.
