### PR TITLE
Remove an unless if statement

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -866,12 +866,9 @@ module ActiveRecord
       @direction         = direction
       @target_version    = target_version
       @migrated_versions = nil
+      @migrations        = migrations
 
-      if Array(migrations).grep(String).empty?
-        @migrations = migrations
-      end
-
-      validate(@migrations)
+      validate(migrations)
 
       ActiveRecord::SchemaMigration.create_table
     end


### PR DESCRIPTION
Hello

Related to commit 6856312 ; the else statement has been removed so the migrations instance variable automatically get the value of the `migrations` parameter.

/cc @carlosantoniodasilva @senny
