### PR TITLE
unable to bundle HEAD rails master

### DIFF
--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', version
   s.add_dependency 'activemodel',   version
 
-  s.add_dependency 'arel',                            '~> 3.0.2'
+  s.add_dependency 'arel',                            '>= 3.0.2'
   s.add_dependency 'activerecord-deprecated_finders', '~> 0.0.3'
 end


### PR DESCRIPTION
Seems to be a problem bundling current rail master (7a32c6300c2b11dc1660338535c653a0132df196)

workaround is removing the arel requirement from Gemfile

seems this is because rails gemspec specified arel and master of arel are incompatible version:

```
Bundler could not find compatible versions for gem "arel":
  In Gemfile:
    rails (>= 0) ruby depends on
      arel (~> 3.0.2) ruby

    arel (4.0.0.beta2.20130314230643)
```

https://github.com/carlhuda/bundler/issues/2419
