### PR TITLE
Fixes #11454 . We should define the return type of select_all method clearly.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -18,8 +18,7 @@ module ActiveRecord
         end
       end
 
-      # Returns an array of record hashes with the column names as keys and
-      # column values as values.
+      # Returns an ActiveRecord::Result instance.
       def select_all(arel, name = nil, binds = [])
         select(to_sql(arel, binds), name, binds)
       end
@@ -355,8 +354,7 @@ module ActiveRecord
           subselect
         end
 
-        # Returns an array of record hashes with the column names as keys and
-        # column values as values.
+        # Returns an ActiveRecord::Result instance.
         def select(sql, name = nil, binds = [])
         end
         undef_method :select

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -229,8 +229,7 @@ module ActiveRecord
 
       alias exec_without_stmt exec_query
 
-      # Returns an array of record hashes with the column names as keys and
-      # column values as values.
+      # Returns an ActiveRecord::Result instance. 
       def select(sql, name = nil, binds = [])
         exec_query(sql, name)
       end

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -3,8 +3,31 @@ module ActiveRecord
   # This class encapsulates a Result returned from calling +exec_query+ on any
   # database connection adapter. For example:
   #
-  #   x = ActiveRecord::Base.connection.exec_query('SELECT * FROM foo')
-  #   x # => #<ActiveRecord::Result:0xdeadbeef>
+  #   result = ActiveRecord::Base.connection.exec_query('SELECT id, title, body FROM posts')
+  #   result # => #<ActiveRecord::Result:0xdeadbeef>
+  #
+  #   # Get the column names of the result:
+  #   result.columns
+  #   # => ["id", "title", "body"]
+  #
+  #   # Get the record values of the result:
+  #   result.rows
+  #   # => [[1, "title_1", "body_1"],
+  #         [2, "title_2", "body_2"],
+  #         ...
+  #        ]
+  #
+  #   # Get an array of hashes representing the result (column => value):
+  #   result.to_hash
+  #   # => [{"id" => 1, "title" => "title_1", "body" => "body_1"},
+  #         {"id" => 2, "title" => "title_2", "body" => "body_2"},
+  #         ...
+  #        ]
+  #
+  #   # ActiveRecord::Result also includes Enumerable.
+  #   result.each do |row|
+  #     puts row['title'] + " " + row['body']
+  #   end
   class Result
     include Enumerable
 
@@ -62,6 +85,7 @@ module ActiveRecord
     end
 
     private
+
     def hash_rows
       @hash_rows ||=
         begin

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -173,6 +173,11 @@ module ActiveRecord
         end
       end
     end
+
+    def test_select_all_always_return_activerecord_result
+      result = @connection.select_all "SELECT * FROM posts"
+      assert result.is_a?(ActiveRecord::Result)
+    end
   end
 
   class AdapterTestWithoutTransaction < ActiveRecord::TestCase


### PR DESCRIPTION
Fixes #11454.

Now `select_all` and `select` methods return an ActiveRecord::Result instance.
I think we should define the return type of select_all method clearly, and fix related comments.
