### PR TITLE
Include the database configuration in activerecord notifications.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -67,22 +67,22 @@ module ActiveRecord
       define_callbacks :checkout, :checkin
 
       attr_accessor :visitor, :pool
-      attr_reader :schema_cache, :last_use, :in_use, :logger
+      attr_reader :schema_cache, :last_use, :in_use, :logger, :config
       alias :in_use? :in_use
 
-      def self.type_cast_config_to_integer(config)
-        if config =~ SIMPLE_INT
-          config.to_i
+      def self.type_cast_config_to_integer(config_value)
+        if config_value =~ SIMPLE_INT
+          config_value.to_i
         else
-          config
+          config_value
         end
       end
 
-      def self.type_cast_config_to_boolean(config)
-        if config == "false"
+      def self.type_cast_config_to_boolean(config_value)
+        if config_value == "false"
           false
         else
-          config
+          config_value
         end
       end
 
@@ -435,6 +435,7 @@ module ActiveRecord
           :sql           => sql,
           :name          => name,
           :connection_id => object_id,
+          :configuration => config,
           :binds         => binds) { yield }
       rescue => e
         message = "#{e.class.name}: #{e.message}: #{sql}"

--- a/activerecord/test/cases/connection_adapters/notifications_test.rb
+++ b/activerecord/test/cases/connection_adapters/notifications_test.rb
@@ -1,0 +1,35 @@
+require "cases/helper"
+
+module ActiveRecord
+  module ConnectionAdapters
+    class NotificationsTest < ActiveRecord::TestCase
+      attr_reader :adapter, :connection
+
+      def setup
+        super
+        @adapter = AbstractAdapter.new nil, nil
+        @connection = ActiveRecord::Base.connection
+      end
+
+      def test_sql_notifications
+        event = nil
+        subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
+          event = args.pop
+        end
+
+        sql = "select * from topics"
+        connection.exec_query(sql, 'SQL')
+
+        assert_equal event[:sql], sql
+        assert_equal event[:name], 'SQL'
+        assert_equal event[:connection_id], connection.object_id
+        assert_equal event[:configuration], connection.config
+        # binds are tested separately in bind_parameter_test.rb
+
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
In some cases it is useful to have the database configuration in an activerecord
notification to initiate an independent connection to the database.
