### PR TITLE
Allow builtin routes to be disabled even in development mode

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add `config.disable_builtin_routes` to disable loading of welcome and info routes.
+
+    *Sam Pohlenz*
 
 ## Rails 4.0.0.beta1 (February 25, 2013) ##
 *   Change Service pages(404, etc). *Stanislav Sobolev*

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -11,7 +11,7 @@ module Rails
                     :force_ssl, :helpers_paths, :logger, :log_formatter, :log_tags,
                     :railties_order, :relative_url_root, :secret_key_base, :secret_token,
                     :serve_static_assets, :ssl_options, :static_cache_control, :session_options,
-                    :time_zone, :reload_classes_only_on_change,
+                    :time_zone, :reload_classes_only_on_change, :disable_builtin_routes,
                     :beginning_of_week, :filter_redirect
 
       attr_writer :log_level
@@ -40,6 +40,7 @@ module Rails
         @railties_order                = [:all]
         @relative_url_root             = ENV["RAILS_RELATIVE_URL_ROOT"]
         @reload_classes_only_on_change = true
+        @disable_builtin_routes        = false
         @file_watcher                  = ActiveSupport::FileUpdateChecker
         @exceptions_app                = nil
         @autoflush_log                 = true

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -20,7 +20,7 @@ module Rails
       end
 
       initializer :add_builtin_route do |app|
-        if Rails.env.development?
+        if Rails.env.development? && !app.config.disable_builtin_routes
           app.routes.append do
             get '/rails/info/properties' => "rails/info#properties"
             get '/rails/info/routes'     => "rails/info#routes"

--- a/railties/test/application/routing_test.rb
+++ b/railties/test/application/routing_test.rb
@@ -75,6 +75,27 @@ module ApplicationTests
       assert_equal 404, last_response.status
     end
 
+    test "rails/welcome with builtin routes disabled" do
+      add_to_config "config.disable_builtin_routes = true"
+      app("development")
+      get "/"
+      assert_equal 404, last_response.status
+    end
+
+    test "rails/info/routes with builtin routes disabled" do
+      add_to_config "config.disable_builtin_routes = true"
+      app("development")
+      get "/rails/info/routes"
+      assert_equal 404, last_response.status
+    end
+
+    test "rails/info/properties with builtin routes disabled" do
+      add_to_config "config.disable_builtin_routes = true"
+      app("development")
+      get "/rails/info/properties"
+      assert_equal 404, last_response.status
+    end
+
     test "simple controller" do
       simple_controller
 


### PR DESCRIPTION
This commits adds a `disable_builtin_routes` configuration option to the Rails Application class, allowing the builtin routes (most importantly the default `/` route) to be disabled even in development mode.
#### Why is this needed?

My CMS uses a dispatcher implemented as a middleware which dynamically routes CMS pages from the database. To ensure that content-managed pages cannot shadow routes defined by the developer, the dispatcher runs after the Rails application routes (checking for the `X-Cascade=pass` header).

With the Rails welcome page now implemented as a controller action, the route for `/` is always accessible in development mode, so the dispatcher cannot dispatch requests for `/`, meaning a CMS-managed home page cannot be viewed.
