### PR TITLE
Use grep instead of select with === in QueryMethods

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1015,7 +1015,7 @@ module ActiveRecord
     end
 
     def validate_order_args(args)
-      args.select { |a| Hash === a  }.each do |h|
+      args.grep(Hash) do |h|
         unless (h.values - [:asc, :desc]).empty?
           raise ArgumentError, 'Direction should be :asc or :desc'
         end


### PR DESCRIPTION
Array#grep seems to be used pretty consistently throughout AR source code, yet it wasn't used here. 

I propose we replace this for consistency, readability and efficiency.
