### PR TITLE
3-2-stable patch: Add respond_to_missing? in TaggedLoggging

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -27,6 +27,10 @@
 
     *Andrew White*
 
+*   Add respond_to_missing? for TaggedLogging which is best practice when overriding method_missing. This permits
+    wrapping TaggedLogging by another log abstraction such as em-logger.
+
+    *Wolfram Arnold*
 
 ## Rails 3.2.13 (Mar 18, 2013) ##
 

--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -72,6 +72,10 @@ module ActiveSupport
       @logger.send(method, *args)
     end
 
+    def respond_to_missing?(*args)
+      @logger.respond_to? *args
+    end
+
     private
       def tags_text
         tags = current_tags

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -66,6 +66,10 @@ class TaggedLoggingTest < ActiveSupport::TestCase
     assert_equal "[BCX] Funky time\n", @output.string
   end
 
+  test "correctly answers responds_to_missing? for methods on logger instance" do
+    assert @logger.respond_to?(:debug?)
+  end
+
   test "tagged once with blank and nil" do
     @logger.tagged(nil, "", "New") { @logger.info "Funky time" }
     assert_equal "[New] Funky time\n", @output.string


### PR DESCRIPTION
Added respond_to_missing? for TaggedLogging which is needed if another log abstracter wraps a TaggedLogging instance.
Implementing respond_to_missing? is also a Ruby best practice when overriding method_missing.
