### PR TITLE
Added ability to apply array to option 'as' of the Routing Mapper

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1358,6 +1358,8 @@ module ActionDispatch
         # match 'path' => 'controller#action'
         # match 'path', to: 'controller#action'
         # match 'path', 'otherpath', on: :member, via: :get
+        # match 'path', 'otherpath', on: :member, via: :get, as: :name
+        # match 'path', 'otherpath', on: :member, via: :get, as: [:foo, :bar]
         def match(path, *rest)
           if rest.empty? && Hash === path
             options  = path
@@ -1416,6 +1418,9 @@ module ActionDispatch
 
           if !options.fetch(:as, true)
             options.delete(:as)
+          elsif options[:as].is_a?(Array)
+            multiple_as = options.delete(:as)
+            return multiple_as.map { |as| add_route(action, options.merge({ as: as })) }
           else
             options[:as] = name_for_action(options[:as], action)
           end

--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -36,6 +36,21 @@ module ActionDispatch
         assert_equal '/bar', url_helpers.bar_path
       end
 
+      test "multiple url helpers are added when provided a set of names" do
+        draw do
+          get 'foo', to: SimpleApp.new('foo#index'), as: :quux
+          get 'bar', to: SimpleApp.new('foo#index'), as: [:bar, :baz]
+        end
+
+        assert_equal '/foo', url_helpers.quux_path
+        assert_raises NoMethodError do
+          assert_equal '/foo', url_helpers.foo_path
+        end
+
+        assert_equal '/bar', url_helpers.bar_path
+        assert_equal '/bar', url_helpers.baz_path
+      end
+
       test "url helpers are updated when route is updated" do
         draw do
           get 'bar', to: SimpleApp.new('bar#index'), as: :bar


### PR DESCRIPTION
Added ability to use an array of names to create multiple url helpers for one url route.

``` ruby
#config/routes.rb
get 'homes', to: 'homes#index', as: [:home, :homes]
```

```
$ rake routes
home GET    /homes(.:format)  homes#index
homes GET    /homes(.:format) homes#index
```
