### PR TITLE
Fix bug in ActiveRecord::Sanitization#sanitize_sql_hash_for_conditions

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fixed a bug in ActiveRecord#sanitize_sql_hash_for_conditions in which
+    `self.class` is an argument to PredicateBuilder#build_from_hash
+    causing PredicateBuilder to call non-existant method
+    Class#reflect_on_association.
+
+    *Zach Ohlgren*
+
 *   While removing index if column option is missing then raise IrreversibleMigration exception.
 
     Following code should raise `IrreversibleMigration`. But the code was
@@ -80,9 +87,9 @@
 *   Abort a rake task when missing db/structure.sql like `db:schema:load` task.
 
     *kennyj*
-    
+
 *   rake:db:test:prepare falls back to original environment after execution.
-    
+
     *Slava Markevich*
 
 Please check [4-0-stable](https://github.com/rails/rails/blob/4-0-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -89,7 +89,7 @@ module ActiveRecord
         attrs = expand_hash_conditions_for_aggregates(attrs)
 
         table = Arel::Table.new(table_name, arel_engine).alias(default_table_name)
-        PredicateBuilder.build_from_hash(self.class, attrs, table).map { |b|
+        PredicateBuilder.build_from_hash(self, attrs, table).map { |b|
           connection.visitor.accept b
         }.join(' AND ')
       end

--- a/activerecord/test/cases/sanitize_test.rb
+++ b/activerecord/test/cases/sanitize_test.rb
@@ -5,6 +5,10 @@ class SanitizeTest < ActiveRecord::TestCase
   def setup
   end
 
+  def test_sanitize_sql_hash_handles_associations
+    assert_equal "`adorable_animals`.`name` = 'Bambi'", Binary.send(:sanitize_sql_hash, {adorable_animals: {name: 'Bambi'}})
+  end
+
   def test_sanitize_sql_array_handles_string_interpolation
     quoted_bambi = ActiveRecord::Base.connection.quote_string("Bambi")
     assert_equal "name=#{quoted_bambi}", Binary.send(:sanitize_sql_array, ["name=%s", "Bambi"])


### PR DESCRIPTION
Currently throwing NoMethodError when using associations because method is always passing Class  to PredicateBuilder#build_from_hash.
