### PR TITLE
Act on default scope in .unscope and .except

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,18 @@
+*   .unscope and .except now act on the default scope. For example:
+
+      class Project < ActiveRecord::Base
+        default_scope -> { where trashed: false }
+      end
+
+      Project.unscope(where: :trashed).to_sql
+      #=> "SELECT \"projects\".* FROM \"projects\""
+      Project.except(:where).to_sql
+      #=> "SELECT \"projects\".* FROM \"projects\""
+
+    *Dave Jachimiak*
+
 *   Flatten merged join_values before building the joins.
-   
+
     While joining_values special treatment is given to string values.
     By flattening the array it ensures that string values are detected
     as strings and not arrays.

--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -50,7 +50,15 @@ module ActiveRecord
     #   Post.order('id asc').except(:order)                  # discards the order condition
     #   Post.where('id > 10').order('id asc').except(:where) # discards the where condition but keeps the order
     def except(*skips)
-      relation_with values.except(*skips)
+      values_except_skips    = values.except(*skips)
+      relation               = relation_with(values_except_skips)
+      skips_in_default_scope = shared_values_in_default_scope(skips)
+
+      if skips_in_default_scope.any?
+        relation.unscope(skips_in_default_scope)
+      else
+        relation
+      end
     end
 
     # Removes any condition from the query other than the one(s) specified in +onlies+.
@@ -68,6 +76,14 @@ module ActiveRecord
         result.default_scoped = default_scoped
         result.extend(*extending_values) if extending_values.any?
         result
+      end
+
+      def shared_values_in_default_scope(values)
+        values.select { |value| in_default_scope?(value) }
+      end
+
+      def in_default_scope?(value)
+        default_scope_values.has_key?(value)
       end
   end
 end

--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -44,6 +44,11 @@ module ActiveRecord
           self.current_scope = nil
         end
 
+        def default_scope_values #:nodoc:
+          return {} unless default_scopes.first.respond_to?(:call)
+          default_scopes.first.call.values
+        end
+
         protected
 
         # Use this macro in your model to set a default scope for all operations on

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1142,6 +1142,18 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal Post.all, all_posts
   end
 
+  def test_except_on_default_scope
+    expected = Post.all.collect { |post| [post.title, post.id] }
+    received = PostWithDefaultScope.except(:order).collect { |post| [post.title, post.id] }
+    assert_equal expected, received
+  end
+
+  def test_except_only_removes_skipped_default_scopes
+    expected = Post.where(id: 1).except(:where).order(:title).collect { |post| [post.title, post.id] }
+    received = PostWithDefaultScope.where(id: 1).except(:where).collect { |post| [post.title, post.id] }
+    assert_equal expected, received
+  end
+
   def test_only
     relation = Post.where(:author_id => 1).order('id ASC').limit(1)
     assert_equal [posts(:welcome)], relation.to_a

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -136,6 +136,24 @@ class DefaultScopingTest < ActiveRecord::TestCase
     assert_equal expected, received
   end
 
+  def test_unscope_default_order
+    expected = Developer.all.collect { |dev| [dev.name, dev.id] }
+    received = DeveloperOrderedBySalary.unscope(:order).collect { |dev| [dev.name, dev.id] }
+    assert_equal expected, received
+  end
+
+  def test_unscope_default_limit
+    expected = Developer.all.collect { |dev| [dev.name, dev.id] }
+    received = DeveloperLimitedByTwo.unscope(:limit).collect { |dev| [dev.name, dev.id] }
+    assert_equal expected, received
+  end
+
+  def test_unscope_default_where
+    expected = Developer.all.collect { |dev| [dev.name, dev.id] }
+    received = LazyBlockDeveloperCalledDavid.unscope(where: :name).collect { |dev| [dev.name, dev.id] }
+    assert_equal expected, received
+  end
+
   def test_unscope_with_grouping_attributes
     expected = Developer.order('salary DESC').collect { |dev| dev.name }
     received = DeveloperOrderedBySalary.group(:name).unscope(:group).collect { |dev| dev.name }
@@ -149,12 +167,6 @@ class DefaultScopingTest < ActiveRecord::TestCase
   def test_unscope_with_limit_in_query
     expected = Developer.order('salary DESC').collect { |dev| dev.name }
     received = DeveloperOrderedBySalary.limit(1).unscope(:limit).collect { |dev| dev.name }
-    assert_equal expected, received
-  end
-
-  def test_order_to_unscope_reordering
-    expected = DeveloperOrderedBySalary.all.collect { |dev| [dev.name, dev.id] }
-    received = DeveloperOrderedBySalary.order('salary DESC, name ASC').reverse_order.unscope(:order).collect { |dev| [dev.name, dev.id] }
     assert_equal expected, received
   end
 

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -110,6 +110,11 @@ class DeveloperFilteredOnJoins < ActiveRecord::Base
   end
 end
 
+class DeveloperLimitedByTwo < ActiveRecord::Base
+  self.table_name = 'developers'
+  default_scope { limit(2) }
+end
+
 class DeveloperOrderedBySalary < ActiveRecord::Base
   self.table_name = 'developers'
   default_scope { order('salary DESC') }


### PR DESCRIPTION
#### Hello!

This pull addresses a couple, but not all, issues noted here: https://github.com/rails/rails/issues/10643.

Currently, `.unscope` and `.except` do not act on the default scope. (Default scope is always applied at the end of a query. Whether or not the default scope has been applied before the end of a query chain is stored as `.default_scoped` on the relation. (`.default_scoped?` is aliased to `.default_scoped`.))

Given:

``` ruby
class Project < ActiveRecord::Base
  default_scope -> { where trashed: false }
end
```

, the current implementations of `.unscope` and `.except` result in the following:

``` ruby
Project.unscope(where: :trashed).to_sql
#=> "SELECT \"projects\".* FROM \"projects\"  WHERE \"projects\".\"trashed\" = 'f'"
Project.except(:where).to_sql
#=> "SELECT \"projects\".* FROM \"projects\"  WHERE \"projects\".\"trashed\" = 'f'"
```

This pull changes `.unscope` and `.except` to act on the default scope:

``` ruby
Project.unscope(where: :trashed).to_sql
#=> "SELECT \"projects\".* FROM \"projects\""
Project.except(:where).to_sql
#=> "SELECT \"projects\".* FROM \"projects\""
```
##### `.unscope`

This pull executes `.unscope`'s existing code with the scope returned from `#with_default_scope`. It changes a few variable names (`scope` -> `arg` in `#unscope`, `scope` -> `clause` in `#symbol_unscoping`) to avoid confusion over the meaning of word "scope."
##### `.except`

Currently, `.except` returns a brand new Relation based on what's passed in and the current relation's `#values`. If any clause passed in is included in the default scope, this pull executes `.unscope` with those clauses on that relation. The spirit of `.except` seems to be _fresher_ than `.unscope` in that it originally returned a brand new Relation. That is why this only calls unscope if any clauses passed in are in the default scope, rather than just calling `.unscope` with the clauses passed in.

This pull's version of `.except` queries the default scope's values. Because such values feel public, this pull adds `.default_scope_values` as a public method. Some in the core may object to its implementation because of the evolution around default scopes in general and deprecations re: eager loading default scopes in particular.

This is my first pull request to rails. :saxophone::racehorse:
