### PR TITLE
fix load order of console sandbox

### DIFF
--- a/railties/lib/rails/commands/console.rb
+++ b/railties/lib/rails/commands/console.rb
@@ -46,6 +46,7 @@ module Rails
     def initialize(app, options={})
       @app     = app
       @options = options
+      app.sandbox = sandbox?
       app.load_console
       @console = app.config.console || IRB
     end
@@ -71,7 +72,6 @@ module Rails
     end
 
     def start
-      app.sandbox = sandbox?
       require_debugger if debugger?
       set_environment! if environment?
 


### PR DESCRIPTION
This fixes the load order problem described in #9513. It is not a complete fix for #9513 though. As pointed out by @nashby the load order was messed up so that `app.sandbox` was nil when the AR console initializer ran. This is now fixed.

Even after the fix the data created will not rollback. There is still something fishy going on with the sandboxing of the console. That's why I did not add a CHANGELOG entry but I think we should merge this to help other people, who are looking at the sandboxing problem.
