### PR TITLE
Key's Value for boolean method?, should be boolean type

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -254,14 +254,15 @@ module ActiveRecord
       end
 
       # Returns a hash of all the methods added to query each of the columns in the table with the name of the method as the key
-      # and true as the value. This makes it possible to do O(1) lookups in respond_to? to check if a given method for attribute
-      # is available.
-      def column_methods_hash #:nodoc:
+      # and the value as what is the return type of that method. This makes it possible to do O(1) lookups in respond_to? to check if a given 
+      # method for attribute is available.
+
+      def column_methods_hash 
         @dynamic_methods_hash ||= column_names.each_with_object(Hash.new(false)) do |attr, methods|
           attr_name = attr.to_s
           methods[attr.to_sym]       = attr_name
           methods["#{attr}=".to_sym] = attr_name
-          methods["#{attr}?".to_sym] = attr_name
+          methods["#{attr}?".to_sym] = 'boolean'
           methods["#{attr}_before_type_cast".to_sym] = attr_name
         end
       end


### PR DESCRIPTION
Currently the method [column_methods_hash](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/model_schema.rb#L259) return this. eg

```
2.0.0p195 :004 > Account.column_methods_hash
 => {:id=>id, :id==>id, :id?=>id, :id_before_type_cast=>id, :name=>name, :name==>name, :name?=>name, :name_before_type_cast=>name, :user_id=>user_id, :user_id==>user_id, :user_id?=>user_id, :user_id_before_type_cast=>user_id, :created_at=>created_at, :created_at==>created_at, :created_at?=>created_at, :created_at_before_type_cast=>created_at, :updated_at=>updated_at, :updated_at==>updated_at, :updated_at?=>updated_at, :updated_at_before_type_cast=>updated_at}
```

```
2.0.0p195 :010 > Account.first.user_id?
Account Load (0.3ms)  SELECT accounts.* FROM accounts ORDER BY accounts.id ASC LIMIT 1
=> true
```

**The above is a boolean return. For boolean method**

```
2.0.0p195 :014 > Account.first.name
Account Load (0.2ms)  SELECT accounts.* FROM accounts ORDER BY accounts.id ASC LIMIT 1
=> Ankit
```

**The above return it's value/type of method name**

The correct return from the method [column_methods_hash](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/model_schema.rb#L259) should include boolean for boolean methods

```
 => {:id=>id, :id==>id, :id?=>boolean, :id_before_type_cast=>id, :name=>name, :name==>name, :name?=>boolean, :name_before_type_cast=>name, :user_id=>user_id, :user_id==>user_id, :user_id?=>boolean, :user_id_before_type_cast=>user_id, :created_at=>created_at, :created_at==>created_at, :created_at?=>boolean, :created_at_before_type_cast=>created_at, :updated_at=>updated_at, :updated_at==>updated_at, :updated_at?=>boolean, :updated_at_before_type_cast=>updated_at}
```
