### PR TITLE
removed explicit arguments from super call

### DIFF
--- a/actionpack/lib/action_controller/metal/flash.rb
+++ b/actionpack/lib/action_controller/metal/flash.rb
@@ -37,7 +37,7 @@ module ActionController #:nodoc:
           flash.update(other_flashes)
         end
 
-        super(options, response_status_and_flash)
+        super
       end
   end
 end

--- a/actionpack/lib/action_controller/metal/helpers.rb
+++ b/actionpack/lib/action_controller/metal/helpers.rb
@@ -86,7 +86,7 @@ module ActionController
       # * <tt>array</tt> - A normalized list of modules for the list of helpers provided.
       def modules_for_helpers(args)
         args += all_application_helpers if args.delete(:all)
-        super(args)
+        super
       end
 
       def all_helpers_from_path(path)

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -129,7 +129,7 @@ module ActionController
         locals.each { |k,v| t2[k] = v }
 
         begin
-          super(name)
+          super
         rescue => e
           begin
             @_response.stream.write(ActionView::Base.streaming_completion_on_exception) if request.format == :html

--- a/actionpack/lib/action_controller/metal/rack_delegation.rb
+++ b/actionpack/lib/action_controller/metal/rack_delegation.rb
@@ -10,7 +10,7 @@ module ActionController
 
     def dispatch(action, request)
       set_response!(request)
-      super(action, request)
+      super
     end
 
     def response_body=(body)

--- a/actionpack/lib/action_controller/metal/rescue.rb
+++ b/actionpack/lib/action_controller/metal/rescue.rb
@@ -12,7 +12,7 @@ module ActionController #:nodoc:
           handler_for_rescue(orig_exception))
         exception = orig_exception
       end
-      super(exception)
+      super
     end
 
     # Override this method if you want to customize when detailed

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -121,7 +121,7 @@ module ActionController
     #   params.permitted?  # => true
     #   Person.new(params) # => #<Person id: nil, name: "Francesco">
     def initialize(attributes = nil)
-      super(attributes)
+      super
       @permitted = self.class.permit_all_parameters
     end
 

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -691,7 +691,7 @@ module ActionController
           if request.remote_addr == "0.0.0.0"
             raise(e)
           else
-            super(e)
+            super
           end
         end
     end

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -17,7 +17,7 @@ module ActionDispatch
       class Constraints #:nodoc:
         def self.new(app, constraints, request = Rack::Request)
           if constraints.any?
-            super(app, constraints, request)
+            super
           else
             app
           end

--- a/actionpack/lib/action_view/lookup_context.rb
+++ b/actionpack/lib/action_view/lookup_context.rb
@@ -196,7 +196,7 @@ module ActionView
           @html_fallback_for_js = true
         end
       end
-      super(values)
+      super
     end
 
     # Do not use the default locale on template lookup.

--- a/activemodel/test/cases/forbidden_attributes_protection_test.rb
+++ b/activemodel/test/cases/forbidden_attributes_protection_test.rb
@@ -7,7 +7,7 @@ class ProtectedParams < ActiveSupport::HashWithIndifferentAccess
   alias :permitted? :permitted
 
   def initialize(attributes)
-    super(attributes)
+    super
     @permitted = false
   end
 

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -99,7 +99,7 @@ module ActiveRecord
         def build_record(attributes)
           ensure_not_nested
 
-          record = super(attributes)
+          record = super
 
           inverse = source_reflection.inverse_of
           if inverse

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -67,7 +67,7 @@ module ActiveRecord
         end
 
         # Carry on.
-        super(attr, value)
+        super
       end
 
       def update_record(*)

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -99,7 +99,7 @@ module ActiveRecord
         module ClassMethods # :nodoc:
           def initialize_attributes(attributes, options = {})
             serialized = (options.delete(:serialized) { true }) ? :serialized : :unserialized
-            super(attributes, options)
+            super
 
             serialized_attributes.each do |key, coder|
               if attributes.key?(key)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -448,7 +448,7 @@ module ActiveRecord
 
       def add_column(table_name, column_name, type, options = {}) #:nodoc:
         if supports_add_column? && valid_alter_table_options( type, options )
-          super(table_name, column_name, type, options)
+          super
         else
           alter_table(table_name) do |definition|
             definition.column(column_name, type, options)

--- a/activerecord/lib/active_record/serialization.rb
+++ b/activerecord/lib/active_record/serialization.rb
@@ -14,7 +14,7 @@ module ActiveRecord #:nodoc:
       options[:except] = Array(options[:except]).map { |n| n.to_s }
       options[:except] |= Array(self.class.inheritance_column)
 
-      super(options)
+      super
     end
   end
 end

--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -67,7 +67,7 @@ module ActiveRecord
     # some <tt>:on</tt> option will only run in the specified context.
     def valid?(context = nil)
       context ||= (new_record? ? :create : :update)
-      output = super(context)
+      output = super
       errors.empty? && output
     end
 

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -346,7 +346,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     topic = Topic.new
     topic.title = "Stop changing the topic"
     def topic.read_attribute(attr_name)
-      super(attr_name).upcase
+      super.upcase
     end
 
     assert_equal "STOP CHANGING THE TOPIC", topic.send(:read_attribute, "title")

--- a/activerecord/test/cases/forbidden_attributes_protection_test.rb
+++ b/activerecord/test/cases/forbidden_attributes_protection_test.rb
@@ -8,7 +8,7 @@ class ProtectedParams < ActiveSupport::HashWithIndifferentAccess
   alias :permitted? :permitted
 
   def initialize(attributes)
-    super(attributes)
+    super
     @permitted = false
   end
 

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -129,7 +129,7 @@ module LogIntercepter
       @logged << [sql, name, binds]
       yield
     else
-      super(sql, name,binds, &block)
+      super
     end
   end
 end

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -18,7 +18,7 @@ module ActiveSupport
     class MemoryStore < Store
       def initialize(options = nil)
         options ||= {}
-        super(options)
+        super
         @data = {}
         @key_access = {}
         @max_size = options[:size] || 32.megabytes

--- a/activesupport/lib/active_support/cache/null_store.rb
+++ b/activesupport/lib/active_support/cache/null_store.rb
@@ -9,7 +9,7 @@ module ActiveSupport
     # ActiveSupport::Cache::Strategy::LocalCache for more details.
     class NullStore < Store
       def initialize(options = nil)
-        super(options)
+        super
         extend Strategy::LocalCache
       end
 

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -131,7 +131,7 @@ module ActiveSupport #:nodoc:
 
     def concat(value)
       if !html_safe? || value.html_safe?
-        super(value)
+        super
       else
         super(ERB::Util.h(value))
       end
@@ -151,7 +151,7 @@ module ActiveSupport #:nodoc:
         end
       end
 
-      self.class.new(super(args))
+      self.class.new(super)
     end
 
     def html_safe?

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -184,7 +184,7 @@ module ActiveSupport #:nodoc:
       end
 
       def unloadable(const_desc = self)
-        super(const_desc)
+        super
       end
     end
 

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -59,7 +59,7 @@ module ActiveSupport
         super()
         update(constructor)
       else
-        super(constructor)
+        super
       end
     end
 
@@ -123,7 +123,7 @@ module ActiveSupport
     #   hash_1.update(hash_2) { |key, old, new| old + new } # => {"key"=>22}
     def update(other_hash)
       if other_hash.is_a? HashWithIndifferentAccess
-        super(other_hash)
+        super
       else
         other_hash.each_pair do |key, value|
           if block_given? && key?(key)

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -27,7 +27,7 @@ class TestJSONEncoding < ActiveSupport::TestCase
 
     def as_json(options={})
       options[:only] = %w(foo bar)
-      super(options)
+      super
     end
   end
 

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -94,7 +94,7 @@ module Rails
     def call(env)
       env["ORIGINAL_FULLPATH"] = build_original_fullpath(env)
       env["ORIGINAL_SCRIPT_NAME"] = env["SCRIPT_NAME"]
-      super(env)
+      super
     end
 
     # Reload application routes regardless if they changed or not.

--- a/railties/lib/rails/generators/base.rb
+++ b/railties/lib/rails/generators/base.rb
@@ -201,7 +201,7 @@ module Rails
         options[:desc]    = "Indicates when to generate #{name.to_s.humanize.downcase}" unless options.key?(:desc)
         options[:aliases] = default_aliases_for_option(name, options)
         options[:default] = default_value_for_option(name, options)
-        super(name, options)
+        super
       end
 
       # Returns the default source root for a given generator. This is used internally


### PR DESCRIPTION
Ruby will automatically forward the arguments that were passed to the method from
which it's called to the parent method.
