### PR TITLE
Increase readability of ternary statement in build method

### DIFF
--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -36,8 +36,7 @@ module ActionController
       raise "MiddlewareStack#build requires an app" unless app
 
       middlewares.reverse.inject(app) do |a, middleware|
-        middleware.valid?(action) ?
-          middleware.build(a) : a
+        middleware.valid?(action) ? middleware.build(a) : a
       end
     end
   end


### PR DESCRIPTION
Trying to grok the actionpack code, this line jarred a little, so moved the ternary statement up one line. All tests passing.
