### PR TITLE
Adding the ability to filter routes by the verb

### DIFF
--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -151,6 +151,18 @@ module ApplicationTests
       assert_equal "Prefix Verb URI Pattern     Controller#Action\ncart GET /cart(.:format) cart#show\n", output
     end
 
+    def test_rake_routes_with_controller_environment
+      app_file "config/routes.rb", <<-RUBY
+        AppTemplate::Application.routes.draw do
+          get '/cart', to: 'cart#show'
+          get '/basketball', to: 'basketball#index'
+        end
+      RUBY
+
+      output = Dir.chdir(app_path){ `CONTROLLER=cart rake routes` }
+      assert_equal "Prefix Verb URI Pattern     Controller#Action\ncart GET /cart(.:format) cart#show\n", output
+    end
+
     def test_rake_routes_displays_message_when_no_routes_are_defined
       app_file "config/routes.rb", <<-RUBY
         AppTemplate::Application.routes.draw do


### PR DESCRIPTION
Right now if you want to confine your `rake routes` output to just show GET the methods, you have to do a `rake routes` and grep for all the GET methods manually. I'm adding a feature so that you can set an environment variable when doing a rake to take care of this.

I also added tests to the `CONTROLLER` environment in `rake routes`.
