### PR TITLE
Store a symbol directly inside DISPATCH_CACHE for additional roflscale

### DIFF
--- a/actionpack/lib/action_dispatch/journey/visitors.rb
+++ b/actionpack/lib/action_dispatch/journey/visitors.rb
@@ -4,7 +4,7 @@ module ActionDispatch
     module Visitors # :nodoc:
       class Visitor # :nodoc:
         DISPATCH_CACHE = Hash.new { |h,k|
-          h[k] = "visit_#{k}"
+          h[k] = :"visit_#{k}"
         }
 
         def accept(node)


### PR DESCRIPTION
`ActionDispatch::Journey::Visitors:Visitor::DISPATCH_CACHE` is used to cache visitor method names for performance reasons.

This pull request changes the hash's default proc so the hash directly stores method names as symbols. This avoids the extra hashtable lookup to convert the string into a symbol when it's passed into `send` on line 17.
