### PR TITLE
ActiveSupport::Dependencies::Loadable#load_dependency blindly calls blame_file! on Exceptions

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## unreleased ##
 
+*   Fix `ActiveSupport::Dependencies::Loadable#load_dependency` calling
+    `#blame_file!` on Exceptions that do not have the Blamable mixin
+
+    *Andrew Kreiling*
+
 *   Fix DateTime comparison with DateTime::Infinity object.
 
     *Dan Kubb*

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -236,7 +236,7 @@ module ActiveSupport #:nodoc:
           yield
         end
       rescue Exception => exception  # errors from loading file
-        exception.blame_file! file
+        exception.blame_file! file if exception.respond_to? :blame_file!
         raise
       end
 

--- a/activesupport/test/dependencies/raises_exception_without_blame_file.rb
+++ b/activesupport/test/dependencies/raises_exception_without_blame_file.rb
@@ -1,0 +1,5 @@
+exception = Exception.new('I am not blamable!')
+class << exception
+  undef_method(:blame_file!)
+end
+raise exception

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -84,6 +84,20 @@ class DependenciesTest < Test::Unit::TestCase
     end
   end
 
+  def test_dependency_which_raises_doesnt_blindly_call_blame_file!
+    with_loading do
+      filename = 'dependencies/raises_exception_without_blame_file'
+      $raises_exception_load_count = 0
+
+      begin
+        require_dependency filename
+        flunk 'should have loaded dependencies/raises_exception which raises an exception'
+      rescue Exception => e
+        assert_equal 'I am not blamable!', e.message
+      end
+    end
+  end
+
   def test_warnings_should_be_enabled_on_first_load
     with_loading 'dependencies' do
       old_warnings, ActiveSupport::Dependencies.warnings_on_first_load = ActiveSupport::Dependencies.warnings_on_first_load, true


### PR DESCRIPTION
It is possible under some environments to receive an Exception that is not extended with Blamable (e.g. JRuby). ActiveSupport::Dependencies::Loadable#load_dependency blindly call blame_file! on the exception which throws it's own NoMethodError exception and hides the original Exception.
