### PR TITLE
Added an `enforce_utf8` hash option for `form_tag` method

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Added an `enforce_utf8` hash option for `form_tag` method.
+
+    Control to output a hidden input tag with name `utf8` without monkey
+    patching.
+
+    Before:
+
+        form_tag
+        # => '<form>..<input name="utf8" type="hidden" value="&#x2713;" />..</form>'
+
+    After:
+
+        form_tag
+        # => '<form>..<input name="utf8" type="hidden" value="&#x2713;" />..</form>'
+
+        form_tag({}, { :enforce_utf8 => false })
+        # => '<form>....</form>'
+
+    *ma2gedev*
+
 *   Remove the deprecated `include_seconds` argument from `distance_of_time_in_words`,
     pass in an `:include_seconds` hash option to use this feature.
 

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -38,6 +38,7 @@ module ActionView
       # * A list of parameters to feed to the URL the form will be posted to.
       # * <tt>:remote</tt> - If set to true, will allow the Unobtrusive JavaScript drivers to control the
       #   submit behavior. By default this behavior is an ajax submit.
+      # * <tt>:enforce_utf8</tt> - If set to false, a hidden input with name utf8 is not output.
       #
       # ==== Examples
       #   form_tag('/posts')
@@ -719,7 +720,8 @@ module ActionView
               method_tag(method) + token_tag(authenticity_token)
           end
 
-          tags = utf8_enforcer_tag << method_tag
+          enforce_utf8 = html_options.delete("enforce_utf8") { true }
+          tags = (enforce_utf8 ? utf8_enforcer_tag : ''.html_safe) << method_tag
           content_tag(:div, tags, :style => 'margin:0;padding:0;display:inline')
         end
 

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -12,9 +12,10 @@ class FormTagHelperTest < ActionView::TestCase
 
   def hidden_fields(options = {})
     method = options[:method]
+    enforce_utf8 = options.fetch(:enforce_utf8, true)
 
     txt =  %{<div style="margin:0;padding:0;display:inline">}
-    txt << %{<input name="utf8" type="hidden" value="&#x2713;" />}
+    txt << %{<input name="utf8" type="hidden" value="&#x2713;" />} if enforce_utf8
     if method && !%w(get post).include?(method.to_s)
       txt << %{<input name="_method" type="hidden" value="#{method}" />}
     end
@@ -108,6 +109,20 @@ class FormTagHelperTest < ActionView::TestCase
 
     expected = whole_form
     assert_dom_equal expected, actual
+  end
+
+  def test_form_tag_enforce_utf8_true
+    actual = form_tag({}, { :enforce_utf8 => true })
+    expected = whole_form("http://www.example.com", :enforce_utf8 => true)
+    assert_dom_equal expected, actual
+    assert actual.html_safe?
+  end
+
+  def test_form_tag_enforce_utf8_false
+    actual = form_tag({}, { :enforce_utf8 => false })
+    expected = whole_form("http://www.example.com", :enforce_utf8 => false)
+    assert_dom_equal expected, actual
+    assert actual.html_safe?
   end
 
   def test_form_tag_with_block_in_erb


### PR DESCRIPTION
Control to output a hidden input tag with name `utf8` without monkey
patching

Before:

```
form_tag
# => '<form>..<input name="utf8" type="hidden" value="&#x2713;" />..</form>'
```

After:

```
form_tag
# => '<form>..<input name="utf8" type="hidden" value="&#x2713;" />..</form>'

form_tag({}, { :enforce_utf8 => false })
# => '<form>....</form>'
```
