### PR TITLE
Use AS::Notifications to instrument Strong Params

### DIFF
--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -48,6 +48,11 @@ module ActionController
       info("Sent data #{event.payload[:filename]} (#{event.duration.round(1)}ms)")
     end
 
+    def unpermitted_parameters(event)
+      unpermitted_keys = event.payload[:keys]
+      debug("Unpermitted parameters: #{unpermitted_keys.join(", ")}")
+    end
+
     %w(write_fragment read_fragment exist_fragment?
        expire_fragment expire_page write_page).each do |method|
       class_eval <<-METHOD, __FILE__, __LINE__ + 1

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -339,7 +339,8 @@ module ActionController
         if unpermitted_keys.any?
           case self.class.action_on_unpermitted_parameters
           when :log
-            ActionController::Base.logger.debug "Unpermitted parameters: #{unpermitted_keys.join(", ")}"
+            name = "unpermitted_parameters.action_controller"
+            ActiveSupport::Notifications.instrument(name, keys: unpermitted_keys)
           when :raise
             raise ActionController::UnpermittedParameters.new(unpermitted_keys)
           end


### PR DESCRIPTION
This pull request decouples Parameters from the actual logging, instead using a LogSubscriber for that. Since ActiveSupport::Notifications is used, it is trivial to add other subscribers if needed. I'd like to add a Statsd subscriber in one of my own apps in order to monitor the frequency of unpermitted param injection attempts, but many other uses seem possible.

It would be nice to include the controller and action in the event payload, but that would require a larger change. If you guys deem it desirable I would be happy to do it.
