### PR TITLE
Fix "rails plugin --help" in docs

### DIFF
--- a/guides/source/plugins.md
+++ b/guides/source/plugins.md
@@ -39,7 +39,7 @@ Rails ships with a `rails plugin new` command which creates a
  and options by asking for help:
 
 ```bash
-$ rails plugin --help
+$ rails plugin new --help
 ```
 
 Testing your newly generated plugin


### PR DESCRIPTION
Since PR #10233 is closed, the issue #10229 remains and the current edge
guide asks user to use "rails plugin --help" which will result in
error.
