### PR TITLE
make "rails dbconsole" work with activerecord-postgis-adapter

### DIFF
--- a/railties/lib/rails/commands/dbconsole.rb
+++ b/railties/lib/rails/commands/dbconsole.rb
@@ -44,7 +44,7 @@ module Rails
 
         find_cmd_and_exec(['mysql', 'mysql5'], *args)
 
-      when "postgresql", "postgres"
+      when "postgresql", "postgres", "postgis"
         ENV['PGUSER']     = config["username"] if config["username"]
         ENV['PGHOST']     = config["host"] if config["host"]
         ENV['PGPORT']     = config["port"].to_s if config["port"]


### PR DESCRIPTION
It's a minor change. I only added "postgis" to the "when" clause to make it recognize "postgis".
