### PR TITLE
Fix ActionMailer testcase break with mail 2.5.4.

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,6 @@
-* No changes.
+* Fix ActionMailer testcase break with mail 2.5.4.
+  ActionMailer's testcase was wrong, because :transfer_encoding option was ignored in mail 2.5.3.
+
+  *kennyj*
 
 Please check [4-0-stable](https://github.com/rails/rails/blob/4-0-stable/actionmailer/CHANGELOG.md) for previous changes.

--- a/actionmailer/test/mailers/base_mailer.rb
+++ b/actionmailer/test/mailers/base_mailer.rb
@@ -38,7 +38,7 @@ class BaseMailer < ActionMailer::Base
   end
 
   def attachment_with_hash
-    attachments['invoice.jpg'] = { data: "\312\213\254\232)b",
+    attachments['invoice.jpg'] = { data: ::Base64.encode64("\312\213\254\232)b"),
                                    mime_type: "image/x-jpg",
                                    transfer_encoding: "base64" }
     mail


### PR DESCRIPTION
According to https://travis-ci.org/rails/rails/jobs/7220308#L148, AM's testcase was break.
I guess that AM's testcase was wrong. When we pass :transfer_encoding option, we should pass _encoded_ content.

I guess this PR should be backported to 3-2-stable, 4-0-stable too.
