### PR TITLE
How should ActiveSupport::Cache handle nil cache key?

### DIFF
--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -320,6 +320,15 @@ module CacheStoreBehavior
     assert_equal "bar", @cache.read("foo=1/fu=2")
   end
 
+  def test_read_nil_cache_key
+    assert_nil @cache.read(nil)
+  end
+
+  def test_write_nil_cache_key
+    @cache.write(nil, "bar")
+    assert_nil @cache.read(nil)
+  end
+
   def test_keys_are_case_sensitive
     @cache.write("foo", "bar")
     assert_nil @cache.read("FOO")


### PR DESCRIPTION
Hi, I notice ActiveSupport::Cache implementations behave differently when cache key is nil. 

```
cache_key = nil
Rails.cache.write(cache_key, 'value')
Rails.cache.read(cache_key)
```

For example, FileStore raises a file system error "No such file or directory" when calling `write()` with nil cache key. This error **does not communicate what actually went wrong** (i.e. cache key cannot be nil). It took me a while to figure out when troubleshooting a production error.

I added the failing tests in this pull request, and below is the test results. I wish to fix this issue, but I'm curious **what should be the expected behavior when cache key is nil?**

| cache store | @cache.write(nil, 'value') | @cache.read(nil) |
| --- | --- | --- |
| FileStore | raises "Errno::ENOENT: No such file or directory" | returns nil |
| MemCacehStore | raises "ArgumentError: key cannot be blank" | raises "ArgumentError: key cannot be blank" |
| MemoryStore | stored successfully | returns the stored value |
| NullStore | returns true | returns nil |

Failing test results:

```
  1) Error:
FileStoreTest#test_write_nil_cache_key:
Errno::ENOENT: No such file or directory - (/Users/huiming/fun/projects/rails/activesupport/tmp_cache/00020130619-5351-14actoh, /Users/huiming/fun/projects/rails/activesupport/tmp_cache/001/000/)
    /Users/huiming/.rubies/ruby-1.9.3-p429/lib/ruby/1.9.1/fileutils.rb:519:in `rename'
    /Users/huiming/.rubies/ruby-1.9.3-p429/lib/ruby/1.9.1/fileutils.rb:519:in `block in mv'
    /Users/huiming/.rubies/ruby-1.9.3-p429/lib/ruby/1.9.1/fileutils.rb:1515:in `block in fu_each_src_dest'
    /Users/huiming/.rubies/ruby-1.9.3-p429/lib/ruby/1.9.1/fileutils.rb:1531:in `fu_each_src_dest0'
    /Users/huiming/.rubies/ruby-1.9.3-p429/lib/ruby/1.9.1/fileutils.rb:1513:in `fu_each_src_dest'
    /Users/huiming/.rubies/ruby-1.9.3-p429/lib/ruby/1.9.1/fileutils.rb:508:in `mv'
    /Users/huiming/fun/projects/rails/activesupport/lib/active_support/core_ext/file/atomic.rb:36:in `atomic_write'
    /Users/huiming/fun/projects/rails/activesupport/lib/active_support/cache/file_store.rb:92:in `write_entry'
    /Users/huiming/fun/projects/rails/activesupport/lib/active_support/cache/strategy/local_cache.rb:135:in `write_entry'
    /Users/huiming/fun/projects/rails/activesupport/lib/active_support/cache.rb:390:in `block in write'
    /Users/huiming/fun/projects/rails/activesupport/lib/active_support/cache.rb:547:in `instrument'
    /Users/huiming/fun/projects/rails/activesupport/lib/active_support/cache.rb:388:in `write'
    /Users/huiming/fun/projects/rails/activesupport/test/caching_test.rb:328:in `test_write_nil_cache_key'


  2) Error:
MemCacheStoreTest#test_read_nil_cache_key:
ArgumentError: key cannot be blank
    /Users/huiming/.gem/ruby/1.9.3/gems/dalli-2.6.2/lib/dalli/client.rb:340:in `validate_key'
    /Users/huiming/.gem/ruby/1.9.3/gems/dalli-2.6.2/lib/dalli/client.rb:318:in `perform'
    /Users/huiming/.gem/ruby/1.9.3/gems/dalli-2.6.2/lib/dalli/client.rb:52:in `get'
    /Users/huiming/fun/projects/rails/activesupport/lib/active_support/cache/mem_cache_store.rb:126:in `read_entry'
    /Users/huiming/fun/projects/rails/activesupport/lib/active_support/cache/strategy/local_cache.rb:129:in `read_entry'
    /Users/huiming/fun/projects/rails/activesupport/lib/active_support/cache/mem_cache_store.rb:181:in `read_entry'
    /Users/huiming/fun/projects/rails/activesupport/lib/active_support/cache.rb:314:in `block in read'
    /Users/huiming/fun/projects/rails/activesupport/lib/active_support/cache.rb:547:in `instrument'
    /Users/huiming/fun/projects/rails/activesupport/lib/active_support/cache.rb:313:in `read'
    /Users/huiming/fun/projects/rails/activesupport/test/caching_test.rb:324:in `test_read_nil_cache_key'


  3) Error:
MemCacheStoreTest#test_write_nil_cache_key:
ArgumentError: key cannot be blank
    /Users/huiming/.gem/ruby/1.9.3/gems/dalli-2.6.2/lib/dalli/client.rb:340:in `validate_key'
    /Users/huiming/.gem/ruby/1.9.3/gems/dalli-2.6.2/lib/dalli/client.rb:318:in `perform'
    /Users/huiming/.gem/ruby/1.9.3/gems/dalli-2.6.2/lib/dalli/client.rb:173:in `set'
    /Users/huiming/fun/projects/rails/activesupport/lib/active_support/cache/mem_cache_store.rb:141:in `write_entry'
    /Users/huiming/fun/projects/rails/activesupport/lib/active_support/cache/strategy/local_cache.rb:135:in `write_entry'
    /Users/huiming/fun/projects/rails/activesupport/lib/active_support/cache/mem_cache_store.rb:189:in `write_entry'
    /Users/huiming/fun/projects/rails/activesupport/lib/active_support/cache.rb:390:in `block in write'
    /Users/huiming/fun/projects/rails/activesupport/lib/active_support/cache.rb:547:in `instrument'
    /Users/huiming/fun/projects/rails/activesupport/lib/active_support/cache.rb:388:in `write'
    /Users/huiming/fun/projects/rails/activesupport/test/caching_test.rb:328:in `test_write_nil_cache_key'


  4) Failure:
MemoryStoreTest#test_write_nil_cache_key [/Users/huiming/fun/projects/rails/activesupport/test/caching_test.rb:329]:
Expected "bar" to be nil.

2941 runs, 9819 assertions, 1 failures, 3 errors, 1 skips
```
