### PR TITLE
Association with inverse_of does not set the parent in association building block

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -388,6 +388,23 @@
         # This will expand the order :name to "authors".name.
         Author.joins(:books).where('books.published = 1').order(:name)
 
+*   Fix associations with `:inverse_of` option when building association
+    with a block. Inside the block the parent object was different then
+    after the block.
+
+    Example:
+
+        parent.association.build do |child|
+          child.parent.equal?(parent) # false
+        end
+
+        # vs
+
+        child = parent.association.build
+        child.parent.equal?(parent) # true
+
+    *Michal Cichra*
+
 
 ## Rails 4.0.0.beta1 (February 25, 2013) ##
 

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -235,6 +235,7 @@ module ActiveRecord
             skip_assign = [reflection.foreign_key, reflection.type].compact
             attributes = create_scope.except(*(record.changed - skip_assign))
             record.assign_attributes(attributes)
+            set_inverse_instance(record)
           end
         end
     end

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -235,6 +235,22 @@ class InverseHasManyTests < ActiveRecord::TestCase
     assert_equal m.name, i.man.name, "Name of man should be the same after changes to newly-created-child-owned instance"
   end
 
+  def test_parent_instance_should_be_shared_within_create_block_of_new_child
+    man = Man.first
+    interest = man.interests.build do |i|
+      assert i.man.equal?(man), "Man of child should be the same instance as a parent"
+    end
+    assert interest.man.equal?(man), "Man of the child should still be the same instance as a parent"
+  end
+
+  def test_parent_instance_should_be_shared_within_build_block_of_new_child
+    man = Man.first
+    interest = man.interests.build do |i|
+      assert i.man.equal?(man), "Man of child should be the same instance as a parent"
+    end
+    assert interest.man.equal?(man), "Man of the child should still be the same instance as a parent"
+  end
+
   def test_parent_instance_should_be_shared_with_poked_in_child
     m = men(:gordon)
     i = Interest.create(:topic => 'Industrial Revolution Re-enactment')


### PR DESCRIPTION
Hi!
I found following issue.

When creating new association object with a block:

``` ruby
    parent.association.build do |child|
      child.parent.equal?(parent) # false
    end
```

The block the `child.parent` did not point to the same object.
But when the object is created it points to same instance:

``` ruby
    child = parent.association.build
    child.parent.equal?(parent) # true
```

So this patch fixes it by setting inverse_of record right after object is build for the association.

If the patch is right I'll add CHANGELOG entry and backport it to `3-2-stable` branch.
