### PR TITLE
Missing ending ``` at 14.2 Merging of scopes

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1202,6 +1202,7 @@ class User < ActiveRecord::Base
   scope :active, -> { where state: 'active' }
   scope :inactive, -> { where state: 'inactive' }
 end
+```
 
 ```ruby
 User.active.inactive


### PR DESCRIPTION
http://edgeguides.rubyonrails.org/active_record_querying.html#merging-of-scopes
