### PR TITLE
Add note about database connection pool in postgres template

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -759,4 +759,15 @@ Since the connection pooling is handled inside of Active Record by default, all 
 
 Any one request will check out a connection the first time it requires access to the database, after which it will check the connection back in, at the end of the request, meaning that the additional connection slot will be available again for the next request in the queue.
 
+If you try to use more connections than are available, Active Record will block
+and wait for a connection from the pool. When it cannot get connection, a timeout
+error similar to given below will be thrown.
+
+```ruby
+ActiveRecord::ConnectionTimeoutError - could not obtain a database connection within 5 seconds. The max pool size is currently 5; consider increasing it:
+```
+
+If you get the above error, you might want to increase the size of connection 
+pool by incrementing the `pool` option in `database.yml`
+
 NOTE. If you have enabled `Rails.threadsafe!` mode then there could be a chance that several threads may be accessing multiple connections simultaneously. So depending on your current request load, you could very well have multiple threads contending for a limited amount of connections.

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml
@@ -55,6 +55,8 @@ production:
   adapter: postgresql
   encoding: unicode
   database: <%= app_name %>_production
+  # For details on connection pooling, see rails configration guide
+  # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: 5
   username: <%= app_name %>
   password:


### PR DESCRIPTION
Two reasons, this is submitted here
1. docrails now seems `read-only`
2. would like opinion is this pool setting behaviour is common for all Database adapters?

Thanks
