### PR TITLE
Use present? rather than empty in assert_template

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -105,7 +105,7 @@ module ActionController
         matches_template =
           case options
           when String
-            !options.empty? && rendered.any? do |t, num|
+            options.present? && rendered.any? do |t, num|
               options_splited = options.split(File::SEPARATOR)
               t_splited = t.split(File::SEPARATOR)
               t_splited.last(options_splited.size) == options_splited


### PR DESCRIPTION
options.present? is clearer than !options.empty? IMHO.
