### PR TITLE
change from blank? to empty? on obvious string values  to save extra calls

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -161,7 +161,7 @@ module ActiveRecord
 
         def value_to_date(value)
           if value.is_a?(String)
-            return nil if value.blank?
+            return nil if value.empty?
             fast_string_to_date(value) || fallback_string_to_date(value)
           elsif value.respond_to?(:to_date)
             value.to_date
@@ -172,14 +172,14 @@ module ActiveRecord
 
         def string_to_time(string)
           return string unless string.is_a?(String)
-          return nil if string.blank?
+          return nil if string.empty?
 
           fast_string_to_time(string) || fallback_string_to_time(string)
         end
 
         def string_to_dummy_time(string)
           return string unless string.is_a?(String)
-          return nil if string.blank?
+          return nil if string.empty?
 
           dummy_time_string = "2000-01-01 #{string}"
 
@@ -192,7 +192,7 @@ module ActiveRecord
 
         # convert something to a boolean
         def value_to_boolean(value)
-          if value.is_a?(String) && value.blank?
+          if value.is_a?(String) && value.empty?
             nil
           else
             TRUE_VALUES.include?(value)


### PR DESCRIPTION
Change `blank?` to `empty?` on obvious strings in `Column` to drop the extra method call
