### PR TITLE
Avoid leak into controller's action_methods

### DIFF
--- a/actionpack/lib/abstract_controller/layouts.rb
+++ b/actionpack/lib/abstract_controller/layouts.rb
@@ -309,6 +309,7 @@ module AbstractController
             RUBY
           when Proc
             define_method :_layout_from_proc, &_layout
+            protected :_layout_from_proc
             <<-RUBY
               result = _layout_from_proc(#{_layout.arity == 0 ? '' : 'self'})
               return #{default_behavior} if result.nil?

--- a/actionpack/test/abstract/layouts_test.rb
+++ b/actionpack/test/abstract/layouts_test.rb
@@ -8,6 +8,8 @@ module AbstractControllerTests
       include AbstractController::Rendering
       include AbstractController::Layouts
 
+      abstract!
+
       self.view_paths = [ActionView::FixtureResolver.new(
         "layouts/hello.erb"             => "With String <%= yield %>",
         "layouts/hello_override.erb"    => "With Override <%= yield %>",
@@ -249,6 +251,10 @@ module AbstractControllerTests
         controller = WithNilLayout.new
         controller.process(:index)
         assert_equal "Hello nil!", controller.response_body
+      end
+
+      test "when layout is specified as a proc, do not leak any methods into controller's action_methods" do
+        assert_equal Set.new(['index']), WithProc.action_methods
       end
 
       test "when layout is specified as a proc, call it and use the layout returned" do


### PR DESCRIPTION
``` ruby
class ExampleController < ActionController::Base
  layout -> { 'smth' }
end

ExampleController.action_methods
# => #<Set: {"_layout_from_proc"}>
```
