### PR TITLE
Fixed a bug in  when using has_many association with :inverse_of option and UUID primary key.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fixed a bug in `ActiveRecord::Associations::CollectionAssociation#find_by_scan` when using has_many association with :inverse_of option and UUID primary key.
+    Fixes #10450.
+
+    *kennyj*
+
 *   Confirm a record has not already been destroyed before decrementing counter cache.
 
     *Ben Tucker*

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -583,14 +583,14 @@ module ActiveRecord
         # specified, then #find scans the entire collection.
         def find_by_scan(*args)
           expects_array = args.first.kind_of?(Array)
-          ids           = args.flatten.compact.map{ |arg| arg.to_i }.uniq
+          ids           = args.flatten.compact.map{ |arg| arg.to_s }.uniq
 
           if ids.size == 1
             id = ids.first
-            record = load_target.detect { |r| id == r.id }
+            record = load_target.detect { |r| id == r.id.to_s }
             expects_array ? [ record ] : record
           else
-            load_target.select { |r| ids.include?(r.id) }
+            load_target.select { |r| ids.include?(r.id.to_s) }
           end
         end
 

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -93,3 +93,43 @@ class PostgresqlUUIDTestNilDefault < ActiveRecord::TestCase
     assert_nil col_desc["default"]
   end
 end
+
+class PostgresqlUUIDTestInverseOf < ActiveRecord::TestCase
+  class UuidPost < ActiveRecord::Base
+    self.table_name = 'pg_uuid_posts'
+    has_many :uuid_comments, inverse_of: :uuid_post
+  end
+
+  class UuidComment < ActiveRecord::Base
+    self.table_name = 'pg_uuid_comments'
+    belongs_to :uuid_post
+  end
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+    @connection.reconnect!
+
+    @connection.transaction do
+      @connection.create_table('pg_uuid_posts', id: :uuid) do |t|
+        t.string 'title'
+      end
+      @connection.create_table('pg_uuid_comments', id: :uuid) do |t|
+        t.uuid :uuid_post_id, default: 'uuid_generate_v4()'
+        t.string 'content'
+      end
+    end
+  end
+
+  def teardown
+    @connection.transaction do
+      @connection.execute 'drop table if exists pg_uuid_comments'
+      @connection.execute 'drop table if exists pg_uuid_posts'
+    end
+  end
+
+  def test_collection_association_with_uuid
+    post    = UuidPost.create!
+    comment = post.uuid_comments.create!
+    assert post.uuid_comments.find(comment.id)
+  end
+end


### PR DESCRIPTION
Closes #10450.

When using UUID primary key and has_many with :inverse_of option, the following error is occurred.

```
ActiveRecord::RecordNotFound: Couldn't find Comment with id=["bca2decc-51e4-4e58-b45b-6afae21c2168"] [WHERE "comments"."post_id" = $1]
```

The cause of problem was we assumed integer id in ActiveRecord::Associations::CollectionAssociation#find_by_scan.
