### PR TITLE
Was reading http://guides.rubyonrails.org/getting_started.html...

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -477,6 +477,7 @@ development:
   pool: 5
   username: blog
   password:
+  host: localhost
 ```
 
 Prepared Statements can be disabled thus:


### PR DESCRIPTION
I was reading about setting up postgresql. I'm using Postgres.app and
needed to add 'host: localhost' in database.yml. Even though Postgres.app
has its own documentation that clearly notes this, I think it would be
nice to mention it on this doc page as well. The example is for the
development environment, so it's likely many people would want to use
'host: localhost'. Thus, I added one line, 'host: localhost', in the
example code for a database.yml file, under the postgresql section,
in guides/source/configuring.md, near line 480.
