### PR TITLE
Pass column to quote when copying a sqlite table.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix quoting for sqlite migrations using copy_table_contents() with binary
+    columns.
+
+    These would fail with "SQLite3::SQLException: unrecognized token" because
+    the column was not being passed to quote() so the data was not quoted
+    correctly.
+
+    *Matthew M. Boedicker*
+
 *   Promotes `change_column_null` to the migrations API. This macro sets/removes
     `NOT NULL` constraints, and accepts an optional argument to replace existing
     `NULL`s if needed. The adapters for SQLite, MySQL, PostgreSQL, and (at least)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -583,9 +583,17 @@ module ActiveRecord
           quoted_columns = columns.map { |col| quote_column_name(col) } * ','
 
           quoted_to = quote_table_name(to)
+
+          raw_column_mappings = Hash[columns(from).map { |c| [c.name, c] }]
+
           exec_query("SELECT * FROM #{quote_table_name(from)}").each do |row|
             sql = "INSERT INTO #{quoted_to} (#{quoted_columns}) VALUES ("
-            sql << columns.map {|col| quote row[column_mappings[col]]} * ', '
+
+            column_values = columns.map do |col|
+              quote(row[column_mappings[col]], raw_column_mappings[col])
+            end
+
+            sql << column_values * ', '
             sql << ')'
             exec_query sql
           end

--- a/activerecord/test/cases/adapters/sqlite3/copy_table_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/copy_table_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 
 class CopyTableTest < ActiveRecord::TestCase
-  fixtures :customers, :companies, :comments
+  fixtures :customers, :companies, :comments, :binaries
 
   def setup
     @connection = ActiveRecord::Base.connection
@@ -70,6 +70,10 @@ class CopyTableTest < ActiveRecord::TestCase
       copied_pk = @connection.primary_key('owners_unconventional')
       assert_equal original_pk, copied_pk
     end
+  end
+
+  def test_copy_table_with_binary_column
+    test_copy_table 'binaries', 'binaries2'
   end
 
 protected


### PR DESCRIPTION
To make quote escape binary data correctly it needs the column passed in.
