### PR TITLE
Fix ActiveRecord `subclass_from_attrs` when eager_load is false.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix ActiveRecord `subclass_from_attrs` when eager_load is false.
+    It cannot find subclass because all classes are loaded automatically
+    when it needs.
+
+    *Dmitry Vorotilin*
+
 *   Assigning "0.0" to a nullable numeric column does not make it dirty.
     Fix #9034.
 

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -167,8 +167,9 @@ module ActiveRecord
       # this will ignore the inheritance column and return nil
       def subclass_from_attrs(attrs)
         subclass_name = attrs.with_indifferent_access[inheritance_column]
-        return nil if subclass_name.blank? || subclass_name == self.name
-        unless subclass = subclasses.detect { |sub| sub.name == subclass_name }
+        return if subclass_name.blank? || subclass_name == self.name
+        subclass = subclass_name.safe_constantize
+        unless subclasses.include?(subclass)
           raise ActiveRecord::SubclassNotFound.new("Invalid single-table inheritance type: #{subclass_name} is not a subclass of #{name}")
         end
         subclass

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -179,6 +179,17 @@ class InheritanceTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::SubclassNotFound) { Company.new(:type => 'Account') }
   end
 
+  def test_new_with_autoload_paths
+    path = File.expand_path('../../models/autoloadable', __FILE__)
+    ActiveSupport::Dependencies.autoload_paths << path
+
+    firm = Company.new(:type => 'ExtraFirm')
+    assert_equal ExtraFirm, firm.class
+  ensure
+    ActiveSupport::Dependencies.autoload_paths.reject! { |p| p == path }
+    ActiveSupport::Dependencies.clear
+  end
+
   def test_inheritance_condition
     assert_equal 10, Company.count
     assert_equal 2, Firm.count

--- a/activerecord/test/models/autoloadable/extra_firm.rb
+++ b/activerecord/test/models/autoloadable/extra_firm.rb
@@ -1,0 +1,2 @@
+class ExtraFirm < Company
+end


### PR DESCRIPTION
It cannot find subclass because all classes are loaded automatically
when it needs. So this way for development mode if we have:

`models/person.rb`

```
class Person < AR
end
```

`models/user.rb`

```
class User < Person
end

Person.subclasses #=> will be []
User # => Try to load this model manually
Person.subclasses #=> will be [User]
```

And `Person.new(type: 'User')` will raise error `ActiveRecord::SubclassNotFound`
