### PR TITLE
Add patch level to Ruby version information

### DIFF
--- a/railties/lib/rails/info.rb
+++ b/railties/lib/rails/info.rb
@@ -61,8 +61,10 @@ module Rails
       end
     end
 
-    # The Ruby version and platform, e.g. "1.8.2 (powerpc-darwin8.2.0)".
-    property 'Ruby version', "#{RUBY_VERSION} (#{RUBY_PLATFORM})"
+    # The Ruby version and platform, e.g. "2.0.0p247 (x86_64-darwin12.4.0)".
+    property 'Ruby version' do
+      "#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL} (#{RUBY_PLATFORM})"
+    end
 
     # The RubyGems version, if it's installed.
     property 'RubyGems version' do


### PR DESCRIPTION
Given the recent security related patches to ruby and rails it is more
important than ever to know what patch level you are running.
