### PR TITLE
the rake task `db:test:prepare` needs to load the configuration

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -360,7 +360,7 @@ db_namespace = namespace :db do
     end
 
     # desc 'Check for pending migrations and load the test schema'
-    task :prepare do
+    task :prepare => :load_config do
       unless ActiveRecord::Base.configurations.blank?
         db_namespace['test:load'].invoke
       end


### PR DESCRIPTION
Fixes #10660 

Without the configuration the task will not perform any work.

The problem was introduced with 76a8091 where the dependencies were refactored.
