### PR TITLE
Preserve context for joins while merging relations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## unreleased ##
 
+*   Maintain context for joins within ActiveRecord::Relation merges.
+    Backport #10164.
+
+    *Neeraj Singh + Andrew Horner*
+    
 *   Make sure the `EXPLAIN` command is never triggered by a `select_db` call.
 
     *Daniel Schierbeck*

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -109,7 +109,7 @@ module ActiveRecord
         case associations
         when Symbol, String
           reflection = parent.reflections[associations.to_s.intern] or
-          raise ConfigurationError, "Association named '#{ associations }' was not found; perhaps you misspelled it?"
+          raise ConfigurationError, "Association named '#{ associations }' was not found on #{parent.active_record.name}; perhaps you misspelled it?"
           unless join_association = find_join_association(reflection, parent)
             @reflections << reflection
             join_association = build_join_association(reflection, parent)

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -55,7 +55,12 @@ module ActiveRecord
 
         def find_parent_in(other_join_dependency)
           other_join_dependency.join_parts.detect do |join_part|
-            parent == join_part
+            case parent
+            when JoinBase
+              parent.active_record == join_part.active_record
+            else
+              parent == join_part
+            end
           end
         end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -4,6 +4,7 @@ require 'models/tagging'
 require 'models/post'
 require 'models/topic'
 require 'models/comment'
+require 'models/rating'
 require 'models/reply'
 require 'models/author'
 require 'models/comment'
@@ -19,7 +20,7 @@ require 'models/minivan'
 
 class RelationTest < ActiveRecord::TestCase
   fixtures :authors, :topics, :entrants, :developers, :companies, :developers_projects, :accounts, :categories, :categorizations, :posts, :comments,
-    :tags, :taggings, :cars, :minivans
+    :ratings, :tags, :taggings, :cars, :minivans
 
   def test_do_not_double_quote_string_id
     van = Minivan.last
@@ -694,6 +695,12 @@ class RelationTest < ActiveRecord::TestCase
   def test_relation_merging_with_joins
     comments = Comment.joins(:post).where(:body => 'Thank you for the welcome').merge(Post.where(:body => 'Such a lovely day'))
     assert_equal 1, comments.count
+  end
+
+  def test_relation_merging_with_merged_joins
+    special_comments_with_ratings = SpecialComment.joins(:ratings)
+    posts_with_special_comments_with_ratings = Post.group('posts.id').joins(:special_comments).merge(special_comments_with_ratings)
+    assert_equal 1, authors(:david).posts.merge(posts_with_special_comments_with_ratings).count.length
   end
 
   def test_count


### PR DESCRIPTION
This is a backport of #10164, already merged into
master. The problem is described in lengthy detail
in issues #3002 and #5494.
