### PR TITLE
move tests out from base_test.rb

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -307,20 +307,6 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal("last_read", ex.errors[0].attribute)
   end
 
-  def test_initialize_abstract_class
-    e = assert_raises(NotImplementedError) do
-      FirstAbstractClass.new
-    end
-    assert_equal("FirstAbstractClass is an abstract class and can not be instantiated.", e.message)
-  end
-
-  def test_initialize_base
-    e = assert_raises(NotImplementedError) do
-      ActiveRecord::Base.new
-    end
-    assert_equal("ActiveRecord::Base is an abstract class and can not be instantiated.", e.message)
-  end
-
   def test_create_after_initialize_without_block
     cb = CustomBulb.create(:name => 'Dude')
     assert_equal('Dude', cb.name)

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -172,6 +172,20 @@ class InheritanceTest < ActiveRecord::TestCase
     assert_equal Firm, firm.class
   end
 
+  def test_new_with_abstract_class
+    e = assert_raises(NotImplementedError) do
+      AbstractCompany.new
+    end
+    assert_equal("AbstractCompany is an abstract class and can not be instantiated.", e.message)
+  end
+
+  def test_new_with_ar_base
+    e = assert_raises(NotImplementedError) do
+      ActiveRecord::Base.new
+    end
+    assert_equal("ActiveRecord::Base is an abstract class and can not be instantiated.", e.message)
+  end
+
   def test_new_with_invalid_type
     assert_raise(ActiveRecord::SubclassNotFound) { Company.new(:type => 'InvalidType') }
   end


### PR DESCRIPTION
These tests should be in inheritance_test.rb since its testing a
feature which is implemented in inheritance.rb

We should extract tests out from base_test.rb if its possible since its getting bigger and bigger... :P 

ref: #9744

/cc @carlosantoniodasilva
