### PR TITLE
Avoid method missing when calling assume_migrated_upto_version

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## unreleased ##
 
 *   Fix pending migrations error when loading schema and ActiveRecord::Base.table_name_prefix
-    it not blank.
+    is not blank.
 
     Fixes #10411.
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## unreleased ##
 
+*   Fix pending migrations error when loading schema and ActiveRecord::Base.table_name_prefix
+    it not blank.
+
+    Fixes #10411.
+
+    *Kyle Stevens*
+
 *   Mute `psql` output when running rake db:schema:load.
 
     *Godfrey Chan*

--- a/activerecord/lib/active_record/schema.rb
+++ b/activerecord/lib/active_record/schema.rb
@@ -43,7 +43,7 @@ module ActiveRecord
 
       unless info[:version].blank?
         initialize_schema_migrations_table
-        assume_migrated_upto_version(info[:version], migrations_paths)
+        connection.assume_migrated_upto_version(info[:version], migrations_paths)
       end
     end
 


### PR DESCRIPTION
This pull request fixes issue #10411.
