### PR TITLE
Allow to retrieve scope names for a given active record class

### DIFF
--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -8,6 +8,11 @@ module ActiveRecord
     module Named
       extend ActiveSupport::Concern
 
+      included do |base|
+        base.class_attribute :scopes
+        base.scopes = []
+      end
+
       module ClassMethods
         # Returns an <tt>ActiveRecord::Relation</tt> scope object.
         #
@@ -141,6 +146,7 @@ module ActiveRecord
         def scope(name, body, &block)
           extension = Module.new(&block) if block
 
+          self.scopes += [name.to_sym]
           singleton_class.send(:define_method, name) do |*args|
             if body.respond_to?(:call)
               scope = all.scoping { body.call(*args) }

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -448,4 +448,15 @@ class NamedScopingTest < ActiveRecord::TestCase
     assert_equal 1, SpecialComment.where(body: 'go crazy').created.count
   end
 
+  def test_scope_names_are_registered
+    assert_equal [:relation_include_posts, :relation_include_tags], Author.scopes
+    klazz = Class.new(ActiveRecord::Base) do
+      self.table_name = "topics"
+      scope :scope_a, Proc.new { none }
+      scope :scope_b, Proc.new { none }
+      scope :scope_c, Proc.new { none }
+    end
+    assert_equal [:scope_a, :scope_b, :scope_c], klazz.scopes
+  end
+
 end


### PR DESCRIPTION
A while back, it was possible to loop through the scopes of a given model and retrieve a Proc for each scope.

Today, scopes are methods but we can't list them.

It would be great to list at least the name of the registered scopes for a given model. This PR covers this basic functionality.

Maybe the naming is not perfect, feel free to propose another name for the attribute.

Thanks
