### PR TITLE
Remove trailing line break in template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/wrap_parameters.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/wrap_parameters.rb.tt
@@ -7,8 +7,8 @@
 ActiveSupport.on_load(:action_controller) do
   wrap_parameters format: [:json] if respond_to?(:wrap_parameters)
 end
-
 <%- unless options.skip_active_record? -%>
+
 # To enable root element in JSON for ActiveRecord objects.
 # ActiveSupport.on_load(:active_record) do
 #  self.include_root_in_json = true


### PR DESCRIPTION
If you generate a fresh app without ActiverRecord, this template
exhibited a lone trailing line break. My watchful pre-commit hook
told me about it so I've fixed it here.
