### PR TITLE
Fix where with polymorphic relation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Correctly handle relations as values in where() for normal and
+    polymorphic associations.
+
+    *Marc Schütz*
+
 *   Previously, the `has_one` macro incorrectly accepted the `counter_cache`
     option, but never actually supported it. Now it will raise an `ArgumentError`
     when using `has_one` with `counter_cache`.

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -55,9 +55,13 @@ module ActiveRecord
       #
       # For polymorphic relationships, find the foreign key and type:
       # PriceEstimate.where(estimate_of: treasure)
-      if klass && value.is_a?(Base) && reflection = klass.reflect_on_association(column.to_sym)
+      if klass && (value.is_a?(Base) || value.is_a?(Relation)) && reflection = klass.reflect_on_association(column.to_sym)
         if reflection.polymorphic?
-          queries << build(table[reflection.foreign_type], value.class.base_class)
+          if value.is_a? Base
+            queries << build(table[reflection.foreign_type], value.class.base_class)
+          elsif value.is_a? Relation
+            queries << build(table[reflection.foreign_type], value.klass.base_class)
+          end
         end
 
         column = reflection.foreign_key

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -55,6 +55,24 @@ module ActiveRecord
       assert_equal expected.to_sql, actual.to_sql
     end
 
+    def test_where_with_relation
+      authors = Author.all
+
+      expected = Post.where.not(author_id: 0)
+      actual   = Post.where(author: authors)
+
+      assert_equal expected.to_a, actual.to_a
+    end
+
+    def test_polymorphic_where_with_relation
+      treasures = Treasure.all
+
+      expected = PriceEstimate.where(estimate_of_type: 'Treasure', estimate_of_id: treasures)
+      actual   = PriceEstimate.where(estimate_of: treasures)
+
+      assert_equal expected.to_sql, actual.to_sql
+    end
+
     def test_polymorphic_sti_shallow_where
       treasure = HiddenTreasure.new
       treasure.id = 1


### PR DESCRIPTION
Say you have classes like this:

```
class Dog < ActiveRecord::Base
    has_many :tags, as: :owner
end

class Cat < ActiveRecord::Base
    has_many :tags, as: :owner
end

class Tag < ActiveRecord::Base
    belongs_to :owner, polymorphic: true
end
```

then this works correctly:

```
Tag.where(owner: Cat.find(42))
=> SELECT "tags".* FROM "tags" WHERE "tags"."owner_type" = 'Cat' AND "tags".owner_id = 42
```

However, using a relation as the find value produces an incorrect query:

```
Tag.where(owner: Dog.all)
=> SELECT "tags".* FROM "tags" WHERE "tags"."owner" IN (SELECT "dogs"."id" FROM "dogs")
```

As you can see, there's no test for the correct `owner_type` in the second query, and it uses a non-existing column `owner`.

The referenced changes fix that problem (failing test included).
