### PR TITLE
has_one through has_one does not save association

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -384,7 +384,7 @@ module ActiveRecord
           record.destroy
         else
           key = reflection.options[:primary_key] ? send(reflection.options[:primary_key]) : id
-          if autosave != false && (new_record? || record.new_record? || record[reflection.foreign_key] != key || autosave)
+          if autosave != false && (new_record? || record.new_record? || record[reflection.foreign_key] != key && !reflection.through_reflection || autosave)
             unless reflection.through_reflection
               record[reflection.foreign_key] = key
             end

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -314,4 +314,11 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
   def test_has_one_through_with_custom_select_on_join_model_default_scope
     assert_equal clubs(:boring_club), members(:groucho).selected_club
   end
+
+  def test_saving_record_does_not_save_has_one_through_has_one_association
+    Club.before_save lambda { self.name='callback' }
+    @member.club
+    @member.save
+    assert_not_equal 'callback', @member.club.name
+  end
 end


### PR DESCRIPTION
Fixes issue #9336

Has-one-through-has-one is incorrectly triggering unnecessary saves on the grandparent relationship. Fixes a save check that is always true for this type of relationship.
