### PR TITLE
`rake db:create` does not change permissions of root user.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `rake db:create` does not change permissions of the MySQL root user.
+    Fixes #8079.
+
+    *Yves Senn*
+
 *   The length of the `version` column in the `schema_migrations` table
     created by the `mysql2` adapter is 191 if the encoding is "utf8mb4".
 

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -26,7 +26,9 @@ module ActiveRecord
           $stdout.print error.error
           establish_connection root_configuration_without_database
           connection.create_database configuration['database'], creation_options
-          connection.execute grant_statement.gsub(/\s+/, ' ').strip
+          if configuration['username'] != 'root'
+            connection.execute grant_statement.gsub(/\s+/, ' ').strip
+          end
           establish_connection configuration
         else
           $stderr.puts "Couldn't create database for #{configuration.inspect}, #{creation_options.inspect}"


### PR DESCRIPTION
Closes #8079.

I had to rework some of the tests because the mock allowed any arguments
for `connection.exeucte`. I think this is very dangerous as there could
anything be executed without the tests noticing it.
