### PR TITLE
No need to load 'rake/packagetask' as it's already in 'rubygems/package_task'

### DIFF
--- a/actionmailer/Rakefile
+++ b/actionmailer/Rakefile
@@ -1,5 +1,4 @@
 require 'rake/testtask'
-require 'rake/packagetask'
 require 'rubygems/package_task'
 
 desc "Default Task"

--- a/actionpack/Rakefile
+++ b/actionpack/Rakefile
@@ -1,5 +1,4 @@
 require 'rake/testtask'
-require 'rake/packagetask'
 require 'rubygems/package_task'
 
 desc "Default Task"

--- a/activemodel/Rakefile
+++ b/activemodel/Rakefile
@@ -20,7 +20,6 @@ namespace :test do
   end
 end
 
-require 'rake/packagetask'
 require 'rubygems/package_task'
 
 spec = eval(File.read("#{dir}/activemodel.gemspec"))

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -1,5 +1,4 @@
 require 'rake/testtask'
-require 'rake/packagetask'
 require 'rubygems/package_task'
 
 require File.expand_path(File.dirname(__FILE__)) + "/test/config"


### PR DESCRIPTION
It's already required here 

https://github.com/rubygems/rubygems/blob/master/lib/rubygems/package_task.rb#L29
