### PR TITLE
`inspect` for AR model classes does not initiate a new connection.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   `inspect` on Active Record model classes does not initiate a
+    new connection. This means that calling `inspect`, when the
+    database is missing, will no longer raise an exception.
+    Fixes #10936.
+
+    Example:
+
+        Author.inspect # => "Author(no database connection)"
+
+    *Yves Senn*
+
 *   Handle single quotes in PostgreSQL default column values.
     Fixes #10881.
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -123,6 +123,8 @@ module ActiveRecord
           super
         elsif abstract_class?
           "#{super}(abstract)"
+        elsif !connected?
+          "#{super}(no database connection)"
         elsif table_exists?
           attr_list = columns.map { |c| "#{c.name}: #{c.type}" } * ', '
           "#{super}(#{attr_list})"

--- a/activerecord/test/cases/invalid_connection_test.rb
+++ b/activerecord/test/cases/invalid_connection_test.rb
@@ -1,0 +1,20 @@
+require "cases/helper"
+require "models/bird"
+
+class TestAdapterWithInvalidConnection < ActiveRecord::TestCase
+  self.use_transactional_fixtures = false
+
+  def setup
+    @spec = ActiveRecord::Base.connection_config
+    non_existing_spec = {adapter: @spec[:adapter], database: "i_do_not_exist"}
+    ActiveRecord::Base.establish_connection(non_existing_spec)
+  end
+
+  def teardown
+    ActiveRecord::Base.establish_connection(@spec)
+  end
+
+  test "inspect on Model class does not raise" do
+    assert_equal "Bird(no database connection)", Bird.inspect
+  end
+end


### PR DESCRIPTION
Closes #10936

The behavior of `Model.inspect` with a missing database connection was different for each adapter:

**sqlite3**

```
irb(main):001:0> User.inspect
=> "User(Table doesn't exist)"
```

**postgresql**

```
irb(main):001:0> User.inspect
PG::Error: FATAL:  database "i_do_not_exist" does not exist
```

**mysql2**

```
irb(main):001:0> User.inspect
Mysql2::Error: Access denied for user 'myuser'@'localhost' (using password: YES)
```

This patch changes the implementation of `inspect` to not initiate a connection and simply return "not connected" if no connection is established. This prevents the exceptions on inspect and should still be expressive enough.
