### PR TITLE
Make some activesupport core_ext collection operations more idiomatic

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -107,7 +107,7 @@ class Array
       if empty?
         'null'
       else
-        collect { |element| element.id }.join(',')
+        collect(&:id).join(',')
       end
     else
       to_default_s

--- a/activesupport/lib/active_support/core_ext/array/grouping.rb
+++ b/activesupport/lib/active_support/core_ext/array/grouping.rb
@@ -31,9 +31,7 @@ class Array
     if block_given?
       collection.each_slice(number) { |slice| yield(slice) }
     else
-      groups = []
-      collection.each_slice(number) { |group| groups << group }
-      groups
+      Array(collection.each_slice(number))
     end
   end
 

--- a/activesupport/lib/active_support/core_ext/object/deep_dup.rb
+++ b/activesupport/lib/active_support/core_ext/object/deep_dup.rb
@@ -25,7 +25,7 @@ class Array
   #   array[1][2] #=> nil
   #   dup[1][2]   #=> 4
   def deep_dup
-    map { |it| it.deep_dup }
+    map(&:deep_dup)
   end
 end
 

--- a/activesupport/lib/active_support/core_ext/object/instance_variables.rb
+++ b/activesupport/lib/active_support/core_ext/object/instance_variables.rb
@@ -23,6 +23,6 @@ class Object
   #
   #   C.new(0, 1).instance_variable_names # => ["@y", "@x"]
   def instance_variable_names
-    instance_variables.map { |var| var.to_s }
+    instance_variables.map(&:to_s)
   end
 end

--- a/activesupport/lib/active_support/core_ext/object/to_param.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_param.rb
@@ -30,7 +30,7 @@ class Array
   # Calls <tt>to_param</tt> on all its elements and joins the result with
   # slashes. This is used by <tt>url_for</tt> in Action Pack.
   def to_param
-    collect { |e| e.to_param }.join '/'
+    collect(&:to_param).join '/'
   end
 end
 


### PR DESCRIPTION
While analyzing activesupport I've discovered some parts that could be rewritten using `map(&:method)` instead of `map { |var| var.method }`. It is more idiomatic and seems to introduce a slight performance boost:

```
vars = Object.methods
Benchmark.realtime { 100000.times { vars.map { |var| var.to_s } } }
=> 2.04459
Benchmark.realtime { 100000.times { vars.map { |var| var.to_s } } }
=> 2.048889
Benchmark.realtime { 100000.times { vars.map(&:to_s) } }
=> 1.917303
Benchmark.realtime { 100000.times { vars.map(&:to_s) } }
=> 1.944543
```
