### PR TITLE
Create the module for namespaced controllers and helpers

### DIFF
--- a/railties/lib/rails/generators/rails/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/rails/controller/controller_generator.rb
@@ -8,6 +8,11 @@ module Rails
         template 'controller.rb', File.join('app/controllers', class_path, "#{file_name}_controller.rb")
       end
 
+      def create_module_file
+        return if regular_class_path.empty?
+        template 'module.rb', File.join('app/controllers', "#{class_path.join('/')}.rb") if behavior == :invoke
+      end
+
       def add_routes
         actions.reverse.each do |action|
           route %{get "#{file_name}/#{action}"}

--- a/railties/lib/rails/generators/rails/controller/templates/module.rb
+++ b/railties/lib/rails/generators/rails/controller/templates/module.rb
@@ -1,0 +1,4 @@
+<% module_namespacing do -%>
+module <%= class_path.map(&:camelize).join('::') %>
+end
+<% end -%>

--- a/railties/lib/rails/generators/rails/helper/helper_generator.rb
+++ b/railties/lib/rails/generators/rails/helper/helper_generator.rb
@@ -7,6 +7,11 @@ module Rails
         template 'helper.rb', File.join('app/helpers', class_path, "#{file_name}_helper.rb")
       end
 
+      def create_module_file
+        return if regular_class_path.empty?
+        template 'module.rb', File.join('app/helpers', "#{class_path.join('/')}.rb") if behavior == :invoke
+      end
+
       hook_for :test_framework
     end
   end

--- a/railties/lib/rails/generators/rails/helper/templates/module.rb
+++ b/railties/lib/rails/generators/rails/helper/templates/module.rb
@@ -1,0 +1,4 @@
+<% module_namespacing do -%>
+module <%= class_path.map(&:camelize).join('::') %>
+end
+<% end -%>

--- a/railties/test/generators/controller_generator_test.rb
+++ b/railties/test/generators/controller_generator_test.rb
@@ -25,6 +25,12 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
     Object.send :remove_const, :ObjectController
   end
 
+  def test_controller_with_namespace
+    run_generator ["admin/account"]
+    assert_file "app/controllers/admin.rb", /module Admin/
+    assert_file "app/controllers/admin/account_controller.rb", /class Admin::AccountController < ApplicationController/
+  end
+
   def test_invokes_helper
     run_generator
     assert_file "app/helpers/account_helper.rb"

--- a/railties/test/generators/helper_generator_test.rb
+++ b/railties/test/generators/helper_generator_test.rb
@@ -33,6 +33,12 @@ class HelperGeneratorTest < Rails::Generators::TestCase
     assert_match(/The name 'AnotherObjectHelperTest' is either already used in your application or reserved/, content)
   end
 
+  def test_helper_with_namespace
+    run_generator ["admin/account"]
+    assert_file "app/helpers/admin.rb", /module Admin/
+    assert_file "app/helpers/admin/account_helper.rb", /module Admin::Account/
+  end
+
   def test_namespaced_and_not_namespaced_helpers
     run_generator ["products"]
 


### PR DESCRIPTION
Because the generators create namespaced controllers and helpers in only one line instead of explicitely specifying the module, it can lead to missing models errors.

```
class Admin::WelcomeController < ApplicationController; end
```

The `Admin` module is expected to exist.

[ActiveRecord](https://github.com/rails/rails/blob/master/activerecord/lib/rails/generators/active_record/model/model_generator.rb#L28) already does this, in order to set the `table_name_prefix`.
This adds a similar behavior to controllers and helpers.

See #10679 for the original bug report.
