### PR TITLE
StatementInvalid takes WrappedDatabaseException's place

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -433,7 +433,7 @@ module ActiveRecord
 
       def translate_exception(exception, message)
         # override in derived class
-        ActiveRecord::StatementInvalid.new(message)
+        ActiveRecord::StatementInvalid.new(message, exception)
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -287,7 +287,7 @@ module ActiveRecord
         end
       rescue ActiveRecord::StatementInvalid => exception
         if exception.message.split(":").first =~ /Packets out of order/
-          raise ActiveRecord::StatementInvalid, "'Packets out of order' error was received from the database. Please update your mysql bindings (gem install mysql) and read http://dev.mysql.com/doc/mysql/en/password-hashing.html for more information. If you're on Windows, use the Instant Rails installer to get the updated mysql bindings."
+          raise ActiveRecord::StatementInvalid.new("'Packets out of order' error was received from the database. Please update your mysql bindings (gem install mysql) and read http://dev.mysql.com/doc/mysql/en/password-hashing.html for more information. If you're on Windows, use the Instant Rails installer to get the updated mysql bindings.", exception.original_exception)
         else
           raise
         end

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -57,24 +57,25 @@ module ActiveRecord
   class RecordNotDestroyed < ActiveRecordError
   end
 
-  # Raised when SQL statement cannot be executed by the database (for example, it's often the case for
-  # MySQL when Ruby driver used is too old).
+  # Superclass for all database execution errors.
+  #
+  # Wraps the underlying database error as +original_exception+.
   class StatementInvalid < ActiveRecordError
+    attr_reader :original_exception
+
+    def initialize(message, original_exception = nil)
+      super(message)
+      @original_exception = original_exception
+    end
   end
 
   # Raised when SQL statement is invalid and the application gets a blank result.
   class ThrowResult < ActiveRecordError
   end
 
-  # Parent class for all specific exceptions which wrap database driver exceptions
-  # provides access to the original exception also.
+  # Defunct wrapper class kept for compatibility.
+  # +StatementInvalid+ wraps the original exception now.
   class WrappedDatabaseException < StatementInvalid
-    attr_reader :original_exception
-
-    def initialize(message, original_exception)
-      super(message)
-      @original_exception = original_exception
-    end
   end
 
   # Raised when a record cannot be inserted because it would violate a uniqueness constraint.


### PR DESCRIPTION
`StatementInvalid` would be much more useful if it gave us access to the originating exception. Hoist that up from `WrappedDatabaseException` without breaking compatibility.
