### PR TITLE
We need to check exception name to be nil

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -322,6 +322,9 @@ module ActiveSupport
     # For instance, Foo::Bar::Baz will generate Foo(::Bar(::Baz)?)?
     def const_regexp(camel_cased_word) #:nodoc:
       parts = camel_cased_word.split("::")
+
+      return Regexp.escape(camel_cased_word) if parts.blank?
+
       last  = parts.pop
 
       parts.reverse.inject(last) do |acc, part|


### PR DESCRIPTION
In Ruby 2.0 Exception leaves the name as nil

See below example.

``` ruby
2.0.0p195 :001 > begin
2.0.0p195 :002 >     Object.const_get('::')
2.0.0p195 :003?>   rescue => e
2.0.0p195 :004?>   puts e.name
2.0.0p195 :005?>   end

 => nil

ruby-1.9.3-p429
1.9.3p429 :001 > begin
1.9.3p429 :002 >     Object.const_get('::')
1.9.3p429 :003?>   rescue => e
1.9.3p429 :004?>   puts e.name
1.9.3p429 :005?>   end
::
 => nil
```

This will fix build broke by #10943 for ruby-2.0
