### PR TITLE
Fix #10658 - Merge scope if it has a different klass from the current scope

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   When a named scope returns a scope that is associated with a different class,
+    it is merged into `all` to ensure the return value is associated with the correct class.
+
+    Fixes #10658.
+
+    *Lachlan Sylvester*
+
 *   Fix accessing of fixtures having non-string labels like Fixnum.
 
     *Prathamesh Sonpatki*

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -154,7 +154,7 @@ module ActiveRecord
           singleton_class.send(:define_method, name) do |*args|
             scope = all.scoping { body.call(*args) }
             scope = scope.extending(extension) if extension
-
+            scope = all.merge(scope) if scope && scope.klass != all.klass
             scope || all
           end
         end

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -6,6 +6,7 @@ require 'models/reply'
 require 'models/author'
 require 'models/developer'
 require 'models/computer'
+require 'models/company'
 
 class NamedScopingTest < ActiveRecord::TestCase
   fixtures :posts, :authors, :topics, :comments, :author_addresses
@@ -519,6 +520,10 @@ class NamedScopingTest < ActiveRecord::TestCase
 
   def test_subclass_merges_scopes_properly
     assert_equal 1, SpecialComment.where(body: 'go crazy').created.count
+  end
+
+  def test_scopes_defined_in_abstract_class
+    assert_equal "companies", Company.abstract_company_scope.table_name
   end
 
 end

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -1,5 +1,7 @@
 class AbstractCompany < ActiveRecord::Base
   self.abstract_class = true
+  
+  scope :abstract_company_scope, ->{ all }
 end
 
 class Company < AbstractCompany


### PR DESCRIPTION
The scope returned from a named scope lambda is associated with the class in which it was defined, which may be an abstract class with no table associcated with it.

This merges the scope into all if its klass is different from the current class ensuring that a scope returned from a named scope is for the class on which the scope was being called.

Fixes #10658
