### PR TITLE
initialize instead of assert to fix warning

### DIFF
--- a/railties/test/application/initializers/load_path_test.rb
+++ b/railties/test/application/initializers/load_path_test.rb
@@ -72,6 +72,7 @@ module ApplicationTests
     end
 
     test "load environment with global" do
+      $initialize_test_set_from_env = nil
       app_file "config/environments/development.rb", <<-RUBY
         $initialize_test_set_from_env = 'success'
         AppTemplate::Application.configure do


### PR DESCRIPTION
change assert to initialize on undefined variable
