### PR TITLE
Add a #select_multi method to cache stores

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -339,6 +339,21 @@ module ActiveSupport
         results
       end
 
+      def select_multi(*names)
+        options = names.extract_options!
+        options = merged_options(options)
+
+        results = read_multi(*names, options)
+        
+        names.select do |name|
+          results.fetch(name) do
+            value = yield(name)
+            write(name, value, options)
+            value
+          end
+        end
+      end
+
       # Writes the value to the cache, with the key.
       #
       # Options are passed to the underlying cache implementation.

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -272,6 +272,22 @@ module CacheStoreBehavior
     assert_nil @cache.read('foo')
   end
 
+  def test_select_multi
+    @cache.write('foo', true)
+    @cache.write('bar', false)
+
+    values = @cache.select_multi('foo', 'bar', 'baz') {|value| true }
+
+    assert_equal(['foo', 'baz'], values)
+  end
+
+  def test_select_multi_writes_back_to_cache
+    @cache.select_multi('foo', 'bar') {|value| value == 'foo' }
+
+    assert_equal(true, @cache.read('foo'))
+    assert_equal(false, @cache.read('bar'))
+  end
+
   def test_cache_key
     obj = Object.new
     def obj.cache_key


### PR DESCRIPTION
Allows selecting a subset of a collection for which the cache returns true values. I extracted it from the following usage:

``` ruby
# In a controller.
@readable_posts = Rails.cache.select_multi(*@posts) do |post|
  # This is very expensive:
  can?(:read, post)
end
```

I'm not sure if it's too specific, but it's really useful and efficient. It uses `read_multi`, so it only sends a single `get` to the cache server.
