### PR TITLE
Fixes #9654. Revert rendering behavior when format is unknown

### DIFF
--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -6,7 +6,7 @@ module ActionController
 
     # Before processing, set the request formats in current controller formats.
     def process_action(*) #:nodoc:
-      self.formats = request.formats.map { |x| x.ref }
+      self.formats = request.formats.select { |x| !x.nil? }.map(&:ref)
       super
     end
 

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -306,10 +306,14 @@ module Mime
       method.to_s.ends_with? '?'
     end
   end
-  
+
   class NullType
     def nil?
       true
+    end
+
+    def respond_to_missing?(method, include_private = false)
+      method.to_s.ends_with? '?'
     end
 
     private


### PR DESCRIPTION
If a request has unknown format (eg. /foo.bar), the renderer
fallbacks to default format.

This patch reverts Rails 3.2 behavior after c2267db commit.

Fixes issue #9654.
