### PR TITLE
Preserve magic comments and content encoding of copied migrations.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   When copying migrations, preserve their magic comments and content encoding.
+
+    *OZAWA Sakuro*
+
 *   Fix ActiveRecord `subclass_from_attrs` when `eager_load` is false.
     It cannot find subclass because all classes are loaded automatically
     when it needs.

--- a/activerecord/test/migrations/magic/1_currencies_have_symbols.rb
+++ b/activerecord/test/migrations/magic/1_currencies_have_symbols.rb
@@ -1,0 +1,12 @@
+# coding: ISO-8859-15
+
+class CurrenciesHaveSymbols < ActiveRecord::Migration
+  def self.up
+    # We use ¤ for default currency symbol
+    add_column "currencies", "symbol", :string, :default => "¤"
+  end
+
+  def self.down
+    remove_column "currencies", "symbol"
+  end
+end


### PR DESCRIPTION
During insertion of "# This migration comes from ... " comment at the beginning of
a migration, presence of magic comment was not considered.
