### PR TITLE
Update the form_tag helper to comply with CSP

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Add `without_inline_styles` option to `form_for` and `form_tag` helpers
+
+    Default:
+
+        form_tag
+        # => '<form><div style="margin:0;padding:0;display:inline">...</div>...</form>'
+
+    With option:
+
+        form_tag '', without_inline_styles: true
+        # => '<form><div>...</div>...</form>'
+
+    This option gives the developer the ability to make the generated forms
+    compatible with Content Security Policy.
+
+    * R Blake Hitchcock *
+
 *   Fix default rendered format problem when calling `render` without :content_type option.
     It should return :html. Fix #11393.
 

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -340,6 +340,28 @@ module ActionView
       #     ...
       #   </form>
       #
+      # === Making the form comply with Content Security Policy
+      #
+      # For browser compatibility, the default hidden input elements generated
+      # by the helper are placed inside of a div with inline style elements
+      # applied. This violates the Content Security Policy which disallows any
+      # inline style attributes. If you wish to generate the form without the
+      # inline styles, specify the "without_inline_styles" option. Example:
+      #
+      #   <%= form_for(@post, html: { without_inline_styles: true }) do |f| %>
+      #     ...
+      #   <% end %>
+      #
+      # The HTML generated for this would be:
+      #
+      #   <form action='http://www.example.com' method='post'>
+      #     <div>
+      #       <input name='_method' type='hidden' value='patch' />
+      #       ...
+      #     </div>
+      #     ...
+      #   </form>
+      #
       # === Removing hidden model id's
       #
       # The form_for method automatically includes the model id as a hidden field in the form.

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -722,7 +722,11 @@ module ActionView
 
           enforce_utf8 = html_options.delete("enforce_utf8") { true }
           tags = (enforce_utf8 ? utf8_enforcer_tag : ''.html_safe) << method_tag
-          content_tag(:div, tags, :style => 'margin:0;padding:0;display:inline')
+          if !html_options.delete("without_inline_styles")
+            content_tag(:div, tags, :style => 'margin:0;padding:0;display:inline')
+          else
+            content_tag(:div, tags)
+          end
         end
 
         def form_tag_html(html_options)

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -14,7 +14,11 @@ class FormTagHelperTest < ActionView::TestCase
     method = options[:method]
     enforce_utf8 = options.fetch(:enforce_utf8, true)
 
-    txt =  %{<div style="margin:0;padding:0;display:inline">}
+    if !options[:without_inline_styles]
+      txt =  %{<div style="margin:0;padding:0;display:inline">}
+    else
+      txt =  %{<div>}
+    end
     txt << %{<input name="utf8" type="hidden" value="&#x2713;" />} if enforce_utf8
     if method && !%w(get post).include?(method.to_s)
       txt << %{<input name="_method" type="hidden" value="#{method}" />}
@@ -108,6 +112,13 @@ class FormTagHelperTest < ActionView::TestCase
     actual = form_tag({}, :remote => false)
 
     expected = whole_form
+    assert_dom_equal expected, actual
+  end
+
+  def test_form_tag_with_without_inline_styles_option
+    actual = form_tag({}, :without_inline_styles => true)
+
+    expected = whole_form("http://www.example.com", :without_inline_styles => true)
     assert_dom_equal expected, actual
   end
 


### PR DESCRIPTION
[Content Security Policy](http://www.w3.org/TR/CSP/) by default does not allow for inline style attributes in HTML tags. The `form_for` and `form_tag` actionview helpers, when adding hidden input fields (such as the one containing the CSRF token) to the generated form, create a  `div` tag that has some inline style rules applied.

``` html
<!-- Generated form -->
<form>
  <div style="margin:0;padding:0;display:inline">
     <input name="authenticity_token" type="hidden" value="xxx">
  </div>
</form>
```

In order to comply with CSP, this `style` attribute should be removed and replaced with a class (if it is desired that the style attributes continue to be applied).

``` html
<!-- Generated form -->
<form>
  <div class="extra_tags">
    <input name="authenticity_token" type="hidden" value="xxx">
  </div>
</form>
```

``` css
/* Stylesheet definition */
form div.extra_tags {
  padding: 0;
  margin: 0;
  display: inline;
}
```

If this change is not made, any developers who wish to return the Content Security Policy header for their application will have to:

1) Patch their install of rails to not use an inline style attribute with this helper
2) Not use the form helpers
3) Define their CSP directive to allow inline style attributes (not ideal or secure)

Hopefully the class name is descriptive enough. First pull request... tried to follow the instructions in the contribution guide. Apologies in advance for anything I overlooked. Thanks!
