### PR TITLE
Add more data to AR::UnknownAttributeError

### DIFF
--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -44,7 +44,7 @@ module ActiveRecord
       if respond_to?("#{k}=")
         raise
       else
-        raise UnknownAttributeError, "unknown attribute: #{k}"
+        raise UnknownAttributeError.new(self, k)
       end
     end
 

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -159,6 +159,15 @@ module ActiveRecord
 
   # Raised when unknown attributes are supplied via mass assignment.
   class UnknownAttributeError < NoMethodError
+
+    attr_reader :record, :attribute
+
+    def initialize(record, attribute)
+      @record = record
+      @attribute = attribute.to_s
+      super("unknown attribute: #{attribute}")
+    end
+
   end
 
   # Raised when an error occurred while doing a mass assignment to an attribute through the

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -711,6 +711,18 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::UnknownAttributeError) { @target.new.attributes = { :title => "Ants in pants" } }
   end
 
+  def test_bulk_update_raise_unknown_attribute_errro
+    error = nil
+    begin
+      @target.new(:hello => "world")
+    rescue ActiveRecord::UnknownAttributeError => error
+    end
+    assert error
+    assert @target, error.record
+    assert "hello", error.attribute
+    assert "unknown attribute: hello", error.message
+  end
+
   def test_read_attribute_overwrites_private_method_not_considered_implemented
     # simulate a model with a db column that shares its name an inherited
     # private method (e.g. Object#system)


### PR DESCRIPTION
This is required in order to be able to rescue such error on app level.

``` ruby
begin
  Topic.new("hello" => "world")
rescue ActiveRecord::UnknownAttributeError => e
  e.record # => #<Topic ... >
  e.attribute # => :hello
end
```
