### PR TITLE
Fix wrong method name

### DIFF
--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -47,7 +47,7 @@ namespace :rails do
         gen = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true },
                                                              destination_root: Rails.root
         File.exists?(Rails.root.join("config", "application.rb")) ?
-          gen.send(:app_const) : gen.send(:valid_app_const?)
+          gen.send(:app_const) : gen.send(:valid_const?)
         gen
       end
     end


### PR DESCRIPTION
`valid_app_const?` -> `valid_const?`

This applies to master, 4-0-stable and 4-0-0.
