### PR TITLE
routing bugfixes when matching multiple paths

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -589,8 +589,7 @@ module ActionDispatch
         private
           def map_method(method, args, &block)
             options = args.extract_options!
-            options[:via]    = method
-            options[:path] ||= args.first if args.first.is_a?(String)
+            options[:via] = method
             match(*args, options, &block)
             self
           end
@@ -1381,7 +1380,11 @@ module ActionDispatch
             raise ArgumentError, "Unknown scope #{on.inspect} given to :on"
           end
 
-          paths.each { |_path| decomposed_match(_path, options.dup) }
+          paths.each do |_path|
+            route_options = options.dup
+            route_options[:path] ||= _path if _path.is_a?(String)
+            decomposed_match(_path, route_options)
+          end
           self
         end
 

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1369,11 +1369,6 @@ module ActionDispatch
             paths = [path] + rest
           end
 
-          path_without_format = path.to_s.sub(/\(\.:format\)$/, '')
-          if using_match_shorthand?(path_without_format, options)
-            options[:to] ||= path_without_format.gsub(%r{^/}, "").sub(%r{/([^/]*)$}, '#\1')
-          end
-
           options[:anchor] = true unless options.key?(:anchor)
 
           if options[:on] && !VALID_ON_OPTIONS.include?(options[:on])
@@ -1383,6 +1378,12 @@ module ActionDispatch
           paths.each do |_path|
             route_options = options.dup
             route_options[:path] ||= _path if _path.is_a?(String)
+
+            path_without_format = _path.to_s.sub(/\(\.:format\)$/, '')
+            if using_match_shorthand?(path_without_format, route_options)
+              route_options[:to] ||= path_without_format.gsub(%r{^/}, "").sub(%r{/([^/]*)$}, '#\1')
+            end
+
             decomposed_match(_path, route_options)
           end
           self

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1149,6 +1149,20 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal 'account#shorthand', @response.body
   end
 
+  def test_match_shorthand_with_multiple_paths_inside_namespace
+    draw do
+      namespace :proposals do
+        put 'activate', 'inactivate'
+      end
+    end
+
+    put '/proposals/activate'
+    assert_equal 'proposals#activate', @response.body
+
+    put '/proposals/inactivate'
+    assert_equal 'proposals#inactivate', @response.body
+  end
+
   def test_match_shorthand_inside_namespace_with_controller
     draw do
       namespace :api do

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1112,6 +1112,21 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal 'projects#info', @response.body
   end
 
+  def test_match_with_many_paths_containing_a_slash
+    draw do
+      get 'get/first', 'get/second', 'get/third', :to => 'get#show'
+    end
+
+    get '/get/first'
+    assert_equal 'get#show', @response.body
+
+    get '/get/second'
+    assert_equal 'get#show', @response.body
+
+    get '/get/third'
+    assert_equal 'get#show', @response.body
+  end
+
   def test_match_shorthand_with_no_scope
     draw do
       get 'account/overview'


### PR DESCRIPTION
#### 1.) multiple paths containing a slash

This is basically a revert of https://github.com/rails/rails/commit/d03aa104e069be4e301efa8cefb90a2a785a7bff and a new fix inside the `#match` method.
#### 2.) multiple paths using the match shorthand syntax

As the `#match` must be aware of multiple paths the shorthand expansion must be applied for each path separately.
