### PR TITLE
Add a test to assert autosaving associations doesn't overwrite id accessor methods

### DIFF
--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -341,6 +341,19 @@ class TestDefaultAutosaveAssociationOnABelongsToAssociation < ActiveRecord::Test
     assert_equal num_tagging + 1, Tagging.count
   end
 
+  def test_association_is_not_overwitten_on_autosave
+    firm_1 = Firm.create!(name: 'Apple')
+    firm_2 = Firm.create!(name: 'Microsoft')
+    client = Client.create!(firm: firm_1, name: 'Business')
+    assert_equal firm_1.id, client.client_of
+
+    client.client_of = firm_2.id
+    assert client.save
+
+    client.reload
+    assert_equal firm_2, client.firm
+  end
+
   def test_build_and_then_save_parent_should_not_reload_target
     client = Client.find(:first)
     apple = client.build_firm(:name => "Apple")


### PR DESCRIPTION
This is a bug on v3.2.13 (reported in #9130 ) where newly created associations will overwrite directly set ids. It seems to be fixed on 3-2-stable but this will help with regressions.
