### PR TITLE
Resolve encoding issues with array-of-hstore columns (fixes bug 11135).

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Perform necessary deeper encoding when hstore is inside an array, and return the
+    hstores as HashWithIndifferentAccess to be consistent with other forms.
+
+    Fixes: #11135
+
+    *Josh Goodall*
+
 *   `has_and_belongs_to_many` is now transparently implemented in terms of
     `has_many :through`.  Behavior should remain the same, if not, it is a bug.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -35,11 +35,11 @@ module ActiveRecord
           end
         end
 
-        def hstore_to_string(object)
+        def hstore_to_string(object, array_member = false)
           if Hash === object
             object.map { |k,v|
               "#{escape_hstore(k)}=>#{escape_hstore(v)}"
-            }.join ','
+            }.join(',').tap { |s| s.replace escape_hstore(s) if array_member }
           else
             object
           end
@@ -49,7 +49,7 @@ module ActiveRecord
           if string.nil?
             nil
           elsif String === string
-            Hash[string.scan(HstorePair).map { |k,v|
+            HashWithIndifferentAccess[string.scan(HstorePair).map { |k,v|
               v = v.upcase == 'NULL' ? nil : v.gsub(/\A"(.*)"\Z/m,'\1').gsub(/\\(.)/, '\1')
               k = k.gsub(/\A"(.*)"\Z/m,'\1').gsub(/\\(.)/, '\1')
               [k,v]

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -109,7 +109,7 @@ module ActiveRecord
             { :value => value, :format => 1 }
           when Hash
             case column.sql_type
-            when 'hstore' then PostgreSQLColumn.hstore_to_string(value)
+            when 'hstore' then PostgreSQLColumn.hstore_to_string(value, array_member)
             when 'json' then PostgreSQLColumn.json_to_string(value)
             else super(value, column)
             end

--- a/activerecord/test/cases/adapters/postgresql/hstore_array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_array_test.rb
@@ -1,0 +1,140 @@
+# encoding: utf-8
+require "cases/helper"
+require 'active_record/base'
+require 'active_record/connection_adapters/postgresql_adapter'
+
+class PostgresqlHstoreArrayTest < ActiveRecord::TestCase
+  class PgHstoreArray < ActiveRecord::Base
+    self.table_name = 'pg_hstore_arrays'
+  end
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+    
+    unless @connection.supports_extensions?
+      return skip "do not test on PG without hstore"
+    end
+
+    unless @connection.extension_enabled?('hstore')
+      @connection.enable_extension 'hstore'
+      @connection.commit_db_transaction
+    end
+
+    @connection.reconnect!
+    
+    @connection.transaction do
+      @connection.create_table('pg_hstore_arrays') do |t|
+        t.hstore 'payload', array: true
+      end
+    end
+    @column = PgHstoreArray.columns.find { |c| c.name == 'payload' }
+    
+    @t_data_hstore = '{"\"AA\"=>\"BB\",\"CC\"=>\"DD\"","\"AA\"=>NULL"}'
+    @t_data_native = [{"AA" => "BB", "CC" => "DD"}, {"AA" => nil}]
+  end
+
+  def teardown
+    @connection.execute 'drop table if exists pg_hstore_arrays'
+  end
+
+  def test_column
+    assert_equal :hstore, @column.type
+    assert @column.array
+  end
+
+  def test_change_column_with_hstore_array
+    @connection.transaction do
+      @connection.change_table('pg_hstore_arrays') do |t|
+        t.hstore 'users', array: true
+      end
+      PgHstoreArray.reset_column_information
+      column = PgHstoreArray.columns.find { |c| c.name == 'users' }
+      assert_equal :hstore, column.type
+
+      raise ActiveRecord::Rollback # reset the schema change
+    end
+  ensure
+    PgHstoreArray.reset_column_information
+  end
+
+  def test_type_cast_hstore_array
+    assert @column
+
+    oid_type  = @column.instance_variable_get('@oid_type').subtype
+    # we are getting the instance variable in this test, but in the
+    # normal use of string_to_array, it's called from the OID::Array
+    # class and will have the OID instance that will provide the type
+    # casting
+    array = @column.class.string_to_array @t_data_hstore, oid_type
+    assert_equal(@t_data_native, array)
+    assert_equal(@t_data_native, @column.type_cast(@t_data_hstore))
+
+    assert_equal([], @column.type_cast('{}'))
+    assert_equal(["key" => nil], @column.type_cast('{"\"key\"=>NULL"}'))
+  end
+
+  def test_rewrite
+    @connection.execute "insert into pg_hstore_arrays (payload) VALUES ('#{@t_data_hstore}')"
+    x = PgHstoreArray.first
+    x.payload = [{"foo" => "bar"}, {"foo" => "baz", "quux" => nil}]
+    assert x.save!
+  end
+
+  def test_select
+    @connection.execute "insert into pg_hstore_arrays (payload) VALUES ('#{@t_data_hstore}')"
+    x = PgHstoreArray.first
+    assert_equal(@t_data_native, x.payload)
+  end
+
+  def test_indifferent_access
+    @connection.execute "insert into pg_hstore_arrays (payload) VALUES ('#{@t_data_hstore}')"
+    x = PgHstoreArray.first
+    assert_equal("BB", x.payload[0][:AA])
+    assert_equal(nil, x.payload[1][:AA])
+  end
+
+  def test_cycle
+    assert_cycle(@t_data_native)
+  end
+
+  def test_strings_with_quotes
+    assert_cycle([{'this has' => 'some "s that need to be escaped"'}])
+  end
+
+  def test_strings_with_commas
+    assert_cycle([{'this,has' => 'many,values'}])
+  end
+
+  def test_strings_with_array_delimiters
+    assert_cycle(['{' => '}'])
+  end
+
+  def test_strings_with_null_strings
+    assert_cycle([{'NULL' => 'NULL'}])
+  end
+
+  def test_contains_nils
+    assert_cycle([{'NULL' => nil}])
+  end
+
+  def test_insert_fixture
+    payload_values = [{"val1" => "val2"}, {"val3_with_'_multiple" => "qu'ote_'_chars"}]
+    @connection.insert_fixture({"payload" => payload_values}, "pg_hstore_arrays" )
+    assert_equal(PgHstoreArray.last.payload, payload_values)
+  end
+
+  private
+  def assert_cycle array
+    # test creation
+    x = PgHstoreArray.create!(payload: array)
+    x.reload
+    assert_equal(array, x.payload)
+
+    # test updating
+    x = PgHstoreArray.create!(payload: [])
+    x.payload = array
+    x.save!
+    x.reload
+    assert_equal(array, x.payload)
+  end
+end


### PR DESCRIPTION
We didn't have enough encoding for the wire protocol to store an array
of hstore types. So, further encode any hstore that is an array member.
Whilst we're here, ensure it's an HashWithIndifferentAccess being
returned, to be consistent with other serialized forms.

So now the following migration:

``` ruby
  enable_extension "hstore"
  create_table :servers do |t|
    t.string  :name
    t.hstore  :interfaces, array: true
  end
```

produces a model that can used like this, to store an array of hashes:

``` ruby
  server = Server.create(name: "server01", interfaces: [
    { name: "bge0", ipv4: "192.0.2.2", state: "up" },
    { name: "de0", state: "disabled", by: "misha" },
    { name: "fe0", state: "up" },
  ])
```

More at http://inopinatus.org/2013/07/12/using-arrays-of-hstore-with-rails-4/
