### PR TITLE
Add SSE functionality for rails based on AC::Live

### DIFF
--- a/actionpack/lib/action_controller.rb
+++ b/actionpack/lib/action_controller.rb
@@ -2,6 +2,7 @@ require 'active_support/rails'
 require 'abstract_controller'
 require 'action_dispatch'
 require 'action_controller/metal/live'
+require 'action_controller/metal/sse'
 require 'action_controller/metal/strong_parameters'
 
 module ActionController

--- a/actionpack/lib/action_controller/metal/sse.rb
+++ b/actionpack/lib/action_controller/metal/sse.rb
@@ -1,0 +1,178 @@
+require 'securerandom'
+
+module ActionController
+  module ServerSentEvents
+    class << self
+      @@sse_server = nil
+
+      def start_server
+        @@sse_server = SseServer.new()
+        @@sse_server.start
+      end
+
+      def stop_server
+        started_server?
+        @@sse_server.stop
+      end
+
+      def send_sse(sse)
+        started_server?
+        @@sse_server.send_sse(sse)
+      end
+
+      def send_sse_hash(sse_hash)
+        started_server?
+        @@sse_server.send_sse_hash(sse_hash)
+      end
+
+      def subscribe(response)
+        started_server?
+        @@sse_server.subscribe(response)
+      end
+
+      def unsubscribe
+        started_server?
+        @@sse_server.unsubscribe
+      end
+
+      private
+
+      def started_server?
+        unless @@sse_server && @@sse_server.continue_sending
+          raise ArgumentError, "SSE server has not been started. You must call start_sse_server first."
+        end
+      end
+    end
+
+
+    class SseServer
+      OPTIONAL_SSE_FIELDS = [:name, :id, :retry]
+      REQUIRED_SSE_FIELDS = [:data]
+
+      SSE_FIELDS = OPTIONAL_SSE_FIELDS + REQUIRED_SSE_FIELDS
+
+      attr_reader :continue_sending
+
+      def initialize(subscriber = nil)
+        @sse_queue = Queue.new
+        @continue_sending = false
+        @subscriber = subscriber
+      end
+
+      # Sends an sse to the browser. Must be called after start_sse_server
+      # has been called and while the sse server is still running.
+      def send_sse(sse)
+        send_sse_hash(sse.to_payload_hash)
+      end
+
+      def empty_queue?
+        @sse_queue.empty?
+      end
+
+      # Subscribes a response to receive sse's.
+      def subscribe(response)
+        response.headers['Content-Type'] = 'text/event-stream'
+        @subscriber = response
+      end
+
+      # Unsubscribes a response from receiving sse's.
+      def unsubscribe
+        if @subscriber
+          @subscriber.stream.close
+          @subscriber = nil
+        end
+      end
+
+      # Sends a hash of sse options to the browser. Must be in the following
+      # format:
+      #
+      # {:id => id, :name => event_name, :data => sse_data}
+      #
+      # The minimum requirements of the hash are the it contains a :data field.
+      # All other fields are optional.
+      def send_sse_hash(sse_hash)
+        REQUIRED_SSE_FIELDS.each do |field|
+          unless sse_hash[field]
+            raise ArgumentError, "Must send an SSE with a '#{field}' field."
+          end
+        end
+        @sse_queue.push(sse_hash)
+      end
+
+      # Starts the sse server and will begin sending any events that are are
+      # sent via the send_sse method.
+      def start
+        @continue_sending = true
+        Thread.new do
+            while @continue_sending
+              unless empty_queue?
+                payload = @sse_queue.pop
+                stream_sse_payload(payload)
+              end
+            end
+
+            unsubscribe
+          end
+        end
+      end
+
+      # Stops the server from sending any sse events.
+      def stop
+        @continue_sending = false
+      end
+
+      private
+
+      # Sends the sse over the rails server to the browser.
+      def stream_sse_payload(payload)
+        message = convert_payload_to_message(payload)
+
+        begin
+          @subscriber.stream.write(message)
+        rescue IOError
+          # The stream has been closed
+          unsubscribe
+        end
+      end
+
+      # Converts a payload received from an sse notification into an sse
+      # message to be sent over http
+      def convert_payload_to_message(payload)
+        message_array = []
+        SSE_FIELDS.each do |field|
+          if payload[field]
+            value = payload[field]
+          elsif field == :id
+            value = SecureRandom.hex
+          end
+          message_array << "\n#{field}: #{value}"
+        end
+
+        message_array << "\n\n"
+        message_array.join("")
+      end
+    end
+
+    class ServerSentEvent
+      SseServer::SSE_FIELDS.each do |field|
+        attr_reader field
+      end
+
+      def initialize(data, opts = {})
+        @data = data
+        SseServer::SSE_FIELDS.each do |field|
+          instance_variable_set("@#{field}", opts[field])
+        end
+      end
+
+      def to_payload_hash
+        payload = {}
+        SseServer::SSE_FIELDS.each do |field|
+          payload[field] = send(field)
+        end
+
+        payload
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_controller/metal/sse.rb
+++ b/actionpack/lib/action_controller/metal/sse.rb
@@ -8,36 +8,36 @@ module ActionController
     SSE_FIELDS = OPTIONAL_SSE_FIELDS + REQUIRED_SSE_FIELDS
 
     class << self
-      @@sse_server = nil
+      @sse_server = nil
 
       def start_server
-        @@sse_server ||= SseServer.new()
-        @@sse_server.start
+        @sse_server ||= SseServer.new()
+        @sse_server.start
       end
 
       def stop_server
         started_server?
-        @@sse_server.stop
+        @sse_server.stop
       end
 
       def send_sse(sse)
         started_server?
-        @@sse_server.send_sse(sse)
+        @sse_server.send_sse(sse)
       end
 
       def send_sse_hash(sse_hash)
         started_server?
-        @@sse_server.send_sse_hash(sse_hash)
+        @sse_server.send_sse_hash(sse_hash)
       end
 
       def subscribe(response)
         started_server?
-        @@sse_server.subscribe(response)
+        @sse_server.subscribe(response)
       end
 
       def unsubscribe
         started_server?
-        @@sse_server.unsubscribe
+        @sse_server.unsubscribe
       end
 
       private
@@ -60,6 +60,10 @@ module ActionController
 
       # Sends an sse to the browser. Must be called after start_sse_server
       # has been called and while the sse server is still running.
+      #
+      # The input must be an object of class
+      # ActionController::ServerSentEvents::ServerSentEvent
+      # and it must have the +to_payload_hash+ method.
       def send_sse(sse)
         send_sse_hash(sse.to_payload_hash)
       end
@@ -106,7 +110,7 @@ module ActionController
         @continue_sending = true
         Thread.new do
           while @continue_sending
-            unless empty_queue?
+            if @subscriber && !empty_queue?
               payload = @sse_queue.pop
               stream_sse_payload(payload)
             end

--- a/actionpack/lib/action_controller/metal/sse.rb
+++ b/actionpack/lib/action_controller/metal/sse.rb
@@ -1,4 +1,5 @@
 require 'securerandom'
+require 'thread_safe'
 
 module ActionController
 
@@ -47,17 +48,15 @@ module ActionController
     SSE_FIELDS = OPTIONAL_SSE_FIELDS + REQUIRED_SSE_FIELDS
 
     module ClassMethods
-      @@sse_clients = {}
-
       def self.extended(base)
         base.class_exec do
           # the entry point for a Controller level SSE source
           def sse_source
             start_serve self.class.client_list
           end
-        end
 
-        @@sse_clients[base] = []
+          @sse_clients = ThreadSafe::Array.new
+        end
       end
 
       def send_sse(sse)
@@ -79,7 +78,7 @@ module ActionController
       end
 
       def client_list
-        @@sse_clients[self]
+        @sse_clients
       end
     end
 

--- a/actionpack/lib/action_controller/metal/sse.rb
+++ b/actionpack/lib/action_controller/metal/sse.rb
@@ -14,7 +14,7 @@ module ActionController
   # class MySSE < ActionController::Base
   #   include ActionController::Live
   #   include ActionController::ServerSentEvents
-  #   include ActionController::ServerSentEvents::ClassMethods
+  #   extend ActionController::ServerSentEvents::ClassMethods
   # end
   # 
   # in this way, an action named sse_source will be created automaticlly and you 

--- a/actionpack/test/controller/sse_server_test.rb
+++ b/actionpack/test/controller/sse_server_test.rb
@@ -3,11 +3,13 @@ require 'active_support/concurrency/latch'
 
 module ActionController
   class SseServerTest < ActionController::TestCase
+
+    # This is a fake controller used for testing purposes. It contains the
+    # ActionController::ServerSentEvents module, as well as the module it
+    # runs on, ActionController::Live.
     class TestController < ActionController::Base
       include ActionController::Live
       include ActionController::ServerSentEvents
-
-      attr_accessor :latch, :tc
 
       def self.controller_path
         'test'
@@ -25,22 +27,98 @@ module ActionController
       end
     end
 
-    tests TestController
+    # Another fake controller, however, it doesn't contain the module
+    # ActionController::Live.
+    class TestControllerWithoutLive < ActionController::Base
+      include ActionController::ServerSentEvents
 
+      def self.controller_path
+       'test_no_live'
+      end
+
+      def send_an_sse
+        ActionController::ServerSentEvents.start_server
+        ActionController::ServerSentEvents.subscribe(response)
+        ActionController::ServerSentEvents.send_sse_hash({:data => "This is something I'm sending"})
+      end
+    end
+
+    # A test response for sending SSEs over.
     class TestResponse < Live::Response
       def recycle!
         initialize
       end
     end
 
-    def build_response
-      TestResponse.new
-    end
+    tests TestController
 
     def test_text_rendering
       @controller = TestController.new
       get :render_text
       assert_equal 'zomg', @response.body
+    end
+
+    def test_server_sent_event_converts_hash_to_correct_payload
+      data = "I only have 21 dollars in my pocket"
+      name = "sse group"
+      retry_time = "2"
+
+      opts = {:name => name, :retry => retry_time}
+      sse_object = ActionController::ServerSentEvents::ServerSentEvent.new(data, opts)
+
+      assert_equal name, sse_object.name, "Should be able to access sse object's name attribute"
+      assert_equal retry_time, sse_object.retry, "Should be able to access sse object's retry attribute"
+      assert_equal data, sse_object.name, "Should be able to access sse object's data attribute"
+
+      payload = sse_object.to_payload_hash
+      assert_equal 4, payload.size, "The payload hash should contain 4 items"
+      assert_equal name, payload[:name]
+      assert_equal retry_time, payload[:retry]
+      assert_equal data, payload[:data]
+    end
+
+    def test_sse_server_only_sends_data_when_there_is_a_subscriber
+      response = TestResponse.new
+
+      sse_data = "I bet this is awesome, dude"
+      sse_server = ActionController::ServerSentEvents::SseServer.new
+      sse_server.subscribe(response)
+      sse_server.unsubscribe(response)
+      sse_server.send_sse_hash({:data => sse_data})
+
+      assert !sse_server.empty_queue?, "There exists data in the queue, so it shouldn't be empty"
+      sse_server.start
+
+      assert !sse_server.empty_queue?, "There is no subscriber on the queue, so it shouldn't be empty"
+      sse_server.subscribe(response)
+      assert sse_server.empty_queue?, "The server should have sent the sse to the response"
+
+      sleep(0.1)
+      response.stream.close
+      result = response.body
+      assert_match /^data: #{sse_data}$/, result
+    end
+
+    def test_stop_server_sets_continue_sending_variable_to_false
+      sse_server = ActionController::ServerSentEvents::SseServer.new
+      sse_server.start
+
+      assert sse_server.empty_queue?, "Sse server should be initialized with an empty queue"
+      assert sse_server.continue_sending, "Sse server should still be sending data"
+      sse_server.stop
+      assert !sse_server.continue_sending, "Stopping the sse server should stop data from getting sent"
+    end
+
+    def test_send_sses_via_the_server_sent_event_object
+      data = "I only have 21 dollars in my pocket"
+      name = "sse group"
+      retry_time = "2"
+
+      sse_server = ActionController::ServerSentEvents::SseServer.new
+      sse_object = ActionController::ServerSentEvents::ServerSentEvent.new(data, {:name => name, :retry => retry_time})
+
+      assert sse_server.empty_queue?, "Sse server should be initialized with an empty queue"
+      assert
     end
 
     def test_streaming_sses_in_response_stream

--- a/actionpack/test/controller/sse_server_test.rb
+++ b/actionpack/test/controller/sse_server_test.rb
@@ -1,0 +1,71 @@
+require 'abstract_unit'
+require 'active_support/concurrency/latch'
+
+module ActionController
+  class SseServerTest < ActionController::TestCase
+    class TestController < ActionController::Base
+      include ActionController::Live
+      include ActionController::ServerSentEvents
+
+      attr_accessor :latch, :tc
+
+      def self.controller_path
+        'test'
+      end
+
+      def render_text
+        render :text => 'zomg'
+      end
+
+      def send_an_sse
+        ActionController::ServerSentEvents.subscribe(response)
+        ActionController::ServerSentEvents.start_sse_server
+        response.stream.write "hello"
+        ActionController::ServerSentEvents.send_sse_hash({:data => "Hi my name is John."})
+      end
+    end
+
+    tests TestController
+
+    class TestResponse < Live::Response
+      def recycle!
+        initialize
+      end
+    end
+
+    def build_response
+      TestResponse.new
+    end
+
+    def test_text_rendering
+      @controller = TestController.new
+      get :render_text
+      assert_equal 'zomg', @response.body
+    end
+
+    def test_streaming_sses_in_response_stream
+      response = TestResponse.new
+
+      sse_data = "I'm sending an sse!"
+      ActionController::ServerSentEvents.subscribe(response)
+      ActionController::ServerSentEvents.send_sse_hash({:data => sse_data})
+
+      assert !ActionController::ServerSentEvents.empty_queue?
+      ActionController::ServerSentEvents.start_sse_server
+      sleep(1)  # Sleep so that the read queue has enough time to see the data
+      ActionController::ServerSentEvents.stop_sse_server
+
+      response.stream.close
+      assert_equal "\ndata: #{sse_data}\n\n", response.body
+    end
+
+    def test_streaming_sses_through_controller_method
+      @controller = TestController.new
+      get :send_an_sse
+
+      sleep(1)  # Sleep so that the read queue has enough time to see the data
+      response.stream.close
+      assert_equal "hello\ndata: Hi my name is John.\n\n", response.body
+    end
+  end
+end


### PR DESCRIPTION
This class is an initial implementation of HTML5 SSE for rails. Currently we provide 2 kinds of ways to implement a SSE server. The first is controller level SSE, in which we do not distinguish clients and will send data to all the clients that subscribe the same sse source.
The second is client level SSE, which we DO distinguish clients and the data sent to different client can be totally different.
## Controlller level SSE:

``` ruby
class MySSE < ActionController::Base
  include ActionController::Live
  include ActionController::ServerSentEvents
  extend ActionController::ServerSentEvents::ClassMethods
end
```

in this way, an action named `sse_source` will be created automaticlly and you can use `MySSE.send_sse` or `MySSE.send_sse_hash` to send event to all clients that subscribed the sse_source (you should register the action in route.rb manually)
## Client level SSE(Session awared):

``` ruby
class MySSE < ActionController::Base
  include ActionController::Live
  include ActionController::ServerSentEvents

  def event
    start_serve do |sse_client|
      # we can access some session variables here
      sse_client.send_sse sse
      sse_client.send_sse_hash :data => "david"
    end

  end
end
```

Please note that Controller level SSE and Client level SSE are not meant to
work together in the same controller.
