### PR TITLE
Eliminates `unknown OID: post_title(705)` message with PostgreSQL

### DIFF
--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -189,7 +189,11 @@ module ActiveRecord
       post = Post.select(:title).first
       assert_equal false, post.respond_to?(:body), "post should not respond_to?(:body) since invoking it raises exception"
 
-      post = Post.select("'title' as post_title").first
+      if current_adapter?(:PostgreSQLAdapter)
+        post = Post.select("'title'::character(255) as post_title").first
+      else
+        post = Post.select("'title' as post_title").first
+      end
       assert_equal false, post.respond_to?(:title), "post should not respond_to?(:body) since invoking it raises exception"
     end
 


### PR DESCRIPTION
This pull request eliminates `unknown OID: post_title(705)` message when tested with PostgreSQL adapter. 

``` ruby
$ ARCONN=postgresql ruby -Itest test/cases/relation_test.rb -n test_respond_to_for_non_selected_element
Using postgresql
Run options: -n test_respond_to_for_non_selected_element --seed 34103

# Running tests:

unknown OID: post_title(705) (SELECT  'title' as post_title FROM "posts"   ORDER BY "posts"."id" ASC LIMIT 1)
.

Finished tests in 0.147927s, 6.7601 tests/s, 13.5202 assertions/s.

1 tests, 2 assertions, 0 failures, 0 errors, 0 skips
$
```
