### PR TITLE
Fix #8856 Ensure has_one association=(associate) triggers save.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## unreleased ##
 
+*   Trigger a save on `has_one association=(associate)` when the associate contents have changed.
+
+    Fix #8856.
+
+    *Chris Thompson*
+
 *   Reload the association target if it's stale. `@stale_state` should be nil
     when a model isn't saved.
     Fixes #7526.

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -8,9 +8,8 @@ module ActiveRecord
         raise_on_type_mismatch(record) if record
         load_target
 
-        # If target and record are nil, or target is equal to record,
-        # we don't need to have transaction.
-        if (target || record) && target != record
+        return self.target if !(target || record)
+        if (target != record) || record.changed?
           transaction_if(save) do
             remove_target!(options[:dependent]) if target && !target.destroyed?
   

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -491,4 +491,20 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     account = Account.find(2)
     assert_queries { company.account = account }
   end
+
+  def test_has_one_assignment_triggers_save_on_change
+    pirate = Pirate.create!(catchphrase: "Don' botharrr talkin' like one, savvy?")
+    ship = pirate.build_ship(name: 'old name')
+    ship.save!
+
+    ship.name = 'new name'
+    assert ship.changed?
+    assert_queries(2) do
+      # One query for updating name and second query for updating pirate_id
+      pirate.ship = ship
+    end
+
+    assert_equal 'new name', pirate.ship.reload.name
+  end
+
 end


### PR DESCRIPTION
`activerecord/lib/active_record/associations.rb` states:

```
# [association=(associate)]
#   Assigns the associate object, extracts the primary key, sets it as the foreign key,
#   and saves the associate object.
```

Since commit 42dd5d9f2976677a4bf22347f2dde1a8135dfbb4 to fix #7191, this
is no longer the case if the associate has changed, but is the same
object. For example:

```
# Pirate has_one :ship
pirate = Pirate.create!(catchphrase: "A Pirate")
ship = pirate.build_ship(name: 'old name')
ship.save!

ship.name = 'new name'
pirate.ship = ship
```

That last line should trigger a save. Although we are not changing the
association, the associate (ship) has changed.

Conflicts:
    activerecord/CHANGELOG.md
