### PR TITLE
Do not allow HTTP Basic Auth with Base64 encrypted blank credentials

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
-* No changes.
+*   In HTTP Basic Authentication, do not continue to login procedure with Base64 encrypted
+    blank credentials.
+    Fixes #9172
+
+    *Lau Taarnskov*
 
 Please check [4-0-stable](https://github.com/rails/rails/blob/4-0-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -90,13 +90,17 @@ module ActionController
       end
 
       def authenticate(request, &login_procedure)
-        unless request.authorization.blank?
+        unless request.authorization.blank? || user_name_or_password_blank?(request)
           login_procedure.call(*user_name_and_password(request))
         end
       end
 
       def user_name_and_password(request)
         decode_credentials(request).split(/:/, 2)
+      end
+
+      def user_name_or_password_blank?(request)
+        user_name_and_password(request).reject(&:blank?).empty?
       end
 
       def decode_credentials(request)


### PR DESCRIPTION
In HTTP Basic Auth, blank credentials are not allowed. But today, if Base64 encryption is used, the login procedure block is called anyway. This PR fixes the issue and has tests. The issue was reported in #9172.
