### PR TITLE
Removing not useful test related to reflect_on_all_associations

### DIFF
--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -186,14 +186,6 @@ class ReflectionTest < ActiveRecord::TestCase
     ActiveRecord::Base.store_full_sti_class = true
   end
 
-  def test_reflection_of_all_associations
-    # FIXME these assertions bust a lot
-    assert_equal 39, Firm.reflect_on_all_associations.size
-    assert_equal 29, Firm.reflect_on_all_associations(:has_many).size
-    assert_equal 10, Firm.reflect_on_all_associations(:has_one).size
-    assert_equal 0, Firm.reflect_on_all_associations(:belongs_to).size
-  end
-
   def test_reflection_should_not_raise_error_when_compared_to_other_object
     assert_nothing_raised { Firm.reflections[:clients] == Object.new }
   end


### PR DESCRIPTION
The comment in the test pretty much summarizes the issue.
`FIXME these assertions bust a lot`

Adding any type of association in class `Firm` will break this test.

I removed some deprecated stuff and this test failed.

I do not think this test provides any useful value. First of all who
counted last that 39 is the right number of associations.

Secondly there are a large number of tests which depend on reflection
returning right information about associations in Active Record. Those tests will start
failing if there is a bug in the code.

/cc @senny @rafaelfranca @carlosantoniodasilva
