### PR TITLE
Removed deprecated methods partial_updates and family

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Removed deprecated methods `partial_updates`, `partial_updates?` and
+    `partial_updates=`.
+
+    *Neeraj Singh*
+
 *   Removed deprecated method `scoped`
 
     *Neeraj Singh*

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -14,17 +14,6 @@ module ActiveRecord
 
         class_attribute :partial_writes, instance_writer: false
         self.partial_writes = true
-
-        def self.partial_updates=(v); self.partial_writes = v; end
-        def self.partial_updates?; partial_writes?; end
-        def self.partial_updates; partial_writes; end
-
-        ActiveSupport::Deprecation.deprecate_methods(
-          singleton_class,
-          :partial_updates= => :partial_writes=,
-          :partial_updates? => :partial_writes?,
-          :partial_updates  => :partial_writes
-        )
       end
 
       # Attempts to +save+ the record and clears changed attributes if successful.

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -608,20 +608,6 @@ class DirtyTest < ActiveRecord::TestCase
     end
   end
 
-  test "partial_updates config attribute is deprecated" do
-    klass = Class.new(ActiveRecord::Base)
-
-    assert klass.partial_writes?
-    assert_deprecated { assert klass.partial_updates? }
-    assert_deprecated { assert klass.partial_updates  }
-
-    assert_deprecated { klass.partial_updates = false }
-
-    assert !klass.partial_writes?
-    assert_deprecated { assert !klass.partial_updates? }
-    assert_deprecated { assert !klass.partial_updates  }
-  end
-
   private
     def with_partial_writes(klass, on = true)
       old = klass.partial_writes?


### PR DESCRIPTION
Removed deprecated methods `partial_updates`, `partial_updates?` and
`partial_updates=`
