### PR TITLE
Remove jruby-openssl from default Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,11 +60,6 @@ platforms :jruby do
   gem 'json'
   gem 'activerecord-jdbcsqlite3-adapter', '>= 1.2.7'
 
-  # This is needed by now to let tests work on JRuby
-  # TODO: When the JRuby guys merge jruby-openssl in
-  # jruby this will be removed
-  gem 'jruby-openssl'
-
   group :db do
     gem 'activerecord-jdbcmysql-adapter', '>= 1.2.7'
     gem 'activerecord-jdbcpostgresql-adapter', '>= 1.2.7'

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -4,8 +4,6 @@ source 'https://rubygems.org'
 
 <%= database_gemfile_entry -%>
 
-<%= "gem 'jruby-openssl'\n" if defined?(JRUBY_VERSION) -%>
-
 <%= assets_gemfile_entry %>
 <%= javascript_gemfile_entry -%>
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -183,9 +183,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator([destination_root, "-d", "jdbcmysql"])
     assert_file "config/database.yml", /mysql/
     assert_gem "activerecord-jdbcmysql-adapter"
-    # TODO: When the JRuby guys merge jruby-openssl in
-    # jruby this will be removed
-    assert_gem "jruby-openssl" if defined?(JRUBY_VERSION)
   end
 
   def test_config_jdbcsqlite3_database


### PR DESCRIPTION
Since JRuby 1.7.0, `jruby-openssl` is now included in JRuby stdlib. It's unlikely that Rails4 will work on the 1.6.x line, and including it in the Gemfile when running on newer versions of JRuby produces lots of warning messages. 
