### PR TITLE
Fix some railties test warnings

### DIFF
--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -53,10 +53,9 @@ module ActiveSupport
 
     class << self
       def logger
-        if defined?(Rails) && Rails.respond_to?(:logger)
-          @logger ||= Rails.logger
+        @logger ||= if defined?(Rails) && Rails.respond_to?(:logger)
+          Rails.logger
         end
-        @logger
       end
 
       attr_writer :logger

--- a/railties/test/generators/plugin_new_generator_test.rb
+++ b/railties/test/generators/plugin_new_generator_test.rb
@@ -124,7 +124,7 @@ class PluginNewGeneratorTest < Rails::Generators::TestCase
     run_generator [destination_root, "--skip_active_record"]
     assert_no_file "test/dummy/config/database.yml"
     assert_file "test/test_helper.rb" do |contents|
-      assert_no_match /ActiveRecord/, contents
+      assert_no_match(/ActiveRecord/, contents)
     end
   end
 


### PR DESCRIPTION
Fix some railties test warnings
1. Initialize variable
2. Encapsulate variable in ()
