### PR TITLE
Ability to manually remove single class cache entry

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -547,6 +547,10 @@ module ActiveSupport #:nodoc:
         self
       end
 
+      def delete(key)
+        @store.delete(key)
+      end
+
       def clear!
         @store.clear
       end

--- a/activesupport/test/class_cache_test.rb
+++ b/activesupport/test/class_cache_test.rb
@@ -14,6 +14,14 @@ module ActiveSupport
         assert !@cache.empty?
       end
 
+      def test_delete!
+        assert @cache.empty?
+        @cache.store(ClassCacheTest)
+        assert @cache.key?(ClassCacheTest.name)
+        @cache.delete(ClassCacheTest.name)
+        assert @cache.empty?
+      end
+
       def test_clear!
         assert @cache.empty?
         @cache.store(ClassCacheTest)


### PR DESCRIPTION
Sometimes within specs it might be useful to substitute particular controller class. However Rails caches its instance if it was already queried before.  So the trick won't work. Currently it's only possible to clear up all the cache at once. Let's add tiny method that allows deletion of particular key. It might be useful for other `ClassCache` users too as well.
