### PR TITLE
Don't modify args in TableDefinition#primary_key

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -65,8 +65,7 @@ module ActiveRecord
       # Appends a primary key definition to the table definition.
       # Can be called multiple times, but this is probably not a good idea.
       def primary_key(name, type = :primary_key, options = {})
-        options[:primary_key] = true
-        column(name, type, options)
+        column(name, type, options.merge(:primary_key => true))
       end
 
       # Returns a ColumnDefinition for the column with name +name+.


### PR DESCRIPTION
Previously, if you reused a hash that was passed into a table definition,
then subsequent tables' primary keys would be set to "true" instead of "id".

This is the same as #10572 which didn't make it into 4.0.0.rc2 from 4-0-stable.
