### PR TITLE
use canonical #controller_path logic in controller test cases

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -558,7 +558,7 @@ module ActionController
         parameters ||= {}
         controller_class_name = @controller.class.anonymous? ?
           "anonymous" :
-          @controller.class.name.underscore.sub(/_controller$/, '')
+          @controller.class.controller_path
 
         @request.assign_parameters(@routes, controller_class_name, action.to_s, parameters)
 


### PR DESCRIPTION
## Background

I'm experimenting with a tweak to the controller pattern that supports putting each action into its own class inside of a controller module. So far the implementation has been very lean. One of my key changes has been to overwrite `#controller_path`, so that views will still be found in the same place. Another has been to delegate `#action` from the controller module to the individual action classes, so that route mapping doesn't need any changes.
## Problem

When I write tests against a controller's action class in my sample application, they consistently fail with a routing error. The tests have correctly inferred the `@controller`, but since `ActionController::TestCase::Behavior#process` contains a duplication of the `#controller_path` logic, the tests do not use my revised logic and so generate a path that does not match existing routes.
## Solution

Patching `ActionController::TestCase::Behavior#process` to use the canonical `@controller.class.controller_path` makes my tests pass.
