### PR TITLE
Abort a rake task when missing db/structure.sql like `db:schema:load` task.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,5 @@
-* No changes.
+*   Abort a rake task when missing db/structure.sql like `db:schema:load` task.
+
+    *kennyj*
 
 Please check [4-0-stable](https://github.com/rails/rails/blob/4-0-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -249,11 +249,8 @@ db_namespace = namespace :db do
     desc 'Load a schema.rb file into the database'
     task :load => [:environment, :load_config] do
       file = ENV['SCHEMA'] || File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, 'schema.rb')
-      if File.exists?(file)
-        load(file)
-      else
-        abort %{#{file} doesn't exist yet. Run `rake db:migrate` to create it, then try again. If you do not intend to use a database, you should instead alter #{Rails.root}/config/application.rb to limit the frameworks that will be loaded.}
-      end
+      ActiveRecord::Tasks::DatabaseTasks.check_schema_file(file)
+      load(file)
     end
 
     task :load_if_ruby => ['db:create', :environment] do
@@ -298,6 +295,7 @@ db_namespace = namespace :db do
     # desc "Recreate the databases from the structure.sql file"
     task :load => [:environment, :load_config] do
       filename = ENV['DB_STRUCTURE'] || File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, "structure.sql")
+      ActiveRecord::Tasks::DatabaseTasks.check_schema_file(filename)
       current_config = ActiveRecord::Tasks::DatabaseTasks.current_config
       ActiveRecord::Tasks::DatabaseTasks.structure_load(current_config, filename)
     end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -148,6 +148,14 @@ module ActiveRecord
         class_for_adapter(configuration['adapter']).new(*arguments).structure_load(filename)
       end
 
+      def check_schema_file(filename)
+        unless File.exists?(filename)
+          message = %{#{filename} doesn't exist yet. Run `rake db:migrate` to create it, then try again.}
+          message << %{ If you do not intend to use a database, you should instead alter #{Rails.root}/config/application.rb to limit the frameworks that will be loaded.} if defined?(::Rails)
+          Kernel.abort message
+        end
+      end
+
       def load_seed
         if seed_loader
           seed_loader.load_seed

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -305,4 +305,11 @@ module ActiveRecord
       end
     end
   end
+
+  class DatabaseTasksCheckSchemaFileTest < ActiveRecord::TestCase
+    def test_check_schema_file
+      Kernel.expects(:abort).with(regexp_matches(/awesome-file.sql/))
+      ActiveRecord::Tasks::DatabaseTasks.check_schema_file("awesome-file.sql")
+    end
+  end
 end


### PR DESCRIPTION
When investigating #10381, I found this issue.

If you execute `db:structure:load` and you don't have `structure.sql`, you'll see an error message. But a rake task will not stop.

BTW, I've this for master (rails 4.1 stable ?). But I guess that this is bug fix for rails 4.0.x.
