### PR TITLE
Removing "kine" from irregular inflections

### DIFF
--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -57,7 +57,6 @@ module ActiveSupport
     inflect.irregular('child', 'children')
     inflect.irregular('sex', 'sexes')
     inflect.irregular('move', 'moves')
-    inflect.irregular('cow', 'kine')
     inflect.irregular('zombie', 'zombies')
 
     inflect.uncountable(%w(equipment information rice money species series fish sheep jeans police))


### PR DESCRIPTION
tl;dr: `kine` is old, nobody uses it anymore.

Today, I was debugging a mongoid [issue](https://github.com/mongoid/mongoid/issues/3079), and on the issue guy is using a class named Cow. I ran the same example local and couldn't find the collection that the cow was going to, I, of course, was looking for a collection named 'cows' and couldnt find it. After a few minutes of debugging I realize that for activesupport/inflections the plural of cow is kine. Me as a non native english speaker started asking around the office to see if someone would guess the right plural of cow, guess what, nobody said 'kine'. After a [few](http://thebettereditor.wordpress.com/2012/02/10/the-plural-of-cow-is/) [research](http://en.wikipedia.org/wiki/Kine), I saw that kine it is indeed a archaic word. So IMO activesupport should remove that irregular plural.
