### PR TITLE
Raise an error when multiple included blocks are defined for a Concern

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Raise an error when multiple `included` blocks are defined for a Concern.
+    The old behavior would silently discard previously defined blocks, running
+    only the last one.
+
+    *Mike Dillon*
+
 *   Replace `multi_json` with `json`.
 
     Since Rails requires Ruby 1.9 and since Ruby 1.9 includes `json` in the standard library,

--- a/activesupport/lib/active_support/concern.rb
+++ b/activesupport/lib/active_support/concern.rb
@@ -98,6 +98,12 @@ module ActiveSupport
   #     include Bar # works, Bar takes care now of its dependencies
   #   end
   module Concern
+    class MultipleIncludedBlocks < StandardError #:nodoc:
+      def initialize
+        super "Cannot define multiple 'included' blocks for a Concern"
+      end
+    end
+
     def self.extended(base) #:nodoc:
       base.instance_variable_set("@_dependencies", [])
     end
@@ -117,6 +123,8 @@ module ActiveSupport
 
     def included(base = nil, &block)
       if base.nil?
+        raise MultipleIncludedBlocks if instance_variable_defined?("@_included_block")
+
         @_included_block = block
       else
         super

--- a/activesupport/test/concern_test.rb
+++ b/activesupport/test/concern_test.rb
@@ -91,4 +91,18 @@ class ConcernTest < ActiveSupport::TestCase
     @klass.send(:include, Foo)
     assert_equal [ConcernTest::Foo, ConcernTest::Bar, ConcernTest::Baz], @klass.included_modules[0..2]
   end
+
+  def test_raise_on_multiple_included_calls
+    assert_raises(ActiveSupport::Concern::MultipleIncludedBlocks) do
+      Module.new do
+        extend ActiveSupport::Concern
+
+        included do
+        end
+
+        included do
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This pull fixes the issue with multiple included blocks in a Concern. See #10650 for more information.
