### PR TITLE
When LoadError#path is nill grab path from message.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fallback on getting path from error message when LoadError#path is nil.
+
+    *Adam Crownoble*
+
 *   Remove deprecated `Date#to_time_in_current_zone` in favour of `Date#in_time_zone`.
 
     *Vipul A M*

--- a/activesupport/lib/active_support/core_ext/load_error.rb
+++ b/activesupport/lib/active_support/core_ext/load_error.rb
@@ -8,17 +8,24 @@ class LoadError
 
   unless method_defined?(:path)
     def path
-      @path ||= begin
-        REGEXPS.find do |regex|
-          message =~ regex
-        end
-        $1
-      end
+      path_from_message
     end
   end
 
   def is_missing?(location)
-    location.sub(/\.rb$/, '') == path.sub(/\.rb$/, '')
+    file_path = (path || path_from_message).to_s
+    location.sub(/\.rb$/, '') == file_path.sub(/\.rb$/, '')
+  end
+
+  private
+
+  def path_from_message
+    @path_from_message ||= begin
+      REGEXPS.find do |regex|
+        message =~ regex
+      end
+      $1
+    end
   end
 end
 

--- a/activesupport/test/core_ext/load_error_test.rb
+++ b/activesupport/test/core_ext/load_error_test.rb
@@ -14,6 +14,19 @@ class TestMissingSourceFile < ActiveSupport::TestCase
       assert_equal 'nor/this/one.rb', e.path
     end
   end
+  def test_is_missing
+    begin load 'nor/that/one.rb'
+    rescue LoadError => e
+      assert_equal e.is_missing?('nor/that/one'), true
+    end
+  end
+  def test_is_missing_with_nil_path
+    begin load 'nor/any/one.rb'
+    rescue LoadError => e
+      e.stubs(:path).returns(nil)
+      assert_equal e.is_missing?('nor/any/one'), true
+    end
+  end
 end
 
 class TestLoadError < ActiveSupport::TestCase
@@ -27,6 +40,19 @@ class TestLoadError < ActiveSupport::TestCase
     begin load 'nor/this/one.rb'
     rescue LoadError => e
       assert_equal 'nor/this/one.rb', e.path
+    end
+  end
+  def test_is_missing
+    begin load 'nor/that/one.rb'
+    rescue LoadError => e
+      assert_equal e.is_missing?('nor/that/one'), true
+    end
+  end
+  def test_is_missing_with_nil_path
+    begin load 'nor/any/one.rb'
+    rescue LoadError => e
+      e.stubs(:path).returns(nil)
+      assert_equal e.is_missing?('nor/any/one'), true
     end
   end
 end


### PR DESCRIPTION
Before Ruby 2.0 `LoadError#path` always pulled the path out of
`LoadError#message`. In Ruby 2.0 the built-in `#path` method is used but it
sometimes returns `nil`. In that case it's best to fall back on the old
method of grabbing it from the `#message`.

Why `LoadError#path` returns nil has been hard to nail down but here is a
[real-world example](https://github.com/adamcrown/rails4-rspec-guard-spork)

Just clone and run `bundle exec guard` and you'll see the error.
