### PR TITLE
Remove WhereChain, and implement where_not.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Altered where.not syntax to where_not. The behavior is the same, but
+    method-chaining is no longer necessary.
+
+    *Ernie Miller*
+
 *   Added functionality to unscope relations in a relations chain. For
     instance, if you are passed in a chain of relations as follows:
 

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -7,8 +7,9 @@ module ActiveRecord
     delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, :to => :all
     delegate :find_each, :find_in_batches, :to => :all
     delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins,
-             :where, :preload, :eager_load, :includes, :from, :lock, :readonly,
-             :having, :create_with, :uniq, :references, :none, :to => :all
+             :where, :where_not, :preload, :eager_load, :includes, :from, :lock,
+             :readonly, :having, :create_with, :uniq, :references, :none,
+             :to => :all
     delegate :count, :average, :minimum, :maximum, :sum, :calculate, :pluck, :ids, :to => :all
 
     # Executes a custom SQL query against your database and returns all the results. The results will

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -4,55 +4,6 @@ module ActiveRecord
   module QueryMethods
     extend ActiveSupport::Concern
 
-    # WhereChain objects act as placeholder for queries in which #where does not have any parameter.
-    # In this case, #where must be chained with either #not, #like, or #not_like to return a new relation.
-    class WhereChain
-      def initialize(scope)
-        @scope = scope
-      end
-
-      # Returns a new relation expressing WHERE + NOT condition according to
-      # the conditions in the arguments.
-      #
-      # +not+ accepts conditions as a string, array, or hash. See #where for
-      # more details on each format.
-      #
-      #    User.where.not("name = 'Jon'")
-      #    # SELECT * FROM users WHERE NOT (name = 'Jon')
-      #
-      #    User.where.not(["name = ?", "Jon"])
-      #    # SELECT * FROM users WHERE NOT (name = 'Jon')
-      #
-      #    User.where.not(name: "Jon")
-      #    # SELECT * FROM users WHERE name != 'Jon'
-      #
-      #    User.where.not(name: nil)
-      #    # SELECT * FROM users WHERE name IS NOT NULL
-      #
-      #    User.where.not(name: %w(Ko1 Nobu))
-      #    # SELECT * FROM users WHERE name NOT IN ('Ko1', 'Nobu')
-      #
-      #    User.where.not(name: "Jon", role: "admin")
-      #    # SELECT * FROM users WHERE name != 'Jon' AND role != 'admin'
-      #
-      def not(opts, *rest)
-        where_value = @scope.send(:build_where, opts, rest).map do |rel|
-          case rel
-          when Arel::Nodes::In
-            Arel::Nodes::NotIn.new(rel.left, rel.right)
-          when Arel::Nodes::Equality
-            Arel::Nodes::NotEqual.new(rel.left, rel.right)
-          when String
-            Arel::Nodes::Not.new(Arel::Nodes::SqlLiteral.new(rel))
-          else
-            Arel::Nodes::Not.new(rel)
-          end
-        end
-        @scope.where_values += where_value
-        @scope
-      end
-    end
-
     Relation::MULTI_VALUE_METHODS.each do |name|
       class_eval <<-CODE, __FILE__, __LINE__ + 1
         def #{name}_values                   # def select_values
@@ -511,39 +462,63 @@ module ActiveRecord
     #    User.joins(:posts).where({ "posts.published" => true })
     #    User.joins(:posts).where({ posts: { published: true } })
     #
-    # === no argument
-    #
-    # If no argument is passed, #where returns a new instance of WhereChain, that
-    # can be chained with #not to return a new relation that negates the where clause.
-    #
-    #    User.where.not(name: "Jon")
-    #    # SELECT * FROM users WHERE name != 'Jon'
-    #
-    # See WhereChain for more details on #not.
-    #
     # === blank condition
     #
     # If the condition is any blank-ish object, then #where is a no-op and returns
     # the current relation.
-    def where(opts = :chain, *rest)
-      if opts == :chain
-        WhereChain.new(spawn)
-      elsif opts.blank?
-        self
-      else
-        spawn.where!(opts, *rest)
-      end
+    def where(opts, *rest)
+      opts.blank? ? self : spawn.where!(opts, *rest)
     end
 
-    def where!(opts = :chain, *rest) # :nodoc:
-      if opts == :chain
-        WhereChain.new(self)
-      else
-        references!(PredicateBuilder.references(opts)) if Hash === opts
+    # Returns a new relation expressing WHERE + NOT condition according to
+    # the conditions in the arguments.
+    #
+    # +where_not+ accepts conditions as a string, array, or hash. See #where for
+    # more details on each format.
+    #
+    #    User.where_not("name = 'Jon'")
+    #    # SELECT * FROM users WHERE NOT (name = 'Jon')
+    #
+    #    User.where_not(["name = ?", "Jon"])
+    #    # SELECT * FROM users WHERE NOT (name = 'Jon')
+    #
+    #    User.where_not(name: "Jon")
+    #    # SELECT * FROM users WHERE name != 'Jon'
+    #
+    #    User.where_not(name: nil)
+    #    # SELECT * FROM users WHERE name IS NOT NULL
+    #
+    #    User.where_not(name: %w(Ko1 Nobu))
+    #    # SELECT * FROM users WHERE name NOT IN ('Ko1', 'Nobu')
+    #
+    #    User.where_not(name: "Jon", role: "admin")
+    #    # SELECT * FROM users WHERE name != 'Jon' AND role != 'admin'
+    #
+    def where_not(opts, *rest)
+      opts.blank? ? self : spawn.where_not!(opts, *rest)
+    end
 
-        self.where_values += build_where(opts, rest)
-        self
+    def where!(opts, *rest) # :nodoc:
+      references!(PredicateBuilder.references(opts)) if Hash === opts
+      self.where_values += build_where(opts, rest)
+      self
+    end
+
+    def where_not!(opts, *rest) # :nodoc:
+      where_value = build_where(opts, rest).map do |rel|
+        case rel
+        when Arel::Nodes::In
+          Arel::Nodes::NotIn.new(rel.left, rel.right)
+        when Arel::Nodes::Equality
+          Arel::Nodes::NotEqual.new(rel.left, rel.right)
+        when String
+          Arel::Nodes::Not.new(Arel::Nodes::SqlLiteral.new(rel))
+        else
+          Arel::Nodes::Not.new(rel)
+        end
       end
+      self.where_values += where_value
+      self
     end
 
     # Allows to specify a HAVING clause. Note that you can't use HAVING

--- a/activerecord/test/cases/relation/where_not_test.rb
+++ b/activerecord/test/cases/relation/where_not_test.rb
@@ -3,35 +3,35 @@ require 'models/post'
 require 'models/comment'
 
 module ActiveRecord
-  class WhereChainTest < ActiveRecord::TestCase
+  class WhereNotTest < ActiveRecord::TestCase
     fixtures :posts
 
     def test_not_eq
       expected = Arel::Nodes::NotEqual.new(Post.arel_table[:title], 'hello')
-      relation = Post.where.not(title: 'hello')
+      relation = Post.where_not(title: 'hello')
       assert_equal([expected], relation.where_values)
     end
 
     def test_not_null
       expected = Arel::Nodes::NotEqual.new(Post.arel_table[:title], nil)
-      relation = Post.where.not(title: nil)
+      relation = Post.where_not(title: nil)
       assert_equal([expected], relation.where_values)
     end
 
     def test_not_in
       expected = Arel::Nodes::NotIn.new(Post.arel_table[:title], %w[hello goodbye])
-      relation = Post.where.not(title: %w[hello goodbye])
+      relation = Post.where_not(title: %w[hello goodbye])
       assert_equal([expected], relation.where_values)
     end
 
     def test_association_not_eq
       expected = Arel::Nodes::NotEqual.new(Comment.arel_table[:title], 'hello')
-      relation = Post.joins(:comments).where.not(comments: {title: 'hello'})
+      relation = Post.joins(:comments).where_not(comments: {title: 'hello'})
       assert_equal(expected.to_sql, relation.where_values.first.to_sql)
     end
 
     def test_not_eq_with_preceding_where
-      relation = Post.where(title: 'hello').where.not(title: 'world')
+      relation = Post.where(title: 'hello').where_not(title: 'world')
 
       expected = Arel::Nodes::Equality.new(Post.arel_table[:title], 'hello')
       assert_equal(expected, relation.where_values.first)
@@ -41,7 +41,7 @@ module ActiveRecord
     end
 
     def test_not_eq_with_succeeding_where
-      relation = Post.where.not(title: 'hello').where(title: 'world')
+      relation = Post.where_not(title: 'hello').where(title: 'world')
 
       expected = Arel::Nodes::NotEqual.new(Post.arel_table[:title], 'hello')
       assert_equal(expected, relation.where_values.first)
@@ -52,18 +52,18 @@ module ActiveRecord
 
     def test_not_eq_with_string_parameter
       expected = Arel::Nodes::Not.new("title = 'hello'")
-      relation = Post.where.not("title = 'hello'")
+      relation = Post.where_not("title = 'hello'")
       assert_equal([expected], relation.where_values)
     end
 
     def test_not_eq_with_array_parameter
       expected = Arel::Nodes::Not.new("title = 'hello'")
-      relation = Post.where.not(['title = ?', 'hello'])
+      relation = Post.where_not(['title = ?', 'hello'])
       assert_equal([expected], relation.where_values)
     end
 
     def test_chaining_multiple
-      relation = Post.where.not(author_id: [1, 2]).where.not(title: 'ruby on rails')
+      relation = Post.where_not(author_id: [1, 2]).where_not(title: 'ruby on rails')
 
       expected = Arel::Nodes::NotIn.new(Post.arel_table[:author_id], [1, 2])
       assert_equal(expected, relation.where_values[0])


### PR DESCRIPTION
While the WhereChain implementation made some sense when we were
supporting where.not, where.like, and where.not_like, it doesn't
really make sense when supporting only the where.not case.

This commit removes WhereChain and implements where_not, instead. While
the method-chaining version might seem a bit prettier (I do tend to
think a dot is more attractive than an underscore) it also incurs extra
method call overhead and makes the implementation more complex to read,
as well.
