### PR TITLE
Fix undefined method `ref' for nil:NilClass for bad accept headers

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `Mime::Type.parse` when bad accepts header is looked up.
+
+    *Becker* 
+   
 *   Element of the `collection_check_boxes` and `collection_radio_buttons` can
     optionally contain html attributes as the last element of the array.
 

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -175,7 +175,7 @@ module Mime
       def parse(accept_header)
         if accept_header !~ /,/
           accept_header = accept_header.split(PARAMETER_SEPARATOR_REGEXP).first
-          parse_trailing_star(accept_header) || [Mime::Type.lookup(accept_header)]
+          parse_trailing_star(accept_header) || [Mime::Type.lookup(accept_header)].compact
         else
           list, index = AcceptList.new, 0
           accept_header.split(',').each do |header|

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -1089,6 +1089,12 @@ class RenderTest < ActionController::TestCase
     assert_equal '<test>passed formatted html erb</test>', @response.body
   end
 
+  def test_should_render_formatted_html_erb_template_with_bad_accepts_header
+    @request.env["HTTP_ACCEPT"] = "; a=dsf"
+    get :formatted_xml_erb
+    assert_equal '<test>passed formatted html erb</test>', @response.body
+  end
+
   def test_should_render_formatted_html_erb_template_with_faulty_accepts_header
     @request.accept = "image/gif, image/x-xbitmap, image/jpeg, image/pjpeg, appliction/x-shockwave-flash, */*"
     get :formatted_xml_erb


### PR DESCRIPTION
One commit for fixing:
Bad HTTP_ACCEPT can cause request.formats to return an array with nil

https://github.com/rails/rails/pull/10965

Full details at link above. 
