### PR TITLE
Always escape the result of link_to_unless method

### DIFF
--- a/actionpack/lib/action_view/helpers/url_helper.rb
+++ b/actionpack/lib/action_view/helpers/url_helper.rb
@@ -380,7 +380,7 @@ module ActionView
           if block_given?
             block.arity <= 1 ? capture(name, &block) : capture(name, options, html_options, &block)
           else
-            name
+            ERB::Util.html_escape(name)
           end
         else
           link_to(name, options, html_options)

--- a/actionpack/test/template/url_helper_test.rb
+++ b/actionpack/test/template/url_helper_test.rb
@@ -348,6 +348,11 @@ class UrlHelperTest < ActiveSupport::TestCase
       link_to_unless(true, "Showing", url_hash) {
         "test"
       }
+
+    assert_equal %{&lt;b&gt;Showing&lt;/b&gt;}, link_to_unless(true, "<b>Showing</b>", url_hash)
+    assert_equal %{<a href="/">&lt;b&gt;Showing&lt;/b&gt;</a>}, link_to_unless(false, "<b>Showing</b>", url_hash)
+    assert_equal %{<b>Showing</b>}, link_to_unless(true, "<b>Showing</b>".html_safe, url_hash)
+    assert_equal %{<a href="/"><b>Showing</b></a>}, link_to_unless(false, "<b>Showing</b>".html_safe, url_hash)
   end
 
   def test_link_to_if


### PR DESCRIPTION
Discussion is at: #10910.

The return string of link_to_unless method should be always html-escaped to keep consistency.

``` ruby
link_to_unless(false, '<b>Showing</b>'.html_safe, 'github.com')
# => "<a href=\"github.com\"><b>Showing</b></a>"

link_to_unless(true, '<b>Showing</b>'.html_safe, 'github.com')
# => "<b>Showing</b>"

link_to_unless(false, '<b>Showing</b>', 'github.com')
# => "<a href=\"github.com\">&lt;b&gt;Showing&lt;/b&gt;</a>"

link_to_unless(true, '<b>Showing</b>', 'github.com')
# => "<b>Showing</b>" should be "&lt;b&gt;Showing&lt;/b&gt;"
```

Could you consider to merge this request?
