### PR TITLE
Improving the performance of callbacks

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -132,6 +132,10 @@ module ActiveSupport
         @@_callback_sequence += 1
       end
 
+      def object_filter?
+        @_is_object_filter
+      end
+
       def matches?(_kind, _filter)
         if @_is_object_filter
           _filter_matches = @filter.to_s.start_with?(_method_name_for_object_filter(_kind, _filter, false))
@@ -337,6 +341,7 @@ module ActiveSupport
           :terminator => "false",
           :scope => [ :kind ]
         }.merge!(config)
+        @callbacks_hash = Hash.new { |h, k| h[k] = [] }
       end
 
       def compile
@@ -361,20 +366,37 @@ module ActiveSupport
 
       private
 
-      def append_one(callback)
-        remove_duplicates(callback)
-        push(callback)
-      end
+        def append_one(callback)
+          handle_duplicates(callback)
+          push(callback)
+        end
 
-      def prepend_one(callback)
-        remove_duplicates(callback)
-        unshift(callback)
-      end
+        def prepend_one(callback)
+          handle_duplicates(callback)
+          unshift(callback)
+        end
 
-      def remove_duplicates(callback)
-        delete_if { |c| callback.duplicates?(c) }
-      end
+        # We check to see if this callback already exists. If it does (i.e. if
+        # +callback.duplicates?(c)+ for any callback +c+ in the list of
+        # callbacks), then we delete the previously defined callback.
+        #
+        # We make use of the rep-invariant that only one callback exists which
+        # might match the new callback. The +@callbacks_hash+ is keyed on the
+        # +kind+ and +filter+ of the callback, the attributes used to check if
+        # two callbacks match.
+        def handle_duplicates(callback)
+          if callback.object_filter?
+            scan_and_remove_duplicates(callback)
+          else
+            hash_key = [callback.kind, callback.filter]
+            delete @callbacks_hash[hash_key] if @callbacks_hash[hash_key]
+            @callbacks_hash[hash_key] = callback
+          end
+        end
 
+        def scan_and_remove_duplicates(callback)
+          delete_if { |c| callback.duplicates?(c) }
+        end
     end
 
     module ClassMethods


### PR DESCRIPTION
Whenever a callback is added to the `CallbackChain`, all of the callbacks in the chain are scanned to check if there are duplicates. I've changed the behavior of the callback chain so that this full scan only happens when the callback is an object filter.

In all other cases (which is the majority of cases), the `CallbackChain` implementation checks a hash of callbacks to see if there is a duplicate. This reduces the number of previous callbacks checked to just one per callback to be added.

In addition, adding the hash means that `matches` and `duplicates?` can be called much less frequently because the hash does the matching automatically.

Here is a gist of the performance before and after this change: https://gist.github.com/wangjohn/5505347
