### PR TITLE
config.reload_classes_only_on_change doesn't honor model mtimes

### DIFF
--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -81,7 +81,7 @@ module Rails
           self.reloaders << reloader
           # We need to set a to_prepare callback regardless of the reloader result, i.e.
           # models should be reloaded if any of the reloaders (i18n, routes) were updated.
-          ActionDispatch::Reloader.to_prepare(:prepend => true){ reloader.execute }
+          ActionDispatch::Reloader.to_prepare(:prepend => true){ reloader.execute_if_updated }
         else
           ActionDispatch::Reloader.to_cleanup(&callback)
         end


### PR DESCRIPTION
Relating to Rails 3-2-stable 

I believe the `config.reload_classes_only_on_change` option does not act as expected.

Code starting here:
https://github.com/rails/rails/blob/3-2-stable/railties/lib/rails/application/finisher.rb#L79

``` ruby
if config.reload_classes_only_on_change
  reloader = config.file_watcher.new(*watchable_args, &callback)
  self.reloaders << reloader
  # We need to set a to_prepare callback regardless of the reloader result, i.e.
  # models should be reloaded if any of the reloaders (i18n, routes) were updated.
  ActionDispatch::Reloader.to_prepare(:prepend => true){ reloader.execute }
else
  ActionDispatch::Reloader.to_cleanup(&callback)
end
```

Is supposed to only reload dependencies if the mtimes of files have changed. That is what the class ActiveSupport::FileUpdateChecker provides as on of the default reloaders. 

But `ActionDispatch::Reloader.to_prepare(:prepend => true){ reloader.execute }` that line will reload all the dependencies regardless if mtimes. 

def execute 
https://github.com/rails/rails/blob/3-2-stable/activesupport/lib/active_support/file_update_checker.rb#L76

I believe that line should be 

``` ruby
ActionDispatch::Reloader.to_prepare(:prepend => true){ reloader.execute_if_updated }
```

def execute_if_updated
https://github.com/rails/rails/blob/3-2-stable/activesupport/lib/active_support/file_update_checker.rb#L84

This way your application code is only reloaded if it has been updated. 
