### PR TITLE
Make SchemaDumper emit "id: :uuid" when using UUID primary keys

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -321,6 +321,7 @@ module ActiveRecord
             result = query(<<-end_sql, 'SCHEMA')[0]
               SELECT attr.attname,
                 CASE
+                  WHEN pg_get_expr(def.adbin, def.adrelid) !~* 'nextval' THEN NULL
                   WHEN split_part(pg_get_expr(def.adbin, def.adrelid), '''', 2) ~ '.' THEN
                     substr(split_part(pg_get_expr(def.adbin, def.adrelid), '''', 2),
                            strpos(split_part(pg_get_expr(def.adbin, def.adrelid), '''', 2), '.')+1)
@@ -332,7 +333,7 @@ module ActiveRecord
               JOIN pg_constraint  cons ON (conrelid = adrelid AND adnum = conkey[1])
               WHERE t.oid = '#{quote_table_name(table)}'::regclass
                 AND cons.contype = 'p'
-                AND pg_get_expr(def.adbin, def.adrelid) ~* 'nextval'
+                AND pg_get_expr(def.adbin, def.adrelid) ~* 'nextval|uuid_generate'
             end_sql
           end
 

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -106,9 +106,12 @@ HEADER
           end
 
           tbl.print "  create_table #{remove_prefix_and_suffix(table).inspect}"
-          if columns.detect { |c| c.name == pk }
+          pkcol = columns.detect { |c| c.name == pk }
+          if pkcol
             if pk != 'id'
               tbl.print %Q(, primary_key: "#{pk}")
+            elsif pkcol.sql_type == 'uuid'
+              tbl.print ", id: :uuid"
             end
           else
             tbl.print ", id: false"

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -50,6 +50,18 @@ class PostgresqlUUIDTest < ActiveRecord::TestCase
     u.reload
     assert_not_nil u.other_uuid
   end
+
+  def test_pk_and_sequence_for_uuid_primary_key
+    pk, seq = @connection.pk_and_sequence_for('pg_uuids')
+    assert_equal 'id', pk
+    assert_equal nil, seq
+  end
+
+  def test_schema_dumper_for_uuid_primary_key
+    schema = StringIO.new
+    ActiveRecord::SchemaDumper.dump(@connection, schema)
+    assert_match /\bcreate_table "pg_uuids", id: :uuid\b/, schema.string
+  end
 end
 
 class PostgresqlUUIDTestNilDefault < ActiveRecord::TestCase


### PR DESCRIPTION
Fixes #10451.
