### PR TITLE
fix activerecord/examples/performance.rb#L101 syntax error

### DIFF
--- a/activerecord/examples/performance.rb
+++ b/activerecord/examples/performance.rb
@@ -98,7 +98,7 @@ Benchmark.ips(TIME) do |x|
   exhibit      = {
     name: ActiveRecord::Faker.name,
     notes: notes,
-    :created_at: Date.today
+    created_at: Date.today
   }
 
   x.report("Model#id") do


### PR DESCRIPTION
ruby activerecord/examples/performance.rb

``` ruby
activerecord/examples/performance.rb:101: syntax error, unexpected ':', expecting =>
    :created_at: Date.today
                ^
activerecord/examples/performance.rb:102: syntax error, unexpected '}', expecting keyword_end
```
