### PR TITLE
Only Validate Secure Password Confirmation if Present

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix regression in has_secure_password: When a password is set, but the
+    confirmation is nil, it would raise validation errors. According to the
+    documentation, the confirmation validations should be bypassed if the
+    confirmation is nil.
+
+    *Michi Huber*
+
 *   Fix regression in has_secure_password. When a password is set, but a
     confirmation is an empty string, it would incorrectly save.
 

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -56,9 +56,13 @@ module ActiveModel
         include InstanceMethodsOnActivation
 
         if options.fetch(:validations, true)
-          validates_confirmation_of :password, if: lambda { |m| m.password.present? }
+          password_present_and_confirmed = lambda do |m|
+            m.password.present? && !m.password_confirmation.nil?
+          end
+
+          validates_confirmation_of :password, if: password_present_and_confirmed
           validates_presence_of     :password, on: :create
-          validates_presence_of     :password_confirmation, if: lambda { |m| m.password.present? }
+          validates_presence_of     :password_confirmation, if: password_present_and_confirmed
 
           before_create { raise "Password digest missing on new record" if password_digest.blank? }
         end

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -103,4 +103,10 @@ class SecurePasswordTest < ActiveModel::TestCase
     @user.password_confirmation = "password"
     assert @user.valid?(:create)
   end
+
+  test "confirmation isn't validated if nil" do
+    @user.password = "password"
+    @user.password_confirmation = nil
+    assert @user.valid?(:create)
+  end
 end


### PR DESCRIPTION
According to the documentation, the password confirmation
should not be validated if it is nil. 5d93ef8 introduced
a regression where a nil password_confirmation raised
validation errors.
