### PR TITLE
Remove deprecated `ActiveRecord::Fixtures.find_table_name` 

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Remove deprecated `ActiveRecord::Fixtures.find_table_name` in favor of
+    `ActiveRecord::Fixtures.default_fixture_model_name`.
+
+    *Vipul A M*
+
 *   Removed deprecated `columns_for_remove` from `SchemaStatements`.
 
     *Neeraj Singh*

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -379,12 +379,6 @@ module ActiveRecord
 
     @@all_cached_fixtures = Hash.new { |h,k| h[k] = {} }
 
-    def self.find_table_name(fixture_set_name) # :nodoc:
-      ActiveSupport::Deprecation.warn(
-        "ActiveRecord::Fixtures.find_table_name is deprecated and shall be removed from future releases.  Use ActiveRecord::Fixtures.default_fixture_model_name instead.")
-      default_fixture_model_name(fixture_set_name)
-    end
-
     def self.default_fixture_model_name(fixture_set_name) # :nodoc:
       ActiveRecord::Base.pluralize_table_names ?
         fixture_set_name.singularize.camelize :


### PR DESCRIPTION
Remove deprecated `ActiveRecord::Fixtures.find_table_name` in favour of `ActiveRecord::Fixtures.default_fixture_model_name`.
