### PR TITLE
Docfix: Use public interface instead of setting instance variables

### DIFF
--- a/activemodel/lib/active_model/serializers/json.rb
+++ b/activemodel/lib/active_model/serializers/json.rb
@@ -109,7 +109,7 @@ module ActiveModel
       #
       #     def attributes=(hash)
       #       hash.each do |key, value|
-      #         instance_variable_set("@#{key}", value)
+      #         send("#{key}=", value)
       #       end
       #     end
       #


### PR DESCRIPTION
Dynamically setting instance variables based on user input probably isn't a great idea. Better to go through the setter methods provided by attr_accessor.

[ci skip]
