### PR TITLE
Create a separate ActiveRecord locale

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Add a separate ActiveRecord::Base.locale to decouple AR name pluralization
+    from the default locale.
+
+    *Sam Ruby*
+
 *   `default_scopes?` is deprecated. Check for `default_scopes.empty?` instead.
 
     *Agis Anastasopoulos*

--- a/activerecord/lib/active_record/associations/builder/collection_association.rb
+++ b/activerecord/lib/active_record/associations/builder/collection_association.rb
@@ -70,7 +70,7 @@ module ActiveRecord::Associations::Builder
       super
 
       mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
-        def #{name.to_s.singularize}_ids
+        def #{ActiveRecord::Base.column_name_for(name)}_ids
           association(:#{name}).ids_reader
         end
       CODE
@@ -80,7 +80,7 @@ module ActiveRecord::Associations::Builder
       super
 
       mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
-        def #{name.to_s.singularize}_ids=(ids)
+        def #{ActiveRecord::Base.column_name_for(name)}_ids=(ids)
           association(:#{name}).ids_writer(ids)
         end
       CODE

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -175,7 +175,7 @@ module ActiveRecord
 
         unless options[:id] == false
           pk = options.fetch(:primary_key) {
-            Base.get_primary_key table_name.to_s.singularize
+            Base.get_primary_key ActiveRecord::Base.column_name_for(table_name)
           }
 
           td.primary_key pk, options.fetch(:id, :primary_key), options
@@ -235,7 +235,7 @@ module ActiveRecord
         column_options = options.delete(:column_options) || {}
         column_options.reverse_merge!(null: false)
 
-        t1_column, t2_column = [table_1, table_2].map{ |t| t.to_s.singularize.foreign_key }
+        t1_column, t2_column = [table_1, table_2].map{ |t| ActiveRecord::Base.column_name_for(t).foreign_key }
 
         create_table(join_table_name, options.merge!(id: false)) do |td|
           td.integer t1_column, column_options

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -387,7 +387,7 @@ module ActiveRecord
 
     def self.default_fixture_model_name(fixture_set_name) # :nodoc:
       ActiveRecord::Base.pluralize_table_names ?
-        fixture_set_name.singularize.camelize :
+        fixture_set_name.singularize(ActiveRecord::Base.locale).camelize :
         fixture_set_name.camelize
     end
 
@@ -788,7 +788,7 @@ module ActiveRecord
         end
 
         fixture_set_names.each do |file_name|
-          file_name = file_name.singularize if ActiveRecord::Base.pluralize_table_names
+          file_name = file_name.singularize(ActiveRecord::Base.locale) if ActiveRecord::Base.pluralize_table_names
           try_to_load_dependency(file_name)
         end
       end

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -34,6 +34,13 @@ module ActiveRecord
 
       ##
       # :singleton-method:
+      # Indicates what locale to use for pluralizing and singularizing table
+      # and collection names
+      class_attribute :locale, instance_writer: false
+      self.locale = :en
+
+      ##
+      # :singleton-method:
       # Indicates whether table names should be the pluralized versions of the corresponding class names.
       # If true, the default table name for a Product class will be +products+. If false, it would just be +product+.
       # See table_name for the full rules on table/class naming. This is true, by default.
@@ -41,6 +48,14 @@ module ActiveRecord
       self.pluralize_table_names = true
 
       self.inheritance_column = 'type'
+
+      def self.table_name_for(name)
+        pluralize_table_names ? name.to_s.pluralize(locale) : name.to_s
+      end
+
+      def self.column_name_for(name)
+        name.to_s.singularize(locale)
+      end
     end
 
     module ClassMethods
@@ -321,7 +336,7 @@ module ActiveRecord
       # Guesses the table name, but does not decorate it with prefix and suffix information.
       def undecorated_table_name(class_name = base_class.name)
         table_name = class_name.to_s.demodulize.underscore
-        pluralize_table_names ? table_name.pluralize : table_name
+        pluralize_table_names ? table_name.pluralize(ActiveRecord::Base.locale) : table_name
       end
 
       # Computes and returns a table name according to default conventions.
@@ -331,7 +346,7 @@ module ActiveRecord
           # Nested classes are prefixed with singular parent table name.
           if parent < Base && !parent.abstract_class?
             contained = parent.table_name
-            contained = contained.singularize if parent.pluralize_table_names
+            contained = contained.singularize(ActiveRecord::Base.locale) if parent.pluralize_table_names
             contained += '_'
           end
           "#{full_table_name_prefix}#{contained}#{undecorated_table_name(name)}#{table_name_suffix}"

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -108,8 +108,7 @@ module ActiveRecord
         @scope         = scope
         @options       = options
         @active_record = active_record
-        @plural_name   = active_record.pluralize_table_names ?
-                            name.to_s.pluralize : name.to_s
+        @plural_name   = ActiveRecord::Base.table_name_for(name)
       end
 
       # Returns the class for the macro.
@@ -227,7 +226,7 @@ module ActiveRecord
 
       def counter_cache_column
         if options[:counter_cache] == true
-          "#{active_record.name.demodulize.underscore.pluralize}_count"
+          "#{active_record.name.demodulize.underscore.pluralize(ActiveRecord::Base.locale)}_count"
         elsif options[:counter_cache]
           options[:counter_cache].to_s
         end
@@ -364,7 +363,7 @@ module ActiveRecord
       private
         def derive_class_name
           class_name = name.to_s.camelize
-          class_name = class_name.singularize if collection?
+          class_name = ActiveRecord::Base.column_name_for(class_name) if collection?
           class_name
         end
 
@@ -529,7 +528,7 @@ module ActiveRecord
       #   # => [:tag, :tags]
       #
       def source_reflection_names
-        @source_reflection_names ||= (options[:source] ? [options[:source]] : [name.to_s.singularize, name]).collect { |n| n.to_sym }
+        @source_reflection_names ||= (options[:source] ? [options[:source]] : [ActiveRecord::Base.column_name_for(name), name]).collect { |n| n.to_sym }
       end
 
       def source_options

--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -43,7 +43,7 @@ module ActiveRecord
         if attribute.foreign_key?
           attribute.name
         else
-          attribute.name.singularize.foreign_key
+          ActiveRecord::Base.column_name_for(attribute.name).foreign_key
         end.to_sym
       end
 


### PR DESCRIPTION
Decouples pluralization activities from the current locale.

https://github.com/rails/rails/pull/10158 changes pluralization to depend on the current locale, which breaks ActiveRecord which makes heavy use of pluralization and depends on this function returning consistent results.  You can see the results http://intertwingly.net/projects/AWDwR4/checkdepot/section-15.2.html where we get a `Could not find table 'cart'` error message when we switch locales.

Preferred solutions are to either revert the original commit, or to give ActiveRecord a separate locale.  This pull request implements the latter.  I'm OK with either option.
