### PR TITLE
Strip extra "controller" from a generated controller name

### DIFF
--- a/railties/lib/rails/generators/rails/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/rails/controller/controller_generator.rb
@@ -15,6 +15,16 @@ module Rails
       end
 
       hook_for :template_engine, :test_framework, :helper, :assets
+
+      protected
+
+      def assign_names!(name) #:nodoc:
+        if self.name =~ /(C|_c)ontroller$/
+          self.name.chomp! $&
+        end
+
+        super
+      end
     end
   end
 end

--- a/railties/test/generators/controller_generator_test.rb
+++ b/railties/test/generators/controller_generator_test.rb
@@ -82,4 +82,12 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
       assert_instance_method :bar, controller
     end
   end
+
+  def test_strip_controller_word_from_name_parameter
+    run_generator ["account_controller"]
+    assert_file "app/controllers/account_controller.rb", /class AccountController < ApplicationController/
+
+    run_generator ["AccountController"]
+    assert_file "app/controllers/account_controller.rb", /class AccountController < ApplicationController/
+  end
 end


### PR DESCRIPTION
This happens to me all the time:

`rails generate controller Admin::FoosController`

and so I end up with crap called `FoosControllerController`. This strips the extra `controller` at the end. I'm not sure about the implementation though, I'd never overridden a protected method before... feedback?

/cc. @mperham @vipulnsward
