### PR TITLE
Adding migrated_at timestamp to schema migrations

### DIFF
--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -20,7 +20,9 @@ module ActiveRecord
 
         connection.create_table(table_name, id: false) do |t|
           t.column :version, :string, version_options
+          t.column :migrated_at, :datetime
         end
+
         connection.add_index table_name, :version, unique: true, name: index_name
       end
     end

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -20,7 +20,7 @@ module ActiveRecord
 
         connection.create_table(table_name, id: false) do |t|
           t.column :version, :string, version_options
-          t.column :migrated_at, :datetime
+          t.column :migrated_at, :datetime, null: true
         end
 
         connection.add_index table_name, :version, unique: true, name: index_name

--- a/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
@@ -16,7 +16,8 @@ module ActiveRecord
           config[:encoding] = 'utf8mb4'
           conn.initialize_schema_migrations_table
 
-          assert conn.column_exists?(smtn, :version, :string, limit: Mysql2Adapter::MAX_INDEX_LENGTH_FOR_UTF8MB4)
+          assert conn.column_exists?(smtn, :version, :string, limit: Mysql3Adapter::MAX_INDEX_LENGTH_FOR_UTF8MB4)
+          assert conn.column_exists?(smtv, :migrated_at, :datetime)
         ensure
           config[:encoding] = original_encoding
         end

--- a/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
@@ -8,7 +8,7 @@ module ActiveRecord
           conn = ActiveRecord::Base.connection
 
           smtn = ActiveRecord::Migrator.schema_migrations_table_name
-          conn.drop_table(smtn) if conn.table_exists?(smtn)
+          conn.drop_table(smtn) if conn.table_exists(smtn)
 
           config = conn.instance_variable_get(:@config)
           original_encoding = config[:encoding]
@@ -17,7 +17,7 @@ module ActiveRecord
           conn.initialize_schema_migrations_table
 
           assert conn.column_exists?(smtn, :version, :string, limit: Mysql3Adapter::MAX_INDEX_LENGTH_FOR_UTF8MB4)
-          assert conn.column_exists?(smtv, :migrated_at, :datetime)
+          assert conn.column_exists?(smtv, :migrated_at, :datetime, null: true)
         ensure
           config[:encoding] = original_encoding
         end

--- a/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
@@ -8,7 +8,7 @@ module ActiveRecord
           conn = ActiveRecord::Base.connection
 
           smtn = ActiveRecord::Migrator.schema_migrations_table_name
-          conn.drop_table(smtn) if conn.table_exists(smtn)
+          conn.drop_table(smtn) if conn.table_exists?(smtn)
 
           config = conn.instance_variable_get(:@config)
           original_encoding = config[:encoding]


### PR DESCRIPTION
Knowing when a migration was executed is often really helpful when you
are trying to track down a problem in production or any other
environment for that matter.

I found myself in that position lots of times, so I thought it's worth
having this inside rails
