### PR TITLE
MOAR cleanups of unused variables. 

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -49,7 +49,7 @@ module ActiveRecord
       Rails.logger.extend ActiveSupport::Logger.broadcast console
     end
 
-    runner do |app|
+    runner do
       require "active_record/base"
     end
 
@@ -64,7 +64,7 @@ module ActiveRecord
       ActiveSupport.on_load(:active_record) { self.logger ||= ::Rails.logger }
     end
 
-    initializer "active_record.migration_error" do |app|
+    initializer "active_record.migration_error" do
       if config.active_record.delete(:migration_error) == :page_load
         config.app_middleware.insert_after "::ActionDispatch::Callbacks",
           "ActiveRecord::Migration::CheckPending"
@@ -158,7 +158,7 @@ module ActiveRecord
     end
 
     # Expose database runtime to controller for logging.
-    initializer "active_record.log_runtime" do |app|
+    initializer "active_record.log_runtime" do
       require "active_record/railties/controller_runtime"
       ActiveSupport.on_load(:action_controller) do
         include ActiveRecord::Railties::ControllerRuntime

--- a/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
@@ -84,7 +84,6 @@ class MysqlReservedWordTest < ActiveRecord::TestCase
     assert_nothing_raised { x.save }
     assert_nothing_raised { Group.find_by_order('y') }
     assert_nothing_raised { Group.find(1) }
-    x = Group.find(1)
   end
 
   # has_one association with reserved-word table name

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -95,7 +95,7 @@ class AssociationsTest < ActiveRecord::TestCase
   def test_force_reload
     firm = Firm.new("name" => "A New Firm, Inc")
     firm.save
-    firm.clients.each {|c|} # forcing to load all clients
+    firm.clients.each {} # forcing to load all clients
     assert firm.clients.empty?, "New firm shouldn't have client objects"
     assert_equal 0, firm.clients.size, "New firm should have 0 clients"
 

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -185,7 +185,7 @@ module ActiveRecord
         assert_not_nil connection
         threads = []
         4.times do |i|
-          threads << Thread.new(i) do |pool_count|
+          threads << Thread.new(i) do
             connection = pool.connection
             assert_not_nil connection
             connection.close


### PR DESCRIPTION
1. ActiverRecord Railtie : We don't use app vars
2. Reserved Word test: Remove unnecessary line
3. Association Test: We don't need 'c'
4. ConnectionPool Test : We dont need pool_count 
