### PR TITLE
Duped the attributes in find_or methods

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -165,17 +165,20 @@ module ActiveRecord
     #   end
     #   # => <User id: 2, first_name: 'Scarlett', last_name: 'Johansson'>
     def find_or_create_by(attributes, &block)
-      find_by(attributes) || create(attributes, &block)
+      temp_attrs = attributes.dup
+      find_by(attributes) || create(temp_attrs , &block)
     end
 
     # Like <tt>find_or_create_by</tt>, but calls <tt>create!</tt> so an exception is raised if the created record is invalid.
     def find_or_create_by!(attributes, &block)
-      find_by(attributes) || create!(attributes, &block)
+      temp_attrs = attributes.dup
+      find_by(attributes) || create!(temp_attrs , &block)
     end
 
     # Like <tt>find_or_create_by</tt>, but calls <tt>new</tt> instead of <tt>create</tt>.
     def find_or_initialize_by(attributes, &block)
-      find_by(attributes) || new(attributes, &block)
+      temp_attrs = attributes.dup
+      find_by(attributes) || new(temp_attrs , &block)
     end
 
     # Runs EXPLAIN on the query or queries triggered by this relation and


### PR DESCRIPTION
We don't want other methods mutating the attributes that are used to create new objects.
