### PR TITLE
Throwing a RecordNotFound exception when a record is scanned using the inverse_of option

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -79,8 +79,20 @@ module ActiveRecord
         if block_given?
           load_target.find(*args) { |*block_args| yield(*block_args) }
         else
-          if options[:finder_sql] || options[:inverse_of]
+          if options[:finder_sql]
             find_by_scan(*args)
+          elsif options[:inverse_of]
+            args = args.flatten
+            raise RecordNotFound, "Must specify an id to find" if args.blank?
+
+            result = find_by_scan(*args)
+
+            result_size = Array(result).size
+            if !result || result_size != args.size
+              scope.raise_record_not_found_exception!(args, result_size, args.size)
+            else
+              result
+            end
           else
             scope.find(*args)
           end

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -303,6 +303,24 @@ class InverseHasManyTests < ActiveRecord::TestCase
     assert_equal man.name, man.interests.find(interest.id).man.name, "The name of the man should match after the child name is changed"
   end
 
+  def test_raise_record_not_found_error_when_invalid_ids_are_passed
+    man = Man.create!
+    interest = Interest.create!(man: man)
+
+    invalid_id = 2394823094892348920348523452345
+    assert_raise(ActiveRecord::RecordNotFound) { man.interests.find(invalid_id) }
+
+    invalid_ids = [8432342, 2390102913, 2453245234523452]
+    assert_raise(ActiveRecord::RecordNotFound) { man.interests.find(invalid_ids) }
+  end
+
+  def test_raise_record_not_found_error_when_no_ids_are_passed
+    man = Man.create!
+    interest = Interest.create!(man: man)
+
+    assert_raise(ActiveRecord::RecordNotFound) { man.interests.find() }
+  end
+
   def test_trying_to_use_inverses_that_dont_exist_should_raise_an_error
     assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Man.first.secret_interests }
   end


### PR DESCRIPTION
This issue https://github.com/rails/rails/issues/10019 cropped up after I made the following change: https://github.com/rails/rails/commit/840ca09.  The change makes it so that if the `:inverse_of` option is specified on an association, then ActiveRecord will first check the in-memory association cache for the record before going to the database when `find()` is called. However, this not longer throws a `RecordNotFound` exception.

In this PR, I'm changing the behavior so that `RecordNotFound` is thrown in the correct circumstances. I've also refactored the code in the `FindersMethod` module so that it can be reused in the new check I've made.
