### PR TITLE
fix stack level Stack level too deep with class

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -72,7 +72,7 @@ module ActiveSupport
     end
 
     def self.new_from_hash_copying_default(hash)
-      new(hash).tap do |new_hash|
+      HashWithIndifferentAccess.new(hash).tap do |new_hash|
         new_hash.default = hash.default
       end
     end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -23,6 +23,12 @@ class HashExtTest < ActiveSupport::TestCase
     end
   end
 
+  class HashExtWithInitializeTest < ActiveSupport::HashWithIndifferentAccess
+    def initialize(hash = {})
+      replace hash
+    end
+  end
+
   def setup
     @strings = { 'a' => 1, 'b' => 2 }
     @nested_strings = { 'a' => { 'b' => { 'c' => 3 } } }
@@ -439,6 +445,23 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal 12, hash[:b]
     assert_same hash, replaced
   end
+
+  def test_indifferent_replace_on_extended_class
+    other = { 'a' => 1, :b => 2 }
+
+    hash = HashExtWithInitializeTest.new(other)
+
+    assert hash.key?('b')
+    assert hash.key?(:a)
+    assert_equal 2, hash[:b]
+
+    replaced = hash.replace(b: 12)
+    assert hash.key?('b')
+    assert !hash.key?(:a)
+    assert_equal 12, hash[:b]
+    assert_same hash, replaced
+  end
+
 
   def test_indifferent_merging_with_block
     hash = HashWithIndifferentAccess.new


### PR DESCRIPTION
that extend HashWithIndifferentAccess and overwrite initialize like
the following

   class HashExtWithInitializeTest < ActiveSupport::HashWithIndifferentAccess
      def initialize(hash = {})
        replace hash
      end
   end

> Foo.new
> tack level too deep

Fixes #11087
