### PR TITLE
Fix bug in ActiveRecord::Sanitization#sanitize_sql_hash_for_conditions

### DIFF
--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -89,7 +89,7 @@ module ActiveRecord
         attrs = expand_hash_conditions_for_aggregates(attrs)
 
         table = Arel::Table.new(table_name, arel_engine).alias(default_table_name)
-        PredicateBuilder.build_from_hash(self.class, attrs, table).map { |b|
+        PredicateBuilder.build_from_hash(self, attrs, table).map { |b|
           connection.visitor.accept b
         }.join(' AND ')
       end


### PR DESCRIPTION
Always passing Class into PredicateBuilder.build_from_hash.  This is a problem when using associations and throws NoMethodError when PredicateBuilder attempts to call Class.reflect_on_association.
