### PR TITLE
Taken error message for attribute uniqueness

### DIFF
--- a/activemodel/lib/active_model/locale/en.yml
+++ b/activemodel/lib/active_model/locale/en.yml
@@ -27,3 +27,4 @@ en:
       other_than: "must be other than %{count}"
       odd: "must be odd"
       even: "must be even"
+      taken: "has already been taken"


### PR DESCRIPTION
Taken error message for attribute uniqueness has been added. 

":taken" message is mentioned in http://guides.rubyonrails.org/i18n.html#interpolation, but it is not being used.
