### PR TITLE
Fix array value escaping: backslashes should be escaped too

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix backslash escaping in PostgreSQL arrays.
+
+    *Alexey Noskov*
+
 *   Perform necessary deeper encoding when hstore is inside an array.
 
     Fixes #11135.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -137,7 +137,7 @@ module ActiveRecord
               if value == ""
                 '""'
               else
-                '"%s"' % value.to_s.gsub(/(["\\])/, '\\\\\1')
+                '"%s"' % escape_quotes(value.to_s)
               end
             end
           end
@@ -147,8 +147,12 @@ module ActiveRecord
             when "NULL", Numeric
               value
             else
-              "\"#{value.gsub(/"/,"\\\"")}\""
+              "\"#{escape_quotes value}\""
             end
+          end
+
+          def escape_quotes(value)
+            value.gsub(/(["\\])/, '\\\\\1')
           end
 
           def type_cast_array(oid, value)

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -113,6 +113,10 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
     assert_cycle(:tags, ['this has','some "s that need to be escaped"'])
   end
 
+  def test_strings_with_quotes_and_backslashes
+    assert_cycle(:tags, ['this has','some \\"s that need to be escaped"', 'and these\ too\"', 'and\\\"these\\\\"'])
+  end
+
   def test_strings_with_commas
     assert_cycle(:tags, ['this,has','many,values'])
   end


### PR DESCRIPTION
Current array escaping doesn't escape backslashes, leading to failures like:

```
ActiveRecord::StatementInvalid: PG::Error: ERROR:  malformed array literal: "{"this has","some \\"s that need to be escaped\""}"
 : INSERT INTO "pg_arrays" ("tags") VALUES ($1) RETURNING "id"
```

This patch fixes it. Correct escaping regexp is taken from [this line](https://github.com/rails/rails/blob/232d2223ebcfe5c9e0425c821f5d30a7d5968512/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb#L73)
