### PR TITLE
Show warning message if delete_all is firing callbacks

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -204,6 +204,15 @@ module ActiveRecord
         dependent = options[:dependent]
 
         if records.first == :all
+
+          if dependent && dependent == :destroy
+            message = 'In Rails 4.1 delete_all on associations would not fire callbacks. ' \
+                      'It means if the :dependent option is :destroy then the associated ' \
+                      'records would be deleted without loading and invoking callbacks.'
+
+            ActiveRecord::Base.logger ? ActiveRecord::Base.logger.warn(message) : $stderr.puts(message)
+          end
+
           if loaded? || dependent == :destroy
             delete_or_destroy(load_target, dependent)
           else


### PR DESCRIPTION
`post.comments.delete_all` will fire callbacks if :dependent option is
:destroy . It will be fixed in Rails 4.1 . In the meantime display
a warning . Look at #9567 for details .
