### PR TITLE
Remove passing the prompt to grouped_options_for_select as an argument, because it was deprecated.

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Remove passing the prompt to `grouped_options_for_select` as an argument, because
+    it was deprecated.
+
+    *kennyj*
+
 *   Always escape the result of `link_to_unless` method.
 
     Before:

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -510,15 +510,8 @@ module ActionView
       # <b>Note:</b> Only the <tt><optgroup></tt> and <tt><option></tt> tags are returned, so you still have to
       # wrap the output in an appropriate <tt><select></tt> tag.
       def grouped_options_for_select(grouped_options, selected_key = nil, options = {})
-        if options.is_a?(Hash)
-          prompt  = options[:prompt]
-          divider = options[:divider]
-        else
-          prompt  = options
-          message = "Passing the prompt to grouped_options_for_select as an argument is deprecated. " \
-                    "Please use an options hash like `{ prompt: #{prompt.inspect} }`."
-          ActiveSupport::Deprecation.warn message
-        end
+        prompt  = options[:prompt]
+        divider = options[:divider]
 
         body = "".html_safe
 

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -310,15 +310,6 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
-  def test_grouped_options_for_select_with_selected_and_prompt_deprecated
-    assert_deprecated 'Passing the prompt to grouped_options_for_select as an argument is deprecated. Please use an options hash like `{ prompt: "Choose a product..." }`.' do
-      assert_dom_equal(
-        "<option value=\"\">Choose a product...</option><optgroup label=\"Hats\"><option value=\"Baseball Cap\">Baseball Cap</option>\n<option selected=\"selected\" value=\"Cowboy Hat\">Cowboy Hat</option></optgroup>",
-        grouped_options_for_select([["Hats", ["Baseball Cap","Cowboy Hat"]]], "Cowboy Hat", "Choose a product...")
-      )
-    end
-  end
-
   def test_grouped_options_for_select_with_selected_and_prompt
     assert_dom_equal(
         "<option value=\"\">Choose a product...</option><optgroup label=\"Hats\"><option value=\"Baseball Cap\">Baseball Cap</option>\n<option selected=\"selected\" value=\"Cowboy Hat\">Cowboy Hat</option></optgroup>",
@@ -335,14 +326,6 @@ class FormOptionsHelperTest < ActionView::TestCase
 
   def test_grouped_options_for_select_returns_html_safe_string
     assert grouped_options_for_select([["Hats", ["Baseball Cap","Cowboy Hat"]]]).html_safe?
-  end
-
-  def test_grouped_options_for_select_with_prompt_returns_html_escaped_string_deprecated
-    ActiveSupport::Deprecation.silence do
-      assert_dom_equal(
-        "<option value=\"\">&lt;Choose One&gt;</option><optgroup label=\"Hats\"><option value=\"Baseball Cap\">Baseball Cap</option>\n<option value=\"Cowboy Hat\">Cowboy Hat</option></optgroup>",
-        grouped_options_for_select([["Hats", ["Baseball Cap","Cowboy Hat"]]], nil, '<Choose One>'))
-    end
   end
 
   def test_grouped_options_for_select_with_prompt_returns_html_escaped_string


### PR DESCRIPTION
I found passing the prompt to grouped_options_for_select as an argument was deprecated. So I tried to remove it.

The previous commit is 0e207a499f82c7aefabcddad04fc562df727e663 .
