### PR TITLE
Don't generate a scaffold.css when --no-assets is specified

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## unreleased ##
 
-*   No changes.
+*   Don't generate a scaffold.css when --no-assets is specified
+    Backport #9837.
+
+    *Kevin Glowacz*
 
 
 ## Rails 3.2.13 (Mar 18, 2013) ##

--- a/railties/lib/rails/generators/rails/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/rails/scaffold/scaffold_generator.rb
@@ -9,6 +9,11 @@ module Rails
       class_option :stylesheets, :type => :boolean, :desc => "Generate Stylesheets"
       class_option :stylesheet_engine, :desc => "Engine for Stylesheets"
 
+      def handle_skip
+        @options = @options.merge(:stylesheets => false) unless options[:assets]
+        @options = @options.merge(:stylesheet_engine => false) unless options[:stylesheets]
+      end
+
       hook_for :scaffold_controller, :required => true
 
       hook_for :assets do |assets|

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -271,7 +271,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
   def test_scaffold_generator_no_assets
     run_generator [ "posts", "--no-assets" ]
-    assert_file "app/assets/stylesheets/scaffold.css"
+    assert_no_file "app/assets/stylesheets/scaffold.css"
     assert_no_file "app/assets/javascripts/posts.js"
     assert_no_file "app/assets/stylesheets/posts.css"
   end


### PR DESCRIPTION
This is back ported from master #9837
