### PR TITLE
Allow global override of default STI inheritance column

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -159,7 +159,7 @@ module ActiveRecord
       # The name of the column containing the object's class when Single Table Inheritance is used
       def inheritance_column
         if self == Base
-          'type'
+          @inheritance_column || 'type'
         else
           (@inheritance_column ||= nil) || superclass.inheritance_column
         end


### PR DESCRIPTION
This change fixes a bug by which 3.2-STABLE users can't globally override the default STI inheritance column with `ActiveRecord::Base.inheritance_column = 'some_column'`. 3.2-STABLE users are forced to use a deprecated method or monkey patch it otherwise.
