### PR TITLE
Fix regression in has_secure_password.

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix regression in has_secure_password. When a password is set, but a
+    confirmation is an empty string, it would incorrectly save.
+
+    *Steve Klabnik* and *Phillip Calvin*
+
 *   Deprecate `Validator#setup`. This should be done manually now in the validator's constructor.
 
     *Nick Sutterer*

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -56,8 +56,9 @@ module ActiveModel
         include InstanceMethodsOnActivation
 
         if options.fetch(:validations, true)
-          validates_confirmation_of :password
+          validates_confirmation_of :password, if: lambda { |m| m.password.present? }
           validates_presence_of     :password, on: :create
+          validates_presence_of     :password_confirmation, if: lambda { |m| m.password.present? }
 
           before_create { raise "Password digest missing on new record" if password_digest.blank? }
         end
@@ -106,9 +107,7 @@ module ActiveModel
       end
 
       def password_confirmation=(unencrypted_password)
-        unless unencrypted_password.blank?
-          @password_confirmation = unencrypted_password
-        end
+        @password_confirmation = unencrypted_password
       end
     end
   end

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -94,4 +94,13 @@ class SecurePasswordTest < ActiveModel::TestCase
     @user.password_confirmation = ""
     assert @user.valid?(:update), "user should be valid"
   end
+
+  test "will not save if confirmation is blank but password is not" do
+    @user.password = "password"
+    @user.password_confirmation = ""
+    assert_not @user.valid?(:create)
+
+    @user.password_confirmation = "password"
+    assert @user.valid?(:create)
+  end
 end


### PR DESCRIPTION
If the confirmation was blank, but the password wasn't, it would still save.

Sent via a PR for feedback. Password stuff is tricky.

/cc @josevalim, @senny
