### PR TITLE
Moving the `pluck` and `ids` methods to their own delegate line.

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -1,15 +1,16 @@
 module ActiveRecord
   module Querying
-    delegate :find, :take, :take!, :first, :first!, :last, :last!, :exists?, :any?, :many?, :to => :all
-    delegate :first_or_create, :first_or_create!, :first_or_initialize, :to => :all
-    delegate :find_or_create_by, :find_or_create_by!, :find_or_initialize_by, :to => :all
-    delegate :find_by, :find_by!, :to => :all
-    delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, :to => :all
-    delegate :find_each, :find_in_batches, :to => :all
+    delegate :find, :take, :take!, :first, :first!, :last, :last!, :exists?, :any?, :many?, to: :all
+    delegate :first_or_create, :first_or_create!, :first_or_initialize, to: :all
+    delegate :find_or_create_by, :find_or_create_by!, :find_or_initialize_by, to: :all
+    delegate :find_by, :find_by!, to: :all
+    delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, to: :all
+    delegate :find_each, :find_in_batches, to: :all
     delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins,
              :where, :preload, :eager_load, :includes, :from, :lock, :readonly,
-             :having, :create_with, :uniq, :distinct, :references, :none, :unscope, :to => :all
-    delegate :count, :average, :minimum, :maximum, :sum, :calculate, :pluck, :ids, :to => :all
+             :having, :create_with, :uniq, :distinct, :references, :none, :unscope, to: :all
+    delegate :count, :average, :minimum, :maximum, :sum, :calculate, to: :all
+    delegate :pluck, :ids, to: :all
 
     # Executes a custom SQL query against your database and returns all the results. The results will
     # be returned as an array with columns requested encapsulated as attributes of the model you call


### PR DESCRIPTION
The two methods `pluck` and `ids` aren't really statistical helper methods and don't belong in the group of delegators that they currently are stuck in. In my opinion, they also don't really belong in any other group which is being delegated for querying, so I'm moving them to their own group of methods.

I've also changed the `:to => :all` hash syntax to `to: :all`.
