### PR TITLE
Handle other pk types in PostgreSQL gracefully.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Allow the PostgreSQL adapter to handle bigserial pk types again.
+
+    Fixes #10410
+
+    *Patrick Robertson*
+
+*   Perform necessary deeper encoding when hstore is inside an array.
+
 * `before_add` callbacks are fired before the record is saved on
   `has_and_belongs_to_many` assocations *and* on `has_many :through`
   associations.  Before this change, `before_add` callbacks would be fired

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -12,7 +12,7 @@ module ActiveRecord
 
         def visit_ColumnDefinition(o)
           sql = super
-          if o.primary_key? && o.type == :uuid
+          if o.primary_key? && o.type != :primary_key
             sql << " PRIMARY KEY "
             add_column_options!(sql, column_options(o))
           end

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -219,3 +219,31 @@ if current_adapter?(:MysqlAdapter, :Mysql2Adapter)
     end
   end
 end
+
+if current_adapter?(:PostgreSQLAdapter)
+  class PrimaryKeyBigSerialTest < ActiveRecord::TestCase
+    self.use_transactional_fixtures = false
+
+    class Widget < ActiveRecord::Base
+    end
+
+    def setup
+      ActiveRecord::Schema.define do
+        create_table :widgets, id: :bigserial do |t|
+        end
+      end
+    end
+
+    def teardown
+      ActiveRecord::Schema.define do
+        drop_table :widgets
+      end
+    end
+
+    def test_bigserial_primary_key
+      widget = Widget.create!
+
+      assert_not_nil widget.id
+    end
+  end
+end


### PR DESCRIPTION
In #10410 it was noted that you can no longer create PK's with the
type of bigserial in PostgreSQL in 4.0.0.rc1. This is mostly
because the newer adapter is checking for column type with the
id column instead of just letting it pass through like it did
before.

Side effects:
You may just create a PK column of a type that you really don't
want to be your PK. As far as I can tell this was allowed in 3.2.X
and perhaps an exception should be raised if you try and do
something extremely dumb.

Let's try this again @tenderlove! I can guarantee that the activerecord suite works just fine with the postgresql ARCONN.
