### PR TITLE
Fix documents for create_join_table

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -214,8 +214,8 @@ module ActiveRecord
       # its block form to do so yourself:
       #
       #   create_join_table :products, :categories do |t|
-      #     t.index :products
-      #     t.index :categories
+      #     t.index :product_id
+      #     t.index :category_id
       #   end
       #
       # ====== Add a backend specific option to the generated SQL (MySQL)

--- a/guides/source/migrations.md
+++ b/guides/source/migrations.md
@@ -390,8 +390,8 @@ will create a `categorization` table.
 
 ```ruby
 create_join_table :products, :categories do |t|
-  t.index :products
-  t.index :categories
+  t.index :product_id
+  t.index :category_id
 end
 ```
 


### PR DESCRIPTION
I fixed documents for `create_join_table`.
It is a typo, right?
