### PR TITLE
define boolean attribute method for store attribute accessors

### DIFF
--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -83,6 +83,10 @@ module ActiveRecord
             define_method(key) do
               read_store_attribute(store_attribute, key)
             end
+            
+            define_method("#{key}?") do
+              !!read_store_attribute(store_attribute, key)
+            end            
           end
         end
 

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -21,6 +21,15 @@ class StoreTest < ActiveRecord::TestCase
     assert_equal 'red', @john.color
     assert_equal '37signals.com', @john.homepage
   end
+      
+  test "boolean attribute is false when attribute is nil" do
+    @john.homepage = nil
+    assert_equal false, @john.homepage?
+  end  
+  
+  test "boolean attribute is true when attribute is set" do
+    assert_equal true, @john.color?
+  end
 
   test "accessing attributes not exposed by accessors" do
     @john.settings[:icecream] = 'graeters'


### PR DESCRIPTION
Define `accessor_name?` method to make store attributes consistent with other AR attributes. For example:

```
class User < ActiveRecord::Base
  store :settings, accessors: [:color]
end

user = User.new
user.color?
# => false
```
