### PR TITLE
Removed support for deprecated finder sql

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Removed support for deprecated `finder_sql` in associations.
+
+    *Neeraj Singh*
+
 *   Support array as root element in JSON fields.
 
     *Alexey Noskov & Francesco Rodriguez*

--- a/activerecord/lib/active_record/associations/builder/collection_association.rb
+++ b/activerecord/lib/active_record/associations/builder/collection_association.rb
@@ -8,7 +8,7 @@ module ActiveRecord::Associations::Builder
     CALLBACKS = [:before_add, :after_add, :before_remove, :after_remove]
 
     def valid_options
-      super + [:table_name, :finder_sql, :before_add,
+      super + [:table_name, :before_add,
                :after_add, :before_remove, :after_remove, :extend]
     end
 

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -200,23 +200,23 @@ module ActiveRecord
       def count(column_name = nil, count_options = {})
         column_name, count_options = nil, column_name if column_name.is_a?(Hash)
 
-          relation = scope
-          if association_scope.distinct_value
-            # This is needed because 'SELECT count(DISTINCT *)..' is not valid SQL.
-            column_name ||= reflection.klass.primary_key
-            relation = relation.distinct
-          end
+        relation = scope
+        if association_scope.distinct_value
+          # This is needed because 'SELECT count(DISTINCT *)..' is not valid SQL.
+          column_name ||= reflection.klass.primary_key
+          relation = relation.distinct
+        end
 
-          value = relation.count(column_name)
+        value = relation.count(column_name)
 
-          limit  = options[:limit]
-          offset = options[:offset]
+        limit  = options[:limit]
+        offset = options[:offset]
 
-          if limit || offset
-            [ [value - offset.to_i, 0].max, limit.to_i ].min
-          else
-            value
-          end
+        if limit || offset
+          [ [value - offset.to_i, 0].max, limit.to_i ].min
+        else
+          value
+        end
       end
 
       # Removes +records+ from this association calling +before_remove+ and

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -58,8 +58,6 @@ module ActiveRecord
         def count_records
           count = if has_cached_counter?
             owner.send(:read_attribute, cached_counter_attribute_name)
-          elsif options[:finder_sql]
-            reflection.klass.count_by_sql(custom_counter_sql)
           else
             scope.count
           end

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -524,25 +524,6 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert ! project.developers.include?(developer)
   end
 
-  def test_find_in_association_with_custom_finder_sql
-    assert_equal developers(:david), projects(:active_record).developers_with_finder_sql.find(developers(:david).id), "SQL find"
-
-    active_record = projects(:active_record)
-    active_record.developers_with_finder_sql.reload
-    assert_equal developers(:david), active_record.developers_with_finder_sql.find(developers(:david).id), "Ruby find"
-  end
-
-  def test_find_in_association_with_custom_finder_sql_and_multiple_interpolations
-    # interpolate once:
-    assert_equal [developers(:david), developers(:jamis), developers(:poor_jamis)], projects(:active_record).developers_with_finder_sql, "first interpolation"
-    # interpolate again, for a different project id
-    assert_equal [developers(:david)], projects(:action_controller).developers_with_finder_sql, "second interpolation"
-  end
-
-  def test_find_in_association_with_custom_finder_sql_and_string_id
-    assert_equal developers(:david), projects(:active_record).developers_with_finder_sql.find(developers(:david).id.to_s), "SQL find"
-  end
-
   def test_find_with_merged_options
     assert_equal 1, projects(:active_record).limited_developers.size
     assert_equal 1, projects(:active_record).limited_developers.to_a.size
@@ -776,13 +757,6 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
   def test_count
     david = Developer.find(1)
     assert_equal 2, david.projects.count
-  end
-
-  unless current_adapter?(:PostgreSQLAdapter)
-    def test_count_with_finder_sql
-      assert_equal 3, projects(:active_record).developers_with_finder_sql.count
-      assert_equal 3, projects(:active_record).developers_with_multiline_finder_sql.count
-    end
   end
 
   def test_association_proxy_transaction_method_starts_transaction_in_association_class

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -48,10 +48,6 @@ class Firm < Company
   has_many :clients_with_interpolated_conditions, ->(firm) { where "rating > #{firm.rating}" }, :class_name => "Client"
   has_many :clients_like_ms, -> { where("name = 'Microsoft'").order("id") }, :class_name => "Client"
   has_many :clients_like_ms_with_hash_conditions, -> { where(:name => 'Microsoft').order("id") }, :class_name => "Client"
-  ActiveSupport::Deprecation.silence do
-    has_many :clients_using_sql, :class_name => "Client", :finder_sql => proc { "SELECT * FROM companies WHERE client_of = #{id}" }
-    has_many :clients_using_finder_sql, :class_name => "Client", :finder_sql => 'SELECT * FROM companies WHERE 1=1'
-  end
   has_many :plain_clients, :class_name => 'Client'
   has_many :readonly_clients, -> { readonly }, :class_name => 'Client'
   has_many :clients_using_primary_key, :class_name => 'Client',

--- a/activerecord/test/models/company_in_module.rb
+++ b/activerecord/test/models/company_in_module.rb
@@ -10,10 +10,6 @@ module MyApplication
       has_many :clients_sorted_desc, -> { order("id DESC") }, :class_name => "Client"
       has_many :clients_of_firm, -> { order "id" }, :foreign_key => "client_of", :class_name => "Client"
       has_many :clients_like_ms, -> { where("name = 'Microsoft'").order("id") }, :class_name => "Client"
-      ActiveSupport::Deprecation.silence do
-        has_many :clients_using_sql, :class_name => "Client", :finder_sql => 'SELECT * FROM companies WHERE client_of = #{id}'
-      end
-
       has_one :account, :class_name => 'MyApplication::Billing::Account', :dependent => :destroy
     end
 

--- a/activerecord/test/models/project.rb
+++ b/activerecord/test/models/project.rb
@@ -9,14 +9,6 @@ class Project < ActiveRecord::Base
   has_and_belongs_to_many :salaried_developers, -> { where "salary > 0" }, :class_name => "Developer"
 
   ActiveSupport::Deprecation.silence do
-    has_and_belongs_to_many :developers_with_finder_sql, :class_name => "Developer", :finder_sql => proc { "SELECT t.*, j.* FROM developers_projects j, developers t WHERE t.id = j.developer_id AND j.project_id = #{id} ORDER BY t.id" }
-    has_and_belongs_to_many :developers_with_multiline_finder_sql, :class_name => "Developer", :finder_sql => proc {
-      "SELECT
-         t.*, j.*
-       FROM
-         developers_projects j,
-         developers t WHERE t.id = j.developer_id AND j.project_id = #{id} ORDER BY t.id"
-    }
     has_and_belongs_to_many :developers_by_sql, :class_name => "Developer", :delete_sql => proc { |record| "DELETE FROM developers_projects WHERE project_id = #{id} AND developer_id = #{record.id}" }
   end
 


### PR DESCRIPTION
To keep the diff sane I did not fix indentation in the first commit. In the second commit indentation is fixed. This is so that one can see the diff in the first commit without all the indentation noise.
