### PR TITLE
Small change to association name sigularization

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -363,9 +363,9 @@ module ActiveRecord
 
       private
         def derive_class_name
-          class_name = name.to_s.camelize
+          class_name = name.to_s
           class_name = class_name.singularize if collection?
-          class_name
+          class_name.camelize
         end
 
         def derive_foreign_key


### PR DESCRIPTION
This is to avoid having to define irregular pluralizations for both snake-case and camel-case version of a multi-word expression.

Say you hava a model called `PluralIrregular` with an associated table `plurales_irregulares` (which isn't that bad in spanish).

I'll have to put two lines in inflections.rb to make this work:

```
inflect.irregular 'plural_irregular', 'plurales_irregulares'
inflect.irregular 'PluralIrregular', 'PluralesIrregulares'
```

This can be painful with many irregular plurals. Of course, you can change the pluralization rules if all your class names will be in spanish, but I found myself having to use quite a lot of irregular plurals for various reasons.
