### PR TITLE
Dump the 'using' options for a SQL index into the schema.

### DIFF
--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -185,6 +185,8 @@ HEADER
 
             statement_parts << ('where: ' + index.where.inspect) if index.where
 
+            statement_parts << ('using: ' + index.using.inspect) if index.using
+
             '  ' + statement_parts.join(', ')
           end
 

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -177,13 +177,19 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
   def test_schema_dumps_index_columns_in_right_order
     index_definition = standard_dump.split(/\n/).grep(/add_index.*companies/).first.strip
-    assert_equal 'add_index "companies", ["firm_id", "type", "rating"], name: "company_index"', index_definition
+    if current_adapter?(:MysqlAdapter) or current_adapter?(:Mysql2Adapter) or current_adapter?(:PostgreSQLAdapter)
+       assert_equal 'add_index "companies", ["firm_id", "type", "rating"], name: "company_index", using: :btree', index_definition
+     else
+       assert_equal 'add_index "companies", ["firm_id", "type", "rating"], name: "company_index"', index_definition
+    end
   end
 
   def test_schema_dumps_partial_indices
     index_definition = standard_dump.split(/\n/).grep(/add_index.*company_partial_index/).first.strip
     if current_adapter?(:PostgreSQLAdapter)
-      assert_equal 'add_index "companies", ["firm_id", "type"], name: "company_partial_index", where: "(rating > 10)"', index_definition
+      assert_equal 'add_index "companies", ["firm_id", "type"], name: "company_partial_index", where: "(rating > 10)", using: :btree', index_definition
+    elsif current_adapter?(:MysqlAdapter) or current_adapter?(:Mysql2Adapter)
+      assert_equal 'add_index "companies", ["firm_id", "type"], name: "company_partial_index", using: :btree', index_definition
     else
       assert_equal 'add_index "companies", ["firm_id", "type"], name: "company_partial_index"', index_definition
     end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -183,6 +183,7 @@ ActiveRecord::Schema.define do
 
   add_index :companies, [:firm_id, :type, :rating], :name => "company_index"
   add_index :companies, [:firm_id, :type], :name => "company_partial_index", :where => "rating > 10"
+  add_index :companies, :name, :name => 'company_name_index', :using => :btree
 
   create_table :vegetables, :force => true do |t|
     t.string :name


### PR DESCRIPTION
This was extracted from: #9944 / #8430 to only contain the functionality to dump the `using` option into the schema file.

In reviewing this I noticed that adding the `algorithm` SQL index options, #9923, did not include the algorithm in the schema dumper.  I think it probably should include it in the schema.  If you want me to make another pull request to add this functionality, let me know, I'd be happy to do so.

@rafaelfranca will you take a look at this?
