### PR TITLE
log the sql that is actually sent to the database

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Log the sql that is actually sent to the database.
+
+    If I have a query that produces sql
+    `WHERE "users"."name" = 'a         b'` then in the log all the
+    whitespace is being squeezed. So the sql that is printed in the
+    log is `WHERE "users"."name" = 'a b'`.
+
+    Do not squeeze whitespace out of sql queries. Fixes #10982.
+
+    *Neeraj Singh*
+
 *   Do not load all child records for inverse case.
 
     currently `post.comments.find(Comment.first.id)` would load all

--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -41,7 +41,7 @@ module ActiveRecord
       return if IGNORE_PAYLOAD_NAMES.include?(payload[:name])
 
       name  = "#{payload[:name]} (#{event.duration.round(1)}ms)"
-      sql   = payload[:sql].squeeze(' ')
+      sql   = payload[:sql]
       binds = nil
 
       unless (payload[:binds] || []).empty?

--- a/activerecord/test/cases/log_subscriber_test.rb
+++ b/activerecord/test/cases/log_subscriber_test.rb
@@ -56,6 +56,13 @@ class LogSubscriberTest < ActiveRecord::TestCase
     assert_equal 2, logger.debugs.length
   end
 
+  def test_sql_statements_are_not_squeezed
+    event = Struct.new(:duration, :payload)
+    logger = TestDebugLogSubscriber.new
+    logger.sql(event.new(0, sql: 'ruby   rails'))
+    assert_match(/ruby   rails/, logger.debugs.first)
+  end
+
   def test_ignore_binds_payload_with_nil_column
     event = Struct.new(:duration, :payload)
 


### PR DESCRIPTION
If I have a query that produces sql
`WHERE "users"."name" = 'a          b'`  ( for some reason markdown is not showing a lot of spaces between a and b. I have 10 white spaces between them) then in the log all the
whitespace is being squeezed. So the sql that is printed in the
log is `WHERE "users"."name" = 'a b'`.

This can be confusing. This commit fixes it by ensuring that
whitespace is not squeezed.

fixes #10982
