### PR TITLE
Do not hit database on empty migration check

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -780,6 +780,7 @@ module ActiveRecord
       end
 
       def needs_migration?
+        return false if last_version == 0
         current_version < last_version
       end
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -70,10 +70,22 @@ class MigrationTest < ActiveRecord::TestCase
     assert_equal 3, ActiveRecord::Migrator.last_version
     assert_equal false, ActiveRecord::Migrator.needs_migration?
 
-    ActiveRecord::Migrator.down(MIGRATIONS_ROOT + "/valid")
+    ActiveRecord::Migrator.down(migrations_path)
     assert_equal 0, ActiveRecord::Migrator.current_version
     assert_equal 3, ActiveRecord::Migrator.last_version
     assert_equal true, ActiveRecord::Migrator.needs_migration?
+  end
+
+  def test_needs_migration_on_empty_does_not_hit_db
+    migrations_path = MIGRATIONS_ROOT + "/empty"
+    ActiveRecord::Migrator.migrations_paths = migrations_path
+    ActiveRecord::Migrator.up(migrations_path)
+
+    assert_equal 0, ActiveRecord::Migrator.current_version
+    assert_equal 0, ActiveRecord::Migrator.last_version
+
+    ActiveRecord::Migrator.expects(:current_version).never
+    assert_equal false, ActiveRecord::Migrator.needs_migration?
   end
 
   def test_create_table_with_force_true_does_not_drop_nonexisting_table


### PR DESCRIPTION
Rails will perform a "pending migration" check on every page load in development starting in Rails 4.0. An exception will be raised if the current version of migrations stored in the database is not greater than or equal to the last version from the db/migrate folder. This check requires a database connection which may not exist. 

The problem comes when someone creates a new application using a non sqlite database

```
$ rails new -d postgresql
```

If someone runs this then visits the server they will get an error because they likely have not created the database yet though our migration check is attempting to get the schema version from the database. This PR fixes that problem.

If there are no migrations in db/migration then there cannot be migrations pending, so a database connection is not needed. This PR checks to see if there are 0 migrations, and if so `needs_migration?` will return false instead of hitting the database to detect the current_version.

ATP Active Record
