### PR TITLE
Reset postgreSQL search path in db:test:clone_structure.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## unreleased ##
 
+*   Resets the postgres search path in the structure.sql after the structure
+    is dumped in order to find schema_migrations table when multiples schemas
+    are used.
+    Fixes #9796.
+
+    *Juan M. Cuello + Dembskiy Alexander*
+
 *   Reload the association target if it's stale. `@stale_state` should be nil
     when a model isn't saved.
     Fixes #7526.

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -427,6 +427,7 @@ db_namespace = namespace :db do
         end
         `pg_dump -i -s -x -O -f #{Shellwords.escape(filename)} #{search_path} #{Shellwords.escape(config['database'])}`
         raise 'Error dumping database' if $?.exitstatus == 1
+        File.open(filename, "a") { |f| f << "SET search_path TO #{ActiveRecord::Base.connection.schema_search_path};\n\n" }
       when /sqlite/
         dbfile = config['database']
         `sqlite3 #{dbfile} .schema > #{filename}`


### PR DESCRIPTION
Is it possible to have this feature in 3.2 branch?
Originally this feature was accepted to master, see https://github.com/rails/rails/pull/4132.

Thanks.
