### PR TITLE
Backported to 3 2 explicit parts order

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## unreleased ##
 
-*   No changes.
+* Explicit multipart messages no longer set the order of the MIME parts.
+  *Nate Berkopec*
 
 
 ## Rails 3.2.13 (Mar 18, 2013) ##

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -645,7 +645,7 @@ module ActionMailer #:nodoc:
       assignable.each { |k, v| m[k] = v }
 
       # Render the templates and blocks
-      responses, explicit_order = collect_responses_and_parts_order(headers, &block)
+      responses = collect_responses(headers, &block)
       create_parts_from_responses(m, responses)
 
       # Setup content type, reapply charset and handle parts order
@@ -653,8 +653,7 @@ module ActionMailer #:nodoc:
       m.charset      = charset
 
       if m.multipart?
-        parts_order ||= explicit_order || headers[:parts_order]
-        m.body.set_sort_order(parts_order)
+        m.body.set_sort_order(headers[:parts_order])
         m.body.sort_parts!
       end
 
@@ -689,14 +688,13 @@ module ActionMailer #:nodoc:
       I18n.t(:subject, :scope => [mailer_scope, action_name], :default => action_name.humanize)
     end
 
-    def collect_responses_and_parts_order(headers) #:nodoc:
-      responses, parts_order = [], nil
+    def collect_responses(headers) #:nodoc:
+      responses = []
 
       if block_given?
         collector = ActionMailer::Collector.new(lookup_context) { render(action_name) }
         yield(collector)
-        parts_order = collector.responses.map { |r| r[:content_type] }
-        responses  = collector.responses
+        responses = collector.responses
       elsif headers[:body]
         responses << {
           :body => headers.delete(:body),
@@ -716,7 +714,7 @@ module ActionMailer #:nodoc:
         end
       end
 
-      [responses, parts_order]
+      responses
     end
 
     def each_template(paths, name, &block) #:nodoc:

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -317,19 +317,6 @@ class BaseTest < ActiveSupport::TestCase
     assert_not_nil(mail.content_type_parameters[:boundary])
   end
 
-  test "explicit multipart does not sort order" do
-    order = ["text/html", "text/plain"]
-    with_default BaseMailer, :parts_order => order do
-      email = BaseMailer.explicit_multipart
-      assert_equal("text/plain", email.parts[0].mime_type)
-      assert_equal("text/html",  email.parts[1].mime_type)
-
-      email = BaseMailer.explicit_multipart(:parts_order => order.reverse)
-      assert_equal("text/plain", email.parts[0].mime_type)
-      assert_equal("text/html",  email.parts[1].mime_type)
-    end
-  end
-
   test "explicit multipart with attachments creates nested parts" do
     email = BaseMailer.explicit_multipart(:attachments => true)
     assert_equal("application/pdf", email.parts[0].mime_type)
@@ -344,10 +331,10 @@ class BaseTest < ActiveSupport::TestCase
     email = BaseMailer.explicit_multipart_templates
     assert_equal(2, email.parts.size)
     assert_equal("multipart/alternative", email.mime_type)
-    assert_equal("text/html", email.parts[0].mime_type)
-    assert_equal("HTML Explicit Multipart Templates", email.parts[0].body.encoded)
-    assert_equal("text/plain", email.parts[1].mime_type)
-    assert_equal("TEXT Explicit Multipart Templates", email.parts[1].body.encoded)
+    assert_equal("text/plain", email.parts[0].mime_type)
+    assert_equal("TEXT Explicit Multipart Templates", email.parts[0].body.encoded)
+    assert_equal("text/html", email.parts[1].mime_type)
+    assert_equal("HTML Explicit Multipart Templates", email.parts[1].body.encoded)
   end
 
   test "explicit multipart with format.any" do
@@ -382,10 +369,23 @@ class BaseTest < ActiveSupport::TestCase
     email = BaseMailer.explicit_multipart_with_one_template
     assert_equal(2, email.parts.size)
     assert_equal("multipart/alternative", email.mime_type)
-    assert_equal("text/html", email.parts[0].mime_type)
-    assert_equal("[:html]", email.parts[0].body.encoded)
-    assert_equal("text/plain", email.parts[1].mime_type)
-    assert_equal("[:text]", email.parts[1].body.encoded)
+    assert_equal("text/plain", email.parts[0].mime_type)
+    assert_equal("[:text]", email.parts[0].body.encoded)
+    assert_equal("text/html", email.parts[1].mime_type)
+    assert_equal("[:html]", email.parts[1].body.encoded)
+  end
+
+  test "explicit multipart with sort order" do
+    order = ["text/html", "text/plain"]
+    with_default BaseMailer, parts_order: order do
+      email = BaseMailer.explicit_multipart
+      assert_equal("text/html", email.parts[0].mime_type)
+      assert_equal("text/plain", email.parts[1].mime_type)
+
+      email = BaseMailer.explicit_multipart(parts_order: order.reverse)
+      assert_equal("text/plain", email.parts[0].mime_type)
+      assert_equal("text/html", email.parts[1].mime_type)
+    end
   end
 
   # Class level API with method missing


### PR DESCRIPTION
Backport to fix #11092 for 3.2 rails, which was fixed in 4.0 by #7978
