### PR TITLE
Remove comments about removing LegacyKeyGenerator in 4.1

### DIFF
--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -1,5 +1,4 @@
 require 'abstract_unit'
-# FIXME remove LegacyKeyGenerator and this require in 4.1
 require 'active_support/key_generator'
 
 class FlashTest < ActionController::TestCase

--- a/actionpack/test/controller/http_digest_authentication_test.rb
+++ b/actionpack/test/controller/http_digest_authentication_test.rb
@@ -1,5 +1,4 @@
 require 'abstract_unit'
-# FIXME remove LegacyKeyGenerator and this require in 4.1
 require 'active_support/key_generator'
 
 class HttpDigestAuthenticationTest < ActionController::TestCase

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -7,7 +7,6 @@ rescue LoadError, NameError
   $stderr.puts "Skipping KeyGenerator test: broken OpenSSL install"
 else
 
-# FIXME remove LegacyKeyGenerator and this require in 4.1
 require 'active_support/key_generator'
 require 'active_support/message_verifier'
 

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -1,6 +1,5 @@
 require 'abstract_unit'
 require 'stringio'
-# FIXME remove LegacyKeyGenerator and this require in 4.1
 require 'active_support/key_generator'
 
 class CookieStoreTest < ActionDispatch::IntegrationTest

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -1,6 +1,5 @@
 require 'fileutils'
 require 'active_support/core_ext/object/blank'
-# FIXME remove LegacyKeyGenerator and this require in 4.1
 require 'active_support/key_generator'
 require 'rails/engine'
 

--- a/railties/test/application/middleware/remote_ip_test.rb
+++ b/railties/test/application/middleware/remote_ip_test.rb
@@ -1,5 +1,4 @@
 require 'isolation/abstract_unit'
-# FIXME remove LegacyKeyGenerator and this require in 4.1
 require 'active_support/key_generator'
 
 module ApplicationTests


### PR DESCRIPTION
We have a deprecation warning in place if you set only `secret_token`, so that should alleviate any concerns we have about security here. 

https://github.com/rails/rails/blob/master/railties/lib/rails/application.rb#L138-L147

People will be nagged into setting `secret_key_base`. Leaving `secret_token` set causes no harm, and its presence allows for a smooth transition from Rails 3.x to 4.x. 

I propose that we leave `LegacyKeyGenerator` around beyond version 4.0.x. 

I suspect that latecomers will attempt to upgrade from 3.x to whatever the most recent 4.x version happens to be. If we remove `LegacyKeyGenerator`, then people attempting to upgrade from 3.x to >= 4.1 won't be able to preserve their existing signed cookies and cookie-based sessions. 
