### PR TITLE
Fix #10856, #10789: `::Logger#silence` and `LoggerSilence` troubles

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -357,14 +357,11 @@ module ActiveRecord
     class CheckPending
       def initialize(app)
         @app = app
-        @last_check = 0
       end
 
       def call(env)
-        mtime = ActiveRecord::Migrator.last_migration.mtime.to_i
-        if @last_check < mtime
+        ActiveRecord::Base.logger.silence do
           ActiveRecord::Migration.check_pending!
-          @last_check = mtime
         end
         @app.call(env)
       end
@@ -722,16 +719,6 @@ module ActiveRecord
 
   end
 
-  class NullMigration < MigrationProxy #:nodoc:
-    def initialize
-      super(nil, 0, nil, nil)
-    end
-
-    def mtime
-      0
-    end
-  end
-
   class Migrator#:nodoc:
     class << self
       attr_writer :migrations_paths
@@ -785,28 +772,28 @@ module ActiveRecord
       end
 
       def get_all_versions
-        SchemaMigration.all.map { |x| x.version.to_i }.sort
-      end
-
-      def current_version
         sm_table = schema_migrations_table_name
         if Base.connection.table_exists?(sm_table)
-          get_all_versions.max || 0
+          SchemaMigration.all.map { |x| x.version.to_i }.sort
         else
-          0
+          []
         end
       end
 
+      def current_version
+        get_all_versions.max || 0
+      end
+
       def needs_migration?
-        current_version < last_version
+        (all_known_versions - get_all_versions).any?
       end
 
       def last_version
-        last_migration.version
+        all_known_versions.max || 0
       end
 
-      def last_migration #:nodoc:
-        migrations(migrations_paths).last || NullMigration.new
+      def all_known_versions
+        migrations(migrations_paths).map(&:version).sort
       end
 
       def proper_table_name(name)

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -70,8 +70,29 @@ class MigrationTest < ActiveRecord::TestCase
     assert_equal 3, ActiveRecord::Migrator.last_version
     assert_equal false, ActiveRecord::Migrator.needs_migration?
 
-    ActiveRecord::Migrator.down(MIGRATIONS_ROOT + "/valid")
+    ActiveRecord::Migrator.down(migrations_path)
     assert_equal 0, ActiveRecord::Migrator.current_version
+    assert_equal 3, ActiveRecord::Migrator.last_version
+    assert_equal true, ActiveRecord::Migrator.needs_migration?
+  end
+
+  def test_need_migration
+    migrations_path = MIGRATIONS_ROOT + "/valid"
+    ActiveRecord::Migrator.migrations_paths = migrations_path
+
+    ActiveRecord::Migrator.up migrations_path
+    assert_equal [1, 2, 3], ActiveRecord::Migrator.get_all_versions
+
+    Reminder.reset_column_information
+    assert Reminder.table_exists?
+
+    ActiveRecord::Migrator.run :down, migrations_path, 2
+    assert_equal [1, 3], ActiveRecord::Migrator.get_all_versions
+
+    Reminder.reset_column_information
+    assert !Reminder.table_exists?
+
+    assert_equal 3, ActiveRecord::Migrator.current_version
     assert_equal 3, ActiveRecord::Migrator.last_version
     assert_equal true, ActiveRecord::Migrator.needs_migration?
   end

--- a/activesupport/lib/active_support/logger.rb
+++ b/activesupport/lib/active_support/logger.rb
@@ -2,10 +2,19 @@ require 'active_support/core_ext/class/attribute_accessors'
 require 'active_support/logger_silence'
 require 'logger'
 
+class Logger
+  include LoggerSilence
+
+  # Overwrite initialize to set a default formatter.
+  alias :old_initialize :initialize
+  def initialize(*args)
+    old_initialize(*args)
+    self.formatter = ActiveSupport::Logger::SimpleFormatter.new
+  end
+end
+
 module ActiveSupport
   class Logger < ::Logger
-    include LoggerSilence
-
     # Broadcasts logs to multiple loggers.
     def self.broadcast(logger) # :nodoc:
       Module.new do
@@ -39,11 +48,6 @@ module ActiveSupport
           super(level)
         end
       end
-    end
-
-    def initialize(*args)
-      super
-      @formatter = SimpleFormatter.new
     end
 
     # Simple formatter which only displays the message.

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -16,7 +16,7 @@ class TaggedLoggingTest < ActiveSupport::TestCase
 
   test 'sets logger.formatter if missing and extends it with a tagging API' do
     logger = Logger.new(StringIO.new)
-    assert_nil logger.formatter
+    logger.formatter = nil
     ActiveSupport::TaggedLogging.new(logger)
     assert_not_nil logger.formatter
     assert logger.formatter.respond_to?(:tagged)

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -62,7 +62,6 @@ module ApplicationTests
 
       require "#{app_path}/config/environment"
       ActiveRecord::Migrator.stubs(:needs_migration?).returns(true)
-      ActiveRecord::NullMigration.any_instance.stubs(:mtime).returns(1)
 
       get "/foo"
       assert_equal 500, last_response.status


### PR DESCRIPTION
- Synchronization has been added to `LoggerSilence#silence`.
- Fix #10856: search pending migrations among all known migrations, not
  only the latest one. `ActiveRecord::Migrator.needs_migration?` works
  as expected now.
- Fix #10789: `LoggerSilence` included into `::Logger`.
- Revert 3970432fcb6a0: it is very bad idea to use mtime to check if
  there are pending migrations. Suppose you did `db:migrate/db:rollback`
  several times: checking will stop working at all (`db:migrate:status` has
  changed but mtime is not).
