### PR TITLE
Remove double trailing slash on url generation

### DIFF
--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -68,6 +68,7 @@ module ActionDispatch
         end
 
         def host_or_subdomain_and_domain(options)
+          options[:host].chomp!('/') if options[:host]
           return options[:host] if !named_host?(options[:host]) || (options[:subdomain].nil? && options[:domain].nil?)
 
           tld_length = options[:tld_length] || @@tld_length

--- a/actionpack/test/dispatch/url_generation_test.rb
+++ b/actionpack/test/dispatch/url_generation_test.rb
@@ -39,6 +39,10 @@ module TestUrlGeneration
       https!
       assert_equal "http://www.example.com/foo", foo_url(:protocol => "http")
     end
+
+    test "remove trailing slash from host" do
+      assert_equal "http://www.example.com/foo", foo_url(host: "www.example.com/")
+    end
   end
 end
 


### PR DESCRIPTION
Mentioned in #9838

Currently this:

```
bar_path(host: 'example.com/')
```

Turns into `example.com//bar`

Which is not correct, this PR fixes that issue.

ATP actionpack cc @pixeltrix
