### PR TITLE
Delete in-memory association record

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Delete in-memory association record when target record is deleted
+    for hm:t case.
+
+    Fixes #9548.
+
+    *Neeraj Singh*
+
 *   Apply default scope when joining associations. For example:
 
         class Post < ActiveRecord::Base
@@ -220,9 +227,9 @@
     *Kyle Stevens*
 
 *   Method `read_attribute_before_type_cast` should accept input as symbol.
-
+ 
     *Neeraj Singh*
-
+ 
 *   Confirm a record has not already been destroyed before decrementing counter cache.
 
     *Ben Tucker*

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -491,6 +491,10 @@ module ActiveRecord
           records.each { |record| callback(:before_remove, record) }
 
           delete_records(existing_records, method) if existing_records.any?
+
+          # remove association records for has_many :through case
+          delete_through_records(records) if reflection.is_a?(ActiveRecord::Reflection::ThroughReflection)
+
           records.each { |record| target.delete(record) }
 
           records.each { |record| callback(:after_remove, record) }

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -882,6 +882,16 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal [tags(:general)], post.reload.tags
   end
 
+  def test_has_many_through_should_delete_in_memory_association_record
+    club = Club.new
+    member = Member.new
+
+    club.members << member
+    club.members.delete member
+
+    refute club.members.include?(member)
+  end
+
   def test_has_many_through_obeys_order_on_through_association
     owner = owners(:blackbeard)
     assert owner.toys.to_sql.include?("pets.name desc")


### PR DESCRIPTION
When target record is deleted then in-memory association
record should be deleted for hm:t case.

Fixes #9548
