### PR TITLE
change to destructive `deep_symbolize_keys` 

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -224,7 +224,7 @@ module ActiveSupport
     undef :symbolize_keys!
     undef :deep_symbolize_keys!
     def symbolize_keys; to_hash.symbolize_keys! end
-    def deep_symbolize_keys; to_hash.deep_symbolize_keys end
+    def deep_symbolize_keys; to_hash.deep_symbolize_keys! end
     def to_options!; self end
 
     # Convert to a regular hash with string keys.


### PR DESCRIPTION
change to destructive `deep_symbolize_keys` after https://github.com/rails/rails/commit/df24b8790f22384a068fece7042f04ffd2fcb33e which allows to do so. 
This helps to avoid extra hash object creation, by symbolizing inplace
