### PR TITLE
AR postgres binary bug fix

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -20,6 +20,7 @@ module ActiveRecord
 
         class Bytea < Type
           def type_cast(value)
+            return if value.nil?
             PGconn.unescape_bytea value
           end
         end

--- a/activerecord/test/cases/adapters/postgresql/bytea_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_test.rb
@@ -1,0 +1,87 @@
+# encoding: utf-8
+
+require "cases/helper"
+require 'active_record/base'
+require 'active_record/connection_adapters/postgresql_adapter'
+
+class PostgresqlByteaTest < ActiveRecord::TestCase
+  class ByteaDataType < ActiveRecord::Base
+    self.table_name = 'bytea_data_type'
+  end
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+    begin
+      @connection.transaction do
+        @connection.create_table('bytea_data_type') do |t|
+          t.binary 'payload'
+        end
+      end
+    end
+    @column = ByteaDataType.columns.find { |c| c.name == 'payload' }
+    assert(@column.is_a?(ActiveRecord::ConnectionAdapters::PostgreSQLColumn))
+  end
+
+  def teardown
+    @connection.execute 'drop table if exists bytea_data_type'
+  end
+
+  def test_column
+    assert_equal :binary, @column.type
+  end
+
+  def test_type_cast_binary_converts_the_encoding
+    assert @column
+
+    data = "\u001F\x8B"
+    assert_equal('UTF-8', data.encoding.name)
+    assert_equal('ASCII-8BIT', @column.type_cast(data).encoding.name)
+  end
+
+  def test_type_cast_binary_value
+    data = "\u001F\x8B".force_encoding("BINARY")
+    assert_equal(data, @column.type_cast(data))
+  end
+
+  def test_type_case_nil
+    assert_equal(nil, @column.type_cast(nil))
+  end
+
+  def test_read_value
+    data = "\u001F"
+    @connection.execute "insert into bytea_data_type (payload) VALUES ('#{data}')"
+    record = ByteaDataType.first
+    assert_equal(data, record.payload)
+    record.delete
+  end
+
+  def test_read_nil_value
+    @connection.execute "insert into bytea_data_type (payload) VALUES (null)"
+    record = ByteaDataType.first
+    assert_equal(nil, record.payload)
+    record.delete
+  end
+
+  def test_write_value
+    data = "\u001F"
+    record = ByteaDataType.create(payload: data)
+    refute record.new_record?
+    assert_equal(data, record.payload)
+  end
+
+  def test_write_file
+    data = File.read(File.join(File.dirname(__FILE__), '..', '..', '..', 'assets', 'example.log'))
+    assert(data.size > 1)
+    record = ByteaDataType.create(payload: data)
+    refute record.new_record?
+    assert_equal(data, record.payload)
+    assert_equal(data, ByteaDataType.where(id: record.id).first.payload)
+  end
+
+  def test_write_nil
+    record = ByteaDataType.create(payload: nil)
+    refute record.new_record?
+    assert_equal(nil, record.payload)
+    assert_equal(nil, ByteaDataType.where(id: record.id).first.payload)
+  end
+end

--- a/activerecord/test/cases/adapters/postgresql/bytea_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_test.rb
@@ -69,7 +69,7 @@ class PostgresqlByteaTest < ActiveRecord::TestCase
     assert_equal(data, record.payload)
   end
 
-  def test_write_file
+  def test_write_binary
     data = File.read(File.join(File.dirname(__FILE__), '..', '..', '..', 'assets', 'example.log'))
     assert(data.size > 1)
     record = ByteaDataType.create(payload: data)


### PR DESCRIPTION
Currently, if a postgres table contains a record with a binary field and this record is fetched from the DB, an exception is raised if the binary data is nil.

This bug is due to the fact that the unescaping of the column value is passed directly to `PGConn` without checking for nil. `PGConn#unescape_bytea` does a check on the value type and raise an exception if the value isn't a string.

This PR adds tests around the binary type (currently no tests exist), and a fix for the mentioned bug.
