### PR TITLE
restore correct scaffold generation

### DIFF
--- a/railties/lib/rails/generators/active_model.rb
+++ b/railties/lib/rails/generators/active_model.rb
@@ -34,7 +34,7 @@ module Rails
 
       # GET index
       def self.all(klass)
-        "#{klass}.scoped.to_a"
+        "#{klass}.all"
       end
 
       # GET show


### PR DESCRIPTION
This restores the original (and correct) behavior, sorry. Broken in https://github.com/rails/rails/pull/11088

```
2.0.0-p195 :003 > User.scope.to_a
ArgumentError: wrong number of arguments (0 for 1..2)
```
