### PR TITLE
add support for url_options in sprockets/rails_helper

### DIFF
--- a/actionpack/lib/sprockets/helpers/rails_helper.rb
+++ b/actionpack/lib/sprockets/helpers/rails_helper.rb
@@ -54,7 +54,16 @@ module Sprockets
       def asset_path(source, options = {})
         source = source.logical_path if source.respond_to?(:logical_path)
         path = asset_paths.compute_public_path(source, asset_prefix, options.merge(:body => true))
-        options[:body] ? "#{path}?body=1" : path
+        default_url_options = url_options.dup.delete_if { |k,v|
+          [:host, :port, :protocol, :_path_segments, :script_name].include?(k)
+        }
+        default_url_options.merge!("body" => 1) if options[:body]
+        if default_url_options.empty?
+          path
+        else
+          params = default_url_options.collect {|k,v| "#{k}=#{v}"}.join("&")
+          "#{path}?#{params}"
+        end
       end
       alias_method :path_to_asset, :asset_path # aliased to avoid conflicts with an asset_path named route
 


### PR DESCRIPTION
Please bear with me as this is my first pull request against rails.

I realize you may not be accepting such "feature" against 3-2-stable anymore
but I would not know how to do it at this point against master/4.0
let me know, I could adapt it for master.

also let me know if 

I also made a gem for 3.2
https://github.com/mjobin-mdsol/url_options_for_assets

the reason for this, is that I am using `url_options` for auto appending parameters to url within my application.
javascripts, stylesheets and other assets also needs to have these parameter appended, but unfortunately it does not automagically works :smile: 

there it is, my little patch.

let me know if there is a better way. I could not find anything on the internet on how to do that.

thanks
