### PR TITLE
Serialized column should not be wrapped twice. Fix #10067.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix a SystemStackError problem when using time zone aware or serialized attributes.
+    In current implementation, we re-use `column_types` argument when initiating an instance.
+    If an instance have serialized or timezone aware attributes,
+    column_types is wrapped multiple times in `decorate_columns` method. Thus the above error occurs.
+
+    *Dan Erikson & kennyj*
+
 *   Fix for a regression bug in which counter cache columns were not being updated
     when record was pushed into a has_many association. For example:
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -51,7 +51,7 @@ module ActiveRecord
       # how this "single-table" inheritance mapping is implemented.
       def instantiate(record, column_types = {})
         klass = discriminate_class_for_record(record)
-        column_types = klass.decorate_columns(column_types)
+        column_types = klass.decorate_columns(column_types.dup)
         klass.allocate.init_with('attributes' => record, 'column_types' => column_types)
       end
 

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -1,5 +1,6 @@
 require 'cases/helper'
 require 'models/topic'
+require 'models/reply'
 require 'models/person'
 require 'models/traffic_light'
 require 'bcrypt'
@@ -240,5 +241,18 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     light = TrafficLight.new
     assert_equal [], light.state
     assert_equal [], light.long_state
+  end
+
+  def test_serialized_columh_should_not_be_wrapped_twice
+    Topic.serialize(:content, MyObject)
+
+    myobj = MyObject.new('value1', 'value2')
+    Topic.create(content: myobj)
+    Topic.create(content: myobj)
+
+    Topic.all.each do |topic|
+      type = topic.instance_variable_get("@columns_hash")["content"]
+      assert !type.instance_variable_get("@column").is_a?(ActiveRecord::AttributeMethods::Serialization::Type)
+    end
   end
 end


### PR DESCRIPTION
See #10067

If AR's instance has serialized attribute ( or timezone aware attribute), instance level @columns_hash is wrapped multiple times during instantiate in current implementation.
