### PR TITLE
Change find_or_create to do INSERT before SELECT

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -179,12 +179,16 @@ module ActiveRecord
     #   end
     #   # => <User id: 2, first_name: 'Scarlett', last_name: 'Johansson'>
     def find_or_create_by(attributes, &block)
-      find_by(attributes) || create(attributes, &block)
+      create(attributes, &block)
+    rescue RecordNotUnique
+      find_by(attributes)
     end
 
     # Like <tt>find_or_create_by</tt>, but calls <tt>create!</tt> so an exception is raised if the created record is invalid.
     def find_or_create_by!(attributes, &block)
-      find_by(attributes) || create!(attributes, &block)
+      create!(attributes, &block)
+    rescue RecordNotUnique
+      find_by(attributes)
     end
 
     # Like <tt>find_or_create_by</tt>, but calls <tt>new</tt> instead of <tt>create</tt>.

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -88,6 +88,7 @@ ActiveRecord::Schema.define do
     t.string :color
     t.integer :pirate_id
   end
+  add_index :birds, :name, :unique => true
 
   create_table :books, :force => true do |t|
     t.integer :author_id


### PR DESCRIPTION
This makes find_or_create() safe to use with concurrent requests by
relying on unique indexes to raise errors if the INSERT fails. By doing
the SELECT first, we leave this method open to the same race conditions
that affect uniqueness validation.
