### PR TITLE
Improve performance of ActiveRecord::Relation#blank?

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -21,6 +21,7 @@ module ActiveRecord
     alias :model :klass
     alias :loaded? :loaded
     alias :default_scoped? :default_scoped
+    alias :blank? :empty?
 
     def initialize(klass, table, values = {})
       @klass             = klass
@@ -573,11 +574,6 @@ module ActiveRecord
       else
         self
       end
-    end
-
-    # Returns true if relation is blank.
-    def blank?
-      to_a.blank?
     end
 
     def values


### PR DESCRIPTION
This is an SQL improvement to ActiveRecord::Relation#blank?. Currently,
it calls `to_a` on the Relation, which loads all records in the
association, and calls `blank?` on the loaded Array. There are other
ways, however, to check the emptiness of an association that are far
more performant. `#empty?`, `#exists?` and `#any?` all attach a `LIMIT
1` to the SQL query before firing it off, which is a nice query
improvement. `#blank?` should do the same! This is easily done by
making `#blank?` an alias of `#empty?`.

Bonus performance improvements will also happen for `#present?`, which
merely calls the negation of `#blank?`

Signed-off-by: David Celis me@davidcel.is
