### PR TITLE
Rake.application may be undefined when Rake is defined.

### DIFF
--- a/railties/lib/rails/test_unit/railtie.rb
+++ b/railties/lib/rails/test_unit/railtie.rb
@@ -1,4 +1,4 @@
-if defined?(Rake) && Rake.application.top_level_tasks.grep(/^(default$|test(:|$))/).any?
+if defined?(Rake) && defined?(Rake.application) && Rake.application.top_level_tasks.grep(/^(default$|test(:|$))/).any?
   ENV['RAILS_ENV'] ||= 'test'
 end
 

--- a/railties/lib/rails/test_unit/railtie.rb
+++ b/railties/lib/rails/test_unit/railtie.rb
@@ -1,4 +1,4 @@
-if defined?(Rake) && defined?(Rake.application) && Rake.application.top_level_tasks.grep(/^(default$|test(:|$))/).any?
+if defined?(Rake.application) && Rake.application.top_level_tasks.grep(/^(default$|test(:|$))/).any?
   ENV['RAILS_ENV'] ||= 'test'
 end
 


### PR DESCRIPTION
The code expects that as soon as Rake module is defined, Rake.application is defined too.  But this may not be true.
E.g. RubyMine's loggers are defined under Rake::TeamCity module and so Rake module is defined, but Rake.application isn't
