### PR TITLE
Delegate each to all

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Delegate `.each` to `.all` for ActiveRecord models.
+
+    Example:
+
+        Model.each { ... }
+        # Same as Model.all.each { ... }
+
+    *Andrey Ognevsky*
+
 *   Promotes `change_column_null` to the migrations API. This macro sets/removes
     `NOT NULL` constraints, and accepts an optional argument to replace existing
     `NULL`s if needed. The adapters for SQLite, MySQL, PostgreSQL, and (at least)

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -10,6 +10,7 @@ module ActiveRecord
              :where, :preload, :eager_load, :includes, :from, :lock, :readonly,
              :having, :create_with, :uniq, :references, :none, :to => :all
     delegate :count, :average, :minimum, :maximum, :sum, :calculate, :pluck, :ids, :to => :all
+    delegate :each, :to => :all
 
     # Executes a custom SQL query against your database and returns all the results. The results will
     # be returned as an array with columns requested encapsulated as attributes of the model you call

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1524,4 +1524,17 @@ class RelationTest < ActiveRecord::TestCase
     assert merged.to_sql.include?("wtf")
     assert merged.to_sql.include?("bbq")
   end
+
+  test "respond to .each delegated method" do
+    assert Topic.respond_to?(:each)
+  end
+
+  test ".each does not raise any exception" do
+    assert_nothing_raised { Post.each }
+  end
+
+  test ".each returns an Enumerator" do
+    each = Post.each
+    assert_equal each.class, Enumerator
+  end
 end


### PR DESCRIPTION
![One does not simple \ User.each](http://cdn.memegenerator.net/instances/400x/35938608.jpg)

So, the main idea is: do we really need to write `User.all.each` instead of `User.each`? It would be very helpful for me, but what about the others?
