### PR TITLE
Fix BacktraceSilencer#noise when multiple silencers are configured

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix return value from `BacktraceCleaner#noise` when the cleaner is configured
+    with multiple silencers.
+
+    Fixes #11030
+
+    *Mark J. Titorenko*
+
 *   `HashWithIndifferentAccess#select` now returns a `HashWithIndifferentAccess`
     instance instead of a `Hash` instance.
 

--- a/activesupport/lib/active_support/backtrace_cleaner.rb
+++ b/activesupport/lib/active_support/backtrace_cleaner.rb
@@ -97,11 +97,7 @@ module ActiveSupport
       end
 
       def noise(backtrace)
-        @silencers.each do |s|
-          backtrace = backtrace.select { |line| s.call(line) }
-        end
-
-        backtrace
+        backtrace - silence(backtrace)
       end
   end
 end

--- a/activesupport/test/clean_backtrace_test.rb
+++ b/activesupport/test/clean_backtrace_test.rb
@@ -36,6 +36,27 @@ class BacktraceCleanerSilencerTest < ActiveSupport::TestCase
   end
 end
 
+class BacktraceCleanerMultipleSilencersTest < ActiveSupport::TestCase
+  def setup
+    @bc = ActiveSupport::BacktraceCleaner.new
+    @bc.add_silencer { |line| line =~ /mongrel/ }
+    @bc.add_silencer { |line| line =~ /yolo/ }
+  end
+
+  test "backtrace should not contain lines that match the silencers" do
+    assert_equal \
+      [ "/other/class.rb" ],
+      @bc.clean([ "/mongrel/class.rb", "/other/class.rb", "/mongrel/stuff.rb", "/other/yolo.rb" ])
+  end
+
+  test "backtrace should only contain lines that match the silencers" do
+    assert_equal \
+      [ "/mongrel/class.rb", "/mongrel/stuff.rb", "/other/yolo.rb" ],
+      @bc.clean([ "/mongrel/class.rb", "/other/class.rb", "/mongrel/stuff.rb", "/other/yolo.rb" ],
+                :noise)
+  end
+end
+
 class BacktraceCleanerFilterAndSilencerTest < ActiveSupport::TestCase
   def setup
     @bc = ActiveSupport::BacktraceCleaner.new


### PR DESCRIPTION
The existing implementation of the `noise` method in `ActiveSupport::BacktraceSilencer` does not work correctly if more than one silencer is configured -- specifically, it will only return noise which is matched by all silencers (which would be an unusual requirement to say the least :smile:), so often returns a rather useless `[]`.

This PR modifies the implementation such that anything that has been matched by silencers is removed from the backtrace using `Array#-` (array difference), ie. returns those elements within a backtrace that have been matched by any silencer.

Shout if you would like this rebased on to or PRs created for any other branch(es).
