### PR TITLE
Backport: Correctly parse bigint defaults in PostgreSQL

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## unreleased ##
 
+*   Default values for PostgreSQL bigint types now get parsed and dumped to the
+    schema correctly.
+    Backport #10098.
+
+    *Erik Peterson*
+
 *   Removed warning when `auto_explain_threshold_in_seconds` is set and the
     connection adapter doesn't support explain.
     This is causing a regression since the Active Record Railtie is trying to

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -142,7 +142,7 @@ module ActiveRecord
             when NilClass
               nil
             # Numeric types
-            when /\A\(?(-?\d+(\.\d*)?\)?)\z/
+            when /\A\(?(-?\d+(\.\d*)?\)?(::bigint)?)\z/
               $1
             # Character types
             when /\A\(?'(.*)'::.*\b(?:character varying|bpchar|text)\z/m

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -206,6 +206,11 @@ class SchemaDumperTest < ActiveRecord::TestCase
   end
 
   if current_adapter?(:PostgreSQLAdapter)
+    def test_schema_dump_includes_bigint_default
+      output = standard_dump
+      assert_match %r{t.integer\s+"bigint_default",\s+:limit => 8,\s+:default => 0}, output
+    end
+
     def test_schema_dump_includes_xml_shorthand_definition
       output = standard_dump
       if %r{create_table "postgresql_xml_data_type"} =~ output

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define do
     char3 text default 'a text field',
     positive_integer integer default 1,
     negative_integer integer default -1,
+    bigint_default bigint default 0::bigint,
     decimal_number decimal(3,2) default 2.78,
     multiline_default text DEFAULT '--- []
 


### PR DESCRIPTION
Backpost #10098.

Conflicts:

```
activerecord/CHANGELOG.md
activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
activerecord/test/cases/schema_dumper_test.rb
```

Had to do some minor adjustments to get it working with `3-2-stable` but nothing severe.
