### PR TITLE
Update request_forgery_protection.rb

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -185,7 +185,7 @@ module ActionController #:nodoc:
       # * Does the X-CSRF-Token header match the form_authenticity_token
       def verified_request?
         !protect_against_forgery? || request.get? || request.head? ||
-          form_authenticity_token == params[request_forgery_protection_token] ||
+          form_authenticity_token == form_authenticity_param ||
           form_authenticity_token == request.headers['X-CSRF-Token']
       end
 


### PR DESCRIPTION
form_authenticity_param should be used in order to override the authenticity parameter?
My case is that the token is not directly accessible from params, but from a Json encoded param.
So I can't just set a different form_authenticity_token

make sense?
