### PR TITLE
fixture setup does not rely on `AR::Base.configurations`.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fixture setup does no longer depend on `ActiveRecord::Base.configurations`.
+    This is relevant when `ENV["DATABASE_URL"]` is used in place of a `database.yml`.
+
+    *Yves Senn*
+
 *   Fix mysql2 adapter raises the correct exception when executing a query on a
     closed connection.
 

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -841,8 +841,6 @@ module ActiveRecord
     end
 
     def setup_fixtures
-      return if ActiveRecord::Base.configurations.blank?
-
       if pre_loaded_fixtures && !use_transactional_fixtures
         raise RuntimeError, 'pre_loaded_fixtures requires use_transactional_fixtures'
       end
@@ -875,8 +873,6 @@ module ActiveRecord
     end
 
     def teardown_fixtures
-      return if ActiveRecord::Base.configurations.blank?
-
       # Rollback changes if a transaction is active.
       if run_in_transaction?
         @fixture_connections.each do |connection|

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -245,6 +245,22 @@ class FixturesTest < ActiveRecord::TestCase
   def test_serialized_fixtures
     assert_equal ["Green", "Red", "Orange"], traffic_lights(:uk).state
   end
+
+  def test_fixtures_are_set_up_with_database_env_variable
+    ENV.stubs(:[]).with("DATABASE_URL").returns("sqlite3:///:memory:")
+    ActiveRecord::Base.stubs(:configurations).returns({})
+    test_case = Class.new(ActiveRecord::TestCase) do
+      fixtures :accounts
+
+      def test_fixtures
+        assert accounts(:signals37)
+      end
+    end
+
+    result = test_case.new(:test_fixtures).run
+
+    assert result.passed?, "Expected #{result.name} to pass:\n#{result}"
+  end
 end
 
 if Account.connection.respond_to?(:reset_pk_sequence!)


### PR DESCRIPTION
As you can also configure your database connection using `ENV["DATABASE_URL"]`,
the fixture setup can't rely on the `.configurations` Hash.

As the fixtures are only loaded when ActiveRecord is actually used
(`rails/test_help.rb`) it should be safe to drop the check for an existing configuration.

Closes https://github.com/ryandotsmith/queue_classic/issues/155

The guard was introduced with a72ace1 more details can be found here: http://web.archive.org/web/20090226044958/http://dev.rubyonrails.org/ticket/5497
