### PR TITLE
Update counter cache when pushing into association

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix for a regression bug in which counter cache columns were not being updated
+    when record was pushed into a has_many association. For example:
+
+        Post.first.comments << Comment.create
+
+    Fixes #3891.
+
+    *Matthew Robertson*
+
 *   If a model was instantiated from the database using `select`, `respond_to?`
     returns false for non-selected attributes. For example:
 

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -25,9 +25,10 @@ module ActiveRecord::Associations::Builder
 
       mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
         def belongs_to_counter_cache_after_create_for_#{name}
-          record = #{name}
-          record.class.increment_counter(:#{cache_column}, record.id) unless record.nil?
-          @_after_create_counter_called = true
+          if record = #{name}
+            record.class.increment_counter(:#{cache_column}, record.id)
+            @_after_create_counter_called = true
+          end
         end
 
         def belongs_to_counter_cache_before_destroy_for_#{name}

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -755,6 +755,15 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal topic.replies.to_a.size, topic.replies_count
   end
 
+  def test_pushing_association_updates_counter_cache
+    topic = Topic.order("id ASC").first
+    reply = Reply.create!
+
+    assert_difference "topic.reload.replies_count", 1 do
+      topic.replies << reply
+    end
+  end
+
   def test_deleting_updates_counter_cache_without_dependent_option
     post = posts(:welcome)
 


### PR DESCRIPTION
This commit fixes a regression bug (issue #3891) in which counter_cache columns were not being updated correctly when newly created records were being pushed into an assocation. EG:

```
# this was fine
@post.comment.create!

# this was fine
@comment = Comment.first
@post.comments << @comment

# this would not update counters
@post.comments << Comment.create!
```
