### PR TITLE
Don't try to EXPLAIN select_db calls

### DIFF
--- a/activerecord/lib/active_record/explain_subscriber.rb
+++ b/activerecord/lib/active_record/explain_subscriber.rb
@@ -19,7 +19,7 @@ module ActiveRecord
     # On the other hand, we want to monitor the performance of our real database
     # queries, not the performance of the access to the query cache.
     IGNORED_PAYLOADS = %w(SCHEMA EXPLAIN CACHE)
-    EXPLAINED_SQLS = /\A\s*(select|update|delete|insert)/i
+    EXPLAINED_SQLS = /\A\s*(select|update|delete|insert)\b/i
     def ignore_payload?(payload)
       payload[:exception] || IGNORED_PAYLOADS.include?(payload[:name]) || payload[:sql] !~ EXPLAINED_SQLS
     end

--- a/activerecord/test/cases/explain_subscriber_test.rb
+++ b/activerecord/test/cases/explain_subscriber_test.rb
@@ -43,6 +43,11 @@ if ActiveRecord::Base.connection.supports_explain?
       assert queries.empty?
     end
 
+    def test_collects_nothing_if_the_statement_is_only_partially_matched
+      SUBSCRIBER.finish(nil, nil, name: 'SQL', sql: 'select_db yo_mama')
+      assert queries.empty?
+    end
+
     def teardown
       ActiveRecord::ExplainRegistry.reset
     end


### PR DESCRIPTION
I'm using the mysql2 adapter and my app switches back and forth between a few databases in order to do sharding. I've been getting these errors: `ActiveRecord::StatementInvalid: Mysql2::Error: Table '<dbname>.select_db' doesn't exist: EXPLAIN select_db <dbname>`.

This pull requests fixes the problem caused by an overly fuzzy matching of the SQL commands that can be explained.
