### PR TITLE
fix error when only require 'active_model/naming'.

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -1,5 +1,7 @@
 require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/module/introspection'
+require 'active_support/core_ext/module/delegation'
+require 'active_support/core_ext/object/blank'
 
 module ActiveModel
   class Name


### PR DESCRIPTION
In active_model 4.0, failed to only require 'active_model/naming'.

```
irb(main):003:0> require 'active_model/naming'
NoMethodError: undefined method `delegate' for ActiveModel::Name:Class
    from /Users/m_mimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/activemodel-4.0.0/lib/active_model/naming.rb:131:in `<class:Name>'
    from /Users/m_mimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/activemodel-4.0.0/lib/active_model/naming.rb:5:in `<module:ActiveModel>'
    from /Users/m_mimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/activemodel-4.0.0/lib/active_model/naming.rb:4:in `<top (required)>'
    from (irb):3:in `require'
    from (irb):3
    from /Users/m_mimura/.rbenv/versions/2.0.0-p195/bin/irb:12:in `<main>'
```

So, i restore to require 'active_support/core_ext/module/delegation' and 'active_support/core_ext/object/blank'.
