### PR TITLE
failure to parse params should trigger a 400 Bad Request

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -12,6 +12,7 @@ module ActionDispatch
       'ActionController::NotImplemented'           => :not_implemented,
       'ActionController::UnknownFormat'            => :not_acceptable,
       'ActionController::InvalidAuthenticityToken' => :unprocessable_entity,
+      'ActionDispatch::ParamsParser::ParseError'   => :bad_request,
       'ActionController::BadRequest'               => :bad_request,
       'ActionController::ParameterMissing'         => :bad_request
     )

--- a/actionpack/test/dispatch/show_exceptions_test.rb
+++ b/actionpack/test/dispatch/show_exceptions_test.rb
@@ -8,6 +8,8 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
       case req.path
       when "/not_found"
         raise AbstractController::ActionNotFound
+      when "/bad_params"
+        raise ActionDispatch::ParamsParser::ParseError.new("", StandardError.new)
       when "/method_not_allowed"
         raise ActionController::MethodNotAllowed
       when "/not_found_original_exception"
@@ -33,6 +35,10 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
     get "/", {}, {'action_dispatch.show_exceptions' => true}
     assert_response 500
     assert_equal "500 error fixture\n", body
+    
+    get "/bad_params", {}, {'action_dispatch.show_exceptions' => true}
+    assert_response 400
+    assert_equal "400 error fixture\n", body
 
     get "/not_found", {}, {'action_dispatch.show_exceptions' => true}
     assert_response 404

--- a/actionpack/test/fixtures/public/400.html
+++ b/actionpack/test/fixtures/public/400.html
@@ -1,0 +1,1 @@
+400 error fixture


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/7444

Someone should not be able to get the server to arbitrarily 500 by passing a simple invalid JSON or XML string.  This creates an easy DOS attack against some load balancers just by hitting up and app over and over with invalid requests... you can pull the entire app offline... a more appropriate response code would be 400 - "The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modifications.".

This commit makes this change.
