### PR TITLE
ActiveSupport::Notifications::Instrumenter#instrument should yield

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `ActiveSupport::Notifications::Instrumenter#instrument` should yield
+    its payload.
+
+    *stopdropandrew*
+
 *   Fix deletion of empty directories in ActiveSupport::Cache::FileStore.
-    
+
     *Charles Jones*
 
 ## Rails 4.0.0.beta1 (February 25, 2013) ##

--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -17,7 +17,7 @@ module ActiveSupport
       def instrument(name, payload={})
         start name, payload
         begin
-          yield
+          yield payload
         rescue Exception => e
           payload[:exception] = [e.class.name, e.message]
           raise e

--- a/activesupport/test/notifications/instrumenter_test.rb
+++ b/activesupport/test/notifications/instrumenter_test.rb
@@ -34,6 +34,14 @@ module ActiveSupport
         assert called
       end
 
+      def test_instrument_yields_the_payload_for_further_modification
+        assert_equal 2, instrumenter.instrument("awesome") { |p| p[:result] = 1 + 1 }
+        assert_equal 1, notifier.finishes.size
+        name, _, payload = notifier.finishes.first
+        assert_equal "awesome", name
+        assert_equal Hash[:result => 2], payload
+      end
+
       def test_start
         instrumenter.start("foo", payload)
         assert_equal [["foo", instrumenter.id, payload]], notifier.starts

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -157,7 +157,7 @@ module Notifications
       assert_equal 2, instrument(:awesome) { 1 + 1 }
     end
 
-    def test_instrument_yields_the_paylod_for_further_modification
+    def test_instrument_yields_the_payload_for_further_modification
       assert_equal 2, instrument(:awesome) { |p| p[:result] = 1 + 1 }
       assert_equal 1, @events.size
       assert_equal :awesome, @events.first.name


### PR DESCRIPTION
ActiveSupport::Notifications::Instrumenter#instrument should yield its payload the same way that ActiveSupport::Notifications does.

This allows you to cache the instrumenter (like in ActiveRecord's AbstractAdapter) but still yield the payload to the block.

This works:

``` ruby
ActiveSupport::Notifications.instrument("pull") do |payload|
  payload[:result] = "success"
end
```

But this doesn't:

``` ruby
ActiveSupport::Notifications.instrumenter.instrument("pull") do |payload|
  payload[:result] = "success"
end
```
