### PR TITLE
Refactoring the ``expanded`` method in the paths module.

### DIFF
--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -183,22 +183,20 @@ module Rails
       # Expands all paths against the root and return all unique values.
       def expanded
         raise "You need to set a path root" unless @root.path
-        result = []
 
-        each do |p|
+        result = @paths.map do |p|
           path = File.expand_path(p, @root.path)
 
           if @glob && File.directory?(path)
             Dir.chdir(path) do
-              result.concat(Dir.glob(@glob).map { |file| File.join path, file }.sort)
+              Dir.glob(@glob).map { |file| File.join path, file }
             end
           else
-            result << path
+            path
           end
         end
 
-        result.uniq!
-        result
+        result.flatten.uniq
       end
 
       # Returns all expanded paths but only if they exist in the filesystem.


### PR DESCRIPTION
I'm changing the `expanded` method to remove an unnecessary `sort`. This `sort` was called on files from directories in the expanded file path. The `sort` shouldn't matter because the method simply returns all unique values of the expanded file path.

I've also refactored the rest of the code a little bit. In particular, I am using `map` instead of concatenating to an array. 
