### PR TITLE
Remove deprecated `ActiveRecord::Generators::ActiveModel#update_attribute`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Remove deprecated `ActiveRecord::Generators::ActiveModel#update_attributes` in
+    favor of `ActiveRecord::Generators::ActiveModel#update`
+
+    *Vipul A M*
+
 *   Remove deprecated `config.whiny_nils` option
 
     *Vipul A M*

--- a/railties/lib/rails/generators/active_model.rb
+++ b/railties/lib/rails/generators/active_model.rb
@@ -65,12 +65,6 @@ module Rails
         "#{name}.update(#{params})"
       end
 
-      def update_attributes(*args) # :nodoc:
-        ActiveSupport::Deprecation.warn("Calling '@orm_instance.update_attributes' " \
-          "is deprecated, please use '@orm_instance.update' instead.")
-        update(*args)
-      end
-
       # POST create
       # PATCH/PUT update
       def errors


### PR DESCRIPTION
Remove deprecated `ActiveRecord::Generators::ActiveModel#update_attribute` in favor of `ActiveRecord::Generators::ActiveModel#update`
