### PR TITLE
Bump TZInfo version to 0.3.37 based on version v2013b of the underlying tz data.

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'erubis',        '~> 2.7.0'
 
   s.add_development_dependency 'activemodel', version
-  s.add_development_dependency 'tzinfo',      '~> 0.3.33'
+  s.add_development_dependency 'tzinfo',      '~> 0.3.37'
 end

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('i18n',       '~> 0.6', '>= 0.6.4')
   s.add_dependency 'multi_json', '~> 1.3'
-  s.add_dependency 'tzinfo',     '~> 0.3.33'
+  s.add_dependency 'tzinfo',     '~> 0.3.37'
   s.add_dependency 'minitest',   '~> 4.2'
   s.add_dependency 'thread_safe','~> 0.1'
 end


### PR DESCRIPTION
This gem is `data` gem. Thus I guess we should use latest version.
