### PR TITLE
Fix that CollectionProxy#scoping was failing to set #proxy_association for the returned scope.

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -842,7 +842,7 @@ module ActiveRecord
       # method, which gets the current scope, which is this object, which
       # delegates to @association, and so on.
       def scoping
-        @association.scope.scoping { yield }
+        scope.scoping { yield }
       end
 
       # Returns a <tt>Relation</tt> object for the records in this association

--- a/activerecord/test/cases/associations/extension_test.rb
+++ b/activerecord/test/cases/associations/extension_test.rb
@@ -70,6 +70,12 @@ class AssociationsExtensionsTest < ActiveRecord::TestCase
     assert_equal post.association(:comments), post.comments.where('1=1').the_association
   end
 
+  def test_proxy_association_after_lambda_scoped
+    post = posts(:welcome)
+    assert_equal post.association(:comments), post.comments.the_association
+    assert_equal post.association(:comments), post.comments.limit_by(3).the_association
+  end
+
   private
 
     def extension_name(model)


### PR DESCRIPTION
This meant that #proxy_association would be nil if your association extension methods were called atop a named scope.

With the change we rely on CollectionProxy's own definition of #scope, which properly sets #proxy_association.
