### PR TITLE
test-case for `Array#to_sentence` with `blank?` items.

### DIFF
--- a/activesupport/test/core_ext/array_ext_test.rb
+++ b/activesupport/test/core_ext/array_ext_test.rb
@@ -96,6 +96,10 @@ class ArrayExtToSentenceTests < ActiveSupport::TestCase
     assert_equal "one two, and three", ['one', 'two', 'three'].to_sentence(options)
     assert_equal({ words_connector: ' ' }, options)
   end
+
+  def test_with_blank_elements
+    assert_equal ", one, , two, and three", [nil, 'one', '', 'two', 'three'].to_sentence
+  end
 end
 
 class ArrayExtToSTests < ActiveSupport::TestCase


### PR DESCRIPTION
origin: #10758

This PR serves as documentation for `Array#to_sentence` when the Array contains `blank?` values.
