### PR TITLE
Calls to the application constant have been refactored

### DIFF
--- a/railties/test/application/asset_debugging_test.rb
+++ b/railties/test/application/asset_debugging_test.rb
@@ -14,7 +14,7 @@ module ApplicationTests
       app_file "app/views/posts/index.html.erb", "<%= javascript_include_tag 'application' %>"
 
       app_file "config/routes.rb", <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get '/posts', to: "posts#index"
         end
       RUBY

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -45,7 +45,7 @@ module ApplicationTests
       app_file "app/assets/javascripts/demo.js.erb", "a = <%= image_path('rails.png').inspect %>;"
 
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get '*path', to: lambda { |env| [200, { "Content-Type" => "text/html" }, ["Not an asset"]] }
         end
       RUBY
@@ -313,7 +313,7 @@ module ApplicationTests
       app_file "app/assets/javascripts/demo.js.erb", "<%= :alert %>();"
 
       app_file "config/routes.rb", <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get '/omg', :to => "omg#index"
         end
       RUBY
@@ -475,7 +475,7 @@ module ApplicationTests
       app_file "app/views/posts/index.html.erb", "<%= javascript_include_tag 'application' %>"
 
       app_file "config/routes.rb", <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get '/posts', :to => "posts#index"
         end
       RUBY

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -41,7 +41,7 @@ module ApplicationTests
 
     test "allows me to configure default url options for ActionMailer" do
       app_file "config/environments/development.rb", <<-RUBY
-        AppTemplate::Application.configure do
+        Rails.application.configure do
           config.action_mailer.default_url_options = { :host => "test.rails" }
         end
       RUBY
@@ -52,7 +52,7 @@ module ApplicationTests
 
     test "does not include url helpers as action methods" do
       app_file "config/routes.rb", <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get "/foo", :to => lambda { |env| [200, {}, []] }, :as => :foo
         end
       RUBY
@@ -115,7 +115,7 @@ module ApplicationTests
       RUBY
 
       app_file "config/routes.rb", <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get "/:controller(/:action)"
         end
       RUBY

--- a/railties/test/application/initializers/i18n_test.rb
+++ b/railties/test/application/initializers/i18n_test.rb
@@ -84,7 +84,7 @@ en:
       RUBY
 
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get '/i18n',   :to => lambda { |env| [200, {}, [Foo.instance_variable_get('@foo')]] }
         end
       RUBY
@@ -108,7 +108,7 @@ en:
       YAML
 
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get '/i18n',   :to => lambda { |env| [200, {}, [I18n.t(:foo)]] }
         end
       RUBY

--- a/railties/test/application/initializers/load_path_test.rb
+++ b/railties/test/application/initializers/load_path_test.rb
@@ -75,7 +75,7 @@ module ApplicationTests
       $initialize_test_set_from_env = nil
       app_file "config/environments/development.rb", <<-RUBY
         $initialize_test_set_from_env = 'success'
-        AppTemplate::Application.configure do
+        Rails.application.configure do
           config.cache_classes = true
           config.time_zone = "Brasilia"
         end
@@ -89,8 +89,8 @@ module ApplicationTests
 
       require "#{app_path}/config/environment"
       assert_equal "success", $initialize_test_set_from_env
-      assert AppTemplate::Application.config.cache_classes
-      assert_equal "Brasilia", AppTemplate::Application.config.time_zone
+      assert Rails.application.config.cache_classes
+      assert_equal "Brasilia", Rails.application.config.time_zone
     end
   end
 end

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -213,7 +213,7 @@ class LoadingTest < ActiveSupport::TestCase
     app_file 'config/routes.rb', <<-RUBY
       $counter ||= 1
       $counter  *= 2
-      AppTemplate::Application.routes.draw do
+      Rails.application.routes.draw do
         get '/c', to: lambda { |env| User; [200, {"Content-Type" => "text/plain"}, [$counter.to_s]] }
       end
     RUBY

--- a/railties/test/application/middleware/cache_test.rb
+++ b/railties/test/application/middleware/cache_test.rb
@@ -45,7 +45,7 @@ module ApplicationTests
       RUBY
 
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get ':controller(/:action)'
         end
       RUBY

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -88,7 +88,7 @@ module ApplicationTests
       add_to_config "config.ssl_options = { host: 'example.com' }"
       boot!
 
-      assert_equal AppTemplate::Application.middleware.first.args, [{host: 'example.com'}]
+      assert_equal Rails.application.middleware.first.args, [{host: 'example.com'}]
     end
 
     test "removing Active Record omits its middleware" do
@@ -225,7 +225,7 @@ module ApplicationTests
       end
 
       def middleware
-        AppTemplate::Application.middleware.map(&:klass).map(&:name)
+        Rails.application.middleware.map(&:klass).map(&:name)
       end
   end
 end

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -30,7 +30,7 @@ module ApplicationTests
       app_file "config/environment.rb", <<-RUBY
         SuperMiddleware = Struct.new(:app)
 
-        AppTemplate::Application.configure do
+        Rails.application.configure do
           config.middleware.use SuperMiddleware
         end
 
@@ -142,7 +142,7 @@ module ApplicationTests
 
     def test_rake_routes_calls_the_route_inspector
       app_file "config/routes.rb", <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get '/cart', to: 'cart#show'
         end
       RUBY
@@ -153,7 +153,7 @@ module ApplicationTests
 
     def test_rake_routes_with_controller_environment
       app_file "config/routes.rb", <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get '/cart', to: 'cart#show'
           get '/basketball', to: 'basketball#index'
         end
@@ -166,7 +166,7 @@ module ApplicationTests
 
     def test_rake_routes_displays_message_when_no_routes_are_defined
       app_file "config/routes.rb", <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
         end
       RUBY
 

--- a/railties/test/application/rendering_test.rb
+++ b/railties/test/application/rendering_test.rb
@@ -17,7 +17,7 @@ module ApplicationTests
 
     test "Unknown format falls back to HTML template" do
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get 'pages/:id', to: 'pages#show'
         end
       RUBY

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -163,7 +163,7 @@ module TestHelpers
       RUBY
 
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           get ':controller(/:action)'
         end
       RUBY

--- a/railties/test/railties/mounted_engine_test.rb
+++ b/railties/test/railties/mounted_engine_test.rb
@@ -16,7 +16,7 @@ module ApplicationTests
       @metrics_plugin = engine "metrics"
 
       app_file 'config/routes.rb', <<-RUBY
-        AppTemplate::Application.routes.draw do
+        Rails.application.routes.draw do
           mount Weblog::Engine, :at => '/', :as => 'weblog'
           resources :posts
           get "/engine_route" => "application_generating#engine_route"


### PR DESCRIPTION
Instead of using `AppTemplate::Application` when drawing routes or creating configurations
on the application, I'm changing to use `Rails.application` which is more agnostic.

Doing this means that in the future, if the Rails application is no longer a singleton, you'll still be able to use the tests by calling the canonical rails application instance.
