### PR TITLE
Obey validation rules on: :save condition

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,5 +1,22 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   In the below case `User.new.valid?` returns true. Also while
+    updating user can set `name` value to `nil` and no validation
+    error is found while saving the record.
+
+       class User < ActiveRecord::Base
+          validates :name, presence: true, on: :save
+        end
+
+    Active Model understands validations in either `:create` or
+    `:update` context. Otherwise it is best to not set any context.
+
+    It removes context if context is `:save`.
+
+    Fixes #10248.
+
+    *Neeraj Singh*
+
 *   Add `ActiveModel::Errors#full_messages_for`, to return all the error messages
     for a given attribute.
 

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -139,8 +139,10 @@ module ActiveModel
       #   value.
       def validate(*args, &block)
         options = args.extract_options!
+        options = options.dup
+        options.delete(:on) if options[:on] == :save
+
         if options.key?(:on)
-          options = options.dup
           options[:if] = Array(options[:if])
           options[:if].unshift("validation_context == :#{options[:on]}")
         end

--- a/activemodel/test/cases/validations/validations_context_test.rb
+++ b/activemodel/test/cases/validations/validations_context_test.rb
@@ -36,4 +36,21 @@ class ValidationsContextTest < ActiveModel::TestCase
     assert topic.invalid?(:create), "Validation does run on create if 'on' is set to create"
     assert topic.errors[:base].include?(ERROR_MESSAGE)
   end
+
+  test "with a class that adds errors on save and validating a new model with no arguments" do
+    Topic.validates_with(ValidatorThatAddsErrors, on: :save)
+    topic = Topic.new
+    assert topic.invalid?, "Validation does run on valid? if 'on' is set to save"
+  end
+
+  test "with a class that adds errors on save and validating model" do
+    Topic.validates_presence_of(:title, on: :save)
+    topic = Topic.new title: 'testing'
+    assert topic.valid?
+
+    topic.title = nil
+    assert topic.invalid?, "Validation should run if 'on' is set to save"
+    assert_equal ["Title can't be blank"], topic.errors.full_messages
+  end
+
 end


### PR DESCRIPTION
class User < ActiveRecord::Base
      validates :name, presence: true, on: :save
    end

In at the above case `User.new.valid?` returns true. Also while
updating user can set `name` value to `nil` and no validation
error is found while saving the record.

Active Model understands validations in either `:create` or
`:update` context. Otherwise it is best to not set any context.
And that's what this fix is attempting to do.

It removes context if context is `:save`.

fixes #10248
