### PR TITLE
first_or_create fix for has_many :through

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
-* No changes.
+ 
+*   If `first_or_create` is invoked like this
+    `physician.patients.first_or_create` then association record
+    is created.
 
-Please check [4-0-stable](https://github.com/rails/rails/blob/4-0-stable/activerecord/CHANGELOG.md) for previous changes.
+    However `physician.patients.where(name: 'neeraj').first_or_create`
+    does not create the association record.
+
+    In the first case `first_or_create` is being invoked on
+    `CollectionProxy` instance. However in the second instance
+    `physician.patients.where(name: 'neeraj')` returns a `Relation`
+    object and not a `CollectionProxy` object.
+
+    Fix is to check if the relation object happens to have
+    `proxy_association` then invoke `create` on that
+    `proxy_association`.
+
+    Fixes #10144.
+
+    *Neeraj Singh*

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -118,7 +118,11 @@ module ActiveRecord
     #   users.create(name: nil) # validation on name
     #   # #<User id: nil, name: nil, ...>
     def create(*args, &block)
-      scoping { @klass.create(*args, &block) }
+      if proxy_association
+        proxy_association.create(*args, &block)
+      else
+        scoping { @klass.create(*args, &block) }
+      end
     end
 
     # Similar to #create, but calls +create!+ on the base class. Raises
@@ -126,7 +130,11 @@ module ActiveRecord
     #
     # Expects arguments in the same format as <tt>Base.create!</tt>.
     def create!(*args, &block)
-      scoping { @klass.create!(*args, &block) }
+      if proxy_association
+        proxy_association.create!(*args, &block)
+      else
+        scoping { @klass.create!(*args, &block) }
+      end
     end
 
     def first_or_create(attributes = nil, &block) # :nodoc:

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -20,6 +20,26 @@ class RelationTest < ActiveRecord::TestCase
   fixtures :authors, :topics, :entrants, :developers, :companies, :developers_projects, :accounts, :categories, :categorizations, :posts, :comments,
     :tags, :taggings, :cars, :minivans
 
+  def test_first_or_create_works_with_has_many_through_with_where_clause
+    post = posts :welcome
+    count = Tagging.count
+    tag = post.tags.where(name: 'ruby').first_or_create(name: 'ruby')
+
+    assert_equal count + 1, Tagging.count
+    assert_equal tag, post.tags.where(name: 'ruby').first_or_create(name: 'ruby')
+    assert_equal tag, post.tags.where(name: 'ruby').first_or_initialize(name: 'ruby')
+  end
+
+  def test_first_or_create_with_bang_works_with_has_many_through_with_where_clause
+    post = posts :welcome
+    count = Tagging.count
+    tag = post.tags.where(name: 'ruby').first_or_create!(name: 'ruby')
+
+    assert_equal count + 1, Tagging.count
+    assert_equal tag, post.tags.where(name: 'ruby').first_or_create!(name: 'ruby')
+    assert_equal tag, post.tags.where(name: 'ruby').first_or_initialize(name: 'ruby')
+  end
+
   def test_do_not_double_quote_string_id
     van = Minivan.last
     assert van


### PR DESCRIPTION
fixes #10144

`physician.patients.first_or_create` creates the association
record.

However `physician.patients.where(name: 'neeraj').first_or_create`
does not create the association record.

In the first case `first_or_create` is being invoked on
`CollectionProxy` instance. However in the second instance
`physician.patients.where(name: 'neeraj')` returns a `Relation`
object and not `CollectionProxy` object.

Fix is to check if the relation object happens to have
`proxy_association` then invoke `create` on that
`proxy_association`.

/cc @jonleighton
