### PR TITLE
dependent: :destroy should call destroy_all

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -23,9 +23,10 @@ module ActiveRecord
           if options[:dependent] == :destroy
             # No point in executing the counter update since we're going to destroy the parent anyway
             load_target.each(&:mark_for_destruction)
+            destroy_all
+          else
+            delete_all
           end
-
-          delete_all
         end
       end
 


### PR DESCRIPTION
Commit https://github.com/rails/rails/pull/9668 shows warning
when `delete_all` is invoked with `:dependent` option
`:destroy`.

Unfortunately invoking `Post.destroy_all` invokes
`post.comments.delete_all` as part of `has_many` callbacks.

This commit ensures that instead `post.comments.destroy_all` is
invoked and in the process no warning is generated.

See issue #9567 for details .
