### PR TITLE
serializable_hash: Jobs should partially define how to as serialize and de-serialize themselves

### DIFF
--- a/activesupport/test/queueing/synchronous_queue_test.rb
+++ b/activesupport/test/queueing/synchronous_queue_test.rb
@@ -3,11 +3,27 @@ require 'active_support/queueing'
 
 class SynchronousQueueTest < ActiveSupport::TestCase
   class Job
-    attr_reader :ran
-    def run; @ran = true end
+    class << self
+      attr_accessor :ran
+    end
+    def to_serializable_hash
+      {}
+    end
+    def self.from_serializable_hash(hash)
+      Job.new
+    end
+    def run
+      self.class.ran = true
+    end
   end
 
   class ExceptionRaisingJob
+    def to_serializable_hash
+      {}
+    end
+    def self.from_serializable_hash(hash)
+      ExceptionRaisingJob.new
+    end
     def run; raise end
   end
 
@@ -18,7 +34,7 @@ class SynchronousQueueTest < ActiveSupport::TestCase
   def test_runs_jobs_immediately
     job = Job.new
     @queue.push job
-    assert job.ran
+    assert Job.ran
 
     assert_raises RuntimeError do
       @queue.push ExceptionRaisingJob.new


### PR DESCRIPTION
(based on feedback from https://github.com/rails/rails/pull/9910)

Problem I'm trying to solve:

Users of Rails Q API expect the Q system to be able to serialize and de-serialize the jobs they enQ.  If it's unable to do so, it should complain about it with an exact reason, at the time of enQ.

My take:

This problem can't easily be solved exclusively by the framework. Any attempt to do so fully would likely lead to a leaky abstraction wherein Job authors end up digging in to the guts of such an implementation.

Instead, a simple and minimal contract should exist between Job objects and the framework responsible for enQ-ing and running them.
1. a run method
2. a serializable_hash method
3. a from_serializable_hash method

Additionally:

Backend job systems should have a choice on how to serialize jobs.  It's fine for Marshal to be the default in Rails, but it's unnecessarily restricting to impose this requirement on all integrators.
