### PR TITLE
Remove code related to the rails test command

### DIFF
--- a/railties/lib/rails/commands.rb
+++ b/railties/lib/rails/commands.rb
@@ -5,7 +5,6 @@ aliases = {
   "d"  => "destroy",
   "c"  => "console",
   "s"  => "server",
-  "t"  => "test",
   "db" => "dbconsole",
   "r"  => "runner"
 }
@@ -17,7 +16,6 @@ The most common rails commands are:
  generate    Generate new code (short-cut alias: "g")
  console     Start the Rails console (short-cut alias: "c")
  server      Start the Rails server (short-cut alias: "s")
- test        Running the test file (short-cut alias: "t")
  dbconsole   Start a console for the database specified in config/database.yml
              (short-cut alias: "db")
  new         Create a new Rails application. "rails new my_app" creates a


### PR DESCRIPTION
Hello,

I've recently upgrade to Rails 4.0 and seen #9080 several months ago. Spontaneously, I run `rails test` but got : 

```
Error: Command 'test' not recognized
...
 test        Running the test file (short-cut alias: "t")
```

This pull request removes the mention about this command in the rails command's help message and remove the "t" alias related to it.

If you want, I can backport it to 4-0-0 and 4-0-0-stable as well ; let me know.

Also I don't add any changelog entry but let me know if I should.

Have a nice day.
