### PR TITLE
Also should supports PostgreSQL 9.1 about extensions.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Also support extentions in PostgreSQL 9.1. This feature has been supported since 9.1.
+
+    *kennyj*
+
 *   Deprecate `ConnectionAdapters::SchemaStatements#distinct`,
     as it is no longer used by internals.
 

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -125,8 +125,6 @@ namespace :postgresql do
     %w(arunit arunit2).each do |db|
       if version < "9.1.0"
         puts "Please prepare hstore data type. See http://www.postgresql.org/docs/9.0/static/hstore.html"
-      else
-        %x( psql #{config[db]['database']} -c "CREATE EXTENSION hstore;" )
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -622,9 +622,9 @@ module ActiveRecord
         true
       end
 
-      # Returns true if pg > 9.2
+      # Returns true if pg > 9.1
       def supports_extensions?
-        postgresql_version >= 90200
+        postgresql_version >= 90100
       end
 
       # Range datatypes weren't introduced until PostgreSQL 9.2
@@ -646,9 +646,9 @@ module ActiveRecord
 
       def extension_enabled?(name)
         if supports_extensions?
-          res = exec_query "SELECT EXISTS(SELECT * FROM pg_available_extensions WHERE name = '#{name}' AND installed_version IS NOT NULL)",
+          res = exec_query "SELECT EXISTS(SELECT * FROM pg_available_extensions WHERE name = '#{name}' AND installed_version IS NOT NULL) as enabled",
             'SCHEMA'
-          res.column_types['exists'].type_cast res.rows.first.first
+          res.column_types['enabled'].type_cast res.rows.first.first
         end
       end
 


### PR DESCRIPTION
In edge rails with PostgrelSQL 9.1.x, `PostgreSQLAdapter#supports_extensions?` always returns false .

But I think that PostgreSQL 9.1.x supports extension feature well (including hstore and uuid-ossp).
