### PR TITLE
Fix uninitialized constant SchemaMigration when schema cache dump exists

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix uninitialized constant SchemaMigration when db/schema_cache.dump exists.
+
+    *Tomohiro Hashidate*
+
 *   Fixture setup does no longer depend on `ActiveRecord::Base.configurations`.
     This is relevant when `ENV["DATABASE_URL"]` is used in place of a `database.yml`.
 

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -789,6 +789,7 @@ module ActiveRecord
       end
 
       def current_version
+        require 'active_record/base'
         sm_table = schema_migrations_table_name
         if Base.connection.table_exists?(sm_table)
           get_all_versions.max || 0


### PR DESCRIPTION
If db/schema_cache.dump exists, raise uninitialized constant SchemaMigration

a commit(15ff21a) remove `ActiveRecord::Base.logger.silence`, and so not work autoloading `Active::Base`.
It causes this error.
## details
1. When I access to rails app, rails calls `ActiveRecord::Migration::check_pending!` and it calls `ActiveRecord::Migrator.current_version` via some methods.
2. `ActiveRecord::Migrator.current_version` calls `ActiveRecord::SchemaMigration.table_name` and `ActiveRecord::SchemaMigration.table_name` needs `ActiveRecord::Base`.
3. When `ActiveRecord::SchemaMigration.table_name` autoloads ActiveRecord::Base, `ActiveSupport.on_load` hook is invoked.
4. `ActiveSupport.on_load` hook calls `ActiveRecord::Migrator.current_version`, if db/schema_cache.dump exists.
5. Circular dependency occurs. `ActiveRecord::Migrator -> ActiveRecord::SchemaMigration -> ActiveRecord::Base -> ActiveRecord::Migrator`

This patch fix it.

But the complexity of dependency is left.
