### PR TITLE
Move initializing process for @query_cache to QueryCache module.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -20,6 +20,12 @@ module ActiveRecord
 
       attr_reader :query_cache, :query_cache_enabled
 
+      def initialize(*)
+        super
+        @query_cache         = Hash.new { |h,sql| h[sql] = {} }
+        @query_cache_enabled = false
+      end
+
       # Enable the query cache within the block.
       def cache
         old, @query_cache_enabled = @query_cache_enabled, true

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -95,8 +95,6 @@ module ActiveRecord
         @last_use            = false
         @logger              = logger
         @pool                = pool
-        @query_cache         = Hash.new { |h,sql| h[sql] = {} }
-        @query_cache_enabled = false
         @schema_cache        = SchemaCache.new self
         @visitor             = nil
       end


### PR DESCRIPTION
There are all operation about `@query_cache` / `@query_cache_enabled` instance variables in `QueryCache` module.
But only initializing process for them in `initialize` of `AbstractAdapter`.

In order to separate the concern, I think that initializing process also should be moved to `QueryCache` module.
When reading code, I can't find initializing process easily.
