### PR TITLE
Extract Firebird / Sqlserver / Oracle database tasks, and They should be deprecated.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Extract and deprecate Firebird / Sqlserver / Oracle database tasks, because
+    These tasks should be supported by 3rd-party adapter.
+
+    *kennyj*
+
 *   Allow `ActiveRecord::Base.connection_handler` to have thread affinity and be
     settable, this effectively allows Active Record to be used in a multi threaded
     setup with multiple connections to multiple dbs.

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -143,6 +143,8 @@ module ActiveRecord
     autoload :MySQLDatabaseTasks,  'active_record/tasks/mysql_database_tasks'
     autoload :PostgreSQLDatabaseTasks,
       'active_record/tasks/postgresql_database_tasks'
+
+    autoload :FirebirdDatabaseTasks, 'active_record/tasks/firebird_database_tasks'
   end
 
   autoload :TestCase

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -146,6 +146,7 @@ module ActiveRecord
 
     autoload :FirebirdDatabaseTasks, 'active_record/tasks/firebird_database_tasks'
     autoload :SqlserverDatabaseTasks, 'active_record/tasks/sqlserver_database_tasks'
+    autoload :OracleDatabaseTasks, 'active_record/tasks/oracle_database_tasks'
   end
 
   autoload :TestCase

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -145,6 +145,7 @@ module ActiveRecord
       'active_record/tasks/postgresql_database_tasks'
 
     autoload :FirebirdDatabaseTasks, 'active_record/tasks/firebird_database_tasks'
+    autoload :SqlserverDatabaseTasks, 'active_record/tasks/sqlserver_database_tasks'
   end
 
   autoload :TestCase

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -270,15 +270,6 @@ db_namespace = namespace :db do
   end
 
   namespace :structure do
-    def set_firebird_env(config)
-      ENV['ISC_USER']     = config['username'].to_s if config['username']
-      ENV['ISC_PASSWORD'] = config['password'].to_s if config['password']
-    end
-
-    def firebird_db_string(config)
-      FireRuby::Database.db_string_for(config.symbolize_keys)
-    end
-
     desc 'Dump the database structure to db/structure.sql. Specify another file with DB_STRUCTURE=db/my_structure.sql'
     task :dump => [:environment, :load_config] do
       filename = ENV['DB_STRUCTURE'] || File.join(Rails.root, "db", "structure.sql")
@@ -289,10 +280,6 @@ db_namespace = namespace :db do
         File.open(filename, "w:utf-8") { |f| f << ActiveRecord::Base.connection.structure_dump }
       when 'sqlserver'
         `smoscript -s #{current_config['host']} -d #{current_config['database']} -u #{current_config['username']} -p #{current_config['password']} -f #{filename} -A -U`
-      when "firebird"
-        set_firebird_env(current_config)
-        db_string = firebird_db_string(current_config)
-        sh "isql -a #{db_string} > #{filename}"
       else
         ActiveRecord::Tasks::DatabaseTasks.structure_dump(current_config, filename)
       end
@@ -317,10 +304,6 @@ db_namespace = namespace :db do
         IO.read(filename).split(";\n\n").each do |ddl|
           ActiveRecord::Base.connection.execute(ddl)
         end
-      when 'firebird'
-        set_firebird_env(current_config)
-        db_string = firebird_db_string(current_config)
-        sh "isql -i #{filename} #{db_string}"
       else
         ActiveRecord::Tasks::DatabaseTasks.structure_load(current_config, filename)
       end
@@ -391,9 +374,6 @@ db_namespace = namespace :db do
         ActiveRecord::Base.connection.structure_drop.split(";\n\n").each do |ddl|
           ActiveRecord::Base.connection.execute(ddl)
         end
-      when 'firebird'
-        ActiveRecord::Base.establish_connection(:test)
-        ActiveRecord::Base.connection.recreate_database!
       else
         ActiveRecord::Tasks::DatabaseTasks.purge abcs['test']
       end

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -286,8 +286,8 @@ db_namespace = namespace :db do
 
     # desc "Recreate the databases from the structure.sql file"
     task :load => [:environment, :load_config] do
-      current_config = ActiveRecord::Tasks::DatabaseTasks.current_config
       filename = ENV['DB_STRUCTURE'] || File.join(Rails.root, "db", "structure.sql")
+      current_config = ActiveRecord::Tasks::DatabaseTasks.current_config
       ActiveRecord::Tasks::DatabaseTasks.structure_load(current_config, filename)
     end
 

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -278,8 +278,6 @@ db_namespace = namespace :db do
       when 'oci', 'oracle'
         ActiveRecord::Base.establish_connection(current_config)
         File.open(filename, "w:utf-8") { |f| f << ActiveRecord::Base.connection.structure_dump }
-      when 'sqlserver'
-        `smoscript -s #{current_config['host']} -d #{current_config['database']} -u #{current_config['username']} -p #{current_config['password']} -f #{filename} -A -U`
       else
         ActiveRecord::Tasks::DatabaseTasks.structure_dump(current_config, filename)
       end
@@ -297,8 +295,6 @@ db_namespace = namespace :db do
       current_config = ActiveRecord::Tasks::DatabaseTasks.current_config
       filename = ENV['DB_STRUCTURE'] || File.join(Rails.root, "db", "structure.sql")
       case current_config['adapter']
-      when 'sqlserver'
-        `sqlcmd -S #{current_config['host']} -d #{current_config['database']} -U #{current_config['username']} -P #{current_config['password']} -i #{filename}`
       when 'oci', 'oracle'
         ActiveRecord::Base.establish_connection(current_config)
         IO.read(filename).split(";\n\n").each do |ddl|
@@ -363,12 +359,6 @@ db_namespace = namespace :db do
     task :purge => [:environment, :load_config] do
       abcs = ActiveRecord::Base.configurations
       case abcs['test']['adapter']
-      when 'sqlserver'
-        test = abcs.deep_dup['test']
-        test_database = test['database']
-        test['database'] = 'master'
-        ActiveRecord::Base.establish_connection(test)
-        ActiveRecord::Base.connection.recreate_database!(test_database)
       when "oci", "oracle"
         ActiveRecord::Base.establish_connection(:test)
         ActiveRecord::Base.connection.structure_drop.split(";\n\n").each do |ddl|

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -274,13 +274,7 @@ db_namespace = namespace :db do
     task :dump => [:environment, :load_config] do
       filename = ENV['DB_STRUCTURE'] || File.join(Rails.root, "db", "structure.sql")
       current_config = ActiveRecord::Tasks::DatabaseTasks.current_config
-      case current_config['adapter']
-      when 'oci', 'oracle'
-        ActiveRecord::Base.establish_connection(current_config)
-        File.open(filename, "w:utf-8") { |f| f << ActiveRecord::Base.connection.structure_dump }
-      else
-        ActiveRecord::Tasks::DatabaseTasks.structure_dump(current_config, filename)
-      end
+      ActiveRecord::Tasks::DatabaseTasks.structure_dump(current_config, filename)
 
       if ActiveRecord::Base.connection.supports_migrations?
         File.open(filename, "a") do |f|
@@ -294,15 +288,7 @@ db_namespace = namespace :db do
     task :load => [:environment, :load_config] do
       current_config = ActiveRecord::Tasks::DatabaseTasks.current_config
       filename = ENV['DB_STRUCTURE'] || File.join(Rails.root, "db", "structure.sql")
-      case current_config['adapter']
-      when 'oci', 'oracle'
-        ActiveRecord::Base.establish_connection(current_config)
-        IO.read(filename).split(";\n\n").each do |ddl|
-          ActiveRecord::Base.connection.execute(ddl)
-        end
-      else
-        ActiveRecord::Tasks::DatabaseTasks.structure_load(current_config, filename)
-      end
+      ActiveRecord::Tasks::DatabaseTasks.structure_load(current_config, filename)
     end
 
     task :load_if_sql => ['db:create', :environment] do
@@ -357,16 +343,7 @@ db_namespace = namespace :db do
 
     # desc "Empty the test database"
     task :purge => [:environment, :load_config] do
-      abcs = ActiveRecord::Base.configurations
-      case abcs['test']['adapter']
-      when "oci", "oracle"
-        ActiveRecord::Base.establish_connection(:test)
-        ActiveRecord::Base.connection.structure_drop.split(";\n\n").each do |ddl|
-          ActiveRecord::Base.connection.execute(ddl)
-        end
-      else
-        ActiveRecord::Tasks::DatabaseTasks.purge abcs['test']
-      end
+      ActiveRecord::Tasks::DatabaseTasks.purge ActiveRecord::Base.configurations['test']
     end
 
     # desc 'Check for pending migrations and load the test schema'

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -18,6 +18,7 @@ module ActiveRecord
       register_task(/mysql/, ActiveRecord::Tasks::MySQLDatabaseTasks)
       register_task(/postgresql/, ActiveRecord::Tasks::PostgreSQLDatabaseTasks)
       register_task(/sqlite/, ActiveRecord::Tasks::SQLiteDatabaseTasks)
+      register_task(/firebird/, ActiveRecord::Tasks::FirebirdDatabaseTasks)
 
       def current_config(options = {})
         options.reverse_merge! :env => Rails.env

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -15,12 +15,13 @@ module ActiveRecord
         @tasks[pattern] = task
       end
 
-      register_task(/mysql/, ActiveRecord::Tasks::MySQLDatabaseTasks)
-      register_task(/postgresql/, ActiveRecord::Tasks::PostgreSQLDatabaseTasks)
-      register_task(/sqlite/, ActiveRecord::Tasks::SQLiteDatabaseTasks)
+      register_task(/mysql/,        ActiveRecord::Tasks::MySQLDatabaseTasks)
+      register_task(/postgresql/,   ActiveRecord::Tasks::PostgreSQLDatabaseTasks)
+      register_task(/sqlite/,       ActiveRecord::Tasks::SQLiteDatabaseTasks)
 
-      register_task(/firebird/,  ActiveRecord::Tasks::FirebirdDatabaseTasks)
-      register_task(/sqlserver/, ActiveRecord::Tasks::SqlserverDatabaseTasks)
+      register_task(/firebird/,     ActiveRecord::Tasks::FirebirdDatabaseTasks)
+      register_task(/sqlserver/,    ActiveRecord::Tasks::SqlserverDatabaseTasks)
+      register_task(/(oci|oracle)/, ActiveRecord::Tasks::OracleDatabaseTasks)
 
       def current_config(options = {})
         options.reverse_merge! :env => Rails.env

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -18,7 +18,9 @@ module ActiveRecord
       register_task(/mysql/, ActiveRecord::Tasks::MySQLDatabaseTasks)
       register_task(/postgresql/, ActiveRecord::Tasks::PostgreSQLDatabaseTasks)
       register_task(/sqlite/, ActiveRecord::Tasks::SQLiteDatabaseTasks)
-      register_task(/firebird/, ActiveRecord::Tasks::FirebirdDatabaseTasks)
+
+      register_task(/firebird/,  ActiveRecord::Tasks::FirebirdDatabaseTasks)
+      register_task(/sqlserver/, ActiveRecord::Tasks::SqlserverDatabaseTasks)
 
       def current_config(options = {})
         options.reverse_merge! :env => Rails.env

--- a/activerecord/lib/active_record/tasks/firebird_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/firebird_database_tasks.rb
@@ -1,0 +1,55 @@
+module ActiveRecord
+  module Tasks # :nodoc:
+    class FirebirdDatabaseTasks # :nodoc:
+      delegate :connection, :establish_connection, to: ActiveRecord::Base
+
+      def initialize(configuration)
+        @configuration = configuration
+      end
+
+      def create
+        $stderr.puts 'sorry, your database adapter is not supported yet, feel free to submit a patch'
+      end
+
+      def drop
+        $stderr.puts 'sorry, your database adapter is not supported yet, feel free to submit a patch'
+      end
+
+      def purge
+        establish_connection(:test)
+        connection.recreate_database!
+      end
+
+      def charset
+        $stderr.puts 'sorry, your database adapter is not supported yet, feel free to submit a patch'
+      end
+
+      def structure_dump(filename)
+        set_firebird_env(configuration)
+        db_string = firebird_db_string(configuration)
+        Kernel.system "isql -a #{db_string} > #{filename}"
+      end
+
+      def structure_load(filename)
+        set_firebird_env(configuration)
+        db_string = firebird_db_string(configuration)
+        Kernel.system "isql -i #{filename} #{db_string}"
+      end
+
+      private
+
+      def set_firebird_env(config)
+        ENV['ISC_USER']     = config['username'].to_s if config['username']
+        ENV['ISC_PASSWORD'] = config['password'].to_s if config['password']
+      end
+
+      def firebird_db_string(config)
+        FireRuby::Database.db_string_for(config.symbolize_keys)
+      end
+
+      def configuration
+        @configuration
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/tasks/firebird_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/firebird_database_tasks.rb
@@ -4,6 +4,7 @@ module ActiveRecord
       delegate :connection, :establish_connection, to: ActiveRecord::Base
 
       def initialize(configuration)
+        ActiveSupport::Deprecation.warn "This database tasks were deprecated, because this tasks should be served by the 3rd party adapter."
         @configuration = configuration
       end
 

--- a/activerecord/lib/active_record/tasks/oracle_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/oracle_database_tasks.rb
@@ -4,6 +4,7 @@ module ActiveRecord
       delegate :connection, :establish_connection, to: ActiveRecord::Base
 
       def initialize(configuration)
+        ActiveSupport::Deprecation.warn "This database tasks were deprecated, because this tasks should be served by the 3rd party adapter."
         @configuration = configuration
       end
 

--- a/activerecord/lib/active_record/tasks/oracle_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/oracle_database_tasks.rb
@@ -1,0 +1,44 @@
+module ActiveRecord
+  module Tasks # :nodoc:
+    class OracleDatabaseTasks # :nodoc:
+      delegate :connection, :establish_connection, to: ActiveRecord::Base
+
+      def initialize(configuration)
+        @configuration = configuration
+      end
+
+      def create
+        $stderr.puts 'sorry, your database adapter is not supported yet, feel free to submit a patch'
+      end
+
+      def drop
+        $stderr.puts 'sorry, your database adapter is not supported yet, feel free to submit a patch'
+      end
+
+      def purge
+        establish_connection(:test)
+        connection.structure_drop.split(";\n\n").each { |ddl| connection.execute(ddl) }
+      end
+
+      def charset
+        $stderr.puts 'sorry, your database adapter is not supported yet, feel free to submit a patch'
+      end
+
+      def structure_dump(filename)
+        establish_connection(configuration)
+        File.open(filename, "w:utf-8") { |f| f << connection.structure_dump }
+      end
+
+      def structure_load(filename)
+        establish_connection(configuration)
+        IO.read(filename).split(";\n\n").each { |ddl| connection.execute(ddl) }
+      end
+
+      private
+
+      def configuration
+        @configuration
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/tasks/sqlserver_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlserver_database_tasks.rb
@@ -6,6 +6,7 @@ module ActiveRecord
       delegate :connection, :establish_connection, to: ActiveRecord::Base
 
       def initialize(configuration)
+        ActiveSupport::Deprecation.warn "This database tasks were deprecated, because this tasks should be served by the 3rd party adapter."
         @configuration = configuration
       end
 

--- a/activerecord/lib/active_record/tasks/sqlserver_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlserver_database_tasks.rb
@@ -1,0 +1,47 @@
+require 'shellwords'
+
+module ActiveRecord
+  module Tasks # :nodoc:
+    class SqlserverDatabaseTasks # :nodoc:
+      delegate :connection, :establish_connection, to: ActiveRecord::Base
+
+      def initialize(configuration)
+        @configuration = configuration
+      end
+
+      def create
+        $stderr.puts 'sorry, your database adapter is not supported yet, feel free to submit a patch'
+      end
+
+      def drop
+        $stderr.puts 'sorry, your database adapter is not supported yet, feel free to submit a patch'
+      end
+
+      def purge
+        test = configuration.deep_dup
+        test_database = test['database']
+        test['database'] = 'master'
+        establish_connection(test)
+        connection.recreate_database!(test_database)
+      end
+
+      def charset
+        $stderr.puts 'sorry, your database adapter is not supported yet, feel free to submit a patch'
+      end
+
+      def structure_dump(filename)
+        Kernel.system("smoscript -s #{configuration['host']} -d #{configuration['database']} -u #{configuration['username']} -p #{configuration['password']} -f #{filename} -A -U")
+      end
+
+      def structure_load(filename)
+        Kernel.system("sqlcmd -S #{configuration['host']} -d #{configuration['database']} -U #{configuration['username']} -P #{configuration['password']} -i #{filename}")
+      end
+
+      private
+
+      def configuration
+        @configuration
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/tasks/firebird_rake_test.rb
+++ b/activerecord/test/cases/tasks/firebird_rake_test.rb
@@ -17,6 +17,13 @@ module ActiveRecord
       }
       ActiveRecord::Base.stubs(:connection).returns(@connection)
       ActiveRecord::Base.stubs(:establish_connection).returns(true)
+
+      @tasks = Class.new(ActiveRecord::Tasks::FirebirdDatabaseTasks) do
+        def initialize(configuration)
+          ActiveSupport::Deprecation.silence { super }
+        end
+      end
+      ActiveRecord::Tasks::DatabaseTasks.stubs(:class_for_adapter).returns(@tasks)
     end
   end
 

--- a/activerecord/test/cases/tasks/firebird_rake_test.rb
+++ b/activerecord/test/cases/tasks/firebird_rake_test.rb
@@ -1,0 +1,93 @@
+require 'cases/helper'
+
+unless defined?(FireRuby::Database)
+module FireRuby
+  module Database; end
+end
+end
+
+module ActiveRecord
+  module FirebirdSetupper
+    def setup
+      @database      = 'db.firebird'
+      @connection    = stub :connection
+      @configuration = {
+        'adapter'  => 'firebird',
+        'database' => @database
+      }
+      ActiveRecord::Base.stubs(:connection).returns(@connection)
+      ActiveRecord::Base.stubs(:establish_connection).returns(true)
+    end
+  end
+
+  class FirebirdDBCreateTest < ActiveRecord::TestCase
+    include FirebirdSetupper
+
+    def test_db_retrieves_create
+      message = capture(:stderr) do
+        ActiveRecord::Tasks::DatabaseTasks.create @configuration
+      end
+      assert_match(/not supported/, message)
+    end
+  end
+ 
+  class FirebirdDBDropTest < ActiveRecord::TestCase
+    include FirebirdSetupper
+
+    def test_db_retrieves_drop
+      message = capture(:stderr) do
+        ActiveRecord::Tasks::DatabaseTasks.drop @configuration
+      end
+      assert_match(/not supported/, message)
+    end
+  end
+ 
+  class FirebirdDBCharsetAndCollationTest < ActiveRecord::TestCase
+    include FirebirdSetupper
+
+    def test_db_retrieves_collation
+      assert_raise NoMethodError do
+        ActiveRecord::Tasks::DatabaseTasks.collation @configuration
+      end
+    end
+
+    def test_db_retrieves_charset
+      message = capture(:stderr) do
+        ActiveRecord::Tasks::DatabaseTasks.charset @configuration
+      end
+      assert_match(/not supported/, message)
+    end
+  end
+
+  class FirebirdStructureDumpTest < ActiveRecord::TestCase
+    include FirebirdSetupper
+
+    def setup
+      super
+      FireRuby::Database.stubs(:db_string_for).returns(@database)
+    end
+
+    def test_structure_dump
+      filename = "filebird.sql"
+      Kernel.expects(:system).with("isql -a #{@database} > #{filename}")
+
+      ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
+    end
+  end
+
+  class FirebirdStructureLoadTest < ActiveRecord::TestCase
+    include FirebirdSetupper
+
+    def setup
+      super
+      FireRuby::Database.stubs(:db_string_for).returns(@database)
+    end
+
+    def test_structure_load
+      filename = "firebird.sql"
+      Kernel.expects(:system).with("isql -i #{filename} #{@database}")
+
+      ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
+    end
+  end
+end

--- a/activerecord/test/cases/tasks/firebird_rake_test.rb
+++ b/activerecord/test/cases/tasks/firebird_rake_test.rb
@@ -23,7 +23,7 @@ module ActiveRecord
           ActiveSupport::Deprecation.silence { super }
         end
       end
-      ActiveRecord::Tasks::DatabaseTasks.stubs(:class_for_adapter).returns(@tasks)
+      ActiveRecord::Tasks::DatabaseTasks.stubs(:class_for_adapter).returns(@tasks) unless defined? ActiveRecord::ConnectionAdapters::FirebirdAdapter
     end
   end
 

--- a/activerecord/test/cases/tasks/oracle_rake_test.rb
+++ b/activerecord/test/cases/tasks/oracle_rake_test.rb
@@ -11,6 +11,13 @@ module ActiveRecord
       }
       ActiveRecord::Base.stubs(:connection).returns(@connection)
       ActiveRecord::Base.stubs(:establish_connection).returns(true)
+
+      @tasks = Class.new(ActiveRecord::Tasks::OracleDatabaseTasks) do
+        def initialize(configuration)
+          ActiveSupport::Deprecation.silence { super }
+        end
+      end
+      ActiveRecord::Tasks::DatabaseTasks.stubs(:class_for_adapter).returns(@tasks)
     end
   end
 

--- a/activerecord/test/cases/tasks/oracle_rake_test.rb
+++ b/activerecord/test/cases/tasks/oracle_rake_test.rb
@@ -17,7 +17,7 @@ module ActiveRecord
           ActiveSupport::Deprecation.silence { super }
         end
       end
-      ActiveRecord::Tasks::DatabaseTasks.stubs(:class_for_adapter).returns(@tasks)
+      ActiveRecord::Tasks::DatabaseTasks.stubs(:class_for_adapter).returns(@tasks) unless defined? ActiveRecord::ConnectionAdapters::OracleAdapter
     end
   end
 

--- a/activerecord/test/cases/tasks/oracle_rake_test.rb
+++ b/activerecord/test/cases/tasks/oracle_rake_test.rb
@@ -1,0 +1,86 @@
+require 'cases/helper'
+
+module ActiveRecord
+  module OracleSetupper
+    def setup
+      @database      = 'db.oracle'
+      @connection    = stub :connection
+      @configuration = {
+        'adapter'  => 'oracle',
+        'database' => @database
+      }
+      ActiveRecord::Base.stubs(:connection).returns(@connection)
+      ActiveRecord::Base.stubs(:establish_connection).returns(true)
+    end
+  end
+
+  class OracleDBCreateTest < ActiveRecord::TestCase
+    include OracleSetupper
+
+    def test_db_retrieves_create
+      message = capture(:stderr) do
+        ActiveRecord::Tasks::DatabaseTasks.create @configuration
+      end
+      assert_match(/not supported/, message)
+    end
+  end
+ 
+  class OracleDBDropTest < ActiveRecord::TestCase
+    include OracleSetupper
+
+    def test_db_retrieves_drop
+      message = capture(:stderr) do
+        ActiveRecord::Tasks::DatabaseTasks.drop @configuration
+      end
+      assert_match(/not supported/, message)
+    end
+  end
+ 
+  class OracleDBCharsetAndCollationTest < ActiveRecord::TestCase
+    include OracleSetupper
+
+    def test_db_retrieves_collation
+      assert_raise NoMethodError do
+        ActiveRecord::Tasks::DatabaseTasks.collation @configuration
+      end
+    end
+
+    def test_db_retrieves_charset
+      message = capture(:stderr) do
+        ActiveRecord::Tasks::DatabaseTasks.charset @configuration
+      end
+      assert_match(/not supported/, message)
+    end
+  end
+
+  class OracleStructureDumpTest < ActiveRecord::TestCase
+    include OracleSetupper
+
+    def setup
+      super
+      @connection.stubs(:structure_dump).returns("select sysdate from dual;")
+    end
+
+    def test_structure_dump
+      filename = "oracle.sql"
+      ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
+      assert File.exists?(filename)
+    ensure
+      FileUtils.rm_f(filename)
+    end
+  end
+
+  class OracleStructureLoadTest < ActiveRecord::TestCase
+    include OracleSetupper
+
+    def test_structure_load
+      filename = "oracle.sql"
+
+      open(filename, 'w') { |f| f.puts("select sysdate from dual;") }
+      @connection.stubs(:execute).with("select sysdate from dual;\n")
+      ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
+    ensure
+      FileUtils.rm_f(filename)
+    end
+  end
+end

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -225,7 +225,7 @@ module ActiveRecord
       Kernel.stubs(:system)
     end
 
-    def test_structure_dump
+    def test_structure_load
       filename = "awesome-file.sql"
       Kernel.expects(:system).with("psql -f #{filename} my-app-db")
 

--- a/activerecord/test/cases/tasks/sqlserver_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlserver_rake_test.rb
@@ -1,0 +1,80 @@
+require 'cases/helper'
+
+module ActiveRecord
+  module SqlserverSetupper
+    def setup
+      @database      = 'db.sqlserver'
+      @connection    = stub :connection
+      @configuration = {
+        'adapter'  => 'sqlserver',
+        'database' => @database,
+        'host'     => 'localhost',
+        'username' => 'username',
+        'password' => 'password',
+      }
+      ActiveRecord::Base.stubs(:connection).returns(@connection)
+      ActiveRecord::Base.stubs(:establish_connection).returns(true)
+    end
+  end
+
+  class SqlserverDBCreateTest < ActiveRecord::TestCase
+    include SqlserverSetupper
+
+    def test_db_retrieves_create
+      message = capture(:stderr) do
+        ActiveRecord::Tasks::DatabaseTasks.create @configuration
+      end
+      assert_match(/not supported/, message)
+    end
+  end
+ 
+  class SqlserverDBDropTest < ActiveRecord::TestCase
+    include SqlserverSetupper
+
+    def test_db_retrieves_drop
+      message = capture(:stderr) do
+        ActiveRecord::Tasks::DatabaseTasks.drop @configuration
+      end
+      assert_match(/not supported/, message)
+    end
+  end
+ 
+  class SqlserverDBCharsetAndCollationTest < ActiveRecord::TestCase
+    include SqlserverSetupper
+
+    def test_db_retrieves_collation
+      assert_raise NoMethodError do
+        ActiveRecord::Tasks::DatabaseTasks.collation @configuration
+      end
+    end
+
+    def test_db_retrieves_charset
+      message = capture(:stderr) do
+        ActiveRecord::Tasks::DatabaseTasks.charset @configuration
+      end
+      assert_match(/not supported/, message)
+    end
+  end
+
+  class SqlserverStructureDumpTest < ActiveRecord::TestCase
+    include SqlserverSetupper
+
+    def test_structure_dump
+      filename = "sqlserver.sql"
+      Kernel.expects(:system).with("smoscript -s localhost -d #{@database} -u username -p password -f #{filename} -A -U")
+
+      ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
+    end
+  end
+
+  class SqlserverStructureLoadTest < ActiveRecord::TestCase
+    include SqlserverSetupper
+
+    def test_structure_load
+      filename = "sqlserver.sql"
+      Kernel.expects(:system).with("sqlcmd -S localhost -d #{@database} -U username -P password -i #{filename}")
+
+      ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
+    end
+  end
+end

--- a/activerecord/test/cases/tasks/sqlserver_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlserver_rake_test.rb
@@ -20,7 +20,7 @@ module ActiveRecord
           ActiveSupport::Deprecation.silence { super }
         end
       end
-      ActiveRecord::Tasks::DatabaseTasks.stubs(:class_for_adapter).returns(@tasks)
+      ActiveRecord::Tasks::DatabaseTasks.stubs(:class_for_adapter).returns(@tasks) unless defined? ActiveRecord::ConnectionAdapters::SQLServerAdapter
     end
   end
 

--- a/activerecord/test/cases/tasks/sqlserver_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlserver_rake_test.rb
@@ -14,6 +14,13 @@ module ActiveRecord
       }
       ActiveRecord::Base.stubs(:connection).returns(@connection)
       ActiveRecord::Base.stubs(:establish_connection).returns(true)
+
+      @tasks = Class.new(ActiveRecord::Tasks::SqlserverDatabaseTasks) do
+        def initialize(configuration)
+          ActiveSupport::Deprecation.silence { super }
+        end
+      end
+      ActiveRecord::Tasks::DatabaseTasks.stubs(:class_for_adapter).returns(@tasks)
     end
   end
 


### PR DESCRIPTION
We'll introduce new `database_tasks.rb` and register tasks api since rails 4.0.

Thus, I think we should extract and deprecate `firebird` / `sqlserver` / `oracle` database tasks because they should be supported by 3rd-party adapters.

/cc @rafaelfranca @carlosantoniodasilva @yahonda
