### PR TITLE
Support include_root_in_json for ActiveResource properly.

### DIFF
--- a/activeresource/CHANGELOG.md
+++ b/activeresource/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## unreleased ##
 
-*   No changes.
+*   Fixes an issue that ActiveResource models ignores ActiveResource::Base.include_root_in_json.
+    Backported from the now separate repo rails/activeresouce.
 
+    *Xinjiang Lu*
 
 ## Rails 3.2.13 (Mar 18, 2013) ##
 

--- a/activeresource/lib/active_resource/base.rb
+++ b/activeresource/lib/active_resource/base.rb
@@ -1336,7 +1336,7 @@ module ActiveResource
     end
 
     def to_json(options={})
-      super({ :root => self.class.element_name }.merge(options))
+      super(include_root_in_json ? { :root => self.class.element_name }.merge(options) : options)
     end
 
     def to_xml(options={})

--- a/activeresource/test/cases/base_test.rb
+++ b/activeresource/test/cases/base_test.rb
@@ -1020,7 +1020,6 @@ class BaseTest < Test::Unit::TestCase
   end
 
   def test_to_json
-    Person.include_root_in_json = true
     joe = Person.find(6)
     encode = joe.encode
     json = joe.to_json
@@ -1030,6 +1029,21 @@ class BaseTest < Test::Unit::TestCase
     assert_match %r{"id":6}, json
     assert_match %r{"name":"Joe"}, json
     assert_match %r{\}\}$}, json
+  end
+
+  def test_to_json_without_root
+    ActiveResource::Base.include_root_in_json = false
+    joe = Person.find(6)
+    encode = joe.encode
+    json = joe.to_json
+
+    assert_equal encode, json
+    assert_no_match %r{^\{"person":\}}, json
+    assert_match %r{"id":6}, json
+    assert_match %r{"name":"Joe"}, json
+    assert_match %r{\}$}, json
+  ensure
+    ActiveResource::Base.include_root_in_json = true
   end
 
   def test_to_json_with_element_name


### PR DESCRIPTION
This commit is a backport from
https://github.com/rails/activeresource/pull/29. The ActiveResource's include_root_in_json option works in 3.1.x, but is broken for 3.2.x.
