### PR TITLE
Module#deprecate dependency ActiveSupport::Deprecation

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/diff.rb
+++ b/activesupport/lib/active_support/core_ext/hash/diff.rb
@@ -1,3 +1,5 @@
+require 'active_support/deprecation'
+
 class Hash
   # Returns a hash that represents the difference between two hashes.
   #

--- a/activesupport/lib/active_support/core_ext/module/deprecation.rb
+++ b/activesupport/lib/active_support/core_ext/module/deprecation.rb
@@ -1,5 +1,3 @@
-require 'active_support/deprecation/method_wrappers'
-
 class Module
   #   deprecate :foo
   #   deprecate bar: 'message'
@@ -20,6 +18,9 @@ class Module
   #     end
   #   end
   def deprecate(*method_names)
+    unless defined? ActiveSupport::Deprecation
+      require 'active_support/deprecation'
+    end
     ActiveSupport::Deprecation.deprecate_methods(self, *method_names)
   end
 end


### PR DESCRIPTION
I used Module#deprecate and raised NoMethodError

``` ruby
require 'active_support/core_ext/module/deprecation'

class Foo
  def foo
  end
  deprecate :foo # raise NoMethodError: undefined method `deprecate_methods' for ActiveSupport::Deprecation:Class
end

Foo.new.foo
```

The following is satisfactory:

``` ruby
require 'active_support/deprecation'
require 'active_support/core_ext/module/deprecation'

class Foo
  def foo
  end
  deprecate :foo
end

Foo.new.foo
```
