### PR TITLE
Prevent mutation of unsaved AR collections by Marshal#dump

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -12,6 +12,11 @@
 
     *Juan M. Cuello + Dembskiy Alexander*
 
+*   Prevent mutation of AR collections during Marshal#dump. This caused breakage
+    when storing model objects in session or cache, among other things.
+
+    *Mack Earnhardt*
+
 *   Reload the association target if it's stale. `@stale_state` should be nil
     when a model isn't saved.
     Fixes #7526.

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -69,9 +69,14 @@ module ActiveRecord
       end
 
       def respond_to?(name, include_private = false)
-        super ||
-        (load_target && target.respond_to?(name, include_private)) ||
-        proxy_association.klass.respond_to?(name, include_private)
+        if super
+          true
+        elsif [:marshal_dump, :_dump].include?(name)
+          false
+        else
+          (load_target && target.respond_to?(name, include_private)) ||
+            proxy_association.klass.respond_to?(name, include_private)
+        end
       end
 
       def method_missing(method, *args, &block)

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -905,4 +905,26 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     post = tags(:general).tagged_posts.create! :title => "foo", :body => "bar"
     assert_equal [tags(:general)], post.reload.tags
   end
+
+  def test_marshal_unsaved_with_has_many_through
+    dump1 = dump2 = nil
+    post_body = "Frist Toast #{SecureRandom.hex}"
+
+    post = posts(:welcome)
+
+    assert_no_queries do
+      post.comments.build(:body => post_body)
+      person = Person.new(:first_name => "Gaga")
+      person.posts << post
+
+      dump1 = Marshal.dump(person)
+      dump2 = Marshal.dump(person)
+    end
+
+    assert_equal dump1, dump2
+
+    loaded_person = Marshal.load(dump1)
+    assert_equal "Gaga", loaded_person.first_name
+    assert loaded_person.posts.first.comments.detect{|c| c.body == post_body}
+  end
 end


### PR DESCRIPTION
Marshal#dump calls CollectionProxy#respond_to? when dumping some AR
collections. The call to load_target may mutate the internal state
mid-dump, resulting in undesirable queries and a dumped string that may
not result in a usable object when processed by Marshal#load.

The proposed fix forces the use of Marshal internals to dump the
collection.
