### PR TITLE
Fix updates not working within after_create hooks

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -443,7 +443,7 @@ module ActiveRecord
           real_column = db_columns_with_values[i].first
           bind_attrs[column] = klass.connection.substitute_at(real_column, i)
         end
-        stmt = klass.unscoped.where(klass.arel_table[klass.primary_key].eq(id_was)).arel.compile_update(bind_attrs)
+        stmt = klass.unscoped.where(klass.arel_table[klass.primary_key].eq(id_was || id)).arel.compile_update(bind_attrs)
         klass.connection.update stmt, 'SQL', db_columns_with_values
       end
     end

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -296,6 +296,22 @@ class PersistencesTest < ActiveRecord::TestCase
     assert_equal "Reply", topic.type
   end
 
+  def test_update_after_create
+    klass = Class.new(Topic) do
+      def self.name; 'Topic'; end
+      after_create do
+        update_attribute("author_name", "David")
+      end
+    end
+    topic = klass.new
+    topic.title = "Another New Topic"
+    topic.save
+
+    topicReloaded = Topic.find(topic.id)
+    assert_equal("Another New Topic", topicReloaded.title)
+    assert_equal("David", topicReloaded.author_name)
+  end
+
   def test_delete
     topic = Topic.find(1)
     assert_equal topic, topic.delete, 'topic.delete did not return self'


### PR DESCRIPTION
TL;DR; Updating a record within an after_create hook no longer works on ActiveRecord 4.x

In prior versions of ActiveRecord (2.x and 3.x), you used to be able to define an `after_create` hook which could make additional `save` calls on the record.  For example:

``` ruby
class Topic < ActiveRecord::Base
  after_create do
    update_attribute("author_name", "David")
  end
end

topic = Topic.new
topic.title = "Another New Topic"
topic.save
```

This was caused by #9707 which just recently was merged.

@route / @jonleighton
