### PR TITLE
Allow pass multipart option to form_for

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -433,7 +433,7 @@ module ActionView
 
         builder = instantiate_builder(object_name, object, options)
         output  = capture(builder, &block)
-        html_options[:multipart] = builder.multipart?
+        html_options[:multipart] ||= builder.multipart?
 
         form_tag(options[:url] || {}, html_options) { output }
       end

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -2791,8 +2791,8 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_form_for_with_html_options_adds_options_to_form_tag
-    form_for(@post, html: { id: 'some_form', class: 'some_class' }) do |f| end
-    expected = whole_form("/posts/123", "some_form", "some_class", method: "patch")
+    form_for(@post, html: { id: 'some_form', class: 'some_class', multipart: true }) do |f| end
+    expected = whole_form("/posts/123", "some_form", "some_class", method: "patch", multipart: "multipart/form-data")
 
     assert_dom_equal expected, output_buffer
   end


### PR DESCRIPTION
Currently in Rails 4 form_for will ignore html: { multipart: true }
To add multipart you need have at last one f.file_field or f.multipart = true (this is so ugly!)

This change will revert posibility to pass multipart as html option
