### PR TITLE
Add `group_by` to `ActiveRecord::FinderMethods`, take two

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add `ActiveRecord::FinderMethods#group_by` method, which collects records
+    into sets, grouped by distinct values for the specified `field`. This patch
+    leverages `ActiveRecord::Relation` to be far more efficient than
+    `Enumerable#group_by` when selecting based on a column name.
+
+    Example:
+
+        User.group_by(:role)
+        # => {"normal" => #<ActiveRecord::Relation [...]>, "admin" => #<ActiveRecord::Relation [...]>}
+
+    *Aidan Feldman*
+
 *   Since the `test_help.rb` in Railties now automatically maintains
     your test schema, the `rake db:test:*` tasks are deprecated. This
     doesn't stop you manually running other tasks on your test database

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -217,6 +217,27 @@ module ActiveRecord
       connection.select_value(relation, "#{name} Exists", relation.bind_values) ? true : false
     end
 
+    # Collect records into sets, grouped by distinct values for the specified +field+.
+    #
+    #   User.select([:id, :name])
+    #   => [#<User id: 1, name: "Oscar">, #<User id: 2, name: "Oscar">, #<User id: 3, name: "Foo">
+    #
+    #   User.group_by(:name)
+    #   => {"Foo" => #<ActiveRecord::Relation [...]>, "Oscar" => #<ActiveRecord::Relation [...]>}
+    def group_by(field = nil, &block)
+      if field.nil? || block_given?
+        super(&block)
+      else
+        result = {}
+        select(field).distinct.each do |item|
+          value = item[field]
+          result[value] = where(field => value)
+        end
+
+        result
+      end
+    end
+
     # This method is called whenever no records are found with either a single
     # id or multiple ids and raises a +ActiveRecord::RecordNotFound+ exception.
     #

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -883,6 +883,35 @@ class FinderTest < ActiveRecord::TestCase
     assert_nothing_raised(ActiveRecord::StatementInvalid) { Topic.offset("3").to_a }
   end
 
+  def test_group_by_with_no_args
+    assert_kind_of Enumerator, Company.all.group_by
+  end
+
+  def test_group_by_with_symbol
+    groups = Company.all.group_by(:type)
+    assert_kind_of Hash, groups
+
+    keys = groups.keys
+    assert_equal 5, keys.size
+    assert_equal [nil, 'Client', 'DependentFirm', 'ExclusivelyDependentFirm', 'Firm'].to_set, keys.to_set
+
+    assert_equal [2, 3, 5, 10], groups['Client'].map(&:id).sort
+    assert_equal [1, 4], groups['Firm'].map(&:id).sort
+    assert_equal nil, groups['Nonexistent']
+  end
+
+  def test_group_by_with_block
+    groups = Company.all.group_by { |c| c.firm_id }
+
+    group = groups[4]
+    assert_kind_of Array, group
+    assert_equal [5, 10], group.map(&:id).sort
+  end
+
+  def test_group_by_with_no_args
+    assert_kind_of Enumerable, Company.all.group_by
+  end
+
   protected
     def bind(statement, *vars)
       if vars.first.is_a?(Hash)

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -638,8 +638,10 @@ will return instead a maximum of 5 clients beginning with the 31st. The SQL look
 SELECT * FROM clients LIMIT 5 OFFSET 30
 ```
 
-Group
------
+Grouping
+--------
+
+### `group`
 
 To apply a `GROUP BY` clause to the SQL fired by the finder, you can specify the `group` method on the find.
 
@@ -658,6 +660,25 @@ SELECT date(created_at) as ordered_date, sum(price) as total_price
 FROM orders
 GROUP BY date(created_at)
 ```
+
+### `group_by`
+
+Similar to [Ruby's `Enumerable#group_by`](http://ruby-doc.org/core/Enumerable.html#method-i-group_by), Active Record's `group_by` method provides a way to retrieve all records that correspond to each distinct value.
+
+For example, to get the list of users with each role:
+
+```ruby
+Address.group_by(:state)
+# => {"AL" => #<ActiveRecord::Relation [...]>, "AK" => #<ActiveRecord::Relation [...]>, ...}
+```
+
+Under the hood, it will execute the SQL to retrieve the distinct values of the column:
+
+```sql
+# SELECT DISTINCT state FROM addresses
+```
+
+Without loading the full records from the database.
 
 Having
 ------


### PR DESCRIPTION
_Replaces #10447, since Github Pull Requests don't understand rebasing._
- Incorporated feedback from @egilburg.
- Updated benchmarks, and included pre-patch times [here](https://gist.github.com/afeld/5516129).

---

Enables collecting of records into sets, grouped by distinct values for the specified `field`. Leverages `ActiveRecord::Relation` to be far more efficient than `Enumerable#group_by` when selecting based on a column name.

Example:

``` ruby
User.group_by(:role)
# => {
#   "normal" => #<ActiveRecord::Relation [...]>,
#   "admin" => #<ActiveRecord::Relation [...]>
# }
```

I work with a lot of people who are new to Rails, and I've had multiple people ask if there was a way to do this with ActiveRecord.  Figured it was time to finally support it.

One question: should documentation be added suggesting an index on any column that `group_by` is being called on regularly?  I haven't seen those kinds of tips anywhere else in the documentation, but think it might be beneficial.
