### PR TITLE
autosave_association issue that occurs when table has unique index (resubmission)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   fixes bug introduced by #3329.  Now, when autosaving associations,
+    deletions happen before inserts and saves.  This prevents a 'duplicate
+    unique value' database error that would occur if a record being created had
+    the same value on a unique indexed field as that of a record being destroyed.
+
+    *Johnny Holton*
+
 *   Handle aliased attributes in ActiveRecord::Relation.
 
     When using symbol keys, ActiveRecord will now translate aliased attribute names to the actual column name used in the database:

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -335,15 +335,18 @@ module ActiveRecord
         autosave = reflection.options[:autosave]
 
         if records = associated_records_to_validate_or_save(association, @new_record_before_save, autosave)
-          records_to_destroy = []
+
+          if autosave
+            records_to_destroy = records.select(&:marked_for_destruction?)
+            records_to_destroy.each { |record| association.destroy(record) }
+            records -= records_to_destroy
+          end
+
           records.each do |record|
-            next if record.destroyed?
 
             saved = true
 
-            if autosave && record.marked_for_destruction?
-              records_to_destroy << record
-            elsif autosave != false && (@new_record_before_save || record.new_record?)
+            if autosave != false && (@new_record_before_save || record.new_record?)
               if autosave
                 saved = association.insert_record(record, false)
               else
@@ -354,10 +357,6 @@ module ActiveRecord
             end
 
             raise ActiveRecord::Rollback unless saved
-          end
-
-          records_to_destroy.each do |record|
-            association.destroy(record)
           end
         end
 


### PR DESCRIPTION
This is a resubmission of #10183.
#10183 was merged and subsequently unmerged due to test failing for MySQL.

Comments [here](https://github.com/rails/rails/commit/e8727d37fc49d5bf9976c3cb5c46badb92cf4ced#commitcomment-3047920)

For this one, I have incorporated the changes suggested by @rafaelfranca in c0a07af.
This change however still changes the schema inside the test and works around that by setting `use_transactional_fixtures` to `false` no matter which connection adapter is in use for that test class.

Is this OK or would it be preferable for me to alter the actual schema (and corresponding models) by adding a unique index on a table there?
I started down this path, but it quickly became more complex than I hoped (i.e. changing the existing schema breaking unrelated test).  I'll work through it though, if that is preferable.
cc @jonleighton 

Thanks.

From original #10183 description:
"Per the comments in pull #3329, 
If you have a table with a unique field index, and you mark a record for destruction, and you build a new record with the same value as the unique field, then when you call `save`, a database level unique index error will be thrown. 

This happens because the record destruction happens after record creation.

In this pull request, I moved the record destruction ahead of the record creation.

This is my first pull request ever, so please go easy on me.  :smile: "
