### PR TITLE
Cosmetic cleanup of generated Gemfile

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -192,13 +192,6 @@ module Rails
           GEMFILE
         end
 
-        if options[:skip_javascript]
-          gemfile += <<-GEMFILE.gsub(/^ {12}/, '')
-            #{coffee_gemfile_entry}
-            #{javascript_runtime_gemfile_entry(2)}
-          GEMFILE
-        end
-
         gemfile.strip_heredoc.gsub(/^[ \t]*$/, '')
       end
 

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -179,26 +179,23 @@ module Rails
 
         gemfile = if options.dev? || options.edge?
           <<-GEMFILE.gsub(/^ {12}/, '')
-            # Gems used only for assets and not required
-            # in production environments by default.
-            group :assets do
-              gem 'sprockets-rails', github: 'rails/sprockets-rails'
-              gem 'sass-rails',   github: 'rails/sass-rails'
-              #{coffee_gemfile_entry if options[:skip_javascript]}
-              #{javascript_runtime_gemfile_entry(2) if options[:skip_javascript]}
-              gem 'uglifier', '>= 1.0.3'
-            end
+            # Gems used for assets
+            gem 'sprockets-rails', github: 'rails/sprockets-rails'
+            gem 'sass-rails',   github: 'rails/sass-rails'
+            gem 'uglifier', '>= 1.0.3'
           GEMFILE
         else
           <<-GEMFILE.gsub(/^ {12}/, '')
-            # Gems used only for assets and not required
-            # in production environments by default.
-            group :assets do
-              gem 'sass-rails',   '~> 4.0.0.beta1'
-              #{coffee_gemfile_entry if options[:skip_javascript]}
-              #{javascript_runtime_gemfile_entry(2) if options[:skip_javascript]}
-              gem 'uglifier', '>= 1.0.3'
-            end
+            # Gems used for assets
+            gem 'sass-rails',   '~> 4.0.0.beta1'
+            gem 'uglifier', '>= 1.0.3'
+          GEMFILE
+        end
+
+        if options[:skip_javascript]
+          gemfile += <<-GEMFILE.gsub(/^ {12}/, '')
+            #{coffee_gemfile_entry}
+            #{javascript_runtime_gemfile_entry(2)}
           GEMFILE
         end
 


### PR DESCRIPTION
- Remove obsolete/misleading comment about assets only being used production
- Remove unnecessary group :assets
- Eliminate blank lines if options[:skip_javascript] is not specified
