### PR TITLE
Make .find_each return an Enumerator if no block given

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Make `find_each` return a (possibly lazy) Enumerable, instead of
+    requiring a block. The previous behavior did not lend itself to more
+    functional styles of programming, where the full active record
+    object was needed but the return value was the only data important
+    enough to keep around between GC runs.
+
+    Example:
+        fancy_emails = User.find_each.map do |user|
+          user.fancy_email
+        end
+
+        fancy_emails.each do |email|
+          NewsLetter.deliver_to(email)
+        end
+
+    * Alex Bartlow *
+
 *   Remove column restrictions for `count`, let the database raise if the SQL is
     invalid. The previos behavior was untested and surprising for the user.
     Fixes #5554.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Make `find_each` return a (possibly lazy) Enumerable, instead of
+*   Make `find_each` return an Enumerable, instead of
     requiring a block. The previous behavior did not lend itself to more
     functional styles of programming, where the full active record
     object was needed but the return value was the only data important

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -11,6 +11,10 @@ module ActiveRecord
     # The #find_each method uses #find_in_batches with a batch size of 1000 (or as
     # specified by the +:batch_size+ option).
     #
+    # If you do not provide a block to find_each, it will return an enumerator,
+    # suitable for chaining functions. If your ruby supports the #lazy method on
+    # Enumerable, that will be called as well.
+    #
     #   Person.all.find_each do |person|
     #     person.do_awesome_stuff
     #   end
@@ -19,11 +23,34 @@ module ActiveRecord
     #     person.party_all_night!
     #   end
     #
+    #   partiers = Person.where("age > 21").find_each.map do |person|
+    #     if person.party_all_night!
+    #       person.name
+    #     else
+    #       nil
+    #     end
+    #   end
+    #
+    #   puts partiers.compact.join("\n") + "\n... all partied!"
+    #
     #  You can also pass the +:start+ option to specify
     #  an offset to control the starting point.
     def find_each(options = {})
-      find_in_batches(options) do |records|
-        records.each { |record| yield record }
+      if block_given?
+        find_in_batches(options) do |records|
+          records.each { |record| yield record }
+        end
+      else
+        e = Enumerator.new do |y|
+          find_in_batches(options) do |records|
+            records.each {|record| y << record}
+          end
+        end
+        if e.respond_to?(:lazy)
+          e.lazy
+        else
+          e
+        end
       end
     end
 

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -40,9 +40,9 @@ module ActiveRecord
           records.each { |record| yield record }
         end
       else
-        e = Enumerator.new do |y|
+        Enumerator.new do |enum|
           find_in_batches(options) do |records|
-            records.each {|record| y << record}
+            records.each {|record| enum << record}
           end
         end
       end

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -12,8 +12,7 @@ module ActiveRecord
     # specified by the +:batch_size+ option).
     #
     # If you do not provide a block to find_each, it will return an enumerator,
-    # suitable for chaining functions. If your ruby supports the #lazy method on
-    # Enumerable, that will be called as well.
+    # suitable for chaining functions. 
     #
     #   Person.all.find_each do |person|
     #     person.do_awesome_stuff
@@ -45,11 +44,6 @@ module ActiveRecord
           find_in_batches(options) do |records|
             records.each {|record| y << record}
           end
-        end
-        if e.respond_to?(:lazy)
-          e.lazy
-        else
-          e
         end
       end
     end

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -26,6 +26,11 @@ class EachTest < ActiveRecord::TestCase
     end
   end
 
+  def test_each_should_return_a_lazy_enumerable_object_if_no_block_given
+    result = Post.find_each(:batch_size => 1)
+    assert_kind_of Enumerable, result
+  end
+
   def test_each_should_raise_if_select_is_set_without_id
     assert_raise(RuntimeError) do
       Post.select(:title).find_each(:batch_size => 1) { |post| post }

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -31,6 +31,14 @@ class EachTest < ActiveRecord::TestCase
     assert_kind_of Enumerable, result
   end
 
+  def test_each_has_enumerable_behavior
+    result = Post.find_each.map(&:title)
+    assert_equal Post.all.map(&:title), result
+
+    result = Post.find_each.inject(0) {|sum, post| sum + post.id}
+    assert_equal Post.sum(:id), result
+  end
+
   def test_each_should_raise_if_select_is_set_without_id
     assert_raise(RuntimeError) do
       Post.select(:title).find_each(:batch_size => 1) { |post| post }


### PR DESCRIPTION
Previously, find_each required a block. This is in-congruent with other enumerable behavior, which can be chained.

By returning a potentially lazy enumerable, the benefit of memory management is maintained, but with the added benefit of chain-able operations.
