### PR TITLE
Restore ActiveRecord connection to original environment after rake:db:test:prepare task.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -35,5 +35,9 @@
 *   Abort a rake task when missing db/structure.sql like `db:schema:load` task.
 
     *kennyj*
+    
+*   rake:db:test:prepare falls back to original environment after execution.
+    
+    *Slava Markevich*
 
 Please check [4-0-stable](https://github.com/rails/rails/blob/4-0-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -319,9 +319,13 @@ db_namespace = namespace :db do
 
     # desc "Recreate the test database from an existent schema.rb file"
     task :load_schema => 'db:test:purge' do
-      ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations['test'])
-      ActiveRecord::Schema.verbose = false
-      db_namespace["schema:load"].invoke
+      begin
+        ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations['test'])
+        ActiveRecord::Schema.verbose = false
+        db_namespace["schema:load"].invoke
+      ensure
+        ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations[Rails.env])
+      end
     end
 
     # desc "Recreate the test database from an existent structure.sql file"


### PR DESCRIPTION
I have a simple application with User model and following rake task:

``` Ruby
  task :setup => :environment do
    Rake::Task['db:drop'].invoke
    Rake::Task['db:create'].invoke
    Rake::Task['db:migrate'].invoke
    Rake::Task['db:seed'].invoke
    Rake::Task['db:test:prepare'].invoke

    User.create(email: 'example@example.com')
  end
```

When i run `rake setup` - user created in test database.

But if i comment out `Rake::Task['db:test:prepare'].invoke` task - user created in development database

PR ensures that ActiveRecord will establish connection back to original environment after execution of this task.
