### PR TITLE
Indexing or Unindexing single columns of a single table via migration generator

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,87 @@
+*   Indexing or Unindexing many columns of a single table via migration generator
+
+    Examples follow:
+
+    rails generate migration add_index_author_id_with_library_id_and_category_id_uniq_on_books author_id:uniq library_id category_id
+
+        class AddIndexAuthorIdWithLibraryIdAndCategoryIdUniqOnBooks < ActiveRecord::Migration
+          def change
+            add_index :books, [:author_id, :library_id, :category_id], unique: true
+          end
+        end
+
+    rails generate migration remove_index_author_id_with_library_id_and_category_id_uniq_on_books author_id library_id:uniq category_id
+
+        class RemoveIndexAuthorIdWithLibraryIdUniqOnBooks < ActiveRecord::Migration
+          def change
+            remove_index :books, column: [:author_id, :library_id, :category_id], unique: true
+          end
+        end
+
+    !!! An empty migration is generated when no attributes are passed !!!
+
+    *Frank Pimenta (frankapimenta)*
+    *Sammy Larbi (codeodor)*
+
+*   Indexing or Unindexing single columns of a single table
+    via migration generator
+
+    Examples follow:
+
+        rails generate migration add_index_author_id_on_books author_id
+
+        class AddIndexAuthorIdOnBooks < ActiveRecord::Migration
+          def change
+            add_index :books, :author_id
+          end
+        end
+
+        rails generate migration remove_index_author_id_on_books author_id
+
+        class RemoveIndexAuthorIdOnBooks < ActiveRecord::Migration
+          def change
+            remove_index :books, column: :author_id
+          end
+        end
+
+        rails generate migration add_index_author_id_uniq_on_books author_id:uniq
+
+        class AddIndexAuthorIdUniqOnBooks < ActiveRecord::Migration
+          def change
+            add_index :books, :author_id, unique: true
+          end
+        end
+
+        rails generate migration remove_index_author_id_uniq_on_books author_id:uniq
+
+        class RemoveIndexAuthorIdUniqOnBooks < ActiveRecord::Migration
+          def change
+            remove_index :books, column: :author_id, unique: true
+          end
+        end
+
+        rails generate migration add_indexes_author_id_uniq_and_library_id_on_books author_id:uniq library_id
+
+        class AddIndexesAuthorIdUniqAndLibraryIdOnBooks < ActiveRecord::Migration
+          def change
+            add_index :books, :author_id, unique: true
+            add_index :books, :library_id
+          end
+        end
+
+        rails generate migration remove_indexes_author_id_uniq_and_library_id_on_books author_id:uniq library_id
+
+        class RemoveIndexesAuthorIdUniqAndLibraryIdOnBooks < ActiveRecord::Migration
+          def change
+            remove_index :books, column: :author_id, unique: true
+            remove_index :books, column: :library_id
+          end
+        end
+
+    !!! An empty migration is generated when no attributes are passed !!!
+
+    *Frank Pimenta (frankapimenta)*
+
 *   Also support extentions in PostgreSQL 9.1. This feature has been supported since 9.1.
 
     *kennyj*

--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -12,7 +12,7 @@ module ActiveRecord
       end
 
       protected
-      attr_reader :migration_action, :join_tables
+      attr_reader :migration_action, :migration_target, :join_tables
 
       # sets the default migration template that is being used for the generation of the migration
       # depending on the arguments which would be sent out in the command line, the migration template 
@@ -24,6 +24,13 @@ module ActiveRecord
         when /^(add|remove)_.*_(?:to|from)_(.*)/
           @migration_action = $1
           @table_name       = $2.pluralize
+        when /^(add|remove)_index(?:es)?_(.*)_(?:on)_(.*)/
+          @migration_action = $1
+          @table_name       = $3.pluralize
+          @migration_template = 'indexes.rb'
+          if $2 =~ /with/
+            @migration_target = 'index_combined'
+          end
         when /join_table/
           if attributes.length == 2
             @migration_action = 'join'

--- a/activerecord/lib/rails/generators/active_record/migration/templates/indexes.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/indexes.rb
@@ -1,0 +1,26 @@
+class <%= migration_class_name %> < ActiveRecord::Migration
+  def change
+<%- if migration_action == 'add' -%>
+<%- if migration_target == 'index_combined' -%>
+  <%- if attributes.any? -%>
+	add_index :<%= table_name %>, [:<%= attributes.map(&:name).join(", :") %>]<%= attributes.map(&:inject_index_options).select(&:present?).first %>
+  <%- end -%>
+<%- else -%>
+  <%- attributes.each do |attribute| -%>
+    add_index :<%= table_name %>, :<%= attribute.name %><%= attribute.inject_index_options %>
+  <%- end -%>
+<%- end -%>
+<%- end -%>
+<%- if migration_action == 'remove' -%>
+<%- if migration_target == 'index_combined' -%>
+  <%- if attributes.any? -%>
+  remove_index :<%= table_name %>, column: [:<%= attributes.map(&:name).join(", :") %>]<%= attributes.map(&:inject_index_options).select(&:present?).first %>
+  <%- end -%>
+<%- else -%>
+  <%- attributes.each do |attribute| -%>
+    remove_index :<%= table_name %>, column: :<%= attribute.name %><%= attribute.inject_index_options %>
+  <%- end -%>
+<%- end -%>
+<%- end -%>
+  end
+end

--- a/guides/source/migrations.md
+++ b/guides/source/migrations.md
@@ -201,6 +201,60 @@ class AddDetailsToProducts < ActiveRecord::Migration
 end
 ```
 
+You can also add or remove indexes on single or multiple columns:
+
+Example to index one single column:
+
+```bash
+$ rails generate migration add_index_category_id_on_products category_id:uniq
+```
+
+generates
+
+```ruby
+class AddIndexCategoryIdOnProducts < ActiveRecord::Migration
+  def change
+    add_index :products, :category_id, unique: true
+  end
+end
+```
+Example to index many single columns:
+
+```bash
+$ rails generate migration add_indexes_category_id_and_manager_id_and_factory_id_on_products category_id manager_id:uniq factory_id
+```
+
+generates
+
+```ruby
+class AddIndexesCategoryIdManagerIdFactoryId < ActiveRecord::Migration
+  def change
+    add_index :products, :category_id
+    add_index :products, :manager_id, unique: true
+    add_index :products, :factory_id
+  end
+end
+```
+
+Example to index many multiple columns:
+
+```bash
+$ rails generate migration add_index_category_id_with_manager_id_and_factory_id_on_products category_id manager_id:uniq factory_id
+```
+
+generates
+
+```ruby
+class AddIndexCategoryIdWithManagerIdAndFactoryIdOnProducts < ActiveRecord::Migration
+  def change
+    add_index :products, [:category_id, :manager_id, :factory_id], unique: true
+  end
+end
+```
+
+Use remove in the beginning of the migration name to create migration to remove indexes.
+
+
 If the migration name is of the form "CreateXXX" and is
 followed by a list of column names and types then a migration creating the table
 XXX with the columns listed will be generated. For example:

--- a/railties/test/application/rake/migrations_test.rb
+++ b/railties/test/application/rake/migrations_test.rb
@@ -127,6 +127,112 @@ module ApplicationTests
         end
       end
 
+      test 'migration for adding indexes and rollback' do
+        Dir.chdir(app_path) do
+          `rails generate model user username:string email:string;
+           rails generate migration add_index_username_on_users username;
+           rails generate migration add_index_email_on_users email:uniq`
+
+           output = `rake db:migrate`
+           assert_match(/create_table\(:users\)/, output)
+           assert_match(/CreateUsers: migrated/, output)
+           assert_match(/add_index\(:users, :username\)/, output)
+           assert_match(/AddIndexUsernameOnUsers: migrated/, output)
+           assert_match(/add_index\(:users, :email, \{:unique=>true\}\)/, output)
+           assert_match(/AddIndexEmailOnUsers: migrated/, output)
+
+           output = `rake db:rollback STEP=3`
+           assert_match(/remove_index\(:users, \{:unique=>true\, :column=>:email}\)/, output)
+           assert_match(/AddIndexEmailOnUsers: reverted/, output)
+           assert_match(/remove_index\(:users, \{:column=>:username}\)/, output)
+           assert_match(/AddIndexUsernameOnUsers: reverted/, output)
+           assert_match(/drop_table\(:users\)/, output)
+           assert_match(/CreateUsers: reverted/, output)
+        end
+      end
+
+      test 'migration for removing indexes and rollback' do
+        Dir.chdir(app_path) do
+          `rails generate model user username:string:index email:string:uniq;
+           rails generate migration remove_index_username_from_users username;
+           rails generate migration remove_index_email_from_users email:uniq`
+
+           output = `rake db:migrate`
+           assert_match(/create_table\(:users\)/, output)
+           assert_match(/CreateUsers: migrated/, output)
+           assert_match(/add_index\(:users, :username\)/, output)
+           assert_match(/add_index\(:users, :email, \{:unique=>true\}\)/, output)
+           assert_match(/remove_index\(:users, \{:column=>:username}\)/, output)
+           assert_match(/RemoveIndexUsernameFromUsers: migrated/, output)
+           assert_match(/remove_index\(:users, \{:column=>:email\, :unique=>true}\)/, output)
+           assert_match(/RemoveIndexEmailFromUsers: migrated/, output)
+
+           output = `rake db:rollback STEP=3`
+           assert_match(/add_index\(:users, :email, \{:unique=>true\}\)/, output)
+           assert_match(/RemoveIndexEmailFromUsers: reverted/, output)
+           assert_match(/add_index\(:users, :username, \{\}\)/, output)
+           assert_match(/RemoveIndexUsernameFromUsers: reverted/, output)
+           assert_match(/remove_index\(:users, \{:unique=>true\, :column=>:email}\)/, output)
+           assert_match(/remove_index\(:users, \{:column=>:username}\)/, output)
+           assert_match(/drop_table\(:users\)/, output)
+           assert_match(/CreateUsers: reverted/, output)
+        end
+      end
+
+      test 'migration for adding index of many columns and rollback' do
+        Dir.chdir(app_path) do
+          `rails generate model user username:string email:string code:integer;
+           rails generate migration add_index_username_with_email_and_code_uniq_on_users username email code:uniq`
+
+           output = `rake db:migrate`
+           assert_match(/create_table\(:users\)/, output)
+           assert_match(/CreateUsers: migrated/, output)
+           assert_match(/add_index\(:users, \[:username, :email, :code\], \{:unique=>true\}\)/, output)
+           assert_match(/AddIndexUsernameWithEmailAndCodeUniqOnUsers: migrated/, output)
+
+           output = `rake db:rollback STEP=2`
+           assert_match(/remove_index\(:users, \{:unique=>true, :column=>\[:username, :email, :code\]\}\)/, output)
+           assert_match(/AddIndexUsernameWithEmailAndCodeUniqOnUsers: reverted/, output)
+           assert_match(/drop_table\(:users\)/, output)
+           assert_match(/CreateUsers: reverted/, output)
+        end
+      end
+
+      test 'migration for removing index of many columns and rollback' do
+        Dir.chdir(app_path) do
+          `rails generate model user username:string email:string code:integer;
+           rails generate migration add_index_username_with_email_and_code_on_users username email:uniq code;
+           rails generate migration remove_index_username_with_email_and_code_on_users username:uniq email code`
+
+           output = `rake db:migrate`
+           assert_match(/create_table\(:users\)/, output)
+           assert_match(/remove_index\(:users, \{:column=>\[:username, :email, :code\], :unique=>true\}\)/, output)
+           assert_match(/CreateUsers: migrated/, output)
+           assert_match(/RemoveIndexUsernameWithEmailAndCodeOnUsers: migrated/, output)
+
+           output = `rake db:rollback STEP=3`
+           assert_match(/add_index\(:users, \[:username, :email, :code\], \{:unique=>true\}\)/, output)
+           assert_match(/RemoveIndexUsernameWithEmailAndCodeOnUsers: reverted/, output)
+           assert_match(/drop_table\(:users\)/, output)
+           assert_match(/CreateUsers: reverted/, output)
+        end
+      end
+
+      test 'migration for adding column named index and rollback' do
+        Dir.chdir(app_path) do
+          `rails generate model user username:string email:string code:integer;
+           rails generate migration add_index_to_users index:integer;`
+
+           output = `rake db:migrate`
+           assert_match(/add_column\(:users, :index, :integer\)/, output)
+           assert_match(/AddIndexToUsers: migrated/, output)
+
+           output = `rake db:rollback STEP=2`
+           assert_match(/remove_column\(:users, :index, :integer\)/, output)
+           assert_match(/AddIndexToUsers: reverted/, output)
+        end
+      end
+
       test 'migration status after rollback and redo without timestamps' do
         add_to_config('config.active_record.timestamped_migrations = false')
 

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -183,6 +183,153 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_should_create_migration_to_add_index
+    migration = "add_index_author_id_on_books"
+    run_generator [migration, "author_id"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_match(/AddIndexAuthorIdOnBooks/, content, "wrong class name")
+      assert_method :change, content do |change|
+        assert_match(/add_index :books, :author_id/, change, "index not present")
+      end
+    end
+  end
+
+  def test_should_create_migration_to_remove_index
+    migration = "remove_index_author_id_on_books"
+    run_generator [migration, "author_id"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_match(/RemoveIndexAuthorIdOnBooks/, content, "wrong class name")
+      assert_method :change, content do |change|
+        assert_match(/remove_index :books, column: :author_id/, change, "index not present")
+      end
+    end
+  end
+
+  def test_should_create_migration_to_add_index_uniq
+    migration = "add_index_author_id_uniq_on_books"
+    run_generator [migration, "author_id:uniq"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_match(/AddIndexAuthorIdUniqOnBooks/, content, "wrong class name")
+      assert_method :change, content do |change|
+        assert_match(/add_index :books, :author_id, unique: true/, change, "index not present")
+      end
+    end
+  end
+
+  def test_should_create_migration_to_remove_index_uniq
+    migration = "remove_index_author_id_uniq_on_books"
+    run_generator [migration, "author_id:uniq"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_match(/RemoveIndexAuthorIdUniqOnBooks/, content, "wrong class name")
+      assert_method :change, content do |change|
+        assert_match(/remove_index :books, column: :author_id, unique: true/, change, "index not present")
+      end
+    end
+  end
+
+  def test_should_create_migration_to_add_multiple_indexes
+    migration = "add_indexes_author_id_uniq_and_library_id_on_books"
+    run_generator [migration, "author_id:uniq", "library_id"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_match(/AddIndexesAuthorIdUniqAndLibraryIdOnBooks/, content, "wrong class name")
+      assert_method :change, content do |change|
+        assert_match(/add_index :books, :author_id, unique: true/, change, "index author_id not present")
+        assert_match(/add_index :books, :library_id/, change, "index library_id not present")
+      end
+    end
+  end
+
+  def test_should_create_migration_to_remove_multiple_indexes_uniq
+    migration = "remove_indexes_author_id_uniq_and_library_id_on_books"
+    run_generator [migration, "author_id:uniq", "library_id"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_match(/RemoveIndexesAuthorIdUniqAndLibraryIdOnBooks/, content, "wrong class name")
+      assert_method :change, content do |change|
+        assert_match(/remove_index :books, column: :author_id, unique: true/, change, "index author_id not present")
+        assert_match(/remove_index :books, column: :library_id/, change, "index library_id not present")
+      end
+    end
+  end
+
+  def test_should_create_migration_to_add_index_of_many_columns
+    migration = "add_index_author_id_with_library_id_and_category_id_on_books"
+    run_generator [migration, "author_id", "library_id", "category_id"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_match(/AddIndexAuthorIdWithLibraryIdAndCategoryIdOnBooks/, content, "wrong class name")
+      assert_method :change, content do |change|
+        assert_match(/add_index :books, \[:author_id, :library_id, :category_id\]/, change, "index author_id library_id category_id not present")
+      end
+    end
+  end
+
+  def test_should_create_migration_to_remove_index_of_many_columns
+    migration = "remove_index_author_id_with_library_id_and_category_id_on_books"
+    run_generator [migration, "author_id", "library_id", "category_id"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_match(/RemoveIndexAuthorIdWithLibraryIdAndCategoryIdOnBooks/, content, "wrong class name")
+      assert_method :change, content do |change|
+        assert_match(/remove_index :books, column: \[:author_id, :library_id, :category_id\]/, change, "index author_id library_id category_id not present")
+      end
+    end
+  end
+
+  def test_should_create_migration_to_add_index_uniq_of_many_columns
+    migration = "add_index_author_id_with_library_id_and_category_id_uniq_on_books"
+    run_generator [migration, "author_id", "library_id", "category_id:uniq"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_match(/AddIndexAuthorIdWithLibraryIdAndCategoryIdUniqOnBooks/, content, "wrong class name")
+      assert_method :change, content do |change|
+        assert_match(/add_index :books, \[:author_id, :library_id, :category_id\], unique: true/, change, "index author_id library_id category_id not present")
+      end
+    end
+  end
+
+  def test_should_create_migration_to_remove_index_uniq_of_many_columns
+    migration = "remove_index_author_id_with_library_id_and_category_id_uniq_on_books"
+    run_generator [migration, "author_id", "library_id", "category_id:uniq"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_match(/RemoveIndexAuthorIdWithLibraryIdAndCategoryIdUniqOnBooks/, content, "wrong class name")
+      assert_method :change, content do |change|
+        assert_match(/remove_index :books, column: \[:author_id, :library_id, :category_id\], unique: true/, change, "index author_id library_id category_id not present")
+      end
+    end
+  end
+
+  def test_should_create_column_index_instead_of_index
+    # cases that one wants to add a column name index: rails g migration add_index_to_posts index:integer
+    migration = "add_index_to_posts"
+    run_generator [migration, "index:integer"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_match(/AddIndexToPosts/, content, "wrong class name")
+      assert_method :change, content do |change|
+        assert_match "add_column :posts, :index, :integer", change, "add_column call is not present"
+      end
+    end
+  end
+
+  def test_should_create_empty_migration_to_add_index_of_many_columns_when_columns_are_not_passed
+    migration = "add_index_author_id_with_library_id_and_category_id_from_books"
+    run_generator [migration]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_match(/AddIndexAuthorIdWithLibraryIdAndCategoryIdFromBooks/, content, "wrong class name")
+      assert_method :change, content do |change|
+        assert change.empty?, "method change was not empty"
+      end
+    end
+  end
+
   def test_should_create_empty_migrations_if_name_not_start_with_add_or_remove_or_create
     migration = "delete_books"
     run_generator [migration, "title:string", "content:text"]


### PR DESCRIPTION
Sometimes happens that later in the development process one realizes that a few columns of a particular table should have been indexed.

This pull request easies the addition and removal of indexes of single columns on/from a single table by using the migration generator via CLI

The changelog as well as the code provides the cases of use.

Looking forward to your feedback.

Frank Pimenta
