### PR TITLE
Remove deprecated `:distinct` option from `Relation#count`.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove deprecated `:distinct` option from `Relation#count`.
+
+    *Yves Senn*
+
 *   Removed deprecated methods `partial_updates`, `partial_updates?` and
     `partial_updates=`.
 

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -194,11 +194,6 @@ module ActiveRecord
 
       # If #count is used with #distinct / #uniq it is considered distinct. (eg. relation.distinct.count)
       distinct = self.distinct_value
-      if options.has_key?(:distinct)
-        ActiveSupport::Deprecation.warn "The :distinct option for `Relation#count` is deprecated. " \
-          "Please use `Relation#distinct` instead. (eg. `relation.distinct.count`)"
-        distinct = options[:distinct]
-      end
 
       if operation == "count"
         if select_values.present?

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -351,16 +351,6 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 5, Account.count(:firm_id)
   end
 
-  def test_count_distinct_option_is_deprecated
-    assert_deprecated do
-      assert_equal 4, Account.select(:credit_limit).count(distinct: true)
-    end
-
-    assert_deprecated do
-      assert_equal 6, Account.select(:credit_limit).count(distinct: false)
-    end
-  end
-
   def test_count_with_distinct
     assert_equal 4, Account.select(:credit_limit).distinct.count
     assert_equal 4, Account.select(:credit_limit).uniq.count


### PR DESCRIPTION
This option was deprecated with `4.0` and should be safe to remove: cd87c85
