### PR TITLE
Use is_a? method instead of === on classes comparisons

### DIFF
--- a/actionmailer/lib/action_mailer/test_case.rb
+++ b/actionmailer/lib/action_mailer/test_case.rb
@@ -44,7 +44,7 @@ module ActionMailer
 
         def determine_default_mailer(name)
           mailer = determine_constant_from_test_name(name) do |constant|
-            Class === constant && constant < ActionMailer::Base
+            constant.is_a?(Class) && constant < ActionMailer::Base
           end
           raise NonInferrableMailerError.new(name) if mailer.nil?
           mailer

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -98,7 +98,7 @@ module ActionController
 
       case options
       when NilClass, Regexp, String, Symbol
-        options = options.to_s if Symbol === options
+        options = options.to_s if options.is_a?(Symbol)
         rendered = @_templates
         msg = message || sprintf("expecting <%s> but rendering with <%s>",
                 options.inspect, rendered.keys)
@@ -441,7 +441,7 @@ module ActionController
 
         def determine_default_controller_class(name)
           determine_constant_from_test_name(name) do |constant|
-            Class === constant && constant < ActionController::Metal
+            constant.is_a?(Class) && constant < ActionController::Metal
           end
         end
 

--- a/actionpack/lib/action_dispatch/http/filter_redirect.rb
+++ b/actionpack/lib/action_dispatch/http/filter_redirect.rb
@@ -24,9 +24,9 @@ module ActionDispatch
 
       def location_filter_match?
         location_filter.any? do |filter|
-          if String === filter
+          if filter.is_a?(String)
             location.include?(filter)
-          elsif Regexp === filter
+          elsif filter.is_a?(Regexp)
             location.match(filter)
           end
         end

--- a/actionpack/lib/action_dispatch/http/upload.rb
+++ b/actionpack/lib/action_dispatch/http/upload.rb
@@ -78,7 +78,7 @@ module ActionDispatch
       # Replace file upload hash with UploadedFile objects
       # when normalize and encode parameters.
       def normalize_encode_params(value)
-        if Hash === value && value.has_key?(:tempfile)
+        if value.is_a?(Hash) && value.has_key?(:tempfile)
           UploadedFile.new(value)
         else
           super

--- a/actionpack/lib/action_dispatch/journey/nfa/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/nfa/transition_table.rb
@@ -148,7 +148,7 @@ module ActionDispatch
             @table.each { |to, hash|
               hash.each { |from, sym|
                 if sym
-                  sym = Nodes::Symbol === sym ? sym.regexp : sym.left
+                  sym = sym.is_a?(Nodes::Symbol) ? sym.regexp : sym.left
                 end
 
                 @inverted[from][sym] << to

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -426,7 +426,7 @@ module ActionDispatch
       include ChainedCookieJars
 
       def initialize(parent_jar, key_generator, options = {})
-        if ActiveSupport::LegacyKeyGenerator === key_generator
+        if key_generator.is_a?(ActiveSupport::LegacyKeyGenerator)
           raise "You didn't set config.secret_key_base, which is required for this cookie jar. " +
             "Read the upgrade documentation to learn more about this new config option."
         end

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -17,7 +17,7 @@ module ActionDispatch
           class_name = app.class.name.to_s
           if class_name == "ActionDispatch::Routing::Mapper::Constraints"
             rack_app(app.app)
-          elsif ActionDispatch::Routing::Redirect === app || class_name !~ /^ActionDispatch::Routing/
+          elsif app.is_a?(ActionDispatch::Routing::Redirect) || class_name !~ /^ActionDispatch::Routing/
             app
           end
         end

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -125,9 +125,9 @@ module ActionDispatch
 
             if options[:format] == true
               @requirements[:format] ||= /.+/
-            elsif Regexp === options[:format]
+            elsif options[:format].is_a?(Regexp)
               @requirements[:format] = options[:format]
-            elsif String === options[:format]
+            elsif options[:format].is_a?(String)
               @requirements[:format] = Regexp.compile(options[:format])
             end
           end
@@ -147,20 +147,20 @@ module ActionDispatch
             @defaults.merge!(options[:defaults]) if options[:defaults]
 
             options.each do |key, default|
-              next if Regexp === default || IGNORE_OPTIONS.include?(key)
+              next if default.is_a?(Regexp) || IGNORE_OPTIONS.include?(key)
               @defaults[key] = default
             end
 
             if options[:constraints].is_a?(Hash)
               options[:constraints].each do |key, default|
-                next unless URL_OPTIONS.include?(key) && (String === default || Fixnum === default)
+                next unless URL_OPTIONS.include?(key) && (default.is_a?(String) || default.is_a?(Fixnum))
                 @defaults[key] ||= default
               end
             end
 
-            if Regexp === options[:format]
+            if options[:format].is_a?(Regexp)
               @defaults[:format] = nil
-            elsif String === options[:format]
+            elsif options[:format].is_a?(String)
               @defaults[:format] = options[:format]
             end
           end
@@ -176,7 +176,7 @@ module ActionDispatch
             @conditions[:required_defaults] = []
             options.each do |key, required_default|
               next if segment_keys.include?(key) || IGNORE_OPTIONS.include?(key)
-              next if Regexp === required_default
+              next if required_default.is_a?(Regexp)
               @conditions[:required_defaults] << key
             end
 
@@ -259,7 +259,7 @@ module ActionDispatch
               constraints.merge!(scope[:constraints]) if scope[:constraints]
 
               options.except(*IGNORE_OPTIONS).each do |key, option|
-                constraints[key] = option if Regexp === option
+                constraints[key] = option if option.is_a?(Regexp)
               end
 
               constraints.merge!(options[:constraints]) if options[:constraints].is_a?(Hash)
@@ -484,7 +484,7 @@ module ActionDispatch
           if options
             path = options.delete(:at)
           else
-            unless Hash === app
+            unless app.is_a?(Hash)
               raise ArgumentError, "must be called with mount point"
             end
 
@@ -1366,7 +1366,7 @@ module ActionDispatch
         # match 'path', to: 'controller#action'
         # match 'path', 'otherpath', on: :member, via: :get
         def match(path, *rest)
-          if rest.empty? && Hash === path
+          if rest.empty? && path.is_a?(Hash)
             options  = path
             path, to = options.find { |name, _value| name.is_a?(String) }
             options[:to] = to

--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -99,7 +99,7 @@ module ActionDispatch
         record = extract_record(record_or_hash_or_array)
         record = convert_to_model(record)
 
-        args = Array === record_or_hash_or_array ?
+        args = record_or_hash_or_array.is_a?(Array) ?
           record_or_hash_or_array.dup :
           [ record_or_hash_or_array ]
 

--- a/actionpack/lib/action_dispatch/routing/redirection.rb
+++ b/actionpack/lib/action_dispatch/routing/redirection.rb
@@ -137,7 +137,7 @@ module ActionDispatch
         path    = args.shift
 
         return OptionRedirect.new(status, options) if options.any?
-        return PathRedirect.new(status, path) if String === path
+        return PathRedirect.new(status, path) if path.is_a?(String)
 
         block = path if path.respond_to? :call
         raise ArgumentError, "redirection argument not supported" unless block

--- a/actionpack/lib/action_dispatch/testing/assertions/response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/response.rb
@@ -22,7 +22,7 @@ module ActionDispatch
       def assert_response(type, message = nil)
         message ||= "Expected response to be a <#{type}>, but was <#{@response.response_code}>"
 
-        if Symbol === type
+        if type.is_a?(Symbol)
           if [:success, :missing, :redirect, :error].include?(type)
             assert @response.send("#{type}?"), message
           else

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -265,7 +265,7 @@ module ActionDispatch
         def process(method, path, parameters = nil, headers_or_env = nil)
           if path =~ %r{://}
             location = URI.parse(path)
-            https! URI::HTTPS === location if location.scheme
+            https! location.is_a?(URI::HTTPS) if location.scheme
             host! "#{location.host}:#{location.port}" if location.host
             path = location.query ? "#{location.path}?#{location.query}" : location.path
           end

--- a/actionpack/lib/action_view/helpers/form_options_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_options_helper.rb
@@ -336,7 +336,7 @@ module ActionView
       #
       # NOTE: Only the option tags are returned, you have to wrap this call in a regular HTML select tag.
       def options_for_select(container, selected = nil)
-        return container if String === container
+        return container if container.is_a?(String)
 
         selected, disabled = extract_selected_and_disabled(selected).map do |r|
           Array(r).map { |item| item.to_s }
@@ -704,8 +704,8 @@ module ActionView
 
       private
         def option_html_attributes(element)
-          if Array === element
-            element.select { |e| Hash === e }.reduce({}, :merge!)
+          if element.is_a?(Array)
+            element.select { |e| e.is_a?(Hash) }.reduce({}, :merge!)
           else
             {}
           end
@@ -714,7 +714,7 @@ module ActionView
         def option_text_and_value(option)
           # Options are [text, value] pairs or strings used for both.
           if !option.is_a?(String) && option.respond_to?(:first) && option.respond_to?(:last)
-            option = option.reject { |e| Hash === e } if Array === option
+            option = option.reject { |e| e.is_a?(Hash) } if option.is_a?(Array)
             [option.first, option.last]
           else
             [option, option]

--- a/actionpack/lib/action_view/helpers/tags/select.rb
+++ b/actionpack/lib/action_view/helpers/tags/select.rb
@@ -32,7 +32,7 @@ module ActionView
         #   [nil, []]
         #   { nil => [] }
         def grouped_choices?
-          !@choices.empty? && @choices.first.respond_to?(:last) && Array === @choices.first.last
+          !@choices.empty? && @choices.first.respond_to?(:last) && @choices.first.last.is_a?(Array)
         end
       end
     end

--- a/actionpack/lib/action_view/path_set.rb
+++ b/actionpack/lib/action_view/path_set.rb
@@ -47,7 +47,7 @@ module ActionView #:nodoc:
     end
 
     def find_all(path, prefixes = [], *args)
-      prefixes = [prefixes] if String === prefixes
+      prefixes = [prefixes] if prefixes.is_a?(String)
       prefixes.each do |prefix|
         paths.each do |resolver|
           templates = resolver.find_all(path, prefix, *args)

--- a/actionpack/lib/action_view/renderer/partial_renderer.rb
+++ b/actionpack/lib/action_view/renderer/partial_renderer.rb
@@ -331,7 +331,7 @@ module ActionView
 
       prepend_formats(options[:formats])
 
-      if String === partial
+      if partial.is_a?(String)
         @object     = options[:object]
         @path       = partial
         @collection = collection

--- a/actionpack/lib/action_view/test_case.rb
+++ b/actionpack/lib/action_view/test_case.rb
@@ -61,7 +61,7 @@ module ActionView
 
         def determine_default_helper_class(name)
           determine_constant_from_test_name(name) do |constant|
-            Module === constant && !(Class === constant)
+            constant.is_a?(Module) && !constant.is_a?(Class)
           end
         end
 

--- a/actionpack/lib/action_view/vendor/html-scanner/html/node.rb
+++ b/actionpack/lib/action_view/vendor/html-scanner/html/node.rb
@@ -5,7 +5,7 @@ module HTML #:nodoc:
   class Conditions < Hash #:nodoc:
     def initialize(hash)
       super()
-      hash = { :content => hash } unless Hash === hash
+      hash = { :content => hash } unless hash.is_a?(Hash)
       hash = keys_to_symbols(hash)
       hash.each do |k,v|
         case k
@@ -113,7 +113,7 @@ module HTML #:nodoc:
     end
 
     def validate_conditions(conditions)
-      Conditions === conditions ? conditions : Conditions.new(conditions)
+      conditions.is_a?(Conditions) ? conditions : Conditions.new(conditions)
     end
 
     def ==(node)
@@ -317,7 +317,7 @@ module HTML #:nodoc:
         s = "<#{@name}"
         @attributes.each do |k,v|
           s << " #{k}"
-          s << "=\"#{v}\"" if String === v
+          s << "=\"#{v}\"" if v.is_a?(String)
         end
         s << " /" if @closing == :self
         s << ">"
@@ -463,7 +463,7 @@ module HTML #:nodoc:
           next if key == :only
           case key
             when :count
-              if Integer === value
+              if value.is_a?(Integer)
                 return false if matches.length != value
               else
                 return false unless value.include?(matches.length)

--- a/actionpack/test/controller/assert_select_test.rb
+++ b/actionpack/test/controller/assert_select_test.rb
@@ -65,8 +65,8 @@ class AssertSelectTest < ActionController::TestCase
 
   def assert_failure(message, &block)
     e = assert_raise(Assertion, &block)
-    assert_match(message, e.message) if Regexp === message
-    assert_equal(message, e.message) if String === message
+    assert_match(message, e.message) if message.is_a?(Regexp)
+    assert_equal(message, e.message) if message.is_a?(String)
   end
 
   #

--- a/activerecord/lib/active_record/associations/alias_tracker.rb
+++ b/activerecord/lib/active_record/associations/alias_tracker.rb
@@ -49,7 +49,7 @@ module ActiveRecord
       private
 
         def initial_count_for(name)
-          return 0 if Arel::Table === table_joins
+          return 0 if table_joins.is_a?(Arel::Table)
 
           # quoted_name should be downcased as some database adapters (Oracle) return quoted name in uppercase
           quoted_name = connection.quote_table_name(name).downcase

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -159,7 +159,7 @@ module ActiveRecord
       end
 
       def find_join_association(name_or_reflection, parent)
-        if String === name_or_reflection
+        if name_or_reflection.is_a?(String)
           name_or_reflection = name_or_reflection.to_sym
         end
 

--- a/activerecord/lib/active_record/attribute_methods/query.rb
+++ b/activerecord/lib/active_record/attribute_methods/query.rb
@@ -16,7 +16,7 @@ module ActiveRecord
         else
           column = self.class.columns_hash[attr_name]
           if column.nil?
-            if Numeric === value || value !~ /[^0-9]/
+            if value.is_a?(Numeric) || value !~ /[^0-9]/
               !value.to_i.zero?
             else
               return false if ActiveRecord::ConnectionAdapters::Column::FALSE_VALUES.include?(value)

--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -78,7 +78,7 @@ module ActiveRecord
 
         # FIXME: we should guarantee that all cached items are Result
         # objects.  Then we can avoid this conditional
-        if ActiveRecord::Result === result
+        if result.is_a?(ActiveRecord::Result)
           result.dup
         else
           result.collect { |row| row.dup }

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -563,7 +563,7 @@ module ActiveRecord
       end
 
       def index_name(table_name, options) #:nodoc:
-        if Hash === options
+        if options.is_a?(Hash)
           if options[:column]
             "index_#{table_name}_on_#{Array(options[:column]) * '_and_'}"
           elsif options[:name]

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -63,7 +63,7 @@ module ActiveRecord
 
       class Column < AbstractMysqlAdapter::Column #:nodoc:
         def self.string_to_time(value)
-          return super unless Mysql::Time === value
+          return super unless value.is_a?(Mysql::Time)
           new_time(
             value.year,
             value.month,
@@ -75,12 +75,12 @@ module ActiveRecord
         end
 
         def self.string_to_dummy_time(v)
-          return super unless Mysql::Time === v
+          return super unless v.is_a?(Mysql::Time)
           new_time(2000, 01, 01, v.hour, v.minute, v.second, v.second_part)
         end
 
         def self.string_to_date(v)
-          return super unless Mysql::Time === v
+          return super unless v.is_a?(Mysql::Time)
           new_date(v.year, v.month, v.day)
         end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -14,7 +14,7 @@ module ActiveRecord
         end
 
         def string_to_time(string)
-          return string unless String === string
+          return string unless string.is_a?(String)
 
           case string
           when 'infinity'; 1.0 / 0.0
@@ -36,7 +36,7 @@ module ActiveRecord
         end
 
         def hstore_to_string(object)
-          if Hash === object
+          if object.is_a?(Hash)
             object.map { |k,v|
               "#{escape_hstore(k)}=>#{escape_hstore(v)}"
             }.join ','
@@ -48,7 +48,7 @@ module ActiveRecord
         def string_to_hstore(string)
           if string.nil?
             nil
-          elsif String === string
+          elsif string.is_a?(String)
             Hash[string.scan(HstorePair).map { |k,v|
               v = v.upcase == 'NULL' ? nil : v.gsub(/\A"(.*)"\Z/m,'\1').gsub(/\\(.)/, '\1')
               k = k.gsub(/\A"(.*)"\Z/m,'\1').gsub(/\\(.)/, '\1')
@@ -60,7 +60,7 @@ module ActiveRecord
         end
 
         def json_to_string(object)
-          if Hash === object || Array === object
+          if object.is_a?(Hash) || object.is_a?(Array)
             ActiveSupport::JSON.encode(object)
           else
             object
@@ -69,7 +69,7 @@ module ActiveRecord
 
         def array_to_string(value, column, adapter, should_be_quoted = false)
           casted_values = value.map do |val|
-            if String === val
+            if val.is_a?(String)
               if val == "NULL"
                 "\"#{val}\""
               else
@@ -89,7 +89,7 @@ module ActiveRecord
         end
 
         def string_to_json(string)
-          if String === string
+          if string.is_a?(String)
             ActiveSupport::JSON.decode(string)
           else
             string
@@ -99,7 +99,7 @@ module ActiveRecord
         def string_to_cidr(string)
           if string.nil?
             nil
-          elsif String === string
+          elsif string.is_a?(String)
             IPAddr.new(string)
           else
             string
@@ -107,7 +107,7 @@ module ActiveRecord
         end
 
         def cidr_to_string(object)
-          if IPAddr === object
+          if object.is_a?(IPAddr)
             "#{object.to_s}/#{object.instance_variable_get(:@mask_addr).to_s(2).count('1')}"
           else
             object

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -20,7 +20,7 @@ module ActiveRecord
 
         class Bit < Type
           def type_cast(value)
-            if String === value
+            if value.is_a?(String)
               ConnectionAdapters::PostgreSQLColumn.string_to_bit value
             else
               value
@@ -76,7 +76,7 @@ module ActiveRecord
 
         class Point < Type
           def type_cast(value)
-            if String === value
+            if value.is_a?(String)
               ConnectionAdapters::PostgreSQLColumn.string_to_point value
             else
               value
@@ -91,7 +91,7 @@ module ActiveRecord
           end
 
           def type_cast(value)
-            if String === value
+            if value.is_a?(String)
               ConnectionAdapters::PostgreSQLColumn.string_to_array value, @subtype
             else
               value

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -255,8 +255,8 @@ module ActiveRecord
       end
 
       def type_cast(value, column) # :nodoc:
-        return value.to_f if BigDecimal === value
-        return super unless String === value
+        return value.to_f if value.is_a?(BigDecimal)
+        return super unless value.is_a?(String)
         return super unless column && value
 
         value = super

--- a/activerecord/lib/active_record/fixture_set/file.rb
+++ b/activerecord/lib/active_record/fixture_set/file.rb
@@ -43,11 +43,11 @@ module ActiveRecord
 
         # Validate our unmarshalled data.
         def validate(data)
-          unless Hash === data || YAML::Omap === data
+          unless data.is_a?(Hash) || data.is_a?(YAML::Omap)
             raise Fixture::FormatError, 'fixture is not a hash'
           end
 
-          raise Fixture::FormatError unless data.all? { |name, row| Hash === row }
+          raise Fixture::FormatError unless data.all? { |name, row| row.is_a?(Hash) }
           data
         end
     end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -41,7 +41,7 @@ module ActiveRecord
     def insert(values) # :nodoc:
       primary_key_value = nil
 
-      if primary_key && Hash === values
+      if primary_key && values.is_a?(Hash)
         primary_key_value = values[values.keys.find { |k|
           k.name == primary_key
         }]

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -157,7 +157,7 @@ module ActiveRecord
     #   Person.exists?(false)
     #   Person.exists?
     def exists?(conditions = :none)
-      conditions = conditions.id if Base === conditions
+      conditions = conditions.id if conditions.is_a?(Base)
       return false if !conditions
 
       join_dependency = construct_join_dependency
@@ -265,7 +265,7 @@ module ActiveRecord
     end
 
     def find_one(id)
-      id = id.id if ActiveRecord::Base === id
+      id = id.id if id.is_a?(ActiveRecord::Base)
 
       column = columns_hash[primary_key]
       substitute = connection.substitute_at(column, bind_values.length)

--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -25,7 +25,7 @@ module ActiveRecord
         other = Relation.new(relation.klass, relation.table)
         hash.each { |k, v|
           if k == :joins
-            if Hash === v
+            if v.is_a?(Hash)
               other.joins!(v)
             else
               other.joins!(*v)

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -280,7 +280,7 @@ module ActiveRecord
       args.flatten!
       validate_order_args args
 
-      references = args.reject { |arg| Arel::Node === arg }
+      references = args.reject { |arg| arg.is_a?(Arel::Node) }
       references.map! { |arg| arg =~ /^([a-zA-Z]\w*)\.(\w+)/ && $1 }.compact!
       references!(references) if references.any?
 
@@ -541,7 +541,7 @@ module ActiveRecord
       if opts == :chain
         WhereChain.new(self)
       else
-        references!(PredicateBuilder.references(opts)) if Hash === opts
+        references!(PredicateBuilder.references(opts)) if opts.is_a?(Hash)
 
         self.where_values += build_where(opts, rest)
         self
@@ -557,7 +557,7 @@ module ActiveRecord
     end
 
     def having!(opts, *rest) # :nodoc:
-      references!(PredicateBuilder.references(opts)) if Hash === opts
+      references!(PredicateBuilder.references(opts)) if opts.is_a?(Hash)
 
       self.having_values += build_where(opts, rest)
       self
@@ -881,7 +881,7 @@ module ActiveRecord
       arel.where(Arel::Nodes::And.new(equalities)) unless equalities.empty?
 
       (wheres - equalities).each do |where|
-        where = Arel.sql(where) if String === where
+        where = Arel.sql(where) if where.is_a?(String)
         arel.where(Arel::Nodes::Grouping.new(where))
       end
     end

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -708,7 +708,7 @@ module ActiveSupport
       #   would call <tt>Audit#save</tt>.
       def define_callbacks(*callbacks)
         config = callbacks.last.is_a?(Hash) ? callbacks.pop : {}
-        if config.key?(:terminator) && String === config[:terminator]
+        if config.key?(:terminator) && config[:terminator].is_a?(String)
           ActiveSupport::Deprecation.warn "String based terminators are deprecated, please use a lambda"
           value = config[:terminator]
           l = class_eval "lambda { |result| #{value} }", __FILE__, __LINE__

--- a/activesupport/lib/active_support/core_ext/logger.rb
+++ b/activesupport/lib/active_support/core_ext/logger.rb
@@ -61,7 +61,7 @@ class Logger
   class SimpleFormatter < Logger::Formatter
     # This method is invoked when a log event occurs
     def call(severity, timestamp, progname, msg)
-      "#{String === msg ? msg : msg.inspect}\n"
+      "#{msg.is_a?(String) ? msg : msg.inspect}\n"
     end
   end
 end

--- a/activesupport/lib/active_support/logger.rb
+++ b/activesupport/lib/active_support/logger.rb
@@ -50,7 +50,7 @@ module ActiveSupport
     class SimpleFormatter < ::Logger::Formatter
       # This method is invoked when a log event occurs
       def call(severity, timestamp, progname, msg)
-        "#{String === msg ? msg : msg.inspect}\n"
+        "#{msg.is_a?(String) ? msg : msg.inspect}\n"
       end
     end
   end

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -3754,7 +3754,7 @@ class Logger::FormatWithTime < Logger::Formatter
   cattr_accessor(:datetime_format) { "%Y%m%d%H%m%S" }
 
   def self.call(severity, timestamp, progname, msg)
-    "#{timestamp.strftime(datetime_format)} -- #{String === msg ? msg : msg.inspect}\n"
+    "#{timestamp.strftime(datetime_format)} -- #{msg.is_a?(String) ? msg : msg.inspect}\n"
   end
 end
 


### PR DESCRIPTION
I don't see any reason to use `===` - it's not obvious that you check instance of the object and also `is_a?` works faster.

Benchmark:

``` ruby
require 'benchmark'

n = 100000

Benchmark.bmbm do |x|
  x.report(:===) { n.times { 'a' === String } }
  x.report(:is_a?) { 'a'.is_a?(String) }
end
```

```
Rehearsal -----------------------------------------
===     0.030000   0.000000   0.030000 (  0.024191)
is_a?   0.000000   0.000000   0.000000 (  0.000004)
-------------------------------- total: 0.030000sec

            user     system      total        real
===     0.030000   0.000000   0.030000 (  0.027194)
is_a?   0.000000   0.000000   0.000000 (  0.000006)
```
