### PR TITLE
Fix explicit names on multiple file fields

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## unreleased ##
 
+*   Fix explicit names on multiple file fields. If a file field tag is passed
+    the multiple option, it is turned into an array field (appending `[]`),
+    but if the file field is passed an explicit name as an option, leave the
+    name alone (do not append `[]`).  Fixes #9830
+
+    *Ryan McGeary*
+
 *   Fix assets loading performance in 3.2.13.
 
     Issue #8756 uses Sprockets for resolving files that already exist on disk,

--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -1196,27 +1196,26 @@ module ActionView
 
         def add_default_name_and_id(options)
           if options.has_key?("index")
-            options["name"] ||= tag_name_with_index(options["index"])
+            options["name"] ||= tag_name_with_index(options["index"], options["multiple"])
             options["id"] = options.fetch("id"){ tag_id_with_index(options["index"]) }
             options.delete("index")
           elsif defined?(@auto_index)
-            options["name"] ||= tag_name_with_index(@auto_index)
+            options["name"] ||= tag_name_with_index(@auto_index, options["multiple"])
             options["id"] = options.fetch("id"){ tag_id_with_index(@auto_index) }
           else
-            options["name"] ||= tag_name
+            options["name"] ||= tag_name(options["multiple"])
             options["id"] = options.fetch("id"){ tag_id }
           end
 
-          options["name"] += "[]" if options["multiple"] && !options["name"].ends_with?("[]")
           options["id"] = [options.delete('namespace'), options["id"]].compact.join("_").presence
         end
 
-        def tag_name
-          "#{@object_name}[#{sanitized_method_name}]"
+        def tag_name(multiple = false)
+          "#{@object_name}[#{sanitized_method_name}]#{"[]" if multiple}"
         end
 
-        def tag_name_with_index(index)
-          "#{@object_name}[#{index}][#{sanitized_method_name}]"
+        def tag_name_with_index(index, multiple = false)
+          "#{@object_name}[#{index}][#{sanitized_method_name}]#{"[]" if multiple}"
         end
 
         def tag_id

--- a/actionpack/test/template/form_helper_test.rb
+++ b/actionpack/test/template/form_helper_test.rb
@@ -301,6 +301,16 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, file_field("user", "avatar")
   end
 
+  def test_file_field_with_multiple_behavior
+    expected = '<input id="import_file" multiple="multiple" name="import[file][]" type="file" />'
+    assert_dom_equal expected, file_field("import", "file", :multiple => true)
+  end
+
+  def test_file_field_with_multiple_behavior_and_explicit_name
+    expected = '<input id="import_file" multiple="multiple" name="custom" type="file" />'
+    assert_dom_equal expected, file_field("import", "file", :multiple => true, :name => "custom")
+  end
+
   def test_hidden_field
     assert_dom_equal '<input id="post_title" name="post[title]" type="hidden" value="Hello World" />',
       hidden_field("post", "title")


### PR DESCRIPTION
If a file field tag is passed the multiple option, it is turned into an array field (appending "[]"), but if the file field is passed an explicit name as an option, leave the name alone (do not append "[]").

Fixes #9830

(Also applied to the master branch in #10106)
