### PR TITLE
Always Escape the Return String of link_to_unless

### DIFF
--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -422,7 +422,7 @@ module ActionView
           if block_given?
             block.arity <= 1 ? capture(name, &block) : capture(name, options, html_options, &block)
           else
-            name
+            ERB::Util.html_escape(name)
           end
         else
           link_to(name, options, html_options)

--- a/actionpack/test/template/url_helper_test.rb
+++ b/actionpack/test/template/url_helper_test.rb
@@ -306,6 +306,11 @@ class UrlHelperTest < ActiveSupport::TestCase
       link_to_unless(true, "Showing", url_hash) {
         "test"
       }
+
+    assert_equal %{&lt;b&gt;Showing&lt;/b&gt;}, link_to_unless(true, "<b>Showing</b>", url_hash)
+    assert_equal %{<a href="/">&lt;b&gt;Showing&lt;/b&gt;</a>}, link_to_unless(false, "<b>Showing</b>", url_hash)
+    assert_equal %{<b>Showing</b>}, link_to_unless(true, "<b>Showing</b>".html_safe, url_hash)
+    assert_equal %{<a href="/"><b>Showing</b></a>}, link_to_unless(false, "<b>Showing</b>".html_safe, url_hash)
   end
 
   def test_link_to_if


### PR DESCRIPTION
The return string of link_to_unless method should be always html-escaped to keep consistency.

``` ruby
link_to_unless(false, 'a>b', 'github.com')
# => "<a href=\"github.com\">a&gt;b</a>"

link_to_unless(true, 'a>b', 'github.com')
# => "a>b" should be "a&gt;b"
```

Could you consider to merge this request?
