### PR TITLE
Implement ActiveRecord::Base#default_scopes? to behave correctly

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
-*   `default_scopes?` is deprecated. Check for `default_scopes.empty?` instead.
+*   `default_scopes?` now correctly returns `true` if there are default scopes
+    defined and `false` otherwise.
 
     *Agis Anastasopoulos*
 

--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -10,11 +10,7 @@ module ActiveRecord
         self.default_scopes = []
 
         def self.default_scopes?
-          ActiveSupport::Deprecation.warn(
-            "#default_scopes? is deprecated. Do something like #default_scopes.empty? instead."
-          )
-
-          !!self.default_scopes
+          !self.default_scopes.empty?
         end
       end
 


### PR DESCRIPTION
ie. return `true` if there are default scopes defined and `false` otherwise.

Previously, `#default_scopes?` would always return `true`, even if there were no default scopes defined in a model (due to it being defined dynamically by `class_attribute`).

cc @carlosantoniodasilva
