### PR TITLE
Fix to remove warning in postgres adapter test

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -768,7 +768,7 @@ module ActiveRecord
         end
 
         def exec_cache(sql, binds)
-          stmt_key = prepare_statement sql
+          stmt_key = prepare_statement(sql)
 
           # Clear the queue
           @connection.get_last_result

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -60,7 +60,7 @@ class PostgresqlUUIDTest < ActiveRecord::TestCase
   def test_schema_dumper_for_uuid_primary_key
     schema = StringIO.new
     ActiveRecord::SchemaDumper.dump(@connection, schema)
-    assert_match /\bcreate_table "pg_uuids", id: :uuid\b/, schema.string
+    assert_match(/\bcreate_table "pg_uuids", id: :uuid\b/, schema.string)
   end
 end
 


### PR DESCRIPTION
1. Changed a method call to comply with coding conventions
2. Adding a pair of parenthesis to eliminate a warning given when postgres specs were run. Warning was: "/vagrant/rails/activerecord/test/cases/adapters/postgresql/uuid_test.rb:63: warning: ambiguous first argument; put parentheses or even spaces"
