### PR TITLE
Fix typo in docs. HABTM associations should use a pluralized name

### DIFF
--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -653,7 +653,7 @@ module ActionView
       #
       # Example object structure for use with this method:
       #   class Post < ActiveRecord::Base
-      #     has_and_belongs_to_many :author
+      #     has_and_belongs_to_many :authors
       #   end
       #   class Author < ActiveRecord::Base
       #     has_and_belongs_to_many :posts

--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -1090,7 +1090,7 @@ Example object structure for use with this method:
 
 ```ruby
 class Post < ActiveRecord::Base
-  has_and_belongs_to_many :author
+  has_and_belongs_to_many :authors
 end
 
 class Author < ActiveRecord::Base


### PR DESCRIPTION
Nothing major, but just noticed this when reading the documentation for something unrelated.
