### PR TITLE
Fix a bug in ActiveRecord::Store accessors

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -42,6 +42,11 @@
 
     *kennyj*
 
+*   Fix `ActiveRecord::Store` incorrectly tracking changes of its attributes.
+    Fixes #10373.
+
+    *Janko Marohnić*
+
 
 ## Rails 3.2.13 (Mar 18, 2013) ##
 

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -37,8 +37,8 @@ module ActiveRecord
         Array(keys).flatten.each do |key|
           define_method("#{key}=") do |value|
             send("#{store_attribute}=", {}) unless send(store_attribute).is_a?(Hash)
-            send(store_attribute)[key] = value
             send("#{store_attribute}_will_change!")
+            send(store_attribute)[key] = value
           end
     
           define_method(key) do

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -40,4 +40,11 @@ class StoreTest < ActiveRecord::TestCase
     @john.remember_login = false
     assert_equal false, @john.remember_login
   end
+
+  test "updating the store will track changes correctly" do
+    @john.color = "blue"
+    assert_equal [{:color => "black"}, {:color => "blue"}], @john.settings_change
+    @john.homepage = "37signals.com"
+    assert_equal [{:color => "black"}, {:color => "blue", :homepage => "37signals.com"}], @john.settings_change
+  end
 end


### PR DESCRIPTION
There is a bug on tracking changes on attributes created by `ActiveRecord::Store`. This would happen before:

``` ruby
class User < ActiveRecord::Base
  store :properties, accessors: [:age]
end

user = User.create!(age: 21)
user.age = 22
user.changes # => {"properties" => [{:age => 22}, {:age => 22}]}
```
