### PR TITLE
Moved update_record logic to relation.rb

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -56,16 +56,7 @@ module ActiveRecord
       im = arel.create_insert
       im.into @table
 
-      conn = @klass.connection
-
-      substitutes = values.sort_by { |arel_attr,_| arel_attr.name }
-      binds       = substitutes.map do |arel_attr, value|
-        [@klass.columns_hash[arel_attr.name], value]
-      end
-
-      substitutes.each_with_index do |tuple, i|
-        tuple[1] = conn.substitute_at(binds[i][0], i)
-      end
+      substitutes, binds = substitute_values values
 
       if values.empty? # empty insert
         im.values = Arel.sql(connection.empty_insert_statement_value)
@@ -73,7 +64,7 @@ module ActiveRecord
         im.insert substitutes
       end
 
-      conn.insert(
+      @klass.connection.insert(
         im,
         'SQL',
         primary_key,
@@ -81,6 +72,29 @@ module ActiveRecord
         nil,
         binds)
     end
+
+    def update_record(values, id, id_was)
+      substitutes, binds = substitute_values values
+      um = @klass.unscoped.where(@klass.arel_table[@klass.primary_key].eq(id_was || id)).arel.compile_update(substitutes)
+      
+      @klass.connection.update(
+        um, 
+        'SQL', 
+        binds)
+    end
+
+    def substitute_values(values)
+      substitutes = values.sort_by { |arel_attr,_| arel_attr.name }
+      binds       = substitutes.map do |arel_attr, value|
+        [@klass.columns_hash[arel_attr.name], value]
+      end
+
+      substitutes.each_with_index do |tuple, i|
+        tuple[1] = @klass.connection.substitute_at(binds[i][0], i)
+      end
+
+      [substitutes, binds]
+    end 
 
     # Initializes new record from relation while maintaining the current
     # scope.


### PR DESCRIPTION
The persistence.rb methods update_record and create_record have similarities in their logic. As the majority of create_record logic is in relation.rb, I moved the update_record logic there as well. Both of the methods now have a similar structure and are easier to understand.

I also extracted value substitution into its own method, which enables both create and update to use the same method as the logic is exactly the same in both cases.

If there's a way to avoid passing the id and id_was variables, that'd be great.
