### PR TITLE
Dis-allow nil confirmations.

### DIFF
--- a/activemodel/lib/active_model/validations/confirmation.rb
+++ b/activemodel/lib/active_model/validations/confirmation.rb
@@ -3,7 +3,8 @@ module ActiveModel
   module Validations
     class ConfirmationValidator < EachValidator # :nodoc:
       def validate_each(record, attribute, value)
-        if (confirmed = record.send("#{attribute}_confirmation")) && (value != confirmed)
+        confirmed = record.send("#{attribute}_confirmation")
+        if value != confirmed
           human_attribute_name = record.class.human_attribute_name(attribute)
           record.errors.add(:"#{attribute}_confirmation", :confirmation, options.merge(:attribute => human_attribute_name))
         end

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -29,6 +29,11 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert @visitor.valid?(:create), 'visitor should be valid'
   end
 
+  test "nil confirmation" do
+    @user.password = "hunter2"
+    assert !@user.valid?(:create), 'user should be invalid'
+  end
+
   test "blank password doesn't override previous password" do
     @user.password = 'test'
     @user.password = ''

--- a/activemodel/test/cases/validations/confirmation_validation_test.rb
+++ b/activemodel/test/cases/validations/confirmation_validation_test.rb
@@ -21,7 +21,7 @@ class ConfirmationValidationTest < ActiveModel::TestCase
 
     t.title_confirmation = nil
     t.title = "Parallel Lives"
-    assert t.valid?
+    assert t.invalid?
 
     t.title_confirmation = "Parallel Lives"
     assert t.valid?


### PR DESCRIPTION
It doesn't make sense that if we don't confirm, we allow things
to be saved.

I'm submitting this as a PR because there is one test that implies this behavior was expected, so I'm curious if this was an oversight or if this is expected behavior.
