### PR TITLE
`Connection#structure_dump` is no longer used

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Warn when `rake db:structure:dump` with a mysl database and
+    `mysqldump` is not in the PATH or fails.
+    Fixes #9518.
+
+    *Yves Senn*
+
 *   Remove `connection#structure_dump`, which is no longer used. *Yves Senn*
 
 *   Make it possible to execute migrations without a transaction even

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Remove `connection#structure_dump`, which is no longer used. *Yves Senn*
+
 *   Make it possible to execute migrations without a transaction even
     if the database adapter supports DDL transactions.
     Fixes #9483.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -516,11 +516,6 @@ module ActiveRecord
       end
       alias :remove_belongs_to :remove_reference
 
-      # Returns a string of <tt>CREATE TABLE</tt> SQL statement(s) for recreating the
-      # entire structure of the database.
-      def structure_dump
-      end
-
       def dump_schema_information #:nodoc:
         sm_table = ActiveRecord::Migrator.schema_migrations_table_name
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -332,20 +332,6 @@ module ActiveRecord
 
       # SCHEMA STATEMENTS ========================================
 
-      def structure_dump #:nodoc:
-        if supports_views?
-          sql = "SHOW FULL TABLES WHERE Table_type = 'BASE TABLE'"
-        else
-          sql = "SHOW TABLES"
-        end
-
-        select_all(sql, 'SCHEMA').map { |table|
-          table.delete('Table_type')
-          sql = "SHOW CREATE TABLE #{quote_table_name(table.to_a.first.last)}"
-          exec_query(sql, 'SCHEMA').first['Create Table'] + ";\n\n"
-        }.join
-      end
-
       # Drops the database specified on the +name+ attribute
       # and creates it again using the provided +options+.
       def recreate_database(name, options = {})

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -57,7 +57,10 @@ module ActiveRecord
         args.concat(["--result-file", "#{filename}"])
         args.concat(["--no-data"])
         args.concat(["#{configuration['database']}"])
-        Kernel.system(*args)
+        unless Kernel.system(*args)
+          $stderr.puts "Could not dump the database structure. "\
+                       "Make sure `mysqldump` is in your PATH and check the command output for warnings."
+        end
       end
 
       def structure_load(filename)

--- a/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
@@ -63,11 +63,6 @@ class MysqlReservedWordTest < ActiveRecord::TestCase
     assert_nothing_raised { @connection.rename_column(:group, :order, :values) }
   end
 
-  # dump structure of table with reserved word name
-  def test_structure_dump
-    assert_nothing_raised { @connection.structure_dump  }
-  end
-
   # introspect table with reserved word name
   def test_introspect
     assert_nothing_raised { @connection.columns(:group) }

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -70,12 +70,6 @@ class MysqlConnectionTest < ActiveRecord::TestCase
     end
   end
 
-  def test_logs_name_structure_dump
-    @connection.structure_dump
-    assert_equal "SCHEMA", @connection.logged[0][1]
-    assert_equal "SCHEMA", @connection.logged[2][1]
-  end
-
   def test_logs_name_show_variable
     @connection.show_variable 'foo'
     assert_equal "SCHEMA", @connection.logged[0][1]

--- a/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
@@ -63,11 +63,6 @@ class MysqlReservedWordTest < ActiveRecord::TestCase
     assert_nothing_raised { @connection.rename_column(:group, :order, :values) }
   end
 
-  # dump structure of table with reserved word name
-  def test_structure_dump
-    assert_nothing_raised { @connection.structure_dump  }
-  end
-
   # introspect table with reserved word name
   def test_introspect
     assert_nothing_raised { @connection.columns(:group) }

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -249,9 +249,20 @@ module ActiveRecord
 
     def test_structure_dump
       filename = "awesome-file.sql"
-      Kernel.expects(:system).with("mysqldump", "--result-file", filename, "--no-data", "test-db")
+      Kernel.expects(:system).with("mysqldump", "--result-file", filename, "--no-data", "test-db").returns(true)
 
       ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
+    end
+
+    def test_warn_when_external_structure_dump_fails
+      filename = "awesome-file.sql"
+      Kernel.expects(:system).with("mysqldump", "--result-file", filename, "--no-data", "test-db").returns(false)
+
+      warnings = capture(:stderr) do
+        ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
+      end
+
+      assert_match(/Could not dump the database structure/, warnings)
     end
   end
 


### PR DESCRIPTION
Origin: #9518

As of ccc6910c we use `mysqldump` to create the `structure.sql`.
The old `#structure_dump` code is still in AR but never used.

I removed all relevant parts from the code-base.

Even though this is just a cleanup I added a CHANGELOG entry. There could be gem authors or app owners that used `#structure_dump`, which will no longer be available.

I've also added a commit to issue a warning when `mysqldump` is not in the PATH. The rake task used to fail silently and left an empty `structure.sql`, which is not very helpful.
