### PR TITLE
removed unnecessary mapping for on options

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -245,7 +245,7 @@ module ActiveRecord
         if options.is_a?(Hash) && options[:on]
           assert_valid_transaction_action(options[:on])
           options[:if] = Array(options[:if])
-          fire_on = Array(options[:on]).map(&:to_sym)
+          fire_on = Array(options[:on])
           options[:if] << "transaction_include_any_action?(#{fire_on})"
         end
       end
@@ -288,17 +288,17 @@ module ActiveRecord
       clear_transaction_record_state
     end
 
-    # Call the after_commit callbacks
+    # Call the +after_commit+ callbacks.
     #
     # Ensure that it is not called if the object was never persisted (failed create),
-    # but call it after the commit of a destroyed object
+    # but call it after the commit of a destroyed object.
     def committed! #:nodoc:
       run_callbacks :commit if destroyed? || persisted?
     ensure
       clear_transaction_record_state
     end
 
-    # Call the after rollback callbacks. The restore_state argument indicates if the record
+    # Call the +after_rollback+ callbacks. The +force_restore_state+ argument indicates if the record
     # state should be rolled back to the beginning or just to the last savepoint.
     def rolledback!(force_restore_state = false) #:nodoc:
       run_callbacks :rollback
@@ -306,7 +306,7 @@ module ActiveRecord
       restore_transaction_record_state(force_restore_state)
     end
 
-    # Add the record to the current transaction so that the :after_rollback and :after_commit callbacks
+    # Add the record to the current transaction so that the +after_rollback+ and +after_commit+ callbacks
     # can be called.
     def add_to_transaction
       if self.class.connection.add_transaction_record(self)


### PR DESCRIPTION
Right before that in `assert_valid_transaction_action` method we make
sure that `options[:on]` contains values from `ACTIONS` array
(`[:create, :destroy, :update]`) and nothing more (i.e. it could not
contain strings or something else, otherwise the error is raised).

Also I've polished some docs.
