### PR TITLE
Added a bang to the raise_nested_attributes_record_not_found method

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -362,7 +362,7 @@ module ActiveRecord
         assign_to_or_mark_for_destruction(record, attributes, options[:allow_destroy]) unless call_reject_if(association_name, attributes)
 
       elsif attributes['id'].present?
-        raise_nested_attributes_record_not_found(association_name, attributes['id'])
+        raise_nested_attributes_record_not_found!(association_name, attributes['id'])
 
       elsif !reject_new_record?(association_name, attributes)
         method = "build_#{association_name}"
@@ -452,7 +452,7 @@ module ActiveRecord
             assign_to_or_mark_for_destruction(existing_record, attributes, options[:allow_destroy])
           end
         else
-          raise_nested_attributes_record_not_found(association_name, attributes['id'])
+          raise_nested_attributes_record_not_found!(association_name, attributes['id'])
         end
       end
     end
@@ -514,7 +514,7 @@ module ActiveRecord
       end
     end
 
-    def raise_nested_attributes_record_not_found(association_name, record_id)
+    def raise_nested_attributes_record_not_found!(association_name, record_id)
       raise RecordNotFound, "Couldn't find #{self.class.reflect_on_association(association_name).klass.name} with ID=#{record_id} for #{self.class.name} with ID=#{id}"
     end
   end


### PR DESCRIPTION
The `raise_nested_attributes_record_not_found` method name should have a bang to signify  that an exception is raised.
