### PR TITLE
Avoid calling define_method in CollectionProxy#scope

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -848,10 +848,8 @@ module ActiveRecord
 
       # Returns a <tt>Relation</tt> object for the records in this association
       def scope
-        association = @association
-
-        @association.scope.extending! do
-          define_method(:proxy_association) { association }
+        @association.scope.tap do |scope|
+          scope.proxy_association = @association
         end
       end
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -17,7 +17,7 @@ module ActiveRecord
     include FinderMethods, Calculations, SpawnMethods, QueryMethods, Batches, Explain, Delegation
 
     attr_reader :table, :klass, :loaded
-    attr_accessor :default_scoped
+    attr_accessor :default_scoped, :proxy_association
     alias :model :klass
     alias :loaded? :loaded
     alias :default_scoped? :default_scoped


### PR DESCRIPTION
Calling define_method busts the method cache, which has a major performance penalty. This refactoring avoids that in CollectionProxy#scope.
