### PR TITLE
Allow associations to be unscoped

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,43 @@
+*   Allow unscoping methods to work on the default scope of associations.
+
+        class User
+          default_scope -> { where(enabled: true) }
+        end
+
+        class Project
+          belongs_to :user, -> { unscoped }
+        end
+
+    We expect .unscoped to remove the default scope of User when the scopes
+    are joined.
+
+        user    = User.create enabled: false
+        project = Project.create user_id: user.id
+        project.user
+        # => <User id: 1, enabled: false>
+
+    This also works with other unscoping methods. For example:
+
+        class Project
+          belongs_to :user, -> { unscope(where: :enabled) }
+        end
+
+    or
+
+        class Project
+          belongs_to :user, -> { except(:where) }
+        end
+
+    Those are particularly useful if there are many clauses on the default
+    scope of User and you want to remove just one of them in the association.
+
+    Before, unscoping methods would not act on the default scope of the
+    association.
+
+    Fixes #10643.
+
+    *Dave Jachimiak*
+
 *   `create_savepoint`, `rollback_to_savepoint` and `release_savepoint` accept
     a savepoint name.
 

--- a/activerecord/lib/active_record/association_relation.rb
+++ b/activerecord/lib/active_record/association_relation.rb
@@ -1,5 +1,8 @@
 module ActiveRecord
   class AssociationRelation < Relation
+    delegate :owner, :reflection, to: :proxy_association
+    delegate :scope, :scope?, to: :reflection, prefix: true
+
     def initialize(klass, table, association)
       super(klass, table)
       @association = association
@@ -7,6 +10,10 @@ module ActiveRecord
 
     def proxy_association
       @association
+    end
+
+    def apply_reflection_scope
+      reflection_scope? ? instance_exec(owner, &reflection_scope) : self
     end
 
     private

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -117,7 +117,9 @@ module ActiveRecord
       # Can be overridden (i.e. in ThroughAssociation) to merge in other scopes (i.e. the
       # through association's scope)
       def target_scope
-        AssociationRelation.create(klass, klass.arel_table, self).merge!(klass.all)
+        relation = AssociationRelation.new(klass, klass.arel_table, self)
+        relation.merge!(klass.all)
+        relation.apply_reflection_scope
       end
 
       # Loads the \target if needed and returns it.

--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -98,7 +98,7 @@ module ActiveRecord
             item  = eval_scope(klass, scope_chain_item)
 
             if scope_chain_item == self.reflection.scope
-              scope.merge! item.except(:where, :includes, :bind)
+              scope.merge! item.except(:where, :includes, :bind, :having)
             end
 
             scope.includes! item.includes_values

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -369,6 +369,10 @@ module ActiveRecord
         options.key? :polymorphic
       end
 
+      def scope?
+        !!scope
+      end
+
       VALID_AUTOMATIC_INVERSE_MACROS = [:has_many, :has_one, :belongs_to]
       INVALID_AUTOMATIC_INVERSE_OPTIONS = [:conditions, :through, :polymorphic, :foreign_key]
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -16,6 +16,8 @@ require 'models/essay'
 require 'models/toy'
 require 'models/invoice'
 require 'models/line_item'
+require 'models/man'
+require 'models/face'
 
 class BelongsToAssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :topics,
@@ -829,5 +831,26 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
 
     assert post.save
     assert_equal post.author_id, author2.id
+  end
+
+  def test_unscoped_belongs_to_association
+    man  = ManWithCoolScope.create cool: false
+    face = FaceWithUnscopedMan.create man_id: man.id
+
+    assert face.man
+  end
+
+  def test_unscope_clause_in_belongs_to_association
+    man  = ManWithCoolScope.create cool: false
+    face = FaceWithUnscopeWhereMan.create man_id: man.id
+
+    assert face.man
+  end
+
+  def test_except_clause_in_belongs_to_association
+    man  = ManWithCoolScope.create cool: false
+    face = FaceWithExceptWhereMan.create man_id: man.id
+
+    assert face.man
   end
 end

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -508,7 +508,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
 
   def test_find_should_append_to_association_order
     ordered_developers = projects(:active_record).developers.order('projects.id')
-    assert_equal ['developers.name desc, developers.id desc', 'projects.id'], ordered_developers.order_values
+    assert_equal ['developers.name desc, developers.id desc', 'projects.id'], ordered_developers.order_values.uniq
   end
 
   def test_dynamic_find_all_should_respect_readonly_access

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -22,6 +22,8 @@ require 'models/engine'
 require 'models/categorization'
 require 'models/minivan'
 require 'models/speedometer'
+require 'models/interest'
+require 'models/man'
 
 class HasManyAssociationsTestForReorderWithJoinDependency < ActiveRecord::TestCase
   fixtures :authors, :posts, :comments
@@ -280,7 +282,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_find_should_append_to_association_order
     ordered_clients =  companies(:first_firm).clients_sorted_desc.order('companies.id')
-    assert_equal ['id DESC', 'companies.id'], ordered_clients.order_values
+    assert_equal ['id DESC', 'companies.id'], ordered_clients.order_values.uniq
   end
 
   def test_dynamic_find_should_respect_association_order
@@ -1757,5 +1759,12 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_equal 1, speedometer.minivans.to_a.size, "Only one association should be present:\n#{speedometer.minivans.to_a}"
     assert_equal 1, speedometer.reload.minivans.to_a.size
+  end
+
+  test "unscoped has many association" do
+    man = ManWithUnscopedInterests.create
+    interest = InterestWithCodeScope.create man_with_unscoped_interests_id: man.id, topic: 'SAX'
+
+    assert_equal [interest], man.interests
   end
 end

--- a/activerecord/test/models/face.rb
+++ b/activerecord/test/models/face.rb
@@ -1,7 +1,24 @@
+require 'models/man'
+
 class Face < ActiveRecord::Base
   belongs_to :man, :inverse_of => :face
   belongs_to :polymorphic_man, :polymorphic => true, :inverse_of => :polymorphic_face
   # These is a "broken" inverse_of for the purposes of testing
   belongs_to :horrible_man, :class_name => 'Man', :inverse_of => :horrible_face
   belongs_to :horrible_polymorphic_man, :polymorphic => true, :inverse_of => :horrible_polymorphic_face
+end
+
+class FaceWithUnscopedMan < ActiveRecord::Base
+  self.table_name = 'faces'
+  belongs_to :man, -> { unscoped }, class_name: ManWithCoolScope
+end
+
+class FaceWithUnscopeWhereMan < ActiveRecord::Base
+  self.table_name = 'faces'
+  belongs_to :man, -> { unscope(:where) }, class_name: ManWithCoolScope
+end
+
+class FaceWithExceptWhereMan < ActiveRecord::Base
+  self.table_name = 'faces'
+  belongs_to :man, -> { except(:where) }, class_name: ManWithCoolScope
 end

--- a/activerecord/test/models/interest.rb
+++ b/activerecord/test/models/interest.rb
@@ -3,3 +3,8 @@ class Interest < ActiveRecord::Base
   belongs_to :polymorphic_man, :polymorphic => true, :inverse_of => :polymorphic_interests
   belongs_to :zine, :inverse_of => :interests
 end
+
+class InterestWithCodeScope < ActiveRecord::Base
+  self.table_name = 'interests'
+  default_scope -> { where(topic: 'code') }
+end

--- a/activerecord/test/models/man.rb
+++ b/activerecord/test/models/man.rb
@@ -1,3 +1,5 @@
+require 'models/interest'
+
 class Man < ActiveRecord::Base
   has_one :face, :inverse_of => :man
   has_one :polymorphic_face, :class_name => 'Face', :as => :polymorphic_man, :inverse_of => :polymorphic_man
@@ -7,4 +9,14 @@ class Man < ActiveRecord::Base
   has_one :dirty_face, :class_name => 'Face', :inverse_of => :dirty_man
   has_many :secret_interests, :class_name => 'Interest', :inverse_of => :secret_man
   has_one :mixed_case_monkey
+end
+
+class ManWithCoolScope < ActiveRecord::Base
+  self.table_name = 'men'
+  default_scope -> { where(cool: true) }
+end
+
+class ManWithUnscopedInterests < ActiveRecord::Base
+  self.table_name = 'men'
+  has_many :interests, -> { unscoped }, class_name: InterestWithCodeScope
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -730,6 +730,7 @@ ActiveRecord::Schema.define do
   # NOTE - the following 4 tables are used by models that have :inverse_of options on the associations
   create_table :men, :force => true do |t|
     t.string  :name
+    t.boolean :cool
   end
 
   create_table :faces, :force => true do |t|
@@ -744,6 +745,7 @@ ActiveRecord::Schema.define do
   create_table :interests, :force => true do |t|
     t.string :topic
     t.integer :man_id
+    t.integer :man_with_unscoped_interests_id
     t.integer :polymorphic_man_id
     t.string :polymorphic_man_type
     t.integer :zine_id


### PR DESCRIPTION
Closes #10643

Given:

``` ruby
class User
  default_scope -> { where(enabled: true) }
end

class Project
  belongs_to :user, -> { unscoped }
end

user    = User.create enabled: false
project = Project.create user_id: user.id
```

Currently, this happens:

``` ruby
project.user
# => nil
```

This pull allows associations to be unscoped :smile::

``` ruby
project.user
# => <User id: 1, enabled: false>
```

This also works with other unscoping methods. For example:

``` ruby
class Project
  belongs_to :user, -> { unscope(where: :enabled) }
end
```

or

``` ruby
class Project
  belongs_to :user, -> { except(:where) }
end
```

Those are particularly useful if there are many clauses on the default scope of User and you want to remove just one of them in the association.
### Notes.
- This pull applies the scope of the association's reflection to the target scope before it is merged with the association scope.
- This pull excludes `:having` in `AssociationScope#add_constraints` when it passes over the reflection scope. This is to avoid three Ruby string interpolation errors that happened when running any database's entire test suite. (The errors didn't happen when running the test file individually, so it was strange.) It happened on queries using the `.having` clause with the `SUM` function.
- Some `order_values` in tests are duplicated. This happens because the reflection scope is applied to both the target and association scope (albeit in different ways). It doesn't seem to be a problem functionally; the sql query string isn't effected. In any case, this pull calls `#uniq` on those test variables -- Their tests' intent is to assert order of order values, not equality.

:saxophone: :racehorse: 
