### PR TITLE
Renumbering the comments in the application boot process.

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -46,10 +46,10 @@ module Rails
   #   6)  Run config.before_initialize callbacks
   #   7)  Run Railtie#initializer defined by railties, engines and application.
   #       One by one, each engine sets up its load paths, routes and runs its config/initializers/* files.
-  #   9)  Custom Railtie#initializers added by railties, engines and applications are executed
-  #   10) Build the middleware stack and run to_prepare callbacks
-  #   11) Run config.before_eager_load and eager_load! if eager_load is true
-  #   12) Run config.after_initialize callbacks
+  #   8)  Custom Railtie#initializers added by railties, engines and applications are executed
+  #   9)  Build the middleware stack and run to_prepare callbacks
+  #   10) Run config.before_eager_load and eager_load! if eager_load is true
+  #   11) Run config.after_initialize callbacks
   #
   class Application < Engine
     autoload :Bootstrap,      'rails/application/bootstrap'


### PR DESCRIPTION
The comments before skipped the number 8. Fixing that so the boot process is numbered correctly in the comments.
