### PR TITLE
Always compact array parameters rather than setting them to nil

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -291,7 +291,6 @@ module ActionDispatch
         when Array
           v.grep(Hash) { |x| deep_munge(x) }
           v.compact!
-          hash[k] = nil if v.empty?
         when Hash
           deep_munge(v)
         end

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -32,7 +32,7 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
 
   test "nils are stripped from collections" do
     assert_parses(
-      {"person" => nil},
+      {"person" => []},
       "{\"person\":[null]}", { 'CONTENT_TYPE' => 'application/json' }
     )
     assert_parses(
@@ -40,7 +40,7 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
       "{\"person\":[\"foo\",null]}", { 'CONTENT_TYPE' => 'application/json' }
     )
     assert_parses(
-      {"person" => nil},
+      {"person" => []},
       "{\"person\":[null, null]}", { 'CONTENT_TYPE' => 'application/json' }
     )
   end

--- a/actionpack/test/dispatch/request/query_string_parsing_test.rb
+++ b/actionpack/test/dispatch/request/query_string_parsing_test.rb
@@ -84,8 +84,8 @@ class QueryStringParsingTest < ActionDispatch::IntegrationTest
     assert_parses({"action" => nil}, "action")
     assert_parses({"action" => {"foo" => nil}}, "action[foo]")
     assert_parses({"action" => {"foo" => { "bar" => nil }}}, "action[foo][bar]")
-    assert_parses({"action" => {"foo" => { "bar" => nil }}}, "action[foo][bar][]")
-    assert_parses({"action" => {"foo" => nil }}, "action[foo][]")
+    assert_parses({"action" => {"foo" => { "bar" => [] }}}, "action[foo][bar][]")
+    assert_parses({"action" => {"foo" => [] }}, "action[foo][]")
     assert_parses({"action"=>{"foo"=>[{"bar"=>nil}]}}, "action[foo][][bar]")
   end
 


### PR DESCRIPTION
The [CVE-2013-0155 security vulnerability](https://groups.google.com/forum/?fromgroups=#!topic/rubyonrails-security/t1WFuuQyavI) outlines how array parameters
containing `nil` values can be dangerous when accepted directly into
Active Record finder methods. The previous fix has been to detect array
parameters with `nil` values and to clobber the entire array into `nil`.

Instead, compacting the array solves the security issue and causes less
surprise in the case where array parameters are expected, as is often
the case when accepting nested attributes for collections.
