### PR TITLE
Fix improperly configured host in generated urls

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Allow default url options to accept host with protocol such as `http://`
+
+        config.action_mailer.default_url_options = { host: "http://mydomain.com" }
+
+    *Richard Schneeman*
+
 *   Ensure that digest authentication responds with a 401 status when a basic
     header is received.
 

--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -59,8 +59,9 @@ module ActionDispatch
           result = ""
 
           unless options[:only_path]
+            protocol = extract_protocol(options)
             unless options[:protocol] == false
-              result << (options[:protocol] || "http")
+              result << protocol
               result << ":" unless result.match(%r{:|//})
             end
             result << "//" unless result.match("//")
@@ -81,6 +82,16 @@ module ActionDispatch
           else
             ""
           end
+        end
+
+        # Extracts protocol http:// or https:// from options[:host]
+        # needs to be called whether the :protocol is being used or not
+        def extract_protocol(options)
+          if options[:host] && match = options[:host].match(/(^.*:\/\/)(.*)/)
+            options[:protocol] ||= match[1]
+            options[:host]     =   match[2]
+          end
+          options[:protocol] || "http"
         end
 
         def host_or_subdomain_and_domain(options)

--- a/actionpack/test/dispatch/url_generation_test.rb
+++ b/actionpack/test/dispatch/url_generation_test.rb
@@ -48,6 +48,14 @@ module TestUrlGeneration
       https!
       assert_equal "http://www.example.com/foo", foo_url(:protocol => "http")
     end
+
+    test "extracting protocol from host when protocol not present" do
+      assert_equal "httpz://www.example.com/foo", foo_url(host: "httpz://www.example.com", protocol: nil)
+    end
+
+    test "formatting host when protocol is present" do
+      assert_equal "http://www.example.com/foo", foo_url(host: "httpz://www.example.com", protocol: "http://")
+    end
   end
 end
 


### PR DESCRIPTION
If the host in `default_url_options` is accidentally set with a protocol such as 

```
host: "http://example.com"
```

then the generated url will have the protocol twice `http://http://example.com` which is not what the user intended. Likely they wanted to define a host `host: "example.com"` and a `protocol: "http://"` but did not know the convention.

This may not the most common problem, but when it happens it can go undetected for a while. I accidentally added `http://` out of habit recently only to find all the links in my emails were broken after deploying a demo site to production. Rather than allow this accident go undetected, we can fix the problem in line by properly setting the protocol and host.

I was able to find this related question on stack overflow: http://stackoverflow.com/questions/5878329/rails-3-devise-how-do-i-make-the-email-confirmation-links-use-secure-https-n where the answer was highly upvoted.

This is based off of work in #7415 cc/ @pixeltrix

ATP Action Mailer and Action Pack
