### PR TITLE
Assert that 2 letter tlds with 3 letter domain names work when option specified.

### DIFF
--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -634,6 +634,13 @@ class CookiesTest < ActionController::TestCase
     assert_cookie_header "user_name=rizwanreza; domain=.nextangle.local; path=/"
   end
 
+  def test_cookie_with_all_domain_option_using_a_non_standard_2_letter_tld
+    @request.host = "admin.lvh.me"
+    get :set_cookie_with_domain_and_tld
+    assert_response :success
+    assert_cookie_header "user_name=rizwanreza; domain=.lvh.me; path=/"
+  end
+
   def test_cookie_with_all_domain_option_using_host_with_port_and_tld_length
     @request.host = "nextangle.local:3000"
     get :set_cookie_with_domain_and_tld


### PR DESCRIPTION
Add a test asserting that edge case domains (like `lvh.me` from #10024) work when manually providing the domain length. Helps document the behaviour for future users.
