### PR TITLE
Removed override of encode_with in TimeWithZone

### DIFF
--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -160,14 +160,6 @@ module ActiveSupport
       end
     end
 
-    def encode_with(coder)
-      if coder.respond_to?(:represent_object)
-        coder.represent_object(nil, utc)
-      else
-        coder.represent_scalar(nil, utc.strftime("%Y-%m-%d %H:%M:%S.%9NZ"))
-      end
-    end
-
     # Returns a string of the object's date and time in the format used by
     # HTTP requests.
     #

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -116,11 +116,14 @@ class TimeWithZoneTest < ActiveSupport::TestCase
   end
 
   def test_to_yaml
-    assert_match(/^--- 2000-01-01 00:00:00(\.0+)?\s*Z\n/, @twz.to_yaml)
+    assert_match(/\A--- 1999-12-31 19:00:00(\.0+)?\s*-05:00\n/, @twz.to_yaml)
+
+    utc_twz = ActiveSupport::TimeWithZone.new(@utc, ActiveSupport::TimeZone['UTC'])
+    assert_match(/\A--- 2000-01-01 00:00:00.000000000 Z\n/, utc_twz.to_yaml)
   end
 
   def test_ruby_to_yaml
-    assert_match(/---\s*\n:twz: 2000-01-01 00:00:00(\.0+)?\s*Z\n/, {:twz => @twz}.to_yaml)
+    assert_match(/---\s*\n:twz: 1999-12-31 19:00:00(\.0+)?\s*-05:00\n/, {:twz => @twz}.to_yaml)
   end
 
   def test_httpdate


### PR DESCRIPTION
Added for ActiveSupport::TimeWithZone to serialize to yaml
with TimeZone information like Time#to_yaml does,
instead saving only UTC value.

Closes #9183
