### PR TITLE
Fixed typos in activesupport [ci skip]

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -403,8 +403,8 @@ module ActiveSupport
       # the same after this point:
       #
       #   Symbols:: Already methods.
-      #   Strings:: class_eval'ed into methods.
-      #   Procs::   define_method'ed into methods.
+      #   Strings:: class_eval'd into methods.
+      #   Procs::   using define_method compiled into methods.
       #   Objects::
       #     a method is created that calls the before_foo method
       #     on the object.
@@ -648,7 +648,7 @@ module ActiveSupport
       #
       # * <tt>:terminator</tt> - Determines when a before filter will halt the
       #   callback chain, preventing following callbacks from being called and
-      #   the event from being triggered. This is a string to be eval'ed. The
+      #   the event from being triggered. This is a string to be eval'd. The
       #   result of the callback is available in the +result+ variable.
       #
       #     define_callbacks :validate, terminator: 'result == false'


### PR DESCRIPTION
- eval'ed to eval'd in accordance with https://github.com/rails/rails/pull/10889
- tried to improve statement about compiling Procs into methods using define_method
