### PR TITLE
`time_zone_options_for_select` should show all time zones below the separator when priority time zones are specified.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   form.select, options_for_select and options_from_collection_for_select now
+    accept a `priority` option. When specified the given values will be placed
+    at the top of select options, followed by all the options separated by a line.
+
+    *Lawrence Pit*
+
 *   Fixed regression when using `assert_template` to verify files sent using
     `render file: 'README.md'`.
     Fixes #9464.

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `time_zone_options_for_select` now shows all time zones below the separator
+    when priority time zones are specified, even when a time zone is specified
+    as a priority time zone.
+
+    *Lawrence Pit*
+
 *   `form.select`, `options_for_select` and `options_from_collection_for_select`
     now accept `priority`, `priority_separator` and `priority_unique` options.
     When specified the given `priority` values will be placed at the top of the

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,8 +1,30 @@
 ## Rails 4.0.0 (unreleased) ##
 
-*   form.select, options_for_select and options_from_collection_for_select now
-    accept a `priority` option. When specified the given values will be placed
-    at the top of select options, followed by all the options separated by a line.
+*   `form.select`, `options_for_select` and `options_from_collection_for_select`
+    now accept `priority`, `priority_separator` and `priority_unique` options.
+    When specified the given `priority` values will be placed at the top of the
+    select options, followed by all the options separated by the
+    `priority_separator` (which defaults to "-------------"). If `priority_unique`
+    is set to +true+ the values from the priority list will not be shown below
+    the separator.
+
+    Examples:
+
+        f.select :country, COUNTRIES, :priority => ["United States", "Canada"]
+
+        options_for_select({"English" => "en", "German" => "de", "Dutch" => "nl", "Japanese" => "jp"},
+                           priority: ["en", "jp"],
+                           priority_separator: "-----",
+                           priority_unique: true)
+        # => <option value="en">English</option>
+        #    <option value="jp">Japanese</option>
+        #    <option value="" disabled="disabled">-----</option>
+        #    <option value="de">German</option>
+        #    <option value="nl">Dutch</option>
+
+        options_for_select(["Denmark", "Japan", "Sweden", "United States"],
+                           priority: "Japan",
+                           priority_separator: lambda {|options| '-' * options.max_by(&:length).length})
 
     *Lawrence Pit*
 

--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -619,7 +619,7 @@ module ActionView
           end
           priority_zones = priority_zones.map(&:to_s)
         end
-        options_from_collection_for_select(container, 'to_s', 'name', selected: selected, priority: priority_zones, priority_unique: true)
+        options_from_collection_for_select(container, 'to_s', 'name', selected: selected, priority: priority_zones)
       end
 
       # Returns radio button tags for the collection of existing return values

--- a/actionpack/lib/action_view/helpers/tags/select.rb
+++ b/actionpack/lib/action_view/helpers/tags/select.rb
@@ -11,11 +11,8 @@ module ActionView
         end
 
         def render
-          option_tags_options = {
-            :selected => @options.fetch(:selected) { value(@object) },
-            :disabled => @options[:disabled],
-            :priority => @options[:priority]
-          }
+          option_tags_options = @options.dup
+          option_tags_options[:selected] = @options.fetch(:selected) { value(@object) }
 
           option_tags = if grouped_choices?
             grouped_options_for_select(@choices, option_tags_options)

--- a/actionpack/lib/action_view/helpers/tags/select.rb
+++ b/actionpack/lib/action_view/helpers/tags/select.rb
@@ -13,7 +13,8 @@ module ActionView
         def render
           option_tags_options = {
             :selected => @options.fetch(:selected) { value(@object) },
-            :disabled => @options[:disabled]
+            :disabled => @options[:disabled],
+            :priority => @options[:priority]
           }
 
           option_tags = if grouped_choices?

--- a/actionpack/test/template/form_options_helper_test.rb
+++ b/actionpack/test/template/form_options_helper_test.rb
@@ -22,7 +22,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
   def setup
     @fake_timezones = %w(A B C D E).map do |id|
-      tz = TZInfo::Timezone.loaded_zones[id] = stub(:name => id, :to_s => id)
+      tz = TZInfo::Timezone.loaded_zones[id] = stub(name: id, to_s: id)
       ActiveSupport::TimeZone.stubs(:[]).with(id).returns(tz)
       tz
     end
@@ -61,42 +61,49 @@ class FormOptionsHelperTest < ActionView::TestCase
   def test_collection_options_with_disabled_value
     assert_dom_equal(
       "<option value=\"&lt;Abe&gt;\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\" disabled=\"disabled\">Babe went home</option>\n<option value=\"Cabe\">Cabe went home</option>",
-      options_from_collection_for_select(dummy_posts, "author_name", "title", :disabled => "Babe")
+      options_from_collection_for_select(dummy_posts, "author_name", "title", disabled: "Babe")
     )
   end
 
   def test_collection_options_with_disabled_array
     assert_dom_equal(
       "<option value=\"&lt;Abe&gt;\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\" disabled=\"disabled\">Babe went home</option>\n<option value=\"Cabe\" disabled=\"disabled\">Cabe went home</option>",
-      options_from_collection_for_select(dummy_posts, "author_name", "title", :disabled => [ "Babe", "Cabe" ])
+      options_from_collection_for_select(dummy_posts, "author_name", "title", disabled: [ "Babe", "Cabe" ])
     )
   end
 
   def test_collection_options_with_preselected_and_disabled_value
     assert_dom_equal(
       "<option value=\"&lt;Abe&gt;\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\" disabled=\"disabled\">Babe went home</option>\n<option value=\"Cabe\" selected=\"selected\">Cabe went home</option>",
-      options_from_collection_for_select(dummy_posts, "author_name", "title", :selected => "Cabe", :disabled => "Babe")
+      options_from_collection_for_select(dummy_posts, "author_name", "title", selected: "Cabe", disabled: "Babe")
     )
   end
 
   def test_collection_options_with_priority_values
     assert_dom_equal(
       "<option value=\"Babe\">Babe went home</option>\n<option value=\"Cabe\">Cabe went home</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\">Babe went home</option>\n<option value=\"Cabe\">Cabe went home</option>",
-      options_from_collection_for_select(dummy_posts, "author_name", "title", :priority => ["Cabe", "Babe"])
+      options_from_collection_for_select(dummy_posts, "author_name", "title", priority: ["Cabe", "Babe"])
     )
   end
 
   def test_collection_options_with_preselected_and_disabled_and_priority_values
     assert_dom_equal(
       "<option value=\"Babe\" disabled=\"disabled\">Babe went home</option>\n<option value=\"Cabe\" selected=\"selected\">Cabe went home</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\" disabled=\"disabled\">Babe went home</option>\n<option value=\"Cabe\">Cabe went home</option>",
-      options_from_collection_for_select(dummy_posts, "author_name", "title", :selected => "Cabe", :disabled => "Babe", :priority => ["Cabe", "Babe"])
+      options_from_collection_for_select(dummy_posts, "author_name", "title", selected: "Cabe", disabled: "Babe", priority: ["Cabe", "Babe"])
+    )
+  end
+
+  def test_collection_options_with_preselected_value_array_and_priority_values
+    assert_dom_equal(
+      "<option value=\"Babe\">Babe went home</option>\n<option value=\"Cabe\" selected=\"selected\">Cabe went home</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"&lt;Abe&gt;\" selected=\"selected\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\">Babe went home</option>\n<option value=\"Cabe\">Cabe went home</option>",
+      options_from_collection_for_select(dummy_posts, "author_name", "title", selected: ["Cabe", "<Abe>"], priority: ["Cabe", "Babe"])
     )
   end
 
   def test_collection_options_with_proc_for_disabled
     assert_dom_equal(
       "<option value=\"&lt;Abe&gt;\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\" disabled=\"disabled\">Babe went home</option>\n<option value=\"Cabe\" disabled=\"disabled\">Cabe went home</option>",
-      options_from_collection_for_select(dummy_posts, "author_name", "title", :disabled => lambda {|p| %w(Babe Cabe).include?(p.author_name)})
+      options_from_collection_for_select(dummy_posts, "author_name", "title", disabled: lambda {|p| %w(Babe Cabe).include?(p.author_name)})
     )
   end
 
@@ -146,56 +153,84 @@ class FormOptionsHelperTest < ActionView::TestCase
   def test_array_options_for_select_with_disabled_value
     assert_dom_equal(
       "<option value=\"Denmark\">Denmark</option>\n<option value=\"&lt;USA&gt;\" disabled=\"disabled\">&lt;USA&gt;</option>\n<option value=\"Sweden\">Sweden</option>",
-      options_for_select([ "Denmark", "<USA>", "Sweden" ], :disabled => "<USA>")
+      options_for_select([ "Denmark", "<USA>", "Sweden" ], disabled: "<USA>")
     )
   end
 
   def test_array_options_for_select_with_disabled_array
     assert_dom_equal(
       "<option value=\"Denmark\">Denmark</option>\n<option value=\"&lt;USA&gt;\" disabled=\"disabled\">&lt;USA&gt;</option>\n<option value=\"Sweden\" disabled=\"disabled\">Sweden</option>",
-      options_for_select([ "Denmark", "<USA>", "Sweden" ], :disabled => ["<USA>", "Sweden"])
+      options_for_select([ "Denmark", "<USA>", "Sweden" ], disabled: ["<USA>", "Sweden"])
     )
   end
 
   def test_array_options_for_select_with_selection_and_disabled_value
     assert_dom_equal(
       "<option value=\"Denmark\" selected=\"selected\">Denmark</option>\n<option value=\"&lt;USA&gt;\" disabled=\"disabled\">&lt;USA&gt;</option>\n<option value=\"Sweden\">Sweden</option>",
-      options_for_select([ "Denmark", "<USA>", "Sweden" ], :selected => "Denmark", :disabled => "<USA>")
+      options_for_select([ "Denmark", "<USA>", "Sweden" ], selected: "Denmark", disabled: "<USA>")
     )
   end
 
   def test_boolean_array_options_for_select_with_selection_and_disabled_value
     assert_dom_equal(
       "<option value=\"true\">true</option>\n<option value=\"false\" selected=\"selected\">false</option>",
-      options_for_select([ true, false ], :selected => false, :disabled => nil)
+      options_for_select([ true, false ], selected: false, disabled: nil)
     )
   end
 
   def test_array_options_for_select_with_selection_and_disabled_and_priority_value
     assert_dom_equal(
       "<option disabled=\"disabled\" value=\"&lt;USA&gt;\">&lt;USA&gt;</option>\n<option value=\"Japan\">Japan</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"Denmark\" selected=\"selected\">Denmark</option>\n<option value=\"&lt;USA&gt;\" disabled=\"disabled\">&lt;USA&gt;</option>\n<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\">Japan</option>",
-      options_for_select([ "Denmark", "<USA>", "Sweden", "Japan" ], :selected => "Denmark", :disabled => "<USA>", :priority => ["<USA>", "Japan"])
+      options_for_select([ "Denmark", "<USA>", "Sweden", "Japan" ], selected: "Denmark", disabled: "<USA>", priority: ["<USA>", "Japan"])
     )
   end
 
   def test_array_options_for_select_with_selected_priority_value
     assert_dom_equal(
       "<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\" selected=\"selected\">Japan</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"Denmark\">Denmark</option>\n<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\">Japan</option>",
-      options_for_select([ "Denmark", "Sweden", "Japan" ], :selected => "Japan", :priority => ["Sweden", "Japan"])
+      options_for_select([ "Denmark", "Sweden", "Japan" ], selected: "Japan", priority: ["Sweden", "Japan"])
     )
   end
 
   def test_array_options_for_select_with_unselected_priority_value
     assert_dom_equal(
       "<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\">Japan</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"Denmark\" selected=\"selected\">Denmark</option>\n<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\">Japan</option>",
-      options_for_select([ "Denmark", "Sweden", "Japan" ], :selected => "Denmark", :priority => ["Sweden", "Japan"])
+      options_for_select([ "Denmark", "Sweden", "Japan" ], selected: "Denmark", priority: ["Sweden", "Japan"])
     )
   end
 
   def test_array_options_for_select_with_non_existing_priority_value
     assert_dom_equal(
       "<option value=\"Denmark\" selected=\"selected\">Denmark</option>\n<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\">Japan</option>",
-      options_for_select([ "Denmark", "Sweden", "Japan" ], :selected => "Denmark", :priority => ["Zweden"])
+      options_for_select([ "Denmark", "Sweden", "Japan" ], selected: "Denmark", priority: ["Zweden"])
+    )
+  end
+
+  def test_array_options_for_select_with_string_for_priority_separator
+    assert_dom_equal(
+      "<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\">Japan</option>\n<option value=\"\" disabled=\"disabled\">_____</option>\n<option value=\"Denmark\" selected=\"selected\">Denmark</option>\n<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\">Japan</option>",
+      options_for_select([ "Denmark", "Sweden", "Japan" ], selected: "Denmark", priority: ["Sweden", "Japan"], priority_separator: '_____')
+    )
+  end
+
+  def test_array_options_for_select_with_proc_for_priority_separator
+    assert_dom_equal(
+      "<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\">Japan</option>\n<option value=\"\" disabled=\"disabled\">-------</option>\n<option value=\"Denmark\" selected=\"selected\">Denmark</option>\n<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\">Japan</option>",
+      options_for_select([ "Denmark", "Sweden", "Japan" ], selected: "Denmark", priority: ["Sweden", "Japan"], priority_separator: lambda {|options| '-' * options.max_by(&:length).length})
+    )
+  end
+
+  def test_array_options_for_select_with_priority_unique
+    assert_dom_equal(
+      "<option value=\"en\" class=\"bold\">English</option>\n<option value=\"jp\">Japanese</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"de\">German</option>\n<option value=\"nl\">Dutch</option>",
+      options_for_select([["English", "en", {class: 'bold'}], ["German", "de"], ["Dutch", "nl"], ["Japanese", "jp"]], priority: ["en", "jp"], priority_unique: true)
+    )
+  end
+
+  def test_hash_options_for_select_with_priority_unique
+    assert_dom_equal(
+      "<option value=\"en\">English</option>\n<option value=\"jp\">Japanese</option>\n<option value=\"\" disabled=\"disabled\">-----</option>\n<option value=\"de\">German</option>\n<option value=\"nl\">Dutch</option>",
+      options_for_select({"English" => "en", "German" => "de", "Dutch" => "nl", "Japanese" => "jp"}, priority: ["en", "jp"], priority_separator: "-----", priority_unique: true)
     )
   end
 
@@ -236,7 +271,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
     assert_dom_equal(
       "<option value=\"Dollar\">$</option>\n<option value=\"Yen\">Y</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"Dollar\">$</option>\n<option value=\"&lt;Kroner&gt;\">&lt;DKR&gt;</option>\n<option value=\"Yen\">Y</option>",
-      options_for_select({ "$" => "Dollar", "<DKR>" => "<Kroner>", "Y" => "Yen" }, :priority => [ "$", "Y" ]).split("\n").join("\n")
+      options_for_select({ "$" => "Dollar", "<DKR>" => "<Kroner>", "Y" => "Yen" }, priority: [ "Dollar", "Yen" ]).split("\n").join("\n")
     )
   end
 
@@ -260,7 +295,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     albums = [ Album.new(1, "first","rap"), Album.new(2, "second","pop")]
     assert_dom_equal(
     %(<option selected="selected" value="1">rap</option>\n<option value="2">pop</option>),
-    options_from_collection_for_select(albums, "id", "genre", :selected => "1")
+    options_from_collection_for_select(albums, "id", "genre", selected: "1")
     )
   end
 
@@ -269,7 +304,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
     assert_dom_equal(
     %(<option selected="selected" value="1">rap</option>\n<option value="2">pop</option>),
-    options_from_collection_for_select(albums, "id", "genre", :selected => 1)
+    options_from_collection_for_select(albums, "id", "genre", selected: 1)
     )
   end
 
@@ -278,7 +313,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
     assert_dom_equal(
     %(<option value="1.0">rap</option>\n<option value="2.0" selected="selected">pop</option>),
-    options_from_collection_for_select(albums, "id", "genre", :selected => "2.0")
+    options_from_collection_for_select(albums, "id", "genre", selected: "2.0")
     )
   end
 
@@ -287,7 +322,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
     assert_dom_equal(
     %(<option value="1.0">rap</option>\n<option value="2.0">pop</option>),
-    options_from_collection_for_select(albums, "id", "genre", :selected => nil)
+    options_from_collection_for_select(albums, "id", "genre", selected: nil)
     )
   end
 
@@ -296,7 +331,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
     assert_dom_equal(
     %(<option value="1.0">rap</option>\n<option value="2.0">pop</option>),
-    options_from_collection_for_select(albums, "id", "genre", :disabled => nil)
+    options_from_collection_for_select(albums, "id", "genre", disabled: nil)
     )
   end
 
@@ -305,7 +340,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
     assert_dom_equal(
     %(<option disabled="disabled" value="1.0">rap</option>\n<option disabled="disabled" value="2.0">pop</option>),
-    options_from_collection_for_select(albums, "id", "genre", :disabled => ["1.0", 2.0])
+    options_from_collection_for_select(albums, "id", "genre", disabled: ["1.0", 2.0])
     )
   end
 
@@ -434,10 +469,8 @@ class FormOptionsHelperTest < ActionView::TestCase
                  "<option value=\"E\">E</option>\n" +
                  "<option value=\"\" disabled=\"disabled\">-------------</option>\n" +
                  "<option value=\"A\">A</option>\n" +
-                 "<option value=\"B\">B</option>\n" +
                  "<option value=\"C\">C</option>\n" +
-                 "<option value=\"D\">D</option>\n" +
-                 "<option value=\"E\">E</option>",
+                 "<option value=\"D\">D</option>",
                  opts
   end
 
@@ -448,10 +481,8 @@ class FormOptionsHelperTest < ActionView::TestCase
                  "<option value=\"E\" selected=\"selected\">E</option>\n" +
                  "<option value=\"\" disabled=\"disabled\">-------------</option>\n" +
                  "<option value=\"A\">A</option>\n" +
-                 "<option value=\"B\">B</option>\n" +
                  "<option value=\"C\">C</option>\n" +
-                 "<option value=\"D\">D</option>\n" +
-                 "<option value=\"E\">E</option>",
+                 "<option value=\"D\">D</option>",
                  opts
   end
 
@@ -462,10 +493,8 @@ class FormOptionsHelperTest < ActionView::TestCase
                  "<option value=\"E\">E</option>\n" +
                  "<option value=\"\" disabled=\"disabled\">-------------</option>\n" +
                  "<option value=\"A\">A</option>\n" +
-                 "<option value=\"B\">B</option>\n" +
                  "<option value=\"C\" selected=\"selected\">C</option>\n" +
-                 "<option value=\"D\">D</option>\n" +
-                 "<option value=\"E\">E</option>",
+                 "<option value=\"D\">D</option>",
                  opts
   end
 
@@ -492,7 +521,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   def test_select_without_multiple
     assert_dom_equal(
       "<select id=\"post_category\" name=\"post[category]\"></select>",
-      select(:post, :category, "", {}, :multiple => false)
+      select(:post, :category, "", {}, multiple: false)
     )
   end
 
@@ -572,7 +601,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     @post = Post.new
     @post.category = "<mus>"
 
-    output_buffer = fields_for :post, @post, :index => 108 do |f|
+    output_buffer = fields_for :post, @post, index: 108 do |f|
       concat f.select(:category, %w( abe <mus> hest))
     end
 
@@ -602,7 +631,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     options = "<option value=\"abe\">abe</option><option value=\"mus\">mus</option><option value=\"hest\">hest</option>".html_safe
 
     output_buffer = fields_for :post, @post do |f|
-      concat f.select(:category, options, :prompt => 'The prompt')
+      concat f.select(:category, options, prompt: 'The prompt')
     end
 
     assert_dom_equal(
@@ -612,7 +641,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   end
 
   def test_select_with_multiple_to_add_hidden_input
-    output_buffer =  select(:post, :category, "", {}, :multiple => true)
+    output_buffer =  select(:post, :category, "", {}, multiple: true)
     assert_dom_equal(
       "<input type=\"hidden\" name=\"post[category][]\" value=\"\"/><select multiple=\"multiple\" id=\"post_category\" name=\"post[category][]\"></select>",
       output_buffer
@@ -620,7 +649,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   end
 
   def test_select_with_multiple_and_without_hidden_input
-    output_buffer =  select(:post, :category, "", {:include_hidden => false}, :multiple => true)
+    output_buffer =  select(:post, :category, "", {include_hidden: false}, multiple: true)
     assert_dom_equal(
       "<select multiple=\"multiple\" id=\"post_category\" name=\"post[category][]\"></select>",
       output_buffer
@@ -628,7 +657,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   end
 
   def test_select_with_multiple_and_disabled_to_add_disabled_hidden_input
-    output_buffer =  select(:post, :category, "", {}, :multiple => true, :disabled => true)
+    output_buffer =  select(:post, :category, "", {}, multiple: true, disabled: true)
     assert_dom_equal(
       "<input disabled=\"disabled\"type=\"hidden\" name=\"post[category][]\" value=\"\"/><select multiple=\"multiple\" disabled=\"disabled\" id=\"post_category\" name=\"post[category][]\"></select>",
       output_buffer
@@ -640,7 +669,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     @post.category = "<mus>"
     assert_dom_equal(
       "<select id=\"post_category\" name=\"post[category]\"><option value=\"\"></option>\n<option value=\"abe\">abe</option>\n<option value=\"&lt;mus&gt;\" selected=\"selected\">&lt;mus&gt;</option>\n<option value=\"hest\">hest</option></select>",
-      select("post", "category", %w( abe <mus> hest), :include_blank => true)
+      select("post", "category", %w( abe <mus> hest), include_blank: true)
     )
   end
 
@@ -649,7 +678,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     @post.category = "<mus>"
     assert_dom_equal(
       "<select id=\"post_category\" name=\"post[category]\"><option value=\"\">None</option>\n<option value=\"abe\">abe</option>\n<option value=\"&lt;mus&gt;\" selected=\"selected\">&lt;mus&gt;</option>\n<option value=\"hest\">hest</option></select>",
-      select("post", "category", %w( abe <mus> hest), :include_blank => 'None')
+      select("post", "category", %w( abe <mus> hest), include_blank: 'None')
     )
   end
 
@@ -658,7 +687,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     @post.category = "<mus>"
     assert_dom_equal(
       "<select id=\"post_category\" name=\"post[category]\"><option value=\"\">&lt;None&gt;</option>\n<option value=\"abe\">abe</option>\n<option value=\"&lt;mus&gt;\" selected=\"selected\">&lt;mus&gt;</option>\n<option value=\"hest\">hest</option></select>",
-      select("post", "category", %w( abe <mus> hest), :include_blank => '<None>')
+      select("post", "category", %w( abe <mus> hest), include_blank: '<None>')
     )
   end
 
@@ -667,7 +696,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     @post.category = ""
     assert_dom_equal(
       "<select id=\"post_category\" name=\"post[category]\"><option value=\"\">Please select</option>\n<option value=\"abe\">abe</option>\n<option value=\"&lt;mus&gt;\">&lt;mus&gt;</option>\n<option value=\"hest\">hest</option></select>",
-      select("post", "category", %w( abe <mus> hest), :prompt => true)
+      select("post", "category", %w( abe <mus> hest), prompt: true)
     )
   end
 
@@ -676,7 +705,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     @post.category = "<mus>"
     assert_dom_equal(
       "<select id=\"post_category\" name=\"post[category]\"><option value=\"abe\">abe</option>\n<option value=\"&lt;mus&gt;\" selected=\"selected\">&lt;mus&gt;</option>\n<option value=\"hest\">hest</option></select>",
-      select("post", "category", %w( abe <mus> hest), :prompt => true)
+      select("post", "category", %w( abe <mus> hest), prompt: true)
     )
   end
 
@@ -685,7 +714,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     @post.category = ""
     assert_dom_equal(
       "<select id=\"post_category\" name=\"post[category]\"><option value=\"\">The prompt</option>\n<option value=\"abe\">abe</option>\n<option value=\"&lt;mus&gt;\">&lt;mus&gt;</option>\n<option value=\"hest\">hest</option></select>",
-      select("post", "category", %w( abe <mus> hest), :prompt => 'The prompt')
+      select("post", "category", %w( abe <mus> hest), prompt: 'The prompt')
     )
   end
 
@@ -693,7 +722,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     @post = Post.new
     assert_dom_equal(
       "<select id=\"post_category\" name=\"post[category]\"><option value=\"\">&lt;The prompt&gt;</option>\n<option value=\"abe\">abe</option>\n<option value=\"&lt;mus&gt;\">&lt;mus&gt;</option>\n<option value=\"hest\">hest</option></select>",
-      select("post", "category", %w( abe <mus> hest), :prompt => '<The prompt>')
+      select("post", "category", %w( abe <mus> hest), prompt: '<The prompt>')
     )
   end
 
@@ -702,7 +731,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     @post.category = ""
     assert_dom_equal(
       "<select id=\"post_category\" name=\"post[category]\"><option value=\"\">Please select</option>\n<option value=\"\"></option>\n<option value=\"abe\">abe</option>\n<option value=\"&lt;mus&gt;\">&lt;mus&gt;</option>\n<option value=\"hest\">hest</option></select>",
-      select("post", "category", %w( abe <mus> hest), :prompt => true, :include_blank => true)
+      select("post", "category", %w( abe <mus> hest), prompt: true, include_blank: true)
     )
   end
 
@@ -711,7 +740,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     @post.category = ""
     assert_dom_equal(
       "<select id=\"post_category\" name=\"post[category]\"><option value=\"\">Please select</option>\n<option value=\"\"></option>\n</select>",
-      select("post", "category", [], :prompt => true, :include_blank => true)
+      select("post", "category", [], prompt: true, include_blank: true)
     )
   end
 
@@ -771,7 +800,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     @post.category = ""
     assert_dom_equal(
       "<select id=\"post_category\" name=\"post[category]\"><option value=\"\">Please select</option>\n<option value=\"\"></option>\n<option value=\"1\">1</option></select>",
-      select("post", "category", [1], :prompt => true, :include_blank => true)
+      select("post", "category", [1], prompt: true, include_blank: true)
     )
   end
 
@@ -780,7 +809,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     @post.category = ""
     assert_dom_equal(
       "<select id=\"post_category\" name=\"post[category]\"><option value=\"\">Please select</option>\n<option value=\"\"></option>\n<option value=\"number\">Number</option>\n<option value=\"text\">Text</option>\n<option value=\"boolean\">Yes/No</option></select>",
-      select("post", "category", [["Number", "number"], ["Text", "text"], ["Yes/No", "boolean"]], :prompt => true, :include_blank => true)
+      select("post", "category", [["Number", "number"], ["Text", "text"], ["Yes/No", "boolean"]], prompt: true, include_blank: true)
     )
   end
 
@@ -789,7 +818,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     @post.category = "<mus>"
     assert_dom_equal(
       "<select id=\"post_category\" name=\"post[category]\"><option value=\"abe\" selected=\"selected\">abe</option>\n<option value=\"&lt;mus&gt;\">&lt;mus&gt;</option>\n<option value=\"hest\">hest</option></select>",
-      select("post", "category", %w( abe <mus> hest ), :selected => 'abe')
+      select("post", "category", %w( abe <mus> hest ), selected: 'abe')
     )
   end
 
@@ -801,7 +830,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
     assert_dom_equal(
       expected,
-      select("album[]", "genre", %w[rap rock country], {}, { :index => nil })
+      select("album[]", "genre", %w[rap rock country], {}, { index: nil })
     )
   end
 
@@ -817,7 +846,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     @post.category = "<mus>"
     assert_dom_equal(
       "<select id=\"post_category\" name=\"post[category]\"><option value=\"abe\">abe</option>\n<option value=\"&lt;mus&gt;\">&lt;mus&gt;</option>\n<option value=\"hest\">hest</option></select>",
-      select("post", "category", %w( abe <mus> hest ), :selected => nil)
+      select("post", "category", %w( abe <mus> hest ), selected: nil)
     )
   end
 
@@ -826,7 +855,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     @post.category = "<mus>"
     assert_dom_equal(
       "<select id=\"post_category\" name=\"post[category]\"><option value=\"abe\">abe</option>\n<option value=\"&lt;mus&gt;\" selected=\"selected\">&lt;mus&gt;</option>\n<option value=\"hest\" disabled=\"disabled\">hest</option></select>",
-      select("post", "category", %w( abe <mus> hest ), :disabled => 'hest')
+      select("post", "category", %w( abe <mus> hest ), disabled: 'hest')
     )
   end
 
@@ -835,7 +864,25 @@ class FormOptionsHelperTest < ActionView::TestCase
     @post.category = "<mus>"
     assert_dom_equal(
       "<select id=\"post_category\" name=\"post[category]\"><option value=\"hest\">hest</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"abe\">abe</option>\n<option value=\"&lt;mus&gt;\" selected=\"selected\">&lt;mus&gt;</option>\n<option value=\"hest\">hest</option></select>",
-      select("post", "category", %w( abe <mus> hest ), :priority => 'hest')
+      select("post", "category", %w( abe <mus> hest ), priority: 'hest')
+    )
+  end
+
+  def test_select_with_priority_separator_value
+    @post = Post.new
+    @post.category = "<mus>"
+    assert_dom_equal(
+      "<select id=\"post_category\" name=\"post[category]\"><option value=\"hest\">hest</option>\n<option value=\"\" disabled=\"disabled\">--</option>\n<option value=\"abe\">abe</option>\n<option value=\"&lt;mus&gt;\" selected=\"selected\">&lt;mus&gt;</option>\n<option value=\"hest\">hest</option></select>",
+      select("post", "category", %w( abe <mus> hest ), priority: 'hest', priority_separator: '--')
+    )
+  end
+
+  def test_select_with_priority_unique_value
+    @post = Post.new
+    @post.category = "<mus>"
+    assert_dom_equal(
+      "<select id=\"post_category\" name=\"post[category]\"><option value=\"hest\">hest</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"abe\">abe</option>\n<option value=\"&lt;mus&gt;\" selected=\"selected\">&lt;mus&gt;</option></select>",
+      select("post", "category", %w( abe <mus> hest ), priority: 'hest', priority_unique: true)
     )
   end
 
@@ -844,7 +891,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     @post.category = "<mus>"
     assert_dom_equal(
       "<select id=\"post_category\" name=\"post[category]\"><option value=\"abe\" disabled=\"disabled\">abe</option>\n<option value=\"&lt;mus&gt;\" selected=\"selected\">&lt;mus&gt;</option>\n<option value=\"hest\" disabled=\"disabled\">hest</option></select>",
-      select("post", "category", %w( abe <mus> hest ), :disabled => ['hest', 'abe'])
+      select("post", "category", %w( abe <mus> hest ), disabled: ['hest', 'abe'])
     )
   end
 
@@ -885,7 +932,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     @post = Post.new
     @post.author_name = "Babe"
 
-    output_buffer = fields_for :post, @post, :index => 815 do |f|
+    output_buffer = fields_for :post, @post, index: 815 do |f|
       concat f.collection_select(:author_name, dummy_posts, :author_name, :author_name)
     end
 
@@ -916,7 +963,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
     assert_dom_equal(
       "<select id=\"post_author_name\" name=\"post[author_name]\" style=\"width: 200px\"><option value=\"\"></option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>",
-      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { :include_blank => true }, "style" => "width: 200px")
+      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { include_blank: true }, style: "width: 200px")
     )
   end
 
@@ -926,7 +973,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
     assert_dom_equal(
       "<select id=\"post_author_name\" name=\"post[author_name]\" style=\"width: 200px\"><option value=\"\">No Selection</option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>",
-      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { :include_blank => 'No Selection' }, "style" => "width: 200px")
+      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { include_blank: 'No Selection' }, style: "width: 200px")
     )
   end
 
@@ -937,10 +984,10 @@ class FormOptionsHelperTest < ActionView::TestCase
     expected = "<input type=\"hidden\" name=\"post[author_name][]\" value=\"\"/><select id=\"post_author_name\" name=\"post[author_name][]\" multiple=\"multiple\"><option value=\"\"></option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>"
 
     # Should suffix default name with [].
-    assert_dom_equal expected, collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { :include_blank => true }, :multiple => true)
+    assert_dom_equal expected, collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { include_blank: true }, multiple: true)
 
     # Shouldn't suffix custom name with [].
-    assert_dom_equal expected, collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { :include_blank => true, :name => 'post[author_name][]' }, :multiple => true)
+    assert_dom_equal expected, collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { include_blank: true, name: 'post[author_name][]' }, multiple: true)
   end
 
   def test_collection_select_with_blank_and_selected
@@ -949,7 +996,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
     assert_dom_equal(
       %{<select id="post_author_name" name="post[author_name]"><option value=""></option>\n<option value="&lt;Abe&gt;" selected="selected">&lt;Abe&gt;</option>\n<option value="Babe">Babe</option>\n<option value="Cabe">Cabe</option></select>},
-      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", {:include_blank => true, :selected => "<Abe>"})
+      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", {include_blank: true, selected: "<Abe>"})
     )
   end
 
@@ -959,7 +1006,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
     assert_dom_equal(
       "<select id=\"post_author_name\" name=\"post[author_name]\"><option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\" disabled=\"disabled\">Cabe</option></select>",
-      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", :disabled => 'Cabe')
+      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", disabled: 'Cabe')
     )
   end
 
@@ -1016,7 +1063,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   def test_time_zone_select_under_fields_for_with_index
     @firm = Firm.new("D")
 
-    output_buffer = fields_for :firm, @firm, :index => 305 do |f|
+    output_buffer = fields_for :firm, @firm, index: 305 do |f|
       concat f.time_zone_select(:time_zone)
     end
 
@@ -1054,7 +1101,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
   def test_time_zone_select_with_blank
     @firm = Firm.new("D")
-    html = time_zone_select("firm", "time_zone", nil, :include_blank => true)
+    html = time_zone_select("firm", "time_zone", nil, include_blank: true)
     assert_dom_equal "<select id=\"firm_time_zone\" name=\"firm[time_zone]\">" +
                  "<option value=\"\"></option>\n" +
                  "<option value=\"A\">A</option>\n" +
@@ -1068,7 +1115,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
   def test_time_zone_select_with_blank_as_string
     @firm = Firm.new("D")
-    html = time_zone_select("firm", "time_zone", nil, :include_blank => 'No Zone')
+    html = time_zone_select("firm", "time_zone", nil, include_blank: 'No Zone')
     assert_dom_equal "<select id=\"firm_time_zone\" name=\"firm[time_zone]\">" +
                  "<option value=\"\">No Zone</option>\n" +
                  "<option value=\"A\">A</option>\n" +
@@ -1082,8 +1129,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
   def test_time_zone_select_with_style
     @firm = Firm.new("D")
-    html = time_zone_select("firm", "time_zone", nil, {},
-      "style" => "color: red")
+    html = time_zone_select("firm", "time_zone", nil, {}, style: "color: red")
     assert_dom_equal "<select id=\"firm_time_zone\" name=\"firm[time_zone]\" style=\"color: red\">" +
                  "<option value=\"A\">A</option>\n" +
                  "<option value=\"B\">B</option>\n" +
@@ -1092,14 +1138,12 @@ class FormOptionsHelperTest < ActionView::TestCase
                  "<option value=\"E\">E</option>" +
                  "</select>",
                  html
-    assert_dom_equal html, time_zone_select("firm", "time_zone", nil, {},
-      :style => "color: red")
+    assert_dom_equal html, time_zone_select("firm", "time_zone", nil, {}, style: "color: red")
   end
 
   def test_time_zone_select_with_blank_and_style
     @firm = Firm.new("D")
-    html = time_zone_select("firm", "time_zone", nil,
-      { :include_blank => true }, "style" => "color: red")
+    html = time_zone_select("firm", "time_zone", nil, { include_blank: true }, style: "color: red")
     assert_dom_equal "<select id=\"firm_time_zone\" name=\"firm[time_zone]\" style=\"color: red\">" +
                  "<option value=\"\"></option>\n" +
                  "<option value=\"A\">A</option>\n" +
@@ -1110,13 +1154,12 @@ class FormOptionsHelperTest < ActionView::TestCase
                  "</select>",
                  html
     assert_dom_equal html, time_zone_select("firm", "time_zone", nil,
-      { :include_blank => true }, :style => "color: red")
+      { include_blank: true }, style: "color: red")
   end
 
   def test_time_zone_select_with_blank_as_string_and_style
     @firm = Firm.new("D")
-    html = time_zone_select("firm", "time_zone", nil,
-      { :include_blank => 'No Zone' }, "style" => "color: red")
+    html = time_zone_select("firm", "time_zone", nil, { include_blank: 'No Zone' }, style: "color: red")
     assert_dom_equal "<select id=\"firm_time_zone\" name=\"firm[time_zone]\" style=\"color: red\">" +
                  "<option value=\"\">No Zone</option>\n" +
                  "<option value=\"A\">A</option>\n" +
@@ -1127,7 +1170,7 @@ class FormOptionsHelperTest < ActionView::TestCase
                  "</select>",
                  html
     assert_dom_equal html, time_zone_select("firm", "time_zone", nil,
-      { :include_blank => 'No Zone' }, :style => "color: red")
+      { include_blank: 'No Zone' }, style: "color: red")
   end
 
   def test_time_zone_select_with_priority_zones
@@ -1138,10 +1181,8 @@ class FormOptionsHelperTest < ActionView::TestCase
                  "<option value=\"A\">A</option>\n" +
                  "<option value=\"D\" selected=\"selected\">D</option>\n" +
                  "<option value=\"\" disabled=\"disabled\">-------------</option>\n" +
-                 "<option value=\"A\">A</option>\n" +
                  "<option value=\"B\">B</option>\n" +
                  "<option value=\"C\">C</option>\n" +
-                 "<option value=\"D\">D</option>\n" +
                  "<option value=\"E\">E</option>" +
                  "</select>",
                  html
@@ -1160,10 +1201,8 @@ class FormOptionsHelperTest < ActionView::TestCase
                  "<option value=\"A\">A</option>\n" +
                  "<option value=\"D\" selected=\"selected\">D</option>\n" +
                  "<option value=\"\" disabled=\"disabled\">-------------</option>\n" +
-                 "<option value=\"A\">A</option>\n" +
                  "<option value=\"B\">B</option>\n" +
                  "<option value=\"C\">C</option>\n" +
-                 "<option value=\"D\">D</option>\n" +
                  "<option value=\"E\">E</option>" +
                  "</select>",
                  html
@@ -1172,7 +1211,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   def test_time_zone_select_with_default_time_zone_and_nil_value
      @firm = Firm.new()
      @firm.time_zone = nil
-      html = time_zone_select( "firm", "time_zone", nil, :default => 'B' )
+      html = time_zone_select( "firm", "time_zone", nil, default: 'B' )
       assert_dom_equal "<select id=\"firm_time_zone\" name=\"firm[time_zone]\">" +
                    "<option value=\"A\">A</option>\n" +
                    "<option value=\"B\" selected=\"selected\">B</option>\n" +
@@ -1185,7 +1224,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
   def test_time_zone_select_with_default_time_zone_and_value
      @firm = Firm.new('D')
-      html = time_zone_select( "firm", "time_zone", nil, :default => 'B' )
+      html = time_zone_select( "firm", "time_zone", nil, default: 'B' )
       assert_dom_equal "<select id=\"firm_time_zone\" name=\"firm[time_zone]\">" +
                    "<option value=\"A\">A</option>\n" +
                    "<option value=\"B\">B</option>\n" +
@@ -1199,42 +1238,42 @@ class FormOptionsHelperTest < ActionView::TestCase
   def test_options_for_select_with_element_attributes
     assert_dom_equal(
       "<option value=\"&lt;Denmark&gt;\" class=\"bold\">&lt;Denmark&gt;</option>\n<option value=\"USA\" onclick=\"alert(&#39;Hello World&#39;);\">USA</option>\n<option value=\"Sweden\">Sweden</option>\n<option value=\"Germany\">Germany</option>",
-      options_for_select([ [ "<Denmark>", { :class => 'bold' } ], [ "USA", { :onclick => "alert('Hello World');" } ], [ "Sweden" ], "Germany" ])
+      options_for_select([ [ "<Denmark>", { class: 'bold' } ], [ "USA", { onclick: "alert('Hello World');" } ], [ "Sweden" ], "Germany" ])
     )
   end
 
   def test_options_for_select_with_data_element
     assert_dom_equal(
       "<option value=\"&lt;Denmark&gt;\" data-test=\"bold\">&lt;Denmark&gt;</option>",
-      options_for_select([ [ "<Denmark>", { :data => { :test => 'bold' } } ] ])
+      options_for_select([ [ "<Denmark>", { data: { test: 'bold' } } ] ])
     )
   end
 
   def test_options_for_select_with_data_element_with_special_characters
     assert_dom_equal(
       "<option value=\"&lt;Denmark&gt;\" data-test=\"&lt;bold&gt;\">&lt;Denmark&gt;</option>",
-      options_for_select([ [ "<Denmark>", { :data => { :test => '<bold>' } } ] ])
+      options_for_select([ [ "<Denmark>", { data: { test: '<bold>' } } ] ])
     )
   end
 
   def test_options_for_select_with_element_attributes_and_selection
     assert_dom_equal(
       "<option value=\"&lt;Denmark&gt;\">&lt;Denmark&gt;</option>\n<option value=\"USA\" class=\"bold\" selected=\"selected\">USA</option>\n<option value=\"Sweden\">Sweden</option>",
-      options_for_select([ "<Denmark>", [ "USA", { :class => 'bold' } ], "Sweden" ], "USA")
+      options_for_select([ "<Denmark>", [ "USA", { class: 'bold' } ], "Sweden" ], "USA")
     )
   end
 
   def test_options_for_select_with_element_attributes_and_selection_array
     assert_dom_equal(
       "<option value=\"&lt;Denmark&gt;\">&lt;Denmark&gt;</option>\n<option value=\"USA\" class=\"bold\" selected=\"selected\">USA</option>\n<option value=\"Sweden\" selected=\"selected\">Sweden</option>",
-      options_for_select([ "<Denmark>", [ "USA", { :class => 'bold' } ], "Sweden" ], [ "USA", "Sweden" ])
+      options_for_select([ "<Denmark>", [ "USA", { class: 'bold' } ], "Sweden" ], [ "USA", "Sweden" ])
     )
   end
 
   def test_options_for_select_with_special_characters
     assert_dom_equal(
       "<option value=\"&lt;Denmark&gt;\" onclick=\"alert(&quot;&lt;code&gt;&quot;)\">&lt;Denmark&gt;</option>",
-      options_for_select([ [ "<Denmark>", { :onclick => %(alert("<code>")) } ] ])
+      options_for_select([ [ "<Denmark>", { onclick: %(alert("<code>")) } ] ])
     )
   end
 
@@ -1248,22 +1287,22 @@ class FormOptionsHelperTest < ActionView::TestCase
 
   def test_option_html_attributes_with_single_element_hash
     assert_equal(
-      {:class => 'fancy'},
-      option_html_attributes([ 'foo', 'bar', { :class => 'fancy' } ])
+      {class: 'fancy'},
+      option_html_attributes([ 'foo', 'bar', { class: 'fancy' } ])
     )
   end
 
   def test_option_html_attributes_with_multiple_element_hash
     assert_equal(
-      {:class => 'fancy', 'onclick' => "alert('Hello World');"},
-      option_html_attributes([ 'foo', 'bar', { :class => 'fancy', 'onclick' => "alert('Hello World');" } ])
+      {class: 'fancy', onclick: "alert('Hello World');"},
+      option_html_attributes([ 'foo', 'bar', { class: 'fancy', onclick: "alert('Hello World');" } ])
     )
   end
 
   def test_option_html_attributes_with_multiple_hashes
     assert_equal(
-      {:class => 'fancy', 'onclick' => "alert('Hello World');"},
-      option_html_attributes([ 'foo', 'bar', { :class => 'fancy' }, { 'onclick' => "alert('Hello World');" } ])
+      {class: 'fancy', onclick: "alert('Hello World');"},
+      option_html_attributes([ 'foo', 'bar', { class: 'fancy' }, { onclick: "alert('Hello World');" } ])
     )
   end
 
@@ -1291,7 +1330,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
     assert_dom_equal(
       %Q{<select id="post_origin" name="post[origin]"><optgroup label="&lt;Africa&gt;"><option value="&lt;sa&gt;">&lt;South Africa&gt;</option>\n<option value="so">Somalia</option></optgroup><optgroup label="Europe"><option value="dk" selected="selected">Denmark</option>\n<option value="ie">Ireland</option></optgroup></select>},
-      grouped_collection_select("post", "origin", dummy_continents, :countries, :continent_name, :country_id, :country_name, :selected => 'dk')
+      grouped_collection_select("post", "origin", dummy_continents, :countries, :continent_name, :country_id, :country_name, selected: 'dk')
     )
   end
 
@@ -1300,7 +1339,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
     assert_dom_equal(
       %Q{<select id="post_origin" name="post[origin]"><optgroup label="&lt;Africa&gt;"><option value="&lt;sa&gt;">&lt;South Africa&gt;</option>\n<option value="so">Somalia</option></optgroup><optgroup label="Europe"><option disabled="disabled" value="dk">Denmark</option>\n<option value="ie">Ireland</option></optgroup></select>},
-      grouped_collection_select("post", "origin", dummy_continents, :countries, :continent_name, :country_id, :country_name, :disabled => 'dk')
+      grouped_collection_select("post", "origin", dummy_continents, :countries, :continent_name, :country_id, :country_name, disabled: 'dk')
     )
   end
 

--- a/actionpack/test/template/form_options_helper_test.rb
+++ b/actionpack/test/template/form_options_helper_test.rb
@@ -79,6 +79,20 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_collection_options_with_priority_values
+    assert_dom_equal(
+      "<option value=\"Babe\">Babe went home</option>\n<option value=\"Cabe\">Cabe went home</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\">Babe went home</option>\n<option value=\"Cabe\">Cabe went home</option>",
+      options_from_collection_for_select(dummy_posts, "author_name", "title", :priority => ["Cabe", "Babe"])
+    )
+  end
+
+  def test_collection_options_with_preselected_and_disabled_and_priority_values
+    assert_dom_equal(
+      "<option value=\"Babe\" disabled=\"disabled\">Babe went home</option>\n<option value=\"Cabe\" selected=\"selected\">Cabe went home</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\" disabled=\"disabled\">Babe went home</option>\n<option value=\"Cabe\">Cabe went home</option>",
+      options_from_collection_for_select(dummy_posts, "author_name", "title", :selected => "Cabe", :disabled => "Babe", :priority => ["Cabe", "Babe"])
+    )
+  end
+
   def test_collection_options_with_proc_for_disabled
     assert_dom_equal(
       "<option value=\"&lt;Abe&gt;\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\" disabled=\"disabled\">Babe went home</option>\n<option value=\"Cabe\" disabled=\"disabled\">Cabe went home</option>",
@@ -157,6 +171,34 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_array_options_for_select_with_selection_and_disabled_and_priority_value
+    assert_dom_equal(
+      "<option disabled=\"disabled\" value=\"&lt;USA&gt;\">&lt;USA&gt;</option>\n<option value=\"Japan\">Japan</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"Denmark\" selected=\"selected\">Denmark</option>\n<option value=\"&lt;USA&gt;\" disabled=\"disabled\">&lt;USA&gt;</option>\n<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\">Japan</option>",
+      options_for_select([ "Denmark", "<USA>", "Sweden", "Japan" ], :selected => "Denmark", :disabled => "<USA>", :priority => ["<USA>", "Japan"])
+    )
+  end
+
+  def test_array_options_for_select_with_selected_priority_value
+    assert_dom_equal(
+      "<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\" selected=\"selected\">Japan</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"Denmark\">Denmark</option>\n<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\">Japan</option>",
+      options_for_select([ "Denmark", "Sweden", "Japan" ], :selected => "Japan", :priority => ["Sweden", "Japan"])
+    )
+  end
+
+  def test_array_options_for_select_with_unselected_priority_value
+    assert_dom_equal(
+      "<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\">Japan</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"Denmark\" selected=\"selected\">Denmark</option>\n<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\">Japan</option>",
+      options_for_select([ "Denmark", "Sweden", "Japan" ], :selected => "Denmark", :priority => ["Sweden", "Japan"])
+    )
+  end
+
+  def test_array_options_for_select_with_non_existing_priority_value
+    assert_dom_equal(
+      "<option value=\"Denmark\" selected=\"selected\">Denmark</option>\n<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\">Japan</option>",
+      options_for_select([ "Denmark", "Sweden", "Japan" ], :selected => "Denmark", :priority => ["Zweden"])
+    )
+  end
+
   def test_range_options_for_select
     assert_dom_equal(
       "<option value=\"1\">1</option>\n<option value=\"2\">2</option>\n<option value=\"3\">3</option>",
@@ -191,6 +233,10 @@ class FormOptionsHelperTest < ActionView::TestCase
     assert_dom_equal(
       "<option value=\"Dollar\" selected=\"selected\">$</option>\n<option value=\"&lt;Kroner&gt;\" selected=\"selected\">&lt;DKR&gt;</option>",
       options_for_select({ "$" => "Dollar", "<DKR>" => "<Kroner>" }, [ "Dollar", "<Kroner>" ]).split("\n").join("\n")
+    )
+    assert_dom_equal(
+      "<option value=\"Dollar\">$</option>\n<option value=\"Yen\">Y</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"Dollar\">$</option>\n<option value=\"&lt;Kroner&gt;\">&lt;DKR&gt;</option>\n<option value=\"Yen\">Y</option>",
+      options_for_select({ "$" => "Dollar", "<DKR>" => "<Kroner>", "Y" => "Yen" }, :priority => [ "$", "Y" ]).split("\n").join("\n")
     )
   end
 
@@ -385,11 +431,13 @@ class FormOptionsHelperTest < ActionView::TestCase
     zones = [ ActiveSupport::TimeZone.new( "B" ), ActiveSupport::TimeZone.new( "E" ) ]
     opts = time_zone_options_for_select( nil, zones )
     assert_dom_equal "<option value=\"B\">B</option>\n" +
-                 "<option value=\"E\">E</option>" +
+                 "<option value=\"E\">E</option>\n" +
                  "<option value=\"\" disabled=\"disabled\">-------------</option>\n" +
                  "<option value=\"A\">A</option>\n" +
+                 "<option value=\"B\">B</option>\n" +
                  "<option value=\"C\">C</option>\n" +
-                 "<option value=\"D\">D</option>",
+                 "<option value=\"D\">D</option>\n" +
+                 "<option value=\"E\">E</option>",
                  opts
   end
 
@@ -397,11 +445,13 @@ class FormOptionsHelperTest < ActionView::TestCase
     zones = [ ActiveSupport::TimeZone.new( "B" ), ActiveSupport::TimeZone.new( "E" ) ]
     opts = time_zone_options_for_select( "E", zones )
     assert_dom_equal "<option value=\"B\">B</option>\n" +
-                 "<option value=\"E\" selected=\"selected\">E</option>" +
+                 "<option value=\"E\" selected=\"selected\">E</option>\n" +
                  "<option value=\"\" disabled=\"disabled\">-------------</option>\n" +
                  "<option value=\"A\">A</option>\n" +
+                 "<option value=\"B\">B</option>\n" +
                  "<option value=\"C\">C</option>\n" +
-                 "<option value=\"D\">D</option>",
+                 "<option value=\"D\">D</option>\n" +
+                 "<option value=\"E\">E</option>",
                  opts
   end
 
@@ -409,11 +459,13 @@ class FormOptionsHelperTest < ActionView::TestCase
     zones = [ ActiveSupport::TimeZone.new( "B" ), ActiveSupport::TimeZone.new( "E" ) ]
     opts = time_zone_options_for_select( "C", zones )
     assert_dom_equal "<option value=\"B\">B</option>\n" +
-                 "<option value=\"E\">E</option>" +
+                 "<option value=\"E\">E</option>\n" +
                  "<option value=\"\" disabled=\"disabled\">-------------</option>\n" +
                  "<option value=\"A\">A</option>\n" +
+                 "<option value=\"B\">B</option>\n" +
                  "<option value=\"C\" selected=\"selected\">C</option>\n" +
-                 "<option value=\"D\">D</option>",
+                 "<option value=\"D\">D</option>\n" +
+                 "<option value=\"E\">E</option>",
                  opts
   end
 
@@ -778,6 +830,15 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_select_with_priority_value
+    @post = Post.new
+    @post.category = "<mus>"
+    assert_dom_equal(
+      "<select id=\"post_category\" name=\"post[category]\"><option value=\"hest\">hest</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"abe\">abe</option>\n<option value=\"&lt;mus&gt;\" selected=\"selected\">&lt;mus&gt;</option>\n<option value=\"hest\">hest</option></select>",
+      select("post", "category", %w( abe <mus> hest ), :priority => 'hest')
+    )
+  end
+
   def test_select_with_disabled_array
     @post = Post.new
     @post.category = "<mus>"
@@ -1075,10 +1136,12 @@ class FormOptionsHelperTest < ActionView::TestCase
     html = time_zone_select("firm", "time_zone", zones )
     assert_dom_equal "<select id=\"firm_time_zone\" name=\"firm[time_zone]\">" +
                  "<option value=\"A\">A</option>\n" +
-                 "<option value=\"D\" selected=\"selected\">D</option>" +
+                 "<option value=\"D\" selected=\"selected\">D</option>\n" +
                  "<option value=\"\" disabled=\"disabled\">-------------</option>\n" +
+                 "<option value=\"A\">A</option>\n" +
                  "<option value=\"B\">B</option>\n" +
                  "<option value=\"C\">C</option>\n" +
+                 "<option value=\"D\">D</option>\n" +
                  "<option value=\"E\">E</option>" +
                  "</select>",
                  html
@@ -1095,10 +1158,12 @@ class FormOptionsHelperTest < ActionView::TestCase
     html = time_zone_select("firm", "time_zone", priority_zones)
     assert_dom_equal "<select id=\"firm_time_zone\" name=\"firm[time_zone]\">" +
                  "<option value=\"A\">A</option>\n" +
-                 "<option value=\"D\" selected=\"selected\">D</option>" +
+                 "<option value=\"D\" selected=\"selected\">D</option>\n" +
                  "<option value=\"\" disabled=\"disabled\">-------------</option>\n" +
+                 "<option value=\"A\">A</option>\n" +
                  "<option value=\"B\">B</option>\n" +
                  "<option value=\"C\">C</option>\n" +
+                 "<option value=\"D\">D</option>\n" +
                  "<option value=\"E\">E</option>" +
                  "</select>",
                  html

--- a/actionpack/test/template/form_options_helper_test.rb
+++ b/actionpack/test/template/form_options_helper_test.rb
@@ -469,8 +469,10 @@ class FormOptionsHelperTest < ActionView::TestCase
                  "<option value=\"E\">E</option>\n" +
                  "<option value=\"\" disabled=\"disabled\">-------------</option>\n" +
                  "<option value=\"A\">A</option>\n" +
+                 "<option value=\"B\">B</option>\n" +
                  "<option value=\"C\">C</option>\n" +
-                 "<option value=\"D\">D</option>",
+                 "<option value=\"D\">D</option>\n" +
+                 "<option value=\"E\">E</option>",
                  opts
   end
 
@@ -481,8 +483,10 @@ class FormOptionsHelperTest < ActionView::TestCase
                  "<option value=\"E\" selected=\"selected\">E</option>\n" +
                  "<option value=\"\" disabled=\"disabled\">-------------</option>\n" +
                  "<option value=\"A\">A</option>\n" +
+                 "<option value=\"B\">B</option>\n" +
                  "<option value=\"C\">C</option>\n" +
-                 "<option value=\"D\">D</option>",
+                 "<option value=\"D\">D</option>\n" +
+                 "<option value=\"E\">E</option>",
                  opts
   end
 
@@ -493,8 +497,10 @@ class FormOptionsHelperTest < ActionView::TestCase
                  "<option value=\"E\">E</option>\n" +
                  "<option value=\"\" disabled=\"disabled\">-------------</option>\n" +
                  "<option value=\"A\">A</option>\n" +
+                 "<option value=\"B\">B</option>\n" +
                  "<option value=\"C\" selected=\"selected\">C</option>\n" +
-                 "<option value=\"D\">D</option>",
+                 "<option value=\"D\">D</option>\n" +
+                 "<option value=\"E\">E</option>",
                  opts
   end
 
@@ -1181,8 +1187,10 @@ class FormOptionsHelperTest < ActionView::TestCase
                  "<option value=\"A\">A</option>\n" +
                  "<option value=\"D\" selected=\"selected\">D</option>\n" +
                  "<option value=\"\" disabled=\"disabled\">-------------</option>\n" +
+                 "<option value=\"A\">A</option>\n" +
                  "<option value=\"B\">B</option>\n" +
                  "<option value=\"C\">C</option>\n" +
+                 "<option value=\"D\">D</option>\n" +
                  "<option value=\"E\">E</option>" +
                  "</select>",
                  html
@@ -1201,8 +1209,10 @@ class FormOptionsHelperTest < ActionView::TestCase
                  "<option value=\"A\">A</option>\n" +
                  "<option value=\"D\" selected=\"selected\">D</option>\n" +
                  "<option value=\"\" disabled=\"disabled\">-------------</option>\n" +
+                 "<option value=\"A\">A</option>\n" +
                  "<option value=\"B\">B</option>\n" +
                  "<option value=\"C\">C</option>\n" +
+                 "<option value=\"D\">D</option>\n" +
                  "<option value=\"E\">E</option>" +
                  "</select>",
                  html


### PR DESCRIPTION
Continuation of Pull Request #9620

The following:

```
   f.time_zone_select :time_zone, [ ActiveSupport::TimeZone['Pacific Time (US & Canada)'] ]
```

will not show time zone "(GMT-08:00) Pacific Time (US & Canada)" below the separator, it will only show at the top of the options list.

We regularly get tickets from our users who say they get confused when they can't find the time zone (or country or language or etc.) in the (long) list below the options separator where they would expect to find the value. 

This usually happens when a user goes into edit mode and a non-priority option is selected (e.g. "(GMT-07:00) Arizona"), and they want to change it to a different selection. It's not obvious they then have to look at the top (as the top is often also out of sight). 

This patch always shows all time zone options below the separator, even when they are listed as a priority time zone.

See also [discussion](https://github.com/rails/rails/pull/9620#discussion-diff-3307962)
