### PR TITLE
Fix microsecond precision of Time#at_with_coercion

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -34,7 +34,7 @@ class Time
     # instances can be used when called with a single argument
     def at_with_coercion(*args)
       if args.size == 1 && args.first.acts_like?(:time)
-        at_without_coercion(args.first.to_i)
+        at_without_coercion(args.first.to_f)
       else
         at_without_coercion(*args)
       end

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -711,6 +711,10 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_at_with_time_microsecond_precision
+    assert_equal Time.at(Time.utc(2000, 1, 1, 0, 0, 0, 111)).to_f, Time.utc(2000, 1, 1, 0, 0, 0, 111).to_f
+  end
+
   def test_eql?
     assert_equal true, Time.utc(2000).eql?( ActiveSupport::TimeWithZone.new(Time.utc(2000), ActiveSupport::TimeZone['UTC']) )
     assert_equal true, Time.utc(2000).eql?( ActiveSupport::TimeWithZone.new(Time.utc(2000), ActiveSupport::TimeZone["Hawaii"]) )


### PR DESCRIPTION
When `Time.at_with_coercion` (wraps `Time.at`) is called with a single
argument that `acts_like?(:time)` it is coerced to integer thus losing
it's microsecond percision.

This commits changes this to use `#to_f` to prevent the problem
