### PR TITLE
specify a custom type string for model in STI

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -149,7 +149,7 @@ module ActiveRecord
         relation = Relation.new(self, arel_table)
 
         if finder_needs_type_condition?
-          relation.where(type_condition).create_with(inheritance_column.to_sym => sti_name)
+          relation.where(type_condition).create_with(inheritance_column.to_sym => sti_db_name)
         else
           relation
         end

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -166,6 +166,15 @@ module ActiveRecord
         @explicit_inheritance_column = true
       end
 
+      def inheritance_name=(value)
+        self.store_full_sti_class = false
+        @inheritance_name = value
+      end
+
+      def inheritance_name
+        @inheritance_name ||= nil
+      end
+
       def sequence_name
         if base_class == self
           @sequence_name ||= reset_sequence_name


### PR DESCRIPTION
This one adds some more flexibilty AR when it comes to work with legacy databases. Several other frameworks use the 'inheritance' column and it would be fine to have AR able to understand those strings as well and translate to the appropriate AR models. 

This allows you to specify the string which maps to the current model, for instance: 

``` ruby
class LegacyPost < LegacyContent 
    self.inheritance_name = '_name_used_by_other_framework' 
end
```

It is working for me in a project I'm currently working on and I think it would e a nice and simple addition to AR. 
If anybody thinks it's worth I can go ahead and work out test cases and docs. 
