### PR TITLE
Fix name of nested attributes option include_id

### DIFF
--- a/actionpack/lib/action_view/helpers/form_helper.rb
+++ b/actionpack/lib/action_view/helpers/form_helper.rb
@@ -692,7 +692,7 @@ module ActionView
       #
       # Note that fields_for will automatically generate a hidden field
       # to store the ID of the record. There are circumstances where this
-      # hidden field is not needed and you can pass <tt>hidden_field_id: false</tt>
+      # hidden field is not needed and you can pass <tt>include_id: false</tt>
       # to prevent fields_for from rendering it automatically.
       def fields_for(record_name, record_object = nil, options = {}, &block)
         builder = instantiate_builder(record_name, record_object, options)
@@ -1507,7 +1507,7 @@ module ActionView
       #
       # Note that fields_for will automatically generate a hidden field
       # to store the ID of the record. There are circumstances where this
-      # hidden field is not needed and you can pass <tt>hidden_field_id: false</tt>
+      # hidden field is not needed and you can pass <tt>include_id: false</tt>
       # to prevent fields_for from rendering it automatically.
       def fields_for(record_name, record_object = nil, fields_options = {}, &block)
         fields_options, record_object = record_object, nil if record_object.is_a?(Hash) && record_object.extractable_options?


### PR DESCRIPTION
The option to disable including a hidden ID field on a `fields_for` nested association was incorrectly documented as `hidden_field_id` instead of `include_id`
