### PR TITLE
use unified and clean formatting in CHANGELOGS.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -64,7 +64,7 @@
     *Brad Dunbar*
 
 *   Include I18n locale fallbacks in view lookup.
-    Fixes GH#3512.
+    Fixes #3512.
 
     *Juan Barreneche*
 

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Add `ActiveModel::Errors#full_messages_for`, to return all the error messages
     for a given attribute.
 
+    Example:
+
         class Person
           include ActiveModel::Validations
 
@@ -19,26 +21,27 @@
 *   Added a method so that validations can be easily cleared on a model.
     For example:
 
-      class Person
-        include ActiveModel::Validations
+        class Person
+          include ActiveModel::Validations
 
-        validates_uniqueness_of :first_name
-        validate :cannot_be_robot
+          validates_uniqueness_of :first_name
+          validate :cannot_be_robot
 
-        def cannot_be_robot
-          errors.add(:base, 'A person cannot be a robot') if person_is_robot
+          def cannot_be_robot
+            errors.add(:base, 'A person cannot be a robot') if person_is_robot
+          end
         end
-      end
 
     Now, if someone runs `Person.clear_validators!`, then the following occurs:
 
-      Person.validators                  # => []
-      Person._validate_callbacks.empty?  # => true
+        Person.validators                  # => []
+        Person._validate_callbacks.empty?  # => true
 
     *John Wang*
 
 *   `has_secure_password` does not fail the confirmation validation
     when assigning empty String to `password` and `password_confirmation`.
+    Fixes #9535.
 
     Example:
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -6,11 +6,11 @@
 
     Example:
 
-      cache = ActiveRecord::StatementCache.new do
-        Book.where(name: "my book").limit(100)
-      end
+        cache = ActiveRecord::StatementCache.new do
+          Book.where(name: "my book").limit(100)
+        end
 
-      books = cache.execute
+        books = cache.execute
 
     The solution attempts to get closer to the speed of `find_by_sql` but still maintaining
     the expressiveness of the Active Record queries.
@@ -44,7 +44,6 @@
     Ths solution is to build JoinAssociation when two relations with join information are being
     merged. And later while building the arel use the  previously built `JoinAssociation` record
     in `JoinDependency#graft` to build the right from clause.
-
     Fixes #3002.
 
     *Jared Armstrong and Neeraj Singh*
@@ -76,7 +75,8 @@
     *Michal Cichra*
 
 *   `has_many` using `:through` now obeys the order clause mentioned in
-    through association. Fixes #10016.
+    through association.
+    Fixes #10016.
 
     *Neeraj Singh*
 
@@ -141,7 +141,8 @@
     *Ken Mazaika*
 
 *   Add an `add_index` override in PostgreSQL adapter and MySQL adapter
-    to allow custom index type support. Fixes #6101.
+    to allow custom index type support.
+    Fixes #6101.
 
         add_index(:wikis, :body, :using => 'gin')
 
@@ -165,7 +166,6 @@
     in the association for a particular id. Then, it will go to the DB if it
     is not found. This is accomplished by calling `find_by_scan` in
     collection associations whenever `options[:inverse_of]` is not nil.
-
     Fixes #9470.
 
     *John Wang*
@@ -1275,7 +1275,7 @@
 
 *   Explain only normal CRUD sql (select / update / insert / delete).
     Fix problem that explains unexplainable sql.
-    Closes #7544 #6458.
+    Fixes #7544 #6458.
 
     *kennyj*
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 *   `fast_xs` support has been removed.  Use `String#encode(xml: :attr)`.
 
-*   `ActiveSupport::Notifications::Instrumenter#instrument` should yield
-    its payload.
+*   `ActiveSupport::Notifications::Instrumenter#instrument` should
+    yield its payload.
 
     *stopdropandrew*
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -58,7 +58,7 @@
 
 *   Improve service pages with new layout (404, etc).
 
-     *Stanislav Sobolev*
+    *Stanislav Sobolev*
 
 
 ## Rails 4.0.0.beta1 (February 25, 2013) ##


### PR DESCRIPTION
I've gone through the changes after `4.0.0.beta1` and cleaned up the CHANGELOG entries and fixed some indentation problems.
