### PR TITLE
Creating a class to handle preparing ARGV.

### DIFF
--- a/railties/lib/rails/commands/application.rb
+++ b/railties/lib/rails/commands/application.rb
@@ -1,30 +1,3 @@
-require 'rails/version'
-
-if ['--version', '-v'].include?(ARGV.first)
-  puts "Rails #{Rails::VERSION::STRING}"
-  exit(0)
-end
-
-if ARGV.first != "new"
-  ARGV[0] = "--help"
-else
-  ARGV.shift
-  unless ARGV.delete("--no-rc")
-    customrc = ARGV.index{ |x| x.include?("--rc=") }
-    railsrc = if customrc
-                File.expand_path(ARGV.delete_at(customrc).gsub(/--rc=/, ""))
-              else
-                File.join(File.expand_path("~"), '.railsrc')
-              end
-    if File.exist?(railsrc)
-      extra_args_string = File.read(railsrc)
-      extra_args = extra_args_string.split(/\n+/).map {|l| l.split}.flatten
-      puts "Using #{extra_args.join(" ")} from #{railsrc}"
-      ARGV.insert(1, *extra_args)
-    end
-  end
-end
-
 require 'rails/generators'
 require 'rails/generators/rails/app/app_generator'
 
@@ -40,4 +13,5 @@ module Rails
   end
 end
 
+Rails::Generators::AppPreparer.new(ARGV).prepare!
 Rails::Generators::AppGenerator.start

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -300,5 +300,67 @@ module Rails
         defined?(::AppBuilder) ? ::AppBuilder : Rails::AppBuilder
       end
     end
+
+    # This class handles preparation of the arguments before the AppGenerator is
+    # called. The class provides version or help information if they were
+    # requested, and also constructs the railsrc file (used for extra configuration
+    # options).
+    #
+    # This class should be called before the AppGenerator is required and started
+    # since it configures and mutates ARGV correctly.
+    class AppPreparer # :nodoc
+      attr_reader :argv
+
+      def initialize(argv = ARGV)
+        @argv = argv
+      end
+
+      def prepare!
+        handle_version_request!(argv.first)
+        unless handle_invalid_command!(argv.first)
+          argv.shift
+          handle_rails_rc!
+        end
+      end
+
+      private
+
+        def handle_version_request!(argument)
+          if ['--version', '-v'].include?(argv.first)
+            require 'rails/version'
+            puts "Rails #{Rails::VERSION::STRING}"
+            exit(0)
+          end
+        end
+
+        def handle_invalid_command!(argument)
+          if argument != "new"
+            argv[0] = "--help"
+          end
+        end
+
+        def handle_rails_rc!
+          unless argv.delete("--no-rc")
+            insert_railsrc(railsrc)
+          end
+        end
+
+        def railsrc
+          if (customrc = argv.index{ |x| x.include?("--rc=") })
+            File.expand_path(argv.delete_at(customrc).gsub(/--rc=/, ""))
+          else
+            File.join(File.expand_path("~"), '.railsrc')
+          end
+        end
+
+        def insert_railsrc(railsrc)
+          if File.exist?(railsrc)
+            extra_args_string = File.read(railsrc)
+            extra_args = extra_args_string.split(/\n+/).map {|l| l.split}.flatten
+            puts "Using #{extra_args.join(" ")} from #{railsrc}"
+            argv.insert(1, *extra_args)
+          end
+        end
+    end
   end
 end


### PR DESCRIPTION
Before the `AppGenerator` is started, `ARGV` needs to be modified to correctly account for some things (like showing the version). I'm extracting these out into their own class, and moving this class inside of the same file that defines `AppGenerator`. 

Right now, the preparation done by the `AppPreparer` class is done inside of the `commands/application.rb` file and it is thrown together in a hacky manner. I think instead of putting this logic in the `commands/application.rb` file (which in my opinion should only make a call the requisite classes), the `AppPreparer` should be extracted some place which is reasonably close to the `AppGenerator` class. 
