### PR TITLE
Also quote extension name in disable_extension

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -600,7 +600,7 @@ module ActiveRecord
       end
 
       def disable_extension(name)
-        exec_query("DROP EXTENSION IF EXISTS #{name} CASCADE").tap {
+        exec_query("DROP EXTENSION IF EXISTS \"#{name}\" CASCADE").tap {
           reload_type_map
         }
       end


### PR DESCRIPTION
A patch was committed recently which quoted the extension name in the SQL for `enable_extension`. But the same wasn't done for `disable_extension`.
