### PR TITLE
Replace marshalling with JSON and payloadizers

### DIFF
--- a/activesupport/lib/active_support/queueing.rb
+++ b/activesupport/lib/active_support/queueing.rb
@@ -17,9 +17,6 @@ module ActiveSupport
       if job_class.blank?
         raise TypeError, "Can't payloadize objects with anonymous classes, given: #{job.inspect}"
       end
-      unless [0,1].include?(job.class.instance_method(:initialize).arity)
-        raise "This payloadizer only supports jobs with initialize method arity: 0 or 1"
-      end
       {'class' => job_class, 'instance_values' => job.instance_values}
     end
 
@@ -29,15 +26,15 @@ module ActiveSupport
       end
       job_class = payload['class'].constantize
       instance_values = payload['instance_values']
-      if job_class.instance_method(:initialize).arity == 1
-        job = job_class.new(instance_values.values.first)
-      else #assumed to be zero
+      if job_class.instance_method(:initialize).arity == 0
         job = job_class.new
         instance_values.each do |k,v|
           job.instance_variable_set("@#{k}", v)
         end
+        job
+      else
+        job_class.new(instance_values.values.first)
       end
-      job
     end
 
     def self.unconstantize

--- a/activesupport/test/queueing/synchronous_queue_test.rb
+++ b/activesupport/test/queueing/synchronous_queue_test.rb
@@ -3,8 +3,12 @@ require 'active_support/queueing'
 
 class SynchronousQueueTest < ActiveSupport::TestCase
   class Job
-    attr_reader :ran
-    def run; @ran = true end
+    class << self
+      attr_accessor :ran
+    end
+    def run
+      self.class.ran = true
+    end
   end
 
   class ExceptionRaisingJob
@@ -18,7 +22,7 @@ class SynchronousQueueTest < ActiveSupport::TestCase
   def test_runs_jobs_immediately
     job = Job.new
     @queue.push job
-    assert job.ran
+    assert Job.ran
 
     assert_raises RuntimeError do
       @queue.push ExceptionRaisingJob.new

--- a/activesupport/test/queueing/threaded_consumer_test.rb
+++ b/activesupport/test/queueing/threaded_consumer_test.rb
@@ -4,10 +4,17 @@ require "active_support/log_subscriber/test_helper"
 
 class TestThreadConsumer < ActiveSupport::TestCase
   class Job
+    class << self; attr_accessor :blocks; end
+    self.blocks = {}
+
     attr_reader :id
     def initialize(id = 1, &block)
       @id = id
-      @block = block
+      if block
+        Job.blocks[id] = block
+      else
+        @block = Job.blocks[id]
+      end
     end
 
     def run
@@ -68,7 +75,8 @@ class TestThreadConsumer < ActiveSupport::TestCase
     consume_queue @queue
 
     assert_equal 1, @logger.logged(:error).size
-    assert_match "Job Error: #{job.inspect}\nRuntimeError: Error!", @logger.logged(:error).last
+    assert_match "Job Error: #<TestThreadConsumer::Job", @logger.logged(:error).last
+    assert_match "RuntimeError: Error!", @logger.logged(:error).last
   end
 
   test "logger defaults to stderr" do


### PR DESCRIPTION
I heard that the use of Marshall was one of the things you didn't like about Rails 4 Queue implementation as it was.

So I took a stab at changing to JSON.  Get's kinda tricky...

What do you think?
