### PR TITLE
Minor refactor of ActiveRecord::SchemaMigration

### DIFF
--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -4,31 +4,37 @@ require 'active_record/base'
 
 module ActiveRecord
   class SchemaMigration < ActiveRecord::Base
+    class << self
 
-    def self.table_name
-      "#{Base.table_name_prefix}schema_migrations#{Base.table_name_suffix}"
-    end
-
-    def self.index_name
-      "#{Base.table_name_prefix}unique_schema_migrations#{Base.table_name_suffix}"
-    end
-
-    def self.create_table(limit=nil)
-      unless connection.table_exists?(table_name)
-        version_options = {null: false}
-        version_options[:limit] = limit if limit
-
-        connection.create_table(table_name, id: false) do |t|
-          t.column :version, :string, version_options
-        end
-        connection.add_index table_name, :version, unique: true, name: index_name
+      def table_name
+        "#{table_name_prefix}schema_migrations#{table_name_suffix}"
       end
-    end
 
-    def self.drop_table
-      if connection.table_exists?(table_name)
-        connection.remove_index table_name, name: index_name
-        connection.drop_table(table_name)
+      def index_name
+        "#{table_name_prefix}unique_schema_migrations#{table_name_suffix}"
+      end
+
+      def table_exists?
+        connection.table_exists?(table_name)
+      end
+
+      def create_table(limit=nil)
+        unless table_exists?
+          version_options = {null: false}
+          version_options[:limit] = limit if limit
+
+          connection.create_table(table_name, id: false) do |t|
+            t.column :version, :string, version_options
+          end
+          connection.add_index table_name, :version, unique: true, name: index_name
+        end
+      end
+
+      def drop_table
+        if table_exists?
+          connection.remove_index table_name, name: index_name
+          connection.drop_table(table_name)
+        end
       end
     end
 


### PR DESCRIPTION
This is a very minor refactor of the ActiveRecord::SchemaMigration class.
- Removed reference to ActiveRecord::Base when calling table_name_prefix and table_name_suffix.
- Override table_exists? class method to bypass schema_cache used on the ActiveRecord::Base version.
- Switched class method definitions to preferred (class << self) style.

No tests added and no documentation modified since this is a small refactor.
