### PR TITLE
Skipping test for OpenSSL::PKCS5 JRuby

### DIFF
--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -1,4 +1,12 @@
 require 'abstract_unit'
+
+begin
+  require 'openssl'
+  OpenSSL::PKCS5
+rescue LoadError, NameError
+  $stderr.puts "Skipping KeyGenerator test: broken OpenSSL install"
+else
+
 # FIXME remove DummyKeyGenerator and this require in 4.1
 require 'active_support/key_generator'
 require 'active_support/message_verifier'
@@ -723,4 +731,6 @@ class CookiesTest < ActionController::TestCase
         assert_not_equal expected.split("\n"), header
       end
     end
+end
+
 end


### PR DESCRIPTION
As we are doing same as https://github.com/rails/rails/blob/master/activesupport/test/key_generator_test.rb#L3-L8

We need to wait this to be fixed. Can be removed later.
