### PR TITLE
Remove `FormBuilder` deprecation warning about block argument and tests

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove deprecated block passing to FormBuilder#new.
+
+    *Vipul A M*
+
 *   Pick `DateField` `DateTimeField` and `ColorField` values from stringified options allowing use of symbol keys with helpers.
 
     *Jon Rowe*

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1237,11 +1237,7 @@ module ActionView
         self
       end
 
-      def initialize(object_name, object, template, options, block=nil)
-        if block
-          ActiveSupport::Deprecation.warn "Giving a block to FormBuilder is deprecated and has no effect anymore."
-        end
-
+      def initialize(object_name, object, template, options)
         @nested_child_index = {}
         @object_name, @object, @template, @options = object_name, object, template, options
         @default_options = @options ? @options.slice(:index, :namespace) : {}

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -2916,18 +2916,6 @@ class FormHelperTest < ActionView::TestCase
     assert_equal "fields", output
   end
 
-  def test_form_builder_block_argument_deprecation
-    builder_class = Class.new(ActionView::Helpers::FormBuilder) do
-      def initialize(object_name, object, template, options, block)
-        super
-      end
-    end
-
-    assert_deprecated(/Giving a block to FormBuilder is deprecated and has no effect anymore/) do
-      builder_class.new(:foo, nil, nil, {}, proc {})
-    end
-  end
-
   def test_form_for_only_instantiates_builder_once
     initialization_count = 0
     builder_class = Class.new(ActionView::Helpers::FormBuilder) do


### PR DESCRIPTION
Remove `FormBuilder` deprecation warning about block argument and associated tests
