### PR TITLE
Fixes #10432 add_column not creating array columns in PostgreSQL

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `add_column` with `array` option when using PostgreSQL. Fixes #10432
+
+    *Adam Anderson*
+
 *   Usage of `implicit_readonly` is being removed`. Please use `readonly` method
     explicitly to mark records as `readonly.
     Fixes #10615.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -269,6 +269,7 @@ module ActiveRecord
         end
 
         column.limit       = limit
+        column.array       = options[:array] if column.respond_to?(:array)
         column.precision   = options[:precision]
         column.scale       = options[:scale]
         column.default     = options[:default]

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -74,6 +74,35 @@ module ActiveRecord
         assert_equal "hello", five.default unless mysql
       end
 
+      def test_add_column_with_array
+        if current_adapter?(:PostgreSQLAdapter)
+          connection.create_table :testings
+          connection.add_column :testings, :foo, :string, :array => true
+
+          columns = connection.columns(:testings)
+          array_column = columns.detect { |c| c.name == "foo" }
+
+          assert array_column.array
+        else
+          skip "array option only supported in PostgreSQLAdapter"
+        end
+      end
+
+      def test_create_table_with_array_column
+        if current_adapter?(:PostgreSQLAdapter)
+          connection.create_table :testings do |t|
+            t.string :foo, :array => true
+          end
+
+          columns = connection.columns(:testings)
+          array_column = columns.detect { |c| c.name == "foo" }
+
+          assert array_column.array
+        else
+          skip "array option only supported in PostgreSQLAdapter"
+        end
+      end
+
       def test_create_table_with_limits
         connection.create_table :testings do |t|
           t.column :foo, :string, :limit => 255


### PR DESCRIPTION
When then PostgreSQL visitor was [added](https://github.com/rails/rails/commit/6b7fdf3bf3675a14eae74acc5241089308153a34)
`add_column` was no longer receiving the column options directly. This
caused the options to be lost along the way.
