### PR TITLE
dependency ActiveSupport::Deprecation

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/diff.rb
+++ b/activesupport/lib/active_support/core_ext/hash/diff.rb
@@ -1,3 +1,5 @@
+require 'active_support/deprecation'
+
 class Hash
   # Returns a hash that represents the difference between two hashes.
   #


### PR DESCRIPTION
use method ActivSupport::Deprecation.warn 

88d59de12d9951c0ac18a1e53e52f92c00c15849
