### PR TITLE
also assign nil in dirty nullable_datetime test. #10237

### DIFF
--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -213,9 +213,11 @@ class DirtyTest < ActiveRecord::TestCase
       topic = target.create
       assert_nil topic.written_on
 
-      topic.written_on = ""
-      assert_nil topic.written_on
-      assert !topic.written_on_changed?
+      ["", nil].each do |value|
+        topic.written_on = value
+        assert_nil topic.written_on
+        assert !topic.written_on_changed?
+      end
     end
   end
 


### PR DESCRIPTION
the origin for this change was #10237.

This is not a fix but adjusts `test_nullable_datetime_not_marked_as_changed_if_new_value_is_blank` to not only assign `""` but also `nil` as all the other `nullable_XX` tests do. We should include this for completeness sake and to prevent regressions.
