### PR TITLE
regression test + mysql2 adapter raises correct error if conn is closed.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix mysql2 adapter raises the correct exception when executing a query on a
+    closed connection.
+
+    *Yves Senn*
+
 *   Ambiguous reflections are on :through relationships are no longer supported.
     For example, you need to change this:
 

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -213,9 +213,11 @@ module ActiveRecord
 
       # Executes the SQL statement in the context of this connection.
       def execute(sql, name = nil)
-        # make sure we carry over any changes to ActiveRecord::Base.default_timezone that have been
-        # made since we established the connection
-        @connection.query_options[:database_timezone] = ActiveRecord::Base.default_timezone
+        if @connection
+          # make sure we carry over any changes to ActiveRecord::Base.default_timezone that have been
+          # made since we established the connection
+          @connection.query_options[:database_timezone] = ActiveRecord::Base.default_timezone
+        end
 
         super
       end

--- a/activerecord/test/cases/disconnected_test.rb
+++ b/activerecord/test/cases/disconnected_test.rb
@@ -1,0 +1,26 @@
+require "cases/helper"
+
+class TestRecord < ActiveRecord::Base
+end
+
+class TestDisconnectedAdapter < ActiveRecord::TestCase
+  self.use_transactional_fixtures = false
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+  end
+
+  def teardown
+    spec = ActiveRecord::Base.connection_config
+    ActiveRecord::Base.establish_connection(spec)
+    @connection = nil
+  end
+
+  test "can't execute statements while disconnected" do
+    @connection.execute "SELECT count(*) from products"
+    @connection.disconnect!
+    assert_raises(ActiveRecord::StatementInvalid) do
+      @connection.execute "SELECT count(*) from products"
+    end
+  end
+end


### PR DESCRIPTION
While investigating the issue described in #10917 I found that it was already solved by 0d63cda however the fix did not add a test-case to prevent regressions from sneaking in.

When I added a test-case I found out that not only the postgresql adapter had a problem but also the mysql2 one, which hasn't been fixed.

This PR adds both a regression test and a fix for the mysql2 adapter.
