### PR TITLE
Add --model-name option into scaffold_controller generator 

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Added `--model-name` scaffld\_controller\_generator option.
+
+    *yalab*
+
 *   Expose MiddlewareStack#unshift to environment configuration.
 
     *Ben Pickles*

--- a/railties/lib/rails/generators/rails/scaffold_controller/scaffold_controller_generator.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/scaffold_controller_generator.rb
@@ -13,7 +13,7 @@ module Rails
       argument :attributes, type: :array, default: [], banner: "field:type field:type"
 
       def create_controller_files
-        template "controller.rb", File.join('app/controllers', class_path, "#{controller_file_name}_controller.rb")
+        template "controller.rb", File.join('app/controllers', controller_class_path, "#{controller_file_name}_controller.rb")
       end
 
       hook_for :template_engine, :test_framework, as: :scaffold

--- a/railties/test/generators/named_base_test.rb
+++ b/railties/test/generators/named_base_test.rb
@@ -117,6 +117,25 @@ class NamedBaseTest < Rails::Generators::TestCase
     assert Rails::Generators.hidden_namespaces.include?('hidden')
   end
 
+  def test_scaffold_plural_names_with_model_name_option
+    g = generator ['Admin::Foo'], model_name: 'User'
+    assert_name g, 'user',        :singular_name
+    assert_name g, 'User',        :name
+    assert_name g, 'user',        :file_path
+    assert_name g, 'User',        :class_name
+    assert_name g, 'user',        :file_name
+    assert_name g, 'User',        :human_name
+    assert_name g, 'users',       :plural_name
+    assert_name g, 'user',        :i18n_scope
+    assert_name g, 'users',       :table_name
+    assert_name g, 'Admin::Foos', :controller_name
+    assert_name g, %w(admin),     :controller_class_path
+    assert_name g, 'Admin::Foos', :controller_class_name
+    assert_name g, 'admin/foos',  :controller_file_path
+    assert_name g, 'foos',        :controller_file_name
+    assert_name g, 'admin.foos',  :controller_i18n_scope
+  end
+
   protected
 
     def assert_name(generator, value, method)

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -166,4 +166,13 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       assert_match(/render action: 'new'/, content)
     end
   end
+
+  def test_model_name_option
+    run_generator ["Admin::User", "--model-name=User"]
+    assert_file "app/controllers/admin/users_controller.rb" do |content|
+      assert_instance_method :index, content do |m|
+        assert_match("@users = User.all", m)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hi.

I want a feature that

```
$ rails g scaffold_controller Admin::User
```

to be generated.

``` ruby
class Admin::UsersController < ApplicationController
  before_action :set_user, only: [:show, :edit, :update, :destroy]

  # GET /users
  def index
    @users = User.all
  end
 ...
```

So I added a --model-name option like this.

```
$ rails g scaffold_controller Admin::User --model-name=User
```

I discussed the feature #11408 .
