### PR TITLE
Remove Array#blank? and Hash#blank? alias to empty?

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -66,22 +66,6 @@ class TrueClass
   end
 end
 
-class Array
-  # An array is blank if it's empty:
-  #
-  #   [].blank?      # => true
-  #   [1,2,3].blank? # => false
-  alias_method :blank?, :empty?
-end
-
-class Hash
-  # A hash is blank if it's empty:
-  #
-  #   {}.blank?                # => true
-  #   { key: 'value' }.blank?  # => false
-  alias_method :blank?, :empty?
-end
-
 class String
   # A string is blank if it's empty or contains whitespaces only:
   #


### PR DESCRIPTION
Hello,

Since `Array` and `Hash` inherit from Object and Object#blank? rely on empty?, the aliases aren't necessary for these two objects.

Have a nice day.
