### PR TITLE
Handle `name` and `"char"` column types in the PostgreSQL adapter.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Handle `name` and `"char"` column types in the PostgreSQL adapter.
+
+    `name` and `"char"` are special character types used internally by
+    PostgreSQL and are used by internal system catalogs. These field types
+    can sometimes show up in structure-sniffing queries that feature internal system
+    structures or with certain PostgreSQL extensions.
+
+    *J Smith*
+
 *   Deprecate unused `ActiveRecord::Base.symbolized_base_class`
     and `ActiveRecord::Base.symbolized_sti_name` without replacement.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -95,7 +95,7 @@ module ActiveRecord
           when /\A\(?(-?\d+(\.\d*)?\)?(::bigint)?)\z/
             $1
           # Character types
-          when /\A\(?'(.*)'::.*\b(?:character varying|bpchar|text)\z/m
+          when /\A\(?'(.*)'::.*\b(?:character varying|bpchar|text|name|"char")\z/m
             $1.gsub(/''/, "'")
           # Binary data types
           when /\A'(.*)'::bytea\z/m
@@ -214,6 +214,10 @@ module ActiveRecord
             :macaddr
           # Character types
           when /^(?:character varying|bpchar)(?:\(\d+\))?$/
+            :string
+          when 'name'
+            :string
+          when '"char"'
             :string
           # Binary data types
           when 'bytea'

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -285,6 +285,20 @@ module ActiveRecord
         end
       end
 
+      def test_internal_name_column_type
+        @connection.exec_query('drop table if exists ex')
+        @connection.exec_query('create table ex(data name)')
+        column = @connection.columns('ex').find { |col| col.name == 'data' }
+        assert_equal :string, column.type
+      end
+
+      def test_internal_char_column_type
+        @connection.exec_query('drop table if exists ex')
+        @connection.exec_query('create table ex(data "char")')
+        column = @connection.columns('ex').find { |col| col.name == 'data' }
+        assert_equal :string, column.type
+      end
+
       private
       def insert(ctx, data)
         binds   = data.map { |name, value|


### PR DESCRIPTION
`name` and `"char"` are special character types used internally by
PostgreSQL and are used by internal system catalogs. These field types can sometimes show up in structure-sniffing queries that feature internal system structures or with certain PostgreSQL extensions. I ran across this issue when using PostGIS, as its `geography_columns` view uses the `name` type for some of its fields. It would be nice if this could be merged into the 4-0-stable branch as well if possible. 

More details on the `name` and `"char"` types can be found at the bottom of this page:

http://www.postgresql.org/docs/9.2/static/datatype-character.html
