### PR TITLE
Fix some typo in method names, variables

### DIFF
--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -77,7 +77,7 @@ class NumericExtTimeAndDateTimeTest < ActiveSupport::TestCase
     assert_equal @dtnow.advance(:days => 1).advance(:months => 2), @dtnow + 1.day + 2.months
   end
 
-  def test_duration_after_convertion_is_no_longer_accurate
+  def test_duration_after_conversion_is_no_longer_accurate
     assert_equal 30.days.to_i.since(@now), 1.month.to_i.since(@now)
     assert_equal 365.25.days.to_f.since(@now), 1.year.to_f.since(@now)
     assert_equal 30.days.to_i.since(@dtnow), 1.month.to_i.since(@dtnow)

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -54,7 +54,7 @@ class RangeTest < ActiveSupport::TestCase
     assert((1...10) === (1...10))
   end
 
-  def test_should_compare_other_with_exlusive_end
+  def test_should_compare_other_with_exclusive_end
     assert((1..10) === (1...10))
   end
 

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -195,7 +195,7 @@ class TestJSONEncoding < ActiveSupport::TestCase
     assert_nothing_raised do
       hash = {
         "CHI" => {
-          :dislay_name => "chicago",
+          :display_name => "chicago",
           :latitude => 123.234
         }
       }

--- a/activesupport/test/rescuable_test.rb
+++ b/activesupport/test/rescuable_test.rb
@@ -97,7 +97,7 @@ class RescuableTest < ActiveSupport::TestCase
     assert_equal expected, result
   end
 
-  def test_children_should_inherit_rescue_defintions_from_parents_and_child_rescue_should_be_appended
+  def test_children_should_inherit_rescue_definitions_from_parents_and_child_rescue_should_be_appended
     expected = ["WraithAttack", "WraithAttack", "NuclearExplosion", "MadRonon", "CoolError"]
     result = @cool_stargate.send(:rescue_handlers).collect {|e| e.first}
     assert_equal expected, result


### PR DESCRIPTION
Fix some typo in method names, variables
