### PR TITLE
update the guides to reflect the new `rails test` command

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -300,6 +300,17 @@ irb(main):001:0>
 
 INFO: You can also use the alias "db" to invoke the dbconsole: `rails db`.
 
+### `rails test`
+
+INFO: A good description of unit testing in Rails is given in
+[A Guide to Testing Rails Applications](testing.html)
+
+Rails comes with a test suite called `Test::Unit`. Rails owes its stability to
+the use of tests. The `rails test` command helps in running the different tests
+you will hopefully write. The
+[commands section in the testing guide](testing.html#commands-to-run-your-tests)
+describes `rails test` in depth.
+
 ### `rails runner`
 
 `runner` runs Ruby code in the context of Rails non-interactively. For instance:
@@ -460,9 +471,9 @@ rspec/model/user_spec.rb:
 
 ### `test`
 
-INFO: A good description of unit testing in Rails is given in [A Guide to Testing Rails Applications](testing.html)
-
-Rails comes with a test suite called `Test::Unit`. Rails owes its stability to the use of tests. The tasks available in the `test:` namespace helps in running the different tests you will hopefully write.
+See the
+[commands section in the testing guide](testing.html#commands-to-run-your-tests)
+for a summary of available tasks.
 
 ### `tmp`
 

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -754,7 +754,7 @@ class UserFlowsTest < ActionDispatch::IntegrationTest
 end
 ```
 
-Rake Tasks for Running your Tests
+Commands to Run your Tests
 ---------------------------------
 
 You don't need to set up and run your tests by hand on a test-by-test basis. Rails comes with a number of commands to help in testing. The table below lists all commands that come along in the default Rakefile when you initiate a Rails project.

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -994,9 +994,18 @@ Other Testing Approaches
 
 The built-in `test/unit` based testing is not the only way to test Rails applications. Rails developers have come up with a wide variety of other approaches and aids for testing, including:
 
-* [NullDB](http://avdi.org/projects/nulldb/), a way to speed up testing by avoiding database use.
-* [Factory Girl](https://github.com/thoughtbot/factory_girl/tree/master), a replacement for fixtures.
-* [Machinist](https://github.com/notahat/machinist/tree/master), another replacement for fixtures.
-* [MiniTest::Spec Rails](https://github.com/metaskills/minitest-spec-rails), use the MiniTest::Spec DSL within your rails tests.
-* [Shoulda](http://www.thoughtbot.com/projects/shoulda), an extension to `test/unit` with additional helpers, macros, and assertions.
-* [RSpec](http://relishapp.com/rspec), a behavior-driven development framework
+* [NullDB](http://avdi.org/projects/nulldb/), a way to speed up
+  testing by avoiding database use.
+* [Factory Girl](https://github.com/thoughtbot/factory_girl), a
+  replacement for fixtures.
+* [Machinist](https://github.com/notahat/machinist), another
+  replacement for fixtures.
+* [MiniTest::Spec Rails](https://github.com/metaskills/minitest-spec-rails),
+  use the MiniTest::Spec DSL within your rails tests.
+* [Shoulda](https://github.com/thoughtbot/shoulda), an extension to
+  `test/unit` and `rspec` with additional helpers, macros, and
+  assertions.
+* [RSpec](http://relishapp.com/rspec), a behavior-driven development
+  framework
+* [Mocha](https://github.com/freerange/mocha), a mocking and stubbing
+  library for Ruby


### PR DESCRIPTION
There were a few sections in the guides that still mentioned the rake tasks to run the tests. I updated them to reference the new `rails test` command and added some links to the testing guide.

Also while I was at it I reconditioned the references section in the testing guide.
