### PR TITLE
fix rails4 regression with asset_host Proc returning nil

### DIFF
--- a/actionpack/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionpack/lib/action_view/helpers/asset_url_helper.rb
@@ -193,7 +193,6 @@ module ActionView
         request = self.request if respond_to?(:request)
         host = config.asset_host if defined? config.asset_host
         host ||= request.base_url if request && options[:protocol] == :request
-        return unless host
 
         if host.respond_to?(:call)
           arity = host.respond_to?(:arity) ? host.arity : host.method(:call).arity
@@ -203,6 +202,8 @@ module ActionView
         elsif host =~ /%d/
           host = host % (Zlib.crc32(source) % 4)
         end
+
+        return unless host
 
         if host =~ URI_REGEXP
           host

--- a/actionpack/test/template/asset_tag_helper_test.rb
+++ b/actionpack/test/template/asset_tag_helper_test.rb
@@ -530,6 +530,17 @@ class AssetTagHelperTest < ActionView::TestCase
     assert_equal copy, source
   end
 
+  def test_image_path_with_asset_host_proc_returning_nil
+    @controller.config.asset_host = Proc.new do |source|
+      unless source.end_with?("tiff")
+        "cdn.example.com"
+      end
+    end
+
+    assert_equal "/images/file.tiff", image_path("file.tiff")
+    assert_equal "http://cdn.example.com/images/file.png", image_path("file.png")
+  end
+
   def test_caching_image_path_with_caching_and_proc_asset_host_using_request
     @controller.config.asset_host = Proc.new do |source, request|
       if request.ssl?


### PR DESCRIPTION
In rails4, when config.asset_host is defined as a proc, returning nil from that proc no longer behaves the same as if config.asset_host were not configured, but rather treats asset_host as an empty string, which is not useful, because it gives urls like this:

```
  1) Failure:
AssetTagHelperTest#test_image_path_with_asset_host_proc_returning_nil [/Users/seanwalbran/projects/rails/actionpack/test/template/asset_tag_helper_test.rb:540]:
Expected: "/images/file.tiff"
  Actual: "http:///images/file.tiff"
```

This PR restores the previous behavior (and adds test coverage).
