### PR TITLE
Fix warning: mismatched indentatmmismatched indentations at 'end' with 'def'

### DIFF
--- a/activesupport/test/xml_mini/jdom_engine_test.rb
+++ b/activesupport/test/xml_mini/jdom_engine_test.rb
@@ -43,7 +43,7 @@ if RUBY_PLATFORM =~ /java/
       assert_equal 'x', Hash.from_xml(attack_xml)["member"]
     end
 
-  def test_not_allowed_to_expand_parameter_entities_to_files
+    def test_not_allowed_to_expand_parameter_entities_to_files
       attack_xml = <<-EOT
       <!DOCTYPE member [
         <!ENTITY % b SYSTEM "file://#{FILES_DIR}/jdom_entities.txt">


### PR DESCRIPTION
When I executed rails's testcases, I saw a warning.

```
activesupport/test/xml_mini/jdom_engine_test.rb:57: warning: mismatched indentations at 'end' with 'def' at 46
```
