### PR TITLE
Use camelize instead of capitalize on template error screen

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/template_error.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/template_error.erb
@@ -2,7 +2,7 @@
 <header>
   <h1>
     <%= @exception.original_exception.class.to_s %> in
-    <%= @request.parameters["controller"].capitalize if @request.parameters["controller"]%>#<%= @request.parameters["action"] %>
+    <%= @request.parameters["controller"].camelize if @request.parameters["controller"] %>#<%= @request.parameters["action"] %>
   </h1>
 </header>
 


### PR DESCRIPTION
This PR makes one minor change. H1 contents of template_error.erb change from this:

```
NameError in Some_controller_name#new
```

to this:

```
NameError in SomeControllerName#new
```
