### PR TITLE
Don't blindly call blame_file! on exceptions in ActiveSupport::Dependes::Loadable

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `ActiveSupport::Dependencies::Loadable#load_dependency` calling
+    `#blame_file!` on Exceptions that do not have the Blamable mixin
+
+    *Andrew Kreiling*
+
 *   Override `Time.at` to support the passing of Time-like values when called with a single argument.
 
     *Andrew White*

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -213,7 +213,7 @@ module ActiveSupport #:nodoc:
           yield
         end
       rescue Exception => exception  # errors from loading file
-        exception.blame_file! file
+        exception.blame_file! file if exception.respond_to? :blame_file!
         raise
       end
 

--- a/activesupport/test/dependencies/raises_exception_without_blame_file.rb
+++ b/activesupport/test/dependencies/raises_exception_without_blame_file.rb
@@ -1,0 +1,5 @@
+exception = Exception.new('I am not blamable!')
+class << exception
+  undef_method(:blame_file!)
+end
+raise exception

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -76,6 +76,14 @@ class DependenciesTest < ActiveSupport::TestCase
     end
   end
 
+  def test_dependency_which_raises_doesnt_blindly_call_blame_file!
+    with_loading do
+      filename = 'dependencies/raises_exception_without_blame_file'
+
+      assert_raises(Exception) { require_dependency filename }
+    end
+  end
+
   def test_warnings_should_be_enabled_on_first_load
     with_loading 'dependencies' do
       old_warnings, ActiveSupport::Dependencies.warnings_on_first_load = ActiveSupport::Dependencies.warnings_on_first_load, true


### PR DESCRIPTION
> It is possible under some environments to receive an Exception that is
> not extended with Blamable (e.g. JRuby).
> ActiveSupport::Dependencies::Loadable#load_dependency blindly call
> blame_file! on the exception which throws it's own NoMethodError
> exception and hides the original Exception.
> 
> This commit fixes #9521

This is me rebasing @akreiling's commit against master since he seems to be mia.
