### PR TITLE
Fix #10842. `assert_redirected_to` does not show user-supplied message.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## unreleased ##
 
+*   Fix `ActionDispatch::Assertions::ResponseAssertions#assert_redirected_to`
+    does not show user-supplied message.
+
+    Issue: when `assert_redirected_to` fails due to the response redirect not
+    matching the expected redirect the user-supplied message (second parameter)
+    is not shown. This message is only shown if the response is not a redirect.
+
+    *Alexey Chernenkov*
+
 *   Merge `:action` from routing scope and assign endpoint if both `:controller`
     and `:action` are present. The endpoint assignment only occurs if there is
     no `:to` present in the options hash so should only affect routes using the

--- a/actionpack/lib/action_dispatch/testing/assertions/response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/response.rb
@@ -62,7 +62,7 @@ module ActionDispatch
         redirect_expected = normalize_argument_to_redirection(options)
 
         if redirect_is != redirect_expected
-          flunk "Expected response to be a redirect to <#{redirect_expected}> but was a redirect to <#{redirect_is}>"
+          flunk(build_message(message, "Expected response to be a redirect to <?> but was a redirect to <?>", redirect_expected, redirect_is))
         end
       end
 

--- a/actionpack/test/dispatch/routing_assertions_test.rb
+++ b/actionpack/test/dispatch/routing_assertions_test.rb
@@ -42,7 +42,7 @@ class RoutingAssertionsTest < ActionController::TestCase
   def test_assert_recognizes_with_extras
     assert_recognizes({ :controller => 'articles', :action => 'index', :page => '1' }, '/articles', { :page => '1' })
   end
- 
+
   def test_assert_recognizes_with_method
     assert_recognizes({ :controller => 'articles', :action => 'create' }, { :path => '/articles', :method => :post })
     assert_recognizes({ :controller => 'articles', :action => 'update', :id => '1' }, { :path => '/articles/1', :method => :put })


### PR DESCRIPTION
Fix #10842

Issue: when `assert_redirected_to` fails due to the response redirect not
matching the expected redirect the user-supplied message (second parameter)
is not shown. This message is only shown if the response is not a redirect.

If ...

```
assert_redirected_to login_path, "Expected redirect to login page"
```

... there is redirection not to `login_path` then we don't see "Expected redirect to login page." but only default "Expected response to be a redirect to /login but was a redirect to /other." message.

The issue was [first mentioned in 2011](https://rails.lighthouseapp.com/projects/8994/tickets/2477-assert_redirected_to-should-surface-the-message-in-all-fail-cases) but was not fixed in 3.\* branch. I faced with it several days ago.

In 4.\* `action_dispatch` tests helpers were refactored so 4.\* has no such bug.
