### PR TITLE
Support array as root element in Postgresql JSON columns

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -60,7 +60,7 @@ module ActiveRecord
         end
 
         def json_to_string(object)
-          if Hash === object
+          if Hash === object || Array === object
             ActiveSupport::JSON.encode(object)
           else
             object

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -30,6 +30,7 @@ module ActiveRecord
           when Array
             case sql_type
             when 'point' then super(PostgreSQLColumn.point_to_string(value))
+            when 'json' then super(PostgreSQLColumn.json_to_string(value))
             else
               if column.array
                 "'#{PostgreSQLColumn.array_to_string(value, column, self).gsub(/'/, "''")}'"
@@ -98,6 +99,7 @@ module ActiveRecord
           when Array
             case column.sql_type
             when 'point' then PostgreSQLColumn.point_to_string(value)
+            when 'json' then PostgreSQLColumn.json_to_string(value)
             else
               return super(value, column) unless column.array
               PostgreSQLColumn.array_to_string(value, column, self)

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -83,4 +83,18 @@ class PostgresqlJSONTest < ActiveRecord::TestCase
     x = JsonDataType.first
     assert_equal(nil, x.payload)
   end
+
+  def test_select_array_json_value
+    @connection.execute %q|insert into json_data_type (payload) VALUES ('["v0",{"k1":"v1"}]')|
+    x = JsonDataType.first
+    assert_equal(['v0', {'k1' => 'v1'}], x.payload)
+  end
+
+  def test_rewrite_array_json_value
+    @connection.execute %q|insert into json_data_type (payload) VALUES ('["v0",{"k1":"v1"}]')|
+    x = JsonDataType.first
+    x.payload = ['v1', {'k2' => 'v2'}, 'v3']
+    assert x.save!
+  end
+
 end


### PR DESCRIPTION
For now json column support in Postgresql adapter is limited to writing structures which have a hash on the top.

So, for example, you can save <tt>{"a": [1,2,3]}</tt>, but not <tt>[{"a": 1}, {"a: 2}]</tt>. However, you can load both.

This patch adds support for saving json structures which have array element as root.

Also, if think, it may make sense to allow saving primitive values to json column (for now only numbers work), but it's blocked by strings, which for now are assigned as raw json values (and so changing it may break some existing code).
