### PR TITLE
Fix for inflector's incorrect camelCase replacement for acronyms Mark II

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fixed a bug in Inflector#underscore where acroynms are incorrectly parsed as camelCases.
+
+    *Fred Wu*
+
 *   Fix deletion of empty directories in `ActiveSupport::Cache::FileStore`.
 
     *Charles Jones*

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -91,7 +91,8 @@ module ActiveSupport
       word = camel_cased_word.to_s.dup
       word.gsub!('::', '/')
       word.gsub!(/(?:([A-Za-z\d])|^)(#{inflections.acronym_regex})(?=\b|[^a-z])/) { "#{$1}#{$1 && '_'}#{$2.downcase}" }
-      word.gsub!(/([A-Z\d]+)([A-Z][a-z])/,'\1_\2')
+      look_behind_for_acronyms = inflections.acronyms.any? ? "(?<!#{inflections.acronyms.values.join('|')})" : ""
+      word.gsub!(/([A-Z\d]+)([A-Z][a-z])#{look_behind_for_acronyms}/,'\1_\2')
       word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
       word.tr!("-", "_")
       word.downcase!

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -167,11 +167,13 @@ class InflectorTest < ActiveSupport::TestCase
   def test_underscore_acronym_sequence
     ActiveSupport::Inflector.inflections do |inflect|
       inflect.acronym("API")
+      inflect.acronym("APIs")
       inflect.acronym("JSON")
       inflect.acronym("HTML")
     end
 
     assert_equal("json_html_api", ActiveSupport::Inflector.underscore("JSONHTMLAPI"))
+    assert_equal("namespaced/apis", ActiveSupport::Inflector.underscore("Namespaced::APIs"))
   end
 
   def test_underscore

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -141,6 +141,7 @@ module InflectorTestCases
     "HTMLTidyGenerator"     => "html_tidy_generator",
     "FreeBSD"               => "free_bsd",
     "HTML"                  => "html",
+    "ForceXMLController"    => "force_xml_controller"
   }
 
   CamelWithModuleToUnderscoreWithSlash = {


### PR DESCRIPTION
This is a new version of the patch #8156

Description of this bug: #8015

cc @fxn @steveklabnik @macksmind @strzalek
