### PR TITLE
fix bad test by making number that fits for integer

### DIFF
--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -402,9 +402,13 @@ class InverseHasManyTests < ActiveRecord::TestCase
   end
 
   def test_raise_record_not_found_error_when_invalid_ids_are_passed
+    # delete all interest records to ensure that hard coded invalid_id(s)
+    # are indeed invalid.
+    Interest.delete_all
+
     man = Man.create!
 
-    invalid_id = 2394823094892348920348523452345
+    invalid_id = 245324523
     assert_raise(ActiveRecord::RecordNotFound) { man.interests.find(invalid_id) }
 
     invalid_ids = [8432342, 2390102913, 2453245234523452]


### PR DESCRIPTION
PR https://github.com/rails/rails/pull/10566 had to be reverted
because after applying the fix test
"test_raise_record_not_found_error_when_invalid_ids_are_passed"
started failing.

In this test invalid_id is being assigned a really large number
which was causing following failure when PR #10566 was applied.

```
RangeError: bignum too big to convert into `long long'
SELECT  `interests`.* FROM `interests`
WHERE `interests`.`man_id` = ? AND `interests`.`id` = ?
LIMIT 1  [["man_id", 970345987], ["id", 2394823094892348920348523452345]]
```

This test is not failing in master because when test code
`man.interests.find(invalid_id)` is executed then interests
are fully loaded in memory and no database query is executed.

After PR #10566 was merged then test code
`man.interests.find(invalid_id)` started executing sql query
and hence the error.

In case someone is wondering why the second part of query is not
failing, then that's because the actual query does not require
any variable substituation where the number is large. In that
case the sql generate is following.

```
SELECT `interests`.* FROM `interests`
WHERE `interests`.`man_id` = ? AND `interests`.`id`
IN (8432342, 2390102913, 2453245234523452)  [["man_id", 970345987]]
```

@wangjohn this test was added in commit https://github.com/rails/rails/commit/6c5032f53de9f4ba1669ff9c9eea25c70bf3af33 . Can you comment if this PR ? It seems to me that having a smaller number does not change the intent of the test.

/cc @jonleighton
