### PR TITLE
Removing a repetitive comment and refactoring the Application class in Railties

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -119,32 +119,9 @@ module Rails
 
     # Stores some of the Rails initial environment parameters which
     # will be used by middlewares and engines to configure themselves.
-    # Currently stores:
-    #
-    #   * "action_dispatch.parameter_filter"             => config.filter_parameters
-    #   * "action_dispatch.redirect_filter"              => config.filter_redirect
-    #   * "action_dispatch.secret_token"                 => config.secret_token
-    #   * "action_dispatch.secret_key_base"              => config.secret_key_base
-    #   * "action_dispatch.show_exceptions"              => config.action_dispatch.show_exceptions
-    #   * "action_dispatch.show_detailed_exceptions"     => config.consider_all_requests_local
-    #   * "action_dispatch.logger"                       => Rails.logger
-    #   * "action_dispatch.backtrace_cleaner"            => Rails.backtrace_cleaner
-    #   * "action_dispatch.key_generator"                => key_generator
-    #   * "action_dispatch.http_auth_salt"               => config.action_dispatch.http_auth_salt
-    #   * "action_dispatch.signed_cookie_salt"           => config.action_dispatch.signed_cookie_salt
-    #   * "action_dispatch.encrypted_cookie_salt"        => config.action_dispatch.encrypted_cookie_salt
-    #   * "action_dispatch.encrypted_signed_cookie_salt" => config.action_dispatch.encrypted_signed_cookie_salt
-    #
     def env_config
       @app_env_config ||= begin
-        if config.secret_key_base.blank?
-          ActiveSupport::Deprecation.warn "You didn't set config.secret_key_base. " +
-            "Read the upgrade documentation to learn more about this new config option."
-
-          if config.secret_token.blank?
-            raise "You must set config.secret_key_base in your app's config."
-          end
-        end
+        validate_secret_token_config!
 
         super.merge({
           "action_dispatch.parameter_filter" => config.filter_parameters,
@@ -399,6 +376,12 @@ module Rails
         "#{script_name}#{path_info}?#{query_string}"
       else
         "#{script_name}#{path_info}"
+      end
+    end
+
+    def validate_secret_token_config! #:nodoc:
+      if config.secret_token.blank?
+        raise "You must set config.secret_key_base in your app's config."
       end
     end
   end


### PR DESCRIPTION
The comment on the `env_config` method is repetitive, likely to get outdated, and provides no useful information which cannot be gleamed from the code. I'm therefore removing it. I'm also refactoring to make the method easier to read.
