### PR TITLE
Don't use self.class in ActiveRecord#sanitize_sql_hash_for_conditions.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   In `ActiveRecord#sanitize_sql_hash_for_conditions`, self is already a
+    class, so do not call `class` on it again, otherwise the PredicateBuilder
+    will try to call the non-existant `Class#reflection_on_association`.
+
+    *Marc Schütz*
+
 *   Do not overwrite manually built records during one-to-one nested attribute assignment
 
     For one-to-one nested associations, if you build the new (in-memory)

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -89,7 +89,7 @@ module ActiveRecord
         attrs = expand_hash_conditions_for_aggregates(attrs)
 
         table = Arel::Table.new(table_name, arel_engine).alias(default_table_name)
-        PredicateBuilder.build_from_hash(self.class, attrs, table).map { |b|
+        PredicateBuilder.build_from_hash(self, attrs, table).map { |b|
           connection.visitor.accept b
         }.join(' AND ')
       end

--- a/activerecord/test/cases/sanitize_test.rb
+++ b/activerecord/test/cases/sanitize_test.rb
@@ -1,5 +1,7 @@
 require "cases/helper"
 require 'models/binary'
+require 'models/price_estimate'
+require 'models/treasure'
 
 class SanitizeTest < ActiveRecord::TestCase
   def setup
@@ -21,5 +23,13 @@ class SanitizeTest < ActiveRecord::TestCase
     quoted_bambi_and_thumper = ActiveRecord::Base.connection.quote("Bambi\nand\nThumper")
     assert_equal "name=#{quoted_bambi_and_thumper}", Binary.send(:sanitize_sql_array, ["name=?", "Bambi\nand\nThumper"])
     assert_equal "name=#{quoted_bambi_and_thumper}", Binary.send(:sanitize_sql_array, ["name=?", "Bambi\nand\nThumper".mb_chars])
+  end
+
+  def test_sanitize_sql_hash_handles_models_as_values
+    treasure = Treasure.new
+    treasure.id = 1
+    assert_nothing_raised do
+      PriceEstimate.send :sanitize_sql, {estimate_of: treasure}
+    end
   end
 end


### PR DESCRIPTION
`self` is already a class here, so don't call `class` on it again, otherwise
the `PredicateBuilder` will call the non-existant `Class#reflect_on_association`.
This makes Cancan's `accessible_by` useable with multiple rules involving
polymorphic relations.
