### PR TITLE
Using secure source https://rubygems.org when generating new plugin with Rails 3.2.13

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Declare your gem's dependencies in <%= name %>.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/10245
