### PR TITLE
Add documentation to ActionDispatch::Request

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -156,14 +156,30 @@ module ActionDispatch
       @original_fullpath ||= (env["ORIGINAL_FULLPATH"] || fullpath)
     end
 
+    # Returns the +String+ full path including params of the last URL requested.
+    #
+    #    app.get "/articles"
+    #    app.response.fullpath # => "/articles"
+    #
+    #    app.get "/articles?page=2"
+    #    app.response.fullpath # => "/articles?page=2"
     def fullpath
       @fullpath ||= super
     end
 
+    # Returns the original request URL as a +String+
+    #
+    #    app.get "/articles?page=2"
+    #    app.request.original_url
+    #    # => "http://www.example.com/articles?page=2"
     def original_url
       base_url + original_fullpath
     end
 
+    # The +String+ MIME type of the request
+    #
+    #    app.get "/articles"
+    #    # => "application/x-www-form-urlencoded"
     def media_type
       content_mime_type.to_s
     end


### PR DESCRIPTION
I've added some documentation to the following:
- `ActionDispatch::Request#fullpath`
- `ActionDispatch::Request#original_url`
- `ActionDispatch::Request#media_type`

Could someone check that I've explained them correctly?

I also have a question about `Request#media_type` referring to it's documentation.

I created a simple blog and used `respond_with` so that the articles index responds to XML and JSON.

Here's what I get in the console:

``` ruby
app.get '/articles.xml'
app.request.media_type
 => "application/x-www-form-urlencoded" 

app.get '/articles.json'
app.request.media_type
 => "application/x-www-form-urlencoded"
```

Should I be seeing `application/xml` and `application/json` respectively?
