### PR TITLE
Update gemspec to require mail 2.4.4 that fixes security issues

### DIFF
--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency('actionpack',  version)
-  s.add_dependency('mail',        '~> 2.2.19')
+  s.add_dependency('mail',        '~> 2.4.4')
 end


### PR DESCRIPTION
There are some security issues in the mail gem that were fixed in 2.4.4 (directory traversal and execution of arbitrary shell commands when using sendmail/exim).

This was fixed in rails master (24d244c1bc1a744de599df18d74c9b343fd4c9fe), 3-1-stable (d3dc2a7a7d5c54547c481d726ca61d7a0e06c3c4), and in 3-2-stable (74b782999f7f2c8913e79e2c65366429b9a3e65e).

I suggest to include this in 3-0-stable as well as the mail gem can't be updated due to the "restrictive" version constraint in actionmailer.

For reference:
http://www.osvdb.org/show/osvdb/81631 (CVE 2012-2139)
http://www.osvdb.org/show/osvdb/81632 (CVE 2012-2140)

Best regards
Joerg
