### PR TITLE
changed variable name active_record => base_klass

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -5,10 +5,10 @@ module ActiveRecord
       autoload :JoinBase,        'active_record/associations/join_dependency/join_base'
       autoload :JoinAssociation, 'active_record/associations/join_dependency/join_association'
 
-      attr_reader :join_parts, :reflections, :alias_tracker, :active_record
+      attr_reader :join_parts, :reflections, :alias_tracker, :base_klass
 
       def initialize(base, associations, joins)
-        @active_record = base
+        @base_klass    = base
         @table_joins   = joins
         @join_parts    = [JoinBase.new(base)]
         @associations  = {}
@@ -54,7 +54,7 @@ module ActiveRecord
           parent
         }.uniq
 
-        remove_duplicate_results!(active_record, records, @associations)
+        remove_duplicate_results!(base_klass, records, @associations)
         records
       end
 
@@ -109,7 +109,7 @@ module ActiveRecord
         case associations
         when Symbol, String
           reflection = parent.reflections[associations.intern] or
-          raise ConfigurationError, "Association named '#{ associations }' was not found on #{ parent.active_record.name }; perhaps you misspelled it?"
+          raise ConfigurationError, "Association named '#{ associations }' was not found on #{ parent.base_klass.name }; perhaps you misspelled it?"
           unless join_association = find_join_association(reflection, parent)
             @reflections << reflection
             join_association = build_join_association(reflection, parent)

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -62,7 +62,7 @@ module ActiveRecord
         def join_to(manager)
           tables        = @tables.dup
           foreign_table = parent_table
-          foreign_klass = parent.active_record
+          foreign_klass = parent.base_klass
 
           # The chain starts with the target table, but we want to end with it here (makes
           # more sense in this context), so we reverse

--- a/activerecord/lib/active_record/associations/join_dependency/join_base.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_base.rb
@@ -4,7 +4,7 @@ module ActiveRecord
       class JoinBase < JoinPart # :nodoc:
         def ==(other)
           other.class == self.class &&
-            other.active_record == active_record
+            other.base_klass == base_klass
         end
 
         def aliased_prefix
@@ -16,7 +16,7 @@ module ActiveRecord
         end
 
         def aliased_table_name
-          active_record.table_name
+          base_klass.table_name
         end
       end
     end

--- a/activerecord/lib/active_record/associations/join_dependency/join_part.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_part.rb
@@ -11,12 +11,12 @@ module ActiveRecord
         # The Active Record class which this join part is associated 'about'; for a JoinBase
         # this is the actual base model, for a JoinAssociation this is the target model of the
         # association.
-        attr_reader :active_record
+        attr_reader :base_klass
 
-        delegate :table_name, :column_names, :primary_key, :reflections, :arel_engine, :to => :active_record
+        delegate :table_name, :column_names, :primary_key, :reflections, :arel_engine, :to => :base_klass
 
-        def initialize(active_record)
-          @active_record = active_record
+        def initialize(base_klass)
+          @base_klass = base_klass
           @cached_record = {}
           @column_names_with_alias = nil
         end
@@ -70,7 +70,7 @@ module ActiveRecord
         end
 
         def instantiate(row)
-          @cached_record[record_id(row)] ||= active_record.instantiate(extract_record(row))
+          @cached_record[record_id(row)] ||= base_klass.instantiate(extract_record(row))
         end
       end
     end


### PR DESCRIPTION
Current code stores the klass name in active_record and this
is used throughout. While reviewing the code time and again
I had the mental picture of active_record being an instance of
a klass. However here the actual klass is being stored in
@active_record.

Secondly at two different places while referring to @active_record
the comment refers to it as base klass. All this points to
active_record being not the best variable name.

So I thought it is better to replace active_record with base_klass.

This change is confined to JoinDependency, JoinBase, JoinPart and
JoinAssociation - all joining related work.
