### PR TITLE
Changed the call to .sort.last to .max when computing the migration version

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -858,7 +858,7 @@ module ActiveRecord
     end
 
     def current_version
-      migrated.sort.last || 0
+      migrated.max || 0
     end
 
     def current_migration


### PR DESCRIPTION
Sorting then picking the last item incurs more cost than just finding the max. I've changed it so that when the current migration version is called, we use `max` instead of `sort.last`. 
