### PR TITLE
Exclude template files for rdoc API [ci skip]

### DIFF
--- a/railties/lib/rails/api/task.rb
+++ b/railties/lib/rails/api/task.rb
@@ -57,7 +57,8 @@ module Rails
             CHANGELOG.md
             MIT-LICENSE
             lib/**/*.rb
-          )
+          ),
+          :exclude => 'lib/rails/generators/rails/**/templates/**/*.rb'
         }
       }
 


### PR DESCRIPTION
To Avoid this http://edgeapi.rubyonrails.org/files/railties/lib/rails/generators/rails/app/templates/app/helpers/application_helper_rb.html
