### PR TITLE
Fix typo in DependenciesTestHelpers module name

### DIFF
--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -1,7 +1,7 @@
 require 'logger'
 require 'abstract_unit'
 require 'active_support/cache'
-require 'dependecies_test_helpers'
+require 'dependencies_test_helpers'
 
 class CacheKeyTest < ActiveSupport::TestCase
   def test_entry_legacy_optional_ivars
@@ -564,7 +564,7 @@ module LocalCacheBehavior
 end
 
 module AutoloadingCacheBehavior
-  include DependeciesTestHelpers
+  include DependenciesTestHelpers
   def test_simple_autoloading
     with_autoloading_fixtures do
       @cache.write('foo', E.new)

--- a/activesupport/test/core_ext/marshal_test.rb
+++ b/activesupport/test/core_ext/marshal_test.rb
@@ -1,10 +1,10 @@
 require 'abstract_unit'
 require 'active_support/core_ext/marshal'
-require 'dependecies_test_helpers'
+require 'dependencies_test_helpers'
 
 class MarshalTest < ActiveSupport::TestCase
   include ActiveSupport::Testing::Isolation
-  include DependeciesTestHelpers
+  include DependenciesTestHelpers
 
   def teardown
     ActiveSupport::Dependencies.clear

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -1,7 +1,7 @@
 require 'abstract_unit'
 require 'pp'
 require 'active_support/dependencies'
-require 'dependecies_test_helpers'
+require 'dependencies_test_helpers'
 
 module ModuleWithMissing
   mattr_accessor :missing_count
@@ -20,7 +20,7 @@ class DependenciesTest < ActiveSupport::TestCase
     ActiveSupport::Dependencies.clear
   end
 
-  include DependeciesTestHelpers
+  include DependenciesTestHelpers
 
   def test_depend_on_path
     skip "LoadError#path does not exist" if RUBY_VERSION < '2.0.0'

--- a/activesupport/test/dependencies_test_helpers.rb
+++ b/activesupport/test/dependencies_test_helpers.rb
@@ -1,4 +1,4 @@
-module DependeciesTestHelpers
+module DependenciesTestHelpers
   def with_loading(*from)
     old_mechanism, ActiveSupport::Dependencies.mechanism = ActiveSupport::Dependencies.mechanism, :load
     this_dir = File.dirname(__FILE__)


### PR DESCRIPTION
Fix typo in DependenciesTestHelpers module name, and relevant requires
