### PR TITLE
Change the way delegates handles nil receivers

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -178,16 +178,13 @@ class Module
       else
         exception = %(raise "#{self}##{method_prefix}#{method} delegated to #{to}.#{method}, but #{to} is nil: \#{self.inspect}")
 
-        module_eval(<<-EOS, file, line - 2)
+        module_eval(<<-EOS, file, line - 5)
           def #{method_prefix}#{method}(#{definition})        # def customer_name(*args, &block)
             _ = #{to}                                         #   _ = client
-            _.#{method}(#{definition})                        #   _.name(*args, &block)
-          rescue NoMethodError                                # rescue NoMethodError
             if _.nil?                                         #   if _.nil?
               #{exception}                                    #     # add helpful message to the exception
-            else                                              #   else
-              raise                                           #     raise
             end                                               #   end
+            _.#{method}(#{definition})                        #   _.name(*args, &block)
           end                                                 # end
         EOS
       end

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -212,7 +212,9 @@ class ModuleTest < ActiveSupport::TestCase
 
   def test_delegation_to_method_that_exists_on_nil
     nil_person = Someone.new(nil)
-    assert_equal 0.0, nil_person.to_f
+    assert_raise RuntimeError do
+      nil_person.to_f
+    end
   end
 
   def test_delegation_to_method_that_exists_on_nil_when_allowing_nil


### PR DESCRIPTION
Inspired by issue #10559

If nill is passed as a receiver, I think an exception should be raised right away, there is the allow_nil option for that.

This caused strange errors because the root of the problem was masked by the exception raised in the rescue of NoMethodError block. (Again, see #10559)

What do you think ?

Thanks and kudos for the release !
