### PR TITLE
Parsing empty array as array of [null] in json request

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Json and html posts are decoded to the same params in the case of empty array
+
+    *Angelo Capilleri*
+
 *   ActionView extracted from ActionPack
 
     *Piotr Sarnacki*, *Łukasz Strzałkowski*

--- a/actionpack/lib/action_dispatch/request/utils.rb
+++ b/actionpack/lib/action_dispatch/request/utils.rb
@@ -8,8 +8,12 @@ module ActionDispatch
             case v
             when Array
               v.grep(Hash) { |x| deep_munge(x) }
-              v.compact!
-              hash[k] = nil if v.empty?
+              if v.empty?
+                hash[k] = []
+              else
+                v.compact!
+                hash[k] = nil if v.empty?
+               end
             when Hash
               deep_munge(v)
             end

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -45,6 +45,13 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
     )
   end
 
+  test "empyt array are not evaluated as nil" do
+    assert_parses(
+          {"person" => [{"name" => "Angelo", "posts" =>[]}]} ,
+          "{\"person\":[{\"name\": \"Angelo\", \"posts\":[]}] }", { 'CONTENT_TYPE' => 'application/json' }
+        )
+  end
+
   test "logs error if parsing unsuccessful" do
     with_test_routing do
       output = StringIO.new


### PR DESCRIPTION
Now with the following params:

```
{ people: [{name: 'angelo', posts:[] }] }
```

In a normal http post are decoded as:

```
{ :people => [{:name => 'angelo', :posts => []} ]}
```

while in json request are decoded as:

```
{ :people => [{:name => 'angelo', :posts => nil }] }
```

With this PR , json request and html have the same decoded params
fixes #11023
