### PR TITLE
change ExplainPrettyPrinter#pp to class method

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -109,71 +109,74 @@ module ActiveRecord
         result  = exec_query(sql, 'EXPLAIN', binds)
         elapsed = Time.now - start
 
-        ExplainPrettyPrinter.new.pp(result, elapsed)
+        ExplainPrettyPrinter.pp(result, elapsed)
       end
 
       class ExplainPrettyPrinter # :nodoc:
-        # Pretty prints the result of a EXPLAIN in a way that resembles the output of the
-        # MySQL shell:
-        #
-        #   +----+-------------+-------+-------+---------------+---------+---------+-------+------+-------------+
-        #   | id | select_type | table | type  | possible_keys | key     | key_len | ref   | rows | Extra       |
-        #   +----+-------------+-------+-------+---------------+---------+---------+-------+------+-------------+
-        #   |  1 | SIMPLE      | users | const | PRIMARY       | PRIMARY | 4       | const |    1 |             |
-        #   |  1 | SIMPLE      | posts | ALL   | NULL          | NULL    | NULL    | NULL  |    1 | Using where |
-        #   +----+-------------+-------+-------+---------------+---------+---------+-------+------+-------------+
-        #   2 rows in set (0.00 sec)
-        #
-        # This is an exercise in Ruby hyperrealism :).
-        def pp(result, elapsed)
-          widths    = compute_column_widths(result)
-          separator = build_separator(widths)
 
-          pp = []
+        class <<self
+          # Pretty prints the result of a EXPLAIN in a way that resembles the output of the
+          # MySQL shell:
+          #
+          #   +----+-------------+-------+-------+---------------+---------+---------+-------+------+-------------+
+          #   | id | select_type | table | type  | possible_keys | key     | key_len | ref   | rows | Extra       |
+          #   +----+-------------+-------+-------+---------------+---------+---------+-------+------+-------------+
+          #   |  1 | SIMPLE      | users | const | PRIMARY       | PRIMARY | 4       | const |    1 |             |
+          #   |  1 | SIMPLE      | posts | ALL   | NULL          | NULL    | NULL    | NULL  |    1 | Using where |
+          #   +----+-------------+-------+-------+---------------+---------+---------+-------+------+-------------+
+          #   2 rows in set (0.00 sec)
+          #
+          # This is an exercise in Ruby hyperrealism :).
+          def pp(result, elapsed)
+            widths    = compute_column_widths(result)
+            separator = build_separator(widths)
 
-          pp << separator
-          pp << build_cells(result.columns, widths)
-          pp << separator
+            pp = []
 
-          result.rows.each do |row|
-            pp << build_cells(row, widths)
+            pp << separator
+            pp << build_cells(result.columns, widths)
+            pp << separator
+
+            result.rows.each do |row|
+              pp << build_cells(row, widths)
+            end
+
+            pp << separator
+            pp << build_footer(result.rows.length, elapsed)
+
+            pp.join("\n") + "\n"
           end
 
-          pp << separator
-          pp << build_footer(result.rows.length, elapsed)
+          private
 
-          pp.join("\n") + "\n"
-        end
-
-        private
-
-        def compute_column_widths(result)
-          [].tap do |widths|
-            result.columns.each_with_index do |column, i|
-              cells_in_column = [column] + result.rows.map {|r| r[i].nil? ? 'NULL' : r[i].to_s}
-              widths << cells_in_column.map(&:length).max
+          def compute_column_widths(result)
+            [].tap do |widths|
+              result.columns.each_with_index do |column, i|
+                cells_in_column = [column] + result.rows.map { |r| r[i].nil? ? 'NULL' : r[i].to_s }
+                widths << cells_in_column.map(&:length).max
+              end
             end
           end
-        end
 
-        def build_separator(widths)
-          padding = 1
-          '+' + widths.map {|w| '-' * (w + (padding*2))}.join('+') + '+'
-        end
-
-        def build_cells(items, widths)
-          cells = []
-          items.each_with_index do |item, i|
-            item = 'NULL' if item.nil?
-            justifier = item.is_a?(Numeric) ? 'rjust' : 'ljust'
-            cells << item.to_s.send(justifier, widths[i])
+          def build_separator(widths)
+            padding = 1
+            '+' + widths.map { |w| '-' * (w + (padding*2)) }.join('+') + '+'
           end
-          '| ' + cells.join(' | ') + ' |'
-        end
 
-        def build_footer(nrows, elapsed)
-          rows_label = nrows == 1 ? 'row' : 'rows'
-          "#{nrows} #{rows_label} in set (%.2f sec)" % elapsed
+          def build_cells(items, widths)
+            cells = []
+            items.each_with_index do |item, i|
+              item = 'NULL' if item.nil?
+              justifier = item.is_a?(Numeric) ? 'rjust' : 'ljust'
+              cells << item.to_s.send(justifier, widths[i])
+            end
+            '| ' + cells.join(' | ') + ' |'
+          end
+
+          def build_footer(nrows, elapsed)
+            rows_label = nrows == 1 ? 'row' : 'rows'
+            "#{nrows} #{rows_label} in set (%.2f sec)" % elapsed
+          end
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -4,43 +4,48 @@ module ActiveRecord
       module DatabaseStatements
         def explain(arel, binds = [])
           sql = "EXPLAIN #{to_sql(arel, binds)}"
-          ExplainPrettyPrinter.new.pp(exec_query(sql, 'EXPLAIN', binds))
+          ExplainPrettyPrinter.pp(exec_query(sql, 'EXPLAIN', binds))
         end
 
         class ExplainPrettyPrinter # :nodoc:
-          # Pretty prints the result of a EXPLAIN in a way that resembles the output of the
-          # PostgreSQL shell:
-          #
-          #                                     QUERY PLAN
-          #   ------------------------------------------------------------------------------
-          #    Nested Loop Left Join  (cost=0.00..37.24 rows=8 width=0)
-          #      Join Filter: (posts.user_id = users.id)
-          #      ->  Index Scan using users_pkey on users  (cost=0.00..8.27 rows=1 width=4)
-          #            Index Cond: (id = 1)
-          #      ->  Seq Scan on posts  (cost=0.00..28.88 rows=8 width=4)
-          #            Filter: (posts.user_id = 1)
-          #   (6 rows)
-          #
-          def pp(result)
-            header = result.columns.first
-            lines  = result.rows.map(&:first)
 
-            # We add 2 because there's one char of padding at both sides, note
-            # the extra hyphens in the example above.
-            width = [header, *lines].map(&:length).max + 2
+          class << self
 
-            pp = []
+            # Pretty prints the result of a EXPLAIN in a way that resembles the output of the
+            # PostgreSQL shell:
+            #
+            #                                     QUERY PLAN
+            #   ------------------------------------------------------------------------------
+            #    Nested Loop Left Join  (cost=0.00..37.24 rows=8 width=0)
+            #      Join Filter: (posts.user_id = users.id)
+            #      ->  Index Scan using users_pkey on users  (cost=0.00..8.27 rows=1 width=4)
+            #            Index Cond: (id = 1)
+            #      ->  Seq Scan on posts  (cost=0.00..28.88 rows=8 width=4)
+            #            Filter: (posts.user_id = 1)
+            #   (6 rows)
+            #
+            def pp(result)
+              header = result.columns.first
+              lines  = result.rows.map(&:first)
 
-            pp << header.center(width).rstrip
-            pp << '-' * width
+              # We add 2 because there's one char of padding at both sides, note
+              # the extra hyphens in the example above.
+              width = [header, *lines].map(&:length).max + 2
 
-            pp += lines.map {|line| " #{line}"}
+              pp = []
 
-            nrows = result.rows.length
-            rows_label = nrows == 1 ? 'row' : 'rows'
-            pp << "(#{nrows} #{rows_label})"
+              pp << header.center(width).rstrip
+              pp << '-' * width
 
-            pp.join("\n") + "\n"
+              pp += lines.map { |line| " #{line}" }
+
+              nrows = result.rows.length
+              rows_label = nrows == 1 ? 'row' : 'rows'
+              pp << "(#{nrows} #{rows_label})"
+
+              pp.join("\n") + "\n"
+            end
+
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -271,20 +271,22 @@ module ActiveRecord
 
       def explain(arel, binds = [])
         sql = "EXPLAIN QUERY PLAN #{to_sql(arel, binds)}"
-        ExplainPrettyPrinter.new.pp(exec_query(sql, 'EXPLAIN', binds))
+        ExplainPrettyPrinter.pp(exec_query(sql, 'EXPLAIN', binds))
       end
 
       class ExplainPrettyPrinter
-        # Pretty prints the result of a EXPLAIN QUERY PLAN in a way that resembles
-        # the output of the SQLite shell:
-        #
-        #   0|0|0|SEARCH TABLE users USING INTEGER PRIMARY KEY (rowid=?) (~1 rows)
-        #   0|1|1|SCAN TABLE posts (~100000 rows)
-        #
-        def pp(result) # :nodoc:
-          result.rows.map do |row|
-            row.join('|')
-          end.join("\n") + "\n"
+        class << self
+          # Pretty prints the result of a EXPLAIN QUERY PLAN in a way that resembles
+          # the output of the SQLite shell:
+          #
+          #   0|0|0|SEARCH TABLE users USING INTEGER PRIMARY KEY (rowid=?) (~1 rows)
+          #   0|1|1|SCAN TABLE posts (~100000 rows)
+          #
+          def pp(result) # :nodoc:
+            result.rows.map do |row|
+              row.join('|')
+            end.join("\n") + "\n"
+          end
         end
       end
 


### PR DESCRIPTION
moved `ExplainPrettyPrinter#pp` to a class method to avoid object creation, as it doesn't need/have any object state
