### PR TITLE
Improve AdapterNotSpecified error message

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_specification.rb
@@ -44,7 +44,7 @@ module ActiveRecord
         def resolve_hash_connection(spec) # :nodoc:
           spec = spec.symbolize_keys
 
-          raise(AdapterNotSpecified, "database configuration does not specify adapter") unless spec.key?(:adapter)
+          raise(AdapterNotSpecified, "database configuration '#{spec[:database]}' does not specify adapter") unless spec.key?(:adapter)
 
           begin
             require "active_record/connection_adapters/#{spec[:adapter]}_adapter"


### PR DESCRIPTION
Add the name of the database to the AdapterNotSpecified error message in resolve_hash_connection.  If you're connecting to multiple databases, it can be seriously crazy-making to not know which one the error is referring to.  This will help.
