### PR TITLE
cache.exists? should return true/false

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -408,7 +408,7 @@ module ActiveSupport
         options = merged_options(options)
         instrument(:exist?, name) do
           entry = read_entry(namespaced_key(name, options), options)
-          entry && !entry.expired?
+          (entry && !entry.expired?) || false
         end
       end
 

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -327,8 +327,8 @@ module CacheStoreBehavior
 
   def test_exist
     @cache.write('foo', 'bar')
-    assert @cache.exist?('foo')
-    assert !@cache.exist?('bar')
+    assert_equal true, @cache.exist?('foo')
+    assert_equal false, @cache.exist?('bar')
   end
 
   def test_nil_exist


### PR DESCRIPTION
cache.exists? returns nil if the entry does not exist.  It should really return false.
