### PR TITLE
add missing semicolon to journey parser.y

### DIFF
--- a/actionpack/lib/action_dispatch/journey/parser.y
+++ b/actionpack/lib/action_dispatch/journey/parser.y
@@ -36,6 +36,7 @@ rule
     ;
   literal
     : LITERAL            { result = Literal.new(val.first) }
+    ;
   dot
     : DOT                { result = Dot.new(val.first) }
     ;


### PR DESCRIPTION
The `literal` production for journey's parser grammar was missing a semicolon. There was no difference in the generated parser after recompiling with racc, so this is just a small typo fix.
