### PR TITLE
Preloading associations that don't exist should not raise an error

### DIFF
--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -717,18 +717,10 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_with_invalid_association_reference
-    assert_raise(ActiveRecord::ConfigurationError, "Association was not found; perhaps you misspelled it?  You specified :include => :monkeys") {
-      Post.all.merge!(:includes=> :monkeys ).find(6)
-    }
-    assert_raise(ActiveRecord::ConfigurationError, "Association was not found; perhaps you misspelled it?  You specified :include => :monkeys") {
-      Post.all.merge!(:includes=>[ :monkeys ]).find(6)
-    }
-    assert_raise(ActiveRecord::ConfigurationError, "Association was not found; perhaps you misspelled it?  You specified :include => :monkeys") {
-      Post.all.merge!(:includes=>[ 'monkeys' ]).find(6)
-    }
-    assert_raise(ActiveRecord::ConfigurationError, "Association was not found; perhaps you misspelled it?  You specified :include => :monkeys, :elephants") {
-      Post.all.merge!(:includes=>[ :monkeys, :elephants ]).find(6)
-    }
+    post = Post.all.merge!(:includes => [ {:special_categories => :bread}, {:monkeys => :bar}, :balls ]).find(6)
+    assert_no_queries do
+      assert_equal 1, post.special_categories.size
+    end
   end
 
   def test_eager_with_default_scope


### PR DESCRIPTION
Today when pre loading associations each association should exist or an error gets thrown. This is not strictly needed as the "wrong" association can just be ignored.

Even more, it could be useful in the case of polymorphic situations. eg: 

``` ruby
Story.includes(subject: [:comments, :thumbnail])
```

Now imagine that subject here is polymorphic and some of the classes in that query do not have a thumbnail association. Now a developer has to deal with n+1 queries, due to the raise. It would be nice if ActiveRecord loads the associations when it can, and silently fails when it can't.

One could argue that the code should at least show a warning, but I believe that tools like Bullet are better suited.
