### PR TITLE
Whitelist video tag and add "poster" as an acceptable attribute of <video>

### DIFF
--- a/actionpack/lib/action_view/vendor/html-scanner/html/sanitizer.rb
+++ b/actionpack/lib/action_view/vendor/html-scanner/html/sanitizer.rb
@@ -80,7 +80,7 @@ module HTML
     self.protocol_separator     = /:|(&#0*58)|(&#x70)|(&#x0*3a)|(%|&#37;)3A/i
 
     # Specifies a Set of HTML attributes that can have URIs.
-    self.uri_attributes         = Set.new(%w(href src cite action longdesc xlink:href lowsrc))
+    self.uri_attributes         = Set.new(%w(href src cite action longdesc poster xlink:href lowsrc))
 
     # Specifies a Set of 'bad' tags that the #sanitize helper will remove completely, as opposed
     # to just escaping harmless tags like &lt;font&gt;
@@ -89,7 +89,7 @@ module HTML
     # Specifies the default Set of tags that the #sanitize helper will allow unscathed.
     self.allowed_tags           = Set.new(%w(strong em b i p code pre tt samp kbd var sub
       sup dfn cite big small address hr br div span h1 h2 h3 h4 h5 h6 ul ol li dl dt dd abbr
-      acronym a img blockquote del ins))
+      acronym a img blockquote del ins video))
 
     # Specifies the default Set of html attributes that the #sanitize helper will leave
     # in the allowed tag.

--- a/actionpack/test/template/html-scanner/sanitizer_test.rb
+++ b/actionpack/test/template/html-scanner/sanitizer_test.rb
@@ -81,6 +81,11 @@ class SanitizerTest < ActionController::TestCase
     assert_sanitized %(<a href="foo" onclick="bar"><script>baz</script></a>), %(<a href="foo"></a>)
   end
 
+  def test_video_poster_sanitization
+    assert_sanitized %(<video src="videofile.ogg" autoplay  poster="posterimage.jpg"></video>), %(<video src="videofile.ogg"></video>)
+    assert_sanitized %(<video src="videofile.ogg" poster=javascript:alert(1)></video>), %(<video src="videofile.ogg"></video>)
+  end
+
   # RFC 3986, sec 4.2
   def test_allow_colons_in_path_component
     assert_sanitized("<a href=\"./this:that\">foo</a>")


### PR DESCRIPTION
Whitelist video tag and add "poster" as an acceptable attribute of <video>
changes wrt: https://code.google.com/p/html5lib/source/detail?spec=svn6a52f08fb7eb81870095b763a50406fc8216054e&r=6a52f08fb7eb81870095b763a50406fc8216054e
