### PR TITLE
Fix Duplicate entries in db/schema.rb (Postgres)

### DIFF
--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -91,7 +91,7 @@ HEADER
       end
 
       def tables(stream)
-        @connection.tables.sort.each do |tbl|
+        @connection.tables.sort.uniq.each do |tbl|
           next if ['schema_migrations', ignore_tables].flatten.any? do |ignored|
             case ignored
             when String; remove_prefix_and_suffix(tbl) == ignored
@@ -207,7 +207,7 @@ HEADER
             '  ' + statement_parts.join(', ')
           end
 
-          stream.puts add_index_statements.sort.join("\n")
+          stream.puts add_index_statements.sort.uniq.join("\n")
           stream.puts
         end
       end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -85,6 +85,16 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_no_match %r{\# Could not dump table}, output
   end
 
+  def test_schema_dump_has_no_duplicate_tables
+    output_lines = standard_dump.split("\n")
+    assert output_lines.select{|i| i.match(/create_table "duplicate_table"/)}.size == 1
+  end
+
+  def test_schema_dump_has_no_duplicate_indexes
+    output_lines = standard_dump.split("\n")
+    assert output_lines.select{|i| i.match(/add_index "duplicate_table"/)}.size == 1
+  end
+
   def test_schema_dump_includes_not_null_columns
     stream = StringIO.new
 

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -87,12 +87,12 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
   def test_schema_dump_has_no_duplicate_tables
     output_lines = standard_dump.split("\n")
-    assert output_lines.select{|i| i.match(/create_table "duplicate_table"/)}.size == 1
+    assert_equal 1, output_lines.select{|i| i.match(/create_table "duplicate_table"/)}.size
   end
 
   def test_schema_dump_has_no_duplicate_indexes
     output_lines = standard_dump.split("\n")
-    assert output_lines.select{|i| i.match(/add_index "duplicate_table"/)}.size == 1
+    assert_equal 1, output_lines.select{|i| i.match(/add_index "duplicate_table"/)}.size
   end
 
   def test_schema_dump_includes_not_null_columns

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -86,13 +86,17 @@ class SchemaDumperTest < ActiveRecord::TestCase
   end
 
   def test_schema_dump_has_no_duplicate_tables
-    output_lines = standard_dump.split("\n")
-    assert_equal 1, output_lines.select{|i| i.match(/create_table "duplicate_table"/)}.size
+    if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
+      output_lines = standard_dump.split("\n")
+      assert_equal 1, output_lines.select{|i| i.match(/create_table "duplicate_table"/)}.size
+    end
   end
 
   def test_schema_dump_has_no_duplicate_indexes
-    output_lines = standard_dump.split("\n")
-    assert_equal 1, output_lines.select{|i| i.match(/add_index "duplicate_table"/)}.size
+    if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
+      output_lines = standard_dump.split("\n")
+      assert_equal 1, output_lines.select{|i| i.match(/add_index "duplicate_table"/)}.size
+    end
   end
 
   def test_schema_dump_includes_not_null_columns


### PR DESCRIPTION
Closes #10327

When a schema.rb dump is created from a Postgres database containing multiple schemas, duplicate statements will be generated in db/schema.rb, which will cause errors when loading the schema.rb.

This patch simply adds "uniq" statements to the method chain to ensure duplicate statements are not output.

I would like to add a test for this, but am unsure how/if y'all would like to handle database-specific tests. I am unaware of how this issue might be duplicated with other RDMS's
