### PR TITLE
alias "rails plugin" to "rails plugin new"

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Alias "rails plugin" to "rails plugin new". *Yves Senn*
+
 *   Move rails.png into a data-uri. One less file to get generated into a new
     application. This is also consistent with the removal of index.html.
 

--- a/railties/lib/rails/commands.rb
+++ b/railties/lib/rails/commands.rb
@@ -40,7 +40,8 @@ case command
 when 'generate', 'destroy', 'plugin'
   require 'rails/generators'
 
-  if command == 'plugin' && ARGV.first == 'new'
+  if command == 'plugin'
+    ARGV.unshift 'new' unless ARGV.first == 'new'
     require "rails/commands/plugin_new"
   else
     require APP_PATH


### PR DESCRIPTION
origin: #10229.

As we only have "rails plugin new" left it is convenient to alias it to "rails plugin". I tripped a few times myself only calling "rails plugin" and if "new" is the only argument left we can safely do the alias.

I think it is handy but I don't have a strong opinion about this one. If you feel like this is a bad change, just close.
