### PR TITLE
Added notes to prefer use to_time instead of to_datetime

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/string/conversions.rb
@@ -43,12 +43,17 @@ class String
     ::Date.parse(self, false) unless blank?
   end
 
-  # Converts a string to a DateTime value.
+  # Converts a +String+ to a +DateTime+ value.
   #
-  #   "1-1-2012".to_datetime            #=> Sun, 01 Jan 2012 00:00:00 +0000
-  #   "01/01/2012 23:59:59".to_datetime #=> Sun, 01 Jan 2012 23:59:59 +0000
-  #   "2012-12-13 12:50".to_datetime    #=> Thu, 13 Dec 2012 12:50:00 +0000
-  #   "12/13/2012".to_datetime          #=> ArgumentError: invalid date
+  # Note that unless you have a specific reason to do so, you should prefer using +to_time+
+  # rather than +to_datetime+
+  #
+  # ==== Examples
+  #
+  #   "1-1-2012".to_datetime            # => Sun, 01 Jan 2012 00:00:00 +0000
+  #   "01/01/2012 23:59:59".to_datetime # => Sun, 01 Jan 2012 23:59:59 +0000
+  #   "2012-12-13 12:50".to_datetime    # => Thu, 13 Dec 2012 12:50:00 +0000
+  #   "12/13/2012".to_datetime          # => ArgumentError: invalid date
   def to_datetime
     ::DateTime.parse(self, false) unless blank?
   end

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -326,6 +326,10 @@ module ActiveSupport
       utc.to_time
     end
 
+    # Converts to a +DateTime+ value.
+    #
+    # Note that unless you have a specific reason to do so, you should prefer using +to_time+
+    # rather than +to_datetime+
     def to_datetime
       utc.to_datetime.new_offset(Rational(utc_offset, 86_400))
     end


### PR DESCRIPTION
After discussion in #10196: added method documentation/note to prefer use of `to_time` instead of `to_datetime`

cc: @pixeltrix
