### PR TITLE
Don't touch test db when `Rails.env == development`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -9,6 +9,8 @@
     added, and each use of the former has been transformed into a use of the
     latter as appropriate.
 
+    *Jeremy Audet*
+
 *   Deprecate `ConnectionAdapters::SchemaStatements#distinct`,
     as it is no longer used by internals.
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -9,6 +9,8 @@
     added, and each use of the former has been transformed into a use of the
     latter as appropriate.
 
+    Also see #2419 and #711
+
     *Jeremy Audet*
 
 *   Deprecate `ConnectionAdapters::SchemaStatements#distinct`,

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Dont touch test db when Rails.env == development
+
+    Executing `rake db:create`, `rake db:drop`, and derived tasks such as `rake
+    db:reset` no longer touches the test database when `'development' ==
+    Rails.env`.
+
+    `ActiveRecord::Tasks::DatabaseTasks#each_current_configuration` has been
+    deleted, `ActiveRecord::Tasks::DatabaseTasks#current_configuration` has been
+    added, and each use of the former has been transformed into a use of the
+    latter as appropriate.
+
 *   Deprecate `ConnectionAdapters::SchemaStatements#distinct`,
     as it is no longer used by internals.
 

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -182,13 +182,7 @@ module ActiveRecord
       end
 
       def each_current_configuration(environment)
-        environments = [environment]
-        environments << 'test' if environment == 'development'
-
-        configurations = ActiveRecord::Base.configurations.values_at(*environments)
-        configurations.compact.each do |configuration|
-          yield configuration unless configuration['database'].blank?
-        end
+        yield ActiveRecord::Base.configurations.values_at(environment).first
       end
 
       def each_local_configuration

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -82,9 +82,7 @@ module ActiveRecord
       end
 
       def create_current(environment = env)
-        each_current_configuration(environment) { |configuration|
-          create configuration
-        }
+        create current_configuration(environment)
         ActiveRecord::Base.establish_connection environment
       end
 
@@ -105,9 +103,7 @@ module ActiveRecord
       end
 
       def drop_current(environment = env)
-        each_current_configuration(environment) { |configuration|
-          drop configuration
-        }
+        drop current_configuration(environment)
       end
 
       def drop_database_url
@@ -181,8 +177,16 @@ module ActiveRecord
         @tasks[key]
       end
 
-      def each_current_configuration(environment)
-        yield ActiveRecord::Base.configurations.values_at(environment).first
+      # Reads +Rails.env+ and returns the matching configuration from
+      # +database.yml+ as a dictionary.
+      #
+      # For example, this method might return:
+      #
+      #     {"adapter"=>"sqlite3", "database"=>"db/development.sqlite3" ...}
+      #
+      def current_configuration(environment)
+        # e.g. [{"adapter"=>"sqlite3", "database"=>"db/development.sqlite3" ...}].first
+        ActiveRecord::Base.configurations.values_at(environment).first
       end
 
       def each_local_configuration

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -131,8 +131,6 @@ module ActiveRecord
     def test_creates_test_database_when_environment_is_database
       ActiveRecord::Tasks::DatabaseTasks.expects(:create).
         with('database' => 'dev-db')
-      ActiveRecord::Tasks::DatabaseTasks.expects(:create).
-        with('database' => 'test-db')
 
       ActiveRecord::Tasks::DatabaseTasks.create_current(
         ActiveSupport::StringInquirer.new('development')
@@ -241,8 +239,6 @@ module ActiveRecord
     def test_creates_test_database_when_environment_is_database
       ActiveRecord::Tasks::DatabaseTasks.expects(:drop).
         with('database' => 'dev-db')
-      ActiveRecord::Tasks::DatabaseTasks.expects(:drop).
-        with('database' => 'test-db')
 
       ActiveRecord::Tasks::DatabaseTasks.drop_current(
         ActiveSupport::StringInquirer.new('development')


### PR DESCRIPTION
Don't touch test db when `Rails.env == development`.

Currently, `rake db:create`, `rake db:drop`, and derived tasks (such as `rake db:reset`) create and drop both the development and test databases when `'development' == Rails.env`. Such behaviour vioates the Principle of Least Surprise. It's extremely confusing to execute this:

```
$ bundle exec rake db:reset
```

or this:

```
$ RAILS_ENV=development bundle exec rake db:reset
```

...and discover that your test database is being recreated. This behaviour can be functionally problematic. For example, assume a Rails project had the following in their `database.yml` config:

```
development:
  adapter: sqlite3
  database: db/development.sqlite3
  pool: 5
  timeout: 5000

test:
  adapter: postgresql
  encoding: unicode
  database: myapp_test
  pool: 5
  username: username
  password: hackme
```

If a developer does not have postgresql installed and configured, Rake tasks which attempt to recreate the development database will fail because of the test database. That's silly.

This commit fixes this behaviour. I've tested the changes with sqlite, mysql, and postgresql. sqlite and mysql pass with flying colors.

postgresql failed unit testing, but I think it failed because of unrelated reasons. If someone else could verify, that would be great. An example of the messages I'm receiving:

```
/home/ichimonji10/code/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:582: warning: instance variable @socket_io not initialized
...
10) Error:
PostgresqlUUIDTest#test_schema_dumper_for_uuid_primary_key:
ActiveRecord::StatementInvalid: PG::Error: ERROR:  current transaction is aborted, commands ignored until end of transaction block
: drop table if exists pg_uuids  
    /home/ichimonji10/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:128:in `exec'
    /home/ichimonji10/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:128:in `block in execute'
    /home/ichimonji10/code/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:425:in `block in log'
    /home/ichimonji10/code/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
    /home/ichimonji10/code/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:420:in `log'
    /home/ichimonji10/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:127:in `execute'
    /home/ichimonji10/code/rails/activerecord/test/cases/adapters/postgresql/uuid_test.rb:35:in `teardown'
```
