### PR TITLE
Editorial pass over generated Gemfile

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -115,7 +115,11 @@ module Rails
       end
 
       def database_gemfile_entry
-        options[:skip_active_record] ? "" : "gem '#{gem_for_database}'"
+        options[:skip_active_record] ? "" : 
+          <<-GEMFILE.gsub(/^ {12}/, '').strip
+            # Use #{options[:database]} as the database for ActiveRecord
+            gem '#{gem_for_database}'
+          GEMFILE
       end
 
       def include_all_railties?
@@ -185,7 +189,7 @@ module Rails
             # Use SCSS for stylesheets
             gem 'sass-rails',   github: 'rails/sass-rails'
 
-            # To use Uglifier as compressor for JavaScript assets
+            # Use Uglifier as compressor for JavaScript assets
             gem 'uglifier', '~> 1.3'
           GEMFILE
         else
@@ -193,7 +197,7 @@ module Rails
             # Use SCSS for stylesheets
             gem 'sass-rails',   '~> 4.0.0.beta1'
 
-            # To use Uglifier as compressor for JavaScript assets
+            # Use Uglifier as compressor for JavaScript assets
             gem 'uglifier', '~> 1.3'
           GEMFILE
         end
@@ -229,7 +233,7 @@ module Rails
           <<-GEMFILE.gsub(/^ {12}/, '').strip_heredoc
             #{coffee_gemfile_entry}
             #{javascript_runtime_gemfile_entry}
-
+            # Use #{options[:javascript]} as the JavaScript library
             gem '#{options[:javascript]}-rails'
 
             # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -17,16 +17,16 @@ end
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 1.0.1'
 
-# To use ActiveModel has_secure_password
+# Use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.0.0'
 
 # Use unicorn as the app server
 # gem 'unicorn'
 
-# Deploy with Capistrano
+# Use Capistrano for deployment
 # gem 'capistrano', group: :development
 
 <% unless defined?(JRUBY_VERSION) -%>
-# To use debugger
+# Use debugger
 # gem 'debugger', group: [:development, :test]
 <% end -%>


### PR DESCRIPTION
- When run with default options, no repeated blank lines
- Every gem has a comment, perhaps a generic one, but a comment nonetheless
- Most comments used to start with "Use", some with "To use" => made consistent
- Made clear in comments when gem is commented out
