### PR TITLE
using `#joins` does not imply `readonly = true`.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Usage of `implicit_readonly` is being removed`. Please use `readonly` method
+    explicitly to mark records as `readonly.
+    Fixes #10615.
+
+    Example:
+
+        user = User.joins(:todos).select("users.*, todos.title as todos_title").readonly(true).first
+        user.todos_title = 'clean pet'
+        user.save! # will raise error
+
+    *Yves Senn*
+
 *   Fix the `:primary_key` option for `has_many` associations.
     Fixes #10693.
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -76,10 +76,10 @@ module ActiveRecord
     def update_record(values, id, id_was) # :nodoc:
       substitutes, binds = substitute_values values
       um = @klass.unscoped.where(@klass.arel_table[@klass.primary_key].eq(id_was || id)).arel.compile_update(substitutes)
-      
+
       @klass.connection.update(
-        um, 
-        'SQL', 
+        um,
+        'SQL',
         binds)
     end
 
@@ -94,7 +94,7 @@ module ActiveRecord
       end
 
       [substitutes, binds]
-    end 
+    end
 
     # Initializes new record from relation while maintaining the current
     # scope.

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -26,7 +26,6 @@ module ActiveRecord
       @klass             = klass
       @table             = table
       @values            = values
-      @implicit_readonly = nil
       @loaded            = false
       @default_scoped    = false
     end
@@ -582,10 +581,7 @@ module ActiveRecord
           ActiveRecord::Associations::Preloader.new(@records, associations).run
         end
 
-        # @readonly_value is true only if set explicitly. @implicit_readonly is true if there
-        # are JOINS and no explicit SELECT.
-        readonly = readonly_value.nil? ? @implicit_readonly : readonly_value
-        @records.each { |record| record.readonly! } if readonly
+        @records.each { |record| record.readonly! } if readonly_value
       else
         @records = default_scoped.to_a
       end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -864,8 +864,6 @@ module ActiveRecord
 
       return [] if joins.empty?
 
-      @implicit_readonly = true
-
       joins.map do |join|
         case join
         when Array
@@ -947,8 +945,6 @@ module ActiveRecord
 
       join_dependency.graft(*stashed_association_joins)
 
-      @implicit_readonly = true unless association_joins.empty? && stashed_association_joins.empty?
-
       # FIXME: refactor this to build an AST
       join_dependency.join_associations.each do |association|
         association.join_to(manager)
@@ -961,7 +957,6 @@ module ActiveRecord
 
     def build_select(arel, selects)
       unless selects.empty?
-        @implicit_readonly = false
         arel.project(*selects)
       else
         arel.project(@klass.arel_table[Arel.star])

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -46,10 +46,10 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
     assert_equal 2, authors.count
   end
 
-  def test_find_with_implicit_inner_joins_honors_readonly_without_select
-    authors = Author.joins(:posts).to_a
-    assert !authors.empty?, "expected authors to be non-empty"
-    assert authors.all? {|a| a.readonly? }, "expected all authors to be readonly"
+  def test_find_with_implicit_inner_joins_without_select_does_not_imply_readonly
+    authors = Author.joins(:posts)
+    assert_not authors.empty?, "expected authors to be non-empty"
+    assert authors.none? {|a| a.readonly? }, "expected no authors to be readonly"
   end
 
   def test_find_with_implicit_inner_joins_honors_readonly_with_select


### PR DESCRIPTION
Fixes #10615

Before this patch using `#joins` resulted in a `readonly` result. However the executed query only selects the columns from the primary table. For example:

``` ruby
Author.joins(:posts) # SELECT authors.* FROM ...
```

As far as I can tell there is no reason we need to mark these records as `readonly`.
