### PR TITLE
Ignore activemodel/log/ folder

### DIFF
--- a/activemodel/test/cases/railtie_test.rb
+++ b/activemodel/test/cases/railtie_test.rb
@@ -7,8 +7,12 @@ class RailtieTest < ActiveModel::TestCase
   def setup
     require 'active_model/railtie'
 
+    # Set a fake logger to avoid creating the log directory automatically
+    fake_logger = mock()
+
     @app ||= Class.new(::Rails::Application) do
       config.eager_load = false
+      config.logger = fake_logger
     end
   end
 


### PR DESCRIPTION
After running tests the `activemodel/log/` folder is appeared. I think it should be in the `.gitignore`
