### PR TITLE
Fixing a failing railtie test by wrapping the command inside of sh -c

### DIFF
--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -159,7 +159,8 @@ module ApplicationTests
         end
       RUBY
 
-      output = Dir.chdir(app_path){ `CONTROLLER=cart rake routes` }
+      ENV['CONTROLLER'] = 'cart'
+      output = Dir.chdir(app_path){ `rake routes` }
       assert_equal "Prefix Verb URI Pattern     Controller#Action\ncart GET /cart(.:format) cart#show\n", output
     end
 


### PR DESCRIPTION
This should prevent the test from thinking that we're moving into a directory instead of giving a shell command and should fix the failing railtie build.
