### PR TITLE
change Hash#to_xml to convert xml with attribute and content properly

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/hash/conversions.rb
@@ -124,6 +124,7 @@ module ActiveSupport
     end
 
     DISALLOWED_TYPES = %w(symbol yaml)
+    RESERVED_TAG_ATTRIBUTES = [["type", "encoding", "__content__"], ["type", "__content__"], ["__content__"]]
 
     def initialize(xml, disallowed_types = nil)
       @xml = normalize_keys(XmlMini.parse(xml))
@@ -193,7 +194,7 @@ module ActiveSupport
       end
 
       def become_content?(value)
-        value['type'] == 'file' || (value['__content__'] && (value.keys.size == 1 || value['__content__'].present?))
+        value['type'] == 'file' || RESERVED_TAG_ATTRIBUTES.include?(value.keys)
       end
 
       def become_array?(value)

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -1235,6 +1235,14 @@ class HashToXmlTest < ActiveSupport::TestCase
     assert_equal "bacon is the best", hash['blog']['name']
   end
 
+  def test_tag_with_content_and_name
+    xml = <<-XML
+      <blog name="bacon is the best">25</blog>
+    XML
+    hash = Hash.from_xml(xml)
+    assert_equal hash, {"blog" => {"name" => "bacon is the best", "__content__" => "25"}}
+  end
+
   def test_empty_cdata_from_xml
     xml = "<data><![CDATA[]]></data>"
 


### PR DESCRIPTION
This is in response to #9965

It rightly parses something like

``` xml
<varValue name="age">25</varValue>
```

to

``` ruby
{"varValue"=>{"name"=>"age", "__content__"=>"25"}}
```
