### PR TITLE
ActiveRecord find_in_batches should work without logger

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -78,8 +78,8 @@ module ActiveRecord
 
       relation = self
 
-      unless arel.orders.blank? && arel.taken.blank?
-        ActiveRecord::Base.logger.warn("Scoped order and limit are ignored, it's forced to be batch order and batch size")
+      if logger && (arel.orders.present? || arel.taken.present?)
+        logger.warn("Scoped order and limit are ignored, it's forced to be batch order and batch size")
       end
 
       start = options.delete(:start)

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -50,6 +50,16 @@ class EachTest < ActiveRecord::TestCase
     Post.order("title").find_each { |post| post }
   end
 
+  def test_logger_not_required
+    previous_logger = ActiveRecord::Base.logger
+    ActiveRecord::Base.logger = nil
+    assert_nothing_raised do
+      Post.limit(1).find_each { |post| post }
+    end
+  ensure
+    ActiveRecord::Base.logger = previous_logger
+  end
+
   def test_find_in_batches_should_return_batches
     assert_queries(@total + 1) do
       Post.find_in_batches(:batch_size => 1) do |batch|


### PR DESCRIPTION
When I set logger to `nil` both methods from `Batches` module `find_in_batches` or `find_each` should work anyway.
