### PR TITLE
Make sure that debugger isn't included in production environment.

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -23,5 +23,5 @@ gem 'jbuilder', '~> 1.0.1'
 
 <% unless defined?(JRUBY_VERSION) -%>
 # To use debugger
-# gem 'debugger'
+# gem 'debugger', group: [:development, :test]
 <% end -%>


### PR DESCRIPTION
Copy this pattern from the capistrano gem.
