### PR TITLE
Fixes NoMethodError: `alias_method_chain` when requiring just active_support/core_ext

### DIFF
--- a/activesupport/lib/active_support/core_ext/marshal.rb
+++ b/activesupport/lib/active_support/core_ext/marshal.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/module/aliasing'
+
 module Marshal
   class << self
     def load_with_autoloading(source)

--- a/activesupport/lib/active_support/core_ext/range/include_range.rb
+++ b/activesupport/lib/active_support/core_ext/range/include_range.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/module/aliasing'
+
 class Range
   # Extends the default Range#include? to support range comparisons.
   #  (1..5).include?(1..5) # => true


### PR DESCRIPTION
This is also present in 4.0.0.rc1. It should be cherry-pickable to
`4-0-stable`.

```
2.0.0-p0 :001 > require 'active_support/core_ext'
NoMethodError: undefined method `alias_method_chain' for Range:Class
  from /home/alindeman/workspace/rails/activesupport/lib/active_support/core_ext/range/include_range.rb:20:in `<class:Range>'
  from /home/alindeman/workspace/rails/activesupport/lib/active_support/core_ext/range/include_range.rb:1:in `<top (required)>'
  from /home/alindeman/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
  from /home/alindeman/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
  from /home/alindeman/workspace/rails/activesupport/lib/active_support/core_ext/range.rb:2:in `<top (required)>'
  from /home/alindeman/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
  from /home/alindeman/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
  from /home/alindeman/workspace/rails/activesupport/lib/active_support/core_ext.rb:3:in `block in <top (required)>'
  from /home/alindeman/workspace/rails/activesupport/lib/active_support/core_ext.rb:1:in `each'
  from /home/alindeman/workspace/rails/activesupport/lib/active_support/core_ext.rb:1:in `<top (required)>'
  from /home/alindeman/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
  from /home/alindeman/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
  from (irb):1
  from /home/alindeman/.rvm/rubies/ruby-2.0.0-p0/bin/irb:16:in `<main>'
```
