### PR TITLE
Generalize error message dependant logic a bit.

### DIFF
--- a/actionpack/test/controller/new_base/render_streaming_test.rb
+++ b/actionpack/test/controller/new_base/render_streaming_test.rb
@@ -90,7 +90,7 @@ module RenderStreaming
       begin
         get "/render_streaming/basic/template_exception"
         io.rewind
-        assert_match "(undefined method `invalid!' for nil:NilClass)", io.read
+        assert_match(/undefined method `invalid!' \w+ nil:NilClass/, io.read)
       ensure
         ActionController::Base.logger = _old
       end

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -259,7 +259,7 @@ module ActiveSupport
       begin
         constantize(camel_cased_word)
       rescue NameError => e
-        raise unless e.message =~ /(uninitialized constant|wrong constant name) #{const_regexp(camel_cased_word)}$/ ||
+        raise unless e.message =~ /(uninitialized constant|wrong constant name).+#{const_regexp(camel_cased_word)}$/ ||
           e.name.to_s == camel_cased_word.to_s
       rescue ArgumentError => e
         raise unless e.message =~ /not missing constant #{const_regexp(camel_cased_word)}\!$/

--- a/activesupport/test/ordered_hash_test.rb
+++ b/activesupport/test/ordered_hash_test.rb
@@ -230,12 +230,8 @@ class OrderedHashTest < Test::Unit::TestCase
   end
 
   def test_alternate_initialization_raises_exception_on_odd_length_args
-    begin
+    assert_raises ArgumentError do
       ActiveSupport::OrderedHash[1,2,3,4,5]
-      flunk "Hash::[] should have raised an exception on initialization " +
-          "with an odd number of parameters"
-    rescue ArgumentError => e
-      assert_equal "odd number of arguments for Hash", e.message
     end
   end
 


### PR DESCRIPTION
I'm trying to get Rubinius to pass the 3-2-stable test-suite.
I've come across some error message dependant logic and tried to remove it or generalize it a bit, at least to have passing test cases.
I'm not sure it's the right way to do it, but I hope to start a conversation about this. :grin:

/cc @dbussink @brixen
