### PR TITLE
Allow serving of static files if relative_url_root is set

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -55,6 +55,9 @@ module ActionDispatch
       case env['REQUEST_METHOD']
       when 'GET', 'HEAD'
         path = env['PATH_INFO'].chomp('/')
+        if Rails.application.config.relative_url_root && path.rindex(Rails.application.config.relative_url_root) == 0 then
+          path = path[Rails.application.config.relative_url_root.length .. -1]
+        end
         if match = @file_handler.match?(path)
           env["PATH_INFO"] = match
           return @file_handler.call(env)


### PR DESCRIPTION
Currently static files aren't served if
Rails.application.config.relative_url_root is set to some path. This is
because the path in request is translated directly to a directory on file
system. With this patch, the relative_url_root path is first stripped
from the request so that static files are now found and served.
