### PR TITLE
Fix rails console --sandbox test for Mac OS

### DIFF
--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -119,16 +119,19 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     assert output.include?(expected), "#{expected.inspect} expected, but got:\n\n#{output}"
   end
 
-  def write_prompt(command, expected_output = nil)
+  def write_prompt(command, expected_output = '> ')
     @master.puts command
     assert_output command
-    assert_output expected_output if expected_output
-    assert_output "> "
+    assert_output expected_output
   end
 
   def kill(pid)
-    Process.kill('QUIT', pid)
-    Process.wait(pid)
+    if RUBY_PLATFORM =~ /darwin/
+      write_prompt "quit", ""
+    else
+      Process.kill('QUIT', pid)
+      Process.wait(pid)
+    end
   rescue Errno::ESRCH
   end
 


### PR DESCRIPTION
Using Process#kill was triggering ReportCrash on Mac OS Moutain Lion and
the test would not complete. This happened whether run from `rake test`
or as ruby -w -Itest ...

/cc @jonleighton @carlosantoniodasilva
