### PR TITLE
Raising an error when nil is passed to update_attributes.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Calling `update_attributes` will now throw an `ArgumentError` whenever it
+    gets a `nil` argument. More specifically, it will throw an error if the
+    argument that it gets passed does not respond to to `stringify_keys`.
+
+    `Example:`
+
+        @my_comment.update_attributes()  # => raises ArgumentError
+
+    *John Wang*
+
 *   Remove Oracle / Sqlserver / Firebird database tasks that were deprecated in 4.0.
 
     *kennyj*

--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -13,7 +13,9 @@ module ActiveRecord
     # of this method is +false+ an <tt>ActiveModel::ForbiddenAttributesError</tt>
     # exception is raised.
     def assign_attributes(new_attributes)
-      return if new_attributes.blank?
+      if !new_attributes.respond_to?(:stringify_keys)
+        raise ArgumentError, "When assigning attributes, you must pass a hash as an argument."
+      end
 
       attributes                  = new_attributes.stringify_keys
       multi_parameter_attributes  = []

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -92,7 +92,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   def test_set_attributes_without_hash
     topic = Topic.new
-    assert_nothing_raised { topic.attributes = '' }
+    assert_raise(ArgumentError) { topic.attributes = '' }
   end
 
   def test_integers_as_nil

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -419,10 +419,6 @@ class PersistenceTest < ActiveRecord::TestCase
     assert !Topic.find(1).approved?
   end
 
-  def test_update_attribute_does_not_choke_on_nil
-    assert Topic.find(1).update(nil)
-  end
-
   def test_update_attribute_for_readonly_attribute
     minivan = Minivan.find('m1')
     assert_raises(ActiveRecord::ActiveRecordError) { minivan.update_attribute(:color, 'black') }
@@ -699,6 +695,17 @@ class PersistenceTest < ActiveRecord::TestCase
     topic.update_attributes(id: 1234)
     assert_nothing_raised { topic.reload }
     assert_equal topic.title, Topic.find(1234).title
+  end
+
+  def test_update_attributes_parameters
+    topic = Topic.find(1)
+    assert_nothing_raised do
+      topic.update_attributes({})
+    end
+
+    assert_raises(ArgumentError) do
+      topic.update_attributes(nil)
+    end
   end
 
   def test_update!


### PR DESCRIPTION
In https://github.com/rails/rails/commit/9e4b715d790aa84dfb3d7aa332e0012cbc264394, @josevalim allowed the ability to send a nil argument to `update_attributes` (in response to #478). However, the reasoning behind that was because a pretty cryptic error was thrown. The current behavior in Rails is that `thing.update_attributes(nil)` will return and not update any attributes without throwing any error.

However, Instead of allowing you to send a nil argument, it might be better to raise an `ArgumentError` which has a clear error message. I've made that change here, but this PR is more intended as a discussion on which behavior is better.

Closes #9858.
