### PR TITLE
Fix noisy output when running rake db:schema:load on postgreSQL and structure.sql

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Mute `psql` output when running rake db:schema:load.
+
+    *Godfrey Chan*
+
 *   Trigger a save on `has_one association=(associate)` when the associate contents have changed.
 
     Fix #8856.

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -59,7 +59,7 @@ module ActiveRecord
 
       def structure_load(filename)
         set_psql_env
-        Kernel.system("psql -f #{filename} #{configuration['database']}")
+        Kernel.system("psql -q -f #{filename} #{configuration['database']}")
       end
 
       private

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -227,7 +227,7 @@ module ActiveRecord
 
     def test_structure_load
       filename = "awesome-file.sql"
-      Kernel.expects(:system).with("psql -f #{filename} my-app-db")
+      Kernel.expects(:system).with("psql -q -f #{filename} my-app-db")
 
       ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
     end


### PR DESCRIPTION
Since upgrading to Rails 4, we have been seeing a lot of noise whenever we run our specs:

```
$ % rake spec             
SET
SET
SET
SET
SET
SET
CREATE EXTENSION
COMMENT
CREATE EXTENSION
COMMENT
SET
SET
SET
CREATE TABLE
CREATE SEQUENCE
ALTER SEQUENCE
CREATE TABLE
CREATE SEQUENCE
ALTER SEQUENCE
CREATE TABLE
CREATE SEQUENCE
ALTER SEQUENCE
...
```

After some investigation today it seems to be caused by [this change](https://github.com/rails/rails/commit/19911959d9a8fa5341f61b028cb489e6ecc2c339) that effectively switched from using backticks to `Kernel.system`.

I wasn't able to figure out how to configure `Kernel.system` to behave like the backtick method, but changing it back fixes the problem.
