### PR TITLE
Wrong variable used inside the block of #concat_records

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -507,8 +507,8 @@ module ActiveRecord
 
           records.flatten.each do |record|
             raise_on_type_mismatch(record)
-            add_to_target(record) do |r|
-              result &&= insert_record(record) unless owner.new_record?
+            add_to_target(record) do |rec|
+              result &&= insert_record(rec) unless owner.new_record?
             end
           end
 


### PR DESCRIPTION
The loop variable was not properly used in the #concat_records method. Fixed the wrong argument while calling the method #insert_record. 
