### PR TITLE
Updated the error message for find to stay consistent across Rails

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -83,7 +83,7 @@ module ActiveRecord
             find_by_scan(*args)
           elsif options[:inverse_of]
             args = args.flatten
-            raise RecordNotFound, "Must specify an id to find" if args.blank?
+            raise RecordNotFound, "Couldn't find #{scope.klass.name} without an ID" if args.blank?
 
             result = find_by_scan(*args)
 

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -305,7 +305,6 @@ class InverseHasManyTests < ActiveRecord::TestCase
 
   def test_raise_record_not_found_error_when_invalid_ids_are_passed
     man = Man.create!
-    interest = Interest.create!(man: man)
 
     invalid_id = 2394823094892348920348523452345
     assert_raise(ActiveRecord::RecordNotFound) { man.interests.find(invalid_id) }
@@ -316,7 +315,6 @@ class InverseHasManyTests < ActiveRecord::TestCase
 
   def test_raise_record_not_found_error_when_no_ids_are_passed
     man = Man.create!
-    interest = Interest.create!(man: man)
 
     assert_raise(ActiveRecord::RecordNotFound) { man.interests.find() }
   end


### PR DESCRIPTION
The `RecordNotFound` error message that is raised when using `find` on an association which has `inverse_of` defined does not match the error message that is thrown for non-inverse-of associations. 

I've changed the error message to stay consistent with the error thrown for `find` without an
inverse_of association.

I also removed some variables that were not needed in the test cases related to the `RecordNotFound` error messages.
