### PR TITLE
Added generated unit test for generator generator.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Added generated unit test for generator generator using new
+    `test:generators` rake task.
+
+    *Josef Šimánek*
+
 *   Removed `update:application_controller` rake task.
 
     *Josef Šimánek*

--- a/railties/lib/rails/generators/rails/generator/USAGE
+++ b/railties/lib/rails/generators/rails/generator/USAGE
@@ -10,3 +10,4 @@ Example:
         lib/generators/awesome/awesome_generator.rb
         lib/generators/awesome/USAGE
         lib/generators/awesome/templates/
+        test/lib/generators/awesome/awesome_generator_test.rb

--- a/railties/lib/rails/generators/rails/generator/generator_generator.rb
+++ b/railties/lib/rails/generators/rails/generator/generator_generator.rb
@@ -10,6 +10,8 @@ module Rails
         directory '.', generator_dir
       end
 
+      hook_for :test_framework
+
       protected
 
         def generator_dir

--- a/railties/lib/rails/generators/test_unit/generator/generator_generator.rb
+++ b/railties/lib/rails/generators/test_unit/generator/generator_generator.rb
@@ -1,0 +1,26 @@
+require 'rails/generators/test_unit'
+
+module TestUnit # :nodoc:
+  module Generators # :nodoc:
+    class GeneratorGenerator < Base # :nodoc:
+      check_class_collision suffix: "GeneratorTest"
+
+      class_option :namespace, type: :boolean, default: true,
+                               desc: "Namespace generator under lib/generators/name"
+
+      def create_generator_files
+        template 'generator_test.rb', File.join('test/lib/generators', class_path, "#{file_name}_generator_test.rb")
+      end
+
+    protected
+
+      def generator_path
+        if options[:namespace]
+          File.join("generators", regular_class_path, file_name, "#{file_name}_generator")
+        else
+          File.join("generators", regular_class_path, "#{file_name}_generator")
+        end
+      end
+    end
+  end
+end

--- a/railties/lib/rails/generators/test_unit/generator/templates/generator_test.rb
+++ b/railties/lib/rails/generators/test_unit/generator/templates/generator_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+require '<%= generator_path %>'
+
+<% module_namespacing do -%>
+class <%= class_name %>GeneratorTest < Rails::Generators::TestCase
+  tests <%= class_name %>Generator
+  destination Rails.root.join('tmp/generators')
+  setup :prepare_destination
+
+  # test "generator runs without errors" do
+  #   assert_nothing_raised do
+  #     run_generator ["arguments"]
+  #   end
+  # end
+end
+<% end -%>

--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -6,6 +6,7 @@ require 'active_support/testing/autorun'
 require 'active_support/test_case'
 require 'action_controller/test_case'
 require 'action_dispatch/testing/integration'
+require 'rails/generators/test_case'
 
 # Config Rails backtrace in tests.
 require 'rails/backtrace_cleaner'

--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -14,7 +14,7 @@ namespace :test do
     # Placeholder task for other Railtie and plugins to enhance. See Active Record for an example.
   end
 
-  task :run => ['test:units', 'test:functionals', 'test:integration']
+  task :run => ['test:units', 'test:functionals', 'test:generators', 'test:integration']
 
   # Inspired by: http://ngauthier.com/2012/02/quick-tests-with-bash.html
   desc "Run tests quickly by merging all types and not resetting db"
@@ -33,6 +33,10 @@ namespace :test do
     Rails::TestTask.new(name => "test:prepare") do |t|
       t.pattern = "test/#{name}/**/*_test.rb"
     end
+  end
+
+  Rails::TestTask.new(generators: "test:prepare") do |t|
+    t.pattern = "test/lib/generators/**/*_test.rb"
   end
 
   Rails::TestTask.new(units: "test:prepare") do |t|

--- a/railties/test/generators/generator_generator_test.rb
+++ b/railties/test/generators/generator_generator_test.rb
@@ -16,6 +16,10 @@ class GeneratorGeneratorTest < Rails::Generators::TestCase
 
     assert_file "lib/generators/awesome/awesome_generator.rb",
                 /class AwesomeGenerator < Rails::Generators::NamedBase/
+    assert_file "test/lib/generators/awesome_generator_test.rb",
+               /class AwesomeGeneratorTest < Rails::Generators::TestCase/
+    assert_file "test/lib/generators/awesome_generator_test.rb",
+               /require 'generators\/awesome\/awesome_generator'/
   end
 
   def test_namespaced_generator_skeleton
@@ -29,6 +33,10 @@ class GeneratorGeneratorTest < Rails::Generators::TestCase
 
     assert_file "lib/generators/rails/awesome/awesome_generator.rb",
                 /class Rails::AwesomeGenerator < Rails::Generators::NamedBase/
+    assert_file "test/lib/generators/rails/awesome_generator_test.rb",
+               /class Rails::AwesomeGeneratorTest < Rails::Generators::TestCase/
+    assert_file "test/lib/generators/rails/awesome_generator_test.rb",
+               /require 'generators\/rails\/awesome\/awesome_generator'/
   end
 
   def test_generator_skeleton_is_created_without_file_name_namespace
@@ -42,6 +50,10 @@ class GeneratorGeneratorTest < Rails::Generators::TestCase
 
     assert_file "lib/generators/awesome_generator.rb",
                 /class AwesomeGenerator < Rails::Generators::NamedBase/
+    assert_file "test/lib/generators/awesome_generator_test.rb",
+               /class AwesomeGeneratorTest < Rails::Generators::TestCase/
+    assert_file "test/lib/generators/awesome_generator_test.rb",
+               /require 'generators\/awesome_generator'/
   end
 
   def test_namespaced_generator_skeleton_without_file_name_namespace
@@ -55,5 +67,9 @@ class GeneratorGeneratorTest < Rails::Generators::TestCase
 
     assert_file "lib/generators/rails/awesome_generator.rb",
                 /class Rails::AwesomeGenerator < Rails::Generators::NamedBase/
+    assert_file "test/lib/generators/rails/awesome_generator_test.rb",
+               /class Rails::AwesomeGeneratorTest < Rails::Generators::TestCase/
+    assert_file "test/lib/generators/rails/awesome_generator_test.rb",
+               /require 'generators\/rails\/awesome_generator'/
   end
 end


### PR DESCRIPTION
## Before this patch

no test was generated for `rails g generator awesome`.
## With this patch

For `rails g generator awesome` is generated:

``` ruby
# test/lib/generators/awesome_generator_test.rb
require 'test_helper'
require 'generators/awesome/awesome_generator'

class AwesomeGeneratorTest < Rails::Generators::TestCase
  tests AwesomeGenerator
  destination Rails.root.join('tmp/generators')
  setup :prepare_destination

  # test "generator runs without errors" do
  #   assert_nothing_raised do
  #     run_generator ["arguments"]
  #   end
  # end
end
```
## Changes
- I created new `test:generators` rake task and added it into `test:all` rake task.
- I added `require 'rails/generators/test_case'` into `railties/lib/rails/test_help.rb`. I'm not sure how big dependency is that. Maybe we could require it per test file.
## Problems
- I couldn't find any hint how to test generators in [rails testing guides](http://guides.rubyonrails.org/testing.html). Maybe some small entry will be fine. What do you think?

/cc @steveklabnik
