### PR TITLE
Allow nested conditions passed to .where to build arel tables in some cases

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -24,6 +24,18 @@
 
     *kennyj*
 
+*   Allow nested conditions to build arel tables
+
+    When passing a hash of conditions to .where, instantiate an arel table
+    if the keys represent a table associated to engine's table. Maintain
+    existing behavior if the keys are attributes of engine's table.
+    This allows queries like these:
+
+      Post.joins(:author => :organization).
+        where(:authors => { :organizations => { :name => 'Acme' } } )
+
+    *DanOlson*
+
 
 ## Rails 3.2.13 (Mar 18, 2013) ##
 

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -10,7 +10,8 @@ module ActiveRecord
           if value.empty?
             '1 = 2'
           else
-            build_from_hash(engine, value, table, false)
+            bool = !is_model_attribute?(engine, column)
+            build_from_hash(engine, value, table, bool)
           end
         else
           column = column.to_s
@@ -59,5 +60,11 @@ module ActiveRecord
 
       predicates.flatten
     end
+
+    private
+
+      def self.is_model_attribute?(klass, column)
+        klass.column_names.include? column.to_s
+      end
   end
 end

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -22,9 +22,7 @@ module ActiveRecord
     end
 
     def test_where_with_association_hash
-      custom_join = "inner join authors on posts.author_id = authors.id " \
-                    "inner join organizations on authors.organization_id = organizations.name"
-      posts_count = Post.joins(custom_join).where(:authors => { :organizations => { :name => 'No Such Agency'} }).count
+      posts_count = Post.joins(:author => :organization).where(:authors => { :organizations => { :name => 'No Such Agency'} }).count
       assert_equal 5, posts_count
     end
 

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -2,10 +2,12 @@ require "cases/helper"
 require 'models/post'
 require 'models/comment'
 require 'models/edge'
+require 'models/author'
+require 'models/organization'
 
 module ActiveRecord
   class WhereTest < ActiveRecord::TestCase
-    fixtures :posts, :edges
+    fixtures :posts, :edges, :organizations, :authors
 
     def test_where_error
       assert_raises(ActiveRecord::StatementInvalid) do
@@ -17,6 +19,13 @@ module ActiveRecord
       assert_raises(ActiveRecord::StatementInvalid) do
         Post.where(:id => { :posts => {:author_id => 10} }).first
       end
+    end
+
+    def test_where_with_association_hash
+      custom_join = "inner join authors on posts.author_id = authors.id " \
+                    "inner join organizations on authors.organization_id = organizations.name"
+      posts_count = Post.joins(custom_join).where(:authors => { :organizations => { :name => 'No Such Agency'} }).count
+      assert_equal 5, posts_count
     end
 
     def test_where_with_table_name

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -127,7 +127,7 @@ class Author < ActiveRecord::Base
 
   belongs_to :author_address,       :dependent => :destroy
   belongs_to :author_address_extra, :dependent => :delete, :class_name => "AuthorAddress"
-  belongs_to :organization
+  belongs_to :organization, :primary_key => :name
 
   has_many :category_post_comments, :through => :categories, :source => :post_comments
 

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -127,6 +127,7 @@ class Author < ActiveRecord::Base
 
   belongs_to :author_address,       :dependent => :destroy
   belongs_to :author_address_extra, :dependent => :delete, :class_name => "AuthorAddress"
+  belongs_to :organization
 
   has_many :category_post_comments, :through => :categories, :source => :post_comments
 


### PR DESCRIPTION
When passing a hash of conditions to .where, instantiate an arel table
if the keys represent a table associated to engine's table. Maintain
existing behavior if the keys are attributes of engine's table.
This allows queries like these:

``` ruby
  Post.joins(:author => :organization).
    where(:authors => { :organizations => { :name => 'Acme' } } )
```

Previously, that same query's WHERE clause would read: 

"... WHERE "authors"."organizations" ...

which would break because the 'authors' table doesn't have an 'organizations' column. This change will instantiate an Arel::Table for 'organizations', and the query will be built correctly
