### PR TITLE
Make HashWithIndifferentAccess#select always return the hash.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Make `HashWithIndifferentAccess#select` always return the hash, even when
+    `Hash#select!` returns `nil`, to allow further chaining.
+
+    *Marc Schütz*
+
 *   Remove deprecated `String#encoding_aware?` core extensions (`core_ext/string/encoding`).
 
     *Arun Agrawal*

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -228,7 +228,7 @@ module ActiveSupport
     def to_options!; self end
 
     def select(*args, &block)
-      dup.select!(*args, &block)
+      dup.tap {|hash| hash.select!(*args, &block)}
     end
 
     # Convert to a regular hash with string keys.

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -487,6 +487,12 @@ class HashExtTest < ActiveSupport::TestCase
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
   end
 
+  def test_indifferent_select_returns_a_hash_when_unchanged
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@strings).select {|k,v| true}
+
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+  end
+
   def test_indifferent_select_bang
     indifferent_strings = ActiveSupport::HashWithIndifferentAccess.new(@strings)
     indifferent_strings.select! {|k,v| v == 1}


### PR DESCRIPTION
`Hash#select!` returns `nil` if the hash didn't change and thus behaves differently from `select`, so it's return value can't be used as result for the latter.
