### PR TITLE
make sure both headers are set before checking for ip spoofing

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -143,7 +143,7 @@ module ActionDispatch
         # proxies with incompatible IP header conventions, and there is no way
         # for us to determine which header is the right one after the fact.
         # Since we have no idea, we give up and explode.
-        should_check_ip = @check_ip && client_ips.last
+        should_check_ip = @check_ip && client_ips.last && forwarded_ips.last
         if should_check_ip && !forwarded_ips.include?(client_ips.last)
           # We don't know which came from the proxy, and which from the user
           raise IpSpoofAttackError, "IP spoofing attack?! " +

--- a/railties/test/application/middleware/remote_ip_test.rb
+++ b/railties/test/application/middleware/remote_ip_test.rb
@@ -33,6 +33,16 @@ module ApplicationTests
       end
     end
 
+    test "works with both headers individually" do
+      make_basic_app
+      assert_nothing_raised(ActionDispatch::RemoteIp::IpSpoofAttackError) do
+        assert_equal "1.1.1.1", remote_ip("HTTP_X_FORWARDED_FOR" => "1.1.1.1")
+      end
+      assert_nothing_raised(ActionDispatch::RemoteIp::IpSpoofAttackError) do
+        assert_equal "1.1.1.2", remote_ip("HTTP_CLIENT_IP" => "1.1.1.2")
+      end
+    end
+
     test "can disable IP spoofing check" do
       make_basic_app do |app|
         app.config.action_dispatch.ip_spoofing_check = false


### PR DESCRIPTION
In my routing stack, `HTTP_CLIENT_IPS` is getting set, but `HTTP_X_FORWARDED_FOR` is not, and this check is blowing up.

This PR adds tests and fixes the underlying problem.
