### PR TITLE
ActiveSupport aliasing support for method delegation

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,9 +1,28 @@
+*   Module#delegate support for delegation with aliasing.
+
+        class Someone
+          # You can use either `[:method, :delegated_as_name]` or a hash
+          # `{method: :delegated_as}`. Both of those form will delegate the
+          # method under different name.
+          delegate [:foo, :quux], {full_name: :name}, to: :class
+
+          def self.full_name
+            'some_table'
+          end
+
+          def self.foo
+            'quux'
+          end
+        end
+
+    *Genadi Samokovarov*
+
 *   `require_dependency` accepts objects that respond to `to_path`, in
     particular `Pathname` instances.
 
     *Benjamin Fleischer*
 
-*   Disable the ability to iterate over Range of AS::TimeWithZone 
+*   Disable the ability to iterate over Range of AS::TimeWithZone
     due to significant performance issues.
 
     *Bogdan Gusiev*

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -35,10 +35,15 @@ class Someone < Struct.new(:name, :place)
   delegate :name=, :to => :place, :prefix => true
   delegate :upcase, :to => "place.city"
   delegate :table_name, :to => :class
+  delegate [:foo, :quux], {:table_name => :table}, :to => :class
   delegate :table_name, :to => :class, :prefix => true
 
   def self.table_name
     'some_table'
+  end
+
+  def self.foo
+    'quux'
   end
 
   FAILED_DELEGATE_LINE = __LINE__ + 1
@@ -152,6 +157,11 @@ class ModuleTest < ActiveSupport::TestCase
   def test_delegation_to_class_method
     assert_equal 'some_table', @david.table_name
     assert_equal 'some_table', @david.class_table_name
+  end
+
+  def test_delegation_aliasing
+    assert_equal 'some_table', @david.table
+    assert_equal 'quux', @david.quux
   end
 
   def test_missing_delegation_target


### PR DESCRIPTION
I find ActiveSupport's method delegation capabilities extremely useful, however I miss the ability to delegate a method under a different name. The first thing that came into my mind was an API like the following:

```
 delegate :config, as: :configure, to: application
```

While this one looks pretty nice, it breaks for the variadic arguments case. Then I taught of the Clojure destructuring and how well :as reads in there, so I came with my current API proposal:

```
 delegate [:config, :as, :configure], to: application
```

This fits well with the variadic arguments case:

```
 delegate :initialize!, :initialized?, [:config, :as, :configure], to: application
```

Plus, with Ruby 2 symbol array literal this one may get even easier to write:

```
 delegate :initialize!, :initialized?, %i(config as configure), to: application
```

Note that this is not limited just to Ruby 2, as the arguments can be strings too, so old array of strings literals can work fine too:

```
 delegate :initialize!, :initialized?, %w(config as configure), to: application
```

I am open to suggestions if you would like to propose a different syntax. Something like:

```
 delegate [:config, :configure], to: application
```

may look a bit more traditional, but the ordering may be a bit confusing. I believe that with argument normalization, we can allow both forms. Your opinion, of course, can differ. Feel free to bash the idea, I just decided to hack it and throw it out there for feedback.

The current implementation is quite sloppy. Its there just as a proof of concept.
