### PR TITLE
 #7347: Destroy marked child records before new child records inserted

### DIFF
--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -754,6 +754,18 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
     assert_equal before, @pirate.reload.birds
   end
 
+  def test_should_destroy_marked_childs_before_new_child_savings
+    @pirate.birds.create! name: 'Parrot', color: 'Colorful'
+    @pirate.birds.create! name: 'Sparrow', color: 'Asphalt'
+
+    @pirate.birds.each(&:mark_for_destruction)
+
+    @pirate.birds.build name: 'Parrot', color: 'Colorful'
+    @pirate.birds.build name: 'Sparrow', color: 'Asphalt'
+
+    @pirate.save!
+  end
+
   def test_when_new_record_a_child_marked_for_destruction_should_not_affect_other_records_from_saving
     @pirate = @ship.build_pirate(:catchphrase => "Arr' now I shall keep me eye on you matey!") # new record
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -89,6 +89,8 @@ ActiveRecord::Schema.define do
     t.integer :pirate_id
   end
 
+  add_index :birds, [:name, :color], :unique => true, :name => 'unique_birds_index'
+
   create_table :books, :force => true do |t|
     t.integer :author_id
     t.column :name, :string


### PR DESCRIPTION
This pull request should resolve #7347 issue.

There was a bug/annoying problem when:
1. there are some child records for has many association marked for destruction,
2. in the the same transaction added new child records which conflicts with marked records by schema constraints like unique values for some attributes,
3. on save there is Rollback Exception, because new conflicted records have been inserted before marked for destruction records are destroyed.

Example code: https://gist.github.com/pftg/5160669
