### PR TITLE
Dump UUID default functions to schema.rb [2nd version]. Fixes #10751.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Migration dump UUID default functions to schema.rb.
+    Fixes #10751.
+
+    *kennyj*
+
 *   Remove extra select and update queries on save/touch/destroy ActiveRecord model
     with belongs to reflection with option `touch: true`.
 

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -61,6 +61,7 @@ class PostgresqlUUIDTest < ActiveRecord::TestCase
     schema = StringIO.new
     ActiveRecord::SchemaDumper.dump(@connection, schema)
     assert_match(/\bcreate_table "pg_uuids", id: :uuid\b/, schema.string)
+    assert_match(/t\.uuid   "other_uuid", default: "uuid_generate_v4\(\)"/, schema.string)
   end
 end
 

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -299,7 +299,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
     def test_schema_dump_includes_uuid_shorthand_definition
       output = standard_dump
-      if %r{create_table "poistgresql_uuids"} =~ output
+      if %r{create_table "postgresql_uuids"} =~ output
         assert_match %r{t.uuid "guid"}, output
       end
     end


### PR DESCRIPTION
This PR is second version for fixing #10751. First version is #10811.

Please see #10751 about original problem.

In master, UUID default functions are not dumped to db/schema.rb, because they are not extracted to `PostgreSQLColum`.

In first version, I modified `PostgreSQLColum.extract_value_from_default` method to return a function name string when `default` argument is uuid generator. But I've understood this was wrong approach, because `extract_value_from_default` method must extract value.
