### PR TITLE
restore whitespace in Gemfile between sqlite3 and sprockets

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -116,7 +116,7 @@ module Rails
 
       def database_gemfile_entry
         options[:skip_active_record] ? "" :
-          <<-GEMFILE.strip_heredoc.chomp
+          <<-GEMFILE.strip_heredoc
             # Use #{options[:database]} as the database for Active Record
             gem '#{gem_for_database}'
           GEMFILE


### PR DESCRIPTION
Restore whitespace in Gemfile:

```
# Use sqlite3 as the database for Active Record
gem 'sqlite3'

# Use edge version of sprockets-rails
gem 'sprockets-rails', github: 'rails/sprockets-rails'
```
