### PR TITLE
Removing tests for deprecated options in active support.

### DIFF
--- a/actionpack/test/template/render_test.rb
+++ b/actionpack/test/template/render_test.rb
@@ -29,14 +29,6 @@ module RenderTestCases
     assert_equal "Hello world!", @view.render(:file => "test/hello_world")
   end
 
-  def test_render_file_not_using_full_path
-    assert_equal "Hello world!", @view.render(:file => "test/hello_world")
-  end
-
-  def test_render_file_without_specific_extension
-    assert_equal "Hello world!", @view.render(:file => "test/hello_world")
-  end
-
   # Test if :formats, :locale etc. options are passed correctly to the resolvers.
   def test_render_file_with_format
     assert_match "<h1>No Comment</h1>", @view.render(:file => "comments/empty", :formats => [:html])


### PR DESCRIPTION
The two tests I'm removing here are actually duplicates of `test_render_file`. The reason they are duplicates is historical: the options that these two tests were supposed to check were deprecated, and the person who deprecated these options forgot to remove the test.

The `use_full_path` option was removed in 3b3790a which stops `test_render_file_not_using_full_path` from being useful. Also, passing the template handler to render was deprecated in 43d27e9, which stops `test_render_file_without_specific_extension` from being useful.
