### PR TITLE
Adding back deprecation require in all.rb

### DIFF
--- a/activesupport/lib/active_support/all.rb
+++ b/activesupport/lib/active_support/all.rb
@@ -1,3 +1,4 @@
 require 'active_support'
+require 'active_support/deprecation'
 require 'active_support/time'
 require 'active_support/core_ext'


### PR DESCRIPTION
Loading this here because it has been removed here 77b587f942bf3768e5b680ac5e9f24c03a40c607 from 

`activesupport/lib/active_support/core_ext/time/calculations.rb` file.
