### PR TITLE
Allows passing arguments to content_tag block.

### DIFF
--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -74,7 +74,8 @@ module ActionView
       # ==== Options
       # The +options+ hash is used with attributes with no value like (<tt>disabled</tt> and
       # <tt>readonly</tt>), which you can give a value of true in the +options+ hash. You can use
-      # symbols or strings for the attribute names.
+      # symbols or strings for the attribute names. You can use <tt>arguments</tt> option to pass
+      # arguments to the block.
       #
       # ==== Examples
       #   content_tag(:p, "Hello world!")
@@ -88,10 +89,15 @@ module ActionView
       #     Hello world!
       #   <% end -%>
       #    # => <div class="strong">Hello world!</div>
-      def content_tag(name, content_or_options_with_block = nil, options = nil, escape = true, &block)
+      #
+      #   <%= content_tag(:ol, arguments: nav, class: 'nav') do |nav|
+      #     <%= nav.navigation_link %>
+      #   <% end -%>
+      def content_tag(name, content_or_options_with_block = {}, options = nil, escape = true, &block)
         if block_given?
           options = content_or_options_with_block if content_or_options_with_block.is_a?(Hash)
-          content_tag_string(name, capture(&block), options, escape)
+          arguments = options.delete(:arguments)
+          content_tag_string(name, capture(*arguments, &block), options, escape)
         else
           content_tag_string(name, content_or_options_with_block, options, escape)
         end

--- a/actionpack/test/template/tag_helper_test.rb
+++ b/actionpack/test/template/tag_helper_test.rb
@@ -59,6 +59,11 @@ class TagHelperTest < ActionView::TestCase
     assert_dom_equal %(<div class="green">Hello world!</div>), content_tag(:div, :class => "green") { "Hello world!" }
   end
 
+  def test_content_tag_with_block_passing_arguments
+    assert_dom_equal %(<div>Hello world!</div>), content_tag(:div, :arguments => 'world') { |who| "Hello #{who}!" }
+    assert_dom_equal %(<div>Hello world!</div>), content_tag(:div, :arguments => ['Hello', 'world']) { |what, who| "#{what} #{who}!" }
+  end
+
   def test_content_tag_with_block_and_options_outside_out_of_erb
     assert_equal content_tag("a", "Create", :href => "create"),
                  content_tag("a", "href" => "create") { "Create" }


### PR DESCRIPTION
This will ease the use on plugins like tabs_on_rails. It may also allow to use
this method more, within methods like form for.
