### PR TITLE
Rails 4 bytea/binary not unescaped?

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -56,7 +56,11 @@ module ActiveRecord
         end
 
         def type_cast(value)
-          value.unserialized_value @column.type_cast value.value
+          if value.state == :serialized
+            value.unserialized_value @column.type_cast value.value
+          else
+            value.unserialized_value
+          end
         end
 
         def type

--- a/activerecord/test/cases/attribute_methods/serialization_test.rb
+++ b/activerecord/test/cases/attribute_methods/serialization_test.rb
@@ -1,0 +1,28 @@
+require "cases/helper"
+
+module ActiveRecord
+  module AttributeMethods
+    class SerializationTest < ActiveSupport::TestCase
+      class FakeColumn < Struct.new(:name)
+        def type; :integer; end
+        def type_cast(s); "#{s}!"; end
+      end
+
+      def test_type_cast_serialized_value
+        value = stub(state: :serialized, value: "Hello world")
+        value.expects(:unserialized_value).with("Hello world!")
+
+        type = Serialization::Type.new(FakeColumn.new)
+        type.type_cast(value)
+      end
+
+      def test_type_cast_unserialized_value
+        value = stub(state: :unserialized, value: "Hello world")
+        value.expects(:unserialized_value).with()
+
+        type = Serialization::Type.new(FakeColumn.new)
+        type.type_cast(value)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I have a bytea field in postgres (says binary in schema.rb).

There seems to be different behavior in Rails 4 compared to Rails 3.2.
If I use ActiveRecord::Base.connection.execute to get raw data, I get the same data in both versions.

However when I inspect the value that ActiveRecord gives me when reading the attribute from the model, I get a different value.

Raw: "\x789c63e108010000730061"
Rails 3.2: "x\x9Cc\xE1\b\x01\x00\x00s\x00a"
Rails 4: "\x789c63e108010000730061"

Obviously this is causing problems for me. What's wrong?
PS: I was using **postgres_ext** and activerecord-postgres-hstore gems in Rails 3.2, removed in Rails 4. I'm getting this issue during upgrading to Rails 4.

PS: It seems I can get the same string in Rails 4 by doing PGconn.unescape_bytea on the string. Did someone forget to unescape it or something? If this is intended I think it should be included in http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html

Thanks.
