### PR TITLE
Fix regression re: #new with an STI object & complex inheritance

### DIFF
--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -174,7 +174,7 @@ module ActiveRecord
         if subclass_name.present? && subclass_name != self.name
           subclass = subclass_name.safe_constantize
 
-          unless subclasses.include?(subclass)
+          unless descendants.include?(subclass)
             raise ActiveRecord::SubclassNotFound.new("Invalid single-table inheritance type: #{subclass_name} is not a subclass of #{name}")
           end
 

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -194,6 +194,10 @@ class InheritanceTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::SubclassNotFound) { Company.new(:type => 'Account') }
   end
 
+  def test_new_with_complex_inheritance
+    assert_nothing_raised { Client.new(type: 'VerySpecialClient') }
+  end
+
   def test_new_with_autoload_paths
     path = File.expand_path('../../models/autoloadable', __FILE__)
     ActiveSupport::Dependencies.autoload_paths << path


### PR DESCRIPTION
Test case fails on the current master branch, but works on 3-2-stable.

Calling #subclasses [here](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/inheritance.rb#L177) only catches the direct children, which causes creating a new complex subclass to fail.
