### PR TITLE
Add notice on server boot if binding to 0.0.0.0

### DIFF
--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -63,6 +63,9 @@ module Rails
       puts "=> Booting #{ActiveSupport::Inflector.demodulize(server)}"
       puts "=> Rails #{Rails.version} application starting in #{Rails.env} on #{url}"
       puts "=> Run `rails server -h` for more startup options"
+      if options[:Host].to_s.match(/0\.0\.0\.0/)
+        puts "=> Notice: server is listening on all interfaces (#{options[:Host]}). Consider using 127.0.0.1 (--binding option)"
+      end
       trap(:INT) { exit }
       puts "=> Ctrl-C to shutdown server" unless options[:daemonize]
 


### PR DESCRIPTION
My colleagues and I spend a lot of our dev time in coffee shops and on public wi-fi. Lightly call attention to a fairly obvious security hole per http://blog.codeclimate.com/blog/2013/03/27/rails-insecure-defaults/
