### PR TITLE
Fixing encoding of non-string arrays

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -69,14 +69,18 @@ module ActiveRecord
 
         def array_to_string(value, column, adapter, should_be_quoted = false)
           casted_values = value.map do |val|
-            if String === val
-              if val == "NULL"
-                "\"#{val}\""
-              else
-                quote_and_escape(adapter.type_cast(val, column, true))
-              end
-            else
+            if val == "NULL"
+              "\"#{val}\""
+            elsif Array === val # Special handling of multidimensional arrays
               adapter.type_cast(val, column, true)
+            else
+              casted_val = adapter.type_cast(val, column, true)
+
+              if String === casted_val
+                quote_and_escape(casted_val)
+              else
+                casted_val
+              end
             end
           end
           "{#{casted_values.join(',')}}"

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -13,6 +13,7 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
       @connection.transaction do
         @connection.create_table('pg_arrays') do |t|
           t.string 'tags', :array => true
+          t.integer 'ints', :array => true
         end
       end
     @column = PgArray.columns.find { |c| c.name == 'tags' }
@@ -85,6 +86,19 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
     tag_values = ["val1", "val2", "val3_with_'_multiple_quote_'_chars"]
     @connection.insert_fixture({"tags" => tag_values}, "pg_arrays" )
     assert_equal(PgArray.last.tags, tag_values)
+  end
+
+  def test_insert_fixture_int_array
+    int_values = [1,2,4,6]
+    @connection.insert_fixture({"ints" => int_values}, "pg_arrays" )
+    assert_equal(PgArray.last.ints, int_values)
+  end
+
+  def test_insert_fixture_int_array_from_strings
+    int_values = [1,2,4,6]
+    int_values_for_insert = ['1','2','4','6']
+    @connection.insert_fixture({"ints" => int_values_for_insert}, "pg_arrays" )
+    assert_equal(PgArray.last.ints, int_values)
   end
 
   private


### PR DESCRIPTION
When array of non-string values assigned from array of strings (controller params, for example) it blows up with <tt>NoMethodError: undefined method `gsub'</tt> in <tt>quote_and_escape</tt>

It's because of <tt>quote_and_escape</tt> is called for values, which are strings before cast, while after casting it may become something other than string.

This patch fixes it, by calling <tt>quote_and_escape</tt> for values, which are strings after cast, not before.
