### PR TITLE
allow link content to be specified in a block to link_to_unless

### DIFF
--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -383,7 +383,7 @@ module ActionView
             name
           end
         else
-          link_to(name, options, html_options)
+          link_to(name, options, html_options, &block)
         end
       end
 

--- a/actionpack/test/template/url_helper_test.rb
+++ b/actionpack/test/template/url_helper_test.rb
@@ -413,6 +413,9 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert_dom_equal %{<a href="/">Listing</a>},
       link_to_unless(false, "Listing", url_hash)
 
+    assert_dom_equal %{<a href="/">Listing</a>},
+      link_to_unless(false, "Ignored", url_hash) { "Listing" }
+
     assert_equal "Showing", link_to_unless(true, "Showing", url_hash)
 
     assert_equal "<strong>Showing</strong>",


### PR DESCRIPTION
block content is ignored by link_to_unless in the case the expression evaluates to false
