### PR TITLE
Fix that a1bb6c8 overloaded the uniq-like behavior of CollectionAssociation#uniq with #distinct

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -319,13 +319,16 @@ module ActiveRecord
         end
       end
 
-      def distinct
+      def uniq
         seen = {}
         load_target.find_all do |record|
           seen[record.id] = true unless seen.key?(record.id)
         end
       end
-      alias uniq distinct
+
+      def distinct
+        scope.distinct
+      end
 
       # Replace this collection with +other_array+. This will perform a diff
       # and delete/add only records that have changed.

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -640,6 +640,8 @@ module ActiveRecord
 
       # Specifies whether the records should be unique or not.
       #
+      #   Returns an array, only loads the targets if necessary.
+      #
       #   class Person < ActiveRecord::Base
       #     has_many :pets
       #   end
@@ -650,12 +652,19 @@ module ActiveRecord
       #   #      #<Pet name: "Fancy-Fancy">
       #   #    ]
       #
-      #   person.pets.select(:name).distinct
+      #   person.pets.select(:name).uniq
       #   # => [#<Pet name: "Fancy-Fancy">]
+      def uniq
+        @association.uniq
+      end
+
+      # Specifies whether the records should be unique or not.
+      #
+      #   Returns an relation, executes a separate query.
+      #
       def distinct
         @association.distinct
       end
-      alias uniq distinct
 
       # Count all records using SQL.
       #

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -404,6 +404,14 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     author            = Author.includes(:taggings).find authors(:david).id
     expected_taggings = taggings(:welcome_general, :thinking_general)
     assert_no_queries do
+      assert_equal expected_taggings, author.taggings.uniq.sort_by { |t| t.id }
+    end
+  end
+
+  def test_include_has_many_through_polymorphic_has_many
+    author            = Author.includes(:taggings).find authors(:david).id
+    expected_taggings = taggings(:welcome_general, :thinking_general)
+    assert_queries 1 do
       assert_equal expected_taggings, author.taggings.distinct.sort_by { |t| t.id }
     end
   end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -492,8 +492,10 @@ class RelationTest < ActiveRecord::TestCase
     expected_taggings = taggings(:welcome_general, :thinking_general)
 
     assert_no_queries do
-      assert_equal expected_taggings, author.taggings.distinct.sort_by { |t| t.id }
       assert_equal expected_taggings, author.taggings.uniq.sort_by { |t| t.id }
+    end
+    assert_queries 1 do
+      assert_equal expected_taggings, author.taggings.distinct.sort_by { |t| t.id }
     end
 
     authors = Author.all


### PR DESCRIPTION
Everywhere else in ActiveRecord there's a clear association between the
# distinct method and the DISTINCT sql statement.

CollectionAssociation#uniq was not at all scope-like and rather returns
an array, as #uniq does elsewhere in Ruby.

It was surprising to me that Author#comments.distinct wasn't chainable
in that context, when it's chainable everywhere else, and the
association is clearly backed by a sql statement. It's particularly strange
given that these three uses of distinct have two different implications:

```
# DISTINCT-like
class Author < ActiveRecord::Base
  has_many :commentables
  has_many :comments, -> { distinct }, through: :commentables
end
Comment.joins(:author).where(author_id: Author.first.id).distinct

# #uniq-like
Author.first.comments.distinct
```

IMO overloading this behavior with #distinct's other behavior will
cause confusion - better to provide these 2 behaviors separately.

I thought about having different behavior when the target was loaded or
not, but the different return values (array vs relation) make that surprising too.
If there is a way to return a relation-like object in the loaded case, populated
with the #uniq records, that could be better.

introducing commit: a1bb6c8b06db8354617
