### PR TITLE
Creating a ChangedFile class for sending file system updates through Notifications

### DIFF
--- a/activesupport/lib/active_support/file_update_checker.rb
+++ b/activesupport/lib/active_support/file_update_checker.rb
@@ -27,6 +27,47 @@ module ActiveSupport
   #     i18n_reloader.execute_if_updated
   #   end
   class FileUpdateChecker
+    # The ChangedFile class provides a means of accessing information about
+    # a file which has recently been changed. The class provides information
+    # about the time of the change, the path for the file which was changed
+    # and the type of change (whether the file was modified, added, or
+    # removed).
+    class ChangedFile
+      class << self
+        VALID_CHANGE_TYPES = [:modified, :added, :removed]
+
+        # Converts a path and change type into a hash of attributes. The hash
+        # contains the path, the type, and the current time.
+        def notifications_hash(path, type)
+          check_change_type!(type)
+          {:path => path, :type => type, :time => Time.now}
+        end
+
+        # Checks to make sure the change type is valid.
+        def check_change_type!(type)
+          if !VALID_CHANGE_TYPES.include?(type)
+            raise ArgumentError, "Change type #{type} is invalid. Valid change types are :#{VALID_CHANGE_TYPES.join(', :')}"
+          end
+        end
+      end
+
+      attr_accessor :path, :time, :type
+
+      def initialize(path, type)
+        self.class.check_change_type!(type)
+
+        @path = path
+        @type = type
+        @time = Time.now
+      end
+
+      # Converts the ChangedFile object to a hash that can be passed as payload
+      # in the Notifications system.
+      def to_notifications_hash
+        {:path => path, :type => type, :time => time}
+      end
+    end
+
     # It accepts two parameters on initialization. The first is an array
     # of files and the second is an optional hash of directories. The hash must
     # have directories as keys and the value is an array of extensions to be

--- a/activesupport/test/file_update_checker_test.rb
+++ b/activesupport/test/file_update_checker_test.rb
@@ -4,6 +4,36 @@ require 'thread'
 
 MTIME_FIXTURES_PATH = File.expand_path("../fixtures", __FILE__)
 
+class FileUpdateCheckerChangedFileClassTest < ActiveSupport::TestCase
+
+  def test_intialize_changed_file_object_and_convert_to_hash
+    path = "/tmp/gone/in/60/seconds.txt"
+    type = :removed
+    changed_file = ActiveSupport::FileUpdateChecker::ChangedFile.new(path, type)
+
+    notify_hash = changed_file.to_notifications_hash
+    assert_equal path, notify_hash[:path]
+    assert_equal type, notify_hash[:type]
+
+    notify_hash_2 = ActiveSupport::FileUpdateChecker::ChangedFile.notifications_hash(path, type)
+    assert_equal path, notify_hash_2[:path]
+    assert_equal type, notify_hash_2[:type]
+  end
+
+  def test_initialize_changed_file_object_with_incorrect_type_raises_exception
+    path = "/tmp/path.txt"
+    type = :blah
+
+    assert_raises(ArgumentError) do
+      ActiveSupport::FileUpdateChecker::ChangedFile.new(path, type)
+    end
+
+    assert_raises(ArgumentError) do
+      ActiveSupport::FileUpdateChecker::ChangedFile.notifications_hash(path, type)
+    end
+  end
+end
+
 class FileUpdateCheckerWithEnumerableTest < ActiveSupport::TestCase
   FILES = %w(1.txt 2.txt 3.txt)
 


### PR DESCRIPTION
I'm creating a wrapper to allow the FileUpdateChecker to send out notifications about changes in the file system. 

The `ChangedFile` class allows one to specify a path and a change type. This object can then be passed around with references, or can be converted to a hash so that its information can easily be passed around as payload in the Notifications system.

This change paves the way for creating a better FileUpdateChecker (see https://github.com/rails/rails/pull/9259) which will identify which files have been changed and send out a notification using the `ChangedFile` class implemented in this PR. However, its a much smaller change than https://github.com/rails/rails/pull/9259 so I'm hoping to incorporate it slowly.
