### PR TITLE
Change CollectionProxy#select to take the same arguments as ActiveRecord::select

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -67,11 +67,11 @@ module ActiveRecord
         @target = []
       end
 
-      def select(select = nil)
+      def select(*fields)
         if block_given?
           load_target.select.each { |e| yield e }
         else
-          scope.select(select)
+          scope.select(*fields)
         end
       end
 

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -76,7 +76,7 @@ module ActiveRecord
       #   #      #<Pet id: nil, name: "Choo-Choo">
       #   #    ]
       #
-      #   person.pets.select([:id, :name])
+      #   person.pets.select(:id, :name )
       #   # => [
       #   #      #<Pet id: 1, name: "Fancy-Fancy">,
       #   #      #<Pet id: 2, name: "Spook">,
@@ -107,8 +107,8 @@ module ActiveRecord
       #   #      #<Pet id: 2, name: "Spook">,
       #   #      #<Pet id: 3, name: "Choo-Choo">
       #   #    ]
-      def select(select = nil, &block)
-        @association.select(select, &block)
+      def select(*fields, &block)
+        @association.select(*fields, &block)
       end
 
       # Finds an object in the collection responding to the +id+. Uses the same

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -523,7 +523,11 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_select_query_method
-    assert_equal ['id'], posts(:welcome).comments.select(:id).first.attributes.keys
+    assert_equal ['id', 'body'], posts(:welcome).comments.select(:id, :body).first.attributes.keys
+  end
+
+  def test_select_with_block
+    assert_equal [1], posts(:welcome).comments.select { |c| c.id == 1 }.map(&:id)
   end
 
   def test_adding


### PR DESCRIPTION
Changes Model.association.select([:attribute1, :attribute2]) to Model.association.select(:attribute1, :attribute2).

This mirrors the changes made in #3165, which were committed in 7bf9db529e69cd3cbcedddc0f9af752b0480d13c
