### PR TITLE
fix repeat of test; remove unused variable by use of each_key

### DIFF
--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -324,7 +324,7 @@ class InflectorTest < ActiveSupport::TestCase
   end
 
   def test_underscore_as_reverse_of_dasherize
-    UnderscoresToDashes.each do |underscored, dasherized|
+    UnderscoresToDashes.each_key do |underscored|
       assert_equal(underscored, ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.dasherize(underscored)))
     end
   end

--- a/activesupport/test/transliterate_test.rb
+++ b/activesupport/test/transliterate_test.rb
@@ -17,7 +17,7 @@ class TransliterateTest < ActiveSupport::TestCase
     # some reason or other are floating in the middle of all the letters.
     string = (0xC0..0x17E).to_a.reject {|c| [0xD7, 0xF7].include?(c)}.pack("U*")
     string.each_char do |char|
-      assert_match %r{^[a-zA-Z']*$}, ActiveSupport::Inflector.transliterate(string)
+      assert_match %r{^[a-zA-Z']*$}, ActiveSupport::Inflector.transliterate(char)
     end
   end
 


### PR DESCRIPTION
1. The loop was unnecessarily repeating itself
2. Removed unused variable by use of each_key in place of each
