### PR TITLE
Callable route constraint verification

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Added verification of route constraints given as a Proc or an object responding
+    to `:matches?`.  Previously, when given an non-complying object, it would just
+    silently fail to enforce the constraint.  It will now raise an ArgumentError
+    when setting up the routes.
+
+    *Xavier Defrang*
+
 *   Fix `Mime::Type.parse` when bad accepts header is looked up. Previously it
     was setting `request.formats` with an array containing a `nil` value, which
     raised an error when setting the controller formats.

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -156,6 +156,8 @@ module ActionDispatch
                 next unless URL_OPTIONS.include?(key) && (String === default || Fixnum === default)
                 @defaults[key] ||= default
               end
+            elsif options[:constraints]
+              verify_callable_constraint(options[:constraints])
             end
 
             if Regexp === options[:format]
@@ -163,6 +165,11 @@ module ActionDispatch
             elsif String === options[:format]
               @defaults[:format] = options[:format]
             end
+          end
+
+          def verify_callable_constraint(callable_constraint)
+            return if callable_constraint.respond_to?(:call) || callable_constraint.respond_to?(:matches?)
+            raise ArgumentError, "Invalid constraint: #{callable_constraint.inspect} must respond to :call or :matches?"
           end
 
           def normalize_conditions!

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3593,6 +3593,21 @@ class TestFormatConstraints < ActionDispatch::IntegrationTest
   end
 end
 
+class TestCallableConstraintValidation < ActionDispatch::IntegrationTest
+
+  def test_constraint_with_object_not_callable
+    assert_raise(ArgumentError) do
+      ActionDispatch::Routing::RouteSet.new.tap do |app|
+        app.draw do
+          ok = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, []] }
+          get '/test', to: ok, constraints: Object.new
+        end
+      end
+    end
+  end
+
+end
+
 class TestRouteDefaults < ActionDispatch::IntegrationTest
   stub_controllers do |routes|
     Routes = routes


### PR DESCRIPTION
#### Current situation

When passing an object (other than a hash) as a routing constraint, it must either respond to `:call` or `:matches?`.

If a non-complying object is provided, the routing configuration is processed but Rails silently fails to enforce the constraint.
#### Improvement

This patch verifies that the given constraint object responds to the expected messages and raises an `ArgumentError` at configuration time.
