### PR TITLE
raise IrreversibleMigration if no column given

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   While removing index if column option is missing then raise IrreversibleMigration exception.
+
+    Following code should raise `IrreversibleMigration`. But the code was
+    failing since options is an array and not a hash.
+
+        def change
+          change_table :users do |t|
+            t.remove_index [:name, :email]
+          end
+        end
+
+    Fix was to check if the options is a Hash before operating on it.
+
+    Fixes #10419.
+
+    *Neeraj Singh*
+
 *   Do not overwrite manually built records during one-to-one nested attribute assignment
 
     For one-to-one nested associations, if you build the new (in-memory)

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -144,7 +144,10 @@ module ActiveRecord
 
       def invert_remove_index(args)
         table, options = *args
-        raise ActiveRecord::IrreversibleMigration, "remove_index is only reversible if given a :column option." unless options && options[:column]
+
+        unless options && options.is_a?(Hash) && options[:column]
+          raise ActiveRecord::IrreversibleMigration, "remove_index is only reversible if given a :column option."
+        end
 
         options = options.dup
         [:add_index, [table, options.delete(:column), options]]


### PR DESCRIPTION
fixes #10419

Following code should raise  IrreversibleMigration. But the code was
failing since options is an array and not a hash.

def change
  change_table :users do |t|
    t.remove_index [:name, :email]
  end
end

Fix was to check if the options is a Hash before operating on it.
