### PR TITLE
Bad HTTP_ACCEPT can cause request.formats to return an array with nil

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -14,4 +14,8 @@
 
     *Bryan Ricker*
 
+*  Fix `Mime::Type.parse` when bad accepts header is looked up.
+
+   *Becker* 
+   
 Please check [4-0-stable](https://github.com/rails/rails/blob/4-0-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -175,7 +175,7 @@ module Mime
       def parse(accept_header)
         if accept_header !~ /,/
           accept_header = accept_header.split(PARAMETER_SEPARATOR_REGEXP).first
-          parse_trailing_star(accept_header) || [Mime::Type.lookup(accept_header)]
+          parse_trailing_star(accept_header) || [Mime::Type.lookup(accept_header)].compact
         else
           list, index = AcceptList.new, 0
           accept_header.split(',').each do |header|

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -1089,6 +1089,12 @@ class RenderTest < ActionController::TestCase
     assert_equal '<test>passed formatted html erb</test>', @response.body
   end
 
+  def test_should_render_formatted_html_erb_template_with_bad_accepts_header
+    @request.env["HTTP_ACCEPT"] = "; a=dsf"
+    get :formatted_xml_erb
+    assert_equal '<test>passed formatted html erb</test>', @response.body
+  end
+
   def test_should_render_formatted_html_erb_template_with_faulty_accepts_header
     @request.accept = "image/gif, image/x-xbitmap, image/jpeg, image/pjpeg, appliction/x-shockwave-flash, */*"
     get :formatted_xml_erb


### PR DESCRIPTION
https://github.com/rails/rails/blob/ccf256d8dcc68d975bbf00780c3b4096f47e29d3/actionpack/lib/action_controller/metal/rendering.rb#L9

With a carefully crafted HTTP_ACCEPT  header request.formats will return [nil] causing the error. Much like https://github.com/rails/rails/issues/7774

NoMethodError: undefined method `ref' for nil:NilClass 

little of my Stacktrace
[PROJECT_ROOT]/vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_controller/metal/rendering.rb:9:in `block in process_action`
[PROJECT_ROOT]/vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_controller/metal/rendering.rb:9:in `map`
[PROJECT_ROOT]/vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_controller/metal/rendering.rb:9:in `process_action`
[PROJECT_ROOT]/vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/abstract_controller/callbacks.rb:18:in `block in process_action`
[PROJECT_ROOT]/vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:469:in `_run__4125533832456839663__process_action__2284511760730381774__callbacks`
[PROJECT_ROOT]/vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:405:in `__run_callback`
[PROJECT_ROOT]/vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:385:in `_run_process_action_callbacks`
[PROJECT_ROOT]/vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:81:in `run_callbacks`

Could/Should be backported? 
