### PR TITLE
Update tzinfo

### DIFF
--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('i18n',       '~> 0.6', '>= 0.6.4')
   s.add_dependency 'json',       '~> 1.7'
-  s.add_dependency 'tzinfo',     '~> 0.3.37'
+  s.add_dependency 'tzinfo',     '~> 1.1'
   s.add_dependency 'minitest',   '~> 5.0'
   s.add_dependency 'thread_safe','~> 0.1'
 end

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -28,3 +28,8 @@ source 'https://rubygems.org'
 # Use debugger
 # gem 'debugger', group: [:development, :test]
 <% end -%>
+
+<% if RUBY_PLATFORM.match(/bccwin|cygwin|emx|mingw|mswin|wince/) -%>
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'tzinfo-data', platforms: [:mingw, :mswin]
+<% end -%>


### PR DESCRIPTION
This patch:
- Updates the `tzinfo` dependency to `~> 1.0`
- Drops one digit of precision from the dependency specification, assuming it follows [SemVer](http://semver.org/) and will maintain a stable public API through version 1.
- Adds a `tzinfo-data` dependency to support operating systems that don't include zoneinfo files (such as Microsoft Windows)
