### PR TITLE
Removed unused loop variable

### DIFF
--- a/activerecord/test/cases/adapters/mysql/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql/connection_test.rb
@@ -17,7 +17,7 @@ class MysqlConnectionTest < ActiveRecord::TestCase
   end
 
   def test_connect_with_url
-    run_without_connection do |orig|
+    run_without_connection do
       ar_config = ARTest.connection_config['arunit']
 
       skip "This test doesn't work with custom socket location" if ar_config['socket']


### PR DESCRIPTION
The loop variable is not used in the test case. So it's been removed. 
