### PR TITLE
Rename the I18n keys for associations' restrict_dependent_destroy errors

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -15,7 +15,7 @@ module ActiveRecord
         when :restrict_with_error
           unless empty?
             record = klass.human_attribute_name(reflection.name).downcase
-            owner.errors.add(:base, :"restrict_dependent_destroy.many", record: record)
+            owner.errors.add(:base, :"restrict_dependent_destroy.has_many", record: record)
             false
           end
 

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -12,7 +12,7 @@ module ActiveRecord
         when :restrict_with_error
           if load_target
             record = klass.human_attribute_name(reflection.name).downcase
-            owner.errors.add(:base, :"restrict_dependent_destroy.one", record: record)
+            owner.errors.add(:base, :"restrict_dependent_destroy.has_one", record: record)
             false
           end
 

--- a/activerecord/lib/active_record/locale/en.yml
+++ b/activerecord/lib/active_record/locale/en.yml
@@ -15,8 +15,8 @@ en:
       messages:
         record_invalid: "Validation failed: %{errors}"
         restrict_dependent_destroy:
-          one: "Cannot delete record because a dependent %{record} exists"
-          many: "Cannot delete record because dependent %{record} exist"
+          has_one: "Cannot delete record because a dependent %{record} exists"
+          has_many: "Cannot delete record because dependent %{record} exist"
         # Append your own errors here or at the model/attributes scope.
 
       # You can define own errors for models or model attributes.


### PR DESCRIPTION
The `:one` and `:many` keys are used for pluralisations, but as such are incorrect in english (since we should be using `:one` for singular and `:other` for plurals).

However in this particular case, we're not describing a pluralized entity, we're describing an error for a particular type of association.

This commit changes the I18n key to be the type of association rather than a misleading pluralization key, so that apps that test the validity of their pluralizations can continue to work.
