### PR TITLE
Extract a Subscriber base class from LogSubscriber

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   An `ActiveSupport::Subscriber` class has been extracted from
+    `ActiveSupport::LogSubscriber`, allowing you to use the event attachment
+    API for other kinds of subscribers.
+
+    *Daniel Schierbeck*
+
 *   `Class#class_attribute` accepts an `instance_predicate` option which
     defaults to `true`. If set to `false` the predicate method will not
     be defined.

--- a/activesupport/lib/active_support/subscriber.rb
+++ b/activesupport/lib/active_support/subscriber.rb
@@ -1,0 +1,76 @@
+module ActiveSupport
+  # ActiveSupport::Subscriber is an object set to consume
+  # ActiveSupport::Notifications.  The subscriber dispatches notifications to
+  # a registered object based on its given namespace.
+  #
+  # An example would be Active Record subscriber responsible for collecting
+  # statistics about queries:
+  #
+  #   module ActiveRecord
+  #     class StatsSubscriber < ActiveSupport::Subscriber
+  #       def sql(event)
+  #         Statsd.timing("sql.#{event.payload[:name]}", event.duration)
+  #       end
+  #     end
+  #   end
+  #
+  # And it's finally registered as:
+  #
+  #   ActiveRecord::Subscriber.attach_to :active_record
+  #
+  # Since we need to know all instance methods before attaching the log
+  # subscriber, the line above should be called after your
+  # <tt>ActiveRecord::Subscriber</tt> definition.
+  #
+  # After configured, whenever a "sql.active_record" notification is published,
+  # it will properly dispatch the event (ActiveSupport::Notifications::Event) to
+  # the `sql` method.
+  class Subscriber
+    class << self
+
+      # Attach the subscriber to a namespace.
+      def attach_to(namespace, subscriber=new, notifier=ActiveSupport::Notifications)
+        subscribers << subscriber
+
+        subscriber.public_methods(false).each do |event|
+          next if %w{ start finish }.include?(event.to_s)
+
+          notifier.subscribe("#{event}.#{namespace}", subscriber)
+        end
+      end
+
+      def subscribers
+        @@subscribers ||= []
+      end
+    end
+
+    def initialize
+      @queue_key = [self.class.name, object_id].join  "-"
+      super
+    end
+
+    def start(name, id, payload)
+      e = ActiveSupport::Notifications::Event.new(name, Time.now, nil, id, payload)
+      parent = event_stack.last
+      parent << e if parent
+
+      event_stack.push e
+    end
+
+    def finish(name, id, payload)
+      finished  = Time.now
+      event     = event_stack.pop
+      event.end = finished
+      event.payload.merge!(payload)
+
+      method = name.split('.').first
+      send(method, event)
+    end
+
+    private
+
+    def event_stack
+      Thread.current[@queue_key] ||= []
+    end
+  end
+end


### PR DESCRIPTION
I'm using the instrumentation framework heavily to do stats collection with Statsd, but have so far relied on a custom base class for attaching the various subscribers to instrument names. I'd like to use the same base class for both stats and log subscribers, hence this PR.

There should be no functional changes to how the LogSubscriber works, but now you can inherit from Subscriber if you just want the attachment logic.

What do you say?
