### PR TITLE
`#reset_counters` verifies counter names.

### DIFF
--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -11,7 +11,7 @@ module ActiveRecord
       # ==== Parameters
       #
       # * +id+ - The id of the object you wish to reset a counter on.
-      # * +counters+ - One or more counter names to reset
+      # * +counters+ - One or more association counters to reset
       #
       # ==== Examples
       #
@@ -21,6 +21,7 @@ module ActiveRecord
         object = find(id)
         counters.each do |association|
           has_many_association = reflect_on_association(association.to_sym)
+          raise ArgumentError, "'#{self.name}' has no association called '#{association}'" unless has_many_association
 
           if has_many_association.is_a? ActiveRecord::Reflection::ThroughReflection
             has_many_association = has_many_association.through_reflection

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -131,4 +131,11 @@ class CounterCacheTest < ActiveRecord::TestCase
       Subscriber.reset_counters(subscriber.id, 'books')
     end
   end
+
+  test "the passed symbol needs to be an association name" do
+    e = assert_raises(ArgumentError) do
+      Topic.reset_counters(@topic.id, :replies_count)
+    end
+    assert_equal "'Topic' has no association called 'replies_count'", e.message
+  end
 end


### PR DESCRIPTION
Closes #9724.

Raise an `ArgumentError` when the name of the counter does not
match an association name.
