### PR TITLE
Rather than raising ThrowResult when construct_limited_ids_conditions comes up empty, set the relation to NullRelation and rely on its results.

### DIFF
--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -69,10 +69,6 @@ module ActiveRecord
     end
   end
 
-  # Raised when SQL statement is invalid and the application gets a blank result.
-  class ThrowResult < ActiveRecordError
-  end
-
   # Defunct wrapper class kept for compatibility.
   # +StatementInvalid+ wraps the original exception now.
   class WrappedDatabaseException < StatementInvalid

--- a/activerecord/lib/active_record/null_relation.rb
+++ b/activerecord/lib/active_record/null_relation.rb
@@ -39,7 +39,7 @@ module ActiveRecord
     end
 
     def to_sql
-      @to_sql ||= ""
+      ""
     end
 
     def where_values_hash

--- a/activerecord/lib/active_record/null_relation.rb
+++ b/activerecord/lib/active_record/null_relation.rb
@@ -55,7 +55,11 @@ module ActiveRecord
     end
 
     def calculate(_operation, _column_name, _options = {})
-      nil
+      if _operation == :count
+        0
+      else
+        nil
+      end
     end
 
     def exists?(_id = false)

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -114,8 +114,6 @@ module ActiveRecord
       else
         relation.calculate(operation, column_name, options)
       end
-    rescue ThrowResult
-      0
     end
 
     # Use <tt>pluck</tt> as a shortcut to select one or more attributes without
@@ -189,8 +187,6 @@ module ActiveRecord
         end
         columns.one? ? result.map!(&:first) : result
       end
-    rescue ThrowResult
-      []
     end
 
     # Pluck all the ID's for the relation using the table's primary key

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -189,6 +189,8 @@ module ActiveRecord
         end
         columns.one? ? result.map!(&:first) : result
       end
+    rescue ThrowResult
+      []
     end
 
     # Pluck all the ID's for the relation using the table's primary key

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -479,6 +479,11 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal [1,2,3,4], Topic.order(:id).pluck(:id)
   end
 
+  def test_pluck_without_column_names
+    assert_equal [[1, "Firm", 1, nil, "37signals", nil, 1, nil, ""]],
+      Company.order(:id).limit(1).pluck
+  end
+
   def test_pluck_type_cast
     topic = topics(:first)
     relation = Topic.where(:id => topic.id)

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -6,6 +6,7 @@ require 'models/edge'
 require 'models/organization'
 require 'models/possession'
 require 'models/topic'
+require 'models/reply'
 require 'models/minivan'
 require 'models/speedometer'
 require 'models/ship_part'
@@ -537,6 +538,11 @@ class CalculationsTest < ActiveRecord::TestCase
 
   def test_plucks_with_ids
     assert_equal Company.all.map(&:id).sort, Company.ids.sort
+  end
+
+  def test_pluck_with_includes_limit_and_empty_result
+    assert_equal [], Topic.includes(:replies).limit(0).pluck(:id)
+    assert_equal [], Topic.includes(:replies).limit(1).where('0 = 1').pluck(:id)
   end
 
   def test_pluck_not_auto_table_name_prefix_if_column_included

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -278,8 +278,9 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_null_relation_calculations_methods
     assert_no_queries do
-      assert_equal 0,     Developer.none.count
-      assert_equal nil,   Developer.none.calculate(:average, 'salary')
+      assert_equal 0, Developer.none.count
+      assert_equal 0, Developer.none.calculate(:count, nil, {})
+      assert_equal nil, Developer.none.calculate(:average, 'salary')
     end
   end
 


### PR DESCRIPTION
This will help avoid errors like 2fcafee, because in most cases NullRelation will do the right thing. Minor bonus is avoiding the use of exceptions for flow control.
