### PR TITLE
apply the order mentioned in the association

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -111,6 +111,8 @@ module ActiveRecord
                 item = ActiveRecord::Relation.new(reflection.klass, table).instance_exec(self, &item)
               end
 
+              item.order_values.each { |o| manager.order o }
+
               if item.arel.constraints.empty?
                 chain
               else


### PR DESCRIPTION
This PR fixes https://github.com/rails/rails/issues/6769 . 

However because of this fix 4 tests started failing because now order is being applied. Here are those failign tests https://gist.github.com/neerajdotname/5856608 .

@jonleighton do you think this PR looks ok ? If it looks okay then I will change those four failing tests to remove column name ambiguity. Lemme know. Thanks.
