### PR TITLE
better error message when app name is not passed in `rails new`

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -151,7 +151,15 @@ module Rails
                              desc: "Show Rails version number and quit"
 
       def initialize(*args)
-        raise Error, "Options should be given after the application name. For details run: rails --help" if args[0].blank?
+        if args[0].blank?
+          if args[1].blank?
+            # rails new
+            raise Error, "Application name should be provided in arguments. For details run: rails --help"
+          else
+            # rails new --skip-bundle my_new_application
+            raise Error, "Options should be given after the application name. For details run: rails --help"
+          end
+        end
 
         super
 


### PR DESCRIPTION
Prior to this change, for the following command:

```
$ rails new
```

we received "Options should be given after the application name" as an error message.

This is outdated and should be "Application name should be provided in arguments".
