### PR TITLE
Adding the --no-rc option to Rails 3.2. As seen in Rails 4.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -5,8 +5,8 @@
 
 ## Rails 3.2.13 (Feb 17, 2013) ##
 
-*   No changes.
-
+*   Addng the --no-rc option to skip the loading of railsrc file during the generation of a new app that has been included in Rails 4.
+*   *Adam Dalton*
 
 ## Rails 3.2.12 (Feb 11, 2013) ##
 

--- a/railties/lib/rails/commands/application.rb
+++ b/railties/lib/rails/commands/application.rb
@@ -9,13 +9,15 @@ if ARGV.first != "new"
   ARGV[0] = "--help"
 else
   ARGV.shift
-  railsrc = File.join(File.expand_path("~"), ".railsrc")
-  if File.exist?(railsrc)
-    extra_args_string = File.open(railsrc).read
-    extra_args = extra_args_string.split(/\n+/).map {|l| l.split}.flatten
-    puts "Using #{extra_args.join(" ")} from #{railsrc}"
-    ARGV << extra_args
-    ARGV.flatten!
+  unless ARGV.delete("--no-rc")
+    railsrc = File.join(File.expand_path("~"), ".railsrc")
+    if File.exist?(railsrc)
+      extra_args_string = File.open(railsrc).read
+      extra_args = extra_args_string.split(/\n+/).map {|l| l.split}.flatten
+      puts "Using #{extra_args.join(" ")} from #{railsrc}"
+      ARGV << extra_args
+      ARGV.flatten!
+    end
   end
 end
 


### PR DESCRIPTION
Inspired by https://github.com/rails/rails/commit/b0d4a205713154a4cd3c065e8bdb42431f63dd74
