### PR TITLE
A failing test which shows that when a collection association is accessed before saving the owner, the proxy caches the #bind_values without the owner's id.

### DIFF
--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -378,6 +378,16 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 2, Firm.find(4).clients_using_sql.count
   end
 
+  def test_update_all
+    firm = Firm.new(name: 'Firm')
+    firm.clients << Client.first
+    firm.save!
+    assert firm.persisted?
+    assert_equal 1, firm.clients.count
+    assert_equal firm.clients.scope.bind_values, firm.clients.bind_values
+    assert_equal 1, firm.clients.update_all(description: 'Great!')
+  end
+
   def test_belongs_to_sanity
     c = Client.new
     assert_nil c.firm


### PR DESCRIPTION
This causes calls like: owner.association.update_all to behave unexpectedly
in this case, because they try to act on association objects where
owner_id is null.

This is related to #bind_values being set on first access at:
https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/collection_proxy.rb#L37

Not sure how to properly deal with this, but it is the case that calling update all on
the #scope of the association works.
