### PR TITLE
Make references with index:true pass Hash options to add_index

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -258,7 +258,7 @@ module ActiveRecord
         args.each do |col|
           column("#{col}_id", :integer, options)
           column("#{col}_type", :string, polymorphic.is_a?(Hash) ? polymorphic : options) if polymorphic
-          index(polymorphic ? %w(id type).map { |t| "#{col}_#{t}" } : "#{col}_id", index_options.is_a?(Hash) ? index_options : nil) if index_options
+          index(polymorphic ? %w(id type).map { |t| "#{col}_#{t}" } : "#{col}_id", index_options.is_a?(Hash) ? index_options : {}) if index_options
         end
       end
       alias :belongs_to :references


### PR DESCRIPTION
The definition for `ActiveRecord::ConnectionAdapters::SchemaStatements::TableDefinition#add_index` looks like

``` ruby
add_index(table_name, column_name, options = {})
```

This can lead plugin writers to assume that `options` will always be a Hash, which has worked well so far.

This change makes the assumption hold when `TableDefinition#references` receives an `index` option set to `true`. I think the few extra hashes created during migrations are well worth not breaking 3rd-party code that relies on the Hash assumption, and I hope that you will agree with me.

Example of broken plugin: https://github.com/dazuma/activerecord-postgis-adapter/pull/60

I hope the test I added is alright, and I'll be happy to change it based on feedback.
