### PR TITLE
Accept Float::INFINITY in active_record limit clause

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Allow `limit` scope to take Float::INFINITY.
+
+    *Naoyoshi Aikawa*
+
 *   `default_scopes?` is deprecated. Check for `default_scopes.empty?` instead.
 
     *Agis Anastasopoulos*

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -325,6 +325,8 @@ module ActiveRecord
           limit
         elsif limit.to_s =~ /,/
           Arel.sql limit.to_s.split(',').map{ |i| Integer(i) }.join(',')
+        elsif limit == Float::INFINITY
+          nil
         else
           Integer(limit)
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -323,10 +323,10 @@ module ActiveRecord
       def sanitize_limit(limit)
         if limit.is_a?(Integer) || limit.is_a?(Arel::Nodes::SqlLiteral)
           limit
-        elsif limit.to_s =~ /,/
-          Arel.sql limit.to_s.split(',').map{ |i| Integer(i) }.join(',')
         elsif limit == Float::INFINITY
           nil
+        elsif limit.to_s =~ /,/
+          Arel.sql limit.to_s.split(',').map{ |i| Integer(i) }.join(',')
         else
           Integer(limit)
         end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -134,6 +134,10 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal 1, Topic.limit(1).to_a.length
   end
 
+  def test_infinity_limit
+    assert_equal Topic.all, Topic.limit(Float::INFINITY)
+  end
+
   def test_invalid_limit
     assert_raises(ArgumentError) do
       Topic.limit("asdfadf").to_a


### PR DESCRIPTION
This change allows `limit` scope to take Float::INFINITY.

Before this change,

```
> Topic.limit(Float::INFINITY).count
FloatDomainError: Infinity
...
```

just raise an error, though other floating point values are accepted.

```
> Topic.limit(1.0).count
1
```

So this change supports our intuitive programming, I believe. How do you think? 
