### PR TITLE
Remove extra decrement of transaction level

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Remove extra decrement of transaction deep level.
+
+    Fixes: #4566
+
+    *Paul Nikitochkin*
+
 *   Reset @column_defaults when assigning `locking_column`.
     We had a potential problem. For example:
 

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -117,6 +117,20 @@ class TransactionTest < ActiveRecord::TestCase
     assert !Topic.find(1).approved?
   end
 
+  def test_raising_exception_in_nested_transaction_restore_state_in_save
+    topic = Topic.new
+
+    def topic.after_save_for_transaction
+      raise 'Make the transaction rollback'
+    end
+
+    assert_raises(RuntimeError) do
+      Topic.transaction { topic.save }
+    end
+
+    assert topic.new_record?, "#{topic.inspect} should be new record"
+  end
+
   def test_update_should_rollback_on_failure
     author = Author.find(1)
     posts_count = author.posts.size


### PR DESCRIPTION
`rollback_active_record_state!` tries to restore model state on `Exception`
by invoking `restore_transaction_record_state` it decrement deep level by `1`.

After restoring state, `rollback_active_record_state!` ensure that states should be cleared
and level decremented by invoking `clear_transaction_record_state`,
which cause the bug: because state already reduced in `restore_transaction_record_state`.

Removed double derement of transaction level
and removed duplicated code which clear transaction state for top level.

Closes: #4566
