### PR TITLE
fix HashWithIndifferentAccess#to_hash behaviour

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -229,7 +229,11 @@ module ActiveSupport
 
     # Convert to a regular hash with string keys.
     def to_hash
-      Hash.new(default).merge!(self)
+      _new_hash= {}
+      each do |key, value|
+        _new_hash[convert_key(key)] = convert_value(value,true)
+      end
+      Hash.new(default).merge!(_new_hash)
     end
 
     protected
@@ -237,9 +241,9 @@ module ActiveSupport
         key.kind_of?(Symbol) ? key.to_s : key
       end
 
-      def convert_value(value)
+      def convert_value(value, _convert_for_to_hash = false)
         if value.is_a? Hash
-          value.nested_under_indifferent_access
+          _convert_for_to_hash ? value.to_hash : value.nested_under_indifferent_access
         elsif value.is_a?(Array)
           value = value.dup if value.frozen?
           value.map! { |e| convert_value(e) }

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -490,6 +490,10 @@ class HashExtTest < ActiveSupport::TestCase
     roundtrip = mixed_with_default.with_indifferent_access.to_hash
     assert_equal @strings, roundtrip
     assert_equal '1234', roundtrip.default
+    new_to_hash = @nested_mixed.with_indifferent_access.to_hash
+    assert_not new_to_hash.instance_of?(HashWithIndifferentAccess)
+    assert_not new_to_hash["a"].instance_of?(HashWithIndifferentAccess)
+    assert_not new_to_hash["a"]["b"].instance_of?(HashWithIndifferentAccess)
   end
 
   def test_lookup_returns_the_same_object_that_is_stored_in_hash_indifferent_access


### PR DESCRIPTION
Currently `HashWithIndifferentAccess#to_hash` ,returns a hash containing HashWithIndifferentAccess within for a nested hash, eg

if 
`{:a => {:b => {:c => '3'}}}` is a HashWithIndifferentAccess
then #to_hash returns 

`{:a => {:b => {:c => '3'}}}`
where {:b => {:c => '3'}} is a `HashWithIndifferentAccess` object, while the whole object itself is a `Hash`
