### PR TITLE
deal with `#append` and `#prepend` on association collections

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,12 +1,18 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   The `#append` method for collection associations behaves like`<<`.
+    `#prepend` is not defined and `<<` or `#append` should be used.
+    Fixes #7364.
+
+    *Yves Senn*
+
 *   Added support for creating a table via Rails migration generator.
-    For example, 
+    For example,
 
         rails g migration create_books title:string content:text
 
-    will generate a migration that creates a table called books with 
-    the listed attributes, without creating a model. 
+    will generate a migration that creates a table called books with
+    the listed attributes, without creating a model.
 
     *Sammy Larbi*
 
@@ -372,7 +378,7 @@
     deprecated and removed in future versions of Rails.
 
     *Amparo Luna + Guillermo Iguaran*
-    
+
 *   `after_commit` and `after_rollback` now validate the `:on` option and raise an `ArgumentError`
     if it is not one of `:create`, `:destroy` or `:update`
 

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -83,9 +83,9 @@ module ActiveRecord
       #   #      #<Pet id: 3, name: "Choo-Choo">
       #   #    ]
       #
-      # Be careful because this also means you’re initializing a model
-      # object with only the fields that you’ve selected. If you attempt
-      # to access a field that is not in the initialized record you’ll
+      # Be careful because this also means you're initializing a model
+      # object with only the fields that you've selected. If you attempt
+      # to access a field that is not in the initialized record you'll
       # receive:
       #
       #   person.pets.select(:name).first.person_id
@@ -924,7 +924,7 @@ module ActiveRecord
       alias_method :to_a, :to_ary
 
       # Adds one or more +records+ to the collection by setting their foreign keys
-      # to the association‘s primary key. Returns +self+, so several appends may be
+      # to the association's primary key. Returns +self+, so several appends may be
       # chained together.
       #
       #   class Person < ActiveRecord::Base

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -947,6 +947,11 @@ module ActiveRecord
         proxy_association.concat(records) && self
       end
       alias_method :push, :<<
+      alias_method :append, :<<
+
+      def prepend(*args)
+        raise NoMethodError, "prepend on association is not defined. Please use << or append"
+      end
 
       # Equivalent to +delete_all+. The difference is that returns +self+, instead
       # of an array with the deleted objects, so methods can be chained. See

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -172,6 +172,18 @@ class AssociationProxyTest < ActiveRecord::TestCase
     assert_equal 1, josh.posts.size
   end
 
+  def test_append_behaves_like_push
+    josh = Author.new(:name => "Josh")
+    josh.posts.append Post.new(:title => "New on Edge", :body => "More cool stuff!")
+    assert josh.posts.loaded?
+    assert_equal 1, josh.posts.size
+  end
+
+  def test_prepend_is_not_defined
+    josh = Author.new(:name => "Josh")
+    assert_raises(NoMethodError) { josh.posts.prepend Post.new }
+  end
+
   def test_save_on_parent_does_not_load_target
     david = developers(:david)
 
@@ -291,7 +303,7 @@ class OverridingAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_requires_symbol_argument
-    assert_raises ArgumentError do 
+    assert_raises ArgumentError do
       Class.new(Post) do
         belongs_to "author"
       end


### PR DESCRIPTION
Closes #7364.

Collection associations behave similar to Arrays. However there is no way to prepend records. And to append one should use `<<`. Before this patch `#append` and `#prepend` did not add the record to the loaded association.

`#append` now behaves like `<<` and `#prepend` is not defined.
