### PR TITLE
Fixes Scaffold generator with --assets=false

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fixes bug with Scaffold generator with --assets=false --resource-route=false See #9525 for more details.
+
+    *Arun Agrawal*
+
 *   Rails::Railtie no longer forces the Rails::Configurable module on everything
     that subclassess it. Instead, the methods from Rails::Configurable have been
     moved to class methods in Railtie and the Railtie has been made abstract.

--- a/railties/lib/rails/generators/rails/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/rails/scaffold/scaffold_generator.rb
@@ -8,6 +8,8 @@ module Rails
 
       class_option :stylesheets, type: :boolean, desc: "Generate Stylesheets"
       class_option :stylesheet_engine, desc: "Engine for Stylesheets"
+      class_option :assets, :type => :boolean
+      class_option :resource_route, :type => :boolean
 
       def handle_skip
         @options = @options.merge(stylesheets: false) unless options[:assets]

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -246,6 +246,20 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     assert_no_file "app/assets/stylesheets/posts.css"
   end
 
+  def test_scaffold_generator_no_assets
+    run_generator [ "posts", "--assets=false" ]
+    assert_file "app/assets/stylesheets/scaffold.css"
+    assert_no_file "app/assets/javascripts/posts.js"
+    assert_no_file "app/assets/stylesheets/posts.css"
+  end
+
+  def test_scaffold_generator_no_assets
+    run_generator [ "posts", "--resource-route=false" ]
+    assert_file "config/routes.rb" do |route|
+      assert_no_match(/resources :posts$/, route)
+    end
+  end
+
   def test_scaffold_generator_no_stylesheets
     run_generator [ "posts", "--no-stylesheets" ]
     assert_no_file "app/assets/stylesheets/scaffold.css"


### PR DESCRIPTION
Scaffold generator with --assets=false option outputs an error

See #9525
