### PR TITLE
to_key doesn't always return an array, breaking to_param on certain case...

### DIFF
--- a/activemodel/lib/active_model/conversion.rb
+++ b/activemodel/lib/active_model/conversion.rb
@@ -62,7 +62,7 @@ module ActiveModel
     #   person = Person.create
     #   person.to_param # => "1"
     def to_param
-      persisted? ? to_key.join('-') : nil
+      persisted? ? [to_key].join('-') : nil
     end
 
     # Returns a +string+ identifying the path associated with the object.


### PR DESCRIPTION
...s

Noticed when using activeresource using a "singleton" API: it is persisted
but doesn't have an id - while the method assumes all persistent models have id.

The `to_key` previously (in 3.2) returns an array of nil - `[nil]` - when `instance.id` returns `nil`.
