### PR TITLE
DB with postgres string array column doesn't load fixtures well

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -44,6 +44,21 @@ module ActiveRecord
           end
         end
 
+
+        # Inserts the given fixture into the table. 
+        def insert_fixture(fixture, table_name)
+          columns = schema_cache.columns_hash(table_name)
+
+          key_list   = []
+          value_list = fixture.map do |name, value|
+            key_list << quote_column_name(name)
+            [columns[name], value]
+          end
+
+          insert_statement = "INSERT INTO #{quote_table_name(table_name)} (#{key_list.join(", ")}) VALUES (#{key_list.count.times.map{|i| "$#{i+1}" }.join(", ")})"
+          exec_insert(insert_statement, 'Fixture Insert', value_list)
+        end
+
         # Executes a SELECT query and returns an array of rows. Each row is an
         # array of field values.
         def select_rows(sql, name = nil)

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -81,6 +81,12 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
     assert_cycle(['1',nil,nil])
   end
 
+  def test_insert_fixture
+    tag_values = ["val1", "val2", "val3_with_quote_'_char"]
+    @connection.insert_fixture({"tags" => ["val1", "val2", "val3_with_quote_'_char"]}, "pg_arrays" )
+    assert_equal(PgArray.last.tags, tag_values)
+  end
+
   private
   def assert_cycle array
     # test creation


### PR DESCRIPTION
I have a rails4 app that uses a model with a string array column.  When I have a fixture that includes a string with a ' (single-quote) mark I get a syntax error when the fixtures attempt to load.  

To reproduce:

```
git clone https://github.com/cconstantine/wattle.git
cd wattle
bundle install
git checkout -b use_fixtures origin/use_fixtures
rake db:create db:migrate db:test:prepare
rspec
```

You can see an example of the exception output I see at:
https://gist.github.com/cconstantine/d4df1f2b29f92058badc

I've attached a commit that fixes it for me (although master appears to be broken right now).  I'm not sure if that's the best way to approach the problem, but it works for me and doesn't break any tests.  

Thanks
