### PR TITLE
Extract ActionDispatch::Request#deep_munge

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -22,6 +22,7 @@ module ActionDispatch
     include ActionDispatch::Http::URL
 
     autoload :Session, 'action_dispatch/request/session'
+    autoload :Utils,   'action_dispatch/request/utils'
 
     LOCALHOST   = Regexp.union [/^127\.0\.0\.\d{1,3}$/, /^::1$/, /^0:0:0:0:0:0:0:1(%.*)?$/]
 
@@ -299,26 +300,10 @@ module ActionDispatch
       LOCALHOST =~ remote_addr && LOCALHOST =~ remote_ip
     end
 
-    # Remove nils from the params hash
-    def deep_munge(hash)
-      hash.each do |k, v|
-        case v
-        when Array
-          v.grep(Hash) { |x| deep_munge(x) }
-          v.compact!
-          hash[k] = nil if v.empty?
-        when Hash
-          deep_munge(v)
-        end
-      end
-
-      hash
-    end
-
     protected
 
     def parse_query(qs)
-      deep_munge(super)
+      Utils.deep_munge(super)
     end
 
     private

--- a/actionpack/lib/action_dispatch/middleware/params_parser.rb
+++ b/actionpack/lib/action_dispatch/middleware/params_parser.rb
@@ -43,7 +43,7 @@ module ActionDispatch
         when :json
           data = ActiveSupport::JSON.decode(request.body)
           data = {:_json => data} unless data.is_a?(Hash)
-          request.deep_munge(data).with_indifferent_access
+          Request::Utils.deep_munge(data).with_indifferent_access
         else
           false
         end

--- a/actionpack/lib/action_dispatch/request/utils.rb
+++ b/actionpack/lib/action_dispatch/request/utils.rb
@@ -1,0 +1,24 @@
+module ActionDispatch
+  class Request < Rack::Request
+    class Utils # :nodoc:
+      class << self
+        # Remove nils from the params hash
+        def deep_munge(hash)
+          hash.each do |k, v|
+            case v
+            when Array
+              v.grep(Hash) { |x| deep_munge(x) }
+              v.compact!
+              hash[k] = nil if v.empty?
+            when Hash
+              deep_munge(v)
+            end
+          end
+
+          hash
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
`ActionDispatch::Request#deep_munge` was introduced as a private method, but was turned into a public one for the use of `ActionDispatch::ParamsParser`.

I have extracted it into `ActionDispatch::Request::Utils`, so it does not get mixed up with the `ActionDispatch::Request` public methods.
