### PR TITLE
Uri::Parser support for malformed utf

### DIFF
--- a/activesupport/lib/active_support/core_ext/uri.rb
+++ b/activesupport/lib/active_support/core_ext/uri.rb
@@ -12,7 +12,7 @@ unless str == parser.unescape(parser.escape(str))
       # YK: My initial experiments say yes, but let's be sure please
       enc = str.encoding
       enc = Encoding::UTF_8 if enc == Encoding::US_ASCII
-      str.gsub(escaped) { [$&[1, 2].hex].pack('C') }.force_encoding(enc)
+      str.force_encoding(enc).gsub(escaped) { [$&[1, 2].hex].pack('C').force_encoding(enc) }
     end
   end
 end


### PR DESCRIPTION
Uri parser throws error when url containing malformed utf is requested. You can try this one

``` ruby
URI.unescape('/collection/all/product/Teutonia-Spirit-S3-прогу%BBочн%B0я')
```

It's ok when it somewhere in app's code. But it's called from journey and server fails with 500.
This is just a little fix. May be better way would be rendering HTTP 400, but just do not throw exception.
