### PR TITLE
Fixed assets loading performance in 3.2.13

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## unreleased ##
 
+*   Fixed assets loading performance in 3.2.13.
+
+    The PR #8756 uses Sprockets for resolving files that already exists on disk, for those files their extensions don't need to be rewritten. Fixes #9803.
+
+    *Fred Wu*
+
 *   `ActiveSupport::NumberHelper#number_to_human` returns the number unaltered when
     the units hash does not contain the needed key, e.g. when the number provided is less
     than the largest key proivided.

--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -163,7 +163,7 @@ module Sprockets
             source
           elsif source_ext.blank?
             "#{source}.#{ext}"
-          elsif exact_match_present?(source)
+          elsif File.exists?(source) || exact_match_present?(source)
             source
           else
             "#{source}.#{ext}"

--- a/actionpack/test/template/sprockets_helper_test.rb
+++ b/actionpack/test/template/sprockets_helper_test.rb
@@ -277,6 +277,15 @@ class SprocketsHelperTest < ActionView::TestCase
     assert_nothing_raised { javascript_include_tag('foo.min') }
   end
 
+  test "assets that exist on filesystem don't need to go through Sprockets" do
+    @config.assets.digest = false
+    @config.assets.debug = true
+
+    Rails.application.assets.expects(:resolve).never
+
+    asset_paths.asset_for(FIXTURES.join("sprockets/app/javascripts/foo.min.js").to_path, 'min')
+  end
+
   test "stylesheet path through asset_path" do
     assert_match %r{/assets/application-[0-9a-f]+.css}, asset_path(:application, :ext => "css")
 


### PR DESCRIPTION
The PR #8756 uses Sprockets for resolving files that already exists on disk, for those files their extensions don't need to be rewritten.

Fixes #9803
