### PR TITLE
Removed where_values_hash from AR::NullRelation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Objects intiantiated using a null relationship will now retain the
+    attributes of the where clause.
+
+    Fixes:  #11676, #11675, #11376
+
+    *Paul Nikitochkin*, *Peter Brown*, *Nthalk*
+
 *   Fixed `ActiveRecord::Associations::CollectionAssociation#find`
     when using `has_many` association with `:inverse_of` and finding an array of one element,
     it should return an array of one element too.

--- a/activerecord/lib/active_record/null_relation.rb
+++ b/activerecord/lib/active_record/null_relation.rb
@@ -42,10 +42,6 @@ module ActiveRecord
       ""
     end
 
-    def where_values_hash
-      {}
-    end
-
     def count(*)
       0
     end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -80,6 +80,13 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 'exotic', bulb.name
   end
 
+  def test_build_from_association_should_respect_scope
+    author = Author.new
+
+    post = author.thinking_posts.build
+    assert_equal 'So I was thinking', post.title
+  end
+
   def test_create_from_association_with_nil_values_should_work
     car = Car.create(:name => 'honda')
 
@@ -1627,6 +1634,22 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     bulb = car.bulbs.build
 
     assert_equal car.id, bulb.attributes_after_initialize['car_id']
+  end
+
+  def test_attributes_are_set_when_initialized_from_has_many_null_relationship
+    car  = Car.new name: 'honda'
+    bulb = car.bulbs.where(name: 'headlight').first_or_initialize
+    assert_equal 'headlight', bulb.name
+  end
+
+  def test_attributes_are_set_when_initialized_from_polymorphic_has_many_null_relationship
+    post    = Post.new title: 'title', body: 'bar'
+    tag     = Tag.create!(name: 'foo')
+
+    tagging = post.taggings.where(tag: tag).first_or_initialize
+
+    assert_equal tag.id, tagging.tag_id
+    assert_equal 'Post', tagging.taggable_type
   end
 
   def test_replace

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -300,6 +300,10 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal({}, Developer.none.where_values_hash)
   end
 
+  def test_null_relation_where_values_hash
+    assert_equal({ 'salary' => 100_000 }, Developer.none.where(salary: 100_000).where_values_hash)
+  end
+
   def test_joins_with_nil_argument
     assert_nothing_raised { DependentFirm.joins(nil).first }
   end


### PR DESCRIPTION
In order to build associated records for owners which has not been saved
need to get where values to use as default attributes.
But for new record owner uses `ActiveRecord::NullRelation` which
override `where_values_hash` to return empty hash stub.

`where_values_hash` is not used to invoke any sql query, but good to
build others chains (even will be never executed) like:

``` ruby
  post          = Post.new
  admin_comment = post.admin_comments.build

  assert_equal 'Admin', admin_comment.author
```

Closes #11376, #11676 and #11675
