### PR TITLE
rails g scaffold_controller --skip_namespace expectation

### DIFF
--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -94,7 +94,11 @@ module Rails
         end
 
         def class_name
-          (class_path + [file_name]).map!{ |m| m.camelize }.join('::')
+          if options[:skip_namespace]
+            file_name.camelize
+          else
+            (class_path + [file_name]).map!{ |m| m.camelize }.join('::')
+          end
         end
 
         def human_name
@@ -106,13 +110,21 @@ module Rails
         end
 
         def i18n_scope
-          @i18n_scope ||= file_path.tr('/', '.')
+          @i18n_scope ||= if options[:skip_namespace]
+                            singular_name
+                          else
+                            file_path.tr('/', '.')
+                          end
         end
 
         def table_name
           @table_name ||= begin
             base = pluralize_table_names? ? plural_name : singular_name
-            (class_path + [base]).join('_')
+            if options[:skip_namespace]
+              base
+            else
+              (class_path + [base]).join('_')
+            end
           end
         end
 

--- a/railties/test/generators/named_base_test.rb
+++ b/railties/test/generators/named_base_test.rb
@@ -65,6 +65,22 @@ class NamedBaseTest < Rails::Generators::TestCase
     ActiveRecord::Base.pluralize_table_names = true
   end
 
+  def test_named_generator_attributes_with_skip_namespace
+    g = generator ['admin/foo'], skip_namespace: true
+    assert_name g, 'admin/foo',   :name
+    assert_name g, %w(admin),     :class_path
+    assert_name g, 'admin/foo',   :file_path
+    assert_name g, 'Foo',         :class_name
+    assert_name g, 'foo',         :file_name
+    assert_name g, 'Foo',         :human_name
+    assert_name g, 'foo',         :singular_name
+    assert_name g, 'foos',        :plural_name
+    assert_name g, 'foo',         :i18n_scope
+    assert_name g, 'foos',        :table_name
+    assert_name g, 'Admin::Foos', :controller_class_name
+    assert_name g, 'admin/foos',  :controller_file_path
+  end
+
   def test_scaffold_plural_names
     g = generator ['admin/foo']
     assert_name g, 'admin/foos',  :controller_name

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -166,4 +166,13 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       assert_match(/render action: 'new'/, content)
     end
   end
+
+  def test_skip_namespace
+    run_generator ["Admin::User", "--skip_namespace"]
+    assert_file "app/controllers/admin/users_controller.rb" do |content|
+      assert_instance_method :index, content do |m|
+        assert_match(/@users = User\.all/, m)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hi.

```
$ rails g scaffold_controller Admin::User
```

I expected to create such code.

``` ruby
class Admin::UsersController < ApplicationController
  before_action :set_user, only: [:show, :edit, :update, :destroy]

  def index
    @users = User.all
  end
```

But It created

``` ruby
class Admin::UsersController < ApplicationController
  before_action :set_admin_user, only: [:show, :edit, :update, :destroy]

  def index
    @admin_users = Admin::User.all
  end
```

I searched '--skip-namespace' specification.
But I could not find it.

I suggest the --skip-namespace behavior this pull request.

Thanks.
