### PR TITLE
Adding find_by in guide to methods that trigger after_find

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -167,6 +167,7 @@ Additionally, the `after_find` callback is triggered by the following finder met
 * `all`
 * `first`
 * `find`
+* `find_by`
 * `find_by_*`
 * `find_by_*!`
 * `find_by_sql`


### PR DESCRIPTION
In the guide, `find_by` is not listed as one of the methods that triggers `after_find`.
