### PR TITLE
Make rake install task depend on build instead of gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -36,7 +36,7 @@ task :smoke do
 end
 
 desc "Install gems for all projects."
-task :install => :gem do
+task :install => :build do
   version = File.read("RAILS_VERSION").strip
   (PROJECTS - ["railties"]).each do |project|
     puts "INSTALLING #{project}"


### PR DESCRIPTION
The rake task doesn't build the Rails gem file so it couldn't be installed. The build task builds all the sub-gems and the Rails gem
