### PR TITLE
Stop sending column info to `substitute_at` as it doesn't get utilized.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -307,8 +307,8 @@ module ActiveRecord
 
       # QUOTING ==================================================
 
-      # Returns a bind substitution value given a +column+ and list of current
-      # +binds+.
+      # Returns a bind substitution value given a bind +index+ and +column+
+      # NOTE: The column param is currently being used by the sqlserver-adapter
       def substitute_at(column, index)
         Arel::Nodes::BindParam.new '?'
       end


### PR DESCRIPTION
Stop sending column info to `substitute_at` as it doesn't get utilized.
