### PR TITLE
Rails 4 prints help for "rails new" when running "rails console"

### DIFF
--- a/railties/lib/rails/app_rails_loader.rb
+++ b/railties/lib/rails/app_rails_loader.rb
@@ -24,10 +24,10 @@ module Rails
         # this is a Bundler binstub, so we load the app ourselves
         Object.const_set(:APP_PATH, File.expand_path('config/application',  Dir.pwd))
         require File.expand_path('../boot', APP_PATH)
-        puts "Your bin/rails file has been overwritten by Bundler."
-        puts "To update your bin/rails for Rails 4, please run: `bundle " \
-          "config --delete binstubs`, then `rm -rf bin`, then `rake " \
-          "rails:update:bin`, then add bin/ to your source control."
+        puts "Rails 4 no longer supports Bundler's --binstub option. You " \
+          "will need to disable it and update your bin/rails file.\n" \
+          "Please run: `bundle config --delete bin && rm -rf bin`, then " \
+          "`rake rails:update:bin` and add the resulting bin/ to git."
         require 'rails/commands'
       end
     rescue SystemCallError

--- a/railties/lib/rails/app_rails_loader.rb
+++ b/railties/lib/rails/app_rails_loader.rb
@@ -24,7 +24,7 @@ module Rails
         # this is a Bundler binstub, so we load the app ourselves
         Object.const_set(:APP_PATH, File.expand_path('config/application',  Dir.pwd))
         require File.expand_path('../boot', APP_PATH)
-        puts "Rails 4 no longer supports Bundler's --binstub option. You " \
+        puts "Rails 4 no longer supports Bundler's --binstubs option. You " \
           "will need to disable it and update your bin/rails file.\n" \
           "Please run: `bundle config --delete bin && rm -rf bin`, then " \
           "`rake rails:update:bin` and add the resulting bin/ to git."

--- a/railties/lib/rails/app_rails_loader.rb
+++ b/railties/lib/rails/app_rails_loader.rb
@@ -20,7 +20,7 @@ module Rails
           # the application is generated in the original working directory.
           exec_app_rails unless cwd == Dir.pwd
         end
-      else
+      elsif exe.match(%r(bin/rails$))
         # this is a Bundler binstub, so we load the app ourselves
         Object.const_set(:APP_PATH, File.expand_path('config/application',  Dir.pwd))
         require File.expand_path('../boot', APP_PATH)


### PR DESCRIPTION
Upgrading an existing Rails 3 app to Rails 4 results in a `rails` command that only ever prints the help for `rails new`. Here are reproduction steps:

```
mkdir app
cd app
curl -sLo Gemfile http://git.io/G3awjw
bundle install --binstubs --path vendor/bundle
bundle exec rails new .
bundle exec rails runner "puts 'WORKING'" #=> WORKING
sed -i -e 's/3.2.13/4.0.0.beta1/g' Gemfile # update to rails 4
ruby -i -ne 'print if not /coffee|sass/' Gemfile
bundle update rails
rm -rf script/rails # like you're supposed to
bundle exec rails runner "puts 'WORKING'" #=> help for rails new
```

There are angry developers about this issue available for perusal in carlhuda/bundler#2253.
