### PR TITLE
Calling .to_json on TimeWithZone objects causes an error when TimeWithZone's "time" method returns a DateTime object rather than a Time object

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Pick `DateField` `DateTimeField` and `ColorField` values from stringified options allowing use of symbol keys with helpers.
+
+    *Jon Rowe*
+
 *   Remove the deprecated `prompt` argument from `grouped_options_for_select`,
     pass in a `:prompt` hash option to use this feature.
 

--- a/actionview/lib/action_view/helpers/tags/color_field.rb
+++ b/actionview/lib/action_view/helpers/tags/color_field.rb
@@ -4,7 +4,7 @@ module ActionView
       class ColorField < TextField # :nodoc:
         def render
           options = @options.stringify_keys
-          options["value"] = options.fetch("value") { validate_color_string(value(object)) }
+          options["value"] ||= validate_color_string(value(object))
           @options = options
           super
         end

--- a/actionview/lib/action_view/helpers/tags/color_field.rb
+++ b/actionview/lib/action_view/helpers/tags/color_field.rb
@@ -4,7 +4,7 @@ module ActionView
       class ColorField < TextField # :nodoc:
         def render
           options = @options.stringify_keys
-          options["value"] = @options.fetch("value") { validate_color_string(value(object)) }
+          options["value"] = options.fetch("value") { validate_color_string(value(object)) }
           @options = options
           super
         end

--- a/actionview/lib/action_view/helpers/tags/datetime_field.rb
+++ b/actionview/lib/action_view/helpers/tags/datetime_field.rb
@@ -4,7 +4,7 @@ module ActionView
       class DatetimeField < TextField # :nodoc:
         def render
           options = @options.stringify_keys
-          options["value"] = @options.fetch("value") { format_date(value(object)) }
+          options["value"] = options.fetch("value") { format_date(value(object)) }
           options["min"] = format_date(options["min"])
           options["max"] = format_date(options["max"])
           @options = options

--- a/actionview/lib/action_view/helpers/tags/datetime_field.rb
+++ b/actionview/lib/action_view/helpers/tags/datetime_field.rb
@@ -4,7 +4,7 @@ module ActionView
       class DatetimeField < TextField # :nodoc:
         def render
           options = @options.stringify_keys
-          options["value"] = options.fetch("value") { format_date(value(object)) }
+          options["value"] ||= format_date(value(object))
           options["min"] = format_date(options["min"])
           options["max"] = format_date(options["max"])
           @options = options

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -702,6 +702,11 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal(expected, color_field("car", "color"))
   end
 
+  def test_color_field_with_value_attr
+    expected = %{<input id="car_color" name="car[color]" type="color" value="#00FF00" />}
+    assert_dom_equal(expected, color_field("car", "color", value: "#00FF00"))
+  end
+
   def test_search_field
     expected = %{<input id="contact_notes_query" name="contact[notes_query]" type="search" />}
     assert_dom_equal(expected, search_field("contact", "notes_query"))
@@ -730,6 +735,12 @@ class FormHelperTest < ActionView::TestCase
     max_value = DateTime.new(2010, 8, 15)
     step = 2
     assert_dom_equal(expected, date_field("post", "written_on", min: min_value, max: max_value, step: step))
+  end
+
+  def test_date_field_with_value_attr
+    expected = %{<input id="post_written_on" name="post[written_on]" type="date" value="2013-06-29" />}
+    value = Date.new(2013,6,29)
+    assert_dom_equal(expected, date_field("post", "written_on", value: value))
   end
 
   def test_date_field_with_timewithzone_value
@@ -800,6 +811,12 @@ class FormHelperTest < ActionView::TestCase
     max_value = DateTime.new(2010, 8, 15, 10, 25, 00)
     step = 60
     assert_dom_equal(expected, datetime_field("post", "written_on", min: min_value, max: max_value, step: step))
+  end
+
+  def test_datetime_field_with_value_attr
+    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime" value="2013-06-29T13:37:00+00:00" />}
+    value = DateTime.new(2013,6,29,13,37)
+    assert_dom_equal(expected, datetime_field("post", "written_on", value: value))
   end
 
   def test_datetime_field_with_timewithzone_value

--- a/activemodel/lib/active_model/validations/clusivity.rb
+++ b/activemodel/lib/active_model/validations/clusivity.rb
@@ -15,15 +15,15 @@ module ActiveModel
     private
 
       def include?(record, value)
-        exclusions = if delimiter.respond_to?(:call)
-                       delimiter.call(record)
-                     elsif delimiter.respond_to?(:to_sym)
-                       record.send(delimiter)
-                     else
-                       delimiter
-                     end
+        members = if delimiter.respond_to?(:call)
+                    delimiter.call(record)
+                  elsif delimiter.respond_to?(:to_sym)
+                    record.send(delimiter)
+                  else
+                    delimiter
+                  end
 
-        exclusions.send(inclusion_method(exclusions), value)
+        members.send(inclusion_method(members), value)
       end
 
       def delimiter

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Remove implicit join references that were deprecated in 4.0.
+
+    Example:
+
+        # before with implicit joins
+        Comment.where('posts.author_id' => 7)
+
+        # after
+        Comment.references(:posts).where('posts.author_id' => 7)
+
+    *Yves Senn*
+
 *   Apply default scope when joining associations. For example:
 
         class Post < ActiveRecord::Base

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -69,13 +69,10 @@ module ActiveRecord
       mattr_accessor :timestamped_migrations, instance_writer: false
       self.timestamped_migrations = true
 
-      ##
-      # :singleton-method:
-      # Disable implicit join references. This feature was deprecated with Rails 4.
-      # If you don't make use of implicit references but still see deprecation warnings
-      # you can disable the feature entirely. This will be the default with Rails 4.1.
-      mattr_accessor :disable_implicit_join_references, instance_writer: false
-      self.disable_implicit_join_references = false
+      def self.disable_implicit_join_references=(value)
+        ActiveSupport::Deprecation.warn("Implicit join references were removed with Rails 4.1." \
+                                        "Make sure to remove this configuration because it does nothing.")
+      end
 
       class_attribute :default_connection_handler, instance_writer: false
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -596,9 +596,7 @@ module ActiveRecord
 
     def references_eager_loaded_tables?
       joined_tables = arel.join_sources.map do |join|
-        if join.is_a?(Arel::Nodes::StringJoin)
-          tables_in_string(join.left)
-        else
+        unless join.is_a?(Arel::Nodes::StringJoin)
           [join.left.table_name, join.left.table_alias]
         end
       end
@@ -607,41 +605,8 @@ module ActiveRecord
 
       # always convert table names to downcase as in Oracle quoted table names are in uppercase
       joined_tables = joined_tables.flatten.compact.map { |t| t.downcase }.uniq
-      string_tables = tables_in_string(to_sql)
 
-      if (references_values - joined_tables).any?
-        true
-      elsif !ActiveRecord::Base.disable_implicit_join_references &&
-            (string_tables - joined_tables).any?
-        ActiveSupport::Deprecation.warn(
-          "It looks like you are eager loading table(s) (one of: #{string_tables.join(', ')}) " \
-          "that are referenced in a string SQL snippet. For example: \n" \
-          "\n" \
-          "    Post.includes(:comments).where(\"comments.title = 'foo'\")\n" \
-          "\n" \
-          "Currently, Active Record recognizes the table in the string, and knows to JOIN the " \
-          "comments table to the query, rather than loading comments in a separate query. " \
-          "However, doing this without writing a full-blown SQL parser is inherently flawed. " \
-          "Since we don't want to write an SQL parser, we are removing this functionality. " \
-          "From now on, you must explicitly tell Active Record when you are referencing a table " \
-          "from a string:\n" \
-          "\n" \
-          "    Post.includes(:comments).where(\"comments.title = 'foo'\").references(:comments)\n" \
-          "\n" \
-          "If you don't rely on implicit join references you can disable the feature entirely " \
-          "by setting `config.active_record.disable_implicit_join_references = true`."
-        )
-        true
-      else
-        false
-      end
-    end
-
-    def tables_in_string(string)
-      return [] if string.blank?
-      # always convert table names to downcase as in Oracle quoted table names are in uppercase
-      # ignore raw_sql_ that is used by Oracle adapter as alias for limit/offset subqueries
-      string.scan(/([a-zA-Z_][.\w]+).?\./).flatten.map{ |s| s.downcase }.uniq - ['raw_sql_']
+      (references_values - joined_tables).any?
     end
   end
 end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -346,9 +346,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_eager_association_loading_with_belongs_to_and_conditions_string_with_unquoted_table_name
     assert_nothing_raised do
-      ActiveSupport::Deprecation.silence do
-        Comment.all.merge!(:includes => :post, :where => ['posts.id = ?',4]).to_a
-      end
+      Comment.includes(:post).references(:posts).where('posts.id = ?', 4)
     end
   end
 
@@ -367,9 +365,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   def test_eager_association_loading_with_belongs_to_and_conditions_string_with_quoted_table_name
     quoted_posts_id= Comment.connection.quote_table_name('posts') + '.' + Comment.connection.quote_column_name('id')
     assert_nothing_raised do
-      ActiveSupport::Deprecation.silence do
-        Comment.all.merge!(:includes => :post, :where => ["#{quoted_posts_id} = ?",4]).to_a
-      end
+      Comment.includes(:post).references(:posts).where("#{quoted_posts_id} = ?", 4)
     end
   end
 
@@ -382,9 +378,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   def test_eager_association_loading_with_belongs_to_and_order_string_with_quoted_table_name
     quoted_posts_id= Comment.connection.quote_table_name('posts') + '.' + Comment.connection.quote_column_name('id')
     assert_nothing_raised do
-      ActiveSupport::Deprecation.silence do
-        Comment.all.merge!(:includes => :post, :order => quoted_posts_id).to_a
-      end
+      Comment.includes(:post).references(:posts).order(quoted_posts_id)
     end
   end
 
@@ -548,14 +542,10 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_with_has_many_and_limit_and_conditions_array_on_the_eagers
-    posts = ActiveSupport::Deprecation.silence do
-      Post.all.merge!(:includes => [ :author, :comments ], :limit => 2, :where => [ "authors.name = ?", 'David' ]).to_a
-    end
+    posts = Post.includes(:author, :comments).limit(2).references(:author).where("authors.name = ?", 'David')
     assert_equal 2, posts.size
 
-    count = ActiveSupport::Deprecation.silence do
-      Post.includes(:author, :comments).limit(2).references(:author).where("authors.name = ?", 'David').count
-    end
+    count = Post.includes(:author, :comments).limit(2).references(:author).where("authors.name = ?", 'David').count
     assert_equal posts.size, count
   end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1208,31 +1208,10 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal "id", Post.all.primary_key
   end
 
-  def test_eager_loading_with_conditions_on_joins
-    scope = Post.includes(:comments)
-
-    # This references the comments table, and so it should cause the comments to be eager
-    # loaded via a JOIN, rather than by subsequent queries.
-    scope = scope.joins(
-      Post.arel_table.create_join(
-        Post.arel_table,
-        Post.arel_table.create_on(Comment.arel_table[:id].eq(3))
-      )
-    )
-
+  def test_disable_implicit_join_references_is_deprecated
     assert_deprecated do
-      assert scope.eager_loading?
+      ActiveRecord::Base.disable_implicit_join_references = true
     end
-  end
-
-  def test_turn_off_eager_loading_with_conditions_on_joins
-    original_value = ActiveRecord::Base.disable_implicit_join_references
-    ActiveRecord::Base.disable_implicit_join_references = true
-
-    scope = Topic.where(author_email_address: 'my.example@gmail.com').includes(:replies)
-    assert_not scope.eager_loading?
-  ensure
-    ActiveRecord::Base.disable_implicit_join_references = original_value
   end
 
   def test_ordering_with_extra_spaces

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -60,11 +60,6 @@ class NamedScopingTest < ActiveRecord::TestCase
     assert Topic.approved.respond_to?(:length)
   end
 
-  def test_respond_to_respects_include_private_parameter
-    assert !Topic.approved.respond_to?(:tables_in_string)
-    assert Topic.approved.respond_to?(:tables_in_string, true)
-  end
-
   def test_scopes_with_options_limit_finds_to_those_matching_the_criteria_specified
     assert !Topic.all.merge!(:where => {:approved => true}).to_a.empty?
 

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -132,7 +132,7 @@ module ActiveSupport
     end
 
     def xmlschema(fraction_digits = 0)
-      fraction = if fraction_digits > 0
+      fraction = if (time.class == Time) and (fraction_digits > 0)
         (".%06i" % time.usec)[0, fraction_digits + 1]
       end
 

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -132,7 +132,7 @@ module ActiveSupport
     end
 
     def xmlschema(fraction_digits = 0)
-      fraction = if (time.class == Time) and (fraction_digits > 0)
+      fraction = if time.respond_to?(:usec) and (fraction_digits > 0)
         (".%06i" % time.usec)[0, fraction_digits + 1]
       end
 

--- a/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml
+++ b/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml
@@ -1,4 +1,4 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/Fixtures.html
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 <% unless attributes.empty? -%>
 <% %w(one two).each do |name| %>
 <%= name %>:


### PR DESCRIPTION
I fix this by not generating microseconds when time is a DateTime object, as DateTime does not support a .usec method.
