### PR TITLE
Rename DummyKeyGenerator -> LegacyKeyGenerator

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -428,7 +428,7 @@ module ActionDispatch
       include ChainedCookieJars
 
       def initialize(parent_jar, key_generator, options = {})
-        if ActiveSupport::DummyKeyGenerator === key_generator
+        if ActiveSupport::LegacyKeyGenerator === key_generator
           raise "You didn't set config.secret_key_base, which is required for this cookie jar. " +
             "Read the upgrade documentation to learn more about this new config option."
         end

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -1,5 +1,5 @@
 require 'abstract_unit'
-# FIXME remove DummyKeyGenerator and this require in 4.1
+# FIXME remove LegacyKeyGenerator and this require in 4.1
 require 'active_support/key_generator'
 
 class FlashTest < ActionController::TestCase
@@ -219,7 +219,7 @@ end
 
 class FlashIntegrationTest < ActionDispatch::IntegrationTest
   SessionKey = '_myapp_session'
-  Generator  = ActiveSupport::DummyKeyGenerator.new('b3c631c314c0bbca50c1b2843150fe33')
+  Generator  = ActiveSupport::LegacyKeyGenerator.new('b3c631c314c0bbca50c1b2843150fe33')
 
   class TestController < ActionController::Base
     add_flash_types :bar

--- a/actionpack/test/controller/http_digest_authentication_test.rb
+++ b/actionpack/test/controller/http_digest_authentication_test.rb
@@ -1,5 +1,5 @@
 require 'abstract_unit'
-# FIXME remove DummyKeyGenerator and this require in 4.1
+# FIXME remove LegacyKeyGenerator and this require in 4.1
 require 'active_support/key_generator'
 
 class HttpDigestAuthenticationTest < ActionController::TestCase
@@ -43,7 +43,7 @@ class HttpDigestAuthenticationTest < ActionController::TestCase
   setup do
     # Used as secret in generating nonce to prevent tampering of timestamp
     @secret = "4fb45da9e4ab4ddeb7580d6a35503d99"
-    @request.env["action_dispatch.key_generator"] = ActiveSupport::DummyKeyGenerator.new(@secret)
+    @request.env["action_dispatch.key_generator"] = ActiveSupport::LegacyKeyGenerator.new(@secret)
   end
 
   teardown do

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -7,7 +7,7 @@ rescue LoadError, NameError
   $stderr.puts "Skipping KeyGenerator test: broken OpenSSL install"
 else
 
-# FIXME remove DummyKeyGenerator and this require in 4.1
+# FIXME remove LegacyKeyGenerator and this require in 4.1
 require 'active_support/key_generator'
 require 'active_support/message_verifier'
 
@@ -413,29 +413,29 @@ class CookiesTest < ActionController::TestCase
 
   def test_raises_argument_error_if_missing_secret
     assert_raise(ArgumentError, nil.inspect) {
-      @request.env["action_dispatch.key_generator"] = ActiveSupport::DummyKeyGenerator.new(nil)
+      @request.env["action_dispatch.key_generator"] = ActiveSupport::LegacyKeyGenerator.new(nil)
       get :set_signed_cookie
     }
 
     assert_raise(ArgumentError, ''.inspect) {
-      @request.env["action_dispatch.key_generator"] = ActiveSupport::DummyKeyGenerator.new("")
+      @request.env["action_dispatch.key_generator"] = ActiveSupport::LegacyKeyGenerator.new("")
       get :set_signed_cookie
     }
   end
 
   def test_raises_argument_error_if_secret_is_probably_insecure
     assert_raise(ArgumentError, "password".inspect) {
-      @request.env["action_dispatch.key_generator"] = ActiveSupport::DummyKeyGenerator.new("password")
+      @request.env["action_dispatch.key_generator"] = ActiveSupport::LegacyKeyGenerator.new("password")
       get :set_signed_cookie
     }
 
     assert_raise(ArgumentError, "secret".inspect) {
-      @request.env["action_dispatch.key_generator"] = ActiveSupport::DummyKeyGenerator.new("secret")
+      @request.env["action_dispatch.key_generator"] = ActiveSupport::LegacyKeyGenerator.new("secret")
       get :set_signed_cookie
     }
 
     assert_raise(ArgumentError, "12345678901234567890123456789".inspect) {
-      @request.env["action_dispatch.key_generator"] = ActiveSupport::DummyKeyGenerator.new("12345678901234567890123456789")
+      @request.env["action_dispatch.key_generator"] = ActiveSupport::LegacyKeyGenerator.new("12345678901234567890123456789")
       get :set_signed_cookie
     }
   end

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -1,12 +1,12 @@
 require 'abstract_unit'
 require 'stringio'
-# FIXME remove DummyKeyGenerator and this require in 4.1
+# FIXME remove LegacyKeyGenerator and this require in 4.1
 require 'active_support/key_generator'
 
 class CookieStoreTest < ActionDispatch::IntegrationTest
   SessionKey = '_myapp_session'
   SessionSecret = 'b3c631c314c0bbca50c1b2843150fe33'
-  Generator = ActiveSupport::DummyKeyGenerator.new(SessionSecret)
+  Generator = ActiveSupport::LegacyKeyGenerator.new(SessionSecret)
 
   Verifier = ActiveSupport::MessageVerifier.new(SessionSecret, :digest => 'SHA1')
   SignedBar = Verifier.generate(:foo => "bar", :session_id => SecureRandom.hex(16))

--- a/activesupport/lib/active_support/key_generator.rb
+++ b/activesupport/lib/active_support/key_generator.rb
@@ -39,7 +39,7 @@ module ActiveSupport
     end
   end
 
-  class DummyKeyGenerator # :nodoc:
+  class LegacyKeyGenerator # :nodoc:
     SECRET_MIN_LENGTH = 30 # Characters
 
     def initialize(secret)

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -1,6 +1,6 @@
 require 'fileutils'
 require 'active_support/core_ext/object/blank'
-# FIXME remove DummyKeyGenerator and this require in 4.1
+# FIXME remove LegacyKeyGenerator and this require in 4.1
 require 'active_support/key_generator'
 require 'rails/engine'
 
@@ -112,7 +112,7 @@ module Rails
           key_generator = ActiveSupport::KeyGenerator.new(config.secret_key_base, iterations: 1000)
           ActiveSupport::CachingKeyGenerator.new(key_generator)
         else
-          ActiveSupport::DummyKeyGenerator.new(config.secret_token)
+          ActiveSupport::LegacyKeyGenerator.new(config.secret_token)
         end
       end
     end

--- a/railties/test/application/middleware/remote_ip_test.rb
+++ b/railties/test/application/middleware/remote_ip_test.rb
@@ -1,5 +1,5 @@
 require 'isolation/abstract_unit'
-# FIXME remove DummyKeyGenerator and this require in 4.1
+# FIXME remove LegacyKeyGenerator and this require in 4.1
 require 'active_support/key_generator'
 
 module ApplicationTests
@@ -10,7 +10,7 @@ module ApplicationTests
       remote_ip = nil
       env = Rack::MockRequest.env_for("/").merge(env).merge!(
         'action_dispatch.show_exceptions' => false,
-        'action_dispatch.key_generator'   => ActiveSupport::DummyKeyGenerator.new('b3c631c314c0bbca50c1b2843150fe33')
+        'action_dispatch.key_generator'   => ActiveSupport::LegacyKeyGenerator.new('b3c631c314c0bbca50c1b2843150fe33')
       )
 
       endpoint = Proc.new do |e|


### PR DESCRIPTION
I don't think "dummy" isn't a very descriptive name. I've settled on "legacy" to refer to signed stuff generated by Rails 3.x in the work I did on #9740 and #9909 . I'm open to other names, but I'd like to move away from "dummy".
