### PR TITLE
Cookies refactoring

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -358,7 +358,7 @@ module ActionDispatch
       end
 
       def [](key)
-        @parent_jar[name.to_s]
+        @parent_jar[key.to_s]
       end
 
       def []=(key, options)

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -31,7 +31,7 @@ module ActionDispatch
   #
   #   # Sets a signed cookie, which prevents users from tampering with its value.
   #   # The cookie is signed by your app's <tt>config.secret_key_base</tt> value.
-  #   # It can be read using the signed method <tt>cookies.signed[:key]</tt>
+  #   # It can be read using the signed method <tt>cookies.signed[:name]</tt>
   #   cookies.signed[:user_id] = current_user.id
   #
   #   # Sets a "permanent" cookie (which expires in 20 years from now).
@@ -53,13 +53,13 @@ module ActionDispatch
   #
   # Please note that if you specify a :domain when setting a cookie, you must also specify the domain when deleting the cookie:
   #
-  #  cookies[:key] = {
+  #  cookies[:name] = {
   #    value: 'a yummy cookie',
   #    expires: 1.year.from_now,
   #    domain: 'domain.com'
   #  }
   #
-  #  cookies.delete(:key, domain: 'domain.com')
+  #  cookies.delete(:name, domain: 'domain.com')
   #
   # The option symbols for setting cookies are:
   #
@@ -70,7 +70,7 @@ module ActionDispatch
   #   restrict to the domain level. If you use a schema like www.example.com
   #   and want to share session with user.example.com set <tt>:domain</tt>
   #   to <tt>:all</tt>. Make sure to specify the <tt>:domain</tt> option with
-  #   <tt>:all</tt> again when deleting keys.
+  #   <tt>:all</tt> again when deleting cookies.
   #
   #     domain: nil  # Does not sets cookie domain. (default)
   #     domain: :all # Allow the cookie for the top most level
@@ -280,7 +280,7 @@ module ActionDispatch
 
       # Sets the cookie named +name+. The second argument may be the very cookie
       # value, or a hash of options as documented above.
-      def []=(key, options)
+      def []=(name, options)
         if options.is_a?(Hash)
           options.symbolize_keys!
           value = options[:value]
@@ -291,10 +291,10 @@ module ActionDispatch
 
         handle_options(options)
 
-        if @cookies[key.to_s] != value or options[:expires]
-          @cookies[key.to_s] = value
-          @set_cookies[key.to_s] = options
-          @delete_cookies.delete(key.to_s)
+        if @cookies[name.to_s] != value or options[:expires]
+          @cookies[name.to_s] = value
+          @set_cookies[name.to_s] = options
+          @delete_cookies.delete(name.to_s)
         end
 
         value
@@ -303,24 +303,24 @@ module ActionDispatch
       # Removes the cookie on the client machine by setting the value to an empty string
       # and the expiration date in the past. Like <tt>[]=</tt>, you can pass in
       # an options hash to delete cookies with extra data such as a <tt>:path</tt>.
-      def delete(key, options = {})
-        return unless @cookies.has_key? key.to_s
+      def delete(name, options = {})
+        return unless @cookies.has_key? name.to_s
 
         options.symbolize_keys!
         handle_options(options)
 
-        value = @cookies.delete(key.to_s)
-        @delete_cookies[key.to_s] = options
+        value = @cookies.delete(name.to_s)
+        @delete_cookies[name.to_s] = options
         value
       end
 
       # Whether the given cookie is to be deleted by this CookieJar.
       # Like <tt>[]=</tt>, you can pass in an options hash to test if a
       # deletion applies to a specific <tt>:path</tt>, <tt>:domain</tt> etc.
-      def deleted?(key, options = {})
+      def deleted?(name, options = {})
         options.symbolize_keys!
         handle_options(options)
-        @delete_cookies[key.to_s] == options
+        @delete_cookies[name.to_s] == options
       end
 
       # Removes all cookies on the client machine by calling <tt>delete</tt> for each cookie
@@ -357,11 +357,11 @@ module ActionDispatch
         @options = options
       end
 
-      def [](key)
-        @parent_jar[key.to_s]
+      def [](name)
+        @parent_jar[name.to_s]
       end
 
-      def []=(key, options)
+      def []=(name, options)
         if options.is_a?(Hash)
           options.symbolize_keys!
         else
@@ -369,7 +369,7 @@ module ActionDispatch
         end
 
         options[:expires] = 20.years.from_now
-        @parent_jar[key] = options
+        @parent_jar[name] = options
       end
     end
 
@@ -389,7 +389,7 @@ module ActionDispatch
         end
       end
 
-      def []=(key, options)
+      def []=(name, options)
         if options.is_a?(Hash)
           options.symbolize_keys!
           options[:value] = @verifier.generate(options[:value])
@@ -398,7 +398,7 @@ module ActionDispatch
         end
 
         raise CookieOverflow if options[:value].size > MAX_COOKIE_SIZE
-        @parent_jar[key] = options
+        @parent_jar[name] = options
       end
 
       private
@@ -440,13 +440,13 @@ module ActionDispatch
         @encryptor = ActiveSupport::MessageEncryptor.new(secret, sign_secret)
       end
 
-      def [](key)
-        if encrypted_message = @parent_jar[key]
+      def [](name)
+        if encrypted_message = @parent_jar[name]
           decrypt_and_verify(encrypted_message)
         end
       end
 
-      def []=(key, options)
+      def []=(name, options)
         if options.is_a?(Hash)
           options.symbolize_keys!
         else
@@ -455,7 +455,7 @@ module ActionDispatch
         options[:value] = @encryptor.encrypt_and_sign(options[:value])
 
         raise CookieOverflow if options[:value].size > MAX_COOKIE_SIZE
-        @parent_jar[key] = options
+        @parent_jar[name] = options
       end
 
       private

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -342,7 +342,6 @@ module ActionDispatch
       self.always_write_cookie = false
 
       private
-
         def write_cookie?(cookie)
           @secure || !cookie[:secure] || always_write_cookie
         end
@@ -402,7 +401,6 @@ module ActionDispatch
       end
 
       private
-
         def verify(signed_message)
           @verifier.verify(signed_message)
         rescue ActiveSupport::MessageVerifier::InvalidSignature
@@ -459,7 +457,6 @@ module ActionDispatch
       end
 
       private
-
         def decrypt_and_verify(encrypted_message)
           @encryptor.decrypt_and_verify(encrypted_message)
         rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveSupport::MessageEncryptor::InvalidMessage

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -349,10 +349,15 @@ class CookiesTest < ActionController::TestCase
     assert response.headers["Set-Cookie"] =~ /user_name=david/
   end
 
-  def test_permanent_cookie
+  def test_set_permanent_cookie
     get :set_permanent_cookie
     assert_match(/Jamie/, @response.headers["Set-Cookie"])
     assert_match(%r(#{20.years.from_now.utc.year}), @response.headers["Set-Cookie"])
+  end
+
+  def test_read_permanent_cookie
+    get :set_permanent_cookie
+    assert_equal 'Jamie', @controller.send(:cookies).permanent[:user_name]
   end
 
   def test_signed_cookie


### PR DESCRIPTION
Should be applied after #10059. 

This is a small refactoring to standardize the language we use when talking about cookies. We use `name` and `key` now. @jeremy suggested `name` would be more appropriate, and I agree if for no other reason that we're using the word `key` a lot when talking about the `key_generator`. 

This also snips :scissors: a couple blank lines below `private` to match current Rails style. 
