### PR TITLE
calling default_scope without a proc will raise ArgumentError

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Calling default_scope without a proc will now raise `ArgumentError`.
+
+    *Neeraj Singh*
+
 *   Removed deprecated method `type_cast_code` from Column.
 
     *Neeraj Singh*

--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -83,12 +83,11 @@ module ActiveRecord
           scope = Proc.new if block_given?
 
           if scope.is_a?(Relation) || !scope.respond_to?(:call)
-            ActiveSupport::Deprecation.warn(
-              "Calling #default_scope without a block is deprecated. For example instead " \
+            raise ArgumentError,
+              "Support for calling #default_scope without a block is removed. For example instead " \
               "of `default_scope where(color: 'red')`, please use " \
               "`default_scope { where(color: 'red') }`. (Alternatively you can just redefine " \
               "self.default_scope.)"
-            )
           end
 
           self.default_scopes += [scope]

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -445,14 +445,13 @@ class NamedScopingTest < ActiveRecord::TestCase
     assert_equal [posts(:welcome).title], klass.welcome_2.map(&:title)
   end
 
-  def test_eager_default_scope_relations_are_deprecated
+  def test_eager_default_scope_relations_are_remove
     klass = Class.new(ActiveRecord::Base)
     klass.table_name = 'posts'
 
-    assert_deprecated do
+    assert_raises(ArgumentError) do
       klass.send(:default_scope, klass.where(:id => posts(:welcome).id))
     end
-    assert_equal [posts(:welcome).title], klass.all.map(&:title)
   end
 
   def test_subclass_merges_scopes_properly


### PR DESCRIPTION
Calling default_scope without a proc will now raise `ArgumentError`.
