### PR TITLE
content_tag will now parse style attribute passed as a Hash

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `content_tag` will now parse style attribute passed as a Hash
+
+        content_tag('p', "test", style: { color: "red", :font_size => "10px" })
+        # => "<p style=\"color: red; font-size: 10px;\" >test</p>"
+
+    *Dmitry Filimonov*
+
 *   Use a case insensitive URI Regexp for #asset_path.
 
     This fix a problem where the same asset path using different case are generating

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -145,6 +145,8 @@ module ActionView
               value.each_pair do |k, v|
                 attrs << data_tag_option(k, v, escape)
               end
+            elsif key.to_s == 'style' && value.is_a?(Hash)
+              attrs << style_tag_option(key, value, escape)
             elsif BOOLEAN_ATTRIBUTES.include?(key)
               attrs << boolean_tag_option(key) if value
             elsif !value.nil?
@@ -160,6 +162,13 @@ module ActionView
             value = value.to_json
           end
           tag_option(key, value, escape)
+        end
+
+        def style_tag_option(key, value, escape)
+          value = value.map do |k, v|
+            "#{k.to_s.dasherize}: #{v};"
+          end.join(" ")
+          tag_option("style", value, escape)
         end
 
         def boolean_tag_option(key)

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -92,6 +92,11 @@ class TagHelperTest < ActionView::TestCase
       content_tag('p', "limelight", data: { number: 1, string: 'hello', string_with_quotes: 'double"quote"party"' })
   end
 
+  def test_content_tag_with_style_attributes
+    assert_dom_equal '<p style="color: red; font-size: 10px;" >limelight</p>',
+      content_tag('p', "limelight", style: { color: "red", :font_size => "10px"  })
+  end
+
   def test_cdata_section
     assert_equal "<![CDATA[<hello world>]]>", cdata_section("<hello world>")
   end


### PR DESCRIPTION
```
content_tag('p', "test", style: { color: "red", top: "10px" })
# => "<p style=\"color: red; top: 10px;\" >test</p>"
```
