### PR TITLE
Make `to_sentence` ignore blank array elements

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -36,4 +36,8 @@
 
     *Daniel Schierbeck*
 
+*   Make `to_sentence` ignore blank array elements. GH#10758
+
+    *Arthur Klepchukov*
+
 Please check [4-0-stable](https://github.com/rails/rails/blob/4-0-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -70,15 +70,16 @@ class Array
     end
     options = default_connectors.merge!(options)
 
-    case length
+    filtered = reject(&:blank?)
+    case filtered.length
     when 0
       ''
     when 1
-      self[0].to_s.dup
+      filtered[0].to_s.dup
     when 2
-      "#{self[0]}#{options[:two_words_connector]}#{self[1]}"
+      "#{filtered[0]}#{options[:two_words_connector]}#{filtered[1]}"
     else
-      "#{self[0...-1].join(options[:words_connector])}#{options[:last_word_connector]}#{self[-1]}"
+      "#{filtered[0...-1].join(options[:words_connector])}#{options[:last_word_connector]}#{filtered[-1]}"
     end
   end
 

--- a/activesupport/test/core_ext/array_ext_test.rb
+++ b/activesupport/test/core_ext/array_ext_test.rb
@@ -96,6 +96,12 @@ class ArrayExtToSentenceTests < ActiveSupport::TestCase
     assert_equal "one two, and three", ['one', 'two', 'three'].to_sentence(options)
     assert_equal({ words_connector: ' ' }, options)
   end
+
+  def test_ignores_empty_elements
+    assert_equal "one", ['', 'one', ''].to_sentence
+    assert_equal "one and two", ['one', nil, 'two'].to_sentence
+    assert_equal "one, two, and three", ['', 'one', nil, 'two', '', 'three'].to_sentence
+  end
 end
 
 class ArrayExtToSTests < ActiveSupport::TestCase


### PR DESCRIPTION
Array#to_sentence should not include blank elements in it's output as
they would not be part of a valid sentence.

```
["", "one", nil, "two", "", "three"].to_sentence
# => "one, two, and three"
# instead of
# => ", one, , two, , and three"
```
