### PR TITLE
Omit turbolinks configuration completely on skip_javascript generator option

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Omit turbolinks configuration completely on skip_javascript generator option.
+
+    *Nikita Fedyashev*
+
 *   Removed deprecated rake tasks for running tests: `rake test:uncommitted` and
     `rake test:recent`.
 

--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -2,8 +2,13 @@
 <html>
 <head>
   <title><%= camelized %></title>
+  <%- if options[:skip_javascript] -%>
+  <%%= stylesheet_link_tag    "application", media: "all" %>
+  <%%= javascript_include_tag "application" %>
+  <%- else -%>
   <%%= stylesheet_link_tag    "application", media: "all", "data-turbolinks-track" => true %>
   <%%= javascript_include_tag "application", "data-turbolinks-track" => true %>
+  <%- end -%>
   <%%= csrf_meta_tags %>
 </head>
 <body>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -53,9 +53,10 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_assets
     run_generator
-    assert_file "app/views/layouts/application.html.erb", /stylesheet_link_tag\s+"application"/
-    assert_file "app/views/layouts/application.html.erb", /javascript_include_tag\s+"application"/
-    assert_file "app/assets/stylesheets/application.css"
+
+    assert_file("app/views/layouts/application.html.erb", /stylesheet_link_tag\s+"application", media: "all", "data-turbolinks-track" => true/)
+    assert_file("app/views/layouts/application.html.erb", /javascript_include_tag\s+"application", "data-turbolinks-track" => true/)
+    assert_file("app/assets/stylesheets/application.css")
   end
 
   def test_invalid_application_name_raises_an_error
@@ -294,6 +295,10 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator [destination_root, "--skip-javascript"]
     assert_file "app/assets/javascripts/application.js" do |contents|
       assert_no_match %r{^//=\s+require\s}, contents
+    end
+    assert_file "app/views/layouts/application.html.erb" do |contents|
+      assert_match(/stylesheet_link_tag\s+"application", media: "all" %>/, contents)
+      assert_match(/javascript_include_tag\s+"application" \%>/, contents)
     end
     assert_file "Gemfile" do |content|
       assert_match(/coffee-rails/, content)


### PR DESCRIPTION
before this commit, when you generate new rails app with `--skip-javascript` option `turbolinks` gem is removed from Gemfile(<a href="https://github.com/rails/rails/blob/55193e449a377c448e43d8fec42899ea1ff93b27/railties/lib/rails/generators/app_base.rb#L236">see app_base.rb</a>) but in `data-turbolinks-track` configuration options are always present in generated application layout.

I've installed rails/railties manually and tried to verify formatting:

```
rails new demoapp --skip-bundle . ; cat demoapp/app/views/layouts/application.html.erb
<!DOCTYPE html><html>
<head>
  <title>DemoApp</title>
  <%= stylesheet_link_tag    "application", media: "all", "data-turbolinks-track" => true %>
  <%= javascript_include_tag "application", "data-turbolinks-track" => true %>
  <%= csrf_meta_tags %>
</head>
<body>

<%= yield %>

</body>
</html>
```

which seems to be ok.
