### PR TITLE
Removed deprecated options for assocations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Removed deprecated options `delete_sql` and `insert_sql` from HABTM
+    association.
+
+    Removed deprecated options `finder_sql` and `counter_sql` from
+    collection association.
+
+    *Neeraj Singh*
+
 *   Remove deprecated `ActiveRecord::Base#connection` method.
     Make sure to access it via the class.
 

--- a/activerecord/lib/active_record/associations/builder/collection_association.rb
+++ b/activerecord/lib/active_record/associations/builder/collection_association.rb
@@ -20,7 +20,6 @@ module ActiveRecord::Associations::Builder
     end
 
     def build
-      show_deprecation_warnings
       wrap_block_extension
       reflection = super
       CALLBACKS.each { |callback_name| define_callback(callback_name) }
@@ -29,14 +28,6 @@ module ActiveRecord::Associations::Builder
 
     def writable?
       true
-    end
-
-    def show_deprecation_warnings
-      [:finder_sql, :counter_sql].each do |name|
-        if options.include? name
-          ActiveSupport::Deprecation.warn("The :#{name} association option is deprecated. Please find an alternative (such as using scopes).")
-        end
-      end
     end
 
     def wrap_block_extension

--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -14,16 +14,6 @@ module ActiveRecord::Associations::Builder
       reflection
     end
 
-    def show_deprecation_warnings
-      super
-
-      [:delete_sql, :insert_sql].each do |name|
-        if options.include? name
-          ActiveSupport::Deprecation.warn("The :#{name} association option is deprecated. Please find an alternative (such as using has_many :through).")
-        end
-      end
-    end
-
     def define_destroy_hook
       name = self.name
       model.send(:include, Module.new {

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -845,18 +845,6 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert project.developers.include?(developer)
   end
 
-  test ":insert_sql is deprecated" do
-    klass = Class.new(ActiveRecord::Base)
-    def klass.name; 'Foo'; end
-    assert_deprecated { klass.has_and_belongs_to_many :posts, :insert_sql => 'lol' }
-  end
-
-  test ":delete_sql is deprecated" do
-    klass = Class.new(ActiveRecord::Base)
-    def klass.name; 'Foo'; end
-    assert_deprecated { klass.has_and_belongs_to_many :posts, :delete_sql => 'lol' }
-  end
-
   test "has and belongs to many associations on new records use null relations" do
     projects = Developer.new.projects
     assert_no_queries do

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1774,16 +1774,6 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     end
   end
 
-  test ":finder_sql is deprecated" do
-    klass = Class.new(ActiveRecord::Base)
-    assert_deprecated { klass.has_many :foo, :finder_sql => 'lol' }
-  end
-
-  test ":counter_sql is deprecated" do
-    klass = Class.new(ActiveRecord::Base)
-    assert_deprecated { klass.has_many :foo, :counter_sql => 'lol' }
-  end
-
   test "has many associations on new records use null relations" do
     post = Post.new
 


### PR DESCRIPTION
Deprecated options `delete_sql`, `insert_sql`, `finder_sql` and `counter_sql`
have been deleted.
