### PR TITLE
Fix inflector to respect default locale.

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -28,7 +28,7 @@ class String
   #   'apple'.pluralize(2)         # => "apples"
   #   'ley'.pluralize(:es)         # => "leyes"
   #   'ley'.pluralize(1, :es)      # => "ley"
-  def pluralize(count = nil, locale = :en)
+  def pluralize(count = nil, locale = I18n.locale)
     locale = count if count.is_a?(Symbol)
     if count == 1
       self
@@ -51,7 +51,7 @@ class String
   #   'the blue mailmen'.singularize # => "the blue mailman"
   #   'CamelOctopi'.singularize      # => "CamelOctopus"
   #   'leyes'.singularize(:es)       # => "ley"
-  def singularize(locale = :en)
+  def singularize(locale = I18n.locale)
     ActiveSupport::Inflector.singularize(self, locale)
   end
 

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -380,6 +380,23 @@ class InflectorTest < ActiveSupport::TestCase
     assert !ActiveSupport::Inflector.inflections.plurals.empty?
     assert !ActiveSupport::Inflector.inflections.singulars.empty?
   end
+  
+  def test_inflector_with_default_locale
+    old_locale = I18n.locale
+
+    begin
+      I18n.locale = :de
+
+      ActiveSupport::Inflector.inflections(:de) do |inflect|
+        inflect.irregular 'region', 'regionen'
+      end
+
+      assert_equal('regionen', 'region'.pluralize)
+      assert_equal('region', 'regionen'.singularize)
+    ensure
+      I18n.locale = old_locale
+    end
+  end
 
   def test_clear_all
     with_dup do


### PR DESCRIPTION
The inflector was made aware of locales in 7db0b073fec6bc3e6f213b58c76e7f43fcc2ab97,
but it defaulted to :en. That should actually be our default
locale instead.

Fixes #10125

I wanted to get some feedback about the tests. Is this the right place, or should I bet testing singularize/pluralize more directly?

/cc @thenickcox 
