### PR TITLE
Preserve class on HashWithIndifferentAccess#select

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -182,6 +182,10 @@ module ActiveSupport
       end
     end
 
+    def select(*args, &block)
+      dup.select!(*args, &block)
+    end
+
     # This method has the same semantics of +update+, except it does not
     # modify the receiver but rather returns a new hash with indifferent
     # access with the result of the merge.

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -575,6 +575,23 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal h.class, h.dup.class
   end
 
+  def test_indifferent_select
+    h = HashWithIndifferentAccess.new
+    h.default = 'the default'
+    h[:the_selected_key] = 'the selected value'
+    h[:not_a_selected_key] = 'not a selected value'
+    selected = h.select {|_,v| v == 'the selected value'}
+
+    # Should copy the default
+    assert_equal h.default, selected.default
+
+    # Should only copy true values
+    assert_equal selected.values, ['the selected value']
+
+    # Should preserve class for the copy
+    assert_equal h.class, selected.class
+  end
+
   def test_assert_valid_keys
     assert_nothing_raised do
       { :failure => "stuff", :funny => "business" }.assert_valid_keys([ :failure, :funny ])


### PR DESCRIPTION
Previously, calling #select on an instance of HashWithIndifferentAccess could
lead to unexpected behaviour as it returned an instance of Hash. This is
because Ruby's implementation makes a copy as an instance of Hash.

This commit defines #select on HashWithIndifferentAccess to return a
hash of the correct class.
