### PR TITLE
fix issue #10502, do not recompute method name for already-stringified object callback filter

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix skipping object callbacks using metadata fetched via callback chain
+    inspection methods (`_*_callbacks`)
+
+    *Sean Walbran*
+
 *   Add a `fetch_multi` method to the cache stores. The method provides
     an easy to use API for fetching multiple values from the cache.
 

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -133,7 +133,7 @@ module ActiveSupport
       end
 
       def matches?(_kind, _filter)
-        if @_is_object_filter
+        if @_is_object_filter && !_filter.is_a?(String)
           _filter_matches = @filter.to_s.start_with?(_method_name_for_object_filter(_kind, _filter, false))
         else
           _filter_matches = (@filter == _filter) 

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -102,6 +102,9 @@ module CallbacksTest
     def no; false; end
   end
 
+  class PersonForProgrammaticSkipping < Person
+  end
+
   class ParentController
     include ActiveSupport::Callbacks
 
@@ -441,6 +444,25 @@ module CallbacksTest
         [:before_save, :proc],
         [:before_save, :object],
         [:before_save, :block],
+        [:after_save, :block],
+        [:after_save, :class],
+        [:after_save, :object],
+        [:after_save, :proc],
+        [:after_save, :string],
+        [:after_save, :symbol]
+      ], person.history
+    end
+
+    def test_skip_person_programmatically
+      PersonForProgrammaticSkipping._save_callbacks.each do |save_callback|
+        if "before" == save_callback.kind.to_s
+          PersonForProgrammaticSkipping.skip_callback("save", save_callback.kind, save_callback.filter)
+        end
+      end
+      person = PersonForProgrammaticSkipping.new
+      assert_equal [], person.history
+      person.save
+      assert_equal [
         [:after_save, :block],
         [:after_save, :class],
         [:after_save, :object],


### PR DESCRIPTION
See discussion at issue #10502
