### PR TITLE
Change routing `normalize_path` regular expression to match /(:param)other_stuff fixes #8578

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Ensure that scoped params at root are not incorrectly matched when combined with more routes, e.g:
+    `scope '/(:optional/):required` needs to be matched as '/(:optional/):required' and not
+    '(/:optional)/:required'. Fixes #8578.
+
+    *Jon Rowe*
+
 *   Fix formatting for `rake routes` when a section is shorter than a header.
 
     *Sıtkı Bağdat*

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -309,7 +309,7 @@ module ActionDispatch
       # for root cases, where the latter is the correct one.
       def self.normalize_path(path)
         path = Journey::Router::Utils.normalize_path(path)
-        path.gsub!(%r{/(\(+)/?}, '\1/') unless path =~ %r{^/\(+[^)]+\)$}
+        path.gsub!(%r{/(\(+)/?}, '\1/') unless path =~ %r{^/\(+[^)]+\)[^\(\)\/]*$}
         path
       end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1411,6 +1411,19 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal 'descriptions#show', @response.body
   end
 
+  def test_optional_scoped_path_with_parameter
+    draw do
+      scope "/(:optional-):required" do
+        root :to => 'projects#index'
+      end
+    end
+
+    get '/required'
+    assert_equal 'projects#index', @response.body
+    get '/optional-required'
+    assert_equal 'projects#index', @response.body
+  end
+
   def test_nested_optional_scoped_path
     draw do
       namespace :admin do


### PR DESCRIPTION
There is an issue where a scoped optional parameter is incorrectly being substituted when at the root of a route so as that it then doesn't match without the parameter at the root. e.g.

`scope "/(:optional/):required"` should match both `/optional/required` and `/required`

This is a change to the `normalize_path` regular expression fixing the incorrect substitution of the root `/` when used with an optional param, which make parameters optional again. e.g.:

```
# before 
 /(:optional/):required => (/:optional):required
# after (correct)
/(:optional/):required => /(:optional/):required
```

Fixes #8578

**Edit** Updated the text to make it clearer what this is fixing
**Edit x2** The test has been reverted to using a `-` so it can't be fixed by rewriting the regexp, but it's still a valid route.
