### PR TITLE
Removed unused variable in proc

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -7,7 +7,7 @@
 
         layout nil
 
-        layout proc { |c| nil }
+        layout proc { nil }
 
         layout :returns_nil
 


### PR DESCRIPTION
- This unused variable is already removed from the code here. d18e8b1a3839c5c214e96c7e37e0d86febe15f99
- So removing it from CHANGELOG to be consistent with code
