### PR TITLE
ActiveSupport::JSON::Encoding.escape implementation

### DIFF
--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -140,6 +140,11 @@ class TestJSONEncoding < ActiveSupport::TestCase
     assert_equal "𐒑", decoded_hash['string']
   end
 
+  def test_escape_utf8_undefined_characters
+    assert_equal '{"key"=>"value"}', ActiveSupport::JSON.encode({ "key" => "value" })
+  end
+
+
   def test_exception_raised_when_encoding_circular_reference_in_array
     a = [1]
     a << a


### PR DESCRIPTION
@rkh could you provide a brief example of data you think `ActiveSupport::JSON doesn't encode properly? I'd like to have a go at fixing #7764...
