### PR TITLE
Code cleanup for ActionDispatch::Flash#call

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/flash.rb
+++ b/actionpack/lib/action_dispatch/middleware/flash.rb
@@ -243,15 +243,9 @@ module ActionDispatch
       session    = Request::Session.find(env) || {}
       flash_hash = env[KEY]
 
-      if flash_hash
-        if !flash_hash.empty? || session.key?('flash')
-          session["flash"] = flash_hash.to_session_value
-          new_hash = flash_hash.dup
-        else
-          new_hash = flash_hash
-        end
-
-        env[KEY] = new_hash
+      if flash_hash.present? || session.key?('flash')
+        session["flash"] = flash_hash.to_session_value
+        env[KEY] = flash_hash.dup
       end
 
       if (!session.respond_to?(:loaded?) || session.loaded?) && # (reset_session uses {}, which doesn't implement #loaded?)


### PR DESCRIPTION
The nested `if` was replaced by using `presence` which takes account for
the given hash when it is `nil` or when it is empty. The `else` was
removed because what it was doing was to assign to `env[KEY]` the
value it already had.
