### PR TITLE
Missing gems on plugin Gemfile template

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/Gemfile
@@ -28,3 +28,5 @@ end
 <% end -%>
 # To use debugger
 # gem 'debugger'
+gem 'jquery-rails'
+gem 'turbolinks'


### PR DESCRIPTION
Hi folks,

When I tried run `rails server` on dummy app from my engine, I received the message _couldn't find file 'jquery'_, and after I added _jquery-rails_ to Gemfile, I received _couldn't find file 'turbolinks'_, then I added _turbolinks_ too.

Now it's OK.

This should be default, doesn't it?

Sorry for my bad writing.
