### PR TITLE
make default value for `:message` on `AM::Errors` explicit.

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -289,7 +289,7 @@ module ActiveModel
     #   # => NameIsInvalid: name is invalid
     #
     #   person.errors.messages # => {}
-    def add(attribute, message = nil, options = {})
+    def add(attribute, message = :invalid, options = {})
       message = normalize_message(attribute, message, options)
       if exception = options[:strict]
         exception = ActiveModel::StrictValidationFailed if exception == true
@@ -331,7 +331,7 @@ module ActiveModel
     #
     #   person.errors.add :name, :blank
     #   person.errors.added? :name, :blank # => true
-    def added?(attribute, message = nil, options = {})
+    def added?(attribute, message = :invalid, options = {})
       message = normalize_message(attribute, message, options)
       self[attribute].include? message
     end
@@ -437,8 +437,6 @@ module ActiveModel
 
   private
     def normalize_message(attribute, message, options)
-      message ||= :invalid
-
       case message
       when Symbol
         generate_message(attribute, message, options.except(*CALLBACKS_OPTIONS))


### PR DESCRIPTION
the old signatures were a bit misleading:

``` ruby
def add(attribute, message = nil, options = {})
def added?(attribute, message = nil, options = {})
```

I think for documentation purposes it's better to have the default value directly in the signature. While this introduces a bit of duplication it's closer to the documentation text, which also mentions the default value and would need to change.

Closes #11048
