### PR TITLE
replace_bind_variables will no longer replace ?'s inside quotes

### DIFF
--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -123,10 +123,35 @@ module ActiveRecord
       alias_method :sanitize_conditions, :sanitize_sql
 
       def replace_bind_variables(statement, values) #:nodoc:
-        raise_if_bind_arity_mismatch(statement, statement.count('?'), values.size)
         bound = values.dup
         c = connection
-        statement.gsub('?') { quote_bound_value(bound.shift, c) }
+
+        # Don't replace any ? which occurs inside a quoted string or identifier.
+        # Support backslashed characters inside quotes.
+        opening_quote = nil
+        currently_in_quotes = false
+        currently_backslashed = false
+        arity = 0
+        output_stmt = statement.each_char.map do |char|
+          output_chunk = char
+          if currently_in_quotes
+            if char == opening_quote && !currently_backslashed
+              currently_in_quotes = false
+              opening_quote = nil
+            end
+            currently_backslashed = char=='\\' && !currently_backslashed
+          elsif %W( ' " ` ).include?(char)
+            currently_in_quotes = true
+            opening_quote = char
+          elsif char == '?'
+            arity += 1
+            output_chunk = quote_bound_value(bound.shift, c)
+          end
+          output_chunk
+        end.join
+
+        raise_if_bind_arity_mismatch(statement, arity, values.size)
+        output_stmt
       end
 
       def replace_named_bind_variables(statement, bind_vars) #:nodoc:

--- a/activerecord/test/cases/sanitize_test.rb
+++ b/activerecord/test/cases/sanitize_test.rb
@@ -22,4 +22,19 @@ class SanitizeTest < ActiveRecord::TestCase
     assert_equal "name=#{quoted_bambi_and_thumper}", Binary.send(:sanitize_sql_array, ["name=?", "Bambi\nand\nThumper"])
     assert_equal "name=#{quoted_bambi_and_thumper}", Binary.send(:sanitize_sql_array, ["name=?", "Bambi\nand\nThumper".mb_chars])
   end
+
+  def test_sanitize_sql_array_handles_bind_variables_with_quotes
+    quoted_bambi_and_thumper = ActiveRecord::Base.connection.quote("Bambi\nand\nThumper")
+    quoted_strs = [ %q{ 'foo?'    },
+                    %q{ 'f''oo?'  },
+                    %q{ "foo???'" },
+                    %q{ 'fo\\'o?' },
+                    %q{ `foo\\`?` },
+                    %q{ 'fo'' \\\\\\'o?' },
+                    ActiveRecord::Base.connection.quote("foo?") ]
+    quoted_strs.each do |quoted_str|
+      assert_equal "foo=#{quoted_str}, name=#{quoted_bambi_and_thumper}", Binary.send(:sanitize_sql_array, ["foo=#{quoted_str}, name=?", "Bambi\nand\nThumper"])
+      assert_equal "foo=#{quoted_str}, name=#{quoted_bambi_and_thumper}", Binary.send(:sanitize_sql_array, ["foo=#{quoted_str}, name=?", "Bambi\nand\nThumper".mb_chars])
+    end
+  end
 end


### PR DESCRIPTION
replace_bind_variables, as written, naively replaces all ?'s, whether or
not they were part of a quoted SQL string or identifier, resulting in an
arity error when quoted ?'s are present.  This commit introduces proper
handling of ?'s within quotes, including handling of backslashed characters.

Code to reproduce the issue:

``` ruby
class Foo < ActiveRecord::Base
  attr_accessible :bar, :baz
end

Foo.where(%q{ bar = ? AND baz = 'quux?' }, 'bindvar')
# without patch => ActiveRecord::PreparedStatementInvalid: wrong number of bind variables (1 for 2) in: bar = ? AND baz = 'quux?'
# with patch => #<ActiveRecord::Relation:0xd744>
```
