### PR TITLE
Cache#fetch_multi returns a Hash instead of an Array

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Change the signature of `fetch_multi` to return a hash rather than an
+    array. This makes it consistent with the output of `read_multi`.
+
+    *Parker Selbert*
+
 *   Introduce `Concern#class_methods` as a sleek alternative to clunky
     `module ClassMethods`. Add `Kernel#concern` to define at the toplevel
     without chunky `module Foo; extend ActiveSupport::Concern` boilerplate.

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -357,20 +357,19 @@ module ActiveSupport
       #
       # Options are passed to the underlying cache implementation.
       #
-      # Returns an array with the data for each of the names. For example:
+      # Returns a hash with the data for each of the names. For example:
       #
       #   cache.write("bim", "bam")
-      #   cache.fetch_multi("bim", "boom") {|key| key * 2 }
-      #   # => ["bam", "boomboom"]
+      #   cache.fetch_multi("bim", "boom") { |key| key * 2 }
+      #   # => { "bam" => "bam", "boom" => "boomboom" }
       #
       def fetch_multi(*names)
         options = names.extract_options!
         options = merged_options(options)
-
         results = read_multi(*names, options)
 
-        names.map do |name|
-          results.fetch(name) do
+        names.each_with_object({}) do |name, memo|
+          memo[name] = results.fetch(name) do
             value = yield name
             write(name, value, options)
             value

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -297,20 +297,21 @@ module CacheStoreBehavior
     @cache.write('foo', 'bar')
     @cache.write('fud', 'biz')
 
-    values = @cache.fetch_multi('foo', 'fu', 'fud') {|value| value * 2 }
+    values = @cache.fetch_multi('foo', 'fu', 'fud') { |value| value * 2 }
 
-    assert_equal(["bar", "fufu", "biz"], values)
-    assert_equal("fufu", @cache.read('fu'))
+    assert_equal({ 'foo' => 'bar', 'fu' => 'fufu', 'fud' => 'biz' }, values)
+    assert_equal('fufu', @cache.read('fu'))
   end
 
   def test_multi_with_objects
-    foo = stub(:title => "FOO!", :cache_key => "foo")
-    bar = stub(:cache_key => "bar")
+    foo = stub(:title => 'FOO!', :cache_key => 'foo')
+    bar = stub(:cache_key => 'bar')
 
-    @cache.write('bar', "BAM!")
+    @cache.write('bar', 'BAM!')
 
-    values = @cache.fetch_multi(foo, bar) {|object| object.title }
-    assert_equal(["FOO!", "BAM!"], values)
+    values = @cache.fetch_multi(foo, bar) { |object| object.title }
+
+    assert_equal({ foo => 'FOO!', bar => 'BAM!' }, values)
   end
 
   def test_read_and_write_compressed_small_data


### PR DESCRIPTION
The current implementation of `fetch_multi` returns an array and has no means to easily backtrack which names yielded which results. By changing the return value to a Hash we retain the name information. Hash#values can be used on the response if only the values are needed.

I've been attempting to add `fetch_multi` support to dalli: mperham/dalli#380 and discovered the disparity between methods. @mperham and I agree that the result should be a Hash rather than an Array. Ideally, and practically, all implementations for the various cache stores should return the same result.

This overwrites the original behavior from rails/rails#10234
