### PR TITLE
Unserializing YAML attributes can silently fail in development mode

### DIFF
--- a/activerecord/lib/active_record/coders/yaml_column.rb
+++ b/activerecord/lib/active_record/coders/yaml_column.rb
@@ -33,7 +33,8 @@ module ActiveRecord
           obj ||= object_class.new if object_class != Object
 
           obj
-        rescue ArgumentError, Psych::SyntaxError
+        rescue ArgumentError , Psych::SyntaxError => e
+          raise if e.to_s =~ /undefined class/
           yaml
         end
       end

--- a/activerecord/lib/active_record/coders/yaml_column.rb
+++ b/activerecord/lib/active_record/coders/yaml_column.rb
@@ -23,20 +23,15 @@ module ActiveRecord
       def load(yaml)
         return object_class.new if object_class != Object && yaml.nil?
         return yaml unless yaml.is_a?(String) && yaml =~ /^---/
-        begin
-          obj = YAML.load(yaml)
+        obj = YAML.load(yaml)
 
-          unless obj.is_a?(object_class) || obj.nil?
-            raise SerializationTypeMismatch,
-              "Attribute was supposed to be a #{object_class}, but was a #{obj.class}"
-          end
-          obj ||= object_class.new if object_class != Object
-
-          obj
-        rescue ArgumentError , Psych::SyntaxError => e
-          raise if e.to_s =~ /undefined class/
-          yaml
+        unless obj.is_a?(object_class) || obj.nil?
+          raise SerializationTypeMismatch,
+            "Attribute was supposed to be a #{object_class}, but was a #{obj.class}"
         end
+        obj ||= object_class.new if object_class != Object
+
+        obj
       end
     end
   end

--- a/activerecord/test/cases/coders/yaml_column_test.rb
+++ b/activerecord/test/cases/coders/yaml_column_test.rb
@@ -43,10 +43,12 @@ module ActiveRecord
         assert_equal [], coder.load([])
       end
 
-      def test_load_swallows_yaml_exceptions
+      def test_load_doesnt_swallow_yaml_exceptions
         coder = YAMLColumn.new
         bad_yaml = '--- {'
-        assert_equal bad_yaml, coder.load(bad_yaml)
+        assert_raises(Psych::SyntaxError) do
+          coder.load(bad_yaml)
+        end
       end
 
       def test_load_doesnt_handle_undefined_class_or_module

--- a/activerecord/test/cases/coders/yaml_column_test.rb
+++ b/activerecord/test/cases/coders/yaml_column_test.rb
@@ -48,6 +48,14 @@ module ActiveRecord
         bad_yaml = '--- {'
         assert_equal bad_yaml, coder.load(bad_yaml)
       end
+
+      def test_load_doesnt_handle_undefined_class_or_module
+        coder = YAMLColumn.new
+        missing_class_yaml = '--- !ruby/object:DoesNotExistAndShouldntEver {}\n'
+        assert_raises(ArgumentError) do
+          coder.load(missing_class_yaml)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
If you use a serialized attribute on an ActiveRecord model and the object to be unserialized has not yet been loaded, AR will silently return the YAML string. This can be confusing to new users and apparently to me, even though I've been bitten by this three or four times in the past.
