### PR TITLE
write sql queries to terminal

### DIFF
--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -1,10 +1,12 @@
 # Activate the gem you are reporting the issue against.
 gem 'activerecord', '3.2.11'
 require 'active_record'
-require "minitest/autorun"
+require 'minitest/autorun'
+require 'logger'
 
 # This connection will do for database-independent bug reports.
 ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+ActiveRecord::Base.logger = Logger.new(STDOUT)
 
 ActiveRecord::Schema.define do
   create_table :posts do |t|

--- a/guides/bug_report_templates/active_record_master.rb
+++ b/guides/bug_report_templates/active_record_master.rb
@@ -12,10 +12,12 @@ require 'bundler'
 Bundler.setup(:default)
 
 require 'active_record'
-require "minitest/autorun"
+require 'minitest/autorun'
+require 'logger'
 
 # This connection will do for database-independent bug reports.
 ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+ActiveRecord::Base.logger = Logger.new(STDOUT)
 
 ActiveRecord::Schema.define do
   create_table :posts do |t|


### PR DESCRIPTION
For debugging Active Record issues one has to look at queries which are being generated. This PR writes SQL queries to terminal.
