### PR TITLE
Backport columns_for_distinct in postgres adapter from #6792

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -505,11 +505,20 @@ module ActiveRecord
       end
 
       # SELECT DISTINCT clause for a given set of columns and a given ORDER BY clause.
-      # Both PostgreSQL and Oracle overrides this for custom DISTINCT syntax.
       #
-      #   distinct("posts.id", "posts.created_at desc")
+      #   distinct("posts.id", ["posts.created_at desc"])
+      #
       def distinct(columns, order_by)
-        "DISTINCT #{columns}"
+        "DISTINCT #{columns_for_distinct(columns, order_by)}"
+      end
+
+      # Given a set of columns and an ORDER BY clause, returns the columns for a SELECT DISTINCT.
+      # Both PostgreSQL and Oracle overrides this for custom DISTINCT syntax - they
+      # require the order columns appear in the SELECT.
+      #
+      #   columns_for_distinct("posts.id", ["posts.created_at desc"])
+      def columns_for_distinct(columns, orders)
+        columns
       end
 
       # Adds timestamps (created_at and updated_at) columns to the named table.

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -183,15 +183,78 @@ module ActiveRecord
         assert_equal Arel.sql('$2'), bind
       end
 
+      def test_raise_error_when_cannot_translate_exception
+        assert_raise TypeError do
+          @connection.send(:log, nil) { @connection.execute(nil) }
+        end
+      end
+
+      def test_distinct_zero_orders
+        assert_equal "DISTINCT posts.id",
+          @connection.distinct("posts.id", [])
+      end
+
+      def test_columns_for_distinct_zero_orders
+        assert_equal "posts.id",
+          @connection.columns_for_distinct("posts.id", [])
+      end
+
+      def test_distinct_one_order
+        assert_equal "DISTINCT posts.id, posts.created_at AS alias_0",
+          @connection.distinct("posts.id", ["posts.created_at desc"])
+      end
+
+      def test_columns_for_distinct_one_order
+        assert_equal "posts.id, posts.created_at AS alias_0",
+          @connection.columns_for_distinct("posts.id", ["posts.created_at desc"])
+      end
+
+      def test_distinct_few_orders
+        assert_equal "DISTINCT posts.id, posts.created_at AS alias_0, posts.position AS alias_1",
+          @connection.distinct("posts.id", ["posts.created_at desc", "posts.position asc"])
+      end
+
+      def test_columns_for_distinct_few_orders
+        assert_equal "posts.id, posts.created_at AS alias_0, posts.position AS alias_1",
+          @connection.columns_for_distinct("posts.id", ["posts.created_at desc", "posts.position asc"])
+      end
+
+      def test_distinct_blank_not_nil_orders
+        assert_equal "DISTINCT posts.id, posts.created_at AS alias_0",
+          @connection.distinct("posts.id", ["posts.created_at desc", "", "   "])
+      end
+
+      def test_columns_for_distinct_blank_not_nil_orders
+        assert_equal "posts.id, posts.created_at AS alias_0",
+          @connection.columns_for_distinct("posts.id", ["posts.created_at desc", "", "   "])
+      end
+
+      def test_distinct_with_arel_order
+        order = Object.new
+        def order.to_sql
+          "posts.created_at desc"
+        end
+        assert_equal "DISTINCT posts.id, posts.created_at AS alias_0",
+          @connection.distinct("posts.id", [order])
+      end
+
+      def test_columns_for_distinct_with_arel_order
+        order = Object.new
+        def order.to_sql
+          "posts.created_at desc"
+        end
+        assert_equal "posts.id, posts.created_at AS alias_0",
+          @connection.columns_for_distinct("posts.id", [order])
+      end
+
       def test_distinct_with_nulls
         assert_equal "DISTINCT posts.title, posts.updater_id AS alias_0", @connection.distinct("posts.title", ["posts.updater_id desc nulls first"])
         assert_equal "DISTINCT posts.title, posts.updater_id AS alias_0", @connection.distinct("posts.title", ["posts.updater_id desc nulls last"])
       end
 
-      def test_raise_error_when_cannot_translate_exception
-        assert_raise TypeError do
-          @connection.send(:log, nil) { @connection.execute(nil) }
-        end
+      def test_columns_for_distinct_with_nulls
+        assert_equal "posts.title, posts.updater_id AS alias_0", @connection.columns_for_distinct("posts.title", ["posts.updater_id desc nulls first"])
+        assert_equal "posts.title, posts.updater_id AS alias_0", @connection.columns_for_distinct("posts.title", ["posts.updater_id desc nulls last"])
       end
 
       private


### PR DESCRIPTION
I've skipped the finder stuff because there was no relation#distinct, maybe I'm missing something
