### PR TITLE
Test for wrong ActiveRecord::Migrator.needs_migration? result.

### DIFF
--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -70,8 +70,29 @@ class MigrationTest < ActiveRecord::TestCase
     assert_equal 3, ActiveRecord::Migrator.last_version
     assert_equal false, ActiveRecord::Migrator.needs_migration?
 
-    ActiveRecord::Migrator.down(MIGRATIONS_ROOT + "/valid")
+    ActiveRecord::Migrator.down(migrations_path)
     assert_equal 0, ActiveRecord::Migrator.current_version
+    assert_equal 3, ActiveRecord::Migrator.last_version
+    assert_equal true, ActiveRecord::Migrator.needs_migration?
+  end
+
+  def test_need_migration
+    migrations_path = MIGRATIONS_ROOT + "/valid"
+    ActiveRecord::Migrator.migrations_paths = migrations_path
+
+    ActiveRecord::Migrator.up migrations_path
+    assert_equal [1, 2, 3], ActiveRecord::Migrator.get_all_versions
+
+    Reminder.reset_column_information
+    assert Reminder.table_exists?
+
+    ActiveRecord::Migrator.run :down, migrations_path, 2
+    assert_equal [1, 3], ActiveRecord::Migrator.get_all_versions
+
+    Reminder.reset_column_information
+    assert !Reminder.table_exists?
+
+    assert_equal 3, ActiveRecord::Migrator.current_version
     assert_equal 3, ActiveRecord::Migrator.last_version
     assert_equal true, ActiveRecord::Migrator.needs_migration?
   end


### PR DESCRIPTION
Refers to #10789 and PR #10836

This test is failing.

Suppose we have 3 migrations (1, 2 and 3), and 1st and 3rd are up, and 2nd is down. So `ActiveRecord::Migrator.needs_migration?` will return `false`, but it should return `true` of course.
