### PR TITLE
Deprecate SchemaStatements#distinct, and make SchemaStatements#columns_for_distinct nodoc.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## unreleased ##
 
+*   Deprecate `ConnectionAdapters::SchemaStatements#distinct`,
+    as it is no longer used by internals.
+
+    *Ben Woosley#
+
 *   Fix pending migrations error when loading schema and `ActiveRecord::Base.table_name_prefix`
     is not blank.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -710,6 +710,7 @@ module ActiveRecord
       #   distinct("posts.id", ["posts.created_at desc"])
       #
       def distinct(columns, order_by)
+        ActiveSupport::Deprecation.warn("#distinct is deprecated and shall be removed from future releases.")
         "DISTINCT #{columns_for_distinct(columns, order_by)}"
       end
 
@@ -718,7 +719,7 @@ module ActiveRecord
       # require the order columns appear in the SELECT.
       #
       #   columns_for_distinct("posts.id", ["posts.created_at desc"])
-      def columns_for_distinct(columns, orders)
+      def columns_for_distinct(columns, orders) # :nodoc:
         columns
       end
 

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -226,8 +226,10 @@ module ActiveRecord
       end
 
       def test_distinct_zero_orders
-        assert_equal "DISTINCT posts.id",
-          @connection.distinct("posts.id", [])
+        assert_deprecated do
+          assert_equal "DISTINCT posts.id",
+            @connection.distinct("posts.id", [])
+        end
       end
 
       def test_columns_for_distinct_zero_orders
@@ -236,8 +238,10 @@ module ActiveRecord
       end
 
       def test_distinct_one_order
-        assert_equal "DISTINCT posts.id, posts.created_at AS alias_0",
-          @connection.distinct("posts.id", ["posts.created_at desc"])
+        assert_deprecated do
+          assert_equal "DISTINCT posts.id, posts.created_at AS alias_0",
+            @connection.distinct("posts.id", ["posts.created_at desc"])
+        end
       end
 
       def test_columns_for_distinct_one_order
@@ -246,8 +250,10 @@ module ActiveRecord
       end
 
       def test_distinct_few_orders
-        assert_equal "DISTINCT posts.id, posts.created_at AS alias_0, posts.position AS alias_1",
-          @connection.distinct("posts.id", ["posts.created_at desc", "posts.position asc"])
+        assert_deprecated do
+          assert_equal "DISTINCT posts.id, posts.created_at AS alias_0, posts.position AS alias_1",
+            @connection.distinct("posts.id", ["posts.created_at desc", "posts.position asc"])
+        end
       end
 
       def test_columns_for_distinct_few_orders
@@ -256,8 +262,10 @@ module ActiveRecord
       end
 
       def test_distinct_blank_not_nil_orders
-        assert_equal "DISTINCT posts.id, posts.created_at AS alias_0",
-          @connection.distinct("posts.id", ["posts.created_at desc", "", "   "])
+        assert_deprecated do
+          assert_equal "DISTINCT posts.id, posts.created_at AS alias_0",
+            @connection.distinct("posts.id", ["posts.created_at desc", "", "   "])
+        end
       end
 
       def test_columns_for_distinct_blank_not_nil_orders
@@ -270,8 +278,10 @@ module ActiveRecord
         def order.to_sql
           "posts.created_at desc"
         end
-        assert_equal "DISTINCT posts.id, posts.created_at AS alias_0",
-          @connection.distinct("posts.id", [order])
+        assert_deprecated do
+          assert_equal "DISTINCT posts.id, posts.created_at AS alias_0",
+            @connection.distinct("posts.id", [order])
+        end
       end
 
       def test_columns_for_distinct_with_arel_order
@@ -284,8 +294,10 @@ module ActiveRecord
       end
 
       def test_distinct_with_nulls
-        assert_equal "DISTINCT posts.title, posts.updater_id AS alias_0", @connection.distinct("posts.title", ["posts.updater_id desc nulls first"])
-        assert_equal "DISTINCT posts.title, posts.updater_id AS alias_0", @connection.distinct("posts.title", ["posts.updater_id desc nulls last"])
+        assert_deprecated do
+          assert_equal "DISTINCT posts.title, posts.updater_id AS alias_0", @connection.distinct("posts.title", ["posts.updater_id desc nulls first"])
+          assert_equal "DISTINCT posts.title, posts.updater_id AS alias_0", @connection.distinct("posts.title", ["posts.updater_id desc nulls last"])
+        end
       end
 
       def test_columns_for_distinct_with_nulls


### PR DESCRIPTION
# distinct was previously used by #construct_limited_ids_condition, but

no more after #6792. #columns_for_distinct is just a utility method for
# construct_limited_ids_condition and shouldn't be public.
