### PR TITLE
Add hook_for :fixture_replacement in scaffold generator for functional test template.

### DIFF
--- a/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
@@ -10,9 +10,13 @@ module TestUnit # :nodoc:
 
       argument :attributes, type: :array, default: [], banner: "field:type field:type"
 
+      hook_for :fixture_replacement
+
       def create_test_files
-        template "functional_test.rb",
-                 File.join("test/controllers", controller_class_path, "#{controller_file_name}_controller_test.rb")
+        if options[:fixture] && options[:fixture_replacement].nil?
+          template "functional_test.rb",
+            File.join("test/controllers", controller_class_path, "#{controller_file_name}_controller_test.rb")
+        end
       end
 
       private


### PR DESCRIPTION
When I run `rails g scaffold post` with factore girl, the controller test file `test/controllers/posts_controller_test.rb` likes this:

``` ruby
require 'test_helper'

class PostsControllerTest < ActionController::TestCase
  setup do
    @post = posts(:one)
  end

  ...

end
```

It write in the fixture style but not factory girl style, so the functional test can not pass.
