### PR TITLE
Add styling to h1 for default rescue layout

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -34,6 +34,12 @@
       padding: 0.5em 1.5em;
     }
 
+    h1 {
+      margin: 0.2em 0;
+      line-height: 1.1em;
+      font-size: 2em;
+    }
+
     h2 {
       color: #C52F24;
       line-height: 25px;


### PR DESCRIPTION
I noticed that the default rescue template didn't have a line-height on the h1, meaning multi line h1s ran too close together and looked ugly.

Trivial change, I know :) Tested on IE9, Firefox, Safari, Chrome to ensure it renders right - IE7 & 8 don't render the rescue layout well already, but this doesn't change that.
