### PR TITLE
Fix detection of engine in rake db:load_config

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -44,7 +44,7 @@ module ActiveRecord
       ActiveRecord::Tasks::DatabaseTasks.migrations_paths = Rails.application.paths['db/migrate'].to_a
       ActiveRecord::Tasks::DatabaseTasks.fixtures_path = File.join Rails.root, 'test', 'fixtures'
 
-      if defined?(ENGINE_PATH) && engine = Rails::Engine.find(ENGINE_PATH)
+      if engine = Rails::Engine.find(find_engine_path(APP_RAKEFILE))
         if engine.paths['db/migrate'].existent
           ActiveRecord::Tasks::DatabaseTasks.migrations_paths += engine.paths['db/migrate'].to_a
         end


### PR DESCRIPTION
d1d7c86d0c8dcb7e75a87644b330c4e9e7d6c1c1 moved engine detection from the `db:load_config` task to `Railtie`, breaking it in the process because `ENGINE_PATH` is not defined at that point.

As a result, running `rake db:migrate` from an engine would only run migrations from the dummy app.

This fixes the issue by trying to find the engine in the same way used to define `ENGINE_PATH`.
