### PR TITLE
Correct time_ago_in_words to handle situation where Fixnum#/ returns a Rational (thanks to mathn)

### DIFF
--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -112,7 +112,7 @@ module ActionView
               # english it would read better as about 80 years.
               minutes_with_offset         = distance_in_minutes - minute_offset_for_leap_year
               remainder                   = (minutes_with_offset % 525600)
-              distance_in_years           = (minutes_with_offset / 525600)
+              distance_in_years           = (minutes_with_offset.div 525600)
               if remainder < 131400
                 locale.t(:about_x_years,  :count => distance_in_years)
               elsif remainder < 394200

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -19,6 +19,8 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def assert_distance_of_time_in_words(from, to=nil)
+    Fixnum.send :private, :/  # test we avoid Integer#/ (redefined by mathn)
+
     to ||= from
 
     # 0..1 with include_seconds
@@ -96,6 +98,9 @@ class DateHelperTest < ActionView::TestCase
     # test to < from
     assert_equal "about 4 hours", distance_of_time_in_words(from + 4.hours, to)
     assert_equal "less than 20 seconds", distance_of_time_in_words(from + 19.seconds, to, true)
+
+   ensure
+     Fixnum.send :public, :/
   end
 
   def test_distance_in_words


### PR DESCRIPTION
[mathn](https://github.com/ruby/ruby/blob/trunk/lib/mathn.rb) from ruby stdlib aliases `Fixnum#/` to `Fixnum#quo`.  If `rational` from stdlib is required (which it is in rails) the result is that `Fixnum/Fixnum` will return a `Rational` number instead of the expected `Fixnum`.  This causes `time_ago_in_words` to break:

```
1) Failure:
test_time_ago_in_words(DateHelperTest) [/private/var/www/rails/actionpack/test/template/date_helper_test.rb:166]:
<"about 1 year"> expected but was
<"about 366/365 years">.
```

This PR adds a call to `.to_i` after the division takes place, to ensure the result is a `Fixnum` as expected.
