### PR TITLE
UniquenessValidator will respect default scopes

### DIFF
--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -18,7 +18,7 @@ module ActiveRecord
         relation = build_relation(finder_class, table, attribute, value)
         relation = relation.and(table[finder_class.primary_key.to_sym].not_eq(record.id)) if record.persisted?
         relation = scope_relation(record, table, relation)
-        relation = finder_class.unscoped.where(relation)
+        relation = finder_class.unscoped.default_scoped.where(relation)
         relation = relation.merge(options[:conditions]) if options[:conditions]
 
         if relation.exists?

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -5,6 +5,7 @@ require 'models/reply'
 require 'models/warehouse_thing'
 require 'models/guid'
 require 'models/event'
+require 'models/reference'
 
 class Wizard < ActiveRecord::Base
   self.abstract_class = true
@@ -291,6 +292,13 @@ class UniquenessValidationTest < ActiveRecord::TestCase
       t2 = Topic.new("title" => "I'm unique!", "author_name" => "David")
       assert !t2.valid?
     end
+  end
+
+  def test_validates_uniqueness_respects_default_scoping
+    BadReference.validates_uniqueness_of(:lock_version)
+    BadReference.create(favourite: true, lock_version: 1234)
+    bad_reference = BadReference.new(favourite: false, lock_version: 1234)
+    assert bad_reference.valid?
   end
 
   def test_validate_uniqueness_with_columns_which_are_sql_keywords


### PR DESCRIPTION
Currently all default scopes are removed. If a developer is explicitly adding a default scope to a model class this scoping should be respected when checking for uniqueness.
