### PR TITLE
Fix STI descentants by constantizing models

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -182,5 +182,9 @@ module ActiveRecord
       path = app.paths["db"].first
       config.watchable_files.concat ["#{path}/schema.rb", "#{path}/structure.sql"]
     end
+
+    initializer "active_record.preload_models" do |app|
+      Dir[Rails.root.join('app','models','*.rb')].map {|f| File.basename(f, '.*').camelize.constantize }
+    end
   end
 end


### PR DESCRIPTION
Assume we've got three models:

```
class Payment < ActiveRecord::Base
class CardPayment < Payment
class CreditCardPayment < CardPayment
```

Assume that at least one CreditCardPayment have been added to database.

Run console:

```
>> CardPayment.last
  CardPayment Load (0.2ms)  SELECT "payments".* FROM "payments" WHERE "payments"."type" IN ('CardPayment') ORDER BY "payments"."id" DESC LIMIT 1
=> nil
>> CardPayment.descendants
=> []
>> CreditCardPayment.last
  CreditCardPayment Load (0.5ms)  SELECT "payments".* FROM "payments" WHERE "payments"."type" IN ('CreditCardPayment') ORDER BY "payments"."id" DESC LIMIT 1
=> #<CreditCardPayment id: 1, type: "CreditCardPayment", created_at: "2013-03-26 15:19:08", updated_at: "2013-03-26 15:19:08">
>> CardPayment.descendants
=> [CreditCardPayment(id: integer, type: string, created_at: datetime, updated_at: datetime)]

```

So the middle sti model `CardPayment` does not have descendants till `CreditCardPayment` will be called. Problem is fixed when preloaded , what do you think?
