### PR TITLE
current_scope is not applied for subclasses

### DIFF
--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -164,7 +164,8 @@ module ActiveRecord
 
               if scope
                 default_scoped = scope.default_scoped
-                scope = relation.merge(scope)
+                _relation = current_scope ?  current_scope.clone : relation
+                scope = _relation.merge(scope)
                 scope.default_scoped = default_scoped
               end
             else

--- a/activerecord/test/cases/named_scope_test.rb
+++ b/activerecord/test/cases/named_scope_test.rb
@@ -446,4 +446,9 @@ class NamedScopeTest < ActiveRecord::TestCase
     end
     assert_equal [posts(:welcome).title], klass.all.map(&:title)
   end
+
+  def test_subclass_merges_scopes_properly
+    assert_equal 1, SpecialComment.crazy_all.count
+  end
+
 end

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -29,6 +29,7 @@ class Comment < ActiveRecord::Base
 end
 
 class SpecialComment < Comment
+  scope :crazy_all, -> { where(body: 'go crazy').created }
 end
 
 class SubSpecialComment < SpecialComment


### PR DESCRIPTION
#9869

The fix is causing a test failure as of now.

```
NamedScopeTest#test_should_not_duplicates_where_values 
[/Users/nsingh/dev/
rails_edge/rails/activerecord/test/cases/named_scope_test.rb:303]:
Expected: ["1=1"]
  Actual: ["1=1", "1=1"]
```

Even though the test is asserting that where values should not be duplicated, the sql that is generated does not have the duplication. So I'm not sure about the validity of the test.

I'll clean up pull request with squashing, change log etc when it is all set to go.

cc @jonleighton @tenderlove 
