### PR TITLE
Prevent side effects in `Hash#with_indifferent_access`.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Prevent side effects to hashes inside arrays when
+    `Hash#with_indifferent_access` is called.
+    Fixes #10526
+
+    *Yves Senn*
+
 *   Raise an error when multiple `included` blocks are defined for a Concern.
     The old behavior would silently discard previously defined blocks, running
     only the last one.

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -503,6 +503,13 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal [1], hash[:a]
   end
 
+  def test_with_indifferent_access_has_no_side_effects_on_existing_hash
+    hash = {content: [{:foo => :bar, 'bar' => 'baz'}]}
+    hash.with_indifferent_access
+
+    assert_equal [:foo, "bar"], hash[:content].first.keys
+  end
+
   def test_indifferent_hash_with_array_of_hashes
     hash = { "urls" => { "url" => [ { "address" => "1" }, { "address" => "2" } ] }}.with_indifferent_access
     assert_equal "1", hash[:urls][:url].first[:address]


### PR DESCRIPTION
Fixes #10526 which was caused by 8c07696f470cff823ad0b538ca4bea1594742580

This patch takes a different approach to solve the problem addressed in 8c07696f470cff823ad0b538ca4bea1594742580 and makes sure that there are no side-effects when `Hash#with_indifferent_access` is called.

The `:for` option to `convert_value` feels a bit overloaded but it was the best thing that came to mind. Please let me know if you have a better idea.
