### PR TITLE
Re-remove deprecated API.

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -524,7 +524,6 @@ module ActionController
 
       def process(action, http_method = 'GET', *args)
         check_required_ivars
-        http_method, args = handle_old_process_api(http_method, args, caller)
 
         if args.first.is_a?(String) && http_method != 'HEAD'
           @request.env['RAW_POST_DATA'] = args.shift
@@ -626,17 +625,6 @@ module ActionController
             raise "#{iv_name} is nil: make sure you set it in your test's setup method."
           end
         end
-      end
-
-      def handle_old_process_api(http_method, args, callstack)
-        # 4.0: Remove this method.
-        if http_method.is_a?(Hash)
-          ActiveSupport::Deprecation.warn("TestCase#process now expects the HTTP method as second argument: process(action, http_method, params, session, flash)", callstack)
-          args.unshift(http_method)
-          http_method = args.last.is_a?(String) ? args.last : "GET"
-        end
-
-        [http_method, args]
       end
 
       def build_request_uri(action, parameters)

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -280,13 +280,6 @@ XML
     assert_equal "/test_case_test/test/test_uri/7", @response.body
   end
 
-  def test_process_with_old_api
-    assert_deprecated do
-      process :test_uri, :id => 7
-      assert_equal "/test_case_test/test/test_uri/7", @response.body
-    end
-  end
-
   def test_process_with_request_uri_with_params_with_explicit_uri
     @request.env['PATH_INFO'] = "/explicit/uri"
     process :test_uri, "GET", :id => 7


### PR DESCRIPTION
The original of this PR was f53c247d10acbaacb0d61824cfce888c4b0520d2 by @tenderlove.
But f53c247d10acbaacb0d61824cfce888c4b0520d2  was reverted  by 4d073df43d6ecd99ab04dbd0773a61559325efb8 , because we should remove this old api in Rails 4.1.

BTW: I couldn't merge f53c247d10acbaacb0d61824cfce888c4b0520d2 because of  complicated conflict ;)
