### PR TITLE
Removing deprecated rake tasks for tests

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Removed deprecated rake tasks. You will no longer be able to use the following
+    commands: `rake test:uncommitted` and `rake test:recent`. Also removed are
+    the tests for these rake tasks.
+
+    *John Wang*
+
 *   Clearing autoloaded constants triggers routes reloading [Fixes #10685].
 
     *Xavier Noria*

--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -3,34 +3,6 @@ require 'rake/testtask'
 require 'rails/test_unit/sub_test_task'
 require 'active_support/deprecation'
 
-TEST_CHANGES_SINCE = Time.now - 600
-
-# Look up tests for recently modified sources.
-def recent_tests(source_pattern, test_path, touched_since = 10.minutes.ago)
-  FileList[source_pattern].map do |path|
-    if File.mtime(path) > touched_since
-      tests = []
-      source_dir = File.dirname(path).split("/")
-      source_file = File.basename(path, '.rb')
-
-      # Support subdirs in app/models and app/controllers
-      modified_test_path = source_dir.length > 2 ? "#{test_path}/" << source_dir[1..source_dir.length].join('/') : test_path
-
-      # For modified files in app/ run the tests for it. ex. /test/controllers/account_controller.rb
-      test = "#{modified_test_path}/#{source_file}_test.rb"
-      tests.push test if File.exist?(test)
-
-      # For modified files in app, run tests in subdirs too. ex. /test/controllers/account/*_test.rb
-      test = "#{modified_test_path}/#{File.basename(path, '.rb').sub("_controller","")}"
-      FileList["#{test}/*_test.rb"].each { |f| tests.push f } if File.exist?(test)
-
-      return tests
-
-    end
-  end.flatten.compact
-end
-
-
 # Recreated here from Active Support because :uncommitted needs it before Rails is available
 module Kernel
   remove_method :silence_stderr # Removing old method to prevent method redefined warning
@@ -84,40 +56,6 @@ namespace :test do
   task :deprecated do
     ActiveSupport::Deprecation.warn "`rake #{ARGV.first}` is deprecated with no replacement."
   end
-
-  Rake::TestTask.new(recent: ["test:deprecated", "test:prepare"]) do |t|
-    since = TEST_CHANGES_SINCE
-    touched = FileList['test/**/*_test.rb'].select { |path| File.mtime(path) > since } +
-      recent_tests('app/models/**/*.rb', 'test/models', since) +
-      recent_tests('app/models/**/*.rb', 'test/unit', since) +
-      recent_tests('app/controllers/**/*.rb', 'test/controllers', since) +
-      recent_tests('app/controllers/**/*.rb', 'test/functional', since)
-
-    t.test_files = touched.uniq
-  end
-  Rake::Task['test:recent'].comment = "Deprecated; Test recent changes"
-
-  Rake::TestTask.new(uncommitted: ["test:deprecated", "test:prepare"]) do |t|
-    def t.file_list
-      if File.directory?(".svn")
-        changed_since_checkin = silence_stderr { `svn status` }.split.map { |path| path.chomp[7 .. -1] }
-      elsif system "git rev-parse --git-dir 2>&1 >/dev/null"
-        changed_since_checkin = silence_stderr { `git ls-files --modified --others --exclude-standard` }.split.map { |path| path.chomp }
-      else
-        abort "Not a Subversion or Git checkout."
-      end
-
-      models      = changed_since_checkin.select { |path| path =~ /app[\\\/]models[\\\/].*\.rb$/ }
-      controllers = changed_since_checkin.select { |path| path =~ /app[\\\/]controllers[\\\/].*\.rb$/ }
-
-      unit_tests       = models.map { |model| "test/models/#{File.basename(model, '.rb')}_test.rb" } +
-                         models.map { |model| "test/unit/#{File.basename(model, '.rb')}_test.rb" } +
-      functional_tests = controllers.map { |controller| "test/controllers/#{File.basename(controller, '.rb')}_test.rb" } +
-                         controllers.map { |controller| "test/functional/#{File.basename(controller, '.rb')}_test.rb" }
-      (unit_tests + functional_tests).uniq.select { |file| File.exist?(file) }
-    end
-  end
-  Rake::Task['test:uncommitted'].comment = "Deprecated; Test changes since last checkin (only Subversion and Git)"
 
   Rails::TestTask.new(single: "test:prepare")
 

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -101,45 +101,6 @@ module ApplicationTests
         Dir.chdir(app_path){ `rake stats` }
     end
 
-    def test_rake_test_uncommitted_always_find_git_in_parent_dir
-      return "FIXME :'("
-      app_name = File.basename(app_path)
-      app_dir = File.dirname(app_path)
-      moved_app_name = app_name + '_moved'
-
-      Dir.chdir(app_dir) do
-        # Go from "./app/" to "./app/app_moved"
-        FileUtils.mv(app_name, moved_app_name)
-        FileUtils.mkdir(app_name)
-        FileUtils.mv(moved_app_name, app_name)
-        # Initialize the git repository and start the test.
-        Dir.chdir(app_name) do
-          `git init`
-          Dir.chdir(moved_app_name){ `rake db:migrate` }
-          silence_stderr { Dir.chdir(moved_app_name) { `rake test:uncommitted` } }
-          assert_equal 0, $?.exitstatus
-        end
-      end
-    end
-
-    def test_rake_test_uncommitted_fails_with_no_scm
-      Dir.chdir(app_path){ `rake db:migrate` }
-      Dir.chdir(app_path) do
-        silence_stderr { `rake test:uncommitted` }
-        assert_equal 1, $?.exitstatus
-      end
-    end
-
-    def test_rake_test_deprecation_messages
-      Dir.chdir(app_path){ `rails generate scaffold user name:string` }
-      Dir.chdir(app_path){ `rake db:migrate` }
-
-      %w(recent uncommitted).each do |test_suit_name|
-        output = Dir.chdir(app_path) { `rake test:#{test_suit_name} 2>&1` }
-        assert_match(/DEPRECATION WARNING: `rake test:#{test_suit_name}` is deprecated/, output)
-      end
-    end
-
     def test_rake_routes_calls_the_route_inspector
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do


### PR DESCRIPTION
The `rake test:recent` and `rake test:uncommitted` tasks were deprecated and are now being removed. I've removed the tests that were associated with them as well.
