### PR TITLE
Fix issue #7526. Reload the association target if it's stale.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## unreleased ##
 
+*   Reload the association target if it's stale. `@stale_state` should be nil
+    when a model isn't saved.
+    Fixes #7526.
+
+    *Larry Lv*
+
 *   Don't read CSV files during execution of `db:fixtures:load`. CSV support for
     fixtures was removed some time ago but the task was still loading them, even
     though later the code was looking for the related yaml file instead.

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -72,7 +72,7 @@ module ActiveRecord
         end
 
         def stale_state
-          owner[reflection.foreign_key].to_s
+          owner[reflection.foreign_key] && owner[reflection.foreign_key].to_s
         end
     end
   end

--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -27,7 +27,8 @@ module ActiveRecord
         end
 
         def stale_state
-          [super, owner[reflection.foreign_type].to_s]
+          foreign_key = super
+          foreign_key && [foreign_key.to_s, owner[reflection.foreign_type].to_s]
         end
     end
   end

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -62,7 +62,7 @@ module ActiveRecord
         # properly support stale-checking for nested associations.
         def stale_state
           if through_reflection.macro == :belongs_to
-            owner[through_reflection.foreign_key].to_s
+            owner[through_reflection.foreign_key] && owner[through_reflection.foreign_key].to_s
           end
         end
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -14,6 +14,8 @@ require 'models/sponsor'
 require 'models/member'
 require 'models/essay'
 require 'models/toy'
+require 'models/person'
+require 'models/reader'
 
 class BelongsToAssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :topics,
@@ -715,5 +717,17 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     sponsor = Sponsor.create!(:sponsorable => toy)
 
     assert_equal toy, sponsor.reload.sponsorable
+  end
+
+  def test_saving_nested_association
+    post1, post2 = Post.limit(2)
+    person = Person.new(:first_name => 'foo')
+    reader = Reader.new(:post => post1)
+
+    reader.post_id = post2.id
+    person.readers = [reader]
+
+    assert person.save
+    assert_equal reader.post_id, post2.id
   end
 end


### PR DESCRIPTION
- Fix issue #7526. The target's state is stale, but is not reloaded.
- This has been fixed at master via [365b8b6](https://github.com/rails/rails/commit/365b8b6db750151b786b0a7ef9e65a6824576f1b), but not at 3-2-stable branch.
- `@stale_state` should be nil when a model isn't saved. via [0f3901e](https://github.com/rails/rails/commit/0f3901e9101837eaab2daba5b01f67ed7e2c75d5).
- set `@stale_state` to nil when reset the target.
