### PR TITLE
SQL keywords in UPPERCASE

### DIFF
--- a/activerecord/examples/performance.rb
+++ b/activerecord/examples/performance.rb
@@ -167,6 +167,6 @@ Benchmark.ips(TIME) do |x|
   end
 
   x.report "AR.execute(query)" do
-    ActiveRecord::Base.connection.execute("Select * from exhibits where id = #{(rand * 1000 + 1).to_i}")
+    ActiveRecord::Base.connection.execute("SELECT * FROM exhibits WHERE id = #{(rand * 1000 + 1).to_i}")
   end
 end


### PR DESCRIPTION
Remove the inconsistency in upper and lowercase.  In SQL world, keywords are preferred uppercase for better readability from columns and table names.
