### PR TITLE
Make `rake doc:guides` works again.  Fix #10384.

### DIFF
--- a/guides/rails_guides.rb
+++ b/guides/rails_guides.rb
@@ -22,7 +22,7 @@ end
 
 begin
   require 'redcarpet'
-rescue Gem::LoadError
+rescue LoadError
   # This can happen if doc:guides is executed in an application.
   $stderr.puts('Generating guides requires Redcarpet 2.1.1+.')
   $stderr.puts(<<ERROR) if bundler?

--- a/railties/lib/rails/tasks/documentation.rake
+++ b/railties/lib/rails/tasks/documentation.rake
@@ -57,8 +57,8 @@ namespace :doc do
 
   # desc "Generate Rails Guides"
   task :guides do
-    # FIXME: Reaching outside lib directory is a bad idea
-    require File.expand_path('../../../../../guides/rails_guides', __FILE__)
+    rails_gem_dir = Gem::Specification.find_by_name("rails").gem_dir
+    require File.expand_path(File.join(rails_gem_dir, "/guides/rails_guides"))
     RailsGuides::Generator.new(Rails.root.join("doc/guides")).generate
   end
 end


### PR DESCRIPTION
Fix bug #10384 since `guides` has been moved to be under `rails` gem directory.
