### PR TITLE
Write_fragment gives undefined method errors

### DIFF
--- a/actionpack/lib/action_controller/caching/fragments.rb
+++ b/actionpack/lib/action_controller/caching/fragments.rb
@@ -59,7 +59,7 @@ module ActionController #:nodoc:
 
         key = fragment_cache_key(key)
         instrument_fragment_cache :write_fragment, key do
-          content = content.to_str
+          content = content.to_str if content.respond_to?(:to_str)
           cache_store.write(key, content, options)
         end
         content


### PR DESCRIPTION
DISCLAIMER: This is me first pull request ever, sorry if i did something wrong :)

When you create an object that has no strict representation as a string, the to_str returns an undefined method error.

It was broken in commit https://github.com/rails/rails/commit/a61e3acef25d8fb86275d41a9d0d1ba163d7e0bb

Just added the if respond_to.

This should be fix in (all) supported version of rails imho.

``` ruby
>> fragment = {"foo"=>0.0, "bar"=>0.0}
=> {"foo"=>0.0, "bar"=>0.0}
>> fragment_name= "foobar"
=> "foobar"
>>  write_fragment(fragment_name, fragment)
!! #<NoMethodError: undefined method `to_str' for {"foo"=>0.0, "bar"=>0.0}:Hash>
>>
```
