### PR TITLE
locking_enabled? now returns boolean

### DIFF
--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -133,7 +133,7 @@ module ActiveRecord
         # (which it is, by default) and the table includes the
         # +locking_column+ column (defaults to +lock_version+).
         def locking_enabled?
-          lock_optimistically && columns_hash[locking_column]
+          lock_optimistically && columns_hash[locking_column].present?
         end
 
         # Set the column to use for optimistic locking. Defaults to +lock_version+.

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -74,6 +74,10 @@ class OptimisticLockingTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::StaleObjectError) { p2.save! }
   end
 
+	def test_locking_enabled
+	  assert_equal true, Person.locking_enabled?
+	end
+
   # See Lighthouse ticket #1966
   def test_lock_destroy
     p1 = Person.find(1)


### PR DESCRIPTION
updated locking_enabled? to keep consistent with [documentation](http://api.rubyonrails.org/classes/ActiveRecord/Locking/Optimistic/ClassMethods.html#method-i-locking_enabled-3F)

Currently locking_enabled? returns a database column object. 

This is my first commit so I apologize in advance if I've failed to follow the contributing guidelines in any way.  
