### PR TITLE
Fix migrations that use enable_extension with table_name_prefix/suffix

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix bug that added `table_name_prefix` and `table_name_suffix` to
+    extension names in PostgreSQL when migrating.
+
+    *Joao Carlos*
+
 *   Usage of `implicit_readonly` is being removed`. Please use `readonly` method
     explicitly to mark records as `readonly.
     Fixes #10615.

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -613,7 +613,7 @@ module ActiveRecord
 
       say_with_time "#{method}(#{arg_list})" do
         unless @connection.respond_to? :revert
-          unless arguments.empty? || method == :execute
+          unless arguments.empty? || [:execute, :enable_extension, :disable_extension].include?(method)
             arguments[0] = Migrator.proper_table_name(arguments.first)
             arguments[1] = Migrator.proper_table_name(arguments.second) if method == :rename_table
           end

--- a/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
@@ -1,0 +1,59 @@
+require "cases/helper"
+require "active_record/base"
+require "active_record/connection_adapters/postgresql_adapter"
+
+class PostgresqlExtensionMigrationTest < ActiveRecord::TestCase
+  self.use_transactional_fixtures = false
+
+  class EnableHstore < ActiveRecord::Migration
+    def change
+      enable_extension "hstore"
+    end
+  end
+
+  class DisableHstore < ActiveRecord::Migration
+    def change
+      disable_extension "hstore"
+    end
+  end
+
+  def setup
+    super
+
+    @connection = ActiveRecord::Base.connection
+
+    unless @connection.supports_extensions?
+      return skip("no extension support")
+    end
+
+    ActiveRecord::Base.table_name_prefix = "p_"
+    ActiveRecord::Base.table_name_suffix = "_s"
+    ActiveRecord::SchemaMigration.delete_all rescue nil
+    ActiveRecord::Migration.verbose = false
+  end
+
+  def teardown
+    ActiveRecord::Base.table_name_prefix = ""
+    ActiveRecord::Base.table_name_suffix = ""
+    ActiveRecord::SchemaMigration.delete_all rescue nil
+    ActiveRecord::Migration.verbose = true
+
+    super
+  end
+
+  def test_enable_extension_migration_ignores_prefix_and_suffix
+    @connection.disable_extension("hstore")
+
+    migrations = [EnableHstore.new(nil, 1)]
+    ActiveRecord::Migrator.new(:up, migrations).migrate
+    assert @connection.extension_enabled?("hstore"), "extension hstore should be enabled"
+  end
+
+  def test_disable_extension_migration_ignores_prefix_and_suffix
+    @connection.enable_extension("hstore")
+
+    migrations = [DisableHstore.new(nil, 1)]
+    ActiveRecord::Migrator.new(:up, migrations).migrate
+    assert_not @connection.extension_enabled?("hstore"), "extension hstore should not be enabled"
+  end
+end


### PR DESCRIPTION
When using `ActiveRecord::Base.table_name_prefix` and/or `table_name_suffix`, extension names get the same treatment as table names when running migrations. This leads to migrations that try to call, for example, `enable_extension("prefix_hstore_suffix")` on the connection.

This pull request fixes that and adds some tests for both `enable_extension` and `disable_extension` in migrations. I think it should also be backported to _4-0-stable_. I can send another pull request for the backport if needed.
