### PR TITLE
Add PK constraint on bigserial ID columns on postgres adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -359,8 +359,12 @@ module ActiveRecord
         # a record (as primary keys cannot be +nil+). This might be done via the
         # +SecureRandom.uuid+ method and a +before_save+ callback, for instance.
         def primary_key(name, type = :primary_key, options = {})
-          return super unless type == :uuid
-          options[:default] = options.fetch(:default, 'uuid_generate_v4()')
+          return super unless type = :primary_key
+
+          if type == :uuid
+            options[:default] = options.fetch(:default, 'uuid_generate_v4()')
+          end
+
           options[:primary_key] = true
           column name, type, options
         end

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -216,3 +216,32 @@ if current_adapter?(:MysqlAdapter, :Mysql2Adapter)
   end
 end
 
+if current_adapter?(:PostgreSQLAdapter)
+  class PrimaryKeyBigSerialTest < ActiveRecord::TestCase
+    self.use_transactional_fixtures = false
+
+    class Widget < ActiveRecord::Base
+    end
+
+    def setup
+      @con = ActiveRecord::Base.connection
+
+      ActiveRecord::Schema.define do
+        create_table :widgets, id: :bigserial do |t|
+        end
+      end
+    end
+
+    def teardown
+      ActiveRecord::Schema.define do
+        drop_table :widgets
+      end
+    end
+
+    def test_bigserial_primary_key
+      widget = Widget.create!
+
+      assert_not_nil widget.id
+    end
+  end
+end


### PR DESCRIPTION
In #10410 it was noted that you can no longer create PK's with the
type of bigserial in PostgreSQL in 4.0.0.rc1. This is mostly
because the newer adapter is checking for column type with the
id column instead of just letting it pass through like it did
before.

Side effects:
You may just create a PK column of a type that you really don't
want to be your PK. As far as I can tell this was allowed in 3.2.X
and perhaps an exception should be raised if you try and do
something extremely dumb.
