### PR TITLE
[Backport to 3-2-stable] Don't reset inheritance_column when setting explicitly.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## unreleased ##
 
+*   Do not reset `inheritance_column` when it's set explicitly.
+    Backport of #5327.
+
+    *kennyj + Fred Wu*
+
 *   Fix a problem wrong exception is occured
     when raising no translatable exception in PostgreSQL.
 

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -173,6 +173,7 @@ module ActiveRecord
       def inheritance_column=(value)
         @original_inheritance_column = inheritance_column
         @inheritance_column          = value.to_s
+        @explicit_inheritance_column = true
       end
 
       def set_inheritance_column(value = nil, &block) #:nodoc:
@@ -300,7 +301,8 @@ module ActiveRecord
         connection.schema_cache.clear_table_cache!(table_name) if table_exists?
 
         @column_names = @content_columns = @column_defaults = @columns = @columns_hash = nil
-        @dynamic_methods_hash = @inheritance_column = nil
+        @dynamic_methods_hash = nil
+        @inheritance_column = nil unless defined?(@explicit_inheritance_column) && @explicit_inheritance_column
         @arel_engine = @relation = nil
       end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1540,6 +1540,16 @@ class BasicsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_dont_clear_inheritnce_column_when_setting_explicitly
+    Joke.inheritance_column = "my_type"
+    before_inherit = Joke.inheritance_column
+
+    Joke.reset_column_information
+    after_inherit = Joke.inheritance_column
+
+    assert_equal before_inherit, after_inherit unless before_inherit.blank? && after_inherit.blank?
+  end
+
   def test_set_table_name_symbol_converted_to_string
     Joke.table_name = :cold_jokes
     assert_equal 'cold_jokes', Joke.table_name


### PR DESCRIPTION
This is backported from master (cdfcbc4).

See pull request https://github.com/rails/rails/pull/5327

cc @tenderlove @jonleighton
