### PR TITLE
 #10428: Added tests for config.assets.precompile

### DIFF
--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -165,6 +165,29 @@ module ApplicationTests
       assert_file_exists("#{app_path}/public/assets/something-*.js")
     end
 
+    test 'precompile use assets defined in app env config' do
+      add_to_env_config 'production', 'config.assets.precompile = [ "something.js" ]'
+
+      app_file 'app/assets/javascripts/something.js.erb', 'alert();'
+
+      precompile! 'RAILS_ENV=production'
+
+      assert_file_exists("#{app_path}/public/assets/something-*.js")
+    end
+
+    test 'precompile use assets defined in app config and reassigned in app env config' do
+      add_to_config 'config.assets.precompile = [ "something.js" ]'
+      add_to_env_config 'production', 'config.assets.precompile += [ "another.js" ]'
+
+      app_file 'app/assets/javascripts/something.js.erb', 'alert();'
+      app_file 'app/assets/javascripts/another.js.erb', 'alert();'
+
+      precompile! 'RAILS_ENV=production'
+
+      assert_file_exists("#{app_path}/public/assets/something-*.js")
+      assert_file_exists("#{app_path}/public/assets/another-*.js")
+    end
+
     test "asset pipeline should use a Sprockets::Index when config.assets.digest is true" do
       add_to_config "config.assets.digest = true"
       add_to_config "config.action_controller.perform_caching = false"


### PR DESCRIPTION
Tests for bug in sprocket-rails:
  do not use value of configuration options
  which changed after environment loaded

This PR connected with https://github.com/rails/sprockets-rails/pull/50 which will resolve #10428 issue
