### PR TITLE
Reverts changes to Rails.version made in #8501

### DIFF
--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -82,6 +82,10 @@ module Rails
       groups
     end
 
+    def version
+      VERSION::STRING
+    end
+
     def public_path
       application && Pathname.new(application.paths["public"].first)
     end

--- a/railties/lib/rails/version.rb
+++ b/railties/lib/rails/version.rb
@@ -1,11 +1,10 @@
 module Rails
-  # Returns the version of the currently loaded Rails as a Gem::Version
-  def self.version
-    Gem::Version.new "4.0.0.beta1"
-  end
+  module VERSION
+    MAJOR  = 4
+    MINOR  = 0
+    TINY   = 0
+    PRE    = "beta1"
 
-  module VERSION #:nodoc:
-    MAJOR, MINOR, TINY, PRE = Rails.version.segments
-    STRING = Rails.version.to_s
+    STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
   end
 end

--- a/version.rb
+++ b/version.rb
@@ -1,10 +1,10 @@
 module Rails
-  def self.version
-    Gem::Version.new "4.0.0.beta1"
-  end
+  module VERSION
+    MAJOR  = 4
+    MINOR  = 0
+    TINY   = 0
+    PRE    = "beta1"
 
-  module VERSION #:nodoc:
-    MAJOR, MINOR, TINY, PRE = Rails.version.segments
-    STRING = Rails.version.to_s
+    STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
   end
 end


### PR DESCRIPTION
`Rails.version` already existed before #8501 and returned a string. Changing it to return a `Gem::Version` caused some compatibility problems.

This pull request reverts the changes made to `Rails.version`.
