### PR TITLE
activate error handling in integration tests `with_rails_error_handling`

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -371,6 +371,15 @@ module ActionDispatch
         end
       end
 
+      def with_rails_error_handling
+        env_config = Rails.application.env_config
+        original_show_exception = env_config["action_dispatch.show_exceptions"]
+        env_config["action_dispatch.show_exceptions"] = true
+        yield
+      ensure
+        env_config["action_dispatch.show_exceptions"] = original_show_exception
+      end
+
       def default_url_options
         reset! unless integration_session
         integration_session.default_url_options


### PR DESCRIPTION
I recently faced a situation where I was integration testing an API and wanted to let Rails handle the raised errors. Sadly passing `"action_dispatch.show_exceptions" => true` to the request won't work as it get's overwritten (https://github.com/rails/rails/blob/master/railties/lib/rails/engine.rb#L507).

Changing `Rails.application.env_config` in a single test-case has side effects and it's important to restore the original value. That's why I created this simple helper method for `ActionDispacth::IntegrationTest`:

``` ruby
test "some example API call" do
  with_rails_error_handling do
    get "/active_record/not_found"
  end

  assert_equal 404, status
end
```
