### PR TITLE
if column is string then ensure that value is string too

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -31,6 +31,12 @@ module ActiveRecord
           # BigDecimals need to be put in a non-normalized form and quoted.
         when nil        then "NULL"
         when BigDecimal then value.to_s('F')
+        when Fixnum
+          case column && column.respond_to?(:type) && column.type
+          when :string then "'#{quote_string(value.to_s)}'"
+          else value.to_s
+          end
+
         when Numeric, ActiveSupport::Duration then value.to_s
         when Date, Time then "'#{quoted_date(value)}'"
         when Symbol     then "'#{quote_string(value.to_s)}'"

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -224,6 +224,10 @@ module ActiveRecord
       def test_quote_duration_int_column
         assert_equal "7200", @quoter.quote(2.hours, FakeColumn.new(:integer))
       end
+
+      def test_quote_when_column_is_string_value_is_integer
+        assert_equal "'1'", @quoter.quote(1, FakeColumn.new(:string))
+      end
     end
   end
 end


### PR DESCRIPTION
The sql query for `User.where(id: '10')` will have the value '10'
in integer even though the value passed by in String format. That's
because proper quoting is applied and while applying the quoting it
was detected that column id is of type 'Integer'.

However the sql for `User.where(name: 10)` will not have the value 10
converted into string. That's because currently no quoting is applied
for Fixnum.

This PR fixes that. If the value is of type Integer and the column is of
type String then proper quoting is applied.

Please note that in order for this code to work properly arel needed a
bit of change. So only after this PR https://github.com/rails/arel/pull/192
is merged the changed code would work properly.

/cc @tenderlove 
