### PR TITLE
`rake db:create` creates a schema when `schema_search_path` is specified

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   `rake db:create` creates a schema when `schema_search_path` is specified in
+    database.yml.
+    Fixes #3624.
+
+    *Yves Senn*
+
 *   `default_scopes?` is deprecated. Check for `default_scopes.empty?` instead.
 
     *Agis Anastasopoulos*


### PR DESCRIPTION
Closes #3624

After this patch `rake db:create` will create a schema if `schema_search_path` is specified. Currently it only works if `schema_search_path` is a single schema. I've seen a couple of tickets related to `schema_search_path` so I first wanted to ask what format we actually support. If something like `first, second` is a valid `schema_search_path` of course I'd have to adjust the patch to create two schemas.
