### PR TITLE
Show routes defined under assets prefix

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `rake routes` shows routes defined in under assets prefix.
+
+    *Ryunosuke SATO*
+
 *   Add Mime::Type.register "text/vcard", :vcf to the default list of mime types
 
     *DHH*

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -69,7 +69,7 @@ module ActionDispatch
       end
 
       def internal?
-        controller.to_s =~ %r{\Arails/(info|welcome)} || path =~ %r{\A#{Rails.application.config.assets.prefix}}
+        controller.to_s =~ %r{\Arails/(info|welcome)} || path =~ %r{\A#{Rails.application.config.assets.prefix}\z}
       end
 
       def engine?

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -203,6 +203,18 @@ module ActionDispatch
         assert_no_match(/\/sprockets/, output.first)
       end
 
+      def test_rake_routes_shows_route_defined_in_under_assets_prefix
+        output = draw do
+          scope '/sprockets' do
+            get '/foo' => 'foo#bar'
+          end
+        end
+        assert_equal [
+          "Prefix Verb URI Pattern              Controller#Action",
+          "   foo GET  /sprockets/foo(.:format) foo#bar"
+        ], output
+      end
+
       def test_redirect
         output = draw do
           get "/foo"    => redirect("/foo/bar"), :constraints => { :subdomain => "admin" }


### PR DESCRIPTION
I want to define my application routes under `assets.prefix`.
- `config/application.rb`

``` ruby
module Demo
  class Application < Rails::Application
    config.assets.prefix = '/demo'
  end
end
```
- `config/routes.rb`

``` ruby
Demo::Application.routes.draw do
  scope '/demo' do
    resource :users
  end
end 
```

In this case, `$ rake routes` couldn't show routes I defined.
So I modified condition for internal routes.

If this PR is acceptable, I'll add test case.
