### PR TITLE
Fixed tests `to_time` returning an instance of `Time` in the local system timezone

### DIFF
--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -293,16 +293,16 @@ end
 
 class StringConversionsTest < ActiveSupport::TestCase
   def test_string_to_time
-    with_env_tz "US/Eastern" do
+    with_env_tz "Europe/Moscow" do
       assert_equal Time.utc(2005, 2, 27, 23, 50), "2005-02-27 23:50".to_time(:utc)
       assert_equal Time.local(2005, 2, 27, 23, 50), "2005-02-27 23:50".to_time
       assert_equal Time.utc(2005, 2, 27, 23, 50, 19, 275038), "2005-02-27T23:50:19.275038".to_time(:utc)
       assert_equal Time.local(2005, 2, 27, 23, 50, 19, 275038), "2005-02-27T23:50:19.275038".to_time
       assert_equal Time.utc(2039, 2, 27, 23, 50), "2039-02-27 23:50".to_time(:utc)
       assert_equal Time.local(2039, 2, 27, 23, 50), "2039-02-27 23:50".to_time
-      assert_equal Time.local(2011, 2, 27, 18, 50), "2011-02-27 22:50 -0100".to_time
+      assert_equal Time.local(2011, 2, 27, 18, 50), "2011-02-27 13:50 -0100".to_time
       assert_equal Time.utc(2011, 2, 27, 23, 50), "2011-02-27 22:50 -0100".to_time(:utc)
-      assert_equal Time.local(2005, 2, 27, 23, 50), "2005-02-27 23:50 -0500".to_time
+      assert_equal Time.local(2005, 2, 27, 23, 50), "2005-02-27 14:50 -0500".to_time
       assert_nil "".to_time
     end
   end
@@ -317,11 +317,11 @@ class StringConversionsTest < ActiveSupport::TestCase
   end
 
   def test_partial_string_to_time
-    with_env_tz "US/Eastern" do
+    with_env_tz "Europe/Moscow" do
       now = Time.now
       assert_equal Time.local(now.year, now.month, now.day, 23, 50), "23:50".to_time
       assert_equal Time.utc(now.year, now.month, now.day, 23, 50), "23:50".to_time(:utc)
-      assert_equal Time.local(now.year, now.month, now.day, 18, 50), "22:50 -0100".to_time
+      assert_equal Time.local(now.year, now.month, now.day, 18, 50), "13:50 -0100".to_time
       assert_equal Time.utc(now.year, now.month, now.day, 23, 50), "22:50 -0100".to_time(:utc)
     end
   end


### PR DESCRIPTION
Tests for `to_time` returning an instance of `Time` in the local system timezone did not take in account DST when they used mixed timezone declarations like 'US/Eastern' and '-0500'.

Replaced timezone with DST by timezone without DST.
