### PR TITLE
Unify the format of returning nil

### DIFF
--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -138,7 +138,7 @@ module ActionController
       # This method also does namespace lookup. Foo::Bar::UsersController will
       # try to find Foo::Bar::User, Foo::User and finally User.
       def _default_wrap_model #:nodoc:
-        return nil if klass.anonymous?
+        return if klass.anonymous?
         model_name = klass.name.sub(/Controller$/, '').classify
 
         begin

--- a/actionpack/lib/action_dispatch/middleware/flash.rb
+++ b/actionpack/lib/action_dispatch/middleware/flash.rb
@@ -87,7 +87,7 @@ module ActionDispatch
       end
 
       def to_session_value
-        return nil if empty?
+        return if empty?
         {'discard' => @discard.to_a, 'flashes' => @flashes}
       end
 

--- a/actionpack/lib/action_view/renderer/partial_renderer.rb
+++ b/actionpack/lib/action_view/renderer/partial_renderer.rb
@@ -282,7 +282,7 @@ module ActionView
     end
 
     def render_collection
-      return nil if @collection.blank?
+      return if @collection.blank?
 
       if @options.key?(:spacer_template)
         spacer = find_template(@options[:spacer_template], @locals.keys).render(@view, @locals)

--- a/actionpack/lib/action_view/vendor/html-scanner/html/tokenizer.rb
+++ b/actionpack/lib/action_view/vendor/html-scanner/html/tokenizer.rb
@@ -33,7 +33,7 @@ module HTML #:nodoc:
     # Return the next token in the sequence, or +nil+ if there are no more tokens in
     # the stream.
     def next
-      return nil if @scanner.eos?
+      return if @scanner.eos?
       @position = @scanner.pos
       @line = @current_line
       if @scanner.check(/<\S/)

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -88,7 +88,7 @@ module ActiveRecord
 
       # Casts value (which is a String) to an appropriate instance.
       def type_cast(value)
-        return nil if value.nil?
+        return if value.nil?
         return coder.load(value) if encoded?
 
         klass = self.class
@@ -161,7 +161,7 @@ module ActiveRecord
 
         def value_to_date(value)
           if value.is_a?(String)
-            return nil if value.empty?
+            return if value.empty?
             fast_string_to_date(value) || fallback_string_to_date(value)
           elsif value.respond_to?(:to_date)
             value.to_date
@@ -172,20 +172,20 @@ module ActiveRecord
 
         def string_to_time(string)
           return string unless string.is_a?(String)
-          return nil if string.empty?
+          return if string.empty?
 
           fast_string_to_time(string) || fallback_string_to_time(string)
         end
 
         def string_to_dummy_time(string)
           return string unless string.is_a?(String)
-          return nil if string.empty?
+          return if string.empty?
 
           dummy_time_string = "2000-01-01 #{string}"
 
           fast_string_to_time(dummy_time_string) || begin
             time_hash = Date._parse(dummy_time_string)
-            return nil if time_hash[:hour].nil?
+            return if time_hash[:hour].nil?
             new_time(*time_hash.values_at(:year, :mon, :mday, :hour, :min, :sec, :sec_fraction))
           end
         end
@@ -239,7 +239,7 @@ module ActiveRecord
 
           def new_time(year, mon, mday, hour, min, sec, microsec)
             # Treat 0000-00-00 00:00:00 as nil.
-            return nil if year.nil? || (year == 0 && mon == 0 && mday == 0)
+            return if year.nil? || (year == 0 && mon == 0 && mday == 0)
 
             Time.send(Base.default_timezone, year, mon, mday, hour, min, sec, microsec) rescue nil
           end

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -20,7 +20,7 @@ module ActiveRecord
       #   { name: "foo'bar", group_id: 4 }  returns "name='foo''bar' and group_id='4'"
       #   "name='foo''bar' and group_id='4'" returns "name='foo''bar' and group_id='4'"
       def sanitize_sql_for_conditions(condition, table_name = self.table_name)
-        return nil if condition.blank?
+        return if condition.blank?
 
         case condition
         when Array; sanitize_sql_array(condition)

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -258,7 +258,7 @@ module ActiveSupport #:nodoc:
       end
 
       def describe_blame
-        return nil if blamed_files.empty?
+        return if blamed_files.empty?
         "This error occurred while loading the following files:\n   #{blamed_files.join "\n   "}"
       end
 

--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -204,8 +204,8 @@ module ActiveSupport #:nodoc:
       protected
 
         def translate_offset(byte_offset) #:nodoc:
-          return nil if byte_offset.nil?
-          return 0   if @wrapped_string == ''
+          return if byte_offset.nil?
+          return 0 if @wrapped_string == ''
 
           begin
             @wrapped_string.byteslice(0...byte_offset).unpack('U*').length


### PR DESCRIPTION
In the rails source code, there are two cases when returning nil with "if" in one line.
- return nil if ...
- return if ...

They are the same meaning.
So I thought they should be unified.
I did grep, and I found that the latter case is major in the rails source code.
I replaced all of the former cases.
