### PR TITLE
Fix freeze applying to cloned objects

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -307,9 +307,11 @@ module ActiveRecord
       id.hash
     end
 
-    # Freeze the attributes hash such that associations are still accessible, even on destroyed records.
+    # Clone and freeze the attributes hash such that associations are still
+    # accessible, even on destroyed records, but cloned models will not be
+    # frozen.
     def freeze
-      @attributes.freeze
+      @attributes = @attributes.clone.freeze
       self
     end
 

--- a/activerecord/test/cases/clone_test.rb
+++ b/activerecord/test/cases/clone_test.rb
@@ -29,5 +29,12 @@ module ActiveRecord
       topic.author_name = 'Aaron'
       assert_equal 'Aaron', cloned.author_name
     end
+
+    def test_freezing_a_cloned_model_does_not_freeze_clone
+      cloned = Topic.new
+      clone = cloned.clone
+      cloned.freeze
+      assert_not clone.frozen?
+    end
   end
 end


### PR DESCRIPTION
Previously, freezing a cloned ActiveRecord object froze the original too. By
cloning `@attributes` before freezing, we prevent cloned objects
(which in Ruby share state of ivars) from being effected by `#freeze`.

Resolves issue #4936, which has further information on this issue, as well as
steps to reproduce.
- Add a test case for `#freeze` not causing `cloned.frozen?` to be true.
- Clone `@attributes` before freezing in `ActiveRecord::Core`, then
  reassign the cloned, frozen hash to the frozen model's `@attributes`
  ivar.

/cc @steveklabnik
