### PR TITLE
Subdomain route constraints fix

### DIFF
--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -100,7 +100,7 @@ module ActionDispatch
           tld_length = options[:tld_length] || @@tld_length
 
           host = ""
-          unless options[:subdomain] == false
+          unless options[:subdomain] == false || options[:subdomain] == ''
             host << (options[:subdomain] || extract_subdomain(options[:host], tld_length)).to_param
             host << "."
           end

--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -102,6 +102,10 @@ module ActionDispatch
             value === request.send(method).to_s
           when Array
             value.include?(request.send(method))
+          when TrueClass
+            request.send(method).present?
+          when FalseClass
+            request.send(method).blank?
           else
             value === request.send(method)
           end

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -89,6 +89,13 @@ module AbstractController
         )
       end
 
+      def test_subdomain_may_be_removed_with_blank_string
+        W.default_url_options[:host] = 'api.basecamphq.com'
+        assert_equal('http://basecamphq.com/c/a/i',
+          W.new.url_for(:subdomain => '', :controller => 'c', :action => 'a', :id => 'i')
+        )
+      end
+
       def test_multiple_subdomains_may_be_removed
         W.default_url_options[:host] = 'mobile.www.api.basecamphq.com'
         assert_equal('http://basecamphq.com/c/a/i',

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3322,6 +3322,10 @@ class TestUrlConstraints < ActionDispatch::IntegrationTest
       end
 
       get '/' => ok, :as => :alternate_root, :constraints => { :port => 8080 }
+
+      get '/search' => ok, :constraints => { :subdomain => false }
+
+      get '/logs' => ok, :constraints => { :subdomain => true }
     end
   end
 
@@ -3347,6 +3351,22 @@ class TestUrlConstraints < ActionDispatch::IntegrationTest
 
     get 'http://www.example.com:8080/'
     assert_response :success
+  end
+
+  test "false constraint expressions check for absence of values" do
+    get 'http://example.com/search'
+    assert_response :success
+
+    get 'http://api.example.com/search'
+    assert_response :not_found
+  end
+
+  test "true constraint expressions check for presence of values" do
+    get 'http://api.example.com/logs'
+    assert_response :success
+
+    get 'http://example.com/logs'
+    assert_response :not_found
   end
 end
 


### PR DESCRIPTION
Fixes #10180
- Passing `subdomain: ''` to `url_for` removes the subdomain (instead of adding a leading .)
- Adding a boolean route constraint checks for presence/absence of request property
