### PR TITLE
Fixing the broken wikipedia link for Optimistic Concurrency control

### DIFF
--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -198,7 +198,7 @@ module ActiveRecord
       # can catch it and restart the transaction (e.g. by telling the user
       # that the title already exists, and asking him to re-enter the title).
       # This technique is also known as optimistic concurrency control:
-      # http://en.wikipedia.org/wiki/Optimistic_concurrency_control.
+      # http://en.wikipedia.org/wiki/Optimistic_concurrency_control .
       #
       # The bundled ActiveRecord::ConnectionAdapters distinguish unique index
       # constraint errors from other types of database errors by throwing an


### PR DESCRIPTION
Because of full stop with link it is forming a invalid url (as http://en.wikipedia.org/wiki/Optimistic_concurrency_control.) which does not exist. The error can be seen here http://api.rubyonrails.org/classes/ActiveRecord/Validations/ClassMethods.html#method-i-validates_uniqueness_of
