### PR TITLE
Handle conditional get in live requests

### DIFF
--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -98,6 +98,10 @@ module ActionController
       def merge_default_headers(original, default)
         Header.new self, super
       end
+
+      def handle_conditional_get!
+        super unless committed?
+      end
     end
 
     def process(name)

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -48,6 +48,10 @@ module ActionController
         end
         response.stream.close
       end
+
+      def with_stale
+        render :text => 'stale' if stale?(:etag => "123")
+      end
     end
 
     tests TestController
@@ -116,6 +120,17 @@ module ActionController
       get :render_text
       assert_equal 'zomg', response.body
       assert response.stream.closed?, 'stream should be closed'
+    end
+
+    def test_stale_without_etag
+      get :with_stale
+      assert_equal 200, @response.status.to_i
+    end
+
+    def test_stale_with_etag
+      @request.if_none_match = Digest::MD5.hexdigest("123")
+      get :with_stale
+      assert_equal 304, @response.status.to_i
     end
   end
 end


### PR DESCRIPTION
This will prevent error when using stale on live stream(issue #9636)

Test application: https://github.com/imanel/liveStale

**Rationale**: sometimes we want to use stale on longer actions(like live ones) and currently it is impossible. With this patch ETag will be set for actions that are not using `stream.write`, which is probably expected behavior.
