### PR TITLE
Changed request.xhr? to return boolean instead of 0 or nil

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -177,7 +177,7 @@ module ActionDispatch
     # (case-insensitive). All major JavaScript libraries send this header with
     # every Ajax request.
     def xml_http_request?
-      @env['HTTP_X_REQUESTED_WITH'] =~ /XMLHttpRequest/i
+      !(@env['HTTP_X_REQUESTED_WITH'] =~ /XMLHttpRequest/i).nil?
     end
     alias :xhr? :xml_http_request?
 

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -370,16 +370,16 @@ class RequestTest < ActiveSupport::TestCase
   test "xml http request" do
     request = stub_request
 
-    assert !request.xml_http_request?
-    assert !request.xhr?
+    assert_equal false, request.xml_http_request?
+    assert_equal false, request.xhr?
 
     request = stub_request 'HTTP_X_REQUESTED_WITH' => 'DefinitelyNotAjax1.0'
     assert !request.xml_http_request?
     assert !request.xhr?
 
     request = stub_request 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'
-    assert request.xml_http_request?
-    assert request.xhr?
+    assert_equal true, request.xml_http_request?
+    assert_equal true, request.xhr?
   end
 
   test "reports ssl" do


### PR DESCRIPTION
Changed return values  for `request.xhr?` to  `true` or `false` instead of `nil` and `0`.
