### PR TITLE
Replace multi_json with json

### DIFF
--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -62,7 +62,7 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
         $stderr = StringIO.new # suppress the log
         json = "[\"person]\": {\"name\": \"David\"}}"
         exception = assert_raise(ActionDispatch::ParamsParser::ParseError) { post "/parse", json, {'CONTENT_TYPE' => 'application/json', 'action_dispatch.show_exceptions' => false} }
-        assert_equal MultiJson::DecodeError, exception.original_exception.class
+        assert_equal JSON::ParserError, exception.original_exception.class
         assert_equal exception.original_exception.message, exception.message
       ensure
         $stderr = STDERR

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.rdoc_options.concat ['--encoding',  'UTF-8']
 
   s.add_dependency('i18n',       '~> 0.6', '>= 0.6.4')
-  s.add_dependency 'multi_json', '~> 1.3'
+  s.add_dependency 'json',       '~> 1.7'
   s.add_dependency 'tzinfo',     '~> 0.3.37'
   s.add_dependency 'minitest',   '~> 4.2'
   s.add_dependency 'thread_safe','~> 0.1'

--- a/activesupport/lib/active_support/json/decoding.rb
+++ b/activesupport/lib/active_support/json/decoding.rb
@@ -1,6 +1,6 @@
 require 'active_support/core_ext/module/attribute_accessors'
 require 'active_support/core_ext/module/delegation'
-require 'multi_json'
+require 'json'
 
 module ActiveSupport
   # Look for and parse json strings that look like ISO 8601 times.
@@ -13,30 +13,13 @@ module ActiveSupport
       #
       #   ActiveSupport::JSON.decode("{\"team\":\"rails\",\"players\":\"36\"}")
       #   => {"team" => "rails", "players" => "36"}
-      def decode(json, options ={})
-        data = MultiJson.load(json, options)
+      def decode(json, proc = nil, options = {})
+        data = ::JSON.load(json, proc, options)
         if ActiveSupport.parse_json_times
           convert_dates_from(data)
         else
           data
         end
-      end
-
-      def engine
-        MultiJson.adapter
-      end
-      alias :backend :engine
-
-      def engine=(name)
-        MultiJson.use(name)
-      end
-      alias :backend= :engine=
-
-      def with_backend(name)
-        old_backend, self.backend = backend, name
-        yield
-      ensure
-        self.backend = old_backend
       end
 
       # Returns the class of the error that will be raised when there is an
@@ -50,7 +33,7 @@ module ActiveSupport
       #     Rails.logger.warn("Attempted to decode invalid JSON: #{some_string}")
       #   end
       def parse_error
-        MultiJson::DecodeError
+        ::JSON::ParserError
       end
 
       private

--- a/activesupport/test/json/decoding_test.rb
+++ b/activesupport/test/json/decoding_test.rb
@@ -55,33 +55,23 @@ class TestJSONDecoding < ActiveSupport::TestCase
     %q({"a":"Line1\u000aLine2"}) => {"a"=>"Line1\nLine2"}
   }
 
-  backends = [:ok_json]
-  backends << :json_gem if defined?(::JSON)
-  backends << :yajl if defined?(::Yajl)
-
-  backends.each do |backend|
-    TESTS.each do |json, expected|
-      test "json decodes #{json} with the #{backend} backend" do
-        prev = ActiveSupport.parse_json_times
-        ActiveSupport.parse_json_times = true
-        silence_warnings do
-          ActiveSupport::JSON.with_backend backend do
-            assert_equal expected, ActiveSupport::JSON.decode(json)
-          end
-        end
-        ActiveSupport.parse_json_times = prev
-      end
-    end
-
-    test "json decodes time json with time parsing disabled with the #{backend} backend" do
+  TESTS.each do |json, expected|
+    test "json decodes #{json}" do
       prev = ActiveSupport.parse_json_times
-      ActiveSupport.parse_json_times = false
-      expected = {"a" => "2007-01-01 01:12:34 Z"}
-      ActiveSupport::JSON.with_backend backend do
-        assert_equal expected, ActiveSupport::JSON.decode(%({"a": "2007-01-01 01:12:34 Z"}))
+      ActiveSupport.parse_json_times = true
+      silence_warnings do
+        assert_equal expected, ActiveSupport::JSON.decode(json)
       end
       ActiveSupport.parse_json_times = prev
     end
+  end
+
+  test "json decodes time json with time parsing disabled" do
+    prev = ActiveSupport.parse_json_times
+    ActiveSupport.parse_json_times = false
+    expected = {"a" => "2007-01-01 01:12:34 Z"}
+    assert_equal expected, ActiveSupport::JSON.decode(%({"a": "2007-01-01 01:12:34 Z"}))
+    ActiveSupport.parse_json_times = prev
   end
 
   def test_failed_json_decoding


### PR DESCRIPTION
Since [Rails 4 will require Ruby 1.9](https://github.com/rails/rails/commit/e883c06a4f924cc4ba74efe4dad36394fad26fa0) and since Ruby 1.9 includes `json` in the standard library, `multi_json` is no longer necessary. I am a longtime maintainer of `multi_json` but [will stop supporting the library in June](https://github.com/intridea/multi_json/pull/113#issuecomment-17668823).

This patch replaces `multi_json` with stdlib `json`. It will use the `json` gem if a newer version is available.

I have already submitted similar pull requests to [`execjs`](https://github.com/sstephenson/execjs/pull/126), [`sprockets`](https://github.com/sstephenson/sprockets/pull/440), and [`uglifier`](https://github.com/lautis/uglifier/pull/51), so `multi_json` need not be a dependency of Rails 4 applications. This should have the effect of making JSON parsing and generation somewhat faster by removing an abstraction layer that is no longer necessary.
