### PR TITLE
Added test for Array#to_formatted_s

### DIFF
--- a/activesupport/test/core_ext/array_ext_test.rb
+++ b/activesupport/test/core_ext/array_ext_test.rb
@@ -30,6 +30,19 @@ class ArrayExtAccessTests < ActiveSupport::TestCase
   end
 end
 
+class ArrayExtToFormattedS < ActiveSupport::TestCase
+  def test_to_formatted_default
+    collection = [
+      Class.new { def id() 1 end; def to_s() 'First Object' end }.new,
+      Class.new { def id() 2 end; def to_s() 'Second Object' end }.new,
+      Class.new { def id() 3 end; def to_s() 'Third Object' end }.new,
+   ]
+
+    assert_equal 'First ObjectSecond ObjectThird Object', collection.to_formatted_s
+    assert_equal "1,2,3", collection.to_formatted_s(:db)
+  end
+end
+
 class ArrayExtToParamTests < ActiveSupport::TestCase
   class ToParam < String
     def to_param


### PR DESCRIPTION
Behavior different from the contents currently written to rdoc is carried out. 

> Blog.all.map(&:title) #=> ["First Post", "Second Post", "Third post"]
> 
> `to_formatted_s` shows us:
> 
>   Blog.all.to_formatted_s # => "First PostSecond PostThird Post"

But, wrote test code is fails.

>  1) Failure:
> ArrayExtToFormattedS#test_to_formatted_default [/Users/eiel/src/rails/activesupp
> ort/test/core_ext/array_ext_test.rb:41]:
> --- expected
> +++ actual
> @@ -1 +1 @@
> -"First ObjectSecond ObjectThird Object"
> +"[#<#Class:0xXXXXXX:0xXXXXXX>, #<#Class:0xXXXXXX:0xXXXXXX>, #<#Class:0xXXXXXX:0xXXXXXX>]"

As the simplistic solution thought of: 

``` diff
diff --git a/activesupport/lib/active_support/core_ext/array/conversions.rb b/activesupport/lib/active_support/core_ext/array/conversions.rb
index 430a35f..500cb73 100644
--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -108,7 +108,7 @@ class Array
         collect { |element| element.id }.join(',')
       end
     else
-      to_default_s
+      collect { |element| element.to_s }.join
     end
   end
   alias_method :to_default_s, :to_s
```

Influence seems to be great to others. 
First of all, please let me know what kind of behavior is right. 
