### PR TITLE
Correct the `allow_nil` and `allow_blank` documentation in ActiveModel::Validations Validators

### DIFF
--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -126,8 +126,6 @@ module ActiveModel
       # Options:
       # * <tt>:on</tt> - Specifies the context where this validation is active
       #   (e.g. <tt>on: :create</tt> or <tt>on: :custom_validation_context</tt>)
-      # * <tt>:allow_nil</tt> - Skip validation if attribute is +nil+.
-      # * <tt>:allow_blank</tt> - Skip validation if attribute is blank.
       # * <tt>:if</tt> - Specifies a method, proc or string to call to determine
       #   if the validation should occur (e.g. <tt>if: :allow_validation</tt>,
       #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>). The method,

--- a/activemodel/lib/active_model/validations/absence.rb
+++ b/activemodel/lib/active_model/validations/absence.rb
@@ -21,7 +21,7 @@ module ActiveModel
       # * <tt>:message</tt> - A custom error message (default is: "must be blank").
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+ and +:strict+.
+      # +:if+, +:unless+, +:on+, <tt>:allow_nil</tt> , <tt>:allow_blank</tt> , and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       def validates_absence_of(*attr_names)
         validates_with AbsenceValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/acceptance.rb
+++ b/activemodel/lib/active_model/validations/acceptance.rb
@@ -38,8 +38,6 @@ module ActiveModel
       # Configuration options:
       # * <tt>:message</tt> - A custom error message (default is: "must be
       #   accepted").
-      # * <tt>:allow_nil</tt> - Skip validation if attribute is +nil+ (default
-      #   is +true+).
       # * <tt>:accept</tt> - Specifies value that is considered accepted.
       #   The default value is a string "1", which makes it easy to relate to
       #   an HTML checkbox. This should be set to +true+ if you are validating
@@ -47,7 +45,7 @@ module ActiveModel
       #   before validation.
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+ and +:strict+.
+      # +:if+, +:unless+, +:on+, <tt>:allow_nil</tt> , <tt>:allow_blank</tt> , and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       def validates_acceptance_of(*attr_names)
         validates_with AcceptanceValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/confirmation.rb
+++ b/activemodel/lib/active_model/validations/confirmation.rb
@@ -57,7 +57,7 @@ module ActiveModel
       #   confirmation").
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+ and +:strict+.
+      # +:if+, +:unless+, +:on+, <tt>:allow_nil</tt> , <tt>:allow_blank</tt> , and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       def validates_confirmation_of(*attr_names)
         validates_with ConfirmationValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/exclusion.rb
+++ b/activemodel/lib/active_model/validations/exclusion.rb
@@ -34,13 +34,9 @@ module ActiveModel
       #   <tt>Range#cover?</tt>, otherwise with <tt>include?</tt>.
       # * <tt>:message</tt> - Specifies a custom error message (default is: "is
       #   reserved").
-      # * <tt>:allow_nil</tt> - If set to true, skips this validation if the
-      #   attribute is +nil+ (default is +false+).
-      # * <tt>:allow_blank</tt> - If set to true, skips this validation if the
-      #   attribute is blank(default is +false+).
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+ and +:strict+.
+      # +:if+, +:unless+, +:on+, <tt>:allow_nil</tt> , <tt>:allow_blank</tt> , and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       def validates_exclusion_of(*attr_names)
         validates_with ExclusionValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/format.rb
+++ b/activemodel/lib/active_model/validations/format.rb
@@ -91,10 +91,6 @@ module ActiveModel
       #
       # Configuration options:
       # * <tt>:message</tt> - A custom error message (default is: "is invalid").
-      # * <tt>:allow_nil</tt> - If set to true, skips this validation if the
-      #   attribute is +nil+ (default is +false+).
-      # * <tt>:allow_blank</tt> - If set to true, skips this validation if the
-      #   attribute is blank (default is +false+).
       # * <tt>:with</tt> - Regular expression that if the attribute matches will
       #   result in a successful validation. This can be provided as a proc or
       #   lambda returning regular expression which will be called at runtime.
@@ -107,7 +103,7 @@ module ActiveModel
       #   beginning or end of the string. These anchors are <tt>^</tt> and <tt>$</tt>.
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+ and +:strict+.
+      # +:if+, +:unless+, +:on+, <tt>:allow_nil</tt> , <tt>:allow_blank</tt> , and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       def validates_format_of(*attr_names)
         validates_with FormatValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/inclusion.rb
+++ b/activemodel/lib/active_model/validations/inclusion.rb
@@ -33,13 +33,9 @@ module ActiveModel
       # * <tt>:within</tt> - A synonym(or alias) for <tt>:in</tt>
       # * <tt>:message</tt> - Specifies a custom error message (default is: "is
       #   not included in the list").
-      # * <tt>:allow_nil</tt> - If set to +true+, skips this validation if the
-      #   attribute is +nil+ (default is +false+).
-      # * <tt>:allow_blank</tt> - If set to +true+, skips this validation if the
-      #   attribute is blank (default is +false+).
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+ and +:strict+.
+      # +:if+, +:unless+, +:on+, <tt>:allow_nil</tt> , <tt>:allow_blank</tt> , and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       def validates_inclusion_of(*attr_names)
         validates_with InclusionValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -110,7 +110,7 @@ module ActiveModel
       # * <tt>:even</tt> - Specifies the value must be an even number.
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+ and +:strict+ .
+      # +:if+, +:unless+, +:on+, <tt>:allow_nil</tt> , <tt>:allow_blank</tt> , and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       #
       # The following checks can also be supplied with a proc or a symbol which

--- a/activemodel/lib/active_model/validations/presence.rb
+++ b/activemodel/lib/active_model/validations/presence.rb
@@ -29,7 +29,7 @@ module ActiveModel
       # * <tt>:message</tt> - A custom error message (default is: "can't be blank").
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+ and +:strict+.
+      # +:if+, +:unless+, +:on+, <tt>:allow_nil</tt> , <tt>:allow_blank</tt> , and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       def validates_presence_of(*attr_names)
         validates_with PresenceValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -83,6 +83,8 @@ module ActiveModel
       #   or <tt>unless: Proc.new { |user| user.signup_step <= 2 }</tt>). The
       #   method, proc or string should return or evaluate to a +true+ or
       #   +false+ value.
+      # * <tt>:allow_nil</tt> - Skip validation if attribute is +nil+.
+      # * <tt>:allow_blank</tt> - Skip validation if attribute is blank.
       # * <tt>:strict</tt> - if the <tt>:strict</tt> option is set to true
       #   will raise ActiveModel::StrictValidationFailed instead of adding the error.
       #   <tt>:strict</tt> option can also be set to any other exception.
@@ -93,7 +95,7 @@ module ActiveModel
       #   validates :token, uniqueness: true, strict: TokenGenerationException
       #
       #
-      # Finally, the options +:if+, +:unless+, +:on+, +:allow_blank+, +:allow_nil+, +:strict+
+      # Finally, the options +:if+, +:unless+, +:on+, <tt>:allow_blank</tt> , <tt>:allow_nil</tt> , +:strict+
       # and +:message+ can be given to one specific validator, as a hash:
       #
       #   validates :password, presence: { if: :password_required?, message: 'is forgotten.' }, confirmation: true


### PR DESCRIPTION
- remove allow_nil, allow_blank doc in `validate` because they are not implemented there.
- move the documentation to the `validates` method as it is referenced by individual validators
- as `allow_nil` and `allow_blank` are available for every subclasses `EachValidator`, added them as `:if`, `:on` etc. options
- move redundant docs for `allow_nil` and `allow_blank` except for special behaviors such as in `numericality.rb`
