### PR TITLE
Adding documentation and tests to ``polymorphic_url`` and ``link_to``

### DIFF
--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -74,6 +74,19 @@ module ActionDispatch
       # * <tt>:routing_type</tt> - Allowed values are <tt>:path</tt> or <tt>:url</tt>.
       #   Default is <tt>:url</tt>.
       #
+      # Also includes all the options from <tt>url_for</tt>. These include such
+      # things as <tt>:anchor</tt> or <tt>:trailing_slash</tt>. Example usage
+      # is given below:
+      #
+      #   polymorphic_url([blog, post], anchor: 'my_anchor')
+      #     # => "http://example.com/blogs/1/posts/1#my_anchor"
+      #   polymorphic_url([blog, post], anchor: 'my_anchor', script_name: "/my_app")
+      #     # => "http://example.com/my_app/blogs/1/posts/1#my_anchor"
+      #
+      # For all of these options, see the documentation for <tt>url_for</tt>.
+      #
+      # ==== Functionality
+      #
       #   # an Article record
       #   polymorphic_url(record)  # same as article_url(record)
       #

--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -92,8 +92,9 @@ module ActionView
       # ==== Data attributes
       #
       # * <tt>confirm: 'question?'</tt> - This will allow the unobtrusive JavaScript
-      #   driver to prompt with the question specified. If the user accepts, the link is
-      #   processed normally, otherwise no action is taken.
+      #   driver to prompt with the question specified (in this case, the
+      #   resulting text would be <tt>question?</tt>. If the user accepts, the
+      #   link is processed normally, otherwise no action is taken.
       # * <tt>:disable_with</tt> - Value of this parameter will be
       #   used as the value for a disabled version of the submit
       #   button when the form is submitted. This feature is provided


### PR DESCRIPTION
Right now, it's hard to find any documentation to tell you if its possible to do this:

``` ruby
polymorphic_url([:comments], anchor: "comment_#{comment.id}")
```

However it is possible because `polymorphic_url` sends its options as arguments to `url_for`. This patch documents the options and adds tests to make sure the options work.
