### PR TITLE
Remove unnecessary require from active_support/inflector/methods.rb

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 
-require 'active_support/inflector/inflections'
 require 'active_support/inflections'
 
 module ActiveSupport


### PR DESCRIPTION
`active_support/inflections` already requires
`active_support/inflector/inflections`. There's no need to require it in
`active_support/inflector/methods`.
