### PR TITLE
OptionMerger no longer performs lambda merging

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `OptionMerger` no longer performs lambda merging.
+    Fixes #9805.
+
+    *Yves Senn*
+
 *   Raise an error when multiple `included` blocks are defined for a Concern.
     The old behavior would silently discard previously defined blocks, running
     only the last one.

--- a/activesupport/lib/active_support/option_merger.rb
+++ b/activesupport/lib/active_support/option_merger.rb
@@ -12,13 +12,7 @@ module ActiveSupport
 
     private
       def method_missing(method, *arguments, &block)
-        if arguments.last.is_a?(Proc)
-          proc = arguments.pop
-          arguments << lambda { |*args| @options.deep_merge(proc.call(*args)) }
-        else
-          arguments << (arguments.last.respond_to?(:to_hash) ? @options.deep_merge(arguments.pop) : @options.dup)
-        end
-
+        arguments << (arguments.last.respond_to?(:to_hash) ? @options.deep_merge(arguments.pop) : @options.dup)
         @context.__send__(method, *arguments, &block)
       end
   end

--- a/activesupport/test/option_merger_test.rb
+++ b/activesupport/test/option_merger_test.rb
@@ -67,10 +67,10 @@ class OptionMergerTest < ActiveSupport::TestCase
   end
 
   def test_nested_method_with_options_using_lambda
-    local_lambda = lambda { { :lambda => true } }
+    local_lambda = lambda { raise "I shall not be evaluated" }
     with_options(@options) do |o|
-      assert_equal @options.merge(local_lambda.call),
-        o.method_with_options(local_lambda).call
+      assert_equal [local_lambda, @options],
+        o.method_with_args_and_options(local_lambda)
     end
   end
 
@@ -82,5 +82,9 @@ class OptionMergerTest < ActiveSupport::TestCase
   private
     def method_with_options(options = {})
       options
+    end
+
+    def method_with_args_and_options(*args)
+      args
     end
 end


### PR DESCRIPTION
This reverts commit 9eaa0a3449595d07fe2ada5c4c93ec226622147c.

Conflicts:

```
activesupport/test/option_merger_test.rb
```

Fixes #9805
