### PR TITLE
Fix `rails plugin --help`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `rails plugin --help` command.
+
+    *Richard Schneeman*
+
 *   Omit turbolinks configuration completely on skip_javascript generator option.
 
     *Nikita Fedyashev*

--- a/railties/lib/rails/commands.rb
+++ b/railties/lib/rails/commands.rb
@@ -35,19 +35,17 @@ command = ARGV.shift
 command = aliases[command] || command
 
 case command
-when 'generate', 'destroy', 'plugin'
+when 'plugin'
+  require "rails/commands/plugin_new"
+when 'generate', 'destroy'
   require 'rails/generators'
 
-  if command == 'plugin' && ARGV.first == 'new'
-    require "rails/commands/plugin_new"
-  else
-    require APP_PATH
-    Rails.application.require_environment!
+  require APP_PATH
+  Rails.application.require_environment!
 
-    Rails.application.load_generators
+  Rails.application.load_generators
 
-    require "rails/commands/#{command}"
-  end
+  require "rails/commands/#{command}"
 
 when 'console'
   require 'rails/commands/console'


### PR DESCRIPTION
Right now if you run the `rails plugin --help` command it fails because rails expects a command in `railties/lib/rails/commands/plugin.rb` that does not exist because the file is named `plugin_new`. This is the error:

``` ruby
ruby-2.0.0-p0  ~/documents/projects/tmp/vanilla (master)
$ rails plugin --help
/Users/schneems/.rvm/gems/ruby-2.0.0-p0/gems/activesupport-4.0.0/lib/active_support/dependencies.rb:228:in `require': cannot load such file -- rails/commands/plugin (LoadError)
    from /Users/schneems/.rvm/gems/ruby-2.0.0-p0/gems/activesupport-4.0.0/lib/active_support/dependencies.rb:228:in `block in require'
    from /Users/schneems/.rvm/gems/ruby-2.0.0-p0/gems/activesupport-4.0.0/lib/active_support/dependencies.rb:213:in `load_dependency'
    from /Users/schneems/.rvm/gems/ruby-2.0.0-p0/gems/activesupport-4.0.0/lib/active_support/dependencies.rb:228:in `require'
    from /Users/schneems/.rvm/gems/ruby-2.0.0-p0/gems/railties-4.0.0/lib/rails/commands.rb:49:in `<top (required)>'
    from bin/rails:4:in `require'
    from bin/rails:4:in `<main>'
```

Now when the `plugin` file is required it will defer to the `plugin_new` file.
