### PR TITLE
Wrong exception is occured when raising no translatable exception

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix a problem wrong exception is occured
+    when raising no translatable exception in PostgreSQL. 
+
+    *kennyj*
+
 *   Support PostgreSQL specific column types when using `change_table`.
     Fixes #9480.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -675,6 +675,8 @@ module ActiveRecord
         UNIQUE_VIOLATION      = "23505"
 
         def translate_exception(exception, message)
+          return exception unless exception.respond_to?(:result)
+
           case exception.result.try(:error_field, PGresult::PG_DIAG_SQLSTATE)
           when UNIQUE_VIOLATION
             RecordNotUnique.new(message, exception)

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -250,6 +250,12 @@ module ActiveRecord
         assert_equal "DISTINCT posts.title, posts.updater_id AS alias_0", @connection.distinct("posts.title", ["posts.updater_id desc nulls last"])
       end
 
+      def test_raise_error_when_cannot_translate_exception
+        assert_raise TypeError do
+          @connection.send(:log, nil) { @connection.execute(nil) }
+        end
+      end
+
       private
       def insert(ctx, data)
         binds   = data.map { |name, value|


### PR DESCRIPTION
When investigating #9491, I found another problem.

If we execute added testcase without this fix, you can see

```
undefined method `result' for #<NoMethodError:0x0000000377d8e8>
```

This message is wrong, because we expect TypeError (original exception).

I think this issue was introduced since my PR 2fe281323c8ccebc592d423b69b5b03ac9254b29 .
