### PR TITLE
HashWithIndifferentAccess#select working as intended

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -227,6 +227,10 @@ module ActiveSupport
     def deep_symbolize_keys; to_hash.deep_symbolize_keys end
     def to_options!; self end
 
+    def select(*args, &block)
+      dup.select!(*args, &block)
+    end
+
     # Convert to a regular hash with string keys.
     def to_hash
       _new_hash= {}

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -480,6 +480,36 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal hash.delete('a'), nil
   end
 
+  def test_indifferent_select
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@strings).select {|k,v| v == 1}
+
+    assert_equal({ 'a' => 1 }, hash)
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+  end
+
+  def test_indifferent_select_bang
+    indifferent_strings = ActiveSupport::HashWithIndifferentAccess.new(@strings)
+    indifferent_strings.select! {|k,v| v == 1}
+
+    assert_equal({ 'a' => 1 }, indifferent_strings)
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, indifferent_strings
+  end
+
+  def test_indifferent_reject
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@strings).reject {|k,v| v != 1}
+
+    assert_equal({ 'a' => 1 }, hash)
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+  end
+
+  def test_indifferent_reject_bang
+    indifferent_strings = ActiveSupport::HashWithIndifferentAccess.new(@strings)
+    indifferent_strings.reject! {|k,v| v != 1}
+
+    assert_equal({ 'a' => 1 }, indifferent_strings)
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, indifferent_strings
+  end
+
   def test_indifferent_to_hash
     # Should convert to a Hash with String keys.
     assert_equal @strings, @mixed.with_indifferent_access.to_hash


### PR DESCRIPTION
Before this commit, #reject returned a HashWithIndifferentAccess, whereas #select returned a Hash. Now #select also returns a HashWithIndifferentAccess.

I think the behavior was confusing, refactoring some code I changed a couple of `hash_with_indifferent_access.reject { |k,v| v.blank? }` by a `hash_with_indifferent_access.select { |k,v| v.present? }` because I found it a lot more readable in the context it was, and was surprised that the behavior changed.

I'm not sure if testing both bang methods is necessary, but I thought it might not hurt.

Hope to hear what you think.

Fixes #10723
