### PR TITLE
Fix failing of AM - https://travis-ci.org/rails/rails/jobs/7286782

### DIFF
--- a/actionmailer/test/mailers/base_mailer.rb
+++ b/actionmailer/test/mailers/base_mailer.rb
@@ -40,7 +40,7 @@ class BaseMailer < ActionMailer::Base
   def attachment_with_hash
     attachments['invoice.jpg'] = { data: "\312\213\254\232)b",
                                    mime_type: "image/x-jpg",
-                                   transfer_encoding: "base64" }
+                                   transfer_encoding: "binary" }
     mail
   end
 


### PR DESCRIPTION
- Failing test was passing "base64" as content_transfer_encoding.
- When a content_transfer_encoding is given explicitly, mail expects
  data to be sent also with the attachment.
- Acc. to https://github.com/mikel/mail/blob/master/lib/mail/attachments_list.rb#L90
  default transfer_encoding is either "binary" or "7bit".
- As we are testing the expected value with binary decoded data,
  passing content_transfer_encoding as "binary" fixes the problem.
