### PR TITLE
Fixing PostgreSQL migrations for array support

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Replace `ConnectionAdapters::PostgreSQLAdapter::TableDefinition#column` with `ConnectionAdapters::PostgreSQLAdapter::TableDefinition#new_column_definition`,
+    so all PostgreSQL migrations can take advantage of arrays.
+
+    *Tommy Fisher*
+
 *   Deprecate `ConnectionAdapters::SchemaStatements#distinct`,
     as it is no longer used by internals.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -365,12 +365,10 @@ module ActiveRecord
           column name, type, options
         end
 
-        def column(name, type = nil, options = {})
-          super
-          column = self[name]
+        def new_column_definition(name, type, options) # :nodoc:
+          column = super
           column.array = options[:array]
-
-          self
+          column
         end
 
         def xml(options = {})


### PR DESCRIPTION
Since the `column` method is not used by the abstract `SchemaStatements::AlterTable`, the following migration will not work properly in PostgreSQL:

```
class AddRolesToUsers < ActiveRecord::Migration
  def change
    change_table :users do |t|
      t.column :roles, :string, array: true
    end
  end
end
```

This change fixes this issue.
