### PR TITLE
Updated the doc for const_regexp [ci skip]

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -319,7 +319,9 @@ module ActiveSupport
     private
 
     # Mount a regular expression that will match part by part of the constant.
-    # For instance, Foo::Bar::Baz will generate Foo(::Bar(::Baz)?)?
+    #
+    #   const_regexp("Foo::Bar::Baz") # => /Foo(::Bar(::Baz)?)?/
+    #   const_regexp("::")            # => /::/
     def const_regexp(camel_cased_word) #:nodoc:
       parts = camel_cased_word.split("::")
 


### PR DESCRIPTION
1. Removed #:nodoc:

I think need a better sentence instead of 

"Mount a regular expression that will match part by part of the constant."

cc/ @fxn 
