### PR TITLE
remove unused parameter passed to assert_query_equal method

### DIFF
--- a/activesupport/test/core_ext/object/to_query_test.rb
+++ b/activesupport/test/core_ext/object/to_query_test.rb
@@ -47,7 +47,7 @@ class ToQueryTest < ActiveSupport::TestCase
   end
 
   private
-    def assert_query_equal(expected, actual, message = nil)
+    def assert_query_equal(expected, actual)
       assert_equal expected.split('&'), actual.to_query.split('&')
     end
 end


### PR DESCRIPTION
Remove an unused parameter passed to assert_query_equal method from tests
