### PR TITLE
handle notes in *.sass files

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `rake notes` to look into `*.sass` files
+
+    *Yuri Artemev*
+
 *   Removed deprecated `Rails.application.railties.engines`.
 
     *Arun Agrawal*

--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -82,7 +82,7 @@ class SourceAnnotationExtractor
             case item
             when /\.(builder|rb|coffee|rake)$/
               /#\s*(#{tag}):?\s*(.*)$/
-            when /\.(css|scss|js)$/
+            when /\.(css|scss|sass|js)$/
               /\/\/\s*(#{tag}):?\s*(.*)$/
             when /\.erb$/
               /<%\s*#\s*(#{tag}):?\s*(.*?)\s*%>/

--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -24,6 +24,7 @@ module ApplicationTests
         app_file "app/assets/javascripts/application.js", "// TODO: note in js"
         app_file "app/assets/stylesheets/application.css", "// TODO: note in css"
         app_file "app/assets/stylesheets/application.css.scss", "// TODO: note in scss"
+        app_file "app/assets/stylesheets/application.css.sass", "// TODO: note in sass"
         app_file "app/controllers/application_controller.rb", 1000.times.map { "" }.join("\n") << "# TODO: note in ruby"
         app_file "lib/tasks/task.rake", "# TODO: note in rake"
 
@@ -46,9 +47,10 @@ module ApplicationTests
           assert_match(/note in js/, output)
           assert_match(/note in css/, output)
           assert_match(/note in scss/, output)
+          assert_match(/note in sass/, output)
           assert_match(/note in rake/, output)
 
-          assert_equal 9, lines.size
+          assert_equal 10, lines.size
 
           lines.each do |line|
             assert_equal 4, line[0].size


### PR DESCRIPTION
`rake notes` doesn't look into `*.sass` files, this commit will fix it
