### PR TITLE
fix :from in mailer

### DIFF
--- a/actionmailer/README.rdoc
+++ b/actionmailer/README.rdoc
@@ -22,7 +22,7 @@ the email.
 This can be as simple as:
 
   class Notifier < ActionMailer::Base
-    default from: 'system@loudthinking.com'
+    default :from => 'system@loudthinking.com'
 
     def welcome(recipient)
       @recipient = recipient


### PR DESCRIPTION
The syntax according to http://api.rubyonrails.org/classes/ActionMailer/Base.html is :from, as opposed to from:. Since this is a code change in the documentation, I assume I need to create a pull request but let me know if that's wrong!
