### PR TITLE
Warning removed for Minitest

### DIFF
--- a/actionpack/test/template/dependency_tracker_test.rb
+++ b/actionpack/test/template/dependency_tracker_test.rb
@@ -45,7 +45,7 @@ class DependencyTrackerTest < ActionView::TestCase
   end
 end
 
-class ERBTrackerTest < MiniTest::Unit::TestCase
+class ERBTrackerTest < Minitest::Test
   def make_tracker(name, template)
     ActionView::DependencyTracker::ERBTracker.new(name, template)
   end


### PR DESCRIPTION
MiniTest::Unit::TestCase is now Minitest::Test. From
