### PR TITLE
Treats hash keys as methods (getter/setter) #delegate

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Treat Hash keys as methods in the method delegation through delegate.
+
+    *Pablo Cantero*
+
 *   Remove deprecated `Date#to_time_in_current_zone` in favour of `Date#in_time_zone`.
 
     *Vipul A M*

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -97,9 +97,15 @@ class SideEffect
   end
 end
 
+class HTTPClient < Struct.new(:host, :headers)
+  delegate :accept, :content_type, :to => :headers
+  delegate :origin=, :to => :headers, :prefix => true
+end
+
 class ModuleTest < ActiveSupport::TestCase
   def setup
     @david = Someone.new("David", Somewhere.new("Paulina", "Chicago"))
+    @request = HTTPClient.new("rubyonrails.org", { accept: "text/plain", content_type: "application/x-www-form-urlencoded" })
   end
 
   def test_delegation_to_methods
@@ -107,9 +113,19 @@ class ModuleTest < ActiveSupport::TestCase
     assert_equal "Chicago", @david.city
   end
 
+  def test_delegation_to_hash
+    assert_equal "text/plain", @request.accept
+    assert_equal "application/x-www-form-urlencoded", @request.content_type
+  end
+
   def test_delegation_to_assignment_method
     @david.place_name = "Fred"
     assert_equal "Fred", @david.place.name
+  end
+
+  def test_delegation_to_assignment_hash
+    @request.headers_origin = "rubyonrails.org"
+    assert_equal "rubyonrails.org", @request.headers[:origin]
   end
 
   def test_delegation_to_index_get_method


### PR DESCRIPTION
I would like to propose to treat Hash keys as methods in the method delegation through `delegate` when the target object `:to` is a Hash.

Example:

``` ruby
  class Order < ActiveRecord::Base
    serialize :response

    delegate :code, :message, to: :response

    def place
      # ...
      response = json_response
      save
    end
  end

  order = Order.new # ...
  order.place
  order.code
  # => 200
  order.message
  # => Order created
```

Currently without this PR, I have to write boilerplate code to expose these values as methods.

``` ruby
  class Order < ActiveRecord::Base
    serialize :response

    delegate :code, :message, to: :response_data

    def place
      # ...
      response = json_response
      save
    end

   def code; response[:code]; end
   def message; response[:message]; end
  end
```
