### PR TITLE
remove deprecated `assert_present` and `assert_blank`.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove deprecated `assert_present` and `assert_blank` methods.
+
+    *Yves Senn*
+
 *   Fix return value from `BacktraceCleaner#noise` when the cleaner is configured
     with multiple silencers.
 

--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -92,36 +92,6 @@ module ActiveSupport
       def assert_no_difference(expression, message = nil, &block)
         assert_difference expression, 0, message, &block
       end
-
-      # Test if an expression is blank. Passes if <tt>object.blank?</tt>
-      # is +true+.
-      #
-      #   assert_blank []   # => true
-      #   assert_blank [[]] # => [[]] is not blank
-      #
-      # An error message can be specified.
-      #
-      #   assert_blank [], 'this should be blank'
-      def assert_blank(object, message=nil)
-        ActiveSupport::Deprecation.warn('"assert_blank" is deprecated. Please use "assert object.blank?" instead')
-        message ||= "#{object.inspect} is not blank"
-        assert object.blank?, message
-      end
-
-      # Test if an expression is not blank. Passes if <tt>object.present?</tt>
-      # is +true+.
-      #
-      #   assert_present({ data: 'x' }) # => true
-      #   assert_present({})            # => {} is blank
-      #
-      # An error message can be specified.
-      #
-      #   assert_present({ data: 'x' }, 'this should not be blank')
-      def assert_present(object, message=nil)
-        ActiveSupport::Deprecation.warn('"assert_present" is deprecated. Please use "assert object.present?" instead')
-        message ||= "#{object.inspect} is blank"
-        assert object.present?, message
-      end
     end
   end
 end

--- a/activesupport/test/test_test.rb
+++ b/activesupport/test/test_test.rb
@@ -87,54 +87,6 @@ class AssertDifferenceTest < ActiveSupport::TestCase
   end
 end
 
-class AssertBlankTest < ActiveSupport::TestCase
-  BLANK = [ EmptyTrue.new, nil, false, '', '   ', "  \n\t  \r ", [], {} ]
-  NOT_BLANK = [ EmptyFalse.new, Object.new, true, 0, 1, 'x', [nil], { nil => 0 } ]
-
-  def test_assert_blank_true
-    BLANK.each { |value|
-      assert_deprecated { assert_blank value }
-    }
-  end
-
-  def test_assert_blank_false
-    NOT_BLANK.each { |v|
-      assert_deprecated {
-        begin
-          assert_blank v
-          fail 'should not get to here'
-        rescue Exception => e
-          assert_match(/is not blank/, e.message)
-        end
-      }
-    }
-  end
-end
-
-class AssertPresentTest < ActiveSupport::TestCase
-  BLANK = [ EmptyTrue.new, nil, false, '', '   ', "  \n\t  \r ", [], {} ]
-  NOT_BLANK = [ EmptyFalse.new, Object.new, true, 0, 1, 'x', [nil], { nil => 0 } ]
-
-  def test_assert_present_true
-    NOT_BLANK.each { |v|
-      assert_deprecated { assert_present v }
-    }
-  end
-
-  def test_assert_present_false
-    BLANK.each { |v|
-      assert_deprecated {
-        begin
-          assert_present v
-          fail 'should not get to here'
-        rescue Exception => e
-          assert_match(/is blank/, e.message)
-        end
-      }
-    }
-  end
-end
-
 class AlsoDoingNothingTest < ActiveSupport::TestCase
 end
 


### PR DESCRIPTION
With `4.0` these methods were deprecated 947e1d5
