### PR TITLE
Using the instance variable for argv.

### DIFF
--- a/railties/lib/rails/commands/commands_tasks.rb
+++ b/railties/lib/rails/commands/commands_tasks.rb
@@ -100,7 +100,7 @@ EOT
     end
 
     def version
-      ARGV.unshift '--version'
+      argv.unshift '--version'
       require_command!("application")
     end
 
@@ -117,7 +117,7 @@ EOT
       end
 
       def shift_argv!
-        ARGV.shift if ARGV.first && ARGV.first[0] != '-'
+        argv.shift if argv.first && argv.first[0] != '-'
       end
 
       def require_command!(command)


### PR DESCRIPTION
Instead of using the global constant ARGV, I'm changing to using the instance variable because it is more testable. This corresponds to the code in `commands_tasks.rb` which gets runs the requested rails command.
