### PR TITLE
Remove unnecessary string interpolation

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
@@ -59,9 +59,9 @@ class <%= controller_class_name %>Controller < ApplicationController
     # Only allow a trusted parameter "white list" through.
     def <%= "#{singular_table_name}_params" %>
       <%- if attributes_names.empty? -%>
-      params[<%= ":#{singular_table_name}" %>]
+      params[:<%= singular_table_name %>]
       <%- else -%>
-      params.require(<%= ":#{singular_table_name}" %>).permit(<%= attributes_names.map { |name| ":#{name}" }.join(', ') %>)
+      params.require(:<%= singular_table_name %>).permit(<%= attributes_names.map { |name| ":#{name}" }.join(', ') %>)
       <%- end -%>
     end
 end


### PR DESCRIPTION
Hello,

@carlosantoniodasilva found this unnecessary interpolation that I grabbed from here and put in responders gem.

I removed to make it a little more clean.
