### PR TITLE
Parameter wrapping doesn't support aliased attributes

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -35,4 +35,8 @@
 
     *Bryan Ricker*
 
+*   Add support for wrapping parameters matching aliased attribute names.
+
+    *Patrick Van Stee*
+
 Please check [4-0-stable](https://github.com/rails/rails/blob/4-0-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -44,7 +44,7 @@ module ActionController
   #
   # On ActiveRecord models with no +:include+ or +:exclude+ option set,
   # it will only wrap the parameters returned by the class method
-  # <tt>attribute_names</tt>.
+  # <tt>attribute_method_names</tt>.
   #
   # If you're going to pass the parameters to an +ActiveModel+ object (such as
   # <tt>User.new(params[:user])</tt>), you might consider passing the model class to
@@ -106,8 +106,8 @@ module ActionController
           @include_set = true
 
           unless super || exclude
-            if m.respond_to?(:attribute_names) && m.attribute_names.any?
-              self.include = m.attribute_names
+            if m.respond_to?(:attribute_method_names) && m.attribute_method_names.any?
+              self.include = m.attribute_method_names
             end
           end
         end

--- a/actionpack/test/controller/params_wrapper_test.rb
+++ b/actionpack/test/controller/params_wrapper_test.rb
@@ -155,8 +155,8 @@ class ParamsWrapperTest < ActionController::TestCase
   end
 
   def test_derived_wrapped_keys_from_matching_model
-    User.expects(:respond_to?).with(:attribute_names).returns(true)
-    User.expects(:attribute_names).twice.returns(["username"])
+    User.expects(:respond_to?).with(:attribute_method_names).returns(true)
+    User.expects(:attribute_method_names).twice.returns(["username"])
 
     with_default_wrapper_options do
       @request.env['CONTENT_TYPE'] = 'application/json'
@@ -167,8 +167,8 @@ class ParamsWrapperTest < ActionController::TestCase
 
   def test_derived_wrapped_keys_from_specified_model
     with_default_wrapper_options do
-      Person.expects(:respond_to?).with(:attribute_names).returns(true)
-      Person.expects(:attribute_names).twice.returns(["username"])
+      Person.expects(:respond_to?).with(:attribute_method_names).returns(true)
+      Person.expects(:attribute_method_names).twice.returns(["username"])
 
       UsersController.wrap_parameters Person
 
@@ -179,8 +179,8 @@ class ParamsWrapperTest < ActionController::TestCase
   end
 
   def test_not_wrapping_abstract_model
-    User.expects(:respond_to?).with(:attribute_names).returns(true)
-    User.expects(:attribute_names).returns([])
+    User.expects(:respond_to?).with(:attribute_method_names).returns(true)
+    User.expects(:attribute_method_names).returns([])
 
     with_default_wrapper_options do
       @request.env['CONTENT_TYPE'] = 'application/json'
@@ -209,13 +209,13 @@ class NamespacedParamsWrapperTest < ActionController::TestCase
   end
 
   class SampleOne
-    def self.attribute_names
+    def self.attribute_method_names
       ["username"]
     end
   end
 
   class SampleTwo
-    def self.attribute_names
+    def self.attribute_method_names
       ["title"]
     end
   end
@@ -298,7 +298,7 @@ class IrregularInflectionParamsWrapperTest < ActionController::TestCase
   include ParamsWrapperTestHelp
 
   class ParamswrappernewsItem
-    def self.attribute_names
+    def self.attribute_method_names
       ['test_attr']
     end
   end

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -7,4 +7,9 @@
 
     *Nick Sutterer*
 
+*   Add the `ActiveModel#attribute_method_names` method, which returns an
+    array of attribute names and aliases as strings.
+
+    *Patrick Van Stee*
+
 Please check [4-0-stable](https://github.com/rails/rails/blob/4-0-stable/activemodel/CHANGELOG.md) for previous changes.

--- a/activemodel/test/cases/attribute_methods_test.rb
+++ b/activemodel/test/cases/attribute_methods_test.rb
@@ -186,6 +186,15 @@ class AttributeMethodsTest < ActiveModel::TestCase
     assert_equal "value of end", ModelWithRubyKeywordNamedAttributes.new.to
   end
 
+  test '#attribute_method_names returns attribute names and attribute aliases' do
+    klass = Class.new(ModelWithAttributes) do
+      define_attribute_methods :foo
+      alias_attribute :bar, :foo
+    end
+
+    assert_equal ["foo", "bar"], klass.attribute_method_names
+  end
+
   test '#undefine_attribute_methods removes attribute methods' do
     ModelWithAttributes.define_attribute_methods(:foo)
     ModelWithAttributes.undefine_attribute_methods

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -514,7 +514,7 @@ module ApplicationTests
 
       app_file 'app/models/post.rb', <<-RUBY
       class Post
-        def self.attribute_names
+        def self.attribute_method_names
           %w(title)
         end
       end


### PR DESCRIPTION
When wrapping parameters, only the `attribute_names` were sliced out. I was hoping we could also support wrapping aliased attribute names as well. To support them, I just included `attribute_aliases.keys` in the list of keys to wrap for the model.
