### PR TITLE
Flag cookies as secure with ignore case in ActionDispatch::SSL

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/ssl.rb
@@ -58,7 +58,7 @@ module ActionDispatch
           cookies = cookies.split("\n")
 
           headers['Set-Cookie'] = cookies.map { |cookie|
-            if cookie !~ /;\s+secure(;|$)/
+            if cookie !~ /;\s+secure(;|$)/i
               "#{cookie}; secure"
             else
               cookie

--- a/actionpack/test/dispatch/ssl_test.rb
+++ b/actionpack/test/dispatch/ssl_test.rb
@@ -119,6 +119,20 @@ class SSLTest < ActionDispatch::IntegrationTest
       response.headers['Set-Cookie'].split("\n")
   end
 
+  def test_flag_cookies_as_secure_with_ignore_case
+    self.app = ActionDispatch::SSL.new(lambda { |env|
+      headers = {
+        'Content-Type' => "text/html",
+        'Set-Cookie' => "problem=def; path=/; Secure; HttpOnly"
+      }
+      [200, headers, ["OK"]]
+    })
+
+    get "https://example.org/"
+    assert_equal ["problem=def; path=/; Secure; HttpOnly"],
+      response.headers['Set-Cookie'].split("\n")
+  end
+
   def test_no_cookies
     self.app = ActionDispatch::SSL.new(lambda { |env|
       [200, {'Content-Type' => "text/html"}, ["OK"]]


### PR DESCRIPTION
> 5.2.5.  The Secure Attribute
> 
> If the attribute-name **case-insensitively** matches the string "Secure",
> the user agent MUST append an attribute to the cookie-attribute-list
> with an attribute-name of Secure and an empty attribute-value.

cite: http://www.ietf.org/rfc/rfc6265.txt
