### PR TITLE
Use NullStore as the default Digestor.cache if ActionView::Base.cache_template_loading is disabled

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Set the default `ActionView::Digestor.cache` to `ActiveSupport::Cache::NullStore.new`
+    if `ActionView::Base.cache_template_loading` is disabled.
+
+    *Sean Huber*
+
 *   Fix an issue where partials with a number in the filename weren't being digested for cache dependencies.
 
     *Bryan Ricker*

--- a/actionpack/lib/action_view/digestor.rb
+++ b/actionpack/lib/action_view/digestor.rb
@@ -3,7 +3,7 @@ require 'action_view/dependency_tracker'
 
 module ActionView
   class Digestor
-    cattr_reader(:cache)
+    cattr_accessor(:cache)
     @@cache = ThreadSafe::Cache.new
 
     def self.digest(name, format, finder, options = {})

--- a/actionpack/lib/action_view/railtie.rb
+++ b/actionpack/lib/action_view/railtie.rb
@@ -33,6 +33,9 @@ module ActionView
         if app.config.action_view.cache_template_loading.nil?
           ActionView::Resolver.caching = app.config.cache_classes
         end
+        unless ActionView::Base.cache_template_loading
+          ActionView::Digestor.cache = ActiveSupport::Cache::NullStore.new
+        end
       end
     end
   end


### PR DESCRIPTION
This fixes the issues discussed in [rails/cache_digests#48](https://github.com/rails/cache_digests/pull/48) and allows cache digests to be recalculated when templates are changed in the development environment (or any environment with the `cache_template_loading` config disabled) without requiring an application restart.

Note that this applies to `4-0-stable` and `4-0-0` as well.
