### PR TITLE
Removing Railtie::Configurable and replacing it with class methods

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
-* No changes.
+*   Rails::Railtie no longer forces the Rails::Configurable module on everything
+    that subclassess it. Instead, the methods from Rails::Configurable have been
+    moved to class methods in Railtie and the Railtie has been made abstract.
+
+    *John Wang*
 
 Please check [4-0-stable](https://github.com/rails/rails/blob/4-0-stable/railties/CHANGELOG.md) for previous changes.

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -634,15 +634,15 @@ module Rails
       end
     end
 
+    def routes? #:nodoc:
+      @routes
+    end
+
     protected
 
     def run_tasks_blocks(*) #:nodoc:
       super
       paths["lib/tasks"].existent.sort.each { |ext| load(ext) }
-    end
-
-    def routes? #:nodoc:
-      @routes
     end
 
     def has_migrations? #:nodoc:

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -112,7 +112,6 @@ module Rails
   # Be sure to look at the documentation of those specific classes for more information.
   #
   class Railtie
-    autoload :Configurable,  "rails/railtie/configurable"
     autoload :Configuration, "rails/railtie/configuration"
 
     include Initializable
@@ -121,6 +120,7 @@ module Rails
 
     class << self
       private :new
+      delegate :config, to: :instance
 
       def subclasses
         @subclasses ||= []
@@ -128,7 +128,6 @@ module Rails
 
       def inherited(base)
         unless base.abstract_railtie?
-          base.send(:include, Railtie::Configurable)
           subclasses << base
         end
       end
@@ -166,13 +165,46 @@ module Rails
         @railtie_name ||= generate_railtie_name(self.name)
       end
 
+      # Since Rails::Railtie cannot be instantiated, any methods that call
+      # +instance+ are intended to be called only on subclasses of a Railtie.
+      def instance
+        @instance ||= new
+      end
+
+      def respond_to_missing?(*args)
+        instance.respond_to?(*args) || super
+      end
+
+      # Allows you to configure the railtie. This is the same method seen in
+      # Railtie::Configurable, but this module is no longer required for all
+      # subclasses of Railtie so we provide the class method here.
+      def configure(&block)
+        class_eval(&block)
+      end
+
       protected
         def generate_railtie_name(class_or_module)
           ActiveSupport::Inflector.underscore(class_or_module).tr("/", "_")
         end
+
+        # If the class method does not have a method, then send the method call
+        # to the Railtie instance.
+        def method_missing(name, *args, &block)
+          if instance.respond_to?(name)
+            instance.public_send(name, *args, &block)
+          else
+            super
+          end
+        end
     end
 
     delegate :railtie_name, to: :class
+
+    def initialize
+      if self.class.abstract_railtie?
+        raise "#{self.class.name} is abstract, you cannot instantiate it directly."
+      end
+    end
 
     def config
       @config ||= Railtie::Configuration.new

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -416,11 +416,6 @@ YAML
       boot_rails
     end
 
-    test "Rails::Engine itself does not respond to config" do
-      boot_rails
-      assert !Rails::Engine.respond_to?(:config)
-    end
-
     test "initializers are executed after application configuration initializers" do
       @plugin.write "lib/bukkits.rb", <<-RUBY
         module Bukkits

--- a/railties/test/railties/railtie_test.rb
+++ b/railties/test/railties/railtie_test.rb
@@ -19,8 +19,8 @@ module RailtiesTest
       @app ||= Rails.application
     end
 
-    test "Rails::Railtie itself does not respond to config" do
-      assert !Rails::Railtie.respond_to?(:config)
+    test "cannot instantiate a Railtie object" do
+      assert_raise(RuntimeError) { Rails::Railtie.new }
     end
 
     test "Railtie provides railtie_name" do
@@ -37,13 +37,6 @@ module RailtiesTest
         railtie_name "bar"
       end
       assert_equal "bar", Foo.railtie_name
-    end
-
-    test "cannot inherit from a railtie" do
-      class Foo < Rails::Railtie ; end
-      assert_raise RuntimeError do
-        class Bar < Foo; end
-      end
     end
 
     test "config is available to railtie" do


### PR DESCRIPTION
I believe the reason `Railtie::Configurable` was created was so that the subclasses of the Railtie class would have the methods in the Configurable module (such as `instance`, `configure`, and `method_missing`). However, the implementer of Railtie did not want Railtie itself to have these methods.

This was implemented by forcing all modules that inherit from Railtie to include the Configurable module like so:

``` ruby
class Railtie
  class << self
    def inherited(base)
      base.send(:include, Railtie::Configurable)
    end
  ...
  end
end
```

This isn't great because it forces all the subclasses of Railtie to have this module, which isn't ideal behavior. Instead, it would be nice to use inheritance to make sure these methods appear in subclasses of Railties.

I've made it so that the Railtie class has the methods from Railtie::Configurable, and that Railtie itself cannot be instantiated and is effectively an abstract class.
