### PR TITLE
Fix `TaggedLogging` when `progname` is displayed and optimize it using t...

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## unreleased ##
+*   Fix `ActiveSupport::TaggedLogging` when using a formatter that displays `progname`.
+    Also, if the severity of the message is less than logger's level and a block is
+    given, the block will not be evaluated. This is useful if the block might slow
+    down the performance of the app.
+
+    *Ionut-Liviu Georgescu*
 
 *   Revert the changes on unicode character encoding from `ActiveSupport::JSON.encode`.
     This was causing a regression where the resulting string is always returning UTF-8.

--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -44,7 +44,17 @@ module ActiveSupport
     deprecate :silence
 
     def add(severity, message = nil, progname = nil, &block)
-      message = (block_given? ? block.call : progname) if message.nil?
+      return true if @logger.respond_to?(:level) && severity < @logger.level
+
+      if message.nil?
+        if block_given?
+          message = block.call
+        else
+          message = progname
+          progname = @logger.respond_to?(:progname) ? @logger.progname : nil
+        end
+      end
+
       @logger.add(severity, "#{tags_text}#{message}", progname)
     end
 

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -9,9 +9,18 @@ class TaggedLoggingTest < ActiveSupport::TestCase
     end
   end
 
+  # Formatter which displays the progname if it's not blank and the message.
+  class MyFormatter < ::Logger::Formatter
+    # This method is invoked when a log event occurs
+    def call(severity, timestamp, progname, msg)
+      "#{progname.blank? ? "" : "[#{progname}] "}#{String === msg ? msg : msg.inspect}\n"
+    end
+  end
+
   setup do
     @output = StringIO.new
     @logger = ActiveSupport::TaggedLogging.new(MyLogger.new(@output))
+    @logger.formatter = MyFormatter.new
   end
 
   test "tagged once" do
@@ -105,4 +114,45 @@ class TaggedLoggingTest < ActiveSupport::TestCase
     assert_equal "[BCX] Funky town\n", @output.string
   end
 
+  test "displays progname if not blank" do
+    @logger.progname = "PROG1"
+    @logger.tagged("BCX") do
+      @logger.info "Cool story bro"
+    end
+
+    @logger.tagged("BCX") do
+      @logger.info("PROG2") { "Funky time" }
+    end
+
+    assert_equal "[PROG1] [BCX] Cool story bro\n[PROG2] [BCX] Funky time\n", @output.string
+  end
+
+  test "does not display progname if blank" do
+    @logger.progname = nil
+    @logger.tagged("BCX") { @logger.info "Funky time" }
+
+    assert_equal "[BCX] Funky time\n", @output.string
+  end
+
+  test "evaluates the block if the severity is greater than or equal to logger's level" do
+    message = ""
+    @logger.level = ::Logger::INFO
+    @logger.tagged("BCX") do
+      @logger.info { message = "Funky time" }
+    end
+
+    assert_equal "Funky time", message
+    assert_equal "[BCX] Funky time\n", @output.string
+  end
+
+  test "does not evaluate the block if the severity is less than logger's level" do
+    message = ""
+    @logger.level = ::Logger::ERROR
+    @logger.tagged("BCX") do
+      @logger.info { message = "Funky time" }
+    end
+
+    assert_blank message
+    assert_blank @output.string
+  end
 end


### PR DESCRIPTION
...he severity

`ActiveSupport::TaggedLogging` does not correctly display a message when a formatter is used that outputs `progname`.
Ex: progname = 'PROG'
`[Funky time] [BCX] Funky time` was displayed instead of `[PROG] [BCX] Funky time`

When a block is given, it will only be evaluated if the severity is greater than or equal to logger's level.
