### PR TITLE
Fix guides error on error class name

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -194,7 +194,7 @@ class PeopleController < ActionController::Base
 
   # This will pass with flying colors as long as there's a person key
   # in the parameters, otherwise it'll raise a
-  # ActionController::MissingParameter exception, which will get
+  # ActionController::ParameterMissing exception, which will get
   # caught by ActionController::Base and turned into that 400 Bad
   # Request reply.
   def update


### PR DESCRIPTION
The error that's raised in case the required key is missing it's actually `ActionController::ParameterMissing` not `ActionController::MissingParameter`. It's important to fix so that people reading the guides knows what error to rescue from when needed.
