### PR TITLE
Allow passing string hash values to AR order method

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Allow passing string values to AR order method:
+
+    Example:
+
+        Model.order(id: 'asc').to_sql == Model.order(id: :asc).to_sql
+
+    Fixes #10732
+
+    *Marcelo Casiraghi*
+
 *   Stop interpreting SQL 'string' columns as :string type because there is no
     common STRING datatype in SQL.
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1019,7 +1019,7 @@ module ActiveRecord
         when Symbol
           table[order].asc
         when Hash
-          order.map { |field, dir| table[field].send(dir) }
+          order.map { |field, dir| table[field].send(dir.to_s.downcase) }
         else
           order
         end
@@ -1029,9 +1029,11 @@ module ActiveRecord
     end
 
     def validate_order_args(args)
-      args.grep(Hash) do |h|
-        unless (h.values - [:asc, :desc]).empty?
-          raise ArgumentError, 'Direction should be :asc or :desc'
+      args.grep(Hash) do |hash|
+        hash.values.each do |arg|
+          unless arg.to_s.casecmp('asc').zero? || arg.to_s.casecmp('desc').zero?
+            raise ArgumentError, 'Direction should be asc or desc'
+          end
         end
       end
     end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -151,7 +151,6 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal topics(:first).title, topics.first.title
   end
 
-
   def test_finding_with_arel_order
     topics = Topic.order(Topic.arel_table[:id].asc)
     assert_equal 4, topics.to_a.size
@@ -174,8 +173,43 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal Topic.order(:id).to_sql, Topic.order(:id => :asc).to_sql
   end
 
+  def test_finding_with_desc_order_with_string
+    topics = Topic.order(id: "desc")
+    assert_equal 4, topics.to_a.size
+    assert_equal [topics(:fourth), topics(:third), topics(:second), topics(:first)], topics.to_a
+  end
+
+  def test_finding_with_asc_order_with_string
+    topics = Topic.order(id: 'asc')
+    assert_equal 4, topics.to_a.size
+    assert_equal [topics(:first), topics(:second), topics(:third), topics(:fourth)], topics.to_a
+  end
+
+  def test_nothing_raises_on_upcase_desc_arg
+    assert_nothing_raised { Topic.order(id: "DESC") }
+  end
+
+  def test_nothing_raises_on_downcase_desc_arg
+    assert_nothing_raised { Topic.order(id: "desc") }
+  end
+
+  def test_nothing_raises_on_upcase_asc_arg
+    assert_nothing_raised { Topic.order(id: "ASC") }
+  end
+
+  def test_nothing_raises_on_downcase_asc_arg
+    assert_nothing_raised { Topic.order(id: "asc") }
+  end
+
+  def test_nothing_raises_on_case_insensitive_args
+    assert_nothing_raised { Topic.order(id: "DeSc") }
+    assert_nothing_raised { Topic.order(id: :DeSc)  }
+    assert_nothing_raised { Topic.order(id: "aSc")  }
+    assert_nothing_raised { Topic.order(id: :aSc)   }
+  end
+
   def test_raising_exception_on_invalid_hash_params
-    assert_raise(ArgumentError) { Topic.order(:name, "id DESC", :id => :DeSc) }
+    assert_raise(ArgumentError) { Topic.order(:name, "id DESC", id: :asfsdf) }
   end
 
   def test_finding_last_with_arel_order


### PR DESCRIPTION
The order method from AR supports different kinds of arguments. When using a hash as the parameter this is now supported:

``` ruby
Topic.order(id: :desc)
```

but this is NOT:

``` ruby
Topic.order(id: 'desc')
```

I think this is not the behavior that a developer would expect from a method like order, so I added a few changes to support that kind of capabilities.

IMHO, this can be useful when passing 'ASC' or 'DESC' directly from the request params, like for a basic list sorting, without the need of making conversions to symbols, which can be annoying or unclean in some situations...
