### PR TITLE
Asia/Ulaanbaatar is incorrect mapping

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -151,7 +151,7 @@ module ActiveSupport
       "Taipei"                       => "Asia/Taipei",
       "Perth"                        => "Australia/Perth",
       "Irkutsk"                      => "Asia/Irkutsk",
-      "Ulaan Bataar"                 => "Asia/Ulaanbaatar",
+      "Ulaanbaatar"                  => "Asia/Ulaanbaatar",
       "Seoul"                        => "Asia/Seoul",
       "Osaka"                        => "Asia/Tokyo",
       "Sapporo"                      => "Asia/Tokyo",


### PR DESCRIPTION
Fixes #9936.

For reference, here is the info:
http://www.timeanddate.com/library/abbreviations/timezones/asia/ulat.html
