### PR TITLE
rename ActiveSupport::Callbacks::Callback#merge to inverse_cond_merge

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -355,7 +355,7 @@ module ActiveSupport
       def filter; @key; end
       def raw_filter; @filter; end
 
-      def merge(chain, new_options)
+      def inverse_cond_merge(chain, new_options)
         options = {
           :if     => @if.dup,
           :unless => @unless.dup
@@ -626,7 +626,7 @@ module ActiveSupport
             filter = chain.find {|c| c.matches?(type, filter) }
 
             if filter && options.any?
-              new_filter = filter.merge(chain, options)
+              new_filter = filter.inverse_cond_merge(chain, options)
               chain.insert(chain.index(filter), new_filter)
             end
 


### PR DESCRIPTION
the `merge` in the context doesn't following the normal `merge` logic for an hash object.
The name is counter-intuitive to understand the behavior.
It in fact inverses the conditions before merge all the options, name if `inverse_conf_merge` to provide a good summary about how it works.
