### PR TITLE
Fix transaction bug in PostgreSQLAdapter#disable_referential_integrity

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix transaction bug in PostgreSQLAdapter#disable_referential_integrity.
+    The existing rescue blocks didn't function within a PostgreSQL transaction
+    because PostgreSQL requires a SAVEPOINT and then ROLLBACK before resuming
+    statement execution.  Fixes bug mentioned in #10885.
+
+    *Toby Ovod-Everett*
+
 *   `create_savepoint`, `rollback_to_savepoint` and `release_savepoint` accept
     a savepoint name.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
@@ -7,21 +7,40 @@ module ActiveRecord
         end
 
         def disable_referential_integrity #:nodoc:
+          @referential_integrity_depth = 0 unless instance_variable_defined?(:@referential_integrity_depth)
+
           if supports_disable_referential_integrity?
+            referential_integrity_savepoint_name = "disable_referential_integrity_#{@referential_integrity_depth}"
+
+            create_savepoint(referential_integrity_savepoint_name) if open_transactions > 0
             begin
               execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL" }.join(";"))
+              have_superuser_privs = true
             rescue
+              rollback_to_savepoint(referential_integrity_savepoint_name) if open_transactions > 0
               execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER USER" }.join(";"))
+              have_superuser_privs = false
             end
-          end
-          yield
-        ensure
-          if supports_disable_referential_integrity?
+            release_savepoint(referential_integrity_savepoint_name) if open_transactions > 0
+            @referential_integrity_depth += 1
+
+            create_savepoint(referential_integrity_savepoint_name) if open_transactions > 0
             begin
-              execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
-            rescue
-              execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER USER" }.join(";"))
+              yield
+            ensure
+              begin
+                release_savepoint(referential_integrity_savepoint_name) if open_transactions > 0
+              rescue ActiveRecord::StatementInvalid
+                rollback_to_savepoint(referential_integrity_savepoint_name) if open_transactions > 0
+                release_savepoint(referential_integrity_savepoint_name) if open_transactions > 0
+              end
+              @referential_integrity_depth -= 1
+              if @referential_integrity_depth <= 0
+                execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER #{have_superuser_privs ? 'ALL' : 'USER'}" }.join(";"))
+              end
             end
+          else
+            yield
           end
         end
       end

--- a/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
@@ -1,0 +1,551 @@
+require "cases/helper"
+require 'active_record/base'
+require 'active_record/connection_adapters/postgresql_adapter'
+
+module PostgresqlReferentialIntegritySupport
+  def setup
+    @connection = ActiveRecord::Base.connection
+    @savepoint_id = 0
+    @fk_id = 0
+
+    @connection.create_table :fk_test_has_ut do |t|
+    end
+
+    @connection.execute <<END_SQL
+      CREATE FUNCTION fk_test_has_ut_rollback() RETURNS trigger AS $fk_test_has_ut_rollback$
+        BEGIN
+          RAISE EXCEPTION 'cannot insert or update records in this table!';
+          RETURN NEW;
+        END;
+      $fk_test_has_ut_rollback$ LANGUAGE plpgsql;
+      CREATE TRIGGER fk_test_has_ut_trigger BEFORE INSERT OR UPDATE ON fk_test_has_ut
+        FOR EACH ROW EXECUTE PROCEDURE fk_test_has_ut_rollback();
+END_SQL
+
+    add_enforce_unique_savepoints
+  end
+
+  def teardown
+    remove_enforce_unique_savepoints
+
+    @connection.execute("DROP TRIGGER IF EXISTS fk_test_has_ut_trigger ON fk_test_has_ut")
+    @connection.execute("DROP FUNCTION IF EXISTS fk_test_has_ut_rollback()")
+    @connection.drop_table :fk_test_has_ut
+  end
+
+  module EnforceUniqueSavepoints
+    def create_savepoint(name = nil)
+      unless name.nil?
+        @__enforce_unique_savepoints = {} unless instance_variable_defined?(:@__enforce_unique_savepoints)
+        raise "Attempt to create a second savepoint with name #{name.inspect}" if @__enforce_unique_savepoints.has_key?(name)
+        @__enforce_unique_savepoints[name] = nil
+      end
+      name.nil? ? super() : super(name)
+    end
+
+    def release_savepoint(name = nil)
+      name.nil? ? super() : super(name)
+      unless name.nil?
+        @__enforce_unique_savepoints = {} unless instance_variable_defined?(:@__enforce_unique_savepoints)
+        @__enforce_unique_savepoints.delete(name)
+      end
+    end
+  end
+
+  def add_enforce_unique_savepoints
+    EnforceUniqueSavepoints.instance_methods.each do |method_name|
+      ::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send(:define_method,
+        method_name, EnforceUniqueSavepoints.instance_method(method_name)
+      )
+    end
+  end
+
+  def remove_enforce_unique_savepoints
+    EnforceUniqueSavepoints.instance_methods.each do |method_name|
+      ::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send(:remove_method, method_name)
+    end
+  end
+
+
+  def get_unique_savepoint_id
+    @savepoint_id += 1
+  end
+
+  def attempt_block
+    if @connection.open_transactions > 0
+      savepoint_id = get_unique_savepoint_id
+      @connection.create_savepoint("attempt_block_#{savepoint_id}")
+    end
+
+    begin
+      yield
+    ensure
+      if @connection.open_transactions > 0
+        begin
+          @connection.release_savepoint("attempt_block_#{savepoint_id}")
+        rescue ActiveRecord::StatementInvalid
+          @connection.rollback_to_savepoint("attempt_block_#{savepoint_id}")
+          @connection.release_savepoint("attempt_block_#{savepoint_id}")
+        end
+      end
+    end
+  end
+
+  def get_unique_fk_id
+    @fk_id += 1
+  end
+
+  def respect_referential_integrity
+    fk_id = get_unique_fk_id
+    @connection.execute "INSERT INTO fk_test_has_pk (id) VALUES (#{fk_id})"
+    @connection.execute "INSERT INTO fk_test_has_fk (fk_id) VALUES (#{fk_id})"
+  end
+
+  def temporarily_violate_referential_integrity
+    fk_id = get_unique_fk_id
+    @connection.execute "INSERT INTO fk_test_has_fk (fk_id) VALUES (#{fk_id})"
+    @connection.execute "INSERT INTO fk_test_has_pk (id) VALUES (#{fk_id})"
+  end
+
+  def persistently_violate_referential_integrity
+    fk_id = get_unique_fk_id
+    @connection.execute "INSERT INTO fk_test_has_fk (fk_id) VALUES (#{fk_id})"
+  end
+
+  def violate_user_trigger
+    @connection.execute "INSERT INTO fk_test_has_ut (id) VALUES (DEFAULT)"
+  end
+
+  def abort_current_transaction
+    @connection.execute "INSERT INTO non_existing_table (fk_id) VALUES (0)" rescue nil
+  end
+
+  def verify_transaction_depth(depth)
+    assert_equal depth, @connection.open_transactions, "Transaction depth did not match"
+  end
+
+  def verify_referential_integrity_is_enabled
+    attempt_block do
+      assert_raises(ActiveRecord::InvalidForeignKey) { temporarily_violate_referential_integrity }
+    end
+  end
+
+  def verify_user_trigger_is_enabled
+    attempt_block do
+      assert_raises(ActiveRecord::StatementInvalid) { violate_user_trigger }
+    end
+  end
+
+  def verify_row_counts(options={})
+    counts = Hash.new
+    counts[:pk] = options.fetch(:pk, 0)
+    counts[:fk] = options.fetch(:fk, counts[:pk])
+    counts[:ut] = options.fetch(:ut, 0)
+
+    counts.each do |name, count|
+      assert_equal count, @connection.select_rows("SELECT COUNT(*) FROM fk_test_has_#{name}")[0][0].to_i,
+        "Count of rows in fk_test_has_#{name} did not match"
+    end
+  end
+
+  def without_superuser_privs
+    current_user = @connection.select_rows("SELECT CURRENT_USER")[0][0]
+    begin
+      @connection.execute "CREATE ROLE temp_superuser SUPERUSER"
+      @connection.execute "GRANT temp_superuser TO #{current_user}"
+      @connection.execute "ALTER ROLE #{current_user} NOSUPERUSER"
+
+      attempt_block { yield }
+    ensure
+      @connection.execute "SET ROLE temp_superuser"
+      @connection.execute "ALTER ROLE #{current_user} SUPERUSER"
+      @connection.execute "RESET ROLE"
+      @connection.execute "DROP ROLE temp_superuser"
+    end
+  end
+end
+
+class PostgresqlReferentialIntegrityTestWithTransactionalFixtures < ActiveRecord::TestCase
+  include PostgresqlReferentialIntegritySupport
+
+  def verify_preconditions
+    verify_transaction_depth 1
+    verify_referential_integrity_is_enabled
+    verify_user_trigger_is_enabled
+    verify_row_counts pk: 0, ut: 0
+  end
+
+  def verify_postconditions(options={})
+    verify_transaction_depth 1
+    verify_referential_integrity_is_enabled
+    verify_user_trigger_is_enabled
+    verify_row_counts options.slice(:pk, :fk, :ut)
+  end
+
+  def test_temporarily_violate_referential_integrity
+    verify_preconditions
+    attempt_block do
+      assert_raises(ActiveRecord::InvalidForeignKey) { temporarily_violate_referential_integrity }
+    end
+    verify_postconditions pk: 0, ut: 0
+  end
+
+  def test_violate_user_trigger
+    verify_preconditions
+    attempt_block do
+      assert_raises(ActiveRecord::StatementInvalid) { violate_user_trigger }
+    end
+    verify_postconditions pk: 0, ut: 0
+  end
+
+  def test_disable_referential_integrity_as_superuser_with_supports_disable_referential_integrity_disabled
+    def @connection.supports_disable_referential_integrity?
+      false
+    end
+
+    verify_preconditions
+    attempt_block do
+      assert_raises(ActiveRecord::InvalidForeignKey) do
+        @connection.disable_referential_integrity do
+          temporarily_violate_referential_integrity
+        end
+      end
+    end
+    verify_postconditions pk: 0, ut: 0
+  ensure
+    @connection.singleton_class.send(:remove_method, :supports_disable_referential_integrity?)
+  end
+
+  def test_disable_referential_integrity_as_superuser_in_simple_transaction
+    verify_preconditions
+    assert_nothing_raised do
+      @connection.disable_referential_integrity do
+        temporarily_violate_referential_integrity
+        violate_user_trigger
+      end
+    end
+    verify_postconditions pk: 1, ut: 1
+  end
+
+  def test_disable_referential_integrity_as_superuser_in_nested_transaction
+    verify_preconditions
+    @connection.transaction do
+      assert_nothing_raised do
+        @connection.disable_referential_integrity do
+          temporarily_violate_referential_integrity
+          violate_user_trigger
+        end
+      end
+    end
+    verify_postconditions pk: 1, ut: 1
+  end
+
+  def test_disable_referential_integrity_as_superuser_in_simple_transaction_with_persistent_violation
+    verify_preconditions
+    assert_nothing_raised do
+      @connection.disable_referential_integrity do
+        respect_referential_integrity
+        temporarily_violate_referential_integrity
+        persistently_violate_referential_integrity
+      end
+    end
+    verify_postconditions pk: 2, fk: 3
+  end
+
+  def test_disable_referential_integrity_as_superuser_in_nested_transaction_with_persistent_violation
+    verify_preconditions
+    @connection.transaction do
+      assert_nothing_raised do
+        @connection.disable_referential_integrity do
+          respect_referential_integrity
+          temporarily_violate_referential_integrity
+          persistently_violate_referential_integrity
+        end
+      end
+    end
+    verify_postconditions pk: 2, fk: 3
+  end
+
+  def test_disable_referential_integrity_as_superuser_in_simple_transaction_with_nested_dri
+    verify_preconditions
+    assert_nothing_raised do
+      @connection.disable_referential_integrity do
+        temporarily_violate_referential_integrity
+        violate_user_trigger
+        @connection.disable_referential_integrity do
+          temporarily_violate_referential_integrity
+          violate_user_trigger
+        end
+        temporarily_violate_referential_integrity
+        violate_user_trigger
+      end
+    end
+    verify_postconditions pk: 3, ut: 3
+  end
+
+  def test_disable_referential_integrity_as_superuser_in_nested_transaction_with_nested_dri
+    verify_preconditions
+    @connection.transaction do
+      assert_nothing_raised do
+        @connection.disable_referential_integrity do
+          temporarily_violate_referential_integrity
+          violate_user_trigger
+          @connection.disable_referential_integrity do
+            temporarily_violate_referential_integrity
+            violate_user_trigger
+          end
+          temporarily_violate_referential_integrity
+          violate_user_trigger
+        end
+      end
+    end
+    verify_postconditions pk: 3, ut: 3
+  end
+
+  def test_disable_referential_integrity_as_superuser_in_simple_transaction_with_aborted_transaction
+    verify_preconditions
+    assert_nothing_raised do
+      @connection.disable_referential_integrity do
+        respect_referential_integrity
+        temporarily_violate_referential_integrity
+        violate_user_trigger
+        abort_current_transaction
+      end
+    end
+    verify_postconditions pk: 0, ut: 0
+  end
+
+  def test_disable_referential_integrity_as_superuser_in_nested_transaction_with_aborted_transaction
+    verify_preconditions
+    @connection.transaction do
+      assert_nothing_raised do
+        @connection.disable_referential_integrity do
+          respect_referential_integrity
+          temporarily_violate_referential_integrity
+          violate_user_trigger
+          abort_current_transaction
+        end
+      end
+    end
+    verify_postconditions pk: 0, ut: 0
+  end
+
+  def test_disable_referential_integrity_as_superuser_in_simple_transaction_with_malicious_exception
+    verify_preconditions
+    assert_raises(Exception) do
+      @connection.disable_referential_integrity do
+        temporarily_violate_referential_integrity
+        violate_user_trigger
+        raise Exception
+      end
+    end
+    verify_postconditions pk: 1, ut: 1
+  end
+
+  def test_disable_referential_integrity_as_superuser_in_nested_transaction_with_malicious_exception
+    verify_preconditions
+    @connection.transaction do
+      assert_raises(Exception) do
+        @connection.disable_referential_integrity do
+          temporarily_violate_referential_integrity
+          violate_user_trigger
+          raise Exception
+        end
+      end
+    end
+    verify_postconditions pk: 1, ut: 1
+  end
+
+  def test_disable_referential_integrity_as_superuser_in_simple_transaction_with_enclosed_rolledback_transaction
+    verify_preconditions
+    assert_nothing_raised do
+      @connection.disable_referential_integrity do
+        respect_referential_integrity
+        temporarily_violate_referential_integrity
+        violate_user_trigger
+        @connection.transaction { raise ActiveRecord::Rollback }
+        abort_current_transaction
+      end
+    end
+    verify_postconditions pk: 0, ut: 0
+  end
+
+  def test_disable_referential_integrity_as_nonsuperuser_fails_in_simple_transaction
+    verify_preconditions
+    without_superuser_privs do
+      assert_raises(ActiveRecord::InvalidForeignKey) do
+        @connection.disable_referential_integrity do
+          respect_referential_integrity
+          violate_user_trigger
+          temporarily_violate_referential_integrity
+        end
+      end
+    end
+    verify_postconditions pk: 0, ut: 0
+  end
+
+  def test_disable_referential_integrity_as_nonsuperuser_fails_in_nested_transaction
+    verify_preconditions
+    without_superuser_privs do
+      @connection.transaction do
+        assert_raises(ActiveRecord::InvalidForeignKey) do
+          @connection.disable_referential_integrity do
+            respect_referential_integrity
+            violate_user_trigger
+            temporarily_violate_referential_integrity
+          end
+        end
+      end
+    end
+    verify_postconditions pk: 0, ut: 0
+  end
+
+  def test_disable_referential_integrity_as_nonsuperuser_disables_user_triggers_in_simple_transaction
+    verify_preconditions
+    without_superuser_privs do
+      assert_nothing_raised do
+        @connection.disable_referential_integrity do
+          respect_referential_integrity
+          violate_user_trigger
+        end
+      end
+    end
+    verify_postconditions pk: 1, ut: 1
+  end
+
+  def test_disable_referential_integrity_as_nonsuperuser_disables_user_triggers_in_nested_transaction
+    verify_preconditions
+    without_superuser_privs do
+      @connection.transaction do
+        assert_nothing_raised do
+          @connection.disable_referential_integrity do
+          respect_referential_integrity
+          violate_user_trigger
+          end
+        end
+      end
+    end
+    verify_postconditions pk: 1, ut: 1
+  end
+
+end
+
+
+class PostgresqlReferentialIntegrityTestWithoutTransactionalFixtures < ActiveRecord::TestCase
+  include PostgresqlReferentialIntegritySupport
+
+  self.use_transactional_fixtures = false
+
+  def verify_preconditions
+    verify_transaction_depth 0
+    verify_referential_integrity_is_enabled
+    verify_user_trigger_is_enabled
+    verify_row_counts pk: 0, ut: 0
+  end
+
+  def verify_postconditions(options={})
+    verify_transaction_depth 0
+    verify_referential_integrity_is_enabled
+    verify_user_trigger_is_enabled
+    verify_row_counts options.slice(:pk, :fk, :ut)
+  end
+
+  def teardown
+    super
+    @connection.execute "DELETE FROM fk_test_has_fk"
+    @connection.execute "DELETE FROM fk_test_has_pk"
+  end
+
+
+  def test_disable_referential_integrity_as_superuser_outside_transaction
+    verify_preconditions
+    assert_nothing_raised do
+      @connection.disable_referential_integrity do
+        temporarily_violate_referential_integrity
+      end
+    end
+    verify_postconditions pk: 1
+  end
+
+  def test_disable_referential_integrity_as_superuser_outside_transaction_with_persistent_violation
+    verify_preconditions
+    assert_nothing_raised do
+      @connection.disable_referential_integrity do
+        respect_referential_integrity
+        temporarily_violate_referential_integrity
+        persistently_violate_referential_integrity
+        violate_user_trigger
+      end
+    end
+    verify_postconditions pk: 2, fk: 3, ut: 1
+  end
+
+  def test_disable_referential_integrity_as_superuser_outside_transaction_with_nested_dri
+    verify_preconditions
+    assert_nothing_raised do
+      @connection.disable_referential_integrity do
+        temporarily_violate_referential_integrity
+        violate_user_trigger
+        @connection.disable_referential_integrity do
+          temporarily_violate_referential_integrity
+          violate_user_trigger
+        end
+        temporarily_violate_referential_integrity
+        violate_user_trigger
+      end
+    end
+    verify_postconditions pk: 3, ut: 3
+  end
+
+  def test_disable_referential_integrity_as_superuser_outside_transaction_with_aborted_transaction
+    verify_preconditions
+    assert_nothing_raised do
+      @connection.disable_referential_integrity do
+        temporarily_violate_referential_integrity
+        violate_user_trigger
+        abort_current_transaction
+      end
+    end
+    verify_postconditions pk: 1, ut: 1
+  end
+
+  def test_disable_referential_integrity_as_superuser_outside_transaction_with_malicious_exception
+    verify_preconditions
+    assert_raises(Exception) do
+      @connection.disable_referential_integrity do
+        temporarily_violate_referential_integrity
+        violate_user_trigger
+        raise Exception
+      end
+    end
+    verify_postconditions pk: 1, ut: 1
+  end
+
+  def test_disable_referential_integrity_as_nonsuperuser_fails_outside_transaction
+    verify_preconditions
+    without_superuser_privs do
+      assert_raises(ActiveRecord::InvalidForeignKey) do
+        @connection.disable_referential_integrity do
+          respect_referential_integrity
+          violate_user_trigger
+          temporarily_violate_referential_integrity
+        end
+      end
+    end
+    verify_postconditions pk: 1, ut: 1
+  end
+
+  def test_disable_referential_integrity_as_nonsuperuser_disables_user_triggers_outside_transaction
+    verify_preconditions
+    without_superuser_privs do
+      assert_nothing_raised do
+        @connection.disable_referential_integrity do
+          respect_referential_integrity
+          violate_user_trigger
+        end
+      end
+    end
+    verify_postconditions pk: 1, ut: 1
+  end
+
+end


### PR DESCRIPTION
PostgreSQL requires a `SAVEPOINT` and `ROLLBACK` to resume execution after a failed statement within a transaction.  Since normal testing is done with superuser privs, the `rescue` clauses in `PostgreSQLAdapter#disable_referential_integrity` weren't being tested in the context of a transaction.

The `test/cases/adapters/postgresql/referential_integrity_test.rb` file was based on merging one of the PostgreSQL-specific test files with `test_disable_referential_integrity` from `test/cases/adapter_test.rb`.  The test `test_disable_referential_integrity_as_nonsuperuser_is_harmless_in_transaction` creates a temporary role to hold superuser privs and then relinquishes superuser privs for the current user before carrying out the actual test and then uses that temporary role to regain superuser privs.

The code added to `PostgreSQLAdapter#disable_referential_integrity` creates `SAVEPOINT`s before attempting statements in the blocks with `rescue` clauses and then uses `ROLLBACK` in the `rescue` clauses.  Note that creating a `SAVEPOINT` isn't permitted if we're not in a transaction, thus the statement level `rescue` to handle that case and to assign a useful value to `in_transaction`.  The `SAVEPOINT`s are released when they are no longer needed to minimize any impact on resources.

Note that it appears that the tests in `referential_integrity_test.rb` are being run in some sort of implicit transaction, but that there are a number of tests in the rest of the test suite that appear to run outside of transactions and that failed when the code didn't deal with
the non-transaction scenario.  I'm not sure how to test for the non-transaction scenario explicitly in `referential_integrity_test.rb`, but there appears to be comprehensive coverage from the rest of the suite.  I left the explicit call to `transaction` in my test to ensure that if whatever creates the implicit transaction changes the test is still valid.
