### PR TITLE
Remove explicit respond_to? and Validator#setup call

### DIFF
--- a/activemodel/lib/active_model/validations/acceptance.rb
+++ b/activemodel/lib/active_model/validations/acceptance.rb
@@ -12,11 +12,11 @@ module ActiveModel
         end
       end
 
-      def setup(klass)
-        attr_readers = attributes.reject { |name| klass.attribute_method?(name) }
-        attr_writers = attributes.reject { |name| klass.attribute_method?("#{name}=") }
-        klass.send(:attr_reader, *attr_readers)
-        klass.send(:attr_writer, *attr_writers)
+      def setup!
+        attr_readers = attributes.reject { |name| @klass.attribute_method?(name) }
+        attr_writers = attributes.reject { |name| @klass.attribute_method?("#{name}=") }
+        @klass.send(:attr_reader, *attr_readers)
+        @klass.send(:attr_writer, *attr_writers)
       end
     end
 

--- a/activemodel/lib/active_model/validations/acceptance.rb
+++ b/activemodel/lib/active_model/validations/acceptance.rb
@@ -4,6 +4,7 @@ module ActiveModel
     class AcceptanceValidator < EachValidator # :nodoc:
       def initialize(options)
         super({ allow_nil: true, accept: "1" }.merge!(options))
+        setup!(options[:class])
       end
 
       def validate_each(record, attribute, value)
@@ -12,11 +13,12 @@ module ActiveModel
         end
       end
 
-      def setup!
-        attr_readers = attributes.reject { |name| @klass.attribute_method?(name) }
-        attr_writers = attributes.reject { |name| @klass.attribute_method?("#{name}=") }
-        @klass.send(:attr_reader, *attr_readers)
-        @klass.send(:attr_writer, *attr_writers)
+      private
+      def setup!(klass)
+        attr_readers = attributes.reject { |name| klass.attribute_method?(name) }
+        attr_writers = attributes.reject { |name| klass.attribute_method?("#{name}=") }
+        klass.send(:attr_reader, *attr_readers)
+        klass.send(:attr_writer, *attr_writers)
       end
     end
 

--- a/activemodel/lib/active_model/validations/confirmation.rb
+++ b/activemodel/lib/active_model/validations/confirmation.rb
@@ -2,6 +2,11 @@ module ActiveModel
 
   module Validations
     class ConfirmationValidator < EachValidator # :nodoc:
+      def initialize(options)
+        super
+        setup!(options[:class])
+      end
+
       def validate_each(record, attribute, value)
         if (confirmed = record.send("#{attribute}_confirmation")) && (value != confirmed)
           human_attribute_name = record.class.human_attribute_name(attribute)
@@ -9,13 +14,14 @@ module ActiveModel
         end
       end
 
-      def setup!
-        @klass.send(:attr_reader, *attributes.map do |attribute|
-          :"#{attribute}_confirmation" unless @klass.method_defined?(:"#{attribute}_confirmation")
+      private
+      def setup!(klass)
+        klass.send(:attr_reader, *attributes.map do |attribute|
+          :"#{attribute}_confirmation" unless klass.method_defined?(:"#{attribute}_confirmation")
         end.compact)
 
-        @klass.send(:attr_writer, *attributes.map do |attribute|
-          :"#{attribute}_confirmation" unless @klass.method_defined?(:"#{attribute}_confirmation=")
+        klass.send(:attr_writer, *attributes.map do |attribute|
+          :"#{attribute}_confirmation" unless klass.method_defined?(:"#{attribute}_confirmation=")
         end.compact)
       end
     end

--- a/activemodel/lib/active_model/validations/confirmation.rb
+++ b/activemodel/lib/active_model/validations/confirmation.rb
@@ -9,13 +9,13 @@ module ActiveModel
         end
       end
 
-      def setup(klass)
-        klass.send(:attr_reader, *attributes.map do |attribute|
-          :"#{attribute}_confirmation" unless klass.method_defined?(:"#{attribute}_confirmation")
+      def setup!
+        @klass.send(:attr_reader, *attributes.map do |attribute|
+          :"#{attribute}_confirmation" unless @klass.method_defined?(:"#{attribute}_confirmation")
         end.compact)
 
-        klass.send(:attr_writer, *attributes.map do |attribute|
-          :"#{attribute}_confirmation" unless klass.method_defined?(:"#{attribute}_confirmation=")
+        @klass.send(:attr_writer, *attributes.map do |attribute|
+          :"#{attribute}_confirmation" unless @klass.method_defined?(:"#{attribute}_confirmation=")
         end.compact)
       end
     end

--- a/activemodel/lib/active_model/validations/with.rb
+++ b/activemodel/lib/active_model/validations/with.rb
@@ -83,9 +83,10 @@ module ActiveModel
       #   end
       def validates_with(*args, &block)
         options = args.extract_options!
+        options[:class] = self
+
         args.each do |klass|
           validator = klass.new(options, &block)
-          validator.setup(self) if validator.respond_to?(:setup)
 
           if validator.respond_to?(:attributes) && !validator.attributes.empty?
             validator.attributes.each do |attribute|

--- a/activemodel/lib/active_model/validator.rb
+++ b/activemodel/lib/active_model/validator.rb
@@ -107,7 +107,9 @@ module ActiveModel
 
     # Accepts options that will be made available through the +options+ reader.
     def initialize(options = {})
-      @options = options.freeze
+      @klass    = options.delete(:class)
+      @options  = options.freeze
+      setup!
     end
 
     # Return the kind for this validator.
@@ -122,6 +124,10 @@ module ActiveModel
     # to the records +errors+ array where necessary.
     def validate(record)
       raise NotImplementedError, "Subclasses must implement a validate(record) method."
+    end
+
+  private
+    def setup!
     end
   end
 

--- a/activemodel/lib/active_model/validator.rb
+++ b/activemodel/lib/active_model/validator.rb
@@ -109,7 +109,7 @@ module ActiveModel
     def initialize(options = {})
       @klass    = options.delete(:class)
       @options  = options.freeze
-      setup!
+      deprecated_setup or setup!
     end
 
     # Return the kind for this validator.
@@ -126,8 +126,25 @@ module ActiveModel
       raise NotImplementedError, "Subclasses must implement a validate(record) method."
     end
 
-  private
+    private
+    # Override this private method to setup the validator.
     def setup!
+    end
+
+    def deprecated_setup # TODO: remove me in 4.2.
+      return unless respond_to?(:setup)
+      ActiveSupport::Deprecation.warn "The `Validator#setup` instance method is deprecated and will be removed on Rails 4.2. Change your `setup` method to something like:
+
+class MyValidator < ActiveModel::Validator
+  private
+
+  def setup!
+    # you have access to @klass here:
+    prepare_something_with(@klass)
+  end
+end
+"
+      setup(@klass)
     end
   end
 

--- a/activemodel/lib/active_model/validator.rb
+++ b/activemodel/lib/active_model/validator.rb
@@ -105,8 +105,8 @@ module ActiveModel
 
     # Accepts options that will be made available through the +options+ reader.
     def initialize(options = {})
-      @klass    = options.delete(:class)
-      @options  = options.freeze
+      @klass    = options[:class]
+      @options  = options.except(:class).freeze
       deprecated_setup or setup!
     end
 

--- a/activemodel/lib/active_model/validator.rb
+++ b/activemodel/lib/active_model/validator.rb
@@ -82,18 +82,16 @@ module ActiveModel
   #     validates :title, presence: true
   #   end
   #
-  # Validator may also define a +setup+ instance method which will get called
-  # with the class that using that validator as its argument. This can be
-  # useful when there are prerequisites such as an +attr_accessor+ being present.
+  # Validator may also define a +setup!+ instance method which will get called
+  # automatically in the constructor. It can be useful to access the class that is
+  # using that validator when there are prerequisites such as an +attr_accessor+ being present.
+  # This class is accessable via +@klass+.
   #
   #   class MyValidator < ActiveModel::Validator
-  #     def setup(klass)
-  #       klass.send :attr_accessor, :custom_attribute
+  #     def setup!
+  #       @klass.send :attr_accessor, :custom_attribute
   #     end
   #   end
-  #
-  # This setup method is only called when used with validation macros or the
-  # class level <tt>validates_with</tt> method.
   class Validator
     attr_reader :options
 

--- a/activemodel/lib/active_model/validator.rb
+++ b/activemodel/lib/active_model/validator.rb
@@ -82,14 +82,14 @@ module ActiveModel
   #     validates :title, presence: true
   #   end
   #
-  # Validator may also define a +setup!+ instance method which will get called
-  # automatically in the constructor. It can be useful to access the class that is
-  # using that validator when there are prerequisites such as an +attr_accessor+ being present.
-  # This class is accessable via +@klass+.
+  # It can be useful to access the class that is using that validator when there are prerequisites such
+  # as an +attr_accessor+ being present. This class is accessable via +options[:class]+ in the constructor.
+  # To setup your validator override the constructor.
   #
   #   class MyValidator < ActiveModel::Validator
-  #     def setup!
-  #       @klass.send :attr_accessor, :custom_attribute
+  #     def initialize(options={})
+  #       super
+  #       options[:class].send :attr_accessor, :custom_attribute
   #     end
   #   end
   class Validator
@@ -105,9 +105,8 @@ module ActiveModel
 
     # Accepts options that will be made available through the +options+ reader.
     def initialize(options = {})
-      @klass    = options[:class]
       @options  = options.except(:class).freeze
-      deprecated_setup or setup!
+      deprecated_setup(options)
     end
 
     # Return the kind for this validator.
@@ -125,11 +124,7 @@ module ActiveModel
     end
 
     private
-    # Override this private method to setup the validator.
-    def setup!
-    end
-
-    def deprecated_setup # TODO: remove me in 4.2.
+    def deprecated_setup(options) # TODO: remove me in 4.2.
       return unless respond_to?(:setup)
       ActiveSupport::Deprecation.warn "The `Validator#setup` instance method is deprecated and will be removed on Rails 4.2. Change your `setup` method to something like:
 
@@ -142,7 +137,7 @@ class MyValidator < ActiveModel::Validator
   end
 end
 "
-      setup(@klass)
+      setup(options[:class])
     end
   end
 

--- a/activemodel/test/cases/validations/with_validation_test.rb
+++ b/activemodel/test/cases/validations/with_validation_test.rb
@@ -100,7 +100,7 @@ class ValidatesWithTest < ActiveModel::TestCase
   test "passes all configuration options to the validator class" do
     topic = Topic.new
     validator = mock()
-    validator.expects(:new).with(foo: :bar, if: "1 == 1").returns(validator)
+    validator.expects(:new).with(foo: :bar, if: "1 == 1", class: Topic).returns(validator)
     validator.expects(:validate).with(topic)
 
     Topic.validates_with(validator, if: "1 == 1", foo: :bar)

--- a/activemodel/test/cases/validations/with_validation_test.rb
+++ b/activemodel/test/cases/validations/with_validation_test.rb
@@ -107,28 +107,6 @@ class ValidatesWithTest < ActiveModel::TestCase
     assert topic.valid?
   end
 
-  test "calls setup method of validator passing in self when validator has setup method" do
-    topic = Topic.new
-    validator = stub_everything
-    validator.stubs(:new).returns(validator)
-    validator.stubs(:validate)
-    validator.stubs(:respond_to?).with(:setup).returns(true)
-    validator.expects(:setup).with(Topic).once
-    Topic.validates_with(validator)
-    assert topic.valid?
-  end
-
-  test "doesn't call setup method of validator when validator has no setup method" do
-    topic = Topic.new
-    validator = stub_everything
-    validator.stubs(:new).returns(validator)
-    validator.stubs(:validate)
-    validator.stubs(:respond_to?).with(:setup).returns(false)
-    validator.expects(:setup).with(Topic).never
-    Topic.validates_with(validator)
-    assert topic.valid?
-  end
-
   test "validates_with with options" do
     Topic.validates_with(ValidatorThatValidatesOptions, field: :first_name)
     topic = Topic.new

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -373,4 +373,25 @@ class ValidationsTest < ActiveModel::TestCase
     assert topic.invalid?
     assert duped.valid?
   end
+
+   # validator test:
+  def test_setup_is_deprecated_but_still_receives_klass # TODO: remove me in 4.2.
+    validator_class = Class.new(ActiveModel::Validator) do
+      def setup(klass)
+        @old_klass = klass
+      end
+
+      def validate(*)
+        @old_klass == Topic or raise "#setup didn't work"
+      end
+    end
+
+    #assert_deprecated do
+      Topic.validates_with validator_class
+    #end
+
+    t = Topic.new
+    t.valid?
+  end
+
 end

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -386,9 +386,9 @@ class ValidationsTest < ActiveModel::TestCase
       end
     end
 
-    #assert_deprecated do
+    assert_deprecated do
       Topic.validates_with validator_class
-    #end
+    end
 
     t = Topic.new
     t.valid?

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -9,11 +9,6 @@ module ActiveRecord
         super({ case_sensitive: true }.merge!(options))
       end
 
-      # Unfortunately, we have to tie Uniqueness validators to a class.
-      def setup(klass)
-        @klass = klass
-      end
-
       def validate_each(record, attribute, value)
         finder_class = find_finder_class_for(record)
         table = finder_class.arel_table

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -7,6 +7,7 @@ module ActiveRecord
                                "Pass a callable instead: `conditions: -> { where(approved: true) }`"
         end
         super({ case_sensitive: true }.merge!(options))
+        @klass = options[:class]
       end
 
       def validate_each(record, attribute, value)
@@ -29,7 +30,6 @@ module ActiveRecord
       end
 
     protected
-
       # The check for an existing value should be run from a class that
       # isn't abstract. This means working down from the current class
       # (self), to the first non-abstract class. Since classes don't know


### PR DESCRIPTION
This moves the setup process of validators into the constructor, pushing all knowledge about this into the validator class itself. Makes it easier to override internals in subclassed validators.
