### PR TITLE
Adds a class level #destroy! method, which raises an

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Added a class level `#destroy!` method, which raises an `ActiveRecord::RecordNotDestroyed`
+    exception instead of returning `false`.
+
+    *Fabio Kreusch*
+
 *   Also support extentions in PostgreSQL 9.1. This feature has been supported since 9.1.
 
     *kennyj*

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -4,7 +4,7 @@ module ActiveRecord
     delegate :first_or_create, :first_or_create!, :first_or_initialize, :to => :all
     delegate :find_or_create_by, :find_or_create_by!, :find_or_initialize_by, :to => :all
     delegate :find_by, :find_by!, :to => :all
-    delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, :to => :all
+    delegate :destroy, :destroy!, :destroy_all, :delete, :delete_all, :update, :update_all, :to => :all
     delegate :find_each, :find_in_batches, :to => :all
     delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins,
              :where, :preload, :eager_load, :includes, :from, :lock, :readonly,

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -76,10 +76,10 @@ module ActiveRecord
     def update_record(values, id, id_was) # :nodoc:
       substitutes, binds = substitute_values values
       um = @klass.unscoped.where(@klass.arel_table[@klass.primary_key].eq(id_was || id)).arel.compile_update(substitutes)
-      
+
       @klass.connection.update(
-        um, 
-        'SQL', 
+        um,
+        'SQL',
         binds)
     end
 
@@ -94,7 +94,7 @@ module ActiveRecord
       end
 
       [substitutes, binds]
-    end 
+    end
 
     # Initializes new record from relation while maintaining the current
     # scope.
@@ -384,6 +384,35 @@ module ActiveRecord
         id.map { |one_id| destroy(one_id) }
       else
         find(id).destroy
+      end
+    end
+
+    # Destroy an object (or multiple objects) that has the given id. The object is instantiated first,
+    # therefore all callbacks and filters are fired off before the object is deleted. This method is
+    # less efficient than ActiveRecord#delete but allows cleanup methods and other actions to be run.
+    #
+    # This essentially finds the object (or multiple objects) with the given id, creates a new object
+    # from the attributes, and then calls destroy on it.
+    #
+    # It raises ActiveRecord::RecordNotDestroyed in case of failure.
+    #
+    # ==== Parameters
+    #
+    # * +id+ - Can be either an Integer or an Array of Integers.
+    #
+    # ==== Examples
+    #
+    #   # Destroy a single object
+    #   Todo.destroy(1)
+    #
+    #   # Destroy multiple objects
+    #   todos = [1,2,3]
+    #   Todo.destroy(todos)
+    def destroy!(id)
+      if id.is_a?(Array)
+        id.map { |one_id| destroy!(one_id) }
+      else
+        find(id).destroy!
       end
     end
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -768,6 +768,15 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::RecordNotFound) { Reply.find(should_be_destroyed_reply.id) }
   end
 
+  def test_class_level_destroy!
+    should_be_destroyed_reply = Reply.create("title" => "hello", "content" => "world")
+    Topic.find(1).replies << should_be_destroyed_reply
+
+    Topic.destroy!(1)
+    assert_raise(ActiveRecord::RecordNotFound) { Topic.find(1) }
+    assert_raise(ActiveRecord::RecordNotFound) { Reply.find(should_be_destroyed_reply.id) }
+  end
+
   def test_class_level_delete
     should_be_destroyed_reply = Reply.create("title" => "hello", "content" => "world")
     Topic.find(1).replies << should_be_destroyed_reply


### PR DESCRIPTION
4faaa811614b408 instroduces the instance level `#destroy!` method, which raises ActiveRecord::RecordNotDestroyed on failure. 

This PR adds a class level `destroy!` method, which delegates to the instance `destroy!` method. That way, one can do `Model.destroy!(id)`.
