### PR TITLE
Change from each to each_value on hash to avoid unused variable warning

### DIFF
--- a/actionpack/test/dispatch/request/url_encoded_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/url_encoded_params_parsing_test.rb
@@ -164,7 +164,7 @@ class UrlEncodedParamsParsingTest < ActionDispatch::IntegrationTest
         return
       end
 
-      object.each do |k,v|
+      object.each_value do |v|
         case v
         when Hash
           assert_utf8(v)


### PR DESCRIPTION
Change from each to each_value on hash to avoid unused variable warning, since we are not using k in test
