### PR TITLE
Add ability to specify how a class is converted to Arel predicate when passed to where

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add ability to define how a class is converted to Arel predicates.
+    For example, adding a very vendor specific regex implementation:
+
+        regex_handler = proc do |column, value|
+          Arel::Nodes::InfixOperation.new('~', column, value.source)
+        end
+        ActiveRecord::PredicateBuilder.register_handler(Regexp, regex_handler)
+
+    *Sean Griffin & @joannecheng*
+
 *   Don't allow `quote_value` to be called without a column.
 
     Some adapters require column information to do their job properly.

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -1,5 +1,10 @@
 module ActiveRecord
   class PredicateBuilder # :nodoc:
+    @handlers = []
+
+    autoload :RelationHandler, 'active_record/relation/predicate_builder/relation_handler'
+    autoload :ArrayHandler, 'active_record/relation/predicate_builder/array_handler'
+
     def self.resolve_column_aliases(klass, hash)
       hash = hash.dup
       hash.keys.grep(Symbol) do |key|
@@ -73,44 +78,36 @@ module ActiveRecord
       end.compact
     end
 
+    # Define how a class is converted to Arel nodes when passed to +where+.
+    # The handler can be any object that responds to +call+, and will be used
+    # for any value that +===+ the class given. For example:
+    #
+    #     MyCustomDateRange = Struct.new(:start, :end)
+    #     handler = proc do |column, range|
+    #       Arel::Nodes::Between.new(column,
+    #         Arel::Nodes::And.new([range.start, range.end])
+    #       )
+    #     end
+    #     ActiveRecord::PredicateBuilder.register_handler(MyCustomDateRange, handler)
+    def self.register_handler(klass, handler)
+      @handlers.unshift([klass, handler])
+    end
+
+    register_handler(BasicObject, ->(attribute, value) { attribute.eq(value) })
+    # FIXME: I think we need to deprecate this behavior
+    register_handler(Class, ->(attribute, value) { attribute.eq(value.name) })
+    register_handler(Base, ->(attribute, value) { attribute.eq(value.id) })
+    register_handler(Range, ->(attribute, value) { attribute.in(value) })
+    register_handler(Relation, RelationHandler.new)
+    register_handler(Array, ArrayHandler.new)
+
     private
       def self.build(attribute, value)
-        case value
-        when Array
-          values = value.to_a.map {|x| x.is_a?(Base) ? x.id : x}
-          ranges, values = values.partition {|v| v.is_a?(Range)}
+        handler_for(value).call(attribute, value)
+      end
 
-          values_predicate = if values.include?(nil)
-            values = values.compact
-
-            case values.length
-            when 0
-              attribute.eq(nil)
-            when 1
-              attribute.eq(values.first).or(attribute.eq(nil))
-            else
-              attribute.in(values).or(attribute.eq(nil))
-            end
-          else
-            attribute.in(values)
-          end
-
-          array_predicates = ranges.map { |range| attribute.in(range) }
-          array_predicates << values_predicate
-          array_predicates.inject { |composite, predicate| composite.or(predicate) }
-        when ActiveRecord::Relation
-          value = value.select(value.klass.arel_table[value.klass.primary_key]) if value.select_values.empty?
-          attribute.in(value.arel.ast)
-        when Range
-          attribute.in(value)
-        when ActiveRecord::Base
-          attribute.eq(value.id)
-        when Class
-          # FIXME: I think we need to deprecate this behavior
-          attribute.eq(value.name)
-        else
-          attribute.eq(value)
-        end
+      def self.handler_for(object)
+        @handlers.detect { |klass, _| klass === object }.last
       end
   end
 end

--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -1,0 +1,29 @@
+module ActiveRecord
+  class PredicateBuilder
+    class ArrayHandler # :nodoc:
+      def call(attribute, value)
+        values = value.map { |x| x.is_a?(Base) ? x.id : x }
+        ranges, values = values.partition { |v| v.is_a?(Range) }
+
+        values_predicate = if values.include?(nil)
+          values = values.compact
+
+          case values.length
+          when 0
+            attribute.eq(nil)
+          when 1
+            attribute.eq(values.first).or(attribute.eq(nil))
+          else
+            attribute.in(values).or(attribute.eq(nil))
+          end
+        else
+          attribute.in(values)
+        end
+
+        array_predicates = ranges.map { |range| attribute.in(range) }
+        array_predicates << values_predicate
+        array_predicates.inject { |composite, predicate| composite.or(predicate) }
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/relation/predicate_builder/relation_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/relation_handler.rb
@@ -1,0 +1,13 @@
+module ActiveRecord
+  class PredicateBuilder
+    class RelationHandler # :nodoc:
+      def call(attribute, value)
+        if value.select_values.empty?
+          value = value.select(value.klass.arel_table[value.klass.primary_key])
+        end
+
+        attribute.in(value.arel.ast)
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/relation/predicate_builder_test.rb
+++ b/activerecord/test/cases/relation/predicate_builder_test.rb
@@ -1,0 +1,14 @@
+require "cases/helper"
+require 'models/topic'
+
+module ActiveRecord
+  class PredicateBuilderTest < ActiveRecord::TestCase
+    def test_registering_new_handlers
+      PredicateBuilder.register_handler(Regexp, proc do |column, value|
+        Arel::Nodes::InfixOperation.new('~', column, value.source)
+      end)
+
+      assert_match %r{["`]topics["`].["`]title["`] ~ 'rails'}, Topic.where(title: /rails/).to_sql
+    end
+  end
+end


### PR DESCRIPTION
This adds the ability for rails apps or gems to have granular control
over how a domain object is converted to sql. One simple use case would
be to add support for Regexp. Another simple case would be something
like the following:

```
class DateRange < Struct.new(:start, :end)
  def include?(date)
    (start..end).cover?(date)
  end
end

class DateRangePredicate
  def call(attribute, range)
    attribute.in(range.start..range.end)
  end
end

ActiveRecord::PredicateBuilder.register_handler(DateRange, DateRangePredicate.new)
```

More complex cases might include taking a currency object and converting
it from EUR to USD before performing the query.

By moving the existing handlers to this format, we were also able to
nicely refactor a rather nasty method in PredicateBuilder.

This would also make it fairly simple to add make it possible to define special handling for individual columns (e.g. for things like database level encryption, which currently requires massive hacking to perform). That's probably suited for a separate pull request, though.
