### PR TITLE
Removing the requirement that Rails::Application be a singleton.

### DIFF
--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -27,10 +27,31 @@ module Rails
   class << self
     attr_accessor :application, :cache, :logger
 
-    # The Configuration instance used to configure the Rails environment
-    def configuration
-      application.config
+    # These methods access and write to the global configuration of the
+    # Rails application, denoted by +Rails.config+. Although multiple rails
+    # applications are allowed, only a single Rails.config is allowed. 
+    #
+    # The +Rails.config+ is set to the configuration of the first application
+    # that is initialized. For example,
+    #
+    #   class MyNewApp < Rails::Application
+    #   end
+    #
+    #   Rails.application = MyNewApp.new do |config|
+    #     config.some_configuration = "some configuration"
+    #   end
+    #
+    # If the above is the first application that is initialized, then
+    # +Rails.config+ will be set to the config of the above application.
+    def config
+      @config ||= application.config
     end
+
+    def config=(configuration)
+      @config = configuration
+    end
+
+    alias :configuration :config
 
     def initialize!
       application.initialize!

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -44,7 +44,7 @@ module Rails
     # If the above is the first application that is initialized, then
     # +Rails.config+ will be set to the config of the above application.
     def config
-      @config ||= Application::Configuration.new(Rails::Engine.find_root_with_flag("config.ru", Dir.pwd)))
+      @config ||= Application::Configuration.new(Rails::Engine.find_root_with_flag("config.ru", Dir.pwd))
     end
 
     # The @config variable is set on the first instantiation of a

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -44,9 +44,12 @@ module Rails
     # If the above is the first application that is initialized, then
     # +Rails.config+ will be set to the config of the above application.
     def config
-      @config ||= application.config
+      @config ||= Application::Configuration.new(Rails::Engine.find_root_with_flag("config.ru", Dir.pwd)))
     end
 
+    # The @config variable is set on the first instantiation of a
+    # Rails::Application object. This configuration then becomes the global
+    # configuration to be used for all applications.
     def config=(configuration)
       @config = configuration
     end

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -37,7 +37,7 @@ module Rails
     #   class MyNewApp < Rails::Application
     #   end
     #
-    #   Rails.application = MyNewApp.new do |config|
+    #   MyNewApp.new do
     #     config.some_configuration = "some configuration"
     #   end
     #
@@ -67,6 +67,18 @@ module Rails
         require 'rails/backtrace_cleaner'
         Rails::BacktraceCleaner.new
       end
+    end
+
+    # This method stores the rake tasks for the main Rails application.
+    # Whenever a new application is configured, the new rake tasks are
+    # sent to this method.
+    #
+    # The +@rake_tasks+ variable serves as a global store of all the rake
+    # tasks available to any application that has been configured.
+    def rake_tasks(&blk)
+      @rake_tasks ||= []
+      @rake_tasks << blk if blk
+      @rake_tasks
     end
 
     def root

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -56,6 +56,12 @@ module Rails
 
     alias :configuration :config
 
+    # This method allows you to configure the global +Rails.config+ from inside
+    # environment files.
+    def configure
+      yield config if block_given?
+    end
+
     def initialize!
       application.initialize!
     end

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -63,6 +63,40 @@ module Rails
         super
       end
 
+      # Redirects all calls of the application instance to the canonical
+      # +Rails.application+ instance which is created on startup of the 
+      # main app.
+      #
+      # This overrides the +instance+ method in Rails::Railties. The original
+      # +instance+ method created a new application if there wasn't one already
+      # cached.
+      #
+      # However, since +Rails.application+ is already defined once the app is
+      # initialized, we set it as the default application instance to use.
+      # Also, we don't want to cache this result in case +Rails.application+
+      # changes.
+      def instance
+        Rails.application
+      end
+
+      # Returns the rails global application configuration in +Rails.config+.
+      #
+      # This overrides the delegation of config to the application instance
+      # which is defined in the Rails::Railtie superclass (in the +delegate+
+      # method).
+      def config
+        Rails.config
+      end
+
+      # Send the this method to the global set of rake tasks for the main Rails
+      # app. Rake tasks are shared across applications should they should be
+      # kept in the +@rake_tasks+ instance variable in the +Rails+ module.
+      # To do this, we send any +rake_tasks+ that are obtained from configuring
+      # a particular app up to the +Rails.rake_tasks+ method.
+      def rake_tasks(&block)
+        Rails.rake_tasks(&block)
+      end
+
       # Makes the +new+ method public.
       #
       # Note that Rails::Application inherits from Rails::Engine, which 
@@ -77,8 +111,15 @@ module Rails
 
     delegate :default_url_options, :default_url_options=, to: :routes
 
-    def initialize
+    def initialize(&block)
       super
+
+      @initialized      = false
+      @reloaders        = []
+      @routes_reloader  = nil
+      @env_config       = nil
+      @ordered_railties = nil
+      @railties         = nil
 
       # If +Rails.application+ is already defined then the base configuration
       # of the new application will be the global +Rails.config+ that was
@@ -99,14 +140,7 @@ module Rails
         add_lib_to_load_path!
       end
 
-      yield config if block_given?
-
-      @initialized      = false
-      @reloaders        = []
-      @routes_reloader  = nil
-      @app_env_config   = nil
-      @ordered_railties = nil
-      @railties         = nil
+      class_eval(&block)
     end
 
     # Returns true if the application is initialized.
@@ -125,7 +159,6 @@ module Rails
     def reload_routes!
       routes_reloader.reload!
     end
-
 
     # Return the application's KeyGenerator
     def key_generator
@@ -247,7 +280,7 @@ module Rails
     end
 
     def config #:nodoc:
-      @config ||= Rails.config
+      Rails.config
     end
 
     def to_app #:nodoc:

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -133,9 +133,9 @@ module Rails
       public :new
     end
 
-    attr_accessor :assets, :sandbox
+    attr_accessor :assets, :sandbox, :reloaders
+    attr_writer :config, :railties, :routes_reloader, :routes, :helpers, :env_config
     alias_method :sandbox?, :sandbox
-    attr_reader :reloaders
 
     delegate :default_url_options, :default_url_options=, to: :routes
 
@@ -193,6 +193,32 @@ module Rails
       end
 
       instance_eval(&block) if block_given?
+    end
+
+    # Makes a shallow copy of this application. Changing any of the
+    # configuration on the original or new copy will change the configuration
+    # on both. The variables that are shared are:
+    #
+    #  reloaders, route_reloader, env_config,
+    #  ordered_railties, railties, config
+    #
+    # One can use this method to create multiple instances of the same rails
+    # application which share the same configuration. For example:
+    #
+    #  apps = 10.times.map do
+    #    Rails.application.clone
+    #  end
+    #
+    def clone
+      obj = self.class.new
+      obj.config = @config
+      obj.railties = railties
+      obj.routes_reloader = routes_reloader
+      obj.reloaders = reloaders
+      obj.routes = routes
+      obj.helpers = helpers
+      obj.env_config = env_config
+      obj
     end
 
     # Returns true if the application is initialized.
@@ -336,7 +362,7 @@ module Rails
     # When configuring an application, you will actually be configuring the
     # global configuration inside of the Rails module.
     def config
-      Rails.config
+      @config ||= Rails.config
     end
 
     # Sends any runner called in the +instance_eval+ of a new application up

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -40,10 +40,11 @@ module Rails
   #
   #   1)  require "config/boot.rb" to setup load paths
   #   2)  require railties and engines
-  #   3)  Define Rails.application as "class MyApp::Application < Rails::Application"
-  #   4)  Run config.before_configuration callbacks
-  #   5)  Load config/environments/ENV.rb
-  #   6)  Run config.before_initialize callbacks
+  #   3)  Run config.before_initialize callbacks
+  #   4)  Define Rails.config then Rails.application by defining "class MyApp::Application < Rails::Application"
+  #       and calling "MyApp.new"
+  #   5)  Run config.before_configuration callbacks
+  #   6)  Load config/environments/ENV.rb
   #   7)  Run Railtie#initializer defined by railties, engines and application.
   #       One by one, each engine sets up its load paths, routes and runs its config/initializers/* files.
   #   8)  Custom Railtie#initializers added by railties, engines and applications are executed

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -86,7 +86,7 @@ module Rails
       #   end
       def environment(data=nil, options={}, &block)
         sentinel = /class [a-z_:]+ < Rails::Application/i
-        env_file_sentinel = /::Application\.configure do/
+        env_file_sentinel = /Rails\.configure do/
         data = block.call if !data && block_given?
 
         in_root do

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -16,6 +16,9 @@ Bundler.require(*Rails.groups(assets: %w(development test)))
 
 module <%= app_const_base %>
   class Application < Rails::Application
+  end
+
+  Rails.application = Application.new do |config|
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -18,7 +18,7 @@ module <%= app_const_base %>
   class Application < Rails::Application
   end
 
-  Rails.application = Application.new do |config|
+  Application.new do
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/railties/lib/rails/generators/rails/app/templates/config/environment.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/environment.rb
@@ -2,4 +2,4 @@
 require File.expand_path('../application', __FILE__)
 
 # Initialize the rails application.
-<%= app_const %>.initialize!
+Rails.application.initialize!

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -1,4 +1,4 @@
-<%= app_const %>.configure do
+Rails.configure do |config|
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -1,4 +1,4 @@
-<%= app_const %>.configure do
+Rails.configure do |config|
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -1,4 +1,4 @@
-<%= app_const %>.configure do
+Rails.configure do |config|
   # Settings specified here will take precedence over those in config/application.rb.
 
   # The test environment is used exclusively to run your application's

--- a/railties/test/abstract_unit.rb
+++ b/railties/test/abstract_unit.rb
@@ -14,7 +14,7 @@ module TestApp
   class Application < Rails::Application
   end
 
-  Rails.application = Application.new do |config|
+  Application.new do
     config.root = File.dirname(__FILE__)
     config.secret_key_base = 'b3c631c314c0bbca50c1b2843150fe33'
   end

--- a/railties/test/abstract_unit.rb
+++ b/railties/test/abstract_unit.rb
@@ -12,6 +12,9 @@ require 'rails/all'
 
 module TestApp
   class Application < Rails::Application
+  end
+
+  Rails.application = Application.new do |config|
     config.root = File.dirname(__FILE__)
     config.secret_key_base = 'b3c631c314c0bbca50c1b2843150fe33'
   end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -158,7 +158,7 @@ module ApplicationTests
       RUBY
 
       require "#{app_path}/config/application"
-      assert AppTemplate::Application.initialize!
+      assert AppTemplate::Application.new.initialize!
     end
 
     test "application is always added to eager_load namespaces" do
@@ -330,7 +330,7 @@ module ApplicationTests
     end
 
     test "request forgery token param can be changed" do
-      make_basic_app do
+      make_basic_app do |app|
         app.config.action_controller.request_forgery_protection_token = '_xsrf_token_here'
       end
 

--- a/railties/test/application/multiple_applications_test.rb
+++ b/railties/test/application/multiple_applications_test.rb
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+require 'isolation/abstract_unit'
+require 'rack/test'
+require 'rails'
+require 'action_controller/railtie'
+
+module ApplicationTests
+  class MultipleApplicationsTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+    include Rack::Test::Methods
+
+    class NewApplication < Rails::Application
+    end
+
+    class AnotherApplication < Rails::Application
+    end
+
+    def setup
+      build_app(initializers: true)
+      app
+      #boot_rails
+    end
+
+    def teardown
+      teardown_app
+    end
+
+    def test_initialization_of_multiple_copies_of_same_application
+      application1 = AppTemplate::Application.new
+      application2 = NewApplication.new
+
+      assert_not_equal Rails.application, application1, "New applications should not be the same as the original application"
+      assert_not_equal Rails.application, application2, "New applications should not be the same as the original application"
+    end
+
+     def test_multiple_applications_can_be_initialized
+      assert_nothing_raised { NewApplication.new }
+      assert_nothing_raised { NewApplication.new }
+      assert_nothing_raised { AnotherApplication.new }
+    end
+
+    def test_multiple_applications_all_have_the_same_global_config
+      application1 = NewApplication.new
+      application2 = AnotherApplication.new
+
+      assert_equal Rails.config, Rails.application.config, "The Rails.application configuration should be the same as the global rails configuration"
+      assert_equal Rails.config, application1.config, "All applications should have the same global config"
+      assert_equal Rails.config, application2.config, "All applications should have the same global config"
+
+      new_secret_key = "123456789"
+      Rails.config.secret_key_base = new_secret_key
+
+      assert_equal new_secret_key, Rails.config.secret_key_base, "We should have a new secret_key_base in the configuration"
+      assert_equal Rails.config.secret_key_base, Rails.application.config.secret_key_base, "Changing the global config should change the configs on all applications"
+      assert_equal Rails.config.secret_key_base, application1.config.secret_key_base, "Changing the global config should change the configs on all applications"
+      assert_equal Rails.config.secret_key_base, application2.config.secret_key_base, "Changing the global config should change the configs on all applications"
+    end
+
+    def test_configuring_Rails_application_will_correctly_change_the_config
+      new_secret_key = "123456789"
+      Rails::Application.configure do
+        config.secret_key_base = new_secret_key
+      end
+
+      assert_equal new_secret_key, Rails.config.secret_key_base, "Using configure on class should change the global configuration"
+      assert_equal new_secret_key, Rails.application.config.secret_key_base, "Using configure on class should change the global configuration"
+
+      new_secret_key = "987654321"
+      Rails.configure do |config|
+        config.secret_key_base = new_secret_key
+      end
+
+      assert_equal new_secret_key, Rails.config.secret_key_base, "Using Rails.configure should change the global configuration"
+      assert_equal new_secret_key, Rails.application.config.secret_key_base, "Using Rails.configure should change the global configuration"
+    end
+  end
+end

--- a/railties/test/application/multiple_applications_test.rb
+++ b/railties/test/application/multiple_applications_test.rb
@@ -18,11 +18,25 @@ module ApplicationTests
     def setup
       build_app(initializers: true)
       app
-      #boot_rails
     end
 
     def teardown
       teardown_app
+    end
+
+    def test_cloning_an_application_makes_a_shallow_copy
+      clone = Rails.application.clone
+
+      assert_equal Rails.application.config, clone.config
+      assert_equal Rails.application.reloaders, clone.reloaders
+      assert_equal Rails.application.routes_reloader, clone.routes_reloader
+      assert_equal Rails.application.railties, clone.railties
+      assert_equal Rails.application.routes, clone.routes
+      assert_equal Rails.application.helpers, clone.helpers
+      assert_equal Rails.application.env_config, clone.env_config
+
+      Rails.application.config.secret_key_base = "555555555"
+      assert_equal Rails.application.config, clone.config
     end
 
     def test_initialization_of_multiple_copies_of_same_application

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -30,11 +30,9 @@ module ApplicationTests
       app_file "config/environment.rb", <<-RUBY
         SuperMiddleware = Struct.new(:app)
 
-        AppTemplate::Application.configure do
+        AppTemplate::Application.new do
           config.middleware.use SuperMiddleware
-        end
-
-        AppTemplate::Application.initialize!
+        end.initialize!
       RUBY
 
       assert_match("SuperMiddleware", Dir.chdir(app_path){ `rake middleware` })

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -65,7 +65,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_invalid_application_name_is_fixed
     run_generator [File.join(destination_root, "things-43")]
-    assert_file "things-43/config/environment.rb", /Things43::Application\.initialize!/
+    assert_file "things-43/config/environment.rb", /Rails.application\.initialize!/
     assert_file "things-43/config/application.rb", /^module Things43$/
   end
 
@@ -111,7 +111,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
                                                                destination_root: app_moved_root, shell: @shell
     generator.send(:app_const)
     quietly { generator.send(:create_config_files) }
-    assert_file "myapp_moved/config/environment.rb", /Myapp::Application\.initialize!/
+    assert_file "myapp_moved/config/environment.rb", /Rails.application\.initialize!/
     assert_file "myapp_moved/config/initializers/session_store.rb", /_myapp_session/
   end
 
@@ -131,7 +131,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_application_names_are_not_singularized
     run_generator [File.join(destination_root, "hats")]
-    assert_file "hats/config/environment.rb", /Hats::Application\.initialize!/
+    assert_file "hats/config/environment.rb", /Rails.application\.initialize!/
   end
 
   def test_gemfile_has_no_whitespace_errors

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -143,7 +143,7 @@ module TestHelpers
       app.config.active_support.deprecation = :log
 
       yield app if block_given?
-      app.initialize!
+      app.new.initialize!
 
       app.routes.draw do
         get "/" => "omg#index"

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -416,11 +416,6 @@ YAML
       boot_rails
     end
 
-    test "Rails::Engine itself does not respond to config" do
-      boot_rails
-      assert !Rails::Engine.respond_to?(:config)
-    end
-
     test "initializers are executed after application configuration initializers" do
       @plugin.write "lib/bukkits.rb", <<-RUBY
         module Bukkits

--- a/railties/test/railties/railtie_test.rb
+++ b/railties/test/railties/railtie_test.rb
@@ -19,10 +19,6 @@ module RailtiesTest
       @app ||= Rails.application
     end
 
-    test "Rails::Railtie itself does not respond to config" do
-      assert !Rails::Railtie.respond_to?(:config)
-    end
-
     test "Railtie provides railtie_name" do
       begin
         class ::FooBarBaz < Rails::Railtie ; end
@@ -44,6 +40,10 @@ module RailtiesTest
       assert_raise RuntimeError do
         class Bar < Foo; end
       end
+    end
+
+    test "cannot instantiate a railtie object" do
+      assert_raise(RuntimeError) { Rails::Railtie.new }
     end
 
     test "config is available to railtie" do


### PR DESCRIPTION
There doesn't seem to be a good reason that `Rails::Application` has to be a singleton, other than the fact that the app needs to get initialized somewhere and its convenient to make it a singleton.
# Overview of Changes

In this PR, I've made it so that Rails is no longer a singleton, and multiple applications can be initialized in a single ruby process. The caveat is that these applications will share a single global configuration which is stored in `Rails.config`, which is created as soon as the first rails application is initialized. 

This also means that `Rails.config` is available before the environment initialization occurs. 
## New Initialization Procedure

You can now initialize multiple rails applications. To do this, I've changed the initialization of an application to the following structure (you can see this inside of `/config/application.rb`). 

``` ruby
class Application < Rails::Application
end

Application.new do
  config.time_zone = 'Eastern'
  config.blah = 'blah'
end
```

This means that you can call `Application.new` as many times as you would like. You don't have to actually create a subclass, and you can just call `Rails::Application.new`, but creating a subclass is backwards compatible with the way applications have been initialized in the past.
## Configuring Applications

When you configure an application now, you will be changing a global configuration object stored in `Rails.config`. You can also configure this directly by doing something like this:

``` ruby
Rails.configure do |config|
  config.time_zone = 'Eastern'
end
```
## Global Configuration

This PR still uses a global configuration for all rails app. Whenever a new application is created, it's configuration will be the same as the configuration of all the other rails applications. (This global config will be relaxed as I continue to work on this PR. The end goal is to make it so that each application has its own, separate configuration).

In addition, the `Rails` module stores the global rake tasks. These rake tasks are shared across all applications. 
## Backwards Compatibility

I've made sure that this PR preserves a lot of old functionality. Initializing and configuring an application in the old way is still possible. For example: inside `/config/application.rb` you can still define an application as follows:

``` ruby
class Application < Rails::Application
  config.time_zone = 'Eastern'
end

Application.initialize!
```

The call to `Application.initialize!` sets `Rails.application` to a new instance of `Application`, but cannot be called twice. 
## Other Changes

I've also gotten rid of the `Railtie::Configurable` module. This is because it currently forces all children of `Rails::Railtie` to include this module, no matter what. This force feeding doesn't seem like good practice, and prevents you from having any say in whether you want the module or not. Moving the guts of the Configurable module inside Railtie itself helps alleviate this issue. 
