### PR TITLE
Fixes AR mysql2 adapter incorrectly casting boolean values

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Fix bug when using Mysql2 adapter where in some cases, boolean values were
+    being output in sql as `t` or `f` instead of `1` or `0`. Example:
+
+        class Model < ActiveRecord::Base
+          validates_uniqueness_of :boolean_col
+        end
+        Model.first.valid?
+
+    Previously generated sql:
+
+        SELECT 1 AS one FROM `models` WHERE
+          `models`.`boolean_col` = BINARY 'f' LIMIT 1
+
+    With fix:
+
+        SELECT 1 AS one FROM `models` WHERE
+          `models`.`boolean_col` = BINARY 0 LIMIT 1
+
+    Fixes: #11119
+
+    *Adam Williams*
+
 *   `change_column` for PostgreSQL adapter respects the `:array` option.
 
     *Yves Senn*

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -272,6 +272,12 @@ module ActiveRecord
         QUOTED_FALSE
       end
 
+      def type_cast(value, column)
+        return super unless value == true || value == false
+
+        value ? 1 : 0
+      end
+
       # REFERENTIAL INTEGRITY ====================================
 
       def disable_referential_integrity(&block) #:nodoc:

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -160,12 +160,6 @@ module ActiveRecord
 
       # QUOTING ==================================================
 
-      def type_cast(value, column)
-        return super unless value == true || value == false
-
-        value ? 1 : 0
-      end
-
       def quote_string(string) #:nodoc:
         @connection.quote(string)
       end

--- a/activerecord/test/cases/adapters/mysql2/quoting_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/quoting_test.rb
@@ -1,0 +1,25 @@
+require "cases/helper"
+
+module ActiveRecord
+  module ConnectionAdapters
+    class Mysql2Adapter
+      class QuotingTest < ActiveRecord::TestCase
+        def setup
+          @conn = ActiveRecord::Base.connection
+        end
+
+        def test_type_cast_true
+          c = Column.new(nil, 1, 'boolean')
+          assert_equal 1, @conn.type_cast(true, nil)
+          assert_equal 1, @conn.type_cast(true, c)
+        end
+
+        def test_type_cast_false
+          c = Column.new(nil, 1, 'boolean')
+          assert_equal 0, @conn.type_cast(false, nil)
+          assert_equal 0, @conn.type_cast(false, c)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Using the mysql2 adapter, boolean values were being incorrectly cast to 't' or 'f'. This
changes the cast to match the mysql adapter behavior, ie 1 and 0.

Fixes #11119
