### PR TITLE
Fix incorrectly appended square brackets to a multiple select box

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix incorrectly appended square brackets to a multiple select box
+    if an explicit name has been given and it already ends with "[]"
+
+    Before:
+
+        select(:category, [], {}, multiple: true, name: "post[category][]")
+        # => <select name="post[category][][]" ...>
+
+    After:
+
+        select(:category, [], {}, multiple: true, name: "post[category][]")
+        # => <select name="post[category][]" ...>
+
+    *Olek Janiszewski*
+
 *   Fixed regression when using `assert_template` to verify files sent using
     `render file: 'README.md'`.
     Fixes #9464.

--- a/actionpack/lib/action_view/helpers/tags/base.rb
+++ b/actionpack/lib/action_view/helpers/tags/base.rb
@@ -84,7 +84,7 @@ module ActionView
             options["id"] = options.fetch("id"){ tag_id }
           end
 
-          options["name"] += "[]" if options["multiple"]
+          options["name"] += "[]" if options["multiple"] && !options["name"].ends_with?("[]")
           options["id"] = [options.delete('namespace'), options["id"]].compact.join("_").presence
         end
 

--- a/actionpack/test/template/form_options_helper_test.rb
+++ b/actionpack/test/template/form_options_helper_test.rb
@@ -575,6 +575,14 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_select_with_multiple_and_with_explicit_name_ending_with_brackets
+    output_buffer =  select(:post, :category, [], {include_hidden: false}, multiple: true, name: 'post[category][]')
+    assert_dom_equal(
+      "<select multiple=\"multiple\" id=\"post_category\" name=\"post[category][]\"></select>",
+      output_buffer
+    )
+  end
+
   def test_select_with_multiple_and_disabled_to_add_disabled_hidden_input
     output_buffer =  select(:post, :category, "", {}, :multiple => true, :disabled => true)
     assert_dom_equal(


### PR DESCRIPTION
Fix incorrectly appended square brackets to a multiple select box, if an explicit name has been given and it already ends with "[]". Actually, I found this bug when upgrading from 3.2.12 to 3.2.13.rc2, so I'd like to backport this to 3-2-13.

Formtastic is always providing an explicit name, and it already ends with "[]" for one-to-many associations (see [here](https://github.com/justinfrench/formtastic/blob/master/lib/formtastic/inputs/select_input.rb#L201)).

Before:

``` ruby
select(:category, [], {}, {:multiple => true, :name => "post[category][]"})
# => <select name="post[category][][]" ...>
```

After:

``` ruby
select(:category, [], {}, {:multiple => true, :name => "post[category][]"})
# => <select name="post[category][]" ...>
```

Probable culprits are 175ba04c on master and 2a6f208e on 3-2-13.

/cc @tenderlove would you like me to open a separate PR with a backport?
