### PR TITLE
Add support for nested query parameter in DATABASE_URL. Fix #9896.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Support nested query parameter in DATABASE_URL.
+    This feature is useful for JDBC adapter. Fixes #9896.
+
+    *kennyj*
+
 *   Also support extensions in PostgreSQL 9.1. This feature has been supported since 9.1.
 
     *kennyj*

--- a/activerecord/test/cases/connection_specification/resolver_test.rb
+++ b/activerecord/test/cases/connection_specification/resolver_test.rb
@@ -57,6 +57,26 @@ module ActiveRecord
 
           assert_match "Could not load 'active_record/connection_adapters/non-existing_adapter'", error.message
         end
+
+        def test_url_properties
+          spec = resolve 'abstract://foo:123?encoding=utf8&properties%5Bname%5D=value&properties%5Bbar%5D=baz'
+          assert_equal({
+            adapter:  "abstract",
+            port:     123,
+            host:     "foo",
+            encoding: "utf8",
+            properties: { name: "value", bar: "baz" } }, spec)
+        end
+
+        def test_url_unescape_properties
+          spec = resolve 'abstract://foo:123?encoding=utf8&properties[name]=value&properties[bar]=baz'
+          assert_equal({
+            adapter:  "abstract",
+            port:     123,
+            host:     "foo",
+            encoding: "utf8",
+            properties: { name: "value", bar: "baz" } }, spec)
+        end
       end
     end
   end


### PR DESCRIPTION
Closes #9896.

We often need to pass driver specific properties to JDBC adapter.

``` ruby
development:
  adapter: postgresql
  ...
  properties:
    name: value
```

But ENV["DATABASE_URL"] can't pass such properties for same purpose. For example

``` ruby
abstract://foo:123?encoding=utf8&properties%5Bname%5D=value
  or
abstract://foo:123?encoding=utf8&properties[name]=value
```

[BTW] my first version for this problem was 0ec6bc58d3d2149ac296496a04d7ceafe23f6067. But I thought AR shouldn't depend on `rack`
