### PR TITLE
Remove current_adapter? from test_sanitize_sql_hash_handles_associations

### DIFF
--- a/activerecord/test/cases/sanitize_test.rb
+++ b/activerecord/test/cases/sanitize_test.rb
@@ -6,11 +6,10 @@ class SanitizeTest < ActiveRecord::TestCase
   end
 
   def test_sanitize_sql_hash_handles_associations
-    if current_adapter?(:MysqlAdapter, :Mysql2Adapter)
-      expected_value = "`adorable_animals`.`name` = 'Bambi'"
-    else
-      expected_value =  "\"adorable_animals\".\"name\" = 'Bambi'"
-    end
+    quoted_bambi = ActiveRecord::Base.connection.quote("Bambi")
+    quoted_column_name = ActiveRecord::Base.connection.quote_column_name("name")
+    quoted_table_name = ActiveRecord::Base.connection.quote_table_name("adorable_animals")
+    expected_value = "#{quoted_table_name}.#{quoted_column_name} = #{quoted_bambi}" 
 
     assert_equal expected_value, Binary.send(:sanitize_sql_hash, {adorable_animals: {name: 'Bambi'}})
   end


### PR DESCRIPTION
This pull request addresses the following Failure since 0f97ac66471270b917103869a56bc409aa3ccf0b merged to master.

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/sanitize_test.rb -n test_sanitize_sql_hash_handles_associations
Using oracle
Run options: -n test_sanitize_sql_hash_handles_associations --seed 34232

# Running tests:

F

Finished tests in 0.015117s, 66.1522 tests/s, 66.1522 assertions/s.

  1) Failure:
SanitizeTest#test_sanitize_sql_hash_handles_associations [test/cases/sanitize_test.rb:15]:
--- expected
+++ actual
@@ -1 +1 @@
-"\"adorable_animals\".\"name\" = 'Bambi'"
+"\"ADORABLE_ANIMALS\".\"NAME\" = 'Bambi'"


1 tests, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

This commit removes current_adapter by using ActiveRecord::ConnectionAdapters::Quoting methods.
