### PR TITLE
typo Railties -> Railtie

### DIFF
--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -8,7 +8,7 @@ ENV['TMPDIR'] = File.join(File.dirname(__FILE__), 'tmp')
 
 require 'active_support/core_ext/kernel/reporting'
 
-# These are the normal settings that will be set up by Railties
+# These are the normal settings that will be set up by Railtie
 # TODO: Have these tests support other combinations of these values
 silence_warnings do
   Encoding.default_internal = "UTF-8"


### PR DESCRIPTION
Fixed a tiny typo, Railties -> Railtie. 
