### PR TITLE
Update csrf_helper.rb (KISS)

### DIFF
--- a/actionpack/lib/action_view/helpers/csrf_helper.rb
+++ b/actionpack/lib/action_view/helpers/csrf_helper.rb
@@ -17,8 +17,7 @@ module ActionView
       def csrf_meta_tags
         if protect_against_forgery?
           [
-            tag('meta', :name => 'csrf-param', :content => request_forgery_protection_token),
-            tag('meta', :name => 'csrf-token', :content => form_authenticity_token)
+            tag('meta', :name => 'csrf_token', :content => form_authenticity_token)
           ].join("\n").html_safe
         end
       end


### PR DESCRIPTION
i want to propose a breaking change to make naming convention simpler. 
I never saw people to modify `request_forgery_protection_token`. Look at this code:

```
 form_authenticity_token == params[request_forgery_protection_token] ||
          form_authenticity_token == request.headers['X-CSRF-Token']
```

Why param's name is variable but header name is constant? And, why default name is 'authenticity_token'? (In fact CSRF is about authorization, not authentication. So, this naming sucks).

I propose to have X-CSRF-Token and csrf_token as constant names for CSRF token. Yes, completely constant in code. Such things are never modified. 

It is a speaking name and developers will understand what does it exactly do. I never understood where is "authenticity" part in authenticity_token.

p.s. PR is not done, what do you think? 
