### PR TITLE
Cleanup tests for unused variables

### DIFF
--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -878,7 +878,7 @@ class DependenciesTest < ActiveSupport::TestCase
   def test_autoload_doesnt_shadow_name_error
     with_autoloading_fixtures do
       Object.send(:remove_const, :RaisesNameError) if defined?(::RaisesNameError)
-      2.times do |i|
+      2.times do
         begin
           ::RaisesNameError::FooBarBaz.object_id
           flunk 'should have raised NameError when autoloaded file referenced FooBarBaz'

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -61,9 +61,7 @@ class InflectorTest < ActiveSupport::TestCase
       assert_equal(plural, ActiveSupport::Inflector.pluralize(plural))
       assert_equal(plural.capitalize, ActiveSupport::Inflector.pluralize(plural.capitalize))
     end
-  end
 
-  SingularToPlural.each do |singular, plural|
     define_method "test_singularize_singular_#{singular}" do
       assert_equal(singular, ActiveSupport::Inflector.singularize(singular))
       assert_equal(singular.capitalize, ActiveSupport::Inflector.singularize(singular.capitalize))

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -105,7 +105,7 @@ module RailtiesTest
         assert_not_nil bukkits_migration_order, "Expected migration to be skipped"
 
         migrations_count = Dir["#{app_path}/db/migrate/*.rb"].length
-        output = `bundle exec rake railties:install:migrations`
+        `bundle exec rake railties:install:migrations`
 
         assert_equal migrations_count, Dir["#{app_path}/db/migrate/*.rb"].length
       end


### PR DESCRIPTION
1. Dependency Test: We dont use "i"
2. Inflector Test: Merge two logical blocks to bypass unused variable warning
3. Engine Test: Output var isn't required
