### PR TITLE
Refactor Delegation Method

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -145,7 +145,7 @@ class Module
       if allow_nil
         module_eval(<<-EOS, file, line - 2)
           def #{method_prefix}#{method}(#{definition})        # def customer_name(*args, &block)
-            if #{to} || #{to}.respond_to?(:#{method})         #   if client || client.respond_to?(:name)
+            if #{to}.respond_to?(:#{method})                  #   if client.respond_to?(:name)
               #{to}.#{method}(#{definition})                  #     client.name(*args, &block)
             end                                               #   end
           end                                                 # end

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -171,6 +171,11 @@ class ModuleTest < ActiveSupport::TestCase
     assert_nil rails.name
   end
 
+  def test_delegation_with_allow_nil_and_invalid_value
+    rails = Project.new("Rails", "David")
+    assert_nil rails.name
+  end
+
   def test_delegation_with_allow_nil_and_nil_value_and_prefix
     Project.class_eval do
       delegate :name, :to => :person, :allow_nil => true, :prefix => true


### PR DESCRIPTION
This change is basically removing a bad condition, since when we want to
delegate is important and sufficient to validate that the object
responds to the method, otherwise there's going to be an exception
because any object that is not nil or false is going to enter the condition.
