### PR TITLE
fix regression in Mapper when `format:` was used in a `scope`.

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -58,8 +58,8 @@ module ActionDispatch
           @set, @scope, @path, @options = set, scope, path, options
           @requirements, @conditions, @defaults = {}, {}, {}
 
-          normalize_path!
           normalize_options!
+          normalize_path!
           normalize_requirements!
           normalize_conditions!
           normalize_defaults!

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1102,6 +1102,28 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal 'projects#index', @response.body
   end
 
+  def test_scope_with_format_option
+    draw do
+      get "direct/index", as: :no_format_direct, format: false
+
+      scope format: false do
+        get "scoped/index", as: :no_format_scoped
+      end
+    end
+
+    assert_equal "/direct/index", no_format_direct_path
+    assert_equal "/direct/index?format=html", no_format_direct_path(format: "html")
+
+    assert_equal "/scoped/index", no_format_scoped_path
+    assert_equal "/scoped/index?format=html", no_format_scoped_path(format: "html")
+
+    get '/scoped/index'
+    assert_equal "scoped#index", @response.body
+
+    get '/scoped/index.html'
+    assert_equal "Not Found", @response.body
+  end
+
   def test_index
     draw do
       get '/info' => 'projects#info', :as => 'info'


### PR DESCRIPTION
Closes #10071

`#normalize_path!` depends on the options so we need to call `#normalize_options!` first to make sure everything is set correctly.

I did not add a CHANGELOG entry as it fixes a regression only present in master. Let me know if I should put one in anyways.
