### PR TITLE
Include aliases in attribute names

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -96,4 +96,8 @@
 
     *Slava Markevich*
 
+*   Include attribute aliases in array returned by `ActiveRecord#attribute_names`.
+
+    *Patrick Van Stee*
+
 Please check [4-0-stable](https://github.com/rails/rails/blob/4-0-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -109,7 +109,7 @@ module ActiveRecord
       #   # => ["id", "created_at", "updated_at", "name", "age"]
       def attribute_names
         @attribute_names ||= if !abstract_class? && table_exists?
-            column_names
+            column_names + attribute_aliases.keys
           else
             []
           end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1421,6 +1421,10 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal [], AbstractCompany.attribute_names
   end
 
+  def test_attribute_names_with_aliases
+    assert_includes Topic.attribute_names, "heading"
+  end
+
   def test_touch_should_raise_error_on_a_new_object
     company = Company.new(:rating => 1, :name => "37signals", :firm_name => "37signals")
     assert_raises(ActiveRecord::ActiveRecordError) do


### PR DESCRIPTION
This came up when trying to include attribute aliases in the list of parameters wrapped by default: https://github.com/rails/rails/pull/10375. Returning both aliases and names in `ActiveRecord#attribute_names` seems like the best solution, as recommended by @jeremy.
