### PR TITLE
Remove deprecated `Time` methods

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Remove deprecated `Time#time_with_datetime_fallback`, `Time#utc_time`
+    and `Time#local_time` in favor of `Time#utc` and `Time#local`.
+
+    *Vipul A M*
+
 *   Remove deprecated `Hash#diff` with no replacement.
 
     If you're using it to compare hashes for the purpose of testing, please use

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -26,41 +26,6 @@ class Time
       end
     end
 
-    # *DEPRECATED*: Use +Time#utc+ or +Time#local+ instead.
-    #
-    # Returns a new Time if requested year can be accommodated by Ruby's Time class
-    # (i.e., if year is within either 1970..2038 or 1902..2038, depending on system architecture);
-    # otherwise returns a DateTime.
-    def time_with_datetime_fallback(utc_or_local, year, month=1, day=1, hour=0, min=0, sec=0, usec=0)
-      ActiveSupport::Deprecation.warn 'time_with_datetime_fallback is deprecated. Use Time#utc or Time#local instead', caller
-      time = ::Time.send(utc_or_local, year, month, day, hour, min, sec, usec)
-
-      # This check is needed because Time.utc(y) returns a time object in the 2000s for 0 <= y <= 138.
-      if time.year == year
-        time
-      else
-        ::DateTime.civil_from_format(utc_or_local, year, month, day, hour, min, sec)
-      end
-    rescue
-      ::DateTime.civil_from_format(utc_or_local, year, month, day, hour, min, sec)
-    end
-
-    # *DEPRECATED*: Use +Time#utc+ instead.
-    #
-    # Wraps class method +time_with_datetime_fallback+ with +utc_or_local+ set to <tt>:utc</tt>.
-    def utc_time(*args)
-      ActiveSupport::Deprecation.warn 'utc_time is deprecated. Use Time#utc instead', caller
-      time_with_datetime_fallback(:utc, *args)
-    end
-
-    # *DEPRECATED*: Use +Time#local+ instead.
-    #
-    # Wraps class method +time_with_datetime_fallback+ with +utc_or_local+ set to <tt>:local</tt>.
-    def local_time(*args)
-      ActiveSupport::Deprecation.warn 'local_time is deprecated. Use Time#local instead', caller
-      time_with_datetime_fallback(:local, *args)
-    end
-
     # Returns <tt>Time.zone.now</tt> when <tt>Time.zone</tt> or <tt>config.time_zone</tt> are set, otherwise just returns <tt>Time.now</tt>.
     def current
       ::Time.zone ? ::Time.zone.now : ::Time.now

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -578,58 +578,6 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal 29, Time.days_in_month(2)
   end
 
-  def test_time_with_datetime_fallback
-    ActiveSupport::Deprecation.silence do
-      assert_equal Time.time_with_datetime_fallback(:utc, 2005, 2, 21, 17, 44, 30), Time.utc(2005, 2, 21, 17, 44, 30)
-      assert_equal Time.time_with_datetime_fallback(:local, 2005, 2, 21, 17, 44, 30), Time.local(2005, 2, 21, 17, 44, 30)
-      assert_equal Time.time_with_datetime_fallback(:utc, 2039, 2, 21, 17, 44, 30), DateTime.civil(2039, 2, 21, 17, 44, 30, 0)
-      assert_equal Time.time_with_datetime_fallback(:local, 2039, 2, 21, 17, 44, 30), DateTime.civil_from_format(:local, 2039, 2, 21, 17, 44, 30)
-      assert_equal Time.time_with_datetime_fallback(:utc, 1900, 2, 21, 17, 44, 30), DateTime.civil(1900, 2, 21, 17, 44, 30, 0)
-      assert_equal Time.time_with_datetime_fallback(:utc, 2005), Time.utc(2005)
-      assert_equal Time.time_with_datetime_fallback(:utc, 2039), DateTime.civil(2039, 1, 1, 0, 0, 0, 0)
-      assert_equal Time.time_with_datetime_fallback(:utc, 2005, 2, 21, 17, 44, 30, 1), Time.utc(2005, 2, 21, 17, 44, 30, 1) #with usec
-      # This won't overflow on 64bit linux
-      unless time_is_64bits?
-        assert_equal Time.time_with_datetime_fallback(:local, 1900, 2, 21, 17, 44, 30), DateTime.civil_from_format(:local, 1900, 2, 21, 17, 44, 30)
-        assert_equal Time.time_with_datetime_fallback(:utc, 2039, 2, 21, 17, 44, 30, 1),
-                     DateTime.civil(2039, 2, 21, 17, 44, 30, 0, 0)
-        assert_equal ::Date::ITALY, Time.time_with_datetime_fallback(:utc, 2039, 2, 21, 17, 44, 30, 1).start # use Ruby's default start value
-      end
-      silence_warnings do
-        0.upto(138) do |year|
-          [:utc, :local].each do |format|
-            assert_equal year, Time.time_with_datetime_fallback(format, year).year
-          end
-        end
-      end
-    end
-  end
-
-  def test_utc_time
-    ActiveSupport::Deprecation.silence do
-      assert_equal Time.utc_time(2005, 2, 21, 17, 44, 30), Time.utc(2005, 2, 21, 17, 44, 30)
-      assert_equal Time.utc_time(2039, 2, 21, 17, 44, 30), DateTime.civil(2039, 2, 21, 17, 44, 30, 0)
-      assert_equal Time.utc_time(1901, 2, 21, 17, 44, 30), DateTime.civil(1901, 2, 21, 17, 44, 30, 0)
-    end
-  end
-
-  def test_local_time
-    ActiveSupport::Deprecation.silence do
-      assert_equal Time.local_time(2005, 2, 21, 17, 44, 30), Time.local(2005, 2, 21, 17, 44, 30)
-      assert_equal Time.local_time(2039, 2, 21, 17, 44, 30), DateTime.civil_from_format(:local, 2039, 2, 21, 17, 44, 30)
-
-      unless time_is_64bits?
-        assert_equal Time.local_time(1901, 2, 21, 17, 44, 30), DateTime.civil_from_format(:local, 1901, 2, 21, 17, 44, 30)
-      end
-    end
-  end
-
-  def test_time_with_datetime_fallback_deprecations
-    assert_deprecated(/time_with_datetime_fallback/) { Time.time_with_datetime_fallback(:utc, 2012, 6, 7) }
-    assert_deprecated(/utc_time/) { Time.utc_time(2012, 6, 7) }
-    assert_deprecated(/local_time/) { Time.local_time(2012, 6, 7) }
-  end
-
   def test_last_month_on_31st
     assert_equal Time.local(2004, 2, 29), Time.local(2004, 3, 31).last_month
   end
@@ -832,9 +780,6 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
       old_tz ? ENV['TZ'] = old_tz : ENV.delete('TZ')
     end
 
-    def time_is_64bits?
-      Time.time_with_datetime_fallback(:utc, 2039, 2, 21, 17, 44, 30, 1).is_a?(Time)
-    end
 end
 
 class TimeExtMarshalingTest < ActiveSupport::TestCase


### PR DESCRIPTION
Remove deprecated `Time#time_with_datetime_fallback`, `Time#utc_time` and `Time#local_time` in favour of `Time#utc` and `Time#local`
