### PR TITLE
Make `.select()` query method accept a hash option for stating field selection on joined tables. 

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   `select` query method can now select fields on joined tables using Hash syntax.
+
+    In this Hash, each key is a table name whose value is an Array. The array is a
+    list of fields.
+
+    Example:
+
+        User.joins(:posts).select(:name, posts: [:id, :title, :body])
+        #   => SELECT name, posts.id, posts.title, posts.body FROM "users" INNER JOIN "posts" ON "posts"."user_id" = "users"."id"
+
+    *Gonzalo Rodríguez-Baltanás Díaz*
+
 *   Don't allow `quote_value` to be called without a column.
 
     Some adapters require column information to do their job properly.

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -237,6 +237,12 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal [2, 4, 6, 8, 10], even_ids.sort
   end
 
+  def test_select_with_hash
+    author = Author.joins(:posts).select(authors: [:id, :name]).first
+    assert_not_nil author.id
+    assert_not_nil author.name
+  end
+
   def test_none
     assert_no_queries do
       assert_equal [], Developer.none

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -168,7 +168,7 @@ class DefaultScopingTest < ActiveRecord::TestCase
 
   def test_unscope_select
     expected = Developer.order('salary ASC').collect { |dev| dev.name }
-    received = Developer.order('salary DESC').reverse_order.select(:name => "Jamis").unscope(:select).collect { |dev| dev.name }
+    received = Developer.order('salary DESC').reverse_order.select(:name).unscope(:select).collect { |dev| dev.name }
     assert_equal expected, received
 
     expected_2 = Developer.all.collect { |dev| dev.id }

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -577,6 +577,17 @@ ActiveModel::MissingAttributeError: missing attribute: <attribute>
 
 Where `<attribute>` is the attribute you asked for. The `id` method will not raise the `ActiveRecord::MissingAttributeError`, so just be careful when working with associations because they need the `id` method to function properly.
 
+If you would like to select fields on joined tables just use this syntax:
+```ruby
+User.joins(:posts).select(:name, posts: [:id, :title, :body])
+```
+
+The SQL for that query would be:
+
+```sql
+SELECT name, posts.id, posts.title, posts.body FROM "users" INNER JOIN "posts" ON "posts"."user_id" = "users"."id"
+```
+
 If you would like to only grab a single record per unique value in a certain field, you can use `distinct`:
 
 ```ruby


### PR DESCRIPTION
Hi,

The `.select` query method accepts multiple arguments. I added that when one of those arguments is a Hash, the key would be understood as the name of a table and each of its values as fields of said table.

Example:  

```
User.joins(:posts).select(:name, posts: [:id, :title, :body])
#   => SELECT name, posts.id, posts.title, posts.body FROM "users" INNER JOIN "posts" ON "posts"."user_id" = "users"."id"
```

Let me know how can I help you to get this merged.

Thanks.
