### PR TITLE
Remove deprecated `connection_pools`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Remove deprecated `ActiveRecord::Base.connection_handler.connection_pools`.
+    now returning `ActiveRecord::Base.connection_handler.connection_pool_list`.
+
+    *Arun Agrawal*
+
 *   Remove extra select and update queries on save/touch/destroy ActiveRecord model
     with belongs to reflection with option `touch: true`.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -495,14 +495,7 @@ module ActiveRecord
       def connection_pool_list
         owner_to_pool.values.compact
       end
-
-      def connection_pools
-        ActiveSupport::Deprecation.warn(
-          "In the next release, this will return the same as #connection_pool_list. " \
-          "(An array of pools, rather than a hash mapping specs to pools.)"
-        )
-        Hash[connection_pool_list.map { |pool| [pool.spec, pool] }]
-      end
+      alias_method :connection_pools, :connection_pool_list
 
       def establish_connection(owner, spec)
         @class_to_pool.clear

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -42,12 +42,6 @@ module ActiveRecord
         @handler.remove_connection @subklass
         assert_same @pool, @handler.retrieve_connection_pool(@subklass)
       end
-
-      def test_connection_pools
-        assert_deprecated do
-          assert_equal({ Base.connection_pool.spec => @pool }, @handler.connection_pools)
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
`ActiveRecord::Base.connection_handler.connection_pools`.
returning `ActiveRecord::Base.connection_handler.connection_pool_list`.
