### PR TITLE
(FIX) Error for array of integers for postgres

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -69,15 +69,16 @@ module ActiveRecord
 
         def array_to_string(value, column, adapter, should_be_quoted = false)
           casted_values = value.map do |val|
-            if String === val
               if val == "NULL"
                 "\"#{val}\""
               else
-                quote_and_escape(adapter.type_cast(val, column, true))
+                casted_value = adapter.type_cast(val, column, true)
+                if String === casted_value
+                  quote_and_escape(casted_value)
+                else
+                  casted_value
+                end
               end
-            else
-              adapter.type_cast(val, column, true)
-            end
           end
           "{#{casted_values.join(',')}}"
         end


### PR DESCRIPTION
Field description in schema: `t.integer :field_name, :type => :array`. 
Error: "undefined method `gsub' for 1:Fixnum" in PostgreSQLColumn#quote_and_escape.
