### PR TITLE
Correctly parse bigint defaults in PostgreSQL

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Default values for PostgreSQL bigint types now get parsed and dumped to the
+    schema correctly.
+
+    *Erik Peterson*
+
 *   `has_many` using `:through` now obeys the order clause mentioned in
     through association. Fixes #10016.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -80,7 +80,7 @@ module ActiveRecord
           when /\A'(.*)'::(num|date|tstz|ts|int4|int8)range\z/m
             $1
           # Numeric types
-          when /\A\(?(-?\d+(\.\d*)?\)?)\z/
+          when /\A\(?(-?\d+(\.\d*)?\)?(::bigint)?)\z/
             $1
           # Character types
           when /\A\(?'(.*)'::.*\b(?:character varying|bpchar|text)\z/m

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -242,6 +242,11 @@ class SchemaDumperTest < ActiveRecord::TestCase
   end
 
   if current_adapter?(:PostgreSQLAdapter)
+    def test_schema_dump_includes_bigint_default
+      output = standard_dump
+      assert_match %r{t.integer\s+"bigint_default",\s+limit: 8,\s+default: 0}, output
+    end
+
     def test_schema_dump_includes_extensions
       connection = ActiveRecord::Base.connection
       skip unless connection.supports_extensions?

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define do
     char3 text default 'a text field',
     positive_integer integer default 1,
     negative_integer integer default -1,
+    bigint_default bigint default 0::bigint,
     decimal_number decimal(3,2) default 2.78,
     multiline_default text DEFAULT '--- []
 


### PR DESCRIPTION
In Postgres, if you have a bigint column with a default value, ActiveRecord would fail to parse to default value correctly and would ignore it. The value coming out of the schema select statement was a typecasted value such as "(0)::bigint". No check was made for such a typecasted value in the default extraction code.

The main consequence of the bug (and how I discovered it) is through schema dumping. A test case is included that covers this issue. Let me know if a test closer to the root cause is required.
