### PR TITLE
Remove varargs from `Object#in?`

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/inclusion.rb
+++ b/activesupport/lib/active_support/core_ext/object/inclusion.rb
@@ -1,25 +1,15 @@
 class Object
-  # Returns true if this object is included in the argument(s). Argument must be
-  # any object which responds to +#include?+ or optionally, multiple arguments can be passed in. Usage:
+  # Returns true if this object is included in the argument. Argument must be
+  # any object which responds to +#include?+. Usage:
   #
-  #   characters = ['Konata', 'Kagami', 'Tsukasa']
-  #   'Konata'.in?(characters) # => true
+  #   characters = ["Konata", "Kagami", "Tsukasa"]
+  #   "Konata".in?(characters) # => true
   #
-  #   character = 'Konata'
-  #   character.in?('Konata', 'Kagami', 'Tsukasa') # => true
-  #
-  # This will throw an ArgumentError if a single argument is passed in and it doesn't respond
+  # This will throw an ArgumentError if the argument doesn't respond
   # to +#include?+.
-  def in?(*args)
-    if args.length > 1
-      args.include? self
-    else
-      another_object = args.first
-      if another_object.respond_to? :include?
-        another_object.include? self
-      else
-        raise ArgumentError.new 'The single parameter passed to #in? must respond to #include?'
-      end
-    end
+  def in?(another_object)
+    another_object.include?(self)
+  rescue NoMethodError
+    raise ArgumentError.new("The parameter passed to #in? must respond to #include?")
   end
 end

--- a/activesupport/test/core_ext/object/inclusion_test.rb
+++ b/activesupport/test/core_ext/object/inclusion_test.rb
@@ -2,16 +2,6 @@ require 'abstract_unit'
 require 'active_support/core_ext/object/inclusion'
 
 class InTest < ActiveSupport::TestCase
-  def test_in_multiple_args
-    assert :b.in?(:a,:b)
-    assert !:c.in?(:a,:b)
-  end
-  
-  def test_in_multiple_arrays
-    assert [1,2].in?([1,2],[2,3])
-    assert ![1,2].in?([1,3],[2,1])
-  end
-  
   def test_in_array
     assert 1.in?([1,2])
     assert !3.in?([1,2])

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -476,12 +476,11 @@ NOTE: Defined in `active_support/core_ext/kernel/reporting.rb`.
 
 ### `in?`
 
-The predicate `in?` tests if an object is included in another object or a list of objects. An `ArgumentError` exception will be raised if a single argument is passed and it does not respond to `include?`.
+The predicate `in?` tests if an object is included in another object. An `ArgumentError` exception will be raised if the argument passed does not respond to `include?`.
 
 Examples of `in?`:
 
 ```ruby
-1.in?(1,2)          # => true
 1.in?([1,2])        # => true
 "lo".in?("hello")   # => true
 25.in?(30..50)      # => false


### PR DESCRIPTION
I am the creator of the `in_enumerable` gem, whose `Object#in?` method was later incorporated into ActiveSupport.

I just discovered that in Rails 4, `in?` was modified to allow varargs. But [there is a good reason I didn't implement varargs](https://github.com/rails/rails/pull/258#issuecomment-985570) in the original implementation of `in?`: it would make the method's behavior ambiguous. [@dhh also didn't like the varargs version](https://github.com/rails/rails/pull/258#issuecomment-986523).

``` ruby
# Test if "B" is included in a list of names with `"B".in?(*names)`:
names = ["BMorearty"]
"B".in?(*names)   # => true

names = ["BMorearty","rubyduo"]
"B".in?(*names)   # => false
```

An ambiguous method is worse than useless. People who call it will get unpredictable behavior.

In this pull request I revert `in?` back to its original useful, unambiguous behavior.
