### PR TITLE
Use shorter prefix and suffix to support Oracle adapter

### DIFF
--- a/activerecord/test/cases/ar_schema_test.rb
+++ b/activerecord/test/cases/ar_schema_test.rb
@@ -11,8 +11,8 @@ if ActiveRecord::Base.connection.supports_migrations?
 
     def teardown
       @connection.drop_table :fruits rescue nil
-      @connection.drop_table :"_pre_fruits_suf_" rescue nil
-      @connection.drop_table :"_pre_schema_migrations_suf_" rescue nil
+      @connection.drop_table :"_p_fruits_s_" rescue nil
+      @connection.drop_table :"_p_schema_migrations_s_" rescue nil
     end
 
     def test_schema_define
@@ -24,8 +24,9 @@ if ActiveRecord::Base.connection.supports_migrations?
     end
 
     def test_schema_define_with_table_prefix_and_suffix
-      ActiveRecord::Base.table_name_prefix = '_pre_'
-      ActiveRecord::Base.table_name_suffix = '_suf_'
+      # Use shorter prefix and suffix as in Oracle database identifier cannot be larger than 30 characters
+      ActiveRecord::Base.table_name_prefix = '_p_'
+      ActiveRecord::Base.table_name_suffix = '_s_'
 
       perform_schema_define!
 


### PR DESCRIPTION
This pull request address a error at `3-2-stable` branch with Oracle database.
because Oracle database identifier cannot be larger than 30 characters.

This pull request is just for `3-2-stable` no cherry-pick for the master branch needed
as its original fix made in #7689, which is created as a backport for `3-2-branch` only.
In master branch, it must be tested in different way.

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/ar_schema_test.rb -n test_schema_define_with_table_prefix_and_suffix
Using oracle with Identity Map off
Run options: -n test_schema_define_with_table_prefix_and_suffix

# Running tests:

[1/1] ActiveRecordSchemaTest#test_schema_define_with_table_prefix_and_suffix-- create_table(:fruits)
   -> 0.0146s
-- initialize_schema_migrations_table()
 = 0.05 s
  1) Error:
test_schema_define_with_table_prefix_and_suffix(ActiveRecordSchemaTest):
ArgumentError: Index name '_pre_unique_schema_migrations_suf_' on table '_pre_schema_migrations_suf_' is too long; the limit is 30 characters
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:151:in `add_index'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:429:in `initialize_schema_migrations_table'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:466:in `block in method_missing'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:438:in `block in say_with_time'
    /home/yahonda/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/benchmark.rb:281:in `measure'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:438:in `say_with_time'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:458:in `method_missing'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:334:in `method_missing'
    /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:53:in `define'
    test/cases/ar_schema_test.rb:52:in `perform_schema_define!'
    test/cases/ar_schema_test.rb:30:in `test_schema_define_with_table_prefix_and_suffix'
    /home/yahonda/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:1301:in `run'
    /home/yahonda/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit/testcase.rb:17:in `run'
    /home/yahonda/git/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:36:in `block in run'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:425:in `_run__1571136118336013312__setup__1288503554465957031__callbacks'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:405:in `__run_callback'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:385:in `_run_setup_callbacks'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:81:in `run_callbacks'
    /home/yahonda/git/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:35:in `run'
    /home/yahonda/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:919:in `block in _run_suite'
    /home/yahonda/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:912:in `map'
    /home/yahonda/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:912:in `_run_suite'
    /home/yahonda/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:657:in `block in _run_suites'
    /home/yahonda/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:655:in `each'
    /home/yahonda/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:655:in `_run_suites'
    /home/yahonda/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:867:in `_run_anything'
    /home/yahonda/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:1060:in `run_tests'
    /home/yahonda/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:1047:in `block in _run'
    /home/yahonda/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:1046:in `each'
    /home/yahonda/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:1046:in `_run'
    /home/yahonda/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:1035:in `run'
    /home/yahonda/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:21:in `run'
    /home/yahonda/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:774:in `run'
    /home/yahonda/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:366:in `block (2 levels) in autorun'
    /home/yahonda/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:27:in `run_once'
    /home/yahonda/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:365:in `block in autorun'

Finished tests in 0.087222s, 11.4650 tests/s, 0.0000 assertions/s.
1 tests, 0 assertions, 0 failures, 1 errors, 0 skips

ruby -v: ruby 2.0.0p0 (2013-02-24 revision 39474) [x86_64-linux]
$
```
