### PR TITLE
Ensure that has_many :through counter cache decrements aren't doubled up

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -149,7 +149,7 @@ module ActiveRecord
 
           delete_through_records(records)
 
-          if source_reflection.options[:counter_cache]
+          if source_reflection.options[:counter_cache] && method != :destroy
             counter = source_reflection.counter_cache_column
             klass.decrement_counter counter, records.map(&:id)
           end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -341,6 +341,16 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal(post.taggings.count, post.taggings_count)
   end
 
+  def test_update_counter_caches_on_replace_association_with_dependent_destroy
+    post = posts(:welcome)
+    tag  = post.tags.create!(:name => 'doomed')
+
+    tag.tagged_posts_with_destroy = []
+    post.reload
+
+    assert_equal(post.taggings.count, post.taggings_count)
+  end
+
   def test_replace_association
     assert_queries(4){posts(:welcome);people(:david);people(:michael); posts(:welcome).people(true)}
 

--- a/activerecord/test/models/tag.rb
+++ b/activerecord/test/models/tag.rb
@@ -4,4 +4,5 @@ class Tag < ActiveRecord::Base
   has_one  :tagging
 
   has_many :tagged_posts, :through => :taggings, :source => :taggable, :source_type => 'Post'
+  has_many :tagged_posts_with_destroy, :through => :taggings, :source => :taggable, :source_type => 'Post', :dependent => :destroy
 end


### PR DESCRIPTION
A has_many :through association must manage the counter cache of its
join model in case the join model is simply deleted (without callbacks)
rather than destroyed when the association is cleared.

The problem is that if :dependent => :destroy is specified on the
has_many :through, the join model will be destroyed (triggering
callbacks). This means that the join model will decrement the counter
cache in addition to the has_many :through association. As a result,
the counter cache is decremented twice.

The has_many :through association should only try to manage the counter
cache if the join model is not destroyed.
