### PR TITLE
Statement cache

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,22 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Added Statement Cache to allow the caching of a single statement. The cache works by
+    duping the relation returned from yielding a statement which allows skipping the AST
+    building phase.
+
+    Example:
+
+      cache = ActiveRecord::StatementCache.new do
+        Book.where(:name => "my book").limit(100)
+      end
+
+      books = cache.execute
+
+    The solution attempts to get closer to the speed of `find_by_sql` but still maintaining
+    the expressiveness of the AR queries.
+
+    *Olli Rissanen*
+
 *   Fixing issue #8345. Now throwing an error when one attempts to touch a
     new object that has not yet been persisted. For instance:
 

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -56,6 +56,7 @@ module ActiveRecord
   autoload :SchemaMigration
   autoload :Scoping
   autoload :Serialization
+  autoload :StatementCache
   autoload :Store
   autoload :Timestamp
   autoload :Transactions

--- a/activerecord/lib/active_record/statement_cache.rb
+++ b/activerecord/lib/active_record/statement_cache.rb
@@ -1,0 +1,26 @@
+module ActiveRecord	
+
+  # Statement cache is used to cache a single statement in order to avoid creating the AST again.
+  # Initializing the cache is done by passing the statement in the initialization block:
+  #
+  # cache = ActiveRecord::StatementCache.new do
+  #   Book.where(:name => "my book").limit(100)
+  # end
+  # 
+  # The cached statement is executed by using the +execute+ method:
+  # 
+  # cache.execute
+  #
+  # The relation returned by yield is cached, and for each +execute+ call the cached relation gets duped.
+  # Database is queried when +to_a+ is called on the relation.
+  class StatementCache 
+    def initialize
+      @relation = yield
+      raise ArgumentError.new("Statement cannot be nil") if @relation.nil?
+    end
+ 
+    def execute
+      @relation.dup.to_a
+    end
+  end
+end

--- a/activerecord/test/cases/statement_cache_test.rb
+++ b/activerecord/test/cases/statement_cache_test.rb
@@ -1,0 +1,64 @@
+require 'cases/helper'
+require 'models/book'
+require 'models/liquid'
+require 'models/molecule'
+require 'models/electron'
+
+module ActiveRecord
+  class StatementCacheTest < ActiveRecord::TestCase
+    def setup
+      @connection = ActiveRecord::Base.connection
+    end
+
+    def test_statement_cache_with_simple_statement
+      cache = ActiveRecord::StatementCache.new do
+        Book.where(name: "my book").where("author_id > 3")
+      end
+
+      Book.create(name: "my book", author_id: 4)
+
+      books = cache.execute
+      assert_equal "my book", books[0].name
+    end
+
+    def test_statement_cache_with_nil_statement_raises_error
+      assert_raise(ArgumentError) do
+        cache = ActiveRecord::StatementCache.new do
+          nil
+        end
+      end
+    end
+
+    def test_statement_cache_with_complex_statement
+      cache = ActiveRecord::StatementCache.new do
+        Liquid.joins(:molecules => :electrons).where('molecules.name' => 'dioxane', 'electrons.name' => 'lepton')
+      end
+      
+      salty = Liquid.create(name: 'salty')
+      molecule = salty.molecules.create(name: 'dioxane')
+      electron = molecule.electrons.create(name: 'lepton')
+
+      liquids = cache.execute
+      assert_equal "salty", liquids[0].name     
+    end
+
+    def test_statement_cache_values_differ
+      cache = ActiveRecord::StatementCache.new do
+        Book.where(name: "my book")
+      end
+ 
+      for i in 0..2 do
+        Book.create(name: "my book")
+      end
+
+      first_books = cache.execute
+      
+      for i in 0..2 do
+        Book.create(name: "my book")
+      end
+
+      additional_books = cache.execute
+      assert first_books != additional_books 
+    end
+  end
+end


### PR DESCRIPTION
The statement cache allows users to cache a single statement, which can then be executed for more optimized performance. This solution attempts to get closer to the performance of find_by_sql while still maintaining the expressiveness of AR queries.

Duping the relation returned from yielding a statement allows skipping the AST building phase, and the cached SQL can be used for the subsequent executions.

This solution will not be able to achieve the performance of find_by_sql however, as ARel has to be visited to fetch the cached SQL for the relation. This process takes some time. 

I have attached the benchmark results of a simple statement test case, where building the AST might not take as much time as in a complex query.

Queries:

Non-cached

<pre><code>
b = Book.where(:name => "my book").limit(100).to_a
</code></pre>


Cached

<pre><code>
cache = ActiveRecord::StatementCache.new do
  Book.where(:name => "my book").limit(100)
end

b = cache.execute
</code></pre>


SQL

<pre><code>
b = Book.find_by_sql('SELECT * FROM BOOKS WHERE name = "my book" LIMIT 100')
</code></pre>

Test results

Table initialization: One matching variable with name = "my book", others with randomized name

The results are the individual times for a query, using a sample of 10000 queries

Table size 10

<pre><code>
non-cached time
0.3672949429
cached time
0.3111773293
sql time
0.20331745149999997
</code></pre>

Table size 100

<pre><code>
non-cached time
0.3689390816
cached time
0.3414276569
sql time
0.2262848629
</code></pre>

Table size 1000

<pre><code>
non-cached time
0.4784290494999999
cached time
0.44194926990000005
sql time
0.3445473818
</code></pre>

Table size 10000

<pre><code>
non-cached time
1.7374471796000002
cached time
1.6614139447999998
sql time
1.5416361941999999
</code></pre>

Table size 100000

<pre><code>
non-cached time
14.0685073448
cached time
14.0078855941
sql time
13.8059879331
</code></pre>
