### PR TITLE
Store request.uuid in the current thread

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -2,4 +2,9 @@
 
     *Bryan Ricker*
 
+*   Store the request id provided by ActionDispatch::RequestId as a thread local-variable so it can be used
+    by code that doesn't have explicit access to the current request.
+
+    *Sam Neubardt*
+
 Please check [4-0-stable](https://github.com/rails/rails/blob/4-0-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_dispatch/middleware/request_id.rb
+++ b/actionpack/lib/action_dispatch/middleware/request_id.rb
@@ -9,6 +9,9 @@ module ActionDispatch
   # by a firewall, load balancer, or the web server, or, if this header is not available, a random uuid. If the
   # header is accepted from the outside world, we sanitize it to a max of 255 chars and alphanumeric and dashes only.
   #
+  # The request id is also stored in the current thread, in the slot 'action_dispatch.request_id'.  This lets code that
+  # doesn't have explicit access to the request access its id.
+  #
   # The unique request id can be used to trace a request end-to-end and would typically end up being part of log files
   # from multiple pieces of the stack.
   class RequestId
@@ -18,6 +21,7 @@ module ActionDispatch
 
     def call(env)
       env["action_dispatch.request_id"] = external_request_id(env) || internal_request_id
+      Thread.current["action_dispatch.request_id"] = env["action_dispatch.request_id"]
       @app.call(env).tap { |_status, headers, _body| headers["X-Request-Id"] = env["action_dispatch.request_id"] }
     end
 

--- a/actionpack/test/dispatch/request_id_test.rb
+++ b/actionpack/test/dispatch/request_id_test.rb
@@ -17,6 +17,15 @@ class RequestIdTest < ActiveSupport::TestCase
     assert_match(/\w+-\w+-\w+-\w+-\w+/, stub_request.uuid)
   end
 
+  test "thread local slot is set" do
+    middleware = ActionDispatch::RequestId.new(lambda do |environment|
+      req = ActionDispatch::Request.new(environment)
+      assert_equal(Thread.current['action_dispatch.request_id'], req.uuid)
+      [ 200, environment, [] ]
+    end)
+    middleware.call({})
+  end
+
   private
 
   def stub_request(env = {})


### PR DESCRIPTION
This change to ActionDispatch::RequestId stores the
request's id in a slot on the current thread.

This lets included gems (or code that doesn't have
explicit access to the Rack env or ActionDispatch::Request)
forward the request's id to downstream services.

That allows for correlation of log entries across
services in a distributed system, which can be very
helpful in diagnosing issues.
