### PR TITLE
Refactoring validate_missing_parameters to validate_required_parameters.

### DIFF
--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -81,7 +81,7 @@ module ActiveRecord
     end
 
     def extract_callstack_for_multiparameter_attributes(pairs)
-      attributes = { }
+      attributes = {}
 
       pairs.each do |(multiparameter_name, value)|
         attribute_name = multiparameter_name.split("(").first
@@ -146,7 +146,7 @@ module ActiveRecord
           end
         else
           # else column is a timestamp, so if Date bits were not provided, error
-          validate_missing_parameters!([1,2,3])
+          validate_required_parameters!([1,2,3])
 
           # If Date bits were provided but blank, then return nil
           return if blank_date_parameter?
@@ -172,14 +172,14 @@ module ActiveRecord
       def read_other(klass)
         max_position = extract_max_param
         positions    = (1..max_position)
-        validate_missing_parameters!(positions)
+        validate_required_parameters!(positions)
 
         set_values = values.values_at(*positions)
         klass.new(*set_values)
       end
 
       # Checks whether some blank date parameter exists. Note that this is different
-      # than the validate_missing_parameters! method, since it just checks for blank
+      # than the validate_required_parameters! method, since it just checks for blank
       # positions instead of missing ones, and does not raise in case one blank position
       # exists. The caller is responsible to handle the case of this returning true.
       def blank_date_parameter?
@@ -187,7 +187,7 @@ module ActiveRecord
       end
 
       # If some position is not provided, it errors out a missing parameter exception.
-      def validate_missing_parameters!(positions)
+      def validate_required_parameters!(positions)
         if missing_parameter = positions.detect { |position| !values.key?(position) }
           raise ArgumentError.new("Missing Parameter - #{name}(#{missing_parameter})")
         end


### PR DESCRIPTION
Inside of assign_attributes, there is a method which checks to make sure that particular parameters exist. The previous method name was `validate_missing_parameters!` and sounds like some parameters should be missing, when in fact it's meant to check to make sure none of the parameters passed in as arguments are missing.

Because of this, I think that `validate_required_parameters!` is a more apt name. I also removed a space in the middle of an empty hash.
