### PR TITLE
Only output Server logs in Development

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `rails server` will only extend the logger to output to STDOUT
+     in development environment.
+
+    *Richard Schneeman*
+
 *   Don't require passing path to app before options in `rails new`
     and `rails plugin new`
 

--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -32,7 +32,8 @@ module Rails
 
         opt_parser.parse! args
 
-        options[:server] = args.shift
+        options[:log_stdout] = options[:daemonize].blank? && options[:environment] == "development"
+        options[:server]     = args.shift
         options
       end
     end
@@ -74,7 +75,7 @@ module Rails
         FileUtils.mkdir_p(File.join(Rails.root, 'tmp', dir_to_make))
       end
 
-      unless options[:daemonize]
+      if options[:log_stdout]
         wrapped_app # touch the app so the logger is set up
 
         console = ActiveSupport::Logger.new($stdout)

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -39,4 +39,14 @@ class Rails::ServerTest < ActiveSupport::TestCase
       assert_equal 'production', server.options[:environment]
     end
   end
+
+  def test_log_stdout
+    args    = ["-e", "development"]
+    options = Rails::Server::Options.new.parse!(args)
+    assert_equal true, options[:log_stdout]
+
+    args    = ["-e", "production"]
+    options = Rails::Server::Options.new.parse!(args)
+    assert_equal false, options[:log_stdout]
+  end
 end


### PR DESCRIPTION
Right now when you start a server via `rails s`, the logger gets extended so that it logs to the file system and also to stdout. This extension behavior is not "intelligent" and if the default logger is already set to output to stdout, then the contents will be received twice.

To capture logs in accordance with http://www.12factor.net/logs some platforms require the logs to be sent to standard out. If a logger is set to stdout, and the server is started using `rails server` instead of another method (i.e. `thin start` etc.) then the app will produce double logs.

This PR fixes the issue by only extending the logger to standard out in the development environment. So that in production you don't get double logs like this:

```
ActionView::Template::Error (wrong number of arguments (5 for 4)):
    1: <% lang_index = 0 %>
    2: <div class="row">
    3:   <ul class="nav nav-tabs nav-stacked span2" data-tabs="tabs" id="repo-tabs">
    4:     <% repos.group_by(&:language).each do |lang, repos| %>
    5:       <% unless lang == nil %>
    6:         <li><a href="#<%= "#{lang.parameterize}#{lang.hash}" %>" data-toggle="tab"><%= lang %></a></li>
    7:       <% end -%>
  app/views/shared/_repos.html.erb:4:in `_app_views_shared__repos_html_erb___1685450633638247395_70300668607000'
  app/views/pages/index.html.erb:13:in `_app_views_pages_index_html_erb__2084723628308867770_70300687584880'

ActionView::Template::Error (wrong number of arguments (5 for 4)):
    1: <% lang_index = 0 %>
    2: <div class="row">
    3:   <ul class="nav nav-tabs nav-stacked span2" data-tabs="tabs" id="repo-tabs">
    4:     <% repos.group_by(&:language).each do |lang, repos| %>
    5:       <% unless lang == nil %>
    6:         <li><a href="#<%= "#{lang.parameterize}#{lang.hash}" %>" data-toggle="tab"><%= lang %></a></li>
    7:       <% end -%>
  app/views/shared/_repos.html.erb:4:in `_app_views_shared__repos_html_erb___1685450633638247395_70300668607000'
  app/views/pages/index.html.erb:13:in `_app_views_pages_index_html_erb__2084723628308867770_70300687584880'
```

ATP Railties. Opened against master in favor of #10999
