### PR TITLE
Add support for creating an index on multiple columns via migration generator

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,4 +1,15 @@
 ## Rails 4.0.0 (unreleased) ##
+*   Added a migration generator to create indexes. To invoke, use the generator from the
+    command line:
+
+        rails g migration IndexAuthorNameAndTitleOnBooks author title
+
+    That will create a migration that adds an index named `index_author_name_and_title`
+    on the `books` table, using the `author` and `title` columns:
+
+        add_index :books, [:author, :title], name: 'index_author_name_and_title'
+
+    *Sammy Larbi*
 
 *   Added Statement Cache to allow the caching of a single statement. The cache works by
     duping the relation returned from yielding a statement, which allows skipping the AST

--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -12,7 +12,7 @@ module ActiveRecord
       end
 
       protected
-      attr_reader :migration_action, :join_tables
+      attr_reader :migration_action, :join_tables, :index_name
 
       def set_local_assigns!
         @migration_template = "migration.rb"
@@ -30,6 +30,11 @@ module ActiveRecord
         when /^create_(.+)/
           @table_name = $1.pluralize
           @migration_template = "create_table_migration.rb"
+        when /^index_(.*)_on_(.*)/
+          @migration_action = 'index'
+          @index_name = $1
+          @table_name = $2
+          @migration_template = "add_index_migration.rb"
         end
       end
 

--- a/activerecord/lib/rails/generators/active_record/migration/templates/add_index_migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/add_index_migration.rb
@@ -1,0 +1,5 @@
+class <%= migration_class_name %> < ActiveRecord::Migration
+  def change
+		add_index :<%= table_name %>, [:<%= attributes.map(&:name).join(", :") %>], name: 'index_<%= index_name %>'
+  end
+end

--- a/guides/source/migrations.md
+++ b/guides/source/migrations.md
@@ -183,6 +183,26 @@ class AddDetailsToProducts < ActiveRecord::Migration
 end
 ```
 
+You can also generate migrations to create table indexes. If the migration name
+matches the form "IndexNameOfIndexOnTableName" and is followed by a list of
+column names, then a migration creating an index named `index_name_of_index`
+on table `table_name` using the columns you listed will be generated.
+For example:
+
+```bash
+$ rails generate migration IndexProductNameAndPriceOnProducts name price
+```
+
+generates
+
+```ruby
+class IndexProductNameOnProducts < ActiveRecord::Migration
+  def change
+    add_index :products, [:name, :price], name: 'index_product_name_and_price'
+  end
+end
+```
+
 If the migration name is of the form "CreateXXX" and is
 followed by a list of column names and types then a migration creating the table
 XXX with the columns listed will be generated. For example:

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -183,7 +183,18 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_should_create_empty_migrations_if_name_not_start_with_add_or_remove_or_create
+  def test_index_migration
+    run_generator ["IndexTitleAndContentOnBooks", "title", "content"]
+    assert_migration "db/migrate/index_title_and_content_on_books.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/add_index :books/, change)
+        assert_match(/[:title, :content]/, change)
+			  assert_match(/name: 'index_title_and_content'/, change)
+      end
+    end
+  end
+
+  def test_should_create_empty_migrations_if_name_not_start_with_add_or_remove_or_create_or_index
     migration = "delete_books"
     run_generator [migration, "title:string", "content:text"]
 


### PR DESCRIPTION
I added a migration generator to create an index on multiple columns. To invoke, use the generator from the command line:

```
rails g migration IndexAuthorNameAndTitleOnBooks author title
```

That will create a migration that adds an index named `index_author_name_and_title`
on the `books` table, using the `author` and `title` columns:

```
add_index :books, [:author, :title], name: 'index_author_name_and_title'
```

Thoughts?
