### PR TITLE
Use SecureRandom.urlsafe_base64 for authenticity_token.

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -191,7 +191,7 @@ module ActionController #:nodoc:
 
       # Sets the token value for the current session.
       def form_authenticity_token
-        session[:_csrf_token] ||= SecureRandom.base64(32)
+        session[:_csrf_token] ||= SecureRandom.urlsafe_base64(32)
       end
 
       # The form's authenticity parameter. Override to provide your own.

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -103,7 +103,7 @@ module RequestForgeryProtectionTests
   def setup
     @token      = "cf50faa3fe97702ca1ae"
 
-    SecureRandom.stubs(:base64).returns(@token)
+    SecureRandom.stubs(:urlsafe_base64).returns(@token)
     ActionController::Base.request_forgery_protection_token = :custom_authenticity_token
   end
 
@@ -293,7 +293,7 @@ class RequestForgeryProtectionControllerUsingResetSessionTest < ActionController
   end
 
   test 'should emit a csrf-param meta tag and a csrf-token meta tag' do
-    SecureRandom.stubs(:base64).returns(@token + '<=?')
+    SecureRandom.stubs(:urlsafe_base64).returns(@token + '<=?')
     get :meta
     assert_select 'meta[name=?][content=?]', 'csrf-param', 'custom_authenticity_token'
     assert_select 'meta[name=?][content=?]', 'csrf-token', 'cf50faa3fe97702ca1ae&lt;=?'
@@ -306,7 +306,7 @@ class NullSessionDummyKeyGenerator
   end
 end
 
-class RequestForgeryProtectionControllerUsingNullSessionTest < ActionController::TestCase  
+class RequestForgeryProtectionControllerUsingNullSessionTest < ActionController::TestCase
   def setup
     @request.env[ActionDispatch::Cookies::GENERATOR_KEY] = NullSessionDummyKeyGenerator.new
   end
@@ -338,7 +338,7 @@ class FreeCookieControllerTest < ActionController::TestCase
     @response   = ActionController::TestResponse.new
     @token      = "cf50faa3fe97702ca1ae"
 
-    SecureRandom.stubs(:base64).returns(@token)
+    SecureRandom.stubs(:urlsafe_base64).returns(@token)
   end
 
   def test_should_not_render_form_with_token_tag

--- a/actionpack/test/dispatch/request/url_encoded_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/url_encoded_params_parsing_test.rb
@@ -23,6 +23,18 @@ class UrlEncodedParamsParsingTest < ActionDispatch::IntegrationTest
     )
   end
 
+  test "base64 strings with + character are modified when encoded" do
+    assert_parses(
+       {'token' => "azAZ09 /="}, "token=azAZ09+/="
+    )
+  end
+
+  test "urlsafe_base64 strings are not modified when encoded" do
+    assert_parses(
+       {'token' => "azAZ09-_="}, "token=azAZ09-_="
+    )
+  end
+
   test "parses nested hash" do
     query = [
       "note[viewers][viewer][][type]=User",


### PR DESCRIPTION
If `base64` is used the authenticity_token can include '+', a character that is not URL-safe.

The authenticity_token can cause problems when it includes a plus sign, because if it's encoded as a space the request can't be verified.

Using the `urlsafe_base64` method the authenticity_token will only include A-Z, a-z, 0-9, - and _ making it URL-safe when sent in any form params.
