### PR TITLE
do not reset associations when preloading twice.

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -56,8 +56,7 @@ module ActiveRecord
               through_options[:include]    = options[:include] || options[:source]
               through_options[:conditions] = options[:conditions]
             end
-
-            through_options[:order] = options[:order]
+            through_options[:order] = options[:order] if options.has_key?(:order)
           end
 
           through_options

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1118,4 +1118,11 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_no_queries { assert_equal 2, author.comments_with_order_and_conditions.size }
     assert_no_queries { assert_equal 5, author.posts.size, "should not cache a subset of the association" }
   end
+
+  test "preloading a through association twice does not reset it" do
+    members = Member.includes(current_membership: :club).includes(:club).to_a
+    assert_no_queries {
+      assert_equal 3, members.map(&:current_membership).map(&:club).size
+    }
+  end
 end


### PR DESCRIPTION
Closes #9806.

As the `through_options` always contained `{:order=>nil}` the second time,
the preloader ran, the association was always reset. This patch only
adds the `:order` to the `through_options` if it is set.

This is a regression and the problem was introduced with #9322
