### PR TITLE
Avoid running bundler on tests that don't need it

### DIFF
--- a/railties/lib/rails/generators/testing/behaviour.rb
+++ b/railties/lib/rails/generators/testing/behaviour.rb
@@ -61,7 +61,10 @@ module Rails
         # You can provide a configuration hash as second argument. This method returns the output
         # printed by the generator.
         def run_generator(args=self.default_arguments, config={})
-          capture(:stdout) { self.generator_class.start(args, config.reverse_merge(destination_root: destination_root)) }
+          capture(:stdout) do
+            args += ['--skip-bundle'] unless args.include? '--dev'
+            self.generator_class.start(args, config.reverse_merge(destination_root: destination_root))
+          end
         end
 
         # Instantiate the generator.


### PR DESCRIPTION
#### Railties test timings on Intel(R) Core(TM) i3 CPU 550  @ 3.20GHz

Before: 18m19.854s
After: 8m57.653s
