### PR TITLE
Model generator USAGE doc improvement

### DIFF
--- a/railties/lib/rails/generators/rails/model/USAGE
+++ b/railties/lib/rails/generators/rails/model/USAGE
@@ -52,20 +52,26 @@ Available field types:
 
         `rails generate model product supplier:references{polymorphic}`
 
-    You can also specify some options just after the field type. You can use the
-    following options:
-
-        limit        Set the maximum size of the field giving a number between curly braces
-        default      Set a default value for the field
-        precision    Defines the precision for the decimal fields
-        scale        Defines the scale for the decimal fields
-        uniq         Defines the field values as unique
-        index        Will add an index on the field
-
-    Examples:
+    For integer, string, text and binary fields an integer in curly braces will
+    be set as the limit:
 
         `rails generate model user pseudo:string{30}`
+
+    For decimal two integers separated by a comma in curly braces will be used
+    for precision and scale:
+
+        `rails generate model product price:decimal{10,2}`
+
+    You can add a `:uniq` or `:index` suffix for unique or standard indexes
+    respectively:
+
         `rails generate model user pseudo:string:uniq`
+        `rails generate model user pseudo:string:index`
+
+    You can combine any single curly brace option with the index options:
+
+        `rails generate model user username:string{30}:uniq`
+        `rails generate model product supplier:references{polymorphic}:index`
 
 
 Examples:


### PR DESCRIPTION
This started with me noticing that the `default` option mentioned in the help docs for `rails g model` didn't actually work.  I removed that, and improved the docs for the other options:
- Added information about syntax for precision/scale of decimals
- Removed incorrect information about being able to set `default`
- Added more examples of usage
