### PR TITLE
Ability to pass block to select form builder helper

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Ability to pass block to `select` helper
+
+        = select(report, "campaign_ids") do
+          - available_campaigns.each do |c|
+            %option{:data => {:tags => c.tags.to_json}, :value => c.id}= c.name
+
+    *Bogdan Gusiev*
+
 *   Handle `:namespace` form option in collection labels
 
     *Vasiliy Ermolovich*

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -152,8 +152,8 @@ module ActionView
       # In case if you don't want the helper to generate this hidden field you can specify
       # <tt>include_hidden: false</tt> option.
       #
-      def select(object, method, choices, options = {}, html_options = {})
-        Tags::Select.new(object, method, self, choices, options, html_options).render
+      def select(object, method, choices = nil, options = {}, html_options = {}, &block)
+        Tags::Select.new(object, method, self, choices, options, html_options, &block).render
       end
 
       # Returns <tt><select></tt> and <tt><option></tt> tags for the collection of existing return values of
@@ -766,8 +766,8 @@ module ActionView
       #   <% end %>
       #
       # Please refer to the documentation of the base helper for details.
-      def select(method, choices, options = {}, html_options = {})
-        @template.select(@object_name, method, choices, objectify_options(options), @default_options.merge(html_options))
+      def select(method, choices = nil, options = {}, html_options = {}, &block)
+        @template.select(@object_name, method, choices, objectify_options(options), @default_options.merge(html_options), &block)
       end
 
       # Wraps ActionView::Helpers::FormOptionsHelper#collection_select for form builders:

--- a/actionview/lib/action_view/helpers/tags/select.rb
+++ b/actionview/lib/action_view/helpers/tags/select.rb
@@ -3,8 +3,9 @@ module ActionView
     module Tags # :nodoc:
       class Select < Base # :nodoc:
         def initialize(object_name, method_name, template_object, choices, options, html_options)
-          @choices = choices
+          @choices = block_given? ? template_object.capture { yield } : choices
           @choices = @choices.to_a if @choices.is_a?(Range)
+
           @html_options = html_options
 
           super(object_name, method_name, template_object, options)

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -556,6 +556,21 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_select_under_fields_for_with_block
+    @post = Post.new
+
+    output_buffer = fields_for :post, @post do |f|
+      concat(f.select(:category) do
+        concat content_tag(:option, "hello world")
+      end)
+    end
+
+    assert_dom_equal(
+      "<select id=\"post_category\" name=\"post[category]\"><option>hello world</option></select>",
+      output_buffer
+    )
+  end
+
   def test_select_with_multiple_to_add_hidden_input
     output_buffer =  select(:post, :category, "", {}, :multiple => true)
     assert_dom_equal(


### PR DESCRIPTION
In case when there is some complicated html inside of <select> tag the default rails helpers won't help and you need to generate html manually.

This patch allows to pass a block to rails form builder helper:

``` haml
    = select(report, "campaign_ids") do
    -# OR
    = f.select(:campaign_ids) do
      - available_campaigns.each do |c|
        %option{:data => {:tags => c.tags.to_json}, :value => c.id}= c.name
```
