### PR TITLE
[for discussion] Use ruby's native String#encode to implement `tidy_bytes`

### DIFF
--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -218,51 +218,13 @@ module ActiveSupport
       # Passing +true+ will forcibly tidy all bytes, assuming that the string's
       # encoding is entirely CP1252 or ISO-8859-1.
       def tidy_bytes(string, force = false)
-        if force
-          return string.unpack("C*").map do |b|
-            tidy_byte(b)
-          end.flatten.compact.pack("C*").unpack("U*").pack("U*")
+        as_utf8 = string.dup.force_encoding(Encoding::UTF_8)
+
+        if !force && as_utf8.valid_encoding?
+          return as_utf8
+        else
+          return as_utf8.encode(Encoding::UTF_8, Encoding::Windows_1252, invalid: :replace, undef: :replace)
         end
-
-        bytes = string.unpack("C*")
-        conts_expected = 0
-        last_lead = 0
-
-        bytes.each_index do |i|
-
-          byte          = bytes[i]
-          is_cont       = byte > 127 && byte < 192
-          is_lead       = byte > 191 && byte < 245
-          is_unused     = byte > 240
-          is_restricted = byte > 244
-
-          # Impossible or highly unlikely byte? Clean it.
-          if is_unused || is_restricted
-            bytes[i] = tidy_byte(byte)
-          elsif is_cont
-            # Not expecting continuation byte? Clean up. Otherwise, now expect one less.
-            conts_expected == 0 ? bytes[i] = tidy_byte(byte) : conts_expected -= 1
-          else
-            if conts_expected > 0
-              # Expected continuation, but got ASCII or leading? Clean backwards up to
-              # the leading byte.
-              (1..(i - last_lead)).each {|j| bytes[i - j] = tidy_byte(bytes[i - j])}
-              conts_expected = 0
-            end
-            if is_lead
-              # Final byte is leading? Clean it.
-              if i == bytes.length - 1
-                bytes[i] = tidy_byte(bytes.last)
-              else
-                # Valid leading byte? Expect continuations determined by position of
-                # first zero bit, with max of 3.
-                conts_expected = byte < 224 ? 1 : byte < 240 ? 2 : 3
-                last_lead = i
-              end
-            end
-          end
-        end
-        bytes.empty? ? "" : bytes.flatten.compact.pack("C*").unpack("U*").pack("U*")
       end
 
       # Returns the KC normalization of the string by default. NFKC is

--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -221,9 +221,9 @@ module ActiveSupport
         as_utf8 = string.dup.force_encoding(Encoding::UTF_8)
 
         if !force && as_utf8.valid_encoding?
-          return as_utf8
+          as_utf8
         else
-          return as_utf8.encode(Encoding::UTF_8, Encoding::Windows_1252, invalid: :replace, undef: :replace)
+          as_utf8.encode(Encoding::UTF_8, Encoding::Windows_1252, invalid: :replace, undef: :replace)
         end
       end
 

--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -653,11 +653,11 @@ class MultibyteCharsExtrasTest < ActiveSupport::TestCase
       assert_equal "#{good}#{good}", chars("#{bad}#{bad}").tidy_bytes
       assert_equal "#{good}#{good}#{good}", chars("#{bad}#{bad}#{bad}").tidy_bytes
       assert_equal "#{good}a", chars("#{bad}a").tidy_bytes
-      assert_equal "#{good}á", chars("#{bad}á").tidy_bytes
+      #assert_equal "#{good}á", chars("#{bad}á").tidy_bytes
       assert_equal "a#{good}a", chars("a#{bad}a").tidy_bytes
-      assert_equal "á#{good}á", chars("á#{bad}á").tidy_bytes
+      #assert_equal "á#{good}á", chars("á#{bad}á").tidy_bytes
       assert_equal "a#{good}", chars("a#{bad}").tidy_bytes
-      assert_equal "á#{good}", chars("á#{bad}").tidy_bytes
+      #assert_equal "á#{good}", chars("á#{bad}").tidy_bytes
     end
 
     byte_string = "\270\236\010\210\245"


### PR DESCRIPTION
**TL;DR: Maybe-negligible regression in exchange for reduced complexity and three-order-of-magnitude performance improvement to a method.**

This couldn't be done when the code was written initially because Rails couldn't rely on the presence of these encoding methods without introducing a dependency on 1.9+.

The behaviour of this proposed version is identical to the current version in any case where a string has an internally-consistent encoding.

It differs where:
1. A string is not a valid UTF-8 string (because it contains at least one ISO-8859-1/CP1252 byte); and
2. The string also contains at least one UTF-8 multibyte character.

In this case, the UTF-8 characters will be reinterpreted as CP1252 bytes. This is in contrast to the current strategy which attempts to resolve a mish-mash of the two disparate encodings. This is demonstrated in the three commented-out tests in the diff.

I normally wouldn't propose something like this, but this is a particularly slow method, and letting ruby handle it natively actually cuts 99.7% off of its runtime. It is my experience that the case this regresses on is very unusual, but I may be wrong on this.

Thoughts?
