### PR TITLE
Fix #10789. Now at last ::Logger doesn't support #silence method .

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -360,9 +360,7 @@ module ActiveRecord
       end
 
       def call(env)
-        ActiveRecord::Base.logger.silence do
-          ActiveRecord::Migration.check_pending!
-        end
+        ActiveRecord::Migration.check_pending!
         @app.call(env)
       end
     end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -849,4 +849,13 @@ class CopyMigrationsTest < ActiveRecord::TestCase
   ensure
     clear
   end
+
+  def test_check_pending_with_stdlib_logger
+    old, ActiveRecord::Base.logger = ActiveRecord::Base.logger, ::Logger.new($stdout)
+    quietly do
+      assert_nothing_raised { ActiveRecord::Migration::CheckPending.new(Proc.new {}).call({}) }
+    end
+  ensure
+    ActiveRecord::Base.logger = old
+  end
 end


### PR DESCRIPTION
Closes #10789.

Now `::Logger` hasn't `silence` method, because `::Logger` doesn't include `LoggerSilence`.

This PR also should be backported to 4-0-stable.
