### PR TITLE
Backport a super-simplified version of #6792, fixing that #exists? can produce invalid SQL: "SELECT DISTINCT DISTINCT"

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## unreleased ##
 
+*   Fix that under some conditions, Active Record could produce invalid SQL of the sort:
+    "SELECT DISTINCT DISTINCT".
+
+    Backport of #6792.
+
+    *Ben Woosley*
+
 *   Require `ActiveRecord::Base` in railtie hooks for rake_tasks, console and runner to
     avoid circular constant loading issues.
 

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -254,6 +254,7 @@ module ActiveRecord
       values = @klass.connection.distinct("#{@klass.connection.quote_table_name table_name}.#{primary_key}", orders)
 
       relation = relation.dup.select(values)
+      relation.uniq_value = nil
 
       id_rows = @klass.connection.select_all(relation.arel, 'SQL', relation.bind_values)
       ids_array = id_rows.map {|row| row[primary_key]}

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -93,6 +93,18 @@ class FinderTest < ActiveRecord::TestCase
     assert !Topic.includes(:replies).limit(1).where('0 = 1').exists?
   end
 
+  def test_exists_with_distinct_association_includes_and_limit
+    author = Author.first
+    assert !author.unique_categorized_posts.includes(:special_comments).limit(0).exists?
+    assert author.unique_categorized_posts.includes(:special_comments).limit(1).exists?
+  end
+
+  def test_exists_with_distinct_association_includes_limit_and_order
+    author = Author.first
+    assert !author.unique_categorized_posts.includes(:special_comments).order('comments.taggings_count DESC').limit(0).exists?
+    assert author.unique_categorized_posts.includes(:special_comments).order('comments.taggings_count DESC').limit(1).exists?
+  end
+
   def test_exists_with_empty_table_and_no_args_given
     Topic.delete_all
     assert !Topic.exists?


### PR DESCRIPTION
To recap, the combination of a :uniq => true association and the #distinct call
in #construct_limited_ids_condition combine to create invalid SQL, because
we're explicitly selecting DISTINCT, and also sending #distinct on to AREL,
via the relation#distinct_value.

Where #6792 was the forever fix, this is the minimal fix. Instead of
properly indicating the distinctness of the query through #uniq_value alone,
we use the literal DISTINCT select statement produced by #distinct and
set #uniq_value to always be falsey

Happy to backport the full #6792 change, but have the sense this is a simpler
intervention for the 3.2 line.
