### PR TITLE
Instrument template compilation

### DIFF
--- a/actionpack/lib/action_view/template.rb
+++ b/actionpack/lib/action_view/template.rb
@@ -138,7 +138,7 @@ module ActionView
     # we use a bang in this instrumentation because you don't want to
     # consume this in production. This is only slow if it's being listened to.
     def render(view, locals, buffer=nil, &block)
-      ActiveSupport::Notifications.instrument("!render_template.action_view", virtual_path: @virtual_path, identifier: @identifier) do
+      instrument("!render_template") do
         compile!(view)
         view.send(method_name, locals, buffer, &block)
       end
@@ -245,7 +245,9 @@ module ActionView
             mod = view.singleton_class
           end
 
-          compile(view, mod)
+          instrument("!compile_template") do
+            compile(view, mod)
+          end
 
           # Just discard the source if we have a virtual path. This
           # means we can get the template back.
@@ -334,6 +336,11 @@ module ActionView
 
       def identifier_method_name #:nodoc:
         inspect.gsub(/[^a-z_]/, '_')
+      end
+
+      def instrument(action, &block)
+        payload = { virtual_path: @virtual_path, identifier: @identifier }
+        ActiveSupport::Notifications.instrument("#{action}.action_view", payload, &block)
       end
   end
 end


### PR DESCRIPTION
This adds instrumentation to the template compilation. I'm using a custom template resolver to fetch templates from a database, and I'd like to check whether the templates are being cached correctly, or whether they're constantly being recompiled.
