### PR TITLE
Revert "Fix SyntaxError in guides sample code"

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -711,7 +711,7 @@ Post.order('id DESC').limit(20).unscope(:order, :limit) = Post.all
 You can additionally unscope specific where clauses. For example:
 
 ```ruby
-Post.where(id: 10).limit(1).unscope(:where, :limit).order('id DESC') = Post.order('id DESC')
+Post.where(id: 10).limit(1).unscope({ where: :id }, :limit).order('id DESC') = Post.order('id DESC')
 ```
 
 ### `only`


### PR DESCRIPTION
This reverts commit f573df32d43c413a5098721ba6151ff190c23c6c.

The original idea of this documentation was to showcase the feature where you can remove some only queries attributes with a single key-value pair.

It's change to use implicit hash to prevent syntax error.
