### PR TITLE
after_filter callback's :if procs should not executed when filter_chain is halted by render

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## unreleased ##
 
+*   Fixed :if procs getting executed even after filter_chain is halted in 3.2.13
+
+    Fixes #9848
+
+    *Rajesh Shanmugam*
+
 *   Fixed assets loading performance in 3.2.13.
 
     #8756 uses Sprockets for resolving files that already exists on disk, for those files

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -142,6 +142,36 @@ class FilterTest < ActionController::TestCase
       end
   end
 
+  class FilterChainHaltProcController < ActionController::Base
+    before_filter :render_something
+    after_filter :after_filter_with_proc, :if => Proc.new{|c| @state << "after_filter_proc" }, :only => :after_filter_proc
+    around_filter :around_filter_with_proc, :if => Proc.new{|c| @state << "around_filter_proc" }, :only => :around_filter_proc
+
+    def after_filter_proc
+      @state << "after_filter_proc"
+    end
+
+    def around_filter_proc
+      @state << "around_filter_proc"
+    end
+
+    private
+
+    def render_something
+      @state ||= ""
+      @state << "render_something"
+      head :ok
+    end
+
+    def after_filter_with_proc
+      @state << "after_filter"
+    end
+
+    def around_filter_with_proc
+      @state << "around_filter"
+    end
+  end
+
   class ConditionalFilterController < ActionController::Base
     def show
       render :inline => "ran action"
@@ -707,6 +737,16 @@ class FilterTest < ActionController::TestCase
     assert_response :redirect
     assert_equal "http://test.host/filter_test/before_filter_redirection/target_of_redirection", redirect_to_url
     assert_equal %w( before_filter_redirects ), assigns["ran_filter"]
+  end
+
+  def test_after_filter_proc_not_getting_executed_when_filter_chain_breaks
+    test_process(FilterChainHaltProcController, 'after_filter_proc')
+    assert_equal "render_something", assigns["state"]
+  end
+
+  def test_around_filter_proc_not_getting_executed_when_filter_chain_breaks
+    test_process(FilterChainHaltProcController, 'around_filter_proc')
+    assert_equal "render_something", assigns["state"]
   end
 
   def test_before_filter_rendering_breaks_filtering_chain_for_preprend_after_filter

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -210,7 +210,7 @@ module ActiveSupport
           name = "_conditional_callback_#{@kind}_#{next_id}"
           @klass.class_eval <<-RUBY_EVAL,  __FILE__, __LINE__ + 1
              def #{name}(halted)
-              if #{@compiled_options} && !halted
+              if !halted && #{@compiled_options}
                 #{@filter} do
                   yield self
                 end
@@ -232,7 +232,7 @@ module ActiveSupport
         when :after
           # after_save :filter_name, :if => :condition
           <<-RUBY_EVAL
-          if #{@compiled_options}
+          if !halted && #{@compiled_options}
             #{@filter}
           end
           RUBY_EVAL
@@ -378,7 +378,7 @@ module ActiveSupport
     module ClassMethods
       # Generate the internal runner method called by +run_callbacks+.
       def __define_runner(symbol) #:nodoc:
-        runner_method = "_run_#{symbol}_callbacks" 
+        runner_method = "_run_#{symbol}_callbacks"
         unless private_method_defined?(runner_method)
           class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
             def #{runner_method}(key = nil, &blk)
@@ -390,7 +390,7 @@ module ActiveSupport
       end
 
       # This method calls the callback method for the given key.
-      # If this called first time it creates a new callback method for the key, 
+      # If this called first time it creates a new callback method for the key,
       # calculating which callbacks can be omitted because of per_key conditions.
       #
       def __run_callback(key, kind, object, &blk) #:nodoc:
@@ -452,7 +452,7 @@ module ActiveSupport
       #
       # Before and around callbacks are called in the order that they are set; after
       # callbacks are called in the reverse order.
-      # 
+      #
       # Around callbacks can access the return value from the event, if it
       # wasn't halted, from the +yield+ call.
       #


### PR DESCRIPTION
This issue seems to be not present in master. This case is handled for multiple before_filters

Fix for issue

https://github.com/rails/rails/issues/9848
