### PR TITLE
The counter cache will now work correctly when the foreign key is changed. Fixes #9722.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,31 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Counter caches on associations will now stay valid when attributes are
+    updated (not just when records are created or destroyed), for example,
+    when calling +update_attributes+. The following code now works:
+
+      class Comment < ActiveRecord::Base
+        belongs_to :post, counter_cache: true
+      end
+
+      class Post < ActiveRecord::Base
+        has_many :comments
+      end
+
+      post = Post.create
+      comment = Comment.create
+
+      post.comments << comment
+      post.save.reload.comments_count     # => 1
+      comment.update_attributes(:post_id => nil)
+
+      post.save.reload.comments_count     # => 0
+
+    Updating the id of a +belongs_to+ object with the id of a new object will
+    also keep the count accurate.
+
+    *John Wang*
+
 *   Referencing join tables implicitly was deprecated. There is a
     possibility that these deprecation warnings are shown even if you
     don't make use of that feature. You can now disable the feature entirely.

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -789,6 +789,37 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_calling_update_attributes_on_id_changes_the_counter_cache
+    topic = Topic.order("id ASC").first
+    original_count = topic.replies.to_a.size
+    assert_equal original_count, topic.replies_count
+
+    first_reply = topic.replies.first
+    first_reply.update_attributes(:parent_id => nil)
+    assert_equal original_count - 1, topic.reload.replies_count
+
+    first_reply.update_attributes(:parent_id => topic.id)
+    assert_equal original_count, topic.reload.replies_count
+  end
+
+  def test_calling_update_attributes_changing_ids_doesnt_change_counter_cache
+    topic1 = Topic.find(1)
+    topic2 = Topic.find(3)
+    original_count1 = topic1.replies.to_a.size
+    original_count2 = topic2.replies.to_a.size
+
+    reply1 = topic1.replies.first
+    reply2 = topic2.replies.first
+
+    reply1.update_attributes(:parent_id => topic2.id)
+    assert_equal original_count1 - 1, topic1.reload.replies_count
+    assert_equal original_count2 + 1, topic2.reload.replies_count
+
+    reply2.update_attributes(:parent_id => topic1.id)
+    assert_equal original_count1, topic1.reload.replies_count
+    assert_equal original_count2, topic2.reload.replies_count
+  end
+
   def test_deleting_a_collection
     force_signal37_to_load_all_clients_of_firm
     companies(:first_firm).clients_of_firm.create("name" => "Another Client")


### PR DESCRIPTION
Currently, defining an association with a counter cache means that the counter only increments or decrements when an object is created or destroyed (see example in #9722). However, if an object updates its foreign key and removes itself from an association, the counter cache will not update correctly.

I've included a `before_save` callback that increments or decrements the counter if the foreign key gets changed in a `belongs_to` association. If the foreign key was present before but is no longer present after the update, then the counter gets decremented. Likewise, if the foreign key was not present before but is present after the update, then the counter gets incremented.

The counter cache only gets changed if the record is not new (so it doesn't conflict with the `after_create` callback currently in place.
