### PR TITLE
Delegating the value getter and setters in the ScopeRegistry

### DIFF
--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -120,11 +120,11 @@ module ActiveRecord
         end
 
         def ignore_default_scope? # :nodoc:
-          ScopeRegistry.current.value_for(:ignore_default_scope, self)
+          ScopeRegistry.value_for(:ignore_default_scope, self)
         end
 
         def ignore_default_scope=(ignore) # :nodoc:
-          ScopeRegistry.current.set_value_for(:ignore_default_scope, self, ignore)
+          ScopeRegistry.set_value_for(:ignore_default_scope, self, ignore)
         end
 
         # The ignore_default_scope flag is used to prevent an infinite recursion


### PR DESCRIPTION
I'm changing the current implementation of the `ScopeRegistry` object so that you don't have to use `ScopeRegistry.current.value_of` which is somewhat verbose. Instead, the `value_of` and `set_value_of` are delegated to `ScopeRegistry.current`.
