### PR TITLE
Fixed README link in API

### DIFF
--- a/railties/RDOC_MAIN.rdoc
+++ b/railties/RDOC_MAIN.rdoc
@@ -55,7 +55,7 @@ can read more about Action Pack in its {README}[link:files/actionpack/README_rdo
 
 5. Follow the guidelines to start developing your application. You may find the following resources handy:
 
-* The README file created within your application.
+* The \README file created within your application.
 * {Getting Started with \Rails}[http://guides.rubyonrails.org/getting_started.html].
 * {Ruby on \Rails Tutorial}[http://ruby.railstutorial.org/ruby-on-rails-tutorial-book].
 * {Ruby on \Rails Guides}[http://guides.rubyonrails.org].


### PR DESCRIPTION
This should not be a link because it's creating a link with activesupport
README right now
