### PR TITLE
Replace string eval with alternatives

### DIFF
--- a/activesupport/lib/active_support/configurable.rb
+++ b/activesupport/lib/active_support/configurable.rb
@@ -1,6 +1,7 @@
 require 'active_support/concern'
 require 'active_support/ordered_options'
 require 'active_support/core_ext/array/extract_options'
+require 'active_support/core_ext/module/delegation'
 
 module ActiveSupport
   # Configurable provides a <tt>config</tt> method to store and retrieve

--- a/activesupport/lib/active_support/configurable.rb
+++ b/activesupport/lib/active_support/configurable.rb
@@ -16,9 +16,9 @@ module ActiveSupport
       # Compiles reader methods so we don't have to go through method_missing.
       def self.compile_methods!(keys)
         keys.reject { |m| method_defined?(m) }.each do |key|
-          class_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def #{key}; _get(#{key.inspect}); end
-          RUBY
+          class_exec do
+            define_method(key) { _get(key) }
+          end
         end
       end
     end
@@ -109,15 +109,13 @@ module ActiveSupport
         names.each do |name|
           raise NameError.new('invalid config attribute name') unless name =~ /^[_A-Za-z]\w*$/
 
-          reader, reader_line = "def #{name}; config.#{name}; end", __LINE__
-          writer, writer_line = "def #{name}=(value); config.#{name} = value; end", __LINE__
-
-          singleton_class.class_eval reader, __FILE__, reader_line
-          singleton_class.class_eval writer, __FILE__, writer_line
+          singleton_class.class_exec do
+            delegate name, "#{name}=", to: :config
+          end
 
           unless options[:instance_accessor] == false
-            class_eval reader, __FILE__, reader_line unless options[:instance_reader] == false
-            class_eval writer, __FILE__, writer_line unless options[:instance_writer] == false
+            delegate name, to: :config unless options[:instance_reader] == false
+            delegate "#{name}=", to: :config unless options[:instance_writer] == false
           end
           send("#{name}=", yield) if block_given?
         end
@@ -144,4 +142,3 @@ module ActiveSupport
     end
   end
 end
-

--- a/activesupport/lib/active_support/core_ext/logger.rb
+++ b/activesupport/lib/active_support/core_ext/logger.rb
@@ -7,14 +7,14 @@ ActiveSupport::Deprecation.warn 'this file is deprecated and will be removed'
 # Adds the 'around_level' method to Logger.
 class Logger #:nodoc:
   def self.define_around_helper(level)
-    module_eval <<-end_eval, __FILE__, __LINE__ + 1
-      def around_#{level}(before_message, after_message)  # def around_debug(before_message, after_message, &block)
-        self.#{level}(before_message)                     #   self.debug(before_message)
-        return_value = yield(self)                        #   return_value = yield(self)
-        self.#{level}(after_message)                      #   self.debug(after_message)
-        return_value                                      #   return_value
-      end                                                 # end
-    end_eval
+    module_exec do
+      define_method("around_#{level}") do |before_message, after_message|  # def around_debug(before_message, after_message, &block)
+        public_send(level, before_message)                                 #   self.debug(before_message)
+        return_value = yield(self)                                         #   return_value = yield(self)
+        public_send(level, after_message)                                  #   self.debug(after_message)
+        return_value                                                       #   return_value
+      end                                                                  # end
+    end
   end
   [:debug, :info, :error, :fatal].each {|level| define_around_helper(level) }
 end

--- a/activesupport/lib/active_support/core_ext/module/aliasing.rb
+++ b/activesupport/lib/active_support/core_ext/module/aliasing.rb
@@ -60,10 +60,10 @@ class Module
   #   e.subject = "Megastars"
   #   e.title    # => "Megastars"
   def alias_attribute(new_name, old_name)
-    module_eval <<-STR, __FILE__, __LINE__ + 1
-      def #{new_name}; self.#{old_name}; end          # def subject; self.title; end
-      def #{new_name}?; self.#{old_name}?; end        # def subject?; self.title?; end
-      def #{new_name}=(v); self.#{old_name} = v; end  # def subject=(v); self.title = v; end
-    STR
+    module_exec do
+      define_method(new_name) { send(old_name) }                     # def subject; self.title; end
+      define_method("#{new_name}?") { send("#{old_name}?") }         # def subject?; self.title?; end
+      define_method("#{new_name}=") { |v| send("#{old_name}=", v) }  # def subject=(v); self.title = v; end
+    end
   end
 end

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -172,16 +172,16 @@ module ActiveSupport #:nodoc:
 
     UNSAFE_STRING_METHODS.each do |unsafe_method|
       if 'String'.respond_to?(unsafe_method)
-        class_eval <<-EOT, __FILE__, __LINE__ + 1
-          def #{unsafe_method}(*args, &block)       # def capitalize(*args, &block)
-            to_str.#{unsafe_method}(*args, &block)  #   to_str.capitalize(*args, &block)
-          end                                       # end
+        class_exec do
+          define_method(unsafe_method) do |*args, &block|     # def capitalize(*args, &block)
+            to_str.public_send(unsafe_method, *args, &block)  #   to_str.capitalize(*args, &block)
+          end                                                 # end
 
-          def #{unsafe_method}!(*args)              # def capitalize!(*args)
-            @html_safe = false                      #   @html_safe = false
-            super                                   #   super
-          end                                       # end
-        EOT
+          define_method("#{unsafe_method}!") do |*args|       # def capitalize!(*args)
+            @html_safe = false                                #   @html_safe = false
+            super(*args)                                      #   super
+          end                                                 # end
+        end
       end
     end
   end

--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -118,13 +118,7 @@ module ActiveSupport
 
   protected
 
-    %w(info debug warn error fatal unknown).each do |level|
-      class_eval <<-METHOD, __FILE__, __LINE__ + 1
-        def #{level}(progname = nil, &block)
-          logger.#{level}(progname, &block) if logger
-        end
-      METHOD
-    end
+    delegate :info, :debug, :warn, :error, :fatal, :unknown, to: :logger
 
     # Set color by using a string or one of the defined constants. If a third
     # option is set to +true+, it also adds bold to the string. This is based

--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/module/attribute_accessors'
 require 'active_support/core_ext/class/attribute'
+require 'active_support/core_ext/module/delegation'
 
 module ActiveSupport
   # ActiveSupport::LogSubscriber is an object set to consume
@@ -118,7 +119,7 @@ module ActiveSupport
 
   protected
 
-    delegate :info, :debug, :warn, :error, :fatal, :unknown, to: :logger
+    delegate :info, :debug, :warn, :error, :fatal, :unknown, to: :logger, allow_nil: true
 
     # Set color by using a string or one of the defined constants. If a third
     # option is set to +true+, it also adds bold to the string. This is based

--- a/activesupport/lib/active_support/log_subscriber/test_helper.rb
+++ b/activesupport/lib/active_support/log_subscriber/test_helper.rb
@@ -78,11 +78,11 @@ module ActiveSupport
         end
 
         ActiveSupport::Logger::Severity.constants.each do |severity|
-          class_eval <<-EOT, __FILE__, __LINE__ + 1
-            def #{severity.downcase}?
-              #{severity} >= @level
+          class_exec do
+            define_method("#{severity.downcase}?") do
+              self.class.const_get(severity) >= @level
             end
-          EOT
+          end
         end
       end
 

--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -328,12 +328,12 @@ module ActiveSupport
 
         # Lazy load the Unicode database so it's only loaded when it's actually used
         ATTRIBUTES.each do |attr_name|
-          class_eval(<<-EOS, __FILE__, __LINE__ + 1)
-            def #{attr_name}     # def codepoints
-              load               #   load
-              @#{attr_name}      #   @codepoints
-            end                  # end
-          EOS
+          class_exec do
+            define_method(attr_name) do               # def codepoints
+              load                                    #   load
+              instance_variable_get("@#{attr_name}")  #   @codepoints
+            end                                       # end
+          end
         end
 
         # Loads the Unicode database and returns all the internal objects of

--- a/activesupport/lib/active_support/testing/declarative.rb
+++ b/activesupport/lib/active_support/testing/declarative.rb
@@ -7,11 +7,9 @@ module ActiveSupport
 
           unless method_defined?(:describe)
             def self.describe(text)
-              class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
-                def self.name
-                  "#{text}"
-                end
-              RUBY_EVAL
+              define_singleton_method(name) do
+                text
+              end
             end
           end
 

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -1,5 +1,6 @@
 require 'active_support/values/time_zone'
 require 'active_support/core_ext/object/acts_like'
+require 'active_support/core_ext/module/delegation'
 
 module ActiveSupport
   # A Time-like class that can represent a time in any time zone. Necessary
@@ -292,13 +293,7 @@ module ActiveSupport
       end
     end
 
-    %w(year mon month day mday wday yday hour min sec to_date).each do |method_name|
-      class_eval <<-EOV, __FILE__, __LINE__ + 1
-        def #{method_name}    # def month
-          time.#{method_name} #   time.month
-        end                   # end
-      EOV
-    end
+    delegate :year, :mon, :month, :day, :mday, :wday, :yday, :hour, :min, :sec, :to_date, to: :time
 
     def usec
       time.respond_to?(:usec) ? time.usec : 0


### PR DESCRIPTION
Similar to @tenderlove's ed9e3f699ab3fac01ad9ef038847d1cdd4c9f063, this pull request swaps out `class_eval` of strings for dynamic methods, and replaces it using either `define_method` or `delegate`.

I originally wrote this in January, for use in RubyMotion which doesn't support string eval. I didn't create a PR because at the time it seemed the preference was to use string eval when generating dynamic methods. If this is no longer the case, then perhaps there is interest in these changes.

This PR leaves `callbacks.rb` and `core_ext/module/delegation.rb` untouched. Rewriting their use of string eval would cause the code to be quite a bit less readable.

I ran the tests using ruby 2.0.0p0.
