### PR TITLE
`RoutesInspector` deals with routes using regexp as `:controller` option

### DIFF
--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -69,7 +69,7 @@ module ActionDispatch
       end
 
       def internal?
-        controller =~ %r{\Arails/(info|welcome)} || path =~ %r{\A#{Rails.application.config.assets.prefix}}
+        controller.to_s =~ %r{\Arails/(info|welcome)} || path =~ %r{\A#{Rails.application.config.assets.prefix}}
       end
 
       def engine?

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -234,6 +234,15 @@ module ActionDispatch
                       "          PUT    /posts/:id(.:format)      posts#update",
                       "          DELETE /posts/:id(.:format)      posts#destroy"], output
       end
+
+      def test_regression_route_with_controller_regexp
+        output = draw do
+          get ':controller(/:action)', controller: /api\/[^\/]+/, format: false
+        end
+
+        assert_equal ["Prefix Verb URI Pattern            Controller#Action",
+                      " GET /:controller(/:action) (?-mix:api\\/[^\\/]+)#:action"], output
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #10782.

Simple patch to make the `RoutesInspector` cope with regexp values for the `:controller` option.
