### PR TITLE
Fetch value(s) from stringified options in tags that stringify options

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Pick `DateField` `DateTimeField` and `ColorField` values from stringified options allowing use of symbol keys with helpers.
+
+    *Jon Rowe*
+
 *   Remove the deprecated `prompt` argument from `grouped_options_for_select`,
     pass in a `:prompt` hash option to use this feature.
 

--- a/actionview/lib/action_view/helpers/tags/color_field.rb
+++ b/actionview/lib/action_view/helpers/tags/color_field.rb
@@ -4,7 +4,7 @@ module ActionView
       class ColorField < TextField # :nodoc:
         def render
           options = @options.stringify_keys
-          options["value"] = @options.fetch("value") { validate_color_string(value(object)) }
+          options["value"] = options.fetch("value") { validate_color_string(value(object)) }
           @options = options
           super
         end

--- a/actionview/lib/action_view/helpers/tags/datetime_field.rb
+++ b/actionview/lib/action_view/helpers/tags/datetime_field.rb
@@ -4,7 +4,7 @@ module ActionView
       class DatetimeField < TextField # :nodoc:
         def render
           options = @options.stringify_keys
-          options["value"] = @options.fetch("value") { format_date(value(object)) }
+          options["value"] = options.fetch("value") { format_date(value(object)) }
           options["min"] = format_date(options["min"])
           options["max"] = format_date(options["max"])
           @options = options

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -702,6 +702,11 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal(expected, color_field("car", "color"))
   end
 
+  def test_color_field_with_value_attr
+    expected = %{<input id="car_color" name="car[color]" type="color" value="#00FF00" />}
+    assert_dom_equal(expected, color_field("car", "color", value: "#00FF00"))
+  end
+
   def test_search_field
     expected = %{<input id="contact_notes_query" name="contact[notes_query]" type="search" />}
     assert_dom_equal(expected, search_field("contact", "notes_query"))
@@ -730,6 +735,12 @@ class FormHelperTest < ActionView::TestCase
     max_value = DateTime.new(2010, 8, 15)
     step = 2
     assert_dom_equal(expected, date_field("post", "written_on", min: min_value, max: max_value, step: step))
+  end
+
+  def test_date_field_with_value_attr
+    expected = %{<input id="post_written_on" name="post[written_on]" type="date" value="2013-06-29" />}
+    value = Date.new(2013,6,29)
+    assert_dom_equal(expected, date_field("post", "written_on", value: value))
   end
 
   def test_date_field_with_timewithzone_value
@@ -800,6 +811,12 @@ class FormHelperTest < ActionView::TestCase
     max_value = DateTime.new(2010, 8, 15, 10, 25, 00)
     step = 60
     assert_dom_equal(expected, datetime_field("post", "written_on", min: min_value, max: max_value, step: step))
+  end
+
+  def test_datetime_field_with_value_attr
+    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime" value="2013-06-29T13:37:00+00:00" />}
+    value = DateTime.new(2013,6,29,13,37)
+    assert_dom_equal(expected, datetime_field("post", "written_on", value: value))
   end
 
   def test_datetime_field_with_timewithzone_value


### PR DESCRIPTION
The `ColorField` `DateTimeField` and `DateField` tags all stringify their option keys before applying their own defaults but they attempt to use the original non-stringified @options to pick values, thus potentially overriding or missing user provided values (if you provide symbols etc)

Replicate-able by `<%= date_field_tag @object, :field, value: Date.today %>` but I couldn't see any tests for this sort of thing so didn't want to bloat the suite.
