### PR TITLE
Fix request raw_post_body.rewind in actionpack-4.0.0/lib/action_dispatch/http/request.rb

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix `ActionDispatch::request#raw_post` to rewind body input stream
+
+    Fixes #11345
+
+    *Adrien Lamothe*
+
 *   Ignore spaces around delimiter in Set-Cookie header.
 
     *Yamagishi Kazutoshi*

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -226,6 +226,7 @@ module ActionDispatch
     def raw_post
       unless @env.include? 'RAW_POST_DATA'
         raw_post_body = body
+        raw_post_body.rewind if raw_post_body.respond_to?(:rewind)
         @env['RAW_POST_DATA'] = raw_post_body.read(@env['CONTENT_LENGTH'].to_i)
         raw_post_body.rewind if raw_post_body.respond_to?(:rewind)
       end

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -70,6 +70,14 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
     end
   end
 
+test 'raw_post is not empty for JSON request' do
+  with_test_routing do
+      post '/parse', '{"posts": [{"title": "Post Title"}]}', 'CONTENT_TYPE' => 'application/json'
+      assert_equal '{"posts": [{"title": "Post Title"}]}', request.raw_post
+    end
+  end
+
+
   private
     def assert_parses(expected, actual, headers = {})
       with_test_routing do


### PR DESCRIPTION
Current code is calling rewind after assigning raw_post data to return value, then rewinding the data body, so the rewinded data is not getting returned nor setting the @env['RAW_POST_DATA'] variable. This fix rewinds the data body before assigning it to the variable that is returned, which causes the variable to be assigned a valid value.

Closes #11345
