### PR TITLE
specific length validator for ActiveRecord to respect `mark_for_destruction`.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `validates_size_of` / `validates_length_of` do not count records,
+    which are `marked_for_destruction?`.
+    Fixes #7247.
+
+    *Yves Senn*
+
 *   Add an `add_index` override in Postgresql adapter and MySQL adapter
     to allow custom index type support. Fixes #6101.
 

--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -83,3 +83,4 @@ end
 require "active_record/validations/associated"
 require "active_record/validations/uniqueness"
 require "active_record/validations/presence"
+require "active_record/validations/length"

--- a/activerecord/lib/active_record/validations/length.rb
+++ b/activerecord/lib/active_record/validations/length.rb
@@ -1,0 +1,23 @@
+module ActiveRecord
+  module Validations
+    class LengthValidator < ActiveModel::Validations::LengthValidator # :nodoc:
+      def validate_each(record, attribute, association_or_value)
+        if association_or_value.respond_to?(:loaded?) && association_or_value.loaded?
+          association_or_value = association_or_value.target.reject { |v|
+            v.marked_for_destruction?
+          }
+        end
+        super
+      end
+    end
+
+    module ClassMethods
+      # See <tt>ActiveModel::Validation::LengthValidator</tt> for more information.
+      def validates_length_of(*attr_names)
+        validates_with LengthValidator, _merge_attributes(attr_names)
+      end
+
+      alias_method :validates_size_of, :validates_length_of
+    end
+  end
+end

--- a/activerecord/test/cases/validations/association_validation_test.rb
+++ b/activerecord/test/cases/validations/association_validation_test.rb
@@ -1,39 +1,13 @@
-# encoding: utf-8
 require "cases/helper"
 require 'models/topic'
 require 'models/reply'
-require 'models/owner'
-require 'models/pet'
 require 'models/man'
 require 'models/interest'
 
 class AssociationValidationTest < ActiveRecord::TestCase
-  fixtures :topics, :owners
+  fixtures :topics
 
-  repair_validations(Topic, Reply, Owner)
-
-  def test_validates_size_of_association
-    assert_nothing_raised { Owner.validates_size_of :pets, :minimum => 1 }
-    o = Owner.new('name' => 'nopets')
-    assert !o.save
-    assert o.errors[:pets].any?
-    o.pets.build('name' => 'apet')
-    assert o.valid?
-  end
-
-  def test_validates_size_of_association_using_within
-    assert_nothing_raised { Owner.validates_size_of :pets, :within => 1..2 }
-    o = Owner.new('name' => 'nopets')
-    assert !o.save
-    assert o.errors[:pets].any?
-
-    o.pets.build('name' => 'apet')
-    assert o.valid?
-
-    2.times { o.pets.build('name' => 'apet') }
-    assert !o.save
-    assert o.errors[:pets].any?
-  end
+  repair_validations(Topic, Reply)
 
   def test_validates_associated_many
     Topic.validates_associated(:replies)
@@ -88,15 +62,6 @@ class AssociationValidationTest < ActiveRecord::TestCase
 
     r.topic = Topic.first
     assert r.valid?
-  end
-
-  def test_validates_size_of_association_utf8
-    assert_nothing_raised { Owner.validates_size_of :pets, :minimum => 1 }
-    o = Owner.new('name' => 'あいうえおかきくけこ')
-    assert !o.save
-    assert o.errors[:pets].any?
-    o.pets.build('name' => 'あいうえおかきくけこ')
-    assert o.valid?
   end
 
   def test_validates_presence_of_belongs_to_association__parent_is_new_record

--- a/activerecord/test/cases/validations/length_validation_test.rb
+++ b/activerecord/test/cases/validations/length_validation_test.rb
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+require "cases/helper"
+require 'models/owner'
+require 'models/pet'
+
+class LengthValidationTest < ActiveRecord::TestCase
+  fixtures :owners
+  repair_validations(Owner)
+
+  def test_validates_size_of_association
+    assert_nothing_raised { Owner.validates_size_of :pets, minimum: 1 }
+    o = Owner.new(name: 'nopets')
+    assert !o.save
+    assert o.errors[:pets].any?
+    o.pets.build(name: 'apet')
+    assert o.valid?
+  end
+
+  def test_validates_size_of_association_using_within
+    assert_nothing_raised { Owner.validates_size_of :pets, within: 1..2 }
+    o = Owner.new(name: 'nopets')
+    assert !o.save
+    assert o.errors[:pets].any?
+
+    o.pets.build(name: 'apet')
+    assert o.valid?
+
+    2.times { o.pets.build('name' => 'apet') }
+    assert !o.save
+    assert o.errors[:pets].any?
+  end
+
+  def test_validates_size_of_association_utf8
+    assert_nothing_raised { Owner.validates_size_of :pets, minimum: 1 }
+    o = Owner.new(name: 'あいうえおかきくけこ')
+    assert !o.save
+    assert o.errors[:pets].any?
+    o.pets.build(name: 'あいうえおかきくけこ')
+    assert o.valid?
+  end
+end

--- a/activerecord/test/cases/validations/length_validation_test.rb
+++ b/activerecord/test/cases/validations/length_validation_test.rb
@@ -2,6 +2,7 @@
 require "cases/helper"
 require 'models/owner'
 require 'models/pet'
+require 'models/person'
 
 class LengthValidationTest < ActiveRecord::TestCase
   fixtures :owners
@@ -38,4 +39,21 @@ class LengthValidationTest < ActiveRecord::TestCase
     o.pets.build(name: 'あいうえおかきくけこ')
     assert o.valid?
   end
+
+  def test_validates_size_of_reprects_records_marked_for_destruction
+    assert_nothing_raised { Owner.validates_size_of :pets, minimum: 1 }
+    owner = Owner.new
+    assert_not owner.save
+    assert owner.errors[:pets].any?
+    pet = owner.pets.build
+    assert owner.valid?
+    assert owner.save
+
+    pet_count = Pet.count
+    assert_not owner.update_attributes pets_attributes: [ {_destroy: 1, id: pet.id} ]
+    assert_not owner.valid?
+    assert owner.errors[:pets].any?
+    assert_equal pet_count, Pet.count
+  end
+
 end

--- a/activerecord/test/models/owner.rb
+++ b/activerecord/test/models/owner.rb
@@ -2,4 +2,6 @@ class Owner < ActiveRecord::Base
   self.primary_key = :owner_id
   has_many :pets
   has_many :toys, :through => :pets
+
+  accepts_nested_attributes_for :pets, :allow_destroy => true
 end


### PR DESCRIPTION
I implemented a separate validator to ensure that records, which are marked for destruction do not count when validating the length.

I also noticed that AR already had specific length tests, which I moved into a separate test-case.

Closes #7247.
