### PR TITLE
Fix issue #8937 after_commit(on: :update) executed erroneously

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -338,6 +338,7 @@ module ActiveRecord
 
     # Save the new record state and id of a record so it can be restored later if a transaction fails.
     def remember_transaction_record_state #:nodoc:
+      @_start_transaction_state[:save_called_in_callback] = (@new_record == false and @_start_transaction_state[:new_record])
       @_start_transaction_state[:id] = id if has_attribute?(self.class.primary_key)
       @_start_transaction_state[:new_record] = @new_record
       @_start_transaction_state[:destroyed] = @destroyed
@@ -383,11 +384,11 @@ module ActiveRecord
       actions.any? do |action|
         case action
         when :create
-          transaction_record_state(:new_record)
+          transaction_record_state(:new_record) || transaction_record_state(:save_called_in_callback)
         when :destroy
           destroyed?
         when :update
-          !(transaction_record_state(:new_record) || destroyed?)
+          !(transaction_record_state(:new_record) || transaction_record_state(:save_called_in_callback) || destroyed?)
         end
       end
     end

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -305,11 +305,25 @@ class SaveFromAfterCommitBlockTest < ActiveRecord::TestCase
     end
   end
 
+  class TopicWithSaveInAfterCreateCallback < ActiveRecord::Base
+    self.table_name = :topics
+    after_create { save! }
+    after_commit(on: :create) { self.was_created = true }
+    after_commit(on: :update) { self.was_updated = true }
+    attr_accessor :was_created, :was_updated
+  end
+
   def test_after_commit_in_save
     topic = TopicWithSaveInCallback.new()
     topic.save
     assert_equal true, topic.cached
     assert_equal true, topic.record_updated
+  end
+
+  def test_after_commit_on_create
+    topic = TopicWithSaveInAfterCreateCallback.create()
+    assert_equal true, topic.was_created
+    assert_equal nil, topic.was_updated
   end
 end
 


### PR DESCRIPTION
We check for a state in the current ActiveRecord
transaction that causes the wrong callbacks to be
executed, and when it occurs, call the correct
callbacks.

Tests lifted from
https://github.com/rails/rails/commit/b42ea033115c1a06160e4092039d6a0fe0bda6f8
