### PR TITLE
activerecord/examples/simple.rb use master branch activesupport gem

### DIFF
--- a/activerecord/examples/simple.rb
+++ b/activerecord/examples/simple.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift "#{File.dirname(__FILE__)}/../lib"
+require File.expand_path('../../../load_paths', __FILE__)
 require 'active_record'
 
 class Person < ActiveRecord::Base


### PR DESCRIPTION
### First

---

```
gem list activesupport

*** LOCAL GEMS ***

```
### Before

---

``` ruby
ruby activerecord/examples/simple.rb

home/tumayun/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require': cannot load such file -- active_support (LoadError)
    from /home/tumayun/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
    from /home/tumayun/workspace/gems/rails/activerecord/lib/active_record.rb:24:in `<top (required)>'
    from /home/tumayun/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
    from /home/tumayun/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
    from activerecord/examples/simple.rb:2:in `<main>'
```
### After

---

``` ruby
ruby activerecord/examples/simple.rb

#<ActiveRecord::Relation [#<Person id: 1, name: "bob">]>
#<ActiveRecord::Relation []>
```
