### PR TITLE
Avoid method missing when calling assume_migrated_upto_version (master)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Fix pending migrations error when loading schema and ActiveRecord::Base.table_name_prefix is not blank.
+
+    Call assume_migrated_upto_version on connection to prevent it from first being picked up in method_missing.
+    In the base class, Migration, method_missing expects the argument to be a table name, and calls proper_table_name
+    on the arguments before sending to connection. If table_name_prefix or table_name_suffix is used, the schema
+    version changes to prefix_version_suffix, breaking `rake test:prepare`.
+
+    Fixes #10411.
+
+    *Kyle Stevens*
+
 *   Method read_attribute_before_type_cast should accept input as symbol.
 
     *Neeraj Singh*

--- a/activerecord/lib/active_record/schema.rb
+++ b/activerecord/lib/active_record/schema.rb
@@ -43,7 +43,7 @@ module ActiveRecord
 
       unless info[:version].blank?
         initialize_schema_migrations_table
-        assume_migrated_upto_version(info[:version], migrations_paths)
+        connection.assume_migrated_upto_version(info[:version], migrations_paths)
       end
     end
 


### PR DESCRIPTION
This pull request fixes issue #10411.
