### PR TITLE
Change default SecurePassword column name

### DIFF
--- a/activemodel/test/models/visitor.rb
+++ b/activemodel/test/models/visitor.rb
@@ -5,7 +5,7 @@ class Visitor
 
   define_model_callbacks :create
 
-  has_secure_password(validations: false)
+  has_secure_password(validations: false, column_name: :password)
 
-  attr_accessor :password_digest, :password_confirmation
+  attr_accessor :password, :password_confirmation
 end


### PR DESCRIPTION
Currently the ActiveModel::SecurePassword module force to create a requires you to have a password_digest attribute. This patch provide the option to switch the attribute name

``` ruby
class Visitor
  extend ActiveModel::Callbacks
  include ActiveModel::Validations
  include ActiveModel::SecurePassword

  define_model_callbacks :create

  has_secure_password(validations: false, column_name: :password)

  attr_accessor :password, :password_confirmation
end
```
