### PR TITLE
Allow a custom dispatcher to be provided to routing.

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -317,7 +317,7 @@ module ActionDispatch
 
       attr_accessor :formatter, :set, :named_routes, :default_scope, :router
       attr_accessor :disable_clear_and_finalize, :resources_path_names
-      attr_accessor :default_url_options
+      attr_accessor :default_url_options, :dispatcher_class
       attr_reader :env_key
 
       alias :routes :set
@@ -360,6 +360,7 @@ module ActionDispatch
         @set    = Journey::Routes.new
         @router = Journey::Router.new @set
         @formatter = Journey::Formatter.new @set
+        @dispatcher_class = Routing::RouteSet::Dispatcher
       end
 
       def relative_url_root
@@ -418,7 +419,7 @@ module ActionDispatch
       end
 
       def dispatcher(defaults)
-        Routing::RouteSet::Dispatcher.new(defaults)
+        dispatcher_class.new(defaults)
       end
 
       module MountedHelpers

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -62,12 +62,16 @@ module ActionDispatch
           raise ActionController::RoutingError, e.message, e.backtrace if default_controller
         end
 
-      private
+      protected
+
+        attr_reader :controller_class_names
 
         def controller_reference(controller_param)
-          const_name = @controller_class_names[controller_param] ||= "#{controller_param.camelize}Controller"
+          const_name = controller_class_names[controller_param] ||= "#{controller_param.camelize}Controller"
           ActiveSupport::Dependencies.constantize(const_name)
         end
+
+      private
 
         def dispatch(controller, action, req)
           controller.action(action).call(req.env)

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -149,14 +149,10 @@ class ActionDispatch::IntegrationTest < ActiveSupport::TestCase
     end
   end
 
-  def self.stub_controllers
-    old_dispatcher = ActionDispatch::Routing::RouteSet::Dispatcher
-    ActionDispatch::Routing::RouteSet.module_eval { remove_const :Dispatcher }
-    ActionDispatch::Routing::RouteSet.module_eval { const_set :Dispatcher, StubDispatcher }
-    yield ActionDispatch::Routing::RouteSet.new
-  ensure
-    ActionDispatch::Routing::RouteSet.module_eval { remove_const :Dispatcher }
-    ActionDispatch::Routing::RouteSet.module_eval { const_set :Dispatcher, old_dispatcher }
+  def self.stub_controllers(config = nil)
+    route_set = ActionDispatch::Routing::RouteSet.new(*[config].compact)
+    route_set.dispatcher_class = StubDispatcher
+    yield route_set
   end
 
   def with_routing(&block)

--- a/actionpack/test/dispatch/mapper_test.rb
+++ b/actionpack/test/dispatch/mapper_test.rb
@@ -19,6 +19,10 @@ module ActionDispatch
           ActionDispatch::Request
         end
 
+        def dispatcher_class
+          RouteSet::Dispatcher
+        end
+
         def add_route(*args)
           routes << args
         end

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -168,12 +168,10 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
   end
 
   def test_session_singleton_resource_for_api_app
-    self.class.stub_controllers do |_|
-      config = ActionDispatch::Routing::RouteSet::Config.new
-      config.api_only = true
+    config = ActionDispatch::Routing::RouteSet::Config.new
+    config.api_only = true
 
-      routes = ActionDispatch::Routing::RouteSet.new(config)
-
+    self.class.stub_controllers(config) do |routes|
       routes.draw do
         resource :session do
           get :create
@@ -550,11 +548,10 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
   end
 
   def test_projects_for_api_app
-    self.class.stub_controllers do |_|
-      config = ActionDispatch::Routing::RouteSet::Config.new
-      config.api_only = true
+    config = ActionDispatch::Routing::RouteSet::Config.new
+    config.api_only = true
 
-      routes = ActionDispatch::Routing::RouteSet.new(config)
+    self.class.stub_controllers(config) do |routes|
       routes.draw do
         resources :projects, controller: :project
       end


### PR DESCRIPTION
The two commits are related but independent: one allows a configurable dispatcher, the other exposes some useful internals of the existing dispatcher to subclasses.

Motivation for this change is to support automatic generation of wrapper controllers for poniard, like this: https://github.com/xaviershay/poniard/pull/2

As a bonus, this change is clearly useful for testing as well, since we can get rid of the ugly constant stubbing :)

cc @rafaelfranca
