### PR TITLE
counter_cache is decremented twice

### DIFF
--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -782,6 +782,20 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_deleting_updates_counter_cache_with_dependent_destroy_in_self_referential_association
+    david = authors(:david)
+    mary = authors(:mary)
+    david.author_favorites.create(:favorite_author_id => mary.id)
+
+    david.reload
+    assert_equal 1, david.author_favorites_count
+
+    mary.destroy
+
+    david.reload
+    assert_equal 0, david.author_favorites_count
+  end
+
   def test_deleting_updates_counter_cache_with_dependent_delete_all
     post = posts(:welcome)
     post.update_columns(taggings_with_delete_all_count: post.taggings_count)

--- a/activerecord/test/cases/json_serialization_test.rb
+++ b/activerecord/test/cases/json_serialization_test.rb
@@ -258,7 +258,7 @@ class DatabaseConnectedJsonEncodingTest < ActiveRecord::TestCase
       authors = [@david, @mary]
       encoded = ActiveSupport::JSON.encode(authors, except: [
         :name, :author_address_id, :author_address_extra_id,
-        :organization_id, :owned_essay_id
+        :organization_id, :owned_essay_id, :author_favorites_count
       ])
       assert_equal %([{"id":1},{"id":2}]), encoded
     end

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -84,6 +84,7 @@ class Author < ActiveRecord::Base
 
   has_many :author_favorites
   has_many :favorite_authors, -> { order('name') }, :through => :author_favorites
+  has_many :author_fans,      :dependent => :destroy, :class_name => "AuthorFavorite", :foreign_key => :favorite_author_id
 
   has_many :taggings,        :through => :posts, :source => :taggings
   has_many :taggings_2,      :through => :posts, :source => :tagging
@@ -187,6 +188,6 @@ class AuthorAddress < ActiveRecord::Base
 end
 
 class AuthorFavorite < ActiveRecord::Base
-  belongs_to :author
+  belongs_to :author, :counter_cache => "author_favorites_count"
   belongs_to :favorite_author, :class_name => "Author"
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define do
     t.integer :author_address_extra_id
     t.string :organization_id
     t.string :owned_essay_id
+    t.integer :author_favorites_count
   end
 
   create_table :author_addresses, :force => true do |t|


### PR DESCRIPTION
counter_cache is decremented twice when a model with a self referential association is destroyed.
Can someone confirm?
