### PR TITLE
removes markdown code markers from displaying in the active record querying guide

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1210,9 +1210,7 @@ class User < ActiveRecord::Base
   scope :active, -> { where state: 'active' }
   scope :inactive, -> { where state: 'inactive' }
 end
-```
 
-```ruby
 User.active.inactive
 # => SELECT "users".* FROM "users" WHERE "users"."state" = 'active' AND "users"."state" = 'inactive'
 ```


### PR DESCRIPTION
Removes code markers (```ruby) which render in the generated Active Record Querying guide as seen below.

![screen shot 2013-07-04 at 8 32 58 pm](https://f.cloud.github.com/assets/155215/751646/750ddad8-e50a-11e2-9993-38b14616d72b.png)
