### PR TITLE
Use Kernel#quietly when checking for pending migrations

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -360,7 +360,7 @@ module ActiveRecord
       end
 
       def call(env)
-        ActiveRecord::Base.logger.silence do
+        ActiveRecord::Base.logger.quietly do
           ActiveRecord::Migration.check_pending!
         end
         @app.call(env)

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -849,4 +849,16 @@ class CopyMigrationsTest < ActiveRecord::TestCase
   ensure
     clear
   end
+
+  def test_check_pending_middleware
+    called = nil
+    app = lambda { |env| called = env }
+    original_logger, ActiveRecord::Base.logger = ActiveRecord::Base.logger, ::Logger.new(StringIO.new)
+    env = {"REMOTE_ADDR" => "127.0.0.1"}
+    ActiveRecord::Migration::CheckPending.new(app).call(env)
+    assert_equal env, called
+  ensure
+    ActiveRecord::Base.logger = original_logger
+  end
+
 end


### PR DESCRIPTION
The default logger Rails provides as ActiveRecord::Base.logger has a
method called `#silence` that takes no arguments. But ActiveSupport's
[core extension](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/kernel/reporting.rb#L82) requires a stream to be passed in, so it would break when
using a regular ::Logger instance.

Switched to using [`Kernel#quietly`](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/kernel/reporting.rb#L102), which silences both STDOUT and
STDERR.

I've also added a test for it. I couldn't find any other tests for this piece of code, so I hope I've added it to the right location.
