### PR TITLE
config.ru uses the effective Rack app

### DIFF
--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -42,6 +42,7 @@ module Rails
       set_environment
     end
 
+    # TODO: this is no longer required but we keep it for the moment to support older config.ru files.
     def app
       @app ||= begin
         app = super

--- a/railties/lib/rails/generators/rails/app/templates/config.ru
+++ b/railties/lib/rails/generators/rails/app/templates/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment',  __FILE__)
-run <%= app_const %>
+run Rails.application


### PR DESCRIPTION
We used to pass the Rails::Application subclass to #run.
The Rails server then called #to_app to convert that class to the
actual Rack application.

if you surround `#run` with a call to `#map` the server no longer
convertes the class to the instance and we end up with unnecessary
delegation calls on every request.
