### PR TITLE
Using public send instead of send for the PerThreadRegistry module.

### DIFF
--- a/activesupport/lib/active_support/per_thread_registry.rb
+++ b/activesupport/lib/active_support/per_thread_registry.rb
@@ -35,7 +35,7 @@ module ActiveSupport
     protected
 
       def method_missing(*args, &block)
-        instance.send(*args, &block)
+        instance.public_send(*args, &block)
       end
   end
 end


### PR DESCRIPTION
This prevents you from accidentally calling a protected method.
