### PR TITLE
exit with non-zero to signal failure

### DIFF
--- a/railties/lib/rails/commands/console.rb
+++ b/railties/lib/rails/commands/console.rb
@@ -94,8 +94,8 @@ module Rails
       require 'debugger'
       puts "=> Debugger enabled"
     rescue LoadError
-      puts "You're missing the 'debugger' gem. Add it to your Gemfile, bundle, and try again."
-      exit
+      puts "You're missing the 'debugger' gem. Add it to your Gemfile, bundle it and try again."
+      exit(1)
     end
   end
 end

--- a/railties/lib/rails/rack/debugger.rb
+++ b/railties/lib/rails/rack/debugger.rb
@@ -12,8 +12,8 @@ module Rails
         ::Debugger.settings[:autoeval] = true if ::Debugger.respond_to?(:settings)
         puts "=> Debugger enabled"
       rescue LoadError
-        puts "You're missing the 'debugger' gem. Add it to your Gemfile, bundle, and try again."
-        exit
+        puts "You're missing the 'debugger' gem. Add it to your Gemfile, bundle it and try again."
+        exit(1)
       end
 
       def call(env)


### PR DESCRIPTION
When failure happens due to debugger being missing from _Gemfile_, we should exit with non-zero status to signal failure.

I've also fixed some grammar.
