### PR TITLE
Fix HWIA#to_hash behavior with array of hashes.

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -231,7 +231,7 @@ module ActiveSupport
     def to_hash
       _new_hash= {}
       each do |key, value|
-        _new_hash[convert_key(key)] = convert_value(value,true)
+        _new_hash[convert_key(key)] = convert_value(value, true)
       end
       Hash.new(default).merge!(_new_hash)
     end
@@ -246,7 +246,7 @@ module ActiveSupport
           _convert_for_to_hash ? value.to_hash : value.nested_under_indifferent_access
         elsif value.is_a?(Array)
           value = value.dup if value.frozen?
-          value.map! { |e| convert_value(e) }
+          value.map! { |e| convert_value(e, _convert_for_to_hash) }
         else
           value
         end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -506,6 +506,11 @@ class HashExtTest < ActiveSupport::TestCase
   def test_indifferent_hash_with_array_of_hashes
     hash = { "urls" => { "url" => [ { "address" => "1" }, { "address" => "2" } ] }}.with_indifferent_access
     assert_equal "1", hash[:urls][:url].first[:address]
+
+    hash = hash.to_hash
+    assert_not hash.instance_of?(HashWithIndifferentAccess)
+    assert_not hash["urls"].instance_of?(HashWithIndifferentAccess)
+    assert_not hash["urls"]["url"].first.instance_of?(HashWithIndifferentAccess)
   end
 
   def test_should_preserve_array_subclass_when_value_is_array


### PR DESCRIPTION
We merged #10266, but if we use HWIA#to_hash with array of hases, the problem still exists.

/cc @vipulnsward @rafaelfranca
