### PR TITLE
DRY-up ActionDispatch::Routing autoloads

### DIFF
--- a/actionpack/lib/action_dispatch/routing.rb
+++ b/actionpack/lib/action_dispatch/routing.rb
@@ -246,11 +246,13 @@ module ActionDispatch
   # Target specific controllers by prefixing the command with <tt>CONTROLLER=x</tt>.
   #
   module Routing
-    autoload :Mapper, 'action_dispatch/routing/mapper'
-    autoload :RouteSet, 'action_dispatch/routing/route_set'
-    autoload :RoutesProxy, 'action_dispatch/routing/routes_proxy'
-    autoload :UrlFor, 'action_dispatch/routing/url_for'
-    autoload :PolymorphicRoutes, 'action_dispatch/routing/polymorphic_routes'
+    extend ActiveSupport::Autoload
+
+    autoload :Mapper
+    autoload :RouteSet
+    autoload :RoutesProxy
+    autoload :UrlFor
+    autoload :PolymorphicRoutes
 
     SEPARATORS = %w( / . ? ) #:nodoc:
     HTTP_METHODS = [:get, :head, :post, :patch, :put, :delete, :options] #:nodoc:


### PR DESCRIPTION
I used the `autoload` goodies out of `ActiveSupport` to DRY-up the `autoload` definitions in `ActionDispatch::Routing`.
