### PR TITLE
Instance variables are now serialized to YAML

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -333,4 +333,10 @@
 
     *Slava Markevich*
 
+*   Instance variables are now correctly serialized to YAML.
+
+    Fixed GH#11035
+
+    *Ryan Endacott*
+
 Please check [4-0-stable](https://github.com/rails/rails/blob/4-0-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -212,6 +212,12 @@ module ActiveRecord
 
       @new_record = false
 
+      if coder['instance_variables']
+        coder['instance_variables'].each do |name, value|
+          instance_variable_set(name, value)
+        end
+      end
+
       run_callbacks :find
       run_callbacks :initialize
 
@@ -281,6 +287,10 @@ module ActiveRecord
     #   coder # => {"attributes" => {"id" => nil, ... }}
     def encode_with(coder)
       coder['attributes'] = attributes
+      coder['instance_variables'] = {}
+      (instance_variables - [:@attributes, :@columns_hash]).each do |variable|
+        coder['instance_variables'][variable] = instance_variable_get(variable)
+      end
     end
 
     # Returns true if +comparison_object+ is the same exact object, or +comparison_object+

--- a/activerecord/test/cases/yaml_serialization_test.rb
+++ b/activerecord/test/cases/yaml_serialization_test.rb
@@ -33,7 +33,16 @@ class YamlSerializationTest < ActiveRecord::TestCase
     topic = Topic.first
     coder = {}
     topic.encode_with coder
-    assert_equal({'attributes' => topic.attributes}, coder)
+
+    instance_variables = {}
+    (topic.instance_variables - [:@attributes, :@columns_hash]).each do |variable|
+        instance_variables[variable] = topic.instance_variable_get(variable)
+    end
+
+    assert_equal({
+      'attributes' => topic.attributes,
+      'instance_variables' => instance_variables
+      }, coder)
   end
 
   def test_psych_roundtrip
@@ -48,5 +57,11 @@ class YamlSerializationTest < ActiveRecord::TestCase
     assert topic
     t = Psych.load Psych.dump topic
     assert_equal topic.attributes, t.attributes
+  end
+
+  def test_saved_instance_variables
+    topic = Topic.new
+    t = YAML.load(topic.to_yaml)
+    assert_equal topic.new_record?, t.new_record?
   end
 end


### PR DESCRIPTION
Fixes #11035
Instance variables were not being serialized to YAML.
Ex:

``` ruby
YAML.load(Topic.new.to_yaml).new_record?
```

This previously returned false, and it now correctly returns true.

To solve this issue, it looked like the instance variables could either be saved or recalculated.  Some (`@readonly`) can't always be recalculated, so they would be lost.  So I opted to save the instance variables.

`Core#encode_with` now saves instance variables (except for `@attributes` and `@column_hash`, because I believe those were already handled).  `Core#init_with` was changed to check if `coder['instance_variables']` exists, and loads the instance variables if it does.  I did this to keep backwards compatibility, because it looks like `init_with` is used for more than just deserializing from YAML.  This is my first attempt at a pull request, so I apologize if anything is incorrect.  I also feel like there may be a more elegant solution, but I'm not sure how much `Persistence#instantiate` depends on the current definition of `init_with` so I didn't make any breaking changes.  Please let me know if there's a better way, and I'll get to implementing it!  Thanks! :-)
