### PR TITLE
Fixes XSS vulnerability in the translate helper method

### DIFF
--- a/actionpack/CHANGELOG
+++ b/actionpack/CHANGELOG
@@ -1,3 +1,22 @@
+*unreleased*
+
+* HTML safety: fix XSS vulnerability in the translate helper method for keys ending in 'html' not escaping variable interpolations.
+
+  Fixes XSS vulnerability in the translate helper method
+
+  There is a security vulnerability in the translate helper when using
+  the rails_xss plugin where translation strings with a name ending in
+  'html' are considered HTML safe. What happens is interpolated input
+  is not escaped, allowing "javascript:" or "data:" to be injected
+  into the "href" attribute.
+
+  It is based off of the 3.0 patch, however I'm not quite sure how to
+  deal with `keys` as an Array (since that is deprecated in 3.0). So
+  I've aired on the safer side and chosen to make all options
+  html-safe.
+ 
+  * Henry Hsu *
+
 *2.3.11 (February 9, 2011)*
 
 * Two security fixes. CVE-2011-0446, CVE-2011-0447

--- a/actionpack/lib/action_view/helpers/translation_helper.rb
+++ b/actionpack/lib/action_view/helpers/translation_helper.rb
@@ -18,7 +18,12 @@ module ActionView
         options[:raise] = true
         keys = scope_keys_by_partial(keys)
 
-        translations = I18n.translate(keys, options)
+        html_safe_options = options.dup
+        options.except(*I18n::RESERVED_KEYS).each do |name, value|
+          html_safe_options[name] = ERB::Util.html_escape(value.to_s)
+        end
+
+        translations = I18n.translate(keys, html_safe_options)
         translations = [translations] if !multiple_keys && translations.size > 1
         translations = html_safe_translation_keys(keys, translations)
 

--- a/actionpack/test/template/translation_helper_test.rb
+++ b/actionpack/test/template/translation_helper_test.rb
@@ -88,6 +88,12 @@ class TranslationHelperTest < ActiveSupport::TestCase
     assert translate("hello_html").html_safe?
   end
 
+  def test_translate_escapes_interpolations_in_translations_with_a_html_suffix
+    I18n.expects(:translate).with(["interpolated_html"], { :word => h('<World>'), :raise => true }).returns(['<a>Hello &lt;World&gt;</a>']).twice
+    assert_equal '<a>Hello &lt;World&gt;</a>', translate("interpolated_html", :word => '<World>')
+    assert_equal '<a>Hello &lt;World&gt;</a>', translate("interpolated_html", :word => stub(:to_s => "<World>"))
+  end
+
   def test_translation_returning_an_array_ignores_html_suffix
     I18n.expects(:translate).with(["foo_html"], :raise => true).returns(["foo", "bar"])
     assert_equal ["foo", "bar"], translate(:foo_html)


### PR DESCRIPTION
@NZKoz @lest,

I'm working on a patch for https://groups.google.com/forum/?fromgroups=#!topic/rubyonrails-security/K2HXD7c8fMU.

I based it off of the 3.0 patch, however, I'm not quite sure how to deal with the `keys` as an Array. So I've aired on the safer side and chosen to make all options html-safe.

What do you think?
