### PR TITLE
Make assert_recognizes to consider request query parameters with extras

### DIFF
--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -38,6 +38,10 @@ module ActionDispatch
           env['REMOTE_ADDR']
         end
 
+        def query_parameters
+          {}
+        end
+
         def [](k); env[k]; end
       end
 
@@ -139,7 +143,7 @@ module ActionDispatch
             match_values = match_data.captures.map { |v| v && Utils.unescape_uri(v) }
             info = Hash[match_names.zip(match_values).find_all { |_, y| y }]
 
-            [match_data, r.defaults.merge(info), r]
+            [match_data, r.defaults.merge(info).merge(req.query_parameters) , r]
           }
         end
 

--- a/actionpack/test/dispatch/routing_assertions_test.rb
+++ b/actionpack/test/dispatch/routing_assertions_test.rb
@@ -48,6 +48,13 @@ class RoutingAssertionsTest < ActionController::TestCase
     assert_recognizes({ :controller => 'articles', :action => 'index', :page => '1' }, '/articles', { :page => '1' })
   end
 
+  def test_assert_recognizes_with_query_parameters
+    assert_raise(Assertion) do
+      assert_recognizes({:controller => 'articles', :action => 'index'}, '/articles?pager=1')
+    end
+    assert_recognizes({:controller => 'articles', :action => 'index', :pager => '1'}, '/articles?pager=1')
+  end
+
   def test_assert_recognizes_with_method
     assert_recognizes({ :controller => 'articles', :action => 'create' }, { :path => '/articles', :method => :post })
     assert_recognizes({ :controller => 'articles', :action => 'update', :id => '1' }, { :path => '/articles/1', :method => :put })

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -2808,6 +2808,11 @@ class TestAltApp < ActionDispatch::IntegrationTest
     def x_header
       @env["HTTP_X_HEADER"] || ""
     end
+
+    def query_parameters
+      {}
+    end
+
   end
 
   class XHeader

--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -32,6 +32,11 @@ module ActionDispatch
         def path_info; env['PATH_INFO']; end
         def request_method; env['REQUEST_METHOD']; end
         def ip; env['REMOTE_ADDR']; end
+
+        def query_parameters
+          {}
+        end
+
       end
 
       def test_dashes


### PR DESCRIPTION
Try fixing #9718

Query Parameters were being ignored, and only path info along with `extras` were used for matching route params. This behaviour made it to ignore wrong parameters.

This PR tries to make query parameters accountable too
