### PR TITLE
fix deprecation warning in scaffold controllers

### DIFF
--- a/railties/lib/rails/generators/active_model.rb
+++ b/railties/lib/rails/generators/active_model.rb
@@ -34,7 +34,7 @@ module Rails
 
       # GET index
       def self.all(klass)
-        "#{klass}.all"
+        "#{klass}.all.to_a"
       end
 
       # GET show


### PR DESCRIPTION
Relation#all is deprecated, using to_a to get an array of records.
