### PR TITLE
Require different core extensions correctly.

### DIFF
--- a/activesupport/lib/active_support/i18n.rb
+++ b/activesupport/lib/active_support/i18n.rb
@@ -1,13 +1,13 @@
+require 'active_support/core_ext/hash/deep_merge'
+require 'active_support/core_ext/hash/except'
+require 'active_support/core_ext/hash/slice'
 begin
-  require 'active_support/core_ext/hash/deep_merge'
-  require 'active_support/core_ext/hash/except'
-  require 'active_support/core_ext/hash/slice'
   require 'i18n'
-  require 'active_support/lazy_load_hooks'
 rescue LoadError => e
   $stderr.puts "The i18n gem is not available. Please add it to your Gemfile and run bundle install"
   raise e
 end
+require 'active_support/lazy_load_hooks'
 
 ActiveSupport.run_load_hooks(:i18n)
 I18n.load_path << "#{File.dirname(__FILE__)}/locale/en.yml"


### PR DESCRIPTION
The begin rescue block is specifically to catch LoadError while loading
i18n gem. Other core extensions, under active support, should be
required outside of the begin rescue block.
