### PR TITLE
Fixed test failures on 1.8.7 caused by 74e59ea

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -110,7 +110,7 @@ module ActionController
 
           case expected_layout
           when String, Symbol
-            assert_includes @layouts.keys, expected_layout.to_s, msg
+            assert(@layouts.keys.include?(expected_layout.to_s), msg)
           when Regexp
             assert(@layouts.keys.any? {|l| l =~ expected_layout }, msg)
           when nil, false


### PR DESCRIPTION
This fixes the backport PR #9899 causing test failures on 1.8.7.
