### PR TITLE
PUT requests have no content when using respond_with

### DIFF
--- a/actionpack/lib/action_controller/metal/responder.rb
+++ b/actionpack/lib/action_controller/metal/responder.rb
@@ -203,6 +203,8 @@ module ActionController #:nodoc:
         display resource
       elsif post?
         display resource, :status => :created, :location => api_location
+      elsif put?
+        display resource, :status => :ok
       else
         head :no_content
       end

--- a/actionpack/test/controller/mime_responds_test.rb
+++ b/actionpack/test/controller/mime_responds_test.rb
@@ -867,21 +867,21 @@ class RespondWithControllerTest < ActionController::TestCase
     end
   end
 
-  def test_using_resource_for_put_with_xml_yields_no_content_on_success
+  def test_using_resource_for_put_with_xml_yields_ok_on_success
     @request.accept = "application/xml"
     put :using_resource
     assert_equal "application/xml", @response.content_type
-    assert_equal 204, @response.status
-    assert_equal "", @response.body
+    assert_equal 200, @response.status
+    assert_equal "<name>david</name>", @response.body
   end
 
-  def test_using_resource_for_put_with_json_yields_no_content_on_success
+  def test_using_resource_for_put_with_json_yields_ok_on_success
     Customer.any_instance.stubs(:to_json).returns('{"name": "David"}')
     @request.accept = "application/json"
     put :using_resource
     assert_equal "application/json", @response.content_type
-    assert_equal 204, @response.status
-    assert_equal "", @response.body
+    assert_equal 200, @response.status
+    assert_equal '{"name": "David"}', @response.body
   end
 
   def test_using_resource_for_put_with_xml_yields_unprocessable_entity_on_failure


### PR DESCRIPTION
explanation in rails/rails#9862

Basically, when using the default responders, have it return the resource from a PUT request the same way it does when POSTing.
