### PR TITLE
Hstore columns should always be saved, if changed or not

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -12,6 +12,9 @@ module ActiveRecord
           raise "You cannot include Dirty after Timestamp"
         end
 
+        class_attribute :dirty_attribute_names, instance_accessor: false
+        self.dirty_attribute_names = Set.new
+
         class_attribute :partial_writes, instance_writer: false
         self.partial_writes = true
 
@@ -81,7 +84,7 @@ module ActiveRecord
       # Serialized attributes should always be written in case they've been
       # changed in place.
       def keys_for_partial_write
-        changed | (attributes.keys & self.class.serialized_attributes.keys)
+        changed | (attributes.keys & self.class.serialized_attributes.keys) | (attributes.keys & self.class.dirty_attribute_names.to_a)
       end
 
       def _field_changed?(attr, old, value)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -213,6 +213,8 @@ module ActiveRecord
         end
 
         class Hstore < Type
+          def dirty?; true; end
+
           def type_cast(value)
             return if value.nil?
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -129,6 +129,10 @@ module ActiveRecord
         end
       end
 
+      def dirty?
+        !!@oid_type.try(:dirty?)
+      end
+
       def type_cast(value)
         return if value.nil?
         return super if encoded?

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -231,6 +231,9 @@ module ActiveRecord
           if create_time_zone_conversion_attribute?(name, col)
             columns_hash[name] = AttributeMethods::TimeZoneConversion::Type.new(col)
           end
+          if col.try(:dirty?)
+            dirty_attribute_names << name
+          end
         end
 
         columns_hash

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -40,6 +40,19 @@ class PostgresqlHstoreTest < ActiveRecord::TestCase
     assert @connection.extensions.include?('hstore'), "extension list should include hstore"
   end
 
+  def test_updating_key
+    x = Hstore.create! :tags => { "key1" => "old value 1", "key2" => "old value 2" }
+    x.reload
+    assert_equal "old value 1", x.tags["key1"]
+
+    # Nothing gets saved/updated here.
+    x.tags["key1"] = "new"
+    x.save!
+
+    assert_equal "new", x.reload.tags["key1"]
+    assert_equal "old value 2",   x.reload.tags["key2"]
+  end
+
   def test_disable_enable_hstore
     assert @connection.extension_enabled?('hstore')
     @connection.disable_extension 'hstore'


### PR DESCRIPTION
According to issue: https://github.com/rails/rails/issues/6127 changes to Hstore columns were not saved unless marked with ***_will_change!**. This Pull Request is going to fix that by introducing a list of columns that should always be saved if their were changed or not. 

**dirty_attribute_names** is a class variable added to **dirty.rb**.
If a column name will be added to that list all then AR will always update that attribute. 

Potentially the **serialized_attributes** may be managed with **dirty_attribute_names** so we can have only one way to deal with those things. 

Tested over ruby-2.0.0-p0 and postgresql 9.2.3.
