### PR TITLE
Add `#any_of` query method to active_record

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add `#any_of` query methods on active_record relations.
+
+    This allows to compute `OR` like queries with usual `#where` syntax,
+    and also allows to compute dynamic `OR` queries.
+
+    A negative `#none_of` version is also added.
+
+    Example:
+
+        manual_removal = User.where( id: params[:users][:destroy_ids] )
+        users = User.any_of( manual_removal, "email like '%@example.com'", {banned: true}).destroy_all
+        active_users = User.none_of({ banned: true }, "confirmed_at IS NULL" )
+
+    *Olivier El Mekki*
+
 *   Make `ActiveRecord::Relation#unscope` affect relations it is merged in to.
 
     *Jon Leighton*

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -84,6 +84,7 @@ module ActiveRecord
       autoload :QueryMethods
       autoload :FinderMethods
       autoload :Calculations
+      autoload :AlternativeBuilder
       autoload :PredicateBuilder
       autoload :SpawnMethods
       autoload :Batches

--- a/activerecord/lib/active_record/relation/alternative_builder.rb
+++ b/activerecord/lib/active_record/relation/alternative_builder.rb
@@ -1,0 +1,104 @@
+module ActiveRecord
+  class AlternativeBuilder # :nodoc:
+    def initialize(match_type, context, *queries)
+      @builder = match_type == :negative ? NegativeBuilder.new(context, *queries) : PositiveBuilder.new(context, *queries)
+    end
+
+    def build
+      @builder.build
+    end
+
+    class Builder
+      attr_accessor :queries_bind_values, :queries_joins_values
+
+      def initialize(context, *source_queries)
+        @context, @source_queries = context, source_queries
+        @queries_bind_values, @queries_joins_values = [], { includes: [],  joins: [], references: [] }
+      end
+
+      def build
+        ActiveRecord::Base.connection.supports_statement_cache? ? with_statement_cache : without_statement_cache
+      end
+
+      private
+
+        def queries
+          @queries ||= @source_queries.map do |query|
+            if String === query || Hash === query
+              query = where(query)
+            elsif Array === query
+              query = where(*query)
+            end
+
+            queries_bind_values.concat(query.bind_values) if query.bind_values.any?
+            queries_joins_values[:includes].concat(query.includes_values) if query.includes_values.any?
+            queries_joins_values[:joins].concat(query.joins_values) if query.joins_values.any?
+            queries_joins_values[:references].concat(query.references_values) if query.references_values.any?
+            query.arel.constraints.reduce(:and)
+          end
+        end
+
+        def uniq_queries_joins_values
+          @uniq_queries_joins_values ||= queries_joins_values.each { |tables| tables.uniq }
+        end
+
+        def method_missing(method_name, *args, &block)
+          @context.send(method_name, *args, &block)
+        end
+
+        def add_joins_to(relation)
+          relation = relation.references(uniq_queries_joins_values[:references])
+          relation = relation.includes(uniq_queries_joins_values[:includes])
+          relation.joins(uniq_queries_joins_values[:joins])
+        end
+
+        def add_related_values_to(relation)
+          relation.bind_values += queries_bind_values
+          relation.includes_values += uniq_queries_joins_values[:includes]
+          relation.joins_values += uniq_queries_joins_values[:joins]
+          relation.references_values += uniq_queries_joins_values[:references]
+
+          relation
+        end
+    end
+
+    class PositiveBuilder < Builder
+      private
+
+        def with_statement_cache
+          if queries && queries_bind_values.any?
+            relation = where([queries.reduce(:or).to_sql, *queries_bind_values.map { |v| v[1] }])
+          else
+            relation = where(queries.reduce(:or).to_sql)
+          end
+
+          add_joins_to relation
+        end
+
+        def without_statement_cache
+          relation = where(queries.reduce(:or))
+          add_related_values_to relation
+        end
+    end
+
+    class NegativeBuilder < Builder
+      private
+
+        def with_statement_cache
+          if queries && queries_bind_values.any?
+            relation = where.not([queries.reduce(:or).to_sql, *queries_bind_values.map { |v| v[1] }])
+          else
+            relation = where.not(queries.reduce(:or).to_sql)
+          end
+
+          add_joins_to relation
+        end
+
+        def without_statement_cache
+          relation = where.not(queries.reduce(:or))
+          add_related_values_to relation
+        end
+    end
+  end
+end
+

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     # WhereChain objects act as placeholder for queries in which #where does not have any parameter.
-    # In this case, #where must be chained with #not to return a new relation.
+    # In this case, #where must be chained with #not, #any_of or #none_of to return a new relation.
     class WhereChain
       def initialize(scope)
         @scope = scope
@@ -49,6 +49,45 @@ module ActiveRecord
         end
         @scope.where_values += where_value
         @scope
+      end
+
+      # Returns a new relation, which includes results matching any of the conditions
+      # passed as parameters. You can think of it as a sql <tt>OR</tt> implementation.
+      #
+      # Each #any_of parameter is the same set you would have passed to #where :
+      #
+      #    Client.where.any_of("orders_count = '2'", ["name = ?", 'Joe'], {email: 'joe@example.com'})
+      #
+      # You can as well pass #any_of to other relations :
+      #
+      #    Client.where("orders_count = '2'").where.any_of({ email: 'joe@example.com' }, { email: 'john@example.com' })
+      #
+      # And with associations :
+      #
+      #    User.find(1).posts.where.any_of({published: false}, "user_id IS NULL")
+      #
+      # The best part is that #any_of accepts other relations as parameter, to help compute
+      # dynamic <tt>OR</tt> queries :
+      #
+      #    banned_users = User.where(banned: true)
+      #    unconfirmed_users = User.where("confirmed_at IS NULL")
+      #    inactive_users = User.where.any_of(banned_users, unconfirmed_users)
+      def any_of(*queries)
+        raise ArgumentError, 'Called any_of() with no arguments.' if queries.none?
+        AlternativeBuilder.new(:positive, @scope, *queries).build
+      end
+
+      # Returns a new relation, which includes results not matching any of the conditions
+      # passed as parameters. It's the negative version of <tt>#any_of</tt>.
+      #
+      # This will return all active users :
+      #
+      #    banned_users = User.where(banned: true)
+      #    unconfirmed_users = User.where("confirmed_at IS NULL")
+      #    active_users = User.where.none_of(banned_users, unconfirmed_users)
+      def none_of(*queries)
+        raise ArgumentError, 'Called none_of() with no arguments.' if queries.none?
+        AlternativeBuilder.new(:negative, @scope, *queries).build
       end
     end
 


### PR DESCRIPTION
Note : This PR has been [extracted as a gem](https://github.com/oelmekki/activerecord_any_of), usable in both 
rails-3 and rails-4.

This method is inspired by [any_of from mongoid](http://two.mongoid.org/docs/querying/criteria.html#any_of).

It is hooked on `WhereChain`, just like `#not`, and allows to compute
an `OR` like query that leverages AR's `#where` syntax:

``` ruby
manual_removal = User.where(id: params[:users][:destroy_ids])
users = User.where.any_of(manual_removal, "email like '%@example.com'", {banned: true}).destroy_all
```

It can be used anywhere `#where` is expected to work :

``` ruby
manual_removal = User.where(id: params[:users][:destroy_ids])
User.where.any_of(manual_removal, "email like '%@example.com'", {banned: true})
@company.users.where.any_of(manual_removal, "email like '%@example.com'", {banned: true})
User.where(offline: false).where.any_of( manual_removal, "email like '%@example.com'", {banned: true})
```

Its main purpose is to both :
- remove the need to write a sql string when we want an `OR`
- allow to write dynamic `OR` queries, which would be a pain with a string

There's also a negative version, `#none_of`. This will return all active
users :

``` ruby
banned_users = User.where(banned: true)
unconfirmed_users = User.where("confirmed_at IS NULL")
active_users = User.where.none_of(banned_users, unconfirmed_users)
```
