### PR TITLE
Prevent server blow up when iterating over TimeWithZone Range

### DIFF
--- a/activesupport/lib/active_support/core_ext/range.rb
+++ b/activesupport/lib/active_support/core_ext/range.rb
@@ -1,3 +1,4 @@
 require 'active_support/core_ext/range/conversions'
 require 'active_support/core_ext/range/include_range'
 require 'active_support/core_ext/range/overlaps'
+require 'active_support/core_ext/range/each'

--- a/activesupport/lib/active_support/core_ext/range/each.rb
+++ b/activesupport/lib/active_support/core_ext/range/each.rb
@@ -1,0 +1,24 @@
+require 'active_support/core_ext/module/aliasing'
+require 'active_support/core_ext/object/acts_like'
+
+class Range #:nodoc:
+
+  def each_with_time_with_zone(&block)
+    ensure_iteration_allowed
+    each_without_time_with_zone(&block)
+  end
+  alias_method_chain :each, :time_with_zone
+
+  def step_with_time_with_zone(n = 1, &block)
+    ensure_iteration_allowed
+    step_without_time_with_zone(n, &block)
+  end
+  alias_method_chain :step, :time_with_zone
+
+  private
+  def ensure_iteration_allowed
+    if first.acts_like?(:time)
+      raise TypeError, "can't iterate from #{first.class}"
+    end
+  end
+end

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -90,4 +90,26 @@ class RangeTest < ActiveSupport::TestCase
     time_range_2 = Time.utc(2005, 12, 10, 17, 31)..Time.utc(2005, 12, 10, 18, 00)
     assert !time_range_1.overlaps?(time_range_2)
   end
+
+  def test_each_on_time_with_zone
+    twz = ActiveSupport::TimeWithZone.new(nil, ActiveSupport::TimeZone['Eastern Time (US & Canada)'] , Time.utc(2006,11,28,10,30))
+    assert_raises TypeError do
+      ((twz - 1.hour)..twz).each {}
+    end
+  end
+
+  def test_step_on_time_with_zone
+    twz = ActiveSupport::TimeWithZone.new(nil, ActiveSupport::TimeZone['Eastern Time (US & Canada)'] , Time.utc(2006,11,28,10,30))
+    assert_raises TypeError do
+      ((twz - 1.hour)..twz).step(1) {}
+    end
+  end
+
+  def test_include_on_time_with_zone
+    twz = ActiveSupport::TimeWithZone.new(nil, ActiveSupport::TimeZone['Eastern Time (US & Canada)'] , Time.utc(2006,11,28,10,30))
+    assert_raises TypeError do
+      ((twz - 1.hour)..twz).include?(twz)
+    end
+  end
+
 end


### PR DESCRIPTION
Iterating over a Range of Time is impossible in ruby:

``` ruby
((Time.now - 1.month)..Time.now).to_a # raises TypeError: can't iterate from Time
```

But it is still possible with ActiveSupport::TimeWithZone

``` ruby
((Time.now.in_time_zone - 1.month)..Time.now.in_time_zone).to_a
    # => Tons of deprecations blow up your console
```

In good case current process is stuck with IO.
In worth case server disk space blow up with production.log file.

This was a huge problem for us and caused a down time on our production app.

In order to prevent that we can generate #succ deprecation warning only once.
And remove TimeWithZone#succ as soon as Time#succ will be removed.
