### PR TITLE
Escape multibyte line terminators in JSON encoding

### DIFF
--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -98,6 +98,8 @@ module ActiveSupport
         "\010" =>  '\b',
         "\f"   =>  '\f',
         "\n"   =>  '\n',
+        "\xe2\x80\xa8" => '\u2028',
+        "\xe2\x80\xa9" => '\u2029',
         "\r"   =>  '\r',
         "\t"   =>  '\t',
         '"'    =>  '\"',
@@ -121,9 +123,9 @@ module ActiveSupport
         def escape_html_entities_in_json=(value)
           self.escape_regex = \
             if @escape_html_entities_in_json = value
-              /[\x00-\x1F"\\><&]/
+              /\xe2\x80(\xa8|\xa9)|[\x00-\x1F"\\><&]/
             else
-              /[\x00-\x1F"\\]/
+              /\xe2\x80(\xa8|\xa9)|[\x00-\x1F"\\]/
             end
         end
 


### PR DESCRIPTION
Currently, json/encoding respects the JSON spec (as it should) which disallows \n and \r inside strings, escaping them as expected.

Unfortunately, ECMA-262 (Javascript) disallows not only \n and \r in strings, but "Line Terminators" which includes U+2028 and U+2029. See here: http://bclary.com/2004/11/07/#a-7.3

This pull request adds U+2028 and U+2029 to be escaped.
# Why? 

It's very common to see something like this in a Rails template:

```
<script type="text/javascript"> 
var posts = <%= @posts.to_json %>;
</script>
```

If U+2028 or U+2029 are part of any attributes output in the to_json call, you will end up with an exception. In Chrome: Uncaught SyntaxError: Unexpected token ILLEGAL.

In other words, if one of your users pastes something into a textarea that happens to include these fancy unicode line terminators, and you run to_json on that model and stick it in a template, that page is probably broken now.
# Why not?

This is JSON encoding, and the JSON spec is specific about how to encode strings. U+2028 and U+2029 don't get special treatment.

That being said, this is non-obvious, counterintuitive, and can be tough to debug (https://www.google.com/?q=u2028). 

What do you do in your apps to deal with this? Is there a convention I'm missing?
