### PR TITLE
Fix some activerecord changelog code to be displayed properly as code

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -39,6 +39,8 @@
         class Tagging < ActiveRecord::Base
         end
 
+    *Aaron Peterson*
+
 *   Remove column restrictions for `count`, let the database raise if the SQL is
     invalid. The previous behavior was untested and surprising for the user.
     Fixes #5554.
@@ -110,7 +112,7 @@
 *   Deprecate `ConnectionAdapters::SchemaStatements#distinct`,
     as it is no longer used by internals.
 
-    *Ben Woosley#
+    *Ben Woosley*
 
 *   Fix pending migrations error when loading schema and `ActiveRecord::Base.table_name_prefix`
     is not blank.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -11,33 +11,33 @@
 *   Ambiguous reflections are on :through relationships are no longer supported.
     For example, you need to change this:
 
-      class Author < ActiveRecord::Base
-        has_many :posts
-        has_many :taggings, :through => :posts
-      end
+        class Author < ActiveRecord::Base
+          has_many :posts
+          has_many :taggings, :through => :posts
+        end
 
-      class Post < ActiveRecord::Base
-        has_one :tagging
-        has_many :taggings
-      end
+        class Post < ActiveRecord::Base
+          has_one :tagging
+          has_many :taggings
+        end
 
-      class Tagging < ActiveRecord::Base
-      end
+        class Tagging < ActiveRecord::Base
+        end
 
     To this:
 
-      class Author < ActiveRecord::Base
-        has_many :posts
-        has_many :taggings, :through => :posts, :source => :tagging
-      end
+        class Author < ActiveRecord::Base
+          has_many :posts
+          has_many :taggings, :through => :posts, :source => :tagging
+        end
 
-      class Post < ActiveRecord::Base
-        has_one :tagging
-        has_many :taggings
-      end
+        class Post < ActiveRecord::Base
+          has_one :tagging
+          has_many :taggings
+        end
 
-      class Tagging < ActiveRecord::Base
-      end
+        class Tagging < ActiveRecord::Base
+        end
 
 *   Remove column restrictions for `count`, let the database raise if the SQL is
     invalid. The previous behavior was untested and surprising for the user.
@@ -70,9 +70,9 @@
     You can turn off the automatic detection of inverse associations by setting
     the `:inverse_of` option to `false` like so:
 
-      class Taggable < ActiveRecord::Base
-        belongs_to :tag, inverse_of: false
-      end
+        class Taggable < ActiveRecord::Base
+          belongs_to :tag, inverse_of: false
+        end
 
     *John Wang*
 


### PR DESCRIPTION
It takes 4 spaces or some backticks to have this code displayed as code in the changelog.
