### PR TITLE
Remove "was successfully" from scaffold controller response messages

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
@@ -29,7 +29,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     @<%= singular_table_name %> = <%= orm_class.build(class_name, "#{singular_table_name}_params") %>
 
     if @<%= orm_instance.save %>
-      redirect_to @<%= singular_table_name %>, notice: <%= "'#{human_name} was successfully created.'" %>
+      redirect_to @<%= singular_table_name %>, notice: <%= "'#{human_name} created.'" %>
     else
       render action: 'new'
     end
@@ -38,7 +38,7 @@ class <%= controller_class_name %>Controller < ApplicationController
   # PATCH/PUT <%= route_url %>/1
   def update
     if @<%= orm_instance.update("#{singular_table_name}_params") %>
-      redirect_to @<%= singular_table_name %>, notice: <%= "'#{human_name} was successfully updated.'" %>
+      redirect_to @<%= singular_table_name %>, notice: <%= "'#{human_name} updated.'" %>
     else
       render action: 'edit'
     end
@@ -47,7 +47,7 @@ class <%= controller_class_name %>Controller < ApplicationController
   # DELETE <%= route_url %>/1
   def destroy
     @<%= orm_instance.destroy %>
-    redirect_to <%= index_helper %>_url, notice: <%= "'#{human_name} was successfully destroyed.'" %>
+    redirect_to <%= index_helper %>_url, notice: <%= "'#{human_name} destroyed.'" %>
   end
 
   private

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -39,7 +39,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
 
       assert_instance_method :destroy, content do |m|
         assert_match(/@user\.destroy/, m)
-        assert_match(/User was successfully destroyed/, m)
+        assert_match(/User destroyed/, m)
       end
 
       assert_instance_method :set_user, content do |m|


### PR DESCRIPTION
The default scaffold messages would be better without the "was successfully" part, for example:

"Account created." vs. "Account was successfully created." or
"User updated." vs. "User was successfully updated."

Shorter, cleaner, nicer. I realize that people customize these normally but defaults matter. Let's get rid of these extra words.
