### PR TITLE
Bugfix for enable_extension in postgresql_adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -594,7 +594,7 @@ module ActiveRecord
       end
 
       def enable_extension(name)
-        exec_query("CREATE EXTENSION IF NOT EXISTS #{name}").tap {
+        exec_query("CREATE EXTENSION IF NOT EXISTS \"#{name}\"").tap {
           reload_type_map
         }
       end


### PR DESCRIPTION
The use of quotations is required to install extensions with certain
nonstandard characters in them (e.g. uuid-ossp). 
