### PR TITLE
Fix bit string problem

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -26,6 +26,13 @@ module ActiveRecord
           end
         end
 
+        def string_to_bit(value)
+          case value
+          when /^[01]*$/      then value             # Bit-string notation
+          when /^[0-9A-F]*$/i then value.hex.to_s(2) # Hexadecimal notation
+          end
+        end
+
         def hstore_to_string(object)
           if Hash === object
             object.map { |k,v|

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -18,6 +18,16 @@ module ActiveRecord
           end
         end
 
+        class Bit < Type
+          def type_cast(value)
+            if String === value
+              ConnectionAdapters::PostgreSQLColumn.string_to_bit value
+            else
+              value
+            end
+          end
+        end
+
         class Bytea < Type
           def type_cast(value)
             return if value.nil?
@@ -323,14 +333,14 @@ module ActiveRecord
         # FIXME: why are we keeping these types as strings?
         alias_type 'tsvector', 'text'
         alias_type 'interval', 'text'
-        alias_type 'bit',      'text'
-        alias_type 'varbit',   'text'
         alias_type 'macaddr',  'text'
         alias_type 'uuid',     'text'
 
         register_type 'money', OID::Money.new
         register_type 'bytea', OID::Bytea.new
         register_type 'bool', OID::Boolean.new
+        register_type 'bit', OID::Bit.new
+        register_type 'varbit', OID::Bit.new
 
         register_type 'float4', OID::Float.new
         alias_type 'float8', 'float4'

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -545,13 +545,13 @@ _SQL
 
   def test_update_bit_string
     new_bit_string = '11111111'
-    new_bit_string_varying = '11111110'
+    new_bit_string_varying = 'FF'
     assert @first_bit_string.bit_string = new_bit_string
     assert @first_bit_string.bit_string_varying = new_bit_string_varying
     assert @first_bit_string.save
     assert @first_bit_string.reload
-    assert_equal new_bit_string, @first_bit_string.bit_string
-    assert_equal new_bit_string_varying, @first_bit_string.bit_string_varying
+    assert_equal @first_bit_string.bit_string, new_bit_string
+    assert_equal @first_bit_string.bit_string, @first_bit_string.bit_string_varying
   end
 
   def test_update_oid


### PR DESCRIPTION
When investigating #8206, I found cdd293cb963b895ff580eb20d10f5d56ecb3d447.

I guess that cdd293cb963b895ff580eb20d10f5d56ecb3d447 wasn't properly fix, because we should support bit/hex string.

When using `OID::Bit` for Bit(1560) or Varbit(1562), we can support bit/hex string properly. 
