### PR TITLE
Use a case insensitive URI Regexp for #asset_path

### DIFF
--- a/actionpack/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionpack/lib/action_view/helpers/asset_url_helper.rb
@@ -105,7 +105,7 @@ module ActionView
     #   )
     #
     module AssetUrlHelper
-      URI_REGEXP = %r{^[-a-z]+://|^(?:cid|data):|^//}
+      URI_REGEXP = %r{^[-a-z]+://|^(?:cid|data):|^//}i
 
       # Computes the path to asset in public directory. If :type
       # options is set, a file extension will be appended and scoped

--- a/actionpack/test/template/asset_tag_helper_test.rb
+++ b/actionpack/test/template/asset_tag_helper_test.rb
@@ -48,6 +48,9 @@ class AssetTagHelperTest < ActionView::TestCase
     %(asset_path("style.min"))        => %(/style.min),
     %(asset_path("style.min.css"))    => %(/style.min.css),
 
+    %(asset_path("http://www.outside.com/image.jpg")) => %(http://www.outside.com/image.jpg),
+    %(asset_path("HTTP://www.outside.com/image.jpg")) => %(HTTP://www.outside.com/image.jpg),
+
     %(asset_path("style", type: :stylesheet)) => %(/stylesheets/style.css),
     %(asset_path("xmlhr", type: :javascript)) => %(/javascripts/xmlhr.js),
     %(asset_path("xml.png", type: :image))    => %(/images/xml.png)
@@ -445,8 +448,8 @@ class AssetTagHelperTest < ActionView::TestCase
     [nil, '/', '/foo/bar/', 'foo/bar/'].each do |prefix|
       assert_equal 'Rails', image_alt("#{prefix}rails.png")
       assert_equal 'Rails', image_alt("#{prefix}rails-9c0a079bdd7701d7e729bd956823d153.png")
-      assert_equal 'Long file name with hyphens', image_alt("#{prefix}long-file-name-with-hyphens.png") 
-      assert_equal 'Long file name with underscores', image_alt("#{prefix}long_file_name_with_underscores.png")  
+      assert_equal 'Long file name with hyphens', image_alt("#{prefix}long-file-name-with-hyphens.png")
+      assert_equal 'Long file name with underscores', image_alt("#{prefix}long_file_name_with_underscores.png")
     end
   end
 


### PR DESCRIPTION
Context: https://gist.github.com/radar/5793814

The `URI_REGEXP` that various AssetUrl helpers use is currently case
sensitive when checking for a URI scheme. This means if you try to pass
a URL like `HTTP://www.example.com/path/to/image.jpg`, you end up with
a bogus asset path: `/assets/HTTP://www.example.com/path/to/image.jpg`.

URLs are case insensitive, so this regexp should be as well.

Signed-off-by: David Celis me@davidcel.is
