### PR TITLE
Add params option for button_to

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add `params` option to `button_to` form helper, which renders the given hash
+    as hidden form fields.
+
+    *Andy Waite*
+
 *   Development mode exceptions are rendered in text format in case of XHR request.
 
     *Kir Shatrov*

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -213,6 +213,7 @@ module ActionView
       # * <tt>:form</tt> - This hash will be form attributes
       # * <tt>:form_class</tt> - This controls the class of the form within which the submit button will
       #   be placed
+      # * <tt>:params</tt> - Hash of parameters to be rendered as hidden fields within the form.
       #
       # ==== Data attributes
       #
@@ -287,6 +288,7 @@ module ActionView
 
         url    = options.is_a?(String) ? options : url_for(options)
         remote = html_options.delete('remote')
+        params = html_options.delete('params')
 
         method     = html_options.delete('method').to_s
         method_tag = BUTTON_TAG_METHOD_VERBS.include?(method) ? method_tag(method) : ''.html_safe
@@ -310,6 +312,11 @@ module ActionView
         end
 
         inner_tags = method_tag.safe_concat(button).safe_concat(request_token_tag)
+        if params
+          params.each do |name, value|
+            inner_tags.safe_concat tag(:input, type: "hidden", name: name, value: value.to_param)
+          end
+        end
         content_tag('form', content_tag('div', inner_tags), form_options)
       end
 

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -160,6 +160,13 @@ class UrlHelperTest < ActiveSupport::TestCase
     )
   end
 
+  def test_button_to_with_params
+    assert_dom_equal(
+      %{<form action="http://www.example.com" class="button_to" method="post"><div><input type="submit" value="Hello" /><input type="hidden" name="foo" value="bar" /><input type="hidden" name="baz" value="quux" /></div></form>},
+      button_to("Hello", "http://www.example.com", params: {foo: :bar, baz: "quux"})
+    )
+  end
+
   def test_link_tag_with_straight_url
     assert_dom_equal %{<a href="http://www.example.com">Hello</a>}, link_to("Hello", "http://www.example.com")
   end


### PR DESCRIPTION
The parameters are rendered as hidden form fields within the generated form. This is useful for when a record has multiple buttons associated with it, each of which target the same controller method, but which need to submit different attributes.

For example, a bug tracking system may have buttons to mark an issue as Closed or Fixed. These should both make a PATCH request to `/issues/:id`. This could be implemented by adding member routes to the Issue resource, but for some apps that may result in a large number of additional entries in routes.rb.

I understand that there is already a mechanism for adding additional params to the query string for `button_on`, but it's usually preferable to have this data in the request body.
