### PR TITLE
Hash subtraction (deep_unmerge!)

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash.rb
+++ b/activesupport/lib/active_support/core_ext/hash.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/hash/conversions'
 require 'active_support/core_ext/hash/deep_merge'
+require 'active_support/core_ext/hash/delete_merge'
 require 'active_support/core_ext/hash/diff'
 require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/hash/indifferent_access'

--- a/activesupport/lib/active_support/core_ext/hash.rb
+++ b/activesupport/lib/active_support/core_ext/hash.rb
@@ -1,6 +1,6 @@
 require 'active_support/core_ext/hash/conversions'
 require 'active_support/core_ext/hash/deep_merge'
-require 'active_support/core_ext/hash/delete_merge'
+require 'active_support/core_ext/hash/deep_unmerge'
 require 'active_support/core_ext/hash/diff'
 require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/hash/indifferent_access'

--- a/activesupport/lib/active_support/core_ext/hash/deep_unmerge.rb
+++ b/activesupport/lib/active_support/core_ext/hash/deep_unmerge.rb
@@ -4,14 +4,14 @@ class Hash
   # {a: {b:"c"}} - {:a=>{:b=>"c"}}                   # => {}
   # {a: [{c:"d"},{b:"c"}]} - {:a => [{c:"d"}, {b:"d"}]} # => {:a=>[{:b=>"c"}]}
   #
-  def delete_merge!(other_hash)
+  def deep_unmerge!(other_hash)
     other_hash.each_pair do |k,v|
       tv = self[k]
       if tv.is_a?(Hash) && v.is_a?(Hash) && v.present? && tv.present?
-        tv.delete_merge!(v)
+        tv.deep_unmerge!(v)
       elsif v.is_a?(Array) && tv.is_a?(Array) && v.present? && tv.present?
         v.each_with_index do |x, i| 
-          tv[i].delete_merge!(x)
+          tv[i].deep_unmerge!(x) if tv[i]
         end
         self[k] = tv - [{}]
       else
@@ -22,11 +22,8 @@ class Hash
     self
   end
 
-  def delete_merge(other_hash)
-    dup.delete_merge!(other_hash)
+  def unmerge(other_hash)
+    clone.deep_unmerge!(other_hash)
   end
 
-  def -(other_hash)
-    self.delete_merge(other_hash)
-  end
 end

--- a/activesupport/lib/active_support/core_ext/hash/delete_merge.rb
+++ b/activesupport/lib/active_support/core_ext/hash/delete_merge.rb
@@ -1,0 +1,32 @@
+class Hash
+  # Returns a hash that removes any matches with the other hash
+  #
+  # {a: {b:"c"}} - {:a=>{:b=>"c"}}                   # => {}
+  # {a: [{c:"d"},{b:"c"}]} - {:a => [{c:"d"}, {b:"d"}]} # => {:a=>[{:b=>"c"}]}
+  #
+  def delete_merge!(other_hash)
+    other_hash.each_pair do |k,v|
+      tv = self[k]
+      if tv.is_a?(Hash) && v.is_a?(Hash) && v.present? && tv.present?
+        tv.delete_merge!(v)
+      elsif v.is_a?(Array) && tv.is_a?(Array) && v.present? && tv.present?
+        v.each_with_index do |x, i| 
+          tv[i].delete_merge!(x)
+        end
+        self[k] = tv - [{}]
+      else
+        self.delete(k) if self.has_key?(k) && tv == v
+      end
+      self.delete(k) if self.has_key?(k) && self[k].blank?
+    end
+    self
+  end
+
+  def delete_merge(other_hash)
+    dup.delete_merge!(other_hash)
+  end
+
+  def -(other_hash)
+    self.delete_merge(other_hash)
+  end
+end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -616,7 +616,7 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal expected, hash_1
   end
 
-  def test_delete_merge
+  def test_deep_unmerge
     hash_1 = { :a => "a", :b => "b", :c => { :c1 => "c1", :c2 => "c2", :c3 => { :d1 => "d1" } } }
     hash_2 = { :a => 1, :b => "b", :c => { :c3 => { :d1 => "d1", :d2 => "d2" } } }
     expected_1 = {:a=>"a", :c=>{:c1=>"c1", :c2=>"c2"}}
@@ -628,7 +628,7 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal expected_1, hash_1
   end
 
-  def test_delete_merge_on_indifferent_access
+  def test_deep_unmerge_on_indifferent_access
     hash_1 = HashWithIndifferentAccess.new({ :a => "a", :b => "b", :c => { :c1 => "c1", :c2 => "c2", :c3 => { :d1 => "d1" } } })
     hash_2 = HashWithIndifferentAccess.new({ :a => 1, :b => "b", :c => { :c3 => { :d1 => "d1", :d2 => "d2" } } })
     expected_1 = {"a"=>"a", "c"=>{"c1"=>"c1", "c2"=>"c2"}}

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -616,6 +616,30 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal expected, hash_1
   end
 
+  def test_delete_merge
+    hash_1 = { :a => "a", :b => "b", :c => { :c1 => "c1", :c2 => "c2", :c3 => { :d1 => "d1" } } }
+    hash_2 = { :a => 1, :b => "b", :c => { :c3 => { :d1 => "d1", :d2 => "d2" } } }
+    expected_1 = {:a=>"a", :c=>{:c1=>"c1", :c2=>"c2"}}
+    expected_2 = {:a=>1, :c=>{:c3=>{:d1=>"d1", :d2=>"d2"}}}
+    assert_equal expected_1, hash_1.delete_merge(hash_2)
+    assert_equal expected_2, hash_2.delete_merge(hash_1)
+
+    hash_1.delete_merge!(hash_2)
+    assert_equal expected_1, hash_1
+  end
+
+  def test_delete_merge_on_indifferent_access
+    hash_1 = HashWithIndifferentAccess.new({ :a => "a", :b => "b", :c => { :c1 => "c1", :c2 => "c2", :c3 => { :d1 => "d1" } } })
+    hash_2 = HashWithIndifferentAccess.new({ :a => 1, :b => "b", :c => { :c3 => { :d1 => "d1", :d2 => "d2" } } })
+    expected_1 = {"a"=>"a", "c"=>{"c1"=>"c1", "c2"=>"c2"}}
+    expected_2 = {"a"=>1, "c"=>{"c3"=>{"d1"=>"d1", "d2"=>"d2"}}}
+    assert_equal expected_1, hash_1.delete_merge(hash_2)
+    assert_equal expected_2, hash_2.delete_merge(hash_1)
+
+    hash_1.delete_merge!(hash_2)
+    assert_equal expected_1, hash_1
+  end
+
   def test_store_on_indifferent_access
     hash = HashWithIndifferentAccess.new
     hash.store(:test1, 1)


### PR DESCRIPTION
methods to remove a hash from another hash
- works with deeply nested hash
- works with hash containing arrays

``` ruby
{a: {b:"c"}}.deep_unmerge!( {a:{b:"c"}} )                           # => {}
{a: [{c:"d"},{b:"c"}]}.deep_unmerge!({a: [{c:"d"}, {b:"d"}]}) # => {:a=>[{:b=>"c"}]}
```
