### PR TITLE
Raise on 'order' being sent to find_each as .id is going to used regardless

### DIFF
--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -331,7 +331,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert ! firm.clients.loaded?
 
     assert_queries(3) do
-      firm.clients.find_each(:batch_size => 1) {|c| assert_equal firm.id, c.firm_id }
+      firm.clients.find_each(batch_size: 1, allow_unused_order: true) {|c| assert_equal firm.id, c.firm_id }
     end
 
     assert ! firm.clients.loaded?
@@ -341,7 +341,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     firm = companies(:first_firm)
 
     assert_queries(2) do
-      firm.clients.where(name: 'Microsoft').find_each(batch_size: 1) do |c|
+      firm.clients.where(name: 'Microsoft').find_each(batch_size: 1, allow_unused_order: true) do |c|
         assert_equal firm.id, c.firm_id
         assert_equal "Microsoft", c.name
       end
@@ -356,7 +356,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert ! firm.clients.loaded?
 
     assert_queries(2) do
-      firm.clients.find_in_batches(:batch_size => 2) do |clients|
+      firm.clients.find_in_batches(batch_size: 2, allow_unused_order: true) do |clients|
         clients.each {|c| assert_equal firm.id, c.firm_id }
       end
     end

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -63,10 +63,16 @@ class EachTest < ActiveRecord::TestCase
     Post.limit(1).find_each { |post| post }
   end
 
+  def test_raise_if_order_scope_is_set_without_allow_unused_order
+    assert_raise(RuntimeError) do
+      Post.order("title").find_each { |post| post }
+    end
+  end
+
   def test_warn_if_order_scope_is_set
     ActiveRecord::Base.logger.expects(:warn)
-    Post.order("title").find_each { |post| post }
-  end
+    Post.order("title").find_each({allow_unused_order: true}) { |post| post }
+  end  
 
   def test_logger_not_required
     previous_logger = ActiveRecord::Base.logger
@@ -134,7 +140,7 @@ class EachTest < ActiveRecord::TestCase
     # First post is with title scope
     first_post = PostWithDefaultScope.first
     posts = []
-    PostWithDefaultScope.find_in_batches  do |batch|
+    PostWithDefaultScope.find_in_batches(allow_unused_order: true)  do |batch|
       posts.concat(batch)
     end
     # posts.first will be ordered using id only. Title order scope should not apply here


### PR DESCRIPTION
This PR includes a suggest additional find_each param _:allow_unused_order_
In short, the idea is to raise an exception when this flag is not being sent, rather than logging this to the log file.
Specifically, I suggest this because I believe that in many cases, find_each / find_in_batches are actually used in background (resque-like) or Rails runner code and are therefore hard to come across when logged to a file.
