### PR TITLE
Postgres arrays improvements

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -71,6 +71,8 @@ module ActiveRecord
           casted_values = value.map do |val|
               if val == "NULL"
                 "\"#{val}\""
+              elsif val.is_a? Array
+                array_to_string(val, column, adapter, should_be_quoted)
               else
                 casted_value = adapter.type_cast(val, column, true)
                 if String === casted_value
@@ -116,7 +118,7 @@ module ActiveRecord
         end
 
         def string_to_array(string, oid)
-          parse_pg_array(string).map{|val| oid.type_cast val}
+          type_cast_array parse_pg_array(string), oid
         end
 
         private
@@ -145,6 +147,16 @@ module ActiveRecord
               value
             else
               "\"#{value.gsub(/"/,"\\\"")}\""
+            end
+          end
+
+          def type_cast_array(array, oid)
+            array.map do |val|
+              if val.is_a?(Array)
+                type_cast_array(val, oid) 
+              else
+                oid.type_cast val
+              end
             end
           end
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -69,15 +69,16 @@ module ActiveRecord
 
         def array_to_string(value, column, adapter, should_be_quoted = false)
           casted_values = value.map do |val|
-            if String === val
               if val == "NULL"
                 "\"#{val}\""
               else
-                quote_and_escape(adapter.type_cast(val, column, true))
+                casted_value = adapter.type_cast(val, column, true)
+                if String === casted_value
+                  quote_and_escape(casted_value)
+                else
+                  casted_value
+                end
               end
-            else
-              adapter.type_cast(val, column, true)
-            end
           end
           "{#{casted_values.join(',')}}"
         end

--- a/activerecord/test/cases/adapters/postgresql/integer_array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/integer_array_test.rb
@@ -1,0 +1,93 @@
+# encoding: utf-8
+require "cases/helper"
+require 'active_record/base'
+require 'active_record/connection_adapters/postgresql_adapter'
+
+class PostgresqlIntegerArrayTest < ActiveRecord::TestCase
+  class PgIntegerArray < ActiveRecord::Base
+    self.table_name = 'pg_integer_arrays'
+  end
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+      @connection.transaction do
+        @connection.create_table('pg_integer_arrays') do |t|
+          t.integer 'tag_ids', :array => true
+        end
+      end
+    @column = PgIntegerArray.columns.find { |c| c.name == 'tag_ids' }
+  end
+
+  def teardown
+    @connection.execute 'drop table if exists pg_integer_arrays'
+  end
+
+  def test_column
+    assert_equal :integer, @column.type
+    assert @column.array
+  end
+
+  def test_type_cast_array
+    assert @column
+
+    data = '{1,2,3}'
+    oid_type  = @column.instance_variable_get('@oid_type').subtype
+    # we are getting the instance variable in this test, but in the
+    # normal use of string_to_array, it's called from the OID::Array
+    # class and will have the OID instance that will provide the type
+    # casting
+    array = @column.class.string_to_array data, oid_type
+    assert_equal([1, 2, 3], array)
+    assert_equal([1, 2, 3], @column.type_cast(data))
+
+    assert_equal([], @column.type_cast('{}'))
+    assert_equal([nil], @column.type_cast('{NULL}'))
+
+    assert_equal([[1, 2, 3], [4]], @column.type_cast('{{1,2,3},{4}}'))
+  end
+
+  def test_rewrite
+    @connection.execute "insert into pg_integer_arrays (tag_ids) VALUES ('{1,2,3}')"
+    x = PgIntegerArray.first
+    x.tag_ids = [1,2,3,4]
+    assert x.save!
+  end
+
+  def test_select
+    @connection.execute "insert into pg_integer_arrays (tag_ids) VALUES ('{1,2,3}')"
+    x = PgIntegerArray.first
+    assert_equal([1,2,3], x.tag_ids)
+  end
+
+  def test_multi_dimensional
+    assert_cycle([[1,2],[2,3]])
+  end
+
+  def test_contains_nils
+    assert_cycle([1,nil,nil])
+  end
+
+  def test_contains_strings
+    assert_cycle([1,'2',3], [1,2,3])
+  end
+
+  def test_insert_fixture
+    tag_values = [1,2,3,4,5]
+    @connection.insert_fixture({"tag_ids" => tag_values}, "pg_integer_arrays" )
+    assert_equal(PgIntegerArray.last.tag_ids, tag_values)
+  end
+
+  private
+  def assert_cycle array, expected = array
+    # test creation
+    x = PgIntegerArray.create!(:tag_ids => array)
+    x.reload
+    assert_equal(expected, x.tag_ids)
+    # test updating
+    x = PgIntegerArray.create!(:tag_ids => [])
+    x.tag_ids = array
+    x.save!
+    x.reload
+    assert_equal(expected, x.tag_ids)
+  end
+end

--- a/activerecord/test/cases/adapters/postgresql/string_array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/string_array_test.rb
@@ -3,23 +3,23 @@ require "cases/helper"
 require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
-class PostgresqlArrayTest < ActiveRecord::TestCase
-  class PgArray < ActiveRecord::Base
-    self.table_name = 'pg_arrays'
+class PostgresqlStringArrayTest < ActiveRecord::TestCase
+  class PgStringArray < ActiveRecord::Base
+    self.table_name = 'pg_string_arrays'
   end
 
   def setup
     @connection = ActiveRecord::Base.connection
       @connection.transaction do
-        @connection.create_table('pg_arrays') do |t|
+        @connection.create_table('pg_string_arrays') do |t|
           t.string 'tags', :array => true
         end
       end
-    @column = PgArray.columns.find { |c| c.name == 'tags' }
+    @column = PgStringArray.columns.find { |c| c.name == 'tags' }
   end
 
   def teardown
-    @connection.execute 'drop table if exists pg_arrays'
+    @connection.execute 'drop table if exists pg_string_arrays'
   end
 
   def test_column
@@ -42,18 +42,20 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
 
     assert_equal([], @column.type_cast('{}'))
     assert_equal([nil], @column.type_cast('{NULL}'))
+
+    assert_equal([['1', '2', '3'], ['4']], @column.type_cast('{{1,2,3},{4}}'))
   end
 
   def test_rewrite
-    @connection.execute "insert into pg_arrays (tags) VALUES ('{1,2,3}')"
-    x = PgArray.first
+    @connection.execute "insert into pg_string_arrays (tags) VALUES ('{1,2,3}')"
+    x = PgStringArray.first
     x.tags = ['1','2','3','4']
     assert x.save!
   end
 
   def test_select
-    @connection.execute "insert into pg_arrays (tags) VALUES ('{1,2,3}')"
-    x = PgArray.first
+    @connection.execute "insert into pg_string_arrays (tags) VALUES ('{1,2,3}')"
+    x = PgStringArray.first
     assert_equal(['1','2','3'], x.tags)
   end
 
@@ -83,19 +85,19 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
 
   def test_insert_fixture
     tag_values = ["val1", "val2", "val3_with_'_multiple_quote_'_chars"]
-    @connection.insert_fixture({"tags" => tag_values}, "pg_arrays" )
-    assert_equal(PgArray.last.tags, tag_values)
+    @connection.insert_fixture({"tags" => tag_values}, "pg_string_arrays" )
+    assert_equal(PgStringArray.last.tags, tag_values)
   end
 
   private
   def assert_cycle array
     # test creation
-    x = PgArray.create!(:tags => array)
+    x = PgStringArray.create!(:tags => array)
     x.reload
     assert_equal(array, x.tags)
 
     # test updating
-    x = PgArray.create!(:tags => [])
+    x = PgStringArray.create!(:tags => [])
     x.tags = array
     x.save!
     x.reload


### PR DESCRIPTION
I have stumbled upon some problems with integer arrays. One of them was this: https://github.com/rails/rails/pull/10340

Error: "undefined method `gsub' for 1:Fixnum" was happening in my _production_ app on 4.0.0.beta1 as well as 4.0.0 when updating integer array columns.

The other issue was with multi-dimensional arrays: they did not work with integer array columns.

@Skile9 's commit fixes the first issue, but it was lacking the tests, and it was actualy breaking multidimensional string arrays by accident. So my second commit adds the tests and fixes the regression that could be caused by @Silke9 's patch alone.
