### PR TITLE
Postgresql array columns don't properly escape single quote strings when loading fixtures

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -32,7 +32,7 @@ module ActiveRecord
             when 'point' then super(PostgreSQLColumn.point_to_string(value))
             else
               if column.array
-                "'#{PostgreSQLColumn.array_to_string(value, column, self)}'"
+                "'#{PostgreSQLColumn.array_to_string(value, column, self).gsub(/'/, "''")}'"
               else
                 super
               end

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -81,6 +81,12 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
     assert_cycle(['1',nil,nil])
   end
 
+  def test_insert_fixture
+    tag_values = ["val1", "val2", "val3_with_'_multiple_quote_'_chars"]
+    @connection.insert_fixture({"tags" => tag_values}, "pg_arrays" )
+    assert_equal(PgArray.last.tags, tag_values)
+  end
+
   private
   def assert_cycle array
     # test creation


### PR DESCRIPTION
In the fixture builder there was a single statement that inserts the fixture row and yields something like:

```
INSERT INTO table_name ("arr_column") VALUES ('{"asdf", "as'df"}')
```

The problem with this was that the single quote in the second array value needs to be escaped.  Normally they won't need to be escaped in strings, but when array columns go all the way to sql (instead of binding to the connection) they get wrapped in '{ and }' and that makes escaping them required.

This fix causes the insert to look more like:

```
INSERT INTO table_name("arr_column") VALUES( $1 ) [ ["arr_column", ["asdf", "as''df"] ] ]
```

The extra single quote (') character is the escape for a single quote in a string. 

I made a test for this, to run the test:

```
cd activerecord && ARCONN=postgresql ruby -Itest test/cases/adapters/postgresql/array_test.rb -n test_insert_fixture
```

To see the test fail revert the change at https://github.com/cconstantine/rails/commit/0e34a7efa6992e6771d34dc8163b79dd7df52667#L0R35

This change is only in postgresql code, and everything passes when I run 

```
ARCONN=postgresql rake test_postgresql
```

This is a followup to the failed attempt to fix https://github.com/rails/rails/pull/10043 .
