### PR TITLE
add method 'extract' to hash

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add `Hash#extract`. The method return a hash to include only the given keys.
+    If key has no present in hash, it will be set to nil.
+
+    *Kirill Mokevnin*
+
 *   Fix return value from `BacktraceCleaner#noise` when the cleaner is configured
     with multiple silencers.
 

--- a/activesupport/lib/active_support/core_ext/hash/slice.rb
+++ b/activesupport/lib/active_support/core_ext/hash/slice.rb
@@ -37,4 +37,17 @@ class Hash
   def extract!(*keys)
     keys.each_with_object(self.class.new) { |key, result| result[key] = delete(key) if has_key?(key) }
   end
+
+  # Return a hash to include only the given keys.
+  # If key has no present in hash, it will be set to nil.
+  #
+  #   { a: 1, b: 2, c: 3, d: 4 }.extract(:a, :z) # => {:a=>1, :z=>nil}
+  #
+  # This is usefull for activerecord query builder:
+  #   
+  #   User.where(params.extract(:id, :confirmation_token).first!
+  def extract(*keys)
+    keys.map! { |key| convert_key(key) } if respond_to?(:convert_key, true)
+    keys.each_with_object(self.class.new) { |k, hash| hash[k] = self[k] }
+  end
 end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -782,6 +782,15 @@ class HashExtTest < ActiveSupport::TestCase
   end
 
   def test_extract
+    original = { :a => 'x', :b => 'y', :c => 10 }
+    expected = { :a => 'x', :b => 'y', :x => nil }
+
+    # Should return a new hash with only the given keys.
+    assert_equal expected, original.extract(:a, :b, :x)
+    assert_not_equal expected, original
+  end
+
+  def test_extract_inplace
     original = {:a => 1, :b => 2, :c => 3, :d => 4}
     expected = {:a => 1, :b => 2}
     remaining = {:c => 3, :d => 4}
@@ -790,7 +799,7 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal remaining, original
   end
 
-  def test_extract_nils
+  def test_extract_inplace_nils
     original = {:a => nil, :b => nil}
     expected = {:a => nil}
     extracted = original.extract!(:a, :x)
@@ -800,7 +809,7 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal nil, extracted[:x]
   end
 
-  def test_indifferent_extract
+  def test_indifferent_extract_inplace
     original = {:a => 1, 'b' => 2, :c => 3, 'd' => 4}.with_indifferent_access
     expected = {:a => 1, :b => 2}.with_indifferent_access
     remaining = {:c => 3, :d => 4}.with_indifferent_access


### PR DESCRIPTION
```
def confirm
  user = User.where(params.extract(:id, :confirmation_token)).first!
```

i can't use method slice, since i get empty hash if params has no key 'confirmation_token'.

i think it is usefull method for a lot of situations.
