### PR TITLE
Create DelegationError class

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -176,7 +176,7 @@ class Module
           end                                                 # end
         EOS
       else
-        exception = %(raise "#{self}##{method_prefix}#{method} delegated to #{to}.#{method}, but #{to} is nil: \#{self.inspect}")
+        exception = %(raise DelegationError, "#{self}##{method_prefix}#{method} delegated to #{to}.#{method}, but #{to} is nil: \#{self.inspect}")
 
         module_eval(<<-EOS, file, line - 2)
           def #{method_prefix}#{method}(#{definition})        # def customer_name(*args, &block)
@@ -194,3 +194,5 @@ class Module
     end
   end
 end
+
+class DelegationError < StandardError ; end

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -207,7 +207,7 @@ class ModuleTest < ActiveSupport::TestCase
 
   def test_delegation_without_allow_nil_and_nil_value
     david = Someone.new("David")
-    assert_raise(RuntimeError) { david.street }
+    assert_raise(DelegationError) { david.street }
   end
 
   def test_delegation_to_method_that_exists_on_nil


### PR DESCRIPTION
I found my self in a situation today where I wanted to rescue from a delegate exception where the object I was delegating to was nil. Right now this throws a standard `RuntimeError` with a detailed message, which is great, but in this case I didn't want to rescue from other exceptions. I think adding this simple `DelegationError` class would make working with these exceptions a bit cleaner.

I hope others find this valuable. Feedback welcome!
