### PR TITLE
Maintain proleptic gregorian in Time#advance

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -110,10 +110,11 @@ class Time
     end
   end
 
-  # Uses Date to provide precise Time calculations for years, months, and days.
-  # The +options+ parameter takes a hash with any of these keys: <tt>:years</tt>,
-  # <tt>:months</tt>, <tt>:weeks</tt>, <tt>:days</tt>, <tt>:hours</tt>,
-  # <tt>:minutes</tt>, <tt>:seconds</tt>.
+  # Uses Date to provide precise Time calculations for years, months, and days
+  # according to the proleptic Gregorian calendar. The +options+ parameter
+  # takes a hash with any of these keys: <tt>:years</tt>, <tt>:months</tt>,
+  # <tt>:weeks</tt>, <tt>:days</tt>, <tt>:hours</tt>, <tt>:minutes</tt>,
+  # <tt>:seconds</tt>.
   def advance(options)
     unless options[:weeks].nil?
       options[:weeks], partial_weeks = options[:weeks].divmod(1)
@@ -126,6 +127,7 @@ class Time
     end
 
     d = to_date.advance(options)
+    d = d.gregorian if d.julian?
     time_advanced_by_date = change(:year => d.year, :month => d.month, :day => d.day)
     seconds_to_advance = \
       options.fetch(:seconds, 0) +

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -464,6 +464,13 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal t, t.advance(:months => 0)
   end
 
+  def test_advance_gregorian_proleptic
+    assert_equal Time.local(1582,10,14,15,15,10), Time.local(1582,10,15,15,15,10).advance(:days => -1)
+    assert_equal Time.local(1582,10,15,15,15,10), Time.local(1582,10,14,15,15,10).advance(:days => 1)
+    assert_equal Time.local(1582,10,5,15,15,10), Time.local(1582,10,4,15,15,10).advance(:days => 1)
+    assert_equal Time.local(1582,10,4,15,15,10), Time.local(1582,10,5,15,15,10).advance(:days => -1)
+  end
+
   def test_last_week
     with_env_tz 'US/Eastern' do
       assert_equal Time.local(2005,2,21), Time.local(2005,3,1,15,15,10).last_week


### PR DESCRIPTION
If Time is assumed to represent a gregorian value (not conspicuously documented, but assumed by Time#to_date in Ruby > 1.8), Time#advance should return a value which is also gregorian. Currently, that is not invariably the case:

```
Time.utc(1582, 10, 15).advance(:days => -1) # => 1582-10-04 00:00:00 UTC
```

If a resulting Time object with implicit julian date is used in calculations with Time objects with implicit gregorian dates, hijinks ensue:

```
t = Time.utc(1582, 10, 15)
distance_of_time_in_words(t - t.advance(:days => -1)) # => "11 days"
```

I'd be glad to backport this fix. In that case ActiveSupport's Time#to_date (for Ruby < 1.9) should also be amended to specify proleptic gregorian for consistent behavior with Ruby 1.9.
