### PR TITLE
Rails default logging to STDOUT

### DIFF
--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -54,6 +54,14 @@ module ActiveSupport
         end
     end
 
+    def self.create(f, formatter, level)
+      logger = ActiveSupport::Logger.new f
+      logger.formatter = formatter
+      logger = new(logger)
+      logger.level = ActiveSupport::Logger.const_get(level.to_s.upcase)
+      logger
+    end
+
     def self.new(logger)
       # Ensure we set a default formatter so we aren't extending nil!
       logger.formatter ||= ActiveSupport::Logger::SimpleFormatter.new

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -22,6 +22,17 @@ class TaggedLoggingTest < ActiveSupport::TestCase
     assert logger.formatter.respond_to?(:tagged)
   end
 
+  test 'creates a tagged logger with the appropriate level and formatter' do
+    stringio = StringIO.new
+    logger = ActiveSupport::TaggedLogging.create(stringio, ActiveSupport::Logger::SimpleFormatter.new, :debug)
+    logger.debug("foo")
+
+    assert_not_nil logger.formatter
+    assert logger.formatter.respond_to?(:tagged)
+    assert_equal 0, logger.level
+    assert stringio.string.include?("foo")
+  end
+
   test "tagged once" do
     @logger.tagged("BCX") { @logger.info "Funky time" }
     assert_equal "[BCX] Funky time\n", @output.string

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   New rails apps log to STDOUT by default
+
+    *Terence Lee*
+
 *   Add support for generate scaffold password:digest
 
     * adds password_digest attribute to the migration

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -39,11 +39,7 @@ INFO
           f.binmode
           f.sync = config.autoflush_log # if true make sure every write flushes
 
-          logger = ActiveSupport::Logger.new f
-          logger.formatter = config.log_formatter
-          logger = ActiveSupport::TaggedLogging.new(logger)
-          logger.level = ActiveSupport::Logger.const_get(config.log_level.to_s.upcase)
-          logger
+          logger = ActiveSupport::TaggedLogging.create(f, config.log_formatter, config.log_level)
         rescue StandardError
           logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(STDERR))
           logger.level = ActiveSupport::Logger::WARN

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -32,5 +32,7 @@ module <%= app_const_base %>
     # Disable the asset pipeline.
     config.assets.enabled = false
 <% end -%>
+
+    config.logger = ActiveSupport::TaggedLogging.create(STDOUT, config.log_formatter, config.log_level)
   end
 end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -670,5 +670,26 @@ module ApplicationTests
         end
       end
     end
+
+    test "set logger to STDOUT by default" do
+      stdout = capture(:stdout) do
+        app = build_app
+
+        controller :omg, <<-RUBY
+          class OmgController < ApplicationController
+            def index
+              Rails.logger.info "HI MOM"
+              render text: "omg"
+            end
+          end
+        RUBY
+
+        require "#{app_path}/config/environment"
+
+        get "/omg/index"
+      end
+
+      assert stdout.include?("HI MOM"), "STDOUT does not include 'HI MOM', #{stdout}"
+    end
   end
 end


### PR DESCRIPTION
Change the default logger for new Rails 4 apps to log to STDOUT. This way when starting an app, you can see the output on the console without tailing the logs file out of the box. Anyone who's serious about logging can replace this. I talked this over with @jeremy and @tenderlove. 
