### PR TITLE
Address ORA-00979: not a GROUP BY expression error

### DIFF
--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -182,7 +182,7 @@ module ActiveRecord
     def test_relation_merging_with_merged_joins
       special_comments_with_ratings = SpecialComment.joins(:ratings)
       posts_with_special_comments_with_ratings = Post.group("posts.id").joins(:special_comments).merge(special_comments_with_ratings)
-      assert_equal 3, authors(:david).posts.merge(posts_with_special_comments_with_ratings).to_a.length
+      assert_equal 3, authors(:david).posts.merge(posts_with_special_comments_with_ratings).count.length
     end
 
   end


### PR DESCRIPTION
This pull request addresses a error since #10164 merged to master branch as Oracle database requires every column selected also needs to be written in group by clause. 

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/relation_test.rb -n test_relation_merging_with_merged_joins
Using oracle
Run options: -n test_relation_merging_with_merged_joins --seed 61987

# Running tests:

E

Finished tests in 0.252468s, 3.9609 tests/s, 0.0000 assertions/s.

  1) Error:
ActiveRecord::RelationTest#test_relation_merging_with_merged_joins:
ActiveRecord::StatementInvalid: OCIError: ORA-00979: not a GROUP BY expression: SELECT "POSTS".* FROM "POSTS" INNER JOIN "COMMENTS" ON "COMMENTS"."POST_ID" = "POSTS"."ID" AND "COMMENTS"."TYPE" IN ('SpecialComment', 'SubSpecialComment') LEFT OUTER JOIN "RATINGS" ON "RATINGS"."COMMENT_ID" = "COMMENTS"."ID" WHERE "POSTS"."AUTHOR_ID" = :a1 AND "COMMENTS"."TYPE" IN ('SpecialComment', 'SubSpecialComment') GROUP BY posts.id
    stmt.c:230:in oci8lib_200.so
    /home/yahonda/.rvm/gems/ruby-2.0.0-p0@railsmaster/gems/ruby-oci8-2.1.5/lib/oci8/cursor.rb:126:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:143:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:759:in `block in exec_query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:425:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:420:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1501:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:739:in `exec_query'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1455:in `select'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:24:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:63:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/querying.rb:36:in `find_by_sql'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:561:in `exec_queries'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:447:in `load'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:196:in `to_a'
    test/cases/relation_test.rb:185:in `test_relation_merging_with_merged_joins'

1 tests, 0 assertions, 0 failures, 1 errors, 0 skips
$
```

This pull request also works with sqlite3, mysql, mysql2 and postgresql adapters and I think it satisfy original requirements. 
