### PR TITLE
Safe migrations with activerecord features

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -608,6 +608,11 @@ module ActiveRecord
       @connection || ActiveRecord::Base.connection
     end
 
+    def use_table(table_name)
+      table_name = Migrator.proper_table_name(table_name)
+      Class.new(ActiveRecord::Base) { self.table_name = table_name }.all
+    end
+
     def method_missing(method, *arguments, &block)
       arg_list = arguments.map{ |a| a.inspect } * ', '
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -103,6 +103,18 @@ class MigrationTest < ActiveRecord::TestCase
     assert_equal connection, migration.connection
   end
 
+  def test_use_table_return_fake_ar_model
+    migration = Class.new(ActiveRecord::Migration).new
+    migration.create_table :users do |t|
+      t.string :name
+    end
+    expected = "SELECT name FROM \"users\"  WHERE \"users\".\"name\" = 'Bob'"
+    real = migration.use_table(:users).where(:name => "Bob").select(:name).to_sql
+    assert_equal expected, real
+  ensure
+    migration.drop_table :users
+  end
+
   def test_method_missing_delegates_to_connection
     migration = Class.new(ActiveRecord::Migration) {
       def connection


### PR DESCRIPTION
Quite often we should change our existing data in migrations. For example, we add new column and should this column for existing records. For do that you can use application  models:

``` ruby
add_column :users, :agree, :boolean
User.reset_column_information
User.update_all(:agree => true)
```

Simple, but you need know `reset_column_information` method. Also if you decided change table_name to persons and model's name to Person this migration will raise exception and will no run.
Another, "right", way to solve problem of updating data in migration is using plain sql.

``` ruby
execute "UPDATE users SET users.agree = 1"
```

This migration doesn't care about app models. So it will not fail if "User" model will not exist when migration will execute. But we all love activerecord because it converts ruby objects to db types, write and execute sql queries in more elegant way, automatically add a lot of useful methods based on table schema. So why we should not use it in migration?
So what about this solution:

``` ruby
use_table(:users).update_all(:valid => true)
```

Method `use_table` creates unnamed activerecord model, sets table name and returns it's default scope. So we can fetch data, update it and etc.
What do you think about it?
