### PR TITLE
Update the feedback instructions

### DIFF
--- a/railties/guides/source/layout.html.erb
+++ b/railties/guides/source/layout.html.erb
@@ -81,11 +81,11 @@
         </p>
         <p>
           If you see any typos or factual errors you are confident to
-          patch, please clone <%= link_to 'docrails', 'https://github.com/lifo/docrails' %>
-          and push the change yourself. That branch of Rails has public write access.
-          Commits are still reviewed, but that happens after you've submitted your
-          contribution. <%= link_to 'docrails', 'https://github.com/lifo/docrails' %> is
-          cross-merged with master periodically.
+          patch, please clone the <%= link_to 'rails', 'https://github.com/rails/rails' %>
+          repository and open a new pull request. You can also ask for commit rights on
+          <%= link_to 'docrails', 'https://github.com/rails/docrails' %> if you plan to submit
+          several patches. Commits are reviewed, but that happens after you've submitted your
+          contribution. This repository is cross-merged with master periodically.
         </p>
         <p>
           You may also find incomplete content, or stuff that is not up to date.


### PR DESCRIPTION
Hello,

I've seen #10871 but since docrails as moved from lifo/docrails to rails/docrails we have to ask for commit rights or submit patches directly to the rails repository so I've updated the instructions.

If this get merged, if you want I can backport it to master (and 4.0.0-stable and 4.0.0).

Have a nice day.
