### PR TITLE
Rename first_or_initialize to first_or_new

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -137,9 +137,11 @@ module ActiveRecord
       first || create!(attributes, &block)
     end
 
-    def first_or_initialize(attributes = nil, &block) # :nodoc:
+    def first_or_new(attributes = nil, &block) # :nodoc:
       first || new(attributes, &block)
     end
+
+    alias :first_or_initialize :first_or_new
 
     # Finds the first record with the given attributes, or creates a record with the attributes
     # if one is not found.


### PR DESCRIPTION
It made sense to use verb "initialize" over noun "new" in "find_or_initialize"
despite it calling "new" under the hood because "find" is a verb.

But "initialize" does no longer make sense for the current method as "first" is a noun.

Does this sound OK?
