### PR TITLE
read_attribute_before_type_cast should accept symbol

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Method read_attribute_before_type_cast should accept input as symbol.
+
+    *Neeraj Singh*
+
 *   Confirm a record has not already been destroyed before decrementing counter cache.
 
     *Ben Tucker*

--- a/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
+++ b/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
@@ -41,8 +41,9 @@ module ActiveRecord
       #   task.read_attribute_before_type_cast('id')           # => '1'
       #   task.read_attribute('completed_on')                  # => Sun, 21 Oct 2012
       #   task.read_attribute_before_type_cast('completed_on') # => "2012-10-21"
+      #   task.read_attribute_before_type_cast(:completed_on)  # => "2012-10-21"
       def read_attribute_before_type_cast(attr_name)
-        @attributes[attr_name]
+        @attributes[attr_name.to_s]
       end
 
       # Returns a hash of attributes before typecasting and deserialization.

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -130,6 +130,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_equal '10', keyboard.id_before_type_cast
     assert_equal nil, keyboard.read_attribute_before_type_cast('id')
     assert_equal '10', keyboard.read_attribute_before_type_cast('key_number')
+    assert_equal '10', keyboard.read_attribute_before_type_cast(:key_number)
   end
 
   # Syck calls respond_to? before actually calling initialize


### PR DESCRIPTION
Method read_attribute_before_type_cast should accept input as symbol.
