### PR TITLE
Address ActiveRecord::StatementInvalid: OCIError: ORA-00979

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1156,8 +1156,8 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_find_keeps_multiple_group_values
-    combined = Developer.all.merge!(:group => 'developers.name, developers.salary, developers.id, developers.created_at, developers.updated_at').to_a
-    assert_equal combined, Developer.all.merge!(:group => ['developers.name', 'developers.salary', 'developers.id', 'developers.created_at', 'developers.updated_at']).to_a
+    combined = Developer.all.merge!(:group => 'developers.name, developers.salary, developers.id, developers.created_at, developers.updated_at, developers.created_on, developers.updated_on').to_a
+    assert_equal combined, Developer.all.merge!(:group => ['developers.name', 'developers.salary', 'developers.id', 'developers.created_at', 'developers.updated_at', 'developers.created_on', 'developers.updated_on']).to_a
   end
 
   def test_find_symbol_ordered_last


### PR DESCRIPTION
This pull request addresses a error since commit 1dc98c143c4bf84ccfb55b30c7d41b29b62d50cf merged, which adds two attributes `:created_on` and `:updated_on` to the `:developers`.
Because of Oracle database implementation, without any aggregate functions
such as count(*), all columns must be listed in select statement.

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/base_test.rb  -n test_find_keeps_multiple_group_values
Using oracle
Run options: -n test_find_keeps_multiple_group_values --seed 12885

# Running tests:

E

Finished tests in 0.623040s, 1.6050 tests/s, 0.0000 assertions/s.

  1) Error:
BasicsTest#test_find_keeps_multiple_group_values:
ActiveRecord::StatementInvalid: OCIError: ORA-00979: not a GROUP BY expression: SELECT "DEVELOPERS".* FROM "DEVELOPERS"  GROUP BY developers.name, developers.salary, developers.id, developers.created_at, developers.updated_at
    stmt.c:230:in oci8lib_200.so
    /home/yahonda/.rvm/gems/ruby-2.0.0-p0@railsmaster/gems/ruby-oci8-2.1.4/lib/oci8/cursor.rb:126:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:143:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:749:in `block in exec_query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:334:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:329:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1491:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:729:in `exec_query'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1445:in `select'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:24:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:63:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/querying.rb:36:in `find_by_sql'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:555:in `exec_queries'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:447:in `load'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:197:in `to_a'
    test/cases/base_test.rb:1145:in `test_find_keeps_multiple_group_values'

1 tests, 0 assertions, 0 failures, 1 errors, 0 skips
$
```

I think this commit should satisfy the `test_find_keeps_multiple_group_values` test purpose.
