### PR TITLE
Fix formats on xhr requests when HTTP_ACCEPT is empty string

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -121,7 +121,7 @@ module ActionDispatch
       BROWSER_LIKE_ACCEPTS = /,\s*\*\/\*|\*\/\*\s*,/
 
       def valid_accept_header
-        (xhr? && (accept || content_mime_type)) ||
+        (xhr? && (accept.present? || content_mime_type)) ||
           (accept.present? && accept !~ BROWSER_LIKE_ACCEPTS)
       end
 

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -594,6 +594,11 @@ class RequestTest < ActiveSupport::TestCase
     request.expects(:parameters).at_least_once.returns({})
     assert_equal [Mime::HTML], request.formats
 
+    request = stub_request 'HTTP_ACCEPT' => '',
+                           'HTTP_X_REQUESTED_WITH' => "XMLHttpRequest"
+    request.expects(:parameters).at_least_once.returns({})
+    assert_equal [Mime::JS], request.formats
+    
     request = stub_request 'CONTENT_TYPE' => 'application/xml; charset=UTF-8',
                            'HTTP_X_REQUESTED_WITH' => "XMLHttpRequest"
     request.expects(:parameters).at_least_once.returns({})


### PR DESCRIPTION
Fix ActionDispatch::Request#formats on xhr requests when HTTP_ACCEPT
header is empty string. About issue #7774, same fix as in commit bebb02f
but for xhr requests.
