### PR TITLE
ActiveModel::OneTimePassword: Adding support for one time passwords (for two-factor auth)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 gem 'mocha', '~> 0.13.0', require: false
 gem 'rack-cache', '~> 1.2'
 gem 'bcrypt-ruby', '~> 3.0.0'
+gem 'rotp'
 gem 'jquery-rails', '~> 2.2.0'
 gem 'turbolinks'
 gem 'coffee-rails', '~> 4.0.0.beta1'

--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -40,6 +40,7 @@ module ActiveModel
   autoload :DeprecatedMassAssignmentSecurity
   autoload :Name, 'active_model/naming'
   autoload :Naming
+  autoload :OneTimePassword
   autoload :SecurePassword
   autoload :Serialization
   autoload :TestCase

--- a/activemodel/lib/active_model/one_time_password.rb
+++ b/activemodel/lib/active_model/one_time_password.rb
@@ -1,0 +1,47 @@
+module ActiveModel
+  module OneTimePassword
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def has_one_time_password
+        begin
+          require 'rotp'
+        rescue LoadError
+          $stderr.puts "You don't have rotp installed in your application. Please add it to your Gemfile and run bundle install"
+          raise
+        end
+
+        include InstanceMethodsOnActivation
+
+        before_create { self.otp_secret_key = ROTP::Base32.random_base32 }
+
+        if respond_to?(:attributes_protected_by_default)
+          def self.attributes_protected_by_default #:nodoc:
+            super + ['otp_secret_key']
+          end
+        end
+      end
+    end
+
+    module InstanceMethodsOnActivation
+      def authenticate_otp(code, options = {})
+        totp = ROTP::TOTP.new(self.otp_secret_key)
+
+        if drift = options[:drift]
+          totp.verify_with_drift(code, drift)
+        else
+          totp.verify(code)
+        end
+      end
+
+      def otp_code(time = Time.now)
+        ROTP::TOTP.new(self.otp_secret_key).at(time)
+      end
+
+      def provisioning_uri(account = nil)
+        account ||= self.email if self.respond_to?(:email)
+        ROTP::TOTP.new(self.otp_secret_key).provisioning_uri(account)
+      end
+    end
+  end
+end

--- a/activemodel/test/cases/one_time_password_test.rb
+++ b/activemodel/test/cases/one_time_password_test.rb
@@ -1,0 +1,35 @@
+require 'cases/helper'
+require 'models/user'
+
+class OneTimePasswordTest < ActiveModel::TestCase
+  setup do
+    @user = User.new
+    @user.email = 'guille@rubyonrails.org'
+    @user.password = ':grin:'
+    @user.run_callbacks :create
+  end
+
+  test "authenticate with otp" do
+    code = @user.otp_code
+
+    assert @user.authenticate_otp(code)
+  end
+
+  test "authenticate with otp when drift is allowed" do
+    code = @user.otp_code(Time.now - 30)
+
+    assert @user.authenticate_otp(code, drift: 60)
+  end
+
+  test "otp code" do
+    assert_match(/\d{6}/, @user.otp_code.to_s)
+  end
+
+  test "provisioning_uri with provided account" do
+    assert_match %r{otpauth://totp/guille\?secret=\w{16}}, @user.provisioning_uri("guille")
+  end
+
+  test "provisioning_uri with email field" do
+    assert_match %r{otpauth://totp/guille@rubyonrails\.org\?secret=\w{16}}, @user.provisioning_uri
+  end
+end

--- a/activemodel/test/models/user.rb
+++ b/activemodel/test/models/user.rb
@@ -2,10 +2,12 @@ class User
   extend ActiveModel::Callbacks
   include ActiveModel::Validations
   include ActiveModel::SecurePassword
-  
+  include ActiveModel::OneTimePassword
+
   define_model_callbacks :create
 
   has_secure_password
+  has_one_time_password
 
-  attr_accessor :password_digest, :password_salt
+  attr_accessor :password_digest, :password_salt, :otp_secret_key, :email
 end


### PR DESCRIPTION
This module encapsulates simple one time password authentication with TOTP for use in two-factor authentication schemes. I've found this very useful in some applications recently. This is 'highly inspired' in AM::SecurePassword
## Usage
### Setting Model

Add otp_secret_key to your model:

```
rails g migration AddOtpSecretKeyToUsers otp_secret_key:string
```

``` ruby
class User < ActiveRecord::Base
  has_one_time_password
end
```

The otp_secret_key is saved automatically when a object is created
### Authenticating using a code

``` ruby
user.authenticate_otp('186522') # => true
sleep 30
user.authenticate_otp('186522') # => false
```
### Authenticating using a slightly old code

``` ruby
user.authenticate_otp('186522') # => true
sleep 30
user.authenticate_otp('186522', drift: 60) # => true
```
### Getting current code (ex. to send via SMS)

``` ruby
user.otp_code # => '186522'
sleep 30
user.otp_code # => '850738'
```
### Getting provision URI (ex. to generate QR codes compatibles with Google Authenticator app)

``` ruby
user.provision_uri # => 'otpauth://totp/alice@google.com?secret=JBSWY3DPEHPK3PXP'
```
