### PR TITLE
`#determine_constant_from_test_name` does not swallow NoMethodErrors.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `#determine_constant_from_test_name` does not swallow NoMethodErrors.
+    Fixes #9933.
+
+    *Yves Senn*.
+
 *   `ActiveSupport::TimeWithZone` raises `NoMethodError` in proper context.
     Fixes #9772.
 

--- a/activesupport/lib/active_support/testing/constant_lookup.rb
+++ b/activesupport/lib/active_support/testing/constant_lookup.rb
@@ -38,6 +38,8 @@ module ActiveSupport
             begin
               constant = names.join("::").constantize
               break(constant) if yield(constant)
+            rescue NoMethodError => e
+              raise e
             rescue NameError
               # Constant wasn't found, move on
             ensure

--- a/activesupport/test/testing/constant_lookup_test.rb
+++ b/activesupport/test/testing/constant_lookup_test.rb
@@ -1,4 +1,5 @@
 require 'abstract_unit'
+require 'dependencies_test_helpers'
 
 class Foo; end
 class Bar < Foo
@@ -10,6 +11,7 @@ module FooBar; end
 
 class ConstantLookupTest < ActiveSupport::TestCase
   include ActiveSupport::Testing::ConstantLookup
+  include DependenciesTestHelpers
 
   def find_foo(name)
     self.class.determine_constant_from_test_name(name) do |constant|
@@ -55,5 +57,13 @@ class ConstantLookupTest < ActiveSupport::TestCase
     assert_nil find_module("DoesntExist::Nadda")
     assert_nil find_module("DoesntExist::Nadda::Nope")
     assert_nil find_module("DoesntExist::Nadda::Nope::NotHere")
+  end
+
+  def test_does_not_swallow_exception_on_no_method_error
+    assert_raises(NoMethodError) {
+      with_autoloading_fixtures {
+        self.class.determine_constant_from_test_name("RaisesNoMethodError")
+      }
+    }
   end
 end


### PR DESCRIPTION
Closes #9933.

Since `NoMethodError` is a subclass of `NameError` determining
the constant from a test name silently swalled them.
