### PR TITLE
Use `Base.strict_decode64` instead of `Base.decode64` 

### DIFF
--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -76,12 +76,12 @@ module ActiveSupport
       encrypted_data = cipher.update(@serializer.dump(value))
       encrypted_data << cipher.final
 
-      [encrypted_data, iv].map {|v| ::Base64.strict_encode64(v)}.join("--")
+      "#{::Base64.strict_encode64 encrypted_data}--#{::Base64.strict_encode64 iv}"
     end
 
     def _decrypt(encrypted_message)
       cipher = new_cipher
-      encrypted_data, iv = encrypted_message.split("--").map {|v| ::Base64.decode64(v)}
+      encrypted_data, iv = encrypted_message.split("--").map {|v| ::Base64.strict_decode64(v)}
 
       cipher.decrypt
       cipher.key = @secret
@@ -91,7 +91,7 @@ module ActiveSupport
       decrypted_data << cipher.final
 
       @serializer.load(decrypted_data)
-    rescue OpenSSLCipherError, TypeError
+    rescue OpenSSLCipherError, TypeError, ArgumentError
       raise InvalidMessage
     end
 

--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -37,7 +37,11 @@ module ActiveSupport
 
       data, digest = signed_message.split("--")
       if data.present? && digest.present? && secure_compare(digest, generate_digest(data))
-        @serializer.load(::Base64.decode64(data))
+        begin
+          @serializer.load(::Base64.strict_decode64(data))
+        rescue ArgumentError
+          raise InvalidSignature
+        end
       else
         raise InvalidSignature
       end


### PR DESCRIPTION
Use `Base.strict_decode64` instead of `Base.decode64` just as we do in encoding;

Also change `map` to `map!` on new array, to map inplace and reduce extra object allocation
