### PR TITLE
use ruby 1.8 Hash syntax [ci skip]

### DIFF
--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1120,7 +1120,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   test "preloading a through association twice does not reset it" do
-    members = Member.includes(current_membership: :club).includes(:club).to_a
+    members = Member.includes(:current_membership => :club).includes(:club).to_a
     assert_no_queries {
       assert_equal 3, members.map(&:current_membership).map(&:club).size
     }


### PR DESCRIPTION
I'm sorry, saw it too late :cold_sweat: 

this is a fix for #9870 
