### PR TITLE
Remove unused quoted_locking_column method.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `quoted_locking_column` method, which isn't used anywhere.
+
+    *kennyj*
+
 *   Migration dump UUID default functions to schema.rb.
 
     Fixes #10751.

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -150,6 +150,7 @@ module ActiveRecord
 
         # Quote the column name used for optimistic locking.
         def quoted_locking_column
+          ActiveSupport::Deprecation.warn "ActiveRecord::Base.quoted_locking_column is deprecated and will be removed in Rails 4.2 or later."
           connection.quote_column_name(locking_column)
         end
 

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -272,6 +272,10 @@ class OptimisticLockingTest < ActiveRecord::TestCase
     assert p.treasures.empty?
     assert RichPerson.connection.select_all("SELECT * FROM peoples_treasures WHERE rich_person_id = 1").empty?
   end
+
+  def test_quoted_locking_column_is_deprecated
+    assert_deprecated { ActiveRecord::Base.quoted_locking_column }
+  end
 end
 
 class OptimisticLockingWithSchemaChangeTest < ActiveRecord::TestCase


### PR DESCRIPTION
This method isn't used anywhere.

This added at https://github.com/rails/rails/commit/722e0b6a8bb62226437e466b5a98356d026b05f5 in 2006.
Maybe, when we were starting to use arel, we forgot to remove this.

If this is public api, we must not remove this, and should deprecate this.
