### PR TITLE
SSE class for ActionController::Live

### DIFF
--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -2,6 +2,94 @@ require 'abstract_unit'
 require 'active_support/concurrency/latch'
 
 module ActionController
+  class SSETest < ActionController::TestCase
+    class SSETestController < ActionController::Base
+      include ActionController::Live
+
+      def basic_sse
+        response.headers['Content-Type'] = 'text/event-stream'
+        sse = SSE.new(response.stream)
+        sse.write("{\"name\":\"John\"}")
+        sse.write({ name: "Ryan" })
+      ensure
+        sse.close
+      end
+
+      def sse_with_event
+        sse = SSE.new(response.stream, event: "send-name")
+        sse.write("{\"name\":\"John\"}")
+        sse.write({ name: "Ryan" })
+      ensure
+        sse.close
+      end
+
+      def sse_with_retry
+        sse = SSE.new(response.stream, retry: 1000)
+        sse.write("{\"name\":\"John\"}")
+        sse.write({ name: "Ryan" }, retry: 1500)
+      ensure
+        sse.close
+      end
+
+      def sse_with_id
+        sse = SSE.new(response.stream)
+        sse.write("{\"name\":\"John\"}", id: 1)
+        sse.write({ name: "Ryan" }, id: 2)
+      ensure
+        sse.close
+      end
+    end
+
+    tests SSETestController
+
+    def wait_for_response_stream_close
+      while !response.stream.closed?
+        sleep 0.01
+      end
+    end
+
+    def test_basic_sse
+      get :basic_sse
+
+      wait_for_response_stream_close
+      assert_match(/data: {\"name\":\"John\"}/, response.body)
+      assert_match(/data: {\"name\":\"Ryan\"}/, response.body)
+    end
+
+    def test_sse_with_event_name
+      get :sse_with_event
+
+      wait_for_response_stream_close
+      assert_match(/data: {\"name\":\"John\"}/, response.body)
+      assert_match(/data: {\"name\":\"Ryan\"}/, response.body)
+      assert_match(/event: send-name/, response.body)
+    end
+
+    def test_sse_with_retry
+      get :sse_with_retry
+
+      wait_for_response_stream_close
+      first_response, second_response = response.body.split("\n\n")
+      assert_match(/data: {\"name\":\"John\"}/, first_response)
+      assert_match(/retry: 1000/, first_response)
+
+      assert_match(/data: {\"name\":\"Ryan\"}/, second_response)
+      assert_match(/retry: 1500/, second_response)
+    end
+
+    def test_sse_with_id
+      get :sse_with_id
+
+      wait_for_response_stream_close
+      first_response, second_response = response.body.split("\n\n")
+      assert_match(/data: {\"name\":\"John\"}/, first_response)
+      assert_match(/id: 1/, first_response)
+
+      assert_match(/data: {\"name\":\"Ryan\"}/, second_response)
+      assert_match(/id: 2/, second_response)
+    end
+  end
+
   class LiveStreamTest < ActionController::TestCase
     class TestController < ActionController::Base
       include ActionController::Live


### PR DESCRIPTION
I've created a class that will handle sending Server Sent Events (SSE)'s to the browser through the `ActionController::Live` module. Since this module provides the ability to stream data, it makes sense to also be able to send data in the form of an SSE.

This PR provides a way to create SSEs quickly from provided data. Hopefully, this will make it easier for Rails developers to send continuous message streams to the browser since they won't have to write their own SSE helper class.

\cc @spastorino 
