### PR TITLE
New Action View helpers: hidden field tags from a flat or nested hash

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,30 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add helper methods to convert flat or nested hashes into a sequence of
+    hidden input fields to be submitted with the form.
+
+    Example:
+
+        hidden_field_tags_from_nested_hash({ :a => { :b => ['c', 'd']}, 'e' => 5 }, :id => nil)
+
+    Output:
+
+        <input name="a[b][]" type="hidden" value="c" />
+        <input name="a[b][]" type="hidden" value="d" />
+        <input name="e" type="hidden" value="5" />
+
+    This method in fact just combines two other:
+
+        hidden_field_tags_from_flat_hash(hash, options = {})
+
+    and
+
+        flat_param_hash_from_nested_hash(nested_hash, key_prefix = '')
+
+    (Originally based on http://marklunds.com/articles/one/314.)
+
+    *Alexey Muranov*
+
 *   Integration and functional tests allow headers and rack env
     variables to be passed when performing requests.
     Fixes #6513.

--- a/actionpack/test/template/form_tag_helper_test.rb
+++ b/actionpack/test/template/form_tag_helper_test.rb
@@ -138,6 +138,27 @@ class FormTagHelperTest < ActionView::TestCase
     assert_match VALID_HTML_ID, input_elem['id']
   end
 
+  def test_hidden_field_tags_from_flat_hash
+    actual = hidden_field_tags_from_flat_hash({ :a => 'b', 'c' => 3 }, :id => nil)
+    expected = %(<input name="a" type="hidden" value="b" />\n) +
+               %(<input name="c" type="hidden" value="3" />)
+    assert_dom_equal expected, actual
+  end
+
+  def test_flat_param_hash_from_nested_hash
+    actual = flat_param_hash_from_nested_hash(:a => { :b => ['c', 'd']}, 'e' => 5)
+    expected = { 'a[b]' => ['c', 'd'], 'e' => 5 }
+    assert_equal expected, actual
+  end
+
+  def test_hidden_field_tags_from_nested_hash
+    actual = hidden_field_tags_from_nested_hash({ :a => { :b => ['c', 'd']}, 'e' => 5 }, :id => nil)
+    expected = %(<input name="a[b][]" type="hidden" value="c" />\n) +
+               %(<input name="a[b][]" type="hidden" value="d" />\n) +
+               %(<input name="e" type="hidden" value="5" />)
+    assert_dom_equal expected, actual
+  end
+
   def test_file_field_tag
     assert_dom_equal "<input name=\"picsplz\" type=\"file\" id=\"picsplz\" />", file_field_tag("picsplz")
   end

--- a/actionpack/test/template/form_tag_helper_test.rb
+++ b/actionpack/test/template/form_tag_helper_test.rb
@@ -139,20 +139,20 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_hidden_field_tags_from_flat_hash
-    actual = hidden_field_tags_from_flat_hash({ :a => 'b', 'c' => 3 }, :id => nil)
+    actual = hidden_field_tags_from_flat_hash({ a: 'b', 'c' => 3 }, id: nil)
     expected = %(<input name="a" type="hidden" value="b" />\n) +
                %(<input name="c" type="hidden" value="3" />)
     assert_dom_equal expected, actual
   end
 
   def test_flat_param_hash_from_nested_hash
-    actual = flat_param_hash_from_nested_hash(:a => { :b => ['c', 'd']}, 'e' => 5)
+    actual = flat_param_hash_from_nested_hash(a: { b: ['c', 'd']}, 'e' => 5)
     expected = { 'a[b]' => ['c', 'd'], 'e' => 5 }
     assert_equal expected, actual
   end
 
   def test_hidden_field_tags_from_nested_hash
-    actual = hidden_field_tags_from_nested_hash({ :a => { :b => ['c', 'd']}, 'e' => 5 }, :id => nil)
+    actual = hidden_field_tags_from_nested_hash({ a: { b: ['c', 'd']}, 'e' => 5 }, id: nil)
     expected = %(<input name="a[b][]" type="hidden" value="c" />\n) +
                %(<input name="a[b][]" type="hidden" value="d" />\n) +
                %(<input name="e" type="hidden" value="5" />)


### PR DESCRIPTION
Add helper methods to convert flat or nested hashes into a sequence of hidden input fields to be submitted with the form.  Example:

``` ruby
hidden_field_tags_from_nested_hash({ :a => { :b => ['c', 'd']}, 'e' => 5 }, :id => nil)
```

Output:

``` html
<input name="a[b][]" type="hidden" value="c" />
<input name="a[b][]" type="hidden" value="d" />
<input name="e" type="hidden" value="5" />
```

Originally based on http://marklunds.com/articles/one/314.

I think this also can be used to fix #2158.
