### PR TITLE
Blacklist->whitelist for reference scans in order!

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -280,7 +280,7 @@ module ActiveRecord
       args.flatten!
       validate_order_args args
 
-      references = args.reject { |arg| Arel::Node === arg }
+      references = args.grep(String)
       references.map! { |arg| arg =~ /^([a-zA-Z]\w*)\.(\w+)/ && $1 }.compact!
       references!(references) if references.any?
 

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -227,6 +227,13 @@ module ActiveRecord
       assert_equal ['"posts".name ASC'], relation.order_values
     end
 
+    test "#order! on non-string does not attempt regexp match for references" do
+      obj = Object.new
+      obj.expects(:=~).never
+      assert relation.order!(obj)
+      assert_equal [obj], relation.order_values
+    end
+
     test '#references!' do
       assert relation.references!(:foo).equal?(relation)
       assert relation.references_values.include?('foo')


### PR DESCRIPTION
Stop special-casing Arel::Nodes as exempt from reference scanning in
order. Instead, only scan order values that are strings for a table
reference.
