### PR TITLE
Include Montevideo time zone in list of aliases (closes Issue #9628)

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -62,6 +62,7 @@ module ActiveSupport
       "Newfoundland"                 => "America/St_Johns",
       "Brasilia"                     => "America/Sao_Paulo",
       "Buenos Aires"                 => "America/Argentina/Buenos_Aires",
+      "Montevideo"                   => "America/Montevideo",
       "Georgetown"                   => "America/Guyana",
       "Greenland"                    => "America/Godthab",
       "Mid-Atlantic"                 => "Atlantic/South_Georgia",


### PR DESCRIPTION
for Uruguay (UYT/UYST)
