### PR TITLE
Removing use of subclassed application constant and replacing with Rails.application

### DIFF
--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -158,12 +158,12 @@ module ApplicationTests
       RUBY
 
       require "#{app_path}/config/application"
-      assert AppTemplate::Application.initialize!
+      assert Rails.application.initialize!
     end
 
     test "application is always added to eager_load namespaces" do
       require "#{app_path}/config/application"
-      assert AppTemplate::Application, AppTemplate::Application.config.eager_load_namespaces
+      assert Rails.application, Rails.application.config.eager_load_namespaces
     end
 
     test "the application can be eager loaded even when there are no frameworks" do

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -48,7 +48,7 @@ class LoadingTest < ActiveSupport::TestCase
 
   test "load config/environments/environment before Bootstrap initializers" do
     app_file "config/environments/development.rb", <<-RUBY
-      AppTemplate::Application.configure do
+      Rails.application.configure do
         config.development_environment_loaded = true
       end
     RUBY
@@ -60,7 +60,7 @@ class LoadingTest < ActiveSupport::TestCase
     RUBY
 
     require "#{app_path}/config/environment"
-    assert ::AppTemplate::Application.config.loaded
+    assert ::Rails.application.config.loaded
   end
 
   test "descendants loaded after framework initialization are cleaned on each request without cache classes" do
@@ -75,7 +75,7 @@ class LoadingTest < ActiveSupport::TestCase
     MODEL
 
     app_file 'config/routes.rb', <<-RUBY
-      AppTemplate::Application.routes.draw do
+      Rails.application.routes.draw do
         get '/load',   to: lambda { |env| [200, {}, Post.all] }
         get '/unload', to: lambda { |env| [200, {}, []] }
       end
@@ -96,7 +96,7 @@ class LoadingTest < ActiveSupport::TestCase
 
   test "initialize cant be called twice" do
     require "#{app_path}/config/environment"
-    assert_raise(RuntimeError) { ::AppTemplate::Application.initialize! }
+    assert_raise(RuntimeError) { Rails.application.initialize! }
   end
 
   test "reload constants on development" do
@@ -105,7 +105,7 @@ class LoadingTest < ActiveSupport::TestCase
     RUBY
 
     app_file 'config/routes.rb', <<-RUBY
-      AppTemplate::Application.routes.draw do
+      Rails.application.routes.draw do
         get '/c', to: lambda { |env| [200, {"Content-Type" => "text/plain"}, [User.counter.to_s]] }
       end
     RUBY
@@ -144,7 +144,7 @@ class LoadingTest < ActiveSupport::TestCase
     RUBY
 
     app_file 'config/routes.rb', <<-RUBY
-      AppTemplate::Application.routes.draw do
+      Rails.application.routes.draw do
         get '/c', to: lambda { |env| [200, {"Content-Type" => "text/plain"}, [User.counter.to_s]] }
       end
     RUBY
@@ -180,7 +180,7 @@ class LoadingTest < ActiveSupport::TestCase
 
     app_file 'config/routes.rb', <<-RUBY
       $counter = 0
-      AppTemplate::Application.routes.draw do
+      Rails.application.routes.draw do
         get '/c', to: lambda { |env| User; [200, {"Content-Type" => "text/plain"}, [$counter.to_s]] }
       end
     RUBY
@@ -211,7 +211,7 @@ class LoadingTest < ActiveSupport::TestCase
     RUBY
 
     app_file 'config/routes.rb', <<-RUBY
-      AppTemplate::Application.routes.draw do
+      Rails.application.routes.draw do
         get '/title', to: lambda { |env| [200, {"Content-Type" => "text/plain"}, [Post.new.title]] }
         get '/body',  to: lambda { |env| [200, {"Content-Type" => "text/plain"}, [Post.new.body]] }
       end
@@ -270,7 +270,7 @@ class LoadingTest < ActiveSupport::TestCase
     RUBY
 
     app_file "config/routes.rb", <<-RUBY
-      AppTemplate::Application.routes.draw do
+      Rails.application.routes.draw do
         get "/:controller(/:action)"
       end
     RUBY
@@ -288,10 +288,10 @@ class LoadingTest < ActiveSupport::TestCase
     require "#{app_path}/config/application"
 
     assert !Rails.initialized?
-    assert !AppTemplate::Application.initialized?
+    assert !Rails.application.initialized?
     Rails.initialize!
     assert Rails.initialized?
-    assert AppTemplate::Application.initialized?
+    assert Rails.application.initialized?
   end
 
   protected

--- a/railties/test/application/middleware/session_test.rb
+++ b/railties/test/application/middleware/session_test.rb
@@ -49,7 +49,7 @@ module ApplicationTests
 
     test "session is empty and isn't saved on unverified request when using :null_session protect method" do
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get  ':controller(/:action)'
           post ':controller(/:action)'
         end
@@ -90,7 +90,7 @@ module ApplicationTests
 
     test "cookie jar is empty and isn't saved on unverified request when using :null_session protect method" do
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get  ':controller(/:action)'
           post ':controller(/:action)'
         end
@@ -131,7 +131,7 @@ module ApplicationTests
 
     test "session using encrypted cookie store" do
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get ':controller(/:action)'
         end
       RUBY
@@ -176,7 +176,7 @@ module ApplicationTests
 
     test "session upgrading signature to encryption cookie store works the same way as encrypted cookie store" do
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get ':controller(/:action)'
         end
       RUBY
@@ -225,7 +225,7 @@ module ApplicationTests
 
     test "session upgrading signature to encryption cookie store upgrades session to encrypted mode" do
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get ':controller(/:action)'
         end
       RUBY
@@ -284,7 +284,7 @@ module ApplicationTests
 
     test "session upgrading legacy signed cookies to new signed cookies" do
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get ':controller(/:action)'
         end
       RUBY

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -34,7 +34,7 @@ module ApplicationTests
           config.middleware.use SuperMiddleware
         end
 
-        AppTemplate::Application.initialize!
+        Rails.application.initialize!
       RUBY
 
       assert_match("SuperMiddleware", Dir.chdir(app_path){ `rake middleware` })

--- a/railties/test/application/routing_test.rb
+++ b/railties/test/application/routing_test.rb
@@ -48,7 +48,7 @@ module ApplicationTests
       RUBY
 
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           root to: "foo#index"
         end
       RUBY
@@ -100,7 +100,7 @@ module ApplicationTests
       RUBY
 
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get ':controller(/:action)'
         end
       RUBY
@@ -111,7 +111,7 @@ module ApplicationTests
 
     test "mount rack app" do
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           mount lambda { |env| [200, {}, [env["PATH_INFO"]]] }, at: "/blog"
           # The line below is required because mount sometimes
           # fails when a resource route is added.
@@ -141,7 +141,7 @@ module ApplicationTests
       RUBY
 
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get ':controller(/:action)'
         end
       RUBY
@@ -173,7 +173,7 @@ module ApplicationTests
       RUBY
 
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get 'admin/foo', to: 'admin/foo#index'
           get 'foo', to: 'foo#index'
         end
@@ -188,7 +188,7 @@ module ApplicationTests
 
     test "routes appending blocks" do
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get ':controller/:action'
         end
       RUBY
@@ -205,7 +205,7 @@ module ApplicationTests
       assert_equal 'WIN', last_response.body
 
       app_file 'config/routes.rb', <<-R
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get 'lol' => 'hello#index'
         end
       R
@@ -229,7 +229,7 @@ module ApplicationTests
         RUBY
 
         app_file 'config/routes.rb', <<-RUBY
-          AppTemplate::Application.routes.draw do
+          Rails.application.routes.draw do
             get 'foo', to: 'foo#bar'
           end
         RUBY
@@ -240,7 +240,7 @@ module ApplicationTests
         assert_equal 'bar', last_response.body
 
         app_file 'config/routes.rb', <<-RUBY
-          AppTemplate::Application.routes.draw do
+          Rails.application.routes.draw do
             get 'foo', to: 'foo#baz'
           end
         RUBY
@@ -261,7 +261,7 @@ module ApplicationTests
       end
 
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get 'foo', to: ::InitializeRackApp
         end
       RUBY
@@ -289,7 +289,7 @@ module ApplicationTests
       RUBY
 
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get 'foo', :to => 'foo#index'
           root :to => 'foo#index'
         end
@@ -321,7 +321,7 @@ module ApplicationTests
       RUBY
 
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get 'foo', to: 'foo#index'
         end
       RUBY
@@ -337,7 +337,7 @@ module ApplicationTests
       end
 
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get 'foo', to: 'foo#index'
           get 'bar', to: 'bar#index'
         end
@@ -354,7 +354,7 @@ module ApplicationTests
       assert_equal '/bar', Rails.application.routes.url_helpers.bar_path
 
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get 'foo', to: 'foo#index'
         end
       RUBY
@@ -380,7 +380,7 @@ module ApplicationTests
       RUBY
 
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           resources :yazilar
         end
       RUBY

--- a/railties/test/application/url_generation_test.rb
+++ b/railties/test/application/url_generation_test.rb
@@ -20,7 +20,7 @@ module ApplicationTests
         config.eager_load = false
       end
 
-      MyApp.initialize!
+      Rails.application.initialize!
 
       class ::ApplicationController < ActionController::Base
       end

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -270,7 +270,7 @@ module RailtiesTest
       RUBY
 
       app_file "config/routes.rb", <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get 'foo', :to => 'foo#index'
         end
       RUBY
@@ -467,7 +467,7 @@ YAML
       RUBY
 
       app_file "config/routes.rb", <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           mount(Bukkits::Engine => "/bukkits")
         end
       RUBY
@@ -602,7 +602,7 @@ YAML
       RUBY
 
       app_file "config/routes.rb", <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get "/bar" => "bar#index", as: "bar"
           mount Bukkits::Engine => "/bukkits", as: "bukkits"
         end
@@ -720,7 +720,7 @@ YAML
       RUBY
 
       app_file "config/routes.rb", <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           mount Bukkits::Engine => "/bukkits", as: "bukkits"
         end
       RUBY
@@ -764,7 +764,7 @@ YAML
       RUBY
 
       app_file "config/routes.rb", <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           mount Bukkits::Awesome::Engine => "/bukkits", :as => "bukkits"
         end
       RUBY
@@ -828,7 +828,7 @@ YAML
       add_to_config "isolate_namespace AppTemplate"
 
       app_file "config/routes.rb", <<-RUBY
-        AppTemplate::Application.routes.draw do end
+        Rails.application.routes.draw do end
       RUBY
 
       boot_rails
@@ -1206,7 +1206,7 @@ YAML
       RUBY
 
       app_file "config/routes.rb", <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get '/bar' => 'bar#index', :as => 'bar'
           mount Bukkits::Engine => "/bukkits", :as => "bukkits"
         end

--- a/railties/test/railties/railtie_test.rb
+++ b/railties/test/railties/railtie_test.rb
@@ -26,7 +26,7 @@ module RailtiesTest
     test "Railtie provides railtie_name" do
       begin
         class ::FooBarBaz < Rails::Railtie ; end
-        assert_equal "foo_bar_baz", ::FooBarBaz.railtie_name
+        assert_equal "foo_bar_baz", FooBarBaz.railtie_name
       ensure
         Object.send(:remove_const, :"FooBarBaz")
       end
@@ -58,7 +58,7 @@ module RailtiesTest
         config.foo.greetings = "hello"
       end
       require "#{app_path}/config/application"
-      assert_equal "hello", AppTemplate::Application.config.foo.greetings
+      assert_equal "hello", Rails.application.config.foo.greetings
     end
 
     test "railtie can add to_prepare callbacks" do
@@ -96,7 +96,7 @@ module RailtiesTest
       require 'rake/testtask'
       require 'rdoc/task'
 
-      AppTemplate::Application.load_tasks
+      Rails.application.load_tasks
       assert $ran_block
     end
 
@@ -120,7 +120,7 @@ module RailtiesTest
       require 'rake/testtask'
       require 'rdoc/task'
 
-      AppTemplate::Application.load_tasks
+      Rails.application.load_tasks
       assert $ran_block.include?("my_tie")
     end
 
@@ -136,7 +136,7 @@ module RailtiesTest
       require "#{app_path}/config/environment"
 
       assert !$ran_block
-      AppTemplate::Application.load_generators
+      Rails.application.load_generators
       assert $ran_block
     end
 
@@ -152,7 +152,7 @@ module RailtiesTest
       require "#{app_path}/config/environment"
 
       assert !$ran_block
-      AppTemplate::Application.load_console
+      Rails.application.load_console
       assert $ran_block
     end
 
@@ -168,7 +168,7 @@ module RailtiesTest
       require "#{app_path}/config/environment"
 
       assert !$ran_block
-      AppTemplate::Application.load_runner
+      Rails.application.load_runner
       assert $ran_block
     end
 


### PR DESCRIPTION
The use of `Rails.application` instead of calling the application constant is a more agnostic syntax. This means tests will be more portable, and won't rely on the existence of a particular subclass. I've changed a bunch of places to use the `Rails.application` syntax.

By not calling the `AppTemplate::Application` constant, in the future it will be easier to have multiple applications or have applications be given by a particular instance of an `Application` instead of a subclass.
