### PR TITLE
Only use race_ttl if race_condition_ttl specified as cache option

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -521,7 +521,7 @@ module ActiveSupport
 
         def handle_expired_entry(entry, key, options)
           if entry && entry.expired?
-            race_ttl = options[:race_condition_ttl].to_i
+            race_ttl = options[:race_condition_ttl].to_i if options[:race_condition_ttl]
             if race_ttl && (Time.now - entry.expires_at <= race_ttl)
               # When an entry has :race_condition_ttl defined, put the stale entry back into the cache
               # for a brief period while the entry is begin recalculated.

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -343,6 +343,17 @@ module CacheStoreBehavior
     assert_nil @cache.read('foo')
   end
 
+  def test_expired_entry_without_race_condition_ttl
+    time = Time.now
+    Time.stubs(:now).returns(time)
+    @cache.write('foo', 'bar', :expires_in => 60)
+
+    ActiveSupport::Cache::Entry.any_instance.stubs(:expired?).returns(true)
+
+    @cache.expects(:delete_entry)
+    @cache.fetch('foo', :expires_in => 60) { 'baz'}
+  end
+
   def test_race_condition_protection
     time = Time.now
     @cache.write('foo', 'bar', :expires_in => 60)


### PR DESCRIPTION
When using a Redis cache store the following method intermittently caused a Redis::CommandError: ERR invalid expire time in SETEX, because it receives 0 as the expire time.

When the race_condition_ttl option is not specified the race_ttl evaluates to 0. The result of this is then used in the conditional, but since 0 evaluates to true it falls into the "if" statement. When the write_entry(..) is called with a race_ttl \* 2 as the expires_in it passes 0 for this option, which causes Redis to raise an exception.

I see this condition when Time.now and entry.expires_at are the same.

``` ruby
        def handle_expired_entry(entry, key, options)
          if entry && entry.expired?
            race_ttl = options[:race_condition_ttl].to_i
            if race_ttl && (Time.now - entry.expires_at <= race_ttl)
              # When an entry has :race_condition_ttl defined, put the stale entry back into the cache
              # for a brief period while the entry is begin recalculated.
              entry.expires_at = Time.now + race_ttl
              write_entry(key, entry, :expires_in => race_ttl * 2)
            else
              delete_entry(key, options)
            end
            entry = nil
          end
          entry
        end
```

The fix is to just not set race_ttl unless the race_condition_ttl options is specified.
