### PR TITLE
Match acronyms greedily in the inflector.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -484,4 +484,6 @@
 
 *   Optimize log subscribers to check log level before doing any processing. *Brian Durand*
 
+*   Match acronyms greedily in the inflector. *Johan Lindblad*
+
 Please check [3-2-stable](https://github.com/rails/rails/blob/3-2-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -95,7 +95,7 @@ module ActiveSupport
       #   camelize 'mcdonald'   #=> 'McDonald'
       def acronym(word)
         @acronyms[word.downcase] = word
-        @acronym_regex = /#{@acronyms.values.join("|")}/
+        @acronym_regex = /#{@acronyms.values.sort_by(&:length).reverse.join("|")}/
       end
 
       # Specifies a new pluralization rule and its replacement. The rule can

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -90,7 +90,14 @@ module ActiveSupport
     def underscore(camel_cased_word)
       word = camel_cased_word.to_s.dup
       word.gsub!('::', '/')
-      word.gsub!(/(?:([A-Za-z\d])|^)(#{inflections.acronym_regex})(?=\b|[^a-z])/) { "#{$1}#{$1 && '_'}#{$2.downcase}" }
+      word.gsub!(/(?:([A-Za-z\d])|^)(#{inflections.acronym_regex})(?=\b|[^a-z])/) do
+        merged = "#{$1}#{$2}"
+        if inflections.acronyms.values.include? merged
+          merged.downcase
+        else
+          "#{$1}#{$1 && '_'}#{$2.downcase}"
+        end
+      end
       word.gsub!(/([A-Z\d]+)([A-Z][a-z])/,'\1_\2')
       word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
       word.tr!("-", "_")

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -99,6 +99,7 @@ class InflectorTest < ActiveSupport::TestCase
   def test_acronyms
     ActiveSupport::Inflector.inflections do |inflect|
       inflect.acronym("API")
+      inflect.acronym("HTM")
       inflect.acronym("HTML")
       inflect.acronym("HTTP")
       inflect.acronym("RESTful")
@@ -106,6 +107,8 @@ class InflectorTest < ActiveSupport::TestCase
       inflect.acronym("PhD")
       inflect.acronym("RoR")
       inflect.acronym("SSL")
+      inflect.acronym("NS")
+      inflect.acronym("DNS")
     end
 
     #  camelize             underscore            humanize              titleize
@@ -122,6 +125,7 @@ class InflectorTest < ActiveSupport::TestCase
       ["PhDRequired",       "phd_required",       "PhD required",       "PhD Required"],
       ["IRoRU",             "i_ror_u",            "I RoR u",            "I RoR U"],
       ["RESTfulHTTPAPI",    "restful_http_api",   "RESTful HTTP API",   "RESTful HTTP API"],
+      ["DNSController",     "dns_controller",     "DNS controller",     "DNS Controller"],
 
       # misdirection
       ["Capistrano",        "capistrano",         "Capistrano",       "Capistrano"],


### PR DESCRIPTION
In its current state, the inflector handles acronyms non-intuitively if
there are acronyms defined that contain other acronyms.

Examples:
- If you define HTM and HTML as acronyms, 'HTMLController'.underscore produces
  different results depending on the order in which the two acronyms are
  defined - in some cases the result is 'htm_l_controller'.
- 'DNSController'.underscore will return 'd_ns_controller' if DNS and NS
  are defined as an acronym, regardless of the order they are defined.

This commit includes tests for both cases and two changes to the
inflector code to handle them. It changes the behaviour so that the
longest suitable acronym is always used.
