### PR TITLE
autosave_association issue that occurs when table has unique index

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   fixes bug introduced by #3329.  Now, when autosaving associations,
+    deletions happen before inserts and saves.  This prevents a 'duplicate
+    unique value' database error that would occur if a record being created had
+    the same value on a unique indexed field as that of a record being destroyed.
+
+    *Johnny Holton*
+
 *   Run `rake migrate:down` & `rake migrate:up` in transaction if database supports.
 
     *Alexander Bondarev*

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -764,6 +764,20 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
     assert_equal 2, @pirate.birds.reload.length
   end
 
+  def test_should_save_new_record_that_has_same_value_as_existing_record_marked_for_destruction_on_field_that_has_unique_index
+    Bird.connection.add_index :birds, :name, unique: true
+
+    3.times { |i| @pirate.birds.create(name: "birds_#{i}") }
+
+    @pirate.birds[0].mark_for_destruction
+    @pirate.birds.build(name: @pirate.birds[0].name)
+    @pirate.save!
+
+    assert_equal 3, @pirate.birds.reload.length
+  ensure
+    Bird.connection.remove_index :birds, column: :name
+  end
+
   # Add and remove callbacks tests for association collections.
   %w{ method proc }.each do |callback_type|
     define_method("test_should_run_add_callback_#{callback_type}s_for_has_many") do


### PR DESCRIPTION
Per the comments in pull #3329, 
If you have a table with a unique field index, and you mark a record for destruction, and you build a new record with the same value as the unique field, then when you call `save`, a database level unique index error will be thrown. 

This happens because the record destruction happens after record creation.

In this pull request, I moved the record destruction ahead of the record creation.

This is my first pull request ever, so please go easy on me.  :smile: 

The existing tests still pass.

Is there a way to write a test that takes into account a table index?
