### PR TITLE
replace #merge with relation API calls in calculations_test.

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -96,25 +96,24 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_should_order_by_grouped_field
-    c = Account.all.merge!(:group => :firm_id, :order => "firm_id").sum(:credit_limit)
+    c = Account.group(:firm_id).order("firm_id").sum(:credit_limit)
     assert_equal [1, 2, 6, 9], c.keys.compact
   end
 
   def test_should_order_by_calculation
-    c = Account.all.merge!(:group => :firm_id, :order => "sum_credit_limit desc, firm_id").sum(:credit_limit)
+    c = Account.group(:firm_id).order("sum_credit_limit desc, firm_id").sum(:credit_limit)
     assert_equal [105, 60, 53, 50, 50], c.keys.collect { |k| c[k] }
     assert_equal [6, 2, 9, 1], c.keys.compact
   end
 
   def test_should_limit_calculation
-    c = Account.all.merge!(:where => "firm_id IS NOT NULL",
-                       :group => :firm_id, :order => "firm_id", :limit => 2).sum(:credit_limit)
+    c = Account.where("firm_id IS NOT NULL").group(:firm_id).order("firm_id").limit(2).sum(:credit_limit)
     assert_equal [1, 2], c.keys.compact
   end
 
   def test_should_limit_calculation_with_offset
-    c = Account.all.merge!(:where => "firm_id IS NOT NULL", :group => :firm_id,
-                       :order => "firm_id", :limit => 2, :offset => 1).sum(:credit_limit)
+    c = Account.where("firm_id IS NOT NULL").group(:firm_id).order("firm_id").
+     limit(2).offset(1).sum(:credit_limit)
     assert_equal [2, 6], c.keys.compact
   end
 
@@ -164,8 +163,7 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_should_group_by_summed_field_having_condition
-    c = Account.all.merge!(:group => :firm_id,
-                       :having => 'sum(credit_limit) > 50').sum(:credit_limit)
+    c = Account.group(:firm_id).having('sum(credit_limit) > 50').sum(:credit_limit)
     assert_nil        c[1]
     assert_equal 105, c[6]
     assert_equal 60,  c[2]
@@ -200,17 +198,15 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_should_group_by_summed_field_with_conditions
-    c = Account.all.merge!(:where => 'firm_id > 1',
-                       :group => :firm_id).sum(:credit_limit)
+    c = Account.where('firm_id > 1').group(:firm_id).sum(:credit_limit)
     assert_nil        c[1]
     assert_equal 105, c[6]
     assert_equal 60,  c[2]
   end
 
   def test_should_group_by_summed_field_with_conditions_and_having
-    c = Account.all.merge!(:where => 'firm_id > 1',
-                       :group => :firm_id,
-                       :having => 'sum(credit_limit) > 60').sum(:credit_limit)
+    c = Account.where('firm_id > 1').group(:firm_id).
+     having('sum(credit_limit) > 60').sum(:credit_limit)
     assert_nil        c[1]
     assert_equal 105, c[6]
     assert_nil        c[2]
@@ -322,7 +318,7 @@ class CalculationsTest < ActiveRecord::TestCase
 
   def test_should_count_scoped_select
     Account.update_all("credit_limit = NULL")
-    assert_equal 0, Account.all.merge!(:select => "credit_limit").count
+    assert_equal 0, Account.select("credit_limit").count
   end
 
   def test_should_count_scoped_select_with_options
@@ -330,11 +326,11 @@ class CalculationsTest < ActiveRecord::TestCase
     Account.last.update_columns('credit_limit' => 49)
     Account.first.update_columns('credit_limit' => 51)
 
-    assert_equal 1, Account.all.merge!(:select => "credit_limit").where('credit_limit >= 50').count
+    assert_equal 1, Account.select("credit_limit").where('credit_limit >= 50').count
   end
 
   def test_should_count_manual_select_with_include
-    assert_equal 6, Account.all.merge!(:select => "DISTINCT accounts.id", :includes => :firm).count
+    assert_equal 6, Account.select("DISTINCT accounts.id").includes(:firm).count
   end
 
   def test_count_with_column_parameter
@@ -366,7 +362,7 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_should_count_field_in_joined_table_with_group_by
-    c = Account.all.merge!(:group => 'accounts.firm_id', :joins => :firm).count('companies.id')
+    c = Account.group('accounts.firm_id').joins(:firm).count('companies.id')
 
     [1,6,2,9].each { |firm_id| assert c.keys.include?(firm_id) }
   end


### PR DESCRIPTION
I was looking at the `#count` implementation trying to resolve some issues. While I did not solve the issues yet I streamlined the calculation_tests to use the Relation API in place of the old hash-syntax using #merge.
