### PR TITLE
Backport #11437 to 4-0-stable. Fix default rendered format when calling render method without :content_type option.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## unreleased ##
 
+*   Fix default rendered format problem when calling `render` without :content_type option.
+    It should return :html.
+
+    Fixes #11393
+
+    *Gleb Mazovetskiy* *Oleg* *kennyj*
+
 *   Fix `ActionDispatch::ParamsParser#parse_formatted_parameters` to rewind body input stream on
     parsing json params.
 

--- a/actionpack/lib/action_view/renderer/template_renderer.rb
+++ b/actionpack/lib/action_view/renderer/template_renderer.rb
@@ -11,7 +11,7 @@ module ActionView
       prepend_formats(template.formats)
 
       unless context.rendered_format
-        context.rendered_format = template.formats.first || formats.last
+        context.rendered_format = template.formats.first || formats.first
       end
 
       render_template(template, options[:layout], options[:locals])

--- a/actionpack/test/template/render_test.rb
+++ b/actionpack/test/template/render_test.rb
@@ -41,6 +41,11 @@ module RenderTestCases
     assert_match "<error>No Comment</error>", @view.render(:template => "comments/empty", :formats => [:xml])
   end
 
+  def test_rendered_format_without_format
+    @view.render(:inline => "test")
+    assert_equal :html, @view.lookup_context.rendered_format
+  end
+
   def test_render_partial_implicitly_use_format_of_the_rendered_template
     @view.lookup_context.formats = [:json]
     assert_equal "Hello world", @view.render(:template => "test/one", :formats => [:html])


### PR DESCRIPTION
Please see #11393 and #11437.

/cc @guilleiguaran If unnecessary, please close this PR.
