### PR TITLE
Add ActiveModel requirement to application.rb

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -4,6 +4,7 @@ require File.expand_path('../boot', __FILE__)
 require 'rails/all'
 <% else -%>
 # Pick the frameworks you want:
+require "active_model/railtie"
 <%= comment_if :skip_active_record %>require "active_record/railtie"
 require "action_controller/railtie"
 require "action_mailer/railtie"


### PR DESCRIPTION
Currently, ActiveModel is only loaded by ActiveRecord. If you skip ActiveRecord, ActiveModel will not be required (or even autoloaded) and including `ActiveModel::Model` into a plain Ruby class will raise `NameError`.

To reproduce this:
- create a new app with `rails new my_app -O`
- create a Ruby class that includes `ActiveModel::Model` in `app/models`
- load up a Rails console and try to do anything with the class :-)

Since ActionPack relies so heavily on the ActiveModel API, this should probably be considered a dependency of the app. Another possibility would be to make it a dependency of ActionController.
