### PR TITLE
Check authentication scheme in Basic auth

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -90,9 +90,13 @@ module ActionController
       end
 
       def authenticate(request, &login_procedure)
-        unless request.authorization.blank?
+        if has_basic_credentials?(request)
           login_procedure.call(*user_name_and_password(request))
         end
+      end
+
+      def has_basic_credentials?(request)
+        request.authorization.present? && (auth_scheme(request) == 'Basic')
       end
 
       def user_name_and_password(request)
@@ -100,12 +104,15 @@ module ActionController
       end
 
       def decode_credentials(request)
-        scheme, param = request.authorization.split(' ', 2)
-        if scheme == 'Basic'
-          ::Base64.decode64(param || '')
-        else
-          ''
-        end
+        ::Base64.decode64(auth_param(request) || '')
+      end
+
+      def auth_scheme(request)
+        request.authorization.split(' ', 2).first
+      end
+
+      def auth_param(request)
+        request.authorization.split(' ', 2).second
       end
 
       def encode_credentials(user_name, password)

--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -100,7 +100,12 @@ module ActionController
       end
 
       def decode_credentials(request)
-        ::Base64.decode64(request.authorization.split(' ', 2).last || '')
+        scheme, param = request.authorization.split(' ', 2)
+        if scheme == 'Basic'
+          ::Base64.decode64(param || '')
+        else
+          ''
+        end
       end
 
       def encode_credentials(user_name, password)

--- a/actionpack/test/controller/http_basic_authentication_test.rb
+++ b/actionpack/test/controller/http_basic_authentication_test.rb
@@ -129,6 +129,13 @@ class HttpBasicAuthenticationTest < ActionController::TestCase
     assert_response :unauthorized
   end
 
+  test "authentication request with wrong scheme" do
+    header = 'Bearer ' + encode_credentials('David', 'Goliath').split(' ', 2)[1]
+    @request.env['HTTP_AUTHORIZATION'] = header
+    get :search
+    assert_response :unauthorized
+  end
+
   private
 
   def encode_credentials(username, password)


### PR DESCRIPTION
`authenticate_with_http_basic` and its families should check the
authentication schema is "Basic".

Different schema, such as OAuth2 Bearer should be rejected by basic auth, but 
it was passing as the test shows.

This fixes #10257.
