### PR TITLE
Used setup to avoid repetition

### DIFF
--- a/activerecord/test/cases/explain_test.rb
+++ b/activerecord/test/cases/explain_test.rb
@@ -6,6 +6,10 @@ if ActiveRecord::Base.connection.supports_explain?
   class ExplainTest < ActiveRecord::TestCase
     fixtures :cars
 
+    def setup
+      @car = Car.where(name: 'honda')
+    end
+
     def base
       ActiveRecord::Base
     end
@@ -15,13 +19,12 @@ if ActiveRecord::Base.connection.supports_explain?
     end
 
     def test_relation_explain
-      message = Car.where(:name => 'honda').explain
-      assert_match(/^EXPLAIN for:/, message)
+      assert_match(/^EXPLAIN for:/, @car.explain)
     end
 
     def test_collecting_queries_for_explain
       queries = ActiveRecord::Base.collecting_queries_for_explain do
-        Car.where(:name => 'honda').to_a
+        @car.to_a
       end
 
       sql, binds = queries[0]


### PR DESCRIPTION
Added a setup block to initialize an object to use in the test case. This setup eliminates repetition.   
