### PR TITLE
Fix bug with nested conditions passed to .where()

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -353,6 +353,16 @@
         # This will expand the order :name to "authors".name.
         Author.joins(:books).where('books.published = 1').order(:name)
 
+*   Fix bug with nested conditions passed to .where()
+
+    Recusion in PredicateBuilder.build_from_hash() so that passing a nested 
+    hash of conditions to .where will build a valid SQL query. Fixes #9511
+    This allows queries like these:
+
+    Post.joins(author: :organization).where(authors: { organizations: { name: 'Acme' } } )
+
+    Dan Olson
+
 
 ## Rails 4.0.0.beta1 (February 25, 2013) ##
 

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -4,7 +4,7 @@ require 'models/comment'
 
 module ActiveRecord
   class WhereChainTest < ActiveRecord::TestCase
-    fixtures :posts
+    fixtures :posts, :comments
 
     def setup
       super

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -5,10 +5,12 @@ require 'models/treasure'
 require 'models/post'
 require 'models/comment'
 require 'models/edge'
+require 'models/organization'
+require 'models/categorization'
 
 module ActiveRecord
   class WhereTest < ActiveRecord::TestCase
-    fixtures :posts, :edges, :authors
+    fixtures :posts, :edges, :authors, :organizations
 
     def test_where_copies_bind_params
       author = authors(:david)
@@ -84,6 +86,11 @@ module ActiveRecord
       assert_raises(ActiveRecord::StatementInvalid) do
         Post.where(:id => { 'posts.author_id' => 10 }).first
       end
+    end
+
+    def test_where_with_joins_and_nested_association_hash
+      posts_count = Post.joins(author: :organization).where(authors: { organizations: { name: 'No Such Agency'} }).count
+      assert_equal 5, posts_count
     end
 
     def test_where_with_table_name

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -120,6 +120,7 @@ class Author < ActiveRecord::Base
 
   belongs_to :author_address,       :dependent => :destroy
   belongs_to :author_address_extra, :dependent => :delete, :class_name => "AuthorAddress"
+  belongs_to :organization, :primary_key => :name
 
   has_many :category_post_comments, :through => :categories, :source => :post_comments
 


### PR DESCRIPTION
Recusion in PredicateBuilder.build_from_hash() so that passing a nested
hash of conditions to .where will build a valid SQL query.
This allows queries like these:

  Post.joins(author: :organization).
    where(authors: { organizations: { name: 'Acme' } } )

This would fix issue #9511
https://github.com/rails/rails/issues/9511

Previously, that same query's WHERE clause would read:

"... WHERE "authors"."organizations" ...

which would break because the 'authors' table doesn't have an 'organizations' column. This change will instantiate an Arel::Table for 'organizations', and the query will be built correctly.
