### PR TITLE
use Fixes in place of Fix

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -21,7 +21,7 @@
     *Olek Janiszewski*
 
 *   Eager loading made to use relation's `in_clause_length` instead of host's one.
-    Fix #8474
+    Fixes #8474.
 
     *Boris Staal*
 
@@ -29,7 +29,7 @@
     *Nate Berkopec*
 
 *   Do not render views when mail() isn't called.
-    Fix #7761
+    Fixes #7761.
 
     *Yves Senn*
 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -252,12 +252,12 @@
     Client-IP and Remote-Addr headers, in that order. Document the rationale
     for that decision, and describe the options that can be passed to the
     RemoteIp middleware to change it.
-    Fix #7979
+    Fixes #7979.
 
     *André Arko*, *Steve Klabnik*, *Alexey Gaziev*
 
 *   Do not append second slash to `root_url` when using `trailing_slash: true`
-    Fix #8700
+    Fixes #8700.
 
     Before:
 
@@ -285,7 +285,7 @@
 
 *   Do not append `charset=` parameter when `head` is called with a
     `:content_type` option.
-    Fix #8661.
+    Fixes #8661.
 
     *Yves Senn*
 
@@ -443,7 +443,7 @@
 
 *   Render every partial with a new `ActionView::PartialRenderer`. This resolves
     issues when rendering nested partials.
-    Fix #8197.
+    Fixes #8197.
 
     *Yves Senn*
 
@@ -451,7 +451,7 @@
     of mime types where template text is not html escaped by default. It prevents `Jack & Joe`
     from rendering as `Jack &amp; Joe` for the whitelisted mime types. The default whitelist
     contains `text/plain`.
-    Fix #7976.
+    Fixes #7976.
 
     *Joost Baaij*
 
@@ -467,7 +467,7 @@
         check_box("post", "comment_ids", { multiple: true, index: "foo" }, 1)
         # => <input name=\"post[foo][comment_ids][]\" type=\"hidden\" value=\"0\" /><input id=\"post_foo_comment_ids_1\" name=\"post[foo][comment_ids][]\" type=\"checkbox\" value=\"1\" />
 
-    Fix #8108.
+    Fixes #8108.
 
     *Daniel Fox, Grant Hutchins & Trace Wax*
 
@@ -490,7 +490,7 @@
     *Josh Peek*
 
 *   `assert_template` can be used to assert on the same template with different locals
-    Fix #3675.
+    Fixes #3675.
 
     *Yves Senn*
 
@@ -501,7 +501,7 @@
 *   Accept `:remote` as symbolic option for `link_to` helper. *Riley Lynch*
 
 *   Warn when the `:locals` option is passed to `assert_template` outside of a view test case
-    Fix #3415.
+    Fixes #3415.
 
     *Yves Senn*
 
@@ -525,12 +525,12 @@
 
 *   Rename internal variables on `ActionController::TemplateAssertions` to prevent
     naming collisions. `@partials`, `@templates` and `@layouts` are now prefixed with an underscore.
-    Fix #7459.
+    Fixes #7459.
 
     *Yves Senn*
 
 *   `resource` and `resources` don't modify the passed options hash.
-    Fix #7777.
+    Fixes #7777.
 
     *Yves Senn*
 
@@ -594,7 +594,7 @@
     *Guillermo Iguaran*
 
 *   Log now displays the correct status code when an exception is raised.
-    Fix #7646.
+    Fixes #7646.
 
     *Yves Senn*
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -120,7 +120,7 @@
     *Yves Senn*
 
 *   Assigning "0.0" to a nullable numeric column does not make it dirty.
-    Fix #9034.
+    Fixes #9034.
 
     Example:
 
@@ -555,17 +555,17 @@
     *Marc-André Lafortune*
 
 *   Serialized attributes can be serialized in integer columns.
-    Fix #8575.
+    Fixes #8575.
 
     *Rafael Mendonça França*
 
 *   Keep index names when using `alter_table` with sqlite3.
-    Fix #3489.
+    Fixes #3489.
 
     *Yves Senn*
 
 *   Add ability for postgresql adapter to disable user triggers in `disable_referential_integrity`.
-    Fix #5523.
+    Fixes #5523.
 
     *Gary S. Weaver*
 
@@ -588,7 +588,7 @@
     *Matthew Robertson*
 
 *   Recognize migrations placed in directories containing numbers and 'rb'.
-    Fix #8492
+    Fixes #8492.
 
     *Yves Senn*
 
@@ -646,13 +646,13 @@
 
 *   Fix performance problem with `primary_key` method in PostgreSQL adapter when having many schemas.
     Uses `pg_constraint` table instead of `pg_depend` table which has many records in general.
-    Fix #8414
+    Fixes #8414.
 
     *kennyj*
 
 *   Do not instantiate intermediate Active Record objects when eager loading.
     These records caused `after_find` to run more than expected.
-    Fix #3313
+    Fixes #3313.
 
     *Yves Senn*
 
@@ -673,12 +673,13 @@
 
 *   Fix dirty attribute checks for `TimeZoneConversion` with nil and blank
     datetime attributes. Setting a nil datetime to a blank string should not
-    result in a change being flagged. Fix #8310
+    result in a change being flagged.
+    Fixes #8310.
 
     *Alisdair McDiarmid*
 
 *   Prevent mass assignment to the type column of polymorphic associations when using `build`
-    Fix #8265
+    Fixes #8265.
 
     *Yves Senn*
 
@@ -731,7 +732,7 @@
     *Bogdan Gusiev*
 
 *   `:counter_cache` option for `has_many` associations to support custom named counter caches.
-    Fix #7993
+    Fixes #7993.
 
     *Yves Senn*
 
@@ -755,7 +756,7 @@
     *Nikita Afanasenko*
 
 *   Use query cache/uncache when using `DATABASE_URL`.
-    Fix #6951.
+    Fixes #6951.
 
     *kennyj*
 
@@ -764,7 +765,7 @@
     *Henrik Nyh*
 
 *   The `create_table` method raises an `ArgumentError` when the primary key column is redefined.
-    Fix #6378
+    Fixes #6378.
 
     *Yves Senn*
 
@@ -874,7 +875,7 @@
     *Alexey Muranov*
 
 *   The postgres adapter now supports tables with capital letters.
-    Fix #5920
+    Fixes #5920.
 
     *Yves Senn*
 
@@ -896,7 +897,7 @@
     *Francesco Rodriguez*
 
 *   Fix `reset_counters` crashing on `has_many :through` associations.
-    Fix #7822.
+    Fixes #7822.
 
     *lulalala*
 
@@ -971,7 +972,7 @@
     *Guillermo Iguaran*
 
 *   Fix the return of querying with an empty hash.
-    Fix #6971.
+    Fixes #6971.
 
         User.where(token: {})
 
@@ -987,7 +988,7 @@
 
 *   Fix creation of through association models when using `collection=[]`
     on a `has_many :through` association from an unsaved model.
-    Fix #7661.
+    Fixes #7661.
 
     *Ernie Miller*
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -39,13 +39,13 @@
     *Amparo Luna*
 
 *   Fixes database.yml when creating a new rails application with '.'
-    Fix #8304
+    Fixes #8304.
 
     *Jeremy W. Rowe*
 
 *   Restore Rails::Engine::Railties#engines with deprecation to ensure
     compatibility with gems such as Thinking Sphinx
-    Fix #8551
+    Fixes #8551.
 
     *Tim Raymond*
 
@@ -119,7 +119,7 @@
 
 *   Environment name can be a start substring of the default environment names
     (production, development, test). For example: tes, pro, prod, dev, devel.
-    Fix #8628.
+    Fixes #8628.
 
     *Mykola Kyryk*
 
@@ -129,7 +129,7 @@
 
 *   Quote column names in generates fixture files. This prevents
     conflicts with reserved YAML keywords such as 'yes' and 'no'
-    Fix #8612.
+    Fixes #8612.
 
     *Yves Senn*
 
@@ -162,19 +162,19 @@
 *   Add `db` to list of folders included by `rake notes` and `rake notes:custom`. *Antonio Cangiano*
 
 *   Engines with a dummy app include the rake tasks of dependencies in the app namespace.
-    Fix #8229
+    Fixes #8229.
 
     *Yves Senn*
 
 *   Add `sqlserver.yml` template file to satisfy `-d sqlserver` being passed to `rails new`.
-    Fix #6882
+    Fixes #6882.
 
     *Robert Nesius*
 
 *   Rake test:uncommitted finds git directory in ancestors *Nicolas Despres*
 
 *   Add dummy app Rake tasks when `--skip-test-unit` and `--dummy-path` is passed to the plugin generator.
-    Fix #8121
+    Fixes #8121.
 
     *Yves Senn*
 


### PR DESCRIPTION
I used to write "Fix XXX" in Changelog entries but I think we settled on "Fixes XXX.". I updated the changelogs to have consistent format.
