### PR TITLE
ActionDispatch:SSL: don't include STS header in non-https responses

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/ssl.rb
@@ -36,8 +36,7 @@ module ActionDispatch
         url.scheme = "https"
         url.host   = @host if @host
         url.port   = @port if @port
-        headers    = hsts_headers.merge('Content-Type' => 'text/html',
-                                        'Location'     => url.to_s)
+        headers    = { 'Content-Type' => 'text/html', 'Location' => url.to_s }
 
         [301, headers, []]
       end

--- a/actionpack/test/dispatch/ssl_test.rb
+++ b/actionpack/test/dispatch/ssl_test.rb
@@ -37,6 +37,11 @@ class SSLTest < ActionDispatch::IntegrationTest
       response.headers['Strict-Transport-Security']
   end
 
+  def test_no_hsts_with_insecure_connection
+    get "http://example.org/"
+    assert_not response.headers['Strict-Transport-Security']
+  end
+
   def test_hsts_header
     self.app = ActionDispatch::SSL.new(default_app, :hsts => true)
     get "https://example.org/"


### PR DESCRIPTION
Reason: the STS spec explicitly says:

"An HSTS Host MUST NOT include the STS header field in HTTP responses conveyed over non-secure transport."

http://tools.ietf.org/html/draft-ietf-websec-strict-transport-sec-14#section-7.2
