### PR TITLE
default to default_locale instead of locale

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -28,7 +28,7 @@ class String
   #   'apple'.pluralize(2)         # => "apples"
   #   'ley'.pluralize(:es)         # => "leyes"
   #   'ley'.pluralize(1, :es)      # => "ley"
-  def pluralize(count = nil, locale = I18n.locale)
+  def pluralize(count = nil, locale = I18n.default_locale)
     locale = count if count.is_a?(Symbol)
     if count == 1
       self
@@ -51,7 +51,7 @@ class String
   #   'the blue mailmen'.singularize # => "the blue mailman"
   #   'CamelOctopi'.singularize      # => "CamelOctopus"
   #   'leyes'.singularize(:es)       # => "ley"
-  def singularize(locale = I18n.locale)
+  def singularize(locale = I18n.default_locale)
     ActiveSupport::Inflector.singularize(self, locale)
   end
 

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -382,10 +382,10 @@ class InflectorTest < ActiveSupport::TestCase
   end
   
   def test_inflector_with_default_locale
-    old_locale = I18n.locale
+    old_default_locale = I18n.default_locale
 
     begin
-      I18n.locale = :de
+      I18n.default_locale = :de
 
       ActiveSupport::Inflector.inflections(:de) do |inflect|
         inflect.irregular 'region', 'regionen'
@@ -394,7 +394,7 @@ class InflectorTest < ActiveSupport::TestCase
       assert_equal('regionen', 'region'.pluralize)
       assert_equal('region', 'regionen'.singularize)
     ensure
-      I18n.locale = old_locale
+      I18n.default_locale = old_default_locale
     end
   end
 


### PR DESCRIPTION
Fixes 8cf88cc75ad0289f39fc2272c372f945b3934e76

Without this change,

```
Processing by StoreController#index as HTML
  Parameters: {"locale"=>"es"}
Completed 500 Internal Server Error in 13ms

ActiveRecord::StatementInvalid (Could not find table 'cart'):
  app/controllers/concerns/current_cart.rb:7:in `set_cart'
```

Note: the desired table name is 'carts'.

Failure can be seen here:

http://intertwingly.net/projects/AWDwR4/checkdepot/section-15.2.html
