### PR TITLE
Define enable_extension method to prevent undefined method error

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -293,6 +293,14 @@ module ActiveRecord
         false
       end
 
+      # This is meant to be implemented by the adapters that support extensions
+      def disable_extension(name)
+      end
+
+      # This is meant to be implemented by the adapters that support extensions
+      def enable_extension(name)
+      end
+
       # A list of extensions, to be filled in by adapters that support them. At
       # the moment only postgresql does.
       def extensions

--- a/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
@@ -108,6 +108,18 @@ module ActiveRecord
         assert_equal 2, result.column_types['status'].type_cast(result.last['status'])
       end
 
+      def test_supports_extensions
+        assert_not @conn.supports_extensions?, 'does not support extensions'
+      end
+
+      def test_respond_to_enable_extension
+        assert @conn.respond_to?(:enable_extension)
+      end
+
+      def test_respond_to_disable_extension
+        assert @conn.respond_to?(:disable_extension)
+      end
+
       private
       def insert(ctx, data, table='ex')
         binds   = data.map { |name, value|

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -354,6 +354,18 @@ module ActiveRecord
         assert_nil @conn.primary_key('failboat')
       end
 
+      def test_supports_extensions
+        assert_not @conn.supports_extensions?, 'does not support extensions'
+      end
+
+      def test_respond_to_enable_extension
+        assert @conn.respond_to?(:enable_extension)
+      end
+
+      def test_respond_to_disable_extension
+        assert @conn.respond_to?(:disable_extension)
+      end
+
       private
 
       def assert_logged logs


### PR DESCRIPTION
I am getting this error when trying to run `rake db:test:prepare` in my application. The problem seems to be that I am using postgresql for development but sqlite3 for testing, and the method `enable_extension` is not defined in `Sqlite3Adapter` nor `AbstractAdapter`. As the schema is dumped from the dev database, the following code in `PostgresqlAdapter` (line 70)

```
def extensions(stream)
  return unless @connection.supports_extensions?
  extensions = @connection.extensions
  if extensions.any?
    stream.puts "  # These are extensions that must be enabled in order to support this database"
    extensions.each do |extension|
      stream.puts "  enable_extension #{extension.inspect}"
    end
    stream.puts
  end
end
```

will always write the line

`enable_extension "plpgsql"`

in `schema.rb`

This patch simply adds an empty definition to prevent it. Another option to fix this would be to modify the schema dumper to write `enable_extension("plpgsql") if supports_extensions?` instead. I can adapt the pull request to this if needed.

I am not sure if this is intended or I am missing something, please let me know if there is a smarter way to fix it (or no need to fix it at all!). Also I am not sure what to test here, can someone point me in the right direction? Should I also modify the changelog?
