### PR TITLE
Removed incorrect warning from application.js templates and replaced it with stub command description

### DIFF
--- a/guides/code/getting_started/app/assets/javascripts/application.js
+++ b/guides/code/getting_started/app/assets/javascripts/application.js
@@ -7,8 +7,7 @@
 // It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
 // compiled file.
 //
-// WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
-// GO AFTER THE REQUIRES BELOW.
+// stub path allows dependency to be excluded from the asset bundle.
 //
 //= require jquery
 //= require jquery_ujs

--- a/railties/lib/rails/generators/rails/app/templates/app/assets/javascripts/application.js.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/assets/javascripts/application.js.tt
@@ -7,8 +7,7 @@
 // It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
 // compiled file.
 //
-// WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
-// GO AFTER THE REQUIRES BELOW.
+// stub path allows dependency to be excluded from the asset bundle.
 //
 <% unless options[:skip_javascript] -%>
 //= require <%= options[:javascript] %>

--- a/railties/lib/rails/generators/rails/plugin_new/templates/rails/javascripts.js
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/rails/javascripts.js
@@ -7,7 +7,6 @@
 // It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
 // compiled file.
 //
-// WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
-// GO AFTER THE REQUIRES BELOW.
+// stub path allows dependency to be excluded from the asset bundle.
 //
 //= require_tree .


### PR DESCRIPTION
Full discussion here: https://github.com/rails/sprockets-rails/issues/56

Blank line warning in application.js is wrong. Here what is says:

```
// WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
// GO AFTER THE REQUIRES BELOW.
```

In fact this is not true, the following compiles just fine:

```
 //= require jquery
 //= require jquery_ujs
 //= require_tree .

 //= require turbolinks
```

In fact `stub` directive should be used: https://github.com/sstephenson/sprockets#the-stub-directive
