### PR TITLE
Allow fixture_path to be a Pathname

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -752,7 +752,7 @@ module ActiveRecord
       def fixtures(*fixture_set_names)
         if fixture_set_names.first == :all
           fixture_set_names = Dir["#{fixture_path}/**/*.{yml}"]
-          fixture_set_names.map! { |f| f[(fixture_path.size + 1)..-5] }
+          fixture_set_names.map! { |f| f[(fixture_path.to_s.size + 1)..-5] }
         else
           fixture_set_names = fixture_set_names.flatten.map { |n| n.to_s }
         end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -576,6 +576,15 @@ class LoadAllFixturesTest < ActiveRecord::TestCase
   end
 end
 
+class LoadAllFixturesWithPathnameTest < ActiveRecord::TestCase
+  self.fixture_path = Pathname.new(FIXTURES_ROOT).join('all')
+  fixtures :all
+
+  def test_all_there
+    assert_equal %w(developers people tasks), fixture_table_names.sort
+  end
+end
+
 class FasterFixturesTest < ActiveRecord::TestCase
   fixtures :categories, :authors
 


### PR DESCRIPTION
When setting the `fixture_path` using `Rails.root.join('my_fixture/path')` and if fixtures are set to `:all`, Rails throws an error that it can't find the file `rails_path/my_fixture/path/.yml`. This error is not very informative and takes a long time to track down. By converting the `fixture_path` to a String before getting its size, future users can easily be spared from wasting time tracking this down.
