### PR TITLE
Fix actionview link_to with block and url_hash

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -172,7 +172,7 @@ module ActionView
       #   link_to "Visit Other Site", "http://www.rubyonrails.org/", data: { confirm: "Are you sure?" }
       #   # => <a href="http://www.rubyonrails.org/" data-confirm="Are you sure?">Visit Other Site</a>
       def link_to(name = nil, options = nil, html_options = nil, &block)
-        html_options, options = options, name if block_given?
+        html_options, options, name = options, name, block if block_given?
         options ||= {}
 
         html_options = convert_options_to_data_attributes(options, html_options)
@@ -180,11 +180,7 @@ module ActionView
         url = url_for(options)
         html_options['href'] ||= url
 
-        if block_given?
-          content_tag(:a, capture(&block) || url, html_options)
-        else
-          content_tag(:a, name || url, html_options)
-        end
+        content_tag(:a, name || url, html_options, &block)
       end
 
       # Generates a form containing a single button that submits to the URL created

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -180,7 +180,11 @@ module ActionView
         url = url_for(options)
         html_options['href'] ||= url
 
-        content_tag(:a, name || url, html_options, &block)
+        if block_given?
+          content_tag(:a, capture(&block) || url, html_options)
+        else
+          content_tag(:a, name || url, html_options)
+        end
       end
 
       # Generates a form containing a single button that submits to the URL created

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -308,6 +308,13 @@ class UrlHelperTest < ActiveSupport::TestCase
       link_to('/', class: "special") { content_tag(:span, 'Example site') }
   end
 
+  def test_link_tag_using_block_and_hash
+    assert_dom_equal(
+      %{<a href="/"><span>Example site</span></a>},
+      link_to(url_hash) { content_tag(:span, 'Example site') }
+    )
+  end
+
   def test_link_tag_using_block_in_erb
     out = render_erb %{<%= link_to('/') do %>Example site<% end %>}
     assert_equal '<a href="/">Example site</a>', out


### PR DESCRIPTION
Use `link_to` with block and url_hash, expect block as name.
But ignore block and use url_hash as name.
**3-2-stable** passes this test. **4-0-stable** and **master** fail this.

```
--- expected
+++ actual
@@ -1 +1 @@
-#<HTML::Node:0xXXXXXX @parent=nil, @children=[#<HTML::Tag:0xXXXXXX @parent=#<HTML::Node:0xXXXXXX ...>, @children=[#<HTML::Tag:0xXXXXXX @parent=#<HTML::Tag:0xXXXXXX ...>, @children=[#<HTML::Text:0xXXXXXX @parent=#<HTML::Tag:0xXXXXXX ...>, @children=[], @line=1, @position=18, @content="Example site">], @line=1, @position=12, @name="span", @attributes={}, @closing=nil>], @line=1, @position=0, @name="a", @attributes={"href"=>"/"}, @closing=nil>], @line=0, @position=0>
+#<HTML::Node:0xXXXXXX @parent=nil, @children=[#<HTML::Tag:0xXXXXXX @parent=#<HTML::Node:0xXXXXXX ...>, @children=[#<HTML::Tag:0xXXXXXX @parent=#<HTML::Tag:0xXXXXXX ...>, @children=[#<HTML::Text:0xXXXXXX @parent=#<HTML::Tag:0xXXXXXX ...>, @children=[], @line=1, @position=39, @content="Example site">], @line=1, @position=33, @name="span", @attributes={}, @closing=nil>], @line=1, @position=0, @name="a", @attributes={"action"=>"bar", "controller"=>"foo"}, @closing=nil>], @line=0, @position=0>
```
