### PR TITLE
Make AR::Base#changed_attributes to return indifferent hash

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -139,7 +139,7 @@ module ActiveModel
     #   person.name = 'robert'
     #   person.changed_attributes # => {"name" => "bob"}
     def changed_attributes
-      @changed_attributes ||= {}
+      @changed_attributes ||= HashWithIndifferentAccess.new
     end
 
     private

--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -125,4 +125,10 @@ class DirtyTest < ActiveModel::TestCase
     assert_equal ["Otto", "Mr. Manfredgensonton"], @model.name_change
     assert_equal @model.name_was, "Otto"
   end
+
+  test "changed_attributes" do
+    @model.name = "Otto"
+    assert_equal nil, @model.changed_attributes["name"]
+    assert_equal nil, @model.changed_attributes[:name]
+  end
 end


### PR DESCRIPTION
`changed_attributes` hash with symbols as keys has better semantics.
