### PR TITLE
collection_association#delete_all should ignore dependent option (Fixes #9567)

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -25,7 +25,7 @@ module ActiveRecord
             load_target.each(&:mark_for_destruction)
           end
 
-          delete_all
+          delete_all_from_dependency
         end
       end
 


### PR DESCRIPTION
This is a fix for issue #9567
I think that the dependent options should be taken into account only when destroy is called on the "parent" of the has_many association. In the issue's example it is the post. When delete_all is called directly on the association it should ignore the dependent option completely but should call the before_add/before_remove callbacks since all existing records will be removed from the collection.

This is not the current behaviour and this change could break some existing apps. This PR might needs some additional tests but I wanted to see if you would agree on this first.
