### PR TITLE
Bugfix in Builder BlankSlate (ensure it uses symbols)

### DIFF
--- a/activesupport/lib/active_support/vendor/builder-2.1.2/blankslate.rb
+++ b/activesupport/lib/active_support/vendor/builder-2.1.2/blankslate.rb
@@ -20,15 +20,17 @@ class BlankSlate
     # Hide the method named +name+ in the BlankSlate class.  Don't
     # hide +instance_eval+ or any method beginning with "__".
     def hide(name)
-      if instance_methods.include?(name.to_s) and
+      name = name.to_sym
+      if instance_methods.include?(name) and
         name !~ /^(__|instance_eval)/
         @hidden_methods ||= {}
-        @hidden_methods[name.to_sym] = instance_method(name)
+        @hidden_methods[name] = instance_method(name)
         undef_method name
       end
     end
 
     def find_hidden_method(name)
+      name = name.to_sym
       @hidden_methods ||= {}
       @hidden_methods[name] || superclass.find_hidden_method(name)
     end
@@ -36,6 +38,7 @@ class BlankSlate
     # Redefine a previously hidden method so that it may be called on a blank
     # slate object.
     def reveal(name)
+      name = name.to_sym
       bound_method = nil
       unbound_method = find_hidden_method(name)
       fail "Don't know how to reveal method '#{name}'" unless unbound_method


### PR DESCRIPTION
The `BlankSlate` class provided by the vendored version of Builder would sometimes use strings instead of symbols. This ensures it always uses symbols to prevent search/lookup errors.
