### PR TITLE
Fixing style in ActiveRecord

### DIFF
--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -227,6 +227,7 @@ module ActiveRecord
       end
 
       private
+
         def reader_method(name, class_name, mapping, allow_nil, constructor)
           define_method(name) do
             if @aggregation_cache[name].nil? && (!allow_nil || mapping.any? {|pair| !read_attribute(pair.first).nil? })

--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -70,12 +70,12 @@ module ActiveRecord::Associations::Builder
     def validate_options
       options.assert_valid_keys(valid_options)
     end
-    
+
     # Defines the setter and getter methods for the association
     # class Post < ActiveRecord::Base
     #   has_many :comments
     # end
-    # 
+    #
     # Post.first.comments and Post.first.comments= methods are defined by this method...
 
     def define_accessors

--- a/activerecord/lib/active_record/associations/builder/singular_association.rb
+++ b/activerecord/lib/active_record/associations/builder/singular_association.rb
@@ -16,7 +16,7 @@ module ActiveRecord::Associations::Builder
     end
 
     # Defines the (build|create)_association methods for belongs_to or has_one association
-    
+
     def define_constructors
       mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
         def build_#{name}(*args, &block)

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -50,7 +50,10 @@ module ActiveRecord
       end
 
       private
-      def method_body; raise NotImplementedError; end
+
+      def method_body
+        raise NotImplementedError
+      end
     end
 
     module ClassMethods

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -377,14 +377,14 @@ module ActiveRecord
           update_sql(sql, name)
         end
 
-      def sql_for_insert(sql, pk, id_value, sequence_name, binds)
-        [sql, binds]
-      end
+        def sql_for_insert(sql, pk, id_value, sequence_name, binds)
+          [sql, binds]
+        end
 
-      def last_inserted_id(result)
-        row = result.rows.first
-        row && row.first
-      end
+        def last_inserted_id(result)
+          row = result.rows.first
+          row && row.first
+        end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -284,6 +284,7 @@ module ActiveRecord
       end
 
       private
+
       def create_column_definition(name, type)
         ColumnDefinition.new name, type
       end
@@ -495,10 +496,10 @@ module ActiveRecord
       end
 
       private
-        def native
-          @base.native_database_types
-        end
-    end
 
+      def native
+        @base.native_database_types
+      end
+    end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -826,6 +826,7 @@ module ActiveRecord
         end
 
       private
+
       def create_table_definition(name, temporary, options)
         TableDefinition.new native_database_types, name, temporary, options
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -10,6 +10,7 @@ module ActiveRecord
         end
 
         private
+
         def visit_ChangeColumnDefinition(o)
           column = o.column
           options = o.options

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -247,6 +247,7 @@ module ActiveRecord
       end
 
       private
+
         def extract_limit(sql_type)
           $1.to_i if sql_type =~ /\((.*)\)/
         end

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -36,6 +36,7 @@ module ActiveRecord
         end
 
         private
+
         def resolve_string_connection(spec) # :nodoc:
           hash = configurations.fetch(spec) do |k|
             connection_url_to_hash(k)

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -118,6 +118,7 @@ module ActiveRecord
         end
 
         private
+
         def cache
           @cache[Process.pid]
         end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -89,6 +89,7 @@ module ActiveRecord
         end
 
         private
+
         def cache
           @cache[$$]
         end

--- a/activerecord/lib/active_record/fixture_set/file.rb
+++ b/activerecord/lib/active_record/fixture_set/file.rb
@@ -26,6 +26,7 @@ module ActiveRecord
 
 
       private
+
         def rows
           return @rows if @rows
 

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -610,6 +610,7 @@ module ActiveRecord
     end
 
     private
+
       def primary_key_name
         @primary_key_name ||= model_class && model_class.primary_key
       end
@@ -885,6 +886,7 @@ module ActiveRecord
     end
 
     private
+
       def load_fixtures
         fixtures = ActiveRecord::FixtureSet.create_fixtures(fixture_path, fixture_table_names, fixture_class_names)
         Hash[fixtures.map { |f| [f.name, f] }]

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -60,6 +60,7 @@ module ActiveRecord
       end
 
       private
+
         def increment_lock
           lock_col = self.class.locking_column
           previous_lock_value = send(lock_col).to_i

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -681,6 +681,7 @@ module ActiveRecord
     end
 
     private
+
     def execute_block
       if connection.respond_to? :execute_block
         super # use normal delegation to record the block
@@ -711,15 +712,14 @@ module ActiveRecord
 
     private
 
-      def migration
-        @migration ||= load_migration
-      end
+    def migration
+      @migration ||= load_migration
+    end
 
-      def load_migration
-        require(File.expand_path(filename))
-        name.constantize.new
-      end
-
+    def load_migration
+      require(File.expand_path(filename))
+      name.constantize.new
+    end
   end
 
   class NullMigration < MigrationProxy #:nodoc:
@@ -937,6 +937,7 @@ module ActiveRecord
     end
 
     private
+
     def ran?(migration)
       migrated.include?(migration.version.to_i)
     end

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -155,6 +155,7 @@ module ActiveRecord
       end
 
       private
+
         def derive_class_name
           name.to_s.camelize
         end
@@ -672,6 +673,7 @@ directive on your declaration like:
       end
 
       private
+
         def derive_class_name
           # get the class_name of the belongs_to association of the through reflection
           options[:source_type] || source_reflection.class_name

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -74,6 +74,7 @@ module ActiveRecord
     end
 
     private
+
       def self.build(attribute, value)
         case value
         when Array

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -62,6 +62,7 @@ module ActiveRecord
     end
 
     private
+
     def hash_rows
       @hash_rows ||=
         begin

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -100,6 +100,7 @@ module ActiveRecord
     end
 
     protected
+
       def read_store_attribute(store_attribute, key)
         attribute = initialize_store_attribute(store_attribute)
         attribute[key]
@@ -114,6 +115,7 @@ module ActiveRecord
       end
 
     private
+
       def initialize_store_attribute(store_attribute)
         attribute = send(store_attribute)
         unless attribute.is_a?(ActiveSupport::HashWithIndifferentAccess)


### PR DESCRIPTION
Removed few spare spaces, little bit fixed definition methods with special access (if two different definition styles are found in one file, changed them to one)

Noticed that we have three different definintion access styles:
1. 

``` ruby
class Foo
  def method
  end

  private

  def private_method
  end
end 
```

2.

``` ruby
class Foo
  def method
  end

private

  def private_method
  end
end 
```

3.

``` ruby
class Foo
  def method
  end

  private

    def private_method
    end
end 
```

Which of this styles is more preferable for using in rails?
