### PR TITLE
Added missing `require` to ActionView::LookupContext

### DIFF
--- a/actionpack/lib/action_view/lookup_context.rb
+++ b/actionpack/lib/action_view/lookup_context.rb
@@ -1,5 +1,6 @@
 require 'thread_safe'
 require 'active_support/core_ext/module/remove_method'
+require 'active_support/core_ext/module/attribute_accessors'
 
 module ActionView
   # = Action View Lookup Context


### PR DESCRIPTION
Reason:

```
require 'action_view'

ActionView::LookupContext.new('views')

=> undefined method `mattr_accessor' for ActionView::LookupContext:Class (NoMethodError)
```

This pull request added missing `require 'active_support/core_ext/module/attribute_accessors'` to `ActionView::LookupContext`.
