### PR TITLE
Fixes Scaffold generator with --assets=false

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/rails/scaffold/scaffold_generator.rb
@@ -8,6 +8,8 @@ module Rails
 
       class_option :stylesheets, :type => :boolean, :desc => "Generate Stylesheets"
       class_option :stylesheet_engine, :desc => "Engine for Stylesheets"
+      class_option :assets, :type => :boolean
+      class_option :resource_route, :type => :boolean
 
       hook_for :scaffold_controller, :required => true
 

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -276,6 +276,20 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     assert_no_file "app/assets/stylesheets/posts.css"
   end
 
+  def test_scaffold_generator_no_assets
+    run_generator [ "posts", "--assets=false" ]
+    assert_file "app/assets/stylesheets/scaffold.css"
+    assert_no_file "app/assets/javascripts/posts.js"
+    assert_no_file "app/assets/stylesheets/posts.css"
+  end
+
+  def test_scaffold_generator_no_assets
+    run_generator [ "posts", "--resource-route=false" ]
+    assert_file "config/routes.rb" do |route|
+      assert_no_match(/resources :posts$/, route)
+    end
+  end
+
   def test_scaffold_generator_no_stylesheets
     run_generator [ "posts", "--no-stylesheets" ]
     assert_no_file "app/assets/stylesheets/scaffold.css"


### PR DESCRIPTION
Scaffold generator with --assets=false option outputs an error

See #9525
