### PR TITLE
plugin new missing license spec

### DIFF
--- a/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
+++ b/railties/lib/rails/generators/rails/plugin_new/templates/%name%.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.homepage    = "TODO"
   s.summary     = "TODO: Summary of <%= camelized %>."
   s.description = "TODO: Description of <%= camelized %>."
+  s.license     = "MIT"
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 <% unless options.skip_test_unit? -%>


### PR DESCRIPTION
When bundling a gem created with `rails plugin new`, Bundler outputs the following warning when building the gem:
`WARNING:  licenses is empty`

Added `s.license = 'MIT'` to plugin gemspec template.
