### PR TITLE
Put coffee-rails in top-level of generated Gemfile

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Allow vanilla apps to render CoffeeScript templates in production
+
+    Vanilla apps already render CoffeeScript templates in development and test
+    environments.  With this change, the production behavior matches that of
+    the other environments.
+
+    Effectively, this meant moving coffee-rails (and the JavaScript runtime on
+    which it is dependent) from the :assets group to the top-level of the
+    generated Gemfile.
+
+    *Gabe Kopley*
+
 *   `Rails.version` now returns an instance of `Gem::Version`
 
     *Charlie Somerville*

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -232,8 +232,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
     assert_file "Gemfile" do |content|
       assert_no_match(/sass-rails/, content)
-      assert_no_match(/coffee-rails/, content)
       assert_no_match(/uglifier/, content)
+      assert_match(/coffee-rails/, content)
     end
     assert_file "config/environments/development.rb" do |content|
       assert_no_match(/config\.assets\.debug = true/, content)
@@ -292,6 +292,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator [destination_root, "--skip-javascript"]
     assert_file "app/assets/javascripts/application.js" do |contents|
       assert_no_match %r{^//=\s+require\s}, contents
+    end
+    assert_file "Gemfile" do |content|
+      assert_match(/coffee-rails/, content)
     end
   end
 


### PR DESCRIPTION
The goal is for a vanilla app to render coffee templates in production the same as it does in development and test.  As far as I can tell, that simply means moving coffee-rails from :assets to the top-level.
