### PR TITLE
remove ancient TODOs

### DIFF
--- a/actionpack/test/controller/output_escaping_test.rb
+++ b/actionpack/test/controller/output_escaping_test.rb
@@ -11,8 +11,6 @@ class OutputEscapingTest < ActiveSupport::TestCase
   end
 
   test "escapeHTML shouldn't touch explicitly safe strings" do
-    # TODO this seems easier to compose and reason about, but
-    # this should be verified
     assert_equal "<", ERB::Util.h("<".html_safe)
   end
 

--- a/actionpack/test/template/url_helper_test.rb
+++ b/actionpack/test/template/url_helper_test.rb
@@ -51,7 +51,6 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert_equal 'javascript:history.back()', url_for(:back)
   end
 
-  # TODO: missing test cases
   def test_button_to_with_straight_url
     assert_dom_equal %{<form method="post" action="http://www.example.com" class="button_to"><div><input type="submit" value="Hello" /></div></form>}, button_to("Hello", "http://www.example.com")
   end

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -341,9 +341,6 @@ end
 # is so cumbersome. Will deadlock Ruby threads if the underlying db.execute
 # blocks, so separate script called by Kernel#system is needed.
 # (See exec vs. async_exec in the PostgreSQL adapter.)
-
-# TODO: The Sybase, and OpenBase adapters currently have no support for pessimistic locking
-
 unless current_adapter?(:SybaseAdapter, :OpenBaseAdapter) || in_memory_db?
   class PessimisticLockingTest < ActiveRecord::TestCase
     self.use_transactional_fixtures = false


### PR DESCRIPTION
these TODOs have been around for a very long time without anyone acting on them. From the git log it's hard to tell what the intention behind them was and I think it's safe to remove them.
