### PR TITLE
Use symbols instead of strings in ActiveSupport::Concern

### DIFF
--- a/activesupport/lib/active_support/concern.rb
+++ b/activesupport/lib/active_support/concern.rb
@@ -105,25 +105,25 @@ module ActiveSupport
     end
 
     def self.extended(base) #:nodoc:
-      base.instance_variable_set("@_dependencies", [])
+      base.instance_variable_set(:@_dependencies, [])
     end
 
     def append_features(base)
-      if base.instance_variable_defined?("@_dependencies")
-        base.instance_variable_get("@_dependencies") << self
+      if base.instance_variable_defined?(:@_dependencies)
+        base.instance_variable_get(:@_dependencies) << self
         return false
       else
         return false if base < self
         @_dependencies.each { |dep| base.send(:include, dep) }
         super
-        base.extend const_get("ClassMethods") if const_defined?("ClassMethods")
-        base.class_eval(&@_included_block) if instance_variable_defined?("@_included_block")
+        base.extend const_get(:ClassMethods) if const_defined?(:ClassMethods)
+        base.class_eval(&@_included_block) if instance_variable_defined?(:@_included_block)
       end
     end
 
     def included(base = nil, &block)
       if base.nil?
-        raise MultipleIncludedBlocks if instance_variable_defined?("@_included_block")
+        raise MultipleIncludedBlocks if instance_variable_defined?(:@_included_block)
 
         @_included_block = block
       else


### PR DESCRIPTION
ActiveSupport::Concern is used all over Rails
This PR will only create 3 new objects once as keys are never recreated and
are not normally subject to garbage collection.

The strings were being uniquely created and garbage collected. I don't
have any performance numbers but this should be better than all of the
GC.
