### PR TITLE
Add `rails engine new <engine-name>` alias

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Alias `rails plugin new <engine-name> --mountable` to
+    `rails engine <engine-name>`.
+
+    *Caleb Thompson*
+
 *   Move rails.png into a data-uri. One less file to get generated into a new
     application. This is also consistent with the removal of index.html.
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Rails 4.0.0 (unreleased) ##
 
 *   Alias `rails plugin new <engine-name> --mountable` to
-    `rails engine <engine-name>`.
+    `rails engine new <engine-name>`.
 
     *Caleb Thompson*
 

--- a/railties/lib/rails/cli.rb
+++ b/railties/lib/rails/cli.rb
@@ -9,8 +9,7 @@ require 'rails/ruby_version_check'
 Signal.trap("INT") { puts; exit(1) }
 
 if ARGV.first == 'engine'
-  ARGV.shift
-  ARGV.unshift('plugin', 'new')
+  ARGV.first = 'plugin'
   ARGV << '--mountable'
 end
 

--- a/railties/lib/rails/cli.rb
+++ b/railties/lib/rails/cli.rb
@@ -8,6 +8,12 @@ Rails::AppRailsLoader.exec_app_rails
 require 'rails/ruby_version_check'
 Signal.trap("INT") { puts; exit(1) }
 
+if ARGV.first == 'engine'
+  ARGV.shift
+  ARGV.unshift('plugin', 'new')
+  ARGV << '--mountable'
+end
+
 if ARGV.first == 'plugin'
   ARGV.shift
   require 'rails/commands/plugin_new'


### PR DESCRIPTION
Alias for `rails plugin new <engine-name>`

Inspiration comes from @steveklabnik’s comment here:
https://github.com/rails/rails/pull/10233#issuecomment-16432249
