### PR TITLE
Fix error due to Time.at 

### DIFF
--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -316,6 +316,7 @@ module ActiveSupport
       utc.to_i
     end
     alias_method :tv_sec, :to_i
+    alias_method :to_int, :to_i
 
     def to_r
       utc.to_r


### PR DESCRIPTION
In changes to fix https://bugs.ruby-lang.org/issues/8173. `Time.at` now requires an object to implement `to_int`. Aliasing `to_int` to `to_i` fixes this.
