### PR TITLE
Reset @column_defaults when assigning locking_column.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Reset @column_defaults when assigning `locking_column`.
+    We had a potential problem. For example:
+
+    class Post < ActiveRecord::Base
+      self.column_defaults  # if we call this unintentionally before setting locking_column ...
+      self.locking_column = 'my_locking_column'
+    end
+
+    Post.column_defaults["my_locking_column"]
+    => nil # expected value is 0 !
+
+    *kennyj*
+
 *   Remove extra select and update queries on save/touch/destroy ActiveRecord model
     with belongs to reflection with option `touch: true`.
 

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -138,6 +138,7 @@ module ActiveRecord
 
         # Set the column to use for optimistic locking. Defaults to +lock_version+.
         def locking_column=(value)
+          @column_defaults = nil
           @locking_column = value.to_s
         end
 

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -17,6 +17,7 @@ class LockWithoutDefault < ActiveRecord::Base; end
 
 class LockWithCustomColumnWithoutDefault < ActiveRecord::Base
   self.table_name = :lock_without_defaults_cust
+  self.column_defaults # to test @column_defaults caching.
   self.locking_column = :custom_lock_version
 end
 


### PR DESCRIPTION
Reset @column_defaults when assigning `locking_column`.
We had a potential problem. For example:

``` ruby
class Post < ActiveRecord::Base
  self.column_defaults  # if we call this unintentionally before setting locking_column ...
  self.locking_column = 'my_locking_column'
end

Post.column_defaults["my_locking_column"]
=> nil # expected value is 0 !
```

The cause of this problem is @column_defaults caching.

``` ruby
# activerecrd/lib/active_record/locking/optimistic.rb
def column_defaults
  @column_defaults ||= begin
    defaults = super

    if defaults.key?(locking_column) && lock_optimistically
      defaults[locking_column] ||= 0
    end

    defaults
  end
end
```
