### PR TITLE
Added non_secure_cookies to ActionDispatch::SSL

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/ssl.rb
@@ -15,6 +15,7 @@ module ActionDispatch
 
       @host    = options[:host]
       @port    = options[:port]
+      @non_secure_cookies = Array(options[:non_secure_cookies])
     end
 
     def call(env)
@@ -57,7 +58,7 @@ module ActionDispatch
           cookies = cookies.split("\n")
 
           headers['Set-Cookie'] = cookies.map { |cookie|
-            if cookie !~ /;\s+secure(;|$)/i
+            if cookie !~ /;\s+secure(;|$)/i && !@non_secure_cookies.any? { |name| cookie.start_with?("#{name}=") }
               "#{cookie}; secure"
             else
               cookie


### PR DESCRIPTION
Allows you to whitelist particular cookies that you do not want to be forced over to secure-only when enabling `config.force_ssl`.

The use-case I encountered is that we have a Rails site that is entirely SSL (via `config.force_ssl`) but that also has another site that is majority readonly and mixed HTTP(S). From the secure application we wanted to manage a secure-only, HTTP-only token to identify the user, and at the same time manage a non-secure, non-HTTP only so that the partner site could know they were logged in from server- and client-side as required.

As the only thing we want to be non-secure is this one cookie it seemed sensible to leave `config.force_ssl` on and monkeypatch `ActionDispatch::SSL` to ignore the one cookie we are happy to be non-secure. That got me out of the corner I was in today but I thought it worth opening a PR to see if it was worth contributing upstream.
