### PR TITLE
Tidying up some require and removing overhead caused by sorting

### DIFF
--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -376,7 +376,4 @@ module ActiveModel
   end
 end
 
-Dir[File.dirname(__FILE__) + "/validations/*.rb"].sort.each do |path|
-  filename = File.basename(path)
-  require "active_model/validations/#{filename}"
-end
+Dir[File.dirname(__FILE__) + "/validations/*.rb"].each { |file| require file }

--- a/activesupport/lib/active_support/core_ext.rb
+++ b/activesupport/lib/active_support/core_ext.rb
@@ -1,4 +1,4 @@
-Dir["#{File.dirname(__FILE__)}/core_ext/*.rb"].sort.each do |path|
+Dir["#{File.dirname(__FILE__)}/core_ext/*.rb"].each do |path|
   next if File.basename(path, '.rb') == 'logger'
-  require "active_support/core_ext/#{File.basename(path, '.rb')}"
+  require path
 end


### PR DESCRIPTION
Hi folks,

First of all, please bear in mind that this is my first pull request here. I've read the guidelines but I may have missed something, please point it out.

I know this is a very small change, but I noticed some code in activemodel and activesupport require all files from a specific directory, but they files are sorted before, which does not seem to be useful or needed, and only cause a little overhead when booting rails.
Moreover, the way the files are required is not consistent with the rest of the code.

What do you think ?
