### PR TITLE
Remove unused return value, because collecting_queries_for_explain isn't public API.

### DIFF
--- a/activerecord/lib/active_record/explain.rb
+++ b/activerecord/lib/active_record/explain.rb
@@ -6,7 +6,8 @@ module ActiveRecord
     def collecting_queries_for_explain # :nodoc:
       current = Thread.current
       original, current[:available_queries_for_explain] = current[:available_queries_for_explain], []
-      return yield, current[:available_queries_for_explain]
+      yield
+      return current[:available_queries_for_explain]
     ensure
       # Note that the return value above does not depend on this assigment.
       current[:available_queries_for_explain] = original

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -188,8 +188,7 @@ module ActiveRecord
     # Please see further details in the
     # {Active Record Query Interface guide}[http://guides.rubyonrails.org/active_record_querying.html#running-explain].
     def explain
-      _, queries = collecting_queries_for_explain { exec_queries }
-      exec_explain(queries)
+      exec_explain(collecting_queries_for_explain { exec_queries })
     end
 
     # Converts relation objects to Array.

--- a/activerecord/test/cases/explain_test.rb
+++ b/activerecord/test/cases/explain_test.rb
@@ -20,7 +20,7 @@ if ActiveRecord::Base.connection.supports_explain?
     end
 
     def test_collecting_queries_for_explain
-      result, queries = ActiveRecord::Base.collecting_queries_for_explain do
+      queries = ActiveRecord::Base.collecting_queries_for_explain do
         Car.where(:name => 'honda').to_a
       end
 
@@ -28,7 +28,6 @@ if ActiveRecord::Base.connection.supports_explain?
       assert_match "SELECT", sql
       assert_match "honda", sql
       assert_equal [], binds
-      assert_equal [cars(:honda)], result
     end
 
     def test_exec_explain_with_no_binds


### PR DESCRIPTION
`ActiveRecord::Explain.collecting_queries_for_explain` isn't public API, and this method is used only once.
In master, the first of this method's return value is not used.

```
_, queries = collecting_queries_for_explain { exec_queries }
```

I think we should remove this return value.
