### PR TITLE
Prefer `{ do_stuff }` instead of `{do_stuff}` [ci skip]

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -515,12 +515,12 @@ module ActiveSupport
           case key
           when Array
             if key.size > 1
-              key = key.collect{|element| expanded_key(element)}
+              key = key.collect { |element| expanded_key(element) }
             else
               key = key.first
             end
           when Hash
-            key = key.sort_by { |k,_| k.to_s }.collect{|k,v| "#{k}=#{v}"}
+            key = key.sort_by { |k,_| k.to_s }.collect { |k,v| "#{k}=#{v}" }
           end
 
           key.to_param
@@ -542,7 +542,7 @@ module ActiveSupport
           if self.class.instrument
             payload = { :key => key }
             payload.merge!(options) if options.is_a?(Hash)
-            ActiveSupport::Notifications.instrument("cache_#{operation}.active_support", payload){ yield(payload) }
+            ActiveSupport::Notifications.instrument("cache_#{operation}.active_support", payload) { yield(payload) }
           else
             yield(nil)
           end


### PR DESCRIPTION
according to http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions
