### PR TITLE
Use MethodNotAllowed exception rather than UnknownHttpMethod

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Return a 405 Method Not Allowed response when a request contains an unknown
+    HTTP method.
+
+    *Lewis Marshall*
+
 *   Add support for extracting the port from the `:host` option passed to `url_for`.
 
     *Andrew White*

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -9,6 +9,7 @@ module ActionDispatch
       'ActionController::RoutingError'             => :not_found,
       'AbstractController::ActionNotFound'         => :not_found,
       'ActionController::MethodNotAllowed'         => :method_not_allowed,
+      'ActionController::UnknownHttpMethod'        => :method_not_allowed,
       'ActionController::NotImplemented'           => :not_implemented,
       'ActionController::UnknownFormat'            => :not_acceptable,
       'ActionController::InvalidAuthenticityToken' => :unprocessable_entity,

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -29,6 +29,8 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
         raise RuntimeError
       when "/method_not_allowed"
         raise ActionController::MethodNotAllowed
+      when "/unknown_http_method"
+        raise ActionController::UnknownHttpMethod
       when "/not_implemented"
         raise ActionController::NotImplemented
       when "/unprocessable_entity"
@@ -112,6 +114,10 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     get "/method_not_allowed", {}, {'action_dispatch.show_exceptions' => true}
     assert_response 405
     assert_match(/ActionController::MethodNotAllowed/, body)
+
+    get "/unknown_http_method", {}, {'action_dispatch.show_exceptions' => true}
+    assert_response 405
+    assert_match(/ActionController::UnknownHttpMethod/, body)
 
     get "/bad_request", {}, {'action_dispatch.show_exceptions' => true}
     assert_response 400

--- a/actionpack/test/dispatch/show_exceptions_test.rb
+++ b/actionpack/test/dispatch/show_exceptions_test.rb
@@ -10,6 +10,8 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
         raise AbstractController::ActionNotFound
       when "/method_not_allowed"
         raise ActionController::MethodNotAllowed
+      when "/unknown_http_method"
+        raise ActionController::UnknownHttpMethod
       when "/not_found_original_exception"
         raise ActionView::Template::Error.new('template', AbstractController::ActionNotFound.new)
       else
@@ -39,6 +41,10 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
     assert_equal "404 error fixture\n", body
 
     get "/method_not_allowed", {}, {'action_dispatch.show_exceptions' => true}
+    assert_response 405
+    assert_equal "", body
+
+    get "/unknown_http_method", {}, {'action_dispatch.show_exceptions' => true}
     assert_response 405
     assert_equal "", body
   end


### PR DESCRIPTION
Raising a MethodNotAllowed exception will cause a 405 response to be
sent to the client, rather than a 500 response due to an uncaught
exception
