### PR TITLE
include README in relevant top-level module for RDoc

### DIFF
--- a/actionmailer/lib/action_mailer.rb
+++ b/actionmailer/lib/action_mailer.rb
@@ -32,6 +32,7 @@ require 'active_support/core_ext/module/attr_internal'
 require 'active_support/core_ext/string/inflections'
 require 'active_support/lazy_load_hooks'
 
+# :include: ../README.rdoc
 module ActionMailer
   extend ::ActiveSupport::Autoload
 

--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -25,6 +25,7 @@ require 'active_support'
 require 'active_support/rails'
 require 'active_model/version'
 
+# :include: ../README.rdoc
 module ActiveModel
   extend ActiveSupport::Autoload
 

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -29,6 +29,7 @@ require 'active_record/deprecated_finders'
 
 require 'active_record/version'
 
+# :include: ../README.rdoc
 module ActiveRecord
   extend ActiveSupport::Autoload
 

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -27,6 +27,7 @@ require "active_support/version"
 require "active_support/logger"
 require "active_support/lazy_load_hooks"
 
+# :include: ../README.rdoc
 module ActiveSupport
   extend ActiveSupport::Autoload
 

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -19,6 +19,7 @@ silence_warnings do
   Encoding.default_internal = Encoding::UTF_8
 end
 
+# :include: ../RDOC_MAIN.rdoc
 module Rails
   autoload :Info, 'rails/info'
   autoload :InfoController,    'rails/info_controller'


### PR DESCRIPTION
The purpose for this is to allow users who've installed the RI documentation for rails to view the associated README contents for all available top-level modules. This should work with rdoc 3.9, as well as future releases of rdoc.
