### PR TITLE
Revert grep to select since they are not the same

### DIFF
--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -565,7 +565,7 @@ module ActionView
 
         if priority_zones
           if priority_zones.is_a?(Regexp)
-            priority_zones = zones.grep(priority_zones)
+            priority_zones = zones.select { |z| z =~ priority_zones }
           end
 
           zone_options.safe_concat options_for_select(convert_zones[priority_zones], selected)

--- a/actionpack/test/template/form_options_helper_test.rb
+++ b/actionpack/test/template/form_options_helper_test.rb
@@ -1095,12 +1095,11 @@ class FormOptionsHelperTest < ActionView::TestCase
   def test_time_zone_select_with_priority_zones_as_regexp
     @firm = Firm.new("D")
 
-    priority_zones = /A|D/
     @fake_timezones.each_with_index do |tz, i|
-      priority_zones.stubs(:===).with(tz).returns(i.zero? || i == 3)
+      tz.stubs(:=~).returns(i.zero? || i == 3)
     end
 
-    html = time_zone_select("firm", "time_zone", priority_zones)
+    html = time_zone_select("firm", "time_zone", /A|D/)
     assert_dom_equal "<select id=\"firm_time_zone\" name=\"firm[time_zone]\">" +
                  "<option value=\"A\">A</option>\n" +
                  "<option value=\"D\" selected=\"selected\">D</option>" +

--- a/actionpack/test/template/form_options_helper_test.rb
+++ b/actionpack/test/template/form_options_helper_test.rb
@@ -1110,6 +1110,26 @@ class FormOptionsHelperTest < ActionView::TestCase
                  "</select>",
                  html
   end
+  
+  def test_time_zone_select_with_priority_zones_as_regexp_using_grep_finds_no_zones
+    @firm = Firm.new("D")
+  
+    priority_zones = /A|D/
+    @fake_timezones.each_with_index do |tz, i|
+      priority_zones.stubs(:===).with(tz).raises(Exception)
+    end
+  
+    html = time_zone_select("firm", "time_zone", priority_zones)
+    assert_dom_equal "<select id=\"firm_time_zone\" name=\"firm[time_zone]\">" +
+                 "<option value=\"\" disabled=\"disabled\">-------------</option>\n" +
+                 "<option value=\"A\">A</option>\n" +
+                 "<option value=\"B\">B</option>\n" +
+                 "<option value=\"C\">C</option>\n" +
+                 "<option value=\"D\" selected=\"selected\">D</option>\n" +
+                 "<option value=\"E\">E</option>" +
+                 "</select>",
+                 html
+  end
 
   def test_time_zone_select_with_default_time_zone_and_nil_value
      @firm = Firm.new()


### PR DESCRIPTION
A previous commit swapped out a call to select for a call to grep in
time_zone_options_for_select. This behavior actually causes the
regexp priority option to stop working.

ActiveSupport::TimeZone overrides the =~ operator which is what the
select block was using previously. Enumerable#grep
checks pattern === element and in this case that would be /US/ ===
ActiveSupport::TimeZone which does not work because
ActiveSupport::TimeZone does not supply an implicit converting to_str
method, only an explicit to_s method.

It would be impossible to provide a to_str method that behaves
identically to the =~ method provided on ActiveSupport::TimeZone
so the only option is to revert back to using select with =~.
