### PR TITLE
add or remove timestamps to or from a table

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Create migration to add or remove timestamps to or from table
+
+    rails generate migration add_timestamps_to_users
+
+        class AddTimestampsToUsers < ActiveRecord::Migration
+          def change
+            add_timestamps :users
+          end
+        end
+
+    rails generate migration remove_timestamps_from_users
+
+        class RemoveTimestampsFromUsers < ActiveRecord::Migration
+          def change
+            remove_timestamps :users
+          end
+        end
+
+      *Frank Pimenta (frankapimenta)*
+
 *   Also support extentions in PostgreSQL 9.1. This feature has been supported since 9.1.
 
     *kennyj*

--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -21,6 +21,10 @@ module ActiveRecord
       def set_local_assigns!
         @migration_template = "migration.rb"
         case file_name
+        when /^(add|remove)_timestamps_(?:to|from)_(.*)/
+          @migration_action = $1
+          @table_name       = $2.pluralize
+          @migration_template = 'timestamps.rb'
         when /^(add|remove)_.*_(?:to|from)_(.*)/
           @migration_action = $1
           @table_name       = $2.pluralize

--- a/activerecord/lib/rails/generators/active_record/migration/templates/timestamps.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/timestamps.rb
@@ -1,0 +1,5 @@
+class <%= migration_class_name %> < ActiveRecord::Migration
+  def change
+    <%= migration_action %>_timestamps :<%= table_name %>
+  end
+end

--- a/guides/source/migrations.md
+++ b/guides/source/migrations.md
@@ -245,6 +245,21 @@ end
 
 This migration will create a `user_id` column and appropriate index.
 
+Did you forget to add the timestamps when creating the table?
+
+```bash
+$ rails generate migration AddTimestampsToUsers
+```
+
+```ruby
+class AddTimestampsToUsers < ActiveRecord::Migration
+  add_timestamps :users
+end
+```
+
+User remove in the beginning of the previous migration name and you will have a migration to remove timestamps generated for you.
+
+
 There is also a generator which will produce join tables if `JoinTable` is part of the name:
 
 ```bash

--- a/railties/test/application/rake/migrations_test.rb
+++ b/railties/test/application/rake/migrations_test.rb
@@ -127,6 +127,44 @@ module ApplicationTests
         end
       end
 
+      test 'migration to add timestamps to products'  do
+        Dir.chdir(app_path) do
+          `rails generate migration create_products name:string;
+           rails generate migration add_timestamps_to_products`
+
+           output = `rake db:migrate`
+           assert_match(/create_table\(:products\)/, output)
+           assert_match(/CreateProducts: migrated/, output)
+           assert_match(/add_timestamps\(:products\)/, output)
+           assert_match(/AddTimestampsToProducts: migrated/, output)
+
+           output = `rake db:rollback STEP=2`
+           assert_match(/drop_table\(:products\)/, output)
+           assert_match(/CreateProducts: reverted/, output)
+           assert_match(/remove_timestamps\(:products\)/, output)
+           assert_match(/AddTimestampsToProducts: reverted/, output)
+        end
+      end
+
+      test 'migration to remove timestamps from products'  do
+        Dir.chdir(app_path) do
+          `rails generate migration create_products name:string;
+           rails generate migration remove_timestamps_from_products`
+
+           output = `rake db:migrate`
+           assert_match(/create_table\(:products\)/, output)
+           assert_match(/CreateProducts: migrated/, output)
+           assert_match(/remove_timestamps\(:products\)/, output)
+           assert_match(/RemoveTimestampsFromProducts: migrated/, output)
+
+           output = `rake db:rollback STEP=2`
+           assert_match(/drop_table\(:products\)/, output)
+           assert_match(/CreateProducts: reverted/, output)
+           assert_match(/add_timestamps\(:products\)/, output)
+           assert_match(/RemoveTimestampsFromProducts: reverted/, output)
+        end
+      end
+
       test 'migration status after rollback and redo without timestamps' do
         add_to_config('config.active_record.timestamped_migrations = false')
 

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -159,6 +159,28 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_add_timestamps_to_books
+    migration = "add_timestamps_to_books"
+    run_generator [migration]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/add_timestamps :books/, change)
+      end
+    end
+  end
+
+  def test_remove_timestamps_from_books
+    migration = "remove_timestamps_from_books"
+    run_generator [migration]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/remove_timestamps :books/, change)
+      end
+    end
+  end
+
   def test_create_join_table_migration
     migration = "add_media_join_table"
     run_generator [migration, "artist_id", "musics:uniq"]


### PR DESCRIPTION
Sometimes developers forget to add the timestamps to a table when creating it.

Migration generator now generates a migration to add or remove timestamps to or from a table automatically via CLI

rails generate migration add_timestamps_to_users
  class AddTimestampsToUsers < ActiveRecord::Migration
    def change
       add_timestamps :users
    end
  end

rails generate migration remove_timestamps_from_users
  class RemoveTimestampsFromUsers < ActiveRecord::Migration
    def change
       remove_timestamps :users
    end
  end
