### PR TITLE
Fixed USAGE file for generator [ci skip]

### DIFF
--- a/railties/lib/rails/generators/rails/generator/USAGE
+++ b/railties/lib/rails/generators/rails/generator/USAGE
@@ -10,4 +10,4 @@ Example:
         lib/generators/awesome/awesome_generator.rb
         lib/generators/awesome/USAGE
         lib/generators/awesome/templates/
-        test/lib/generators/awesome/awesome_generator_test.rb
+        test/lib/generators/awesome_generator_test.rb


### PR DESCRIPTION
As per this test https://github.com/rails/rails/blob/master/railties/test/generators/generator_generator_test.rb#L21

file generated on top level
