### PR TITLE
Extended ActiveSupport::Concern instead of regular plain hooks in Rails::Generators::Migration module

### DIFF
--- a/activemodel/test/cases/serializers/xml_serialization_test.rb
+++ b/activemodel/test/cases/serializers/xml_serialization_test.rb
@@ -130,7 +130,7 @@ class XmlSerializationTest < ActiveModel::TestCase
   end
 
   test "should serialize nil" do
-    assert_match %r{<pseudonyms nil=\"true\"/>}, @contact.to_xml(methods: :pseudonyms)
+    assert_match %r{<pseudonyms nil="true"/>}, @contact.to_xml(methods: :pseudonyms)
   end
 
   test "should serialize integer" do
@@ -138,23 +138,23 @@ class XmlSerializationTest < ActiveModel::TestCase
   end
 
   test "should serialize datetime" do
-    assert_match %r{<created-at type=\"dateTime\">2006-08-01T00:00:00Z</created-at>}, @contact.to_xml
+    assert_match %r{<created-at type="dateTime">2006-08-01T00:00:00Z</created-at>}, @contact.to_xml
   end
 
   test "should serialize boolean" do
-    assert_match %r{<awesome type=\"boolean\">false</awesome>}, @contact.to_xml
+    assert_match %r{<awesome type="boolean">false</awesome>}, @contact.to_xml
   end
 
   test "should serialize array" do
-    assert_match %r{<social type=\"array\">\s*<social>twitter</social>\s*<social>github</social>\s*</social>}, @contact.to_xml(methods: :social)
+    assert_match %r{<social type="array">\s*<social>twitter</social>\s*<social>github</social>\s*</social>}, @contact.to_xml(methods: :social)
   end
 
   test "should serialize hash" do
-    assert_match %r{<network>\s*<git type=\"symbol\">github</git>\s*</network>}, @contact.to_xml(methods: :network)
+    assert_match %r{<network>\s*<git type="symbol">github</git>\s*</network>}, @contact.to_xml(methods: :network)
   end
 
   test "should serialize yaml" do
-    assert_match %r{<preferences type=\"yaml\">--- !ruby/struct:Customer(\s*)\nname: John\n</preferences>}, @contact.to_xml
+    assert_match %r{<preferences type="yaml">--- !ruby/struct:Customer(\s*)\nname: John\n</preferences>}, @contact.to_xml
   end
 
   test "should call proc on object" do

--- a/railties/lib/rails/generators/migration.rb
+++ b/railties/lib/rails/generators/migration.rb
@@ -6,8 +6,8 @@ module Rails
     # [0-9]*_name format and can be used by another frameworks (like Sequel)
     # just by implementing the next migration version method.
     module Migration
-      attr_reader :migration_number, :migration_file_name, :migration_class_name
       extend ActiveSupport::Concern
+      attr_reader :migration_number, :migration_file_name, :migration_class_name
 
       module ClassMethods
         def migration_lookup_at(dirname) #:nodoc:

--- a/railties/lib/rails/generators/migration.rb
+++ b/railties/lib/rails/generators/migration.rb
@@ -1,3 +1,5 @@
+require 'active_support/concern'
+
 module Rails
   module Generators
     # Holds common methods for migrations. It assumes that migrations has the
@@ -5,10 +7,7 @@ module Rails
     # just by implementing the next migration version method.
     module Migration
       attr_reader :migration_number, :migration_file_name, :migration_class_name
-
-      def self.included(base) #:nodoc:
-        base.extend ClassMethods
-      end
+      extend ActiveSupport::Concern
 
       module ClassMethods
         def migration_lookup_at(dirname) #:nodoc:

--- a/railties/test/application/multiple_applications_test.rb
+++ b/railties/test/application/multiple_applications_test.rb
@@ -1,0 +1,148 @@
+require 'isolation/abstract_unit'
+
+module ApplicationTests
+  class MultipleApplicationsTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+
+    def setup
+      build_app(initializers: true)
+      boot_rails
+      require "#{rails_root}/config/environment"
+    end
+
+    def teardown
+      teardown_app
+    end
+
+    def test_cloning_an_application_makes_a_shallow_copy_of_config
+      clone = Rails.application.clone
+
+      assert_equal Rails.application.config, clone.config, "The cloned application should get a copy of the config"
+      assert_equal Rails.application.config.secret_key_base, clone.config.secret_key_base, "The base secret key on the config should be the same"
+    end
+
+    def test_initialization_of_multiple_copies_of_same_application
+      application1 = AppTemplate::Application.new
+      application2 = AppTemplate::Application.new
+
+      assert_not_equal Rails.application.object_id, application1.object_id, "New applications should not be the same as the original application"
+      assert_not_equal Rails.application.object_id, application2.object_id, "New applications should not be the same as the original application"
+    end
+
+    def test_initialization_of_application_with_previous_config
+      application1 = AppTemplate::Application.new(config: Rails.application.config)
+      application2 = AppTemplate::Application.new
+
+      assert_equal Rails.application.config, application1.config, "Creating a new application while setting an initial config should result in the same config"
+      assert_not_equal Rails.application.config, application2.config, "New applications without setting an initial config should not have the same config"
+    end
+
+    def test_initialization_of_application_with_previous_railties
+      application1 = AppTemplate::Application.new(railties: Rails.application.railties)
+      application2 = AppTemplate::Application.new
+
+      assert_equal Rails.application.railties, application1.railties
+      assert_not_equal Rails.application.railties, application2.railties
+    end
+
+    def test_initialize_new_application_with_all_previous_initialization_variables
+      application1 = AppTemplate::Application.new(
+        config:           Rails.application.config,
+        railties:         Rails.application.railties,
+        routes_reloader:  Rails.application.routes_reloader,
+        reloaders:        Rails.application.reloaders,
+        routes:           Rails.application.routes,
+        helpers:          Rails.application.helpers,
+        app_env_config:   Rails.application.env_config
+      )
+
+      assert_equal Rails.application.config, application1.config
+      assert_equal Rails.application.railties, application1.railties
+      assert_equal Rails.application.routes_reloader, application1.routes_reloader
+      assert_equal Rails.application.reloaders, application1.reloaders
+      assert_equal Rails.application.routes, application1.routes
+      assert_equal Rails.application.helpers, application1.helpers
+      assert_equal Rails.application.env_config, application1.env_config
+    end
+
+    def test_rake_tasks_defined_on_different_applications_go_to_the_same_class
+      $run_count = 0
+
+      application1 = AppTemplate::Application.new
+      application1.rake_tasks do
+        $run_count += 1
+      end
+
+      application2 = AppTemplate::Application.new
+      application2.rake_tasks do
+        $run_count += 1
+      end
+
+      require "#{app_path}/config/environment"
+
+      assert_equal 0, $run_count, "The count should stay at zero without any calls to the rake tasks"
+      require 'rake'
+      require 'rake/testtask'
+      require 'rdoc/task'
+      Rails.application.load_tasks
+      assert_equal 2, $run_count, "Calling a rake task should result in two increments to the count"
+    end
+
+    def test_multiple_applications_can_be_initialized
+      assert_nothing_raised { AppTemplate::Application.new }
+    end
+
+    def test_initializers_run_on_different_applications_go_to_the_same_class
+      application1 = AppTemplate::Application.new
+      $run_count = 0
+
+      AppTemplate::Application.initializer :init0 do
+        $run_count += 1
+      end
+
+      application1.initializer :init1 do
+        $run_count += 1
+      end
+
+      AppTemplate::Application.new.initializer :init2 do
+        $run_count += 1
+      end
+
+      assert_equal 0, $run_count, "Without loading the initializers, the count should be 0"
+
+      # Set config.eager_load to false so that a eager_load warning doesn't pop up
+      AppTemplate::Application.new { config.eager_load = false }.initialize!
+
+      assert_equal 3, $run_count, "There should have been three initializers that incremented the count"
+    end
+
+    def test_runners_run_on_different_applications_go_to_the_same_class
+      $run_count = 0
+      AppTemplate::Application.runner { $run_count += 1 }
+      AppTemplate::Application.new.runner { $run_count += 1 }
+
+      assert_equal 0, $run_count, "Without loading the runners, the count should be 0"
+      Rails.application.load_runner
+      assert_equal 2, $run_count, "There should have been two runners that increment the count"
+    end
+
+    def test_isolate_namespace_on_an_application
+      assert_nil Rails.application.railtie_namespace, "Before isolating namespace, the railtie namespace should be nil"
+      Rails.application.isolate_namespace(AppTemplate)
+      assert_equal Rails.application.railtie_namespace, AppTemplate, "After isolating namespace, we should have a namespace"
+    end
+
+    def test_inserting_configuration_into_application
+      app = AppTemplate::Application.new(config: Rails.application.config)
+      new_config = Rails::Application::Configuration.new("root_of_application")
+      new_config.secret_key_base = "some_secret_key_dude"
+      app.config.secret_key_base = "a_different_secret_key"
+
+      assert_equal "a_different_secret_key", app.config.secret_key_base, "The configuration's secret key should be set."
+      app.config = new_config
+      assert_equal "some_secret_key_dude", app.config.secret_key_base, "The configuration's secret key should have changed."
+      assert_equal "root_of_application", app.config.root, "The root should have changed to the new config's root."
+      assert_equal new_config, app.config, "The application's config should have changed to the new config."
+    end
+  end
+end


### PR DESCRIPTION
In the module Rails::Generator::Migration, we are using the benefit of ActiveSupport::Concern instead of plain old hooks so as to add methods of ClassMethods module in the class...
