### PR TITLE
Use Request#raw_post instead Request#body in ParamsParser#parse_formatted_parameters

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix `ActionDispatch::ParamsParser#parse_formatted_parameters` to rewind body input stream on
+    parsing json params.
+
+    Fixes #11345
+
+    *Yuri Bol*, *Paul Nikitochkin*
+
 *   Ignore spaces around delimiter in Set-Cookie header.
 
     *Yamagishi Kazutoshi*

--- a/actionpack/lib/action_dispatch/middleware/params_parser.rb
+++ b/actionpack/lib/action_dispatch/middleware/params_parser.rb
@@ -41,7 +41,7 @@ module ActionDispatch
         when Proc
           strategy.call(request.raw_post)
         when :json
-          data = ActiveSupport::JSON.decode(request.body)
+          data = ActiveSupport::JSON.decode(request.raw_post)
           data = {:_json => data} unless data.is_a?(Hash)
           Request::Utils.deep_munge(data).with_indifferent_access
         else

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -70,6 +70,13 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'raw_post is not empty for JSON request' do
+    with_test_routing do
+      post '/parse', '{"posts": [{"title": "Post Title"}]}', 'CONTENT_TYPE' => 'application/json'
+      assert_equal '{"posts": [{"title": "Post Title"}]}', request.raw_post
+    end
+  end
+
   private
     def assert_parses(expected, actual, headers = {})
       with_test_routing do


### PR DESCRIPTION
In order to get `raw_post` to be not empty after `ParamsParser#parse_formatted_parameters`, added rewinding of body stream input.

Closes #11345
