### PR TITLE
Add router DSL to explicitly match all verbs

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -198,7 +198,7 @@ module ActionDispatch
           end
 
           def request_method_condition
-            if via = @options[:via]
+            if (via = @options[:via]) && (via != :all)
               list = Array(via).map { |m| m.to_s.dasherize.upcase }
               { :request_method => list }
             else
@@ -313,6 +313,7 @@ module ActionDispatch
         #
         #      match 'path' => 'c#a', :via => :get
         #      match 'path' => 'c#a', :via => [:get, :post]
+        #      match 'path' => 'c#a', :via => :all
         #
         # [:to]
         #   Points to a +Rack+ endpoint. Can be an object that responds to

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -758,6 +758,18 @@ class LegacyRouteSetTests < Test::Unit::TestCase
     assert_equal 'not_get_or_post', params[:action]
   end
 
+  def test_recognize_all_option
+    rs.draw do
+      match '/match' => 'books#all', :via => :all
+    end
+
+    params = rs.recognize_path("/match", :method => :get)
+    assert_equal 'all', params[:action]
+
+    params = rs.recognize_path("/match", :method => :post)
+    assert_equal 'all', params[:action]
+  end
+
   def test_subpath_recognized
     rs.draw do
       match '/books/:id/edit'    => 'subpath_books#edit'


### PR DESCRIPTION
This commit allows calling +match+ with a :via => :all option to explicitly match all verbs.

The :via => :all option was added to Rails 4 in the  process of deprecating +match+ (#5964). To facilitate the migration to Rails 4, it would be helpful to make this option available in Rails 3.
