### PR TITLE
Remove attributes_protected_by_default reference

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -77,13 +77,6 @@ module ActiveModel
           validates_length_of :password, maximum: ActiveModel::SecurePassword::MAX_PASSWORD_LENGTH_ALLOWED
           validates_confirmation_of :password, allow_blank: true
         end
-
-        # This code is necessary as long as the protected_attributes gem is supported.
-        if respond_to?(:attributes_protected_by_default)
-          def self.attributes_protected_by_default #:nodoc:
-            super + ['password_digest']
-          end
-        end
       end
     end
 


### PR DESCRIPTION
Remove attributes_protected_by_default reference, since MassAssignmentSecurity was removed from ActiveModel f8c9a4d3e88181
