### PR TITLE
Remove conditional, results are always an instance of `ActiveRecord::Result`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -75,14 +75,7 @@ module ActiveRecord
           else
             @query_cache[sql][binds] = yield
           end
-
-        # FIXME: we should guarantee that all cached items are Result
-        # objects.  Then we can avoid this conditional
-        if ActiveRecord::Result === result
-          result.dup
-        else
-          result.collect { |row| row.dup }
-        end
+        result.dup
       end
 
       # If arel is locked this is a SELECT ... FOR UPDATE or somesuch. Such


### PR DESCRIPTION
Remove conditional, since results are always an instance of `ActiveRecord::Result`
