### PR TITLE
enable memcached session store support for domain: :all config credit go...

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/session/mem_cache_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/mem_cache_store.rb
@@ -17,6 +17,13 @@ module ActionDispatch
         options[:expire_after] ||= options[:expires]
         super
       end
+
+      private
+
+      def set_cookie(env, session_id, cookie)
+        request = ActionDispatch::Request.new(env)
+        request.cookie_jar[key] = cookie
+      end
     end
   end
 end


### PR DESCRIPTION
``` ruby
# All credit to https://github.com/rails/rails/pull/6084

# config/application.rb

# bundler and require stuff
module MyApp
  class Application < Rails::Application
     # config stuff

     # enable magic domain: :all support
     config.session_store :mem_cache_store, domain: :all
  end
end
```

Could core team help to put in a test case for this.
