### PR TITLE
replace class_eval by define_method in active_record/relation

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -53,33 +53,27 @@ module ActiveRecord
     end
 
     Relation::MULTI_VALUE_METHODS.each do |name|
-      class_eval <<-CODE, __FILE__, __LINE__ + 1
-        def #{name}_values                   # def select_values
-          @values[:#{name}] || []            #   @values[:select] || []
-        end                                  # end
-                                             #
-        def #{name}_values=(values)          # def select_values=(values)
-          raise ImmutableRelation if @loaded #   raise ImmutableRelation if @loaded
-          @values[:#{name}] = values         #   @values[:select] = values
-        end                                  # end
-      CODE
+      define_method "#{name}_values" do           # def select_values
+        @values[:"#{name}"] || []                 #   @values[:select] || []
+      end                                         # end
+                                                  #
+      define_method "#{name}_values=" do |values| # def select_values=(values)
+        raise ImmutableRelation if @loaded        #   raise ImmutableRelation if @loaded
+        @values[:"#{name}"] = values              #   @values[:select] = values
+      end                                         # end
     end
 
     (Relation::SINGLE_VALUE_METHODS - [:create_with]).each do |name|
-      class_eval <<-CODE, __FILE__, __LINE__ + 1
-        def #{name}_value                    # def readonly_value
-          @values[:#{name}]                  #   @values[:readonly]
-        end                                  # end
-      CODE
+      define_method "#{name}_value" do            # def readonly_value
+        @values[:"#{name}"]                       #   @values[:readonly]
+      end                                         # end
     end
 
     Relation::SINGLE_VALUE_METHODS.each do |name|
-      class_eval <<-CODE, __FILE__, __LINE__ + 1
-        def #{name}_value=(value)            # def readonly_value=(value)
-          raise ImmutableRelation if @loaded #   raise ImmutableRelation if @loaded
-          @values[:#{name}] = value          #   @values[:readonly] = value
-        end                                  # end
-      CODE
+      define_method "#{name}_value=" do |value|   # def readonly_value=(value)
+        raise ImmutableRelation if @loaded        #   raise ImmutableRelation if @loaded
+        @values[:"#{name}"] = value               #   @values[:readonly] = value
+      end                                         # end
     end
 
     def create_with_value # :nodoc:


### PR DESCRIPTION
The class_eval version is slower than the define_method version.
(http://tenderlovemaking.com/2013/03/03/dynamic_method_definitions.html)

modified:   activerecord/lib/active_record/relation/query_methods.rb
