### PR TITLE
Allow numbers in partial name for digesting

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,5 @@
-* No changes.
+*   Fix an issue where partials with a number in the filename weren't being digested for cache dependencies.
+
+    *Bryan Ricker*
 
 Please check [4-0-stable](https://github.com/rails/rails/blob/4-0-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_view/dependency_tracker.rb
+++ b/actionpack/lib/action_view/dependency_tracker.rb
@@ -39,7 +39,7 @@ module ActionView
         render\s*                     # render, followed by optional whitespace
         \(?                           # start an optional parenthesis for the render call
         (partial:|:partial\s+=>)?\s*  # naming the partial, used with collection -- 1st capture
-        ([@a-z"'][@a-z_\/\."']+)      # the template name itself -- 2nd capture
+        ([@a-z"'][@\w\/\."']+)        # the template name itself -- 2nd capture
       /x
 
       def self.call(name, template)

--- a/actionpack/test/fixtures/digestor/messages/show.html.erb
+++ b/actionpack/test/fixtures/digestor/messages/show.html.erb
@@ -7,6 +7,7 @@
 <%= render @message.history.events %>
 
 <%# render "something_missing"  %>
+<%# render "something_missing_1"  %>
 
 <%
   # Template Dependency: messages/form

--- a/actionpack/test/template/digestor_test.rb
+++ b/actionpack/test/template/digestor_test.rb
@@ -83,6 +83,12 @@ class TemplateDigestorTest < ActionView::TestCase
     end
   end
 
+  def test_logging_of_missing_template_ending_with_number
+    assert_logged "Couldn't find template for digesting: messages/something_missing_1.html" do
+      digest("messages/show")
+    end
+  end
+
   def test_nested_template_directory
     assert_digest_difference("messages/show") do
       change_template("messages/actions/_move")


### PR DESCRIPTION
The regular expression would not match templates with numbers in the filename. For example:

``` ruby
<%= render 'shared/layout_1' %>
```

Would result in (in the log):

`Couldn't find template for digesting: shared/layout_.html`

... and no digest would be generated.
