### PR TITLE
Fix XmlMini different backends tests

### DIFF
--- a/activesupport/test/xml_mini/jdom_engine_test.rb
+++ b/activesupport/test/xml_mini/jdom_engine_test.rb
@@ -178,7 +178,7 @@ if RUBY_PLATFORM =~ /java/
     private
       def assert_equal_rexml(xml)
         parsed_xml = XmlMini.parse(xml)
-        hash = XmlMini.with_backend('REXML') { parsed_xml }
+        hash = XmlMini.with_backend('REXML') { XmlMini.parse(xml) }
         assert_equal(hash, parsed_xml)
       end
   end

--- a/activesupport/test/xml_mini/libxml_engine_test.rb
+++ b/activesupport/test/xml_mini/libxml_engine_test.rb
@@ -195,7 +195,7 @@ class LibxmlEngineTest < ActiveSupport::TestCase
   private
     def assert_equal_rexml(xml)
       parsed_xml = XmlMini.parse(xml)
-      hash = XmlMini.with_backend('REXML') { parsed_xml }
+      hash = XmlMini.with_backend('REXML') { XmlMini.parse(xml) }
       assert_equal(hash, parsed_xml)
     end
 end

--- a/activesupport/test/xml_mini/libxmlsax_engine_test.rb
+++ b/activesupport/test/xml_mini/libxmlsax_engine_test.rb
@@ -186,7 +186,7 @@ class LibXMLSAXEngineTest < ActiveSupport::TestCase
   private
     def assert_equal_rexml(xml)
       parsed_xml = XmlMini.parse(xml)
-      hash = XmlMini.with_backend('REXML') { parsed_xml }
+      hash = XmlMini.with_backend('REXML') { XmlMini.parse(xml) }
       assert_equal(hash, parsed_xml)
     end
 end

--- a/activesupport/test/xml_mini/nokogiri_engine_test.rb
+++ b/activesupport/test/xml_mini/nokogiri_engine_test.rb
@@ -208,7 +208,7 @@ class NokogiriEngineTest < ActiveSupport::TestCase
   private
     def assert_equal_rexml(xml)
       parsed_xml = XmlMini.parse(xml)
-      hash = XmlMini.with_backend('REXML') { parsed_xml }
+      hash = XmlMini.with_backend('REXML') { XmlMini.parse(parsed_xml) }
       assert_equal(hash, parsed_xml)
     end
 end

--- a/activesupport/test/xml_mini/nokogirisax_engine_test.rb
+++ b/activesupport/test/xml_mini/nokogirisax_engine_test.rb
@@ -209,7 +209,7 @@ class NokogiriSAXEngineTest < ActiveSupport::TestCase
   private
     def assert_equal_rexml(xml)
       parsed_xml = XmlMini.parse(xml)
-      hash = XmlMini.with_backend('REXML') { parsed_xml }
+      hash = XmlMini.with_backend('REXML') { XmlMini.parse(xml) }
       assert_equal(hash, parsed_xml)
     end
 end

--- a/activesupport/test/xml_mini/rexml_engine_test.rb
+++ b/activesupport/test/xml_mini/rexml_engine_test.rb
@@ -30,7 +30,7 @@ class REXMLEngineTest < ActiveSupport::TestCase
   private
     def assert_equal_rexml(xml)
       parsed_xml = XmlMini.parse(xml)
-      hash = XmlMini.with_backend('REXML') { parsed_xml }
+      hash = XmlMini.with_backend('REXML') { XmlMini.parse(xml) }
       assert_equal(hash, parsed_xml)
     end
 end


### PR DESCRIPTION
Currently in some of the tests for each backend we're comparing the parsed result with the result of the default backend 'REXML' but the implementation of the helper method used to do that I think is wrong.

This PR fix that problem
