### PR TITLE
use nokogirisax as a backend

### DIFF
--- a/activesupport/test/xml_mini/nokogirisax_engine_test.rb
+++ b/activesupport/test/xml_mini/nokogirisax_engine_test.rb
@@ -56,9 +56,9 @@ class NokogiriSAXEngineTest < ActiveSupport::TestCase
     end
   end
 
-  def test_setting_nokogiri_as_backend
-    XmlMini.backend = 'Nokogiri'
-    assert_equal XmlMini_Nokogiri, XmlMini.backend
+  def test_setting_nokogirisax_as_backend
+    XmlMini.backend = 'NokogiriSAX'
+    assert_equal XmlMini_NokogiriSAX, XmlMini.backend
   end
 
   def test_blank_returns_empty_hash


### PR DESCRIPTION
Most likely someone just forgot to change it during copying and
pasting test cases from nokigiri engine test.
