### PR TITLE
Move the javascript include tag after the yield on layout/application.html.erb

### DIFF
--- a/guides/code/getting_started/app/views/layouts/application.html.erb
+++ b/guides/code/getting_started/app/views/layouts/application.html.erb
@@ -3,12 +3,12 @@
 <head>
   <title>Blog</title>
   <%= stylesheet_link_tag    "application", media: "all", "data-turbolinks-track" => true %>
-  <%= javascript_include_tag "application", "data-turbolinks-track" => true %>
   <%= csrf_meta_tags %>
 </head>
 <body>
 
 <%= yield %>
 
+<%= javascript_include_tag "application", "data-turbolinks-track" => true %>
 </body>
 </html>

--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -3,12 +3,12 @@
 <head>
   <title><%= camelized %></title>
   <%%= stylesheet_link_tag    "application", media: "all", "data-turbolinks-track" => true %>
-  <%%= javascript_include_tag "application", "data-turbolinks-track" => true %>
   <%%= csrf_meta_tags %>
 </head>
 <body>
 
 <%%= yield %>
 
+<%%= javascript_include_tag "application", "data-turbolinks-track" => true %>
 </body>
 </html>


### PR DESCRIPTION
Well, we all talk about performance, best practices and improvements. Moving
the include tag to the bottom will decrease the page load of your app just a bit.
It's just a way to start.

we always do this as a common practice to better performance, so why not do this
super simple change on the very first layout, it doesn't hurt anybody.
