### PR TITLE
Add a generator for ActiveModel validators

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -890,7 +890,8 @@ write your own validators or validation methods as you prefer.
 
 Custom validators are classes that extend `ActiveModel::Validator`. These
 classes must implement a `validate` method which takes a record as an argument
-and performs the validation on it. The custom validator is called using the
+and performs the validation on it. You can generate a new validator invoking
+the `rails generate validator` command. The custom validator is called using the
 `validates_with` method.
 
 ```ruby

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add a generator for ActiveModel validators
+
+    Add a new command to generate ActiveModel validators. It will simply create
+    a file under `app/validators` and also a test file (under `test/validators`).
+    It's also possible to pass a `--each` option to generate an `EachValidator`
+    instead of a simple `Validator`.
+
+    Like any other generator, this command allows namespacing.
+
+    *Robin Dupret*
+
 *   Fix `rails plugin --help` command.
 
     *Richard Schneeman*

--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -178,6 +178,7 @@ module Rails
           "#{test}:model",
           "#{test}:scaffold",
           "#{test}:view",
+          "#{test}:validator",
           "#{template}:controller",
           "#{template}:scaffold",
           "#{template}:mailer",

--- a/railties/lib/rails/generators/rails/validator/USAGE
+++ b/railties/lib/rails/generators/rails/validator/USAGE
@@ -1,0 +1,19 @@
+Description:
+    Create a new ActiveModel validator. Pass the validator name
+    either CamelCased or under_scored.
+
+    You can also, optionally, pass a --each option to generate a new
+    ActiveModel::EachValidator instead of a simple validator.
+
+    If you pass a namespaced name (e.g. user/email or User::Email)
+    then the generator will put the generated file under a folder with
+    the namespace's name and put the validator class under a module.
+
+Example:
+    `rails generate validator Email`
+
+      With TestUnit as your testing framework, it will generate
+      the following files:
+
+        Validator:  app/validators/email_validator.rb
+        Test:       test/validators/email_validator_test.rb

--- a/railties/lib/rails/generators/rails/validator/templates/each_validator.rb
+++ b/railties/lib/rails/generators/rails/validator/templates/each_validator.rb
@@ -1,0 +1,6 @@
+<% module_namespacing do -%>
+class <%= class_name %>Validator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+  end
+end
+<% end -%>

--- a/railties/lib/rails/generators/rails/validator/templates/validator.rb
+++ b/railties/lib/rails/generators/rails/validator/templates/validator.rb
@@ -1,0 +1,6 @@
+<% module_namespacing do -%>
+class <%= class_name %>Validator < ActiveModel::Validator
+  def validate(record)
+  end
+end
+<% end -%>

--- a/railties/lib/rails/generators/rails/validator/validator_generator.rb
+++ b/railties/lib/rails/generators/rails/validator/validator_generator.rb
@@ -1,0 +1,17 @@
+module Rails
+  module Generators
+    class ValidatorGenerator < NamedBase # :nodoc:
+      check_class_collision
+
+      class_option :each, type: :boolean, default: false,
+                          desc: "Generate ActiveModel::EachValidator"
+
+      def create_validator_file
+        template_name = (options[:each]) ? "each_validator" : "validator"
+        template "#{template_name}.rb", File.join('app/validators', class_path, "#{file_name}_validator.rb")
+      end
+
+      hook_for :test_framework
+    end
+  end
+end

--- a/railties/lib/rails/generators/test_unit/validator/templates/validator_test.rb
+++ b/railties/lib/rails/generators/test_unit/validator/templates/validator_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+<% module_namespacing do -%>
+class <%= class_name %>Test < ActiveModel::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end
+<% end -%>

--- a/railties/lib/rails/generators/test_unit/validator/validator_generator.rb
+++ b/railties/lib/rails/generators/test_unit/validator/validator_generator.rb
@@ -1,0 +1,13 @@
+require 'rails/generators/test_unit'
+
+module TestUnit
+  module Generators
+    class ValidatorGenerator < Base # :nodoc:
+      check_class_collision suffix: "Test"
+
+      def create_test_file
+        template 'validator_test.rb', File.join('test/validators', class_path, "#{file_name}_validator_test.rb")
+      end
+    end
+  end
+end

--- a/railties/test/generators/validator_generator_test.rb
+++ b/railties/test/generators/validator_generator_test.rb
@@ -1,0 +1,30 @@
+require 'generators/generators_test_helper'
+require 'rails/generators/rails/validator/validator_generator'
+
+class ValidatorGeneratorTest < Rails::Generators::TestCase
+  include GeneratorsTestHelper
+
+  def test_validator
+    run_generator ["Email"]
+    assert_file "app/validators/email_validator.rb", /ActiveModel::Validator/
+    assert_file "test/validators/email_validator_test.rb"
+  end
+
+  def test_with_each_option
+    run_generator ["Email", "--each"]
+    assert_file "app/validators/email_validator.rb", /ActiveModel::EachValidator/
+    assert_file "test/validators/email_validator_test.rb"
+  end
+
+  def test_namespace
+    run_generator ["admin/email"]
+    assert_file "app/validators/admin/email_validator.rb", /class Admin::EmailValidator/
+    assert_file "test/validators/admin/email_validator_test.rb"
+  end
+
+  def test_namespace_with_each
+    run_generator ["foo/bar", "--each"]
+    assert_file "app/validators/foo/bar_validator.rb", /class Foo::BarValidator < ActiveModel::EachValidator/
+    assert_file "test/validators/foo/bar_validator_test.rb"
+  end
+end


### PR DESCRIPTION
Hello,

This pull request adds a new command to generate ActiveModel validators. It will simply generate a file under `app/validators` and also a test file (under `test/validators`). It is also possible to pass a `--each` option to generate an `EachValidator` instead of a simple validator.

Like any other generator, this command allows namespacing.

Have a nice day.
