### PR TITLE
Moved the check for the rails test environment into rails.rb

### DIFF
--- a/railties/lib/rails/all.rb
+++ b/railties/lib/rails/all.rb
@@ -1,9 +1,5 @@
 require "rails"
 
-if defined?(Rake) && Rake.application.top_level_tasks.grep(/^(default$|test(:|$))/).any?
-  ENV['RAILS_ENV'] ||= 'test'
-end
-
 %w(
   active_record
   action_controller

--- a/railties/lib/rails/test_unit/railtie.rb
+++ b/railties/lib/rails/test_unit/railtie.rb
@@ -1,3 +1,7 @@
+if defined?(Rake) && Rake.application.top_level_tasks.grep(/^(default$|test(:|$))/).any?
+  ENV['RAILS_ENV'] ||= 'test'
+end
+
 module Rails
   class TestUnitRailtie < Rails::Railtie
     config.app_generators do |c|


### PR DESCRIPTION
This addresses issue #10238. The problem right now is that the `ENV["RAILS_ENV"]` variable only gets set to test when you do a `require rails.all`. This is because the command that checks to see if the Rake tasks are performing tests are only defined there.

I've moved the code that checks for whether rake is running tests into the rails.rb file.

However, I'm stumped as to how to write a test for this. Any input would be welcome!
