### PR TITLE
Move the write portion of fragment_for to its own method.

### DIFF
--- a/actionpack/lib/action_view/helpers/cache_helper.rb
+++ b/actionpack/lib/action_view/helpers/cache_helper.rb
@@ -179,17 +179,21 @@ module ActionView
         if fragment = controller.read_fragment(name, options)
           fragment
         else
-          # VIEW TODO: Make #capture usable outside of ERB
-          # This dance is needed because Builder can't use capture
-          pos = output_buffer.length
-          yield
-          output_safe = output_buffer.html_safe?
-          fragment = output_buffer.slice!(pos..-1)
-          if output_safe
-            self.output_buffer = output_buffer.class.new(output_buffer)
-          end
-          controller.write_fragment(name, fragment, options)
+          write_fragment_for(name, options, &block)
         end
+      end
+
+      def write_fragment_for(name = {}, options = nil, &block) #:nodoc:
+        # VIEW TODO: Make #capture usable outside of ERB
+        # This dance is needed because Builder can't use capture
+        pos = output_buffer.length
+        yield
+        output_safe = output_buffer.html_safe?
+        fragment = output_buffer.slice!(pos..-1)
+        if output_safe
+          self.output_buffer = output_buffer.class.new(output_buffer)
+        end
+        controller.write_fragment(name, fragment, options)
       end
     end
   end


### PR DESCRIPTION
To allow for easier creation of custom cache methods.

In this commit I moved the write portion out into its own method called write_fragment_for. Which allows for easier creation of custom cache helpers that involve doing some type of action when the cache is or is not expired. Or for the creation of cache methods that might be passed additional procs/lambdas that need to be called before the view is rendered.
