### PR TITLE
Fix secure_password password_confirmation validations

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix has_secure_password. `password_confirmation` validations are triggered
+    even if no `password_confirmation` is set.
+
+    *Vladimir Kiselev*
+
 *   `inclusion` / `exclusion` validations with ranges will only use the faster
     `Range#cover` for numerical ranges, and the more accurate `Range#include?`
     for non-numerical ones.

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -56,9 +56,9 @@ module ActiveModel
         include InstanceMethodsOnActivation
 
         if options.fetch(:validations, true)
-          validates_confirmation_of :password, if: lambda { |m| m.password.present? }
+          validates_confirmation_of :password, if: :should_confirm_password?
           validates_presence_of     :password, on: :create
-          validates_presence_of     :password_confirmation, if: lambda { |m| m.password.present? }
+          validates_presence_of     :password_confirmation, if: :should_confirm_password?
 
           before_create { raise "Password digest missing on new record" if password_digest.blank? }
         end
@@ -108,6 +108,12 @@ module ActiveModel
 
       def password_confirmation=(unencrypted_password)
         @password_confirmation = unencrypted_password
+      end
+
+      private
+
+      def should_confirm_password?
+        password_confirmation && password.present?
       end
     end
   end

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -95,6 +95,11 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert @user.valid?(:update), "user should be valid"
   end
 
+  test "password_confirmation validations will not be triggered if password_confirmation is not sent" do
+    @user.password = "password"
+    assert @user.valid?(:create)
+  end
+
   test "will not save if confirmation is blank but password is not" do
     @user.password = "password"
     @user.password_confirmation = ""


### PR DESCRIPTION
As documentation says:

**If you don't need the confirmation validation, just don't set any
value to the password_confirmation attribute and the validation
will not be triggered.**
