### PR TITLE
Fix unused variable warning in mapper.rb

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -67,8 +67,6 @@ module ActionDispatch
         private
 
           def normalize_options!
-            path_without_format = @path.sub(/\(\.:format\)$/, '')
-
             @options.merge!(default_controller_and_action)
 
             requirements.each do |name, requirement|


### PR DESCRIPTION
I currently get this warning when loading Rails:

```
~/.rvm/gems/ruby-head/gems/actionpack-3.2.13.rc1/lib/action_dispatch/routing/mapper.rb:70: warning: assigned but unused variable - path_without_format
```

This patch fixes the warning.
