### PR TITLE
Adding a bang to method name of raise_on_type_mismatch.

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -203,7 +203,7 @@ module ActiveRecord
         # Raises ActiveRecord::AssociationTypeMismatch unless +record+ is of
         # the kind of the class of the associated objects. Meant to be used as
         # a sanity check when you are about to assign an associated record.
-        def raise_on_type_mismatch(record)
+        def raise_on_type_mismatch!(record)
           unless record.is_a?(reflection.klass) || record.is_a?(reflection.class_name.constantize)
             message = "#{reflection.class_name}(##{reflection.klass.object_id}) expected, got #{record.class}(##{record.class.object_id})"
             raise ActiveRecord::AssociationTypeMismatch, message

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -8,7 +8,7 @@ module ActiveRecord
       end
 
       def replace(record)
-        raise_on_type_mismatch(record) if record
+        raise_on_type_mismatch!(record) if record
 
         update_counters(record)
         replace_keys(record)

--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -22,7 +22,7 @@ module ActiveRecord
           reflection.polymorphic_inverse_of(record.class)
         end
 
-        def raise_on_type_mismatch(record)
+        def raise_on_type_mismatch!(record)
           # A polymorphic association cannot have a type mismatch, by definition
         end
 

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -318,7 +318,7 @@ module ActiveRecord
       # Replace this collection with +other_array+. This will perform a diff
       # and delete/add only records that have changed.
       def replace(other_array)
-        other_array.each { |val| raise_on_type_mismatch(val) }
+        other_array.each { |val| raise_on_type_mismatch!(val) }
         original_target = load_target.dup
 
         if owner.new_record?
@@ -465,7 +465,7 @@ module ActiveRecord
 
         def delete_or_destroy(records, method)
           records = records.flatten
-          records.each { |record| raise_on_type_mismatch(record) }
+          records.each { |record| raise_on_type_mismatch!(record) }
           existing_records = records.reject { |r| r.new_record? }
 
           if existing_records.empty?
@@ -506,7 +506,7 @@ module ActiveRecord
           result = true
 
           records.flatten.each do |record|
-            raise_on_type_mismatch(record)
+            raise_on_type_mismatch!(record)
             add_to_target(record) do |rec|
               result &&= insert_record(rec) unless owner.new_record?
             end

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -29,7 +29,7 @@ module ActiveRecord
       def concat(*records)
         unless owner.new_record?
           records.flatten.each do |record|
-            raise_on_type_mismatch(record)
+            raise_on_type_mismatch!(record)
             record.save! if record.new_record?
           end
         end

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -22,7 +22,7 @@ module ActiveRecord
       end
 
       def replace(record, save = true)
-        raise_on_type_mismatch(record) if record
+        raise_on_type_mismatch!(record) if record
         load_target
 
         # If target and record are nil, or target is equal to record,


### PR DESCRIPTION
Most of the validation methods that I've seen around Rails have used a bang at the end of the method name to signify that an error can possibly be raised. I've refactored `raise_on_type_mismatch` to `raise_on_type_mismatch!` to follow this convention.
