### PR TITLE
fix preloading of has_many :through associations with STI

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix `#includes` on has_many :through association in combination with
+    STI models.
+    Fixes #11078.
+
+    *Yves Senn*
+
 *   Remove implicit join references that were deprecated in 4.0.
 
     Example:

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -48,7 +48,8 @@ module ActiveRecord
           else
             unless reflection_scope.where_values.empty?
               scope.includes_values = Array(reflection_scope.values[:includes] || options[:source])
-              scope.where_values    = reflection_scope.values[:where]
+              base_wheres           = reflection.klass.unscoped.values[:where] || []
+              scope.where_values    = reflection_scope.values[:where] - base_wheres
             end
 
             scope.references! reflection_scope.values[:references]

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -481,6 +481,14 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal [comments(:does_it_hurt)], assert_no_queries { author.special_post_comments }
   end
 
+  test "preloading has_many :through with association inheritance" do
+    authors = Author.includes(:very_special_comments).to_a
+    assert_no_queries do
+      special_comment_authors = authors.map { |author| [author.name, author.very_special_comments.size]}
+      assert_equal [["David", 1], ["Mary", 0], ["Bob", 0]], special_comment_authors
+    end
+  end
+
   def test_eager_with_has_many_through_an_sti_join_model_with_conditions_on_both
     author = Author.all.merge!(:includes => :special_nonexistant_post_comments, :order => 'authors.id').first
     assert_equal [], author.special_nonexistant_post_comments


### PR DESCRIPTION
This bug only occured when preloading a has_many :through association,
targeting a STI class, which is no direct descendent of `ActiveRecord::Base`.

This triggered `finder_needs_type_condition?`, which resulted in an
illegal where condition in the preloader:

```
ActiveRecord::StatementInvalid: SQLite3::SQLException:
no such column: posts.type: SELECT "users".* FROM "users"
WHERE "posts"."type" IN ('Article')
```

This patch removes all the where values from preloading that are present
on the `#unscoped` relation.

Closes #11078
