### PR TITLE
WIP: Extract the compilation stuff from ActionView::Template

### DIFF
--- a/actionpack/lib/action_view/compiler.rb
+++ b/actionpack/lib/action_view/compiler.rb
@@ -17,11 +17,14 @@ module ActionView
       # Make sure that the resulting String to be evalled is in the
       # encoding of the code
       source = <<-end_src
-        def initialize(view)
+        attr_reader :local_assigns
+
+        def initialize(view, local_assigns)
           @view = view
           @view_flow = view.view_flow
           @virtual_path = #{virtual_path.inspect}
           @output_buffer = view.output_buffer
+          @local_assigns = local_assigns
 
           if view.respond_to?(:assigns)
             view.assigns.each do |key, value|
@@ -30,10 +33,10 @@ module ActionView
           end
         end
 
-        def render(local_assigns, output_buffer)
-          _old_virtual_path, @view.virtual_path = @view.virtual_path, @virtual_path;_old_output_buffer = @output_buffer;#{locals_code};#{code}
+        def render(output_buffer)
+          @view.virtual_path = @virtual_path;_old_output_buffer = @output_buffer;#{locals_code};#{code}
         ensure
-          @view.virtual_path, @output_buffer = _old_virtual_path, _old_output_buffer
+          @view.virtual_path, @output_buffer = @virtual_path, _old_output_buffer
         end
 
         def method_missing(method, *args, &block)

--- a/actionpack/lib/action_view/compiler.rb
+++ b/actionpack/lib/action_view/compiler.rb
@@ -1,0 +1,69 @@
+module ActionView
+  class Compiler
+    def self.compile_template(template)
+      new(template).compile
+    end
+
+    def initialize(template)
+      @template = template
+    end
+
+    def compile
+      source = @template.source
+      code = @template.handler.call(@template)
+      virtual_path = @template.virtual_path
+      compiled_template = Class.new
+
+      # Make sure that the resulting String to be evalled is in the
+      # encoding of the code
+      source = <<-end_src
+        def initialize(view)
+          @view = view
+          @view_flow = view.view_flow
+          @virtual_path = #{virtual_path.inspect}
+          @output_buffer = view.output_buffer
+
+          if view.respond_to?(:assigns)
+            view.assigns.each do |key, value|
+              instance_variable_set("@\#{key}", value)
+            end
+          end
+        end
+
+        def render(local_assigns, output_buffer)
+          _old_virtual_path, @view.virtual_path = @view.virtual_path, @virtual_path;_old_output_buffer = @output_buffer;#{locals_code};#{code}
+        ensure
+          @view.virtual_path, @output_buffer = _old_virtual_path, _old_output_buffer
+        end
+
+        def method_missing(method, *args, &block)
+          @view.send(method, *args, &block)
+        end
+      end_src
+
+      # Make sure the source is in the encoding of the returned code
+      source.force_encoding(code.encoding)
+
+      # In case we get back a String from a handler that is not in
+      # BINARY or the default_internal, encode it to the default_internal
+      source.encode!
+
+      # Now, validate that the source we got back from the template
+      # handler is valid in the default_internal. This is for handlers
+      # that handle encoding but screw up
+      unless source.valid_encoding?
+        raise WrongEncodingError.new(@source, Encoding.default_internal)
+      end
+
+      compiled_template.class_eval(source)
+      compiled_template
+    end
+
+    private
+
+    def locals_code #:nodoc:
+      # Double assign to suppress the dreaded 'assigned but unused variable' warning
+      @template.locals.map { |key| "#{key} = #{key} = local_assigns[:#{key}];" }.join
+    end
+  end
+end

--- a/actionpack/lib/action_view/compiler.rb
+++ b/actionpack/lib/action_view/compiler.rb
@@ -33,8 +33,15 @@ module ActionView
           end
         end
 
-        def render(output_buffer)
+        def call(output_buffer)
+          old_ivars = instance_variables
           #{locals_code};#{code}
+        ensure
+          ivars = instance_variables - old_ivars
+          ivars.each do |ivar|
+            value = instance_variable_get(ivar)
+            @view.instance_variable_set(ivar, value)
+          end
         end
 
         def method_missing(method, *args, &block)
@@ -56,7 +63,7 @@ module ActionView
         raise WrongEncodingError.new(@source, Encoding.default_internal)
       end
 
-      compiled_template.class_eval(source)
+      compiled_template.class_eval(source, @template.identifier, 0)
       compiled_template
     end
 

--- a/actionpack/lib/action_view/compiler.rb
+++ b/actionpack/lib/action_view/compiler.rb
@@ -35,6 +35,7 @@ module ActionView
 
         def call(output_buffer)
           old_ivars = instance_variables
+          @view.virtual_path = @virtual_path
           #{locals_code};#{code}
         ensure
           ivars = instance_variables - old_ivars

--- a/actionpack/lib/action_view/compiler.rb
+++ b/actionpack/lib/action_view/compiler.rb
@@ -34,9 +34,7 @@ module ActionView
         end
 
         def render(output_buffer)
-          @view.virtual_path = @virtual_path;_old_output_buffer = @output_buffer;#{locals_code};#{code}
-        ensure
-          @view.virtual_path, @output_buffer = @virtual_path, _old_output_buffer
+          #{locals_code};#{code}
         end
 
         def method_missing(method, *args, &block)

--- a/actionpack/lib/action_view/context.rb
+++ b/actionpack/lib/action_view/context.rb
@@ -14,7 +14,7 @@ module ActionView
   # (although you can call _prepare_context defined below).
   module Context
     include CompiledTemplates
-    attr_accessor :output_buffer, :view_flow
+    attr_accessor :output_buffer, :view_flow, :virtual_path
 
     # Prepares the context by setting the appropriate instance variables.
     # :api: plugin

--- a/actionpack/lib/action_view/template.rb
+++ b/actionpack/lib/action_view/template.rb
@@ -142,7 +142,7 @@ module ActionView
       instrument("!render_template") do
         @compiled_template ||= compile!
         compiled_view = @compiled_template.new(view, locals)
-        compiled_view.render(buffer, &block)
+        compiled_view.call(buffer, &block)
       end
     rescue Exception => e
       handle_render_error(view, e)

--- a/actionpack/lib/action_view/template.rb
+++ b/actionpack/lib/action_view/template.rb
@@ -142,8 +142,8 @@ module ActionView
       instrument("!render_template") do
         encode!
         compiled_template = Compiler.compile_template(self)
-        compiled_view = compiled_template.new(view)
-        compiled_view.render(locals, buffer, &block)
+        compiled_view = compiled_template.new(view, locals)
+        compiled_view.render(buffer, &block)
       end
     rescue Exception => e
       handle_render_error(view, e)

--- a/actionpack/lib/action_view/template.rb
+++ b/actionpack/lib/action_view/template.rb
@@ -140,8 +140,7 @@ module ActionView
     # consume this in production. This is only slow if it's being listened to.
     def render(view, locals, buffer=nil, &block)
       instrument("!render_template") do
-        encode!
-        compiled_template = Compiler.compile_template(self)
+        compiled_template = compile!
         compiled_view = compiled_template.new(view, locals)
         compiled_view.render(buffer, &block)
       end
@@ -230,87 +229,10 @@ module ActionView
 
       # Compile a template. This method ensures a template is compiled
       # just once and removes the source after it is compiled.
-      def compile!(view) #:nodoc:
-        return if @compiled
-
-        # Templates can be used concurrently in threaded environments
-        # so compilation and any instance variable modification must
-        # be synchronized
-        @compile_mutex.synchronize do
-          # Any thread holding this lock will be compiling the template needed
-          # by the threads waiting. So re-check the @compiled flag to avoid
-          # re-compilation
-          return if @compiled
-
-          if view.is_a?(ActionView::CompiledTemplates)
-            mod = ActionView::CompiledTemplates
-          else
-            mod = view.singleton_class
-          end
-
-          instrument("!compile_template") do
-            compile(view, mod)
-          end
-
-          # Just discard the source if we have a virtual path. This
-          # means we can get the template back.
-          @source = nil if @virtual_path
-          @compiled = true
-        end
-      end
-
-      # Among other things, this method is responsible for properly setting
-      # the encoding of the compiled template.
-      #
-      # If the template engine handles encodings, we send the encoded
-      # String to the engine without further processing. This allows
-      # the template engine to support additional mechanisms for
-      # specifying the encoding. For instance, ERB supports <%# encoding: %>
-      #
-      # Otherwise, after we figure out the correct encoding, we then
-      # encode the source into <tt>Encoding.default_internal</tt>.
-      # In general, this means that templates will be UTF-8 inside of Rails,
-      # regardless of the original source encoding.
-      def compile(view, mod) #:nodoc:
+      def compile! #:nodoc:
         encode!
-        method_name = self.method_name
-        code = @handler.call(self)
-
-        # Make sure that the resulting String to be evalled is in the
-        # encoding of the code
-        source = <<-end_src
-          def #{method_name}(local_assigns, output_buffer)
-            _old_virtual_path, @virtual_path = @virtual_path, #{@virtual_path.inspect};_old_output_buffer = @output_buffer;#{locals_code};#{code}
-          ensure
-            @virtual_path, @output_buffer = _old_virtual_path, _old_output_buffer
-          end
-        end_src
-
-        # Make sure the source is in the encoding of the returned code
-        source.force_encoding(code.encoding)
-
-        # In case we get back a String from a handler that is not in
-        # BINARY or the default_internal, encode it to the default_internal
-        source.encode!
-
-        # Now, validate that the source we got back from the template
-        # handler is valid in the default_internal. This is for handlers
-        # that handle encoding but screw up
-        unless source.valid_encoding?
-          raise WrongEncodingError.new(@source, Encoding.default_internal)
-        end
-
-        begin
-          mod.module_eval(source, identifier, 0)
-          ObjectSpace.define_finalizer(self, Finalizer[method_name, mod])
-        rescue Exception => e # errors from template code
-          if logger = (view && view.logger)
-            logger.debug "ERROR: compiling #{method_name} RAISED #{e}"
-            logger.debug "Function body: #{source}"
-            logger.debug "Backtrace: #{e.backtrace.join("\n")}"
-          end
-
-          raise ActionView::Template::Error.new(self, e)
+        instrument("!compile_template") do
+          Compiler.compile_template(self)
         end
       end
 

--- a/actionpack/lib/action_view/template.rb
+++ b/actionpack/lib/action_view/template.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/object/try'
 require 'active_support/core_ext/kernel/singleton_class'
+require 'action_view/compiler'
 require 'thread'
 
 module ActionView
@@ -139,8 +140,10 @@ module ActionView
     # consume this in production. This is only slow if it's being listened to.
     def render(view, locals, buffer=nil, &block)
       instrument("!render_template") do
-        compile!(view)
-        view.send(method_name, locals, buffer, &block)
+        encode!
+        compiled_template = Compiler.compile_template(self)
+        compiled_view = compiled_template.new(view)
+        compiled_view.render(locals, buffer, &block)
       end
     rescue Exception => e
       handle_render_error(view, e)

--- a/actionpack/lib/action_view/template.rb
+++ b/actionpack/lib/action_view/template.rb
@@ -140,8 +140,8 @@ module ActionView
     # consume this in production. This is only slow if it's being listened to.
     def render(view, locals, buffer=nil, &block)
       instrument("!render_template") do
-        compiled_template = compile!
-        compiled_view = compiled_template.new(view, locals)
+        @compiled_template ||= compile!
+        compiled_view = @compiled_template.new(view, locals)
         compiled_view.render(buffer, &block)
       end
     rescue Exception => e
@@ -230,9 +230,11 @@ module ActionView
       # Compile a template. This method ensures a template is compiled
       # just once and removes the source after it is compiled.
       def compile! #:nodoc:
-        encode!
         instrument("!compile_template") do
-          Compiler.compile_template(self)
+          encode!
+          compiled_template = Compiler.compile_template(self)
+          @source = nil if @virtual_path
+          compiled_template
         end
       end
 

--- a/actionpack/test/template/template_test.rb
+++ b/actionpack/test/template/template_test.rb
@@ -17,9 +17,12 @@ class TestERBTemplate < ActiveSupport::TestCase
   end
 
   class Context
+    attr_accessor :output_buffer, :virtual_path, :assigns, :view_flow
+
     def initialize
       @output_buffer = "original"
       @virtual_path = nil
+      @assigns = {}
     end
 
     def hello


### PR DESCRIPTION
This is a work-in-progress attempt to extract the compilation code from Template. The end goal is to make the code more modular, and to be able to use alternative compilers.
