### PR TITLE
Fixes action_view issue where pages do not render due to NoMethodError

### DIFF
--- a/actionpack/lib/action_view/lookup_context.rb
+++ b/actionpack/lib/action_view/lookup_context.rb
@@ -147,8 +147,8 @@ module ActionView
 
       # Compute details hash and key according to user options (e.g. passed from #render).
       def detail_args_for(options)
-        return @details, details_key if options.empty? # most common path.
-        user_details = @details.merge(options)
+        return @details, details_key if options && options.empty? # most common path.
+        user_details = options ? @details.merge(options) : @details
         [user_details, DetailsKey.get(user_details)]
       end
 

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -592,6 +592,11 @@ class AssertTemplateTest < ActionController::TestCase
     assert_template :layout => :standard
   end
 
+  def test_passes_detail_args_for_with_nil_options
+    view = ActionView::LookupContext.new('/')
+    assert_nothing_raised { view.send(:detail_args_for, nil) }
+  end
+
   def test_assert_template_reset_between_requests
     get :hello_world
     assert_template 'test/hello_world'


### PR DESCRIPTION
The detail_args_for method, without this fix, results in a NoMethodError there are no options being passed into it as it tries to execute the empty? method on a nil object.

The exact error that I used to get was the following...

Completed 500 Internal Server Error in 17ms
NoMethodError (undefined method empty?' for nil:NilClass):
actionpack (3.2.13) lib/action_view/lookup_context.rb:145:indetail_args_for'
actionpack (3.2.13) lib/action_view/lookup_context.rb:139:in args_for_lookup'
actionpack (3.2.13) lib/action_view/lookup_context.rb:109:infind'
actionpack (3.2.13) lib/action_view/renderer/abstract_renderer.rb:3:in find_template'
actionpack (3.2.13) lib/action_view/renderer/template_renderer.rb:34:indetermine_template'
...
