### PR TITLE
Match Dev/Prod parity for Index Page

### DIFF
--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -25,8 +25,10 @@ module Rails
             get '/rails/info/properties' => "rails/info#properties"
             get '/rails/info/routes'     => "rails/info#routes"
             get '/rails/info'            => "rails/info#index"
-            get '/'                      => "rails/welcome#index"
           end
+        end
+        app.routes.append do
+          get '/' => "rails/welcome#index"
         end
       end
 

--- a/railties/lib/rails/templates/rails/welcome/index.html.erb
+++ b/railties/lib/rails/templates/rails/welcome/index.html.erb
@@ -227,7 +227,7 @@
 
             <li>
               <h2>Set up a root route to replace this page</h2>
-              <p>You're seeing this page because you're running in development mode and you haven't set a root route yet.</p>
+              <p>You're seeing this page because you haven't set a root route yet.</p>
               <p>Routes are set up in <span class="filename">config/routes.rb</span>.</p>
             </li>
 

--- a/railties/test/application/routing_test.rb
+++ b/railties/test/application/routing_test.rb
@@ -60,7 +60,7 @@ module ApplicationTests
     test "rails/welcome in production" do
       app("production")
       get "/"
-      assert_equal 404, last_response.status
+      assert_equal 200, last_response.status
     end
 
     test "rails/info/routes in production" do


### PR DESCRIPTION
With Rails 4 the default index page was moved from a static file `index.html` inside the `public/` folder to an internal controller/view inside of the railties gem. This was to allow use of erb in the default index page and to remove the requirement that new apps must delete a static file to make their index pages work. While this was a good change, the functionality was unexpected to developers who wish to get their apps running in production ASAP. They will create a new app `rails new my app`, start a server to verify it works, then immediately deploy the app to verify that it can start working in production. Unfortunately locally they see a page when they visit `localhost:3000` when they visit their production app they get an error page.

We initially anticipated this problem in the original pull request, but did not properly anticipate the severity or quantity of people who would like this functionality. Having a default index page serves as an excellent litmus test for a passed deploy on default apps, and it is very unexpected to have a page work locally, but not on production. 

This change makes the default index page available in production if the developer has not over-written it by defining their own `root` path inside of routes.
