### PR TITLE
Refactor ActionDispatch::Http::Parameters#normalize_encode_params

### DIFF
--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -64,17 +64,13 @@ module ActionDispatch
         end
 
         new_hash = {}
-        params.each do |k, v|
-          new_key = k.is_a?(String) ? k.dup.force_encoding(Encoding::UTF_8).encode! : k
-          new_hash[new_key] =
-            case v
-            when Hash
-              normalize_encode_params(v)
-            when Array
-              v.map! {|el| normalize_encode_params(el) }
-            else
-              normalize_encode_params(v)
-            end
+        params.each do |key, val|
+          new_key = key.is_a?(String) ? key.dup.force_encoding(Encoding::UTF_8).encode! : key
+          new_hash[new_key] = if val.is_a?(Array)
+            val.map! { |el| normalize_encode_params(el) }
+          else
+            normalize_encode_params(val)
+          end
         end
         new_hash.with_indifferent_access
       end


### PR DESCRIPTION
There was an unneeded `case` branch at `ActionDispatch::Http::Parameters#normalize_encode_params`. While removing it, I have decided that an `if/else` will work a bit better than:

``` ruby
case val
when Array
  # Do stuff...
else
  # Do some other stuff...
end
```

Additionally there seem to be a `TODO` note in the comment above the function and I am not sure if it is still up-to-date. Anyway, I decided not to go that deep, into what seemed as a simple refactor.
