### PR TITLE
Mark unused variables and make some style fixes

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -223,8 +223,8 @@ module Mime
         Mime.instance_eval { remove_const(symbol) }
 
         SET.delete_if { |v| v.eql?(mime) }
-        LOOKUP.delete_if { |k,v| v.eql?(mime) }
-        EXTENSION_LOOKUP.delete_if { |k,v| v.eql?(mime) }
+        LOOKUP.delete_if { |_,v| v.eql?(mime) }
+        EXTENSION_LOOKUP.delete_if { |_,v| v.eql?(mime) }
       end
     end
 

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -58,7 +58,7 @@ module ActionDispatch
             end
           end
 
-          parameterized_parts.keep_if { |_, v| v  }
+          parameterized_parts.keep_if { |_, v| v }
           parameterized_parts
         end
 

--- a/actionpack/lib/action_dispatch/middleware/request_id.rb
+++ b/actionpack/lib/action_dispatch/middleware/request_id.rb
@@ -18,7 +18,7 @@ module ActionDispatch
 
     def call(env)
       env["action_dispatch.request_id"] = external_request_id(env) || internal_request_id
-      @app.call(env).tap { |status, headers, body| headers["X-Request-Id"] = env["action_dispatch.request_id"] }
+      @app.call(env).tap { |_status, headers, _body| headers["X-Request-Id"] = env["action_dispatch.request_id"] }
     end
 
     private

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.erb
@@ -13,7 +13,7 @@
   request_dump = clean_params.empty? ? 'None' : clean_params.inspect.gsub(',', ",\n")
 
   def debug_hash(object)
-    object.to_hash.sort_by { |k, v| k.to_s }.map { |k, v| "#{k}: #{v.inspect rescue $!.message}" }.join("\n")
+    object.to_hash.sort_by { |k, _| k.to_s }.map { |k, v| "#{k}: #{v.inspect rescue $!.message}" }.join("\n")
   end unless self.class.method_defined?(:debug_hash)
 %>
 

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -489,7 +489,7 @@ module ActionDispatch
             end
 
             options = app
-            app, path = options.find { |k, v| k.respond_to?(:call) }
+            app, path = options.find { |k, _| k.respond_to?(:call) }
             options.delete(app) if app
           end
 
@@ -1361,7 +1361,7 @@ module ActionDispatch
         def match(path, *rest)
           if rest.empty? && Hash === path
             options  = path
-            path, to = options.find { |name, value| name.is_a?(String) }
+            path, to = options.find { |name, _value| name.is_a?(String) }
             options[:to] = to
             options.delete(path)
             paths = [path]

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -665,7 +665,7 @@ module ActionDispatch
         end
 
         req = @request_class.new(env)
-        @router.recognize(req) do |route, matches, params|
+        @router.recognize(req) do |route, _matches, params|
           params.merge!(extras)
           params.each do |key, value|
             if value.is_a?(String)

--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -81,7 +81,7 @@ module ActionDispatch
         # Load routes.rb if it hasn't been loaded.
 
         generated_path, extra_keys = @routes.generate_extras(options, defaults)
-        found_extras = options.reject {|k, v| ! extra_keys.include? k}
+        found_extras = options.reject { |k, _| ! extra_keys.include? k }
 
         msg = message || sprintf("found extras <%s>, not <%s>", found_extras, extras)
         assert_equal(extras, found_extras, msg)
@@ -120,7 +120,7 @@ module ActionDispatch
           options[:controller] = "/#{controller}"
         end
 
-        generate_options = options.dup.delete_if{ |k,v| defaults.key?(k) }
+        generate_options = options.dup.delete_if{ |k, _| defaults.key?(k) }
         assert_generates(path.is_a?(Hash) ? path[:path] : path, generate_options, defaults, extras, message)
       end
 

--- a/actionpack/lib/action_dispatch/testing/assertions/selector.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/selector.rb
@@ -377,8 +377,8 @@ module ActionDispatch
           node.content.gsub(/<!\[CDATA\[(.*)(\]\]>)?/m) { Rack::Utils.escapeHTML($1) }
         end
 
-        selected = elements.map do |_element|
-          text = _element.children.select{ |c| not c.tag? }.map{ |c| fix_content[c] }.join
+        selected = elements.map do |elem|
+          text = elem.children.select{ |c| not c.tag? }.map{ |c| fix_content[c] }.join
           root = HTML::Document.new(CGI.unescapeHTML("<encoded>#{text}</encoded>")).root
           css_select(root, "encoded:root", &block)[0]
         end

--- a/actionpack/lib/action_dispatch/testing/test_process.rb
+++ b/actionpack/lib/action_dispatch/testing/test_process.rb
@@ -6,7 +6,7 @@ module ActionDispatch
   module TestProcess
     def assigns(key = nil)
       assigns = {}.with_indifferent_access
-      @controller.view_assigns.each {|k, v| assigns.regular_writer(k, v)}
+      @controller.view_assigns.each { |k, v| assigns.regular_writer(k, v) }
       key.nil? ? assigns : assigns[key]
     end
 


### PR DESCRIPTION
It'd be a nice convention to mark the unused variables like this, now that Ruby 2 will issue no warnings for such vars not being used.
