### PR TITLE
fix dependencies on AS:Concern in ActiveModel::Name

### DIFF
--- a/activemodel/lib/active_model/conversion.rb
+++ b/activemodel/lib/active_model/conversion.rb
@@ -1,3 +1,5 @@
+require 'active_support/concern'
+
 module ActiveModel
   # == Active \Model Conversion
   #


### PR DESCRIPTION
ActiveSupport::Concern is used at [L24](https://github.com/rails/rails/tree/master/activemodel/lib/active_model/conversion.rb#L24) but isnt' required explicitly.
