### PR TITLE
Fix for Active Record mysql/mysql2 tests

### DIFF
--- a/activerecord/test/cases/adapters/mysql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql/active_schema_test.rb
@@ -14,6 +14,7 @@ class ActiveSchemaTest < ActiveRecord::TestCase
       remove_method :execute
       alias_method :execute, :execute_without_stub
     end
+    ActiveRecord::Base.connection.reconnect!
   end
 
   def test_add_index

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -14,6 +14,7 @@ class ActiveSchemaTest < ActiveRecord::TestCase
       remove_method :execute
       alias_method :execute, :execute_without_stub
     end
+    ActiveRecord::Base.connection.reconnect!
   end
 
   def test_add_index


### PR DESCRIPTION
  1) Failure:
DefaultsTestWithoutTransactionalFixtures#test_mysql_integer_not_null_defaults [/home/travis/build/rails/rails/activerecord/test/cases/defaults_test.rb:138]:
ActiveRecord::StatementInvalid expected but nothing was raised.

The issue was caused by 2088bf2 ... the setup and tear down for test/cases/adapters/mysql2/active_schema_test.rb overrides the adapter's execute method to just return the sql rather execute it which doesn't allow the mysql session variables to be set.  Which causes strict mode not to get set after the reconnect!
