### PR TITLE
Update HTML boolean attributes per the HTML 5.1 spec

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Update the HTML `BOOLEAN_ATTRIBUTES` in `ActionView::Helpers::TagHelper`
+    to conform to the latest HTML 5.1 spec. Add attributes `allowfullscreen`,
+    `default`, `inert`, `sortable`, `truespeed`, `typemustmatch`. Fix attribute
+    `seamless` (previously misspelled `seemless`).
+
+    *Alex Peattie*
+
 *   Fix an issue where partials with a number in the filename weren't being digested for cache dependencies.
 
     *Bryan Ricker*

--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -12,8 +12,11 @@ module ActionView
 
       BOOLEAN_ATTRIBUTES = %w(disabled readonly multiple checked autobuffer
                            autoplay controls loop selected hidden scoped async
-                           defer reversed ismap seemless muted required
-                           autofocus novalidate formnovalidate open pubdate itemscope).to_set
+                           defer reversed ismap seamless muted required
+                           autofocus novalidate formnovalidate open pubdate
+                           itemscope allowfullscreen default inert sortable
+                           truespeed typemustmatch).to_set
+
       BOOLEAN_ATTRIBUTES.merge(BOOLEAN_ATTRIBUTES.map {|attribute| attribute.to_sym })
 
       PRE_CONTENT_STRINGS = {

--- a/actionpack/test/template/tag_helper_test.rb
+++ b/actionpack/test/template/tag_helper_test.rb
@@ -30,8 +30,8 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_tag_options_converts_boolean_option
-    assert_equal '<p disabled="disabled" itemscope="itemscope" multiple="multiple" readonly="readonly" />',
-      tag("p", :disabled => true, :itemscope => true, :multiple => true, :readonly => true)
+    assert_dom_equal '<p disabled="disabled" itemscope="itemscope" multiple="multiple" readonly="readonly" allowfullscreen="allowfullscreen" seamless="seamless" typemustmatch="typemustmatch" sortable="sortable" default="default" inert="inert" truespeed="truespeed" />',
+      tag("p", :disabled => true, :itemscope => true, :multiple => true, :readonly => true, :allowfullscreen => true, :seamless => true, :typemustmatch => true, :sortable => true, :default => true, :inert => true, :truespeed => true)
   end
 
   def test_content_tag


### PR DESCRIPTION
A bunch of new boolean attributes have been introduced by the W3C over the past year.  This just makes Rails aware of them, so it can handle them correctly - i.e.

``` ruby
tag("table", :sortable => true)

#=> <table sortable="sortable">

# Instead of <table sortable="true">
```

The new attributes:
- `allowfullscreen` (http://www.w3.org/html/wg/drafts/html/master/single-page.html#attr-iframe-allowfullscreen)
- `default` (http://www.w3.org/html/wg/drafts/html/master/single-page.html#attr-menuitem-default)
- `inert` (http://www.w3.org/html/wg/drafts/html/master/single-page.html#attr-inert)
- `sortable` (http://www.w3.org/html/wg/drafts/html/master/single-page.html#attr-table-sortable)
- `truespeed` (http://www.w3.org/html/wg/drafts/html/master/single-page.html#attr-marquee-truespeed)
- `typemustmatch` (http://www.w3.org/html/wg/drafts/html/master/single-page.html#attr-object-typemustmatch)

Also fixes the `seamless` attribute, which is currently misspelled as `seemless`.
