### PR TITLE
Module#delegate cannot delegate to receivers named :args or :block for normal methods or :arg for setters.

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -155,11 +155,15 @@ class Module
     file, line = caller.first.split(':', 2)
     line = line.to_i
 
+    translations = {
+      'class' => 'self.class',
+      'block' => 'self.block',
+      'args' => 'self.args',
+      'arg' => 'self.arg'
+    }
+
     to = to.to_s
-    to = 'self.class' if to == 'class'
-    to = 'self.block' if to == 'block'
-    to = 'self.args' if to == 'args'
-    to = 'self.arg' if to == 'arg'
+    to = translations[to] || to
 
     methods.each do |method|
       # Attribute writer methods only accept one argument. Makes sure []=

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -157,6 +157,9 @@ class Module
 
     to = to.to_s
     to = 'self.class' if to == 'class'
+    to = 'self.block' if to == 'block'
+    to = 'self.args' if to == 'args'
+    to = 'self.arg' if to == 'arg'
 
     methods.each do |method|
       # Attribute writer methods only accept one argument. Makes sure []=

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -59,9 +59,7 @@ class Someone < Struct.new(:name, :place)
 
   delegate :setter=, to: :arg
   def arg
-    @arg ||= Class.new do
-      attr_writer :setter
-    end.new
+    @arg ||= Struct.new(:setter).new
   end
 end
 

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -47,27 +47,17 @@ class Someone < Struct.new(:name, :place)
   FAILED_DELEGATE_LINE_2 = __LINE__ + 1
   delegate :bar, :to => :place, :allow_nil => true
 
-  delegate :from_block, :to => :block
-
+  delegate :from_block, to: :block
   def block
-    @block ||= Class.new do
-      def from_block
-        'from_block'
-      end
-    end.new
+    @block ||= Struct.new(:from_block).new('from_block')
   end
 
-  delegate :from_args, :to => :args
-
+  delegate :from_args, to: :args
   def args
-    @args ||= Class.new do
-      def from_args
-        'from_args'
-      end
-    end.new
+    @args ||= Struct.new(:from_args).new('from_args')
   end
 
-  delegate :setter=, :to => :arg
+  delegate :setter=, to: :arg
   def arg
     @arg ||= Class.new do
       attr_writer :setter

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -46,6 +46,33 @@ class Someone < Struct.new(:name, :place)
 
   FAILED_DELEGATE_LINE_2 = __LINE__ + 1
   delegate :bar, :to => :place, :allow_nil => true
+
+  delegate :from_block, :to => :block
+
+  def block
+    @block ||= Class.new do
+      def from_block
+        'from_block'
+      end
+    end.new
+  end
+
+  delegate :from_args, :to => :args
+
+  def args
+    @args ||= Class.new do
+      def from_args
+        'from_args'
+      end
+    end.new
+  end
+
+  delegate :setter=, :to => :arg
+  def arg
+    @arg ||= Class.new do
+      attr_writer :setter
+    end.new
+  end
 end
 
 Invoice   = Struct.new(:client) do
@@ -135,6 +162,12 @@ class ModuleTest < ActiveSupport::TestCase
   def test_delegation_to_class_method
     assert_equal 'some_table', @david.table_name
     assert_equal 'some_table', @david.class_table_name
+  end
+
+  def test_delegation_to_dynamic_method_arg_names
+    assert_equal 'from_block', @david.from_block
+    assert_equal 'from_args', @david.from_args
+    assert_equal 10, @david.setter = 10
   end
 
   def test_missing_delegation_target


### PR DESCRIPTION
I found this bug while trying to delegate to a method called `block`. Consider the following code:

``` ruby
require 'active_support/core_ext'

class Foo
  def block
    @block ||= Object.new
  end  

  delegate :dup, to: :block
end  

Foo.new.dup
```

I expected this to return a new instance of `Object`, but instead it raised the following error:

```
TypeError: can't dup NilClass
```

This is because `block` is an argument in the dynamically generated `dup` method on `Foo`. The signature of that method looks like this:

``` ruby
class Foo
  def dup(*args, &block)
    # ...
  end
end
```

No block is given to the `dup` call, so `block` is nil, thus the error. The same problem exists with delegating to `args` and delegating to `arg` if the method you're delegating happens to be an attribute writer.

I'm not super thrilled with how the tests turned out and would appreciate suggestions on how to make them a bit clearer and possibly shorter, but they fail without the patch and pass with it.

Please let me know if there's anything I should have done differently.
