### PR TITLE
Refactor of ::Rails module

### DIFF
--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -3,7 +3,9 @@ require 'rails/ruby_version_check'
 require 'pathname'
 
 require 'active_support'
+require 'active_support/dependencies/autoload'
 require 'active_support/core_ext/kernel/reporting'
+require 'active_support/core_ext/module/delegation'
 require 'active_support/core_ext/array/extract_options'
 
 require 'rails/application'
@@ -20,24 +22,20 @@ silence_warnings do
 end
 
 module Rails
-  autoload :Info, 'rails/info'
-  autoload :InfoController,    'rails/info_controller'
-  autoload :WelcomeController, 'rails/welcome_controller'
+  extend ActiveSupport::Autoload
+
+  autoload :Info
+  autoload :InfoController
+  autoload :WelcomeController
 
   class << self
     attr_accessor :application, :cache, :logger
 
+    delegate :initialize!, :initialized?, to: :application
+
     # The Configuration instance used to configure the Rails environment
     def configuration
       application.config
-    end
-
-    def initialize!
-      application.initialize!
-    end
-
-    def initialized?
-      application.initialized?
     end
 
     def backtrace_cleaner
@@ -76,7 +74,7 @@ module Rails
       env = Rails.env
       groups.unshift(:default, env)
       groups.concat ENV["RAILS_GROUPS"].to_s.split(",")
-      groups.concat hash.map { |k,v| k if v.map(&:to_s).include?(env) }
+      groups.concat hash.map { |k, v| k if v.map(&:to_s).include?(env) }
       groups.compact!
       groups.uniq!
       groups


### PR DESCRIPTION
1. Used `ActiveSupport::Autoload` to dry-up the `autoload` definitions.
2. Used `ActiveSupport`'s `delegate` to dry up the application proxied attributes. This actually let me to the introduction of the `config` attribute and making `configuration` an alias to it. I think that the `config` attribute is a nice addition, but you may disagree.
3. Did a little white space change on `Rails.groups`.
