### PR TITLE
handle non lambda scope properly

### DIFF
--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -139,21 +139,20 @@ module ActiveRecord
         if values[:where].empty? || relation.where_values.empty?
           relation.where_values + values[:where]
         else
-          # Remove equalities from the existing relation with a LHS which is
-          # present in the relation being merged in.
+          sanitized_wheres + values[:where]
+        end
+      end
 
-          seen = Set.new
-          values[:where].each { |w|
-            if w.respond_to?(:operator) && w.operator == :==
-              seen << w.left
-            end
-          }
+      # Remove equalities from the existing relation with a LHS which is
+      # present in the relation being merged in.
+      def sanitized_wheres
+        seen = Set.new
+        values[:where].each do |w|
+          seen << w.left if w.respond_to?(:operator) && w.operator == :==
+        end
 
-          relation.where_values.reject { |w|
-            w.respond_to?(:operator) &&
-              w.operator == :== &&
-              seen.include?(w.left)
-          } + values[:where]
+        relation.where_values.reject do |w|
+          w.respond_to?(:operator) && w.operator == :== && seen.include?(w.left)
         end
       end
     end

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -163,7 +163,11 @@ module ActiveRecord
               scope = all.scoping { body.call(*args) }
               scope = scope.extending(extension) if extension
             else
-              scope = body
+              if body.is_a?(ActiveRecord::Relation) && current_scope.present?
+                scope = Relation::Merger.new(current_scope, body).merge(false)
+              else
+                scope = body
+              end
             end
 
             scope || all


### PR DESCRIPTION
This PR is only for 4-0-stable since in master scope without lambda is no longer supported.

I will add tests and change log if the fix looks ok.

fixes #10421

If `@post.comments.approved_only_without_lambda.count` is invoked
then the result is equivalent to calling
`Comment.approved_only_without_lambda`.

This is because when `scope` is defined without lambda then `scope`
stores an already built relation.

`@post.comments.approved_only_without_lambda` invokes the method
using `scoping`.

`scoping` changes the `current_scope` so that the relation that is
to built can make use of the `current_scope`.

However if `scope` is defined without lambda then the relation is
already built and I could not find anyway to apply current_scope
on an already built relation.

If I use `merge` then last where condition wins and that was removing
conditions from `current_scope`.

Hence I added a way to merge two relations without anyone clobbering
on another.

All existing tests are passing.

/cc @jonleighton
