### PR TITLE
Don't autorequire mocha to avoid deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,11 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'mocha', '~> 0.14'
+# This needs to be with require false as it is
+# loaded after loading the test library to
+# ensure correct loading order
+gem 'mocha', '~> 0.14', require: false
+
 gem 'rack-cache', '~> 1.2'
 gem 'bcrypt-ruby', '~> 3.0.0'
 gem 'jquery-rails', '~> 2.2.0'


### PR DESCRIPTION
- https://travis-ci.org/rails/rails/jobs/7264822 contains deprecated
  warnings given by Mocha version 0.14.0
- 632f215da added Mocha 0.14.0 to Gemfile
- But with the version, require: false was removed
- So Mocha started giving deprecation warnings
- Acc.to Mocha documentation(https://github.com/freerange/mocha#bundler)
  it should not be auto required.
