### PR TITLE
Quote ActiveRecord::Relation with their SQL queries

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -34,6 +34,7 @@ module ActiveRecord
         when Numeric, ActiveSupport::Duration then value.to_s
         when Date, Time then "'#{quoted_date(value)}'"
         when Symbol     then "'#{quote_string(value.to_s)}'"
+        when ActiveRecord::Relation then "(#{value.to_sql})"
         when Class      then "'#{value.to_s}'"
         else
           "'#{quote_string(YAML.dump(value))}'"

--- a/activerecord/test/cases/connection_adapters/quoting_test.rb
+++ b/activerecord/test/cases/connection_adapters/quoting_test.rb
@@ -1,9 +1,16 @@
 require "cases/helper"
+require 'models/default'
 
 module ActiveRecord
   module ConnectionAdapters
     module Quoting
       class QuotingTest < ActiveRecord::TestCase
+        def test_quoting_relation
+          relation = Default.select('id').where('id > ?', 0)
+          assert_equal "(SELECT id FROM \"defaults\"  WHERE (id > 0))",
+            AbstractAdapter.new(nil).quote(relation)
+        end
+
         def test_quoting_classes
           assert_equal "'Object'", AbstractAdapter.new(nil).quote(Object)
         end


### PR DESCRIPTION
This makes writing nested queries simpler, without any need for explicit
`to_sql` call. In some situations, where using `JOIN` becomes too
complicated, nested queries come in handy.
