### PR TITLE
Always use Rack::Sendfile so it can be automatically configured by the webserver

### DIFF
--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -20,9 +20,7 @@ module Rails
             middleware.use ::ActionDispatch::SSL, config.ssl_options
           end
 
-          if config.action_dispatch.x_sendfile_header.present?
-            middleware.use ::Rack::Sendfile, config.action_dispatch.x_sendfile_header
-          end
+          middleware.use ::Rack::Sendfile, config.action_dispatch.x_sendfile_header
 
           if config.serve_static_assets
             middleware.use ::ActionDispatch::Static, paths["public"].first, config.static_cache_control


### PR DESCRIPTION
Currently if `config.action_dispatch.x_sendfile_header` is not set Rails will never take advantage of the `X-Sendfile-Type` header informing it whether to use `X-Sendfile` or `X-Accel-Redirect` or no such acceleration, since it doesn't even load `Rack::Sendfile`.

By always loading `Rack::Sendfile` we make the docs actually correspond to reality:

https://github.com/rails/rails/blob/master/guides/source/3_1_release_notes.md#action-dispatch

> config.action_dispatch.x_sendfile_header now defaults to nil and config/environments/production.rb doesn't set any particular value for it. This allows servers to set it through X-Sendfile-Type.

https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/metal/data_streaming.rb#L18

> Your server can also configure this for you by setting the X-Sendfile-Type header.

https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/metal/data_streaming.rb#L78-L80

> Avoid having to pass an open file handle as the response body. Rack::Sendfile will usually intercept the response and uses the path directly, so there is no reason to open the file.

So clearly Rails was meant to autodetect whether or not to use a `X-Sendfile`/`X-Accel-Redirect` header without forcing the user to specify which header to use.

(By setting `x_sendfile_header` to any value `Rack::Sendfile` gets inserted in the middleware chain, but the value of `x_sendfile_header` is always used as the `X-Sendfile-Type` variant, thus breaking automatic configuration by the web server. With this pull request not setting `x_sendfile_header` makes Rails/Rack autodetect which header to use, while the user can explicitly force a certain header by setting `x_sendfile_header` to e.g. `X-Sendfile`)
