### PR TITLE
Stop swallowing exceptions from`after_commit` callbacks

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -329,6 +329,10 @@
 
     *Vipul A M*
 
+*   Exceptions from `after_commit` callbacks are no longer rescued
+
+    *Vipul A M*
+
 *   `change_column` for PostgreSQL adapter respects the `:array` option.
 
     *Yves Senn*

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -213,7 +213,7 @@ module ActiveRecord
         begin
           commit_transaction unless error
         rescue Exception
-          rollback_transaction
+          rollback_transaction unless transaction.state.complete?
           raise
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -31,6 +31,10 @@ module ActiveRecord
         @state == :rolledback
       end
 
+      def complete?
+        committed? || rolledback?
+      end
+
       def set_state(state)
         if !VALID_STATES.include?(state)
           raise ArgumentError, "Invalid transaction state: #{state}"
@@ -143,6 +147,7 @@ module ActiveRecord
             record.committed!
           rescue => e
             record.logger.error(e) if record.respond_to?(:logger) && record.logger
+            raise
           end
         end
       end

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -250,8 +250,8 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
   def test_after_transaction_callbacks_should_prevent_callbacks_from_being_called
     def @first.last_after_transaction_error=(e); @last_transaction_error = e; end
     def @first.last_after_transaction_error; @last_transaction_error; end
-    @first.after_commit_block{|r| r.last_after_transaction_error = :commit; raise "fail!";}
-    @first.after_rollback_block{|r| r.last_after_transaction_error = :rollback; raise "fail!";}
+    @first.after_commit_block{|r| r.last_after_transaction_error = :commit}
+    @first.after_rollback_block{|r| r.last_after_transaction_error = :rollback}
     @second.after_commit_block{|r| r.history << :after_commit}
     @second.after_rollback_block{|r| r.history << :after_rollback}
 
@@ -270,6 +270,11 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
     end
     assert_equal :rollback, @first.last_after_transaction_error
     assert_equal [:after_rollback], @second.history
+  end
+
+  def test_after_commit_callbacks_should_raise_block_errors
+    @first.after_commit_block{|r| 42/0}
+    assert_raise(ZeroDivisionError){@first.save!}
   end
 
   def test_after_rollback_callbacks_should_validate_on_condition


### PR DESCRIPTION
Stop swallowing exceptions from`after_commit` callbacks. 
Fixes #3205
