### PR TITLE
fixes plugin test for tutorial

### DIFF
--- a/guides/source/plugins.md
+++ b/guides/source/plugins.md
@@ -68,7 +68,7 @@ In this example you will add a method to String named `to_squawk`. To begin, cre
 
 require 'test_helper'
 
-class CoreExtTest < Test::Unit::TestCase
+class CoreExtTest < ActiveSupport::TestCase
   def test_to_squawk_prepends_the_word_squawk
     assert_equal "squawk! Hello World", "Hello World".to_squawk
   end


### PR DESCRIPTION
Using Test::Unit::Testcase with the default rails/plugin setup fails if following the tutorial in the Plugin Rails Guide.  Changing to ActiveSupport::Testcase makes it work with minimal change.
