### PR TITLE
`asset_path` respects SCRIPT_NAME.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `asset_path` respects SCRIPT_NAME. Fixes #2992. *Yves Senn*
+
 *   Fix incorrectly appended square brackets to a multiple select box
     if an explicit name has been given and it already ends with "[]"
 

--- a/actionpack/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionpack/lib/action_view/helpers/asset_url_helper.rb
@@ -133,6 +133,8 @@ module ActionView
         end
 
         relative_url_root = defined?(config.relative_url_root) && config.relative_url_root
+        request = self.request if respond_to?(:request)
+        relative_url_root ||= request.script_name if request
         if relative_url_root
           source = "#{relative_url_root}#{source}" unless source.starts_with?("#{relative_url_root}/")
         end

--- a/actionpack/test/template/asset_tag_helper_test.rb
+++ b/actionpack/test/template/asset_tag_helper_test.rb
@@ -733,6 +733,16 @@ class AssetUrlHelperEmptyModuleTest < ActionView::TestCase
     assert_equal "http://www.example.com/foo", @module.asset_url("foo")
   end
 
+  def test_asset_url_with_script_name
+    @module.instance_eval do
+      def request
+        Struct.new(:base_url, :script_name).new("http://www.example.com", "/app")
+      end
+    end
+
+    assert_equal "http://www.example.com/app/foo", @module.asset_url("foo")
+  end
+
   def test_asset_url_with_config_asset_host
     @module.instance_eval do
       def config

--- a/actionpack/test/template/asset_tag_helper_test.rb
+++ b/actionpack/test/template/asset_tag_helper_test.rb
@@ -443,8 +443,8 @@ class AssetTagHelperTest < ActionView::TestCase
     [nil, '/', '/foo/bar/', 'foo/bar/'].each do |prefix|
       assert_equal 'Rails', image_alt("#{prefix}rails.png")
       assert_equal 'Rails', image_alt("#{prefix}rails-9c0a079bdd7701d7e729bd956823d153.png")
-      assert_equal 'Long file name with hyphens', image_alt("#{prefix}long-file-name-with-hyphens.png") 
-      assert_equal 'Long file name with underscores', image_alt("#{prefix}long_file_name_with_underscores.png")  
+      assert_equal 'Long file name with hyphens', image_alt("#{prefix}long-file-name-with-hyphens.png")
+      assert_equal 'Long file name with underscores', image_alt("#{prefix}long_file_name_with_underscores.png")
     end
   end
 


### PR DESCRIPTION
Closes #2992 

The code on `3-2-stable` is very different but It should be an easy fix too.
