### PR TITLE
provide a more sementic local variables name in ActiveModel::Validation::Clusivity

### DIFF
--- a/activemodel/lib/active_model/validations/clusivity.rb
+++ b/activemodel/lib/active_model/validations/clusivity.rb
@@ -15,15 +15,15 @@ module ActiveModel
     private
 
       def include?(record, value)
-        exclusions = if delimiter.respond_to?(:call)
-                       delimiter.call(record)
-                     elsif delimiter.respond_to?(:to_sym)
-                       record.send(delimiter)
-                     else
-                       delimiter
-                     end
+        members = if delimiter.respond_to?(:call)
+                    delimiter.call(record)
+                  elsif delimiter.respond_to?(:to_sym)
+                    record.send(delimiter)
+                  else
+                    delimiter
+                  end
 
-        exclusions.send(inclusion_method(exclusions), value)
+        members.send(inclusion_method(members), value)
       end
 
       def delimiter


### PR DESCRIPTION
The original local variable name `exclusion` is a bit confusing when using with the method `inclusion_method`

Rename it to a more logic neutral name
