### PR TITLE
Fix missing action_missing

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fixed ActionController#action_missing not being called.
+    Fixes GH#9799.
+
+    *Janko Luin*
+
 *   Ensure that digest authentication responds with a 401 status when a basic
     header is received.
 

--- a/actionpack/lib/action_controller/metal/hide_actions.rb
+++ b/actionpack/lib/action_controller/metal/hide_actions.rb
@@ -27,7 +27,7 @@ module ActionController
       end
 
       def visible_action?(action_name)
-        action_methods.include?(action_name)
+        not hidden_actions.include?(action_name)
       end
 
       # Overrides AbstractController::Base#action_methods to remove any methods

--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -68,6 +68,12 @@ class RecordIdentifierWithoutDeprecationController < ActionController::Base
   include ActionView::RecordIdentifier
 end
 
+class ActionMissingController < ActionController::Base
+  def action_missing(action)
+    render :text => "Response for #{action}"
+  end
+end
+
 class ControllerClassTests < ActiveSupport::TestCase
 
   def test_controller_path
@@ -185,6 +191,12 @@ class PerformActionTest < ActionController::TestCase
     use_controller NonEmptyController
     assert_raise(AbstractController::ActionNotFound) { get :hidden_action }
     assert_raise(AbstractController::ActionNotFound) { get :another_hidden_action }
+  end
+
+  def test_action_missing_should_work
+    use_controller ActionMissingController
+    get :arbitrary_action
+    assert_equal "Response for arbitrary_action", @response.body
   end
 end
 


### PR DESCRIPTION
This reverts commit 7cc5bf51b4c16e89340b8c45ca0297e387226aaf, which assumed that all controller actions can be known beforehand - completely negating action_missing.

Also adds a test to ensure this mistake does not happen again.

Fixes issue #9799.
