### PR TITLE
Readd $rails_rake_task = true

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -245,6 +245,7 @@ module Rails
       require "rails/tasks"
       config = self.config
       task :environment do
+        $rails_rake_task = true
         config.eager_load = false
         require_environment!
       end


### PR DESCRIPTION
`$rake_rails_task` was removed in https://github.com/rails/rails/commit/e6747d87f3a061d153215715d56acbb0be20191f#commitcomment-1749296

Could we readd it or properly deprecate it like in https://github.com/rails/rails/commit/c3ca7ac09e960fa1287adc730e8ddc713e844c37 ?

/cc @josevalim
