### PR TITLE
Dump UUID default functions to schema.rb. Fixes #10751.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Migration dump UUID default functions to schema.rb.
+    Fixes #10751.
+
+    *kennyj*
+
 *   Usage of `implicit_readonly` is being removed`. Please use `readonly` method
     explicitly to mark records as `readonly.
     Fixes #10615.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -119,6 +119,9 @@ module ActiveRecord
           # JSON
           when /\A'(.*)'::json\z/
             $1
+          # UUID functions
+          when /\A(uuid_generate.*)\z/
+            $1
           # Object identifier types
           when /\A-?\d+\z/
             $1

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -299,8 +299,10 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
     def test_schema_dump_includes_uuid_shorthand_definition
       output = standard_dump
-      if %r{create_table "poistgresql_uuids"} =~ output
+      if %r{create_table "postgresql_uuids"} =~ output
         assert_match %r{t.uuid "guid"}, output
+        assert_match %r{t.uuid "v1_guid",\s+default: "uuid_generate_v1\(\)"}, output
+        assert_match %r{t.uuid "v4_guid",\s+default: "uuid_generate_v4\(\)"}, output
       end
     end
 

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -70,7 +70,9 @@ _SQL
   CREATE TABLE postgresql_uuids (
     id SERIAL PRIMARY KEY,
     guid uuid,
-    compact_guid uuid
+    compact_guid uuid,
+    v1_guid uuid default uuid_generate_v1(),
+    v4_guid uuid default uuid_generate_v4()
   );
 _SQL
 


### PR DESCRIPTION
Please see #10751 about this problem.

In current implementation, UUID default functions are not dumped to db/schema.rb, because default value isn't extracted.

I think we should back port to 4-0-stable too.
