### PR TITLE
Fix named routing regression from 3.2.13

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -218,6 +218,7 @@ module ActionDispatch
                 keys -= t.url_options.keys if t.respond_to?(:url_options)
                 keys -= options.keys
               end
+              keys -= inner_options.keys
               result.merge!(Hash[keys.zip(args)])
             end
 

--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -69,6 +69,17 @@ module ActionDispatch
         end
       end
 
+      test "explicit keys win over implicit keys" do
+        draw do
+          resources :foo do
+            resources :bar, to: SimpleApp.new('foo#show')
+          end
+        end
+
+        assert_equal '/foo/1/bar/2', url_helpers.foo_bar_path(1, 2)
+        assert_equal '/foo/1/bar/2', url_helpers.foo_bar_path(2, foo_id: 1)
+      end
+
       private
         def clear!
           @set.clear!


### PR DESCRIPTION
When named route that is nested is used in 3.2.13 

Example `routes.rb`:

``` ruby
resources :nested do
  resources :builder, :controller => 'nested/builder'
end
```

In 3.2.12 and 3.2.12 this named route would work:

``` ruby
nested_builder_path(:last_step, :nested_id => "foo")
```

Generating a url that looks like `/nested/foo/builder/last_step`. This PR fixes the regression when building urls via the optimized helper. Any explicit keys set in the options are removed from the list of implicitly mapped keys.

Not sure if this is exactly how the original version worked, but this fixes this use case regression.

ATP action pack
