### PR TITLE
Using define method instead of class eval when defining model callbacks.

### DIFF
--- a/activemodel/lib/active_model/callbacks.rb
+++ b/activemodel/lib/active_model/callbacks.rb
@@ -120,30 +120,24 @@ module ActiveModel
     private
 
     def _define_before_model_callback(klass, callback) #:nodoc:
-      klass.class_eval <<-CALLBACK, __FILE__, __LINE__ + 1
-        def self.before_#{callback}(*args, &block)
-          set_callback(:#{callback}, :before, *args, &block)
-        end
-      CALLBACK
+      klass.define_singleton_method("before_#{callback}") do |*args, &block|
+        set_callback(:"#{callback}", :before, *args, &block)
+      end
     end
 
     def _define_around_model_callback(klass, callback) #:nodoc:
-      klass.class_eval <<-CALLBACK, __FILE__, __LINE__ + 1
-        def self.around_#{callback}(*args, &block)
-          set_callback(:#{callback}, :around, *args, &block)
-        end
-      CALLBACK
+      klass.define_singleton_method("around_#{callback}") do |*args, &block|
+        set_callback(:"#{callback}", :around, *args, &block)
+      end
     end
 
     def _define_after_model_callback(klass, callback) #:nodoc:
-      klass.class_eval <<-CALLBACK, __FILE__, __LINE__ + 1
-        def self.after_#{callback}(*args, &block)
-          options = args.extract_options!
-          options[:prepend] = true
-          options[:if] = Array(options[:if]) << "value != false"
-          set_callback(:#{callback}, :after, *(args << options), &block)
-        end
-      CALLBACK
+      klass.define_singleton_method("after_#{callback}") do |*args, &block|
+        options = args.extract_options!
+        options[:prepend] = true
+        options[:if] = Array(options[:if]) << "value != false"
+        set_callback(:"#{callback}", :after, *(args << options), &block)
+      end
     end
   end
 end


### PR DESCRIPTION
Based on my benchmark results, this change improves performance
substantially when defining callbacks (especially for apps that are defining large numbers of callbacks).

This benchmark (https://gist.github.com/wangjohn/5542610) was run using
the current master and also using my experimental branch which replaced
class_eval with define_single_method.

Using class_eval (current master):

```
                    user     system      total        real
10 trials       0.000000   0.000000   0.000000 (  0.001568)
50 trials       0.020000   0.000000   0.020000 (  0.021715)
500 trials      0.110000   0.000000   0.110000 (  0.115357)
1000 trials     0.250000   0.000000   0.250000 (  0.260025)
10000 trials    2.560000   0.000000   2.560000 (  2.568408)
50000 trials   12.800000   0.010000  12.810000 ( 12.886871)
```

Using define_single_method (experimental branch):

```
                    user     system      total        real
10 trials       0.000000   0.000000   0.000000 (  0.000790)
50 trials       0.000000   0.000000   0.000000 (  0.002960)
500 trials      0.050000   0.010000   0.060000 (  0.055690)
1000 trials     0.100000   0.000000   0.100000 (  0.094073)
10000 trials    0.890000   0.000000   0.890000 (  0.900364)
50000 trials    4.650000   0.000000   4.650000 (  4.686127)
```
