### PR TITLE
Remove update:application_controller rake task.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Removed `update:application_controller` rake task.
+
+    *Josef Šimánek*
+
 *   Fix `rake environment` to do not eager load modules
 
     *Paul Nikitochkin*

--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -1,6 +1,6 @@
 namespace :rails do
-  desc "Update configs and some other initially generated files (or use just update:configs, update:bin, or update:application_controller)"
-  task update: [ "update:configs", "update:bin", "update:application_controller" ]
+  desc "Update configs and some other initially generated files (or use just update:configs or update:bin)"
+  task update: [ "update:configs", "update:bin" ]
 
   desc "Applies the template supplied by LOCATION=(/path/to/template) or URL"
   task :template do
@@ -61,16 +61,6 @@ namespace :rails do
     # desc "Adds new executables to the application bin/ directory"
     task :bin do
       invoke_from_app_generator :create_bin_files
-    end
-
-    # desc "Rename application.rb to application_controller.rb"
-    task :application_controller do
-      old_style = Rails.root + '/app/controllers/application.rb'
-      new_style = Rails.root + '/app/controllers/application_controller.rb'
-      if File.exists?(old_style) && !File.exists?(new_style)
-        FileUtils.mv(old_style, new_style)
-        puts "#{old_style} has been renamed to #{new_style}, update your SCM as necessary"
-      end
     end
   end
 end


### PR DESCRIPTION
This rake task was introduced in [9e08a3](https://github.com/rails/rails/commit/9e08a3bb1d47f79b6953056e72eee58e86d83ead) and was used to rename `app/controllers/application.rb` to `app/controllers/application_controller.rb`.

This was used to migrate from Rails < 2.3 to Rails 2.3. I think this can be removed now.

I'm not sure if this needs changelog entry if anyone will decide to merge it.
