### PR TITLE
Refactor Person/Friendship relationships to be more intuitive

### DIFF
--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -118,7 +118,7 @@ class CounterCacheTest < ActiveRecord::TestCase
   test "reset the right counter if two have the same foreign key" do
     michael = people(:michael)
     assert_nothing_raised(ActiveRecord::StatementInvalid) do
-      Person.reset_counters(michael.id, :followers)
+      Person.reset_counters(michael.id, :friends_too)
     end
   end
 

--- a/activerecord/test/fixtures/friendships.yml
+++ b/activerecord/test/fixtures/friendships.yml
@@ -1,4 +1,4 @@
 Connection 1:
   id: 1
-  person_id: 1
-  friend_id: 2
+  friend_id: 1
+  follower_id: 2

--- a/activerecord/test/fixtures/people.yml
+++ b/activerecord/test/fixtures/people.yml
@@ -5,6 +5,7 @@ michael:
   number1_fan_id: 3
   gender: M
   followers_count: 1
+  friends_too_count: 1
 david:
   id: 2
   first_name: David
@@ -12,6 +13,7 @@ david:
   number1_fan_id: 1
   gender: M
   followers_count: 1
+  friends_too_count: 1
 susan:
   id: 3
   first_name: Susan
@@ -19,3 +21,4 @@ susan:
   number1_fan_id: 1
   gender: F
   followers_count: 1
+  friends_too_count: 1

--- a/activerecord/test/models/friendship.rb
+++ b/activerecord/test/models/friendship.rb
@@ -1,4 +1,6 @@
 class Friendship < ActiveRecord::Base
   belongs_to :friend, class_name: 'Person'
-  belongs_to :follower, foreign_key: 'friend_id', class_name: 'Person', counter_cache: :followers_count
+  # friend_too exists to test a bug, and probably shouldn't be used elsewhere
+  belongs_to :friend_too, foreign_key: 'friend_id', class_name: 'Person', counter_cache: :friends_too_count
+  belongs_to :follower, class_name: 'Person'
 end

--- a/activerecord/test/models/person.rb
+++ b/activerecord/test/models/person.rb
@@ -8,7 +8,10 @@ class Person < ActiveRecord::Base
   has_many :posts_with_no_comments, -> { includes(:comments).where('comments.id is null').references(:comments) },
                                     :through => :readers, :source => :post
 
-  has_many :followers, foreign_key: 'friend_id', class_name: 'Friendship'
+  has_many :friendships, foreign_key: 'friend_id'
+  # friends_too exists to test a bug, and probably shouldn't be used elsewhere
+  has_many :friends_too, foreign_key: 'friend_id', class_name: 'Friendship'
+  has_many :followers, through: :friendships
 
   has_many :references
   has_many :bad_references

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -280,7 +280,7 @@ ActiveRecord::Schema.define do
 
   create_table :friendships, :force => true do |t|
     t.integer :friend_id
-    t.integer :person_id
+    t.integer :follower_id
   end
 
   create_table :goofy_string_id, :force => true, :id => false do |t|
@@ -494,6 +494,7 @@ ActiveRecord::Schema.define do
     t.integer    :lock_version, :null => false, :default => 0
     t.string     :comments
     t.integer    :followers_count, :default => 0
+    t.integer    :friends_too_count, :default => 0
     t.references :best_friend
     t.references :best_friend_of
     t.integer    :insures, null: false, default: 0


### PR DESCRIPTION
PR #5210 added a Friendship model to illustrate a bug, but in doing so
created a confusing structure because both belongs_to declarations in
Friendship referred to the same side of the join. The new structure
maintains the integrity of the bug test while changing the follower
relationship to be more useful for other testing.
