### PR TITLE
Move method used only in the test to the test code itself

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -253,14 +253,6 @@ module ActiveRecord
         @available = Queue.new self
       end
 
-      # Hack for tests to be able to add connections.  Do not call outside of tests
-      def insert_connection_for_test!(c) #:nodoc:
-        synchronize do
-          @connections << c
-          @available.add c
-        end
-      end
-
       # Retrieve the connection associated with the current thread, or call
       # #checkout to obtain one if necessary.
       #

--- a/activerecord/test/cases/connection_adapters/abstract_adapter_test.rb
+++ b/activerecord/test/cases/connection_adapters/abstract_adapter_test.rb
@@ -2,6 +2,15 @@ require "cases/helper"
 
 module ActiveRecord
   module ConnectionAdapters
+    class ConnectionPool
+      def insert_connection_for_test!(c)
+        synchronize do
+          @connections << c
+          @available.add c
+        end
+      end
+    end
+
     class AbstractAdapterTest < ActiveRecord::TestCase
       attr_reader :adapter
 


### PR DESCRIPTION
This pull request moves a hacky helper method in ConnectionPool class to the test file where it is used in tests.
