### PR TITLE
Delegation method bug

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -112,6 +112,20 @@ class Module
   #   end
   #
   #   Foo.new.zoo   # returns nil
+  #
+  # If the delegate object is not +nil+ or +false+ and the object doesn't
+  # respond to the delegated method it will raise an exception.
+  #
+  #   class Foo
+  #     def initialize(bar)
+  #       @bar = bar
+  #     end
+  #
+  #     delegate :name, to: :@bar
+  #   end
+  #
+  #   Foo.new("Bar").name # raises NoMethodError: undefined method `name'
+  #
   def delegate(*methods)
     options = methods.pop
     unless options.is_a?(Hash) && to = options[:to]

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -171,6 +171,11 @@ class ModuleTest < ActiveSupport::TestCase
     assert_nil rails.name
   end
 
+  def test_delegation_with_allow_nil_and_invalid_value
+    rails = Project.new("Rails", "David")
+    assert_raise(NoMethodError) { rails.name }
+  end
+
   def test_delegation_with_allow_nil_and_nil_value_and_prefix
     Project.class_eval do
       delegate :name, :to => :person, :allow_nil => true, :prefix => true


### PR DESCRIPTION
Add documentation and test to delegation method that make sure we're
aware that when a delegated object is not nil or false and doesn't
respond to the method it will still raise a NoMethodError exception.
