### PR TITLE
Fix mismatching variable names when using an underscore

### DIFF
--- a/actionpack/lib/action_view/dependency_tracker.rb
+++ b/actionpack/lib/action_view/dependency_tracker.rb
@@ -74,7 +74,7 @@ module ActionView
             # render(@topic)         => render("topics/topic")
             # render(topics)         => render("topics/topic")
             # render(message.topics) => render("topics/topic")
-            collect { |name| name.sub(/\A@?([a-z]+\.)*([a-z_]+)\z/) { "#{$2.pluralize}/#{$2.singularize}" } }.
+            collect { |name| name.sub(/\A@?([a-z_]+\.)*([a-z_]+)\z/) { "#{$2.pluralize}/#{$2.singularize}" } }.
 
             # render("headline") => render("message/headline")
             collect { |name| name.include?("/") ? name : "#{directory}/#{name}" }.

--- a/actionpack/test/template/dependency_tracker_test.rb
+++ b/actionpack/test/template/dependency_tracker_test.rb
@@ -1,24 +1,24 @@
 require 'abstract_unit'
 require 'action_view/dependency_tracker'
 
+class NeckbeardTracker
+  def self.call(name, template)
+    ["foo/#{name}"]
+  end
+end
+
+class FakeTemplate
+  attr_reader :source, :handler
+
+  def initialize(source, handler = Neckbeard)
+    @source, @handler = source, handler
+  end
+end
+
+Neckbeard = lambda {|template| template.source }
+Bowtie = lambda {|template| template.source }
+
 class DependencyTrackerTest < ActionView::TestCase
-  Neckbeard = lambda {|template| template.source }
-  Bowtie = lambda {|template| template.source }
-
-  class NeckbeardTracker
-    def self.call(name, template)
-      ["foo/#{name}"]
-    end
-  end
-
-  class FakeTemplate
-    attr_reader :source, :handler
-
-    def initialize(source, handler = Neckbeard)
-      @source, @handler = source, handler
-    end
-  end
-
   def tracker
     ActionView::DependencyTracker
   end
@@ -44,3 +44,31 @@ class DependencyTrackerTest < ActionView::TestCase
     assert_equal [], dependencies
   end
 end
+
+class ERBTrackerTest < MiniTest::Unit::TestCase
+  def make_tracker(name, template)
+    ActionView::DependencyTracker::ERBTracker.new(name, template)
+  end
+
+  def test_dependency_of_erb_template_with_number_in_filename
+    template = FakeTemplate.new("<%# render 'messages/message123' %>", :erb)
+    tracker = make_tracker('messages/_message123', template)
+
+    assert_equal ["messages/message123"], tracker.dependencies
+  end
+
+  def test_finds_dependency_in_correct_directory
+    template = FakeTemplate.new("<%# render(message.topic) %>", :erb)
+    tracker = make_tracker('messages/_message', template)
+
+    assert_equal ["topics/topic"], tracker.dependencies
+  end
+
+  def test_finds_dependency_in_correct_directory_with_underscore
+    template = FakeTemplate.new("<%# render(message_type.messages) %>", :erb)
+    tracker = make_tracker('message_types/_message_type', template)
+
+    assert_equal ["messages/message"], tracker.dependencies
+  end
+end
+


### PR DESCRIPTION
This is a port of https://github.com/rails/cache_digests/pull/51

The ERBTracker template digest helper class was using a regex to match render calls and it was incorrectly not matching against variables with underscores in the name. This caused it to use the wrong regex match data to populate the template dependency. Because underscore is a valid character for a variable, this fixes the ERBTracker to match it properly.
