### PR TITLE
Adding the available_queries_for_explain thread local into the AR Runtime Registry

### DIFF
--- a/activerecord/lib/active_record/explain.rb
+++ b/activerecord/lib/active_record/explain.rb
@@ -4,13 +4,12 @@ module ActiveRecord
   module Explain
     # Relation#explain needs to be able to collect the queries.
     def collecting_queries_for_explain # :nodoc:
-      current = Thread.current
-      original, current[:available_queries_for_explain] = current[:available_queries_for_explain], []
+      original = ActiveRecord::RuntimeRegistry.save(:available_queries_for_explain)
       yield
-      return current[:available_queries_for_explain]
+      return ActiveRecord::RuntimeRegistry.available_queries_for_explain
     ensure
       # Note that the return value above does not depend on this assignment.
-      current[:available_queries_for_explain] = original
+      ActiveRecord::RuntimeRegistry.restore(:available_queries_for_explain)
     end
 
     # Makes the adapter execute EXPLAIN for the tuples of queries and bindings.

--- a/activerecord/lib/active_record/explain.rb
+++ b/activerecord/lib/active_record/explain.rb
@@ -4,12 +4,12 @@ module ActiveRecord
   module Explain
     # Relation#explain needs to be able to collect the queries.
     def collecting_queries_for_explain # :nodoc:
-      original = ActiveRecord::RuntimeRegistry.save(:available_queries_for_explain)
+      ActiveRecord::RuntimeRegistry.save_available_queries
       yield
       return ActiveRecord::RuntimeRegistry.available_queries_for_explain
     ensure
       # Note that the return value above does not depend on this assignment.
-      ActiveRecord::RuntimeRegistry.restore(:available_queries_for_explain)
+      ActiveRecord::RuntimeRegistry.restore_available_queries
     end
 
     # Makes the adapter execute EXPLAIN for the tuples of queries and bindings.

--- a/activerecord/lib/active_record/explain_subscriber.rb
+++ b/activerecord/lib/active_record/explain_subscriber.rb
@@ -7,7 +7,7 @@ module ActiveRecord
     end
 
     def finish(name, id, payload)
-      if queries = Thread.current[:available_queries_for_explain]
+      if queries = ActiveRecord::RuntimeRegistry.available_queries_for_explain
         queries << payload.values_at(:sql, :binds) unless ignore_payload?(payload)
       end
     end

--- a/activerecord/lib/active_record/explain_subscriber.rb
+++ b/activerecord/lib/active_record/explain_subscriber.rb
@@ -7,8 +7,8 @@ module ActiveRecord
     end
 
     def finish(name, id, payload)
-      if queries = ActiveRecord::RuntimeRegistry.available_queries_for_explain
-        queries << payload.values_at(:sql, :binds) unless ignore_payload?(payload)
+      if ActiveRecord::RuntimeRegistry.collecting_queries_flag && !ignore_payload?(payload)
+        ActiveRecord::RuntimeRegistry.available_queries_for_explain << payload.values_at(:sql, :binds)
       end
     end
 

--- a/activerecord/lib/active_record/runtime_registry.rb
+++ b/activerecord/lib/active_record/runtime_registry.rb
@@ -12,6 +12,54 @@ module ActiveRecord
   class RuntimeRegistry
     extend ActiveSupport::PerThreadRegistry
 
-    attr_accessor :connection_handler, :sql_runtime, :connection_id
+    attr_accessor :connection_handler, :sql_runtime, :connection_id,
+                  :available_queries_for_explain
+
+    def initialize
+      @available_queries_for_explain = []
+      @saved_variables               = {}
+    end
+
+    # Saves the current value of +variable_name+ into an internal hash inside
+    # the +RuntimeRegistry+ object. This allows you to later call +restore+
+    # and obtain the old value for the variable and mutate the value between
+    # the save and restore calls.
+    #
+    # Note that if save was called previously, then a new call to save will
+    # overwrite the previous saved value.
+    #
+    # Requires that +variable_name+ be a symbol matching a valid attribute.
+    def save(variable_name)
+      value = instance_variable_get("@#{variable_name}")
+      instance_variable_set("@#{variable_name}", reset_value(variable_name))
+      @saved_variables[variable_name] = value
+    end
+
+    # Restores the value of +variable_name+ and returns the value. After
+    # calling this, the attribute +variable_name+ should be restored to the
+    # original value it had when +save+ was called.
+    #
+    # If there is no stored value, then nil is returned.
+    #
+    # Requires that +variable_name+ be a symbol matching a valid attribute.
+    def restore(variable_name)
+      stored_value = @saved_variables[variable_name]
+      if stored_value
+        @saved_variables[variable_name] = reset_value(variable_name)
+        instance_variable_set("@#{variable_name}", stored_value)
+        stored_value
+      end
+    end
+
+    private
+
+      # The reset value will be nil unless the variable name passed in is
+      # +available_queries_for_explain+, in which case we pass back an empty
+      # array as the reset value.
+      def reset_value(variable_name)
+        if variable_name == :available_queries_for_explain
+          []
+        end
+      end
   end
 end

--- a/activerecord/test/cases/explain_subscriber_test.rb
+++ b/activerecord/test/cases/explain_subscriber_test.rb
@@ -46,11 +46,11 @@ if ActiveRecord::Base.connection.supports_explain?
     end
 
     def with_queries(queries)
-      ActiveRecord::RuntimeRegistry.save(:available_queries_for_explain)
+      ActiveRecord::RuntimeRegistry.save_available_queries
       ActiveRecord::RuntimeRegistry.available_queries_for_explain = queries
       yield queries
     ensure
-      ActiveRecord::RuntimeRegistry.restore(:available_queries_for_explain)
+      ActiveRecord::RuntimeRegistry.restore_available_queries
     end
   end
 end

--- a/activerecord/test/cases/explain_subscriber_test.rb
+++ b/activerecord/test/cases/explain_subscriber_test.rb
@@ -7,7 +7,7 @@ if ActiveRecord::Base.connection.supports_explain?
     def test_collects_nothing_if_available_queries_for_explain_is_nil
       with_queries(nil) do
         SUBSCRIBER.finish(nil, nil, {})
-        assert_nil Thread.current[:available_queries_for_explain]
+        assert_nil ActiveRecord::RuntimeRegistry.available_queries_for_explain
       end
     end
 
@@ -46,10 +46,11 @@ if ActiveRecord::Base.connection.supports_explain?
     end
 
     def with_queries(queries)
-      Thread.current[:available_queries_for_explain] = queries
+      ActiveRecord::RuntimeRegistry.save(:available_queries_for_explain)
+      ActiveRecord::RuntimeRegistry.available_queries_for_explain = queries
       yield queries
     ensure
-      Thread.current[:available_queries_for_explain] = nil
+      ActiveRecord::RuntimeRegistry.restore(:available_queries_for_explain)
     end
   end
 end

--- a/activerecord/test/cases/runtime_registry_test.rb
+++ b/activerecord/test/cases/runtime_registry_test.rb
@@ -1,0 +1,76 @@
+require 'cases/helper'
+
+class RuntimeRegistryTest < ActiveRecord::TestCase
+  def setup
+    @instance = ActiveRecord::RuntimeRegistry.instance
+  end
+
+  def teardown
+    # Reset the runtime registry
+    Thread.current["ActiveRecord::RuntimeRegistry"] = ActiveRecord::RuntimeRegistry.new
+  end
+
+  def test_runtime_registry_stored_as_thread_local
+    local_runtime_registry = Thread.current["ActiveRecord::RuntimeRegistry"]
+
+    assert_not_nil local_runtime_registry
+    assert_equal @instance, local_runtime_registry
+  end
+
+  def test_runtime_registry_variable_handling
+    connection = "some_crazy_connection"
+    @instance.connection_handler = connection
+
+    assert_not_nil @instance.connection_handler
+    assert_not_nil ActiveRecord::RuntimeRegistry.connection_handler
+    assert_equal @instance.connection_handler, connection
+    assert_equal ActiveRecord::RuntimeRegistry.connection_handler, connection
+  end
+
+  def test_saving_and_restoring_variables
+    old_connection = "some_old_childhood_friend"
+    @instance.connection_handler = old_connection
+
+    assert_equal old_connection, @instance.save(:connection_handler)
+    assert_nil @instance.connection_handler
+
+    new_connection = "some_new_friend"
+    @instance.connection_handler = new_connection
+
+    assert_equal new_connection, @instance.connection_handler
+    assert_equal old_connection, @instance.restore(:connection_handler)
+    assert_equal old_connection, @instance.connection_handler
+  end
+
+  def test_save_overwrites_previous_saved_value
+    old_connection = "I like to move it move it"
+    @instance.connection_handler = old_connection
+    assert_equal old_connection, @instance.save(:connection_handler)
+
+    new_connection = "It's the eye of the tiger"
+    @instance.connection_handler = new_connection
+    assert_equal new_connection, @instance.save(:connection_handler)
+    assert_nil @instance.connection_handler
+
+    assert_equal new_connection, @instance.restore(:connection_handler)
+    assert_equal new_connection, @instance.connection_handler
+  end
+
+  def test_restore_without_save_returns_nil
+    assert_nil @instance.restore(:connection_handler)
+
+    connection = "Don't stop me now"
+    @instance.connection_handler = connection
+    assert_nil @instance.restore(:connection_handler)
+  end
+
+  def test_available_queries_for_explain_is_an_array_after_save_and_restore
+    assert @instance.available_queries_for_explain.kind_of?(Array)
+    @instance.save(:available_queries_for_explain)
+
+    assert @instance.available_queries_for_explain.kind_of?(Array)
+    @instance.restore(:available_queries_for_explain)
+
+    assert @instance.available_queries_for_explain.kind_of?(Array)
+  end
+end

--- a/activerecord/test/cases/runtime_registry_test.rb
+++ b/activerecord/test/cases/runtime_registry_test.rb
@@ -2,7 +2,7 @@ require 'cases/helper'
 
 class RuntimeRegistryTest < ActiveRecord::TestCase
   def setup
-    @instance = ActiveRecord::RuntimeRegistry.instance
+    @instance = ActiveRecord::RuntimeRegistry
   end
 
   def teardown
@@ -14,7 +14,7 @@ class RuntimeRegistryTest < ActiveRecord::TestCase
     local_runtime_registry = Thread.current["ActiveRecord::RuntimeRegistry"]
 
     assert_not_nil local_runtime_registry
-    assert_equal @instance, local_runtime_registry
+    assert local_runtime_registry.kind_of?(ActiveRecord::RuntimeRegistry)
   end
 
   def test_runtime_registry_variable_handling
@@ -66,10 +66,10 @@ class RuntimeRegistryTest < ActiveRecord::TestCase
 
   def test_available_queries_for_explain_is_an_array_after_save_and_restore
     assert @instance.available_queries_for_explain.kind_of?(Array)
-    @instance.save(:available_queries_for_explain)
+    @instance.save(:available_queries_for_explain, [])
 
     assert @instance.available_queries_for_explain.kind_of?(Array)
-    @instance.restore(:available_queries_for_explain)
+    @instance.restore(:available_queries_for_explain, [])
 
     assert @instance.available_queries_for_explain.kind_of?(Array)
   end


### PR DESCRIPTION
Before, the `:available_queries_for_explain` thread local could be accessed by using `Thread.current[:available_queries_for_explain]`. However, the `ActiveRecord::RuntimeRegistry` object has recently been added to limit the number of thread locals that are passed around.

This PR moves the handling of `:available_queries_for_explain` into the `RuntimeRegistry` object and changes the appropriate logic.
