### PR TITLE
fix identifier error message of partial with unvalid charter

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Added an explicit error message, in `ActionView::PartialRenderer`
+    for partial `rendering`, when the value of option `as` has invalid charters.
+
+    *Angelo Capilleri*
+
 *   Always escape the result of `link_to_unless` method.
 
     Before:

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -347,7 +347,7 @@ module ActionView
       end
 
       if as = options[:as]
-        raise_invalid_identifier(as) unless as.to_s =~ /\A[a-z_]\w*\z/
+        raise_invalid_option_as(as) unless as.to_s =~ /\A[a-z_]\w*\z/
         as = as.to_sym
       end
 
@@ -482,11 +482,19 @@ module ActionView
     end
 
     IDENTIFIER_ERROR_MESSAGE = "The partial name (%s) is not a valid Ruby identifier; " +
-                               "make sure your partial name starts with a lowercase letter or underscore, " +
+                               "make sure your partial name starts with underscore, " +
+                               "and is followed by any combination of letters, numbers and underscores."
+
+    OPTION_AS_ERROR_MESSAGE  = "The value (%s) of the option `as` is not a valid Ruby identifier; " +
+                               "make sure it starts with lowercase letter, " +
                                "and is followed by any combination of letters, numbers and underscores."
 
     def raise_invalid_identifier(path)
       raise ArgumentError.new(IDENTIFIER_ERROR_MESSAGE % (path))
+    end
+
+    def raise_invalid_option_as(as)
+      raise ArgumentError.new(OPTION_AS_ERROR_MESSAGE % (as))
     end
   end
 end

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -171,14 +171,14 @@ module RenderTestCases
   def test_render_partial_with_invalid_name
     e = assert_raises(ArgumentError) { @view.render(:partial => "test/200") }
     assert_equal "The partial name (test/200) is not a valid Ruby identifier; " +
-      "make sure your partial name starts with a lowercase letter or underscore, " +
+      "make sure your partial name starts with underscore, " +
       "and is followed by any combination of letters, numbers and underscores.", e.message
   end
 
   def test_render_partial_with_missing_filename
     e = assert_raises(ArgumentError) { @view.render(:partial => "test/") }
     assert_equal "The partial name (test/) is not a valid Ruby identifier; " +
-      "make sure your partial name starts with a lowercase letter or underscore, " +
+      "make sure your partial name starts with underscore, " +
       "and is followed by any combination of letters, numbers and underscores.", e.message
   end
 
@@ -190,7 +190,21 @@ module RenderTestCases
   def test_render_partial_with_hyphen
     e = assert_raises(ArgumentError) { @view.render(:partial => "test/a-in") }
     assert_equal "The partial name (test/a-in) is not a valid Ruby identifier; " +
-      "make sure your partial name starts with a lowercase letter or underscore, " +
+      "make sure your partial name starts with underscore, " +
+      "and is followed by any combination of letters, numbers and underscores.", e.message
+  end
+
+  def test_render_partial_with_invalid_option_as
+    e = assert_raises(ArgumentError) { @view.render(:partial => "test/partial_only", :as => 'a-in') }
+    assert_equal "The value (a-in) of the option `as` is not a valid Ruby identifier; " +
+      "make sure it starts with lowercase letter, " +
+      "and is followed by any combination of letters, numbers and underscores.", e.message
+  end
+
+  def test_render_partial_with_hyphen_and_invalid_option_as
+    e = assert_raises(ArgumentError) { @view.render(:partial => "test/a-in", :as => 'a-in') }
+    assert_equal "The value (a-in) of the option `as` is not a valid Ruby identifier; " +
+      "make sure it starts with lowercase letter, " +
       "and is followed by any combination of letters, numbers and underscores.", e.message
   end
 


### PR DESCRIPTION
The partial should start with an underscore not with a underscore or letter.
It  possibile render an alias partial inside a view using the <%= render file: 'name/no_start_with_undescore' %>
but it is not a partial.

before this PR IDENTIFIER_ERROR_MESSAGE could lead to misunderstand the convention of partial name.
Added OPTION_AS_ERROR_MESSAGE for unvalid charter in as option.
