### PR TITLE
Fix ActionView::Digestor to correctly pass format to LookupContext

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Rails 4.0.0 (unreleased) ##
 
+*   Fix cache digests to respect the format of view files being looked up.
+    Digestor called LookupContext.find with the options as the wrong argument
+    causing the formats option to be ignored.
+
+    Caching article/show.pdf.erb now correctly digests any dependencies as
+    _partial.pdf.erb and not _partial.html.erb.
+
+    *Martin Westin*
+
 *   Return a 405 Method Not Allowed response when a request contains an unknown
     HTTP method.
 

--- a/actionpack/lib/action_view/digestor.rb
+++ b/actionpack/lib/action_view/digestor.rb
@@ -57,7 +57,7 @@ module ActionView
       end
 
       def template
-        @template ||= finder.find(logical_name, [], partial?, formats: [ format ])
+        @template ||= finder.find(logical_name, [], partial?, [], formats: [ format ])
       end
 
       def source

--- a/actionpack/test/template/digestor_test.rb
+++ b/actionpack/test/template/digestor_test.rb
@@ -15,7 +15,7 @@ end
 class FixtureFinder
   FIXTURES_DIR = "#{File.dirname(__FILE__)}/../fixtures/digestor"
 
-  def find(logical_name, keys, partial, options)
+  def find(logical_name, prefixes, partial, keys, options)
     FixtureTemplate.new("digestor/#{partial ? logical_name.gsub(%r|/([^/]+)$|, '/_\1') : logical_name}.#{options[:formats].first}.erb")
   end
 end


### PR DESCRIPTION
Hi, I was playing around trying to use cache_digests to generate a checksum for a generated pdf (based on views with pdf as the format).

After much head-scratching I think I actually found a small bug in TemplateDigestor. There seems to be a missing argument in the call to ActionView::LookupContext which causes formats of templates to be ignored.

@dhh asked me to do a PR of this for rails too. I followed the contributing guide to the best of my abilities. Please let me know if I should improve the PR in some way.
