### PR TITLE
Allow concerns defined as a string array

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1716,7 +1716,7 @@ module ActionDispatch
         # <tt>call</tt>.
         def concern(name, callable = nil, &block)
           callable ||= lambda { |mapper, options| mapper.instance_exec(options, &block) }
-          @concerns[name] = callable
+          @concerns[name.to_sym] = callable
         end
 
         # Use the named concerns
@@ -1733,7 +1733,7 @@ module ActionDispatch
         def concerns(*args)
           options = args.extract_options!
           args.flatten.each do |name|
-            if concern = @concerns[name]
+            if concern = @concerns[name.to_sym]
               concern.call(self, options)
             else
               raise ArgumentError, "No concern named #{name} was found!"

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -359,6 +359,7 @@ end
 class ThreadsController  < ResourcesController; end
 class MessagesController < ResourcesController; end
 class CommentsController < ResourcesController; end
+class TagsController < ResourcesController; end
 class ReviewsController < ResourcesController; end
 class AuthorsController < ResourcesController; end
 class LogosController < ResourcesController; end

--- a/actionpack/test/dispatch/routing/concerns_test.rb
+++ b/actionpack/test/dispatch/routing/concerns_test.rb
@@ -13,6 +13,10 @@ class RoutingConcernsTest < ActionDispatch::IntegrationTest
         resources :comments, options
       end
 
+      concern 'taggable' do |options|
+        resources 'tags', options
+      end
+
       concern :image_attachable do
         resources :images, only: :index
       end
@@ -28,6 +32,8 @@ class RoutingConcernsTest < ActionDispatch::IntegrationTest
       resource :picture, concerns: :commentable do
         resources :posts, concerns: :commentable
       end
+
+      resource :article, concerns: %w(commentable taggable)
 
       scope "/videos" do
         concerns :commentable, except: :destroy
@@ -48,6 +54,13 @@ class RoutingConcernsTest < ActionDispatch::IntegrationTest
     get "/picture/comments"
     assert_equal "200", @response.code
     assert_equal "/picture/comments", picture_comments_path
+  end
+
+  def test_accessing_concern_defined_using_string
+    get "/article/tags"
+    assert_equal "200", @response.code
+    assert_equal "/article/tags", article_tags_path
+    assert_equal "/article/comments", article_comments_path
   end
 
   def test_accessing_concern_from_nested_resource


### PR DESCRIPTION
Right now several of the route options (only, except) can be defined
as arrays of string or symbols. I was surprised when playing with
rails 4 and this didn't work for concerns.
- Added test for string array declaration.

With this change concerns could be declared with strings or symbols:

```
resources :posts, concerns: [:commentable, :taggable]
resources :media, concerns: %w(commentable taggable)
```

**This includes changes mentioned in an original pull request: https://github.com/rails/rails/pull/9725**
