### PR TITLE
Replace uses of 'lambda' with new stubby syntax

### DIFF
--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -21,8 +21,8 @@ end
 ActiveSupport::Deprecation.debug = true
 
 # Bogus template processors
-ActionView::Template.register_template_handler :haml, lambda { |template| "Look its HAML!".inspect }
-ActionView::Template.register_template_handler :bak, lambda { |template| "Lame backup".inspect }
+ActionView::Template.register_template_handler :haml, ->(template) { "Look its HAML!".inspect }
+ActionView::Template.register_template_handler :bak, ->(template) { "Lame backup".inspect }
 
 FIXTURE_LOAD_PATH = File.expand_path('fixtures', File.dirname(__FILE__))
 ActionMailer::Base.view_paths = FIXTURE_LOAD_PATH

--- a/actionpack/lib/action_dispatch/http/filter_parameters.rb
+++ b/actionpack/lib/action_dispatch/http/filter_parameters.rb
@@ -16,7 +16,7 @@ module ActionDispatch
     #   env["action_dispatch.parameter_filter"] = [:foo, "bar"]
     #   => replaces the value to all keys matching /foo|bar/i with "[FILTERED]"
     #
-    #   env["action_dispatch.parameter_filter"] = lambda do |k,v|
+    #   env["action_dispatch.parameter_filter"] = ->(k,v) do
     #     v.reverse! if k =~ /secret/i
     #   end
     #   => reverses the value to all keys matching /secret/i

--- a/actionpack/lib/action_dispatch/http/parameter_filter.rb
+++ b/actionpack/lib/action_dispatch/http/parameter_filter.rb
@@ -19,7 +19,7 @@ module ActionDispatch
 
       class CompiledFilter # :nodoc:
         def self.compile(filters)
-          return lambda { |params| params.dup } if filters.empty?
+          return ->(params) { params.dup } if filters.empty?
 
           strings, regexps, blocks = [], [], []
 

--- a/actionpack/lib/action_dispatch/middleware/reloader.rb
+++ b/actionpack/lib/action_dispatch/middleware/reloader.rb
@@ -9,7 +9,7 @@ module ActionDispatch
   # the response body. This is important for streaming responses such as the
   # following:
   #
-  #     self.response_body = lambda { |response, output|
+  #     self.response_body = ->(response, output) {
   #       # code here which refers to application models
   #     }
   #

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -357,7 +357,7 @@ module ActionDispatch
         # A pattern can also point to a +Rack+ endpoint i.e. anything that
         # responds to +call+:
         #
-        #   match 'photos/:id', to: lambda {|hash| [200, {}, ["Coming soon"]] }
+        #   match 'photos/:id', to: ->(hash) { [200, {}, ["Coming soon"]] }
         #   match 'photos/:id', to: PhotoRackApp
         #   # Yes, controller actions are just rack endpoints
         #   match 'photos/:id', to: PhotosController.action(:show)
@@ -402,7 +402,7 @@ module ActionDispatch
         #   +call+ or a string representing a controller's action.
         #
         #      match 'path', to: 'controller#action'
-        #      match 'path', to: lambda { |env| [200, {}, ["Success!"]] }
+        #      match 'path', to: ->(env) { [200, {}, ["Success!"]] }
         #      match 'path', to: RackApp
         #
         # [:on]
@@ -810,7 +810,7 @@ module ActionDispatch
         #
         # Requests to routes can be constrained based on specific criteria:
         #
-        #    constraints(lambda { |req| req.env["HTTP_USER_AGENT"] =~ /iPhone/ }) do
+        #    constraints(->(req) { req.env["HTTP_USER_AGENT"] =~ /iPhone/ }) do
         #      resources :iphones
         #    end
         #
@@ -1715,7 +1715,7 @@ module ActionDispatch
         # callable, they're accessible from the Mapper that's passed to
         # <tt>call</tt>.
         def concern(name, callable = nil, &block)
-          callable ||= lambda { |mapper, options| mapper.instance_exec(options, &block) }
+          callable ||= ->(mapper, options) { mapper.instance_exec(options, &block) }
           @concerns[name] = callable
         end
 

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -469,7 +469,7 @@ module ActionDispatch
       private :build_conditions
 
       class Generator #:nodoc:
-        PARAMETERIZE = lambda do |name, value|
+        PARAMETERIZE = ->(name, value) do
           if name == :controller
             value
           elsif value.is_a?(Array)

--- a/actionpack/lib/action_dispatch/testing/assertions/selector.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/selector.rb
@@ -313,7 +313,7 @@ module ActionDispatch
       end
 
       def count_description(min, max, count) #:nodoc:
-        pluralize = lambda {|word, quantity| word << (quantity == 1 ? '' : 's')}
+        pluralize = ->(word, quantity) { word << (quantity == 1 ? '' : 's')}
 
         if min && max && (max != min)
           "between #{min} and #{max} elements"
@@ -372,7 +372,7 @@ module ActionDispatch
             raise ArgumentError, "Argument is optional, and may be node or array of nodes"
         end
 
-        fix_content = lambda do |node|
+        fix_content = ->(node) do
           # Gets around a bug in the Rails 1.1 HTML parser.
           node.content.gsub(/<!\[CDATA\[(.*)(\]\]>)?/m) { Rack::Utils.escapeHTML($1) }
         end

--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -80,7 +80,7 @@ module ActionView
     #
     # When used with the <tt>collection_select</tt> helper, <tt>:disabled</tt> can also be a Proc that identifies those options that should be disabled.
     #
-    #   collection_select(:post, :category_id, Category.all, :id, :name, {disabled: lambda{|category| category.archived? }})
+    #   collection_select(:post, :category_id, Category.all, :id, :name, {disabled: ->(category) { category.archived? }})
     #
     # If the categories "2008 stuff" and "Christmas" return true when the method <tt>archived?</tt> is called, this would return:
     #   <select name="post[category_id]">
@@ -561,7 +561,7 @@ module ActionView
         zone_options = "".html_safe
 
         zones = model.all
-        convert_zones = lambda { |list| list.map { |z| [ z.to_s, z.name ] } }
+        convert_zones = ->(list) { list.map { |z| [ z.to_s, z.name ] } }
 
         if priority_zones
           if priority_zones.is_a?(Regexp)

--- a/actionpack/lib/action_view/helpers/translation_helper.rb
+++ b/actionpack/lib/action_view/helpers/translation_helper.rb
@@ -93,7 +93,7 @@ module ActionView
           defaults     = Array(defaults)
           while key = defaults.shift
             if key.is_a?(Symbol)
-              new_defaults << lambda { |_, options| translate key, options.merge(:default => defaults) }
+              new_defaults << ->(_, options) { translate key, options.merge(default: defaults) }
               break
             else
               new_defaults << key

--- a/actionpack/lib/action_view/renderer/streaming_template_renderer.rb
+++ b/actionpack/lib/action_view/renderer/streaming_template_renderer.rb
@@ -62,9 +62,9 @@ module ActionView
       # to the buffer, it is not appended to an array, but streamed straight
       # to the client.
       output  = ActionView::StreamingBuffer.new(buffer)
-      yielder = lambda { |*name| view._layout_for(*name) }
+      yielder = ->(*name) { view._layout_for(*name) }
 
-      instrument(:template, :identifier => template.identifier, :layout => layout.try(:virtual_path)) do
+      instrument(:template, identifier: template.identifier, layout: layout.try(:virtual_path)) do
         fiber = Fiber.new do
           if layout
             layout.render(view, locals, output, &yielder)

--- a/actionpack/lib/action_view/template/resolver.rb
+++ b/actionpack/lib/action_view/template/resolver.rb
@@ -42,10 +42,10 @@ module ActionView
       end
 
       # preallocate all the default blocks for performance/memory consumption reasons
-      PARTIAL_BLOCK = lambda {|cache, partial| cache[partial] = SmallCache.new}
-      PREFIX_BLOCK  = lambda {|cache, prefix|  cache[prefix]  = SmallCache.new(&PARTIAL_BLOCK)}
-      NAME_BLOCK    = lambda {|cache, name|    cache[name]    = SmallCache.new(&PREFIX_BLOCK)}
-      KEY_BLOCK     = lambda {|cache, key|     cache[key]     = SmallCache.new(&NAME_BLOCK)}
+      PARTIAL_BLOCK = ->(cache, partial) { cache[partial] = SmallCache.new}
+      PREFIX_BLOCK  = ->(cache, prefix)  { cache[prefix]  = SmallCache.new(&PARTIAL_BLOCK)}
+      NAME_BLOCK    = ->(cache, name)    { cache[name]    = SmallCache.new(&PREFIX_BLOCK)}
+      KEY_BLOCK     = ->(cache, key)     { cache[key]     = SmallCache.new(&NAME_BLOCK)}
 
       # usually a majority of template look ups return nothing, use this canonical preallocated array to save memory
       NO_TEMPLATES = [].freeze

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -3,7 +3,7 @@ require 'controller/fake_controllers'
 require 'action_view/vendor/html-scanner'
 
 class SessionTest < ActiveSupport::TestCase
-  StubApp = lambda { |env|
+  StubApp = ->(env) {
     [200, {"Content-Type" => "text/html", "Content-Length" => "13"}, ["Hello, World!"]]
   }
 

--- a/actionpack/test/controller/layout_test.rb
+++ b/actionpack/test/controller/layout_test.rb
@@ -7,7 +7,7 @@ require 'active_support/core_ext/array/extract_options'
 old_load_paths = ActionController::Base.view_paths
 
 ActionView::Template::register_template_handler :mab,
-  lambda { |template| template.source.inspect }
+  ->(template) { template.source.inspect }
 
 ActionController::Base.view_paths = [ File.dirname(__FILE__) + '/../fixtures/layout_tests/' ]
 

--- a/actionpack/test/controller/rescue_test.rb
+++ b/actionpack/test/controller/rescue_test.rb
@@ -160,9 +160,9 @@ class ExceptionInheritanceRescueController < ActionController::Base
   class GrandchildException < ChildException
   end
 
-  rescue_from ChildException,      :with => lambda { head :ok }
-  rescue_from ParentException,     :with => lambda { head :created }
-  rescue_from GrandchildException, :with => lambda { head :no_content }
+  rescue_from ChildException,      with: -> { head :ok }
+  rescue_from ParentException,     with: -> { head :created }
+  rescue_from GrandchildException, with: -> { head :no_content }
 
   def raise_parent_exception
     raise ParentException
@@ -196,7 +196,7 @@ class ControllerInheritanceRescueController < ExceptionInheritanceRescueControll
   class SecondExceptionInChildController < StandardError
   end
 
-  rescue_from FirstExceptionInChildController, 'SecondExceptionInChildController', :with => lambda { head :gone }
+  rescue_from FirstExceptionInChildController, 'SecondExceptionInChildController', with: -> { head :gone }
 
   def raise_first_exception_in_child_controller
     raise FirstExceptionInChildController

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -85,7 +85,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_symbols_with_dashes
     rs.draw do
-      get '/:artist/:song-omg', :to => lambda { |env|
+      get '/:artist/:song-omg', to: ->(env) {
         resp = JSON.dump env[ActionDispatch::Routing::RouteSet::PARAMETERS_KEY]
         [200, {}, [resp]]
       }
@@ -97,7 +97,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_id_with_dash
     rs.draw do
-      get '/journey/:id', :to => lambda { |env|
+      get '/journey/:id', to: ->(env) {
         resp = JSON.dump env[ActionDispatch::Routing::RouteSet::PARAMETERS_KEY]
         [200, {}, [resp]]
       }
@@ -109,7 +109,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_dash_with_custom_regexp
     rs.draw do
-      get '/:artist/:song-omg', :constraints => { :song => /\d+/ }, :to => lambda { |env|
+      get '/:artist/:song-omg', constraints: { song: /\d+/ }, to: ->(env) {
         resp = JSON.dump env[ActionDispatch::Routing::RouteSet::PARAMETERS_KEY]
         [200, {}, [resp]]
       }
@@ -122,7 +122,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_pre_dash
     rs.draw do
-      get '/:artist/omg-:song', :to => lambda { |env|
+      get '/:artist/omg-:song', to: ->(env) {
         resp = JSON.dump env[ActionDispatch::Routing::RouteSet::PARAMETERS_KEY]
         [200, {}, [resp]]
       }
@@ -134,7 +134,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_pre_dash_with_custom_regexp
     rs.draw do
-      get '/:artist/omg-:song', :constraints => { :song => /\d+/ }, :to => lambda { |env|
+      get '/:artist/omg-:song', constraints: { song: /\d+/ }, to: ->(env) {
         resp = JSON.dump env[ActionDispatch::Routing::RouteSet::PARAMETERS_KEY]
         [200, {}, [resp]]
       }
@@ -147,7 +147,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_star_paths_are_greedy
     rs.draw do
-      get "/*path", :to => lambda { |env|
+      get "/*path", to: ->(env) {
         x = env["action_dispatch.request.path_parameters"][:path]
         [200, {}, [x]]
       }, :format => false
@@ -159,7 +159,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_star_paths_are_greedy_but_not_too_much
     rs.draw do
-      get "/*path", :to => lambda { |env|
+      get "/*path", to: ->(env) {
         x = JSON.dump env["action_dispatch.request.path_parameters"]
         [200, {}, [x]]
       }
@@ -172,7 +172,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_optional_star_paths_are_greedy
     rs.draw do
-      get "/(*filters)", :to => lambda { |env|
+      get "/(*filters)", to: ->(env) {
         x = env["action_dispatch.request.path_parameters"][:filters]
         [200, {}, [x]]
       }, :format => false
@@ -184,7 +184,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_optional_star_paths_are_greedy_but_not_too_much
     rs.draw do
-      get "/(*filters)", :to => lambda { |env|
+      get "/(*filters)", to: ->(env) {
         x = JSON.dump env["action_dispatch.request.path_parameters"]
         [200, {}, [x]]
       }
@@ -198,11 +198,11 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_regexp_precidence
     rs.draw do
-      get '/whois/:domain', :constraints => {
-        :domain => /\w+\.[\w\.]+/ },
-        :to     => lambda { |env| [200, {}, %w{regexp}] }
+      get '/whois/:domain', constraints: {
+        domain: /\w+\.[\w\.]+/ },
+        to:     ->(env) { [200, {}, %w{regexp}] }
 
-      get '/whois/:id', :to => lambda { |env| [200, {}, %w{id}] }
+      get '/whois/:id', to: ->(env) { [200, {}, %w{id}] }
     end
 
     assert_equal 'regexp', get(URI('http://example.org/whois/example.org'))
@@ -217,10 +217,10 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     }
 
     rs.draw do
-      get '/', :constraints => subdomain.new,
-                 :to          => lambda { |env| [200, {}, %w{default}] }
-      get '/', :constraints => { :subdomain => 'clients' },
-                 :to          => lambda { |env| [200, {}, %w{clients}] }
+      get '/', constraints: subdomain.new,
+               to:          ->(env) { [200, {}, %w{default}] }
+      get '/', constraints: { subdomain: 'clients' },
+               to:          ->(env) { [200, {}, %w{clients}] }
     end
 
     assert_equal 'default', get(URI('http://www.example.org/'))
@@ -229,13 +229,13 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_lambda_constraints
     rs.draw do
-      get '/', :constraints => lambda { |req|
+      get '/', constraints: ->(req) {
         req.subdomain.present? and req.subdomain != "clients" },
-                 :to          => lambda { |env| [200, {}, %w{default}] }
+               to:          ->(env) { [200, {}, %w{default}] }
 
-      get '/', :constraints => lambda { |req|
+      get '/', constraints: ->(req) {
         req.subdomain.present? && req.subdomain == "clients" },
-                 :to          => lambda { |env| [200, {}, %w{clients}] }
+               to:          ->(env) { [200, {}, %w{clients}] }
     end
 
     assert_equal 'default', get(URI('http://www.example.org/'))
@@ -244,8 +244,8 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_empty_string_match
     rs.draw do
-      get '/:username', :constraints => { :username => /[^\/]+/ },
-                       :to => lambda { |e| [200, {}, ['foo']] }
+      get '/:username', constraints: { username: /[^\/]+/ },
+                        to:          ->(e) { [200, {}, ['foo']] }
     end
     assert_equal 'Not Found', get(URI('http://example.org/'))
     assert_equal 'foo', get(URI('http://example.org/hello'))
@@ -254,8 +254,8 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   def test_non_greedy_glob_regexp
     params = nil
     rs.draw do
-      get '/posts/:id(/*filters)', :constraints => { :filters => /.+?/ },
-        :to => lambda { |e|
+      get '/posts/:id(/*filters)', constraints: { :filters => /.+?/ },
+        to: ->(e) {
         params = e["action_dispatch.request.path_parameters"]
         [200, {}, ['foo']]
       }
@@ -272,7 +272,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_specific_controller_action_failure
     rs.draw do
-      mount lambda {} => "/foo"
+      mount -> {} => "/foo"
     end
 
     assert_raises(ActionController::UrlGenerationError) do
@@ -1452,7 +1452,7 @@ class RouteSetTest < ActiveSupport::TestCase
   def test_route_with_subdomain_and_constraints_must_receive_params
     name_param = nil
     set.draw do
-      get 'page/:name' => 'pages#show', :constraints => lambda {|request|
+      get 'page/:name' => 'pages#show', constraints: ->(request) {
         name_param = request.params[:name]
         return true
       }
@@ -1735,7 +1735,7 @@ class RackMountIntegrationTests < ActiveSupport::TestCase
 
   Model = Struct.new(:to_param)
 
-  Mapping = lambda {
+  Mapping = -> {
     namespace :admin do
       resources :users, :posts
     end

--- a/actionpack/test/controller/url_for_integration_test.rb
+++ b/actionpack/test/controller/url_for_integration_test.rb
@@ -9,7 +9,7 @@ module ActionPack
 
     Model = Struct.new(:to_param)
 
-    Mapping = lambda {
+    Mapping = -> {
       namespace :admin do
         resources :users, :posts
       end

--- a/actionpack/test/dispatch/mapper_test.rb
+++ b/actionpack/test/dispatch/mapper_test.rb
@@ -102,7 +102,7 @@ module ActionDispatch
       def test_raising_helpful_error_on_invalid_arguments
         fakeset = FakeSet.new
         mapper = Mapper.new fakeset
-        app = lambda { |env| [200, {}, [""]] }
+        app = ->(env) { [200, {}, [""]] }
         assert_raises ArgumentError do
           mapper.mount app
         end

--- a/actionpack/test/dispatch/mount_test.rb
+++ b/actionpack/test/dispatch/mount_test.rb
@@ -14,7 +14,7 @@ class TestRoutingMount < ActionDispatch::IntegrationTest
   end
 
   Router.draw do
-    SprocketsApp = lambda { |env|
+    SprocketsApp = ->(env) {
       [200, {"Content-Type" => "text/html"}, ["#{env["SCRIPT_NAME"]} -- #{env["PATH_INFO"]}"]]
     }
 

--- a/actionpack/test/dispatch/reloader_test.rb
+++ b/actionpack/test/dispatch/reloader_test.rb
@@ -57,7 +57,7 @@ class ReloaderTest < ActiveSupport::TestCase
     i, j = 0, 0, 0, 0
     Reloader.to_prepare { |*args| i += 1 }
     Reloader.to_cleanup { |*args| j += 1 }
-    app = Reloader.new(lambda { |env| [200, {}, []] }, lambda { i < 3 })
+    app = Reloader.new(->(env) { [200, {}, []] }, -> { i < 3 })
     5.times do
       resp = app.call({})
       resp[2].close

--- a/actionpack/test/dispatch/request_id_test.rb
+++ b/actionpack/test/dispatch/request_id_test.rb
@@ -20,7 +20,7 @@ class RequestIdTest < ActiveSupport::TestCase
   private
 
   def stub_request(env = {})
-    ActionDispatch::RequestId.new(lambda { |environment| [ 200, environment, [] ] }).call(env)
+    ActionDispatch::RequestId.new(->(environment) { [ 200, environment, [] ] }).call(env)
     ActionDispatch::Request.new(env)
   end
 end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -700,7 +700,7 @@ class RequestTest < ActiveSupport::TestCase
       assert_equal after_filter, parameter_filter.filter(before_filter)
 
       filter_words << 'blah'
-      filter_words << lambda { |key, value|
+      filter_words << ->(key, value) {
         value.reverse! if key =~ /bargain/
       }
 

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -222,7 +222,7 @@ class ResponseIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "response cache control from railsish app" do
-    @app = lambda { |env|
+    @app = ->(env) {
       ActionDispatch::Response.new.tap { |resp|
         resp.cache_control[:public] = true
         resp.etag = '123'
@@ -241,7 +241,7 @@ class ResponseIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "response cache control from rackish app" do
-    @app = lambda { |env|
+    @app = ->(env) {
       [200,
         {'ETag' => '"202cb962ac59075b964b07152d234b70"',
           'Cache-Control' => 'public'}, ['Hello']]
@@ -258,7 +258,7 @@ class ResponseIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "response charset and content type from railsish app" do
-    @app = lambda { |env|
+    @app = ->(env) {
       ActionDispatch::Response.new.tap { |resp|
         resp.charset = 'utf-16'
         resp.content_type = Mime::XML
@@ -276,7 +276,7 @@ class ResponseIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "response charset and content type from rackish app" do
-    @app = lambda { |env|
+    @app = ->(env) {
       [200,
         {'Content-Type' => 'application/xml; charset=utf-16'},
         ['Hello']]

--- a/actionpack/test/dispatch/routing_assertions_test.rb
+++ b/actionpack/test/dispatch/routing_assertions_test.rb
@@ -16,11 +16,11 @@ class RoutingAssertionsTest < ActionController::TestCase
         resources :articles, :controller => 'secure_articles'
       end
 
-      scope 'block', :constraints => lambda { |r| r.ssl? } do
+      scope 'block', constraints: ->(r) { r.ssl? } do
         resources :articles, :controller => 'block_articles'
       end
 
-      scope 'query', :constraints => lambda { |r| r.params[:use_query] == 'true' } do
+      scope 'query', constraints: ->(r) { r.params[:use_query] == 'true' } do
         resources :articles, :controller => 'query_articles'
       end
     end

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4,7 +4,7 @@ require 'abstract_unit'
 require 'controller/fake_controllers'
 
 class TestRoutingMapper < ActionDispatch::IntegrationTest
-  SprocketsApp = lambda { |env|
+  SprocketsApp = ->(env) {
     [200, {"Content-Type" => "text/html"}, ["javascripts"]]
   }
 
@@ -2509,7 +2509,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_symbolized_path_parameters_is_not_stale
     draw do
-      scope '/countries/:country', :constraints => lambda { |params, req| %w(all France).include?(params[:country]) } do
+      scope '/countries/:country', constraints: ->(params, req) { %w(all France).include?(params[:country]) } do
         get '/',       :to => 'countries#index'
         get '/cities', :to => 'countries#cities'
       end
@@ -2900,7 +2900,7 @@ end
 
 class TestAppendingRoutes < ActionDispatch::IntegrationTest
   def simple_app(resp)
-    lambda { |e| [ 200, { 'Content-Type' => 'text/plain' }, [resp] ] }
+    ->(e) { [ 200, { 'Content-Type' => 'text/plain' }, [resp] ] }
   end
 
   def setup
@@ -3027,7 +3027,7 @@ class TestHttpMethods < ActionDispatch::IntegrationTest
   RFC5789 = %w(PATCH)
 
   def simple_app(response)
-    lambda { |env| [ 200, { 'Content-Type' => 'text/plain' }, [response] ] }
+    ->(env) { [ 200, { 'Content-Type' => 'text/plain' }, [response] ] }
   end
 
   setup do
@@ -3052,7 +3052,7 @@ end
 class TestUriPathEscaping < ActionDispatch::IntegrationTest
   Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
     app.draw do
-      get '/:segment' => lambda { |env|
+      get '/segment' => lambda { |env|
         path_params = env['action_dispatch.request.path_parameters']
         [200, { 'Content-Type' => 'text/plain' }, [path_params[:segment]]]
       }, :as => :segment
@@ -3089,7 +3089,7 @@ end
 class TestUnicodePaths < ActionDispatch::IntegrationTest
   Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
     app.draw do
-      get "/ほげ" => lambda { |env|
+      get "/ほげ" => ->(env) {
         [200, { 'Content-Type' => 'text/plain' }, []]
       }, :as => :unicode_path
     end
@@ -3138,7 +3138,7 @@ end
 class TestTildeAndMinusPaths < ActionDispatch::IntegrationTest
   Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
     app.draw do
-      ok = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, []] }
+      ok = ->(env) { [200, { 'Content-Type' => 'text/plain' }, []] }
 
       get "/~user" => ok
       get "/young-and-fine" => ok
@@ -3163,7 +3163,7 @@ end
 class TestRedirectInterpolation < ActionDispatch::IntegrationTest
   Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
     app.draw do
-      ok = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, []] }
+      ok = ->(env) { [200, { 'Content-Type' => 'text/plain' }, []] }
 
       get "/foo/:id" => redirect("/foo/bar/%{id}")
       get "/bar/:id" => redirect(:path => "/foo/bar/%{id}")
@@ -3198,9 +3198,9 @@ end
 class TestConstraintsAccessingParameters < ActionDispatch::IntegrationTest
   Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
     app.draw do
-      ok = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, []] }
+      ok = ->(env) { [200, { 'Content-Type' => 'text/plain' }, []] }
 
-      get "/:foo" => ok, :constraints => lambda { |r| r.params[:foo] == 'foo' }
+      get "/:foo" => ok, constraints: ->(r) { r.params[:foo] == 'foo' }
       get "/:bar" => ok
     end
   end
@@ -3217,7 +3217,7 @@ end
 class TestGlobRoutingMapper < ActionDispatch::IntegrationTest
   Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
     app.draw do
-      ok = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, []] }
+      ok = ->(env) { [200, { 'Content-Type' => 'text/plain' }, []] }
 
       get "/*id" => redirect("/not_cars"), :constraints => {id: /dummy/}
       get "/cars" => ok
@@ -3246,7 +3246,7 @@ end
 class TestOptimizedNamedRoutes < ActionDispatch::IntegrationTest
   Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
     app.draw do
-      ok = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, []] }
+      ok = ->(env) { [200, { 'Content-Type' => 'text/plain' }, []] }
       get '/foo' => ok, as: :foo
       get '/post(/:action(/:id))' => ok, as: :posts
     end
@@ -3311,7 +3311,7 @@ end
 class TestUrlConstraints < ActionDispatch::IntegrationTest
   Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
     app.draw do
-      ok = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, []] }
+      ok = ->(env) { [200, { 'Content-Type' => 'text/plain' }, []] }
 
       constraints :subdomain => 'admin' do
         get '/' => ok, :as => :admin_root
@@ -3411,7 +3411,7 @@ end
 class TestPortConstraints < ActionDispatch::IntegrationTest
   Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
     app.draw do
-      ok = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, []] }
+      ok = ->(env) { [200, { 'Content-Type' => 'text/plain' }, []] }
 
       get '/integer', to: ok, constraints: { :port =>  8080  }
       get '/string',  to: ok, constraints: { :port => '8080' }
@@ -3459,7 +3459,7 @@ end
 class TestFormatConstraints < ActionDispatch::IntegrationTest
   Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
     app.draw do
-      ok = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, []] }
+      ok = ->(env) { [200, { 'Content-Type' => 'text/plain' }, []] }
 
       get '/string', to: ok, constraints: { format: 'json'  }
       get '/regexp',  to: ok, constraints: { format: /json/ }

--- a/actionpack/test/dispatch/session/abstract_store_test.rb
+++ b/actionpack/test/dispatch/session/abstract_store_test.rb
@@ -49,7 +49,7 @@ module ActionDispatch
       private
       def app(&block)
         @env = nil
-        lambda { |env| @env = env }
+        ->(env) { @env = env }
       end
     end
   end

--- a/actionpack/test/dispatch/show_exceptions_test.rb
+++ b/actionpack/test/dispatch/show_exceptions_test.rb
@@ -77,7 +77,7 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
   end
 
   test "calls custom exceptions app" do
-    exceptions_app = lambda do |env|
+    exceptions_app = ->(env) do
       assert_kind_of AbstractController::ActionNotFound, env["action_dispatch.exception"]
       assert_equal "/404", env["PATH_INFO"]
       [404, { "Content-Type" => "text/plain" }, ["YOU FAILED BRO"]]
@@ -90,7 +90,7 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
   end
 
   test "returns an empty response if custom exceptions app returns X-Cascade pass" do
-    exceptions_app = lambda do |env|
+    exceptions_app = ->(env) do
       [404, { "X-Cascade" => "pass" }, []]
     end
 

--- a/actionpack/test/dispatch/ssl_test.rb
+++ b/actionpack/test/dispatch/ssl_test.rb
@@ -2,7 +2,7 @@ require 'abstract_unit'
 
 class SSLTest < ActionDispatch::IntegrationTest
   def default_app
-    lambda { |env|
+    ->(env) {
       headers = {'Content-Type' => "text/html"}
       headers['Set-Cookie'] = "id=1; path=/\ntoken=abc; path=/; secure; HttpOnly"
       [200, headers, ["OK"]]
@@ -78,7 +78,7 @@ class SSLTest < ActionDispatch::IntegrationTest
   end
 
   def test_flag_cookies_as_secure_at_end_of_line
-    self.app = ActionDispatch::SSL.new(lambda { |env|
+    self.app = ActionDispatch::SSL.new(->(env) {
       headers = {
         'Content-Type' => "text/html",
         'Set-Cookie' => "problem=def; path=/; HttpOnly; secure"
@@ -92,7 +92,7 @@ class SSLTest < ActionDispatch::IntegrationTest
   end
 
   def test_flag_cookies_as_secure_with_more_spaces_before
-    self.app = ActionDispatch::SSL.new(lambda { |env|
+    self.app = ActionDispatch::SSL.new(->(env) {
       headers = {
         'Content-Type' => "text/html",
         'Set-Cookie' => "problem=def; path=/; HttpOnly;  secure"
@@ -106,7 +106,7 @@ class SSLTest < ActionDispatch::IntegrationTest
   end
 
   def test_flag_cookies_as_secure_with_more_spaces_after
-    self.app = ActionDispatch::SSL.new(lambda { |env|
+    self.app = ActionDispatch::SSL.new(->(env) {
       headers = {
         'Content-Type' => "text/html",
         'Set-Cookie' => "problem=def; path=/; secure;  HttpOnly"
@@ -120,7 +120,7 @@ class SSLTest < ActionDispatch::IntegrationTest
   end
 
   def test_no_cookies
-    self.app = ActionDispatch::SSL.new(lambda { |env|
+    self.app = ActionDispatch::SSL.new(->(env) {
       [200, {'Content-Type' => "text/html"}, ["OK"]]
     })
     get "https://example.org/"

--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -142,7 +142,7 @@ module StaticTests
 end
 
 class StaticTest < ActiveSupport::TestCase
-  DummyApp = lambda { |env|
+  DummyApp = ->(env) {
     [200, {"Content-Type" => "text/plain"}, ["Hello, World!"]]
   }
   App = ActionDispatch::Static.new(DummyApp, "#{FIXTURE_LOAD_PATH}/public", "public, max-age=60")

--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -212,7 +212,7 @@ module ActionDispatch
       def test_clear_trailing_slash_from_script_name_on_root_unanchored_routes
         strexp = Router::Strexp.new("/", {}, ['/', '.', '?'], false)
         path   = Path::Pattern.new strexp
-        app    = lambda { |env| [200, {}, ['success!']] }
+        app    = ->(env) { [200, {}, ['success!']] }
         @router.routes.add_route(app, path, {}, {}, {})
 
         env  = rack_env('SCRIPT_NAME' => '', 'PATH_INFO' => '/weblog')
@@ -340,7 +340,7 @@ module ActionDispatch
           nil,
           Hash[params],
           {},
-          lambda { |k,v| parameterized << [k,v]; v })
+          ->(k,v) { parameterized << [k,v]; v })
 
         assert_equal params.map(&:to_s).sort, parameterized.map(&:to_s).sort
       end

--- a/actionpack/test/template/dependency_tracker_test.rb
+++ b/actionpack/test/template/dependency_tracker_test.rb
@@ -2,8 +2,8 @@ require 'abstract_unit'
 require 'action_view/dependency_tracker'
 
 class DependencyTrackerTest < ActionView::TestCase
-  Neckbeard = lambda {|template| template.source }
-  Bowtie = lambda {|template| template.source }
+  Neckbeard = ->(template) { template.source }
+  Bowtie = ->(template) { template.source }
 
   class NeckbeardTracker
     def self.call(name, template)

--- a/actionpack/test/template/form_options_helper_test.rb
+++ b/actionpack/test/template/form_options_helper_test.rb
@@ -54,7 +54,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   def test_collection_options_with_proc_for_selected
     assert_dom_equal(
       "<option value=\"&lt;Abe&gt;\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\" selected=\"selected\">Babe went home</option>\n<option value=\"Cabe\">Cabe went home</option>",
-      options_from_collection_for_select(dummy_posts, "author_name", "title", lambda{|p| p.author_name == 'Babe' })
+      options_from_collection_for_select(dummy_posts, "author_name", "title", ->(p) { p.author_name == 'Babe' })
     )
   end
 
@@ -82,21 +82,21 @@ class FormOptionsHelperTest < ActionView::TestCase
   def test_collection_options_with_proc_for_disabled
     assert_dom_equal(
       "<option value=\"&lt;Abe&gt;\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\" disabled=\"disabled\">Babe went home</option>\n<option value=\"Cabe\" disabled=\"disabled\">Cabe went home</option>",
-      options_from_collection_for_select(dummy_posts, "author_name", "title", :disabled => lambda {|p| %w(Babe Cabe).include?(p.author_name)})
+      options_from_collection_for_select(dummy_posts, "author_name", "title", disabled: ->(p) { %w(Babe Cabe).include?(p.author_name)})
     )
   end
 
   def test_collection_options_with_proc_for_value_method
     assert_dom_equal(
       "<option value=\"&lt;Abe&gt;\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\">Babe went home</option>\n<option value=\"Cabe\">Cabe went home</option>",
-      options_from_collection_for_select(dummy_posts, lambda { |p| p.author_name }, "title")
+      options_from_collection_for_select(dummy_posts, ->(p) { p.author_name }, "title")
     )
   end
 
   def test_collection_options_with_proc_for_text_method
     assert_dom_equal(
       "<option value=\"&lt;Abe&gt;\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\">Babe went home</option>\n<option value=\"Cabe\">Cabe went home</option>",
-      options_from_collection_for_select(dummy_posts, "author_name", lambda { |p| p.title })
+      options_from_collection_for_select(dummy_posts, "author_name", ->(p) { p.title })
     )
   end
 
@@ -915,7 +915,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
     assert_dom_equal(
       "<select id=\"post_author_name\" name=\"post[author_name]\"><option value=\"&lt;Abe&gt;\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\">Babe went home</option>\n<option value=\"Cabe\">Cabe went home</option></select>",
-      collection_select("post", "author_name", dummy_posts, lambda { |p| p.author_name }, "title")
+      collection_select("post", "author_name", dummy_posts, ->(p) { p.author_name }, "title")
     )
   end
 
@@ -924,7 +924,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
     assert_dom_equal(
       "<select id=\"post_author_name\" name=\"post[author_name]\"><option value=\"&lt;Abe&gt;\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\">Babe went home</option>\n<option value=\"Cabe\">Cabe went home</option></select>",
-      collection_select("post", "author_name", dummy_posts, "author_name", lambda { |p| p.title })
+      collection_select("post", "author_name", dummy_posts, "author_name", ->(p) { p.title })
     )
   end
 

--- a/actionpack/test/template/render_test.rb
+++ b/actionpack/test/template/render_test.rb
@@ -355,7 +355,7 @@ module RenderTestCases
     assert_equal "Hello, World!", @view.render(:inline => "Hello, World!", :type => :bar)
   end
 
-  CustomHandler = lambda do |template|
+  CustomHandler = ->(template) do
     "@output_buffer = ''\n" +
       "@output_buffer << 'source: #{template.source.inspect}'\n"
   end

--- a/actionpack/test/template/test_case_test.rb
+++ b/actionpack/test/template/test_case_test.rb
@@ -229,7 +229,7 @@ module ActionView
             @routes ||= ActionDispatch::Routing::RouteSet.new
           end
 
-          routes.draw { get "bar", :to => lambda {} }
+          routes.draw { get "bar", to: -> {} }
 
           def self.call(*)
           end

--- a/activemodel/test/cases/validations/exclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/exclusion_validation_test.rb
@@ -54,7 +54,7 @@ class ExclusionValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_exclusion_of_with_lambda
-    Topic.validates_exclusion_of :title, :in => lambda{ |topic| topic.author_name == "sikachu" ? %w( monkey elephant ) : %w( abe wasabi ) }
+    Topic.validates_exclusion_of :title, in: ->(topic) { topic.author_name == "sikachu" ? %w( monkey elephant ) : %w( abe wasabi ) }
 
     t = Topic.new
     t.title = "elephant"

--- a/activemodel/test/cases/validations/format_validation_test.rb
+++ b/activemodel/test/cases/validations/format_validation_test.rb
@@ -109,7 +109,7 @@ class PresenceValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_format_of_with_lambda
-    Topic.validates_format_of :content, :with => lambda{ |topic| topic.title == "digit" ? /\A\d+\Z/ : /\A\S+\Z/ }
+    Topic.validates_format_of :content, with: ->(topic) { topic.title == "digit" ? /\A\d+\Z/ : /\A\S+\Z/ }
 
     t = Topic.new
     t.title = "digit"
@@ -121,7 +121,7 @@ class PresenceValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_format_of_without_lambda
-    Topic.validates_format_of :content, :without => lambda{ |topic| topic.title == "characters" ? /\A\d+\Z/ : /\A\S+\Z/ }
+    Topic.validates_format_of :content, without: ->(topic) { topic.title == "characters" ? /\A\d+\Z/ : /\A\S+\Z/ }
 
     t = Topic.new
     t.title = "characters"

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -47,12 +47,12 @@ class I18nValidationTest < ActiveModel::TestCase
   # are used to generate tests to keep things DRY
   #
   COMMON_CASES = [
-  # [ case,                                validation_options,            generate_message_options]
-    [ "given no options",                  {},                            {}],
-    [ "given custom message",              {:message => "custom"},        {:message => "custom"}],
-    [ "given if condition",                {:if     => lambda { true }},  {}],
-    [ "given unless condition",            {:unless => lambda { false }}, {}],
-    [ "given option that is not reserved", {:format => "jpg"},            {:format => "jpg" }]
+  # [ case,                                validation_options,      generate_message_options]
+    [ "given no options",                  {},                      {}],
+    [ "given custom message",              {message: "custom"},     {message: "custom"}],
+    [ "given if condition",                {if:      -> { true }},  {}],
+    [ "given unless condition",            {unless:  -> { false }}, {}],
+    [ "given option that is not reserved", {format:  "jpg"},        {format: "jpg" }]
   ]
 
   # validates_confirmation_of w/ mocha

--- a/activemodel/test/cases/validations/inclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/inclusion_validation_test.rb
@@ -86,7 +86,7 @@ class InclusionValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_inclusion_of_with_lambda
-    Topic.validates_inclusion_of :title, :in => lambda{ |topic| topic.author_name == "sikachu" ? %w( monkey elephant ) : %w( abe wasabi ) }
+    Topic.validates_inclusion_of :title, in: ->(topic) { topic.author_name == "sikachu" ? %w( monkey elephant ) : %w( abe wasabi ) }
 
     t = Topic.new
     t.title = "wasabi"

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -321,7 +321,7 @@ class LengthValidationTest < ActiveModel::TestCase
 
   def test_validates_length_of_with_block
     Topic.validates_length_of :content, minimum: 5, too_short: "Your essay must be at least %{count} words.",
-                                        tokenizer: lambda {|str| str.scan(/\w+/) }
+                                        tokenizer: ->(str) { str.scan(/\w+/) }
     t = Topic.new(content: "this content should be long enough")
     assert t.valid?
 

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -114,7 +114,7 @@ class NumericalityValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_numericality_with_proc
-    Topic.send(:define_method, :min_approved, lambda { 5 })
+    Topic.send(:define_method, :min_approved, -> { 5 })
     Topic.validates_numericality_of :approved, :greater_than_or_equal_to => Proc.new {|topic| topic.min_approved }
 
     invalid!([3, 4])
@@ -123,7 +123,7 @@ class NumericalityValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_numericality_with_symbol
-    Topic.send(:define_method, :max_approved, lambda { 5 })
+    Topic.send(:define_method, :max_approved, -> { 5 })
     Topic.validates_numericality_of :approved, :less_than_or_equal_to => :max_approved
 
     invalid!([6])

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -512,7 +512,7 @@ module ActiveRecord
 
         def alter_table(table_name, options = {}) #:nodoc:
           altered_table_name = "a#{table_name}"
-          caller = lambda {|definition| yield definition if block_given?}
+          caller = ->(definition) { yield definition if block_given?}
 
           transaction do
             move_table(table_name, altered_table_name,

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -648,7 +648,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     post    = posts(:welcome)
     comment = comments(:greetings)
 
-    assert_difference lambda { post.reload.taggings_count }, -1 do
+    assert_difference -> { post.reload.taggings_count }, -1 do
       assert_difference 'comment.reload.taggings_count', +1 do
         tagging.taggable = comment
       end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1332,10 +1332,10 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_modifying_a_through_a_has_many_should_raise
     [
-      lambda { authors(:mary).comment_ids = [comments(:greetings).id, comments(:more_greetings).id] },
-      lambda { authors(:mary).comments = [comments(:greetings), comments(:more_greetings)] },
-      lambda { authors(:mary).comments << Comment.create!(:body => "Yay", :post_id => 424242) },
-      lambda { authors(:mary).comments.delete(authors(:mary).comments.first) },
+      -> { authors(:mary).comment_ids = [comments(:greetings).id, comments(:more_greetings).id] },
+      -> { authors(:mary).comments = [comments(:greetings), comments(:more_greetings)] },
+      -> { authors(:mary).comments << Comment.create!(:body => "Yay", :post_id => 424242) },
+      -> { authors(:mary).comments.delete(authors(:mary).comments.first) },
     ].each {|block| assert_raise(ActiveRecord::HasManyThroughCantAssociateThroughHasOneOrManyReflection, &block) }
   end
 

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -597,9 +597,9 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_modifying_has_many_through_has_one_reflection_should_raise
     [
-      lambda { authors(:david).very_special_comments = [VerySpecialComment.create!(:body => "Gorp!", :post_id => 1011), VerySpecialComment.create!(:body => "Eep!", :post_id => 1012)] },
-      lambda { authors(:david).very_special_comments << VerySpecialComment.create!(:body => "Hoohah!", :post_id => 1013) },
-      lambda { authors(:david).very_special_comments.delete(authors(:david).very_special_comments.first) },
+      -> { authors(:david).very_special_comments = [VerySpecialComment.create!(:body => "Gorp!", :post_id => 1011), VerySpecialComment.create!(:body => "Eep!", :post_id => 1012)] },
+      -> { authors(:david).very_special_comments << VerySpecialComment.create!(:body => "Hoohah!", :post_id => 1013) },
+      -> { authors(:david).very_special_comments.delete(authors(:david).very_special_comments.first) },
     ].each {|block| assert_raise(ActiveRecord::HasManyThroughCantAssociateThroughHasOneOrManyReflection, &block) }
   end
 

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -110,7 +110,7 @@ class AssociationsTest < ActiveRecord::TestCase
   end
 
   def test_using_limitable_reflections_helper
-    using_limitable_reflections = lambda { |reflections| Tagging.all.send :using_limitable_reflections?, reflections }
+    using_limitable_reflections = ->(reflections) { Tagging.all.send :using_limitable_reflections?, reflections }
     belongs_to_reflections = [Tagging.reflect_on_association(:tag), Tagging.reflect_on_association(:super_tag)]
     has_many_reflections = [Tag.reflect_on_association(:taggings), Developer.reflect_on_association(:projects)]
     mixed_reflections = (belongs_to_reflections + has_many_reflections).uniq

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1222,7 +1222,7 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_assert_queries
-    query = lambda { ActiveRecord::Base.connection.execute 'select count(*) from developers' }
+    query = -> { ActiveRecord::Base.connection.execute 'select count(*) from developers' }
     assert_queries(2) { 2.times { query.call } }
     assert_queries 1, &query
     assert_no_queries { assert true }

--- a/activerecord/test/cases/connection_management_test.rb
+++ b/activerecord/test/cases/connection_management_test.rb
@@ -102,7 +102,7 @@ module ActiveRecord
 
       test "proxy is polite to it's body and responds to it" do
         body = Class.new(String) { def to_path; "/path"; end }.new
-        app = lambda { |_| [200, {}, body] }
+        app = ->(_) { [200, {}, body] }
         response_body = ConnectionManagement.new(app).call(@env)[2]
         assert response_body.respond_to?(:to_path)
         assert_equal response_body.to_path, "/path"

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -180,7 +180,7 @@ class MigrationTest < ActiveRecord::TestCase
     assert !Person.column_methods_hash.include?(:last_name)
     assert !Reminder.table_exists?
 
-    name_filter = lambda { |migration| migration.name == "ValidPeopleHaveLastNames" }
+    name_filter = ->(migration) { migration.name == "ValidPeopleHaveLastNames" }
     ActiveRecord::Migrator.up(MIGRATIONS_ROOT + "/valid", &name_filter)
 
     Person.reset_column_information

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -32,7 +32,7 @@ class PersistencesTest < ActiveRecord::TestCase
 
     def test_update_all_doesnt_ignore_order
       assert_equal authors(:david).id + 1, authors(:mary).id # make sure there is going to be a duplicate PK error
-      test_update_with_order_succeeds = lambda do |order|
+      test_update_with_order_succeeds = ->(order) do
         begin
           Author.order(order).update_all('id = id + 1')
         rescue ActiveRecord::ActiveRecordError

--- a/activerecord/test/cases/validations/i18n_validation_test.rb
+++ b/activerecord/test/cases/validations/i18n_validation_test.rb
@@ -35,12 +35,12 @@ class I18nValidationTest < ActiveRecord::TestCase
   # are used to generate tests to keep things DRY
   #
   COMMON_CASES = [
-  # [ case,                                validation_options,            generate_message_options]
-    [ "given no options",                  {},                            {}],
-    [ "given custom message",              {:message => "custom"},        {:message => "custom"}],
-    [ "given if condition",                {:if     => lambda { true }},  {}],
-    [ "given unless condition",            {:unless => lambda { false }}, {}],
-    [ "given option that is not reserved", {:format => "jpg"},            {:format => "jpg" }]
+  # [ case,                                validation_options,      generate_message_options]
+    [ "given no options",                  {},                      {}],
+    [ "given custom message",              {message: "custom"},     {message: "custom"}],
+    [ "given if condition",                {if:      -> { true }},  {}],
+    [ "given unless condition",            {unless:  -> { false }}, {}],
+    [ "given option that is not reserved", {format:  "jpg"},        {format: "jpg" }]
     # TODO Add :on case, but below doesn't work, because then the validation isn't run for some reason
     #      even when using .save instead .valid?
     # [ "given on condition",     {on: :save},                {}]

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -1,5 +1,5 @@
 class Comment < ActiveRecord::Base
-  scope :limit_by, lambda {|l| limit(l) }
+  scope :limit_by, ->(l) { limit(l) }
   scope :containing_the_letter_e, -> { where("comments.body LIKE '%e%'") }
   scope :not_again, -> { where("comments.body NOT LIKE '%again%'") }
   scope :for_first_post, -> { where(:post_id => 1) }

--- a/activerecord/test/models/customer.rb
+++ b/activerecord/test/models/customer.rb
@@ -5,7 +5,7 @@ class Customer < ActiveRecord::Base
   composed_of :balance, :class_name => "Money", :mapping => %w(balance amount), :converter => Proc.new { |balance| balance.to_money }
   composed_of :gps_location, :allow_nil => true
   composed_of :non_blank_gps_location, :class_name => "GpsLocation", :allow_nil => true, :mapping => %w(gps_location gps_location),
-              :converter => lambda { |gps| self.gps_conversion_was_run = true; gps.blank? ? nil : GpsLocation.new(gps)}
+              converter: ->(gps) { self.gps_conversion_was_run = true; gps.blank? ? nil : GpsLocation.new(gps)}
   composed_of :fullname, :mapping => %w(name to_s), :constructor => Proc.new { |name| Fullname.parse(name) }, :converter => :parse
 end
 

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -124,7 +124,7 @@ end
 
 class LazyLambdaDeveloperCalledDavid < ActiveRecord::Base
   self.table_name = 'developers'
-  default_scope lambda { where(:name => 'David') }
+  default_scope -> { where(:name => 'David') }
 end
 
 class LazyBlockDeveloperCalledDavid < ActiveRecord::Base
@@ -218,7 +218,7 @@ class EagerDeveloperWithLambdaDefaultScope < ActiveRecord::Base
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
-  default_scope lambda { includes(:projects) }
+  default_scope -> { includes(:projects) }
 end
 
 class EagerDeveloperWithBlockDefaultScope < ActiveRecord::Base

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -14,7 +14,7 @@ class Post < ActiveRecord::Base
   scope :containing_the_letter_a, -> { where("body LIKE '%a%'") }
   scope :ranked_by_comments,      -> { order("comments_count DESC") }
 
-  scope :limit_by, lambda {|l| limit(l) }
+  scope :limit_by, ->(l) { limit(l) }
 
   belongs_to :author
 
@@ -125,10 +125,10 @@ class Post < ActiveRecord::Base
   has_many :secure_people, :through => :secure_readers
   has_many :single_people, :through => :readers
   has_many :people_with_callbacks, :source=>:person, :through => :readers,
-              :before_add    => lambda {|owner, reader| log(:added,   :before, reader.first_name) },
-              :after_add     => lambda {|owner, reader| log(:added,   :after,  reader.first_name) },
-              :before_remove => lambda {|owner, reader| log(:removed, :before, reader.first_name) },
-              :after_remove  => lambda {|owner, reader| log(:removed, :after,  reader.first_name) }
+              before_add:    ->(owner, reader) { log(:added,   :before, reader.first_name) },
+              after_add:     ->(owner, reader) { log(:added,   :after,  reader.first_name) },
+              before_remove: ->(owner, reader) { log(:removed, :before, reader.first_name) },
+              after_remove:  ->(owner, reader) { log(:removed, :after,  reader.first_name) }
   has_many :skimmers, -> { where :skimmer => true }, :class_name => 'Reader'
   has_many :impatient_people, :through => :skimmers, :source => :person
 

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -1,6 +1,6 @@
 class Topic < ActiveRecord::Base
   scope :base, -> { all }
-  scope :written_before, lambda { |time|
+  scope :written_before, ->(time) {
     if time
       where 'written_on < ?', time
     end
@@ -8,7 +8,7 @@ class Topic < ActiveRecord::Base
   scope :approved, -> { where(:approved => true) }
   scope :rejected, -> { where(:approved => false) }
 
-  scope :scope_with_lambda, lambda { all }
+  scope :scope_with_lambda, -> { all }
 
   scope :by_lifo, -> { where(:author_name => 'lifo') }
   scope :replied, -> { where 'replies_count > 0' }

--- a/activesupport/lib/active_support/core_ext/date_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/conversions.rb
@@ -27,7 +27,7 @@ class DateTime
   #
   #   # config/initializers/time_formats.rb
   #   Time::DATE_FORMATS[:month_and_year] = '%B %Y'
-  #   Time::DATE_FORMATS[:short_ordinal] = lambda { |time| time.strftime("%B #{time.day.ordinalize}") }
+  #   Time::DATE_FORMATS[:short_ordinal] = ->(time) { time.strftime("%B #{time.day.ordinalize}") }
   def to_formatted_s(format = :default)
     if formatter = ::Time::DATE_FORMATS[format]
       formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)

--- a/activesupport/lib/active_support/core_ext/hash/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/hash/conversions.rb
@@ -31,7 +31,7 @@ class Hash
   #   with +key+ as <tt>:root</tt>, and +key+ singularized as second argument. The
   #   callable can add nodes by using <tt>options[:builder]</tt>.
   #
-  #     'foo'.to_xml(lambda { |options, key| options[:builder].b(key) })
+  #     'foo'.to_xml(->(options, key) { options[:builder].b(key) })
   #     # => "<b>foo</b>"
   #
   # * If +value+ responds to +to_xml+ the method is invoked with +key+ as <tt>:root</tt>.

--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -119,7 +119,7 @@ module ActiveSupport
   # You can subscribe to some event temporarily while some block runs. For
   # example, in
   #
-  #   callback = lambda {|*args| ... }
+  #   callback = ->(*args) { ... }
   #   ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
   #     ...
   #   end

--- a/activesupport/lib/active_support/option_merger.rb
+++ b/activesupport/lib/active_support/option_merger.rb
@@ -14,7 +14,7 @@ module ActiveSupport
       def method_missing(method, *arguments, &block)
         if arguments.last.is_a?(Proc)
           proc = arguments.pop
-          arguments << lambda { |*args| @options.deep_merge(proc.call(*args)) }
+          arguments << ->(*args) { @options.deep_merge(proc.call(*args)) }
         else
           arguments << (arguments.last.respond_to?(:to_hash) ? @options.deep_merge(arguments.pop) : @options.dup)
         end

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -148,7 +148,7 @@ class CacheStoreNamespaceTest < ActiveSupport::TestCase
 
   def test_proc_namespace
     test_val = "tester"
-    proc = lambda{test_val}
+    proc = -> {test_val}
     cache = ActiveSupport::Cache.lookup_store(:memory_store, :namespace => proc)
     cache.write("foo", "bar")
     assert_equal "bar", cache.read("foo")
@@ -553,7 +553,7 @@ module LocalCacheBehavior
   end
 
   def test_middleware
-    app = lambda { |env|
+    app = ->(env) {
       result = @cache.write('foo', 'bar')
       assert_equal 'bar', @cache.read('foo') # make sure 'foo' was written
       assert result

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -701,7 +701,7 @@ module CallbacksTest
 
   class WriterSkipper < Person
     attr_accessor :age
-    skip_callback :save, :before, :before_save_method, :if => lambda {self.age > 21}
+    skip_callback :save, :before, :before_save_method, if: -> {self.age > 21}
   end
 
   class WriterCallbacksTest < ActiveSupport::TestCase

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -31,7 +31,7 @@ module Notifications
       expected = [name, name]
 
       events   = []
-      callback = lambda {|*_| events << _.first}
+      callback = ->(*_) { events << _.first}
       ActiveSupport::Notifications.subscribed(callback, name) do
         ActiveSupport::Notifications.instrument(name)
         ActiveSupport::Notifications.instrument(name2)

--- a/activesupport/test/option_merger_test.rb
+++ b/activesupport/test/option_merger_test.rb
@@ -67,7 +67,7 @@ class OptionMergerTest < ActiveSupport::TestCase
   end
 
   def test_nested_method_with_options_using_lambda
-    local_lambda = lambda { { :lambda => true } }
+    local_lambda = -> { { :lambda => true } }
     with_options(@options) do |o|
       assert_equal @options.merge(local_lambda.call),
         o.method_with_options(local_lambda).call

--- a/activesupport/test/xml_mini/libxml_engine_test.rb
+++ b/activesupport/test/xml_mini/libxml_engine_test.rb
@@ -14,7 +14,7 @@ class LibxmlEngineTest < ActiveSupport::TestCase
     @default_backend = XmlMini.backend
     XmlMini.backend = 'LibXML'
 
-    LibXML::XML::Error.set_handler(&lambda { |error| }) #silence libxml, exceptions will do
+    LibXML::XML::Error.set_handler(&->(error) { }) #silence libxml, exceptions will do
   end
 
   def teardown

--- a/activesupport/test/xml_mini_test.rb
+++ b/activesupport/test/xml_mini_test.rb
@@ -64,12 +64,12 @@ module XmlMiniTest
     end
 
     test "#to_tag accepts a callable object and passes options with the builder" do
-      @xml.to_tag(:some_tag, lambda {|o| o[:builder].br }, @options)
+      @xml.to_tag(:some_tag, ->(o) { o[:builder].br }, @options)
       assert_xml "<br/>"
     end
 
     test "#to_tag accepts a callable object and passes options and tag name" do
-      @xml.to_tag(:tag, lambda {|o, t| o[:builder].b(t) }, @options)
+      @xml.to_tag(:tag, ->(o, t) { o[:builder].b(t) }, @options)
       assert_xml "<b>tag</b>"
     end
 

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -46,7 +46,7 @@ module ApplicationTests
 
       app_file 'config/routes.rb', <<-RUBY
         AppTemplate::Application.routes.draw do
-          get '*path', to: lambda { |env| [200, { "Content-Type" => "text/html" }, ["Not an asset"]] }
+          get '*path', to: ->(env) { [200, { "Content-Type" => "text/html" }, ["Not an asset"]] }
         end
       RUBY
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -182,7 +182,7 @@ module ApplicationTests
 
     test "filter_parameters should be able to set via config.filter_parameters" do
       add_to_config <<-RUBY
-        config.filter_parameters += [ :foo, 'bar', lambda { |key, value|
+        config.filter_parameters += [ :foo, 'bar', ->(key, value) {
           value = value.reverse if key =~ /baz/
         }]
       RUBY

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -53,7 +53,7 @@ module ApplicationTests
     test "does not include url helpers as action methods" do
       app_file "config/routes.rb", <<-RUBY
         AppTemplate::Application.routes.draw do
-          get "/foo", :to => lambda { |env| [200, {}, []] }, :as => :foo
+          get "/foo", to: ->(env) { [200, {}, []] }, :as => :foo
         end
       RUBY
 

--- a/railties/test/application/initializers/i18n_test.rb
+++ b/railties/test/application/initializers/i18n_test.rb
@@ -85,7 +85,7 @@ en:
 
       app_file 'config/routes.rb', <<-RUBY
         AppTemplate::Application.routes.draw do
-          get '/i18n',   :to => lambda { |env| [200, {}, [Foo.instance_variable_get('@foo')]] }
+          get '/i18n',   to: ->(env) { [200, {}, [Foo.instance_variable_get('@foo')]] }
         end
       RUBY
 
@@ -109,7 +109,7 @@ en:
 
       app_file 'config/routes.rb', <<-RUBY
         AppTemplate::Application.routes.draw do
-          get '/i18n',   :to => lambda { |env| [200, {}, [I18n.t(:foo)]] }
+          get '/i18n',   to: ->(env) { [200, {}, [I18n.t(:foo)]] }
         end
       RUBY
 

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -76,8 +76,8 @@ class LoadingTest < ActiveSupport::TestCase
 
     app_file 'config/routes.rb', <<-RUBY
       AppTemplate::Application.routes.draw do
-        get '/load',   to: lambda { |env| [200, {}, Post.all] }
-        get '/unload', to: lambda { |env| [200, {}, []] }
+        get '/load',   to: ->(env) { [200, {}, Post.all] }
+        get '/unload', to: ->(env) { [200, {}, []] }
       end
     RUBY
 
@@ -106,7 +106,7 @@ class LoadingTest < ActiveSupport::TestCase
 
     app_file 'config/routes.rb', <<-RUBY
       AppTemplate::Application.routes.draw do
-        get '/c', to: lambda { |env| [200, {"Content-Type" => "text/plain"}, [User.counter.to_s]] }
+        get '/c', to: ->(env) { [200, {"Content-Type" => "text/plain"}, [User.counter.to_s]] }
       end
     RUBY
 
@@ -145,7 +145,7 @@ class LoadingTest < ActiveSupport::TestCase
 
     app_file 'config/routes.rb', <<-RUBY
       AppTemplate::Application.routes.draw do
-        get '/c', to: lambda { |env| [200, {"Content-Type" => "text/plain"}, [User.counter.to_s]] }
+        get '/c', to: ->(env) { [200, {"Content-Type" => "text/plain"}, [User.counter.to_s]] }
       end
     RUBY
 
@@ -181,7 +181,7 @@ class LoadingTest < ActiveSupport::TestCase
     app_file 'config/routes.rb', <<-RUBY
       $counter = 0
       AppTemplate::Application.routes.draw do
-        get '/c', to: lambda { |env| User; [200, {"Content-Type" => "text/plain"}, [$counter.to_s]] }
+        get '/c', to: ->(env) { User; [200, {"Content-Type" => "text/plain"}, [$counter.to_s]] }
       end
     RUBY
 
@@ -212,8 +212,8 @@ class LoadingTest < ActiveSupport::TestCase
 
     app_file 'config/routes.rb', <<-RUBY
       AppTemplate::Application.routes.draw do
-        get '/title', to: lambda { |env| [200, {"Content-Type" => "text/plain"}, [Post.new.title]] }
-        get '/body',  to: lambda { |env| [200, {"Content-Type" => "text/plain"}, [Post.new.body]] }
+        get '/title', to: ->(env) { [200, {"Content-Type" => "text/plain"}, [Post.new.title]] }
+        get '/body',  to: ->(env) { [200, {"Content-Type" => "text/plain"}, [Post.new.body]] }
       end
     RUBY
 

--- a/railties/test/application/middleware/exceptions_test.rb
+++ b/railties/test/application/middleware/exceptions_test.rb
@@ -48,7 +48,7 @@ module ApplicationTests
 
     test "uses custom exceptions app" do
       add_to_config <<-RUBY
-        config.exceptions_app = lambda do |env|
+        config.exceptions_app = ->(env) do
           [404, { "Content-Type" => "text/plain" }, ["YOU FAILED BRO"]]
         end
       RUBY

--- a/railties/test/application/routing_test.rb
+++ b/railties/test/application/routing_test.rb
@@ -112,7 +112,7 @@ module ApplicationTests
     test "mount rack app" do
       app_file 'config/routes.rb', <<-RUBY
         AppTemplate::Application.routes.draw do
-          mount lambda { |env| [200, {}, [env["PATH_INFO"]]] }, at: "/blog"
+          mount ->(env) { [200, {}, [env["PATH_INFO"]]] }, at: "/blog"
           # The line below is required because mount sometimes
           # fails when a resource route is added.
           resource :user
@@ -195,7 +195,7 @@ module ApplicationTests
 
       add_to_config <<-R
         routes.append do
-          get '/win' => lambda { |e| [200, {'Content-Type'=>'text/plain'}, ['WIN']] }
+          get '/win' => ->(e) { [200, {'Content-Type'=>'text/plain'}, ['WIN']] }
         end
       R
 
@@ -257,7 +257,7 @@ module ApplicationTests
 
       # Create the rack app just inside after initialize callback
       ActiveSupport.on_load(:after_initialize) do
-        ::InitializeRackApp = lambda { |env| [200, {}, ["InitializeRackApp"]] }
+        ::InitializeRackApp = ->(env) { [200, {}, ["InitializeRackApp"]] }
       end
 
       app_file 'config/routes.rb', <<-RUBY

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -465,7 +465,7 @@ YAML
       @plugin.write "lib/bukkits.rb", <<-RUBY
         module Bukkits
           class Engine < ::Rails::Engine
-            endpoint lambda { |env| [200, {'Content-Type' => 'text/html'}, ['Hello World']] }
+            endpoint ->(env) { [200, {'Content-Type' => 'text/html'}, ['Hello World']] }
             config.middleware.use ::RailtiesTest::EngineTest::Upcaser
           end
         end
@@ -521,7 +521,7 @@ YAML
 
       @plugin.write "config/routes.rb", <<-RUBY
         Bukkits::Engine.routes.draw do
-          get "/foo" => lambda { |env| [200, {'Content-Type' => 'text/html'}, ['foo']] }
+          get "/foo" => ->(env) { [200, {'Content-Type' => 'text/html'}, ['foo']] }
         end
       RUBY
 
@@ -568,7 +568,7 @@ YAML
       @plugin.write "lib/bukkits.rb", <<-RUBY
         module Bukkits
           class Engine < ::Rails::Engine
-            endpoint lambda { |env| [200, {'Content-Type' => 'text/html'}, ['hello']] }
+            endpoint ->(env) { [200, {'Content-Type' => 'text/html'}, ['hello']] }
           end
         end
       RUBY
@@ -847,7 +847,7 @@ YAML
       # file has changed
       add_to_config <<-RUBY
         routes do
-          mount lambda{|env| [200, {}, ["foo"]]} => "/foo"
+          mount ->(env) { [200, {}, ["foo"]]} => "/foo"
           mount Bukkits::Engine => "/bukkits"
         end
       RUBY
@@ -856,7 +856,7 @@ YAML
 
       @plugin.write "config/routes.rb", <<-RUBY
         Bukkits::Engine.routes.draw do
-          mount lambda{|env| [200, {}, ["bar"]]} => "/bar"
+          mount ->(env) { [200, {}, ["bar"]]} => "/bar"
         end
       RUBY
 


### PR DESCRIPTION
Replace uses of 'lambda' with new "stubby lambda" syntax where possible.
