### PR TITLE
ActiveSupport::TaggedLogger should tag each line of output

### DIFF
--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -17,10 +17,9 @@ module ActiveSupport
     module Formatter # :nodoc:
       # This method is invoked when a log event occurs.
       def call(severity, timestamp, progname, msg)
-        message =
-          (String === msg ? msg : msg.inspect).split("\n").map do |line|
-            "#{tags_text}#{line}"
-          end.join("\n")
+        lines = (String === msg ? msg : msg.inspect).split("\n", -1)
+        lines = [""] if lines.empty?
+        message = lines.map{|line| "#{tags_text}#{line}" }.join("\n")
         super(severity, timestamp, progname, message)
       end
 

--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -17,7 +17,11 @@ module ActiveSupport
     module Formatter # :nodoc:
       # This method is invoked when a log event occurs.
       def call(severity, timestamp, progname, msg)
-        super(severity, timestamp, progname, "#{tags_text}#{msg}")
+        message =
+          (String === msg ? msg : msg.inspect).split("\n").map do |line|
+            "#{tags_text}#{line}"
+          end.join("\n")
+        super(severity, timestamp, progname, message)
       end
 
       def tagged(*tags)

--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -19,8 +19,9 @@ module ActiveSupport
       def call(severity, timestamp, progname, msg)
         lines = (String === msg ? msg : msg.inspect).split("\n", -1)
         lines = [""] if lines.empty?
-        message = lines.map{|line| "#{tags_text}#{line}" }.join("\n")
-        super(severity, timestamp, progname, message)
+        lines.map do |line|
+          super(severity, timestamp, progname, "#{tags_text}#{line}")
+        end.join
       end
 
       def tagged(*tags)

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -104,4 +104,9 @@ class TaggedLoggingTest < ActiveSupport::TestCase
     @logger.tagged("BCX") { @logger.info "Funky time\nJunky time" }
     assert_equal "[BCX] Funky time\n[BCX] Junky time\n", @output.string
   end
+
+  test "renders trailing newlines" do
+    @logger.tagged("BCX") { @logger.info "Funky time\nJunky time\n\n" }
+    assert_equal "[BCX] Funky time\n[BCX] Junky time\n[BCX] \n[BCX] \n", @output.string
+  end
 end

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -99,4 +99,9 @@ class TaggedLoggingTest < ActiveSupport::TestCase
 
     assert_equal "[BCX] [Jason] Funky time\n[BCX] Junky time!\n", @output.string
   end
+
+  test "renders tags on each line" do
+    @logger.tagged("BCX") { @logger.info "Funky time\nJunky time" }
+    assert_equal "[BCX] Funky time\n[BCX] Junky time\n", @output.string
+  end
 end


### PR DESCRIPTION
``` ruby
logger.tagged("REQUEST-XYZ") { logger.info "Hello\nWorld!" }
```

outputs

```
[REQUEST-XYZ] Hello
World!
```

It would be better to output

```
[REQUEST-XYZ] Hello
[REQUEST-XYZ] World!
```

Otherwise, in a distributed environment, you don't know which request generated the second line.
