### PR TITLE
As we have moved to rails/docrails from lifo/docrails

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -182,9 +182,9 @@ Contributing to the Rails Documentation
 
 Ruby on Rails has two main sets of documentation: the guides help you in learning about Ruby on Rails, and the API is a reference.
 
-You can help improve the Rails guides by making them more coherent, consistent or readable, adding missing information, correcting factual errors, fixing typos, or bringing it up to date with the latest edge Rails. To get involved in the translation of Rails guides, please see [Translating Rails Guides](https://wiki.github.com/lifo/docrails/translating-rails-guides).
+You can help improve the Rails guides by making them more coherent, consistent or readable, adding missing information, correcting factual errors, fixing typos, or bringing it up to date with the latest edge Rails. To get involved in the translation of Rails guides, please see [Translating Rails Guides](https://wiki.github.com/rails/docrails/translating-rails-guides).
 
-If you're confident about your changes, you can push them directly yourself via [docrails](https://github.com/lifo/docrails). Docrails is a branch with an **open commit policy** and public write access. Commits to docrails are still reviewed, but this happens after they are pushed. Docrails is merged with master regularly, so you are effectively editing the Ruby on Rails documentation.
+If you're confident about your changes, you can push them directly yourself via [docrails](https://github.com/rails/docrails). Docrails is a branch with an **open commit policy** and public write access. Commits to docrails are still reviewed, but this happens after they are pushed. Docrails is merged with master regularly, so you are effectively editing the Ruby on Rails documentation.
 
 If you are unsure of the documentation changes, you can create an issue in the [Rails](https://github.com/rails/rails/issues) issues tracker on GitHub.
 

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -64,7 +64,7 @@ Creating a New Rails Project
 The best way to use this guide is to follow each step as it happens, no code or
 step needed to make this example application has been left out, so you can
 literally follow along step by step. You can get the complete code
-[here](https://github.com/lifo/docrails/tree/master/guides/code/getting_started).
+[here](https://github.com/rails/docrails/tree/master/guides/code/getting_started).
 
 By following along with this guide, you'll create a Rails project called
 `blog`, a

--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -102,10 +102,10 @@
         </p>
         <p>
           If you see any typos or factual errors you are confident to
-          patch, please clone <%= link_to 'docrails', 'https://github.com/lifo/docrails' %>
+          patch, please clone <%= link_to 'docrails', 'https://github.com/rails/docrails' %>
           and push the change yourself. That branch of Rails has public write access.
           Commits are still reviewed, but that happens after you've submitted your
-          contribution. <%= link_to 'docrails', 'https://github.com/lifo/docrails' %> is
+          contribution. <%= link_to 'docrails', 'https://github.com/rails/docrails' %> is
           cross-merged with master periodically.
         </p>
         <p>


### PR DESCRIPTION
Changing links to guides.

We are not worried for old versions as GitHub is 
handling the redirects.

I could have done this PR here https://github.com/rails/docrails
