### PR TITLE
Fix #11393. Fix default rendered format when calling render method without :content_type option.

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix default rendered format problem when calling `render` without :content_type option.
+    It should return :html. Fix #11393.
+
+    *Gleb Mazovetskiy* *Oleg* *kennyj*
+
 *   Fix `link_to` with block and url hashes.
 
     Before:

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -11,7 +11,7 @@ module ActionView
       prepend_formats(template.formats)
 
       unless context.rendered_format
-        context.rendered_format = template.formats.first || formats.last
+        context.rendered_format = template.formats.first || formats.first
       end
 
       render_template(template, options[:layout], options[:locals])

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -41,6 +41,11 @@ module RenderTestCases
     assert_match "<error>No Comment</error>", @view.render(:template => "comments/empty", :formats => [:xml])
   end
 
+  def test_rendered_format_without_format
+    @view.render(:inline => "test")
+    assert_equal :html, @view.lookup_context.rendered_format
+  end
+
   def test_render_partial_implicitly_use_format_of_the_rendered_template
     @view.lookup_context.formats = [:json]
     assert_equal "Hello world", @view.render(:template => "test/one", :formats => [:html])


### PR DESCRIPTION
Closes #11393.

Please see #11393.
If we call `render` method with :inline option only (without :content_type), the rendered format is :zip.
It seems that this behavior is bad.

/cc @steveklabnik @GBH @glebm
