### PR TITLE
Fixes bug 10628.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,5 @@
+*   Fixes bug with testing nil Rake::Application (bug #10628).
+
 *   Fixes bug with scaffold generator with `--assets=false --resource-route=false`.
     Fixes #9525.
 

--- a/railties/lib/rails/test_unit/railtie.rb
+++ b/railties/lib/rails/test_unit/railtie.rb
@@ -1,4 +1,4 @@
-if defined?(Rake) && Rake.application.top_level_tasks.grep(/^(default$|test(:|$))/).any?
+if defined?(Rake) && defined?(Rake.application) && Rake.application.top_level_tasks.grep(/^(default$|test(:|$))/).any?
   ENV['RAILS_ENV'] ||= 'test'
 end
 


### PR DESCRIPTION
Railties tests non-existent Rake::Application in some cases. Fixed in this pull request.

Fixes #10628
