### PR TITLE
fix :restrict_with_error message

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -14,7 +14,7 @@ module ActiveRecord
 
         when :restrict_with_error
           unless empty?
-            record = klass.human_attribute_name(reflection.name).downcase
+            record = owner.class.human_attribute_name(reflection.name).downcase
             owner.errors.add(:base, :"restrict_dependent_destroy.many", record: record)
             false
           end


### PR DESCRIPTION
Suppose `User has_many :posts`, klass on this context is Post, not User.
We should call `human_attribute_name` with the owner.
