### PR TITLE
Handle single quotes in PostgreSQL default column values

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -84,7 +84,7 @@ module ActiveRecord
             $1
           # Character types
           when /\A\(?'(.*)'::.*\b(?:character varying|bpchar|text)\z/m
-            $1
+            $1.gsub(/''/, "'")
           # Binary data types
           when /\A'(.*)'::bytea\z/m
             $1

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -39,6 +39,31 @@ class DefaultTest < ActiveRecord::TestCase
   end
 end
 
+class DefaultStringsTest < ActiveRecord::TestCase
+  class DefaultString < ActiveRecord::Base; end
+
+  setup do
+    @connection = ActiveRecord::Base.connection
+    @connection.create_table :default_strings do |t|
+      t.string :string_col, default: "Smith"
+      t.string :string_col_with_quotes, default: "O'Connor"
+    end
+    DefaultString.reset_column_information
+  end
+
+  def test_default_strings
+    assert_equal "Smith", DefaultString.new.string_col
+  end
+
+  def test_default_strings_containing_single_quotes
+    assert_equal "O'Connor", DefaultString.new.string_col_with_quotes
+  end
+
+  teardown do
+    @connection.drop_table :default_strings
+  end
+end
+
 if current_adapter?(:MysqlAdapter, :Mysql2Adapter)
   class DefaultsTestWithoutTransactionalFixtures < ActiveRecord::TestCase
     # ActiveRecord::Base#create! (and #save and other related methods) will


### PR DESCRIPTION
PostgreSQL escapes single quotes by using an additional single quote. When Rails queries the column information, PostgreSQL returns the default values with the escaped single quotes.

`#extract_value_from_default` now converts these to one single quote each.

Fixes #10881.

(This is my first time digging into the ActiveRecord source, so I took a stab in the dark with where to include the tests for this; if anyone has any input it'd be appreciated. Thanks!)
