### PR TITLE
Add explicit dependencies of ActiveSupport to enable independent usage of ActiveModel::Name

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -1,5 +1,7 @@
 require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/module/introspection'
+require 'active_support/core_ext/module/delegation'
+require 'active_support/core_ext/object/blank'
 
 module ActiveModel
   class Name


### PR DESCRIPTION
There are two missing ActiveSupport dependencies to use ActiveModel::Name class or ActiveModel::Naming module independently. 

Missing dependencies for Module#delegate defined in `active_support/core_ext/module/delegation`, used at [L148](https://github.com/rails/rails/blob/master/activemodel/lib/active_model/naming.rb#L148)

Missing dependencies for Object#blank? defined in `active_support/core_ext/object/blank`, used at [L131](https://github.com/rails/rails/blob/master/activemodel/lib/active_model/naming.rb#L131)
