### PR TITLE
Uniqueness validation uses a proc to specify the `:conditions` option.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Uniqueness validation allows you to pass `:conditions` to limit
+    the constraint lookup.
+
+    Example:
+
+        validates_uniqueness_of :title, conditions: -> { where('approved = ?', true) }
+
+    *Mattias Pfeiffer + Yves Senn*
+
 *   `connection` is deprecated as an instance method.
     This allows end-users to have a `connection` method on their models
     without clashing with ActiveRecord internals.

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -348,7 +348,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
   end
 
   def test_validate_uniqueness_with_conditions
-    Topic.validates_uniqueness_of(:title, :conditions => Topic.where('approved = ?', true))
+    Topic.validates_uniqueness_of :title, conditions: -> { where('approved = ?', true) }
     Topic.create("title" => "I'm a topic", "approved" => true)
     Topic.create("title" => "I'm an unapproved topic", "approved" => false)
 
@@ -357,6 +357,12 @@ class UniquenessValidationTest < ActiveRecord::TestCase
 
     t4 = Topic.new("title" => "I'm an unapproved topic", "approved" => false)
     assert t4.valid?, "t4 should be valid"
+  end
+
+  def test_validate_uniqueness_with_non_callable_conditions_is_not_supported
+    assert_raises(ArgumentError) {
+      Topic.validates_uniqueness_of :title, conditions: Topic.where('approved = ?', true)
+    }
   end
 
   def test_validate_uniqueness_with_array_column


### PR DESCRIPTION
This is a follow up to #5321 and follows the general direction in AR to make things lazy evaluated.

Open points:
- Do we need a deprecation for the old syntax?
- Do we need to support the old syntax?
