### PR TITLE
Only update the necesary columns on touch

### DIFF
--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -26,15 +26,17 @@ module ActiveRecord
     #   product.touch(:designed_at) # updates the designed_at attribute
     def touch(attribute = nil)
       current_time = current_time_from_proper_timezone
+      attrs_to_update = []
 
       if attribute
         write_attribute(attribute, current_time)
+        attrs_to_update << attribute
       else
-        write_attribute('updated_at', current_time) if respond_to?(:updated_at)
-        write_attribute('updated_on', current_time) if respond_to?(:updated_on)
+        write_attribute('updated_at', current_time) and attrs_to_update << 'updated_at' if respond_to?(:updated_at)
+        write_attribute('updated_on', current_time) and attrs_to_update << attribute if respond_to?(:updated_on)
       end
-
-      save!
+      
+      self.class.update_all(attrs_to_update.inject({}){|hash, key| hash[key] = current_time; hash}, { self.class.primary_key => self.id})
     end
 
 

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -7,7 +7,7 @@ class TimestampTest < ActiveRecord::TestCase
   fixtures :developers, :owners, :pets
 
   def setup
-    @developer = Developer.first
+    @developer = Developer.find(12)
     @previously_updated_at = @developer.updated_at
   end
 
@@ -28,6 +28,12 @@ class TimestampTest < ActiveRecord::TestCase
     @developer.touch
     
     assert @previously_updated_at != @developer.updated_at
+  end
+
+  def test_touching_a_record_updates_its_timestamp_after_reload
+    @developer.touch
+    
+    assert @previously_updated_at != @developer.reload.updated_at
   end
   
   def test_touching_a_different_attribute

--- a/activerecord/test/fixtures/developers.yml
+++ b/activerecord/test/fixtures/developers.yml
@@ -2,7 +2,7 @@ david:
   id: 1
   name: David
   salary: 80000
-
+  
 jamis:
   id: 2
   name: Jamis
@@ -19,3 +19,12 @@ poor_jamis:
   id: 11
   name: Jamis
   salary: 9000
+
+paco:
+  id: 12
+  name: Paco
+  salary: 80000
+  created_at: 2003-07-16t15:28:11.2233+01:00
+  updated_at: 2003-07-16t15:28:11.2233+01:00
+  
+  


### PR DESCRIPTION
In rails 2.3.x touch is having a weird behavior where its not only writing the expected attribute but it is calling save! wich is running callbacks and validations unnecessarily. It also leads to nasty race conditions. This is mostly to make this to look more like things happen in Rails 3.
